### PR TITLE
fix(e2e): run DCode wrapper check through managed launcher

### DIFF
--- a/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
+++ b/test/e2e/e2e-cloud-experimental/checks/07-deepagents-code-headless-inference.sh
@@ -78,7 +78,7 @@ sandbox_direct_dcode() {
 sandbox_dcode_wrapper_contract() {
   # Keep this assertion as one atomic shell expression for clear failure attribution.
   # shellcheck disable=SC2016
-  sandbox_exec 'dcode_path="$(command -v dcode 2>/dev/null || true)"; [ "$dcode_path" = /usr/local/bin/dcode ] && [ -x /usr/local/lib/nemoclaw/dcode-launcher.sh ] && [ -x /usr/local/lib/nemoclaw/dcode-managed-exec ] && [ -x /usr/local/lib/nemoclaw/dcode-wrapper.sh ] && cmp -s /usr/local/bin/dcode /usr/local/lib/nemoclaw/dcode-launcher.sh && cmp -s /usr/local/lib/nemoclaw/dcode-managed-exec /usr/local/lib/nemoclaw/dcode-launcher.sh && python3 -c '\''import importlib.util,sys; sys.exit(0 if importlib.util.find_spec("deepagents_code") else 1)'\'' && printf "%s\\n" NEMOCLAW_DCODE_WRAPPER_CHAIN_OK'
+  sandbox_direct_rlimit_exec 'dcode_path="$(command -v dcode 2>/dev/null || true)"; [ "$dcode_path" = /usr/local/bin/dcode ] && [ -x /usr/local/lib/nemoclaw/dcode-launcher.sh ] && [ -x /usr/local/lib/nemoclaw/dcode-managed-exec ] && [ -x /usr/local/lib/nemoclaw/dcode-wrapper.sh ] && cmp -s /usr/local/bin/dcode /usr/local/lib/nemoclaw/dcode-launcher.sh && cmp -s /usr/local/lib/nemoclaw/dcode-managed-exec /usr/local/lib/nemoclaw/dcode-launcher.sh && python3 -c '\''import importlib.util,sys; sys.exit(0 if importlib.util.find_spec("deepagents_code") else 1)'\'' && printf "%s\\n" NEMOCLAW_DCODE_WRAPPER_CHAIN_OK'
 }
 
 write_openshell_target_shim() {

--- a/test/langchain-deepagents-code-image.test.ts
+++ b/test/langchain-deepagents-code-image.test.ts
@@ -839,6 +839,11 @@ describe("LangChain Deep Agents Code image contracts", () => {
   });
   it("ships a headless inference acceptance check for Deep Agents Code", () => {
     const headlessCheck = fs.readFileSync(headlessCheckPath, "utf8");
+    const wrapperContract = headlessCheck.match(
+      /sandbox_dcode_wrapper_contract\(\) \{(?<body>[\s\S]*?)\n\}/,
+    )?.groups?.body;
+    expect(wrapperContract).toContain("sandbox_direct_rlimit_exec");
+    expect(wrapperContract).not.toMatch(/\bsandbox_exec /);
     for (const expected of [
       'sandbox_exec "test -d /sandbox/.deepagents"',
       "command -v dcode",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Route the Deep Agents Code wrapper-chain live assertion through the managed launcher. In [Actions run 31767577321](https://github.com/NVIDIA/NemoClaw/actions/runs/31767577321), the generic sandbox helper caused the protected login profile to omit the managed runtime environment because the assertion text named the launcher without executing it. The module check then reported a missing wrapper chain even though the preceding managed inference checks passed.

## Changes

- Run the wrapper-chain assertion through the existing `sandbox_direct_rlimit_exec` helper.
- Extract that assertion function in the image contract and require the managed-launcher helper.
- Reject a future change that routes the assertion through the generic `sandbox_exec` helper.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes a live E2E assertion path and its source contract. Supported commands, output, configuration, and runtime behavior do not change.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The two-file diff changes only the live assertion path and its source contract. Current Deep Agents Code documentation already describes the managed launcher and protected login profile.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 9bbee9294 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused image contract: 1 passed, 20 filtered; login-profile and proxy-runtime contracts: 3 passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this two-file live-check correction. The combined three-file run passed 23 tests; one dependency-lock test could not run because the host `pip3` does not support `--dry-run`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated headless inference acceptance checks to validate execution through the resource-limited sandbox path.
  - Added coverage ensuring the managed launcher avoids the standard sandbox execution route.
  - Expanded wrapper-contract verification for more reliable deep-agent code execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->