### PR TITLE
fix(ci): refresh staging QA source for libssh2

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -111,8 +111,8 @@ jobs:
       CANDIDATE_SHA: ${{ github.event.pull_request.head.sha }}
       # Retains the reviewed discovery-permission repair and the current
       # managed-image security inventory. The previous staging source pinned
-      # Vim 9.2.0782, which cannot satisfy the candidate's 9.2.0858 contract.
-      STAGING_QA_SOURCE_SHA: af2a73f0d6ce8f08a2975560f376470387c535d0
+      # libssh2 nemoclaw1, which cannot satisfy the candidate's nemoclaw2 contract.
+      STAGING_QA_SOURCE_SHA: ce96811ddb418ad01c040521a1fe912b5bcb405e
       STAGING_QA_BASE_IMAGE: nemoclaw-deepagents-code-base:staging-31396519688
       STAGING_QA_FINAL_IMAGE: nemoclaw-managed-pr/langchain-deepagents-code-staging-qa
     steps:

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -725,7 +725,7 @@ describe("complete managed-image publication workflow", () => {
     expect(qaBuilder.permissions).toEqual({ contents: "read" });
     expect(qaBuilder.env).toMatchObject({
       CANDIDATE_SHA: "${{ github.event.pull_request.head.sha }}",
-      STAGING_QA_SOURCE_SHA: "af2a73f0d6ce8f08a2975560f376470387c535d0",
+      STAGING_QA_SOURCE_SHA: "ce96811ddb418ad01c040521a1fe912b5bcb405e",
       STAGING_QA_BASE_IMAGE: "nemoclaw-deepagents-code-base:staging-31396519688",
     });
     expect(qaBuilder.env).not.toHaveProperty("STAGING_PRODUCER_SHA");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Refresh the Deep Agents Code staging QA source from `af2a73f…` to PR #8941's merge commit, `ce96811…`. The rebuilt staging base now contains the `libssh2` `nemoclaw2` inventory required by current candidate images, so unrelated PRs such as #8903 no longer inherit this mismatch from `main`.

## Changes

- Pin `STAGING_QA_SOURCE_SHA` to `ce96811ddb418ad01c040521a1fe912b5bcb405e`.
- Update the workflow comment and exact integration assertion for the `nemoclaw2` contract.
- Root cause: PR #8941 advanced the managed-image `libssh2` contract, while the staging QA source remained on the earlier `nemoclaw1` inventory.
- Detection gap: the source test enforced the recorded SHA but could not establish image compatibility. The staging QA job detected the package mismatch and remains the integration evidence for this repair.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change only refreshes an internal staging QA source pin and its exact workflow assertion. It changes no CLI, public configuration, API, default, or supported user workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed commit `7445324bf` across all nine security categories. The full commit SHA remains immutable, checkout credentials remain disabled, permissions remain `contents: read`, and identity failures still stop the job.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Independent review: PASS — the internal staging comment identifies the exact libssh2 inventory mismatch and the workflow assertion pins the same reviewed source; no supported user-facing behavior changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7445324bf64b21f057631d204b6a5d3cd1602287 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/managed-image-publication-workflow.test.ts` passed 19 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this focused workflow pin update.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the staging quality-assurance workflow to use the latest approved source revision and description.
  * Improved consistency between staging validation settings and the intended candidate configuration.

* **Tests**
  * Updated workflow validation expectations to reflect the revised staging source revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
