### PR TITLE
fix(onboard): gate forwarding on recreated readiness

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2068,9 +2068,18 @@ $$nemoclaw onboard
 ```
 
 The variable accepts seconds and applies to the readiness wait only.
-When the deadline expires, NemoClaw tries to delete the partially created sandbox.
+When the ordinary create deadline expires, NemoClaw tries to delete the partially created sandbox.
 After successful cleanup, the output ends with `Retry: $$nemoclaw onboard`.
 If cleanup fails, NemoClaw instead reports that the failed sandbox could not be removed and prints `Manual cleanup: openshell sandbox delete "<name>"`.
+
+The failure path differs when NemoClaw recreates an OpenShell-managed Docker runtime immediately before this wait.
+NemoClaw pins the exact OpenShell sandbox ID before recreation.
+Within the same deadline, NemoClaw requires two consecutive `Ready` observations that each confirm the exact ID and successful command execution.
+It retries only OpenShell's exact `sandbox is not ready` response.
+If the deadline expires, the ID changes, or another probe fails, NemoClaw preserves diagnostics and rolls back the direct runtime patch.
+NemoClaw does not start dashboard or other host forwarding, and it does not delete a sandbox by its mutable name.
+It leaves the sandbox in place for inspection and recovery.
+
 If readiness still fails after the extended budget, inspect the gateway and sandbox status:
 
 ```bash

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2076,7 +2076,8 @@ The failure path differs when NemoClaw recreates an OpenShell-managed Docker run
 NemoClaw pins the exact OpenShell sandbox ID before recreation.
 Within the same deadline, NemoClaw requires two consecutive `Ready` observations that each confirm the exact ID and successful command execution.
 It retries only OpenShell's exact `sandbox is not ready` response.
-If the deadline expires, the ID changes, or another probe fails, NemoClaw preserves diagnostics and rolls back the direct runtime patch.
+If the deadline expires, the ID changes, or another probe fails, NemoClaw preserves diagnostics and attempts to restore the pre-recreation Docker container.
+If restoration fails, NemoClaw reports that the sandbox and container state is uncertain.
 NemoClaw does not start dashboard or other host forwarding, and it does not delete a sandbox by its mutable name.
 It leaves the sandbox in place for inspection and recovery.
 

