### PR TITLE
fix(ci): keep local PR bases visible

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -383,6 +383,7 @@ jobs:
           done
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Set up Node.js
@@ -401,6 +402,7 @@ jobs:
           CANDIDATE_SHA: ${{ github.event.pull_request.head.sha }}
           DISPLAY_NAME: ${{ matrix.display_name }}
           LOCAL_BASE_REFERENCE: nemoclaw-managed-pr/${{ matrix.agent }}-base:${{ github.event.pull_request.head.sha }}
+          REMOTE_BASE_BUILDER: ${{ steps.buildx.outputs.name }}
         run: |
           set -euo pipefail
           if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ || ! "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
@@ -419,12 +421,14 @@ jobs:
           if [ "$diff_status" -eq 1 ]; then
             echo "::notice::${DISPLAY_NAME} base Dockerfile changed; building the exact PR base locally"
             docker buildx build \
+              --builder default \
               --platform linux/amd64 \
               --load \
               --file "$BASE_DOCKERFILE" \
               --tag "$LOCAL_BASE_REFERENCE" \
               .
             printf 'ref=%s\n' "$LOCAL_BASE_REFERENCE" >> "$GITHUB_OUTPUT"
+            printf 'builder=default\n' >> "$GITHUB_OUTPUT"
             printf '### %s PR base\n\nLocally built from `%s` at `%s`.\n' \
               "$DISPLAY_NAME" "$BASE_DOCKERFILE" "$CANDIDATE_SHA" \
               >> "$GITHUB_STEP_SUMMARY"
@@ -467,6 +471,7 @@ jobs:
             exit 1
           fi
           printf 'ref=%s\n' "$reference" >> "$GITHUB_OUTPUT"
+          printf 'builder=%s\n' "$REMOTE_BASE_BUILDER" >> "$GITHUB_OUTPUT"
           printf '### %s PR base\n\n`%s`\n' "$DISPLAY_NAME" "$reference" \
             >> "$GITHUB_STEP_SUMMARY"
 
@@ -486,6 +491,7 @@ jobs:
       - name: Build PR managed image locally
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
+          builder: ${{ steps.base.outputs.builder }}
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64
@@ -670,6 +676,7 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
+          builder: ${{ steps.base.outputs.builder }}
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64

--- a/test/managed-image-pr-base-resolution.test.ts
+++ b/test/managed-image-pr-base-resolution.test.ts
@@ -79,6 +79,7 @@ exit 90
     GITHUB_OUTPUT: output,
     GITHUB_STEP_SUMMARY: summary,
     LOCAL_BASE_REFERENCE: "nemoclaw-managed-pr/openclaw-base:test",
+    REMOTE_BASE_BUILDER: "remote-builder",
     PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
     RUNNER_TEMP: temporaryRoot,
   };
@@ -90,9 +91,11 @@ exit 90
       env: environment,
     });
     expect(result.status, result.stderr).toBe(0);
