### PR TITLE
fix(e2e): align live probes with runtime state

### DIFF
--- a/docs/security/configure-corporate-ca-trust.mdx
+++ b/docs/security/configure-corporate-ca-trust.mdx
@@ -39,6 +39,7 @@ It sets `NODE_EXTRA_CA_CERTS` before build-time Node.js dependency verification,
 When NemoClaw selects a corporate CA, it sets `NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root` for the image build.
 The OpenClaw managed startup runtime creates `/run/nemoclaw/managed-startup-ca-bundle.pem` as `root:root` with mode `0444` before it starts agent commands as the `sandbox` user.
 The `sandbox` user can read the merged bundle but cannot modify or replace it.
+Sandboxes still using the staged legacy direct-start path create `/tmp/nemoclaw-ca-bundle.pem` with mode `0444` as the same `sandbox` identity that runs the entrypoint and agent, so that compatibility path is read-only by mode but is not a privilege boundary.
 
 </AgentOnly>
 

--- a/test/e2e/fixtures/corporate-ca.ts
+++ b/test/e2e/fixtures/corporate-ca.ts
@@ -79,13 +79,23 @@ expect_export() {
 }
 
 corp='/usr/local/share/nemoclaw/corporate-ca.pem'
-bundle='/run/nemoclaw/managed-startup-ca-bundle.pem'
-runtime_env='/run/nemoclaw/managed-startup-runtime.env'
+managed_completion='/run/nemoclaw/managed-startup-complete.json'
+if [ -e "$managed_completion" ] || [ -L "$managed_completion" ]; then
+  [ -f "$managed_completion" ] && [ ! -L "$managed_completion" ] || probe_fail invalid-managed-completion
+  bundle='/run/nemoclaw/managed-startup-ca-bundle.pem'
+  runtime_env='/run/nemoclaw/managed-startup-runtime.env'
+  expected_bundle_metadata='0:0:444'
+else
+  bundle='/tmp/nemoclaw-ca-bundle.pem'
+  runtime_env='/tmp/nemoclaw-proxy-env.sh'
+  expected_bundle_metadata="$(id -u):$(id -g):444"
+fi
 
 [ -s "$corp" ] || probe_fail missing-corporate-ca
 [ -s "$bundle" ] || probe_fail missing-merged-bundle
 [ -s "$runtime_env" ] || probe_fail missing-runtime-env
-[ "$(stat -c '%u:%g:%a' "$bundle")" = '0:0:444' ] || probe_fail merged-bundle-owner-mode
+[ ! -L "$bundle" ] || probe_fail symlinked-merged-bundle
+[ "$(stat -c '%u:%g:%a' "$bundle")" = "$expected_bundle_metadata" ] || probe_fail merged-bundle-owner-mode
 grep -F '${CORPORATE_CA_CANARY_LINE}' "$corp" >/dev/null || probe_fail corporate-canary-missing
 grep -F '${CORPORATE_CA_CANARY_LINE}' "$bundle" >/dev/null || probe_fail bundle-canary-missing
 set -- $(wc -c < "$corp")

--- a/test/e2e/live/mcp-bridge.test.ts
+++ b/test/e2e/live/mcp-bridge.test.ts
@@ -562,7 +562,7 @@ async function assertRealAdapterToolCall(
   ];
   const command =
     options.agent === "openclaw"
