### PR TITLE
fix(e2e): exercise policy picker through terminal

### DIFF
--- a/test/e2e/live/network-policy-interactive.ts
+++ b/test/e2e/live/network-policy-interactive.ts
@@ -1,17 +1,33 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Trust boundary: the Expect program receives only a numeric preset index
-// parsed from NemoClaw's own numbered menu plus the literal confirmation Y.
-// No dispatch input, secret, or other user-controlled text enters the script.
+import type { HostCliClient } from "../fixtures/clients/host.ts";
+import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+
+// Trust boundary: the Expect program receives a fixture-owned preset name.
+// It compares that name with NemoClaw's rendered menu entries before it sends
+// the matching numeric index and the literal confirmation Y.
 // Exit codes: 2=preset timeout, 3=preset EOF, 4=confirmation timeout,
-// 5=confirmation EOF, and 6=post-confirmation timeout.
+// 5=confirmation EOF, 6=post-confirmation timeout, and
+// 7=requested preset absent from menu.
 export const POLICY_ADD_EXPECT_SCRIPT = String.raw`
 set timeout 60
+match_max 20000
 spawn env NEMOCLAW_NON_INTERACTIVE= node $env(NEMOCLAW_E2E_CLI) $env(NEMOCLAW_E2E_SANDBOX) policy-add
 expect {
   -glob "*Choose preset*" {
-    send -- "$env(NEMOCLAW_E2E_PRESET_NUM)\r"
+    set preset_number ""
+    foreach line [split $expect_out(buffer) "\n"] {
+      if {[regexp {^[[:space:]]*([0-9]+)\)[[:space:]]+[●○][[:space:]]+([^[:space:]]+)} $line -> candidate_number candidate_name] && $candidate_name eq $env(NEMOCLAW_E2E_PRESET)} {
+        set preset_number $candidate_number
+        break
+      }
+    }
+    if {$preset_number eq ""} {
+      puts stderr "requested policy preset was not present in the interactive menu"
+      exit 7
+    }
+    send -- "$preset_number\r"
   }
   timeout {
     puts stderr "timed out waiting for the policy preset prompt"
@@ -46,18 +62,27 @@ set wait_result [wait]
 exit [lindex $wait_result 3]
 `;
 
