### PR TITLE
fix(onboard): extend dashboard readiness wait

### DIFF
--- a/docs/get-started/quickstart-hermes.mdx
+++ b/docs/get-started/quickstart-hermes.mdx
@@ -286,8 +286,8 @@ Use these details when your first-run path needs more control.
     The onboard flow starts both port forwards automatically.
     For a new sandbox, NemoClaw reserves the selected dashboard loopback port through sandbox preparation and the image build.
     If another listener claims the port before NemoClaw binds the reservation, NemoClaw selects another port before changing sandbox resources.
-    If OpenShell reports `sandbox is not ready`, NemoClaw waits 5 seconds and retries the affected forward up to three times.
-    These retries preserve the existing sandbox and selected host port.
+    If OpenShell returns the exact `sandbox is not ready` response, NemoClaw waits 5 seconds and retries the affected forward up to 12 times.
+    The readiness-specific delays total at most 1 minute and preserve the existing sandbox and selected host port.
     NemoClaw releases the reservation immediately before OpenShell starts the dashboard forward.
     If forwarding then fails, onboarding removes the new sandbox and tells you to resolve the reported error before retrying.
     The Hermes dashboard URL does not include an OpenClaw `#token=` fragment.

--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -419,8 +419,8 @@ Use these details when your first-run path needs more control.
     When that port is occupied, NemoClaw uses the next free dashboard port, such as `18790`, and includes the port in the URL.
     For a new sandbox, NemoClaw reserves the selected loopback port through sandbox preparation and the image build.
     If another listener claims the port before NemoClaw binds the reservation, NemoClaw selects another port before changing sandbox resources.
-    If OpenShell reports `sandbox is not ready`, NemoClaw waits 5 seconds and retries the dashboard forward up to three times.
-    These retries preserve the existing sandbox and selected port.
+    If OpenShell returns the exact `sandbox is not ready` response, NemoClaw waits 5 seconds and retries the dashboard forward up to 12 times.
+    The readiness-specific delays total at most 1 minute and preserve the existing sandbox and selected port.
     NemoClaw releases the reservation immediately before OpenShell starts the dashboard forward.
     If forwarding then fails, onboarding removes the new sandbox and tells you to resolve the reported error before retrying.
     The installation transcript does not print the gateway token.

--- a/src/lib/onboard/forward-start.test.ts
+++ b/src/lib/onboard/forward-start.test.ts
@@ -27,6 +27,21 @@ function forwardListWith(
   return [header, ...rows].join("\n");
 }
 
