### PR TITLE
feat(onboard): make configuration review editable

### DIFF
--- a/docs/get-started/quickstart-hermes.mdx
+++ b/docs/get-started/quickstart-hermes.mdx
@@ -189,8 +189,20 @@ Use these details when your first-run path needs more control.
 
   <Accordion title="Onboarding and Integration Details">
     The wizard asks for an inference provider, model, required credential, and sandbox name before it prints the review summary.
-    After confirmation, NemoClaw registers inference, prompts for optional Tavily Search and supported messaging channels, builds and starts the sandbox, sets up Hermes, and applies the selected network policy tier and presets.
-    At any prompt, press Enter to accept the default shown in `[brackets]`, type `back` to return to the previous prompt, or type `exit` to quit.
+    The review offers these actions:
+
+    - **Apply configuration** continues to provider registration.
+    - **Edit inference provider or model** returns to provider and model selection.
+    - **Edit sandbox name** prompts for the sandbox name again.
+    - **Exit onboarding** stops onboarding before provider registration.
+
+    When you edit inference, NemoClaw clears the credential staged for the discarded selection.
+    NemoClaw preserves the sandbox name.
+    When you edit the sandbox name, NemoClaw preserves the inference selection.
+    The sandbox prompt shows the prior name as its default.
+    After you apply the configuration, routine editing ends.
+    If inference setup fails and offers a `back` recovery action, you can return to provider and model selection and then review the updated configuration again.
+    NemoClaw registers inference, prompts for optional Tavily Search and supported messaging channels, builds and starts the sandbox, sets up Hermes, and applies the selected network policy tier and presets.
 
     The default Hermes sandbox name is `hermes`.
     Use a distinct name, such as `my-hermes`, when you run Hermes and OpenClaw sandboxes side by side.
@@ -212,7 +224,7 @@ Use these details when your first-run path needs more control.
     NemoClaw removes `nous-web` from the effective managed-tool selection while preserving selected Nous image, audio, browser, and code tools.
     API-key mode is inference-only and does not enable managed tool gateways.
 
-    After you select a provider and model, review the summary and confirm the build.
+    After you select a provider and model, review the summary and apply the configuration.
     NemoClaw writes Hermes configuration into `/sandbox/.hermes`, routes model traffic through `inference.local`, and starts the Hermes gateway inside the sandbox.
     The Hermes image includes runtime dependencies for supported NemoClaw messaging integrations, the API service, and its health endpoint.
     The base image does not include unsupported Hermes integrations.

--- a/docs/get-started/quickstart-langchain-deepagents-code.mdx
+++ b/docs/get-started/quickstart-langchain-deepagents-code.mdx
@@ -131,8 +131,21 @@ nemoclaw onboard --agent deepagents
 nemoclaw onboard --agent langchain
 ```
 
-The wizard asks for an inference provider, model, required credential, sandbox name, and policy tier before it prints the review summary.
-At any prompt, press Enter to accept the default shown in `[brackets]`, type `back` to return to the previous prompt, or type `exit` to quit.
+The wizard asks for an inference provider, model, required credential, and sandbox name before it prints the review summary.
+The review offers these actions:
+
+- **Apply configuration** continues to provider registration.
+- **Edit inference provider or model** returns to provider and model selection.
+- **Edit sandbox name** prompts for the sandbox name again.
+- **Exit onboarding** stops onboarding before provider registration.
+
+When you edit inference, NemoClaw clears the credential staged for the discarded selection.
+NemoClaw preserves the sandbox name.
+When you edit the sandbox name, NemoClaw preserves the inference selection.
+The sandbox prompt shows the prior name as its default.
+After you apply the configuration, routine editing ends.
+If inference setup fails and offers a `back` recovery action, you can return to provider and model selection and then review the updated configuration again.
+Provider registration, inference setup, policy selection, and sandbox creation then continue forward.
 The default Deep Agents sandbox name is `deepagents-code`.
 Use a distinct name, such as `my-deepagents`, when you run Deep Agents, Hermes, and OpenClaw sandboxes side by side.
 Refer to [Choose an Inference Provider](../inference/learn-and-choose/choose-inference-provider) for provider-specific prompts.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -226,9 +226,21 @@ Use these details when your first-run path needs more control.
     The wizard runs preflight checks, starts or reuses the OpenShell gateway, asks for an inference provider and model, collects required credentials, and asks for a sandbox name.
     It prints a review summary before it registers the provider with OpenShell.
 
-    After confirmation, NemoClaw registers inference, prompts for optional web search and messaging channels, builds and starts the sandbox, sets up OpenClaw, and applies the selected network policy tier and presets.
+    The review offers these actions:
 
-    At any prompt, press Enter to accept the default shown in `[brackets]`, type `back` to return to the previous prompt, or type `exit` to quit.
+    - **Apply configuration** continues to provider registration.
+    - **Edit inference provider or model** returns to provider and model selection.
+    - **Edit sandbox name** prompts for the sandbox name again.
+    - **Exit onboarding** stops onboarding before provider registration.
+
+    When you edit inference, NemoClaw clears the credential staged for the discarded selection.
+    NemoClaw preserves the sandbox name.
+    When you edit the sandbox name, NemoClaw preserves the inference selection.
+    The sandbox prompt shows the prior name as its default.
+
+    After you apply the configuration, routine editing ends.
+    If inference setup fails and offers a `back` recovery action, you can return to provider and model selection and then review the updated configuration again.
+    NemoClaw registers inference, prompts for optional web search and messaging channels, builds and starts the sandbox, sets up OpenClaw, and applies the selected network policy tier and presets.
 
     <Note>
     Onboarding builds the sandbox image with a managed `NEMOCLAW_DISABLE_DEVICE_AUTH=1` compatibility setting so the dashboard is usable during setup.
@@ -301,15 +313,23 @@ Use these details when your first-run path needs more control.
       Note:          Sandbox build typically takes 5–15 minutes on this host.
       ──────────────────────────────────────────────────
       Web search and messaging channels will be prompted next.
-      Apply this configuration? [Y/n]:
+      Choose an action:
+        1) Apply configuration
+        2) Edit inference provider or model
+        3) Edit sandbox name
+        4) Exit onboarding
+      Choose [1]:
     ```
 
