### PR TITLE
fix(ci): restore main checks

### DIFF
--- a/src/lib/shields/index.ts
+++ b/src/lib/shields/index.ts
@@ -4725,6 +4725,31 @@ function startFreshShieldsDownTimer(input: {
   }
 }
 
+function persistIncompleteShieldsDownPosture(
+  sandboxName: string,
+  transition: ShieldsDownTransition,
+  timerAuthority: TimerMarker,
+  rollback: ShieldsDownRollbackResult,
+): ShieldsDownTransition {
+  if (rollback.outcome !== "manual_intervention_required" || rollback.timerAuthorityRevoked) {
+    return transition;
+  }
+
+  try {
+    assertFreshShieldsDownAuthority(sandboxName, timerAuthority, transition, "preparing");
+    transition = { ...transition, phase: "active" };
+    writeShieldsDownTransition(transition, "preparing");
+    assertFreshShieldsDownAuthority(sandboxName, timerAuthority, transition, "active");
+  } catch (transitionError) {
+    const transitionMessage =
+      transitionError instanceof Error ? transitionError.message : String(transitionError);
+    console.error(
+      `  CRITICAL: Could not persist the incomplete Shields down posture. Treat the config as mutable and recover it manually. ${transitionMessage}`,
+    );
+  }
+  return transition;
+}
+
 function shieldsDownWithoutHostLock(sandboxName: string, opts: ShieldsDownOpts = {}): void {
   validateName(sandboxName, "sandbox name");
 
@@ -5150,25 +5175,12 @@ function shieldsDownWithoutHostLock(sandboxName: string, opts: ShieldsDownOpts =
       opts.allowLegacyHermesProtocol === true,
       protocol,
     );
-    if (
-      transition &&
-      timerAuthority &&
-      rollback.outcome === "manual_intervention_required" &&
-      !rollback.timerAuthorityRevoked
-    ) {
-      try {
-        assertFreshShieldsDownAuthority(sandboxName, timerAuthority, transition, "preparing");
-        transition = { ...transition, phase: "active" };
-        writeShieldsDownTransition(transition, "preparing");
-        assertFreshShieldsDownAuthority(sandboxName, timerAuthority, transition, "active");
-      } catch (transitionError) {
-        const transitionMessage =
-          transitionError instanceof Error ? transitionError.message : String(transitionError);
-        console.error(
-          `  CRITICAL: Could not persist the incomplete Shields down posture. Treat the config as mutable and recover it manually. ${transitionMessage}`,
-        );
-      }
-    }
+    transition = persistIncompleteShieldsDownPosture(
+      sandboxName,
+      transition,
+      timerAuthority,
+      rollback,
+    );
     if (transition && rollback.timerAuthorityRevoked) {
       clearShieldsDownTransition(sandboxName, transition.processToken);
     }

--- a/src/lib/shields/openclaw-transition.test.ts
+++ b/src/lib/shields/openclaw-transition.test.ts
@@ -196,7 +196,7 @@ describe("OpenClaw shields top-config transaction", () => {
     );
 
     shields = requireSource(INDEX_MODULE);
-  });
+  }, 30_000);
 
   afterEach(() => {
     for (const spy of spies) spy.mockRestore();

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -67,6 +67,7 @@ describe("base-image dependency contracts", () => {
       PLATFORM: "${{ inputs.platform }}",
     });
     expect(validate.run).toContain('reference="${IMAGE}@${DIGEST}"');
+    expect(validate.run).toContain("^sha256:[0-9a-f]{64}$");
     expect(validate.run).toContain('docker run --rm --platform "$PLATFORM"');
     expect(validate.run).toContain("--network none");
     expect(validate.run).toContain("--cap-drop ALL");
@@ -74,7 +75,11 @@ describe("base-image dependency contracts", () => {
     expect(validate.run).toContain("--read-only");
     expect(validate.run).toContain("--user 999:999");
     expect(validate.run).toContain("test -x /usr/bin/dos2unix");
+    expect(validate.run).toContain('test "$(command -v dos2unix)" = /usr/bin/dos2unix');
     expect(validate.run).toContain("dos2unix --version");
+    expect(buildIndex).toBeGreaterThanOrEqual(0);
+    expect(validateIndex).toBeGreaterThanOrEqual(0);
+    expect(exportIndex).toBeGreaterThanOrEqual(0);
     expect(validateIndex).toBeGreaterThan(buildIndex);
     expect(validateIndex).toBeLessThan(exportIndex);
   });

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -5,6 +5,14 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+type Step = {
+  env?: Record<string, unknown>;
+  if?: string;
+  name?: string;
+  run?: string;
+};
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const baseDockerfiles = [
@@ -29,5 +37,43 @@ describe("base-image dependency contracts", () => {
       const source = fs.readFileSync(path.join(repoRoot, dockerfile), "utf8");
       expect(source, dockerfile).toMatch(/^FROM\s+\S+@sha256:[0-9a-f]{64}\s*$/m);
     }
+  });
+
+  it("executes dos2unix from each Deep Agents Code platform image before manifest publication (#8870)", () => {
+    const action = YAML.parse(
+      fs.readFileSync(
+        path.join(repoRoot, ".github", "actions", "build-base-image-platform", "action.yaml"),
+        "utf8",
+      ),
+    ) as { runs?: { steps?: Step[] } };
+    const steps = action.runs?.steps ?? [];
+    const validate = steps.find(
+      (candidate) => candidate.name === "Validate Deep Agents Code dos2unix executable",
+    );
+    expect(validate, "base-image platform action is missing the dos2unix validation").toBeDefined();
+    if (!validate) return;
+    const buildIndex = steps.findIndex(
+      (candidate) => candidate.name === "Build and push platform digest",
+    );
+    const validateIndex = steps.indexOf(validate);
+    const exportIndex = steps.findIndex((candidate) => candidate.name === "Export platform digest");
+
+    expect(validate.if).toBe("${{ inputs.agent == 'langchain-deepagents-code' }}");
+    expect(validate.env).toMatchObject({
+      DIGEST: "${{ steps.build.outputs.digest }}",
+      IMAGE: "${{ inputs.registry }}/${{ inputs.image }}",
+      PLATFORM: "${{ inputs.platform }}",
+    });
+    expect(validate.run).toContain('reference="${IMAGE}@${DIGEST}"');
+    expect(validate.run).toContain('docker run --rm --platform "$PLATFORM"');
+    expect(validate.run).toContain("--network none");
+    expect(validate.run).toContain("--cap-drop ALL");
+    expect(validate.run).toContain("--security-opt no-new-privileges");
+    expect(validate.run).toContain("--read-only");
+    expect(validate.run).toContain("--user 999:999");
+    expect(validate.run).toContain("test -x /usr/bin/dos2unix");
+    expect(validate.run).toContain("dos2unix --version");
+    expect(validateIndex).toBeGreaterThan(buildIndex);
+    expect(validateIndex).toBeLessThan(exportIndex);
   });
 });

