### PR TITLE
fix(e2e): reject all-skipped catalogue targets

### DIFF
--- a/test/e2e-risk-signal-reporter.test.ts
+++ b/test/e2e-risk-signal-reporter.test.ts
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TestModule, TestSpecification, Vitest } from "vitest/node";
 import {
   classifyLiveTestOutcome,
@@ -31,6 +31,7 @@ vi.mock("node:child_process", () => ({
 
 const EXPECTED_SHA = "a".repeat(40);
 const CORRELATION_ID = "12345678-1234-4123-8123-123456789abc";
+const ORIGINAL_PROCESS_EXIT_CODE = process.exitCode;
 
 function moduleWithStates(states: Array<"passed" | "failed" | "skipped" | "pending">): TestModule {
   return {
@@ -83,8 +84,14 @@ function environment(artifactDir: string): RiskSignalEnvironment {
 }
 
 describe("E2E risk signal reporter", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = ORIGINAL_PROCESS_EXIT_CODE;
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
+    process.exitCode = ORIGINAL_PROCESS_EXIT_CODE;
   });
 
   it("stays disabled when no expected commit is configured", () => {
@@ -307,6 +314,43 @@ describe("E2E risk signal reporter", () => {
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("fails a successful live selection when every selected test skips (#9022)", () => {
+    vi.stubEnv("NEMOCLAW_E2E_REQUIRE_EXECUTED_TEST", "1");
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    process.exitCode = undefined;
+    const reporter = new E2eRiskSignalReporter();
+
+    reporter.onTestRunEnd([moduleWithStates(["skipped"])], [], "passed");
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr).toHaveBeenCalledWith(
+      "::error::Live E2E selection ran no tests (1 skipped, 0 pending)\n",
+    );
+  });
+
+  it("keeps a successful live selection successful when a test passes (#9022)", () => {
+    vi.stubEnv("NEMOCLAW_E2E_REQUIRE_EXECUTED_TEST", "1");
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    process.exitCode = undefined;
+    const reporter = new E2eRiskSignalReporter();
+
+    reporter.onTestRunEnd([moduleWithStates(["passed", "skipped"])], [], "passed");
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicit unsupported registry skips outside catalogue execution (#9022)", () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    process.exitCode = undefined;
+    const reporter = new E2eRiskSignalReporter();
+
+    reporter.onTestRunEnd([moduleWithStates(["skipped"])], [], "passed");
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stderr).not.toHaveBeenCalled();
   });
 
   it("refuses a symlinked prior signal without modifying its target", () => {

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -275,6 +275,7 @@ The manifest uses kind `nemoclaw-e2e-evidence-v1`.
 It records `targetId`, the candidate repository and commit, the trusted workflow repository and commit, the GitHub Actions run ID and attempt, the job status, the artifact directory, and `productEvidenceFileCount`.
 A successful target must write at least one product evidence file before the workflow writes a successful manifest.
 If the target reports success without product evidence, manifest creation fails instead of certifying an empty run.
+A catalogue Vitest selection that runs no tests exits nonzero before manifest creation, including when every selected test skips.
 Failed targets still write a manifest for diagnosis, and the existing artifact upload publishes the manifest with the target artifacts.
 The manifest is secret-free diagnostic evidence.
 It does not replace the workflow job result or the `Release qualification` release gate.

--- a/test/e2e/risk-signal-reporter.ts
+++ b/test/e2e/risk-signal-reporter.ts
@@ -57,6 +57,23 @@ function counts(testModules: ReadonlyArray<TestModule>, testNamePattern?: RegExp
   return result;
 }
 
+function failClosedWhenNoTestsRan(
+  summary: ReturnType<typeof counts>,
+  runReason: TestRunEndReason,
+): void {
+  if (
+    process.env.NEMOCLAW_E2E_REQUIRE_EXECUTED_TEST !== "1" ||
+    runReason !== "passed" ||
+    summary.passed + summary.failed > 0
+  ) {
+    return;
+  }
+  process.exitCode = 1;
+  process.stderr.write(
+    `::error::Live E2E selection ran no tests (${summary.skipped} skipped, ${summary.pending} pending)\n`,
+  );
+}
+
 function failedTestErrors(testModules: ReadonlyArray<TestModule>): unknown[] {
   const errors: unknown[] = [];
   for (const module of testModules) {
@@ -174,6 +191,7 @@ export default class E2eRiskSignalReporter implements Reporter {
     unhandledErrors: ReadonlyArray<unknown>,
     reason: TestRunEndReason,
   ): void {
+    const summary = counts(testModules, this.testNamePattern);
     if (this.environment) {
       writeRiskSignal(this.environment, testModules, unhandledErrors, reason, this.testNamePattern);
     }
@@ -183,5 +201,6 @@ export default class E2eRiskSignalReporter implements Reporter {
         outcomeForRun(testModules, unhandledErrors, reason, this.processTimedOut),
       );
     }
+    failClosedWhenNoTestsRan(summary, reason);
   }
 }

--- a/test/e2e/support/runner-pressure-workflow-boundary.test.ts
+++ b/test/e2e/support/runner-pressure-workflow-boundary.test.ts
@@ -63,6 +63,7 @@ describe("runner-pressure catalogue boundary", () => {
         "E2E_TERMINAL_CLASSIFICATION_FILE",
         "E2E_TEST_OUTCOME_FILE",
         "NEMOCLAW_CLI_BIN",
+        "NEMOCLAW_E2E_REQUIRE_EXECUTED_TEST",
       ];
       for (const name of environmentNames) vi.stubEnv(name, process.env[name] ?? "");
       vi.stubEnv("E2E_ARTIFACT_DIR", directory);
@@ -76,6 +77,7 @@ describe("runner-pressure catalogue boundary", () => {
           "--test-path",
           target.testFile,
         ]);
+        expect(process.env.NEMOCLAW_E2E_REQUIRE_EXECUTED_TEST).toBe("1");
         expect(mocks.spawnSync.mock.calls.map((call) => call[1].at(-1))).toEqual([
           "snapshot",
           "initialize-evidence",

--- a/test/e2e/support/workflow-plan.test.ts
+++ b/test/e2e/support/workflow-plan.test.ts
@@ -122,14 +122,6 @@ describe("E2E workflow plan", () => {
         OPENSHELL_GATEWAY: "nemoclaw",
       },
     });
-    expect(catalogueTarget("issue-4434-tui-unreachable-inference")).toMatchObject({
-      profile: "nvidia-inference",
-      timeoutMinutes: 120,
-      installMode: "authenticated",
-      installNonInteractive: true,
-      hostPackages: ["expect", "iptables"],
-      environment: { NEMOCLAW_ISSUE_4434_LIVE: "1" },
-    });
     expect(catalogueTarget("network-policy")).toMatchObject({
       profile: "nvidia-inference",
       timeoutMinutes: 90,
@@ -237,7 +229,7 @@ describe("E2E workflow plan", () => {
     });
 
     const plan = buildE2eWorkflowPlan({
-      jobs: "gateway-guard-recovery,hermes-slack,issue-4434-tui-unreachable-inference,network-policy,openclaw-inference-switch,openclaw-tui-chat-correlation,sandbox-operations",
+      jobs: "gateway-guard-recovery,hermes-slack,network-policy,openclaw-inference-switch,openclaw-tui-chat-correlation,sandbox-operations",
     });
     expect(plan.catalogueMatrices["nvidia-inference"]).toEqual(
       expect.arrayContaining([
@@ -251,11 +243,6 @@ describe("E2E workflow plan", () => {
           display_name: "Messaging: isolates Hermes Slack credentials and reaches Slack APIs",
           runner: "linux-amd64-cpu4",
           test_file: "test/e2e/live/hermes-slack-e2e.test.ts",
-        }),
-        expect.objectContaining({
-          id: "issue-4434-tui-unreachable-inference",
-          host_packages: "expect iptables",
-          install_non_interactive: true,
         }),
         expect.objectContaining({
           id: "network-policy",
@@ -282,6 +269,24 @@ describe("E2E workflow plan", () => {
     const retainedJobs = readFreeStandingJobsInventory().allowedJobs;
     for (const target of ["hermes-slack", "openclaw-inference-switch", "sandbox-operations"]) {
       expect(retainedJobs).not.toContain(target);
+    }
+  });
+
+  it.each([
+    [
+      "issue-4434-tui-unreachable-inference",
+      "the nvidia-inference profile uses gateway-managed inference, which this test skips by design",
+    ],
+    [
+      "overlayfs-autofix",
+      "the managed Linux Docker gateway bypasses the legacy overlayfs autofix path",
+    ],
+  ])("excludes %s from catalogue planning with a reason (#9022)", (id, reason) => {
+    expect(E2E_TARGET_CATALOGUE.map((target) => target.id)).not.toContain(id);
+    for (const selector of ["jobs", "targets"] as const) {
+      expect(() => buildE2eWorkflowPlan({ [selector]: id })).toThrow(
+        `E2E catalogue target ${id} is not scheduled: ${reason}`,
+      );
     }
   });
 

--- a/tools/e2e/target-catalogue.mts
+++ b/tools/e2e/target-catalogue.mts
@@ -324,6 +324,19 @@ const GATEWAY_UPGRADE_TARGET_BY_ID = new Map(
   GATEWAY_UPGRADE_TARGETS.map((entry) => [entry.id, entry]),
 );
 
+export const E2E_CATALOGUE_EXCLUSION_REASONS = {
+  "issue-4434-tui-unreachable-inference":
+    "the nvidia-inference profile uses gateway-managed inference, which this test skips by design",
+  "overlayfs-autofix":
+    "the managed Linux Docker gateway bypasses the legacy overlayfs autofix path",
+} as const satisfies Readonly<Record<string, string>>;
+
+export function catalogueExclusionReason(id: string): string | undefined {
+  return Object.hasOwn(E2E_CATALOGUE_EXCLUSION_REASONS, id)
+    ? E2E_CATALOGUE_EXCLUSION_REASONS[id as keyof typeof E2E_CATALOGUE_EXCLUSION_REASONS]
+    : undefined;
+}
+
 export const E2E_TARGET_CATALOGUE: readonly E2eCatalogueTarget[] = [
   target("agent-turn-latency", {
     displayName: "Performance: bounds hosted inference turns for OpenClaw and Hermes",
@@ -762,23 +775,6 @@ export const E2E_TARGET_CATALOGUE: readonly E2eCatalogueTarget[] = [
       NEMOCLAW_SANDBOX_NAME: "e2e-issue-4462",
     },
   }),
-  target("issue-4434-tui-unreachable-inference", {
-    displayName: "TUI: reports unreachable inference and stops the connected spinner",
-    profile: "nvidia-inference",
-    timeoutMinutes: 120,
-    installMode: "authenticated",
-    installNonInteractive: true,
-    restoreCli: true,
-    exposeCliBin: true,
-    hostPackages: ["expect", "iptables"],
-    owningPaths: ["test/e2e/support/issue-4434-tui-capture.ts"],
-    environment: {
-      ...hostedInference,
-      ...nonInteractive,
-      NEMOCLAW_ISSUE_4434_LIVE: "1",
-      OPENSHELL_GATEWAY: "nemoclaw",
-    },
-  }),
   target("inference-routing", {
     displayName: "Inference: rejects unsafe routes and proves runtime identities",
     profile: "standard",
@@ -996,26 +992,6 @@ export const E2E_TARGET_CATALOGUE: readonly E2eCatalogueTarget[] = [
     },
   }),
   ...GATEWAY_UPGRADE_TARGETS,
-  target("overlayfs-autofix", {
-    displayName: "Install: uses a patched cluster image for Docker overlayfs",
-    profile: "nvidia-inference",
-    timeoutMinutes: 90,
-    installMode: "none",
-    restoreCli: true,
-    exposeCliBin: true,
-    owningPaths: [
-      "test/e2e/live/overlayfs-autofix-cleanup.ts",
-      "test/e2e/live/overlayfs-autofix-outcome.ts",
-      "src/lib/onboard/docker-driver-platform.ts",
-    ],
-    environment: {
-      ...hostedInference,
-      ...nonInteractive,
-      NEMOCLAW_SANDBOX_NAME: "e2e-overlayfs",
-      NEMOCLAW_E2E_TIMEOUT_SECONDS: "1500",
-      OPENSHELL_GATEWAY: "nemoclaw",
-    },
-  }),
   target("rebuild-openclaw", {
     displayName: "Rebuild: preserves OpenClaw state and rotates the gateway token",
     profile: "nvidia-inference",
@@ -1573,6 +1549,7 @@ export async function runCatalogueTarget(id: string, testFile: string): Promise<
     runPressureCommand("initialize-evidence");
   }
   const { runLiveVitestCommand } = await import("./live-vitest-invocation.mts");
+  process.env.NEMOCLAW_E2E_REQUIRE_EXECUTED_TEST = "1";
   const selector = entry.selector ? ["--selector", entry.selector] : [];
   const exitCode = await runLiveVitestCommand(["run", "--test-path", entry.testFile, ...selector]);
   if (entry.runnerPressure && exitCode !== 0) {

--- a/tools/e2e/workflow-plan.mts
+++ b/tools/e2e/workflow-plan.mts
@@ -16,6 +16,7 @@ import { JETSON_DISPATCH_TARGET } from "./jetson-dispatch-contract.mts";
 import { selectedRetiredControllerJobs } from "./retired-selector-compatibility.mts";
 import { normalizeE2eSelectorIds } from "./selector-aliases.mts";
 import {
+  catalogueExclusionReason,
   catalogueMatrix,
   catalogueTarget,
   catalogueTargetsForChangedFiles,
@@ -417,6 +418,13 @@ export function buildE2eWorkflowPlan(
 ): E2eWorkflowPlan {
   const jobs = selectorIds(selectors.jobs, "jobs");
   const targets = selectorIds(selectors.targets, "targets");
+
+  for (const id of [...jobs, ...targets]) {
+    const reason = catalogueExclusionReason(id);
+    if (reason) {
+      throw new Error(`E2E catalogue target ${id} is not scheduled: ${reason}`);
+    }
+  }
 
   const inventory = readFreeStandingJobsInventory();
   const jetsonDispatchSelected =


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Prevent catalogue E2E jobs from reporting success when Vitest executes no selected assertions. The planner now excludes the two targets whose declared environments always skip their tests, and the catalogue runner fails closed if a future selection is all skipped.

## Related Issue

Fixes #9022

## Changes

- Remove `issue-4434-tui-unreachable-inference` and `overlayfs-autofix` from the release catalogue while preserving explicit exclusion reasons for manual selectors.
- Require catalogue Vitest runs to execute at least one passing or failing assertion before returning success.
- Preserve the typed registry's existing explicit unsupported-target skip behavior outside catalogue execution.
- Document the catalogue execution contract and add planner, reporter, and runner-boundary regression tests.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: No supported product behavior changes. `test/e2e/README.md` documents the contributor-facing qualification contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed the security rubric. Secrets, injection, authentication, authorization, dependencies, errors and logging, configuration, security tests, and system interaction pass; cryptography is not applicable. The catalogue owns the fixed activation flag, the reporter emits only aggregate counts, and no credential or shell boundary changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/README.md` documents the all-skipped catalogue execution failure. Public docs do not change because this is a contributor qualification boundary, not supported product behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 59dc4740d -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `75` focused E2E-support tests and `24` reporter integration tests passed. The exact all-skipped #4434 reproduction exits `1` with the expected annotation.
- [x] Applicable broad gate passed — `npm run checks:repository` passed; `npm run test:e2e-phases:check` covered 127 tests across 83 files. A full E2E-support attempt passed 1,923 tests and hit six unrelated macOS host limitations involving systemd, GNU `find`, and worker timeouts; GitHub Actions remains authoritative for that Linux lane.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live E2E selections now fail when no tests execute, including when all selected tests are skipped.
  * Ordinary unsupported-registry skips no longer incorrectly change the run’s exit status.
  * Removed E2E targets are rejected with clear exclusion reasons.

* **Documentation**
  * Updated E2E guidance to explain that selections with no executed tests fail before evidence is created.

* **Testing**
  * Added coverage for skipped, passed, excluded, and environment-variable execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->