### PR TITLE
docs(e2e): align recovery scope

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -663,9 +663,9 @@ The runner-allocation and internal-error failures handled by Hosted Runner
 Recovery originate in GitHub Actions, outside repository-controlled workflow
 code. Hosted Runner Recovery contains these failures without claiming to repair
 their source. Remove `.github/workflows/hosted-runner-recovery.yaml` and its
-controller only after the three platform workflows record 30 consecutive days
-with no first-attempt failure accepted by the recovery classifier, or after those
-workflows stop using GitHub-hosted runners. Each accepted Hosted Runner Recovery
+controller only after `CI / Platform Evidence` records 30 consecutive days with
+no first-attempt failure accepted by the recovery classifier, or after that
+workflow stops using GitHub-hosted runners. Each accepted Hosted Runner Recovery
 request resets that observation window.
 
 ### Runner comparison telemetry
@@ -788,7 +788,7 @@ to the portable free-memory value and labels that value as `memory free`.
 The comparison time series is diagnostic-only and is not an input to terminal
 classification or retry policy. Runner-comparison telemetry does not affect
 `E2E / Main Retry` decisions. Hosted Runner Recovery remains limited to
-authenticated runner-loss evidence for its three platform workflows.
+authenticated runner-loss evidence from `CI / Platform Evidence`.
 
 Treat a missing summary as unavailable evidence, not as low utilization. A
 hard runner loss can prevent finalization or artifact upload. When you compare


### PR DESCRIPTION
## Summary

Follow up on #9040 by correcting the two remaining references to the former platform-workflow layout. Hosted Runner Recovery guidance now names the consolidated `CI / Platform Evidence` workflow consistently.

## Changes

- Tie the recovery retirement window to `CI / Platform Evidence`.
- Describe recovery telemetry as evidence from that workflow instead of three workflows.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This is a prose-only workflow-name correction; executable behavior and code samples do not change.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: An independent documentation writer review verified the recovery scope against `.github/workflows/hosted-runner-recovery.yaml` at the exact commit.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/README.md`; the writing rules and documentation style were reviewed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4f5b3f901c -->
<!-- docs-review-agents-blob-sha: e30afb270b -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Tests are not applicable because no executable behavior changed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — command passed; Fern reported two unrelated warnings for unauthenticated redirect checking and the existing light-mode accent contrast.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated recovery-removal guidance to reference `CI / Platform Evidence`.
  * Clarified that runner-loss evidence no longer needs to originate from three separate platform workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->