### PR TITLE
fix(onboard): avoid overlapping portable policies

### DIFF
--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -155,6 +155,9 @@ The sandbox's filesystem, process, gateway authentication, and managed credentia
 Use this tier only for trusted personal workloads with trusted prompts and data.
 </Warning>
 
+The experimental portable profile selects only `personal-open-internet` from the Personal tier.
+Its broad L4 rule already permits matching `weather`, `public-reference`, and `github` destinations on ports `80` and `443`, so portable onboarding does not add those narrower overlapping presets.
+
 After selecting a tier, a combined preset and access-mode screen lets you include or exclude individual presets and toggle each between read (GET only) and read-write (GET + POST/PUT/PATCH) access.
 Tier-default presets are pre-selected; additional presets can be added from the built-in preset list available to the sandbox's active agent.
 NemoClaw filters tier defaults and built-in preset choices by the active agent's supported integrations.

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -533,13 +533,14 @@ describe("onboard command options", () => {
     expect(env.NEMOCLAW_SERVING_PRESET).toBeUndefined();
   });
 
-  it("keeps local portable defaults when no descriptor is present", async () => {
+  it("selects only the broad Personal preset for local portable onboarding (#8991)", async () => {
     const env: NodeJS.ProcessEnv = {
       NEMOCLAW_EXPERIMENTAL_PROFILE: "previous-profile",
       NEMOCLAW_PROVIDER: "previous-provider",
       NEMOCLAW_MODEL: "previous-model",
       NEMOCLAW_OLLAMA_NO_AUTOSTART: "0",
       NEMOCLAW_POLICY_MODE: "previous-mode",
+      NEMOCLAW_POLICY_PRESETS: "previous-presets",
       NEMOCLAW_POLICY_TIER: "previous-tier",
       NEMOCLAW_TOOL_DISCLOSURE: "progressive",
     };
@@ -555,6 +556,7 @@ describe("onboard command options", () => {
           "NEMOCLAW_MODEL",
           "NEMOCLAW_OLLAMA_NO_AUTOSTART",
           "NEMOCLAW_POLICY_MODE",
+          "NEMOCLAW_POLICY_PRESETS",
           "NEMOCLAW_POLICY_TIER",
           "NEMOCLAW_TOOL_DISCLOSURE",
         ]) {
@@ -568,7 +570,8 @@ describe("onboard command options", () => {
       NEMOCLAW_PROVIDER: "ollama",
       NEMOCLAW_MODEL: "qwen3-vl:4b",
       NEMOCLAW_OLLAMA_NO_AUTOSTART: "1",
-      NEMOCLAW_POLICY_MODE: "suggested",
+      NEMOCLAW_POLICY_MODE: "custom",
+      NEMOCLAW_POLICY_PRESETS: "personal-open-internet",
       NEMOCLAW_POLICY_TIER: "personal",
       NEMOCLAW_TOOL_DISCLOSURE: "direct",
     });
@@ -578,6 +581,7 @@ describe("onboard command options", () => {
       NEMOCLAW_MODEL: "previous-model",
       NEMOCLAW_OLLAMA_NO_AUTOSTART: "0",
       NEMOCLAW_POLICY_MODE: "previous-mode",
+      NEMOCLAW_POLICY_PRESETS: "previous-presets",
       NEMOCLAW_POLICY_TIER: "previous-tier",
       NEMOCLAW_TOOL_DISCLOSURE: "progressive",
     });

--- a/src/lib/onboard/command.ts
+++ b/src/lib/onboard/command.ts
@@ -468,7 +468,8 @@ function applyPortableEnvironment(
     NEMOCLAW_ENDPOINT_URL: activation?.baseUrl,
     NEMOCLAW_PREFERRED_API: activation ? "openai-completions" : undefined,
     NEMOCLAW_OLLAMA_NO_AUTOSTART: "1",
-    NEMOCLAW_POLICY_MODE: "suggested",
+    NEMOCLAW_POLICY_MODE: "custom",
+    NEMOCLAW_POLICY_PRESETS: "personal-open-internet",
     NEMOCLAW_POLICY_TIER: "personal",
   } as const;
   const previousPortableEnv = new Map<string, string | undefined>();

--- a/test/policy-tiers-onboard.test.ts
+++ b/test/policy-tiers-onboard.test.ts
@@ -580,6 +580,18 @@ describe("policy tier setup", () => {
     assert.deepEqual(result.appliedCalls, ["brave", "npm"]);
   });
 
+  it("keeps a custom Personal selection authoritative before policy mutation (#8991)", async () => {
+    const result = await runPolicySetup({
+      tierName: "personal",
+      policyMode: "custom",
+      policyPresets: "personal-open-internet",
+    });
+
+    assert.deepEqual(result.applied, ["personal-open-internet"]);
+    assert.deepEqual(result.appliedCalls, ["personal-open-internet"]);
+    assert.deepEqual(result.syncCalls[0]?.selected, ["personal-open-internet"]);
+  });
+
   it("preserves a recorded Balanced tier default during resumed reapply (#6844)", async () => {
     const result = await runPolicySetup(
       {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Portable onboarding previously combined the broad `personal-open-internet` preset with narrower Personal-tier presets. OpenShell rejected the resulting ambiguous endpoints, and the original CLI output surfaced that rejection as a generic HTTP/2 stream reset.

This merged change selects only `personal-open-internet` for portable onboarding. It is an intermediate preset reduction, not a resolution for #8991. Exact live validation with OpenShell 0.0.101 still fails because the hostless endpoint overlaps mandatory exact-host policy entries. The change does not establish that portable onboarding completes or that the Personal policy tier retains its intended access.

## Related Issue

Related to #8991

## Changes

- Select `personal-open-internet` as the only portable policy preset while retaining the Personal tier as the user-facing policy choice.
- Add focused command and policy-sync coverage proving that the custom selection remains authoritative before policy mutation.
- Document the intended broad L4 coverage for the named weather, public-reference, and GitHub destinations on ports 80 and 443. This does not establish successful composition with mandatory baseline policy entries.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: This merged change narrows portable policy composition to one existing preset. It adds no retry, fallback, credential handling, command execution path, or new policy mutation path. Exact live validation remains blocked by the OpenShell 0.0.101 overlap with mandatory policy entries.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/network-policies.mdx` describes the single portable preset and its existing port coverage. Documentation synchronization and build validation passed, and the generated agent variants matched the source.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5de116916 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this PR does not change `scripts/prepare-dgx-station-host.sh`.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `vitest` CLI and integration projects: 2 files and 95 tests passed; `npm run build:cli`, `npm run typecheck:cli`, `npm run checks:repository`, and `git diff --check` passed. These tests cover deterministic policy selection. They do not exercise OpenShell ambiguity validation. Exact live validation with OpenShell 0.0.101 failed during policy application.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused policy-selection change. Targeted projects cover deterministic selection behavior but do not establish successful OpenShell policy application.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
