### PR TITLE
fix(e2e): preserve dev artifact trust through install

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1839,17 +1839,6 @@ jobs:
           ref: ${{ inputs.checkout_sha || github.sha }}
           persist-credentials: false
 
-      - name: Checkout trusted OpenShell dev tooling
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: ${{ github.repository }}
-          ref: ${{ inputs.workflow_sha || github.workflow_sha }}
-          path: .trusted-openshell-dev-artifact
-          persist-credentials: false
-          sparse-checkout: |
-            scripts/install-openshell.sh
-            tools/e2e/openshell-dev-artifact.mts
-
       - *dockerhub-auth
 
       - name: Prepare E2E workspace
@@ -1861,6 +1850,18 @@ jobs:
         uses: NVIDIA/NemoClaw/.github/actions/restore-e2e-cli-artifact@c246409193a31133cab10c8a3589001cc0d59eb3
         with:
           provenance-json: ${{ needs.generate-matrix.outputs.cli_artifact_provenance }}
+
+      - name: Checkout trusted OpenShell dev tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ inputs.workflow_sha || github.workflow_sha }}
+          path: .trusted-openshell-dev-artifact
+          persist-credentials: false
+          sparse-checkout: |
+            .github/scripts/docker-auth-cleanup.sh
+            scripts/install-openshell.sh
+            tools/e2e/openshell-dev-artifact.mts
 
       - name: Restore immutable OpenShell dev artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -1881,34 +1882,11 @@ jobs:
           "$OPENSHELL_DEV_EXPECTED_SOURCE_COMMIT"
           "$OPENSHELL_DEV_EXPECTED_MANIFEST_SHA256"
 
-      - name: Install and verify cloudflared prerequisite
-        # Update posture: keep this dev compatibility lane on the same reviewed
-        # version/SHA256 pair as the stable lane; workflow-contract tests fail
-        # if the pins diverge or installation becomes mutable.
-        env:
-          CLOUDFLARED_VERSION: "2026.6.1"
-          CLOUDFLARED_DEB_SHA256: "ccd02ec216c62bfa573395d8f72cb2e91e95cbdf8726a8acc06b3e2d9aa31526"
-        run: |
-          set -euo pipefail
-          cloudflared_deb="${RUNNER_TEMP}/cloudflared-${CLOUDFLARED_VERSION}-linux-amd64.deb"
-          curl -fL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64.deb" -o "${cloudflared_deb}"
-          printf '%s  %s\n' "${CLOUDFLARED_DEB_SHA256}" "${cloudflared_deb}" | sha256sum -c -
-          package="$(dpkg-deb -f "${cloudflared_deb}" Package)"
-          version="$(dpkg-deb -f "${cloudflared_deb}" Version)"
-          architecture="$(dpkg-deb -f "${cloudflared_deb}" Architecture)"
-          if [[ "${package}" != "cloudflared" || "${version}" != "${CLOUDFLARED_VERSION}" || "${architecture}" != "amd64" ]]; then
-            printf 'Unexpected cloudflared package metadata: package=%s version=%s architecture=%s\n' "${package}" "${version}" "${architecture}" >&2
-            exit 1
-          fi
-          sudo dpkg -i "${cloudflared_deb}"
-          cloudflared --version | grep -F "cloudflared version ${CLOUDFLARED_VERSION}"
-
-      - name: Generate MCP test TLS
-        run: bash test/e2e/setup-mcp-test-tls.sh
-
       - name: Revoke Docker auth before OpenShell development tooling
         shell: bash
-        run: bash .github/scripts/docker-auth-cleanup.sh
+        run: >-
+          bash
+          "${{ github.workspace }}/.trusted-openshell-dev-artifact/.github/scripts/docker-auth-cleanup.sh"
 
       - name: Install immutable OpenShell dev artifact
         env:
@@ -1947,6 +1925,31 @@ jobs:
           chmod 700 "$shim_dir/gh" "$shim_dir/curl"
           PATH="$shim_dir:$PATH" \
             bash "${{ github.workspace }}/.trusted-openshell-dev-artifact/scripts/install-openshell.sh"
