### PR TITLE
fix(uninstall): preserve receipted vLLM runtime

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -4082,7 +4082,7 @@ For a managed dual-Station vLLM runtime, full uninstall revalidates the exact re
 If that cleanup fails, uninstall exits nonzero, preserves its owner-only cleanup receipt, and tells you to resolve the reported peer error before retrying.
 Pair cleanup can partially complete before an error; verify both Stations before the retry.
 For an authenticated host-local vLLM runtime, full uninstall verifies the exact named container, NemoClaw ownership label, persisted API key, and authentication fingerprint before removing the container by its inspected ID.
-When that ownership state is missing, full uninstall removes the reserved `nemoclaw-vllm` container only when Docker reports its NemoClaw managed label and a valid container ID.
+When both the host-local runtime receipt and API key are missing, full uninstall removes the reserved `nemoclaw-vllm` container only when Docker reports its NemoClaw managed label and a valid container ID.
 An unlabeled container or malformed inspection remains in place and stops the remaining uninstall steps.
 For managed llama.cpp, full uninstall verifies the exact named container and network ownership before removing both resources by their inspected IDs.
 These host-local checks run before NemoClaw deletes their state.

--- a/src/lib/actions/uninstall/run-plan-local-model-profile.test.ts
+++ b/src/lib/actions/uninstall/run-plan-local-model-profile.test.ts
@@ -38,9 +38,22 @@ const ORPHANED_VLLM_INSPECT_ARGS = [
   "nemoclaw-vllm",
 ];
 
+const ORPHANED_VLLM_ABSENCE_ARGS = [
+  "container",
+  "ls",
+  "--all",
+  "--no-trunc",
+  "--filter",
+  "name=^/nemoclaw-vllm$",
+  "--format",
+  "{{.ID}}",
+];
+
 const RESERVED_INFERENCE_NAMES_ARGS = ["ps", "-a", "--format", "{{.Names}}"];
 
 function runUninstallPlan(options: UninstallRunOptions, deps: UninstallRunDeps) {
+  const commandExists = deps.commandExists;
+  const hasExplicitDocker = deps.runDocker !== undefined;
   return runUninstallPlanBase(options, {
     resolveGatewayTeardownAuthority: ({ gatewayName, gatewayPort }) => ({
       gatewayName,
@@ -53,6 +66,16 @@ function runUninstallPlan(options: UninstallRunOptions, deps: UninstallRunDeps) 
       requiredCapabilities: [],
     }),
     ...deps,
+    commandExists: (command) =>
+      (!hasExplicitDocker && command === "docker") || commandExists?.(command) === true,
+    runDocker:
+      deps.runDocker ??
+      dockerResults(
+        new Map([
+          [JSON.stringify(ORPHANED_VLLM_INSPECT_ARGS), notFound()],
+          [JSON.stringify(ORPHANED_VLLM_ABSENCE_ARGS), ok()],
+        ]),
+      ),
   });
 }
 
