### PR TITLE
fix(onboard): synchronize OpenShell readiness handoffs

### DIFF
--- a/src/lib/onboard/forward-start.test.ts
+++ b/src/lib/onboard/forward-start.test.ts
@@ -949,7 +949,9 @@ describe("runDetachedForwardStartWithRetries", () => {
         events.push("spawn-1");
         fs.writeSync(
           stderr,
-          "Error: code: 'The system is not in a state required for the operation's execution', message: \"sandbox is not ready\"\n",
+          `Error:   × code: 'The system is not in a state required for the operation's
+  │ execution', message: "sandbox is not ready"
+`,
         );
         return { pid: 784 };
       })
@@ -988,7 +990,9 @@ describe("runDetachedForwardStartWithRetries", () => {
     const spawn = vi.fn().mockImplementation(({ stderr }: { stderr: number }) => {
       fs.writeSync(
         stderr,
-        "Permission denied (publickey); previous attempt reported Error: code: 'The system is not in a state required for the operation's execution', message: \"sandbox is not ready\"\n",
+        `Permission denied (publickey); previous attempt reported Error:   × code: 'The system is not in a state required for the operation's
+  │ execution', message: "sandbox is not ready"
+`,
       );
       return { pid: 784 };
     });
@@ -1132,7 +1136,8 @@ describe("looksLikeForwardListenerStartFailure", () => {
   it("matches only definitive listener termination diagnostics", () => {
     expect(
       looksLikeForwardListenerStartFailure(
-        "Error: code: 'The system is not in a state required for the operation's execution', message: \"sandbox is not ready\"",
+        `Error:   × code: 'The system is not in a state required for the operation's
+  │ execution', message: "sandbox is not ready"`,
       ),
     ).toBe(true);
     expect(

--- a/src/lib/onboard/forward-start.ts
+++ b/src/lib/onboard/forward-start.ts
@@ -110,7 +110,8 @@ const OPENSHELL_SANDBOX_NOT_READY_DIAGNOSTIC =
   /^Error: code: 'The system is not in a state required for the operation's execution', message: "sandbox is not ready"$/i;
 
 function looksLikeSandboxNotReadyForwardStart(diagnostic: string): boolean {
-  return OPENSHELL_SANDBOX_NOT_READY_DIAGNOSTIC.test(diagnostic);
+  const normalized = compactText(diagnostic.replace(/[×│]/gu, " "));
+  return OPENSHELL_SANDBOX_NOT_READY_DIAGNOSTIC.test(normalized);
 }
 
 /**

--- a/test/e2e/live/gateway-guard-recovery.test.ts
+++ b/test/e2e/live/gateway-guard-recovery.test.ts
@@ -157,13 +157,14 @@ async function inspectStartupCommand(
   return result.stdout.trim();
 }
 
-async function waitForSandboxExecAfterContainerRestart(
+async function waitForSandboxExecReady(
   host: HostCliClient,
   sandboxName: string,
   progress: TestProgress,
+  artifactPrefix: string,
 ): Promise<void> {
   await pollUntil({
-    artifactPrefix: "legacy-restart-openshell-ready",
+    artifactPrefix,
     attempts: 12,
     delayMs: 3_000,
     probe: async (_attempt, artifactName) =>
@@ -454,6 +455,15 @@ test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)
     },
   );
   expect(createLegacyKeepalive.exitCode, resultText(createLegacyKeepalive)).toBe(0);
+  // Do not overlap the fixture's recreation with the restart below. The
+  // fixture runs in its own process, so the host must observe the replacement
+  // through OpenShell before starting the next container lifecycle transition.
+  await waitForSandboxExecReady(
+    host,
+    instance.sandboxName,
+    progress,
+    "legacy-recreate-openshell-ready",
+  );
 
   const legacyContainerId = await findSandboxContainer(host, "legacy-restart-container-before");
   expect(legacyContainerId).not.toBe(recoveredContainerId);
@@ -466,7 +476,12 @@ test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)
     timeoutMs: 120_000,
   });
   expect(legacyRestart.exitCode, resultText(legacyRestart)).toBe(0);
-  await waitForSandboxExecAfterContainerRestart(host, instance.sandboxName, progress);
+  await waitForSandboxExecReady(
+    host,
+    instance.sandboxName,
+    progress,
+    "legacy-restart-openshell-ready",
+  );
   await gateway.waitForMissingManagedSupervisor(legacyContainerId, {
     onRetry: (attempt) => progress.event(`managed supervisor absence proof retry ${attempt}`),
   });


### PR DESCRIPTION
## Summary

Recognize OpenShell's decorated sandbox-readiness diagnostic so detached dashboard forwards enter the existing bounded retry path instead of polling a completed attempt for 180 seconds. Wait until OpenShell can execute in the recreated legacy container before the gateway recovery E2E starts a second Docker lifecycle transition.

## Changes

- Normalize only OpenShell's observed `×` and `│` diagnostic decorations before applying the existing exact sandbox-readiness match.
- Preserve fail-closed handling for composite authentication errors and unrelated diagnostics.
- Add an explicit OpenShell readiness handoff between legacy-container recreation and restart, with separate probe artifact names for each transition.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal retry classification and E2E synchronization without changing commands, configuration, or documented user behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed the diagnostic trust boundary and lifecycle ordering. Retry remains limited to the exact normalized readiness error; decorated composite authentication failures remain terminal; existing port-ownership checks and bounded retry limits are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `blocked`
- Evidence: No documentation paths changed and no public interface changed. The Codex side-conversation boundary prohibits subagent use, so an independent documentation-writer pass could not be run.
- Agent: Codex Desktop
<!-- docs-review-head-sha: cb9c3462f -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/forward-start.test.ts --coverage=false` (45 passed); `npx vitest run --project e2e-support test/e2e/support/gateway-guard-legacy-keepalive-fixture.test.ts --coverage=false` (6 passed); `npm run typecheck:cli`; `npm run test:e2e-phases:check`
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: prekshivyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sandbox readiness messages, including multiline and formatted diagnostics.
  * More reliably detects readiness failures and retries when appropriate.
  * Improved recovery checks after sandbox recreation and restart operations.
* **Tests**
  * Expanded coverage for readiness failures, listener errors, and authentication diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->