### PR TITLE
fix(e2e): separate launch readiness states

### DIFF
--- a/test/e2e/live/full-e2e.test.ts
+++ b/test/e2e/live/full-e2e.test.ts
@@ -148,6 +148,7 @@ async function runOpenClawLaunchTurnAfterRecovery(input: {
     env: env(PORTABLE_PROFILE ? { DOCKER_HOST: "" } : {}),
     exitCommand: "/exit",
     host: input.host,
+    postReplyReadyText: "connected | idle",
     readyText: "gateway connected | idle",
     redactionValues: input.redactionValues,
     sandboxName: SANDBOX_NAME,

--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -116,7 +116,7 @@ has_post_reply_ready() {
         sub(/^[[:space:]]+/, "", line)
         sub(/[[:space:]]+$/, "", line)
         if (line == expected) reply = 1
-        if (reply && index(line, ready) != 0) found = 1
+        if (reply && line == ready) found = 1
       }
       END { exit found ? 0 : 1 }
     '

--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -110,7 +110,7 @@ has_exact_reply() {
 has_post_reply_ready() {
   normalized_response | awk \
     -v expected="$NEMOCLAW_LAUNCH_EXPECTED_REPLY" \
-    -v ready="$NEMOCLAW_LAUNCH_READY_TEXT" '
+    -v ready="$NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT" '
       {
         line = $0
         sub(/^[[:space:]]+/, "", line)
@@ -132,7 +132,7 @@ for _ in {1..180}; do
   sleep 1
 done
 
-if [[ "$reply_seen" = 1 && -n "$NEMOCLAW_LAUNCH_READY_TEXT" ]]; then
+if [[ "$reply_seen" = 1 && -n "$NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT" ]]; then
   post_reply_ready_seen=0
   for _ in {1..60}; do
     if has_post_reply_ready; then
@@ -187,6 +187,7 @@ export interface LaunchAgentTurnOptions {
   env: NodeJS.ProcessEnv;
   exitCommand?: string;
   host: HostCliClient;
+  postReplyReadyText?: string;
   readyText?: string;
   redactionValues: string[];
   sandboxName: string;
@@ -210,6 +211,7 @@ export async function runLaunchAgentTurn(
       NEMOCLAW_LAUNCH_EXIT_COMMAND: options.exitCommand ?? "",
       NEMOCLAW_LAUNCH_EXPECTED_REPLY: options.expectedReply ?? EXPECTED_REPLY,
       NEMOCLAW_LAUNCH_PROMPT: options.prompt ?? PROMPT,
+      NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT: options.postReplyReadyText ?? "",
       NEMOCLAW_LAUNCH_READY_TEXT: options.readyText ?? "",
       NEMOCLAW_LAUNCH_SANDBOX: options.sandboxName,
       TERM: "xterm-256color",

--- a/test/e2e/live/launch-readiness-lease-acceptance.test.ts
+++ b/test/e2e/live/launch-readiness-lease-acceptance.test.ts
@@ -38,6 +38,7 @@ test.runIf(process.platform === "linux" && SANDBOX_NAME.length > 0)(
       env: process.env,
       exitCommand: "/exit",
       host,
+      postReplyReadyText: "connected | idle",
       readyText: "gateway connected | idle",
       redactionValues: [],
       sandboxName: SANDBOX_NAME,

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -145,6 +145,7 @@ fi
 printf 'gateway connected | idle\n' | tee -a "$capture"
 IFS= read -r -d $'\r' _
 printf 'PONG\n' | tee -a "$capture"
+printf 'gateway connected | idle\n' | tee -a "$capture"
 if IFS= read -r -t 1 -d $'\r' _; then
   echo "exit arrived before post-reply readiness" >&2
   exit 1

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -51,6 +51,7 @@ exit ${exitStatus}
         NEMOCLAW_LAUNCH_EXIT_COMMAND: closeAfterReply ? "" : "/exit",
         NEMOCLAW_LAUNCH_EXPECTED_REPLY: "PONG",
         NEMOCLAW_FIXTURE_REPLY: reply,
+        NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT: "",
         NEMOCLAW_LAUNCH_PROMPT: "prompt",
         NEMOCLAW_LAUNCH_READY_TEXT: "",
         NEMOCLAW_LAUNCH_SANDBOX: "sandbox",
@@ -87,6 +88,7 @@ it.runIf(process.platform === "linux")(
       env: {},
       exitCommand: "/exit",
       host: host as never,
+      postReplyReadyText: "connected | idle",
       readyText: "gateway connected | idle",
       redactionValues: [],
       sandboxName: "alpha",
@@ -108,11 +110,18 @@ it.runIf(process.platform === "linux")(
       "/exit",
       "/exit",
     ]);
+    expect(calls.slice(1).map((call) => call.env?.NEMOCLAW_LAUNCH_READY_TEXT)).toEqual([
+      "gateway connected | idle",
+      "gateway connected | idle",
+    ]);
+    expect(
+      calls.slice(1).map((call) => call.env?.NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT),
+    ).toEqual(["connected | idle", "connected | idle"]);
   },
 );
 
 it.runIf(process.platform !== "win32")(
-  "waits for OpenClaw idle before the prompt and again before the exit command (#9023)",
+  "waits for 'gateway connected | idle' before the prompt and 'connected | idle' before exit (#9023)",
   () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "nemoclaw-launch-turn-ready-"));
     const scriptStub = join(fixtureRoot, "script");
@@ -140,7 +149,7 @@ if IFS= read -r -t 1 -d $'\r' _; then
   echo "exit arrived before post-reply readiness" >&2
   exit 1
 fi
-printf 'gateway connected | idle\n' | tee -a "$capture"
+printf 'connected | idle\n' | tee -a "$capture"
 IFS= read -r -d $'\r' exit_command
 [[ "$exit_command" == "/exit" ]]
 exit 0
@@ -161,6 +170,7 @@ exit 0
           NEMOCLAW_LAUNCH_EXIT_COMMAND: "/exit",
           NEMOCLAW_LAUNCH_EXPECTED_REPLY: "PONG",
           NEMOCLAW_LAUNCH_PROMPT: "prompt",
+          NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT: "connected | idle",
           NEMOCLAW_LAUNCH_READY_TEXT: "gateway connected | idle",
           NEMOCLAW_LAUNCH_SANDBOX: "sandbox",
           PATH: `${fixtureRoot}:${process.env.PATH ?? ""}`,


### PR DESCRIPTION
## Summary

Separate the OpenClaw launch helper's initial readiness text from its post-reply readiness text. The live TUI first reports `gateway connected | idle`, then reports `connected | idle` after a reply; the helper now waits for each exact state before its corresponding input and requires exact normalized-line equality for the post-reply state.

PR #9034 was externally merged while its live acceptance remained blocked. This fix-forward repairs acceptance infrastructure only. It does not retroactively claim that #9034 passed live acceptance; the exact probe and two-turn PTY acceptance will be rerun for the latest PR commit.

## Related Issue

Related to #9023. Follow-up to #9034.

## Live acceptance status

On commit `c601bb61675f6561b3fdcd5131b633d9d45bd371`, the repaired readiness sequence reached the exact reply, post-reply `connected | idle`, `/exit`, and `gateway disconnected: closed | idle`. Final launch status remained blocked by the separate portable/rootless-Podman cleanup recurrence tracked in #9054, which is a recurrence of #8584/#8585 rather than a defect in this helper.

This PR remains acceptance-infrastructure repair only. It does not claim that the overall #9023 two-turn live acceptance passed.

## Changes

- Add a distinct optional post-reply readiness value to the native launch helper.
- Configure OpenClaw live callers with startup `gateway connected | idle` and post-reply `connected | idle` states.
- Add a realistic regression that rejects `/exit` until the post-reply state is visible.
- Require the post-reply readiness marker to equal one normalized terminal line, so a repeated `gateway connected | idle` cannot satisfy `connected | idle`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes live E2E orchestration only; it does not change a user command, configuration, default, diagnostic, runtime contract, or supported workflow.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The exact four-file E2E-helper diff was independently reviewed. It affects test orchestration only, and its names, test title, and diagnostic comply with `WRITING.md`.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 1c3a2741e -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/launch-agent-turn.test.ts`: 5 passed, 1 platform-skipped
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this narrow live-helper correction; focused support tests and all normal hooks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>