### PR TITLE
fix(sandbox): preserve gateway auth at launch

### DIFF
--- a/docs/security/filesystem-controls.mdx
+++ b/docs/security/filesystem-controls.mdx
@@ -31,6 +31,7 @@ The container mounts system directories read-only to prevent the agent from modi
 
 The `/sandbox/.openclaw` directory contains the OpenClaw gateway configuration (model routing, CORS settings, channel config).
 The current entrypoint reads the gateway auth token from OpenClaw config when present, exports it as `OPENCLAW_GATEWAY_TOKEN`, and writes it to `/tmp/nemoclaw-proxy-env.sh` so interactive sandbox sessions can reach the gateway through system-wide shell hooks.
+The launch boundary removes `OPENCLAW_GATEWAY_TOKEN` from the gateway process environment and does not pass its value in process arguments.
 
 In root mode, the gateway process still runs as the separate `gateway` user, but the token is intentionally available to sandbox shells for local gateway access.
 
@@ -90,12 +91,13 @@ Cross-device entries, detected traversal races, or failures to remove or replace
   The same limitation applies when the locked file set grew after the existing seal was captured.
   Rebuild the sandbox for a known-good baseline before trusting a new seal.
 - **Gateway token environment.**
-  The gateway exports `OPENCLAW_GATEWAY_TOKEN` and writes it to `/tmp/nemoclaw-proxy-env.sh` for interactive sandbox sessions.
+  The entrypoint exports `OPENCLAW_GATEWAY_TOKEN` and writes it to `/tmp/nemoclaw-proxy-env.sh` for interactive sandbox sessions.
+  The gateway process reads the token from `openclaw.json` instead.
   Keep this in mind when deciding whether a workload should run with mutable config or an immutable config posture.
 
 | Aspect | Detail |
 |---|---|
-| Default | The sandbox keeps `/sandbox/.openclaw` writable (`2770 sandbox:sandbox`), sets `openclaw.json` to `660 sandbox:sandbox`, lets the agent manage state directly, and has the gateway place `OPENCLAW_GATEWAY_TOKEN` in `/tmp/nemoclaw-proxy-env.sh` for interactive shells. |
+| Default | The sandbox keeps `/sandbox/.openclaw` writable (`2770 sandbox:sandbox`), sets `openclaw.json` to `660 sandbox:sandbox`, lets the agent manage state directly, and has the entrypoint place `OPENCLAW_GATEWAY_TOKEN` in `/tmp/nemoclaw-proxy-env.sh` for interactive shells. The gateway process does not receive the token through its environment or process arguments. |
 | What you can change | Apply a reviewed host-side immutability workflow to lock config and state directories with DAC permissions and the immutable flag where available. |
 | Risk of default | A writable `.openclaw` directory lets the agent modify its own gateway config: disabling CORS or redirecting inference to an attacker-controlled endpoint. |
 | Recommendation | For always-on assistants handling sensitive workloads, lock config after initial setup. For development workflows, the writable default is appropriate. |

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -5176,9 +5176,9 @@ launch_openclaw_gateway_process() {
       # Replace the predictable log path immediately before the initial launch.
       # The descriptor-safe launcher below then pins that exact regular file.
       if [ "$(id -u)" -eq 0 ]; then
-        _nemoclaw_safe_create_tmp_file /tmp/gateway.log 644 gateway:gateway
+        _nemoclaw_safe_create_tmp_file /tmp/gateway.log 644 gateway:gateway || return 1
       else
-        _nemoclaw_safe_create_tmp_file /tmp/gateway.log 644
+        _nemoclaw_safe_create_tmp_file /tmp/gateway.log 644 || return 1
       fi
       ;;
     *)
@@ -5265,7 +5265,7 @@ launch_openclaw_gateway() {
   launch_openclaw_gateway_process truncate \
     "${STEP_DOWN_PREFIX_GATEWAY[@]}" env HOME=/sandbox sh -c \
     'umask 0007; exec "$@"' sh \
-    "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}"
+    "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" || return 1
   if ! capture_openclaw_pid_start_identity "$GATEWAY_PID" GATEWAY_PID_START_IDENTITY; then
     # An uncaptured numeric PID is never safe to signal: Bash may already have
     # reaped the short-lived child and the kernel may have reused its PID. Fail
@@ -5286,7 +5286,7 @@ launch_openclaw_gateway_non_root() {
   arm_openclaw_gateway_supervisor_cleanup
   mark_in_container_gateway
   launch_openclaw_gateway_process truncate \
-    "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}"
+    "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" || return 1
   capture_openclaw_pid_start_identity "$GATEWAY_PID" GATEWAY_PID_START_IDENTITY || exit 1
   record_gateway_pid "$GATEWAY_PID" "$GATEWAY_PID_START_IDENTITY"
   echo "[gateway] openclaw gateway launched (pid $GATEWAY_PID)" >&2

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -2337,6 +2337,11 @@ try {
   const gateway = cfg.gateway && typeof cfg.gateway === "object" ? cfg.gateway : (cfg.gateway = {});
   const auth = gateway.auth && typeof gateway.auth === "object" ? gateway.auth : (gateway.auth = {});
   auth.token = tokenUrlSafe(32);
+  const meta = cfg.meta && typeof cfg.meta === "object" ? cfg.meta : (cfg.meta = {});
+  // Record OpenClaw's configuration-write metadata. Without this field,
+  // OpenClaw 2026.7 can classify the authenticated configuration as overwritten
+  // and restore the tokenless build-time backup before gateway authentication resolves.
+  meta.lastTouchedAt = new Date().toISOString();
 
   const dirPath = pathModule.dirname(path);
   let fd;
@@ -5166,31 +5171,15 @@ launch_openclaw_gateway_process() {
   local log_mode="$1"
   shift
   case "$log_mode" in
-    append | truncate) ;;
+    append)
+      nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN "$@" >>/tmp/gateway.log 2>&1 &
+      ;;
+    truncate)
+      nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN "$@" >/tmp/gateway.log 2>&1 &
+      ;;
     *)
       echo "[gateway] invalid gateway log mode: $log_mode" >&2
       return 1
