### PR TITLE
fix(uninstall): scope Docker cleanup fields

### DIFF
--- a/src/lib/actions/uninstall/run-plan-docker-scope.test.ts
+++ b/src/lib/actions/uninstall/run-plan-docker-scope.test.ts
@@ -41,15 +41,19 @@ const PS_OUTPUT = [
   // leaves a randomly named container that only its image identifies.
   "c-probe nemoclaw-hermes-sandbox-base-local:image-abc nostalgic_curie",
   "c-openclaw ghcr.io/openclaw/openclaw:latest my-openclaw-test",
+  "c-registry registry.example.com/nemoclaw/tool:1 registry-tool",
   "c-unrelated redis:7 cache",
 ].join("\n");
 
 const IMAGES_OUTPUT = [
   "i-nemoclaw ghcr.io/nvidia/nemoclaw:test",
+  "i-managed ghcr.io/nvidia/nemoclaw/openclaw-sandbox:latest",
   // The gateway builds sandbox images under this repository, so the `openshell`
   // half of the filter selects real resources and must stay covered.
   "i-openshell openshell/sandbox-from:1780294581",
   "i-openclaw ghcr.io/openclaw/openclaw:latest",
+  "i-tag python:3.12-nemoclaw",
+  "i-registry registry.example.com/nemoclaw/tool:1",
   "i-unrelated redis:7",
 ].join("\n");
 
@@ -109,6 +113,7 @@ describe("uninstall Docker resource scope", () => {
     const calls = runWithDockerInventory();
 
     expect(calls).not.toContainEqual(["rm", "-f", "c-openclaw"]);
+    expect(calls).not.toContainEqual(["rm", "-f", "c-registry"]);
     expect(calls).not.toContainEqual(["rm", "-f", "c-unrelated"]);
   });
 
@@ -116,6 +121,8 @@ describe("uninstall Docker resource scope", () => {
     const calls = runWithDockerInventory();
 
     expect(calls).not.toContainEqual(["rmi", "-f", "i-openclaw"]);
+    expect(calls).not.toContainEqual(["rmi", "-f", "i-tag"]);
+    expect(calls).not.toContainEqual(["rmi", "-f", "i-registry"]);
     expect(calls).not.toContainEqual(["rmi", "-f", "i-unrelated"]);
   });
 