@@ -144,7 +167,7 @@ describe("uninstall local model profile cleanup", () => {
 
     expect(result.exitCode).toBe(1);
     expect(runDocker.mock.calls.some(([args]) => args[0] === "rm")).toBe(false);
-    expect(errors.join("\n")).toContain("remains after ownership-aware cleanup");
+    expect(errors.join("\n")).toContain("Could not verify NemoClaw ownership");
   });
 
   it("preserves an orphaned host-local vLLM container after malformed inspection output (#8981)", () => {
@@ -172,7 +195,109 @@ describe("uninstall local model profile cleanup", () => {
 
     expect(result.exitCode).toBe(1);
     expect(runDocker.mock.calls.some(([args]) => args[0] === "rm")).toBe(false);
-    expect(errors.join("\n")).toContain("remains after ownership-aware cleanup");
+    expect(errors.join("\n")).toContain("Could not verify NemoClaw ownership");
+  });
+
+  it("stops orphan cleanup after an empty successful inspection (#8981)", () => {
+    const errors: string[] = [];
+    const runDocker = dockerResults(new Map([[JSON.stringify(ORPHANED_VLLM_INSPECT_ARGS), ok()]]));
+
+    const result = runUninstallPlan(
+      { assumeYes: true, deleteModels: false, keepOpenShell: true },
+      {
+        commandExists: (command) => command === "openshell" || command === "docker",
+        env: { HOME: "/tmp/nemoclaw-uninstall-empty-vllm-inspection" } as NodeJS.ProcessEnv,
+        existsSync: () => false,
+        error: (message) => errors.push(message),
+        isTty: false,
+        log: () => {},
+        run: vi.fn(okWithKnownGatewayList),
+        runDocker,
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(runDocker).toHaveBeenCalledTimes(1);
+    expect(errors.join("\n")).toContain("Could not verify NemoClaw ownership");
+  });
+
+  it("stops orphan cleanup when Docker is unavailable (#8981)", () => {
+    const errors: string[] = [];
+    const runDocker = vi.fn((_args: string[]) => ok());
+
+    const result = runUninstallPlan(
+      { assumeYes: true, deleteModels: false, keepOpenShell: true },
+      {
+        commandExists: (command) => command === "openshell",
+        env: { HOME: "/tmp/nemoclaw-uninstall-vllm-no-docker" } as NodeJS.ProcessEnv,
+        existsSync: () => false,
+        error: (message) => errors.push(message),
+        isTty: false,
+        log: () => {},
+        run: vi.fn(okWithKnownGatewayList),
+        runDocker,
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(runDocker).not.toHaveBeenCalled();
+    expect(errors.join("\n")).toContain("Docker is unavailable");
+  });
+
+  it("continues orphan cleanup only after Docker proves the container is absent (#8981)", () => {
+    const runDocker = dockerResults(
+      new Map([
+        [JSON.stringify(ORPHANED_VLLM_INSPECT_ARGS), notFound()],
+        [JSON.stringify(ORPHANED_VLLM_ABSENCE_ARGS), ok()],
+      ]),
+    );
+
+    const result = runUninstallPlan(
+      { assumeYes: true, deleteModels: false, keepOpenShell: true },
+      {
+        commandExists: (command) => command === "openshell" || command === "docker",
+        env: { HOME: "/tmp/nemoclaw-uninstall-vllm-absent" } as NodeJS.ProcessEnv,
+        existsSync: () => false,
+        isTty: false,
+        log: () => {},
+        run: vi.fn(okWithKnownGatewayList),
+        runDocker,
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(runDocker).toHaveBeenCalledWith(
+      ORPHANED_VLLM_ABSENCE_ARGS,
+      expect.objectContaining({ timeout: 10_000 }),
+    );
+  });
+
+  it("stops orphan cleanup when Docker cannot prove the container is absent (#8981)", () => {
+    const errors: string[] = [];
+    const runDocker = dockerResults(
+      new Map([
+        [JSON.stringify(ORPHANED_VLLM_INSPECT_ARGS), notFound()],
+        [JSON.stringify(ORPHANED_VLLM_ABSENCE_ARGS), notFound()],
+      ]),
+    );
+
+    const result = runUninstallPlan(
+      { assumeYes: true, deleteModels: false, keepOpenShell: true },
+      {
+        commandExists: (command) => command === "openshell" || command === "docker",
+        env: { HOME: "/tmp/nemoclaw-uninstall-vllm-ambiguous" } as NodeJS.ProcessEnv,
+        existsSync: () => false,
+        error: (message) => errors.push(message),
+        isTty: false,
+        log: () => {},
+        run: vi.fn(okWithKnownGatewayList),
+        runDocker,
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(runDocker.mock.calls.some(([args]) => args[0] === "ps")).toBe(false);
+    expect(errors.join("\n")).toContain("Could not confirm");
   });
 
   it("uses exact cleanup when the host-local vLLM receipt remains without its API key (#8981)", () => {
@@ -247,6 +372,7 @@ describe("uninstall local model profile cleanup", () => {
         ]),
         notFound(),
       ],
+      [JSON.stringify(ORPHANED_VLLM_ABSENCE_ARGS), ok()],
       [JSON.stringify(["ps", "-a", "--format", "{{.Names}}"]), ok("nemoclaw-llama-cpp\n")],
       [
         JSON.stringify(["ps", "-a", "--format", "{{.ID}} {{.Image}} {{.Names}}"]),
@@ -301,9 +427,13 @@ describe("uninstall local model profile cleanup", () => {
         isTty: false,
         log: () => {},
         run: vi.fn(okWithKnownGatewayList),
-        runDocker: vi.fn((args: string[]) =>
-          args[0] === "ps" && args.at(-1) === "{{.Names}}" ? notFound() : ok(),
-        ),
+        runDocker: vi.fn((args: string[]) => {
+          if (JSON.stringify(args) === JSON.stringify(ORPHANED_VLLM_INSPECT_ARGS)) {
+            return notFound();
+          }
+          if (JSON.stringify(args) === JSON.stringify(ORPHANED_VLLM_ABSENCE_ARGS)) return ok();
+          return args[0] === "ps" && args.at(-1) === "{{.Names}}" ? notFound() : ok();
+        }),
       },
     );
 

--- a/src/lib/actions/uninstall/run-plan-local-model-profile.test.ts
+++ b/src/lib/actions/uninstall/run-plan-local-model-profile.test.ts
@@ -175,6 +175,32 @@ describe("uninstall local model profile cleanup", () => {
     expect(errors.join("\n")).toContain("remains after ownership-aware cleanup");
   });
 
+  it("uses exact cleanup when the host-local vLLM receipt remains without its API key (#8981)", () => {
+    const errors: string[] = [];
+    const runDocker = vi.fn((_args: string[]) => ok());
+    const runLocalModelRuntimeCleanup = vi.fn(() => notFound());
+
+    const result = runUninstallPlan(
+      { assumeYes: true, deleteModels: false, keepOpenShell: true },
+      {
+        commandExists: (command) => command === "openshell" || command === "docker",
+        env: { HOME: "/tmp/nemoclaw-uninstall-receipted-vllm" } as NodeJS.ProcessEnv,
+        existsSync: (target) => String(target).endsWith("/host-local-vllm-runtime.json"),
+        error: (message) => errors.push(message),
+        isTty: false,
+        log: () => {},
+        run: vi.fn(okWithKnownGatewayList),
+        runDocker,
+        runLocalModelRuntimeCleanup,
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(runLocalModelRuntimeCleanup).toHaveBeenCalledOnce();
+    expect(runDocker).not.toHaveBeenCalled();
+    expect(errors.join("\n")).toContain("Host-local model runtime cleanup did not complete");
+  });
+
   it("stops uninstall when orphaned host-local vLLM removal fails (#8981)", () => {
     const errors: string[] = [];
     const containerId = "c".repeat(64);

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -32,6 +32,7 @@ import {
   cleanupManagedLlamaCppRuntimeForSandbox,
   HOST_LOCAL_VLLM_CONTAINER_NAME,
   HOST_LOCAL_VLLM_MANAGED_LABEL,
+  HOST_LOCAL_VLLM_RUNTIME_RECEIPT_FILE,
   type ManagedLlamaCppCleanupTarget,
   resolveManagedLlamaCppCleanupTarget,
 } from "../../inference/local-model-profile/cleanup";
@@ -1592,12 +1593,20 @@ function removeHostLocalModelRuntimes(paths: UninstallPaths, runtime: UninstallR
   const sharedRoot = path.dirname(paths.managedSwapMarkerPath);
   const hasLlamaState = runtime.existsSync(path.join(sharedRoot, "managed-llama-cpp"));
   const hasManagedKey = runtime.existsSync(path.join(sharedRoot, MANAGED_VLLM_API_KEY_FILE));
+  const hasHostLocalReceipt = runtime.existsSync(
+    path.join(sharedRoot, HOST_LOCAL_VLLM_RUNTIME_RECEIPT_FILE),
+  );
   const hasDistributedReceipt = [
     MANAGED_CLUSTER_VLLM_RUNTIME_RECEIPT_FILE,
     DUAL_STATION_VLLM_RUNTIME_RECEIPT_FILE,
   ].some((name) => runtime.existsSync(path.join(sharedRoot, name)));
-  if (!hasLlamaState && (!hasManagedKey || hasDistributedReceipt)) {
-    if (!hasManagedKey && !hasDistributedReceipt && !removeOrphanedManagedHostLocalVllm(runtime)) {
+  if (!hasLlamaState && ((!hasManagedKey && !hasHostLocalReceipt) || hasDistributedReceipt)) {
+    if (
+      !hasManagedKey &&
+      !hasHostLocalReceipt &&
+      !hasDistributedReceipt &&
+      !removeOrphanedManagedHostLocalVllm(runtime)
+    ) {
       return false;
     }
     return true;

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -1623,7 +1623,12 @@ function removeHostLocalModelRuntimes(paths: UninstallPaths, runtime: UninstallR
 }
 
 function removeOrphanedManagedHostLocalVllm(runtime: UninstallRuntime): boolean {
-  if (!runtime.commandExists("docker")) return true;
+  if (!runtime.commandExists("docker")) {
+    runtime.error(
+      `Docker is unavailable, so NemoClaw could not confirm that '${HOST_LOCAL_VLLM_CONTAINER_NAME}' is absent. NemoClaw did not start the remaining uninstall steps.`,
+    );
+    return false;
+  }
   const inspection = runtime.runDocker(
     [
       "container",
@@ -1634,10 +1639,32 @@ function removeOrphanedManagedHostLocalVllm(runtime: UninstallRuntime): boolean 
     ],
     { env: runtime.env, timeout: 10_000 },
   );
-  if (inspection.status !== 0 || !inspection.stdout.trim()) return true;
+  if (inspection.status !== 0) {
+    const absence = runtime.runDocker(
+      [
+        "container",
+        "ls",
+        "--all",
+        "--no-trunc",
+        "--filter",
+        `name=^/${HOST_LOCAL_VLLM_CONTAINER_NAME}$`,
+        "--format",
+        "{{.ID}}",
+      ],
+      { env: runtime.env, timeout: 10_000 },
+    );
+    if (absence.status === 0 && !absence.stdout.trim()) return true;
+    runtime.error(
+      `Could not confirm that orphaned managed inference container '${HOST_LOCAL_VLLM_CONTAINER_NAME}' is absent. NemoClaw did not start the remaining uninstall steps.`,
+    );
+    return false;
+  }
   const [containerId, managedLabel, ...extra] = inspection.stdout.trim().split(/\s+/);
   if (!/^[0-9a-f]{64}$/u.test(containerId ?? "") || managedLabel !== "true" || extra.length > 0) {
-    return true;
+    runtime.error(
+      `Could not verify NemoClaw ownership of orphaned managed inference container '${HOST_LOCAL_VLLM_CONTAINER_NAME}'. NemoClaw did not start the remaining uninstall steps.`,
+    );
+    return false;
   }
   const removal = runtime.runDocker(["rm", "-f", containerId], {
     env: runtime.env,

--- a/src/lib/inference/local-model-profile/cleanup.ts
+++ b/src/lib/inference/local-model-profile/cleanup.ts
@@ -46,7 +46,11 @@ import {
 } from "../serving/vllm-host-local-lifecycle";
 import { loadManagedVllmApiKey, managedVllmStateDir } from "../vllm-api-key";
 
-export { HOST_LOCAL_VLLM_CONTAINER_NAME, HOST_LOCAL_VLLM_MANAGED_LABEL };
+export {
+  HOST_LOCAL_VLLM_CONTAINER_NAME,
+  HOST_LOCAL_VLLM_MANAGED_LABEL,
+  HOST_LOCAL_VLLM_RUNTIME_RECEIPT_FILE,
+};
 
 const LLAMA_MANAGED_LABEL = "io.nvidia.nemoclaw.host-local-inference.managed";
 const LLAMA_PROVIDER_LABEL = "io.nvidia.nemoclaw.host-local-inference.provider";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Prevent uninstall from treating a receipted managed vLLM container as an unowned orphan when the API key is absent. Keep the container when ownership or absence cannot be proven, and document the ownership boundary.

## Related Issue

Follow-up to #9032 and #8981.

## Changes

- Require both the host-local runtime receipt and API key to be absent before label-only orphan cleanup.
- Route a remaining receipt through the existing exact ownership-aware cleanup path.
- Fail closed when Docker cannot verify orphan ownership or exact absence.
- Cover receipt-only, managed removal, exact absence, and ambiguous inspection outcomes.
- Document the two-absence requirement for label-only cleanup.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed input handling, command construction, secrets, authorization and ownership, network behavior, sandbox boundaries, dependencies, CI exposure, and resource cleanup. PASS: the change reads only the fixed receipt path, exposes no receipt or credential content, adds no command or network input, strengthens ownership selection, and fails closed when exact cleanup cannot complete.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed the complete four-file effective diff at `2d78b5de8004bc627541ee425cf66b16cd2754e4` against `105c1dfb2710e3fbdcbd9411ae0c3c07c3d1e4bf`, including changed documentation path `docs/reference/commands.mdx`. The complete commit tree and all four reviewed file blobs are byte-identical to previously reviewed commit `c610f594fa1a285080dcf272f0c6cf265908cad3`. The append-only history preserves `446a5f5b199add091929e6e5d655e4fdc15fa4b4` and adds the fail-closed repair. The focused uninstall test passed 23/23, the test-title check and CLI typecheck passed, all three agent variants matched the source page, and the docs build passed with 0 errors and 2 existing Fern warnings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 2d78b5d -->
<!-- docs-review-agents-blob-sha: e30afb2 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/actions/uninstall/run-plan-local-model-profile.test.ts` passed 23/23. Repository checks, test-title check, CLI typecheck, and `npm run validate:pr` also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable. This is a focused ownership-routing correction; `npm run validate:pr` passed the repository checks and affected CLI typecheck.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — the docs build passed with 0 errors and 2 existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — no new documentation pages.

---

Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uninstall handling for host-local vLLM runtimes when runtime records or API credentials are incomplete.
  * Prevented cleanup from being skipped when runtime information is present without an API key.
  * Added safeguards to remove reserved containers only when Docker confirms they are managed by NemoClaw.
  * Uninstall now reports failures clearly when local runtime cleanup cannot be verified.

* **Documentation**
  * Updated uninstall guidance for host-local vLLM cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->