-      ;;
-  esac
-
-  # OpenClaw startup repair can restore a tokenless build-time config backup
-  # before gateway authentication resolves. Pass the runtime gateway token
-  # through the supported --token option and remove OPENCLAW_GATEWAY_TOKEN from
-  # the gateway process environment. This keeps the gateway authenticated
-  # without passing the credential to child processes through environment
-  # inheritance (#8693).
-  local gateway_token="${OPENCLAW_GATEWAY_TOKEN:-}"
-  local -a gateway_auth_args=()
-  if [ -n "$gateway_token" ]; then
-    gateway_auth_args=(--token "$gateway_token")
-  fi
-
-  case "$log_mode" in
-    append)
-      nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN "$@" "${gateway_auth_args[@]}" >>/tmp/gateway.log 2>&1 &
-      ;;
-    truncate)
-      nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN "$@" "${gateway_auth_args[@]}" >/tmp/gateway.log 2>&1 &
       ;;
   esac
   GATEWAY_PID=$!

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -5166,15 +5166,31 @@ launch_openclaw_gateway_process() {
   local log_mode="$1"
   shift
   case "$log_mode" in
-    append)
-      nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN "$@" >>/tmp/gateway.log 2>&1 &
-      ;;
-    truncate)
-      nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN "$@" >/tmp/gateway.log 2>&1 &
-      ;;
+    append | truncate) ;;
     *)
       echo "[gateway] invalid gateway log mode: $log_mode" >&2
       return 1
+      ;;
+  esac
+
+  # OpenClaw startup repair can restore a tokenless build-time config backup
+  # before gateway authentication resolves. Pass the runtime gateway token
+  # through the supported --token option and remove OPENCLAW_GATEWAY_TOKEN from
+  # the gateway process environment. This keeps the gateway authenticated
+  # without passing the credential to child processes through environment
+  # inheritance (#8693).
+  local gateway_token="${OPENCLAW_GATEWAY_TOKEN:-}"
+  local -a gateway_auth_args=()
+  if [ -n "$gateway_token" ]; then
+    gateway_auth_args=(--token "$gateway_token")
+  fi
+
+  case "$log_mode" in
+    append)
+      nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN "$@" "${gateway_auth_args[@]}" >>/tmp/gateway.log 2>&1 &
+      ;;
+    truncate)
+      nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN "$@" "${gateway_auth_args[@]}" >/tmp/gateway.log 2>&1 &
       ;;
   esac
   GATEWAY_PID=$!

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -5171,17 +5171,82 @@ launch_openclaw_gateway_process() {
   local log_mode="$1"
   shift
   case "$log_mode" in
-    append)
-      nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN "$@" >>/tmp/gateway.log 2>&1 &
-      ;;
+    append) ;;
     truncate)
-      nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN "$@" >/tmp/gateway.log 2>&1 &
+      # Replace the predictable log path immediately before the initial launch.
+      # The descriptor-safe launcher below then pins that exact regular file.
+      if [ "$(id -u)" -eq 0 ]; then
+        _nemoclaw_safe_create_tmp_file /tmp/gateway.log 644 gateway:gateway
+      else
+        _nemoclaw_safe_create_tmp_file /tmp/gateway.log 644
+      fi
       ;;
     *)
       echo "[gateway] invalid gateway log mode: $log_mode" >&2
       return 1
       ;;
   esac
+
+  nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN \
+    python3 -I - "$log_mode" "$@" <<'PYGATEWAYLAUNCH' &
+import os
+import stat
+import sys
+
+log_path = "/tmp/gateway.log"
+log_mode = sys.argv[1]
+argv = sys.argv[2:]
+if not argv:
+    print("[gateway] refusing empty gateway launch command", file=sys.stderr)
+    raise SystemExit(1)
+if not hasattr(os, "O_NOFOLLOW"):
+    print("[SECURITY] refusing gateway launch because O_NOFOLLOW is unavailable", file=sys.stderr)
+    raise SystemExit(1)
+
+try:
+    before = os.lstat(log_path)
+except OSError as exc:
+    print(f"[SECURITY] refusing unavailable gateway log path: {log_path}: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+    print(f"[SECURITY] refusing unsafe gateway log path: {log_path}", file=sys.stderr)
+    raise SystemExit(1)
+
+flags = os.O_WRONLY | os.O_NOFOLLOW
+for optional_flag in ("O_CLOEXEC", "O_NONBLOCK"):
+    flags |= getattr(os, optional_flag, 0)
+if log_mode == "append":
+    flags |= os.O_APPEND
+elif log_mode != "truncate":
+    print(f"[gateway] invalid gateway log mode: {log_mode}", file=sys.stderr)
+    raise SystemExit(1)
+
+try:
+    descriptor = os.open(log_path, flags)
+except OSError as exc:
+    print(f"[SECURITY] refusing unsafe gateway log path: {log_path}: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+try:
+    opened = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(opened.st_mode)
+        or opened.st_nlink != 1
+        or (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino)
+    ):
+        print(f"[SECURITY] refusing replaced gateway log path: {log_path}", file=sys.stderr)
+        raise SystemExit(1)
+    if log_mode == "truncate":
+        os.ftruncate(descriptor, 0)
+    os.dup2(descriptor, 1)
+    os.dup2(descriptor, 2)
+finally:
+    if descriptor > 2:
+        os.close(descriptor)
+
+environment = os.environ.copy()
+environment.pop("OPENCLAW_GATEWAY_TOKEN", None)
+os.execvpe(argv[0], argv, environment)
+PYGATEWAYLAUNCH
   GATEWAY_PID=$!
 }
 