-    The default is `Y`.
-    Press Enter to accept the configuration.
-    If you answer `n`, onboarding exits with a nonzero status and clears the recorded provider, model, and sandbox name.
-    The rejected run does not register a new gateway credential.
-    Run `nemoclaw onboard` to make new choices.
-    Non-interactive runs print the summary and skip the prompt.
+    The default is option 1.
+    Press Enter to apply the configuration.
+    Option 2 returns to provider and model selection.
+    NemoClaw removes the staged credential for the discarded selection from the onboarding process.
+    It preserves the sandbox name.
+    Option 3 asks for the sandbox name again.
+    It uses the prior name as the default and preserves the inference selection.
+    Option 4 exits with a nonzero status without registering a new gateway credential.
+    Non-interactive runs print the summary and skip the action menu.
   </Accordion>
 
   <Accordion title="Web Search Messaging and Network Policies">

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -350,10 +350,10 @@ Legacy sessions without a profile-provenance record continue to resume normally,
 Before the configuration review, NemoClaw records the sandbox name and the selected provider and model as an incomplete choice.
 If onboarding stops at the review prompt, an interactive `--resume` run shows the prompt again.
 A non-interactive `--resume` run reuses the recorded choice and continues to inference setup.
-After you accept the review, NemoClaw records the choice before inference setup starts.
+After you choose **Apply configuration**, NemoClaw records the choice before inference setup starts.
 If inference setup fails, `--resume` reuses the accepted provider, model, and sandbox name.
-If you reject the review, onboarding exits with a nonzero status and clears those recorded choices.
-Run `$$nemoclaw onboard` to make new choices after rejection.
+If you choose **Exit onboarding**, onboarding exits with a nonzero status and clears those recorded choices.
+Run `$$nemoclaw onboard` to make new choices after exit.
 During a resume without terminal input, `--yes` or `NEMOCLAW_YES=1` also selects non-interactive resume behavior.
 For a new or fresh session, `--yes` and `NEMOCLAW_YES=1` accept supported confirmations but do not replace `--non-interactive`.
 