--- a/test/dcode-base-image-workflow.test.ts
+++ b/test/dcode-base-image-workflow.test.ts
@@ -47,11 +47,13 @@ describe("base-image dependency contracts", () => {
       ),
     ) as { runs?: { steps?: Step[] } };
     const steps = action.runs?.steps ?? [];
-    const validate = steps.find(
-      (candidate) => candidate.name === "Validate Deep Agents Code dos2unix executable",
-    );
-    expect(validate, "base-image platform action is missing the dos2unix validation").toBeDefined();
-    if (!validate) return;
+    const validate =
+      steps.find(
+        (candidate) => candidate.name === "Validate Deep Agents Code dos2unix executable",
+      ) ??
+      (() => {
+        throw new Error("Base-image platform action is missing the dos2unix validation");
+      })();
     const buildIndex = steps.findIndex(
       (candidate) => candidate.name === "Build and push platform digest",
     );

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -106,6 +106,13 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     ),
   },
   {
+    pattern: /(?:^|\/)\.github\/actions\/build-base-image-platform\/action\.yaml$/,
+    testsToRun: runTests(
+      "test/dcode-base-image-workflow.test.ts",
+      "test/openclaw-dependency-review.test.ts",
+    ),
+  },
+  {
     pattern: /(?:^|\/)scripts\/checks\/validate-managed-base-index\.sh$/,
     testsToRun: runTests("test/validate-managed-base-index.test.ts"),
   },

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -458,43 +458,6 @@ describe("complete managed-image publication workflow", () => {
     }
   });
 