@@ -5199,7 +5264,7 @@ launch_openclaw_gateway() {
   mark_in_container_gateway
   launch_openclaw_gateway_process truncate \
     "${STEP_DOWN_PREFIX_GATEWAY[@]}" env HOME=/sandbox sh -c \
-    'umask 0007; exec "$@" >>/tmp/gateway.log 2>&1' sh \
+    'umask 0007; exec "$@"' sh \
     "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}"
   if ! capture_openclaw_pid_start_identity "$GATEWAY_PID" GATEWAY_PID_START_IDENTITY; then
     # An uncaptured numeric PID is never safe to signal: Bash may already have
@@ -5815,10 +5880,6 @@ if [ "$(id -u)" -ne 0 ]; then
   write_auth_profile
   harden_auth_profiles
 
-  # In non-root mode, detach gateway stdout/stderr from the sandbox-create
-  # stream so openshell sandbox create can return once the container is ready.
-  _nemoclaw_safe_create_tmp_file /tmp/gateway.log 644
-
   # Separate log for auto-pair in non-root mode as well.
   _nemoclaw_safe_create_tmp_file /tmp/auto-pair.log 600
 
@@ -5952,10 +6013,6 @@ if [ ${#NEMOCLAW_CMD[@]} -gt 0 ]; then
   run_oneshot_command "${STEP_DOWN_PREFIX_SANDBOX[@]}" "${NEMOCLAW_CMD[@]}" || _nemoclaw_cmd_rc=$?
   exit "$_nemoclaw_cmd_rc"
 fi
-
-# Gateway log: owned by gateway user, world-readable for diagnostics.
-# The sandbox user can read but not truncate/overwrite (not owner, sticky /tmp).
-_nemoclaw_safe_create_tmp_file /tmp/gateway.log 644 gateway:gateway
 
 # Separate log for auto-pair so sandbox user can write to it
 _nemoclaw_safe_create_tmp_file /tmp/auto-pair.log 600 sandbox:sandbox

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -5169,13 +5169,28 @@ arm_openclaw_gateway_supervisor_cleanup() {
 
 launch_openclaw_gateway_process() {
   local log_mode="$1"
-  shift
+  local launch_identity="$2"
+  local -a gateway_launch_prefix=()
+  shift 2
+  case "$launch_identity" in
+    current) ;;
+    gateway)
+      gateway_launch_prefix=(
+        "${STEP_DOWN_PREFIX_GATEWAY[@]}" env HOME=/sandbox sh -c
+        'umask 0007; exec "$@"' sh
+      )
+      ;;
+    *)
+      echo "[gateway] invalid gateway launch identity: $launch_identity" >&2
+      return 1
+      ;;
+  esac
   case "$log_mode" in
     append) ;;
     truncate)
       # Replace the predictable log path immediately before the initial launch.
       # The descriptor-safe launcher below then pins that exact regular file.
-      if [ "$(id -u)" -eq 0 ]; then
+      if [ "$launch_identity" = gateway ] && [ "$(id -u)" -eq 0 ]; then
         _nemoclaw_safe_create_tmp_file /tmp/gateway.log 644 gateway:gateway || return 1
       else
         _nemoclaw_safe_create_tmp_file /tmp/gateway.log 644 || return 1
