### PR TITLE
fix(onboard): preserve resumable incomplete sessions

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3757,8 +3757,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
     collector: null,
     span: null,
   };
-  let completed = false;
-  let returnedNormally = false;
+  let completed = false, returnedNormally = false;
   try {
     onboardTrace = onboardTracing.startOnboardTrace(opts, process.env);
     let selectedMessagingChannels: string[] = [];
@@ -3814,11 +3813,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
       process.exit(1);
     }
 
-    registerIncompleteOnboardExitHandlerForSession(
-      onboardSession,
-      () => completed || returnedNormally,
-    );
-
+    registerIncompleteOnboardExitHandlerForSession(onboardSession, () => completed || returnedNormally);
     const agent = await selectOnboardAgent({
       agentFlag: opts.agent,
       session,

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3758,6 +3758,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
     span: null,
   };
   let completed = false;
+  let returnedNormally = false;
   try {
     onboardTrace = onboardTracing.startOnboardTrace(opts, process.env);
     let selectedMessagingChannels: string[] = [];
@@ -3813,7 +3814,10 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
       process.exit(1);
     }
 
-    registerIncompleteOnboardExitHandlerForSession(onboardSession, () => completed);
+    registerIncompleteOnboardExitHandlerForSession(
+      onboardSession,
+      () => completed || returnedNormally,
+    );
 
     const agent = await selectOnboardAgent({
       agentFlag: opts.agent,
@@ -4318,6 +4322,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
       hostMountScope.restore();
     }
   }
+  returnedNormally = true;
 }
 
 module.exports = {

--- a/test/onboard-exit-handler.test.ts
+++ b/test/onboard-exit-handler.test.ts
@@ -197,7 +197,7 @@ const { onboard } = require(${onboardPath});
     expect(payload.loaded.machine.state).toBe("failed");
   });
 
-  it("onboard() maps final machine completion to the process exit status (#8987)", () => {
+  it("onboard() preserves a resumable session after a normal incomplete result (#9048)", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const scriptPath = path.join(tmpDir, "onboard-exit-completed.cjs");
     const openshellPath = writeSuccessfulOpenShell(tmpDir);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

A normal incomplete onboarding result now exits with status 1 without changing its resumable session to `failed`. Unhandled failures and process interruptions still record a terminal failure.

## Related Issue

Fixes #9048

## Changes

- Separate normal return from machine completion when the onboard exit listener classifies a nonzero exit.
- Preserve `in_progress` and the last completed checkpoint after final verification returns an incomplete result.
- Keep terminal failure recording for thrown failures and process interruptions.
- Bind the existing complete, incomplete, and thrown integration seam to issue #9048.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing quickstart and architecture pages already describe nonzero readiness failure, retained resumable state, and `onboard --resume`.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The nine-category review found no security control change. The change keeps the existing exit-handler trust boundary and preserves terminal failure for unhandled failures and signals.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing docs already describe nonzero HTTP 5xx readiness failure, retained session state, and `onboard --resume`. The reviewer found no blocker or suggestion.
- Agent: Codex Desktop
<!-- docs-review-head-sha: ecb97bd09f -->
<!-- docs-review-agents-blob-sha: e30afb270b -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/onboard-exit-handler.test.ts`: 4 tests passed. `npx vitest run --project cli src/lib/onboard/exit-step-failure.test.ts`: 13 tests passed. `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; this change updates one onboarding exit-state predicate and its focused integration seam.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding completion handling when the process returns normally after an incomplete result.
  * Resumable onboarding sessions are now preserved correctly in this scenario.

* **Tests**
  * Updated coverage to verify resumable session behavior after a normal incomplete onboarding result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->