### PR TITLE
ci(installer): trust Homebrew lifecycle boundary

### DIFF
--- a/scripts/checks/extract-installer-pins.mts
+++ b/scripts/checks/extract-installer-pins.mts
@@ -51,12 +51,13 @@ const MAX_INSTALLER_INPUT_BYTES = 1024 * 1024;
 // only in a prerequisite trust-anchor PR that keeps the currently selected
 // release; the later pin PR may then change release data without authorizing
 // any operational installer change. A mismatch reports the candidate hash.
-// #7555 completes the Homebrew trust transition anchored by #7601. Keep only
-// the reviewed successor: it trusts a checksum-verified stable formula,
-// revokes that temporary trust after success or failure, and removes inherited
-// trust around an unverified dev install.
+// #7739 extends the Homebrew trust transition into one operation boundary used
+// by installation and later lifecycle calls. The first hash preserves the
+// current installer while this prerequisite lands; the second pre-authorizes
+// the reviewed successor for the implementation PR.
 const TRUSTED_INSTALLER_TEMPLATE_SHA256_ALLOWLIST = [
   "0fa737a64cf2a7a6a437dc5f203dad81f66f191dc316214c2f343f762ad9b0a5",
+  "6226811887cc5c1a721a96fbf062f5ce5f75b09d3a8a1de49ed4dadc3236eb0c",
 ] as const;
 const TRUSTED_BREV_TEMPLATE_SHA256_ALLOWLIST = [
   "c0a4ddf25a02a9fe02b2df53a60942ea887610f04d4ce16a121b6e79a5aeff1a",


### PR DESCRIPTION
## Summary

- preserve the currently trusted installer template while the prerequisite lands
- pre-authorize the reviewed Homebrew lifecycle-operation template from #7739
- keep the selected OpenShell release and all installer pin data unchanged

## Validation

- `node --experimental-strip-types scripts/checks/extract-installer-pins.mts --blueprint nemoclaw-blueprint/blueprint.yaml --installer scripts/install-openshell.sh --brev-installer scripts/brev-launchable-ci-cpu.sh --format tsv`
- `npx vitest run test/installer-sandbox-build-trust.test.ts` (12 passed)
- `npx biome check scripts/checks/extract-installer-pins.mts`

## Dependency

This is the prerequisite trust-anchor change required by the base-trusted installer hash workflow before #7739 can merge its operational installer update.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated installer verification to recognize an additional pre-authorized SHA-256 hash.
  * Preserved support for both the current installer template and its reviewed successor during the Homebrew trust transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->