@@ -560,6 +560,19 @@ Do not set `NEMOCLAW_MODEL` for the managed llama.cpp path.
 For prerequisites, external traffic, verification, and recovery, refer to [Install Managed llama.cpp on DGX Spark](../inference/local-inference/choose-local-inference-server#install-managed-llamacpp-on-dgx-spark).
 
 After provider selection, the wizard reviews the provider, model, credential state, and sandbox name before registering inference.
+The interactive review offers these actions:
+
+- **Apply configuration** continues to provider registration.
+- **Edit inference provider or model** returns to provider and model selection.
+- **Edit sandbox name** prompts for the sandbox name again.
+- **Exit onboarding** stops onboarding before provider registration.
+
+When you edit inference, NemoClaw clears the credential staged for the discarded selection.
+NemoClaw preserves the sandbox name.
+When you edit the sandbox name, NemoClaw preserves the inference selection.
+The sandbox prompt shows the prior name as its default.
+After you apply the configuration, routine editing ends.
+If inference setup fails and offers a `back` recovery action, you can return to provider and model selection and then review the updated configuration again.
 <AgentOnly variant="openclaw,hermes">
 It then prompts for optional web search and messaging channels, builds and starts the sandbox, and asks for a **policy tier** that controls the default set of network policy presets applied to the sandbox.
 </AgentOnly>

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -381,6 +381,7 @@ const {
   exitOnboardFromPrompt,
   getNavigationChoice,
   isAffirmativeAnswer,
+  promptOnboardConfigurationReview,
   selectFromNumberedMenuOrExit,
   step,
   ...onboardPromptHelpers
@@ -4060,7 +4061,11 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
           assessHost,
           formatSandboxBuildEstimateNote,
           formatOnboardConfigSummary,
-          promptYesNoOrDefault,
+          promptConfigurationReview: () =>
+            promptOnboardConfigurationReview({
+              prompt,
+              log: (message) => console.log(message),
+            }),
           cliName,
           log: (message) => console.log(message),
           error: (message) => console.error(message),

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -381,7 +381,6 @@ const {
   exitOnboardFromPrompt,
   getNavigationChoice,
   isAffirmativeAnswer,
-  promptOnboardConfigurationReview,
   selectFromNumberedMenuOrExit,
   step,
   ...onboardPromptHelpers
@@ -4061,11 +4060,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
           assessHost,
           formatSandboxBuildEstimateNote,
           formatOnboardConfigSummary,
-          promptConfigurationReview: () =>
-            promptOnboardConfigurationReview({
-              prompt,
-              log: (message) => console.log(message),
-            }),
+          prompt,
           cliName,
           log: (message) => console.log(message),
           error: (message) => console.error(message),

--- a/src/lib/onboard/machine/core-flow-phases.test.ts
+++ b/src/lib/onboard/machine/core-flow-phases.test.ts
@@ -190,7 +190,7 @@ function createPhases(
       assessHost: () => ({ memoryGb: 64 }),
       formatSandboxBuildEstimateNote: () => null,
       formatOnboardConfigSummary: () => "summary",
-      promptYesNoOrDefault: vi.fn(async () => true),
+      promptConfigurationReview: vi.fn(async () => "apply" as const),
       cliName: () => "nemoclaw",
       log: vi.fn(),
       error: vi.fn(),

--- a/src/lib/onboard/machine/core-flow-phases.test.ts
+++ b/src/lib/onboard/machine/core-flow-phases.test.ts
@@ -190,7 +190,7 @@ function createPhases(
       assessHost: () => ({ memoryGb: 64 }),
       formatSandboxBuildEstimateNote: () => null,
       formatOnboardConfigSummary: () => "summary",
-      promptConfigurationReview: vi.fn(async () => "apply" as const),
+      prompt: vi.fn(async () => "1"),
       cliName: () => "nemoclaw",
       log: vi.fn(),
       error: vi.fn(),

--- a/src/lib/onboard/machine/handlers/provider-inference-route-containment.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference-route-containment.test.ts
@@ -126,7 +126,7 @@ function createDeps() {
     formatSandboxBuildEstimateNote: () => "estimate",
     formatOnboardConfigSummary: ({ provider, model, sandboxName }) =>
       `summary:${provider}/${model}/${sandboxName}`,
-    promptYesNoOrDefault: vi.fn(async () => true),
+    promptConfigurationReview: vi.fn(async () => "apply" as const),
     cliName: () => "nemoclaw",
     log: calls.log,
     error: calls.error,

--- a/src/lib/onboard/machine/handlers/provider-inference-route-containment.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference-route-containment.test.ts
@@ -126,7 +126,7 @@ function createDeps() {
     formatSandboxBuildEstimateNote: () => "estimate",
     formatOnboardConfigSummary: ({ provider, model, sandboxName }) =>
       `summary:${provider}/${model}/${sandboxName}`,
-    promptConfigurationReview: vi.fn(async () => "apply" as const),
+    prompt: vi.fn(async () => "1"),
     cliName: () => "nemoclaw",
     log: calls.log,
     error: calls.error,

--- a/src/lib/onboard/machine/handlers/provider-inference.test-support.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test-support.ts
@@ -137,7 +137,7 @@ export function createDeps(
     checkpointSandboxIdentity: vi.fn(async () => undefined),
     prepareLocalProviderForInference: vi.fn(async () => null),
     promptName: vi.fn(async () => "my-assistant"),
-    promptReview: vi.fn(async () => "apply" as const),
+    prompt: vi.fn(async () => "1"),
     log: vi.fn(),
     error: vi.fn(),
     exit: vi.fn((code: number): never => {
@@ -209,7 +209,7 @@ export function createDeps(
         model: string;
         sandboxName: string;
       }) => `summary:${options.provider}/${options.model}/${options.sandboxName}`,
-      promptConfigurationReview: calls.promptReview,
+      prompt: calls.prompt,
       cliName: () => "nemoclaw",
       log: calls.log,
       error: calls.error,

--- a/src/lib/onboard/machine/handlers/provider-inference.test-support.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test-support.ts
@@ -137,7 +137,7 @@ export function createDeps(
     checkpointSandboxIdentity: vi.fn(async () => undefined),
     prepareLocalProviderForInference: vi.fn(async () => null),
     promptName: vi.fn(async () => "my-assistant"),
-    promptYesNo: vi.fn(async () => true),
+    promptReview: vi.fn(async () => "apply" as const),
     log: vi.fn(),
     error: vi.fn(),
     exit: vi.fn((code: number): never => {
@@ -209,7 +209,7 @@ export function createDeps(
         model: string;
         sandboxName: string;
       }) => `summary:${options.provider}/${options.model}/${options.sandboxName}`,
-      promptYesNoOrDefault: calls.promptYesNo,
+      promptConfigurationReview: calls.promptReview,
       cliName: () => "nemoclaw",
       log: calls.log,
       error: calls.error,

--- a/src/lib/onboard/machine/handlers/provider-inference.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.ts
@@ -18,6 +18,7 @@ import type { HermesAuthMethod, Session, SessionUpdates } from "../../../state/o
 import { checkpointSandboxIdentityMatches } from "../../checkpoint-replay";
 import type { OnboardInferenceCapabilityCache } from "../../inference-capability-cache";
 import type { RepairLocalInferenceSystemdOverrideOptions } from "../../local-inference-topology";
+import type { OnboardConfigurationReviewAction } from "../../prompt-helpers";
 import {
   describeIgnoredReasoningEffortEnv,
   describeIgnoredReasoningEnv,
@@ -245,7 +246,7 @@ export interface ProviderInferenceStateOptions<Gpu, Agent, Host> {
     registryUpdateSandbox(sandboxName: string, updates: { nimContainer?: string | null }): void;
     checkpointSandboxIdentity(sandboxName: string, agent: Agent): Promise<void>;
     prepareLocalProviderForInference(provider: string): Promise<string | null>;
-    promptValidatedSandboxName(agent: Agent): Promise<string>;
+    promptValidatedSandboxName(agent: Agent, previousName?: string | null): Promise<string>;
     assessHost(): Host;
     formatSandboxBuildEstimateNote(host: Host): string | null;
     formatOnboardConfigSummary(options: {
@@ -260,11 +261,7 @@ export interface ProviderInferenceStateOptions<Gpu, Agent, Host> {
       servingProfileProvenance?: ServingProfileProvenance | null;
       notes: string[];
     }): string;
-    promptYesNoOrDefault(
-      question: string,
-      envVar: string | null,
-      defaultIsYes: boolean,
-    ): Promise<boolean>;
+    promptConfigurationReview(): Promise<OnboardConfigurationReviewAction>;
     cliName(): string;
     log(message?: string): void;
     error(message?: string): void;
@@ -532,6 +529,86 @@ async function repairResumedLocalInference(
     state: "provider_selection",
     metadata,
   });
+}
+
+type ConfigurationReviewDeps<Agent> = Pick<
+  ProviderInferenceStateOptions<unknown, Agent, unknown>["deps"],
+  | "checkpointSandboxIdentity"
+  | "cliName"
+  | "exitProcess"
+  | "formatOnboardConfigSummary"
+  | "isNonInteractive"
+  | "log"
+  | "promptConfigurationReview"
+  | "promptValidatedSandboxName"
+  | "recordStepRejected"
+  | "startRecordedStep"
+>;
+
+interface ConfigurationReviewInput<Agent> {
+  sandboxName: string | null;
+  agent: Agent;
+  provider: string;
+  model: string;
+  credentialEnv: string | null;
+  hermesAuthMethod: HermesAuthMethod | null;
+  webSearchConfig: WebSearchConfig | null;
+  hermesToolGateways: string[];
+  selectedMessagingChannels: string[];
+  session: Session | null;
+  buildEstimateNote: string | null;
+}
+
+async function reviewProviderConfiguration<Agent>(
+  input: ConfigurationReviewInput<Agent>,
+  deps: ConfigurationReviewDeps<Agent>,
+): Promise<{ sandboxName: string; editInference: boolean }> {
+  let sandboxName = input.sandboxName;
+  const needsSelectionRecovery = input.session?.steps?.provider_selection?.status !== "complete";
+  let selectionRecoveryStarted = false;
+
+  while (true) {
+    if (!sandboxName) sandboxName = await deps.promptValidatedSandboxName(input.agent);
+    deps.log(
+      deps.formatOnboardConfigSummary({
+        provider: input.provider,
+        model: input.model,
+        credentialEnv: input.credentialEnv,
+        hermesAuthMethod: input.hermesAuthMethod,
+        webSearchConfig: input.webSearchConfig,
+        hermesToolGateways: input.hermesToolGateways,
+        enabledChannels:
+          input.selectedMessagingChannels.length > 0 ? input.selectedMessagingChannels : null,
+        sandboxName,
+        servingProfileProvenance: input.session?.servingProfileProvenance ?? null,
+        notes: input.buildEstimateNote ? [input.buildEstimateNote] : [],
+      }),
+    );
+    deps.log("  Web search and messaging channels will be prompted next.");
+    // This secret-free checkpoint makes an interrupted review resumable without
+    // claiming that provider registration or inference setup completed.
+    await deps.checkpointSandboxIdentity(sandboxName, input.agent);
+    if (needsSelectionRecovery && !selectionRecoveryStarted) {
+      await deps.startRecordedStep("provider_selection", {
+        provider: input.provider,
+        model: input.model,
+      });
+      selectionRecoveryStarted = true;
+    }
+    if (deps.isNonInteractive()) return { sandboxName, editInference: false };
+
+    const action = await deps.promptConfigurationReview();
+    if (action === "apply") return { sandboxName, editInference: false };
+    if (action === "edit-inference") return { sandboxName, editInference: true };
+    if (action === "exit") {
+      await deps.recordStepRejected("provider_selection");
+      deps.log(`  Aborted. Re-run \`${deps.cliName()} onboard\` to start over.`);
+      deps.log("  Credentials entered so far were only staged in memory for this run.");
+      deps.log("  No new gateway credential was registered because onboarding stopped here.");
+      deps.exitProcess(1);
+    }
+    sandboxName = await deps.promptValidatedSandboxName(input.agent, sandboxName);
+  }
 }
 
 export async function handleProviderInferenceState<Gpu, Agent, Host>({
@@ -1071,46 +1148,32 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
 
     let inferenceResult: ProviderInferenceRetry;
     try {
-      if (!sandboxName) sandboxName = await deps.promptValidatedSandboxName(agent);
-      const confirmedSandboxName = sandboxName;
       const buildEstimateNote =
         env.NEMOCLAW_IGNORE_RUNTIME_RESOURCES === "1"
           ? null
           : deps.formatSandboxBuildEstimateNote(deps.assessHost());
-      deps.log(
-        deps.formatOnboardConfigSummary({
+      const review = await reviewProviderConfiguration(
+        {
+          sandboxName,
+          agent,
           provider,
           model,
           credentialEnv,
           hermesAuthMethod,
           webSearchConfig,
           hermesToolGateways,
-          enabledChannels: selectedMessagingChannels.length > 0 ? selectedMessagingChannels : null,
-          sandboxName: confirmedSandboxName,
-          servingProfileProvenance: session?.servingProfileProvenance ?? null,
-          notes: buildEstimateNote ? [buildEstimateNote] : [],
-        }),
+          selectedMessagingChannels,
+          session,
+          buildEstimateNote,
+        },
+        deps,
       );
-      deps.log("  Web search and messaging channels will be prompted next.");
-      // Persist canonical sandbox identity and selection before local-provider
-      // preparation. A preparation failure or SIGINT must leave a no-TTY-
-      // resumable provider_selection step without claiming inference setup
-      // completed.
-      await deps.checkpointSandboxIdentity(confirmedSandboxName, agent);
-      const needsReviewSelectionRecovery =
-        session?.steps?.provider_selection?.status !== "complete";
-      if (needsReviewSelectionRecovery) {
-        await deps.startRecordedStep("provider_selection", { provider, model });
+      sandboxName = review.sandboxName;
+      if (review.editInference) {
+        forceProviderSelection = true;
+        continue;
       }
-      if (!deps.isNonInteractive()) {
-        if (!(await deps.promptYesNoOrDefault("  Apply this configuration?", null, true))) {
-          await deps.recordStepRejected("provider_selection");
-          deps.log(`  Aborted. Re-run \`${deps.cliName()} onboard\` to start over.`);
-          deps.log("  Credentials entered so far were only staged in memory for this run.");
-          deps.log("  No new gateway credential was registered because onboarding stopped here.");
-          deps.exitProcess(1);
-        }
-      }
+      const confirmedSandboxName = review.sandboxName;
       // The review acceptance authorizes this fresh selection. Persist it
       // before inference setup starts so an interruption in setup can resume
       // the accepted provider/model rather than returning to the default menu.

--- a/src/lib/onboard/machine/handlers/provider-inference.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.ts
@@ -18,7 +18,7 @@ import type { HermesAuthMethod, Session, SessionUpdates } from "../../../state/o
 import { checkpointSandboxIdentityMatches } from "../../checkpoint-replay";
 import type { OnboardInferenceCapabilityCache } from "../../inference-capability-cache";
 import type { RepairLocalInferenceSystemdOverrideOptions } from "../../local-inference-topology";
-import type { OnboardConfigurationReviewAction } from "../../prompt-helpers";
+import { promptOnboardConfigurationReview } from "../../prompt-helpers";
 import {
   describeIgnoredReasoningEffortEnv,
   describeIgnoredReasoningEnv,
@@ -261,7 +261,7 @@ export interface ProviderInferenceStateOptions<Gpu, Agent, Host> {
       servingProfileProvenance?: ServingProfileProvenance | null;
       notes: string[];
     }): string;
-    promptConfigurationReview(): Promise<OnboardConfigurationReviewAction>;
+    prompt(question: string): Promise<string>;
     cliName(): string;
     log(message?: string): void;
     error(message?: string): void;
@@ -539,7 +539,7 @@ type ConfigurationReviewDeps<Agent> = Pick<
   | "formatOnboardConfigSummary"
   | "isNonInteractive"
   | "log"
-  | "promptConfigurationReview"
+  | "prompt"
   | "promptValidatedSandboxName"
   | "recordStepRejected"
   | "startRecordedStep"
@@ -597,7 +597,10 @@ async function reviewProviderConfiguration<Agent>(
     }
     if (deps.isNonInteractive()) return { sandboxName, editInference: false };
 
-    const action = await deps.promptConfigurationReview();
+    const action = await promptOnboardConfigurationReview({
+      prompt: deps.prompt,
+      log: deps.log,
+    });
     if (action === "apply") return { sandboxName, editInference: false };
     if (action === "edit-inference") return { sandboxName, editInference: true };
     if (action === "exit") {

--- a/src/lib/onboard/machine/handlers/provider-review-recovery.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-review-recovery.test.ts
@@ -12,7 +12,7 @@ describe("provider inference review recovery", () => {
   it("rejects configuration review with a non-zero exit before inference setup (#8686)", async () => {
     const { deps, calls } = createDeps({
       isNonInteractive: () => false,
-      promptConfigurationReview: vi.fn(async () => "exit" as const),
+      prompt: vi.fn(async () => "4"),
     });
 
     await expect(handleProviderInferenceState(baseOptions(deps))).rejects.toThrow("exit 1");
@@ -66,19 +66,19 @@ describe("provider inference review recovery", () => {
   });
 
   it("checkpoints a prompted sandbox identity before interactive review (#8686)", async () => {
-    const promptConfigurationReview = vi.fn(async () => "apply" as const);
+    const prompt = vi.fn(async () => "1");
     const { deps, calls } = createDeps({
       isNonInteractive: () => false,
-      promptConfigurationReview,
+      prompt,
     });
 
     await handleProviderInferenceState(baseOptions(deps));
 
     expect(calls.promptName).toHaveBeenCalledWith(null);
     expect(calls.checkpointSandboxIdentity).toHaveBeenCalledWith("my-assistant", null);
-    expect(promptConfigurationReview).toHaveBeenCalledOnce();
+    expect(prompt).toHaveBeenCalledOnce();
     expect(calls.checkpointSandboxIdentity.mock.invocationCallOrder[0]).toBeLessThan(
-      promptConfigurationReview.mock.invocationCallOrder[0],
+      prompt.mock.invocationCallOrder[0],
     );
     expect(calls.setupInference).toHaveBeenCalled();
     expect(calls.complete).toHaveBeenCalledWith(
@@ -98,13 +98,13 @@ describe("provider inference review recovery", () => {
         model: "gpt-5",
         credentialEnv: "OPENAI_API_KEY",
       });
-    const promptConfigurationReview = vi
+    const prompt = vi
       .fn()
-      .mockResolvedValueOnce("edit-inference")
-      .mockResolvedValueOnce("apply");
+      .mockResolvedValueOnce("2")
+      .mockResolvedValueOnce("1");
     const { deps, calls } = createDeps({
       isNonInteractive: () => false,
-      promptConfigurationReview,
+      prompt,
       setupNim,
     });
 
@@ -139,13 +139,13 @@ describe("provider inference review recovery", () => {
       .fn()
       .mockResolvedValueOnce("first-name")
       .mockResolvedValueOnce("edited-name");
-    const promptConfigurationReview = vi
+    const prompt = vi
       .fn()
-      .mockResolvedValueOnce("edit-sandbox")
-      .mockResolvedValueOnce("apply");
+      .mockResolvedValueOnce("3")
+      .mockResolvedValueOnce("1");
     const { deps, calls } = createDeps({
       isNonInteractive: () => false,
-      promptConfigurationReview,
+      prompt,
       promptValidatedSandboxName,
     });
 
@@ -154,7 +154,7 @@ describe("provider inference review recovery", () => {
     expect(calls.setupNim).toHaveBeenCalledOnce();
     expect(promptValidatedSandboxName).toHaveBeenNthCalledWith(1, null);
     expect(promptValidatedSandboxName).toHaveBeenNthCalledWith(2, null, "first-name");
-    expect(promptConfigurationReview).toHaveBeenCalledTimes(2);
+    expect(prompt).toHaveBeenCalledTimes(2);
     expect(calls.setupInference).toHaveBeenCalledOnce();
     expect(calls.setupInference).toHaveBeenCalledWith(
       "edited-name",
@@ -178,7 +178,7 @@ describe("provider inference review recovery", () => {
     const { deps, calls } = createDeps({
       setupInference,
       isInferenceRouteReady: vi.fn(() => false),
-      promptConfigurationReview: vi.fn(async () => "apply" as const),
+      prompt: vi.fn(async () => "1"),
     });
     calls.complete.mockImplementation(async (...args: unknown[]) => {
       const stepName = args[0] as string;
@@ -208,10 +208,10 @@ describe("provider inference review recovery", () => {
   });
 
   it("checkpoints a supplied sandbox identity before review (#8687)", async () => {
-    const promptConfigurationReview = vi.fn(async () => "exit" as const);
+    const prompt = vi.fn(async () => "4");
     const { deps, calls } = createDeps({
       isNonInteractive: () => false,
-      promptConfigurationReview,
+      prompt,
     });
 
     await expect(
@@ -221,7 +221,7 @@ describe("provider inference review recovery", () => {
     expect(calls.promptName).not.toHaveBeenCalled();
     expect(calls.checkpointSandboxIdentity).toHaveBeenCalledWith("supplied-review", null);
     expect(calls.checkpointSandboxIdentity.mock.invocationCallOrder[0]).toBeLessThan(
-      promptConfigurationReview.mock.invocationCallOrder[0],
+      prompt.mock.invocationCallOrder[0],
     );
     expect(calls.startStep).toHaveBeenCalledWith("provider_selection", {
       provider: "nvidia-prod",
@@ -258,7 +258,7 @@ describe("provider inference review recovery", () => {
         credentialEnv: null,
       })),
       prepareLocalProviderForInference: providerReviewDeps.prepareLocalProviderForInference,
-      promptConfigurationReview: vi.fn(async () => "exit" as const),
+      prompt: vi.fn(async () => "4"),
     });
 
     await expect(handleProviderInferenceState(baseOptions(deps))).rejects.toThrow("exit 1");
@@ -286,7 +286,7 @@ describe("provider inference review recovery", () => {
         credentialEnv: null,
       })),
       prepareLocalProviderForInference,
-      promptConfigurationReview: vi.fn(async () => "apply" as const),
+      prompt: vi.fn(async () => "1"),
     });
 
     await handleProviderInferenceState(baseOptions(deps));
@@ -308,12 +308,12 @@ describe("provider inference review recovery", () => {
   });
 
   it("skips configuration review in explicit non-interactive mode (#8687)", async () => {
-    const promptConfigurationReview = vi.fn(async () => "apply" as const);
-    const { deps, calls } = createDeps({ isNonInteractive: () => true, promptConfigurationReview });
+    const prompt = vi.fn(async () => "1");
+    const { deps, calls } = createDeps({ isNonInteractive: () => true, prompt });
 
     await handleProviderInferenceState(baseOptions(deps));
 
-    expect(promptConfigurationReview).not.toHaveBeenCalled();
+    expect(prompt).not.toHaveBeenCalled();
     expect(calls.startStep).toHaveBeenCalledWith("provider_selection", {
       provider: "nvidia-prod",
       model: "nvidia/test",
@@ -339,10 +339,10 @@ describe("provider inference review recovery", () => {
 
   it("prompts for review when interactive resume reuses an interrupted selection (#8687)", async () => {
     const session = failedReviewSession();
-    const promptConfigurationReview = vi.fn(async () => "apply" as const);
+    const prompt = vi.fn(async () => "1");
     const { deps, calls } = createDeps({
       isNonInteractive: () => false,
-      promptConfigurationReview,
+      prompt,
       isInferenceRouteReady: vi.fn(() => false),
     });
 
@@ -353,7 +353,7 @@ describe("provider inference review recovery", () => {
     });
 
     expect(calls.setupNim).not.toHaveBeenCalled();
-    expect(promptConfigurationReview).toHaveBeenCalledOnce();
+    expect(prompt).toHaveBeenCalledOnce();
     expect(calls.setupInference).toHaveBeenCalledWith(
       "review-interrupted",
       "qwen3.5:9b",
@@ -368,10 +368,10 @@ describe("provider inference review recovery", () => {
 
   it("bypasses review when non-interactive resume reuses an interrupted selection (#8687)", async () => {
     const session = failedReviewSession();
-    const promptConfigurationReview = vi.fn(async () => "apply" as const);
+    const prompt = vi.fn(async () => "1");
     const { deps, calls } = createDeps({
       isNonInteractive: () => true,
-      promptConfigurationReview,
+      prompt,
       isInferenceRouteReady: vi.fn(() => false),
     });
 
@@ -382,7 +382,7 @@ describe("provider inference review recovery", () => {
     });
 
     expect(calls.setupNim).not.toHaveBeenCalled();
-    expect(promptConfigurationReview).not.toHaveBeenCalled();
+    expect(prompt).not.toHaveBeenCalled();
     expect(calls.setupInference).toHaveBeenCalledWith(
       "review-interrupted",
       "qwen3.5:9b",

--- a/src/lib/onboard/machine/handlers/provider-review-recovery.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-review-recovery.test.ts
@@ -12,7 +12,7 @@ describe("provider inference review recovery", () => {
   it("rejects configuration review with a non-zero exit before inference setup (#8686)", async () => {
     const { deps, calls } = createDeps({
       isNonInteractive: () => false,
-      promptYesNoOrDefault: vi.fn(async () => false),
+      promptConfigurationReview: vi.fn(async () => "exit" as const),
     });
 
     await expect(handleProviderInferenceState(baseOptions(deps))).rejects.toThrow("exit 1");
@@ -25,6 +25,7 @@ describe("provider inference review recovery", () => {
     });
     expect(calls.rejected).toHaveBeenCalledWith("provider_selection");
     expect(calls.exit).toHaveBeenCalledWith(1);
+    expect(calls.deleteEnv).toHaveBeenCalledWith(baseSelection.credentialEnv);
     expect(calls.setupInference).not.toHaveBeenCalled();
   });
 
@@ -65,16 +66,19 @@ describe("provider inference review recovery", () => {
   });
 
   it("checkpoints a prompted sandbox identity before interactive review (#8686)", async () => {
-    const promptYesNoOrDefault = vi.fn(async () => true);
-    const { deps, calls } = createDeps({ isNonInteractive: () => false, promptYesNoOrDefault });
+    const promptConfigurationReview = vi.fn(async () => "apply" as const);
+    const { deps, calls } = createDeps({
+      isNonInteractive: () => false,
+      promptConfigurationReview,
+    });
 
     await handleProviderInferenceState(baseOptions(deps));
 
     expect(calls.promptName).toHaveBeenCalledWith(null);
     expect(calls.checkpointSandboxIdentity).toHaveBeenCalledWith("my-assistant", null);
-    expect(promptYesNoOrDefault).toHaveBeenCalledWith("  Apply this configuration?", null, true);
+    expect(promptConfigurationReview).toHaveBeenCalledOnce();
     expect(calls.checkpointSandboxIdentity.mock.invocationCallOrder[0]).toBeLessThan(
-      promptYesNoOrDefault.mock.invocationCallOrder[0],
+      promptConfigurationReview.mock.invocationCallOrder[0],
     );
     expect(calls.setupInference).toHaveBeenCalled();
     expect(calls.complete).toHaveBeenCalledWith(
@@ -82,6 +86,87 @@ describe("provider inference review recovery", () => {
       expect.objectContaining({ provider: "nvidia-prod", model: "nvidia/test" }),
     );
     expect(calls.exit).not.toHaveBeenCalled();
+  });
+
+  it("reselects inference and clears its discarded staged credential before Apply (#6005)", async () => {
+    const setupNim = vi
+      .fn()
+      .mockResolvedValueOnce({ ...baseSelection, credentialEnv: "FIRST_API_KEY" })
+      .mockResolvedValueOnce({
+        ...baseSelection,
+        provider: "openai",
+        model: "gpt-5",
+        credentialEnv: "OPENAI_API_KEY",
+      });
+    const promptConfigurationReview = vi
+      .fn()
+      .mockResolvedValueOnce("edit-inference")
+      .mockResolvedValueOnce("apply");
+    const { deps, calls } = createDeps({
+      isNonInteractive: () => false,
+      promptConfigurationReview,
+      setupNim,
+    });
+
+    const result = await handleProviderInferenceState(baseOptions(deps));
+
+    expect(setupNim).toHaveBeenCalledTimes(2);
+    expect(calls.deleteEnv).toHaveBeenCalledWith("FIRST_API_KEY");
+    expect(calls.deleteEnv.mock.invocationCallOrder[0]).toBeLessThan(
+      setupNim.mock.invocationCallOrder[1],
+    );
+    expect(calls.promptName).toHaveBeenCalledOnce();
+    expect(calls.setupInference).toHaveBeenCalledOnce();
+    expect(calls.setupInference).toHaveBeenCalledWith(
+      "my-assistant",
+      "gpt-5",
+      "openai",
+      baseSelection.endpointUrl,
+      "OPENAI_API_KEY",
+      null,
+      [],
+      expect.any(Object),
+    );
+    expect(result).toMatchObject({
+      sandboxName: "my-assistant",
+      provider: "openai",
+      model: "gpt-5",
+    });
+  });
+
+  it("edits the sandbox name without reopening inference before Apply (#6005)", async () => {
+    const promptValidatedSandboxName = vi
+      .fn()
+      .mockResolvedValueOnce("first-name")
+      .mockResolvedValueOnce("edited-name");
+    const promptConfigurationReview = vi
+      .fn()
+      .mockResolvedValueOnce("edit-sandbox")
+      .mockResolvedValueOnce("apply");
+    const { deps, calls } = createDeps({
+      isNonInteractive: () => false,
+      promptConfigurationReview,
+      promptValidatedSandboxName,
+    });
+
+    const result = await handleProviderInferenceState(baseOptions(deps));
+
+    expect(calls.setupNim).toHaveBeenCalledOnce();
+    expect(promptValidatedSandboxName).toHaveBeenNthCalledWith(1, null);
+    expect(promptValidatedSandboxName).toHaveBeenNthCalledWith(2, null, "first-name");
+    expect(promptConfigurationReview).toHaveBeenCalledTimes(2);
+    expect(calls.setupInference).toHaveBeenCalledOnce();
+    expect(calls.setupInference).toHaveBeenCalledWith(
+      "edited-name",
+      baseSelection.model,
+      baseSelection.provider,
+      baseSelection.endpointUrl,
+      baseSelection.credentialEnv,
+      null,
+      [],
+      expect.any(Object),
+    );
+    expect(result.sandboxName).toBe("edited-name");
   });
 
   it("resumes an accepted selection after inference setup throws (#8687)", async () => {
@@ -93,7 +178,7 @@ describe("provider inference review recovery", () => {
     const { deps, calls } = createDeps({
       setupInference,
       isInferenceRouteReady: vi.fn(() => false),
-      promptYesNoOrDefault: vi.fn(async () => true),
+      promptConfigurationReview: vi.fn(async () => "apply" as const),
     });
     calls.complete.mockImplementation(async (...args: unknown[]) => {
       const stepName = args[0] as string;
@@ -123,8 +208,11 @@ describe("provider inference review recovery", () => {
   });
 
   it("checkpoints a supplied sandbox identity before review (#8687)", async () => {
-    const promptYesNoOrDefault = vi.fn(async () => false);
-    const { deps, calls } = createDeps({ isNonInteractive: () => false, promptYesNoOrDefault });
+    const promptConfigurationReview = vi.fn(async () => "exit" as const);
+    const { deps, calls } = createDeps({
+      isNonInteractive: () => false,
+      promptConfigurationReview,
+    });
 
     await expect(
       handleProviderInferenceState({ ...baseOptions(deps), sandboxName: "supplied-review" }),
@@ -133,7 +221,7 @@ describe("provider inference review recovery", () => {
     expect(calls.promptName).not.toHaveBeenCalled();
     expect(calls.checkpointSandboxIdentity).toHaveBeenCalledWith("supplied-review", null);
     expect(calls.checkpointSandboxIdentity.mock.invocationCallOrder[0]).toBeLessThan(
-      promptYesNoOrDefault.mock.invocationCallOrder[0],
+      promptConfigurationReview.mock.invocationCallOrder[0],
     );
     expect(calls.startStep).toHaveBeenCalledWith("provider_selection", {
       provider: "nvidia-prod",
@@ -170,7 +258,7 @@ describe("provider inference review recovery", () => {
         credentialEnv: null,
       })),
       prepareLocalProviderForInference: providerReviewDeps.prepareLocalProviderForInference,
-      promptYesNoOrDefault: vi.fn(async () => false),
+      promptConfigurationReview: vi.fn(async () => "exit" as const),
     });
 
     await expect(handleProviderInferenceState(baseOptions(deps))).rejects.toThrow("exit 1");
@@ -198,7 +286,7 @@ describe("provider inference review recovery", () => {
         credentialEnv: null,
       })),
       prepareLocalProviderForInference,
-      promptYesNoOrDefault: vi.fn(async () => true),
+      promptConfigurationReview: vi.fn(async () => "apply" as const),
     });
 
     await handleProviderInferenceState(baseOptions(deps));
@@ -220,12 +308,12 @@ describe("provider inference review recovery", () => {
   });
 
   it("skips configuration review in explicit non-interactive mode (#8687)", async () => {
-    const promptYesNoOrDefault = vi.fn(async () => true);
-    const { deps, calls } = createDeps({ isNonInteractive: () => true, promptYesNoOrDefault });
+    const promptConfigurationReview = vi.fn(async () => "apply" as const);
+    const { deps, calls } = createDeps({ isNonInteractive: () => true, promptConfigurationReview });
 
     await handleProviderInferenceState(baseOptions(deps));
 
-    expect(promptYesNoOrDefault).not.toHaveBeenCalled();
+    expect(promptConfigurationReview).not.toHaveBeenCalled();
     expect(calls.startStep).toHaveBeenCalledWith("provider_selection", {
       provider: "nvidia-prod",
       model: "nvidia/test",
@@ -251,10 +339,10 @@ describe("provider inference review recovery", () => {
 
   it("prompts for review when interactive resume reuses an interrupted selection (#8687)", async () => {
     const session = failedReviewSession();
-    const promptYesNoOrDefault = vi.fn(async () => true);
+    const promptConfigurationReview = vi.fn(async () => "apply" as const);
     const { deps, calls } = createDeps({
       isNonInteractive: () => false,
-      promptYesNoOrDefault,
+      promptConfigurationReview,
       isInferenceRouteReady: vi.fn(() => false),
     });
 
@@ -265,7 +353,7 @@ describe("provider inference review recovery", () => {
     });
 
     expect(calls.setupNim).not.toHaveBeenCalled();
-    expect(promptYesNoOrDefault).toHaveBeenCalledWith("  Apply this configuration?", null, true);
+    expect(promptConfigurationReview).toHaveBeenCalledOnce();
     expect(calls.setupInference).toHaveBeenCalledWith(
       "review-interrupted",
       "qwen3.5:9b",
@@ -280,10 +368,10 @@ describe("provider inference review recovery", () => {
 
   it("bypasses review when non-interactive resume reuses an interrupted selection (#8687)", async () => {
     const session = failedReviewSession();
-    const promptYesNoOrDefault = vi.fn(async () => true);
+    const promptConfigurationReview = vi.fn(async () => "apply" as const);
     const { deps, calls } = createDeps({
       isNonInteractive: () => true,
-      promptYesNoOrDefault,
+      promptConfigurationReview,
       isInferenceRouteReady: vi.fn(() => false),
     });
 
@@ -294,7 +382,7 @@ describe("provider inference review recovery", () => {
     });
 
     expect(calls.setupNim).not.toHaveBeenCalled();
-    expect(promptYesNoOrDefault).not.toHaveBeenCalled();
+    expect(promptConfigurationReview).not.toHaveBeenCalled();
     expect(calls.setupInference).toHaveBeenCalledWith(
       "review-interrupted",
       "qwen3.5:9b",

--- a/src/lib/onboard/prompt-helpers.test.ts
+++ b/src/lib/onboard/prompt-helpers.test.ts
@@ -3,7 +3,11 @@
 
 import { describe, expect, it, vi } from "vitest";
 // Import source directly so tests cannot pass against a stale build.
-import { promptOrDefault, selectFromNumberedMenuOrExit } from "./prompt-helpers";
+import {
+  promptOnboardConfigurationReview,
+  promptOrDefault,
+  selectFromNumberedMenuOrExit,
+} from "./prompt-helpers";
 
 function makeDeps(promptReply: string) {
   return {
@@ -27,6 +31,41 @@ describe("promptOrDefault interactive default fallback (#4387)", () => {
   it("returns the user's reply verbatim when non-empty", async () => {
     const deps = makeDeps("3");
     expect(await promptOrDefault(deps, "  Choose [6]: ", null, "6")).toBe("3");
+  });
+});
+
+describe("onboarding configuration review actions (#6005)", () => {
+  function createReviewDeps(...answers: string[]) {
+    return {
+      prompt: vi.fn(async () => answers.shift() ?? ""),
+      log: vi.fn(),
+    };
+  }
+
+  it.each([
+    ["", "apply"],
+    ["apply", "apply"],
+    ["2", "edit-inference"],
+    ["model", "edit-inference"],
+    ["3", "edit-sandbox"],
+    ["name", "edit-sandbox"],
+    ["4", "exit"],
+    ["quit", "exit"],
+  ] as const)("returns action %s as %s (#6005)", async (answer, expected) => {
+    await expect(promptOnboardConfigurationReview(createReviewDeps(answer))).resolves.toBe(
+      expected,
+    );
+  });
+
+  it("re-prompts after an unknown action", async () => {
+    const deps = createReviewDeps("unknown", "1");
+
+    await expect(promptOnboardConfigurationReview(deps)).resolves.toBe("apply");
+
+    expect(deps.prompt).toHaveBeenCalledTimes(2);
+    expect(deps.log).toHaveBeenCalledWith(
+      "  Choose Apply, Edit inference, Edit sandbox name, or Exit onboarding.",
+    );
   });
 });
 

--- a/src/lib/onboard/prompt-helpers.ts
+++ b/src/lib/onboard/prompt-helpers.ts
@@ -53,6 +53,38 @@ export interface PromptHelperDeps {
   prompt(question: string): Promise<string>;
 }
 
+export type OnboardConfigurationReviewAction =
+  | "apply"
+  | "edit-inference"
+  | "edit-sandbox"
+  | "exit";
+
+export interface OnboardConfigurationReviewDeps {
+  prompt(question: string): Promise<string>;
+  log(message?: string): void;
+}
+
+export async function promptOnboardConfigurationReview(
+  deps: OnboardConfigurationReviewDeps,
+): Promise<OnboardConfigurationReviewAction> {
+  while (true) {
+    deps.log("  Choose an action:");
+    deps.log("    1) Apply configuration");
+    deps.log("    2) Edit inference provider or model");
+    deps.log("    3) Edit sandbox name");
+    deps.log("    4) Exit onboarding");
+
+    const answer = (await deps.prompt("  Choose [1]: ")).trim().toLowerCase();
+    if (!answer || answer === "1" || answer === "apply") return "apply";
+    if (answer === "2" || answer === "inference" || answer === "provider" || answer === "model") {
+      return "edit-inference";
+    }
+    if (answer === "3" || answer === "sandbox" || answer === "name") return "edit-sandbox";
+    if (answer === "4" || answer === "exit" || answer === "quit") return "exit";
+    deps.log("  Choose Apply, Edit inference, Edit sandbox name, or Exit onboarding.");
+  }
+}
+
 // Prompt wrapper: returns env var value or default in non-interactive mode,
 // otherwise prompts the user interactively.
 export async function promptOrDefault(

--- a/src/lib/onboard/sandbox-agent.test.ts
+++ b/src/lib/onboard/sandbox-agent.test.ts
@@ -52,4 +52,25 @@ describe("sandbox name prompt", () => {
     await expect(promptValidatedSandboxName()).rejects.toBe(checkpointError);
     expect(promptOrDefault).toHaveBeenCalledTimes(1);
   });
+
+  it("uses the reviewed sandbox name as the edit default (#6005)", async () => {
+    const promptOrDefault = vi.fn(async (_question, _envVar, defaultValue) => defaultValue);
+    const promptValidatedSandboxName = createPromptValidatedSandboxName({
+      promptOrDefault,
+      cliDisplayName: () => "NemoClaw",
+      isNonInteractive: () => false,
+      checkpointSandboxName: vi.fn(async () => undefined),
+      exit: (code) => {
+        throw new Error(`unexpected exit ${code}`);
+      },
+    });
+
+    await expect(promptValidatedSandboxName(null, "reviewed-name")).resolves.toBe("reviewed-name");
+
+    expect(promptOrDefault).toHaveBeenCalledWith(
+      expect.stringContaining("[reviewed-name]"),
+      "NEMOCLAW_SANDBOX_NAME",
+      "reviewed-name",
+    );
+  });
 });

--- a/src/lib/onboard/sandbox-agent.ts
+++ b/src/lib/onboard/sandbox-agent.ts
@@ -149,9 +149,12 @@ export interface PromptSandboxNameDeps {
 }
 
 export function createPromptValidatedSandboxName(deps: PromptSandboxNameDeps) {
-  return async function promptValidatedSandboxName(agent: AgentDefinition | null = null) {
+  return async function promptValidatedSandboxName(
+    agent: AgentDefinition | null = null,
+    previousName: string | null = null,
+  ) {
     const MAX_ATTEMPTS = 3;
-    const defaultSandboxName = getSandboxPromptDefault(agent);
+    const defaultSandboxName = previousName ?? getSandboxPromptDefault(agent);
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
       const nameAnswer = await deps.promptOrDefault(
         `  Sandbox name (${NAME_ALLOWED_FORMAT}) [${defaultSandboxName}]: `,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Replace the onboarding review's yes/no confirmation with an explicit action menu so users can correct the inference provider/model or sandbox name before applying the configuration. This is the first small replacement slice after #8171: provider registration and sandbox materialization remain behind **Apply configuration**, while web search, messaging, resources, policy, and general post-Apply editing remain out of scope.

## Related Issue

Part of #6005

Tracks NVBug 6392526.

## Changes

- Add typed review actions for **Apply configuration**, **Edit inference provider or model**, **Edit sandbox name**, and **Exit onboarding** using the existing prompt-helper module.
- Return inference edits to provider/model selection, preserve the sandbox name, and clear the discarded selection's staged credential before collecting a replacement.
- Re-prompt sandbox-name edits with the prior name as the default while preserving the inference selection.
- Keep non-interactive behavior unchanged and stop Exit before new provider registration or inference setup.
- Preserve the existing post-Apply inference-failure recovery path: if setup offers `back`, users can select a provider/model again and review the updated configuration.
- Update the OpenClaw, Hermes, Deep Agents, and command-reference documentation to describe the exact boundary and remove the inaccurate “back at any prompt” claim.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact-head review passed. No raw credential values are persisted or logged; discarded staged credential env is cleared in `finally` on edit and Exit; existing provider, model, and sandbox validators remain authoritative; provider registration and sandbox materialization remain behind Apply; no authentication, authorization, dependency, cryptography, network-policy, or security-header behavior changes; focused and broad tests cover action parsing, state transitions, cleanup ordering, preservation, Exit, resume, and non-interactive behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed `docs/get-started/quickstart.mdx`, `docs/get-started/quickstart-hermes.mdx`, `docs/get-started/quickstart-langchain-deepagents-code.mdx`, and `docs/reference/commands.mdx` against the exact implementation; confirmed the four actions, credential cleanup, preserved selections, resumable interrupted-review checkpoint, non-interactive and Exit behavior, and the post-Apply inference-failure recovery exception; generated OpenClaw, Hermes, and Deep Agents command references were verified; `npm run docs` passed with 0 errors and 2 existing Fern warnings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 224e4d570d -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli` for the five focused onboarding suites passed 68/68; `npm run build:cli`, `npm run typecheck:cli -- --incremental`, `npm run lint`, `git diff --check`, and `npm run docs` passed on the rebased head.
- [x] Applicable broad gate passed — `npx vitest run --changed origin/main --project cli --project plugin --project e2e-support --maxWorkers=4` passed 1,808/1,808 tests across 152 files.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
