### PR TITLE
feat(e2e): render the execution plan

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -236,11 +236,21 @@ Failed targets still write a manifest for diagnosis, and the existing artifact u
 The manifest is secret-free diagnostic evidence.
 It does not replace the workflow job result or the `Release qualification` release gate.
 
-Run the planner locally to inspect the complete default selection:
+Run the planner locally to render the complete default selection as a Markdown table:
 
 ```bash
-npx tsx tools/e2e/workflow-plan.mts
+npx tsx tools/e2e/workflow-plan.mts --summary
 ```
+
+Add the existing `--jobs` or `--targets` selector to render a filtered plan:
+
+```bash
+npx tsx tools/e2e/workflow-plan.mts --summary --jobs hermes-e2e
+npx tsx tools/e2e/workflow-plan.mts --summary --targets ubuntu-repo-cloud-openclaw
+```
+
+The command uses the GitHub Actions summary renderer.
+The table includes the typed registry matrix, shared test matrix, three catalogue profile matrices, and retained workflow jobs.
 
 ## Inactive Windows MXC OpenClaw qualification
 
@@ -821,6 +831,29 @@ If no E2E target owns a changed file, `Relevant E2E` reports a successful no-op.
 Otherwise, `Relevant E2E` requires every selected workflow job to pass.
 The central workflow skips the Jetson nvmap and DGX Spark llama.cpp jobs on push.
 The central workflow has no scheduled trigger.
+
+The workflow planner connects each trusted input to its execution and evidence boundary:
+
+```mermaid
+flowchart LR
+  push["main push diff"] --> planner["Workflow planner"]
+  manual["Exact-SHA full manual dispatch<br/>or manual selectors"] --> planner
+  planner --> registry["Typed registry matrix"]
+  planner --> shared["Shared test matrix"]
+  planner --> profiles["Three catalogue profile matrices"]
+  planner --> retained["Retained workflow jobs"]
+  profiles --> reusable["Reusable profile workflow"]
+  registry --> dedicated["Dedicated GitHub Actions jobs"]
+  shared --> dedicated
+  retained --> dedicated
+  reusable --> evidence["Diagnostic product evidence"]
+  dedicated --> evidence
+  reusable -->|"push job results"| relevant["Relevant E2E"]
+  dedicated -->|"push job results"| relevant
+  reusable -->|"full manual job results"| release["Release qualification"]
+  dedicated -->|"full manual job results"| release
+  release --> gate["Release gate"]
+```
 
 Selected jobs retain their runner, credential, evidence, and cleanup boundaries.
 A main push can queue repository-owned GPU runners or create external resources when a selected target requires them.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -249,7 +249,14 @@ npx tsx tools/e2e/workflow-plan.mts --summary --jobs hermes-e2e
 npx tsx tools/e2e/workflow-plan.mts --summary --targets ubuntu-repo-cloud-openclaw
 ```
 
-The command uses the GitHub Actions summary renderer.
+The command renders a Markdown summary to standard output.
+To publish that output in a GitHub Actions job, append it to `$GITHUB_STEP_SUMMARY`:
+
+```bash
+npx tsx tools/e2e/workflow-plan.mts --summary >> "$GITHUB_STEP_SUMMARY"
+```
+
+The workflow's `--ci-output` mode uses the same renderer for its job summary.
 The table includes the typed registry matrix, shared test matrix, three catalogue profile matrices, and retained workflow jobs.
 
 ## Inactive Windows MXC OpenClaw qualification

--- a/test/e2e/support/workflow-plan.test.ts
+++ b/test/e2e/support/workflow-plan.test.ts
@@ -597,6 +597,38 @@ describe("E2E workflow plan", () => {
     expect(output).toBe(`${JSON.stringify(parsed)}\n`);
   });
 
+  it("renders the selected matrix and retained jobs as a readable plan", () => {
+    const plan = buildE2eWorkflowPlan({ jobs: "hermes-e2e" });
+    let output = "";
+    const write = process.stdout.write;
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      output += chunk.toString();
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      runE2eWorkflowPlanCli(["--summary", "--jobs", "hermes-e2e"]);
+    } finally {
+      process.stdout.write = write;
+    }
+
+    expect(output).toBe(renderE2eWorkflowPlanSummary(plan));
+    expect(output).toContain("| Target or job | Execution | Runner |");
+    expect(output).toContain("| `hermes-e2e` | retained workflow job | declared by job |");
+
+    const completeSummary = renderE2eWorkflowPlanSummary(buildE2eWorkflowPlan());
+    expect(completeSummary).toContain("| typed registry |");
+    expect(completeSummary).toContain("| shared E2E job |");
+    expect(completeSummary).toContain("| `standard` profile |");
+    expect(completeSummary).toContain("| `nvidia-api` profile |");
+    expect(completeSummary).toContain("| `nvidia-inference` profile |");
+  });
+
+  it("keeps CI and readable summary output modes separate", () => {
+    expect(() => runE2eWorkflowPlanCli(["--ci-output", "--summary"])).toThrow(
+      "--ci-output and --summary cannot be combined",
+    );
+  });
+
   it("reports CLI failures as workflow annotations", () => {
     const result = spawnSync(
       TSX,

--- a/test/e2e/support/workflow-plan.test.ts
+++ b/test/e2e/support/workflow-plan.test.ts
@@ -598,29 +598,39 @@ describe("E2E workflow plan", () => {
   });
 
   it("renders the selected matrix and retained jobs as a readable plan", () => {
-    const plan = buildE2eWorkflowPlan({ jobs: "hermes-e2e" });
-    let output = "";
-    const write = process.stdout.write;
-    process.stdout.write = ((chunk: string | Uint8Array) => {
-      output += chunk.toString();
-      return true;
-    }) as typeof process.stdout.write;
-    try {
-      runE2eWorkflowPlanCli(["--summary", "--jobs", "hermes-e2e"]);
-    } finally {
-      process.stdout.write = write;
-    }
+    const filtered = spawnSync(TSX, [PLANNER_CLI, "--summary", "--jobs", "hermes-e2e"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      timeout: 30_000,
+    });
 
-    expect(output).toBe(renderE2eWorkflowPlanSummary(plan));
-    expect(output).toContain("| Target or job | Execution | Runner |");
-    expect(output).toContain("| `hermes-e2e` | retained workflow job | declared by job |");
+    expect(filtered.status, filtered.stderr).toBe(0);
+    expect(filtered.stdout).toBe(`## E2E Execution Plan
 