-      ? `nemoclaw-start mcporter call fake.fake_echo --args ${JSON.stringify(JSON.stringify({ challenge: TOOL_CHALLENGE }))} --output json`
+      ? `nemoclaw-start mcporter --root ${shellQuote(OPENCLAW_MCPORTER_ROOT)} call fake.fake_echo --args ${JSON.stringify(JSON.stringify({ challenge: TOOL_CHALLENGE }))} --output json`
       : options.agent === "hermes"
         ? [
             "set -a",

--- a/test/e2e/live/token-rotation.test.ts
+++ b/test/e2e/live/token-rotation.test.ts
@@ -4,6 +4,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { testTimeoutOptions } from "../../helpers/timeouts";
+import { parseOpenShellSandboxId } from "../../../src/lib/adapters/openshell/sandbox-identity.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import {
   cleanupWhenCommandAvailable,
@@ -224,6 +225,31 @@ async function assertSandboxRunning(
   expect(sandboxList.exitCode, output).toBe(0);
   expect(plainStdout, output).toContain(SANDBOX_NAME);
   expect(plainStdout, output).toMatch(/\b(?:Ready|Running)\b/i);
+}
+
+async function sandboxIdentity(
+  host: import("../fixtures/clients/host.ts").HostCliClient,
+  artifactName: string,
+): Promise<string> {
+  const sandboxGet = await host.command("openshell", ["sandbox", "get", SANDBOX_NAME], {
+    artifactName,
+    env: buildAvailabilityProbeEnv(),
+    timeoutMs: 30_000,
+  });
+  const output = resultText(sandboxGet);
+  expect(sandboxGet.exitCode, output).toBe(0);
+  const sandboxId = parseOpenShellSandboxId(output);
+  expect(sandboxId, output).not.toBeNull();
+  return sandboxId ?? "";
+}
+
+async function assertSandboxReused(
+  host: import("../fixtures/clients/host.ts").HostCliClient,
+  beforeId: string,
+  artifactName: string,
+): Promise<void> {
+  expect(await sandboxIdentity(host, `${artifactName}-identity`)).toBe(beforeId);
+  await assertSandboxRunning(host, `${artifactName}-running`);
 }
 
 async function deleteSandboxIfOpenshellExists(
@@ -502,6 +528,10 @@ test(
     await assertSandboxRunning(host, "phase-2-sandbox-running-after-telegram-rotation");
 
     progress.phase("reuse the sandbox after the unchanged Telegram token");
+    const beforeTelegramReuseId = await sandboxIdentity(
+      host,
+      "phase-3-before-same-telegram-identity",
+    );
     const afterTelegramSame = await runOnboard(
       host,
       fakeOpenAI.baseUrl,
@@ -510,8 +540,11 @@ test(
     );
     const afterTelegramSameText = resultText(afterTelegramSame);
     expect(afterTelegramSame.exitCode, afterTelegramSameText).toBe(0);
-    expect(afterTelegramSameText).toContain(`Sandbox '${SANDBOX_NAME}' exists and is ready`);
-    expect(afterTelegramSameText).toContain("reusing it");
+    await assertSandboxReused(
+      host,
+      beforeTelegramReuseId,
+      "phase-3-after-same-telegram",
+    );
 
     progress.phase("rotate only the Discord provider");
     const discord = await runOnboard(
@@ -534,6 +567,10 @@ test(
     await assertSandboxRunning(host, "phase-4-sandbox-running-after-discord-rotation");
 
     progress.phase("reuse the sandbox after the unchanged Discord token");
+    const beforeDiscordReuseId = await sandboxIdentity(
+      host,
+      "phase-5-before-same-discord-identity",
+    );
     const afterDiscordSame = await runOnboard(
       host,
       fakeOpenAI.baseUrl,
@@ -542,8 +579,11 @@ test(
     );
     const afterDiscordSameText = resultText(afterDiscordSame);
     expect(afterDiscordSame.exitCode, afterDiscordSameText).toBe(0);
-    expect(afterDiscordSameText).toContain(`Sandbox '${SANDBOX_NAME}' exists and is ready`);
-    expect(afterDiscordSameText).toContain("reusing it");
+    await assertSandboxReused(
+      host,
+      beforeDiscordReuseId,
+      "phase-5-after-same-discord",
+    );
 
     progress.phase("rotate only the Slack providers");
     const slack = await runOnboard(host, fakeOpenAI.baseUrl, TOKEN_B, "phase-6-rotate-slack");
@@ -557,6 +597,10 @@ test(
     await assertSandboxRunning(host, "phase-6-sandbox-running-after-slack-rotation");
 
     progress.phase("reuse the sandbox and record rotation evidence");
+    const beforeSlackReuseId = await sandboxIdentity(
+      host,
+      "phase-7-before-same-slack-identity",
+    );
     const afterSlackSame = await runOnboard(
       host,
       fakeOpenAI.baseUrl,
@@ -565,8 +609,7 @@ test(
     );
     const afterSlackSameText = resultText(afterSlackSame);
     expect(afterSlackSame.exitCode, afterSlackSameText).toBe(0);
-    expect(afterSlackSameText).toContain(`Sandbox '${SANDBOX_NAME}' exists and is ready`);
-    expect(afterSlackSameText).toContain("reusing it");
+    await assertSandboxReused(host, beforeSlackReuseId, "phase-7-after-same-slack");
 
     await artifacts.target.complete({
       id: "token-rotation",


### PR DESCRIPTION
## Summary

Follow up #8929 after its exact live run exposed three remaining test-contract mismatches. This keeps the fixes deterministic and limited to the affected probes: runtime mode, MCP workspace root, and durable sandbox identity.

## Root Cause

- The corporate CA probe assumed every sandbox had completed the managed-startup migration, but the affected live jobs still use the staged legacy direct-start path.
- The MCP setup and list probes selected the OpenClaw workspace root, but the actual `mcporter call` did not, so it resolved a different configuration.
- Token rotation asserted obsolete CLI prose even though the unchanged-token onboard succeeded; wording could neither prove nor disprove sandbox reuse.

## Changes

- Select the managed `/run/nemoclaw` CA artifacts only when the managed completion marker exists; otherwise validate the shipped legacy `/tmp` artifacts and their actual same-identity ownership boundary.
- Pass the canonical OpenClaw workspace root to the real MCP adapter call.
- Prove unchanged-token reuse by comparing OpenShell's durable sandbox ID before and after each onboard, then confirming the sandbox remains Ready/Running.
- Document the legacy direct-start CA bundle's read-only mode and same-identity trust boundary.

## Impact

No production behavior, retries, timing budgets, compatibility layers, or new abstractions are added. The live tests now assert the runtime state that each supported path actually guarantees.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review confirms the mode selection requires a regular, non-symlink managed completion marker; both CA paths retain content, export, symlink, size, owner, and mode checks; MCP uses the existing fixed workspace root and shell quoting; token reuse is proven by the existing strict durable-ID parser and live readiness state.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/security/configure-corporate-ca-trust.mdx`
- Agent: `Codex Desktop`
<!-- docs-review-head-sha: 2feefb4a39 -->
<!-- docs-review-agents-blob-sha: c4923a3e36 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; DGX Station preparation scripts are unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] `npm run validate:pr` passed on the exact current commit after refreshing `origin/main`
- [x] `npm run docs` passed with 0 errors; the repository's same 2 pre-existing warnings remain
- [x] The five affected live suites collect under the `e2e-live` Vitest project
- [x] The pre-commit and pre-push hooks passed, including TypeScript, shellcheck, secret scanning, E2E semantic phases, repository policy, and test-size limits
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md)

Exact live verification: [E2E run 31649727919](https://github.com/NVIDIA/NemoClaw/actions/runs/31649727919), dispatched against `2feefb4a39` with correlation `1043ac75-c99d-48cf-989b-d4dcdc23e0ea`. All eight original targets passed: `onboard-repair`, `onboard-resume`, `cloud-onboard`, OpenClaw `mcp-bridge`, `token-rotation`, `double-onboard`, `openclaw-plugin-runtime-exdev`, and the Deep Agents live job.

---
Signed-off-by: prekshivyas <prekshiv@nvidia.com>