--- a/src/lib/onboard/__test-helpers__/sandbox-gpu-create-flow.ts
+++ b/src/lib/onboard/__test-helpers__/sandbox-gpu-create-flow.ts
@@ -51,7 +51,15 @@ export function createGpuFlowInput(): SandboxGpuCreateFlowInput {
 
 export function createGpuFlowDeps(): SandboxGpuCreateFlowDeps {
   return {
-    runOpenshell: vi.fn(() => ({ status: 0 })),
+    runOpenshell: vi.fn((args: string[]) =>
+      args[0] === "sandbox" && args[1] === "get"
+        ? {
+            status: 0,
+            stdout: "Name: alpha\nId: alpha-sandbox-id\nState: Ready\n",
+            stderr: "",
+          }
+        : { status: 0, stdout: "", stderr: "" },
+    ),
     runCaptureOpenshell: vi.fn(() => "alpha Ready"),
     sleep: vi.fn(),
     openshellArgv: vi.fn((args: string[]) => ["openshell", ...args]),

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -111,6 +111,24 @@ const DEFAULT_RUNTIME_SNAPSHOT = {
   containerId: "container-a",
 };
 
+type OpenShellResult = ReturnType<SandboxGpuCreateFlowDeps["runOpenshell"]>;
+
+function readySandboxGetResult(): OpenShellResult {
+  return {
+    status: 0,
+    stdout: "Name: alpha\nId: alpha-sandbox-id\nState: Ready\n",
+    stderr: "",
+  };
+}
+
+function createSequencedOpenShellRunner(
+  entries: Array<[string, OpenShellResult[]]>,
+): SandboxGpuCreateFlowDeps["runOpenshell"] {
+  const resultsByCommand = new Map(entries);
+  return (args) =>
+    resultsByCommand.get(args.join(" "))?.shift() ?? { status: 0, stdout: "", stderr: "" };
+}
+
 function failNativeCreate(output = "error: unexpected argument '--gpu' found"): void {
   mocks.streamSandboxCreate.mockResolvedValueOnce({ status: 1, output, sawProgress: false });
 }
@@ -589,19 +607,15 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
       { name: "nofile", soft: 65_536, hard: 65_536 },
     ];
     const deps = createDeps();
-    vi.mocked(deps.runOpenshell).mockImplementation((args: string[]) => {
-      if (args[0] === "sandbox" && args[1] === "get") {
-        return {
-          status: 0,
-          stdout: "Name: alpha\nId: alpha-sandbox-id\nState: Ready\n",
-          stderr: "",
-        };
-      }
-      if (args[0] === "sandbox" && args[1] === "exec") {
-        return { status: 1, stdout: "", stderr: "permission denied" };
-      }
-      return { status: 0, stdout: "", stderr: "" };
-    });
+    vi.mocked(deps.runOpenshell).mockImplementation(
+      createSequencedOpenShellRunner([
+        ["sandbox get alpha", [readySandboxGetResult(), readySandboxGetResult()]],
+        [
+          "sandbox exec --name alpha -- true",
+          [{ status: 1, stdout: "", stderr: "permission denied" }],
+        ],
+      ]),
+    );
     mocks.waitForCreatedSandboxReadyWithTrace.mockImplementationOnce((options) => {
       expect(options.checkReadyIdentity?.()).toBe("probe_failed");
       return {
@@ -645,29 +659,27 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
       { name: "nofile", soft: 65_536, hard: 65_536 },
     ];
     const deps = createDeps();
-    let execAttempts = 0;
-    vi.mocked(deps.runOpenshell).mockImplementation((args: string[]) => {
-      if (args[0] === "sandbox" && args[1] === "get") {
-        return {
-          status: 0,
-          stdout: "Name: alpha\nId: alpha-sandbox-id\nState: Ready\n",
-          stderr: "",
-        };
-      }
-      if (args[0] === "sandbox" && args[1] === "exec") {
-        execAttempts += 1;
-        return execAttempts === 1
-          ? {
+    vi.mocked(deps.runOpenshell).mockImplementation(
+      createSequencedOpenShellRunner([
+        [
+          "sandbox get alpha",
+          [readySandboxGetResult(), readySandboxGetResult(), readySandboxGetResult()],
+        ],
+        [
+          "sandbox exec --name alpha -- true",
+          [
+            {
               status: 1,
               stdout: "",
               stderr:
                 `Error:   × code: 'The system is not in a state required for the operation's\n` +
                 '  │ execution\', message: "sandbox is not ready"\n',
-            }
-          : { status: 0, stdout: "", stderr: "" };
-      }
-      return { status: 0, stdout: "", stderr: "" };
-    });
+            },
+            { status: 0, stdout: "", stderr: "" },
+          ],
+        ],
+      ]),
+    );
     mocks.waitForCreatedSandboxReadyWithTrace.mockImplementationOnce((options) => {
       expect(options.checkReadyIdentity?.()).toBe("not_ready");
       expect(options.checkReadyIdentity?.()).toBe("ready");
@@ -678,7 +690,11 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
       route: "none",
     });
 
-    expect(execAttempts).toBe(2);
+    expect(
+      vi
+        .mocked(deps.runOpenshell)
+        .mock.calls.filter(([args]) => args.join(" ") === "sandbox exec --name alpha -- true"),
+    ).toHaveLength(2);
     expect(patch.rollbackManagedStartupAfterCreateFailure).not.toHaveBeenCalled();
     expect(deps.runOpenshell).not.toHaveBeenCalledWith(
       ["sandbox", "delete", "alpha"],

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -622,7 +622,9 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
     expect(mocks.printSandboxCreateFailureDiagnostics).toHaveBeenCalledWith("alpha", {
       backupPath: null,
     });
-    expect(errorOutput()).toContain("sandbox was left in place for inspection and recovery");
+    expect(errorOutput()).toContain(
+      "NemoClaw left the sandbox in place for inspection and recovery",
+    );
   });
 
   it("keeps a transient recreated-sandbox not-ready response inside the readiness wait (#9050)", async () => {

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -563,6 +563,125 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
     );
     expect(patch.maybeApplyDuringCreate).not.toHaveBeenCalled();
     expect(createHandoff).toEqual(["poll", "create-complete", "ensure-applied"]);
+    expect(mocks.waitForCreatedSandboxReadyWithTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stableReadyPolls: 2,
+        checkReadyIdentity: expect.any(Function),
+      }),
+    );
+  });
+
+  it("does not delete a recreated sandbox when the exact readiness probe fails (#9050)", async () => {
+    const input = createInput();
+    const patch = createPatch();
+    mocks.createDockerGpuSandboxCreatePatch.mockReturnValueOnce(patch);
+    input.sandboxGpuConfig = {
+      ...input.sandboxGpuConfig,
+      mode: "0",
+      sandboxGpuEnabled: false,
+    };
+    input.gpuRoutePlan = "none";
+    input.initialGpuRoute = "none";
+    input.createArgv = ["openshell", "sandbox", "create"];
+    input.persistStartupCommand = true;
+    input.requiredUlimits = [
+      { name: "nproc", soft: 512, hard: 512 },
+      { name: "nofile", soft: 65_536, hard: 65_536 },
+    ];
+    const deps = createDeps();
+    vi.mocked(deps.runOpenshell).mockImplementation((args: string[]) => {
+      if (args[0] === "sandbox" && args[1] === "get") {
+        return {
+          status: 0,
+          stdout: "Name: alpha\nId: alpha-sandbox-id\nState: Ready\n",
+          stderr: "",
+        };
+      }
+      if (args[0] === "sandbox" && args[1] === "exec") {
+        return { status: 1, stdout: "", stderr: "permission denied" };
+      }
+      return { status: 0, stdout: "", stderr: "" };
+    });
+    mocks.waitForCreatedSandboxReadyWithTrace.mockImplementationOnce((options) => {
+      expect(options.checkReadyIdentity?.()).toBe("probe_failed");
+      return {
+        ready: false,
+        reason: "identity_probe_failed",
+        failurePhase: null,
+      };
+    });
+    mockExit();
+
+    await expect(runSandboxGpuCreateFlow(input, deps)).rejects.toThrow("process.exit:1");
+
+    expect(patch.rollbackManagedStartupAfterCreateFailure).toHaveBeenCalledOnce();
+    expect(deps.runOpenshell).not.toHaveBeenCalledWith(
+      ["sandbox", "delete", "alpha"],
+      expect.anything(),
+    );
+    expect(mocks.printSandboxCreateFailureDiagnostics).toHaveBeenCalledWith("alpha", {
+      backupPath: null,
+    });
+    expect(errorOutput()).toContain("sandbox was left in place for inspection and recovery");
+  });
+
+  it("keeps a transient recreated-sandbox not-ready response inside the readiness wait (#9050)", async () => {
+    const input = createInput();
+    const patch = createPatch();
+    mocks.createDockerGpuSandboxCreatePatch.mockReturnValueOnce(patch);
+    input.sandboxGpuConfig = {
+      ...input.sandboxGpuConfig,
+      mode: "0",
+      sandboxGpuEnabled: false,
+    };
+    input.gpuRoutePlan = "none";
+    input.initialGpuRoute = "none";
+    input.createArgv = ["openshell", "sandbox", "create"];
+    input.persistStartupCommand = true;
+    input.requiredUlimits = [
+      { name: "nproc", soft: 512, hard: 512 },
+      { name: "nofile", soft: 65_536, hard: 65_536 },
+    ];
+    const deps = createDeps();
+    let execAttempts = 0;
+    vi.mocked(deps.runOpenshell).mockImplementation((args: string[]) => {
+      if (args[0] === "sandbox" && args[1] === "get") {
+        return {
+          status: 0,
+          stdout: "Name: alpha\nId: alpha-sandbox-id\nState: Ready\n",
+          stderr: "",
+        };
+      }
+      if (args[0] === "sandbox" && args[1] === "exec") {
+        execAttempts += 1;
+        return execAttempts === 1
+          ? {
+              status: 1,
+              stdout: "",
+              stderr:
+                `Error:   × code: 'The system is not in a state required for the operation's\n` +
+                '  │ execution\', message: "sandbox is not ready"\n',
+            }
+          : { status: 0, stdout: "", stderr: "" };
+      }
+      return { status: 0, stdout: "", stderr: "" };
+    });
+    mocks.waitForCreatedSandboxReadyWithTrace.mockImplementationOnce((options) => {
+      expect(options.checkReadyIdentity?.()).toBe("not_ready");
+      expect(options.checkReadyIdentity?.()).toBe("ready");
+      return { ready: true, reason: "ready", failurePhase: null };
+    });
+
+    await expect(runSandboxGpuCreateFlow(input, deps)).resolves.toMatchObject({
+      route: "none",
+    });
+
+    expect(execAttempts).toBe(2);
+    expect(patch.rollbackManagedStartupAfterCreateFailure).not.toHaveBeenCalled();
+    expect(deps.runOpenshell).not.toHaveBeenCalledWith(
+      ["sandbox", "delete", "alpha"],
+      expect.anything(),
+    );
   });
 
   it("does not replace a native GPU container solely to persist its startup command", async () => {

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -471,7 +471,7 @@ export function createSandboxGpuCreateAttemptRunner(
       if (compatibility) runtimePatch.printReadinessFailureIfEnabled();
       else if (expectedRecreatedSandboxId) {
         console.error(
-          "  Dashboard forwarding was not started. The sandbox was left in place for inspection and recovery.",
+          "  NemoClaw did not start dashboard forwarding. NemoClaw left the sandbox in place for inspection and recovery.",
         );
       } else {
         const deletion = deps.runOpenshell(["sandbox", "delete", input.sandboxName], {

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { resolveOpenShellSandboxId } from "../adapters/openshell/sandbox-identity";
+import {
+  parseOpenShellSandboxId,
+  resolveOpenShellSandboxId,
+} from "../adapters/openshell/sandbox-identity";
 import { printSandboxCreateRecoveryHints } from "../build-context";
 import { getSandboxDeleteOutcome } from "../domain/sandbox/destroy";
 import { streamSandboxCreate } from "../sandbox/create-stream";
@@ -27,6 +30,7 @@ import type {
   SandboxGpuCreateFlowInput,
 } from "./sandbox-gpu-create-flow";
 import * as sandboxGpuPreflight from "./sandbox-gpu-preflight";
+import type { CreatedSandboxReadyIdentityCheck } from "./sandbox-readiness-tracing";
 import * as sandboxReadinessTracing from "./sandbox-readiness-tracing";
 import { addTraceEvent } from "./tracing";
 
@@ -43,6 +47,61 @@ export type SandboxGpuCreateAttemptState = {
 // container's stale Ready row. Require one confirmation poll before advancing
 // to live validation or the GPU proof.
 const REPLACEMENT_STABLE_READY_POLLS = 2;
+
+const ANSI_RE = /\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\)|[@-_])/gu;
+const OPENSHELL_SANDBOX_NOT_READY =
+  /^Error: code: 'The system is not in a state required for the operation's execution', message: "sandbox is not ready"$/iu;
+
+type OpenShellCommandResult = ReturnType<SandboxGpuCreateFlowDeps["runOpenshell"]>;
+
+function normalizedOpenShellCommandOutput(result: OpenShellCommandResult): string {
+  return `${String(result.stderr ?? "")}\n${String(result.stdout ?? "")}`
+    .replace(ANSI_RE, "")
+    .replace(/[×│]/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+type OpenShellSandboxIdentityProbe =
+  | { state: "identified"; sandboxId: string }
+  | { state: "not_ready" }
+  | { state: "failed" };
+
+function probeExactOpenShellSandboxId(
+  sandboxName: string,
+  deps: SandboxGpuCreateFlowDeps,
+): OpenShellSandboxIdentityProbe {
+  const result = deps.runOpenshell(["sandbox", "get", sandboxName], {
+    ignoreError: true,
+    suppressOutput: true,
+  });
+  if (result.status === 0 && !result.error) {
+    const sandboxId = parseOpenShellSandboxId(String(result.stdout ?? ""));
+    return sandboxId ? { state: "identified", sandboxId } : { state: "failed" };
+  }
+  return OPENSHELL_SANDBOX_NOT_READY.test(normalizedOpenShellCommandOutput(result))
+    ? { state: "not_ready" }
+    : { state: "failed" };
+}
+
+function checkRecreatedSandboxReadyIdentity(
+  sandboxName: string,
+  expectedSandboxId: string,
+  deps: SandboxGpuCreateFlowDeps,
+): ReturnType<CreatedSandboxReadyIdentityCheck> {
+  const identity = probeExactOpenShellSandboxId(sandboxName, deps);
+  if (identity.state === "not_ready") return "not_ready";
+  if (identity.state === "failed") return "probe_failed";
+  if (identity.sandboxId !== expectedSandboxId) return "identity_changed";
+  const result = deps.runOpenshell(["sandbox", "exec", "--name", sandboxName, "--", "true"], {
+    ignoreError: true,
+    suppressOutput: true,
+  });
+  if (result.status === 0 && !result.error) return "ready";
+  return OPENSHELL_SANDBOX_NOT_READY.test(normalizedOpenShellCommandOutput(result))
+    ? "not_ready"
+    : "probe_failed";
+}
 
 class ManagedBootstrapCreateStreamFailure extends Error {
   constructor(readonly result: Awaited<ReturnType<typeof streamSandboxCreate>>) {
@@ -334,6 +393,21 @@ export function createSandboxGpuCreateAttemptRunner(
         );
       }
     }
+    const preRecreateIdentity = deferRestartSafeCutover
+      ? probeExactOpenShellSandboxId(input.sandboxName, deps)
+      : null;
+    const expectedRecreatedSandboxId =
+      preRecreateIdentity?.state === "identified" ? preRecreateIdentity.sandboxId : null;
+    if (deferRestartSafeCutover && !expectedRecreatedSandboxId) {
+      console.error("");
+      console.error(
+        `  Sandbox '${input.sandboxName}' reached Ready, but OpenShell did not return one exact durable sandbox ID before runtime recreation.`,
+      );
+      printSandboxCreateFailureDiagnostics(input.sandboxName, {
+        backupPath: input.restoreBackupPath,
+      });
+      process.exit(createResult.status === 0 ? 1 : createResult.status);
+    }
     await runtimePatch.ensureApplied();
     await runtimePatch.waitForSupervisorReconnectIfNeeded();
     console.log("  Waiting for sandbox to become ready...");
@@ -343,7 +417,14 @@ export function createSandboxGpuCreateAttemptRunner(
       runCaptureOpenshell: deps.runCaptureOpenshell,
       isSandboxReady,
       getSandboxFailurePhase,
-      stableReadyPolls: compatibility || managedBootstrap ? REPLACEMENT_STABLE_READY_POLLS : 1,
+      stableReadyPolls:
+        compatibility || managedBootstrap || expectedRecreatedSandboxId
+          ? REPLACEMENT_STABLE_READY_POLLS
+          : 1,
+      checkReadyIdentity: expectedRecreatedSandboxId
+        ? () =>
+            checkRecreatedSandboxReadyIdentity(input.sandboxName, expectedRecreatedSandboxId, deps)
+        : undefined,
       sleep: deps.sleep,
     });
     if (!readiness.ready) {
@@ -388,7 +469,11 @@ export function createSandboxGpuCreateAttemptRunner(
         backupPath: input.restoreBackupPath,
       });
       if (compatibility) runtimePatch.printReadinessFailureIfEnabled();
-      else {
+      else if (expectedRecreatedSandboxId) {
+        console.error(
+          "  Dashboard forwarding was not started. The sandbox was left in place for inspection and recovery.",
+        );
+      } else {
         const deletion = deps.runOpenshell(["sandbox", "delete", input.sandboxName], {
           ignoreError: true,
           suppressOutput: true,

--- a/src/lib/onboard/sandbox-readiness-tracing.test.ts
+++ b/src/lib/onboard/sandbox-readiness-tracing.test.ts
@@ -123,7 +123,7 @@ describe("waitForCreatedSandboxReadyWithTrace terminal-phase handling", () => {
     expect(sleep).not.toHaveBeenCalled();
   });
 
-  it("keeps an unrelated recreated-runtime probe failure terminal (#9050)", () => {
+  it("stops after an unknown recreated-runtime probe failure (#9050)", () => {
     const { runCaptureOpenshell, sleep } = replay([`${NAME}   Ready`]);
 
     expect(

--- a/src/lib/onboard/sandbox-readiness-tracing.test.ts
+++ b/src/lib/onboard/sandbox-readiness-tracing.test.ts
@@ -86,6 +86,64 @@ describe("createSandboxReadyWaiter", () => {
 });
 
 describe("waitForCreatedSandboxReadyWithTrace terminal-phase handling", () => {
+  it("waits for the exact recreated sandbox to become executable before accepting stable Ready (#9050)", () => {
+    const { runCaptureOpenshell, sleep } = replay([`${NAME}   Ready`]);
+    const checkReadyIdentity = vi.fn().mockReturnValueOnce("not_ready").mockReturnValue("ready");
+
+    expect(
+      waitForCreatedSandboxReadyWithTrace({
+        sandboxName: NAME,
+        timeoutSecs: 30,
+        runCaptureOpenshell,
+        isSandboxReady,
+        stableReadyPolls: 2,
+        checkReadyIdentity,
+        sleep,
+      }),
+    ).toEqual({ ready: true, reason: "ready", failurePhase: null });
+    expect(checkReadyIdentity).toHaveBeenCalledTimes(3);
+    expect(runCaptureOpenshell).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops when the recreated sandbox identity changes (#9050)", () => {
+    const { runCaptureOpenshell, sleep } = replay([`${NAME}   Ready`]);
+
+    expect(
+      waitForCreatedSandboxReadyWithTrace({
+        sandboxName: NAME,
+        timeoutSecs: 30,
+        runCaptureOpenshell,
+        isSandboxReady,
+        checkReadyIdentity: () => "identity_changed",
+        sleep,
+      }),
+    ).toEqual({ ready: false, reason: "identity_changed", failurePhase: null });
+    expect(runCaptureOpenshell).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("keeps an unrelated recreated-runtime probe failure terminal (#9050)", () => {
+    const { runCaptureOpenshell, sleep } = replay([`${NAME}   Ready`]);
+
+    expect(
+      waitForCreatedSandboxReadyWithTrace({
+        sandboxName: NAME,
+        timeoutSecs: 30,
+        runCaptureOpenshell,
+        isSandboxReady,
+        checkReadyIdentity: () => "probe_failed",
+        sleep,
+      }),
+    ).toEqual({
+      ready: false,
+      reason: "identity_probe_failed",
+      failurePhase: null,
+    });
+    expect(runCaptureOpenshell).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
   it("does not probe when the readiness deadline is zero (#3768)", () => {
     const { runCaptureOpenshell, sleep } = replay([`${NAME}   Ready`]);
 

--- a/src/lib/onboard/sandbox-readiness-tracing.ts
+++ b/src/lib/onboard/sandbox-readiness-tracing.ts
@@ -216,7 +216,7 @@ export function waitForCreatedSandboxReadyWithTrace(options: {
    * Optional exact-identity and executability proof for a sandbox whose
    * runtime was replaced after OpenShell first reported Ready. A transient
    * not-ready result stays inside this bounded wait. Identity changes and
-   * unrelated probe failures remain terminal.
+   * all other probe failures remain terminal.
    */
   checkReadyIdentity?: CreatedSandboxReadyIdentityCheck;
   /**
@@ -407,7 +407,7 @@ export function formatCreatedSandboxReadinessFailureMessage(
     return `  Sandbox '${sandboxName}' changed identity before its recreated runtime became ready.`;
   }
   if (readiness.reason === "identity_probe_failed") {
-    return `  Sandbox '${sandboxName}' reached Ready, but its recreated runtime could not be verified.`;
+    return `  NemoClaw could not verify that sandbox '${sandboxName}' still had the expected ID and accepted commands.`;
   }
   return `  Sandbox '${sandboxName}' was created but did not become ready within ${timeoutSecs}s.`;
 }

--- a/src/lib/onboard/sandbox-readiness-tracing.ts
+++ b/src/lib/onboard/sandbox-readiness-tracing.ts
@@ -81,7 +81,15 @@ export function getSandboxReadyErrorDebouncePolls(
 export type CreatedSandboxReadinessResult =
   | { ready: true; reason: "ready"; failurePhase: null }
   | { ready: false; reason: "terminal_failure_phase"; failurePhase: string | null }
+  | { ready: false; reason: "identity_changed"; failurePhase: null }
+  | { ready: false; reason: "identity_probe_failed"; failurePhase: null }
   | { ready: false; reason: "timeout"; failurePhase: null };
+
+export type CreatedSandboxReadyIdentityCheck = () =>
+  | "ready"
+  | "not_ready"
+  | "identity_changed"
+  | "probe_failed";
 
 export interface SandboxReadyWaitDeps {
   runCaptureOpenshell: RunCaptureOpenshell;
@@ -205,6 +213,13 @@ export function waitForCreatedSandboxReadyWithTrace(options: {
    */
   stableReadyPolls?: number;
   /**
+   * Optional exact-identity and executability proof for a sandbox whose
+   * runtime was replaced after OpenShell first reported Ready. A transient
+   * not-ready result stays inside this bounded wait. Identity changes and
+   * unrelated probe failures remain terminal.
+   */
+  checkReadyIdentity?: CreatedSandboxReadyIdentityCheck;
+  /**
    * Consecutive Error-phase polls required before the wait treats the phase as
    * terminal. Defaults to {@link getSandboxReadyErrorDebouncePolls} (30 polls).
    *
@@ -267,6 +282,32 @@ export function waitForCreatedSandboxReadyWithTrace(options: {
       attempt += 1;
       const list = runCaptureOpenshell(["sandbox", "list"], { ignoreError: true });
       if (isSandboxReady(list, sandboxName)) {
+        const identity = options.checkReadyIdentity?.() ?? "ready";
+        if (identity === "identity_changed") {
+          addTraceEvent("identity_changed", { attempt });
+          result = {
+            ready: false,
+            reason: "identity_changed",
+            failurePhase: null,
+          };
+          return true;
+        }
+        if (identity === "probe_failed") {
+          addTraceEvent("identity_probe_failed", { attempt });
+          result = {
+            ready: false,
+            reason: "identity_probe_failed",
+            failurePhase: null,
+          };
+          return true;
+        }
+        if (identity === "not_ready") {
+          consecutiveReadyPolls = 0;
+          consecutiveFailurePolls = 0;
+          lastFailurePhase = null;
+          addTraceEvent("ready_identity_pending", { attempt });
+          return false;
+        }
         consecutiveReadyPolls += 1;
         consecutiveFailurePolls = 0;
         lastFailurePhase = null;
@@ -361,6 +402,12 @@ export function formatCreatedSandboxReadinessFailureMessage(
   if (readiness.reason === "terminal_failure_phase") {
     const phase = readiness.failurePhase ?? "a terminal failure";
     return `  Sandbox '${sandboxName}' entered ${phase} phase before it became ready (waited up to ${timeoutSecs}s).`;
+  }
+  if (readiness.reason === "identity_changed") {
+    return `  Sandbox '${sandboxName}' changed identity before its recreated runtime became ready.`;
+  }
+  if (readiness.reason === "identity_probe_failed") {
+    return `  Sandbox '${sandboxName}' reached Ready, but its recreated runtime could not be verified.`;
   }
   return `  Sandbox '${sandboxName}' was created but did not become ready within ${timeoutSecs}s.`;
 }


### PR DESCRIPTION
## Summary

Gateway-upgrade onboarding could observe a stale `Ready` row after Docker runtime recreation, start dashboard forwarding too soon, and delete a sandbox that was still starting. This change pins the durable sandbox ID and requires two stable `Ready` and executable probes inside the existing bounded readiness timeout before forwarding.

## Related Issue

Fixes #9050

## Changes

- Pin the exact OpenShell sandbox ID before restart-safe Docker runtime recreation.
- Retry only OpenShell's exact `sandbox is not ready` response inside the existing readiness deadline.
- Keep identity changes and unknown probe failures terminal, preserve diagnostics, attempt container restoration, and avoid mutable-name sandbox deletion when identity is uncertain.
- Add deterministic delayed-readiness, identity-change, and terminal-probe tests.
- Document the recreated-runtime recovery exception in the shared troubleshooting page for OpenClaw, Hermes, and Deep Agents.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior; justification:
- [ ] Tests not applicable; justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable; justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded; reviewer/approval link/justification: Codex Desktop contributor self-review passed. OpenShell commands use array arguments, durable IDs use the existing allowlist parser, only the exact transient response is retried, the existing timeout remains authoritative, unknown errors fail closed, and uncertain identity never triggers mutable-name deletion. No credential or policy behavior changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer; check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/troubleshooting.mdx`; shared OpenClaw, Hermes, and Deep Agents variants verified
- Agent: Codex Desktop
<!-- docs-review-head-sha: 41c84b64b -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above: `npx vitest run --project cli src/lib/onboard/sandbox-readiness-tracing.test.ts src/lib/onboard/sandbox-gpu-create-flow.test.ts`: 67 passed, 1 skipped. `npm run typecheck:cli` and `npm run checks:repository` passed.
- [ ] Applicable broad gate passed; not applicable to this focused onboarding runtime change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only); build passed with 0 errors. Fern reported only the missing-auth redirect check and existing accent-contrast warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Remaining external release gate: all five gateway-upgrade E2E shards must pass at exact candidate commit `41c84b64b`.

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU sandbox onboarding recovery after runtime recreation.
  * Readiness checks now verify the expected sandbox identity before continuing.
  * Transient “not ready” responses are retried, while identity changes or failed checks stop safely.
  * Failed recovery preserves the sandbox for inspection, avoids unsafe deletion, and reports uncertain state clearly.
* **Documentation**
  * Updated troubleshooting guidance for sandbox cleanup, recreation failures, diagnostics, and manual recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->