+const SANDBOX_NOT_READY_FORWARD_DIAGNOSTIC = `Error:   × code: 'The system is not in a state required for the operation's
+  │ execution', message: "sandbox is not ready"
+`;
+
+function readinessHandoffSpawn(rejections: number) {
+  let attempt = 0;
+  return vi.fn(({ stderr }: { stderr: number }) => {
+    attempt++;
+    if (attempt <= rejections) {
+      fs.writeSync(stderr, SANDBOX_NOT_READY_FORWARD_DIAGNOSTIC);
+    }
+    return {};
+  });
+}
+
 describe("runDetachedForwardStartWithDiagnostics", () => {
   it("returns ok as soon as the forward appears in the list", () => {
     const fetchList = vi
@@ -984,24 +999,12 @@ describe("runDetachedForwardStartWithRetries", () => {
   });
 
   it("keeps retrying when four consecutive readiness handoffs are still settling", () => {
-    let spawnAttempt = 0;
+    const spawn = readinessHandoffSpawn(4);
     const fetchList = vi.fn(() =>
-      spawnAttempt >= 5
+      spawn.mock.calls.length >= 5
         ? forwardListWith([{ sandbox: "my-sandbox", port: 18789 }])
         : forwardListWith([]),
     );
-    const spawn = vi.fn(({ stderr }: { stderr: number }) => {
-      spawnAttempt++;
-      if (spawnAttempt <= 4) {
-        fs.writeSync(
-          stderr,
-          `Error:   × code: 'The system is not in a state required for the operation's
-  │ execution', message: "sandbox is not ready"
-`,
-        );
-      }
-      return {};
-    });
     const beforeRetry = vi.fn();
     const sleep = vi.fn();
 
@@ -1025,15 +1028,7 @@ describe("runDetachedForwardStartWithRetries", () => {
   });
 
   it("stops after the independent sandbox readiness retry bound", () => {
-    const spawn = vi.fn(({ stderr }: { stderr: number }) => {
-      fs.writeSync(
-        stderr,
-        `Error:   × code: 'The system is not in a state required for the operation's
-  │ execution', message: "sandbox is not ready"
-`,
-      );
-      return {};
-    });
+    const spawn = readinessHandoffSpawn(13);
     const beforeRetry = vi.fn();
     const sleep = vi.fn();
 

--- a/src/lib/onboard/forward-start.test.ts
+++ b/src/lib/onboard/forward-start.test.ts
@@ -32,12 +32,12 @@ const SANDBOX_NOT_READY_FORWARD_DIAGNOSTIC = `Error:   × code: 'The system is n
 `;
 
 function readinessHandoffSpawn(rejections: number) {
-  let attempt = 0;
+  const diagnostics = [
+    ...Array<string>(rejections).fill(SANDBOX_NOT_READY_FORWARD_DIAGNOSTIC),
+    "",
+  ];
   return vi.fn(({ stderr }: { stderr: number }) => {
-    attempt++;
-    if (attempt <= rejections) {
-      fs.writeSync(stderr, SANDBOX_NOT_READY_FORWARD_DIAGNOSTIC);
-    }
+    fs.writeSync(stderr, diagnostics.shift() ?? "");
     return {};
   });
 }

--- a/src/lib/onboard/forward-start.test.ts
+++ b/src/lib/onboard/forward-start.test.ts
@@ -983,6 +983,79 @@ describe("runDetachedForwardStartWithRetries", () => {
     expect(events).toEqual(["spawn-1", "sleep-5000", "spawn-2"]);
   });
 
+  it("keeps retrying when four consecutive readiness handoffs are still settling", () => {
+    let spawnAttempt = 0;
+    const fetchList = vi.fn(() =>
+      spawnAttempt >= 5
+        ? forwardListWith([{ sandbox: "my-sandbox", port: 18789 }])
+        : forwardListWith([]),
+    );
+    const spawn = vi.fn(({ stderr }: { stderr: number }) => {
+      spawnAttempt++;
+      if (spawnAttempt <= 4) {
+        fs.writeSync(
+          stderr,
+          `Error:   × code: 'The system is not in a state required for the operation's
+  │ execution', message: "sandbox is not ready"
+`,
+        );
+      }
+      return {};
+    });
+    const beforeRetry = vi.fn();
+    const sleep = vi.fn();
+
+    const result = runDetachedForwardStartWithRetries(
+      spawn,
+      fetchList,
+      { port: 18789, sandboxName: "my-sandbox" },
+      beforeRetry,
+      {
+        sleepMs: sleep,
+        isPortListening: vi.fn().mockReturnValue(false),
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe("ok");
+    expect(beforeRetry).not.toHaveBeenCalled();
+    expect(spawn).toHaveBeenCalledTimes(5);
+    expect(sleep).toHaveBeenCalledTimes(4);
+    expect(sleep).toHaveBeenCalledWith(5_000);
+  });
+
+  it("stops after the independent sandbox readiness retry bound", () => {
+    const spawn = vi.fn(({ stderr }: { stderr: number }) => {
+      fs.writeSync(
+        stderr,
+        `Error:   × code: 'The system is not in a state required for the operation's
+  │ execution', message: "sandbox is not ready"
+`,
+      );
+      return {};
+    });
+    const beforeRetry = vi.fn();
+    const sleep = vi.fn();
+
+    const result = runDetachedForwardStartWithRetries(
+      spawn,
+      vi.fn().mockReturnValue(forwardListWith([])),
+      { port: 18789, sandboxName: "my-sandbox" },
+      beforeRetry,
+      {
+        sleepMs: sleep,
+        isPortListening: vi.fn().mockReturnValue(false),
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("listener-start-failure");
+    expect(beforeRetry).not.toHaveBeenCalled();
+    expect(spawn).toHaveBeenCalledTimes(13);
+    expect(sleep).toHaveBeenCalledTimes(12);
+    expect(sleep).toHaveBeenCalledWith(5_000);
+  });
+
   it("does not retry a composite authentication diagnostic that mentions readiness", () => {
     let now = 0;
     vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/src/lib/onboard/forward-start.ts
+++ b/src/lib/onboard/forward-start.ts
@@ -61,7 +61,9 @@ export interface DetachedForwardStartOptions {
   onProgress?: (info: { elapsedMs: number; listSnapshot: string }) => void;
   progressIntervalMs?: number;
   // Number of retryable startup attempts after the initial attempt. Honoured
-  // only by `runDetachedForwardStartWithRetries`. Defaults to 3.
+  // only by `runDetachedForwardStartWithRetries`. An explicit value applies
+  // to every retryable outcome. Ordinary failures default to 3 retries; exact
+  // sandbox readiness handoffs use their own longer default below.
   maxRetries?: number;
   // Loopback port-liveness probe. Defaults to `probeLocalPortListening` (a
   // synchronous Node TCP connect to 127.0.0.1:port). The retry wrapper uses it
@@ -191,6 +193,11 @@ function blockingSleepMs(ms: number): void {
 // exposes an atomic recovery operation.
 const DEAD_FORWARD_GRACE_MS = 2_000;
 const SANDBOX_READY_RETRY_SETTLE_MS = 5_000;
+// A newly created sandbox can remain between OpenShell's create-ready and
+// forward-ready states longer than the ordinary listener retry budget. Keep
+// this exact-diagnostic path bounded to one additional minute without
+// widening retries for authentication, ownership, or listener failures.
+const SANDBOX_READY_MAX_RETRIES = 12;
 
 /**
  * Build a `DetachedForwardSpawnRunner` that spawns the given argv as a
@@ -515,8 +522,10 @@ export function runDetachedForwardStartWithRetries(
   options: DetachedForwardStartOptions = {},
 ): DetachedForwardStartOutcome {
   const maxRetries = options.maxRetries ?? 3;
+  const maxSandboxReadyRetries = options.maxRetries ?? SANDBOX_READY_MAX_RETRIES;
   const sleepImpl = options.sleepMs ?? blockingSleepMs;
   let deadForwardRecoveryAvailable = true;
+  let sandboxReadyRetries = 0;
   const isPortListening = options.isPortListening ?? probeLocalPortListening;
   const runAttempt = (): DetachedForwardStartOutcome =>
     isPortListening(expect.port)
@@ -534,20 +543,26 @@ export function runDetachedForwardStartWithRetries(
       deadForwardRecoveryAvailable = false;
       beforeRetryCleanup();
     } else {
-      const isRetryableStandardFailure =
-        (attempt.reason !== "listener-ownership-conflict" &&
-          looksLikeForwardPortConflict(attempt.diagnostic)) ||
-        attempt.reason === "listener-start-failure";
-      if (!isRetryableStandardFailure || standardRetries >= maxRetries) break;
-      if (looksLikeForwardPortConflict(attempt.diagnostic)) {
-        beforeRetryCleanup();
-      }
-      if (looksLikeSandboxNotReadyForwardStart(attempt.diagnostic)) {
+      const isSandboxReadinessHandoff =
+        attempt.reason === "listener-start-failure" &&
+        looksLikeSandboxNotReadyForwardStart(attempt.diagnostic);
+      if (isSandboxReadinessHandoff) {
+        if (sandboxReadyRetries >= maxSandboxReadyRetries) break;
         // Keep the existing sandbox and port ownership intact while the
         // OpenShell gateway finishes the readiness handoff.
         sleepImpl(SANDBOX_READY_RETRY_SETTLE_MS);
+        sandboxReadyRetries++;
+      } else {
+        const isRetryableStandardFailure =
+          (attempt.reason !== "listener-ownership-conflict" &&
+            looksLikeForwardPortConflict(attempt.diagnostic)) ||
+          attempt.reason === "listener-start-failure";
+        if (!isRetryableStandardFailure || standardRetries >= maxRetries) break;
+        if (looksLikeForwardPortConflict(attempt.diagnostic)) {
+          beforeRetryCleanup();
+        }
+        standardRetries++;
       }
-      standardRetries++;
     }
     attempt = runAttempt();
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Dashboard-forward startup now gives OpenShell's exact `sandbox is not ready` handoff up to 1 minute to settle. [Actions run 31767577321](https://github.com/NVIDIA/NemoClaw/actions/runs/31767577321) showed multiple onboarding lanes exhausting the ordinary three-retry allowance while the new sandbox was still transitioning to forward-ready state.

Authentication, ownership, port-conflict, and ordinary listener failures keep their existing retry and cleanup behavior.

## Changes

- Give the exact OpenShell readiness response a separate default of 12 retries with 5-second delays.
- Preserve `maxRetries` as an explicit override for every retryable outcome.
- Cover recovery after four consecutive readiness responses and the persistent 12-retry bound.
- Update the OpenClaw and Hermes quickstarts with the readiness-specific wait.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The repository security checklist covered the complete four-file diff. The longer wait remains limited to one exact OpenShell diagnostic and one minute; authentication, ownership, cleanup, and ordinary listener retry boundaries are unchanged. No security finding was identified.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated both quickstarts to describe the exact readiness response, 12 retries, 5-second intervals, and the 1-minute maximum readiness-specific delay. `npm run docs`, file-scoped hooks, and diff validation passed.
- Agent: Codex documentation writer subagent
<!-- docs-review-head-sha: 6cb3217e6 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; DGX Station preparation is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused forward-start suite: 47 passed; affected test selection: 370 passed across 28 files
- [x] Applicable broad gate passed — `npm run typecheck:cli`, `npm run docs`, source-shape and test-conditional validation, targeted repository hooks, and diff validation passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — result: zero errors; two existing Fern notices
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox startup handoff reliability by retrying “sandbox is not ready” responses up to 12 times.
  - Added five-second delays between readiness retries, allowing up to one minute for the sandbox to become available.
  - Preserved existing sandbox and selected host-port settings throughout retries.
  - Kept standard retry behavior separate and unchanged.

- **Documentation**
  - Updated quickstart guides to explain the extended sandbox-readiness retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->