### PR TITLE
test(onboard): update sandbox identity fixtures

### DIFF
--- a/test/onboard-custom-dockerfile.test.ts
+++ b/test/onboard-custom-dockerfile.test.ts
@@ -228,8 +228,11 @@ fs.statSync = (target, ...rest) => {
   return stats;
 };
 runner.run = (command, opts = {}) => {
-  commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  const normalized = _n(command);
+  commands.push({ command: normalized, env: opts.env || null });
+  return normalized.includes("sandbox get") && normalized.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return "";

--- a/test/onboard-extra-provider-reconciliation.test.ts
+++ b/test/onboard-extra-provider-reconciliation.test.ts
@@ -73,7 +73,9 @@ runner.run = (command, opts = {}) => {
   if (normalized.includes("provider get -g nemoclaw ")) {
     return { status: 0, stdout: "" };
   }
-  return { status: 0 };
+  return normalized.includes("sandbox get") && normalized.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   const normalized = _n(command);

--- a/test/onboard-installer-restore-intent.test.ts
+++ b/test/onboard-installer-restore-intent.test.ts
@@ -65,7 +65,9 @@ runner.run = (command) => {
   const cmd = _n(command);
   events.push({ kind: "run", cmd });
   if (cmd.includes("sandbox delete")) sandboxDeleted = true;
-  return { status: 0 };
+  return cmd.includes("sandbox get") && cmd.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   const cmd = _n(command);

--- a/test/onboard-messaging.test.ts
+++ b/test/onboard-messaging.test.ts
@@ -82,7 +82,7 @@ runner.run = (command, opts = {}) => {
   commands.push({ command: _n(command), env: opts.env || null });
   // provider-get returns not-found so messaging providers are created fresh
   if (_n(command).includes("provider get")) return { status: 1 };
-  return { status: 0 };
+  return _n(command).includes("sandbox get") && _n(command).includes("my-assistant") ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return "";
@@ -524,7 +524,7 @@ runner.run = (command, opts = {}) => {
   if (normalized.includes("provider get -g nemoclaw my-assistant-slack-bridge")) return { status: 0, stdout: "Name: my-assistant-slack-bridge\nType: generic\nCredential keys: SLACK_BOT_TOKEN\nConfig keys: <none>\n" };
   if (normalized.includes("provider get -g nemoclaw my-assistant-slack-app")) return { status: 0, stdout: "Name: my-assistant-slack-app\nType: generic\nCredential keys: SLACK_APP_TOKEN\nConfig keys: <none>\n" };
   if (normalized.includes("provider get")) return { status: 1 };
-  return { status: 0 };
+  return normalized.includes("sandbox get") && normalized.includes("my-assistant") ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return "";
@@ -682,7 +682,7 @@ runner.run = (command, opts = {}) => {
   commands.push({ command: normalized, env: opts.env || null });
   if (normalized.includes("provider get -g nemoclaw my-assistant-telegram-bridge")) return { status: 0, stdout: "Name: my-assistant-telegram-bridge\nType: generic\nCredential keys: TELEGRAM_BOT_TOKEN\nConfig keys: <none>\n" };
   if (normalized.includes("provider get")) return { status: 1 };
-  return { status: 0 };
+  return normalized.includes("sandbox get") && normalized.includes("my-assistant") ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return "";
@@ -830,7 +830,7 @@ runner.run = (command, opts = {}) => {
   const normalized = _n(command);
   commands.push({ command: normalized, env: opts.env || null });
   if (normalized.includes("provider get")) return { status: 1 };
-  return { status: 0 };
+  return normalized.includes("sandbox get") && normalized.includes("my-assistant") ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return "";
@@ -985,7 +985,7 @@ runner.run = (command, opts = {}) => {
   const normalized = _n(command);
   commands.push({ command: normalized, env: opts.env || null });
   if (normalized.includes("provider get")) return { status: 1 };
-  return { status: 0 };
+  return normalized.includes("sandbox get") && normalized.includes("my-assistant") ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return "";
@@ -1300,7 +1300,7 @@ runner.run = (command, opts = {}) => {
   commands.push({ command: _n(command), env: opts.env || null });
   // provider-get returns not-found so messaging providers are created fresh
   if (_n(command).includes("provider get")) return { status: 1 };
-  return { status: 0 };
+  return _n(command).includes("sandbox get") && _n(command).includes("my-assistant") ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return "";
@@ -1429,7 +1429,7 @@ const { EventEmitter } = require("node:events");
 const commands = [];
 runner.run = (command, opts = {}) => {
   commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  return _n(command).includes("sandbox get") && _n(command).includes("my-assistant") ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return "";

--- a/test/onboard-prepared-build-context.test.ts
+++ b/test/onboard-prepared-build-context.test.ts
@@ -134,8 +134,11 @@ imageTag.resolveSandboxImageTagFromCreateOutput = (output, receivedBuildId, warn
 const normalize = (command) =>
   (Array.isArray(command) ? command.join(" ") : String(command)).replace(/'/g, "");
 runner.run = (command) => {
-  commands.push(normalize(command));
-  return { status: 0 };
+  const normalized = normalize(command);
+  commands.push(normalized);
+  return normalized.includes("sandbox get") && normalized.includes(sandboxName)
+    ? { status: 0, stdout: Buffer.from(sandboxName + "\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runFile = (file, args = []) => {
   commands.push(normalize([file, ...args]));

--- a/test/onboard-reservation-recreate.test.ts
+++ b/test/onboard-reservation-recreate.test.ts
@@ -67,7 +67,9 @@ runner.run = (command) => {
   const cmd = _n(command);
   events.push({ kind: "run", cmd });
   if (cmd.includes("sandbox delete")) sandboxDeleted = true;
-  return { status: 0 };
+  return cmd.includes("sandbox get") && cmd.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   const cmd = _n(command);

--- a/test/onboard-sandbox-build.test.ts
+++ b/test/onboard-sandbox-build.test.ts
@@ -56,8 +56,11 @@ const registerCalls = [];
 const updateCalls = [];
 const defaultCalls = [];
 runner.run = (command, opts = {}) => {
-  commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  const normalized = _n(command);
+  commands.push({ command: normalized, env: opts.env || null });
+  return normalized.includes("sandbox get") && normalized.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return "";
@@ -473,8 +476,11 @@ buildContext.stageOptimizedSandboxBuildContext = () => {
 };
 
 runner.run = (command, opts = {}) => {
-  commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  const normalized = _n(command);
+  commands.push({ command: normalized, env: opts.env || null });
+  return normalized.includes("sandbox get") && normalized.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runFile = (file, args = [], opts = {}) => {
   commands.push({ command: _n([file, ...args]), env: opts.env || null });
@@ -579,8 +585,11 @@ const { EventEmitter } = require("node:events");
 
 const commands = [];
 runner.run = (command, opts = {}) => {
-  commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  const normalized = _n(command);
+  commands.push({ command: normalized, env: opts.env || null });
+  return normalized.includes("sandbox get") && normalized.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return "";
@@ -677,8 +686,11 @@ const { EventEmitter } = require("node:events");
 
 const commands = [];
 runner.run = (command, opts = {}) => {
-  commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  const normalized = _n(command);
+  commands.push({ command: normalized, env: opts.env || null });
+  return normalized.includes("sandbox get") && normalized.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runFile = (file, args = [], opts = {}) => {
   commands.push({ command: _n([file, ...args]), env: opts.env || null });

--- a/test/onboard-sandbox-recreation.test.ts
+++ b/test/onboard-sandbox-recreation.test.ts
@@ -138,9 +138,12 @@ const sourceSandbox = {
   },
 };
 runner.run = (command, opts = {}) => {
-  _deleted = _deleted || _n(command).includes("sandbox delete");
-  commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  const cmd = _n(command);
+  _deleted = _deleted || cmd.includes("sandbox delete");
+  commands.push({ command: cmd, env: opts.env || null });
+  return cmd.includes("sandbox get") && cmd.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("my-assistant\nId: " + _sandboxId + "\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return _deleted ? "" : ["my-assistant", "Id: " + _sandboxId].join(String.fromCharCode(10));
@@ -269,9 +272,12 @@ const { EventEmitter } = require("node:events");
 
 const events = [];
 runner.run = (command) => {
-  _deleted = _deleted || _n(command).includes("sandbox delete");
-  events.push({ kind: "run", cmd: _n(command) });
-  return { status: 0 };
+  const cmd = _n(command);
+  _deleted = _deleted || cmd.includes("sandbox delete");
+  events.push({ kind: "run", cmd });
+  return cmd.includes("sandbox get") && cmd.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   const cmd = _n(command);
@@ -420,9 +426,12 @@ const { EventEmitter } = require("node:events");
 
 const events = [];
 runner.run = (command) => {
-  _deleted = _deleted || _n(command).includes("sandbox delete");
-  events.push({ kind: "run", cmd: _n(command) });
-  return { status: 0 };
+  const cmd = _n(command);
+  _deleted = _deleted || cmd.includes("sandbox delete");
+  events.push({ kind: "run", cmd });
+  return cmd.includes("sandbox get") && cmd.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   const cmd = _n(command);
@@ -546,11 +555,13 @@ const { EventEmitter } = require("node:events");
 const events = [];
 let sandboxDeleted = false;
 runner.run = (command) => {
-  _deleted = _deleted || _n(command).includes("sandbox delete");
   const cmd = _n(command);
+  _deleted = _deleted || cmd.includes("sandbox delete");
   events.push({ kind: "run", cmd });
   if (cmd.includes("sandbox delete")) sandboxDeleted = true;
-  return { status: 0 };
+  return cmd.includes("sandbox get") && cmd.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   const cmd = _n(command);
@@ -694,9 +705,12 @@ const { EventEmitter } = require("node:events");
 
 const commands = [];
 runner.run = (command, opts = {}) => {
-  _deleted = _deleted || _n(command).includes("sandbox delete");
-  commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  const cmd = _n(command);
+  _deleted = _deleted || cmd.includes("sandbox delete");
+  commands.push({ command: cmd, env: opts.env || null });
+  return cmd.includes("sandbox get") && cmd.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return _deleted ? "" : ["my-assistant", "Id: sbx-4f2a91c0d7"].join(String.fromCharCode(10));
@@ -818,9 +832,10 @@ const path = require("node:path");
 
 const commands = [];
 runner.run = (command, opts = {}) => {
-  _deleted = _deleted || _n(command).includes("sandbox delete");
+  const cmd = _n(command);
+  _deleted = _deleted || cmd.includes("sandbox delete");
   const commandString = Array.isArray(command) ? command.join(" ") : String(command);
-  if (_n(command).includes("sandbox download")) {
+  if (cmd.includes("sandbox download")) {
     const parts = commandString.match(/'([^']*)'/g) || [];
     const downloadDir = Array.isArray(command)
       ? String(command[command.length - 1] || "")
@@ -835,8 +850,10 @@ runner.run = (command, opts = {}) => {
       );
     }
   }
-  commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  commands.push({ command: cmd, env: opts.env || null });
+  return cmd.includes("sandbox get") && cmd.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runFile = (file, args = [], opts = {}) => {
   commands.push({ type: "runFile", command: _n([file, ...args]), file, args, env: opts.env || null });
@@ -951,9 +968,10 @@ const path = require("node:path");
 
 const commands = [];
 runner.run = (command, opts = {}) => {
-  _deleted = _deleted || _n(command).includes("sandbox delete");
+  const cmd = _n(command);
+  _deleted = _deleted || cmd.includes("sandbox delete");
   const commandString = Array.isArray(command) ? command.join(" ") : String(command);
-  if (_n(command).includes("sandbox download")) {
+  if (cmd.includes("sandbox download")) {
     const parts = commandString.match(/'([^']*)'/g) || [];
     const downloadDir = Array.isArray(command)
       ? String(command[command.length - 1] || "")
@@ -968,8 +986,10 @@ runner.run = (command, opts = {}) => {
       );
     }
   }
-  commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  commands.push({ command: cmd, env: opts.env || null });
+  return cmd.includes("sandbox get") && cmd.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runFile = (file, args = [], opts = {}) => {
   commands.push({ type: "runFile", command: _n([file, ...args]), file, args, env: opts.env || null });
@@ -1096,10 +1116,13 @@ const { EventEmitter } = require("node:events");
 const commands = [];
 let sandboxDeleted = false;
 runner.run = (command, opts = {}) => {
-  _deleted = _deleted || _n(command).includes("sandbox delete");
-  commands.push({ command: _n(command), env: opts.env || null });
-  if (_n(command).includes("sandbox delete")) sandboxDeleted = true;
-  return { status: 0 };
+  const cmd = _n(command);
+  _deleted = _deleted || cmd.includes("sandbox delete");
+  commands.push({ command: cmd, env: opts.env || null });
+  if (cmd.includes("sandbox delete")) sandboxDeleted = true;
+  return cmd.includes("sandbox get") && cmd.includes("my-assistant")
+    ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   // Existing sandbox that is NOT ready initially, becomes Ready after recreation
@@ -1252,9 +1275,12 @@ let sandboxCreated = false;
 let registeredSandbox = null;
 const keepAlive = setInterval(() => {}, 1000);
 runner.run = (command, opts = {}) => {
-  _deleted = _deleted || _n(command).includes("sandbox delete");
-  commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  const cmd = _n(command);
+  _deleted = _deleted || cmd.includes("sandbox delete");
+  commands.push({ command: cmd, env: opts.env || null });
+  return cmd.includes("sandbox get") && cmd.includes("my-assistant") && sandboxCreated
+    ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-fresh-create\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") || _n(command).includes("sandbox list")) {

--- a/test/onboard-terminal-dashboard.test.ts
+++ b/test/onboard-terminal-dashboard.test.ts
@@ -92,8 +92,11 @@ agentOnboard.createAgentSandbox = () => {
 };
 
 runner.run = (command, opts = {}) => {
-  commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  const normalized = _n(command);
+  commands.push({ command: normalized, env: opts.env || null });
+  return normalized.includes("sandbox get") && normalized.includes(sandboxName)
+    ? { status: 0, stdout: Buffer.from("Name: " + sandboxName + "\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
+    : { status: 0 };
 };
 runner.runFile = (file, args = [], opts = {}) => {
   commands.push({ command: _n([file, ...args]), env: opts.env || null });


### PR DESCRIPTION
## Summary

After #9064 pinned the durable sandbox identity, several integration harnesses still returned empty structured output for `openshell sandbox get`. That caused CI to stop before the scenarios reached their intended assertions. This follow-up makes those mocks return the same durable identities their existing capture mocks already advertise.

## Related Issue

Follow-up to #9064 for #9050.

## Changes

- Return a durable sandbox ID from the structured runner mocks used by nine onboarding integration fixtures.
- Preserve each scenario's existing sandbox lifecycle state and identity transitions.
- Keep the fixtures branchless so the source-shape test budget does not grow.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior; justification:
- [ ] Tests not applicable; justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable; justification: this changes only integration fixture responses. The user-visible behavior and troubleshooting guidance landed in #9064.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded; reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer; check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: nine onboarding integration fixtures under `test/` only; `docs/reference/troubleshooting.mdx` already owns the behavior through #9064
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7d751b7d8 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above: nine affected integration files, 54 tests passed. The test conditional growth scanner passed.
- [ ] Applicable broad gate passed; PR CI is the applicable broad gate. The local full integration lane is not supported on this macOS host and encountered unrelated Linux and Python 3.9 failures before timing out.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved onboarding test coverage for sandbox lookup and recreation workflows.
  - Added realistic sandbox identity data to test scenarios, including names and IDs.
  - Strengthened validation of lifecycle handling, deletion and recreation, registration timing, policy preservation, and terminal dashboard behavior.
  - Preserved command tracking and successful default responses across test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->