### PR TITLE
fix(uninstall): remove orphaned managed vllm

### DIFF
--- a/src/lib/actions/uninstall/run-plan-local-model-profile.test.ts
+++ b/src/lib/actions/uninstall/run-plan-local-model-profile.test.ts
@@ -66,9 +66,74 @@ function publishManagedLlamaOwner(
 }
 
 describe("uninstall local model profile cleanup", () => {
+  it("removes an orphaned host-local vLLM container only when its managed label is present (#8981)", () => {
+    const containerId = "a".repeat(64);
+    const runDocker = vi.fn((args: string[]) => {
+      if (args[0] === "container" && args[1] === "inspect") return ok(`${containerId} true\n`);
+      if (args[0] === "rm") return ok();
+      return ok();
+    });
+
+    const result = runUninstallPlan(
+      { assumeYes: true, deleteModels: false, keepOpenShell: true },
+      {
+        commandExists: (command) => command === "openshell" || command === "docker",
+        env: { HOME: "/tmp/nemoclaw-uninstall-orphaned-vllm" } as NodeJS.ProcessEnv,
+        existsSync: () => false,
+        isTty: false,
+        log: () => {},
+        run: vi.fn(okWithKnownGatewayList),
+        runDocker,
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(runDocker).toHaveBeenCalledWith(
+      ["rm", "-f", containerId],
+      expect.objectContaining({ timeout: 10_000 }),
+    );
+  });
+
+  it("preserves an orphaned host-local vLLM container without the managed label (#8981)", () => {
+    const errors: string[] = [];
+    const runDocker = vi.fn((args: string[]) => {
+      if (args[0] === "container" && args[1] === "inspect") return ok(`${"b".repeat(64)} false\n`);
+      if (args[0] === "ps" && args.at(-1) === "{{.Names}}") return ok("nemoclaw-vllm\n");
+      return ok();
+    });
+
+    const result = runUninstallPlan(
+      { assumeYes: true, deleteModels: false, keepOpenShell: true },
+      {
+        commandExists: (command) => command === "openshell" || command === "docker",
+        env: { HOME: "/tmp/nemoclaw-uninstall-unlabeled-vllm" } as NodeJS.ProcessEnv,
+        existsSync: () => false,
+        error: (message) => errors.push(message),
+        isTty: false,
+        log: () => {},
+        run: vi.fn(okWithKnownGatewayList),
+        runDocker,
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(runDocker.mock.calls.some(([args]) => args[0] === "rm")).toBe(false);
+    expect(errors.join("\n")).toContain("remains after ownership-aware cleanup");
+  });
+
   it("fails before generic Docker cleanup when a reserved inference name remains", () => {
     const errors: string[] = [];
     const psResults = new Map([
+      [
+        JSON.stringify([
+          "container",
+          "inspect",
+          "--format",
+          '{{.Id}} {{index .Config.Labels "com.nvidia.nemoclaw.managed-vllm"}}',
+          "nemoclaw-vllm",
+        ]),
+        notFound(),
+      ],
       [JSON.stringify(["ps", "-a", "--format", "{{.Names}}"]), ok("nemoclaw-llama-cpp\n")],
       [
         JSON.stringify(["ps", "-a", "--format", "{{.ID}} {{.Image}} {{.Names}}"]),

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -44,6 +44,10 @@ import {
   MANAGED_VLLM_API_KEY_FILE,
   MCP_LIFECYCLE_LOCK_DIRNAME,
 } from "../../inference/serving/managed-runtime-receipts";
+import {
+  HOST_LOCAL_VLLM_CONTAINER_NAME,
+  HOST_LOCAL_VLLM_MANAGED_LABEL,
+} from "../../inference/serving/vllm-host-local-lifecycle";
 import { buildDockerGatewayDebEnvFile } from "../../onboard/docker-driver-gateway-env";
 import {
   getNemoclawOpenShellGatewayUserServicePath,
@@ -1517,6 +1521,9 @@ function removeHostLocalModelRuntimes(
     DUAL_STATION_VLLM_RUNTIME_RECEIPT_FILE,
   ].some((name) => runtime.existsSync(path.join(sharedRoot, name)));
   if (!hasLlamaState && (!hasManagedKey || hasDistributedReceipt)) {
+    if (!hasManagedKey && !hasDistributedReceipt && !removeOrphanedManagedHostLocalVllm(runtime)) {
+      return false;
+    }
     return true;
   }
   const result = runtime.runLocalModelRuntimeCleanup(deleteModels, {
@@ -1526,6 +1533,32 @@ function removeHostLocalModelRuntimes(
   if (result.status === 0) return true;
   runtime.error(
     "Host-local model cleanup did not complete. NemoClaw did not start the remaining uninstall steps. Resolve the reported ownership or Docker error and retry uninstall.",
+  );
+  return false;
+}
+
+function removeOrphanedManagedHostLocalVllm(runtime: UninstallRuntime): boolean {
+  if (!runtime.commandExists("docker")) return true;
+  const inspection = runtime.runDocker(
+    [
+      "container",
+      "inspect",
+      "--format",
+      `{{.Id}} {{index .Config.Labels ${JSON.stringify(HOST_LOCAL_VLLM_MANAGED_LABEL)}}}`,
+      HOST_LOCAL_VLLM_CONTAINER_NAME,
+    ],
+    { env: runtime.env, timeout: 10_000 },
+  );
+  if (inspection.status !== 0 || !inspection.stdout.trim()) return true;
+  const [containerId, managedLabel, ...extra] = inspection.stdout.trim().split(/\s+/);
+  if (!containerId || managedLabel !== "true" || extra.length > 0) return true;
+  const removal = runtime.runDocker(["rm", "-f", containerId], {
+    env: runtime.env,
+    timeout: 10_000,
+  });
+  if (removal.status === 0) return true;
+  runtime.error(
+    `Could not remove orphaned managed inference container '${HOST_LOCAL_VLLM_CONTAINER_NAME}'. NemoClaw did not start the remaining uninstall steps.`,
   );
   return false;
 }


### PR DESCRIPTION
## Summary

- remove an orphaned `nemoclaw-vllm` container during full uninstall when Docker verifies its NemoClaw managed label
- retain fail-closed behavior for a missing or mismatched label, malformed inspection, or failed removal
- add focused uninstall regression coverage for the labeled and unlabeled cases

## Root cause

The host-local vLLM cleanup only ran when its local key state existed. A legacy/orphaned managed container with the reserved name and managed label but no local state was skipped, then caused the residual-container guard to abort the rest of uninstall.

## Validation

- `npx vitest run src/lib/actions/uninstall/run-plan-local-model-profile.test.ts`
- `npm run typecheck:cli`
- `npx @biomejs/biome check src/lib/actions/uninstall/run-plan.ts src/lib/actions/uninstall/run-plan-local-model-profile.test.ts`
- live DGX Spark full uninstall: completed successfully after removing the reproduced `nemoclaw-vllm` orphan and all NemoClaw resources

Closes #8981


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Uninstall now cleans up orphaned host-local vLLM containers when they are verified as managed by the application.
  - Unmanaged or unlabeled containers are preserved to prevent accidental removal.
  - If container verification or removal fails, the uninstall process reports the error and stops subsequent cleanup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->