### PR TITLE
test(release): harden admin waiver evidence gates

### DIFF
--- a/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
+++ b/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
@@ -135,6 +135,19 @@ describe("upload-e2e-artifacts workflow boundary", () => {
     );
   });
 
+  it("rejects release qualification waiver upload drift", () => {
+    const workflow = mutableWorkflow();
+    const upload = workflow.jobs["release-qualification"].steps?.find(
+      (step) => step.name === "Upload release qualification waiver evidence",
+    );
+    expect(upload).toBeDefined();
+    upload!.with!["retention-days"] = 7;
+
+    expect(validateUploadE2eArtifactsInvocations(workflow)).toContain(
+      "release-qualification must not invoke actions/upload-artifact directly",
+    );
+  });
+
   it.each([
     ["name", "another-cache-artifact"],
     ["path", "another-cache-path/"],

--- a/test/release-latest-tag.test.ts
+++ b/test/release-latest-tag.test.ts
@@ -222,6 +222,7 @@ function installReleaseGateStubs(
   fixture: Fixture,
   qualification: "failed-unwaived" | "missing" | "success" | "waived" | "waived-invalid",
   originRemote: string,
+  waiverEvidenceJson?: string,
 ): string {
   const binDir = path.join(fixture.root, `release-gate-bin-${qualification}`);
   fs.mkdirSync(binDir);
@@ -244,11 +245,14 @@ exec ${shellQuote(realGit)} "$@"
   );
   const waiverDownload =
     qualification === "waived"
-      ? `destination="\${!#}"
+      ? waiverEvidenceJson === undefined
+        ? `destination="\${!#}"
 candidate="$(${shellQuote(realGit)} rev-parse origin/main)"
 cat >"\${destination}/waiver.json" <<JSON
 {"schemaVersion":1,"kind":"nemoclaw-release-qualification-waiver-v1","candidateSha":"\${candidate}","workflowRunId":123,"workflowRunAttempt":1,"actor":"release-admin","triggeringActor":"release-admin","reason":"Brev credential expired","jobs":[{"id":"staging-brev-launchable","result":"failure"}]}
 JSON`
+        : `destination="\${!#}"
+printf '%s\n' ${shellQuote(waiverEvidenceJson)} >"\${destination}/waiver.json"`
       : "exit 1";
   fs.writeFileSync(
     path.join(binDir, "gh"),
@@ -272,6 +276,72 @@ esac
   fs.chmodSync(path.join(binDir, "gh"), 0o755);
   return binDir;
 }
+
+type WaiverEvidence = {
+  schemaVersion: number;
+  kind: string;
+  candidateSha: string;
+  workflowRunId: number;
+  workflowRunAttempt: number;
+  actor: string;
+  triggeringActor: string;
+  reason: string;
+  jobs: Array<{ id: string; result: string }>;
+};
+
+function validWaiverEvidence(candidateSha: string): WaiverEvidence {
+  return {
+    schemaVersion: 1,
+    kind: "nemoclaw-release-qualification-waiver-v1",
+    candidateSha,
+    workflowRunId: 123,
+    workflowRunAttempt: 1,
+    actor: "release-admin",
+    triggeringActor: "release-admin",
+    reason: "Brev credential expired",
+    jobs: [{ id: "staging-brev-launchable", result: "failure" }],
+  };
+}
+
+const INVALID_WAIVER_EVIDENCE_CASES: Array<
+  [string, (evidence: WaiverEvidence) => Record<string, unknown>]
+> = [
+  ["schema version", (evidence) => ({ ...evidence, schemaVersion: 2 })],
+  ["kind", (evidence) => ({ ...evidence, kind: "untrusted-waiver" })],
+  ["candidate commit", (evidence) => ({ ...evidence, candidateSha: "0".repeat(40) })],
+  ["workflow run ID", (evidence) => ({ ...evidence, workflowRunId: 124 })],
+  ["workflow run attempt", (evidence) => ({ ...evidence, workflowRunAttempt: 2 })],
+  ["dispatch actor", (evidence) => ({ ...evidence, actor: "-invalid" })],
+  ["triggering actor", (evidence) => ({ ...evidence, triggeringActor: "invalid-" })],
+  ["reason", (evidence) => ({ ...evidence, reason: "short" })],
+  ["jobs type", (evidence) => ({ ...evidence, jobs: "not-an-array" })],
+  ["empty jobs", (evidence) => ({ ...evidence, jobs: [] })],
+  [
+    "duplicate job IDs",
+    (evidence) => ({
+      ...evidence,
+      jobs: [evidence.jobs[0], { ...evidence.jobs[0], result: "success" }],
+    }),
+  ],
+  [
+    "job ID",
+    (evidence) => ({ ...evidence, jobs: [{ id: "Invalid Job", result: "failure" }] }),
+  ],
+  [
+    "job result",
+    (evidence) => ({
+      ...evidence,
+      jobs: [{ id: "staging-brev-launchable", result: "cancelled" }],
+    }),
+  ],
+  [
+    "failed-job presence",
+    (evidence) => ({
+      ...evidence,
+      jobs: [{ id: "staging-brev-launchable", result: "success" }],
+    }),
+  ],
+];
 
 function createPlan(
   fixture: Fixture,
@@ -669,6 +739,37 @@ describe("release-latest-tag.sh", () => {
       "workflow evidence: https://github.com/NVIDIA/NemoClaw/actions/runs/123 (conclusion: failure)",
     );
   });
+
+  it.each(INVALID_WAIVER_EVIDENCE_CASES)(
+    "rejects a failed workflow whose waiver artifact has an invalid %s",
+    (_field, invalidEvidence) => {
+      const fixture = createFixture();
+      pushTag(fixture, "v0.0.1", fixture.firstCommit);
+      const releaseCommit = commit(fixture, "planned release commit");
+      const planPath = path.join(fixture.root, "release", "plan.json");
+      createPlan(fixture, planPath, releaseCommit);
+      const originRemote = "git@github.com:NVIDIA/NemoClaw";
+      rewritePlanOrigin(planPath, originRemote);
+      const evidence = invalidEvidence(validWaiverEvidence(releaseCommit));
+      const binDir = installReleaseGateStubs(
+        fixture,
+        "waived",
+        originRemote,
+        JSON.stringify(evidence),
+      );
+
+      const result = runScript(
+        fixture.work,
+        ["bash", cutScriptPath, "--plan", planPath, "--preflight-only"],
+        { PATH: `${binDir}:${process.env.PATH ?? ""}` },
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        `No completed successful Release qualification check exists for candidate commit ${releaseCommit}`,
+      );
+    },
+  );
 
   it("rejects a failed workflow run when Release qualification also fails", () => {
     const fixture = createFixture();

--- a/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
+++ b/tools/e2e/upload-e2e-artifacts-workflow-boundary.mts
@@ -41,6 +41,17 @@ const MANAGED_IMAGE_BUILD_CACHE_ARTIFACT_NAME =
   "${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE_ARTIFACT }}";
 const MANAGED_IMAGE_BUILD_CACHE_ARTIFACT_PATH =
   "${{ env.NEMOCLAW_PROTECTED_MANAGED_IMAGE_BUILD_CACHE }}/";
+const RELEASE_QUALIFICATION_WAIVER_UPLOAD_CONTRACT: WorkflowStep = {
+  name: "Upload release qualification waiver evidence",
+  if: "${{ inputs.release_qualification_waived_jobs != '' }}",
+  uses: UPLOAD_ARTIFACT_ACTION,
+  with: {
+    name: "release-qualification-waiver-${{ github.run_id }}-${{ github.run_attempt }}",
+    path: "${{ runner.temp }}/release-qualification-waiver/waiver.json",
+    "if-no-files-found": "error",
+    "retention-days": 30,
+  },
+};
 const INNER_ALWAYS = "${{ always() }}";
 const CALLER_ALWAYS = "always()";
 const RETIRED_SELECTOR_COMPATIBILITY_JOB = "retired-selector-compatibility";
@@ -87,6 +98,16 @@ function isExactManagedImageBuildCacheUpload(jobName: string, step: WorkflowStep
     step.uses === UPLOAD_ARTIFACT_ACTION &&
     inputs.name === MANAGED_IMAGE_BUILD_CACHE_ARTIFACT_NAME &&
     inputs.path === MANAGED_IMAGE_BUILD_CACHE_ARTIFACT_PATH
+  );
+}
+
+function isExactReleaseQualificationWaiverUpload(
+  jobName: string,
+  step: WorkflowStep,
+): boolean {
+  return (
+    jobName === "release-qualification" &&
+    isDeepStrictEqual(step, RELEASE_QUALIFICATION_WAIVER_UPLOAD_CONTRACT)
   );
 }
 
@@ -412,7 +433,8 @@ export function validateUploadE2eArtifactsInvocations(workflow: WorkflowRecord):
       if (
         uses.startsWith(UPLOAD_ARTIFACT_ACTION_PREFIX) &&
         !isExactCommitCliArtifactUpload &&
-        !isExactManagedImageBuildCacheUpload(jobName, step)
+        !isExactManagedImageBuildCacheUpload(jobName, step) &&
+        !isExactReleaseQualificationWaiverUpload(jobName, step)
       ) {
         errors.push(`${jobName} must not invoke actions/upload-artifact directly`);
       }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Harden the administrator waiver support merged in #9080. The follow-up permits only the exact trusted waiver-evidence upload contract and makes the release preflight reject malformed evidence for every trusted field.

## Changes

- Allow `release-qualification` to invoke the pinned artifact uploader only when the full step matches the reviewed job name, step name, condition, action SHA, artifact name, path, missing-file policy, and retention.
- Add a workflow-boundary regression test that rejects drift in the waiver upload contract.
- Add table-driven release-preflight cases for schema, kind, candidate SHA, run ID and attempt, actors, reason, jobs shape, duplicates, job IDs, outcomes, and the required failed-job evidence.

This is the smallest follow-up to the CI failure and advisor warning observed after #9080 merged. It does not change the documented administrator-waiver behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This follow-up only enforces the waiver-evidence contract documented and merged in #9080.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The follow-up narrows the direct artifact-upload exception to an exact immutable contract and exercises every field trusted by the release preflight. The independent review found no blocking issue.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Validation and test-only changes in `tools/e2e/upload-e2e-artifacts-workflow-boundary.mts`, `test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts`, and `test/release-latest-tag.test.ts`; existing maintainer guidance remains accurate.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 1bbf9640e2 -->
<!-- docs-review-agents-blob-sha: e30afb270b -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — deferred to GitHub CI at maintainer direction; normal hooks passed.
- [ ] Applicable broad gate passed — deferred to GitHub CI at maintainer direction.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened release validation for waiver evidence, rejecting invalid schema, identity, candidate, workflow, reason, and job details.
  * Added validation to prevent unauthorized artifact upload configurations.

* **Tests**
  * Added end-to-end coverage for release-qualification waiver artifact uploads.
  * Expanded release-gate tests with valid waiver fixtures and invalid evidence scenarios.
  * Confirmed signing preflight fails when waiver artifacts do not meet requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->