+
+      - name: Install and verify cloudflared prerequisite
+        # Update posture: keep this dev compatibility lane on the same reviewed
+        # version/SHA256 pair as the stable lane; workflow-contract tests fail
+        # if the pins diverge or installation becomes mutable.
+        env:
+          CLOUDFLARED_VERSION: "2026.6.1"
+          CLOUDFLARED_DEB_SHA256: "ccd02ec216c62bfa573395d8f72cb2e91e95cbdf8726a8acc06b3e2d9aa31526"
+        run: |
+          set -euo pipefail
+          cloudflared_deb="${RUNNER_TEMP}/cloudflared-${CLOUDFLARED_VERSION}-linux-amd64.deb"
+          curl -fL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64.deb" -o "${cloudflared_deb}"
+          printf '%s  %s\n' "${CLOUDFLARED_DEB_SHA256}" "${cloudflared_deb}" | sha256sum -c -
+          package="$(dpkg-deb -f "${cloudflared_deb}" Package)"
+          version="$(dpkg-deb -f "${cloudflared_deb}" Version)"
+          architecture="$(dpkg-deb -f "${cloudflared_deb}" Architecture)"
+          if [[ "${package}" != "cloudflared" || "${version}" != "${CLOUDFLARED_VERSION}" || "${architecture}" != "amd64" ]]; then
+            printf 'Unexpected cloudflared package metadata: package=%s version=%s architecture=%s\n' "${package}" "${version}" "${architecture}" >&2
+            exit 1
+          fi
+          sudo dpkg -i "${cloudflared_deb}"
+          cloudflared --version | grep -F "cloudflared version ${CLOUDFLARED_VERSION}"
+
+      - name: Generate MCP test TLS
+        run: bash test/e2e/setup-mcp-test-tls.sh
 
       - id: mcp_runtime_compatibility
         name: Classify OpenShell credential-boundary compatibility

--- a/test/e2e/support/mcp-workflow-boundary.test.ts
+++ b/test/e2e/support/mcp-workflow-boundary.test.ts
@@ -284,6 +284,32 @@ describe("MCP workflow artifact boundary", () => {
     }
   });
 
