### PR TITLE
fix(cli): use numeric UID for portable privileged exec

### DIFF
--- a/src/lib/sandbox/privileged-exec.test.ts
+++ b/src/lib/sandbox/privileged-exec.test.ts
@@ -338,7 +338,7 @@ describe("privileged sandbox exec routing", () => {
     ]);
   });
 
-  it("uses the receipt-owned Podman socket when the default Docker daemon has no container (#8584)", () => {
+  it("uses numeric container UID 0 on the receipt-owned portable target (#9054)", () => {
     let dockerPsCalls = 0;
     const assertRuntimeAuthority = vi.fn();
     let backfillRegistryGeneration: ((generation: string) => boolean) | undefined;
@@ -372,7 +372,8 @@ describe("privileged sandbox exec routing", () => {
         resolvePortableDemoPrivilegedExecTarget,
       },
       ({ privilegedSandboxExecArgv }) => {
-        expect(privilegedSandboxExecArgv("alpha", ["id"], false, true)).toEqual([
+        const argv = privilegedSandboxExecArgv("alpha", ["id"], false, true);
+        expect(argv).toEqual([
           "--host",
           "unix:///run/user/1001/podman/podman.sock",
           "exec",
@@ -411,10 +412,11 @@ describe("privileged sandbox exec routing", () => {
           "--env",
           "RUBYOPT=",
           "--user",
-          "root",
+          "0",
           "a".repeat(64),
           "id",
         ]);
+        expect(argv).not.toContain("root");
       },
     );
     expect(dockerPsCalls).toBe(0);
@@ -450,7 +452,7 @@ describe("privileged sandbox exec routing", () => {
     expect(resolvePortableDemoPrivilegedExecTarget).not.toHaveBeenCalled();
   });
 
-  it("bounds direct sandbox container discovery", () => {
+  it("keeps ordinary Docker discovery bounded and uses symbolic root (#9054)", () => {
     const discoveryCalls: Array<{
       args: readonly string[];
       timeout: number | undefined;

--- a/src/lib/sandbox/privileged-exec.ts
+++ b/src/lib/sandbox/privileged-exec.ts
@@ -292,7 +292,7 @@ function privilegedSandboxExecArgv(
       ...(stdin ? ["-i"] : []),
       ...sanitizedEnvArgs,
       "--user",
-      "root",
+      "0",
       portableTarget.containerId,
       ...cmd,
     ];


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Portable privileged sandbox execution now selects fixed numeric container UID `0` instead of the symbolic `root` account. This preserves the existing Docker-compatible transport and privilege contract while avoiding symbolic account lookup on qualified rootless-Podman workloads; ordinary Docker execution continues to use `--user root`.

## Related Issue

Fixes #9054

## Changes

- Emit literal `--user 0` only for the existing receipt-qualified portable execution target.
- Preserve the direct Docker branch's literal `--user root` behavior.
- Assert the exact portable and direct-Docker argument separation, including that portable execution never emits symbolic `root`.
- Keep the existing execution lease, lifecycle and mutation fencing, socket and exact-container revalidation, sanitized environment, timeout, diagnostics, and fail-closed behavior unchanged. This adds no transport fallback, retry, configuration, or caller-controlled user selection.

### Protected and live evidence

Protected production-path acceptance passed on the receipt-owned rootless-Podman workload through `withPrivilegedSandboxExecutionLease` and `privilegedSandboxExecArgv`:

- Harness SHA-256: `3837df60368600b65416a43ddc87506827d3d4eef347ba026a9cba5436b428a6`
- Report SHA-256: `353ca97ebee084b3246348979fe765204434260f468378619735b99f8cb6166e`
- `/usr/bin/id -u` returned exactly `0` (SHA-256 `5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9`).
- The actual inspect/normalize/verify path passed with directory mode `2770`, file mode `660`, and non-root `sandbox:sandbox` ownership; repair was applied and verified with no errors.
- The stale expected-container sentinel failed before spawn (error SHA-256 `c372366c780b4f670bd340089ffb4bd30676f4c70df40ee82b482eec99f074df`).
- Credential-free authority evidence: container ID SHA-256 `c2640e7abcb21e2afd113f09aa256fdb295ffac721babe408653b0ad53b63bbb`; lifecycle generation SHA-256 `c425f97001645b342ebafafa2385df2031c127c3d561942d50dd15919b416c32`; socket-authority projection SHA-256 `e982ea9ac30fa5dd6a3ffe9ea1a7d33cbae1c37289b443893c7d61208c6ec55b`.
- Registry and portable lifecycle receipt content, size, and modification time remained byte-identical: `5e283cbd7971e49ae3b06b8474e71a7b937f4ac676022c30f4645a971b2a2598` and `58d7a5538263ca47aa1d07f2abab5da3922178b4d46601b5db60a5deb8cc6d8e`.
- No native-Podman fallback ran. A live socket replacement was not attempted because it would mutate the preserved host; deterministic socket-authority negatives and the live stale-container pre-spawn sentinel cover the fail-closed boundary.

Probe-only passed with status 0 in 8,856 ms. Result/stdout/stderr SHA-256 values were `a2feb4f2076cc777472a86e5b48df056fd4468dafbcb4ebe03fedd1482439e38`, `b726fd8578f824928479f62707e7a32500e1aa4537530c51864d045f56afe29a`, and `2051b7f4eae939cabf067e50e7cd1298b7086d5f4668d5c30ee7e4ab4de73f34`. The normally published launch-readiness receipt SHA-256 was `eff4d647320e78f5af8fb5895475ddb9ab427704c597953910582078ee1d2c36`.

Two-turn live acceptance is not passed or claimed. The first turn ended with status 1 after 198,283 ms because the preserved OpenClaw main conversation did not produce the new exact reply following its recorded auto-compaction/session-history condition. The helper reported `launch did not produce the expected agent reply.` before `/exit`, so `/exit` was not sent and a second turn did not run. Result/stdout/stderr SHA-256 values were `40d130b3ee39f47a7a1ec7653c0430dd206e5feda99e421f9670cdeaf90ca1c1`, `12bd608d69b8ec9ced8a0bc6fb12ea130c591710e4fcddf367ed6ac1f394a1aa`, and `0bb600316b6d2e1b502767fdc9d72a0df3329b433911f663d914a4a5c1fdff68`; direct report SHA-256 was `917b9a9436af6e2d8b09caadb74e4c9c46f934d82a48e8c134e01f6fdcef8172`. No conversation reset, `/new`, `/compact`, retry, registry/pairing/sandbox cleanup, or fabricated evidence was used. Post-command permission inspection remained healthy.

Merge remains blocked pending either two-turn evidence on an authorized fresh OpenClaw session or explicit maintainer acceptance of this scoped live waiver. Publication of this ready PR does not grant merge approval, and auto-merge is off.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this restores the existing internal portable privileged-execution contract without changing a command, option, configuration, output, or supported workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: maintainer review approved this literal portable-only UID change and the publication-only live waiver; protected production-path and incomplete live evidence are recorded above.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change is internal to portable privileged execution and adds no user-visible command, option, configuration, output, or workflow surface.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 3b50725bc -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/sandbox/privileged-exec.test.ts src/lib/sandbox/privileged-exec.integration.test.ts src/lib/sandbox/portable-exec-target.test.ts src/lib/sandbox/runtime-verify.test.ts src/lib/actions/sandbox/launch.test.ts` passed 5 files and 70 tests; `npm run test:changed` passed 103 files and 1,325 tests; `npm run build:cli`, `npm run typecheck:cli`, and `npm run checks:repository` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privileged execution for portable demo environments by using the numeric administrator account identifier.
  * Preserved reliable container socket access and lifecycle behavior.
* **Tests**
  * Expanded coverage for portable execution, bounded container discovery, and administrator-account handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->