### PR TITLE
fix(install): explain dev setup heap exhaustion

### DIFF
--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -244,37 +244,6 @@ print_node_heap_oom_guidance() {
   printf 'Next: %s\n' "${remediation}" >&2
 }
 
-check_quiet_command() {
-  local label="$1"
-  local remediation="$2"
-  local classification command_status matcher_status pipeline_result
-  local -a pipeline_status
-  shift 2
-
-  # Drain the complete stream and retain one classification word. This bounds
-  # shell memory and keeps command output out of the doctor report.
-  pipeline_result="$(
-    "$@" 2>&1 | awk '
-      index($0, "JavaScript heap out of memory") { found = 1 }
-      END { printf "%s", found ? "heap" : "other" }
-    '
-    pipeline_status=("${PIPESTATUS[@]}")
-    printf '|%s|%s' "${pipeline_status[0]}" "${pipeline_status[1]}"
-  )"
-  IFS='|' read -r classification command_status matcher_status <<<"${pipeline_result}"
-
-  if [ "${command_status}" = "0" ] && [ "${matcher_status}" = "0" ]; then
-    pass "${label}"
-  elif [ "${classification}" = "heap" ] && [ "${matcher_status}" = "0" ]; then
-    # Node.js derives its default old-space limit from host memory, so this
-    # reports the host size rather than a fault in the checked sources.
-    fail "${label}: ran out of Node.js heap" \
-      "Raise the limit, then rerun: export NODE_OPTIONS=--max-old-space-size=5120"
-  else
-    fail "${label}: failed" "${remediation}"
-  fi
-}
-
 check_quiet_command_with_heap_hint() {
   local label="$1"
   local remediation="$2"
@@ -379,7 +348,10 @@ run_setup_step_with_heap_hint() {
   shift 2
 
   printf '\n==> %s\n' "${label}"
-  output_file="$(mktemp "${TMPDIR:-/tmp}/nemoclaw-dev-setup.XXXXXX")" || return 1
+  output_file="$(mktemp "${TMPDIR:-/tmp}/nemoclaw-dev-setup.XXXXXX")" || {
+    printf 'Setup stopped while attempting: %s\n' "${label}" >&2
+    return 1
+  }
   if "$@" >"${output_file}" 2>&1; then
     rm -f "${output_file}"
     return 0

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -15,6 +15,8 @@ WARN_COUNT=0
 FAIL_COUNT=0
 OUTPUT_FORMAT="human"
 JSON_RESULTS=""
+NODE_HEAP_REMEDIATION_CLI="Run: NODE_OPTIONS=--max-old-space-size=5120 npm run typecheck:cli"
+NODE_HEAP_REMEDIATION_PLUGIN="Run: NODE_OPTIONS=--max-old-space-size=5120 npm --prefix nemoclaw run build"
 
 usage() {
   cat <<'EOF'
@@ -227,6 +229,21 @@ check_executable() {
   fi
 }
 
+is_node_heap_oom_output() {
+  local output_file="$1"
+
+  grep -Eq \
+    "JavaScript heap out of memory|Ineffective mark-compacts near heap limit|Allocation failed - JavaScript heap out of memory" \
+    "${output_file}" 2>/dev/null
+}
+
+print_node_heap_oom_guidance() {
+  local remediation="$1"
+
+  printf 'Node.js exhausted its V8 heap while running this type check.\n' >&2
+  printf 'Next: %s\n' "${remediation}" >&2
+}
+
 check_quiet_command() {
   local label="$1"
   local remediation="$2"
@@ -254,6 +271,29 @@ check_quiet_command() {
     fail "${label}: ran out of Node.js heap" \
       "Raise the limit, then rerun: export NODE_OPTIONS=--max-old-space-size=5120"
   else
+    fail "${label}: failed" "${remediation}"
+  fi
+}
+
+check_quiet_command_with_heap_hint() {
+  local label="$1"
+  local remediation="$2"
+  local heap_remediation="$3"
+  local output_file
+  shift 3
+
+  output_file="$(mktemp "${TMPDIR:-/tmp}/nemoclaw-dev-doctor.XXXXXX")" || {
+    fail "${label}: failed" "${remediation}"
+    return
+  }
+  if "$@" >"${output_file}" 2>&1; then
+    rm -f "${output_file}"
+    pass "${label}"
+  elif is_node_heap_oom_output "${output_file}"; then
+    rm -f "${output_file}"
+    fail "${label}: ran out of Node.js heap" "${heap_remediation}"
+  else
+    rm -f "${output_file}"
     fail "${label}: failed" "${remediation}"
   fi
 }
@@ -332,6 +372,28 @@ run_setup_step() {
   return 1
 }
 
+run_setup_step_with_heap_hint() {
+  local label="$1"
+  local heap_remediation="$2"
+  local output_file
+  shift 2
+
+  printf '\n==> %s\n' "${label}"
+  output_file="$(mktemp "${TMPDIR:-/tmp}/nemoclaw-dev-setup.XXXXXX")" || return 1
+  if "$@" >"${output_file}" 2>&1; then
+    rm -f "${output_file}"
+    return 0
+  fi
+  if is_node_heap_oom_output "${output_file}"; then
+    print_node_heap_oom_guidance "${heap_remediation}"
+  else
+    cat "${output_file}" >&2
+  fi
+  rm -f "${output_file}"
+  printf 'Setup stopped while attempting: %s\n' "${label}" >&2
+  return 1
+}
+
 repair_repository() {
   local setup_failed=0 hooks_path
 
@@ -382,8 +444,10 @@ repair_repository() {
   run_setup_step "Build the CLI" npm run build:cli || return 1
   run_setup_step "Build and type-check the plugin" npm --prefix nemoclaw run build || return 1
   # Keep the explicit checks aligned with the broader pre-push and CI contracts.
-  run_setup_step "Type-check the CLI" npm run typecheck:cli || return 1
-  run_setup_step "Type-check the plugin without emitting files" \
+  run_setup_step_with_heap_hint "Type-check the CLI" "${NODE_HEAP_REMEDIATION_CLI}" \
+    npm run typecheck:cli || return 1
+  run_setup_step_with_heap_hint "Type-check the plugin without emitting files" \
+    "${NODE_HEAP_REMEDIATION_PLUGIN}" \
     "${REPO_ROOT}/nemoclaw/node_modules/.bin/tsc" --noEmit \
     -p "${REPO_ROOT}/nemoclaw/tsconfig.json" || return 1
   run_setup_step "Install repository Git hooks" "${REPO_ROOT}/node_modules/.bin/prek" install || return 1
@@ -612,11 +676,13 @@ run_doctor() {
     "Run: cd nemoclaw && npm run build" "${REPO_ROOT}/nemoclaw/src" \
     "${REPO_ROOT}/nemoclaw/tsconfig.json" "${REPO_ROOT}/nemoclaw/package.json"
   if [ -x "${root_tsc}" ]; then
-    check_quiet_command "CLI type check" "Run: npm run typecheck:cli" \
+    check_quiet_command_with_heap_hint "CLI type check" "Run: npm run typecheck:cli" \
+      "${NODE_HEAP_REMEDIATION_CLI}" \
       "${root_tsc}" -p "${REPO_ROOT}/tsconfig.cli.json"
   fi
   if [ -x "${plugin_tsc}" ]; then
-    check_quiet_command "Plugin type check" "Run: npm --prefix nemoclaw run build" \
+    check_quiet_command_with_heap_hint "Plugin type check" "Run: npm --prefix nemoclaw run build" \
+      "${NODE_HEAP_REMEDIATION_PLUGIN}" \
       "${plugin_tsc}" --noEmit -p "${REPO_ROOT}/nemoclaw/tsconfig.json"
   fi
 

--- a/test/dev-setup-doctor.test.ts
+++ b/test/dev-setup-doctor.test.ts
@@ -522,6 +522,20 @@ describe("contributor environment doctor", () => {
     expect(result.output).not.toContain("Native stack trace");
   });
 
+  it("reports an actionable heap-limit remedy when the plugin type check exhausts V8 memory", () => {
+    const fixture = createFixture();
+    writeNodeHeapOomTool(path.join(fixture.repo, "nemoclaw", "node_modules", ".bin", "tsc"));
+
+    const result = runDoctor(fixture);
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain("Plugin type check: ran out of Node.js heap");
+    expect(result.output).toContain(
+      "Next: Run: NODE_OPTIONS=--max-old-space-size=5120 npm --prefix nemoclaw run build",
+    );
+    expect(result.output).not.toContain("Native stack trace");
+  });
+
   it("rejects a foreign PATH CLI even when the global package links to this checkout", () => {
     const fixture = createFixture();
     fs.rmSync(path.join(fixture.fakeBin, "nemoclaw"));
@@ -785,6 +799,37 @@ describe("contributor repository setup", () => {
     expect(result.output).not.toContain("Native stack trace");
     expect(result.output).not.toContain("Type-check the plugin without emitting files");
     expect(readCommandLog(fixture)).toContain("npm run typecheck:cli");
+  });
+
+  it("stops plugin type-check setup failures with a heap-limit remedy instead of the V8 stack", () => {
+    const fixture = createFixture();
+    writeNodeHeapOomTool(path.join(fixture.repo, "nemoclaw", "node_modules", ".bin", "tsc"));
+
+    const result = runSetup(fixture);
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain("Node.js exhausted its V8 heap while running this type check.");
+    expect(result.output).toContain(
+      "Next: Run: NODE_OPTIONS=--max-old-space-size=5120 npm --prefix nemoclaw run build",
+    );
+    expect(result.output).toContain(
+      "Setup stopped while attempting: Type-check the plugin without emitting files",
+    );
+    expect(result.output).not.toContain("Native stack trace");
+    const commands = readCommandLog(fixture);
+    expect(commands).toContain("npm --prefix nemoclaw run build");
+    expect(commands).not.toContain("prek install");
+  });
+
+  it("names the setup step when the heap-check output capture cannot be created", () => {
+    const fixture = createFixture();
+    writeTool(fixture.fakeBin, "mktemp", "exit 1");
+
+    const result = runSetup(fixture);
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain("Setup stopped while attempting: Type-check the CLI");
+    expect(result.output).not.toContain("Install repository Git hooks");
   });
 
   it.each([

--- a/test/dev-setup-doctor.test.ts
+++ b/test/dev-setup-doctor.test.ts
@@ -40,6 +40,18 @@ ${body}
   );
 }
 
+function writeNodeHeapOomTool(filePath: string): void {
+  writeExecutable(
+    filePath,
+    `#!/usr/bin/env bash
+printf '%s\\n' '<--- Last few GCs --->' >&2
+printf '%s\\n' 'FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory' >&2
+printf '%s\\n' '----- Native stack trace -----' >&2
+exit 134
+`,
+  );
+}
+
 function writeManagedCliShim(
   fakeBin: string,
   repo: string,
@@ -132,6 +144,11 @@ elif [ "\${FAKE_NPM_ROOT_INSTALL_FAIL:-}" = "1" ] && [ "\${1:-}" = "install" ]; 
   exit 1
 elif [ "\${FAKE_NPM_PLUGIN_INSTALL_FAIL:-}" = "1" ] && [ "\${1:-}" = "--prefix" ] && [ "\${2:-}" = "nemoclaw" ] && [ "\${3:-}" = "install" ]; then
   exit 1
+elif [ "\${FAKE_NPM_CLI_TYPECHECK_OOM:-}" = "1" ] && [ "\${1:-}" = "run" ] && [ "\${2:-}" = "typecheck:cli" ]; then
+  printf '%s\\n' '<--- Last few GCs --->' >&2
+  printf '%s\\n' 'FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory' >&2
+  printf '%s\\n' '----- Native stack trace -----' >&2
+  exit 134
 else
   echo "10.9.0"
 fi`,
@@ -491,6 +508,20 @@ describe("contributor environment doctor", () => {
     expect(readCommandLog(fixture)).not.toMatch(/^npm .* exec(?: |$)/m);
   });
 
+  it("reports an actionable heap-limit remedy when the CLI type check exhausts V8 memory", () => {
+    const fixture = createFixture();
+    writeNodeHeapOomTool(path.join(fixture.repo, "node_modules", ".bin", "tsc"));
+
+    const result = runDoctor(fixture);
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain("CLI type check: ran out of Node.js heap");
+    expect(result.output).toContain(
+      "Next: Run: NODE_OPTIONS=--max-old-space-size=5120 npm run typecheck:cli",
+    );
+    expect(result.output).not.toContain("Native stack trace");
+  });
+
   it("rejects a foreign PATH CLI even when the global package links to this checkout", () => {
     const fixture = createFixture();
     fs.rmSync(path.join(fixture.fakeBin, "nemoclaw"));
@@ -738,6 +769,22 @@ describe("contributor repository setup", () => {
     const commands = readCommandLog(fixture);
     expect(commands).toContain("npm install --include=dev --ignore-scripts");
     expect(commands).not.toContain("npm --prefix nemoclaw install");
+  });
+
+  it("stops CLI type-check setup failures with a heap-limit remedy instead of the V8 stack", () => {
+    const fixture = createFixture();
+
+    const result = runSetup(fixture, [], { FAKE_NPM_CLI_TYPECHECK_OOM: "1" });
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain("Node.js exhausted its V8 heap while running this type check.");
+    expect(result.output).toContain(
+      "Next: Run: NODE_OPTIONS=--max-old-space-size=5120 npm run typecheck:cli",
+    );
+    expect(result.output).toContain("Setup stopped while attempting: Type-check the CLI");
+    expect(result.output).not.toContain("Native stack trace");
+    expect(result.output).not.toContain("Type-check the plugin without emitting files");
+    expect(readCommandLog(fixture)).toContain("npm run typecheck:cli");
   });
 
   it.each([


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Contributor setup now recognizes Node.js heap exhaustion during TypeScript checks and gives a direct rerun command. Before this change, `dev:setup` and `dev:doctor` surfaced a generic type-check failure or a noisy V8 native stack; now the recognized heap-OOM case points contributors to `NODE_OPTIONS=--max-old-space-size=5120`.

## Related Issue

Fixes #8688

## Changes

- Add heap-OOM detection for the contributor setup and doctor type-check paths.
- Keep ordinary type-check failures on the existing remediation path so non-memory TypeScript errors are not hidden.
- Suppress the long V8 native stack only for the recognized heap-OOM signature.
- Add regression coverage for doctor output, large discarded type-check output, non-heap type-check failures, and mutating setup failure output.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change improves existing contributor setup and `--doctor` remediation output for a recognized failure mode; it adds no command, flag, default, configuration, API, policy schema, or new documented workflow.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `scripts/dev-setup.sh`, `test/dev-setup-doctor.test.ts`; existing contributor guidance to follow doctor remediation remains accurate.
- Agent: Codex CLI
<!-- docs-review-head-sha: 29eaae8c0 -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/dev-setup-doctor.test.ts` passed 43 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: danielpolimac <danielpolimac@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup and diagnostic checks to recognize Node.js heap out-of-memory failures for CLI and plugin checks.
  * Added actionable guidance for increasing the Node.js memory limit.
  * Suppressed unnecessary native stack output for clearer failure reports.
  * Setup now stops appropriately when memory-related checks fail and reports command details.

* **Tests**
  * Added coverage for heap exhaustion during CLI and plugin type checking in diagnostic and setup modes.
  * Added coverage for setup failures, skipped steps, and temporary-file errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->