### PR TITLE
test(e2e): cover shared job selector mapping

### DIFF
--- a/test/e2e/support/e2e-workflow.test.ts
+++ b/test/e2e/support/e2e-workflow.test.ts
@@ -630,6 +630,30 @@ describe("e2e workflow boundary", () => {
     },
   );
 
+  it("maps a credential-free target selector to shared-e2e and its test row", () => {
+    expect(
+      evaluateE2eWorkflowDispatchSelectors({
+        targets: "vllm-docker-storage",
+      }),
+    ).toMatchObject({
+      valid: true,
+      liveTargetsRun: false,
+      selectedFreeStandingJobs: ["vllm-docker-storage"],
+      registryTargets: [],
+    });
+    expect(buildE2eWorkflowPlan({ targets: "vllm-docker-storage" })).toMatchObject({
+      matrix: [],
+      testMatrix: [
+        {
+          id: "vllm-docker-storage",
+          file: "test/vllm-docker-storage.test.ts",
+          project: "integration",
+        },
+      ],
+      selectedJobs: ["shared-e2e"],
+    });
+  });
+
   it("rejects malformed free-standing workflow metadata before matrix generation", {
     timeout: 60_000,
   }, () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

#8961 replaced dedicated E2E jobs with catalogue and profile execution, but its selector test covered only an identity target-to-job mapping. This follow-up verifies that `vllm-docker-storage` remains target-based during selector evaluation and schedules the `shared-e2e` workflow job with its integration test row.

## Related Issue

Refs #8961
Refs #7912

## Changes

- Add one focused E2E-support assertion for `vllm-docker-storage`.
- Verify that selector evaluation returns the target ID and planning schedules `shared-e2e` with the exact integration test row.
- Add no abstraction, configuration, fallback, migration, or compatibility path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change adds regression coverage for existing behavior introduced and documented by #8961; no product behavior or documented surface changes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Test-only regression coverage for existing selector-to-`shared-e2e` planning behavior; no behavior or documented surface changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 75acbb786 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/e2e-workflow.test.ts --reporter=dot` passed 34 tests.
- [ ] Applicable broad gate passed — Not applicable to this focused test-only change; GitHub CI owns the broad suite.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the `vllm-docker-storage` workflow.
  * Verifies target selection, job mapping, integration test matrix generation, and shared job selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->