### PR TITLE
fix(cli): admit remediable host storage

### DIFF
--- a/docs/reference/system-readiness.mdx
+++ b/docs/reference/system-readiness.mdx
@@ -117,7 +117,7 @@ Use `host.docker.storage_compatible` when a consumer requires compatibility befo
 The strict internal readiness report remains `incompatible` with exit code `2` until a consumer applies its operation-specific admission policy.
 Public NemoClaw lifecycle admission can accept either `host.docker.storage_compatible` or `host.docker.storage_remediation_available`.
 When remediation is available, `host.docker.storage_compatible` remains `absent`.
-If `host.docker.storage_incompatible` is the sole blocking finding, `host probe` publishes status `supported` and exit code `0`.
+If `host.docker.storage_incompatible` is the sole blocking finding and `host.docker.storage_remediation_available` is `present`, `host probe` publishes status `supported` and exit code `0`.
 The public report retains `host.docker.storage_incompatible` as a warning.
 Any other blocking or fatal finding prevents this public projection.
 The public status indicates a supported remediation path, not that the current Docker storage configuration is compatible.

--- a/docs/reference/system-readiness.mdx
+++ b/docs/reference/system-readiness.mdx
@@ -37,7 +37,7 @@ The command uses deterministic exit codes:
 
 | Exit code | Status | Meaning |
 | --- | --- | --- |
-| `0` | `supported` | Required readiness checks passed. |
+| `0` | `supported` | Required readiness checks passed, or the sole blocking finding is a Docker storage conflict with a supported remediation path. |
 | `2` | `incompatible` | A blocking or fatal finding prevents onboarding. |
 | `3` | `inconclusive` | NemoClaw could not determine a required capability. |
 
@@ -113,11 +113,14 @@ The Docker storage capabilities separate the current host configuration from Nem
 | `host.docker.storage_compatible` | The current Docker storage configuration supports nested overlay mounts without remediation. |
 | `host.docker.storage_remediation_available` | NemoClaw can build a patched cluster image for a non-WSL Linux host using Docker with an `overlayfs` containerd-snapshotter conflict. |
 
-Use `host.docker.storage_compatible` for pre-mutation host diagnosis.
-For public NemoClaw lifecycle admission, require either `host.docker.storage_compatible` or `host.docker.storage_remediation_available`.
+Use `host.docker.storage_compatible` when a consumer requires compatibility before mutation.
+The strict internal readiness report remains `incompatible` with exit code `2` until a consumer applies its operation-specific admission policy.
+Public NemoClaw lifecycle admission can accept either `host.docker.storage_compatible` or `host.docker.storage_remediation_available`.
 When remediation is available, `host.docker.storage_compatible` remains `absent`.
-The report also retains `host.docker.storage_incompatible`, status `incompatible`, and exit code `2` because `host probe` does not change the host.
-Evaluate every other blocking finding before you run onboarding.
+If `host.docker.storage_incompatible` is the sole blocking finding, `host probe` publishes status `supported` and exit code `0`.
+The public report retains `host.docker.storage_incompatible` as a warning.
+Any other blocking or fatal finding prevents this public projection.
+The public status indicates a supported remediation path, not that the current Docker storage configuration is compatible.
 The remediation capability does not prove that a later image build or gateway attachment succeeds.
 Use these storage capabilities when the lifecycle may create or recreate a gateway.
 Gateway attachment is a separate readiness decision.

--- a/src/commands/host/probe.test.ts
+++ b/src/commands/host/probe.test.ts
@@ -10,14 +10,14 @@ import type { SystemReadinessReport } from "../../lib/readiness/types";
 
 const mocks = vi.hoisted(() => ({
   createProductionGatewayReadinessDependencies: vi.fn(),
-  createPublicReadinessReport: vi.fn(),
+  createPublicHostProbeReadinessReport: vi.fn(),
   createSystemReadinessReport: vi.fn(),
   getBuildIdentity: vi.fn(),
   renderReadinessReport: vi.fn(),
 }));
 
 vi.mock("../../lib/readiness/index", () => ({
-  createPublicReadinessReport: mocks.createPublicReadinessReport,
+  createPublicHostProbeReadinessReport: mocks.createPublicHostProbeReadinessReport,
   createSystemReadinessReport: mocks.createSystemReadinessReport,
   renderReadinessReport: mocks.renderReadinessReport,
 }));
@@ -87,7 +87,7 @@ describe("host probe command (#7412)", () => {
     });
     mocks.createProductionGatewayReadinessDependencies.mockReturnValue(gatewayDependencies);
     mocks.createSystemReadinessReport.mockResolvedValue(report(READINESS_OUTCOMES[0]));
-    mocks.createPublicReadinessReport.mockImplementation((value) => value);
+    mocks.createPublicHostProbeReadinessReport.mockImplementation((value) => value);
     mocks.renderReadinessReport.mockReturnValue("System readiness: supported");
   });
 
