### PR TITLE
ci(release): add admin E2E qualification waivers

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -40,7 +40,7 @@ The downstream scheduled reconciliation remains available if the event-driven di
 - Treat the dated MDX entry as the canonical release history. A conventional Release Notes page or post-tag Announcement draft cannot replace it.
 - If `origin/main` changes after plan generation, regenerate the plan before cutting the tag.
 - Before asking for release confirmation, satisfy the canonical [pre-tag E2E evidence policy](../nemoclaw-maintainer-policies/references/release-train.md#pre-tag-e2e-evidence) for that commit.
-- Use a passing `Release qualification` check from a full manual run at the candidate SHA.
+- Use a passing `Release qualification` check from a full pre-tag run, with or without an administrator-authorized job waiver.
 - Let `scripts/release-cut-tag.sh` perform the final canonical GitHub evidence check before a signing preflight or tag push.
 - Ask the maintainer to paste the confirmation phrase from the plan before cutting the tag.
 - Push only the semver tag (`vX.Y.Z`) from the agent-controlled step.
@@ -124,12 +124,22 @@ Read the generated `plan.json` and show the maintainer:
 Unless Step 1 records an explicit waiver, verify that the plan's next tag matches the H2 version heading in the dated changelog entry at the candidate SHA.
 When the entry is waived, show the recorded waiver reason in the plan presentation and confirmation handoff instead.
 
-For the plan's full `origin/main` SHA, require a completed, successful `Release qualification` check from a full manual `.github/workflows/e2e.yaml` run.
-The workflow planner derives the required jobs from the workflow's E2E metadata, and the check requires every result, including `Exact staging Brev Launchable`, to succeed.
+For the plan's full `origin/main` SHA, require a completed, successful `Release qualification` check from a pre-tag `.github/workflows/e2e.yaml` run.
+The workflow planner derives the required jobs from the workflow's E2E metadata.
+By default, the check requires every release-required E2E execution result, including `Exact staging Brev Launchable`, to succeed.
+A repository administrator may waive one or more release-required E2E execution jobs for a documented release exception.
+The waiver requires a comma-separated `release_qualification_waived_jobs` list and a `release_qualification_waiver_reason`.
+The reason must begin with an ASCII letter or digit and contain 10-500 characters chosen from ASCII letters, digits, spaces, and `.,:;/_()'-`.
+Both inputs must be nonempty, or both inputs must be empty.
+Both `github.actor` and `github.triggering_actor` must have repository `admin` permission.
+Trusted controller jobs cannot be waived.
+The trusted planner validates the job IDs and removes only those jobs from `release_required_jobs`.
+Every waived job still runs, and `include_staging_brev_launchable=true` remains required.
 Push runs publish `Relevant E2E` and are not release evidence.
-Do not maintain a second release-gating list or rebuild GitHub job status from artifacts.
+Do not maintain a second release-gating list.
+The release qualification waiver artifact is the sole artifact allowed to bind a failed workflow to planner-validated waived job results.
 
-Use an existing qualifying full manual run for the candidate SHA when one exists.
+Use an existing qualifying pre-tag run for the candidate SHA when one exists.
 If no qualifying run exists, load `nemoclaw-maintainer-e2e` and dispatch one full run with:
 
 - empty selectors;
@@ -139,7 +149,23 @@ If no qualifying run exists, load `nemoclaw-maintainer-e2e` and dispatch one ful
 
 Monitor the dispatched correlation ID with bounded status queries, then require its `Release qualification` job to succeed.
 
+When a repository administrator explicitly authorizes a job waiver, use the waiver mode in `nemoclaw-maintainer-e2e`.
+Keep both selectors empty and set:
+
+- `include_staging_brev_launchable=true`;
+- `release_qualification_waived_jobs` to the approved comma-separated job IDs;
+- `release_qualification_waiver_reason` to the recorded reason in the allowed format;
+- `allow_jetson_dispatch=false`; and
+- `allow_dgx_spark_runner_queue=false`.
+
+Require the `generate-matrix` dispatch receipt, written after waiver authorization and before that job's source checkout, to record the requested job IDs, reason, both actor identities, and candidate SHA.
+Require the `Release qualification` summary and waiver artifact to record the planner-validated canonical job IDs and each waived job's completed outcome.
+The successful check confirms that every unwaived release-required job passed.
+A normal full run must conclude with `success`.
+An administrator-waived full run may conclude with `failure` when a waived execution job fails, `Release qualification` succeeds, and the waiver artifact binds that failure to the candidate, run, actors, reason, and canonical waived job IDs.
+
 Before showing the confirmation prompt, present the candidate SHA, workflow URL, and `Release qualification` job URL.
+For a waived run, also present the waived jobs, their outcomes, the waiver reason, and both recorded actor identities.
 No release-note-only delta exception is currently defined.
 
 Run the release script's signing preflight before asking for confirmation:
@@ -148,8 +174,9 @@ Run the release script's signing preflight before asking for confirmation:
 npm run release:cut -- --plan <plan.json> --preflight-only
 ```
 
-For the canonical `NVIDIA/NemoClaw` remote, the script first searches completed, successful manual `.github/workflows/e2e.yaml` runs at the exact planned commit.
-It accepts the first run with exactly one completed, successful `Release qualification` job.
+For the canonical `NVIDIA/NemoClaw` remote, the script first searches completed manual `.github/workflows/e2e.yaml` runs with conclusion `success` or `failure` at the exact planned commit.
+It accepts the first successful run with exactly one completed, successful `Release qualification` job.
+For a failed run, it also requires a valid exact-run waiver artifact with at least one canonical waived job failure.
 A run with zero or multiple jobs of that name is not evidence.
 The script fails closed when no qualifying run exists or GitHub cannot provide the evidence.
 Local fixture remotes skip this production gate only when tests set `NEMOCLAW_RELEASE_ALLOW_NON_CANONICAL=1` and the shared classifier confirms a noncanonical origin.
@@ -297,7 +324,7 @@ If the Announcement is valid, return its URL with the release artifacts and mark
 - Planned changelog entry is missing or malformed: stop before plan generation and run the pre-tag `nemoclaw-contributor-update-docs` workflow. Use post-release recovery only when the tag already exists.
 - Full-mode E2E waits in the Launchable concurrency queue: keep the run pending until the earlier Launchable E2E job finishes.
 - Full-mode E2E ran for another SHA: reject the run and dispatch full mode for the plan candidate SHA.
-- No qualifying `Release qualification` exists: inspect the GitHub result and run full E2E for the planned SHA only when no qualifying full run already exists. Do not release until the release script accepts the canonical check.
+- No qualifying `Release qualification` exists: inspect the GitHub result and run pre-tag E2E for the planned SHA only when no qualifying run already exists. Use a job waiver only with explicit repository administrator authorization. Do not release until the release script accepts the canonical check.
 - Launchable E2E or cleanup fails: inspect the diagnostic artifacts, correct the failure, and rerun the affected E2E work. Do not infer Launchable success from another workflow result.
 - `origin/main` moved after plan generation: regenerate the plan and ask for the new confirmation phrase.
 - Remote semver tag already exists: stop; do not retag unless the maintainer explicitly starts protected-tag remediation.

--- a/.agents/skills/nemoclaw-maintainer-e2e/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-e2e/SKILL.md
@@ -14,7 +14,7 @@ Each trusted push also selects the CPU-only `jetson-nvmap-gpu` proof.
 Push runs skip `llama-cpp-dgx-spark-plan` and `llama-cpp-dgx-spark-qualification` because push events cannot set the required workflow dispatch flag.
 Manual Jetson runs remain opt-in through `allow_jetson_dispatch`, which defaults to `false`.
 Push runs publish `Relevant E2E` and do not publish `Release qualification`.
-Only the full `workflow_dispatch` mode described below publishes `Release qualification`.
+Only the full `workflow_dispatch` mode, with or without an administrator-authorized job waiver, publishes `Release qualification`.
 Do not substitute local `npm run test:live-e2e` unless the maintainer explicitly requests local execution.
 
 ## Manual PR E2E
@@ -158,6 +158,7 @@ A changed head repository, head SHA, or base SHA invalidates the evidence and re
 | “deploy pre-release full E2E” | Full | empty | `true` |
 | “run pre-tag full E2E” | Full | empty | `true` |
 | “run release-candidate E2E” | Full | empty | `true` |
+| “run pre-tag E2E with an administrator job waiver” | Administrator-waived full | empty | `true` |
 
 A generic E2E request must not authorize the Brev Launchable path.
 Do not infer full mode from words such as “all” or “complete.”
@@ -166,7 +167,10 @@ Ask for clarification only when the request contains conflicting mode phrases.
 Ordinary mode selects every default-selected workflow E2E except `Exact staging Brev Launchable`.
 Launchable mode runs only `Exact staging Brev Launchable`.
 Full mode adds `Exact staging Brev Launchable` to the default E2E selection in the same workflow run.
-The documented invocations for all three modes keep the Jetson dispatch and DGX Spark runner-queue flags set to `false`.
+Administrator-waived full mode runs the full suite but omits the approved execution jobs from release qualification.
+Every waived job still runs.
+Use this mode only when a repository administrator explicitly authorizes the job IDs and supplies the reason.
+The documented invocations for all four modes keep the Jetson dispatch and DGX Spark runner-queue flags set to `false`.
 
 ## Resolve the Candidate
 
@@ -238,12 +242,41 @@ gh workflow run .github/workflows/e2e.yaml \
   -f "correlation_id=${CORRELATION_ID}"
 ```
 
+For administrator-waived full mode, set the approved job IDs and a reason.
+The reason must begin with an ASCII letter or digit and contain 10-500 characters chosen from ASCII letters, digits, spaces, and `.,:;/_()'-`.
+
+```bash
+RELEASE_QUALIFICATION_WAIVED_JOBS='staging-brev-launchable'
+RELEASE_QUALIFICATION_WAIVER_REASON='Repository administrator waived Brev qualification while a Brev administrator replaces an expired credential.'
+gh workflow run .github/workflows/e2e.yaml \
+  --repo NVIDIA/NemoClaw \
+  --ref main \
+  -f targets= \
+  -f jobs= \
+  -f inference_mode=mock \
+  -f include_staging_brev_launchable=true \
+  -f "release_qualification_waived_jobs=${RELEASE_QUALIFICATION_WAIVED_JOBS}" \
+  -f "release_qualification_waiver_reason=${RELEASE_QUALIFICATION_WAIVER_REASON}" \
+  -f allow_jetson_dispatch=false \
+  -f allow_dgx_spark_runner_queue=false \
+  -f "correlation_id=${CORRELATION_ID}"
+```
+
 Do not set `jobs=staging-brev-launchable` for full mode.
 Empty `jobs` and `targets` select every default-selected workflow E2E except `Exact staging Brev Launchable`.
 The `include_staging_brev_launchable` input adds the Launchable E2E job to that same run.
 The trusted `main` workflow verifies that the dispatching and rerunning actors have
 repository `maintain` or `admin` permission before the Launchable path's source
 checkout. That role check is the authorization.
+For administrator-waived full mode, both `github.actor` and `github.triggering_actor` must have repository `admin` permission.
+Both waiver inputs must be nonempty, or both inputs must be empty.
+The trusted planner validates the comma-separated IDs against the release-required E2E execution jobs.
+It rejects unknown, duplicate, and non-release-required IDs.
+Trusted controller jobs cannot be waived.
+The planner removes only the approved IDs from `release_required_jobs` and emits canonical waived-job JSON.
+The `generate-matrix` dispatch receipt is written after waiver authorization and before that job's source checkout.
+It records the requested job IDs, reason, both actor identities, and candidate SHA.
+After trusted planner validation, the `Release qualification` summary and waiver artifact record the canonical job IDs and each waived job's completed outcome.
 A user permitted to dispatch this workflow may set `allow_jetson_dispatch=true`
 to add `jetson-nvmap-gpu` to an empty-selector manual run or enable its explicit
 selection. Set it only after the operator-owned service is available and
@@ -288,11 +321,12 @@ Do not reuse it as evidence.
 Wait for completion:
 
 ```bash
-gh run watch "$RUN_ID" --repo NVIDIA/NemoClaw --exit-status
+gh run watch "$RUN_ID" --repo NVIDIA/NemoClaw
 ```
 
 Launchable and full modes can wait in the non-cancelling Launchable concurrency queue.
 Queued, waiting, or accepted dispatch state is not success.
+Classify the completed workflow and `Release qualification` job with the checks below.
 
 ## Verify the Result
 
@@ -310,23 +344,31 @@ gh api "repos/NVIDIA/NemoClaw/actions/runs/$RUN_ID/jobs?filter=latest&per_page=1
 Require `run-$RUN_ID.json` to report:
 
 - `head_sha` equal to `CANDIDATE_SHA`;
-- `status` equal to `completed`; and
-- `conclusion` equal to `success`.
+- `status` equal to `completed`.
+
+For ordinary, Launchable, and unwaived full modes, require `conclusion` equal to `success`.
+For administrator-waived full mode, permit `conclusion` equal to `success` or `failure`.
+A `failure` conclusion is acceptable only when one completed, successful `Release qualification` job and a valid exact-run waiver artifact with at least one canonical waived job failure both exist.
 
 For Launchable mode, also require `jobs-latest-$RUN_ID.json` to contain one completed, successful
 `Exact staging Brev Launchable` job. Return the workflow and job URLs.
 
-For full mode, require `jobs-latest-$RUN_ID.json` to contain one completed, successful
+For a full run, with or without a job waiver, require `jobs-latest-$RUN_ID.json` to contain one completed, successful
 `Release qualification` job. Return its job URL with the workflow URL.
-That job waits for every default-required E2E result, including `Exact staging Brev Launchable`.
+In full mode, that job waits for every default-required E2E result, including `Exact staging Brev Launchable`.
 The Launchable job directly verifies the candidate checkout, in-guest full E2E result, and workspace cleanup before it succeeds.
 Its `launchable-e2e.json`, `full-e2e.log`, and `cleanup.json` artifacts remain available for diagnosis.
 A skipped, cancelled, queued, or failed `Release qualification` job is not evidence.
 A Launchable-only run is not full-mode or pre-tag release evidence.
 
+For administrator-waived full mode, the job waits for every unwaived release-required result.
+A waived execution job may fail without failing `Release qualification`.
+For a failed workflow, require the waiver artifact to bind at least one canonical waived job failure to the candidate SHA, run ID and attempt, actors, and reason.
+Return the canonical waived-job IDs, their outcomes, reason, both actor identities, and candidate SHA with the workflow and job URLs.
+
 ## Bind Release Evidence
 
-If no release plan exists, label a successful full run against `origin/main` as provisional release evidence.
+If no release plan exists, label a full run with a successful `Release qualification` job against `origin/main` as provisional release evidence.
 Return:
 
 - candidate SHA;
@@ -334,12 +376,13 @@ Return:
 - `Release qualification` job URL; and
 - workflow run attempt.
 
-If the release candidate SHA changes, discard the earlier full run and dispatch full mode for the new SHA.
+If the release candidate SHA changes, discard the earlier pre-tag run and dispatch the authorized mode for the new SHA.
 No release-note-only delta exception is currently defined.
 
 When `nemoclaw-maintainer-cut-release-tag` invokes this skill, return the exact-SHA workflow and `Release qualification` job URLs.
 The stable check is provisional pre-tag E2E evidence until `scripts/release-cut-tag.sh` verifies the canonical GitHub job at the planned commit.
-Do not build a second status ledger from artifacts.
+Do not build a second general status ledger from artifacts.
+The waiver artifact is narrow binding evidence for a failed workflow, not a replacement for the `Release qualification` result.
 Do not ask for the release confirmation phrase in this skill.
 
 ## Access Failures

--- a/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
@@ -49,21 +49,36 @@ At cutoff:
 
 The release candidate is the full `origin/main` commit SHA captured by the generated release plan. At that commit, `.github/workflows/e2e.yaml` is the sole source of truth for the release E2E test set. Do not maintain a separate release-gating test list.
 
-Before asking for the release confirmation phrase, require a completed, successful `Release qualification` check from a full manual run at that SHA.
+Before asking for the release confirmation phrase, require a completed, successful `Release qualification` check from a pre-tag manual run at that SHA.
 
 - `.github/workflows/e2e.yaml` derives the release-required jobs from its E2E metadata. Do not copy them into a second release test list.
-- Push runs publish `Relevant E2E`; only full manual runs dispatched against `main` publish `Release qualification`.
-- The check requires every default-required workflow E2E result to succeed, including `Exact staging Brev Launchable`.
+- Push runs publish `Relevant E2E`; only full manual runs dispatched against `main` with empty selectors publish `Release qualification`.
+- By default, the check requires every default-required workflow E2E result to succeed, including `Exact staging Brev Launchable`.
+- A repository administrator may waive one or more release-required E2E execution jobs with `release_qualification_waived_jobs` and `release_qualification_waiver_reason`.
+- `release_qualification_waived_jobs` is a comma-separated list of requested job IDs.
+- The reason must begin with an ASCII letter or digit and contain 10-500 characters chosen from ASCII letters, digits, spaces, and `.,:;/_()'-`.
+- Both inputs must be nonempty, or both inputs must be empty.
+- Both `github.actor` and `github.triggering_actor` must have repository `admin` permission for the waiver.
+- The trusted planner must reject unknown, duplicate, or non-release-required job IDs.
+- Trusted controller jobs cannot be waived.
+- The trusted planner removes only the named jobs from `release_required_jobs` and emits canonical waived-job JSON.
+- Every waived job still runs, and `include_staging_brev_launchable=true` remains required.
+- The `generate-matrix` dispatch receipt is written after waiver authorization and before that job's source checkout. It records the requested job IDs, reason, both actor identities, and candidate SHA.
+- After trusted planner validation, the `Release qualification` summary and waiver artifact record the canonical job IDs and each waived job's completed outcome.
+- A normal full run must conclude with `success`.
+- An administrator-waived full run may conclude with `failure` when a waived execution job fails, `Release qualification` succeeds, and the waiver artifact binds that failure to the candidate, run, actors, reason, and canonical waived job IDs.
 - `jetson-nvmap-gpu`, `llama-cpp-dgx-spark-plan`, and `llama-cpp-dgx-spark-qualification` remain separate opt-in work and do not block this check.
-- The successful Launchable job proves the candidate checkout, in-guest full E2E result, and cleanup. Its artifacts are diagnostic evidence, not a second status ledger.
+- A successful Launchable job proves the candidate checkout, in-guest full E2E result, and cleanup. Its artifacts are diagnostic evidence, not a second status ledger.
 - A skipped, queued, in-progress, cancelled, or failed `Release qualification` check is not release evidence.
 - A check from another commit SHA is not release evidence.
-- Use an existing qualifying full manual run for the candidate SHA, or run `nemoclaw-maintainer-e2e` in full mode when none exists.
+- Use an existing qualifying pre-tag run for the candidate SHA; run `nemoclaw-maintainer-e2e` in full mode when none exists, with an administrator-authorized job waiver when required.
 
 Record the workflow and `Release qualification` job URLs.
 Run the release script's signing preflight before confirmation.
-For the canonical `NVIDIA/NemoClaw` remote, `scripts/release-cut-tag.sh` searches completed, successful manual `.github/workflows/e2e.yaml` runs at the exact planned `origin/main` commit.
-It accepts the first run with exactly one completed, successful `Release qualification` job and fails closed when no qualifying run exists.
+For the canonical `NVIDIA/NemoClaw` remote, `scripts/release-cut-tag.sh` searches completed, successful manual `.github/workflows/e2e.yaml` runs and completed failed manual runs at the exact planned `origin/main` commit.
+It accepts the first successful run with exactly one completed, successful `Release qualification` job.
+For a failed run, it also requires a valid waiver artifact with at least one planner-validated waived job failure.
+It fails closed when no qualifying run exists.
 A run with zero or multiple jobs of that name is not evidence.
 The script repeats this check before it pushes the tag.
 Local fixture remotes skip the production gate only when tests set `NEMOCLAW_RELEASE_ALLOW_NON_CANONICAL=1` and the shared classifier confirms a noncanonical origin.

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,6 +24,16 @@ on:
         required: false
         default: false
         type: boolean
+      release_qualification_waived_jobs:
+        description: "Admin-only comma-separated release-required E2E job IDs to waive. Leave empty to require every release E2E job."
+        required: false
+        default: ""
+        type: string
+      release_qualification_waiver_reason:
+        description: "Admin-only reason for release qualification waived jobs. Required when release_qualification_waived_jobs is not empty."
+        required: false
+        default: ""
+        type: string
       inference_mode:
         description: "Inference adapter mode for compatible Vitest E2E jobs: mock, internal-nvidia, or public-nvidia."
         required: false
@@ -188,6 +198,7 @@ jobs:
       hermes_selected: ${{ steps.matrix.outputs.hermes_selected }}
       explicit_only_jobs: ${{ steps.matrix.outputs.explicit_only_jobs }}
       release_required_jobs: ${{ steps.matrix.outputs.release_required_jobs }}
+      release_qualification_waived_jobs: ${{ steps.matrix.outputs.release_qualification_waived_jobs }}
       selected_jobs: ${{ steps.matrix.outputs.selected_jobs }}
       selected_workflow_jobs: ${{ steps.matrix.outputs.selected_workflow_jobs }}
       catalogue_standard_matrix: ${{ steps.matrix.outputs.catalogue_standard_matrix }}
@@ -334,9 +345,80 @@ jobs:
           [[ "$(jq -r '.head.sha' <<< "$pull_json")" == "$CHECKOUT_SHA" ]] || { echo "::error::checkout_sha must match the PR head SHA" >&2; exit 1; }
           [[ "$(jq -r '.base.sha' <<< "$pull_json")" == "$BASE_SHA" ]] || { echo "::error::base_sha must match the PR base SHA" >&2; exit 1; }
 
+      - name: Authorize release qualification waiver
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.release_qualification_waived_jobs != '' || inputs.release_qualification_waiver_reason != '') }}
+        env:
+          ACTOR: ${{ github.actor }}
+          ALLOW_DGX_SPARK_RUNNER_QUEUE: ${{ inputs.allow_dgx_spark_runner_queue && 'true' || 'false' }}
+          ALLOW_JETSON_DISPATCH: ${{ inputs.allow_jetson_dispatch && 'true' || 'false' }}
+          CHECKOUT_SHA: ${{ inputs.checkout_sha }}
+          GITHUB_TOKEN: ${{ github.token }}
+          INCLUDE_LAUNCHABLE: ${{ inputs.include_staging_brev_launchable && 'true' || 'false' }}
+          JOBS: ${{ inputs.jobs }}
+          TARGETS: ${{ inputs.targets }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          WAIVED_JOBS: ${{ inputs.release_qualification_waived_jobs }}
+          WAIVER_REASON: ${{ inputs.release_qualification_waiver_reason }}
+          WORKFLOW_REF: ${{ github.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          require_admin() {
+            local administrator="$1"
+            if [[ ! "$administrator" =~ ^[A-Za-z0-9-]{1,39}$ || "$administrator" == -* || "$administrator" == *- ]]; then
+              echo "::error::Release qualification waiver actor is invalid" >&2
+              exit 1
+            fi
+
+            local permission_json
+            permission_json="$(curl --fail --silent --show-error --proto '=https' \
+              --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/collaborators/${administrator}/permission")"
+            if [[ "$(jq -r '.user.login // ""' <<< "$permission_json" | tr '[:upper:]' '[:lower:]')" != "$(tr '[:upper:]' '[:lower:]' <<< "$administrator")" ]]; then
+              echo "::error::Release qualification waiver permission response did not match the actor" >&2
+              exit 1
+            fi
+            [[ "$(jq -r '.role_name // ""' <<< "$permission_json")" == "admin" ]] || {
+              echo "::error::Release qualification waiver requires a repository administrator" >&2
+              exit 1
+            }
+          }
+
+          [[ "$WORKFLOW_REF" == "refs/heads/main" ]] || {
+            echo "::error::Release qualification waiver must be dispatched from main" >&2
+            exit 1
+          }
+          [[ -z "$CHECKOUT_SHA" && -z "$JOBS" && -z "$TARGETS" ]] || {
+            echo "::error::Release qualification waiver requires an exact main release run with empty selectors" >&2
+            exit 1
+          }
+          [[ "$INCLUDE_LAUNCHABLE" == "true" && "$ALLOW_JETSON_DISPATCH" == "false" && "$ALLOW_DGX_SPARK_RUNNER_QUEUE" == "false" ]] || {
+            echo "::error::Release qualification waiver conflicts with another release-run override" >&2
+            exit 1
+          }
+          waived_jobs_pattern='^[a-z0-9]+(-[a-z0-9]+)*(,[a-z0-9]+(-[a-z0-9]+)*)*$'
+          [[ "$WAIVED_JOBS" =~ $waived_jobs_pattern ]] || {
+            echo "::error::release_qualification_waived_jobs must contain comma-separated E2E job IDs" >&2
+            exit 1
+          }
+          waiver_reason_pattern="^[A-Za-z0-9][A-Za-z0-9 .,:;/_()'-]*$"
+          [[ ${#WAIVER_REASON} -ge 10 && ${#WAIVER_REASON} -le 500 && "$WAIVER_REASON" =~ $waiver_reason_pattern ]] || {
+            echo "::error::release_qualification_waiver_reason must start with a letter or number and contain 10 to 500 allowed ASCII characters" >&2
+            exit 1
+          }
+
+          require_admin "$ACTOR"
+          if [[ "$(printf '%s' "$TRIGGERING_ACTOR" | tr '[:upper:]' '[:lower:]')" != "$(printf '%s' "$ACTOR" | tr '[:upper:]' '[:lower:]')" ]]; then
+            require_admin "$TRIGGERING_ACTOR"
+          fi
+
       - name: Record trusted E2E dispatch receipt
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
+          ACTOR: ${{ github.actor }}
           ALLOW_DGX_SPARK_RUNNER_QUEUE: ${{ inputs.allow_dgx_spark_runner_queue && 'true' || 'false' }}
           ALLOW_JETSON_DISPATCH: ${{ inputs.allow_jetson_dispatch && 'true' || 'false' }}
           ALLOW_JETSON_RUNNER_QUEUE: "false"
@@ -352,12 +434,16 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
           RUN_ID: ${{ github.run_id }}
+          RELEASE_QUALIFICATION_WAIVED_JOBS: ${{ inputs.release_qualification_waived_jobs }}
+          RELEASE_QUALIFICATION_WAIVER_REASON: ${{ inputs.release_qualification_waiver_reason }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         shell: bash
         run: |
           set -euo pipefail
           install -d -m 0700 "$DISPATCH_RECEIPT_DIR"
           jq -n \
+            --arg actor "$ACTOR" \
             --arg baseSha "$BASE_SHA" \
             --arg candidateRepository "$CANDIDATE_REPOSITORY" \
             --arg candidateSha "$CANDIDATE_SHA" \
@@ -365,7 +451,10 @@ jobs:
             --arg jobs "$DISPATCH_JOBS" \
             --arg prNumber "$PR_NUMBER" \
             --arg repository "$REPOSITORY" \
+            --arg releaseQualificationWaivedJobs "$RELEASE_QUALIFICATION_WAIVED_JOBS" \
+            --arg releaseQualificationWaiverReason "$RELEASE_QUALIFICATION_WAIVER_REASON" \
             --arg targets "$DISPATCH_TARGETS" \
+            --arg triggeringActor "$TRIGGERING_ACTOR" \
             --arg workflowRunId "$RUN_ID" \
             --arg workflowSha "$WORKFLOW_SHA" \
             --argjson allowDgxSparkRunnerQueue "$ALLOW_DGX_SPARK_RUNNER_QUEUE" \
@@ -375,6 +464,7 @@ jobs:
             --argjson workflowRunAttempt "$RUN_ATTEMPT" \
             '{
               kind: "nemoclaw-e2e-dispatch-v2",
+              actor: $actor,
               repository: $repository,
               prNumber: (if $prNumber == "" then null else ($prNumber | tonumber) end),
               candidateRepository: $candidateRepository,
@@ -390,6 +480,9 @@ jobs:
               allowJetsonDispatch: $allowJetsonDispatch,
               allowJetsonRunnerQueue: $allowJetsonRunnerQueue,
               includeStagingBrevLaunchable: $includeStagingBrevLaunchable,
+              releaseQualificationWaivedJobs: (if $releaseQualificationWaivedJobs == "" then [] else ($releaseQualificationWaivedJobs | split(",")) end),
+              releaseQualificationWaiverReason: (if $releaseQualificationWaiverReason == "" then null else $releaseQualificationWaiverReason end),
+              triggeringActor: $triggeringActor,
               emptySelectors: ($jobs == "" and $targets == "")
             }' >"$DISPATCH_RECEIPT_DIR/dispatch.json"
 
@@ -658,6 +751,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BEFORE_SHA: ${{ github.event.before }}
           CANDIDATE_SHA: ${{ github.sha }}
+          RELEASE_QUALIFICATION_WAIVED_JOBS: ${{ inputs.release_qualification_waived_jobs }}
         run: |
           set -euo pipefail
           if [ "${EVENT_NAME:-}" = "push" ]; then
@@ -3773,8 +3867,68 @@ jobs:
       - name: Require every release E2E result
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}
+          RELEASE_QUALIFICATION_WAIVED_JOBS: ${{ needs.generate-matrix.outputs.release_qualification_waived_jobs }}
           RELEASE_REQUIRED_JOBS: ${{ needs.generate-matrix.outputs.release_required_jobs }}
         run: node --experimental-strip-types --no-warnings tools/e2e/release-qualification.mts
+      - name: Record release qualification waiver
+        if: ${{ inputs.release_qualification_waived_jobs != '' }}
+        env:
+          ACTOR: ${{ github.actor }}
+          CANDIDATE_SHA: ${{ github.sha }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          WAIVED_JOBS: ${{ needs.generate-matrix.outputs.release_qualification_waived_jobs }}
+          WAIVER_REASON: ${{ inputs.release_qualification_waiver_reason }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_dir="${RUNNER_TEMP}/release-qualification-waiver"
+          install -d -m 0700 "$evidence_dir"
+          jq -n \
+            --arg actor "$ACTOR" \
+            --arg candidateSha "$CANDIDATE_SHA" \
+            --arg reason "$WAIVER_REASON" \
+            --arg triggeringActor "$TRIGGERING_ACTOR" \
+            --argjson needs "$NEEDS_JSON" \
+            --argjson waived "$WAIVED_JOBS" \
+            --argjson workflowRunAttempt "$RUN_ATTEMPT" \
+            --argjson workflowRunId "$RUN_ID" \
+            '{
+              schemaVersion: 1,
+              kind: "nemoclaw-release-qualification-waiver-v1",
+              candidateSha: $candidateSha,
+              workflowRunId: $workflowRunId,
+              workflowRunAttempt: $workflowRunAttempt,
+              actor: $actor,
+              triggeringActor: $triggeringActor,
+              reason: $reason,
+              jobs: [$waived[] as $job | {id: $job, result: $needs[$job].result}]
+            }' >"$evidence_dir/waiver.json"
+          {
+            echo "## Release qualification waiver"
+            echo
+            echo "A repository administrator waived release-required E2E jobs."
+            echo
+            printf -- '- Candidate commit: `%s`\n' "$CANDIDATE_SHA"
+            printf -- '- Dispatch actor: `%s`\n' "$ACTOR"
+            printf -- '- Triggering actor: `%s`\n' "$TRIGGERING_ACTOR"
+            printf -- '- Reason: %s\n' "$WAIVER_REASON"
+            echo '- Waived jobs:'
+            jq -r --argjson waived "$WAIVED_JOBS" '
+              . as $needs |
+              $waived[] | "  - `\(.)`: `\($needs[.].result // \"missing\")`"
+            ' <<< "$NEEDS_JSON"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload release qualification waiver evidence
+        if: ${{ inputs.release_qualification_waived_jobs != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-qualification-waiver-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/release-qualification-waiver/waiver.json
+          if-no-files-found: error
+          retention-days: 30
 
   # ── Push/manual scorecard ─────────────────────────────────────────────────
   scorecard:

--- a/scripts/release-cut-tag.sh
+++ b/scripts/release-cut-tag.sh
@@ -107,13 +107,13 @@ verify_release_qualification() {
   local run_lines
   if ! run_lines="$(gh api --paginate \
     "repos/NVIDIA/NemoClaw/actions/workflows/e2e.yaml/runs?branch=main&head_sha=${target}&event=workflow_dispatch&status=completed&per_page=100" \
-    --jq ".workflow_runs[] | select(.head_sha == \"${target}\" and .head_branch == \"main\" and .event == \"workflow_dispatch\" and .status == \"completed\" and .conclusion == \"success\") | [.id, .html_url] | @tsv")"; then
+    --jq ".workflow_runs[] | select(.head_sha == \"${target}\" and .head_branch == \"main\" and .event == \"workflow_dispatch\" and .status == \"completed\" and (.conclusion == \"success\" or .conclusion == \"failure\")) | [.id, .html_url, .conclusion, .run_attempt] | @tsv")"; then
     fail "GitHub could not list E2E runs for candidate commit $target"
   fi
 
-  local run_id run_url job_lines match_count job_status job_conclusion job_url
-  while IFS=$'\t' read -r run_id run_url; do
-    [[ "$run_id" =~ ^[1-9][0-9]*$ && "$run_url" == https://github.com/NVIDIA/NemoClaw/actions/runs/* ]] || continue
+  local run_id run_url run_conclusion run_attempt job_lines match_count job_status job_conclusion job_url waiver_dir waiver_path
+  while IFS=$'\t' read -r run_id run_url run_conclusion run_attempt; do
+    [[ "$run_id" =~ ^[1-9][0-9]*$ && "$run_url" == https://github.com/NVIDIA/NemoClaw/actions/runs/* && "$run_conclusion" =~ ^(success|failure)$ && "$run_attempt" =~ ^[1-9][0-9]*$ ]] || continue
     if ! job_lines="$(gh api --paginate \
       "repos/NVIDIA/NemoClaw/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
       --jq '.jobs[] | select(.name == "Release qualification") | [.status, .conclusion, .html_url] | @tsv')"; then
@@ -123,8 +123,47 @@ verify_release_qualification() {
     [[ "$match_count" == "1" ]] || continue
     IFS=$'\t' read -r job_status job_conclusion job_url <<<"$job_lines"
     if [[ "$job_status" == "completed" && "$job_conclusion" == "success" && "$job_url" == https://github.com/NVIDIA/NemoClaw/actions/runs/* ]]; then
+      if [[ "$run_conclusion" == "failure" ]]; then
+        waiver_dir="$(mktemp -d)"
+        chmod 700 "$waiver_dir"
+        waiver_path="$waiver_dir/waiver.json"
+        if ! gh run download "$run_id" \
+          --repo NVIDIA/NemoClaw \
+          --name "release-qualification-waiver-${run_id}-${run_attempt}" \
+          --dir "$waiver_dir" >/dev/null 2>&1; then
+          rm -rf -- "$waiver_dir"
+          continue
+        fi
+        if ! node -e '
+          const fs = require("node:fs");
+          const [file, candidateSha, runId, runAttempt] = process.argv.slice(1);
+          const evidence = JSON.parse(fs.readFileSync(file, "utf8"));
+          const jobId = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+          const actor = /^(?!-)[A-Za-z0-9-]{1,39}(?<!-)$/;
+          const reason = /^[A-Za-z0-9][A-Za-z0-9 .,:;/_()\x27-]{9,499}$/;
+          if (
+            evidence.schemaVersion !== 1 ||
+            evidence.kind !== "nemoclaw-release-qualification-waiver-v1" ||
+            evidence.candidateSha !== candidateSha ||
+            evidence.workflowRunId !== Number(runId) ||
+            evidence.workflowRunAttempt !== Number(runAttempt) ||
+            !actor.test(evidence.actor) ||
+            !actor.test(evidence.triggeringActor) ||
+            !reason.test(evidence.reason) ||
+            !Array.isArray(evidence.jobs) ||
+            evidence.jobs.length === 0 ||
+            new Set(evidence.jobs.map((job) => job.id)).size !== evidence.jobs.length ||
+            evidence.jobs.some((job) => !jobId.test(job.id) || !["failure", "success"].includes(job.result)) ||
+            !evidence.jobs.some((job) => job.result === "failure")
+          ) process.exit(1);
+        ' "$waiver_path" "$target" "$run_id" "$run_attempt"; then
+          rm -rf -- "$waiver_dir"
+          continue
+        fi
+        rm -rf -- "$waiver_dir"
+      fi
       printf 'release-cut-tag: verified Release qualification for %s\n' "$target"
-      printf 'release-cut-tag: workflow evidence: %s\n' "$run_url"
+      printf 'release-cut-tag: workflow evidence: %s (conclusion: %s)\n' "$run_url" "$run_conclusion"
       printf 'release-cut-tag: qualification evidence: %s\n' "$job_url"
       return
     fi

--- a/test/e2e/support/e2e-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-operations-workflow-boundary.test.ts
@@ -84,6 +84,19 @@ describe("E2E operations workflow boundary", testTimeoutOptions(15_000), () => {
     );
   });
 
+  it("requires release qualification to preserve admin waiver evidence", () => {
+    const workflow = readE2eOperationsWorkflow();
+    const summary = workflow.jobs["release-qualification"].steps!.find(
+      (step) => step.name === "Record release qualification waiver",
+    )!;
+    delete summary.env?.TRIGGERING_ACTOR;
+    summary.run = "true";
+
+    expect(validateE2eOperationsWorkflow(workflow)).toContain(
+      "release-qualification must record and upload authorized waived job outcomes, identities, and reason",
+    );
+  });
+
   it("pins the relevant E2E aggregate to the trusted push result set (#7912)", () => {
     const workflow = readE2eOperationsWorkflow();
     const job = workflow.jobs["relevant-e2e"];
@@ -300,64 +313,66 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
     ["maintain", "network-policy", "", "false", 1, "accepts only empty selectors"],
     ["maintain", "gpu-e2e", "", "false", 1, "accepts only empty selectors"],
     ["write", "", "", "false", 1, "requires a repository maintainer or administrator"],
-  ])("requires a maintainer role and bounded selector before manual PR E2E for %s with jobs %s and targets %s", (role, jobs, targets, allowJetsonDispatch, expectedStatus, expectedStderr) => {
-    const workflow = readE2eOperationsWorkflow();
-    const authentication = workflow.jobs["generate-matrix"].steps!.find(
-      (step) => step.name === "Authenticate manual PR dispatch",
-    )!;
-    const headSha = "a".repeat(40);
-    const baseSha = "b".repeat(40);
-    const workflowSha = "c".repeat(40);
-    const prefix = [
-      "curl() {",
-      '  case "${@: -1}" in',
-      `    *collaborators*) printf '%s' '{"role_name":"${role}"}' ;;`,
-      `    *pulls/42) printf '%s' '{"state":"open","head":{"repo":{"full_name":"contributor/NemoClaw"},"sha":"${headSha}"},"base":{"sha":"${baseSha}"}}' ;;`,
-      "    *) return 1 ;;",
-      "  esac",
-      "}",
-    ].join("\n");
-    const result = spawnSync(
-      "bash",
-      ["--noprofile", "--norc", "-e", "-o", "pipefail", "-c", `${prefix}\n${authentication.run}`],
-      {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          ACTOR: "maintainer",
-          ALLOW_JETSON_DISPATCH: allowJetsonDispatch,
-          BASE_SHA: baseSha,
-          CHECKOUT_REPOSITORY: "contributor/NemoClaw",
-          CHECKOUT_SHA: headSha,
-          EXPECTED_WORKFLOW_SHA: workflowSha,
-          GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
-          GITHUB_TOKEN: "token",
-          INCLUDE_LAUNCHABLE: "false",
-          JOBS: jobs,
-          PR_NUMBER: "42",
-          REVIEW_REASON: "Reviewed PR head revision",
-          RUN_ATTEMPT: "1",
-          TARGETS: targets,
-          TRIGGERING_ACTOR: "maintainer",
-          WORKFLOW_EVENT: "workflow_dispatch",
-          WORKFLOW_REF: "refs/heads/main",
-          WORKFLOW_SHA: workflowSha,
+  ])(
+    "requires a maintainer role and bounded selector before manual PR E2E for %s with jobs %s and targets %s",
+    (role, jobs, targets, allowJetsonDispatch, expectedStatus, expectedStderr) => {
+      const workflow = readE2eOperationsWorkflow();
+      const authentication = workflow.jobs["generate-matrix"].steps!.find(
+        (step) => step.name === "Authenticate manual PR dispatch",
+      )!;
+      const headSha = "a".repeat(40);
+      const baseSha = "b".repeat(40);
+      const workflowSha = "c".repeat(40);
+      const prefix = [
+        "curl() {",
+        '  case "${@: -1}" in',
+        `    *collaborators*) printf '%s' '{"role_name":"${role}"}' ;;`,
+        `    *pulls/42) printf '%s' '{"state":"open","head":{"repo":{"full_name":"contributor/NemoClaw"},"sha":"${headSha}"},"base":{"sha":"${baseSha}"}}' ;;`,
+        "    *) return 1 ;;",
+        "  esac",
+        "}",
+      ].join("\n");
+      const result = spawnSync(
+        "bash",
+        ["--noprofile", "--norc", "-e", "-o", "pipefail", "-c", `${prefix}\n${authentication.run}`],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            ACTOR: "maintainer",
+            ALLOW_JETSON_DISPATCH: allowJetsonDispatch,
+            BASE_SHA: baseSha,
+            CHECKOUT_REPOSITORY: "contributor/NemoClaw",
+            CHECKOUT_SHA: headSha,
+            EXPECTED_WORKFLOW_SHA: workflowSha,
+            GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
+            GITHUB_TOKEN: "token",
+            INCLUDE_LAUNCHABLE: "false",
+            JOBS: jobs,
+            PR_NUMBER: "42",
+            REVIEW_REASON: "Reviewed PR head revision",
+            RUN_ATTEMPT: "1",
+            TARGETS: targets,
+            TRIGGERING_ACTOR: "maintainer",
+            WORKFLOW_EVENT: "workflow_dispatch",
+            WORKFLOW_REF: "refs/heads/main",
+            WORKFLOW_SHA: workflowSha,
+          },
         },
-      },
-    );
+      );
 
-    expect(result.status, result.stderr).toBe(expectedStatus);
-    expect(result.stderr).toContain(expectedStderr);
-  });
+      expect(result.status, result.stderr).toBe(expectedStatus);
+      expect(result.stderr).toContain(expectedStderr);
+    },
+  );
 
   it("uses central maintainer authorization for protected managed-image qualification", () => {
     const workflow = readE2eOperationsWorkflow();
     const guards = [
       ["managed-image-multiarch-startup", "Validate protected exact-head dispatch"],
       ["managed-image-protected-runtime", "Validate protected runtime exact-head dispatch"],
-    ].map(
-      ([jobName, stepName]) =>
-        workflow.jobs[jobName].steps!.find((step) => step.name === stepName)!,
+    ].map(([jobName, stepName]) =>
+      workflow.jobs[jobName].steps!.find((step) => step.name === stepName)!,
     );
 
     for (const guard of guards) {

--- a/test/e2e/support/e2e-workflow.test.ts
+++ b/test/e2e/support/e2e-workflow.test.ts
@@ -4,6 +4,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 
 import { describe, expect, it } from "vitest";
 import YAML from "yaml";
@@ -26,6 +27,63 @@ import { testTimeoutOptions } from "../../helpers/timeouts";
 import { assertChannelsStopStartSandboxName } from "../live/channels-stop-start-safety.ts";
 import { COMMON_EGRESS_TEST_TIMEOUT_MS } from "../live/common-egress-agent-helpers.ts";
 import { requireFixture } from "./require-fixture";
+
+function runReleaseWaiverAuthorization(
+  overrides: Record<string, string> = {},
+): ReturnType<typeof spawnSync> & { permissionChecks: string[] } {
+  const workflow = readWorkflow() as {
+    jobs: Record<string, { steps?: Array<{ name?: string; run?: string }> }>;
+  };
+  const script = workflow.jobs["generate-matrix"]!.steps!.find(
+    (step) => step.name === "Authorize release qualification waiver",
+  )!.run!;
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-release-waiver-auth-"));
+  const curlLog = path.join(fixture, "curl.log");
+  const curlPath = path.join(fixture, "curl");
+  fs.writeFileSync(
+    curlPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+url="\${!#}"
+administrator="\${url##*/}"
+printf '%s\n' "$administrator" >>"$CURL_LOG"
+case "$administrator" in
+  maintainer) role=maintain ;;
+  mismatch) printf '%s\n' '{"user":{"login":"different-user"},"role_name":"admin"}'; exit 0 ;;
+  *) role=admin ;;
+esac
+printf '{"user":{"login":"%s"},"role_name":"%s"}\n' "$administrator" "$role"
+`,
+  );
+  fs.chmodSync(curlPath, 0o755);
+  const result = spawnSync("bash", ["-c", script], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fixture}:${process.env.PATH ?? ""}`,
+      ACTOR: "dispatch-admin",
+      ALLOW_DGX_SPARK_RUNNER_QUEUE: "false",
+      ALLOW_JETSON_DISPATCH: "false",
+      CHECKOUT_SHA: "",
+      CURL_LOG: curlLog,
+      GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
+      GITHUB_TOKEN: "test-token",
+      INCLUDE_LAUNCHABLE: "true",
+      JOBS: "",
+      TARGETS: "",
+      TRIGGERING_ACTOR: "rerun-admin",
+      WAIVED_JOBS: "staging-brev-launchable",
+      WAIVER_REASON: "Brev's credential expired",
+      WORKFLOW_REF: "refs/heads/main",
+      ...overrides,
+    },
+  });
+  const permissionChecks = fs.existsSync(curlLog)
+    ? fs.readFileSync(curlLog, "utf8").trim().split("\n")
+    : [];
+  fs.rmSync(fixture, { force: true, recursive: true });
+  return Object.assign(result, { permissionChecks });
+}
 
 describe("e2e workflow boundary", () => {
   it("guards channels-stop-start destructive cleanup to test-owned sandboxes", () => {
@@ -82,6 +140,88 @@ describe("e2e workflow boundary", () => {
         "staging-brev-launchable BREV_API_KEY must use the trusted-run secret guard",
       ]),
     );
+  });
+
+  it("rejects release qualification waiver authorization and planner drift", () => {
+    const workflow = readWorkflow() as {
+      on: {
+        workflow_dispatch: {
+          inputs: Record<string, { default?: string; description?: string; type?: string }>;
+        };
+      };
+      jobs: Record<
+        string,
+        {
+          outputs?: Record<string, string>;
+          steps?: Array<{
+            env?: Record<string, string>;
+            name?: string;
+            run?: string;
+          }>;
+        }
+      >;
+    };
+    workflow.on.workflow_dispatch.inputs.release_qualification_waived_jobs.default =
+      "staging-brev-launchable";
+    const steps = workflow.jobs["generate-matrix"]!.steps!;
+    const authorization = steps.find(
+      (step) => step.name === "Authorize release qualification waiver",
+    )!;
+    delete authorization.env!.TRIGGERING_ACTOR;
+    authorization.run = authorization.run!.replace('== "admin"', '== "maintain"');
+    const matrix = steps.find((step) => step.name === "Generate E2E target matrix")!;
+    delete matrix.env!.RELEASE_QUALIFICATION_WAIVED_JOBS;
+    delete workflow.jobs["generate-matrix"]!.outputs!.release_qualification_waived_jobs;
+
+    expect(validateE2eWorkflow(workflow)).toEqual(
+      expect.arrayContaining([
+        "workflow_dispatch release_qualification_waived_jobs input must be a string and default to empty",
+        "release qualification waiver authorization must bind only trusted identity and release-run inputs",
+        "step 'Authorize release qualification waiver' run script must include == \"admin\"",
+        "matrix generation step must pass release qualification waived jobs through env",
+        "generate-matrix job must expose release_qualification_waived_jobs output",
+      ]),
+    );
+  });
+
+  it("authorizes both administrator identities and accepts an apostrophe in the reason", () => {
+    const result = runReleaseWaiverAuthorization();
+
+    expect(result.status).toBe(0);
+    expect(result.permissionChecks).toEqual(["dispatch-admin", "rerun-admin"]);
+  });
+
+  it.each([
+    ["dispatch actor", { ACTOR: "maintainer" }, "requires a repository administrator"],
+    ["rerun actor", { TRIGGERING_ACTOR: "maintainer" }, "requires a repository administrator"],
+    ["permission identity", { ACTOR: "mismatch" }, "did not match the actor"],
+  ])("rejects an invalid %s", (_case, overrides, error) => {
+    const result = runReleaseWaiverAuthorization(overrides);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(error);
+  });
+
+  it.each([
+    ["candidate checkout", { CHECKOUT_SHA: "a".repeat(40) }],
+    ["non-main workflow ref", { WORKFLOW_REF: "refs/heads/release" }],
+    ["job selector", { JOBS: "live" }],
+    ["target selector", { TARGETS: "cloud-onboard" }],
+    ["missing Launchable", { INCLUDE_LAUNCHABLE: "false" }],
+    ["Jetson override", { ALLOW_JETSON_DISPATCH: "true" }],
+    ["DGX override", { ALLOW_DGX_SPARK_RUNNER_QUEUE: "true" }],
+  ])("rejects a release waiver with %s", (_case, overrides) => {
+    expect(runReleaseWaiverAuthorization(overrides).status).not.toBe(0);
+  });
+
+  it.each([
+    ["reason only", { WAIVED_JOBS: "" }],
+    ["jobs only", { WAIVER_REASON: "" }],
+    ["short reason", { WAIVER_REASON: "too short" }],
+    ["long reason", { WAIVER_REASON: `A${"x".repeat(500)}` }],
+    ["unsupported reason character", { WAIVER_REASON: "Brev key expired & rotated" }],
+  ])("rejects invalid paired waiver input: %s", (_case, overrides) => {
+    expect(runReleaseWaiverAuthorization(overrides).status).not.toBe(0);
   });
 
   it("rejects an inverted selected-jobs condition", () => {

--- a/test/e2e/support/release-qualification.test.ts
+++ b/test/e2e/support/release-qualification.test.ts
@@ -25,6 +25,20 @@ describe("release qualification", () => {
     ).toEqual([]);
   });
 
+  it("accepts recorded failures only for planner-waived E2E jobs", () => {
+    const needs = {
+      ...successfulNeeds,
+      "staging-brev-launchable": { result: "failure" },
+    };
+
+    expect(() =>
+      assertReleaseQualification(JSON.stringify(needs), '["live"]', '["staging-brev-launchable"]'),
+    ).not.toThrow();
+    expect(() =>
+      assertReleaseQualification(JSON.stringify(needs), '["live","staging-brev-launchable"]', "[]"),
+    ).toThrow("Release qualification did not pass: staging-brev-launchable");
+  });
+
   it("treats an empty test selection as a successful controller-only no-op (#7912)", () => {
     expect(failedReleaseQualificationJobs(successfulNeeds, [])).toEqual([]);
     expect(() => assertReleaseQualification(JSON.stringify(successfulNeeds), "[]")).not.toThrow();
@@ -55,6 +69,47 @@ describe("release qualification", () => {
       assertReleaseQualification(JSON.stringify(successfulNeeds), '["live","bad job"]'),
     ).toThrow("Invalid release-required job IDs: bad job");
   });
+
+  it("rejects controller, overlapping, duplicate, and missing waiver evidence", () => {
+    expect(() =>
+      assertReleaseQualification(
+        JSON.stringify(successfulNeeds),
+        '["live"]',
+        '["generate-matrix"]',
+      ),
+    ).toThrow("Release controller jobs cannot be waived: generate-matrix");
+    expect(() =>
+      assertReleaseQualification(JSON.stringify(successfulNeeds), '["live"]', '["live"]'),
+    ).toThrow("Waived jobs remain release-required: live");
+    expect(() =>
+      assertReleaseQualification(
+        JSON.stringify(successfulNeeds),
+        '["live"]',
+        '["staging-brev-launchable","staging-brev-launchable"]',
+      ),
+    ).toThrow("Release qualification waived jobs must not contain duplicates");
+    expect(() =>
+      assertReleaseQualification(JSON.stringify(successfulNeeds), '["live"]', '["hermes-e2e"]'),
+    ).toThrow("Waived jobs must finish with success or failure: hermes-e2e");
+  });
+
+  it.each(["cancelled", "skipped"])(
+    "rejects a %s waived job because the execution did not complete",
+    (result) => {
+      const needs = {
+        ...successfulNeeds,
+        "staging-brev-launchable": { result },
+      };
+
+      expect(() =>
+        assertReleaseQualification(
+          JSON.stringify(needs),
+          '["live"]',
+          '["staging-brev-launchable"]',
+        ),
+      ).toThrow("Waived jobs must finish with success or failure: staging-brev-launchable");
+    },
+  );
 
   it("exits with status 1 when a required job fails (#7912)", () => {
     const result = spawnSync(

--- a/test/e2e/support/workflow-plan.test.ts
+++ b/test/e2e/support/workflow-plan.test.ts
@@ -21,6 +21,7 @@ import { readFreeStandingJobsInventory } from "../../../tools/e2e/workflow-bound
 import {
   buildE2eWorkflowPlan,
   releaseRequiredWorkflowJobs,
+  parseReleaseQualificationWaivedJobs,
   renderE2eWorkflowPlanSummary,
   runE2eWorkflowPlanCli,
   selectedWorkflowJobs,
@@ -58,6 +59,7 @@ function expectedCiOutput(plan: ReturnType<typeof buildE2eWorkflowPlan>): string
     `selected_workflow_jobs=${JSON.stringify(selectedWorkflowJobs(plan))}`,
     `hermes_selected=${plan.hermesSelected}`,
     `explicit_only_jobs=${plan.explicitOnlyJobs.join(",")}`,
+    "release_qualification_waived_jobs=[]",
     `release_required_jobs=${JSON.stringify(releaseRequiredWorkflowJobs())}`,
     "",
   ].join("\n");
@@ -89,6 +91,23 @@ describe("E2E workflow plan", () => {
     expect(releaseRequiredWorkflowJobs()).toContain("live");
     expect(releaseRequiredWorkflowJobs()).toContain("staging-brev-launchable");
     expect(releaseRequiredWorkflowJobs()).not.toContain("llama-cpp-dgx-spark-qualification");
+  });
+
+  it("waives only named release-required E2E jobs", () => {
+    const defaultJobs = releaseRequiredWorkflowJobs();
+    const requestedWaivers = ["live", "staging-brev-launchable"];
+    const requiredJobs = releaseRequiredWorkflowJobs({ waivedJobs: requestedWaivers });
+
+    expect(requiredJobs).toEqual(defaultJobs.filter((job) => !requestedWaivers.includes(job)));
+    expect(parseReleaseQualificationWaivedJobs(requestedWaivers.join(","))).toEqual(
+      requestedWaivers,
+    );
+    expect(() => releaseRequiredWorkflowJobs({ waivedJobs: ["generate-matrix"] })).toThrow(
+      "Cannot waive non-release E2E jobs: generate-matrix",
+    );
+    expect(() => releaseRequiredWorkflowJobs({ waivedJobs: ["live", "live"] })).toThrow(
+      "Release qualification waived jobs must not contain duplicates",
+    );
   });
 
   it("validates jobs and selects only matching credential-free tests", () => {
@@ -292,9 +311,9 @@ describe("E2E workflow plan", () => {
 
   it("rejects unreviewed catalogue execution metadata", () => {
     const target = catalogueTarget("network-policy");
-    expect(() =>
-      validateE2eTargetCatalogue([{ ...target, runnerKey: "unknown-runner" }]),
-    ).toThrow("invalid runner routing key");
+    expect(() => validateE2eTargetCatalogue([{ ...target, runnerKey: "unknown-runner" }])).toThrow(
+      "invalid runner routing key",
+    );
     expect(() =>
       validateE2eTargetCatalogue([{ ...target, hostPackages: ["curl"] as never }]),
     ).toThrow("invalid or duplicate host packages");

--- a/test/release-latest-tag.test.ts
+++ b/test/release-latest-tag.test.ts
@@ -220,7 +220,7 @@ function rewritePlanOrigin(planPath: string, originRemote: string): void {
 
 function installReleaseGateStubs(
   fixture: Fixture,
-  qualification: "missing" | "success",
+  qualification: "failed-unwaived" | "missing" | "success" | "waived" | "waived-invalid",
   originRemote: string,
 ): string {
   const binDir = path.join(fixture.root, `release-gate-bin-${qualification}`);
@@ -242,16 +242,27 @@ fi
 exec ${shellQuote(realGit)} "$@"
 `,
   );
+  const waiverDownload =
+    qualification === "waived"
+      ? `destination="\${!#}"
+candidate="$(${shellQuote(realGit)} rev-parse origin/main)"
+cat >"\${destination}/waiver.json" <<JSON
+{"schemaVersion":1,"kind":"nemoclaw-release-qualification-waiver-v1","candidateSha":"\${candidate}","workflowRunId":123,"workflowRunAttempt":1,"actor":"release-admin","triggeringActor":"release-admin","reason":"Brev credential expired","jobs":[{"id":"staging-brev-launchable","result":"failure"}]}
+JSON`
+      : "exit 1";
   fs.writeFileSync(
     path.join(binDir, "gh"),
     `#!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
   *'/actions/workflows/e2e.yaml/runs?'*)
-    ${qualification === "success" ? "printf '%s\\t%s\\n' 123 https://github.com/NVIDIA/NemoClaw/actions/runs/123" : ":"}
+    ${qualification === "missing" ? ":" : `printf '%s\\t%s\\t%s\\t%s\\n' 123 https://github.com/NVIDIA/NemoClaw/actions/runs/123 ${qualification.startsWith("waived") || qualification === "failed-unwaived" ? "failure" : "success"} 1`}
     ;;
   *'/actions/runs/123/jobs?'*)
-    printf '%s\\t%s\\t%s\\n' completed success https://github.com/NVIDIA/NemoClaw/actions/runs/123/job/456
+    printf '%s\\t%s\\t%s\\n' completed ${qualification === "waived-invalid" ? "failure" : "success"} https://github.com/NVIDIA/NemoClaw/actions/runs/123/job/456
+    ;;
+  'run download 123 --repo NVIDIA/NemoClaw --name release-qualification-waiver-123-1 --dir '*)
+    ${waiverDownload}
     ;;
   *) exit 2 ;;
 esac
@@ -636,17 +647,38 @@ describe("release-latest-tag.sh", () => {
     );
   });
 
-  it.each([
-    "git@github.com:NVIDIA/NemoClaw",
-    "https://contributor@github.com/NVIDIA/NemoClaw.git",
-  ])("rejects signing preflight without exact-commit qualification for %s", (originRemote) => {
+  it("accepts a failed workflow with successful qualification and trusted failed-job waiver evidence", () => {
     const fixture = createFixture();
     pushTag(fixture, "v0.0.1", fixture.firstCommit);
     const releaseCommit = commit(fixture, "planned release commit");
     const planPath = path.join(fixture.root, "release", "plan.json");
     createPlan(fixture, planPath, releaseCommit);
+    const originRemote = "git@github.com:NVIDIA/NemoClaw";
     rewritePlanOrigin(planPath, originRemote);
-    const binDir = installReleaseGateStubs(fixture, "missing", originRemote);
+    const binDir = installReleaseGateStubs(fixture, "waived", originRemote);
+
+    const result = runScript(
+      fixture.work,
+      ["bash", cutScriptPath, "--plan", planPath, "--preflight-only"],
+      { PATH: `${binDir}:${process.env.PATH ?? ""}` },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(`verified Release qualification for ${releaseCommit}`);
+    expect(result.stdout).toContain(
+      "workflow evidence: https://github.com/NVIDIA/NemoClaw/actions/runs/123 (conclusion: failure)",
+    );
+  });
+
+  it("rejects a failed workflow run when Release qualification also fails", () => {
+    const fixture = createFixture();
+    pushTag(fixture, "v0.0.1", fixture.firstCommit);
+    const releaseCommit = commit(fixture, "planned release commit");
+    const planPath = path.join(fixture.root, "release", "plan.json");
+    createPlan(fixture, planPath, releaseCommit);
+    const originRemote = "git@github.com:NVIDIA/NemoClaw";
+    rewritePlanOrigin(planPath, originRemote);
+    const binDir = installReleaseGateStubs(fixture, "waived-invalid", originRemote);
 
     const result = runScript(
       fixture.work,
@@ -658,8 +690,54 @@ describe("release-latest-tag.sh", () => {
     expect(result.stderr).toContain(
       `No completed successful Release qualification check exists for candidate commit ${releaseCommit}`,
     );
-    expect(localTagObject(fixture, "v0.0.2")).toBe("");
   });
+
+  it("rejects a failed unwaived workflow when Release qualification succeeds", () => {
+    const fixture = createFixture();
+    pushTag(fixture, "v0.0.1", fixture.firstCommit);
+    const releaseCommit = commit(fixture, "planned release commit");
+    const planPath = path.join(fixture.root, "release", "plan.json");
+    createPlan(fixture, planPath, releaseCommit);
+    const originRemote = "git@github.com:NVIDIA/NemoClaw";
+    rewritePlanOrigin(planPath, originRemote);
+    const binDir = installReleaseGateStubs(fixture, "failed-unwaived", originRemote);
+
+    const result = runScript(
+      fixture.work,
+      ["bash", cutScriptPath, "--plan", planPath, "--preflight-only"],
+      { PATH: `${binDir}:${process.env.PATH ?? ""}` },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      `No completed successful Release qualification check exists for candidate commit ${releaseCommit}`,
+    );
+  });
+
+  it.each(["git@github.com:NVIDIA/NemoClaw", "https://contributor@github.com/NVIDIA/NemoClaw.git"])(
+    "rejects signing preflight without exact-commit qualification for %s",
+    (originRemote) => {
+      const fixture = createFixture();
+      pushTag(fixture, "v0.0.1", fixture.firstCommit);
+      const releaseCommit = commit(fixture, "planned release commit");
+      const planPath = path.join(fixture.root, "release", "plan.json");
+      createPlan(fixture, planPath, releaseCommit);
+      rewritePlanOrigin(planPath, originRemote);
+      const binDir = installReleaseGateStubs(fixture, "missing", originRemote);
+
+      const result = runScript(
+        fixture.work,
+        ["bash", cutScriptPath, "--plan", planPath, "--preflight-only"],
+        { PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        `No completed successful Release qualification check exists for candidate commit ${releaseCommit}`,
+      );
+      expect(localTagObject(fixture, "v0.0.2")).toBe("");
+    },
+  );
 
   it("does not let the noncanonical test override bypass a canonical remote", () => {
     const fixture = createFixture();

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -59,6 +59,7 @@ type WorkflowStep = {
   if?: string;
   name?: string;
   run?: string;
+  shell?: string;
   uses?: string;
   with?: Record<string, unknown>;
 };
@@ -673,10 +674,16 @@ function validateReleaseQualification(errors: string[], workflow: OperationsWork
   const steps = job.steps ?? [];
   const checkout = findStep(job, "Check out the qualification evaluator");
   const requireResults = findStep(job, "Require every release E2E result");
+  const recordWaiver = findStep(job, "Record release qualification waiver");
+  const uploadWaiver = findStep(job, "Upload release qualification waiver evidence");
   requirePinnedAction(errors, checkout, "release-qualification checkout");
+  requirePinnedAction(errors, uploadWaiver, "release-qualification waiver upload");
   if (
-    steps.length !== 2 ||
+    steps.length !== 4 ||
     steps[0] !== checkout ||
+    steps[1] !== requireResults ||
+    steps[2] !== recordWaiver ||
+    steps[3] !== uploadWaiver ||
     checkout.with?.ref !== "${{ github.workflow_sha }}" ||
     checkout.with?.["persist-credentials"] !== false ||
     checkout.with?.["sparse-checkout"] !== "tools/e2e/release-qualification.mts" ||
@@ -686,12 +693,42 @@ function validateReleaseQualification(errors: string[], workflow: OperationsWork
   }
   if (
     requireResults.env?.NEEDS_JSON !== "${{ toJSON(needs) }}" ||
+    requireResults.env?.RELEASE_QUALIFICATION_WAIVED_JOBS !==
+      "${{ needs.generate-matrix.outputs.release_qualification_waived_jobs }}" ||
     requireResults.env?.RELEASE_REQUIRED_JOBS !==
       "${{ needs.generate-matrix.outputs.release_required_jobs }}" ||
     requireResults.run !==
       "node --experimental-strip-types --no-warnings tools/e2e/release-qualification.mts"
   ) {
     errors.push("release-qualification must evaluate planner-selected jobs from needs");
+  }
+  if (
+    recordWaiver.if !== "${{ inputs.release_qualification_waived_jobs != '' }}" ||
+    recordWaiver.shell !== "bash" ||
+    !isDeepStrictEqual(recordWaiver.env, {
+      ACTOR: "${{ github.actor }}",
+      CANDIDATE_SHA: "${{ github.sha }}",
+      NEEDS_JSON: "${{ toJSON(needs) }}",
+      RUN_ATTEMPT: "${{ github.run_attempt }}",
+      RUN_ID: "${{ github.run_id }}",
+      TRIGGERING_ACTOR: "${{ github.triggering_actor }}",
+      WAIVED_JOBS: "${{ needs.generate-matrix.outputs.release_qualification_waived_jobs }}",
+      WAIVER_REASON: "${{ inputs.release_qualification_waiver_reason }}",
+    }) ||
+    !String(recordWaiver.run ?? "").includes("nemoclaw-release-qualification-waiver-v1") ||
+    !String(recordWaiver.run ?? "").includes("$GITHUB_STEP_SUMMARY") ||
+    uploadWaiver.if !== "${{ inputs.release_qualification_waived_jobs != '' }}" ||
+    !String(uploadWaiver.uses ?? "").startsWith("actions/upload-artifact@") ||
+    !isDeepStrictEqual(uploadWaiver.with, {
+      name: "release-qualification-waiver-${{ github.run_id }}-${{ github.run_attempt }}",
+      path: "${{ runner.temp }}/release-qualification-waiver/waiver.json",
+      "if-no-files-found": "error",
+      "retention-days": 30,
+    })
+  ) {
+    errors.push(
+      "release-qualification must record and upload authorized waived job outcomes, identities, and reason",
+    );
   }
 }
 

--- a/tools/e2e/release-qualification.mts
+++ b/tools/e2e/release-qualification.mts
@@ -9,6 +9,22 @@ type WorkflowNeed = {
 
 const CONTROLLER_JOBS = ["base-image-publication", "generate-matrix"] as const;
 const JOB_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+const COMPLETED_WORKFLOW_RESULTS = new Set(["failure", "success"]);
+
+function parseJobIds(value: string, label: string, invalidLabel = label.toLowerCase()): string[] {
+  const jobs = JSON.parse(value) as unknown;
+  if (!Array.isArray(jobs)) {
+    throw new Error(`${label} must be a JSON array`);
+  }
+  const invalidJobs = jobs.filter((job) => typeof job !== "string" || !JOB_ID_PATTERN.test(job));
+  if (invalidJobs.length > 0) {
+    throw new Error(`Invalid ${invalidLabel}: ${invalidJobs.join(", ")}`);
+  }
+  if (new Set(jobs).size !== jobs.length) {
+    throw new Error(`${label} must not contain duplicates`);
+  }
+  return jobs as string[];
+}
 
 export function failedReleaseQualificationJobs(
   needs: Record<string, WorkflowNeed>,
@@ -22,19 +38,38 @@ export function failedReleaseQualificationJobs(
 export function assertReleaseQualification(
   needsJson: string,
   releaseRequiredJobsJson: string,
+  releaseQualificationWaivedJobsJson = "[]",
 ): void {
   const needs = JSON.parse(needsJson) as Record<string, WorkflowNeed>;
-  const releaseRequiredJobs = JSON.parse(releaseRequiredJobsJson) as unknown;
-  if (!Array.isArray(releaseRequiredJobs)) {
-    throw new Error("Release-required jobs must be a JSON array");
-  }
-  const invalidJobs = releaseRequiredJobs.filter(
-    (job) => typeof job !== "string" || !JOB_ID_PATTERN.test(job),
+  const releaseRequiredJobs = parseJobIds(
+    releaseRequiredJobsJson,
+    "Release-required jobs",
+    "release-required job IDs",
   );
-  if (invalidJobs.length > 0) {
-    throw new Error(`Invalid release-required job IDs: ${invalidJobs.join(", ")}`);
+  const waivedJobs = parseJobIds(
+    releaseQualificationWaivedJobsJson,
+    "Release qualification waived jobs",
+  );
+  const controllerWaivers = waivedJobs.filter((job) =>
+    (CONTROLLER_JOBS as readonly string[]).includes(job),
+  );
+  if (controllerWaivers.length > 0) {
+    throw new Error(`Release controller jobs cannot be waived: ${controllerWaivers.join(", ")}`);
   }
-  const failedJobs = failedReleaseQualificationJobs(needs, releaseRequiredJobs as string[]);
+  const requiredJobSet = new Set(releaseRequiredJobs);
+  const overlappingJobs = waivedJobs.filter((job) => requiredJobSet.has(job));
+  if (overlappingJobs.length > 0) {
+    throw new Error(`Waived jobs remain release-required: ${overlappingJobs.join(", ")}`);
+  }
+  const invalidWaiverEvidence = waivedJobs.filter(
+    (job) => !COMPLETED_WORKFLOW_RESULTS.has(String(needs[job]?.result ?? "")),
+  );
+  if (invalidWaiverEvidence.length > 0) {
+    throw new Error(
+      `Waived jobs must finish with success or failure: ${invalidWaiverEvidence.join(", ")}`,
+    );
+  }
+  const failedJobs = failedReleaseQualificationJobs(needs, releaseRequiredJobs);
   if (failedJobs.length > 0) {
     throw new Error(`Release qualification did not pass: ${failedJobs.join(", ")}`);
   }
@@ -44,5 +79,6 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   assertReleaseQualification(
     process.env.NEEDS_JSON ?? "{}",
     process.env.RELEASE_REQUIRED_JOBS ?? "",
+    process.env.RELEASE_QUALIFICATION_WAIVED_JOBS ?? "[]",
   );
 }

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -1901,6 +1901,109 @@ function validateStagingBrevLaunchableInput(
   }
 }
 
+function validateReleaseQualificationWaiverInputs(
+  errors: string[],
+  dispatchInputs: WorkflowRecord,
+): void {
+  const jobsInput = requireInput(errors, dispatchInputs, "release_qualification_waived_jobs");
+  if (jobsInput.type !== "string" || jobsInput.default !== "") {
+    errors.push(
+      "workflow_dispatch release_qualification_waived_jobs input must be a string and default to empty",
+    );
+  }
+  const jobsDescription = stringValue(jobsInput.description);
+  if (
+    !jobsDescription.includes("Admin-only") ||
+    !jobsDescription.includes("release-required E2E job IDs") ||
+    !jobsDescription.includes("Leave empty")
+  ) {
+    errors.push(
+      "workflow_dispatch release_qualification_waived_jobs input must document its admin-only release scope",
+    );
+  }
+  const reasonInput = requireInput(errors, dispatchInputs, "release_qualification_waiver_reason");
+  if (reasonInput.type !== "string" || reasonInput.default !== "") {
+    errors.push(
+      "workflow_dispatch release_qualification_waiver_reason input must be a string and default to empty",
+    );
+  }
+  const reasonDescription = stringValue(reasonInput.description);
+  if (
+    !reasonDescription.includes("Admin-only") ||
+    !reasonDescription.includes("Required when release_qualification_waived_jobs is not empty")
+  ) {
+    errors.push(
+      "workflow_dispatch release_qualification_waiver_reason input must document its paired admin-only scope",
+    );
+  }
+}
+
+function validateReleaseQualificationWaiverAuthorization(
+  errors: string[],
+  generateSteps: readonly WorkflowStep[],
+): void {
+  const authorization = requireJobStep(
+    errors,
+    "generate-matrix",
+    generateSteps,
+    "Authorize release qualification waiver",
+  );
+  if (
+    authorization?.if !==
+    "${{ github.event_name == 'workflow_dispatch' && (inputs.release_qualification_waived_jobs != '' || inputs.release_qualification_waiver_reason != '') }}"
+  ) {
+    errors.push("release qualification waiver authorization must cover either nonempty input");
+  }
+  if (authorization?.shell !== "bash") {
+    errors.push("release qualification waiver authorization must use bash");
+  }
+  const expectedEnv = {
+    ACTOR: "${{ github.actor }}",
+    ALLOW_DGX_SPARK_RUNNER_QUEUE: "${{ inputs.allow_dgx_spark_runner_queue && 'true' || 'false' }}",
+    ALLOW_JETSON_DISPATCH: "${{ inputs.allow_jetson_dispatch && 'true' || 'false' }}",
+    CHECKOUT_SHA: "${{ inputs.checkout_sha }}",
+    GITHUB_TOKEN: "${{ github.token }}",
+    INCLUDE_LAUNCHABLE: "${{ inputs.include_staging_brev_launchable && 'true' || 'false' }}",
+    JOBS: "${{ inputs.jobs }}",
+    TARGETS: "${{ inputs.targets }}",
+    TRIGGERING_ACTOR: "${{ github.triggering_actor }}",
+    WAIVED_JOBS: "${{ inputs.release_qualification_waived_jobs }}",
+    WAIVER_REASON: "${{ inputs.release_qualification_waiver_reason }}",
+    WORKFLOW_REF: "${{ github.ref }}",
+  };
+  if (!isDeepStrictEqual(asRecord(authorization?.env), expectedEnv)) {
+    errors.push(
+      "release qualification waiver authorization must bind only trusted identity and release-run inputs",
+    );
+  }
+  for (const required of [
+    "/collaborators/${administrator}/permission",
+    "'.user.login // \"\"'",
+    "'.role_name // \"\"'",
+    '== "admin"',
+    'require_admin "$ACTOR"',
+    'require_admin "$TRIGGERING_ACTOR"',
+    '[[ -z "$CHECKOUT_SHA" && -z "$JOBS" && -z "$TARGETS" ]]',
+    '[[ "$INCLUDE_LAUNCHABLE" == "true"',
+    '[[ "$WAIVED_JOBS" =~ $waived_jobs_pattern ]]',
+    "${#WAIVER_REASON} -ge 10",
+    "${#WAIVER_REASON} -le 500",
+    "requires a repository administrator",
+  ]) {
+    requireRunContains(errors, authorization, required);
+  }
+  const checkout = generateSteps.find((step) =>
+    stringValue(step.uses).startsWith("actions/checkout@"),
+  );
+  if (
+    authorization &&
+    checkout &&
+    generateSteps.indexOf(authorization) >= generateSteps.indexOf(checkout)
+  ) {
+    errors.push("release qualification waiver authorization must run before candidate checkout");
+  }
+}
+
 function validateRetiredSelectorCompatibilityJob(errors: string[], jobs: WorkflowRecord): void {
   const job = asRecord(jobs["retired-selector-compatibility"]);
   if (Object.keys(job).length === 0) {
@@ -1970,6 +2073,7 @@ function validateTrustedE2eDispatchReceipt(
   }
   const dispatchReceiptEnv = asRecord(dispatchReceipt?.env);
   const expectedDispatchReceiptEnv = {
+    ACTOR: "${{ github.actor }}",
     ALLOW_DGX_SPARK_RUNNER_QUEUE: "${{ inputs.allow_dgx_spark_runner_queue && 'true' || 'false' }}",
     ALLOW_JETSON_DISPATCH: "${{ inputs.allow_jetson_dispatch && 'true' || 'false' }}",
     ALLOW_JETSON_RUNNER_QUEUE: "false",
@@ -1986,6 +2090,9 @@ function validateTrustedE2eDispatchReceipt(
     REPOSITORY: "${{ github.repository }}",
     RUN_ATTEMPT: "${{ github.run_attempt }}",
     RUN_ID: "${{ github.run_id }}",
+    RELEASE_QUALIFICATION_WAIVED_JOBS: "${{ inputs.release_qualification_waived_jobs }}",
+    RELEASE_QUALIFICATION_WAIVER_REASON: "${{ inputs.release_qualification_waiver_reason }}",
+    TRIGGERING_ACTOR: "${{ github.triggering_actor }}",
     WORKFLOW_SHA: "${{ github.workflow_sha }}",
   };
   if (!isDeepStrictEqual(dispatchReceiptEnv, expectedDispatchReceiptEnv)) {
@@ -1998,6 +2105,7 @@ function validateTrustedE2eDispatchReceipt(
   }
   for (const fragment of [
     'kind: "nemoclaw-e2e-dispatch-v2"',
+    "actor: $actor",
     "repository: $repository",
     'prNumber: (if $prNumber == "" then null else ($prNumber | tonumber) end)',
     "candidateRepository: $candidateRepository",
@@ -2013,6 +2121,9 @@ function validateTrustedE2eDispatchReceipt(
     "allowJetsonDispatch: $allowJetsonDispatch",
     "allowJetsonRunnerQueue: $allowJetsonRunnerQueue",
     "includeStagingBrevLaunchable: $includeStagingBrevLaunchable",
+    'releaseQualificationWaivedJobs: (if $releaseQualificationWaivedJobs == "" then [] else ($releaseQualificationWaivedJobs | split(",")) end)',
+    'releaseQualificationWaiverReason: (if $releaseQualificationWaiverReason == "" then null else $releaseQualificationWaiverReason end)',
+    "triggeringActor: $triggeringActor",
     'emptySelectors: ($jobs == "" and $targets == "")',
     '>"$DISPATCH_RECEIPT_DIR/dispatch.json"',
   ]) {
@@ -2036,10 +2147,14 @@ function validateTrustedE2eDispatchReceipt(
   }
 
   const authentication = namedStep(generateSteps, "Authenticate manual PR dispatch");
+  const waiverAuthorization = namedStep(generateSteps, "Authorize release qualification waiver");
   const candidateCheckout = generateSteps.find((step) =>
     stringValue(step.uses).startsWith("actions/checkout@"),
   );
   const authenticationIndex = authentication ? generateSteps.indexOf(authentication) : -1;
+  const waiverAuthorizationIndex = waiverAuthorization
+    ? generateSteps.indexOf(waiverAuthorization)
+    : -1;
   const receiptIndex = dispatchReceipt ? generateSteps.indexOf(dispatchReceipt) : -1;
   const uploadIndex = dispatchUpload ? generateSteps.indexOf(dispatchUpload) : -1;
   const checkoutIndex = candidateCheckout ? generateSteps.indexOf(candidateCheckout) : -1;
@@ -2047,6 +2162,7 @@ function validateTrustedE2eDispatchReceipt(
     "Build trusted controller target matrix",
     "Build trusted larger-runner routing",
     "Authenticate manual PR dispatch",
+    "Authorize release qualification waiver",
     "Record trusted E2E dispatch receipt",
     "Upload trusted E2E dispatch receipt",
   ];
@@ -2056,7 +2172,8 @@ function validateTrustedE2eDispatchReceipt(
       trustedPrefix,
     ) ||
     authenticationIndex < 0 ||
-    receiptIndex !== authenticationIndex + 1 ||
+    waiverAuthorizationIndex !== authenticationIndex + 1 ||
+    receiptIndex !== waiverAuthorizationIndex + 1 ||
     uploadIndex !== receiptIndex + 1 ||
     checkoutIndex <= uploadIndex
   ) {
@@ -2100,6 +2217,7 @@ export function validateE2eWorkflow(workflowValue: unknown): string[] {
   requireInput(errors, dispatchInputs, "targets");
   validateFullE2eConcurrency(errors, workflow);
   validateStagingBrevLaunchableInput(errors, dispatchInputs);
+  validateReleaseQualificationWaiverInputs(errors, dispatchInputs);
   validateInferenceModeInput(errors, workflow, dispatchInputs);
   const jobsInput = requireInput(errors, dispatchInputs, "jobs");
   const jobsDescription = stringValue(jobsInput.description);
@@ -2159,6 +2277,12 @@ export function validateE2eWorkflow(workflowValue: unknown): string[] {
     generateOutputs.release_required_jobs !== "${{ steps.matrix.outputs.release_required_jobs }}"
   ) {
     errors.push("generate-matrix job must expose release_required_jobs output");
+  }
+  if (
+    generateOutputs.release_qualification_waived_jobs !==
+    "${{ steps.matrix.outputs.release_qualification_waived_jobs }}"
+  ) {
+    errors.push("generate-matrix job must expose release_qualification_waived_jobs output");
   }
   const generateSteps = asSteps(generateMatrix.steps);
   requireNoDispatchInputInterpolation(errors, generateSteps);
@@ -2289,6 +2413,12 @@ export function validateE2eWorkflow(workflowValue: unknown): string[] {
   if (generateEnv.TARGETS !== "${{ inputs.targets }}") {
     errors.push("matrix generation step must pass targets through TARGETS env");
   }
+  if (
+    generateEnv.RELEASE_QUALIFICATION_WAIVED_JOBS !==
+    "${{ inputs.release_qualification_waived_jobs }}"
+  ) {
+    errors.push("matrix generation step must pass release qualification waived jobs through env");
+  }
   validateInferenceModeGeneration(errors, generate, generateEnv);
   requireRunContains(errors, generate, "npx tsx tools/e2e/workflow-plan.mts");
   requireRunContains(errors, generate, "--ci-output");
@@ -2306,6 +2436,7 @@ export function validateE2eWorkflow(workflowValue: unknown): string[] {
     "E2E planner matrix does not match controller-selected targets",
   );
   validateTrustedE2eDispatchReceipt(errors, generateSteps);
+  validateReleaseQualificationWaiverAuthorization(errors, generateSteps);
 
   const liveTargets = asRecord(jobs["live"]);
   if (Object.keys(liveTargets).length === 0) errors.push("workflow missing live job");

--- a/tools/e2e/workflow-plan.mts
+++ b/tools/e2e/workflow-plan.mts
@@ -380,14 +380,16 @@ function emptyE2eWorkflowPlan(): E2eWorkflowPlan {
   };
 }
 
-export function releaseRequiredWorkflowJobs(): string[] {
+export function releaseRequiredWorkflowJobs(options?: {
+  waivedJobs?: readonly string[];
+}): string[] {
   const inventory = readFreeStandingJobsInventory();
   const sharedTestsRun = discoverCredentialFreeTests().length > 0;
   const liveTargetsRun = buildLiveTargetMatrix().length > 0;
   const catalogueJobs = E2E_EXECUTION_PROFILES.filter((profile) =>
     E2E_TARGET_CATALOGUE.some((target) => target.profile === profile && target.releaseRequired),
   ).map((profile) => CATALOGUE_JOB_BY_PROFILE[profile]);
-  return [
+  const requiredJobs = [
     ...new Set([
       ...inventory.workflowJobs,
       ...catalogueJobs,
@@ -398,6 +400,27 @@ export function releaseRequiredWorkflowJobs(): string[] {
     .filter((job) => !inventory.explicitOnlyJobs.includes(job))
     .filter((job) => job !== SHARED_E2E_JOB_ID || sharedTestsRun)
     .sort();
+  const waivedJobs = options?.waivedJobs ?? [];
+  if (new Set(waivedJobs).size !== waivedJobs.length) {
+    throw new Error("Release qualification waived jobs must not contain duplicates");
+  }
+  const requiredJobSet = new Set(requiredJobs);
+  const invalidJobs = waivedJobs.filter((job) => !requiredJobSet.has(job));
+  if (invalidJobs.length > 0) {
+    throw new Error(`Cannot waive non-release E2E jobs: ${invalidJobs.join(", ")}`);
+  }
+  const waivedJobSet = new Set(waivedJobs);
+  return requiredJobs.filter((job) => !waivedJobSet.has(job));
+}
+
+export function parseReleaseQualificationWaivedJobs(value: string | undefined): string[] {
+  if (!value) return [];
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*(?:,[a-z0-9]+(?:-[a-z0-9]+)*)*$/u.test(value)) {
+    throw new Error("Release qualification waived jobs must be comma-separated E2E job IDs");
+  }
+  const waivedJobs = value.split(",");
+  releaseRequiredWorkflowJobs({ waivedJobs });
+  return waivedJobs;
 }
 
 export function selectedWorkflowJobs(plan: E2eWorkflowPlan): string[] {
@@ -676,6 +699,9 @@ export function writeE2eWorkflowPlanCiOutput(
   const output = environment.GITHUB_OUTPUT;
   const summary = environment.GITHUB_STEP_SUMMARY;
   if (!output || !summary) throw new Error("GitHub output paths are required");
+  const releaseQualificationWaivedJobs = parseReleaseQualificationWaivedJobs(
+    environment.RELEASE_QUALIFICATION_WAIVED_JOBS,
+  );
   appendFileSync(
     output,
     [
@@ -690,7 +716,10 @@ export function writeE2eWorkflowPlanCiOutput(
       `selected_workflow_jobs=${JSON.stringify(selectedWorkflowJobs(plan))}`,
       `hermes_selected=${plan.hermesSelected}`,
       `explicit_only_jobs=${plan.explicitOnlyJobs.join(",")}`,
-      `release_required_jobs=${JSON.stringify(releaseRequiredWorkflowJobs())}`,
+      `release_qualification_waived_jobs=${JSON.stringify(releaseQualificationWaivedJobs)}`,
+      `release_required_jobs=${JSON.stringify(
+        releaseRequiredWorkflowJobs({ waivedJobs: releaseQualificationWaivedJobs }),
+      )}`,
       "",
     ].join("\n"),
   );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add an audited administrator override for exceptional releases blocked by a failing release-required E2E job. Waived jobs still run, while trusted authorization, planning, qualification, and tag-cut checks fail closed around the named jobs and recorded reason.

## Changes

- Add paired admin-only workflow inputs for comma-separated waived job IDs and a required reason.
- Require both the dispatch actor and rerun actor to have repository `admin` permission before the `generate-matrix` source checkout, and restrict waivers to full empty-selector release runs on `main`.
- Validate waived IDs against the planner-derived release-required execution jobs, keep controller jobs non-waivable, and record actors, reason, candidate SHA, canonical IDs, and completed job outcomes.
- Allow the tag-cut script to accept a failed workflow only when that exact-SHA run contains one completed, successful `Release qualification` job and a trusted waiver artifact naming at least one failed waived job.
- Update maintainer guidance and add regression coverage for authorization, planning, qualification, workflow structure, and tag-cut evidence.

This configuration path serves the current requirement to let a repository administrator ship an exceptional release without removing or skipping the failing E2E execution job. Directly treating the full workflow as successful is insufficient because GitHub correctly reports the waived job failure; the trusted `Release qualification` job is the narrow release decision protected by the workflow boundary, planner, evaluator, and release-script tests.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer approved the exceptional-release design in this task. The implementation author reviewed the admin authorization before the `generate-matrix` checkout, trusted planner boundary, non-waivable controllers, waiver artifact binding, and fail-closed evaluator behavior. Behavioral tests execute the authorization step across actor roles, identity mismatch, paired inputs, selectors, flags, and reason bounds.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md`; `.agents/skills/nemoclaw-maintainer-e2e/SKILL.md`; `.agents/skills/nemoclaw-maintainer-policies/references/release-train.md`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6fd4829c47 -->
<!-- docs-review-agents-blob-sha: e30afb270b -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — deferred to GitHub CI at maintainer direction; normal commit hooks passed.
- [ ] Applicable broad gate passed — deferred to GitHub CI at maintainer direction.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added administrator-authorized waivers for selected release-required E2E jobs.
  * Added validation for waiver permissions, job IDs, reasons, trusted dispatches, and candidate commit matching.
  * Release qualification can now accept failed workflows when valid waiver evidence is provided.
  * Added waiver details to workflow receipts, summaries, and downloadable release evidence.

* **Bug Fixes**
  * Improved release qualification handling for incomplete, invalid, duplicate, or unauthorized waiver evidence.

* **Tests**
  * Added comprehensive coverage for valid and rejected waiver scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->