@@ -5188,6 +5203,7 @@ launch_openclaw_gateway_process() {
   esac
 
   nohup /usr/bin/env -u OPENCLAW_GATEWAY_TOKEN \
+    "${gateway_launch_prefix[@]+"${gateway_launch_prefix[@]}"}" \
     python3 -I - "$log_mode" "$@" <<'PYGATEWAYLAUNCH' &
 import os
 import stat
@@ -5262,9 +5278,7 @@ launch_openclaw_gateway() {
   # script -- keeps it in place.
   arm_openclaw_gateway_supervisor_cleanup
   mark_in_container_gateway
-  launch_openclaw_gateway_process truncate \
-    "${STEP_DOWN_PREFIX_GATEWAY[@]}" env HOME=/sandbox sh -c \
-    'umask 0007; exec "$@"' sh \
+  launch_openclaw_gateway_process truncate gateway \
     "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" || return 1
   if ! capture_openclaw_pid_start_identity "$GATEWAY_PID" GATEWAY_PID_START_IDENTITY; then
     # An uncaptured numeric PID is never safe to signal: Bash may already have
@@ -5285,7 +5299,7 @@ launch_openclaw_gateway() {
 launch_openclaw_gateway_non_root() {
   arm_openclaw_gateway_supervisor_cleanup
   mark_in_container_gateway
-  launch_openclaw_gateway_process truncate \
+  launch_openclaw_gateway_process truncate current \
     "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}" || return 1
   capture_openclaw_pid_start_identity "$GATEWAY_PID" GATEWAY_PID_START_IDENTITY || exit 1
   record_gateway_pid "$GATEWAY_PID" "$GATEWAY_PID_START_IDENTITY"
@@ -5952,7 +5966,7 @@ if [ "$(id -u)" -ne 0 ]; then
     echo "[gateway] pid $EXITED_GATEWAY_PID exited (rc=$RC); respawning (#$RESPAWN_COUNT in 60s window) in 2s" >&2
     sleep 2
     prepare_openclaw_automatic_respawn || exit 1
-    launch_openclaw_gateway_process append \
+    launch_openclaw_gateway_process append current \
       "$OPENCLAW" gateway run --port "${_DASHBOARD_PORT}"
     capture_openclaw_pid_start_identity "$GATEWAY_PID" GATEWAY_PID_START_IDENTITY || exit 1
     record_gateway_pid "$GATEWAY_PID" "$GATEWAY_PID_START_IDENTITY"

--- a/test/nemoclaw-start-gateway-health.test.ts
+++ b/test/nemoclaw-start-gateway-health.test.ts
@@ -575,7 +575,7 @@ describe("gateway launch wiring (#4710)", () => {
         [
           "set -uo pipefail",
           `EVENT_LOG=${JSON.stringify(eventLog)}`,
-          "STEP_DOWN_PREFIX_GATEWAY=()",
+          "STEP_DOWN_PREFIX_GATEWAY=(env)",
           "OPENCLAW=/usr/bin/true",
           "_DASHBOARD_PORT=19000",
           "GATEWAY_PID=0",
@@ -586,6 +586,7 @@ describe("gateway launch wiring (#4710)", () => {
           'clear_gateway_pid_record() { printf "clear\\n" >>"$EVENT_LOG"; }',
           'kill() { printf "unexpected-kill:%s\\n" "$*" >>"$EVENT_LOG"; }',
           'wait() { printf "unexpected-wait:%s\\n" "$*" >>"$EVENT_LOG"; }',
+          safeTmpHelpers(src),
           extractShellFunction(src, "arm_openclaw_gateway_supervisor_cleanup"),
           extractShellFunction(src, "launch_openclaw_gateway_process"),
           launch,
@@ -595,7 +596,7 @@ describe("gateway launch wiring (#4710)", () => {
       { encoding: "utf-8", timeout: 5000 },
     );
 
-    expect(result.status).toBe(1);
+    expect(result.status, result.stderr).toBe(1);
     expect(result.stderr).toContain("could not capture gateway process identity");
     expect(fs.readFileSync(eventLog, "utf-8")).toBe("clear\n");
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -759,6 +760,7 @@ describe("respawn loop pidfile refresh (#4710)", () => {
         mode: 0o755,
       },
     );
+    fs.writeFileSync(gatewayLog, "gateway booting\n");
 
     fs.writeFileSync(
       scriptPath,

--- a/test/nemoclaw-start-gateway-token-env.test.ts
+++ b/test/nemoclaw-start-gateway-token-env.test.ts
@@ -32,7 +32,7 @@ describe("OpenClaw gateway credential environment", () => {
       safeTmpHelpers(source),
       launch,
       "export OPENCLAW_GATEWAY_TOKEN=gateway-secret",
-      `launch_openclaw_gateway_process ${logMode} sh -c 'printf "ENV=%s\\nARGS=%s\\n" "\${OPENCLAW_GATEWAY_TOKEN-unset}" "$*"' sh`,
+      `launch_openclaw_gateway_process ${logMode} current sh -c 'printf "ENV=%s\\nARGS=%s\\n" "\${OPENCLAW_GATEWAY_TOKEN-unset}" "$*"' sh`,
       'wait "$GATEWAY_PID"',
     ].join("\n");
 
@@ -71,7 +71,7 @@ describe("OpenClaw gateway credential environment", () => {
         safeTmpHelpers(source),
         launch,
         "export OPENCLAW_GATEWAY_TOKEN=gateway-secret",
-        `launch_openclaw_gateway_process ${logMode} node -e 'setTimeout(() => {}, 30000)' nemoclaw-proc-credential-probe`,
+        `launch_openclaw_gateway_process ${logMode} current node -e 'setTimeout(() => {}, 30000)' nemoclaw-proc-credential-probe`,
         'trap \'kill "$GATEWAY_PID" 2>/dev/null || true; wait "$GATEWAY_PID" 2>/dev/null || true\' EXIT',
         "ready=0",
         "for _ in $(seq 1 100); do",
@@ -111,7 +111,7 @@ describe("OpenClaw gateway credential environment", () => {
     ).replaceAll("/tmp/gateway.log", gatewayLog);
     const result = spawnSync(
       "bash",
-      ["-c", [launch, "launch_openclaw_gateway_process invalid true"].join("\n")],
+      ["-c", [launch, "launch_openclaw_gateway_process invalid current true"].join("\n")],
       { encoding: "utf8", timeout: 5000 },
     );
 

--- a/test/nemoclaw-start-gateway-token-env.test.ts
+++ b/test/nemoclaw-start-gateway-token-env.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { safeTmpHelpers } from "./nemoclaw-start-gateway.test-helpers";
 import { extractShellFunctionFromSource } from "./support/shell-function-extractor";
 
 const START_SCRIPT = path.resolve(import.meta.dirname, "../scripts/nemoclaw-start.sh");
@@ -28,6 +29,7 @@ describe("OpenClaw gateway credential environment", () => {
     fs.writeFileSync(gatewayLog, seed);
     const script = [
       "set -euo pipefail",
+      safeTmpHelpers(source),
       launch,
       "export OPENCLAW_GATEWAY_TOKEN=gateway-secret",
       `launch_openclaw_gateway_process ${logMode} sh -c 'printf "ENV=%s\\nARGS=%s\\n" "\${OPENCLAW_GATEWAY_TOKEN-unset}" "$*"' sh`,
@@ -63,11 +65,13 @@ describe("OpenClaw gateway credential environment", () => {
         source,
         "launch_openclaw_gateway_process",
       ).replaceAll("/tmp/gateway.log", gatewayLog);
+      fs.writeFileSync(gatewayLog, "");
       const script = [
         "set -euo pipefail",
+        safeTmpHelpers(source),
         launch,
         "export OPENCLAW_GATEWAY_TOKEN=gateway-secret",
-        `launch_openclaw_gateway_process ${logMode} ${JSON.stringify(process.execPath)} -e 'setTimeout(() => {}, 30000)' nemoclaw-proc-credential-probe`,
+        `launch_openclaw_gateway_process ${logMode} node -e 'setTimeout(() => {}, 30000)' nemoclaw-proc-credential-probe`,
         'trap \'kill "$GATEWAY_PID" 2>/dev/null || true; wait "$GATEWAY_PID" 2>/dev/null || true\' EXIT',
         "ready=0",
         "for _ in $(seq 1 100); do",

--- a/test/nemoclaw-start-gateway-token-env.test.ts
+++ b/test/nemoclaw-start-gateway-token-env.test.ts
@@ -16,26 +16,34 @@ describe("OpenClaw gateway credential environment", () => {
   it.each([
     "truncate",
     "append",
-  ])("removes the dashboard token from a %s gateway launch (#8693)", (logMode) => {
+  ])("passes --token and removes OPENCLAW_GATEWAY_TOKEN when the log mode is %s (#8693)", (logMode) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-token-env-"));
     const gatewayLog = path.join(tmpDir, "gateway.log");
+    const seed = "existing gateway output\n";
     const source = fs.readFileSync(START_SCRIPT, "utf8");
     const launch = extractShellFunctionFromSource(
       source,
       "launch_openclaw_gateway_process",
     ).replaceAll("/tmp/gateway.log", gatewayLog);
+    fs.writeFileSync(gatewayLog, seed);
     const script = [
       "set -euo pipefail",
       launch,
-      "export OPENCLAW_GATEWAY_TOKEN=dashboard-secret",
-      `launch_openclaw_gateway_process ${logMode} sh -c 'printf "%s\\n" "\${OPENCLAW_GATEWAY_TOKEN-unset}"'`,
+      "export OPENCLAW_GATEWAY_TOKEN=gateway-secret",
+      `launch_openclaw_gateway_process ${logMode} sh -c 'printf "ENV=%s\\nARGS=%s\\n" "\${OPENCLAW_GATEWAY_TOKEN-unset}" "$*"' sh`,
       'wait "$GATEWAY_PID"',
     ].join("\n");
 
     try {
-      const result = spawnSync("bash", ["-c", script], { encoding: "utf8", timeout: 5000 });
+      const result = spawnSync("bash", ["-c", script], {
+        encoding: "utf8",
+        timeout: 5000,
+      });
       expect(result.status, result.stderr).toBe(0);
-      expect(fs.readFileSync(gatewayLog, "utf8")).toBe("unset\n");
+      const expectedOutput = "ENV=unset\nARGS=--token gateway-secret\n";
+      expect(fs.readFileSync(gatewayLog, "utf8")).toBe(
+        logMode === "append" ? `${seed}${expectedOutput}` : expectedOutput,
+      );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/nemoclaw-start-gateway-token-env.test.ts
+++ b/test/nemoclaw-start-gateway-token-env.test.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 
 import { describe, expect, it } from "vitest";
 
@@ -16,7 +16,7 @@ describe("OpenClaw gateway credential environment", () => {
   it.each([
     "truncate",
     "append",
-  ])("passes --token and removes OPENCLAW_GATEWAY_TOKEN when the log mode is %s (#8693)", (logMode) => {
+  ])("removes OPENCLAW_GATEWAY_TOKEN from the gateway environment without passing its value in argv when the log mode is %s (#8693)", (logMode) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-token-env-"));
     const gatewayLog = path.join(tmpDir, "gateway.log");
     const seed = "existing gateway output\n";
@@ -40,13 +40,61 @@ describe("OpenClaw gateway credential environment", () => {
         timeout: 5000,
       });
       expect(result.status, result.stderr).toBe(0);
-      const expectedOutput = "ENV=unset\nARGS=--token gateway-secret\n";
+      const expectedOutput = "ENV=unset\nARGS=\n";
       expect(fs.readFileSync(gatewayLog, "utf8")).toBe(
         logMode === "append" ? `${seed}${expectedOutput}` : expectedOutput,
       );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  describe.skipIf(!fs.existsSync("/proc/self/cmdline"))("Linux process inspection", () => {
+    it.each([
+      { logMode: "truncate", launchPath: "initial launch" },
+      { logMode: "append", launchPath: "automatic respawn" },
+    ])("keeps the gateway token out of process cmdline and environ during $launchPath (#8693)", ({
+      logMode,
+    }) => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-token-proc-"));
+      const gatewayLog = path.join(tmpDir, "gateway.log");
+      const source = fs.readFileSync(START_SCRIPT, "utf8");
+      const launch = extractShellFunctionFromSource(
+        source,
+        "launch_openclaw_gateway_process",
+      ).replaceAll("/tmp/gateway.log", gatewayLog);
+      const script = [
+        "set -euo pipefail",
+        launch,
+        "export OPENCLAW_GATEWAY_TOKEN=gateway-secret",
+        `launch_openclaw_gateway_process ${logMode} ${JSON.stringify(process.execPath)} -e 'setTimeout(() => {}, 30000)' nemoclaw-proc-credential-probe`,
+        'trap \'kill "$GATEWAY_PID" 2>/dev/null || true; wait "$GATEWAY_PID" 2>/dev/null || true\' EXIT',
+        "ready=0",
+        "for _ in $(seq 1 100); do",
+        '  [ -r "/proc/$GATEWAY_PID/cmdline" ] || { sleep 0.01; continue; }',
+        "  process_cmdline=\"$(tr '\\0' '\\n' < \"/proc/$GATEWAY_PID/cmdline\")\"",
+        '  case "$process_cmdline" in *nemoclaw-proc-credential-probe*) ready=1; break ;; esac',
+        "  sleep 0.01",
+        "done",
+        '[ "$ready" -eq 1 ] || { echo "gateway process did not become inspectable" >&2; exit 30; }',
+        "process_environment=\"$(tr '\\0' '\\n' < \"/proc/$GATEWAY_PID/environ\")\"",
+        'case "$process_cmdline" in *"$OPENCLAW_GATEWAY_TOKEN"*) exit 31 ;; esac',
+        'case "$process_environment" in *"OPENCLAW_GATEWAY_TOKEN=$OPENCLAW_GATEWAY_TOKEN"*) exit 32 ;; esac',
+        'kill "$GATEWAY_PID"',
+        'wait "$GATEWAY_PID" 2>/dev/null || true',
+        "trap - EXIT",
+      ].join("\n");
+
+      try {
+        const result = spawnSync("bash", ["-c", script], {
+          encoding: "utf8",
+          timeout: 5000,
+        });
+        expect(result.status, result.stderr).toBe(0);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
   });
 
   it("rejects an unknown gateway log mode before launch (#8693)", () => {

--- a/test/nemoclaw-start-safe-tmp.test.ts
+++ b/test/nemoclaw-start-safe-tmp.test.ts
@@ -67,7 +67,6 @@ describe("nemoclaw-start safe tmp file creation", () => {
         "set -euo pipefail",
         safeTmpHelpers(src),
         launch,
-        `_nemoclaw_safe_create_tmp_file ${JSON.stringify(gatewayLog)} 644`,
         "export OPENCLAW_GATEWAY_TOKEN=gateway-secret",
         `launch_openclaw_gateway_process truncate printf '%s\\n' 'gateway started'`,
         'wait "$GATEWAY_PID"',
@@ -78,9 +77,45 @@ describe("nemoclaw-start safe tmp file creation", () => {
       });
 
       expect(result.status, result.stderr).toBe(0);
-      expect(fs.lstatSync(gatewayLog).isSymbolicLink()).toBe(false);
-      expect(fs.readFileSync(gatewayLog, "utf-8")).toBe("gateway started\n");
+      const descriptor = fs.openSync(gatewayLog, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+      try {
+        expect(fs.readFileSync(descriptor, "utf-8")).toBe("gateway started\n");
+      } finally {
+        fs.closeSync(descriptor);
+      }
       expect(fs.readFileSync(symlinkTarget, "utf-8")).toBe("do not overwrite\n");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a planted gateway-log symlink during automatic respawn", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-start-safe-tmp-"));
+    const gatewayLog = path.join(tmpDir, "gateway.log");
+    const symlinkTarget = path.join(tmpDir, "symlink-target.log");
+    const launch = extractShellFunctionFromSource(
+      src,
+      "launch_openclaw_gateway_process",
+    ).replaceAll("/tmp/gateway.log", gatewayLog);
+
+    try {
+      fs.writeFileSync(symlinkTarget, "do not append\n");
+      fs.symlinkSync(symlinkTarget, gatewayLog);
+      const script = [
+        "set -uo pipefail",
+        launch,
+        "export OPENCLAW_GATEWAY_TOKEN=gateway-secret",
+        "launch_openclaw_gateway_process append true",
+        'wait "$GATEWAY_PID"',
+      ].join("\n");
+      const result = spawnSync("bash", ["-c", script], {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+
+      expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain("refusing unsafe gateway log path");
+      expect(fs.readFileSync(symlinkTarget, "utf-8")).toBe("do not append\n");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/nemoclaw-start-safe-tmp.test.ts
+++ b/test/nemoclaw-start-safe-tmp.test.ts
@@ -68,7 +68,7 @@ describe("nemoclaw-start safe tmp file creation", () => {
         safeTmpHelpers(src),
         launch,
         "export OPENCLAW_GATEWAY_TOKEN=gateway-secret",
-        `launch_openclaw_gateway_process truncate printf '%s\\n' 'gateway started'`,
+        `launch_openclaw_gateway_process truncate current printf '%s\\n' 'gateway started'`,
         'wait "$GATEWAY_PID"',
       ].join("\n");
       const result = spawnSync("bash", ["-c", script], {
@@ -105,7 +105,7 @@ describe("nemoclaw-start safe tmp file creation", () => {
         "set -uo pipefail",
         "_nemoclaw_safe_create_tmp_file() { return 1; }",
         processLaunch,
-        `if launch_openclaw_gateway_process truncate sh -c 'printf launched > ${JSON.stringify(launchSentinel)}'; then wait "$GATEWAY_PID"; exit 30; fi`,
+        `if launch_openclaw_gateway_process truncate current sh -c 'printf launched > ${JSON.stringify(launchSentinel)}'; then wait "$GATEWAY_PID"; exit 30; fi`,
         '[ -z "${GATEWAY_PID:-}" ] || exit 31',
         `[ ! -e ${JSON.stringify(launchSentinel)} ] || exit 32`,
         "launch_openclaw_gateway_process() { return 1; }",
@@ -150,7 +150,7 @@ describe("nemoclaw-start safe tmp file creation", () => {
         "set -uo pipefail",
         launch,
         "export OPENCLAW_GATEWAY_TOKEN=gateway-secret",
-        "launch_openclaw_gateway_process append true",
+        "launch_openclaw_gateway_process append current true",
         'wait "$GATEWAY_PID"',
       ].join("\n");
       const result = spawnSync("bash", ["-c", script], {

--- a/test/nemoclaw-start-safe-tmp.test.ts
+++ b/test/nemoclaw-start-safe-tmp.test.ts
@@ -114,7 +114,7 @@ describe("nemoclaw-start safe tmp file creation", () => {
         'capture_openclaw_pid_start_identity() { printf launched > "$CAPTURE_SENTINEL"; return 0; }',
         `CAPTURE_SENTINEL=${JSON.stringify(launchSentinel)}`,
         "record_gateway_pid() { :; }",
-        "STEP_DOWN_PREFIX_GATEWAY=()",
+        "STEP_DOWN_PREFIX_GATEWAY=(env)",
         "OPENCLAW=true",
         "_DASHBOARD_PORT=18789",
         gatewayLaunch,

--- a/test/nemoclaw-start-safe-tmp.test.ts
+++ b/test/nemoclaw-start-safe-tmp.test.ts
@@ -89,6 +89,51 @@ describe("nemoclaw-start safe tmp file creation", () => {
     }
   });
 
+  it("does not launch a gateway when initial log replacement fails", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-start-safe-tmp-"));
+    const gatewayLog = path.join(tmpDir, "gateway.log");
+    const launchSentinel = path.join(tmpDir, "gateway-launched");
+    const processLaunch = extractShellFunctionFromSource(
+      src,
+      "launch_openclaw_gateway_process",
+    ).replaceAll("/tmp/gateway.log", gatewayLog);
+    const gatewayLaunch = extractShellFunctionFromSource(src, "launch_openclaw_gateway");
+
+    try {
+      fs.writeFileSync(gatewayLog, "stale gateway output\n");
+      const script = [
+        "set -uo pipefail",
+        "_nemoclaw_safe_create_tmp_file() { return 1; }",
+        processLaunch,
+        `if launch_openclaw_gateway_process truncate sh -c 'printf launched > ${JSON.stringify(launchSentinel)}'; then wait "$GATEWAY_PID"; exit 30; fi`,
+        '[ -z "${GATEWAY_PID:-}" ] || exit 31',
+        `[ ! -e ${JSON.stringify(launchSentinel)} ] || exit 32`,
+        "launch_openclaw_gateway_process() { return 1; }",
+        "arm_openclaw_gateway_supervisor_cleanup() { :; }",
+        "mark_in_container_gateway() { :; }",
+        'capture_openclaw_pid_start_identity() { printf launched > "$CAPTURE_SENTINEL"; return 0; }',
+        `CAPTURE_SENTINEL=${JSON.stringify(launchSentinel)}`,
+        "record_gateway_pid() { :; }",
+        "STEP_DOWN_PREFIX_GATEWAY=()",
+        "OPENCLAW=true",
+        "_DASHBOARD_PORT=18789",
+        gatewayLaunch,
+        "if launch_openclaw_gateway; then exit 33; fi",
+        '[ -z "${GATEWAY_PID:-}" ] || exit 31',
+        `[ ! -e ${JSON.stringify(launchSentinel)} ] || exit 32`,
+      ].join("\n");
+      const result = spawnSync("bash", ["-c", script], {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(fs.readFileSync(gatewayLog, "utf-8")).toBe("stale gateway output\n");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("refuses a planted gateway-log symlink during automatic respawn", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-start-safe-tmp-"));
     const gatewayLog = path.join(tmpDir, "gateway.log");

--- a/test/nemoclaw-start-safe-tmp.test.ts
+++ b/test/nemoclaw-start-safe-tmp.test.ts
@@ -8,6 +8,8 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { extractShellFunctionFromSource } from "./support/shell-function-extractor";
+
 const START_SCRIPT = path.join(import.meta.dirname, "..", "scripts", "nemoclaw-start.sh");
 
 function safeTmpHelpers(src: string): string {
@@ -44,6 +46,41 @@ describe("nemoclaw-start safe tmp file creation", () => {
       expect((fs.statSync(pidFile).mode & 0o777).toString(8)).toBe("600");
       expect(fs.readFileSync(pidFile, "utf-8")).toBe("12345\n");
       expect(fs.readdirSync(tmpDir).filter((entry) => entry.includes(".tmp."))).toEqual([]);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces a planted gateway-log symlink before the initial launch", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-start-safe-tmp-"));
+    const gatewayLog = path.join(tmpDir, "gateway.log");
+    const symlinkTarget = path.join(tmpDir, "symlink-target.log");
+    const launch = extractShellFunctionFromSource(
+      src,
+      "launch_openclaw_gateway_process",
+    ).replaceAll("/tmp/gateway.log", gatewayLog);
+
+    try {
+      fs.writeFileSync(symlinkTarget, "do not overwrite\n");
+      fs.symlinkSync(symlinkTarget, gatewayLog);
+      const script = [
+        "set -euo pipefail",
+        safeTmpHelpers(src),
+        launch,
+        `_nemoclaw_safe_create_tmp_file ${JSON.stringify(gatewayLog)} 644`,
+        "export OPENCLAW_GATEWAY_TOKEN=gateway-secret",
+        `launch_openclaw_gateway_process truncate printf '%s\\n' 'gateway started'`,
+        'wait "$GATEWAY_PID"',
+      ].join("\n");
+      const result = spawnSync("bash", ["-c", script], {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(fs.lstatSync(gatewayLog).isSymbolicLink()).toBe(false);
+      expect(fs.readFileSync(gatewayLog, "utf-8")).toBe("gateway started\n");
+      expect(fs.readFileSync(symlinkTarget, "utf-8")).toBe("do not overwrite\n");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -706,8 +706,8 @@ describe("nemoclaw-start gateway token export (#1114)", () => {
     );
 
     expect(result.status, result.stderr || result.stdout).toBe(0);
-    expect(configAfter.gateway.auth.token).toEqual(expect.any(String));
     expect(configAfter.gateway.auth.token).not.toBe("");
+    expect(Number.isNaN(Date.parse(configAfter.meta.lastTouchedAt))).toBe(false);
     expect(envFile).toContain("export OPENCLAW_GATEWAY_PORT='18790'");
     expect(envFile).toContain("export NEMOCLAW_OPENCLAW_GATEWAY_URL='ws://127.0.0.1:18790'");
     expect(envFile).not.toContain("export OPENCLAW_GATEWAY_URL='ws://127.0.0.1:18790'");

--- a/test/openclaw-2026-7-startup-compat.test.ts
+++ b/test/openclaw-2026-7-startup-compat.test.ts
@@ -8,6 +8,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
+import { safeTmpHelpers } from "./nemoclaw-start-gateway.test-helpers";
+
 const ROOT = path.resolve(import.meta.dirname, "..");
 const NORMALIZER = path.join(ROOT, "scripts", "lib", "normalize_mutable_config_perms.py");
 const START_SCRIPT = path.join(ROOT, "scripts", "nemoclaw-start.sh");
@@ -164,13 +166,14 @@ describe("OpenClaw 2026.7 startup compatibility", () => {
         "#!/usr/bin/env bash",
         "set -euo pipefail",
         "export HOME=/root",
-        "STEP_DOWN_PREFIX_GATEWAY=()",
+        "STEP_DOWN_PREFIX_GATEWAY=(env)",
         `OPENCLAW=${JSON.stringify(gateway)}`,
         "_DASHBOARD_PORT=18789",
         "arm_openclaw_gateway_supervisor_cleanup() { :; }",
         "mark_in_container_gateway() { :; }",
         "capture_openclaw_pid_start_identity() { printf -v \"$2\" '%s' test-identity; }",
         "record_gateway_pid() { :; }",
+        safeTmpHelpers(source),
         extractShellFunction(source, "launch_openclaw_gateway_process").replaceAll(
           "/tmp/gateway.log",
           gatewayLog,

--- a/test/openclaw-2026-7-startup-compat.test.ts
+++ b/test/openclaw-2026-7-startup-compat.test.ts
@@ -147,11 +147,29 @@ describe("OpenClaw 2026.7 startup compatibility", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-home-"));
     temporaryRoots.push(root);
     const observedHome = path.join(root, "observed-home");
+    const observedStepDown = path.join(root, "observed-step-down");
+    const observedUmask = path.join(root, "observed-umask");
     const gatewayLog = path.join(root, "gateway.log");
     const gateway = path.join(root, "openclaw-fixture");
+    const stepDown = path.join(root, "step-down-fixture");
     fs.writeFileSync(
       gateway,
-      `#!/usr/bin/env bash\nprintf '%s\\n' "$HOME" >${JSON.stringify(observedHome)}\n`,
+      [
+        "#!/usr/bin/env bash",
+        `printf '%s\\n' "$HOME" >${JSON.stringify(observedHome)}`,
+        `umask >${JSON.stringify(observedUmask)}`,
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+    fs.writeFileSync(
+      stepDown,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        `printf 'stepped-down\\n' >${JSON.stringify(observedStepDown)}`,
+        `chmod 600 ${JSON.stringify(gatewayLog)}`,
+        'exec "$@"',
+      ].join("\n"),
       { mode: 0o700 },
     );
     const source = fs.readFileSync(START_SCRIPT, "utf-8");
@@ -166,7 +184,7 @@ describe("OpenClaw 2026.7 startup compatibility", () => {
         "#!/usr/bin/env bash",
         "set -euo pipefail",
         "export HOME=/root",
-        "STEP_DOWN_PREFIX_GATEWAY=(env)",
+        `STEP_DOWN_PREFIX_GATEWAY=(${JSON.stringify(stepDown)})`,
         `OPENCLAW=${JSON.stringify(gateway)}`,
         "_DASHBOARD_PORT=18789",
         "arm_openclaw_gateway_supervisor_cleanup() { :; }",
@@ -174,6 +192,9 @@ describe("OpenClaw 2026.7 startup compatibility", () => {
         "capture_openclaw_pid_start_identity() { printf -v \"$2\" '%s' test-identity; }",
         "record_gateway_pid() { :; }",
         safeTmpHelpers(source),
+        // Model the root-created gateway-owned log as unavailable to the
+        // launcher until the privilege-transition fixture runs.
+        '_nemoclaw_safe_create_tmp_file() { : >"$1"; chmod 000 "$1"; }',
         extractShellFunction(source, "launch_openclaw_gateway_process").replaceAll(
           "/tmp/gateway.log",
           gatewayLog,
@@ -189,5 +210,7 @@ describe("OpenClaw 2026.7 startup compatibility", () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(fs.readFileSync(observedHome, "utf-8").trim()).toBe("/sandbox");
+    expect(fs.readFileSync(observedStepDown, "utf-8").trim()).toBe("stepped-down");
+    expect(fs.readFileSync(observedUmask, "utf-8").trim()).toBe("0007");
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

OpenClaw managed-image activation stopped before binding the gateway port after #8872 correctly removed `OPENCLAW_GATEWAY_TOKEN` from the gateway process environment.
The direct cause was OpenClaw 2026.7 classifying NemoClaw's freshly authenticated config as clobbered because the atomic token rotation did not stamp OpenClaw's `meta.lastTouchedAt` field.
OpenClaw then restored its tokenless build-time backup before gateway authentication resolved.

This change stamps that metadata in the existing atomic config write, so OpenClaw keeps the rotated authenticated config while the bearer remains absent from both gateway argv and the gateway/descendant environment. Gateway logging now also opens the fixed log path through a descriptor-pinned, no-follow boundary under the final gateway identity.

## Related Issue

Refs #8693

## Changes

- Stamp `meta.lastTouchedAt` when rotating the gateway token through the existing pinned-directory, no-symlink, owner-only temporary file, `fsync`, and atomic-rename path.
- Keep the gateway launch command credential-free and continue removing `OPENCLAW_GATEWAY_TOKEN` at the process boundary for initial launches and automatic respawns.
- Open `/tmp/gateway.log` with `O_NOFOLLOW`, pin and verify the opened inode before redirecting output, prevent gateway launch when safe initial log replacement fails, and fail closed if a respawn encounters a symlink or replaced path.
- In root mode, step down to the `gateway` identity before opening that log descriptor while preserving `HOME=/sandbox` and umask `0007`.
- Add Linux process-level coverage that reads `/proc/<pid>/cmdline` and `/proc/<pid>/environ` for both launch paths and rejects token exposure.
- Preserve and test truncate-on-initial-launch and append-on-respawn log behavior, including replacement of a planted symlink at initial launch and refusal of one at respawn.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The final diff removes the interim argv credential path entirely. The token remains in the existing OpenClaw config and is rotated through the existing symlink-rejecting, exclusive temporary file, `fsync`, atomic rename, and hash-refresh flow. The gateway launcher removes `OPENCLAW_GATEWAY_TOKEN`, steps down before the descriptor-safe opener in root mode, opens the log with `O_NOFOLLOW`, verifies the opened inode, and only then redirects and execs the gateway. Safe initial-log replacement failure prevents launch. Linux process tests inspect both argv and environment for initial launch and respawn; filesystem regressions prove initial launch replaces a planted gateway-log symlink without changing its target, refuses to launch on safe-replacement failure, and refuses a respawn symlink. No input parsing, shell interpolation, network bind, dependency, or cryptographic boundary is expanded.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/security/filesystem-controls.mdx` accurately documents that the entrypoint retains the token path for interactive sandbox shells while the OpenClaw launch boundary removes `OPENCLAW_GATEWAY_TOKEN` from the gateway/descendant environment and does not add the bearer to process arguments; the gateway reads it from `openclaw.json`. The privilege-drop change moves the descriptor-safe gateway-log opener under the `gateway` identity in root mode and requires no additional public documentation.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 495a4333f46cfeed60b13ed447217113f342ba20 -->
<!-- docs-review-agents-blob-sha: c4923a3e367681ea6f796fb595f3b97497d92fa0 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass for the current change set — the focused changed-file review passed 149 tests with 3 platform skips; the fail-closed safe-log suite passes 4/4, including refusal to launch after initial log replacement failure. The exact published OpenClaw 2026.7.1 managed image passed all 32 affected gateway lifecycle, credential, and log-safety tests, including live initial-launch and respawn `/proc` assertions. The earlier exact-image activation reached HTTP 200, preserved the rotated config token, and exposed the token in neither `/proc/<pid>/cmdline` nor `/proc/<pid>/environ`.
- [x] Applicable broad gate passed — `npm run typecheck`, repository checks, ShellCheck, secret scanning, source-shape budget, and test-file-size budget passed through local validation and normal hooks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

`npm run docs` passes with 0 errors and the repository's 2 known pre-existing Fern warnings.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
