### PR TITLE
fix(test): remove the duplicate WSL spy from the connect harness

### DIFF
--- a/test/support/connect-flow-test-harness.ts
+++ b/test/support/connect-flow-test-harness.ts
@@ -7,7 +7,6 @@ import { createRequire } from "node:module";
 import { type MockInstance, vi } from "vitest";
 import type { ManagedGatewayControlCompletion } from "../../src/lib/actions/sandbox/gateway-restart";
 import type { SecretBoundaryRefusalReason } from "../../src/lib/actions/sandbox/hermes-secret-boundary-recovery";
-import type { WslDetectionOptions } from "../../src/lib/platform";
 import type { ConfigObject } from "../../src/lib/security/credential-filter";
 import type { SandboxEntry } from "../../src/lib/state/registry";
 
@@ -275,15 +274,6 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
   const probeOllamaAuthProxyHealthSpy = vi
     .spyOn(ollamaProxy, "probeOllamaAuthProxyHealth")
     .mockReturnValue({ ok: true });
-  const realIsWsl = platform.isWsl as (opts?: WslDetectionOptions) => boolean;
-  // Pin the platform gate for every isWsl consumer the harness loads: isWsl
-  // answers false off Linux before it reads WSL_DISTRO_NAME, so a case that
-  // stubs that variable cannot reach the WSL route on a macOS contributor
-  // machine. With the gate pinned, the stubbed environment decides, on every
-  // host, and a caller's own options still win over the pin (#8868).
-  vi.spyOn(platform, "isWsl").mockImplementation((...args: unknown[]) =>
-    realIsWsl({ platform: "linux", ...((args[0] as WslDetectionOptions | undefined) ?? {}) }),
-  );
   const primaryRegistryEntry: SandboxEntry = {
     name: "alpha",
     agent: options.agentName ?? "openclaw",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`test/support/connect-flow-test-harness.ts` installs two spies on `platform.isWsl`. The explicit `options.isWsl` spy added in #8951 runs first, then the platform pin added in #8984 replaces it and delegates to the binding captured just before, so a case that passes `isWsl: true` resolves against the environment instead of the option. On `main` today, `repairs a WSL Ollama route without requiring an auth proxy token` takes the non-WSL branch, calls the auth-proxy probe, and exits 1. This change removes the pin and keeps the explicit option.

## Changes

- `test/support/connect-flow-test-harness.ts`: remove the `platform.isWsl` pin and its now-unused `WslDetectionOptions` import. The explicit `options.isWsl` supersedes it — it states the WSL decision per case instead of inferring one from the host, and it already delivers the host independence the pin was added for.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the case this restores, `repairs a WSL Ollama route without requiring an auth proxy token`, is the regression test; it fails on `main` and passes here.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: test-support change only; no user-facing surface.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: one test-support file; the removed lines were an internal comment and a spy, and no documentation page references the connect harness or WSL detection in tests.
- Agent: Claude Code
<!-- docs-review-head-sha: 292fdfb78 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli` over all seven suites that use the harness → 92 passed; the same command on unmodified `main` → 1 failed, 91 passed. `npm run typecheck:cli` clean.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable; the change removes one spy from one test-support file, validated by every suite that consumes it.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Note on an unrelated red check: `static-checks` fails on this branch through `source-architecture`, reporting `src/lib/onboard: root files fell from 309 to 308. Lower the limit.` That reproduces on unmodified `main` with no changes applied, so it is a stale ratchet in `ci/source-architecture-budget.json` rather than anything in this diff. I left it alone to keep this change to one concern; happy to send the one-line ratchet update separately if that helps.

Signed-off-by: Kushagar Garg <dreamstick909@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated connection-flow test behavior to use the platform’s native WSL detection.
  * Added support for explicitly configured WSL detection overrides in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->