### PR TITLE
fix(e2e): echo unique launch replies in mock inference

### DIFF
--- a/test/e2e/fixtures/fake-openai-compatible.ts
+++ b/test/e2e/fixtures/fake-openai-compatible.ts
@@ -40,6 +40,7 @@ export interface FakeOpenAiCompatibleServerOptions {
   readonly apiKey?: string;
   readonly chatContent?: string;
   readonly forbiddenMarkers?: readonly string[];
+  readonly launchReplyFromPrompt?: boolean;
   /** Non-secret marker expected in a request under test. */
   readonly requestCanaryMarker?: string;
   readonly host?: string;
@@ -184,6 +185,7 @@ export async function startFakeOpenAiCompatibleServer(
           NEMOCLAW_FAKE_OPENAI_FORBIDDEN_MARKERS: JSON.stringify(options.forbiddenMarkers ?? []),
           NEMOCLAW_FAKE_OPENAI_HOST: host,
           NEMOCLAW_FAKE_OPENAI_LOG_FILE: logFile,
+          NEMOCLAW_FAKE_OPENAI_LAUNCH_REPLY_FROM_PROMPT: options.launchReplyFromPrompt ? "1" : "0",
           NEMOCLAW_FAKE_OPENAI_MAX_MODEL_LEN:
             options.maxModelLen !== undefined ? String(options.maxModelLen) : "",
           NEMOCLAW_FAKE_OPENAI_MODEL: options.model ?? "test-model",

--- a/test/e2e/fixtures/inference-adapter.ts
+++ b/test/e2e/fixtures/inference-adapter.ts
@@ -390,6 +390,7 @@ export async function createE2EInferenceAdapter(
       // alias, so listen on the bridge-facing interfaces. The workflow uses an
       // ephemeral ubuntu-latest VM, an OS-assigned port, and a per-run credential.
       host: "0.0.0.0",
+      launchReplyFromPrompt: true,
       model,
       publicHost: SANDBOX_HOST_ALIAS,
       progress: options.progress,

--- a/test/e2e/lib/fake-openai-compatible-api.mts
+++ b/test/e2e/lib/fake-openai-compatible-api.mts
@@ -28,6 +28,8 @@ const requireAuth = process.env.NEMOCLAW_FAKE_OPENAI_REQUIRE_AUTH === "1";
 const requireAuthModels = process.env.NEMOCLAW_FAKE_OPENAI_REQUIRE_AUTH_MODELS === "1";
 const chatContent = process.env.NEMOCLAW_FAKE_OPENAI_CHAT_CONTENT || "ok";
 const responseText = process.env.NEMOCLAW_FAKE_OPENAI_RESPONSE_TEXT || chatContent;
+const launchReplyFromPrompt =
+  process.env.NEMOCLAW_FAKE_OPENAI_LAUNCH_REPLY_FROM_PROMPT === "1";
 const requestCanaryMarker = process.env.NEMOCLAW_FAKE_OPENAI_REQUEST_CANARY_MARKER || "";
 const forbiddenMarkers = (() => {
   try {
@@ -145,6 +147,27 @@ function requestCanaryPresent(req: IncomingMessage, raw: Buffer): boolean | unde
   return requestMaterial.includes(requestCanaryMarker);
 }
 
+function latestUserPrompt(payload: JsonObject): string | null {
+  const entries = Array.isArray(payload.messages) ? payload.messages : [];
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (!entry || typeof entry !== "object") continue;
+    const message = entry as JsonObject;
+    if (message.role !== "user") continue;
+    if (typeof message.content === "string") return message.content;
+  }
+  return null;
+}
+
+function requestedLaunchReply(payload: JsonObject): string | null {
+  if (!launchReplyFromPrompt) return null;
+  const prompt = latestUserPrompt(payload);
+  const match = prompt?.match(
+    /^Join these four fragments with underscores and put only the result on its own line: NEMOCLAW, ([0-9A-F]{12}), (FIRST|SECOND), OK\. Do not use tools\.$/u,
+  );
+  return match ? `NEMOCLAW_${match[1]}_${match[2]}_OK` : null;
+}
+
 const server = createServer(async (req, res) => {
   const path = requestPath(req);
 
@@ -198,8 +221,9 @@ const server = createServer(async (req, res) => {
       sendJson(res, 401, { error: { message: "missing bearer credential" } });
       return;
     }
+    const content = requestedLaunchReply(payload) ?? chatContent;
     if (payload.stream) {
-      sendChatSse(res, chatContent);
+      sendChatSse(res, content);
       return;
     }
     sendJson(res, 200, {
@@ -210,7 +234,7 @@ const server = createServer(async (req, res) => {
       choices: [
         {
           index: 0,
-          message: { role: "assistant", content: chatContent },
+          message: { role: "assistant", content },
           finish_reason: "stop",
         },
       ],

--- a/test/e2e/support/inference-adapter.test.ts
+++ b/test/e2e/support/inference-adapter.test.ts
@@ -180,6 +180,23 @@ describe("E2E inference adapter", () => {
     );
   });
 
+  it("returns the unique launch reply requested by the mock prompt (#9046)", async () => {
+    const adapter = await createAdapter({ env: {} });
+    const expectedReply = "NEMOCLAW_0123456789AB_FIRST_OK";
+    const prompt =
+      "Join these four fragments with underscores and put only the result on its own line: " +
+      "NEMOCLAW, 0123456789AB, FIRST, OK. Do not use tools.";
+
+    expect(await adapter.directChat(prompt)).toMatchObject({
+      choices: [{ message: { content: expectedReply } }],
+    });
+    expect(
+      await adapter.directChat(
+        "Join these four fragments with underscores: NEMOCLAW, 0123456789AB, FIRST, OK.",
+      ),
+    ).toMatchObject({ choices: [{ message: { content: "PONG" } }] });
+  });
+
   it("keeps unrelated ambient secrets out of adapter and fake-server child environments", async () => {
     const secretName = "UNRELATED_E2E_SENTINEL_SECRET";
     const secretValue = "sentinel-value-that-must-not-propagate";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The release E2E run showed two agent-turn failures: OpenClaw rendered the expected unique reply inside terminal control sequences, and the shared mock inference endpoint returned fixed `PONG` to Hermes. Current `main` already contains the OpenClaw OSC normalization and regression from #9034; this change repairs the remaining mock behavior by deriving each unique reply from the exact launch prompt.

## Related Issue

Fixes #9046

## Changes

- Add an opt-in launch-prompt parser to the fake Chat Completions endpoint. The shared fake server serves unrelated fixtures, so changing its default response would alter other tests; the adapter enables the parser only for mock inference.
- Accept only the generated four-fragment prompt and preserve the configured `PONG` response for partial or altered prompts.
- Add a regression test that failed with fixed `PONG` before the change and now verifies both the unique reply and fallback behavior.
- Close the detection gap where the adapter test exercised only a fixed `PONG` prompt and did not cover the generated launch-turn contract.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal E2E mock endpoint and its support test. It does not change a public command, API, configuration, default, workflow, or supported product behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The mock Chat Completions input boundary accepts one exact uppercase prompt shape. A negative regression preserves the fixed response for altered input. Authentication, credential redaction, request metadata, production inference routes, dependencies, and network policy are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The reviewed four-file diff changes only E2E fixture and support behavior. It adds no public API, CLI, configuration, default, workflow, or supported product behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5d38dbed9 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/inference-adapter.test.ts test/e2e/support/hosted-inference.test.ts test/e2e/support/device-auth-health-helpers.test.ts test/e2e/support/launch-agent-turn.test.ts`: 4 files passed, 32 tests passed, 1 platform skip.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this isolated mock behavior. An additional `npx vitest run --project e2e-support` passed 197 files and failed in seven unrelated macOS host-sensitive files that require GNU `find`, trusted Homebrew state, systemd or Ollama, or longer subprocess timeouts.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end inference testing for launch-specific prompts.
  * Added coverage for both streaming and non-streaming responses.
  * Verified exact prompt-derived responses while preserving default responses for similar prompts without explicit instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->