### PR TITLE
docs(security): document gateway authentication controls

### DIFF
--- a/docs/security/gateway-authentication-controls.mdx
+++ b/docs/security/gateway-authentication-controls.mdx
@@ -17,6 +17,18 @@ LangChain Deep Agents Code has no in-sandbox agent gateway or dashboard, so devi
 The shared secret-handling controls below still apply.
 </AgentOnly>
 
+## OpenShell Gateway Authentication
+
+On Docker-driver deployments, NemoClaw gives host CLI calls and sandbox callbacks separate authenticated paths to the OpenShell gateway.
+
+| Aspect | Detail |
+|---|---|
+| Default | NemoClaw enables local TLS, mTLS user authentication, and sandbox JWT authentication. Host-side OpenShell CLI calls use local mTLS. Sandbox callbacks use the guest mTLS bundle plus a sandbox-scoped JWT. The generated config sets `allow_unauthenticated_users = false`, and gateway launch removes an inherited `OPENSHELL_DISABLE_GATEWAY_AUTH=true`. |
+| Token lifetime | Local sandbox JWTs use OpenShell's `ttl_secs = 0` contract for a non-expiring token on a local single-user gateway. Sandbox identity checks and the local mTLS boundary still apply to each callback. |
+| What you can change | These authentication controls are not user-facing settings. Use NemoClaw to configure and start the Docker-driver gateway. |
+| Risk if relaxed | Disabling gateway authentication or widening the gateway listener can expose privileged gateway methods to another local or network client. |
+| Recommendation | Keep the OpenShell gateway on `127.0.0.1`. Use the dashboard forward when a supported agent dashboard needs remote access. |
+
 ## Gateway Compatibility Container
 
 On Linux hosts whose glibc is older than the OpenShell gateway binary requires, NemoClaw can run `openshell-gateway` in a Docker compatibility container so the Docker-driver gateway still starts.

--- a/src/lib/onboard/docker-driver-gateway-config-auth-contract.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-config-auth-contract.test.ts
@@ -20,6 +20,24 @@ import {
 } from "../../../test/support/openshell-gateway-config-helpers";
 
 describe("docker-driver-gateway auth contract", () => {
+  it("keeps supported OpenShell gateway authentication in public security guidance", () => {
+    const publicGatewayControls = fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "../../../docs/security/gateway-authentication-controls.mdx",
+      ),
+      "utf-8",
+    );
+
+    expect(publicGatewayControls).toContain("Host-side OpenShell CLI calls use local mTLS");
+    expect(publicGatewayControls).toContain(
+      "Sandbox callbacks use the guest mTLS bundle plus a sandbox-scoped JWT",
+    );
+    expect(publicGatewayControls).toContain("allow_unauthenticated_users = false");
+    expect(publicGatewayControls).toContain("OPENSHELL_DISABLE_GATEWAY_AUTH=true");
+    expect(publicGatewayControls).toContain("ttl_secs = 0");
+  });
+
   it("keeps the OpenShell gateway auth source review aligned with the generated config", () => {
     const compatibilityReview = fs.readFileSync(GATEWAY_AUTH_REVIEW_NOTE, "utf-8");
     const migrationReview = fs.readFileSync(GATEWAY_MIGRATION_REVIEW_NOTE, "utf-8");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Document the Docker-driver OpenShell gateway authentication boundary that was missing after #9062 moved internal review evidence out of public docs. The public security page now names the host and sandbox authentication paths, token lifetime, fixed settings, and exposure risk.

## Changes

- Add supported OpenShell gateway authentication guidance to the canonical gateway security page.
- Add a contract test that keeps the public guidance aligned with the generated gateway configuration.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior; justification:
- [ ] Tests not applicable; justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable; justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded; reviewer/approval link/justification: Codex Desktop independently reviewed the authentication claims against the current implementation and found no findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer; check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed `docs/security/gateway-authentication-controls.mdx` and `src/lib/onboard/docker-driver-gateway-config-auth-contract.test.ts`. The review covered the writing rules, documentation style, authentication claims, generated guide variants, and documentation contract test.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 1b7a37ba7e -->
<!-- docs-review-agents-blob-sha: e30afb270b -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above; `npx vitest run --project cli src/lib/onboard/docker-driver-gateway-config-auth-contract.test.ts`: 5 tests passed.
- [ ] Applicable broad gate passed; not run because this change adds one focused documentation contract test and public guidance.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

`npm run docs` passed with 0 errors and 2 existing Fern warnings. All three generated guide variants contain the new guidance. `git diff --check` passed.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for gateway authentication, including host and sandbox authentication paths.
  * Documented local TLS/mTLS, sandbox JWT defaults, non-expiring local JWTs, configuration constraints, security considerations, and loopback binding recommendations.

* **Tests**
  * Added coverage to verify that public authentication guidance includes required security settings and recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->