-    expect(fs.readFileSync(output, "utf8")).toBe("ref=nemoclaw-managed-pr/openclaw-base:test\n");
+    expect(fs.readFileSync(output, "utf8")).toBe(
+      "ref=nemoclaw-managed-pr/openclaw-base:test\nbuilder=default\n",
+    );
     expect(fs.readFileSync(dockerLog, "utf8")).toContain(
-      "buildx build --platform linux/amd64 --load --file Dockerfile.base --tag nemoclaw-managed-pr/openclaw-base:test .",
+      "buildx build --builder default --platform linux/amd64 --load --file Dockerfile.base --tag nemoclaw-managed-pr/openclaw-base:test .",
     );
     expect(fs.readFileSync(dockerLog, "utf8")).not.toContain("imagetools inspect");
 

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -408,6 +408,7 @@ describe("complete managed-image publication workflow", () => {
     const matrix = prBuilder.strategy?.matrix?.include ?? [];
     const steps = prBuilder.steps ?? [];
     const permissionDrift = step(prBuilder, "Reproduce reviewed discovery permission drift");
+    const setupBuildx = step(prBuilder, "Set up Docker Buildx");
     const build = step(prBuilder, "Build PR managed image locally");
     const contract = step(prBuilder, "Validate exact PR managed image contract");
 
@@ -485,6 +486,7 @@ describe("complete managed-image publication workflow", () => {
       steps.indexOf(step(prBuilder, "Checkout")),
     );
     expect(steps.indexOf(permissionDrift)).toBeLessThan(steps.indexOf(build));
+    expect(setupBuildx.id).toBe("buildx");
 
     for (const action of steps.filter((candidate) => candidate.uses)) {
       expect(action.uses, action.name).toMatch(fullShaAction);
@@ -500,10 +502,14 @@ describe("complete managed-image publication workflow", () => {
     );
     expect(resolveBase).toContain('--file "$BASE_DOCKERFILE"');
     expect(resolveBase).toContain('--tag "$LOCAL_BASE_REFERENCE"');
+    expect(resolveBase).toContain("--builder default");
+    expect(resolveBase).toContain("printf 'builder=default\\n'");
+    expect(resolveBase).toContain("printf 'builder=%s\\n' \"$REMOTE_BASE_BUILDER\"");
     expect(resolveBase).toContain('reference="${BASE_REPOSITORY}@${digest}"');
     expect(resolveBase).toContain('actual="sha256:$(sha256sum "$exact_raw"');
 
     expect(build.with).toMatchObject({
+      builder: "${{ steps.base.outputs.builder }}",
       platforms: "linux/amd64",
       load: true,
       push: false,
@@ -634,6 +640,7 @@ describe("complete managed-image publication workflow", () => {
     expect(login.if).toBe(sameRepository);
     expect(publish.if).toBe(sameRepository);
     expect(publish.with).toMatchObject({
+      builder: "${{ steps.base.outputs.builder }}",
       platforms: "linux/amd64",
       outputs:
         "type=image,name=${{ matrix.repository }},push-by-digest=true,name-canonical=true,push=true",
@@ -865,6 +872,7 @@ fi
           GITHUB_STEP_SUMMARY: summary,
           LOCAL_BASE_REFERENCE: "nemoclaw-managed-pr/openclaw-base:test",
           PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          REMOTE_BASE_BUILDER: "remote-builder",
           RUNNER_TEMP: temporaryRoot,
         },
       });
@@ -875,6 +883,7 @@ fi
       expect(fs.readFileSync(output, "utf8")).toContain(
         `ref=ghcr.io/nvidia/nemoclaw/sandbox-base@${digest}`,
       );
+      expect(fs.readFileSync(output, "utf8")).toContain("builder=remote-builder\n");
 
       writeAlias([descriptor, descriptor]);
       const duplicate = runResolver();


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Keep an exact PR base image visible through every managed-image build after a base Dockerfile changes. The changed-base path now uses Docker's default builder for the base, local validation image, and same-repository digest publication; the unchanged-base path keeps the configured Buildx builder and exact remote digest.

## Related Issue

Fixes #9039.

## Changes

- Publish the selected builder with the exact PR base reference.
- Use Docker's default builder for all consumers of an engine-only local base tag.
- Keep the setup action's builder for unchanged bases resolved by immutable registry digest.
- Protect the local validation and same-repository publication paths with focused workflow tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only the internal pull-request managed-image workflow and does not change a command, configuration, runtime image contract, or supported workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed all nine security categories. PASS: the same-repository condition, package permission, single scoped login, immediate logout, immutable digest verification, pinned actions, and image contract are unchanged. The selected builder is passed only to the two builds that consume the base reference. No secret or credential value enters the builder output or build arguments.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed the complete three-file diff against base `a774d0a`. The change affects only the internal managed-image pull-request workflow. A changed base Dockerfile now selects Docker's default builder for the exact local base, local managed-image validation build, and same-repository digest publication. An unchanged base retains the digest-verified remote reference and setup Buildx builder. Workflow tests protect both builder consumers. Publication conditions, credential handling, immutable digest verification, and the managed-image contract remain unchanged. The focused suite passed 20/20, `npm run validate:pr` passed, independent workflow assertions passed, and `git diff --check` passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6f19db2 -->
<!-- docs-review-agents-blob-sha: e30afb2 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/managed-image-publication-workflow.test.ts test/managed-image-pr-base-resolution.test.ts` passed 20/20. The new assertions failed 2/20 before the workflow repair.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable. The change is limited to one workflow's builder routing and its focused tests; `npm run validate:pr` passed the complete changed-file hook suite, including workflow YAML, repository checks, source-shape and test budgets, secret scan, and affected CLI typecheck.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — no documentation changes.
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only) — no documentation changes.
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — no new documentation pages.

---

Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed-image builds by consistently using the selected Docker builder across base-image resolution, local builds, remote builds, and digest publication.
  - Added support for configured remote builders when resolving pull request base images.

- **Tests**
  - Expanded workflow coverage to verify Docker Buildx setup and builder propagation across managed-image build and publication steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->