-  it("executes dos2unix from each Deep Agents Code platform image before manifest publication (#8870)", () => {
-    const action = YAML.parse(
-      fs.readFileSync(
-        path.join(repoRoot, ".github", "actions", "build-base-image-platform", "action.yaml"),
-        "utf8",
-      ),
-    ) as { runs?: { steps?: Step[] } };
-    const steps = action.runs?.steps ?? [];
-    const validate = required(
-      steps.find((candidate) => candidate.name === "Validate Deep Agents Code dos2unix executable"),
-      "base-image platform action is missing the Deep Agents Code dos2unix validation",
-    );
-    const buildIndex = steps.findIndex(
-      (candidate) => candidate.name === "Build and push platform digest",
-    );
-    const validateIndex = steps.indexOf(validate);
-    const exportIndex = steps.findIndex((candidate) => candidate.name === "Export platform digest");
-
-    expect(validate.if).toBe("${{ inputs.agent == 'langchain-deepagents-code' }}");
-    expect(validate.env).toMatchObject({
-      DIGEST: "${{ steps.build.outputs.digest }}",
-      IMAGE: "${{ inputs.registry }}/${{ inputs.image }}",
-      PLATFORM: "${{ inputs.platform }}",
-    });
-    expect(validate.run).toContain('reference="${IMAGE}@${DIGEST}"');
-    expect(validate.run).toContain('docker run --rm --platform "$PLATFORM"');
-    expect(validate.run).toContain("--network none");
-    expect(validate.run).toContain("--cap-drop ALL");
-    expect(validate.run).toContain("--security-opt no-new-privileges");
-    expect(validate.run).toContain("--read-only");
-    expect(validate.run).toContain("--user 999:999");
-    expect(validate.run).toContain("test -x /usr/bin/dos2unix");
-    expect(validate.run).toContain("dos2unix --version");
-    expect(validateIndex).toBeGreaterThan(buildIndex);
-    expect(validateIndex).toBeLessThan(exportIndex);
-  });
-
   it("builds and exercises every shipped agent from an exact PR image before merge (#7744)", () => {
     const workflow = readWorkflow("managed-images.yaml");
     const reviewedAudit = managedPrReviewedAudit(workflow);

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -144,6 +144,10 @@ describe("Vitest opaque-input watch triggers", () => {
       "test/managed-image-publication-workflow.test.ts",
       "test/dcode-base-image-workflow.test.ts",
     ]);
+    expect(triggeredBy(".github/actions/build-base-image-platform/action.yaml")).toEqual([
+      "test/dcode-base-image-workflow.test.ts",
+      "test/openclaw-dependency-review.test.ts",
+    ]);
     expect(triggeredBy("scripts/checks/validate-managed-base-index.sh")).toEqual([
       "test/validate-managed-base-index.test.ts",
     ]);


### PR DESCRIPTION
## Summary

Restore the checks that currently fail on `main`. This change preserves Shields behavior while reducing its lint complexity, gives the coverage-instrumented setup enough time, and moves the Deep Agents Code image contract below the repository's test-file limit.

The regressions entered through #8821, #8830, and #8937 after those PRs passed against stale base commits.

## Changes

- Extract incomplete Shields-down posture persistence from `shieldsDownWithoutHostLock` without changing rollback state transitions or recovery output.
- Allow 30 seconds for the OpenClaw transition setup hook under V8 coverage.
- Move the existing Deep Agents Code `dos2unix` contract into its focused base-image test and protect its digest, executable, and step-order requirements.
- Select the DCode and OpenClaw contract tests when the base-image platform action changes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the existing Shields unsafe-path rollback tests protect the extracted state transitions, and the moved Deep Agents Code workflow contract protects its existing digest, executable, security-option, and step-order requirements.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this PR changes internal structure, test organization, a test timeout, and local test selection; product behavior and user-visible text are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: the fail-closed Shields rollback state transitions and unchanged recovery output were reviewed against the security rubric; all seven unsafe-path rollback tests pass under coverage.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit `5bf13daab` changes no public API, CLI command, configuration, UI, runtime default, user-visible error, image content, publication behavior, or supported workflow. Existing documentation already covers `dos2unix` in the Deep Agents Code image.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5bf13daab -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 12 OpenClaw top-config tests and 7 Hermes unsafe-path tests pass under V8 coverage; 26 managed-image and watch-trigger tests pass; `npm run test-size:check`, `npm run typecheck:cli`, and `npm run checks:repository` pass.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>