+  it("rejects candidate execution inside the trusted OpenShell installation sequence (#9051)", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-workflow-"));
+    const workflowPath = path.join(directory, "e2e.yaml");
+    try {
+      const workflow = YAML.parse(fs.readFileSync(".github/workflows/e2e.yaml", "utf8")) as {
+        jobs: Record<string, { steps: Array<Record<string, unknown>> }>;
+      };
+      const steps = workflow.jobs["mcp-bridge-dev"].steps;
+      const installIndex = steps.findIndex(
+        (step) => step.name === "Install immutable OpenShell dev artifact",
+      );
+      requireFixture(installIndex >= 0, "OpenShell dev installation fixture is missing");
+      steps.splice(installIndex, 0, {
+        name: "Run candidate workspace script",
+        run: "bash test/e2e/setup-mcp-test-tls.sh",
+      });
+      fs.writeFileSync(workflowPath, YAML.stringify(workflow));
+
+      expect(validateMcpOpenShellWorkflowBoundary(workflowPath)).toContain(
+        "mcp-bridge-dev must keep trusted checkout, restore, verification, credential revocation, and install contiguous",
+      );
+    } finally {
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
   it("rejects moving or unverified inputs for the OpenShell dev shards (#9051)", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-workflow-"));
     const workflowPath = path.join(directory, "e2e.yaml");

--- a/tools/e2e/mcp-workflow-boundary.mts
+++ b/tools/e2e/mcp-workflow-boundary.mts
@@ -24,6 +24,8 @@ const TERMINAL_JOBS = [
 ] as const;
 const DOCKER_CLEANUP_RUN = "bash .github/scripts/docker-auth-cleanup.sh";
 const DEV_DOCKER_CLEANUP_NAME = "Revoke Docker auth before OpenShell development tooling";
+const DEV_DOCKER_CLEANUP_RUN =
+  'bash "${{ github.workspace }}/.trusted-openshell-dev-artifact/.github/scripts/docker-auth-cleanup.sh"';
 const DEV_ARTIFACT_TOOL = "tools/e2e/openshell-dev-artifact.mts";
 const DEV_ARTIFACT_JOB_CONDITION =
   "${{ contains(fromJSON(needs.generate-matrix.outputs.selected_jobs), 'mcp-bridge-dev') }}";
@@ -33,6 +35,8 @@ const DEV_ARTIFACT_TRUSTED_CHECKOUT_NAME = "Checkout trusted OpenShell dev tooli
 const DEV_ARTIFACT_TRUSTED_CHECKOUT = ".trusted-openshell-dev-artifact";
 const DEV_ARTIFACT_TRUSTED_PATHS =
   "scripts/install-openshell.sh\ntools/e2e/openshell-dev-artifact.mts\n";
+const DEV_ARTIFACT_SHARD_TRUSTED_PATHS =
+  `.github/scripts/docker-auth-cleanup.sh\n${DEV_ARTIFACT_TRUSTED_PATHS}`;
 const DEV_ARTIFACT_TRUSTED_TOOL = `\${{ github.workspace }}/${DEV_ARTIFACT_TRUSTED_CHECKOUT}/${DEV_ARTIFACT_TOOL}`;
 const DEV_ARTIFACT_TRUSTED_INSTALLER = `\${{ github.workspace }}/${DEV_ARTIFACT_TRUSTED_CHECKOUT}/scripts/install-openshell.sh`;
 const DEV_ARTIFACT_SOURCE_OUTPUT = "${{ needs.openshell-dev-artifact.outputs.source_commit }}";
@@ -309,7 +313,7 @@ function validateJobSecurity(
     errors.push(`${jobName} must use the canonical unconditional Docker auth cleanup`);
   }
   const steps = asSteps(job);
-  const checkoutIndex = Math.max(...checkouts.map((checkout) => steps.indexOf(checkout)));
+  const checkoutIndex = steps.indexOf(checkouts[0] ?? {});
   if (steps.indexOf(login) !== checkoutIndex + 1) {
     errors.push(`${jobName} must authenticate immediately after credential-free checkout`);
   }
@@ -324,7 +328,7 @@ function validateJobSecurity(
         ref: "${{ inputs.workflow_sha || github.workflow_sha }}",
         path: DEV_ARTIFACT_TRUSTED_CHECKOUT,
         "persist-credentials": false,
-        "sparse-checkout": DEV_ARTIFACT_TRUSTED_PATHS,
+        "sparse-checkout": DEV_ARTIFACT_SHARD_TRUSTED_PATHS,
       })
     ) {
       errors.push("mcp-bridge-dev must check out only the trusted OpenShell dev tooling");
@@ -334,7 +338,7 @@ function validateJobSecurity(
     const expectedDevCleanup = {
       name: DEV_DOCKER_CLEANUP_NAME,
       shell: "bash",
-      run: DOCKER_CLEANUP_RUN,
+      run: DEV_DOCKER_CLEANUP_RUN,
     };
     if (JSON.stringify(devCleanup) !== JSON.stringify(expectedDevCleanup)) {
       errors.push("mcp-bridge-dev must revoke Docker auth before OpenShell development tooling");
@@ -421,10 +425,16 @@ function validateJobExecution(
     errors,
     tls.run,
     "bash test/e2e/setup-mcp-test-tls.sh",
-    `${jobName} must generate its HTTPS fixture before installation`,
+    `${jobName} must use the reviewed HTTPS fixture generator`,
   );
-  if (steps.indexOf(tls) < 0 || steps.indexOf(install) <= steps.indexOf(tls)) {
-    errors.push(`${jobName} must generate HTTPS fixtures before installing OpenShell`);
+  if (jobName === "mcp-bridge-dev") {
+    if (steps.indexOf(install) < 0 || steps.indexOf(cloudflared) <= steps.indexOf(install)) {
+      errors.push(
+        "mcp-bridge-dev must install the trusted OpenShell artifact before candidate fixture preparation",
+      );
+    }
+  } else if (steps.indexOf(tls) < 0 || steps.indexOf(install) <= steps.indexOf(tls)) {
+    errors.push("mcp-bridge must generate HTTPS fixtures before installing OpenShell");
   }
   const installEnv = asRecord(install.env);
   if (jobName === "mcp-bridge-dev") {
@@ -463,6 +473,7 @@ function validateJobExecution(
     );
   }
   if (jobName === "mcp-bridge-dev") {
+    const trustedCheckout = namedStep(job, DEV_ARTIFACT_TRUSTED_CHECKOUT_NAME);
     const restoreCli = namedStep(job, "Restore exact-commit CLI artifact");
     const restoreArtifact = namedStep(job, "Restore immutable OpenShell dev artifact");
     const verifyArtifact = namedStep(job, "Verify immutable OpenShell dev artifact");
@@ -524,15 +535,23 @@ function validateJobExecution(
       errors.push("mcp-bridge-dev must not maintain a second OpenShell installer");
     }
     const devCleanup = namedStep(job, DEV_DOCKER_CLEANUP_NAME);
+    const trustedCheckoutIndex = steps.indexOf(trustedCheckout);
+    const trustedInstallSequence = [
+      trustedCheckout,
+      restoreArtifact,
+      verifyArtifact,
+      devCleanup,
+      install,
+    ];
     if (
       steps.indexOf(restoreCli) < 0 ||
-      steps.indexOf(restoreArtifact) <= steps.indexOf(restoreCli) ||
-      steps.indexOf(verifyArtifact) <= steps.indexOf(restoreArtifact) ||
-      steps.indexOf(devCleanup) <= steps.indexOf(verifyArtifact) ||
-      steps.indexOf(install) <= steps.indexOf(devCleanup)
+      trustedCheckoutIndex <= steps.indexOf(restoreCli) ||
+      trustedInstallSequence.some(
+        (step, offset) => steps[trustedCheckoutIndex + offset] !== step,
+      )
     ) {
       errors.push(
-        "mcp-bridge-dev must restore, verify, revoke Docker auth, and install in reviewed order",
+        "mcp-bridge-dev must keep trusted checkout, restore, verification, credential revocation, and install contiguous",
       );
     }
     if (compatibilitySteps.length !== 1 || compatibilitySteps[0] !== compatibility) {

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -1440,8 +1440,7 @@ function validateDockerHubAuthBoundary(errors: string[], jobs: WorkflowRecord): 
       }
       return stringValue(step.uses).startsWith("actions/checkout@") ? [index] : [];
     });
-    const checkoutIndex =
-      jobName === "mcp-bridge-dev" ? (checkoutIndexes.at(-1) ?? -1) : (checkoutIndexes[0] ?? -1);
+    const checkoutIndex = checkoutIndexes[0] ?? -1;
     const protectedCacheDownloadIndex =
       jobName === "managed-image-protected-runtime"
         ? workflowSteps.findIndex(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The merged #9063 workflow verifies retained OpenShell assets, then runs candidate-controlled setup before consuming those assets. This follow-up removes that mutation window by keeping trusted checkout, restore, verification, credential revocation, and installation contiguous.

## Related Issue

Follow-up to #9051 and #9063. Related to #9077, which addresses the same post-merge gap through a different installation path.

## Changes

- Move the shard's trusted sparse checkout after candidate workspace preparation and include the Docker credential cleanup helper.
- Restore, verify, revoke Docker credentials, and invoke the unchanged trusted installer without any candidate-controlled step in between.
- Run cloudflared and TLS fixture setup only after installation, and enforce the boundary with workflow validators and a regression test.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior, justification:
- [ ] Tests not applicable, justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable, justification: This changes internal E2E infrastructure only. The independent writer review confirmed that the existing `test/e2e/README.md` trust-boundary description is accurate after the fix.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded, reviewer/approval link/justification: Review found a candidate-controlled mutation window between verification and installation. The workflow now refreshes trusted tooling after candidate preparation and permits no candidate execution before the trusted installer consumes the verified artifact.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer, check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `test/e2e/README.md` lines 471-476 remain accurate because the trusted installation sequence is now contiguous. No public behavior changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 27ee5db6e -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above, command/result or justification: 64 focused and broader E2E workflow-boundary tests passed across five files. `npm run typecheck`, `npm run checks:repository`, formatting, and the protected installer hash check also passed.
- [ ] Applicable broad gate passed, `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes, command/result: Not applicable for this focused internal workflow-boundary repair.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end workflow validation for trusted development installations.
  * Ensured Docker credentials are cleaned up before development assets are installed.
  * Corrected workflow ordering for authentication, artifact installation, fixture preparation, and TLS setup.
  * Added validation to reject interrupted trusted installation sequences.

* **Tests**
  * Added coverage for invalid workflow boundaries and non-contiguous trusted steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->