### PR TITLE
fix(security): keep Sigstore audit out of image builds

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -59,7 +59,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout exact PR head
+      - name: Checkout commit under review
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -16,11 +16,13 @@ on:
   workflow_call:
   pull_request:
     paths:
+      - ".github/actions/ci-reviewed-npm-audit/**"
       - ".github/workflows/managed-images.yaml"
       - ".dockerignore"
       - "Dockerfile"
       - "agents/**"
       - "ci/npm-audit-exceptions.json"
+      - "ci/reviewed-npm-audit.json"
       - "nemoclaw/**"
       - "nemoclaw-blueprint/**"
       - "scripts/**"
@@ -49,6 +51,55 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  pr-reviewed-npm-audit:
+    name: PR reviewed npm audit
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: candidate
+          persist-credentials: false
+
+      - name: Checkout trusted reviewed npm audit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .trusted-reviewed-npm-audit
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions/ci-reviewed-npm-audit
+            ci/npm-audit-exceptions.json
+            ci/reviewed-npm-audit.json
+            scripts/audit-reviewed-npm-graph.mts
+            scripts/lib/openclaw-npm-remediation.mts
+            scripts/lib/reviewed-npm-archive.mts
+            scripts/lib/reviewed-npm-audit.mts
+          sparse-checkout-cone-mode: false
+
+      - name: Verify exact audit source and target
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$BASE_SHA" =~ ^[a-f0-9]{40}$ ]]
+          [[ "$CANDIDATE_SHA" =~ ^[a-f0-9]{40}$ ]]
+          test "$(git -C .trusted-reviewed-npm-audit rev-parse --verify HEAD)" = "$BASE_SHA"
+          test "$(git -C candidate rev-parse --verify HEAD)" = "$CANDIDATE_SHA"
+
+      - name: Audit exact PR production npm graphs
+        uses: ./.trusted-reviewed-npm-audit/.github/actions/ci-reviewed-npm-audit
+        with:
+          target-root: ${{ github.workspace }}/candidate
+          report-dir: artifacts/reviewed-npm-audit
+
   pr-staging-qa-deep-code:
     name: Staging QA base permission regression (Deep Agents Code)
     if: github.event_name == 'pull_request'
@@ -269,6 +320,7 @@ jobs:
     # External contributor PRs retain the local build/direct-startup lane after
     # GitHub's maintainer workflow approval. Exact digest publication is limited
     # to branches in NVIDIA/NemoClaw; fork jobs never log in or push.
+    needs: pr-reviewed-npm-audit
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 90

--- a/Dockerfile
+++ b/Dockerfile
@@ -804,15 +804,20 @@ COPY --from=codex-acp-runtime /usr/local/bin/codex-acp /usr/local/bin/codex-acp
 RUN command -v codex-acp >/dev/null
 
 # Upgrade OpenClaw if the base image is stale.
-# Reuse exact OpenClaw and locked-mcporter base installs only when the protected
-# provenance marker matches this build target; otherwise reinstall both.
+# Reuse exact OpenClaw and locked-mcporter base installs only from a published
+# NemoClaw base whose package provenance marker matches this build target;
+# otherwise reinstall both.
 #
 # The GHCR base image (sandbox-base:latest) may lag behind the version pinned in
 # Dockerfile.base, and legacy/custom bases may report the target version without
-# proving which archive and lifecycle produced it. Current official/local bases
-# emit the marker only after installing and auditing both dependencies. The
-# final image consumes it before applying NemoClaw patches so it cannot
-# masquerade as a pristine base when reused as a custom BASE_IMAGE.
+# proving which archive and lifecycle produced it. The marker records package
+# and advisory-audit metadata, not trusted-CI signature attestation. Only a
+# digest-pinned base from the official GHCR publication path supplies that
+# independent gate. Mutable tags and local bases cannot authorize reuse even
+# when their marker matches; the existing version checks reinstall the locked
+# runtimes or reject a newer base. The final image consumes the marker before
+# applying NemoClaw patches so a custom base cannot masquerade as a pristine
+# published base.
 #
 # OPENCLAW_VERSION is the NemoClaw runtime build target. It must be at least the
 # blueprint minimum, which also supports the legacy direct-blueprint image path.
@@ -889,12 +894,12 @@ RUN --network=default set -eu; \
         "mcporter-audit-exceptions=${MCPORTER_EXPECTED_AUDIT_EXCEPTIONS}" \
         'mcporter-recipe=locked-ci+reviewed-audit-v3' \
         > "$OPENCLAW_EXPECTED_PROVENANCE"; \
-    TRUSTED_BASE_IMAGE=0; \
+    CI_GATED_BASE_IMAGE=0; \
     case "$BASE_IMAGE" in \