-    const completeSummary = renderE2eWorkflowPlanSummary(buildE2eWorkflowPlan());
-    expect(completeSummary).toContain("| typed registry |");
-    expect(completeSummary).toContain("| shared E2E job |");
-    expect(completeSummary).toContain("| `standard` profile |");
-    expect(completeSummary).toContain("| `nvidia-api` profile |");
-    expect(completeSummary).toContain("| `nvidia-inference` profile |");
+| Target or job | Execution | Runner |
+| --- | --- | --- |
+| \`hermes-e2e\` | retained workflow job | declared by job |
+`);
+
+    const complete = spawnSync(TSX, [PLANNER_CLI, "--summary"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+
+    expect(complete.status, complete.stderr).toBe(0);
+    expect(complete.stdout).toContain(
+      "| `cloud-onboard` | retained workflow job | declared by job |",
+    );
+    expect(complete.stdout).toContain(
+      "| `ubuntu-repo-cloud-openclaw` | typed registry | `ubuntu-latest` |",
+    );
+    expect(complete.stdout).toContain("| shared E2E job | `ubuntu-latest` |");
+    expect(complete.stdout).toContain("| `channels-add-remove` | `standard` profile |");
+    expect(complete.stdout).toContain(
+      "| `model-router-provider-routed-inference` | `nvidia-api` profile |",
+    );
+    expect(complete.stdout).toContain("| `cloud-inference` | `nvidia-inference` profile |");
   });
 
   it("keeps CI and readable summary output modes separate", () => {

--- a/tools/e2e/workflow-plan.mts
+++ b/tools/e2e/workflow-plan.mts
@@ -52,6 +52,7 @@ type WorkflowPlanOptions = {
 
 type WorkflowPlanCliOptions = WorkflowPlanSelectors & {
   ciOutput: boolean;
+  summary: boolean;
 };
 
 type TrustedControllerSelectorMap = {
@@ -558,9 +559,12 @@ export function renderE2eWorkflowPlanSummary(plan: E2eWorkflowPlan): string {
   const lines = [
     "## E2E Execution Plan",
     "",
-    "| Test | Execution | Runner |",
+    "| Target or job | Execution | Runner |",
     "| --- | --- | --- |",
   ];
+  for (const job of plan.selectedJobs) {
+    lines.push(`| \`${job}\` | retained workflow job | declared by job |`);
+  }
   for (const row of plan.matrix) {
     lines.push(`| \`${row.id}\` | typed registry | \`${row.runner}\` |`);
   }
@@ -626,11 +630,15 @@ export function writeE2eWorkflowPlanCiOutput(
 }
 
 function parseArgs(argv: readonly string[]): WorkflowPlanCliOptions {
-  const options: WorkflowPlanCliOptions = { ciOutput: false };
+  const options: WorkflowPlanCliOptions = { ciOutput: false, summary: false };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--ci-output") {
       options.ciOutput = true;
+      continue;
+    }
+    if (arg === "--summary") {
+      options.summary = true;
       continue;
     }
     if (arg !== "--jobs" && arg !== "--targets") {
@@ -641,6 +649,9 @@ function parseArgs(argv: readonly string[]): WorkflowPlanCliOptions {
     if (arg === "--jobs") options.jobs = value;
     else options.targets = value;
     index += 1;
+  }
+  if (options.ciOutput && options.summary) {
+    throw new Error("--ci-output and --summary cannot be combined");
   }
   return options;
 }
@@ -654,7 +665,10 @@ export function runE2eWorkflowPlanCli(argv = process.argv.slice(2)): void {
     );
     return;
   }
-  process.stdout.write(`${JSON.stringify(buildE2eWorkflowPlan(options))}\n`);
+  const plan = buildE2eWorkflowPlan(options);
+  process.stdout.write(
+    options.summary ? renderE2eWorkflowPlanSummary(plan) : `${JSON.stringify(plan)}\n`,
+  );
 }
 
 const invokedFile = process.argv[1] ? path.resolve(process.argv[1]) : "";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Maintainers could inspect the E2E planner as JSON, while the readable GitHub Actions summary omitted retained workflow jobs. This change adds a readable planner view that covers every execution category and documents the path from trusted inputs to evidence, aggregate checks, and the release gate.

## Related Issue

Refs #7912

## Changes

- Add `--summary` to `tools/e2e/workflow-plan.mts` and keep it mutually exclusive with the GitHub-only `--ci-output` mode.
- Include retained workflow jobs in the same summary renderer that already owns typed registry, shared-test, and catalogue profile rows.
- Document default and filtered plan commands plus the main-push and full-manual execution flow.
- Protect the readable view, all execution categories, and output-mode boundary in the focused planner contract.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/README.md`; documents the planner's Markdown stdout mode, selector-filtered commands, GitHub Actions summary append command, all rendered execution categories, and the push/full-manual evidence and release-gate flow. Reviewed `tools/e2e/workflow-plan.mts` and `test/e2e/support/workflow-plan.test.ts` against those claims.
- Agent: `Codex Desktop`
<!-- docs-review-head-sha: 011b2d0cc -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/workflow-plan.test.ts` passed 57/57 after updating to current `main`; both documented filtered commands exit 0; Markdown lint, plugin and CLI builds, and CLI type-check pass.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run locally by maintainer direction; GitHub CI owns the broad suite.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a readable workflow-plan summary mode with the `--summary` option.
  * Summaries show selected jobs, registry targets, shared jobs, matrix entries, catalogue profiles, retained jobs, and formatted output.
  * Added documentation, including a Mermaid diagram covering planning, evidence generation, result checks, and release gating.

* **Bug Fixes**
  * Prevented incompatible use of `--summary` and `--ci-output` together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->