### PR TITLE
fix(policy): drop missing python3.11 binary allowlist

### DIFF
--- a/nemoclaw-blueprint/policies/presets/nous-audio.yaml
+++ b/nemoclaw-blueprint/policies/presets/nous-audio.yaml
@@ -35,8 +35,7 @@ network_policies:
           - allow: { method: DELETE, path: "/openai-audio/**" }
     binaries:
       - { path: /usr/local/bin/hermes }
-      - { path: /usr/bin/python3 }
-      - { path: /usr/bin/python3.11 }
+      - { path: /usr/bin/python3* }
       - { path: /opt/hermes/.venv/bin/python }
       - { path: /usr/bin/curl }
       - { path: /usr/local/bin/curl }

--- a/nemoclaw-blueprint/policies/presets/nous-browser.yaml
+++ b/nemoclaw-blueprint/policies/presets/nous-browser.yaml
@@ -121,8 +121,7 @@ network_policies:
       - { path: /sandbox/.hermes/node/bin/node* }
       - { path: /sandbox/.hermes/node/bin/npx* }
       - { path: /sandbox/.hermes/node/bin/agent-browser* }
-      - { path: /usr/bin/python3 }
-      - { path: /usr/bin/python3.11 }
+      - { path: /usr/bin/python3* }
       - { path: /opt/hermes/.venv/bin/python }
       - { path: /usr/bin/curl }
       - { path: /usr/local/bin/curl }

--- a/nemoclaw-blueprint/policies/presets/nous-code.yaml
+++ b/nemoclaw-blueprint/policies/presets/nous-code.yaml
@@ -35,8 +35,7 @@ network_policies:
           - allow: { method: DELETE, path: "/modal/**" }
     binaries:
       - { path: /usr/local/bin/hermes }
-      - { path: /usr/bin/python3 }
-      - { path: /usr/bin/python3.11 }
+      - { path: /usr/bin/python3* }
       - { path: /opt/hermes/.venv/bin/python }
       - { path: /usr/bin/curl }
       - { path: /usr/local/bin/curl }

--- a/nemoclaw-blueprint/policies/presets/nous-image.yaml
+++ b/nemoclaw-blueprint/policies/presets/nous-image.yaml
@@ -35,8 +35,7 @@ network_policies:
           - allow: { method: DELETE, path: "/fal-queue/**" }
     binaries:
       - { path: /usr/local/bin/hermes }
-      - { path: /usr/bin/python3 }
-      - { path: /usr/bin/python3.11 }
+      - { path: /usr/bin/python3* }
       - { path: /opt/hermes/.venv/bin/python }
       - { path: /usr/bin/curl }
       - { path: /usr/local/bin/curl }

--- a/nemoclaw-blueprint/policies/presets/nous-web.yaml
+++ b/nemoclaw-blueprint/policies/presets/nous-web.yaml
@@ -35,8 +35,7 @@ network_policies:
           - allow: { method: DELETE, path: "/firecrawl/**" }
     binaries:
       - { path: /usr/local/bin/hermes }
-      - { path: /usr/bin/python3 }
-      - { path: /usr/bin/python3.11 }
+      - { path: /usr/bin/python3* }
       - { path: /opt/hermes/.venv/bin/python }
       - { path: /usr/bin/curl }
       - { path: /usr/local/bin/curl }

--- a/nemoclaw-blueprint/policies/presets/public-reference.yaml
+++ b/nemoclaw-blueprint/policies/presets/public-reference.yaml
@@ -85,7 +85,6 @@ network_policies:
       - { path: /usr/bin/node }
       - { path: /usr/local/bin/hermes }
       - { path: /opt/hermes/.venv/bin/python }
-      - { path: /usr/bin/python3 }
-      - { path: /usr/bin/python3.11 }
+      - { path: /usr/bin/python3* }
       - { path: /usr/bin/curl }
       - { path: /usr/local/bin/curl }

--- a/nemoclaw-blueprint/policies/presets/weather.yaml
+++ b/nemoclaw-blueprint/policies/presets/weather.yaml
@@ -85,7 +85,6 @@ network_policies:
       - { path: /usr/bin/node }
       - { path: /usr/local/bin/hermes }
       - { path: /opt/hermes/.venv/bin/python }
-      - { path: /usr/bin/python3 }
-      - { path: /usr/bin/python3.11 }
+      - { path: /usr/bin/python3* }
       - { path: /usr/bin/curl }
       - { path: /usr/local/bin/curl }


### PR DESCRIPTION
## Summary

Seven policy presets listed `/usr/bin/python3.11` in their `binaries` allow-list, a path the sandbox image has never shipped. OpenShell logs a symlink-resolution warning for each missing path on every policy reload of an applied preset. This replaces the stale pair with the `/usr/bin/python3*` glob already used elsewhere in the repository, so the entry matches the resolved interpreter on both the canonical and the degraded literal-matching path.

## Related Issue

Fixes #8955

## Changes

- Replace `/usr/bin/python3` and `/usr/bin/python3.11` with `/usr/bin/python3*` in the `binaries` list of `nous-audio`, `nous-browser`, `nous-code`, `nous-image`, `nous-web`, `public-reference`, and `weather`.

The glob form is the existing convention in this repository: `pypi.yaml` and `tavily.yaml` already use `/usr/bin/python3*` and `/opt/venv/bin/python3*`, and `src/lib/actions/sandbox/mcp-bridge-policy-render.ts` uses it for the `hermes-config` adapter with the rationale in-line — `/proc/<pid>/exe` resolves the venv interpreter to the system Python binary after the console-script wrapper execs it.

No abstraction, configuration, fallback, migration, or compatibility path is added.

This PR intentionally excludes the eighth occurrence in `agents/hermes/policy-additions.yaml` (`managed_inference`), which is outside this issue's preset scope and is pinned by an assertion in `test/validate-blueprint.test.ts`. It is described in a comment on #8955, pending maintainer direction on whether to fold it in here or split it.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test/validate-blueprint.test.ts` owns the preset `binaries` contract and asserts `pypi` already carries `/usr/bin/python3*`. None of its `toEqual` assertions cover the seven presets changed here, so the existing suite verifies the surrounding contract is unaffected. #8955 also proposes generalizing the hardcoded `not.toContain("/usr/local/bin/claude")` guard from #2748 into an invariant over every preset's `binaries`; that is held for maintainer direction rather than bundled here.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: No user-facing behavior or documented surface changes. The allow-list entry removed was unreachable in the shipped image, and no documentation references it.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Requesting maintainer review. Contributor-side evidence: the removed path is absent from the shipped image (`ls -la /usr/bin/python3*` on the pinned base image digest shows only `python3 -> python3.13` and `python3.13`); the replacement is narrower in intent than a new host or method grant, adds no endpoint, method, path, or host; and the three policy suites pass unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation paths changed. The diff is limited to seven `nemoclaw-blueprint/policies/presets/*.yaml` `binaries` entries; no prose, no code samples, and no referenced doc page describes the removed path.
- Agent:
<!-- docs-review-head-sha: -->
<!-- docs-review-agents-blob-sha: -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — all hooks ran on commit `d7cc0ffba`, including `gitleaks (secret scan)`, `check yaml`, `detect private key`, and `commitlint`.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/validate-blueprint.test.ts test/policies.test.ts test/policy-tiers-onboard.test.ts` — 3 files passed, 133 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable. The change touches no runtime, test-harness, or repo-wide validation surface.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: XuanWu <xuwu@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated supported Python 3 executable paths across audio, browser, coding, image, web, reference, and weather presets.
  * Presets now recognize compatible Python 3 versions automatically, improving consistency and reducing configuration gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->