### PR TITLE
fix(e2e): parse replies after terminal erase controls

### DIFF
--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -92,7 +92,7 @@ reply_seen=0
 normalized_response() {
   tail -c "+$((response_start + 1))" "$capture" \
     | sed -E $'s/\x1B][^\x07\x1B]*(\x07|\x1B\\\\)//g' \
-    | sed -E $'s/\x1B\\[[0-?]*[ -\\/]*[@-~]//g' \
+    | sed -E $'s|\x1B\\[[0-?]*[ -/]*[@-~]||g' \
     | tr '\r' '\n' \
     | LC_ALL=C tr -d '\000-\010\013\014\016-\037\177'
 }

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -216,6 +216,17 @@ it.runIf(process.platform !== "win32")(
 );
 
 it.runIf(process.platform !== "win32")(
+  "accepts an exact reply after a CSI erase-in-line sequence",
+  () => {
+    const result = runLaunchTurnFixture(0, "\u001b[2KPONG");
+
+    expect(result.signal, result.stderr).toBeNull();
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("NEMOCLAW_LAUNCH_TURN_OK");
+  },
+);
+
+it.runIf(process.platform !== "win32")(
   "rejects a reply token embedded in extra prose (#8942)",
   () => {
     for (const reply of [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Repair the live launch-turn normalizer so a CSI erase-in-line control ends before the reply text. [Actions run 31767577321](https://github.com/NVIDIA/NemoClaw/actions/runs/31767577321) rendered the requested OpenClaw reply after `ESC[2K`, but the previous expression consumed the reply prefix and reported a missing reply.

## Changes

- Use a non-slash expression delimiter so the CSI intermediate-byte range remains `0x20` through `0x2F`.
- Add a regression that requires an exact `PONG` reply after `ESC[2K`.
- Retain the existing rejection coverage for reply tokens embedded in extra prose.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal live E2E normalizer. The CLI, configuration, policies, and documented exact-reply contract do not change.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The two-file E2E helper diff changes only terminal normalization and its regression. `test/e2e/README.md` already states the exact-reply contract.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7b7a7aa71 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/launch-agent-turn.test.ts`: 6 passed, 1 platform-skipped
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm test` produced failures outside the changed files across existing macOS suites and was stopped; focused tests, type checking, and normal hooks pass.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of terminal escape sequences when validating command responses.
  - Fixed response normalization for CSI sequences.

- **Tests**
  - Added end-to-end coverage confirming that valid `PONG` responses with terminal formatting are accepted on Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->