-export function findPolicyPresetNumber(output: string, preset: string): string | null {
-  const escapedPreset = preset.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = new RegExp(`^\\s*(\\d+)\\)\\s+(?:[●○]\\s+)?${escapedPreset}(?:\\s|$)`, "m").exec(
-    output,
-  );
-  return match?.[1] ?? null;
+export interface RunInteractivePolicyAddOptions {
+  artifactName: string;
+  cliEntrypoint: string;
+  env: NodeJS.ProcessEnv;
+  preset: string;
+  sandboxName: string;
+  timeoutMs: number;
 }
 
-export function requirePolicyPresetNumber(output: string, preset: string): string {
-  const presetNumber = findPolicyPresetNumber(output, preset);
-  if (!presetNumber) {
-    throw new Error(`preset ${preset} not found in interactive policy-add list: ${output}`);
-  }
-  return presetNumber;
+export function runInteractivePolicyAdd(
+  host: Pick<HostCliClient, "command">,
+  options: RunInteractivePolicyAddOptions,
+): Promise<ShellProbeResult> {
+  return host.command("expect", ["-c", POLICY_ADD_EXPECT_SCRIPT], {
+    artifactName: options.artifactName,
+    env: {
+      ...options.env,
+      NEMOCLAW_E2E_CLI: options.cliEntrypoint,
+      NEMOCLAW_E2E_PRESET: options.preset,
+      NEMOCLAW_E2E_SANDBOX: options.sandboxName,
+    },
+    timeoutMs: options.timeoutMs,
+  });
 }

--- a/test/e2e/live/network-policy.test.ts
+++ b/test/e2e/live/network-policy.test.ts
@@ -28,10 +28,7 @@ import { CLI_DIST_ENTRYPOINT, CLI_ENTRYPOINT, REPO_ROOT } from "../fixtures/path
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import { pollDeniedReasonLog } from "./network-policy-denied-log.ts";
 import { requireInferenceLocalCompletionText } from "./network-policy-inference.ts";
-import {
-  POLICY_ADD_EXPECT_SCRIPT,
-  requirePolicyPresetNumber,
-} from "./network-policy-interactive.ts";
+import { runInteractivePolicyAdd } from "./network-policy-interactive.ts";
 import { isTransientProviderValidationFailure } from "./network-policy-transient-provider.ts";
 import { expectPackageDatabaseReadOnly } from "./package-database-read-only.ts";
 import { parseVerifiedActivePolicyPresets } from "./policy-list-state.ts";
@@ -125,30 +122,12 @@ async function applyPresetInteractively(
   host: HostCliClient,
   preset: string,
 ): Promise<ShellProbeResult> {
-  const listResult = await host.command(
-    "bash",
-    [
-      "-lc",
-      'env NEMOCLAW_NON_INTERACTIVE= node "$NEMOCLAW_E2E_CLI" "$NEMOCLAW_E2E_SANDBOX" policy-add </dev/null',
-    ],
-    {
-      artifactName: `policy-add-${preset}-interactive-list`,
-      env: baseEnv({
-        NEMOCLAW_E2E_CLI: CLI_ENTRYPOINT,
-        NEMOCLAW_E2E_SANDBOX: SANDBOX_NAME,
-      }),
-      timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,
-    },
-  );
-  const presetNumber = requirePolicyPresetNumber(text(listResult), preset);
-
-  const result = await host.command("expect", ["-c", POLICY_ADD_EXPECT_SCRIPT], {
+  const result = await runInteractivePolicyAdd(host, {
     artifactName: `policy-add-${preset}-interactive`,
-    env: baseEnv({
-      NEMOCLAW_E2E_CLI: CLI_ENTRYPOINT,
-      NEMOCLAW_E2E_SANDBOX: SANDBOX_NAME,
-      NEMOCLAW_E2E_PRESET_NUM: presetNumber,
-    }),
+    cliEntrypoint: CLI_ENTRYPOINT,
+    env: baseEnv(),
+    preset,
+    sandboxName: SANDBOX_NAME,
     timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,
   });
   await sleep(POLICY_SETTLE_MS);

--- a/test/e2e/support/network-policy-interactive.test.ts
+++ b/test/e2e/support/network-policy-interactive.test.ts
@@ -1,33 +1,155 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
 
 import {
-  findPolicyPresetNumber,
   POLICY_ADD_EXPECT_SCRIPT,
-  requirePolicyPresetNumber,
+  runInteractivePolicyAdd,
 } from "../live/network-policy-interactive.ts";
 
 describe("network-policy interactive preset harness", () => {
-  it("selects the exact requested preset from the interactive list", () => {
-    const output = `
-  14) ○ hermes-slack — unrelated prefix
-  15) ○ slack — Slack API access
-  16) ● pypi — Python Package Index
-`;
+  it("passes the preset-picker inputs to Expect (#9045)", async () => {
+    const result = {
+      artifacts: { result: "result.json", stderr: "stderr.txt", stdout: "stdout.txt" },
+      command: ["expect"],
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      stdout: "",
+      timedOut: false,
+    };
+    const command = vi.fn().mockResolvedValue(result);
 
-    expect(findPolicyPresetNumber(output, "slack")).toBe("15");
-    expect(findPolicyPresetNumber(output, "pypi")).toBe("16");
-    expect(findPolicyPresetNumber(output, "missing")).toBeNull();
-    expect(() => requirePolicyPresetNumber(output, "missing")).toThrow(/preset missing not found/);
+    await expect(
+      runInteractivePolicyAdd(
+        { command },
+        {
+          artifactName: "policy-add-slack-interactive",
+          cliEntrypoint: "/repo/dist/cli.js",
+          env: { PATH: "/usr/bin" },
+          preset: "slack",
+          sandboxName: "e2e-net-policy",
+          timeoutMs: 120_000,
+        },
+      ),
+    ).resolves.toBe(result);
+
+    expect(command).toHaveBeenCalledOnce();
+    expect(command).toHaveBeenCalledWith("expect", ["-c", POLICY_ADD_EXPECT_SCRIPT], {
+      artifactName: "policy-add-slack-interactive",
+      env: {
+        PATH: "/usr/bin",
+        NEMOCLAW_E2E_CLI: "/repo/dist/cli.js",
+        NEMOCLAW_E2E_PRESET: "slack",
+        NEMOCLAW_E2E_SANDBOX: "e2e-net-policy",
+      },
+      timeoutMs: 120_000,
+    });
   });
 
-  it("waits for each prompt before sending the corresponding response", () => {
-    expect(POLICY_ADD_EXPECT_SCRIPT).toContain('-glob "*Choose preset*"');
-    expect(POLICY_ADD_EXPECT_SCRIPT).toContain('send -- "$env(NEMOCLAW_E2E_PRESET_NUM)\\r"');
-    expect(POLICY_ADD_EXPECT_SCRIPT).toContain('-glob "*Y/n*"');
-    expect(POLICY_ADD_EXPECT_SCRIPT).toContain('send -- "Y\\r"');
-    expect(POLICY_ADD_EXPECT_SCRIPT).not.toMatch(/printf.*Y/);
+  it("selects the requested rendered entry before it confirms the change", () => {
+    const selectPrompt = POLICY_ADD_EXPECT_SCRIPT.indexOf('-glob "*Choose preset*"');
+    const selectRequestedPreset = POLICY_ADD_EXPECT_SCRIPT.indexOf(
+      "$candidate_name eq $env(NEMOCLAW_E2E_PRESET)",
+    );
+    const sendPresetNumber = POLICY_ADD_EXPECT_SCRIPT.indexOf('send -- "$preset_number\\r"');
+    const confirmPrompt = POLICY_ADD_EXPECT_SCRIPT.indexOf('-glob "*Y/n*"');
+    const sendConfirmation = POLICY_ADD_EXPECT_SCRIPT.indexOf('send -- "Y\\r"');
+    const order = [
+      selectPrompt,
+      selectRequestedPreset,
+      sendPresetNumber,
+      confirmPrompt,
+      sendConfirmation,
+    ];
+
+    expect(order.every((index) => index >= 0)).toBe(true);
+    expect([...order].sort((left, right) => left - right)).toEqual(order);
+    expect(POLICY_ADD_EXPECT_SCRIPT).not.toContain("</dev/null");
+  });
+
+  const expectAvailable =
+    spawnSync("expect", ["-v"], {
+      encoding: "utf8",
+      killSignal: "SIGKILL",
+      timeout: 5_000,
+    }).status === 0;
+  const fixtureDir = mkdtempSync(join(tmpdir(), "nemoclaw-policy-add-pty-"));
+  const fixtureCli = join(fixtureDir, "fake-policy-add.mjs");
+  writeFileSync(
+    fixtureCli,
+    `import { createInterface } from "node:readline/promises";
+import process from "node:process";
+
+if (!process.stdin.isTTY || !process.stderr.isTTY) {
+  console.error("policy picker requires a terminal");
+  process.exit(20);
+}
+
+const prompts = createInterface({ input: process.stdin, output: process.stderr, terminal: true });
+process.stderr.write("\\n  Available presets:\\n");
+process.stderr.write("    14) ○ hermes-slack — unrelated prefix\\n");
+process.stderr.write("    15) ○ slack — Slack API access\\n");
+process.stderr.write("    16) ● pypi — Python Package Index\\n\\n");
+const preset = await prompts.question("  Choose preset [14]: ");
+if (preset.trim() !== "15") {
+  console.error("unexpected preset selection: " + preset);
+  process.exit(21);
+}
+const confirmation = await prompts.question("  Apply 'slack'? [Y/n]: ");
+if (confirmation.trim() !== "Y") {
+  console.error("unexpected confirmation: " + confirmation);
+  process.exit(22);
+}
+prompts.close();
+console.log("FAKE_POLICY_ADD_OK");
+`,
+    "utf8",
+  );
+  afterAll(() => rmSync(fixtureDir, { force: true, recursive: true }));
+
+  describe.runIf(expectAvailable)("Expect pseudo-terminal behavior", () => {
+    function runExpect(preset: string) {
+      return spawnSync("expect", ["-c", POLICY_ADD_EXPECT_SCRIPT], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          NEMOCLAW_E2E_CLI: fixtureCli,
+          NEMOCLAW_E2E_PRESET: preset,
+          NEMOCLAW_E2E_SANDBOX: "e2e-net-policy",
+        },
+        killSignal: "SIGKILL",
+        timeout: 5_000,
+      });
+    }
+
+    it("selects the exact preset when the picker rejects input without a terminal (#9045)", () => {
+      const noTerminal = spawnSync(process.execPath, [fixtureCli], {
+        encoding: "utf8",
+        input: "15\\nY\\n",
+        killSignal: "SIGKILL",
+        timeout: 5_000,
+      });
+      expect(noTerminal.status, noTerminal.stderr).toBe(20);
+
+      const result = runExpect("slack");
+      expect(result.status, `${result.stdout}\\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("FAKE_POLICY_ADD_OK");
+    });
+
+    it("rejects a preset that the rendered menu does not contain (#9045)", () => {
+      const result = runExpect("missing");
+
+      expect(result.status, `${result.stdout}\\n${result.stderr}`).toBe(7);
+      expect(result.stderr).toContain(
+        "requested policy preset was not present in the interactive menu",
+      );
+      expect(result.stdout).not.toContain("FAKE_POLICY_ADD_OK");
+    });
   });
 });

--- a/test/e2e/support/network-policy-interactive.test.ts
+++ b/test/e2e/support/network-policy-interactive.test.ts
@@ -52,27 +52,6 @@ describe("network-policy interactive preset harness", () => {
     });
   });
 
-  it("selects the requested rendered entry before it confirms the change", () => {
-    const selectPrompt = POLICY_ADD_EXPECT_SCRIPT.indexOf('-glob "*Choose preset*"');
-    const selectRequestedPreset = POLICY_ADD_EXPECT_SCRIPT.indexOf(
-      "$candidate_name eq $env(NEMOCLAW_E2E_PRESET)",
-    );
-    const sendPresetNumber = POLICY_ADD_EXPECT_SCRIPT.indexOf('send -- "$preset_number\\r"');
-    const confirmPrompt = POLICY_ADD_EXPECT_SCRIPT.indexOf('-glob "*Y/n*"');
-    const sendConfirmation = POLICY_ADD_EXPECT_SCRIPT.indexOf('send -- "Y\\r"');
-    const order = [
-      selectPrompt,
-      selectRequestedPreset,
-      sendPresetNumber,
-      confirmPrompt,
-      sendConfirmation,
-    ];
-
-    expect(order.every((index) => index >= 0)).toBe(true);
-    expect([...order].sort((left, right) => left - right)).toEqual(order);
-    expect(POLICY_ADD_EXPECT_SCRIPT).not.toContain("</dev/null");
-  });
-
   const expectAvailable =
     spawnSync("expect", ["-v"], {
       encoding: "utf8",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The network-policy E2E test now exercises the interactive `policy-add` preset picker through one pseudo-terminal session. Previously, the test tried to discover the preset number through a separate command with standard input closed, but the picker requires a terminal and did not render its menu.

## Related Issue

Fixes #9045

## Changes

- Run preset selection and confirmation through one Expect pseudo-terminal session.
- Match the fixture-requested preset against the rendered menu and send only its numeric index. Exit with a distinct error when the menu does not contain the preset.
- Add `runInteractivePolicyAdd` for the live E2E consumer because menu discovery and confirmation must share one terminal session. The E2E-support tests cover its command and environment contract.
- Add a real pseudo-terminal regression test that verifies the picker rejects closed standard input but succeeds through Expect.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change affects only the E2E harness. Production CLI behavior and the documented interactive preset workflow do not change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed the fixture-owned preset input, exact menu-name comparison, numeric-only terminal input, and fail-closed missing-preset result.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The final diff changes only the E2E harness and its tests. Existing documentation already describes the interactive preset screen accurately.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 83cbcc0f8 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/network-policy-interactive.test.ts` passed 1 file and 3 tests after the review repair.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm test` did not complete because many unrelated suites timed out on the local macOS host. The targeted test and path-scoped hooks passed; CI remains required.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved interactive network policy testing with exact preset selection and clearer handling when a preset is unavailable.
  * Added coverage for environment settings, timeouts, confirmations, and command results.
  * Added terminal-based validation using a temporary test CLI to verify realistic interactive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->