-        ghcr.io/nvidia/nemoclaw/sandbox-base:*|ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:*|nemoclaw-sandbox-base-local|nemoclaw-sandbox-base-local:*) TRUSTED_BASE_IMAGE=1 ;; \
+        ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:*) CI_GATED_BASE_IMAGE=1 ;; \
     esac; \
     USE_REVIEWED_BASE_RUNTIME=0; \
-    if [ "$TRUSTED_BASE_IMAGE" = "1" ] \
+    if [ "$CI_GATED_BASE_IMAGE" = "1" ] \
         && [ -f "$OPENCLAW_PROVENANCE_PATH" ] \
         && [ ! -L "$OPENCLAW_PROVENANCE_PATH" ] \
         && [ "$(stat -c '%u:%g:%a' "$OPENCLAW_PROVENANCE_PATH" 2>/dev/null || true)" = "0:0:444" ] \

--- a/Dockerfile
+++ b/Dockerfile
@@ -677,9 +677,8 @@ RUN if [ -n "${NEMOCLAW_CORPORATE_CA_B64}" ]; then \
     fi
 
 # Anchor the corporate CA for build-time TLS too, not just runtime. The
-# OpenClaw/mcporter reinstall path runs npm audit signatures, which fetches the
-# sigstore TUF root over TLS; behind a TLS-intercepting corporate proxy that
-# fetch needs the operator CA or it fails with SELF_SIGNED_CERT_IN_CHAIN. Node
+# OpenClaw/mcporter reinstall path makes registry-backed npm requests; behind a
+# TLS-intercepting corporate proxy those requests need the operator CA. Node
 # ignores a missing file, so this is a no-op when no CA was baked; at runtime
 # nemoclaw-start overrides it with the merged OpenShell + corporate bundle.
 ENV NODE_EXTRA_CA_CERTS=/usr/local/share/nemoclaw/corporate-ca.pem
@@ -875,7 +874,7 @@ RUN --network=default set -eu; \
     OPENCLAW_PROVENANCE_PATH=/usr/local/share/nemoclaw/openclaw-base-provenance-v1; \
     OPENCLAW_EXPECTED_PROVENANCE="$(mktemp)"; \
     printf '%s\n' \
-        'schema=3' \
+        'schema=4' \
         "package=openclaw@${OPENCLAW_VERSION}" \
         "integrity=${EXPECTED_INTEGRITY}" \
         "tarball=${EXPECTED_TARBALL}" \
@@ -888,7 +887,7 @@ RUN --network=default set -eu; \
         "mcporter-audit-policy-sha256=${MCPORTER_AUDIT_POLICY_SHA256}" \
         "mcporter-audit-status=${MCPORTER_EXPECTED_AUDIT_STATUS}" \
         "mcporter-audit-exceptions=${MCPORTER_EXPECTED_AUDIT_EXCEPTIONS}" \
-        'mcporter-recipe=locked-ci+reviewed-audit+signatures-v2' \
+        'mcporter-recipe=locked-ci+reviewed-audit-v3' \
         > "$OPENCLAW_EXPECTED_PROVENANCE"; \
     TRUSTED_BASE_IMAGE=0; \
     case "$BASE_IMAGE" in \
@@ -981,7 +980,6 @@ RUN --network=default set -eu; \
         node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts \
             --directory /usr/local/lib/nemoclaw/mcporter-runtime \
             --exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --threshold high; \
-        npm --prefix /usr/local/lib/nemoclaw/mcporter-runtime audit signatures; \
     fi
 
 # Patch OpenClaw media fetch for proxy-only sandbox (NVIDIA/NemoClaw#1755).

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -556,7 +556,6 @@ RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/bluep
         --directory /usr/local/lib/nemoclaw/mcporter-runtime \
         --exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --threshold high \
         --report /tmp/mcporter-npm-audit.json --result /tmp/mcporter-npm-audit-policy.json \
-    && npm --prefix /usr/local/lib/nemoclaw/mcporter-runtime audit signatures \
     && MCPORTER_AUDIT_STATUS="$(node -p "require('/tmp/mcporter-npm-audit-policy.json').status")" \
     && MCPORTER_AUDIT_EXCEPTIONS="$(node -p "require('/tmp/mcporter-npm-audit-policy.json').acceptedAdvisories.join(',') || 'none'")" \
     && MCPORTER_AUDIT_POLICY_SHA256="$(node -p "require('/tmp/mcporter-npm-audit-policy.json').exceptionPolicySha256")" \
@@ -568,7 +567,7 @@ RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/bluep
     && mkdir -p "$OPENCLAW_PROVENANCE_DIR" \
     && OPENCLAW_PROVENANCE_TMP="$(mktemp "${OPENCLAW_PROVENANCE_PATH}.tmp.XXXXXX")" \
     && printf '%s\n' \
-        'schema=3' \
+        'schema=4' \
         "package=openclaw@${OPENCLAW_VERSION}" \
         "integrity=${EXPECTED_INTEGRITY}" \
         "tarball=${EXPECTED_TARBALL}" \
