### PR TITLE
fix(onboard): compare durable messaging authority

### DIFF
--- a/src/lib/messaging/plan-authority.ts
+++ b/src/lib/messaging/plan-authority.ts
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isDeepStrictEqual } from "node:util";
+
 import type { SandboxMessagingPlan } from "./manifest";
+import { compactSandboxMessagingPlanForPersistence } from "./persistence";
 
 export type RegistryMessagingAuthority =
   | {
@@ -23,6 +26,20 @@ export interface MessagingPlanAuthorityInput {
 export interface MessagingPlanAuthorityResult {
   readonly source: "registry" | "staged" | "session" | "none";
   readonly plan: SandboxMessagingPlan | null;
+}
+
+/** Compare the durable channel state while ignoring fields regenerated from manifests. */
+export function sameRegistryMessagingAuthority(
+  left: RegistryMessagingAuthority,
+  right: RegistryMessagingAuthority,
+): boolean {
+  if (left.authoritative !== right.authoritative) return false;
+  if (!left.authoritative || !right.authoritative) return true;
+  if (!left.plan || !right.plan) return left.plan === right.plan;
+  return isDeepStrictEqual(
+    compactSandboxMessagingPlanForPersistence(left.plan),
+    compactSandboxMessagingPlanForPersistence(right.plan),
+  );
 }
 
 function planTargetsSandbox(plan: SandboxMessagingPlan | null, sandboxName: string): boolean {

--- a/src/lib/onboard/machine/handlers/sandbox-credential-drift.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-credential-drift.test.ts
@@ -716,4 +716,42 @@ describe("sandbox messaging credential drift", () => {
     expect(calls.removeSandbox).not.toHaveBeenCalled();
     expect(calls.createSandbox).not.toHaveBeenCalled();
   });
+
+  it("allows rebuild recreation when manifest-derived messaging fields are rehydrated", async () => {
+    const plan = makeMinimalPlan("my-assistant", "openclaw", ["telegram"]);
+    const rehydratedPlan = {
+      ...plan,
+      buildSteps: [
+        {
+          channelId: "telegram",
+          kind: "build-arg",
+          outputId: "telegram-config",
+          required: true,
+          value: "enabled",
+        },
+      ],
+    } satisfies typeof plan;
+    let sandboxLockHeld = false;
+    const { deps, calls } = createDeps({
+      getRegistrySandboxMessagingAuthority: () => ({
+        authoritative: true,
+        plan: sandboxLockHeld ? rehydratedPlan : plan,
+      }),
+      withSandboxMutationLock: async (_sandboxName, operation) => {
+        sandboxLockHeld = true;
+        try {
+          return await operation();
+        } finally {
+          sandboxLockHeld = false;
+        }
+      },
+    });
+
+    await handleSandboxState(baseOptions(deps));
+
+    expect(calls.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("Messaging channel state"),
+    );
+    expect(calls.createSandbox).toHaveBeenCalledOnce();
+  });
 });

--- a/src/lib/onboard/machine/handlers/sandbox-messaging.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.ts
@@ -14,6 +14,7 @@ import type { MessagingAgentId, SandboxMessagingPlan } from "../../../messaging/
 import {
   type RegistryMessagingAuthority,
   resolveMessagingPlanAuthority,
+  sameRegistryMessagingAuthority,
 } from "../../../messaging/plan-authority";
 import { hashCredential } from "../../../security/credential-hash";
 import { isDecisionSelected, isDecisionUnset } from "../../../state/onboard-checkpoint-decision";
@@ -21,7 +22,11 @@ import type { Session } from "../../../state/onboard-session";
 import { detectMessagingChannelsFromEnv } from "../../messaging-channel-setup";
 import { getActiveChannelsFromPlan, getChannelsFromPlan } from "../../messaging-plan-session";
 
-export { resolveMessagingPlanAuthority };
+export {
+  type RegistryMessagingAuthority,
+  resolveMessagingPlanAuthority,
+  sameRegistryMessagingAuthority,
+};
 
 function sameChannelSet(a: readonly string[], b: readonly string[]): boolean {
   if (a.length !== b.length) return false;

--- a/src/lib/onboard/machine/handlers/sandbox.ts
+++ b/src/lib/onboard/machine/handlers/sandbox.ts
@@ -18,7 +18,6 @@ import {
   webSearchProviderForConfig,
 } from "../../../inference/web-search";
 import type { SandboxMessagingPlan } from "../../../messaging/manifest";
-import type { RegistryMessagingAuthority } from "../../../messaging/plan-authority";
 import {
   decisionValue,
   isDecisionSelected,
@@ -108,9 +107,11 @@ import { branchTo, type OnboardStateTransitionResult } from "../result";
 import * as dcodeResume from "./sandbox-dcode-resume";
 import {
   hasMessagingCredentialDrift,
+  type RegistryMessagingAuthority,
   reconcileReusedSandboxMessaging,
   reconcileSandboxMessaging,
   resolveMessagingPlanAuthority,
+  sameRegistryMessagingAuthority,
 } from "./sandbox-messaging";
 import {
   decideSandboxResume,
@@ -1061,12 +1062,7 @@ class SandboxStateFlow<
     expectedAuthority: RegistryMessagingAuthority,
   ): void {
     const currentAuthority = this.deps.getRegistrySandboxMessagingAuthority(sandboxName);
-    if (
-      fingerprintSandboxRecreateValue(currentAuthority) ===
-      fingerprintSandboxRecreateValue(expectedAuthority)
-    ) {
-      return;
-    }
+    if (sameRegistryMessagingAuthority(currentAuthority, expectedAuthority)) return;
     this.deps.error(
       `  Messaging channel state for sandbox '${sandboxName}' changed while onboarding was in progress.`,
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Sandbox rebuilds hydrate manifest-derived messaging fields that are not stored in the sandbox registry. The rebuild guard compared those transient fields and could reject an unchanged channel selection as a concurrent edit; this change compares the existing compact, persisted authority instead while still rejecting actual durable state changes.

## Changes

- Compare registry messaging snapshots through the existing persistence compactor.
- Keep the fail-closed rebuild guard for changes to channel state, configuration, credential metadata, workflow, and network policy.
- Add a regression test that rehydrates manifest-derived build steps during recreation and retain coverage for a real stopped-channel race.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing messaging and rebuild documentation already describes preserved channel state; this restores that documented behavior without changing the interface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The comparison is narrowed to the existing persisted messaging contract; no credential values or credential validation are changed, and the existing concurrent durable-state mutation test still fails closed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing `docs/manage-sandboxes/messaging-channels.mdx` and `docs/manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes.mdx` already document validation and messaging-state preservation across rebuilds. The fix restores that contract; the type-only facade re-export is not user-visible.
- Agent: Codex Desktop
<!-- docs-review-head-sha: ac52fdcb1 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run src/lib/onboard/machine/handlers/sandbox-credential-drift.test.ts src/lib/onboard/machine/handlers/sandbox-messaging.test.ts src/lib/messaging/plan-authority.test.ts` (39 tests passed)
- [ ] Applicable broad gate passed — Not applicable: this is a narrow messaging-authority comparison covered by targeted tests; `npm run typecheck:cli` and `npm run checks:repository` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: prekshivyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sandbox rebuilds being incorrectly blocked by messaging-state conflicts after manifest-derived settings were recreated.
  * Improved comparison of messaging configuration so regenerated fields no longer trigger false changes.
  * Sandbox recreation now proceeds reliably when messaging settings remain functionally unchanged.

* **Tests**
  * Added regression coverage to verify successful sandbox recreation and prevent future messaging-state conflict regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->