@@ -131,7 +131,7 @@ describe("host probe command (#7412)", () => {
   it("uses one readiness report for human output (#7412)", async () => {
     const publicReport = report(READINESS_OUTCOMES[0]);
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-    mocks.createPublicReadinessReport.mockReturnValueOnce(publicReport);
+    mocks.createPublicHostProbeReadinessReport.mockReturnValueOnce(publicReport);
 
     await HostProbeCommand.run([], process.cwd());
 
@@ -143,7 +143,7 @@ describe("host probe command (#7412)", () => {
       { gateway: gatewayDependencies },
     );
     expect(mocks.createProductionGatewayReadinessDependencies).toHaveBeenCalledOnce();
-    expect(mocks.createPublicReadinessReport).toHaveBeenCalledWith(
+    expect(mocks.createPublicHostProbeReadinessReport).toHaveBeenCalledWith(
       await mocks.createSystemReadinessReport.mock.results[0]?.value,
     );
     expect(mocks.renderReadinessReport).toHaveBeenCalledWith(publicReport);
@@ -158,7 +158,7 @@ describe("host probe command (#7412)", () => {
 
     expect(mocks.createSystemReadinessReport).toHaveBeenCalledTimes(2);
     expect(mocks.createProductionGatewayReadinessDependencies).toHaveBeenCalledTimes(2);
-    expect(mocks.createPublicReadinessReport).toHaveBeenCalledTimes(2);
+    expect(mocks.createPublicHostProbeReadinessReport).toHaveBeenCalledTimes(2);
     expect(mocks.renderReadinessReport).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/commands/host/probe.ts
+++ b/src/commands/host/probe.ts
@@ -4,7 +4,7 @@
 import { NemoClawCommand } from "../../lib/cli/nemoclaw-oclif-command";
 import { getBuildIdentity } from "../../lib/core/version";
 import {
-  createPublicReadinessReport,
+  createPublicHostProbeReadinessReport,
   createSystemReadinessReport,
   renderReadinessReport,
 } from "../../lib/readiness";
@@ -33,7 +33,7 @@ export default class HostProbeCommand extends NemoClawCommand {
 
   public async run(): Promise<unknown> {
     await this.parse(HostProbeCommand);
-    const report = createPublicReadinessReport(
+    const report = createPublicHostProbeReadinessReport(
       await createSystemReadinessReport(getBuildIdentity(), {
         gateway: createProductionGatewayReadinessDependencies(),
       }),

--- a/src/lib/readiness/index.ts
+++ b/src/lib/readiness/index.ts
@@ -57,7 +57,11 @@ export {
   collectPlatformIdentity,
   projectPlatformQualification,
 } from "./platform-qualification.js";
-export { createPublicReadinessReport, renderReadinessReport } from "./presentation.js";
+export {
+  createPublicHostProbeReadinessReport,
+  createPublicReadinessReport,
+  renderReadinessReport,
+} from "./presentation.js";
 export { getSystemReadinessReferenceErrors } from "./references.js";
 export type { CollectSystemReadinessOptions } from "./system.js";
 export { composeSystemReadinessReport, createSystemReadinessReport } from "./system.js";

--- a/src/lib/readiness/presentation.test.ts
+++ b/src/lib/readiness/presentation.test.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { createPublicReadinessReport, renderReadinessReport } from "./presentation";
+import {
+  createPublicHostProbeReadinessReport,
+  createPublicReadinessReport,
+  renderReadinessReport,
+} from "./presentation";
 import type { SystemReadinessReport } from "./types";
 
 type ReadinessOutcome =
@@ -54,6 +58,87 @@ describe("public readiness presentation (#7412)", () => {
     const publicReport = createPublicReadinessReport(report({}, outcome));
 
     expect(publicReport).toMatchObject({ ...outcome, mutated: false });
+  });
+
+  it("admits a sole storage conflict when supported lifecycle remediation is available (#8849)", () => {
+    const strictReport = report(
+      {
+        capabilities: [
+          { id: "host.docker.storage_compatible", state: "absent" },
+          { id: "host.docker.storage_remediation_available", state: "present" },
+        ],
+        findings: [
+          {
+            id: "host.docker.storage_incompatible",
+            severity: "blocking",
+            summary: "The Docker storage configuration cannot support nested overlay mounts.",
+            capabilityIds: ["host.docker.storage_compatible"],
+          },
+        ],
+      },
+      { status: "incompatible", exitCode: 2 },
+    );
+
+    const publicReport = createPublicHostProbeReadinessReport(strictReport);
+
+    expect(publicReport).toMatchObject({ status: "supported", exitCode: 0, mutated: false });
+    expect(publicReport.findings).toContainEqual(
+      expect.objectContaining({
+        id: "host.docker.storage_incompatible",
+        severity: "warning",
+      }),
+    );
+    expect(strictReport).toMatchObject({ status: "incompatible", exitCode: 2 });
+    expect(strictReport.findings[0]).toMatchObject({ severity: "blocking" });
+  });
+
+  it.each([
+    {
+      name: "remediation is unavailable",
+      capabilities: [
+        { id: "host.docker.storage_compatible", state: "absent" as const },
+        { id: "host.docker.storage_remediation_available", state: "absent" as const },
+      ],
+      findings: [
+        {
+          id: "host.docker.storage_incompatible",
+          severity: "blocking" as const,
+          summary: "The Docker storage configuration cannot support nested overlay mounts.",
+          capabilityIds: ["host.docker.storage_compatible"],
+        },
+      ],
+    },
+    {
+      name: "another blocker remains",
+      capabilities: [
+        { id: "host.docker.storage_compatible", state: "absent" as const },
+        { id: "host.docker.storage_remediation_available", state: "present" as const },
+        { id: "host.docker.daemon_reachable", state: "absent" as const },
+      ],
+      findings: [
+        {
+          id: "host.docker.storage_incompatible",
+          severity: "blocking" as const,
+          summary: "The Docker storage configuration cannot support nested overlay mounts.",
+          capabilityIds: ["host.docker.storage_compatible"],
+        },
+        {
+          id: "host.docker.daemon_unreachable",
+          severity: "blocking" as const,
+          summary: "The Docker daemon is unreachable.",
+          capabilityIds: ["host.docker.daemon_reachable"],
+        },
+      ],
+    },
+  ])("keeps host probe incompatible when $name (#8849)", ({ capabilities, findings }) => {
+    const publicReport = createPublicHostProbeReadinessReport(
+      report({ capabilities, findings }, { status: "incompatible", exitCode: 2 }),
+    );
+
+    expect(publicReport).toMatchObject({ status: "incompatible", exitCode: 2 });
+    expect(publicReport.findings.filter(({ severity }) => severity === "blocking")).toEqual(
+      findings,
+    );
   });
 
   it("preserves valid immutable build provenance (#7777)", () => {

--- a/src/lib/readiness/presentation.ts
+++ b/src/lib/readiness/presentation.ts
@@ -4,6 +4,7 @@
 import { validateBuildIdentity } from "../core/version.js";
 import { redactForLog } from "../security/redact.js";
 import { sanitizeReadinessText } from "./sanitize.js";
+import { hasRemediableStorageConflict } from "./storage-remediation.js";
 import type {
   EvidenceScalar,
   ReadinessCapability,
@@ -276,6 +277,23 @@ export function createPublicReadinessReport(
     qualifications: selectedQualifications.map(qualification),
     findings: selectedFindings.map(finding),
     evidence: selectedEvidence.map(evidence),
+  };
+}
+
+/** Apply the read-only host probe policy after the shared report is sanitized. */
+export function createPublicHostProbeReadinessReport(
+  report: Readonly<SystemReadinessReport>,
+): SystemReadinessReport {
+  const publicReport = createPublicReadinessReport(report);
+  if (!hasRemediableStorageConflict(publicReport)) return publicReport;
+
+  return {
+    ...publicReport,
+    status: "supported",
+    exitCode: 0,
+    findings: publicReport.findings.map((entry) =>
+      entry.id === "host.docker.storage_incompatible" ? { ...entry, severity: "warning" } : entry,
+    ),
   };
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`nemoclaw host probe` now reports `supported` with exit code `0` when a Docker storage conflict is the sole blocker and a supported lifecycle remediation path is available.
The public report retains the storage conflict as a warning, while the strict internal readiness report remains incompatible for operation-specific admission.

## Related Issue

Fixes #8849

## Changes

- Add a host-probe-specific public projection that uses the existing storage remediation predicate.
  A direct change to the shared public projection could admit remediation for unrelated consumers.
  Presentation tests protect the sole-blocker, unavailable-remediation, and additional-blocker cases.
- Keep `host.docker.storage_incompatible` visible as a warning without mutating the strict readiness report.
- Route `host probe` through the new projection and update its command tests.
- Update the system readiness reference for the public exit status, strict internal report, and observation-only command boundary.
- Record the detection gap with regression tests.
  Existing tests covered remediation availability but did not cover the public host-probe status and exit-code projection.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop confirmed that `host probe` remains read-only, strict internal readiness remains fail-closed, and any additional blocking or fatal finding prevents the projection.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/system-readiness.mdx`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 04c3fbc0e -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: CLI readiness and host-probe source tests passed 63 tests; the sandbox agent surface parity integration test passed 1 test.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted test commands:

```text
npm exec -- vitest run --project cli src/lib/readiness/presentation.test.ts src/lib/readiness/host.test.ts --testTimeout=15000
npm exec -- vitest run --project cli src/commands/host/probe.test.ts --testTimeout=15000
npm exec -- vitest run --project integration test/sandbox-agent-surface-parity.test.ts --testTimeout=15000
```

The docs build completed with 0 errors and 2 existing warnings.
The CLI type check and build completed successfully.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Host readiness checks now recognize supported Docker storage remediation paths.
  * Remediable storage conflicts can report a supported status with exit code `0`, while remaining visible as warnings.
  * Host probe results now consistently present readiness status and remediation outcomes.

* **Documentation**
  * Clarified readiness status, exit-code behavior, and the distinction between compatibility results and public lifecycle admission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->