@@ -581,7 +580,7 @@ RUN --mount=type=bind,source=nemoclaw-blueprint/blueprint.yaml,target=/tmp/bluep
         "mcporter-audit-policy-sha256=${MCPORTER_AUDIT_POLICY_SHA256}" \
         "mcporter-audit-status=${MCPORTER_AUDIT_STATUS}" \
         "mcporter-audit-exceptions=${MCPORTER_AUDIT_EXCEPTIONS}" \
-        'mcporter-recipe=locked-ci+reviewed-audit+signatures-v2' \
+        'mcporter-recipe=locked-ci+reviewed-audit-v3' \
         > "$OPENCLAW_PROVENANCE_TMP" \
     && chmod 0444 "$OPENCLAW_PROVENANCE_TMP" \
     && mv -f "$OPENCLAW_PROVENANCE_TMP" "$OPENCLAW_PROVENANCE_PATH" \

--- a/agents/openclaw/dependency-review.md
+++ b/agents/openclaw/dependency-review.md
@@ -64,6 +64,16 @@ The lock records the exact version, registry URL, and integrity for every transi
 
 - `invalidState`: the image installs a package graph, tarball, license, or advisory state that differs from the independently queried npm registry records for `mcporter@0.7.3`, resolves `@hono/node-server` to any version other than exact `2.0.11`, resolves `fast-uri` to any version other than exact `3.1.5`, resolves `hono` to any version other than exact `4.12.34`, or resolves `ip-address` to any version other than exact `10.3.1`.
 - `sourceBoundary`: npm owns registry metadata, tarball integrity, provenance signatures, and advisory responses; NemoClaw owns the exact lock, script-disabled install, Docker integrity assertion, empty-by-default audit exception registry, and review record.
-- `whyNotSourceFix`: a repository note cannot make external registry state trustworthy, so image builds execute `npm audit` and `npm audit signatures` against the locked production graph and reviewers compare the lock with the registry response.
-- `regressionTest`: `test/mcporter-supply-chain.test.ts` keeps the version, integrity, lock metadata, Docker install flags, audit commands, and this review synchronized; `test/reviewed-npm-audit.test.ts` proves exact matching and fail-closed exception validation.
+- `whyNotSourceFix`: a repository note cannot make external registry state trustworthy, so the required `reviewed-npm-audit` CI check materializes the exact locked production graph and verifies its registry signatures.
+- `imageBuildBoundary`: image builds verify the committed lock, registry origin, tarball integrity, installed graph, lifecycle suppression, and reviewed advisory policy without connecting to Sigstore.
+  The `schema=4` and `mcporter-recipe=locked-ci+reviewed-audit-v3` provenance values record this boundary.
+- `enforcementBoundary`: any nonzero `npm audit signatures` status fails the required CI check.
+  The PR workflow requires this check before merge.
+  The `pr-reviewed-npm-audit` job loads its audit implementation from the base SHA and evaluates the exact PR-head tree.
+  The managed-image build job requires that result before local builds and same-repository digest publication.
+  The base-image workflow requires its audit result before it builds or publishes any base image.
+  It also requires the result before it invokes managed-image publication.
+- `regressionTest`: `test/mcporter-supply-chain.test.ts` keeps the version, integrity, lock metadata, Docker install flags, image-build audit boundary, trusted CI signature check, and this review synchronized.
+  `test/managed-image-publication-workflow.test.ts` verifies the base-SHA audit implementation, exact PR-head input, and publication dependency.
+  `test/reviewed-npm-audit.test.ts` proves exact matching and fail-closed exception validation.
 - `removalCondition`: remove this runtime dependency and review when OpenClaw provides the required authenticated Streamable HTTP client lifecycle without mcporter, or repeat the independent review for a newly pinned version.

--- a/agents/openclaw/dependency-review.md
+++ b/agents/openclaw/dependency-review.md
@@ -67,13 +67,18 @@ The lock records the exact version, registry URL, and integrity for every transi
 - `whyNotSourceFix`: a repository note cannot make external registry state trustworthy, so the required `reviewed-npm-audit` CI check materializes the exact locked production graph and verifies its registry signatures.
 - `imageBuildBoundary`: image builds verify the committed lock, registry origin, tarball integrity, installed graph, lifecycle suppression, and reviewed advisory policy without connecting to Sigstore.
   The `schema=4` and `mcporter-recipe=locked-ci+reviewed-audit-v3` provenance values record this boundary.
+  They do not attest that trusted CI verified registry signatures.
 - `enforcementBoundary`: any nonzero `npm audit signatures` status fails the required CI check.
   The PR workflow requires this check before merge.
-  The `pr-reviewed-npm-audit` job loads its audit implementation from the base SHA and evaluates the exact PR-head tree.
+  The `pr-reviewed-npm-audit` job loads its audit implementation from the base branch revision and evaluates the dependency files from the commit under review.
   The managed-image build job requires that result before local builds and same-repository digest publication.
   The base-image workflow requires its audit result before it builds or publishes any base image.
   It also requires the result before it invokes managed-image publication.
