### PR TITLE
fix(onboard): tear down managed gateway when onboard aborts

### DIFF
--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -1215,6 +1215,17 @@ export async function verifyOnboardInferenceSmoke(options: any) {
   console.error(
     `  Upstream error: ${compactText(redact(probe.message || "unknown inference failure"))}`,
   );
+  // #8952: tear down an unowned managed gateway before fatal exit.
+  try {
+    const { teardownOrphanManagedGatewayOnAbort } =
+      require("../onboard/abort-gateway-teardown") as typeof import("../onboard/abort-gateway-teardown");
+    teardownOrphanManagedGatewayOnAbort();
+  } catch (error) {
+    // Helper never throws; this covers require/load failures only.
+    console.error(
+      `  Gateway teardown after onboard abort failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
   process.exit(1);
 }
 

--- a/src/lib/onboard/abort-gateway-teardown.test.ts
+++ b/src/lib/onboard/abort-gateway-teardown.test.ts
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  gatewayHasRegisteredSandbox,
+  teardownOrphanManagedGatewayOnAbort,
+} from "./abort-gateway-teardown";
+import { GatewayAuthorityError } from "./gateway-teardown-authority";
+
+describe("gatewayHasRegisteredSandbox", () => {
+  it("returns true when a sandbox is bound to the gateway name", () => {
+    const listSandboxes = () => ({
+      sandboxes: [{ name: "alpha", gatewayName: "nemoclaw-8814", gatewayPort: 8814 }],
+      defaultSandbox: "alpha" as string | null,
+    });
+    expect(gatewayHasRegisteredSandbox("nemoclaw-8814", listSandboxes)).toBe(true);
+  });
+
+  it("returns false when no sandbox owns the gateway", () => {
+    const listSandboxes = () => ({
+      sandboxes: [{ name: "alpha", gatewayName: "nemoclaw", gatewayPort: 8080 }],
+      defaultSandbox: "alpha" as string | null,
+    });
+    expect(gatewayHasRegisteredSandbox("nemoclaw-8814", listSandboxes)).toBe(false);
+  });
+
+  it("fails closed when a registry binding cannot be resolved", () => {
+    const listSandboxes = () => ({
+      sandboxes: [{ name: "alpha", gatewayName: "not-a-nemoclaw-gateway" }],
+      defaultSandbox: "alpha" as string | null,
+    });
+    expect(gatewayHasRegisteredSandbox("nemoclaw-8814", listSandboxes)).toBe(true);
+  });
+});
+
+describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
+  it("skips teardown when a sandbox still owns the gateway", () => {
+    const release = vi.fn();
+    const remove = vi.fn();
+    const attempted = teardownOrphanManagedGatewayOnAbort({
+      gatewayPort: 8814,
+      gatewayName: "nemoclaw-8814",
+      listSandboxes: () => ({
+        sandboxes: [{ name: "alpha", gatewayName: "nemoclaw-8814", gatewayPort: 8814 }],
+        defaultSandbox: "alpha",
+      }),
+      releaseManagedGatewayPort: release,
+      removeGatewayRegistration: remove,
+    });
+    expect(attempted).toBe(false);
+    expect(release).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it("skips teardown for an externally supervised gateway", () => {
+    const release = vi.fn();
+    const remove = vi.fn();
+    const log = vi.fn();
+    const attempted = teardownOrphanManagedGatewayOnAbort({
+      gatewayPort: 8814,
+      gatewayName: "nemoclaw-8814",
+      listSandboxes: () => ({ sandboxes: [], defaultSandbox: null }),
+      resolveAuthority: () => ({
+        gatewayName: "nemoclaw-8814",
+        gatewayPort: 8814,
+        mode: "externally-supervised",
+        source: "declared",
+        endpoint: "https://gateway.example",
+        stateDir: null,
+        supervisor: null,
+        requiredCapabilities: [],
+      }),
+      releaseManagedGatewayPort: release,
+      removeGatewayRegistration: remove,
+      log,
+    });
+    expect(attempted).toBe(false);
+    expect(release).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+    expect(log.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
+      "externally supervised",
+    );
+  });
+
+  it("skips teardown when authority cannot be revalidated", () => {
+    const release = vi.fn();
+    const remove = vi.fn();
+    const warn = vi.fn();
+    const attempted = teardownOrphanManagedGatewayOnAbort({
+      gatewayPort: 8814,
+      gatewayName: "nemoclaw-8814",
+      listSandboxes: () => ({ sandboxes: [], defaultSandbox: null }),
+      resolveAuthority: () => {
+        throw new GatewayAuthorityError("authority mismatch");
+      },
+      releaseManagedGatewayPort: release,
+      removeGatewayRegistration: remove,
+      warn,
+    });
+    expect(attempted).toBe(false);
+    expect(release).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+    expect(warn.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
+      "authority mismatch",
+    );
+  });
+
+  it("stops the host listener and removes registration when no sandbox owns the gateway", () => {
+    const release = vi.fn(() => ({
+      port: 8814,
+      released: true,
+      stopped: [4242],
+      remaining: [],
+      scanned: true,
+      skipped: false,
+    }));
+    const remove = vi.fn();
+    const log = vi.fn();
+    const attempted = teardownOrphanManagedGatewayOnAbort({
+      gatewayPort: 8814,
+      gatewayName: "nemoclaw-8814",
+      listSandboxes: () => ({ sandboxes: [], defaultSandbox: null }),
+      resolveAuthority: () => ({
+        gatewayName: "nemoclaw-8814",
+        gatewayPort: 8814,
+        mode: "nemoclaw-managed",
+        source: "standalone",
+        endpoint: null,
+        stateDir: null,
+        supervisor: null,
+        requiredCapabilities: [],
+      }),
+      releaseManagedGatewayPort: release,
+      removeGatewayRegistration: remove,
+      log,
+    });
+    expect(attempted).toBe(true);
+    expect(release).toHaveBeenCalledWith({ port: 8814 });
+    expect(remove).toHaveBeenCalledWith("nemoclaw-8814");
+    const output = log.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toContain("Onboard aborted before a sandbox was created");
+    expect(output).toContain("Released gateway port 8814");
+  });
+
+  it("warns and returns false when the sandbox registry cannot be read", () => {
+    const release = vi.fn();
+    const remove = vi.fn();
+    const warn = vi.fn();
+    const attempted = teardownOrphanManagedGatewayOnAbort({
+      gatewayPort: 8814,
+      gatewayName: "nemoclaw-8814",
+      listSandboxes: () => {
+        throw new Error("registry unreadable");
+      },
+      releaseManagedGatewayPort: release,
+      removeGatewayRegistration: remove,
+      warn,
+    });
+    expect(attempted).toBe(false);
+    expect(release).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+    expect(warn.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
+      "registry unreadable",
+    );
+  });
+});

--- a/src/lib/onboard/abort-gateway-teardown.test.ts
+++ b/src/lib/onboard/abort-gateway-teardown.test.ts
@@ -165,4 +165,70 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
       "registry unreadable",
     );
   });
+
+  it("keeps registration when listener release is not confirmed", () => {
+    const release = vi.fn(() => ({
+      port: 8814,
+      released: false,
+      stopped: [],
+      remaining: [4242],
+      scanned: true,
+      skipped: false,
+    }));
+    const remove = vi.fn();
+    const warn = vi.fn();
+    const attempted = teardownOrphanManagedGatewayOnAbort({
+      gatewayPort: 8814,
+      gatewayName: "nemoclaw-8814",
+      listSandboxes: () => ({ sandboxes: [], defaultSandbox: null }),
+      resolveAuthority: () => ({
+        gatewayName: "nemoclaw-8814",
+        gatewayPort: 8814,
+        mode: "nemoclaw-managed",
+        source: "standalone",
+        endpoint: null,
+        stateDir: null,
+        supervisor: null,
+        requiredCapabilities: [],
+      }),
+      releaseManagedGatewayPort: release,
+      removeGatewayRegistration: remove,
+      warn,
+    });
+    expect(attempted).toBe(true);
+    expect(release).toHaveBeenCalledWith({ port: 8814 });
+    expect(remove).not.toHaveBeenCalled();
+    expect(warn.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
+      "not confirmed released",
+    );
+  });
+
+  it("keeps registration when listener release throws", () => {
+    const release = vi.fn(() => {
+      throw new Error("stop boom");
+    });
+    const remove = vi.fn();
+    const warn = vi.fn();
+    const attempted = teardownOrphanManagedGatewayOnAbort({
+      gatewayPort: 8814,
+      gatewayName: "nemoclaw-8814",
+      listSandboxes: () => ({ sandboxes: [], defaultSandbox: null }),
+      resolveAuthority: () => ({
+        gatewayName: "nemoclaw-8814",
+        gatewayPort: 8814,
+        mode: "nemoclaw-managed",
+        source: "standalone",
+        endpoint: null,
+        stateDir: null,
+        supervisor: null,
+        requiredCapabilities: [],
+      }),
+      releaseManagedGatewayPort: release,
+      removeGatewayRegistration: remove,
+      warn,
+    });
+    expect(attempted).toBe(true);
+    expect(remove).not.toHaveBeenCalled();
+    expect(warn.mock.calls.map((call) => String(call[0])).join("\n")).toContain("stop boom");
+  });
 });

--- a/src/lib/onboard/abort-gateway-teardown.ts
+++ b/src/lib/onboard/abort-gateway-teardown.ts
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tear down an unowned NemoClaw-managed host gateway after onboard aborts
+ * once the gateway is up but before a sandbox is registered (#8952).
+ * The Docker-driver gateway inherits provider credentials from the onboard
+ * process environment, so the listener must not survive a failed run.
+ */
+
+import { GATEWAY_PORT } from "../core/ports";
+import { listSandboxes as listRegisteredSandboxes } from "../state/registry";
+import { releaseManagedGatewayPort } from "../tunnel/gateway-port-release";
+import { resolveGatewayName, resolveSandboxGatewayName } from "./gateway-binding";
+import { isExternallySupervised } from "./gateway-ownership";
+import {
+  GatewayAuthorityError,
+  resolveGatewayTeardownAuthority,
+} from "./gateway-teardown-authority";
+
+export type AbortGatewayTeardownDeps = {
+  env?: NodeJS.ProcessEnv;
+  gatewayPort?: number;
+  gatewayName?: string;
+  listSandboxes?: typeof listRegisteredSandboxes;
+  resolveAuthority?: typeof resolveGatewayTeardownAuthority;
+  releaseManagedGatewayPort?: typeof releaseManagedGatewayPort;
+  removeGatewayRegistration?: (gatewayName: string) => void;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+};
+
+function defaultRemoveGatewayRegistration(gatewayName: string): void {
+  // Lazy require keeps unit tests free of openshell binary resolution.
+  const runtime =
+    require("../adapters/openshell/runtime") as typeof import("../adapters/openshell/runtime");
+  runtime.runOpenshell(["gateway", "remove", gatewayName], {
+    ignoreError: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+/**
+ * True when any registered sandbox is bound to `gatewayName`. An unreadable
+ * binding fails closed (treat as owned) so abort teardown never guesses.
+ */
+export function gatewayHasRegisteredSandbox(
+  gatewayName: string,
+  listSandboxes: typeof listRegisteredSandboxes = listRegisteredSandboxes,
+): boolean {
+  for (const sandbox of listSandboxes().sandboxes) {
+    try {
+      if (resolveSandboxGatewayName(sandbox) === gatewayName) return true;
+    } catch {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Best-effort: stop the managed host gateway listener and remove its OpenShell
+ * registration when no sandbox still owns that gateway. Never throws — callers
+ * on fatal exit paths must still be able to `process.exit(1)` after a warn.
+ *
+ * @returns true when a teardown attempt ran (stop and/or remove).
+ */
+export function teardownOrphanManagedGatewayOnAbort(deps: AbortGatewayTeardownDeps = {}): boolean {
+  const log = deps.log ?? ((message: string) => console.error(message));
+  const warn = deps.warn ?? ((message: string) => console.error(message));
+
+  try {
+    const env = deps.env ?? process.env;
+    const port = deps.gatewayPort ?? GATEWAY_PORT;
+    const gatewayName = deps.gatewayName ?? resolveGatewayName(port);
+    const listSandboxes = deps.listSandboxes ?? listRegisteredSandboxes;
+    const resolveAuthority = deps.resolveAuthority ?? resolveGatewayTeardownAuthority;
+    const release = deps.releaseManagedGatewayPort ?? releaseManagedGatewayPort;
+    const removeRegistration = deps.removeGatewayRegistration ?? defaultRemoveGatewayRegistration;
+
+    if (gatewayHasRegisteredSandbox(gatewayName, listSandboxes)) {
+      return false;
+    }
+
+    try {
+      const owner = resolveAuthority({ gatewayName, gatewayPort: port }, { env });
+      if (isExternallySupervised(owner)) {
+        log(
+          `  Keeping externally supervised OpenShell gateway '${gatewayName}' running after onboard abort.`,
+        );
+        return false;
+      }
+    } catch (error) {
+      if (error instanceof GatewayAuthorityError) {
+        warn(`  Skipping gateway teardown after onboard abort: ${error.message}`);
+        return false;
+      }
+      warn(
+        `  Skipping gateway teardown after onboard abort: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return false;
+    }
+
+    log(
+      `  Onboard aborted before a sandbox was created; releasing managed gateway '${gatewayName}' so provider credentials do not remain in a live process.`,
+    );
+
+    let attempted = false;
+    try {
+      const result = release({ port });
+      attempted = true;
+      if (result.released && result.stopped.length > 0) {
+        log(
+          `  Released gateway port ${String(result.port)} (stopped host process ${result.stopped.join(", ")}).`,
+        );
+      } else if (!result.released && !result.skipped) {
+        warn(
+          `  Gateway port ${String(result.port ?? port)} was not confirmed released after onboard abort. Inspect the listener and stop only the matching openshell-gateway process.`,
+        );
+      }
+    } catch (error) {
+      attempted = true;
+      warn(
+        `  Gateway process stop after onboard abort failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    try {
+      removeRegistration(gatewayName);
+      attempted = true;
+    } catch (error) {
+      warn(
+        `  Gateway registration remove after onboard abort failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    return attempted;
+  } catch (error) {
+    // Warn and continue to fatal exit; do not hide a still-live listener.
+    warn(
+      `  Gateway teardown after onboard abort failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return false;
+  }
+}

--- a/src/lib/onboard/abort-gateway-teardown.ts
+++ b/src/lib/onboard/abort-gateway-teardown.ts
@@ -106,9 +106,11 @@ export function teardownOrphanManagedGatewayOnAbort(deps: AbortGatewayTeardownDe
     );
 
     let attempted = false;
+    let releaseConfirmed = false;
     try {
       const result = release({ port });
       attempted = true;
+      releaseConfirmed = result.released;
       if (result.released && result.stopped.length > 0) {
         log(
           `  Released gateway port ${String(result.port)} (stopped host process ${result.stopped.join(", ")}).`,
@@ -124,6 +126,10 @@ export function teardownOrphanManagedGatewayOnAbort(deps: AbortGatewayTeardownDe
         `  Gateway process stop after onboard abort failed: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
+
+    // Keep the OpenShell registration when the listener may still be up — it is
+    // the supported recovery handle for a credential-bearing process.
+    if (!releaseConfirmed) return attempted;
 
     try {
       removeRegistration(gatewayName);

--- a/src/lib/onboard/inference-selection-validation.test.ts
+++ b/src/lib/onboard/inference-selection-validation.test.ts
@@ -500,6 +500,9 @@ describe("inference selection validation", () => {
       ).rejects.toThrow("Non-interactive endpoint validation failed.");
       expect(teardownOrphanManagedGatewayOnAbort).toHaveBeenCalledTimes(1);
       expect(exit).toHaveBeenCalledWith(1);
+      expect(teardownOrphanManagedGatewayOnAbort.mock.invocationCallOrder[0]).toBeLessThan(
+        exit.mock.invocationCallOrder[0] ?? 0,
+      );
     } finally {
       process.exitCode = originalExitCode;
       exit.mockRestore();
@@ -536,6 +539,9 @@ describe("inference selection validation", () => {
       expect(teardownOrphanManagedGatewayOnAbort).toHaveBeenCalledTimes(1);
       expect(error.mock.calls.map((call) => String(call[0])).join("\n")).toContain("teardown boom");
       expect(exit).toHaveBeenCalledWith(1);
+      expect(teardownOrphanManagedGatewayOnAbort.mock.invocationCallOrder[0]).toBeLessThan(
+        exit.mock.invocationCallOrder[0] ?? 0,
+      );
     } finally {
       process.exitCode = originalExitCode;
       exit.mockRestore();

--- a/src/lib/onboard/inference-selection-validation.test.ts
+++ b/src/lib/onboard/inference-selection-validation.test.ts
@@ -474,6 +474,75 @@ describe("inference selection validation", () => {
     }
   });
 
+  it("tears down an orphan managed gateway before non-interactive validation exit (#8952)", async () => {
+    const originalExitCode = process.exitCode;
+    const teardownOrphanManagedGatewayOnAbort = vi.fn();
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const helpers = createInferenceSelectionValidationHelpers({
+      isNonInteractive: () => true,
+      agentProductName: () => "OpenClaw",
+      getCredential: () => "test-key",
+      probeAnthropicEndpoint: vi.fn(),
+      teardownOrphanManagedGatewayOnAbort,
+      promptValidationRecovery: vi.fn(async () => "selection" as const),
+      resolveEndpointHost: async () => [{ address: "169.254.169.254", family: 4 }],
+    });
+
+    try {
+      await expect(
+        helpers.validateCustomAnthropicSelection(
+          "Custom Anthropic",
+          "https://metadata-name.example/v1",
+          "model-a",
+          "COMPATIBLE_ANTHROPIC_API_KEY",
+        ),
+      ).rejects.toThrow("Non-interactive endpoint validation failed.");
+      expect(teardownOrphanManagedGatewayOnAbort).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenCalledWith(1);
+    } finally {
+      process.exitCode = originalExitCode;
+      exit.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("still exits when abort teardown throws during non-interactive validation (#8952)", async () => {
+    const originalExitCode = process.exitCode;
+    const teardownOrphanManagedGatewayOnAbort = vi.fn(() => {
+      throw new Error("teardown boom");
+    });
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const helpers = createInferenceSelectionValidationHelpers({
+      isNonInteractive: () => true,
+      agentProductName: () => "OpenClaw",
+      getCredential: () => "test-key",
+      probeAnthropicEndpoint: vi.fn(),
+      teardownOrphanManagedGatewayOnAbort,
+      promptValidationRecovery: vi.fn(async () => "selection" as const),
+      resolveEndpointHost: async () => [{ address: "169.254.169.254", family: 4 }],
+    });
+
+    try {
+      await expect(
+        helpers.validateCustomAnthropicSelection(
+          "Custom Anthropic",
+          "https://metadata-name.example/v1",
+          "model-a",
+          "COMPATIBLE_ANTHROPIC_API_KEY",
+        ),
+      ).rejects.toThrow("Non-interactive endpoint validation failed.");
+      expect(teardownOrphanManagedGatewayOnAbort).toHaveBeenCalledTimes(1);
+      expect(error.mock.calls.map((call) => String(call[0])).join("\n")).toContain("teardown boom");
+      expect(exit).toHaveBeenCalledWith(1);
+    } finally {
+      process.exitCode = originalExitCode;
+      exit.mockRestore();
+      error.mockRestore();
+    }
+  });
+
   it("probes a custom endpoint that resolves to a public address (#6293)", async () => {
     const probeOpenAiLikeEndpoint = vi.fn(() => ({ ok: true, api: "openai-completions" }));
     const capabilityCache = new OnboardInferenceCapabilityCache();

--- a/src/lib/onboard/inference-selection-validation.ts
+++ b/src/lib/onboard/inference-selection-validation.ts
@@ -65,6 +65,11 @@ export interface InferenceSelectionValidationDeps {
   resolveEndpointHost?: EndpointDnsLookupFn;
   /** Exact private endpoint hosts trusted by the operator (tests may inject this). */
   trustedPrivateEndpointHosts?: readonly string[];
+  /**
+   * Optional abort teardown hook for tests. Production loads the helper lazily
+   * so openshell binaries stay out of the validation unit graph.
+   */
+  teardownOrphanManagedGatewayOnAbort?: () => void;
   promptValidationRecovery(
     label: string,
     recovery: ReturnType<typeof getProbeRecovery>,
@@ -147,6 +152,22 @@ export function createInferenceSelectionValidationHelpers(
     deps.trustedPrivateEndpointHosts ?? parseTrustedPrivateInferenceHostsFromEnv(process.env);
 
   function exitNonInteractiveValidationFailure(): never {
+    // #8952: tear down an unowned managed gateway before fatal exit.
+    try {
+      const teardown =
+        deps.teardownOrphanManagedGatewayOnAbort ??
+        (() => {
+          const { teardownOrphanManagedGatewayOnAbort } =
+            require("./abort-gateway-teardown") as typeof import("./abort-gateway-teardown");
+          teardownOrphanManagedGatewayOnAbort();
+        });
+      teardown();
+    } catch (error) {
+      // Helper never throws; this covers require/load / inject failures.
+      console.error(
+        `  Gateway teardown after onboard abort failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
     process.exitCode = 1;
     (process.exit as (code?: number) => void)(1);
     throw new Error("Non-interactive endpoint validation failed.");

--- a/src/lib/tunnel/gateway-port-resolution.ts
+++ b/src/lib/tunnel/gateway-port-resolution.ts
@@ -16,6 +16,25 @@ function isValidPort(value: number | undefined): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535;
 }
 
+/**
+ * Parse an operator-set `NEMOCLAW_GATEWAY_PORT` (not the 8080 default).
+ * Returns null when unset, empty, or not a usable port integer.
+ */
+export function resolveExplicitGatewayPortEnv(env: NodeJS.ProcessEnv = process.env): number | null {
+  const raw = env.NEMOCLAW_GATEWAY_PORT;
+  if (raw === undefined) return null;
+  const trimmed = String(raw).trim();
+  if (trimmed === "" || !/^\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) return null;
+  return parsed;
+}
+
+/** True when the operator set a usable NEMOCLAW_GATEWAY_PORT override. */
+export function hasExplicitGatewayPortEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return resolveExplicitGatewayPortEnv(env) !== null;
+}
+
 export function makeGatewayDebug(env: NodeJS.ProcessEnv): (message: string) => void {
   const enabled = (env.NODE_DEBUG ?? "").includes("nemoclaw:gateway");
   return enabled ? (message: string) => console.error(`[nemoclaw:gateway] ${message}`) : () => {};

--- a/src/lib/tunnel/gateway-stop.ts
+++ b/src/lib/tunnel/gateway-stop.ts
@@ -4,8 +4,21 @@
 import { resolveGatewayPortFromName, resolveSandboxGatewayName } from "../onboard/gateway-binding";
 import * as registry from "../state/registry";
 import * as gatewayPortRelease from "./gateway-port-release";
+import { resolveExplicitGatewayPortEnv } from "./gateway-port-resolution";
 
 type Log = (message: string) => void;
+
+/**
+ * Outcome of the gateway step in `stop`, so the final line can report whether
+ * a managed gateway was in scope.
+ */
+export type GatewayStopOutcome =
+  /** A release ran against a resolved gateway port. */
+  | "attempted"
+  /** A registered peer still owns the gateway, so it stays up by design. */
+  | "kept-shared"
+  /** No sandbox name and no explicit NEMOCLAW_GATEWAY_PORT — nothing was scoped. */
+  | "not-scoped";
 
 export interface GatewayStopDeps {
   env?: NodeJS.ProcessEnv;
@@ -62,23 +75,65 @@ function findSharedGatewayOwner(
   return null;
 }
 
+function reportUnconfirmedGatewayRelease(
+  warn: Log,
+  release: { port: number | null; released: boolean; skipped: boolean },
+): void {
+  // The release helper reports invalid bindings itself. For an attempted but
+  // unconfirmed release, do not recommend killing raw lsof PIDs: an unrelated
+  // listener may be one the scoped stopper deliberately left alone.
+  if (!release.released && !release.skipped) {
+    warn(
+      `NemoClaw gateway port ${release.port ?? "?"} was not confirmed released. ` +
+        "Inspect the remaining listener and stop it only if it is the matching gateway process.",
+    );
+  }
+}
+
+function reportAmbiguousGatewayRelease(warn: Log, env: NodeJS.ProcessEnv, error: unknown): void {
+  // A corrupt peer registry entry makes gateway ownership ambiguous. Do not
+  // block the selected sandbox's non-gateway stop work, but skip destructive
+  // release so a potentially shared gateway is never torn down by guessing.
+  warn(
+    `Could not release the NemoClaw gateway port: ${(error as Error).message ?? String(error)}. ` +
+      "Gateway ownership is ambiguous; repair the sandbox registry and retry. " +
+      "Run with NODE_DEBUG=nemoclaw:gateway for details.",
+  );
+  // Best-effort by design: keep normal output concise, with the full stack
+  // available only to an operator explicitly debugging gateway teardown.
+  if ((env.NODE_DEBUG ?? "").includes("nemoclaw:gateway")) {
+    console.error((error as Error).stack ?? String(error));
+  }
+}
+
 /**
  * Release the selected sandbox's host gateway only when no registered peer
- * shares it. A missing sandbox name is a deliberate no-op: falling back to the
- * process-wide default port could tear down another worktree's gateway.
+ * shares it. Without a sandbox name, release only an explicit
+ * `NEMOCLAW_GATEWAY_PORT` so a bare `stop` cannot kill the default shared
+ * gateway (#8952).
  */
 export function releaseGatewayPortForStop(
   sandboxName: string | undefined,
   deps: GatewayStopDeps = {},
-): void {
-  if (!sandboxName) return;
-
+): GatewayStopOutcome {
   const env = deps.env ?? process.env;
   const info = deps.info ?? console.log;
   const warn = deps.warn ?? console.warn;
   const listSandboxes = deps.listSandboxes ?? registry.listSandboxes;
   const releaseManagedGatewayPort =
     deps.releaseManagedGatewayPort ?? gatewayPortRelease.releaseManagedGatewayPort;
+
+  if (!sandboxName) {
+    // Use the same parsed port that passed the gate; do not fall back to GATEWAY_PORT.
+    const port = resolveExplicitGatewayPortEnv(env);
+    if (port === null) return "not-scoped";
+    try {
+      reportUnconfirmedGatewayRelease(warn, releaseManagedGatewayPort({ port }, { env }));
+    } catch (error) {
+      reportAmbiguousGatewayRelease(warn, env, error);
+    }
+    return "attempted";
+  }
 
   try {
     const sharedOwner = findSharedGatewayOwner(sandboxName, listSandboxes);
@@ -87,32 +142,12 @@ export function releaseGatewayPortForStop(
         `Keeping shared NemoClaw gateway port ${sharedOwner.port} running for ` +
           `registered sandbox '${sharedOwner.name}'.`,
       );
-      return;
+      return "kept-shared";
     }
 
-    const release = releaseManagedGatewayPort({ sandboxName });
-    // The release helper reports invalid bindings itself. For an attempted but
-    // unconfirmed release, do not recommend killing raw lsof PIDs: an unrelated
-    // listener may be one the scoped stopper deliberately left alone.
-    if (!release.released && !release.skipped) {
-      warn(
-        `NemoClaw gateway port ${release.port ?? "?"} was not confirmed released. ` +
-          "Inspect the remaining listener and stop it only if it is the matching gateway process.",
-      );
-    }
+    reportUnconfirmedGatewayRelease(warn, releaseManagedGatewayPort({ sandboxName }));
   } catch (error) {
-    // A corrupt peer registry entry makes gateway ownership ambiguous. Do not
-    // block the selected sandbox's non-gateway stop work, but skip destructive
-    // release so a potentially shared gateway is never torn down by guessing.
-    warn(
-      `Could not release the NemoClaw gateway port: ${(error as Error).message ?? String(error)}. ` +
-        "Gateway ownership is ambiguous; repair the sandbox registry and retry. " +
-        "Run with NODE_DEBUG=nemoclaw:gateway for details.",
-    );
-    // Best-effort by design: keep normal output concise, with the full stack
-    // available only to an operator explicitly debugging gateway teardown.
-    if ((env.NODE_DEBUG ?? "").includes("nemoclaw:gateway")) {
-      console.error((error as Error).stack ?? String(error));
-    }
+    reportAmbiguousGatewayRelease(warn, env, error);
   }
+  return "attempted";
 }

--- a/src/lib/tunnel/gateway-stop.ts
+++ b/src/lib/tunnel/gateway-stop.ts
@@ -13,12 +13,14 @@ type Log = (message: string) => void;
  * a managed gateway was in scope.
  */
 export type GatewayStopOutcome =
-  /** A release ran against a resolved gateway port. */
+  /** A release ran and was confirmed (or intentionally skipped as invalid). */
   | "attempted"
   /** A registered peer still owns the gateway, so it stays up by design. */
   | "kept-shared"
   /** No sandbox name and no explicit NEMOCLAW_GATEWAY_PORT — nothing was scoped. */
-  | "not-scoped";
+  | "not-scoped"
+  /** A scoped release ran but the listener was not confirmed gone. */
+  | "unconfirmed";
 
 export interface GatewayStopDeps {
   env?: NodeJS.ProcessEnv;
@@ -78,7 +80,7 @@ function findSharedGatewayOwner(
 function reportUnconfirmedGatewayRelease(
   warn: Log,
   release: { port: number | null; released: boolean; skipped: boolean },
-): void {
+): boolean {
   // The release helper reports invalid bindings itself. For an attempted but
   // unconfirmed release, do not recommend killing raw lsof PIDs: an unrelated
   // listener may be one the scoped stopper deliberately left alone.
@@ -87,7 +89,9 @@ function reportUnconfirmedGatewayRelease(
       `NemoClaw gateway port ${release.port ?? "?"} was not confirmed released. ` +
         "Inspect the remaining listener and stop it only if it is the matching gateway process.",
     );
+    return true;
   }
+  return false;
 }
 
 function reportAmbiguousGatewayRelease(warn: Log, env: NodeJS.ProcessEnv, error: unknown): void {
@@ -128,9 +132,11 @@ export function releaseGatewayPortForStop(
     const port = resolveExplicitGatewayPortEnv(env);
     if (port === null) return "not-scoped";
     try {
-      reportUnconfirmedGatewayRelease(warn, releaseManagedGatewayPort({ port }, { env }));
+      const result = releaseManagedGatewayPort({ port }, { env });
+      if (reportUnconfirmedGatewayRelease(warn, result)) return "unconfirmed";
     } catch (error) {
       reportAmbiguousGatewayRelease(warn, env, error);
+      return "unconfirmed";
     }
     return "attempted";
   }
@@ -145,9 +151,11 @@ export function releaseGatewayPortForStop(
       return "kept-shared";
     }
 
-    reportUnconfirmedGatewayRelease(warn, releaseManagedGatewayPort({ sandboxName }));
+    const result = releaseManagedGatewayPort({ sandboxName });
+    if (reportUnconfirmedGatewayRelease(warn, result)) return "unconfirmed";
   } catch (error) {
     reportAmbiguousGatewayRelease(warn, env, error);
+    return "unconfirmed";
   }
   return "attempted";
 }

--- a/src/lib/tunnel/services-gateway-ownership.test.ts
+++ b/src/lib/tunnel/services-gateway-ownership.test.ts
@@ -110,13 +110,14 @@ describe("releaseGatewayPortForStop", () => {
     const release = gatewayRelease(releaseResult({ port: 8814, stopped: [99] }));
     const warn = vi.fn<(message: string) => void>();
 
-    gatewayStop.releaseGatewayPortForStop(undefined, {
+    const outcome = gatewayStop.releaseGatewayPortForStop(undefined, {
       env: { NEMOCLAW_GATEWAY_PORT: "8814" },
       listSandboxes: sandboxList([]),
       releaseManagedGatewayPort: release,
       warn,
     });
 
+    expect(outcome).toBe("attempted");
     expect(release).toHaveBeenCalledTimes(1);
     expect(release).toHaveBeenCalledWith(
       { port: 8814 },
@@ -127,12 +128,13 @@ describe("releaseGatewayPortForStop", () => {
   it("does not release when NEMOCLAW_GATEWAY_PORT is set but not a usable port (#8952)", () => {
     const release = gatewayRelease(releaseResult({ port: 8814, stopped: [99] }));
 
-    gatewayStop.releaseGatewayPortForStop(undefined, {
+    const outcome = gatewayStop.releaseGatewayPortForStop(undefined, {
       env: { NEMOCLAW_GATEWAY_PORT: "not-a-port" },
       listSandboxes: sandboxList([]),
       releaseManagedGatewayPort: release,
     });
 
+    expect(outcome).toBe("not-scoped");
     expect(release).not.toHaveBeenCalled();
   });
 
@@ -142,14 +144,13 @@ describe("releaseGatewayPortForStop", () => {
     });
     const warn = vi.fn<(message: string) => void>();
 
-    expect(() =>
-      gatewayStop.releaseGatewayPortForStop("alpha", {
-        listSandboxes: sandboxList([{ name: "alpha", gatewayPort: 8080 }]),
-        releaseManagedGatewayPort: release,
-        warn,
-      }),
-    ).not.toThrow();
+    const outcome = gatewayStop.releaseGatewayPortForStop("alpha", {
+      listSandboxes: sandboxList([{ name: "alpha", gatewayPort: 8080 }]),
+      releaseManagedGatewayPort: release,
+      warn,
+    });
 
+    expect(outcome).toBe("unconfirmed");
     const output = warn.mock.calls.map((call) => call[0]).join("\n");
     expect(output).toContain("Could not release the NemoClaw gateway port: registry boom");
     expect(output).toContain("repair the sandbox registry and retry");
@@ -159,7 +160,7 @@ describe("releaseGatewayPortForStop", () => {
   it("uses inspect-only guidance when release cannot confirm the port is free", () => {
     const warn = vi.fn<(message: string) => void>();
 
-    gatewayStop.releaseGatewayPortForStop("alpha", {
+    const outcome = gatewayStop.releaseGatewayPortForStop("alpha", {
       listSandboxes: sandboxList([{ name: "alpha", gatewayPort: 8080 }]),
       releaseManagedGatewayPort: gatewayRelease(
         releaseResult({ released: false, remaining: [4242] }),
@@ -167,6 +168,7 @@ describe("releaseGatewayPortForStop", () => {
       warn,
     });
 
+    expect(outcome).toBe("unconfirmed");
     const output = warn.mock.calls.map((call) => call[0]).join("\n");
     expect(output).toContain("gateway port 8080 was not confirmed released");
     expect(output).not.toContain("4242");
@@ -192,7 +194,7 @@ describe("releaseGatewayPortForStop", () => {
     const release = gatewayRelease();
     const warn = vi.fn<(message: string) => void>();
 
-    gatewayStop.releaseGatewayPortForStop("alpha", {
+    const outcome = gatewayStop.releaseGatewayPortForStop("alpha", {
       listSandboxes: sandboxList([
         { name: "alpha", gatewayPort: 8080 },
         { name: "beta", gatewayPort: 0 },
@@ -201,6 +203,7 @@ describe("releaseGatewayPortForStop", () => {
       warn,
     });
 
+    expect(outcome).toBe("unconfirmed");
     expect(release).not.toHaveBeenCalled();
     const output = warn.mock.calls.map((call) => call[0]).join("\n");
     expect(output).toContain("Invalid persisted sandbox gateway for peer 'beta'");
@@ -331,5 +334,25 @@ describe("stopAll gateway-stop wiring", () => {
     expect(logged).not.toContain("All services stopped");
     expect(logged).toContain("managed gateway not released");
     expect(logged).toContain("NEMOCLAW_GATEWAY_PORT");
+  });
+
+  it("does not claim every service stopped when gateway release is unconfirmed (#8952)", () => {
+    const pidDir = mkdtempSync(join(tmpdir(), "nemoclaw-unconfirmed-gateway-stop-"));
+    vi.stubEnv("PATH", "");
+    vi.stubEnv("NEMOCLAW_GATEWAY_PORT", "8814");
+    vi.spyOn(gatewayStop, "releaseGatewayPortForStop").mockImplementation(() => "unconfirmed");
+    vi.spyOn(agentForwardStop, "stopAgentForwardPortsForStop").mockImplementation(() => {});
+    vi.spyOn(sandboxGatewayStop, "stopSandboxChannels").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      stopAll({ pidDir, releaseGatewayPort: true });
+    } finally {
+      rmSync(pidDir, { recursive: true, force: true });
+    }
+
+    const logged = logSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(logged).not.toContain("All services stopped");
+    expect(logged).toContain("managed gateway release was not confirmed");
   });
 });

--- a/src/lib/tunnel/services-gateway-ownership.test.ts
+++ b/src/lib/tunnel/services-gateway-ownership.test.ts
@@ -106,6 +106,36 @@ describe("releaseGatewayPortForStop", () => {
     expect(release).not.toHaveBeenCalled();
   });
 
+  it("releases an explicit NEMOCLAW_GATEWAY_PORT when no sandbox name is available (#8952)", () => {
+    const release = gatewayRelease(releaseResult({ port: 8814, stopped: [99] }));
+    const warn = vi.fn<(message: string) => void>();
+
+    gatewayStop.releaseGatewayPortForStop(undefined, {
+      env: { NEMOCLAW_GATEWAY_PORT: "8814" },
+      listSandboxes: sandboxList([]),
+      releaseManagedGatewayPort: release,
+      warn,
+    });
+
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledWith(
+      { port: 8814 },
+      expect.objectContaining({ env: { NEMOCLAW_GATEWAY_PORT: "8814" } }),
+    );
+  });
+
+  it("does not release when NEMOCLAW_GATEWAY_PORT is set but not a usable port (#8952)", () => {
+    const release = gatewayRelease(releaseResult({ port: 8814, stopped: [99] }));
+
+    gatewayStop.releaseGatewayPortForStop(undefined, {
+      env: { NEMOCLAW_GATEWAY_PORT: "not-a-port" },
+      listSandboxes: sandboxList([]),
+      releaseManagedGatewayPort: release,
+    });
+
+    expect(release).not.toHaveBeenCalled();
+  });
+
   it("warns without failing stop when gateway release throws", () => {
     const release = vi.fn(() => {
       throw new Error("registry boom");
@@ -201,6 +231,7 @@ describe("stopAll gateway-stop wiring", () => {
       .spyOn(gatewayStop, "releaseGatewayPortForStop")
       .mockImplementation(() => {
         order.push("gateway-release");
+        return "attempted";
       });
     const stopAgentForwards = vi
       .spyOn(agentForwardStop, "stopAgentForwardPortsForStop")
@@ -238,7 +269,7 @@ describe("stopAll gateway-stop wiring", () => {
     vi.stubEnv("PATH", "");
     const releaseForStop = vi
       .spyOn(gatewayStop, "releaseGatewayPortForStop")
-      .mockImplementation(() => {});
+      .mockImplementation(() => "attempted");
     const stopAgentForwards = vi
       .spyOn(agentForwardStop, "stopAgentForwardPortsForStop")
       .mockImplementation(() => {});
@@ -252,5 +283,53 @@ describe("stopAll gateway-stop wiring", () => {
 
     expect(releaseForStop).not.toHaveBeenCalled();
     expect(stopAgentForwards).not.toHaveBeenCalled();
+  });
+
+  it("releases an explicit gateway port on full stop even without a sandbox name (#8952)", () => {
+    const pidDir = mkdtempSync(join(tmpdir(), "nemoclaw-orphan-gateway-stop-"));
+    vi.stubEnv("PATH", "");
+    const releaseForStop = vi
+      .spyOn(gatewayStop, "releaseGatewayPortForStop")
+      .mockImplementation(() => "attempted");
+    const stopAgentForwards = vi
+      .spyOn(agentForwardStop, "stopAgentForwardPortsForStop")
+      .mockImplementation(() => {});
+    vi.spyOn(sandboxGatewayStop, "stopSandboxChannels").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      stopAll({ pidDir, releaseGatewayPort: true });
+    } finally {
+      rmSync(pidDir, { recursive: true, force: true });
+    }
+
+    expect(stopAgentForwards).not.toHaveBeenCalled();
+    expect(releaseForStop).toHaveBeenCalledWith(undefined, {
+      info: expect.any(Function),
+      warn: expect.any(Function),
+    });
+    expect(logSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n")).toContain(
+      "All services stopped",
+    );
+  });
+
+  it("does not claim every service stopped when no gateway scope exists (#8952)", () => {
+    const pidDir = mkdtempSync(join(tmpdir(), "nemoclaw-unscoped-gateway-stop-"));
+    vi.stubEnv("PATH", "");
+    vi.spyOn(gatewayStop, "releaseGatewayPortForStop").mockImplementation(() => "not-scoped");
+    vi.spyOn(agentForwardStop, "stopAgentForwardPortsForStop").mockImplementation(() => {});
+    vi.spyOn(sandboxGatewayStop, "stopSandboxChannels").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      stopAll({ pidDir, releaseGatewayPort: true });
+    } finally {
+      rmSync(pidDir, { recursive: true, force: true });
+    }
+
+    const logged = logSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(logged).not.toContain("All services stopped");
+    expect(logged).toContain("managed gateway not released");
+    expect(logged).toContain("NEMOCLAW_GATEWAY_PORT");
   });
 });

--- a/src/lib/tunnel/services-sandbox.test.ts
+++ b/src/lib/tunnel/services-sandbox.test.ts
@@ -142,7 +142,7 @@ describe("stopAll with sandbox channels", () => {
       .mockImplementation(() => {});
     const releaseGateway = vi
       .spyOn(gatewayStop, "releaseGatewayPortForStop")
-      .mockImplementation(() => {});
+      .mockImplementation(() => "attempted");
     writeFileSync(join(pidDir, "cloudflared.pid"), "999999999");
 
     expect(() =>

--- a/src/lib/tunnel/services.ts
+++ b/src/lib/tunnel/services.ts
@@ -538,9 +538,28 @@ export function stopAll(opts: ServiceOptions = {}): void {
     warn("Invalid sandbox name without an explicit PID directory; skipping host service stop.");
   }
 
-  if (opts.releaseGatewayPort && sandboxName) {
-    agentForwardStop.stopAgentForwardPortsForStop(sandboxName, { info, warn });
-    gatewayStop.releaseGatewayPortForStop(sandboxName, { info, warn });
+  let gatewayOutcome: gatewayStop.GatewayStopOutcome | undefined;
+  if (opts.releaseGatewayPort) {
+    if (sandboxName) {
+      agentForwardStop.stopAgentForwardPortsForStop(sandboxName, { info, warn });
+      gatewayOutcome = gatewayStop.releaseGatewayPortForStop(sandboxName, { info, warn });
+    } else if (!rawSandboxName) {
+      // #8952: no registry name — release only when NEMOCLAW_GATEWAY_PORT is
+      // explicit. A requested-but-malformed name stays out: scope is unknown, not absent.
+      gatewayOutcome = gatewayStop.releaseGatewayPortForStop(undefined, { info, warn });
+    }
+  }
+
+  // When nothing scoped the gateway, do not claim every service stopped.
+  if (gatewayOutcome === "not-scoped") {
+    warn(
+      "No sandbox name and no explicit NEMOCLAW_GATEWAY_PORT — the managed OpenShell gateway was not released.",
+    );
+    warn(
+      "Hint: rerun with NEMOCLAW_GATEWAY_PORT=<port> to release that gateway, or 'openshell gateway list' to find it.",
+    );
+    info("Host services stopped; managed gateway not released.");
+    return;
   }
 
   info("All services stopped.");

--- a/src/lib/tunnel/services.ts
+++ b/src/lib/tunnel/services.ts
@@ -550,7 +550,8 @@ export function stopAll(opts: ServiceOptions = {}): void {
     }
   }
 
-  // When nothing scoped the gateway, do not claim every service stopped.
+  // When nothing scoped the gateway, or a scoped release was not confirmed, do
+  // not claim every service stopped.
   if (gatewayOutcome === "not-scoped") {
     warn(
       "No sandbox name and no explicit NEMOCLAW_GATEWAY_PORT — the managed OpenShell gateway was not released.",
@@ -559,6 +560,11 @@ export function stopAll(opts: ServiceOptions = {}): void {
       "Hint: rerun with NEMOCLAW_GATEWAY_PORT=<port> to release that gateway, or 'openshell gateway list' to find it.",
     );
     info("Host services stopped; managed gateway not released.");
+    return;
+  }
+
+  if (gatewayOutcome === "unconfirmed") {
+    info("Host services stopped; managed gateway release was not confirmed.");
     return;
   }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Failed provider / inference validation could leave a credential-bearing `openshell-gateway` running, and official `stop` / `gateway remove` did not terminate it when no sandbox was registered. After this change, onboard abort tears down an unowned managed gateway, and full `stop` releases an explicitly scoped `NEMOCLAW_GATEWAY_PORT` even without a sandbox name. When nothing scopes the gateway, `stop` no longer prints a false `All services stopped.` success line.

## Related Issue
Fixes #8952

## Changes
- Add `teardownOrphanManagedGatewayOnAbort` under `src/lib/onboard/` to stop a NemoClaw-managed host gateway and remove its OpenShell registration when no registered sandbox owns that gateway (skips externally supervised / authority-refused / peer-owned cases).
- Call that teardown from `verifyOnboardInferenceSmoke` before `process.exit(1)`, and from `exitNonInteractiveValidationFailure` (endpoint validation 404 path observed on Brev), so a failed provider validation does not leave API keys in a live process environment.
- Teach full `stop` (`releaseGatewayPort`) to invoke gateway release when there is no sandbox name but `NEMOCLAW_GATEWAY_PORT` is set explicitly; bare `stop` without that override still refuses a process-wide default release. A requested-but-malformed sandbox name keeps its prior behavior and skips gateway release, because its scope is unknown rather than absent.
- Report the gateway outcome honestly: when nothing scoped the gateway, `stop` warns and prints `Host services stopped; managed gateway not released.` instead of `All services stopped.`
- Cover abort teardown and stop wiring with unit tests in `abort-gateway-teardown.test.ts`, `inference-selection-validation.test.ts`, and `services-gateway-ownership.test.ts`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: lifecycle / security fix for CLI cleanup and onboard abort; no user-facing doc pages or install guides claim that failed onboard leaves a gateway, and recovery still uses existing `stop` / pid-file paths.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
- [ ] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no `docs/` or changelog paths changed; behavior is abort teardown + scoped `stop` release of an explicit gateway port. Operator-visible strings are CLI stderr/stdout only.
- Agent: 
<!-- docs-review-head-sha: -->
<!-- docs-review-agents-blob-sha: -->

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `vitest run src/lib/onboard/abort-gateway-teardown.test.ts src/lib/tunnel/services-gateway-ownership.test.ts src/lib/tunnel/services-sandbox.test.ts` → 3 files, 33 tests passed. Brev A/B on `nemoclaw-cc1d6e`: (1) `build` + nonexistent model; (2) reporter-aligned `anthropicCompatible` + `langchain-deepagents-code` + `NEMOCLAW_ENDPOINT_URL=https://api.anthropic.com/` + model `fvr/nonexistent-8a12`. Main leaves `listening=true` + secret matches after failed onboard and after official stop/remove; patched build tears down immediately (`Released gateway port 8814`, `listening=false`).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Rui Luo <ruluo@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of unowned managed gateways when onboarding or inference validation is aborted.
  * Added support for explicitly configured gateway ports during service shutdown.
  * Added clearer shutdown status reporting when gateway release cannot be confirmed.

* **Bug Fixes**
  * Prevented shared or externally managed gateways from being stopped accidentally.
  * Invalid gateway port settings are safely ignored with appropriate warnings.
  * Teardown failures no longer obscure the original onboarding or validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->