### PR TITLE
fix(base-image): require Deep Agents Code dos2unix

### DIFF
--- a/.github/actions/build-base-image-platform/action.yaml
+++ b/.github/actions/build-base-image-platform/action.yaml
@@ -104,6 +104,30 @@ runs:
         cache-to: type=registry,ref=${{ inputs.registry }}/${{ inputs.image }}:buildcache-${{ inputs.arch }},mode=max
         build-args: ${{ steps.production-build-args.outputs.openclaw_build_arg }}
 
+    - name: Validate Deep Agents Code dos2unix executable
+      if: ${{ inputs.agent == 'langchain-deepagents-code' }}
+      shell: bash
+      env:
+        DIGEST: ${{ steps.build.outputs.digest }}
+        IMAGE: ${{ inputs.registry }}/${{ inputs.image }}
+        PLATFORM: ${{ inputs.platform }}
+      run: |
+        set -euo pipefail
+        if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+          echo "ERROR: Deep Agents Code base image build did not return a valid digest: $DIGEST" >&2
+          exit 1
+        fi
+        reference="${IMAGE}@${DIGEST}"
+        docker run --rm --platform "$PLATFORM" \
+          --network none \
+          --cap-drop ALL \
+          --security-opt no-new-privileges \
+          --read-only \
+          --user 999:999 \
+          --entrypoint /bin/sh \
+          "$reference" -eu -c \
+          'test -x /usr/bin/dos2unix; test "$(command -v dos2unix)" = /usr/bin/dos2unix; dos2unix --version >/dev/null'
+
     - name: Export platform digest
       shell: bash
       env:

--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -150,7 +150,7 @@ NemoClaw/OpenShell keeps real provider credentials in credential handling and do
 Deep Agents Code reaches `inference.local` through the managed OpenShell L7 proxy rather than direct sandbox DNS.
 The image launcher normalizes the runtime proxy environment for interactive, login-shell, and direct-exec paths and removes inherited proxy credentials and bypass entries before `dcode` starts.
 Managed interactive sessions pre-complete Deep Agents Code's optional first-run onboarding, skip its dependency and model selection screens, then open the TUI with the model selected during NemoClaw onboarding.
-The image includes `ripgrep`, and ordinary sessions suppress the optional Tavily warning unless web search is configured or invoked.
+The image includes `ripgrep` and `dos2unix`, and ordinary sessions suppress the optional Tavily warning unless web search is configured or invoked.
 
   </Accordion>
 

--- a/src/lib/agent/base-image.test.ts
+++ b/src/lib/agent/base-image.test.ts
@@ -481,7 +481,7 @@ describe("agent base image provisioning", () => {
           ],
           validateImage: expect.any(Function),
           validationDescription:
-            "deepagents-code==0.1.34 and the immutable security package inventory",
+            "deepagents-code==0.1.34, dos2unix, and the immutable security package inventory",
         }),
       );
     });