@@ -136,6 +143,7 @@ describe("uninstall Docker resource scope", () => {
     const calls = runWithDockerInventory();
 
     expect(calls).toContainEqual(["rmi", "-f", "i-nemoclaw"]);
+    expect(calls).toContainEqual(["rmi", "-f", "i-managed"]);
   });
 
   it("still removes gateway-built OpenShell sandbox images", () => {

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -1704,7 +1704,9 @@ function removeDockerContainers(runtime: UninstallRuntime, gatewayName?: string)
   });
   const ids = splitNonEmptyLines(result.stdout)
     .filter((line) => {
-      const name = line.trim().split(/\s+/).at(-1) ?? "";
+      const fields = dockerInventoryFields(line, 3);
+      const image = fields[1] ?? "";
+      const name = fields[2] ?? "";
       if (!gatewayName) {
         if (MANAGED_INFERENCE_CONTAINER_NAME_PATTERN.test(name)) {
           return false;
@@ -1713,12 +1715,11 @@ function removeDockerContainers(runtime: UninstallRuntime, gatewayName?: string)
         // `openshell-*` (cluster and sandbox) and `nemoclaw-*` (gateway compat
         // and managed inference), so that term only ever selected the separate
         // OpenClaw project's containers for `docker rm -f` (#8496).
-        // The whole `{{.ID}} {{.Image}} {{.Names}}` line is matched rather than
-        // the name alone. Probe containers that run with `--rm` and no
-        // `--name`, such as `hermesBaseImageSupportsMcp`, take a random Docker
-        // name. Their NemoClaw image reference is the only way to reclaim one
-        // that an interrupted run orphaned.
-        return /openshell-cluster|openshell|nemoclaw/i.test(line);
+        // Probe containers that run with `--rm` and no `--name`, such as
+        // `hermesBaseImageSupportsMcp`, take a random Docker name. Their
+        // NemoClaw image reference is the only way to reclaim one that an
+        // interrupted run orphaned.
+        return isOwnedDockerContainerName(name) || isOwnedDockerImageRepository(image);
       }
       return (
         name === `openshell-cluster-${gatewayName}` ||
@@ -1749,7 +1750,7 @@ function removeDockerImages(runtime: UninstallRuntime): void {
     // name, so the term only ever selected the separate OpenClaw project's
     // images — including any `ghcr.io/openclaw/*` pulled by an unrelated
     // workload — for `docker rmi -f` (#8496).
-    .filter((line) => /openshell|nemoclaw/i.test(line))
+    .filter((line) => isOwnedDockerImageRepository(dockerInventoryFields(line, 2)[1] ?? ""))
     .map((line) => line.split(/\s+/)[0]);
   if (ids.length === 0) {
     runtime.log(`No ${runtimeBranding(runtime).display}/OpenShell Docker images found`);
@@ -1760,6 +1761,31 @@ function removeDockerImages(runtime: UninstallRuntime): void {
       runtime.log(`Removed Docker image ${id}`);
     else runtime.warn(`Failed to remove Docker image ${id}`);
   }
+}
+
+function dockerInventoryFields(line: string, expectedFields: number): string[] {
+  return line.trim().split(/\s+/, expectedFields);
+}
+
+function dockerImageRepository(imageRef: string): string {
+  const withoutDigest = imageRef.split("@", 1)[0] ?? "";
+  const tagSeparator = withoutDigest.lastIndexOf(":");
+  if (tagSeparator === -1) return withoutDigest;
+  const slashSeparator = withoutDigest.lastIndexOf("/");
+  return tagSeparator > slashSeparator ? withoutDigest.slice(0, tagSeparator) : withoutDigest;
+}
+
+function isOwnedDockerContainerName(name: string): boolean {
+  return /^openshell-(?:cluster-)?/iu.test(name) || /^nemoclaw-/iu.test(name);
+}
+
+function isOwnedDockerImageRepository(imageRef: string): boolean {
+  const repository = dockerImageRepository(imageRef);
+  return (
+    /^nemoclaw-/iu.test(repository) ||
+    /^openshell\//iu.test(repository) ||
+    /^ghcr\.io\/nvidia\/nemoclaw(?:[/-]|$)/iu.test(repository)
+  );
 }
 
 function removeDockerVolume(name: string, runtime: UninstallRuntime): void {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Uninstall Docker cleanup now scopes broad cleanup to parsed Docker inventory fields instead of matching the whole output line. This keeps cleanup for NemoClaw/OpenShell-owned container names and image repositories, while avoiding third-party containers or images whose registry path or tag merely contains `nemoclaw`.

## Related Issue

Fixes #8496

## Changes

- Parse `docker ps` inventory into ID, image, and container-name fields before selecting broad uninstall cleanup targets.
- Parse `docker images` inventory into ID and image-reference fields, then match only the repository portion instead of tags or registry path substrings.
- Preserve existing owned cleanup for `openshell-*` and `nemoclaw-*` container names, `nemoclaw-*` local repositories, `openshell/*` sandbox images, and `ghcr.io/nvidia/nemoclaw` managed images.
- Add regression coverage for third-party registry paths and image tags that contain `nemoclaw` but are not NemoClaw-owned cleanup targets.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing uninstall docs already describe scoped NemoClaw/OpenShell Docker cleanup and preserving separate OpenClaw resources; this narrows implementation to that documented behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex reviewed the uninstall cleanup trust boundary; the change narrows Docker deletion predicates to parsed container names and image repositories, adds negative tests for third-party registry/tag over-matches, and does not add new deletion authority.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `src/lib/actions/uninstall/run-plan.ts`, `src/lib/actions/uninstall/run-plan-docker-scope.test.ts`; existing uninstall docs already describe scoped NemoClaw/OpenShell Docker cleanup and preservation of separate OpenClaw resources.
- Agent: Codex CLI
<!-- docs-review-head-sha: 533d6b68e -->
<!-- docs-review-agents-blob-sha: c4923a3e3 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/actions/uninstall/run-plan-docker-scope.test.ts src/lib/actions/uninstall/run-plan.test.ts` passed 46 tests; `npx tsc -p tsconfig.cli.json --noEmit` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: danielpolimac <danielpolimac@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker cleanup to target only resources managed by the application.
  * Preserved unrelated containers and images, including registry-backed and similarly named resources.
  * Added support for accurately identifying managed images across supported tags and digests.
* **Tests**
  * Expanded uninstall coverage for container and image ownership matching.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->