-- `regressionTest`: `test/mcporter-supply-chain.test.ts` keeps the version, integrity, lock metadata, Docker install flags, image-build audit boundary, trusted CI signature check, and this review synchronized.
-  `test/managed-image-publication-workflow.test.ts` verifies the base-SHA audit implementation, exact PR-head input, and publication dependency.
+  Final OpenClaw images reuse a matching installed runtime only from a digest-pinned base in the official GHCR namespace.
+  The publication workflow gates that base on the check.
+  A matching marker from a local base or mutable tag is package metadata without independent CI attestation.
+  It cannot authorize reuse; the existing version checks reinstall the locked runtime or reject a newer base.
+- `regressionTest`: `test/mcporter-supply-chain.test.ts` keeps the version, integrity, lock metadata, Docker install flags, image-build audit boundary, `reviewed-npm-audit` CI check, and this review synchronized.
+  `test/managed-image-publication-workflow.test.ts` verifies that the base branch supplies the audit implementation, the commit under review supplies the input, and publication depends on the audit.
   `test/reviewed-npm-audit.test.ts` proves exact matching and fail-closed exception validation.
 - `removalCondition`: remove this runtime dependency and review when OpenClaw provides the required authenticated Streamable HTTP client lifecycle without mcporter, or repeat the independent review for a newly pinned version.

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -58,7 +58,7 @@
     },
     {
       "file": "test/corporate-ca-build-tls-anchor.test.ts",
-      "test": "decodes the CA and exports NODE_EXTRA_CA_CERTS before the reinstall audit-signatures step",
+      "test": "decodes the CA and exports NODE_EXTRA_CA_CERTS before registry-backed dependency requests (#8925)",
       "category": "security"
     },
     {

--- a/docs/security/configure-corporate-ca-trust.mdx
+++ b/docs/security/configure-corporate-ca-trust.mdx
@@ -35,7 +35,15 @@ This lets the in-sandbox OpenShell proxy validate TLS when it opens the upstream
 
 <AgentOnly variant="openclaw">
 
-It sets `NODE_EXTRA_CA_CERTS` before build-time Node.js dependency verification, including `npm audit signatures` requests that cross a TLS-inspecting proxy.
+It sets `NODE_EXTRA_CA_CERTS` before registry-backed build-time Node.js dependency requests that cross a TLS-inspecting proxy.
+The required `reviewed-npm-audit` CI check materializes the exact committed dependency lock and verifies its registry signatures.
+Any nonzero `npm audit signatures` status fails the check.
+The pull request (PR) check must pass before merge.
+The managed-image PR workflow loads its audit implementation from the PR base SHA and evaluates the exact PR head commit.
+The image-build job requires that result before local builds and same-repository digest publication.
+The base-image workflow requires its audit result before it builds or publishes any base image.
+It also requires the result before it invokes managed-image publication.
+Managed OpenClaw sandbox image builds do not repeat that Sigstore request.
 When NemoClaw selects a corporate CA, it sets `NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root` for the image build.
 The OpenClaw entrypoint creates `/tmp/nemoclaw-ca-bundle.pem` as `root:root` with mode `0444` before it starts agent commands as the `sandbox` user.
 The `sandbox` user can read the merged bundle but cannot modify or replace it.

--- a/docs/security/configure-corporate-ca-trust.mdx
+++ b/docs/security/configure-corporate-ca-trust.mdx
@@ -36,14 +36,18 @@ This lets the in-sandbox OpenShell proxy validate TLS when it opens the upstream
 <AgentOnly variant="openclaw">
 
 It sets `NODE_EXTRA_CA_CERTS` before registry-backed build-time Node.js dependency requests that cross a TLS-inspecting proxy.
-The required `reviewed-npm-audit` CI check materializes the exact committed dependency lock and verifies its registry signatures.
+The required `reviewed-npm-audit` CI check materializes the dependency graph from the committed lock and verifies its registry signatures.
 Any nonzero `npm audit signatures` status fails the check.
 The pull request (PR) check must pass before merge.
-The managed-image PR workflow loads its audit implementation from the PR base SHA and evaluates the exact PR head commit.
+The managed-image PR workflow loads its audit implementation from the base branch revision and evaluates the dependency files from the commit under review.
 The image-build job requires that result before local builds and same-repository digest publication.
 The base-image workflow requires its audit result before it builds or publishes any base image.
 It also requires the result before it invokes managed-image publication.
 Managed OpenClaw sandbox image builds do not repeat that Sigstore request.
+The base provenance marker records package and advisory-audit metadata, not the CI signature result.
+The final image reuses those runtimes only from a digest-pinned base in the official GHCR namespace.
+A locally built base or mutable tag does not provide independent CI publication evidence.
+Its marker cannot authorize reuse; the existing version checks reinstall the locked OpenClaw and mcporter runtimes or reject a newer base.
 When NemoClaw selects a corporate CA, it sets `NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root` for the image build.
 The OpenClaw entrypoint creates `/tmp/nemoclaw-ca-bundle.pem` as `root:root` with mode `0444` before it starts agent commands as the `sandbox` user.
 The `sandbox` user can read the merged bundle but cannot modify or replace it.

--- a/test/corporate-ca-build-tls-anchor.test.ts
+++ b/test/corporate-ca-build-tls-anchor.test.ts
@@ -17,8 +17,8 @@ describe("corporate proxy CA build-time TLS anchor (#6839)", () => {
     expect(matches).toHaveLength(1);
   });
 
-  // source-shape-contract: security -- The build-time TLS trust anchor must precede registry and signature-verifying fetches
-  it("decodes the CA and exports NODE_EXTRA_CA_CERTS before the reinstall audit-signatures step", () => {
+  // source-shape-contract: security -- The build-time TLS trust anchor must precede registry-backed dependency requests
+  it("decodes the CA and exports NODE_EXTRA_CA_CERTS before registry-backed dependency requests (#8925)", () => {
     const argIndex = dockerfile.indexOf("ARG NEMOCLAW_CORPORATE_CA_B64=");
     const decodeIndex = dockerfile.indexOf('RUN if [ -n "${NEMOCLAW_CORPORATE_CA_B64}" ]; then');
     const anchorIndex = dockerfile.indexOf(
@@ -32,7 +32,9 @@ describe("corporate proxy CA build-time TLS anchor (#6839)", () => {
       "node --experimental-strip-types /scripts/lib/patch-bundled-npm-ip-address.mts",
       curlAnchorIndex,
     );
-    const auditSignaturesIndex = dockerfile.indexOf("mcporter-runtime audit signatures");
+    const mcporterInstallIndex = dockerfile.indexOf(
+      "npm --prefix /usr/local/lib/nemoclaw/mcporter-runtime ci",
+    );
 
     for (const [name, index] of Object.entries({
       argIndex,
@@ -40,7 +42,7 @@ describe("corporate proxy CA build-time TLS anchor (#6839)", () => {
       anchorIndex,
       curlAnchorIndex,
       ipAddressPatchIndex,
-      auditSignaturesIndex,
+      mcporterInstallIndex,
     })) {
       expect(index, name).toBeGreaterThan(-1);
     }
@@ -48,7 +50,7 @@ describe("corporate proxy CA build-time TLS anchor (#6839)", () => {
     expect(decodeIndex).toBeLessThan(anchorIndex);
     expect(anchorIndex).toBeLessThan(curlAnchorIndex);
     expect(curlAnchorIndex).toBeLessThan(ipAddressPatchIndex);
-    expect(anchorIndex).toBeLessThan(auditSignaturesIndex);
+    expect(anchorIndex).toBeLessThan(mcporterInstallIndex);
   });
 });
 

--- a/test/fetch-guard-patch-regression.test.ts
+++ b/test/fetch-guard-patch-regression.test.ts
@@ -422,6 +422,7 @@ describe("fetch-guard patch regression guard", () => {
     expect(invocation.calls).toMatch(
       /node --experimental-strip-types \/scripts\/lib\/reviewed-npm-audit\.mts --directory \S+ --exceptions \S+ --graph mcporter-runtime --threshold high/,
     );
+    expect(invocation.calls).not.toContain("audit signatures");
     readRequiredMatch(
       DOCKERFILE_BASE,
       /(npm --prefix \/usr\/local\/lib\/nemoclaw\/mcporter-runtime ci\s*\\\s*--ignore-scripts --omit=dev --no-audit --no-fund --no-progress)/,

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -161,6 +161,13 @@ function managedPrBuilder(workflow: Workflow): Job {
   );
 }
 
+function managedPrReviewedAudit(workflow: Workflow): Job {
+  return required(
+    workflow.jobs?.["pr-reviewed-npm-audit"],
+    "managed-image workflow is missing its exact PR reviewed npm audit",
+  );
+}
+
 function stagingQaDeepCodeBuilder(workflow: Workflow): Job {
   return required(
     workflow.jobs?.["pr-staging-qa-deep-code"],
@@ -452,6 +459,7 @@ describe("complete managed-image publication workflow", () => {
 
   it("builds and exercises every shipped agent from an exact PR image before merge (#7744)", () => {
     const workflow = readWorkflow("managed-images.yaml");
+    const reviewedAudit = managedPrReviewedAudit(workflow);
     const prBuilder = managedPrBuilder(workflow);
     const matrix = prBuilder.strategy?.matrix?.include ?? [];
     const steps = prBuilder.steps ?? [];
@@ -459,6 +467,58 @@ describe("complete managed-image publication workflow", () => {
     const build = step(prBuilder, "Build PR managed image locally");
     const contract = step(prBuilder, "Validate exact PR managed image contract");
 
+    expect(workflow.on?.pull_request?.paths).toEqual(
+      expect.arrayContaining([
+        ".github/actions/ci-reviewed-npm-audit/**",
+        "ci/reviewed-npm-audit.json",
+      ]),
+    );
+    expect(reviewedAudit).toMatchObject({
+      if: "github.event_name == 'pull_request'",
+      permissions: { contents: "read" },
+      "runs-on": "ubuntu-latest",
+      "timeout-minutes": 15,
+    });
+    const candidateCheckout = step(reviewedAudit, "Checkout exact PR head");
+    expect(candidateCheckout.with).toMatchObject({
+      ref: "${{ github.event.pull_request.head.sha }}",
+      path: "candidate",
+      "persist-credentials": false,
+    });
+    const trustedCheckout = step(reviewedAudit, "Checkout trusted reviewed npm audit");
+    expect(trustedCheckout.with).toMatchObject({
+      ref: "${{ github.event.pull_request.base.sha }}",
+      path: ".trusted-reviewed-npm-audit",
+      "persist-credentials": false,
+      "sparse-checkout-cone-mode": false,
+    });
+    expect(trustedCheckout.with?.["sparse-checkout"]).toContain(
+      ".github/actions/ci-reviewed-npm-audit",
+    );
+    expect(trustedCheckout.with?.["sparse-checkout"]).toContain("ci/reviewed-npm-audit.json");
+    const verifyAuditIdentities = step(reviewedAudit, "Verify exact audit source and target");
+    expect(verifyAuditIdentities.env).toEqual({
+      BASE_SHA: "${{ github.event.pull_request.base.sha }}",
+      CANDIDATE_SHA: "${{ github.event.pull_request.head.sha }}",
+    });
+    expect(verifyAuditIdentities.run).toContain(
+      "git -C .trusted-reviewed-npm-audit rev-parse --verify HEAD",
+    );
+    expect(verifyAuditIdentities.run).toContain("git -C candidate rev-parse --verify HEAD");
+    expect(step(reviewedAudit, "Audit exact PR production npm graphs")).toMatchObject({
+      uses: "./.trusted-reviewed-npm-audit/.github/actions/ci-reviewed-npm-audit",
+      with: {
+        "report-dir": "artifacts/reviewed-npm-audit",
+        "target-root": "${{ github.workspace }}/candidate",
+      },
+    });
+    for (const action of reviewedAudit.steps?.filter((candidate) =>
+      candidate.uses?.startsWith("actions/"),
+    ) ?? []) {
+      expect(action.uses, action.name).toMatch(fullShaAction);
+    }
+
+    expect(prBuilder.needs).toBe("pr-reviewed-npm-audit");
     expect(prBuilder.if).toBe("github.event_name == 'pull_request'");
     expect(prBuilder["runs-on"]).toBe("ubuntu-24.04");
     expect(prBuilder["timeout-minutes"]).toBe(90);

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -479,7 +479,7 @@ describe("complete managed-image publication workflow", () => {
       "runs-on": "ubuntu-latest",
       "timeout-minutes": 15,
     });
-    const candidateCheckout = step(reviewedAudit, "Checkout exact PR head");
+    const candidateCheckout = step(reviewedAudit, "Checkout commit under review");
     expect(candidateCheckout.with).toMatchObject({
       ref: "${{ github.event.pull_request.head.sha }}",
       path: "candidate",

--- a/test/mcporter-supply-chain.test.ts
+++ b/test/mcporter-supply-chain.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -32,6 +33,22 @@ const expectedFastUriTarball = "https://registry.npmjs.org/fast-uri/-/fast-uri-3
 const expectedIpAddressVersion = "10.3.1";
 const expectedIpAddressTarball = "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz";
 const runtimePrefix = "npm --prefix /usr/local/lib/nemoclaw/mcporter-runtime";
+const reviewedAuditConfig = JSON.parse(
+  fs.readFileSync(path.join(repoRoot, "ci", "reviewed-npm-audit.json"), "utf8"),
+) as {
+  lockedGraphs: Array<{
+    directory: string;
+    id: string;
+    integrity: string;
+    lockSha256: string;
+    packageSpec: string;
+    tarballUrl: string;
+  }>;
+};
+const reviewedAuditDriver = fs.readFileSync(
+  path.join(repoRoot, "scripts", "audit-reviewed-npm-graph.mts"),
+  "utf8",
+);
 
 function extractIntegrityGate(contents: string): string {
   const startMarker = 'MCPORTER_EXPECTED_INTEGRITY=""';
@@ -197,10 +214,28 @@ describe("mcporter image supply-chain controls", () => {
       "node --experimental-strip-types /scripts/lib/reviewed-npm-audit.mts --directory /usr/local/lib/nemoclaw/mcporter-runtime --exceptions /scripts/npm-audit-exceptions.json --graph mcporter-runtime --threshold high",
     );
     expect(contents).not.toContain(`${runtimePrefix} audit --omit=dev --audit-level=low`);
-    expect(contents).toContain(`${runtimePrefix} audit signatures`);
+    expect(contents).not.toContain(`${runtimePrefix} audit signatures`);
     expect(flattenedContents).toContain(
       `${runtimePrefix} ls --omit=dev --all @hono/node-server @modelcontextprotocol/sdk hono mcporter`,
     );
     expect(contents).toContain("StreamableHTTPServerTransport");
+  });
+
+  it("verifies the exact committed dependency graph signatures in trusted CI (#8925)", () => {
+    const graph = reviewedAuditConfig.lockedGraphs.find(
+      (candidate) => candidate.id === "mcporter-runtime",
+    );
+    expect(graph).toMatchObject({
+      directory: "agents/openclaw/mcporter-runtime",
+      integrity: expectedIntegrity,
+      packageSpec: `mcporter@${expectedVersion}`,
+      tarballUrl: expectedTarball,
+    });
+
+    const lockfile = fs.readFileSync(path.join(runtimeDirectory, "package-lock.json"));
+    expect(createHash("sha256").update(lockfile).digest("hex")).toBe(graph?.lockSha256);
+    expect(reviewedAuditDriver).toContain(
+      'run("npm", ["audit", "signatures", "--omit=dev"], directory);',
+    );
   });
 });

--- a/test/openclaw-dependency-review.test.ts
+++ b/test/openclaw-dependency-review.test.ts
@@ -648,7 +648,7 @@ for dockerfile in Dockerfile Dockerfile.base; do
   check_contains "$openclaw_block" 'mcporter-audit-policy-sha256=' "$dockerfile mcporter audit policy hash"
   check_contains "$openclaw_block" 'mcporter-audit-status=' "$dockerfile mcporter audit status"
   check_contains "$openclaw_block" 'mcporter-audit-exceptions=' "$dockerfile mcporter audit exceptions"
-  check_contains "$openclaw_block" 'mcporter-recipe=locked-ci+reviewed-audit+signatures-v2' "$dockerfile mcporter provenance recipe"
+  check_contains "$openclaw_block" 'mcporter-recipe=locked-ci+reviewed-audit-v3' "$dockerfile mcporter provenance recipe"
 done
 
 check_contains "$(cat Dockerfile.base)" 'chmod 0444 "$OPENCLAW_PROVENANCE_TMP"' "base provenance protected mode"

--- a/test/openclaw-integrity-pin-suite.ts
+++ b/test/openclaw-integrity-pin-suite.ts
@@ -145,7 +145,7 @@ function openClawBaseProvenance(
         ? "ignore-scripts+reviewed-lifecycle+transitive-remediation-v1"
         : "ignore-scripts+reviewed-lifecycle-v1";
   return [
-    "schema=3",
+    "schema=4",
     `package=openclaw@${version}`,
     `integrity=${integrity}`,
     `tarball=${tarball}`,
@@ -158,7 +158,7 @@ function openClawBaseProvenance(
     `mcporter-audit-policy-sha256=${auditPolicy.sha256}`,
     `mcporter-audit-status=${auditPolicy.status}`,
     `mcporter-audit-exceptions=${auditPolicy.exceptions}`,
-    "mcporter-recipe=locked-ci+reviewed-audit+signatures-v2",
+    "mcporter-recipe=locked-ci+reviewed-audit-v3",
     "",
   ].join("\n");
 }
@@ -1076,7 +1076,7 @@ export function registerOpenClawIntegrityPinTests(group: OpenClawIntegrityPinTes
         ["missing marker", { baseProvenance: null }],
         [
           "wrong schema",
-          { baseProvenance: openClawBaseProvenance().replace("schema=3", "schema=2") },
+          { baseProvenance: openClawBaseProvenance().replace("schema=4", "schema=3") },
         ],
         [
           "wrong version",
@@ -1154,7 +1154,7 @@ export function registerOpenClawIntegrityPinTests(group: OpenClawIntegrityPinTes
           "wrong mcporter recipe",
           {
             baseProvenance: openClawBaseProvenance().replace(
-              "mcporter-recipe=locked-ci+reviewed-audit+signatures-v2",
+              "mcporter-recipe=locked-ci+reviewed-audit-v3",
               "mcporter-recipe=locked-ci-only-v1",
             ),
           },

--- a/test/openclaw-integrity-pin-suite.ts
+++ b/test/openclaw-integrity-pin-suite.ts
@@ -1215,6 +1215,27 @@ export function registerOpenClawIntegrityPinTests(group: OpenClawIntegrityPinTes
           "custom base reference",
           { baseProvenance: openClawBaseProvenance(), baseImage: "registry.example/base:custom" },
         ],
+        [
+          "local base without independent CI attestation",
+          {
+            baseProvenance: openClawBaseProvenance(),
+            baseImage: "nemoclaw-sandbox-base-local:current",
+          },
+        ],
+        [
+          "bare local base without independent CI attestation",
+          {
+            baseProvenance: openClawBaseProvenance(),
+            baseImage: "nemoclaw-sandbox-base-local",
+          },
+        ],
+        [
+          "mutable official base tag without immutable publication identity",
+          {
+            baseProvenance: openClawBaseProvenance(),
+            baseImage: "ghcr.io/nvidia/nemoclaw/sandbox-base:latest",
+          },
+        ],
       ])("falls back to the reviewed archive for %s", (_label, overrides) => {
         const { result, calls, provenanceExists } = runInstallBlock(
           extractRunBlock(
@@ -1239,6 +1260,11 @@ export function registerOpenClawIntegrityPinTests(group: OpenClawIntegrityPinTes
         expect(calls).toMatch(/npm --prefix \S+\/openclaw-runtime ci /u);
         expect(calls).toContain("--verify-installed-lock");
         expect(calls).toContain("postinstall-bundled-plugins.mjs");
+        expect(result.stdout).not.toContain("Reusing reviewed base");
+        expect(result.stdout).toContain(
+          `Installing locked mcporter ${PINNED_MCPORTER_VERSION} dependency graph`,
+        );
+        expect(calls).toMatch(/npm --prefix \S+\/mcporter-runtime ci /u);
         expect(provenanceExists).toBe(false);
       });
 

--- a/test/openclaw-locked-install.test.ts
+++ b/test/openclaw-locked-install.test.ts
@@ -359,7 +359,7 @@ describe("locked OpenClaw production installation (#5896)", () => {
     expect(branchEnd).toBeGreaterThan(installIndex);
     expect(currentInstallBranch).toContain(`--lock-sha256 \"$OPENCLAW_LOCK_SHA256\"`);
     expect(currentInstallBranch).not.toContain("npm install -g");
-    expect(contents).toContain("'schema=3'");
+    expect(contents).toContain("'schema=4'");
     expect(contents).toContain('"lock-sha256=${OPENCLAW_LOCK_SHA256}"');
     expect(contents).toContain("locked-ci+reviewed-lifecycle-v2");
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Restricted OpenClaw sandbox image builds no longer contact Sigstore while installing the committed mcporter graph, so denied TUF egress cannot abort onboarding or rebuild.
Registry-signature verification remains fail closed in trusted CI for the committed lock, including every merge and image-publication path.

## Related Issue

Fixes #8925

## Changes

- Remove the duplicate `npm audit signatures` request from `Dockerfile` and `Dockerfile.base` while retaining exact lock, registry origin, integrity, installed-graph, lifecycle, runtime, and reviewed-advisory checks.
- Advance protected OpenClaw base provenance to `schema=4` and `mcporter-recipe=locked-ci+reviewed-audit-v3` so older base markers cannot cross the updated control boundary.
- Add a trusted audit from the base branch that evaluates dependency files from the commit under review before the managed-image PR workflow can build locally or publish a same-repository digest.
- Restrict installed-runtime reuse to digest-pinned bases in the official GHCR namespace. Local, custom, and mutable-tag markers cannot substitute for trusted-CI signature evidence.
- Add regression coverage for image-build egress, committed-lock CI signature verification, provenance reuse, corporate CA ordering, and all merge and publication dependencies.
- Document the image-build, trusted-CI, publication, and base-reuse responsibilities in the OpenClaw dependency review and corporate CA guide.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed all nine security categories after the review fix and reported PASS with no findings. Exact lock, integrity, lifecycle, advisory, signature, provenance, base-identity, and publication controls remain fail closed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated `docs/security/configure-corporate-ca-trust.mdx` and `agents/openclaw/dependency-review.md` to separate package provenance from CI signature evidence and explain the digest-pinned base-reuse boundary. `npm run docs` passed at the final commit with zero errors and two existing Fern warnings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 27c375eb3 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — Nine integration files passed 141 tests at `27c375e`. Documentation, project-boundary, source-shape, title, size, Dockerfile lint, type-check, formatting, and secret-scan checks passed.
- [ ] Applicable broad gate passed — `npm test` encountered unrelated host-specific WSL, Homebrew trust, process, and filesystem failures. Required GitHub CI is the authoritative broad gate and must pass before merge.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — the build passed with zero errors and two existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Strengthened dependency auditing and registry trust verification during pull requests and managed image builds.
  - Restricted reusable base images to verified, digest-pinned sources.
  - Improved provenance metadata and rejected unauthenticated or mutable base images.

- **Documentation**
  - Added guidance for corporate CA trust, dependency verification, image publication gating, and base-image requirements.

- **Tests**
  - Expanded coverage for audit enforcement, provenance validation, trusted base reuse, certificate setup, and dependency installation safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->