--- a/src/lib/agent/deep-agents-code-base-image.test.ts
+++ b/src/lib/agent/deep-agents-code-base-image.test.ts
@@ -20,7 +20,7 @@ import {
 
 describe("Deep Agents Code base image compatibility", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    mocks.dockerCapture.mockReset();
   });
 
   it("accepts only the exact installed distribution version (#6456)", () => {
@@ -41,6 +41,7 @@ describe("Deep Agents Code base image compatibility", () => {
     );
     mocks.dockerCapture
       .mockReturnValueOnce("9.8.7")
+      .mockReturnValueOnce("nemoclaw-dcode-dos2unix-ok")
       .mockReturnValueOnce("nemoclaw-security-inventory-ok");
 
     expect(options).toMatchObject({
@@ -48,9 +49,46 @@ describe("Deep Agents Code base image compatibility", () => {
         "/test/root/agents/langchain-deepagents-code/manifest.yaml",
         "/test/root/agents/langchain-deepagents-code/requirements.lock",
       ],
-      validationDescription: "deepagents-code==9.8.7 and the immutable security package inventory",
+      validationDescription:
+        "deepagents-code==9.8.7, dos2unix, and the immutable security package inventory",
     });
     expect(options?.validateImage?.("dcode-base:manifest-version")).toBe(true);
+  });
+
+  it("rejects a matching distribution from a base without dos2unix (#8870)", () => {
+    const options = createDeepAgentsCodeBaseImageResolutionOptions(
+      makeAgent({
+        name: "langchain-deepagents-code",
+        displayName: "LangChain Deep Agents Code",
+        expectedVersion: "0.1.34",
+      }),
+      "/test/root/agents/langchain-deepagents-code/Dockerfile.base",
+    );
+    mocks.dockerCapture.mockReturnValueOnce("0.1.34").mockReturnValueOnce("");
+
+    expect(options?.validateImage?.("dcode-base:missing-dos2unix")).toBe(false);
+    expect(mocks.dockerCapture).toHaveBeenCalledTimes(2);
+    expect(mocks.dockerCapture.mock.calls[1]?.[0]).toEqual(
+      expect.arrayContaining([
+        "run",
+        "--network",
+        "none",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--read-only",
+        "--user",
+        "999:999",
+        "--entrypoint",
+        "/bin/sh",
+        "dcode-base:missing-dos2unix",
+        "-eu",
+        "-c",
+      ]),
+    );
+    expect(mocks.dockerCapture.mock.calls[1]?.[0].at(-1)).toContain("test -x /usr/bin/dos2unix");
+    expect(mocks.dockerCapture.mock.calls[1]?.[0].at(-1)).toContain("dos2unix --version");
   });
 
   it("rejects a matching distribution from a base with an old security inventory (#7809)", () => {
@@ -62,11 +100,14 @@ describe("Deep Agents Code base image compatibility", () => {
       }),
       "/test/root/agents/langchain-deepagents-code/Dockerfile.base",
     );
-    mocks.dockerCapture.mockReturnValueOnce("0.1.34").mockReturnValueOnce("");
+    mocks.dockerCapture
+      .mockReturnValueOnce("0.1.34")
+      .mockReturnValueOnce("nemoclaw-dcode-dos2unix-ok")
+      .mockReturnValueOnce("");
 
     expect(options?.validateImage?.("dcode-base:v0.0.96")).toBe(false);
-    expect(mocks.dockerCapture).toHaveBeenCalledTimes(2);
-    expect(mocks.dockerCapture.mock.calls[1]?.[0]).toEqual(
+    expect(mocks.dockerCapture).toHaveBeenCalledTimes(3);
+    expect(mocks.dockerCapture.mock.calls[2]?.[0]).toEqual(
       expect.arrayContaining([
         "run",
         "--network",
@@ -82,7 +123,7 @@ describe("Deep Agents Code base image compatibility", () => {
         "-c",
       ]),
     );
-    expect(mocks.dockerCapture.mock.calls[1]?.[0].at(-1)).toContain(
+    expect(mocks.dockerCapture.mock.calls[2]?.[0].at(-1)).toContain(
       `cmp -s - "$security_inventory"`,
     );
   });

--- a/src/lib/agent/deep-agents-code-base-image.ts
+++ b/src/lib/agent/deep-agents-code-base-image.ts
@@ -9,6 +9,16 @@ import { sandboxBaseImageHasSecurityInventory } from "../sandbox-base-image/secu
 import type { AgentDefinition } from "./defs";
 
 const DEEPAGENTS_CODE_DISTRIBUTION = "deepagents-code";
+const DEEPAGENTS_CODE_DOS2UNIX_PROBE_OK = "nemoclaw-dcode-dos2unix-ok";
+const DEEPAGENTS_CODE_BASE_IMAGE_PROBE_GUARDS = [
+  "--network",
+  "none",
+  "--cap-drop",
+  "ALL",
+  "--security-opt",
+  "no-new-privileges",
+  "--read-only",
+] as const;
 
 type DeepAgentsCodeResolutionOptions = Pick<
   ResolveBaseImageOptions,
@@ -29,13 +39,7 @@ export function deepAgentsCodeBaseImageMatchesVersion(
     [
       "run",
       "--rm",
-      "--network",
-      "none",
-      "--cap-drop",
-      "ALL",
-      "--security-opt",
-      "no-new-privileges",
-      "--read-only",
+      ...DEEPAGENTS_CODE_BASE_IMAGE_PROBE_GUARDS,
       "--entrypoint",
       "/opt/venv/bin/python3",
       imageRef,
@@ -57,6 +61,35 @@ export function deepAgentsCodeBaseImageMatchesVersion(
   return installedVersion === expectedVersion;
 }
 
+/**
+ * Reject a published or cached Deep Agents Code base image that omits
+ * dos2unix, which workspace and repository workflows require.
+ */
+export function deepAgentsCodeBaseImageHasDos2Unix(imageRef: string): boolean {
+  const output = dockerCapture(
+    [
+      "run",
+      "--rm",
+      ...DEEPAGENTS_CODE_BASE_IMAGE_PROBE_GUARDS,
+      "--user",
+      "999:999",
+      "--entrypoint",
+      "/bin/sh",
+      imageRef,
+      "-eu",
+      "-c",
+      [
+        "test -x /usr/bin/dos2unix",
+        'test "$(command -v dos2unix)" = /usr/bin/dos2unix',
+        "dos2unix --version >/dev/null",
+        `printf '%s\\n' "${DEEPAGENTS_CODE_DOS2UNIX_PROBE_OK}"`,
+      ].join("; "),
+    ],
+    { ignoreError: true, timeout: 20_000 },
+  );
+  return output.trim() === DEEPAGENTS_CODE_DOS2UNIX_PROBE_OK;
+}
+
 export function createDeepAgentsCodeBaseImageResolutionOptions(
   agent: AgentDefinition,
   dockerfilePath: string,
@@ -76,9 +109,10 @@ export function createDeepAgentsCodeBaseImageResolutionOptions(
     inputPaths: [path.join(agentRoot, "manifest.yaml"), path.join(agentRoot, "requirements.lock")],
     validateImage: (imageRef) =>
       deepAgentsCodeBaseImageMatchesVersion(imageRef, expectedVersion) &&
+      deepAgentsCodeBaseImageHasDos2Unix(imageRef) &&
       sandboxBaseImageHasSecurityInventory(imageRef),
     validationDescription:
-      `${DEEPAGENTS_CODE_DISTRIBUTION}==${expectedVersion} and ` +
+      `${DEEPAGENTS_CODE_DISTRIBUTION}==${expectedVersion}, dos2unix, and ` +
       "the immutable security package inventory",
   };
 }

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -450,6 +450,43 @@ describe("complete managed-image publication workflow", () => {
     }
   });
 
+  it("executes dos2unix from each Deep Agents Code platform image before manifest publication (#8870)", () => {
+    const action = YAML.parse(
+      fs.readFileSync(
+        path.join(repoRoot, ".github", "actions", "build-base-image-platform", "action.yaml"),
+        "utf8",
+      ),
+    ) as { runs?: { steps?: Step[] } };
+    const steps = action.runs?.steps ?? [];
+    const validate = required(
+      steps.find((candidate) => candidate.name === "Validate Deep Agents Code dos2unix executable"),
+      "base-image platform action is missing the Deep Agents Code dos2unix validation",
+    );
+    const buildIndex = steps.findIndex(
+      (candidate) => candidate.name === "Build and push platform digest",
+    );
+    const validateIndex = steps.indexOf(validate);
+    const exportIndex = steps.findIndex((candidate) => candidate.name === "Export platform digest");
+
+    expect(validate.if).toBe("${{ inputs.agent == 'langchain-deepagents-code' }}");
+    expect(validate.env).toMatchObject({
+      DIGEST: "${{ steps.build.outputs.digest }}",
+      IMAGE: "${{ inputs.registry }}/${{ inputs.image }}",
+      PLATFORM: "${{ inputs.platform }}",
+    });
+    expect(validate.run).toContain('reference="${IMAGE}@${DIGEST}"');
+    expect(validate.run).toContain('docker run --rm --platform "$PLATFORM"');
+    expect(validate.run).toContain("--network none");
+    expect(validate.run).toContain("--cap-drop ALL");
+    expect(validate.run).toContain("--security-opt no-new-privileges");
+    expect(validate.run).toContain("--read-only");
+    expect(validate.run).toContain("--user 999:999");
+    expect(validate.run).toContain("test -x /usr/bin/dos2unix");
+    expect(validate.run).toContain("dos2unix --version");
+    expect(validateIndex).toBeGreaterThan(buildIndex);
+    expect(validateIndex).toBeLessThan(exportIndex);
+  });
+
   it("builds and exercises every shipped agent from an exact PR image before merge (#7744)", () => {
     const workflow = readWorkflow("managed-images.yaml");
     const prBuilder = managedPrBuilder(workflow);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Deep Agents Code base-image reuse now rejects published or cached images unless `dos2unix` is available and executable. Platform builds also execute `dos2unix` from each exact image digest before multi-platform manifest publication, closing the release validation gap that allowed the regression to escape.

## Related Issue
Fixes #8870

## Changes
- Add a locked-down compatibility probe for `dos2unix` before accepting a Deep Agents Code base image. The existing package pin could not protect consumers that reused a matching-version cached image; `rejects a matching distribution from a base without dos2unix (#8870)` protects this contract.
- Execute `dos2unix` from every built Deep Agents Code platform digest before exporting the digest for manifest publication. `executes dos2unix from each Deep Agents Code platform image before manifest publication (#8870)` protects the workflow ordering and runtime contract.
- Document `dos2unix` in the Deep Agents Code image inventory.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The contributor security review confirmed that the digest-pinned validation container has no network, drops all capabilities, enables `no-new-privileges`, uses a read-only filesystem, runs as UID/GID 999, and receives no registry credentials.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/get-started/quickstart-langchain-deepagents-code.mdx`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 87af81ce0 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli --project integration src/lib/agent/deep-agents-code-base-image.test.ts src/lib/agent/base-image.test.ts test/managed-image-publication-workflow.test.ts` — 56/56 passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Docs validation: `npm run docs` completed with 0 errors and 2 existing Fern warnings.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deep Agents Code images now include and validate the `dos2unix` utility.
  * Image validation confirms the utility is executable, correctly resolved, and reports its version.
  * Validation runs with restricted privileges and networking for improved safety.

* **Documentation**
  * Updated the quickstart documentation to list both `ripgrep` and `dos2unix` as included tools.

* **Bug Fixes**
  * Base images that lack a functional `dos2unix` installation are now rejected before publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->