### PR TITLE
fix(onboard): explain incompatible gateway database

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -575,6 +575,40 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 
 The next installer run must continue past the OpenShell installation step without reporting a version mismatch.
 
+### Docker Driver Gateway Reports a Missing Migration
+
+Onboarding can stop when the Docker driver gateway log contains both parts of this error:
+
+```text
+migration N was previously applied
+is missing in the resolved migrations
+```
+
+NemoClaw identifies `<selected-state-dir>/openshell.db` as incompatible with the installed OpenShell migration set.
+This failure can occur after an OpenShell downgrade.
+NemoClaw offers state-move recovery only when the current gateway process wrote this error and then exited.
+The diagnostic prints the database path, an unused archive path beside the selected state directory, and the profile-specific onboarding command.
+
+<Warning>
+The selected state directory contains the gateway database, mutual TLS private keys, JSON Web Token signing material, and every sandbox and provider registration on the selected gateway.
+Moving it makes those registrations and credentials unavailable to the fresh gateway.
+Other sandboxes on the selected gateway can require re-onboarding and credential entry.
+</Warning>
+
+Use this recovery only after the diagnostic confirms that the gateway process exited.
+Run the exact commands that NemoClaw prints:
+
+1. Create the printed `.incompatible` archive with owner-only access.
+   If that path exists, NemoClaw adds a numeric suffix instead of nesting or replacing an earlier archive.
+2. Move the selected state directory into the archive as `gateway-state`.
+3. Run the printed onboarding command only after the archive and move succeed.
+   Standard onboarding prints `$$nemoclaw onboard --resume`.
+   The portable experimental profile prints its required fresh-onboarding command because it does not support resume.
+
+The archive remains beside the selected state directory and retains the previous gateway records and credentials.
+Keep it owner-only until onboarding completes and every required sandbox and provider registration is restored.
+Delete the archive only after you no longer need its gateway records or credentials for recovery.
+
 ### Installer Reports That the Systemd User Manager Is Unavailable
 
 On Linux, an OpenShell package can install `/usr/lib/systemd/user/openshell-gateway.service` on a host without a reachable systemd user manager.

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -1901,11 +1901,13 @@ async function startDockerDriverGateway({
 
   fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
   const logPath = path.join(stateDir, "openshell-gateway.log");
-  const logFd = dockerDriverGatewayLaunch.openDockerDriverGatewayLog(logPath, { exitOnFailure });
+  const gatewayLog = dockerDriverGatewayLaunch.openDockerDriverGatewayLog(logPath, {
+    exitOnFailure,
+  });
   console.log("  Starting OpenShell Docker-driver gateway...");
   console.log(`  Gateway log: ${logPath}`);
   dockerDriverGatewayLaunch.prepareAndLogDockerDriverGatewayLaunch(gatewayLaunch);
-  const child = dockerDriverGatewayLaunch.spawnDockerDriverGateway(gatewayLaunch, logFd);
+  const child = dockerDriverGatewayLaunch.spawnDockerDriverGateway(gatewayLaunch, gatewayLog.fd);
   const childExit = trackChildExit(child); // #3111 zombie-safe liveness
   child.unref();
   const childPid = child.pid ?? 0;
@@ -1951,7 +1953,10 @@ async function startDockerDriverGateway({
     return;
   }
 
-  reportDockerDriverGatewayStartFailure(logPath, childExit, { exitOnFailure });
+  reportDockerDriverGatewayStartFailure(logPath, childExit, {
+    exitOnFailure,
+    launchLogOffset: gatewayLog.startOffset,
+  });
   if (gatewayStartup === "exited") {
     throw new Error("Docker-driver gateway failed to start because the process exited");
   }

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -519,7 +519,7 @@ const { isGatewayTcpReady: probeGatewayTcpReady } =
   require("./onboard/gateway-tcp-readiness") as typeof import("./onboard/gateway-tcp-readiness");
 const { trackChildExit } =
   require("./onboard/child-exit-tracker") as typeof import("./onboard/child-exit-tracker");
-const { reportDockerDriverGatewayStartFailure } =
+const { reportDockerDriverGatewayStartFailure: reportGatewayFailure } =
   require("./onboard/docker-driver-gateway-failure") as typeof import("./onboard/docker-driver-gateway-failure");
 const {
   createFinalGatewayStartFailureHandler,
@@ -1901,13 +1901,11 @@ async function startDockerDriverGateway({
 
   fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
   const logPath = path.join(stateDir, "openshell-gateway.log");
-  const gatewayLog = dockerDriverGatewayLaunch.openDockerDriverGatewayLog(logPath, {
-    exitOnFailure,
-  });
+  const log = dockerDriverGatewayLaunch.openDockerDriverGatewayLog(logPath, { exitOnFailure });
   console.log("  Starting OpenShell Docker-driver gateway...");
   console.log(`  Gateway log: ${logPath}`);
   dockerDriverGatewayLaunch.prepareAndLogDockerDriverGatewayLaunch(gatewayLaunch);
-  const child = dockerDriverGatewayLaunch.spawnDockerDriverGateway(gatewayLaunch, gatewayLog.fd);
+  const child = dockerDriverGatewayLaunch.spawnDockerDriverGateway(gatewayLaunch, log.fd);
   const childExit = trackChildExit(child); // #3111 zombie-safe liveness
   child.unref();
   const childPid = child.pid ?? 0;
@@ -1953,10 +1951,7 @@ async function startDockerDriverGateway({
     return;
   }
 
-  reportDockerDriverGatewayStartFailure(logPath, childExit, {
-    exitOnFailure,
-    launchLogOffset: gatewayLog.startOffset,
-  });
+  reportGatewayFailure(logPath, childExit, { exitOnFailure, launchLogOffset: log.startOffset });
   if (gatewayStartup === "exited") {
     throw new Error("Docker-driver gateway failed to start because the process exited");
   }

--- a/src/lib/onboard/docker-driver-gateway-failure.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-failure.test.ts
@@ -11,6 +11,10 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ChildExitState } from "./child-exit-tracker";
+import {
+  printOnboardResumeHint,
+  resetOnboardResumeHintForTests,
+} from "./resume-hint";
 import { reportDockerDriverGatewayStartFailure } from "./docker-driver-gateway-failure";
 
 function makeExitState(partial: Partial<ChildExitState> = {}): ChildExitState {
@@ -28,6 +32,7 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    resetOnboardResumeHintForTests();
     errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     // Stub process.exit so assertions can still run.
     exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
@@ -36,6 +41,7 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     errSpy.mockRestore();
     exitSpy.mockRestore();
   });
@@ -44,6 +50,7 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
     expect(() =>
       reportDockerDriverGatewayStartFailure("/tmp/nonexistent-gateway.log", makeExitState(), {
         exitOnFailure: false,
+        launchLogOffset: 0,
       }),
     ).not.toThrow();
     const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
@@ -61,7 +68,7 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
         code: 127,
         describeExit: () => "exited with code 127",
       }),
-      { exitOnFailure: false },
+      { exitOnFailure: false, launchLogOffset: 0 },
     );
     const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
     expect(joined).toContain("Gateway process exited with code 127 before becoming ready");
@@ -70,6 +77,7 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
   it("omits the child-exit line when the child is still running", () => {
     reportDockerDriverGatewayStartFailure("/tmp/nonexistent-gateway.log", makeExitState(), {
       exitOnFailure: false,
+      launchLogOffset: 0,
     });
     const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
     expect(joined).not.toContain("before becoming ready");
@@ -78,6 +86,7 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
   it("reports an unhealthy-within-timeout gateway without asserting liveness, and points at status commands (#5334)", () => {
     reportDockerDriverGatewayStartFailure("/tmp/nonexistent-gateway.log", makeExitState(), {
       exitOnFailure: false,
+      launchLogOffset: 0,
     });
     const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
     expect(joined).toContain("did not become healthy within the timeout");
@@ -92,7 +101,7 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
     reportDockerDriverGatewayStartFailure(
       "/tmp/nonexistent-gateway.log",
       makeExitState({ exited: true, code: 1, describeExit: () => "exited with code 1" }),
-      { exitOnFailure: false },
+      { exitOnFailure: false, launchLogOffset: 0 },
     );
     const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
     expect(joined).toContain("exited with code 1");
@@ -106,6 +115,7 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
     try {
       reportDockerDriverGatewayStartFailure(log, makeExitState(), {
         exitOnFailure: false,
+        launchLogOffset: 0,
       });
       const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
       expect(joined).toContain("Gateway log tail");
@@ -127,6 +137,7 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
     try {
       reportDockerDriverGatewayStartFailure(log, makeExitState(), {
         exitOnFailure: false,
+        launchLogOffset: 0,
       });
       const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
       expect(joined).toContain("Docker daemon is not running");
@@ -136,10 +147,174 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
     }
   });
 
+  it("prints a shell-quoted state-directory move after the current gateway process reports an incompatible database (#8797)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gw-fail-"));
+    const stateDir = path.join(dir, "gateway state;echo it's ignored");
+    const log = path.join(stateDir, "openshell-gateway.log");
+    fs.mkdirSync(stateDir);
+    fs.writeFileSync(
+      log,
+      [
+        "Error: execution error: migration error: migration 6 was previously applied",
+        "  is missing in the resolved migrations",
+      ].join("\n"),
+    );
+    try {
+      reportDockerDriverGatewayStartFailure(log, makeExitState({ exited: true }), {
+        exitOnFailure: false,
+        launchLogOffset: 0,
+      });
+      const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
+      expect(joined).toContain("cannot use the existing gateway database");
+      expect(joined).toContain(`Database: ${path.join(stateDir, "openshell.db")}`);
+      expect(joined).toContain("it'\\''s ignored'");
+      expect(joined).toContain("it'\\''s ignored.incompatible'");
+      expect(joined).toContain("contains credentials and all registrations");
+      expect(joined).toContain("mkdir -m 700");
+      expect(joined).toContain("incompatible/gateway-state'");
+      expect(joined).toContain("nemoclaw onboard --resume");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not recommend moving gateway state for an unrelated SQLite error (#8797)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gw-fail-"));
+    const log = path.join(dir, "openshell-gateway.log");
+    fs.writeFileSync(log, "database is locked while applying migration 6\n");
+    try {
+      reportDockerDriverGatewayStartFailure(log, makeExitState(), {
+        exitOnFailure: false,
+        launchLogOffset: 0,
+      });
+      const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
+      expect(joined).not.toContain("cannot use the existing gateway database");
+      expect(joined).not.toContain(".incompatible");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores a migration signature written before the current gateway launch (#8797)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gw-fail-"));
+    const log = path.join(dir, "openshell-gateway.log");
+    const previousLaunch = [
+      "migration 6 was previously applied",
+      "is missing in the resolved migrations",
+      "",
+    ].join("\n");
+    fs.writeFileSync(log, `${previousLaunch}current launch failed for another reason\n`);
+    try {
+      reportDockerDriverGatewayStartFailure(log, makeExitState({ exited: true }), {
+        exitOnFailure: false,
+        launchLogOffset: Buffer.byteLength(previousLaunch),
+      });
+      const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
+      expect(joined).toContain("current launch failed for another reason");
+      expect(joined).not.toContain("cannot use the existing gateway database");
+      expect(joined).not.toContain(".incompatible");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not print state-move guidance while the current gateway process can still be running (#8797)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gw-fail-"));
+    const log = path.join(dir, "openshell-gateway.log");
+    fs.writeFileSync(
+      log,
+      "migration 6 was previously applied and is missing in the resolved migrations\n",
+    );
+    try {
+      reportDockerDriverGatewayStartFailure(log, makeExitState(), {
+        exitOnFailure: false,
+        launchLogOffset: 0,
+      });
+      const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
+      expect(joined).toContain("did not become healthy within the timeout");
+      expect(joined).not.toContain(".incompatible");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("selects a second archive path when the first archive path exists (#8797)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gw-fail-"));
+    const stateDir = path.join(dir, "gateway");
+    const log = path.join(stateDir, "openshell-gateway.log");
+    fs.mkdirSync(stateDir);
+    fs.mkdirSync(`${stateDir}.incompatible`);
+    fs.writeFileSync(
+      log,
+      "migration 6 was previously applied and is missing in the resolved migrations\n",
+    );
+    try {
+      reportDockerDriverGatewayStartFailure(log, makeExitState({ exited: true }), {
+        exitOnFailure: false,
+        launchLogOffset: 0,
+      });
+      const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
+      expect(joined).toContain(`mkdir -m 700 '${stateDir}.incompatible-2'`);
+      expect(joined).toContain(`'${stateDir}.incompatible-2/gateway-state'`);
+      expect(joined).not.toContain(`mkdir -m 700 '${stateDir}.incompatible' &&`);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not offer onboarding when no gateway-state archive path is available (#8797)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gw-fail-"));
+    const stateDir = path.join(dir, "gateway");
+    const log = path.join(stateDir, "openshell-gateway.log");
+    fs.mkdirSync(stateDir);
+    for (let suffix = 1; suffix <= 100; suffix += 1) {
+      fs.mkdirSync(`${stateDir}.incompatible${suffix === 1 ? "" : `-${suffix}`}`);
+    }
+    fs.writeFileSync(
+      log,
+      "migration 6 was previously applied and is missing in the resolved migrations\n",
+    );
+    try {
+      reportDockerDriverGatewayStartFailure(log, makeExitState({ exited: true }), {
+        exitOnFailure: false,
+        launchLogOffset: 0,
+      });
+      printOnboardResumeHint(false, console.error);
+      const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
+      expect(joined).toContain("could not select an unused archive path");
+      expect(joined).toContain("Keep the gateway stopped");
+      expect(joined).not.toContain("nemoclaw onboard");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prints fresh portable onboarding instead of resume for incompatible database recovery (#8797)", () => {
+    vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gw-fail-"));
+    const log = path.join(dir, "openshell-gateway.log");
+    fs.writeFileSync(
+      log,
+      "migration 6 was previously applied and is missing in the resolved migrations\n",
+    );
+    try {
+      reportDockerDriverGatewayStartFailure(log, makeExitState({ exited: true }), {
+        exitOnFailure: false,
+        launchLogOffset: 0,
+      });
+      const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
+      expect(joined).toContain("nemoclaw onboard --experimental-profile portable");
+      expect(joined).not.toContain("nemoclaw onboard --resume");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("calls process.exit(1) when exitOnFailure is true", () => {
     expect(() =>
       reportDockerDriverGatewayStartFailure("/tmp/nonexistent-gateway.log", makeExitState(), {
         exitOnFailure: true,
+        launchLogOffset: 0,
       }),
     ).toThrow("process.exit(1)");
     expect(exitSpy).toHaveBeenCalledWith(1);
@@ -148,6 +323,7 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
   it("does NOT call process.exit when exitOnFailure is false", () => {
     reportDockerDriverGatewayStartFailure("/tmp/nonexistent-gateway.log", makeExitState(), {
       exitOnFailure: false,
+      launchLogOffset: 0,
     });
     expect(exitSpy).not.toHaveBeenCalled();
   });

--- a/src/lib/onboard/docker-driver-gateway-failure.ts
+++ b/src/lib/onboard/docker-driver-gateway-failure.ts
@@ -23,12 +23,14 @@
  */
 
 import fs from "node:fs";
+import path from "node:path";
 
 import { redact } from "../security/redact";
 import { classifyGatewayStartFailure } from "../validation";
 
 import type { ChildExitState } from "./child-exit-tracker";
 import { printDockerDaemonRecovery } from "./gateway-start-failure";
+import { noteOnboardResumeHintShown, onboardRecoveryCommand } from "./resume-hint";
 
 export type ReportDockerDriverGatewayStartFailureOpts = {
   /**
@@ -37,7 +39,22 @@ export type ReportDockerDriverGatewayStartFailureOpts = {
    * path), just print and let the caller decide.
    */
   exitOnFailure: boolean;
+  /** Byte offset where the current gateway launch began writing the append-only log. */
+  launchLogOffset: number;
 };
+
+function findAvailableGatewayStateArchivePath(stateDir: string): string | null {
+  for (let suffix = 1; suffix <= 100; suffix += 1) {
+    const candidate = `${stateDir}.incompatible${suffix === 1 ? "" : `-${suffix}`}`;
+    try {
+      fs.lstatSync(candidate);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return candidate;
+      return null;
+    }
+  }
+  return null;
+}
 
 /**
  * Print the standard Docker-driver-gateway-start failure diagnostic set
@@ -52,11 +69,13 @@ export type ReportDockerDriverGatewayStartFailureOpts = {
 export function reportDockerDriverGatewayStartFailure(
   logPath: string,
   childExit: ChildExitState,
-  { exitOnFailure }: ReportDockerDriverGatewayStartFailureOpts,
+  { exitOnFailure, launchLogOffset }: ReportDockerDriverGatewayStartFailureOpts,
 ): void {
-  const tail = fs.existsSync(logPath)
-    ? fs.readFileSync(logPath, "utf-8").split("\n").filter(Boolean).slice(-20).join("\n")
-    : "";
+  const logBytes = fs.existsSync(logPath) ? fs.readFileSync(logPath) : Buffer.alloc(0);
+  const currentLaunchLog = logBytes
+    .subarray(Math.min(Math.max(launchLogOffset, 0), logBytes.length))
+    .toString("utf-8");
+  const tail = currentLaunchLog.split("\n").filter(Boolean).slice(-20).join("\n");
 
   console.error("  Docker-driver gateway failed to start.");
   if (childExit.exited) {
@@ -74,8 +93,42 @@ export function reportDockerDriverGatewayStartFailure(
     console.error("  Gateway log tail:");
     for (const line of tail.split("\n")) console.error(`    ${redact(line)}`);
   }
-  if (classifyGatewayStartFailure(tail).kind === "docker_unreachable") {
+  const failure = classifyGatewayStartFailure(tail);
+  if (failure.kind === "docker_unreachable") {
     printDockerDaemonRecovery(console.error);
+  } else if (failure.kind === "database_migration_incompatible" && childExit.exited) {
+    const stateDir = path.dirname(logPath);
+    const databasePath = path.join(stateDir, "openshell.db");
+    console.error("  The installed OpenShell version cannot use the existing gateway database.");
+    console.error(`  Database: ${databasePath}`);
+    console.error("  The database records a migration that this OpenShell version does not include.");
+    console.error("  This can happen after an OpenShell downgrade.");
+    const archivePath = findAvailableGatewayStateArchivePath(stateDir);
+    if (archivePath) {
+      const archivedStatePath = path.join(archivePath, "gateway-state");
+      const [stateDirArg, archivePathArg, archivedStatePathArg] = [
+        stateDir,
+        archivePath,
+        archivedStatePath,
+      ].map(
+        (value) => `'${value.replaceAll("'", `'\\''`)}'`,
+      );
+      console.error(
+        "  The selected gateway state contains credentials and all registrations for this gateway.",
+      );
+      console.error("  Keep the archive owner-only until every required registration is restored.");
+      console.error(
+        "  Create the archive, move the selected gateway state, then continue onboarding:",
+      );
+      console.error(
+        `    mkdir -m 700 ${archivePathArg} && mv ${stateDirArg} ${archivedStatePathArg} && ${onboardRecoveryCommand()}`,
+      );
+      noteOnboardResumeHintShown();
+    } else {
+      console.error("  NemoClaw could not select an unused archive path for the gateway state.");
+      console.error("  Keep the gateway stopped and inspect the state directory before recovery.");
+      noteOnboardResumeHintShown();
+    }
   }
   console.error("  Troubleshooting:");
   console.error(`    tail -100 ${logPath}`);

--- a/src/lib/onboard/docker-driver-gateway-launch.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-launch.test.ts
@@ -14,6 +14,7 @@ import {
   buildDockerDriverGatewayConfigToml,
   buildDockerDriverGatewayLaunch,
   buildDockerDriverGatewayRuntimeIdentity,
+  openDockerDriverGatewayLog,
   parseGlibcVersionsFromBinaryText,
   resolveDriftGatewayBin,
   shouldUseContainerizedGateway,
@@ -36,6 +37,20 @@ function withTempBinaries<T>(
 }
 
 describe("docker-driver-gateway-launch", () => {
+  it("records the current-launch offset before appending gateway output (#8797)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-gateway-log-"));
+    const logPath = path.join(dir, "openshell-gateway.log");
+    const previousLog = "previous gateway launch\n";
+    fs.writeFileSync(logPath, previousLog);
+    try {
+      const gatewayLog = openDockerDriverGatewayLog(logPath);
+      expect(gatewayLog.startOffset).toBe(Buffer.byteLength(previousLog));
+      fs.closeSync(gatewayLog.fd);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("extracts GLIBC versions from binary text", () => {
     expect(parseGlibcVersionsFromBinaryText("GLIBC_2.35\0GLIBC_2.39\0GLIBC_2.39")).toEqual([
       "2.35",

--- a/src/lib/onboard/docker-driver-gateway-launch.ts
+++ b/src/lib/onboard/docker-driver-gateway-launch.ts
@@ -54,14 +54,25 @@ export type DockerDriverGatewayRuntimeIdentity = {
   identityGatewayBin: string | null;
 };
 
+export type DockerDriverGatewayLog = {
+  fd: number;
+  startOffset: number;
+};
+
 export function openDockerDriverGatewayLog(
   logPath: string,
   options: { exitOnFailure?: boolean } = {},
-): number {
+): DockerDriverGatewayLog {
   const appendNoFollow =
     fs.constants.O_APPEND | fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_NOFOLLOW;
   try {
-    return fs.openSync(logPath, appendNoFollow, 0o600);
+    const fd = fs.openSync(logPath, appendNoFollow, 0o600);
+    try {
+      return { fd, startOffset: fs.fstatSync(fd).size };
+    } catch (error) {
+      fs.closeSync(fd);
+      throw error;
+    }
   } catch (error) {
     console.error(
       `  Failed to open OpenShell Docker-driver gateway log '${logPath}': ${String(error)}`,

--- a/src/lib/onboard/gateway-start-failure.test.ts
+++ b/src/lib/onboard/gateway-start-failure.test.ts
@@ -66,6 +66,23 @@ describe("classifyGatewayStartFailure", () => {
     });
   });
 
+  it("classifies a gateway database migration absent from installed OpenShell as incompatible (#8797)", () => {
+    const output = [
+      "Error: execution error: migration error: migration 6 was previously applied",
+      "  is missing in the resolved migrations",
+    ].join("\n");
+
+    expect(classifyGatewayStartFailure(output)).toEqual({
+      kind: "database_migration_incompatible",
+    });
+  });
+
+  it("does not classify an unrelated SQLite migration failure as incompatible database state (#8797)", () => {
+    const output = "database is locked while applying migration 6";
+
+    expect(classifyGatewayStartFailure(output)).toEqual({ kind: "unknown" });
+  });
+
   it("returns unknown for healthy-but-slow output (should not short-circuit)", () => {
     // Real output seen during a slow first-time k3s bootstrap — the retry
     // loop must stay engaged for these, so we must not misclassify them.

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -41,10 +41,12 @@ export interface GatewayStartFailure {
    * - `docker_unreachable`: the underlying Docker daemon (Colima on macOS,
    *   dockerd on Linux) is not responding. Retrying the openshell health
    *   poll cannot recover from this — the user must start Docker first.
+   * - `database_migration_incompatible`: the gateway database records a
+   *   migration that the installed OpenShell version does not include.
    * - `unknown`: any other failure; callers should fall through to the
    *   normal retry/health-wait behavior.
    */
-  kind: "docker_unreachable" | "unknown";
+  kind: "database_migration_incompatible" | "docker_unreachable" | "unknown";
 }
 
 export function classifyValidationFailure({
@@ -217,16 +219,18 @@ export function planSandboxCreateRecovery(
  * Classify a non-zero `openshell gateway start` result so the onboard retry
  * loop can short-circuit on unrecoverable failures.
  *
- * The only case we special-case today is "Docker daemon not reachable" — on
- * macOS this surfaces as `Socket not found: /var/run/docker.sock` (Colima
- * stopped) and on Linux as `Cannot connect to the Docker daemon at
- * unix:///var/run/docker.sock. Is the docker daemon running?`. Retrying the
- * health poll against a stopped daemon wastes ~5–15 minutes and produces an
- * unactionable error at the end; bailing out immediately with a clear
- * "start Docker" message is strictly better UX. See NemoClaw #2347.
+ * The classifier identifies failures for which callers can select a supported
+ * recovery instead of generic retry or health-wait behavior.
  */
 export function classifyGatewayStartFailure(output = ""): GatewayStartFailure {
   const text = String(output || "");
+  if (
+    /migration\s+\d+\s+was previously applied[\s\S]{0,512}\bis missing in the resolved migrations\b/i.test(
+      text,
+    )
+  ) {
+    return { kind: "database_migration_incompatible" };
+  }
   // Match both macOS (Colima / Docker Desktop) and Linux docker daemon-down
   // signatures. The openshell CLI echoes these verbatim from the underlying
   // Docker client error when the gateway controller starts.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Onboarding previously reduced OpenShell's missing-migration database failure to a generic gateway-start error. This change recognizes that signature only in the current, exited gateway launch and prints a state-preserving recovery command with the credential and registration effects made explicit.

## Related Issue

Fixes #8797

## Changes

- Classify the OpenShell migration signature and restrict the diagnosis to log bytes written by the current gateway launch.
- Require confirmed process exit before offering recovery, select a non-colliding owner-only archive, shell-quote every path, and fail closed when no archive path is available.
- Cover stale logs, live processes, injection-shaped paths, archive collisions and exhaustion, and portable-profile recovery.
- Document the gateway-wide credential, registration, retention, and restoration effects in the troubleshooting guide.
- Keep the top-level onboarding entrypoint net-neutral by using a local alias for the focused failure reporter.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop independently reviewed final head `9b1341263b2027ccd5627ff33ede6103d60d30ad`; all nine security-rubric categories passed with no blockers or suggestions.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/troubleshooting.mdx`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 9b1341263 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/gateway-start-failure.test.ts src/lib/onboard/docker-driver-gateway-failure.test.ts src/lib/onboard/docker-driver-gateway-launch.test.ts` passed 43/43; `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — Not run: this is a focused onboarding diagnostic; targeted tests, CLI type-checking, and normal hooks cover the affected contracts.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — Not applicable to this code-with-docs PR. The build passed with Fern reporting 0 errors and 2 hidden warnings.
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
