### PR TITLE
fix(onboard): preserve portable policy presets

### DIFF
--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -155,8 +155,9 @@ The sandbox's filesystem, process, gateway authentication, and managed credentia
 Use this tier only for trusted personal workloads with trusted prompts and data.
 </Warning>
 
-The experimental portable profile selects only `personal-open-internet` from the Personal tier.
-Its broad L4 rule already permits matching `weather`, `public-reference`, and `github` destinations on ports `80` and `443`, so portable onboarding does not add those narrower overlapping presets.
+By default, the experimental portable profile selects only `personal-open-internet` from the Personal tier.
+Portable onboarding does not add narrower Personal presets when it uses this default.
+If `NEMOCLAW_POLICY_PRESETS` contains a non-blank list, portable onboarding treats that explicit list as authoritative instead.
 
 After selecting a tier, a combined preset and access-mode screen lets you include or exclude individual presets and toggle each between read (GET only) and read-write (GET + POST/PUT/PATCH) access.
 Tier-default presets are pre-selected; additional presets can be added from the built-in preset list available to the sandbox's active agent.

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -533,14 +533,15 @@ describe("onboard command options", () => {
     expect(env.NEMOCLAW_SERVING_PRESET).toBeUndefined();
   });
 
-  it("selects only the broad Personal preset for local portable onboarding (#8991)", async () => {
+  it("preserves an explicit preset list during portable onboarding (#8991)", async () => {
+    const explicitPresets = "weather,public-reference,github";
     const env: NodeJS.ProcessEnv = {
       NEMOCLAW_EXPERIMENTAL_PROFILE: "previous-profile",
       NEMOCLAW_PROVIDER: "previous-provider",
       NEMOCLAW_MODEL: "previous-model",
       NEMOCLAW_OLLAMA_NO_AUTOSTART: "0",
       NEMOCLAW_POLICY_MODE: "previous-mode",
-      NEMOCLAW_POLICY_PRESETS: "previous-presets",
+      NEMOCLAW_POLICY_PRESETS: explicitPresets,
       NEMOCLAW_POLICY_TIER: "previous-tier",
       NEMOCLAW_TOOL_DISCLOSURE: "progressive",
     };
@@ -571,7 +572,7 @@ describe("onboard command options", () => {
       NEMOCLAW_MODEL: "qwen3-vl:4b",
       NEMOCLAW_OLLAMA_NO_AUTOSTART: "1",
       NEMOCLAW_POLICY_MODE: "custom",
-      NEMOCLAW_POLICY_PRESETS: "personal-open-internet",
+      NEMOCLAW_POLICY_PRESETS: explicitPresets,
       NEMOCLAW_POLICY_TIER: "personal",
       NEMOCLAW_TOOL_DISCLOSURE: "direct",
     });
@@ -581,10 +582,48 @@ describe("onboard command options", () => {
       NEMOCLAW_MODEL: "previous-model",
       NEMOCLAW_OLLAMA_NO_AUTOSTART: "0",
       NEMOCLAW_POLICY_MODE: "previous-mode",
-      NEMOCLAW_POLICY_PRESETS: "previous-presets",
+      NEMOCLAW_POLICY_PRESETS: explicitPresets,
       NEMOCLAW_POLICY_TIER: "previous-tier",
       NEMOCLAW_TOOL_DISCLOSURE: "progressive",
     });
+  });
+
+  it(
+    "defaults portable onboarding to the broad Personal preset when no list is supplied (#8991)",
+    async () => {
+      const env: NodeJS.ProcessEnv = {};
+      let observedPresets: string | undefined;
+
+      await runOnboardCommand({
+        flags: { "experimental-profile": "portable" },
+        env,
+        loadPortableInferenceDescriptor: async () => null,
+        runOnboard: async () => {
+          observedPresets = env.NEMOCLAW_POLICY_PRESETS;
+        },
+      });
+
+      expect(observedPresets).toBe("personal-open-internet");
+      expect(env.NEMOCLAW_POLICY_PRESETS).toBeUndefined();
+    },
+  );
+
+  it("does not change an explicit preset list outside portable onboarding (#8991)", async () => {
+    const env: NodeJS.ProcessEnv = {
+      NEMOCLAW_POLICY_PRESETS: "weather,public-reference,github",
+    };
+    let observedPresets: string | undefined;
+
+    await runOnboardCommand({
+      flags: {},
+      env,
+      runOnboard: async () => {
+        observedPresets = env.NEMOCLAW_POLICY_PRESETS;
+      },
+    });
+
+    expect(observedPresets).toBe("weather,public-reference,github");
+    expect(env.NEMOCLAW_POLICY_PRESETS).toBe("weather,public-reference,github");
   });
 
   it("configures portable onboarding from an admitted descriptor without exporting its credential", async () => {
@@ -690,6 +729,7 @@ describe("onboard command options", () => {
         "NEMOCLAW_PROVIDER",
         "NEMOCLAW_MODEL",
         "NEMOCLAW_OLLAMA_NO_AUTOSTART",
+        "NEMOCLAW_POLICY_PRESETS",
       ],
     },
     {

--- a/src/lib/onboard/command.ts
+++ b/src/lib/onboard/command.ts
@@ -469,7 +469,7 @@ function applyPortableEnvironment(
     NEMOCLAW_PREFERRED_API: activation ? "openai-completions" : undefined,
     NEMOCLAW_OLLAMA_NO_AUTOSTART: "1",
     NEMOCLAW_POLICY_MODE: "custom",
-    NEMOCLAW_POLICY_PRESETS: "personal-open-internet",
+    NEMOCLAW_POLICY_PRESETS: env.NEMOCLAW_POLICY_PRESETS ?? "personal-open-internet",
     NEMOCLAW_POLICY_TIER: "personal",
   } as const;
   const previousPortableEnv = new Map<string, string | undefined>();

--- a/test/policy-tiers-onboard.test.ts
+++ b/test/policy-tiers-onboard.test.ts
@@ -580,17 +580,21 @@ describe("policy tier setup", () => {
     assert.deepEqual(result.appliedCalls, ["brave", "npm"]);
   });
 
-  it("keeps a custom Personal selection authoritative before policy mutation (#8991)", async () => {
-    const result = await runPolicySetup({
-      tierName: "personal",
-      policyMode: "custom",
-      policyPresets: "personal-open-internet",
-    });
+  it(
+    "keeps an explicit Personal preset list authoritative before policy mutation (#8991)",
+    async () => {
+      const explicitPresets = ["weather", "public-reference", "github"];
+      const result = await runPolicySetup({
+        tierName: "personal",
+        policyMode: "custom",
+        policyPresets: explicitPresets.join(","),
+      });
 
-    assert.deepEqual(result.applied, ["personal-open-internet"]);
-    assert.deepEqual(result.appliedCalls, ["personal-open-internet"]);
-    assert.deepEqual(result.syncCalls[0]?.selected, ["personal-open-internet"]);
-  });
+      assert.deepEqual(result.applied, explicitPresets);
+      assert.deepEqual(result.appliedCalls, explicitPresets);
+      assert.deepEqual(result.syncCalls[0]?.selected, explicitPresets);
+    },
+  );
 
   it("preserves a recorded Balanced tier default during resumed reapply (#6844)", async () => {
     const result = await runPolicySetup(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Portable onboarding now preserves a caller-supplied `NEMOCLAW_POLICY_PRESETS` value. When the variable is absent, the existing `personal-open-internet` default remains unchanged. This restores caller configurability after #8994 and provides a validated workaround for #8991; it does not resolve the default OpenShell policy overlap.

## Related Issue

Related to #8991. This PR intentionally does not close the issue.

## Changes

- Apply the portable preset default only when `NEMOCLAW_POLICY_PRESETS` is absent.
- Cover explicit-list preservation, defaulting, environment restoration, non-portable behavior, and checkpoint policy selection.
- Document that a non-blank explicit portable preset list is authoritative.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer-approved narrow configurability scope; the change does not modify policy manifests or OpenShell policy semantics, and the explicit-list path passed live onboarding, policy, status, chat, and network-access validation.
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: `checks:repository` has a maintainer-approved baseline-only waiver. The candidate adds no imports or files, and unchanged `main` at `15bd5aa0` reports the same pre-existing architecture-budget failures: `runtime.ts` fan-in 53 > 52; `ports.ts` 89 > 88; `gateway-binding.ts` 50 > 49; `registry.ts` 100 > 99; `onboard-probes.ts` fan-out 21 > 20; and `src/lib/onboard` root files 309 > 308.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/network-policies.mdx` documents the existing default and the authoritative non-blank override. Generated agent variants contain the same wording. `npm run docs` and `git diff --check` pass.
- Agent: Codex Desktop
<!-- docs-review-head-sha: abf6dea93 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli --project integration src/lib/onboard/command.test.ts test/policy-tiers-onboard.test.ts` — 97 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused environment-default change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation:

- `npm run build:cli` passed.
- `npm run typecheck:cli` passed.
- `npm run docs:sync-agent-variants` passed.
- `npm run docs` completed with zero errors and two unchanged warnings.
- `git diff --check` passed.
- All non-waived pre-commit hooks passed; `commit-msg` passed; `pre-push` passed.
- Live validation with OpenShell 0.0.101 passed using an explicit preset list: portable onboarding completed, the sandbox reached Ready, status contained exactly the requested presets with `personal-open-internet` absent, a basic chat completed, and both a direct weather request and an agent weather request succeeded. This validates the explicit-list workaround, not the default `personal-open-internet` path.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portable onboarding now defaults to the `personal-open-internet` policy preset when no preset is specified.
  * Explicit policy preset lists are preserved and treated as authoritative during onboarding and synchronization.

* **Documentation**
  * Updated network policy documentation to describe portable defaults and custom preset behavior.

* **Bug Fixes**
  * Improved environment restoration after onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->