### PR TITLE
test(e2e): accept supervisor gateway recovery

### DIFF
--- a/test/e2e/live/issue-2478-crash-loop-recovery.test.ts
+++ b/test/e2e/live/issue-2478-crash-loop-recovery.test.ts
@@ -229,7 +229,7 @@ async function runProbeOnly(
   },
   sandboxName: string,
   artifactName: string,
-): Promise<void> {
+): Promise<"connect" | "supervisor"> {
   const result = await host.nemoclaw([sandboxName, "connect", "--probe-only"], {
     artifactName,
     env: probeEnv(),
@@ -239,10 +239,18 @@ async function runProbeOnly(
     result.exitCode,
     `${artifactName} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
   ).toBe(0);
+  const connectRecovery = `Probe complete: recovered OpenClaw gateway in '${sandboxName}'.`;
+  const supervisorRecovery = `Probe complete: OpenClaw gateway is running in '${sandboxName}'.`;
+  const recoveryPath = result.stdout.includes(connectRecovery)
+    ? "connect"
+    : result.stdout.includes(supervisorRecovery)
+      ? "supervisor"
+      : null;
   expect(
-    result.stdout,
-    `${artifactName} did not exercise connect-driven recovery\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
-  ).toContain(`Probe complete: recovered OpenClaw gateway in '${sandboxName}'.`);
+    recoveryPath,
+    `${artifactName} did not observe a healthy gateway after termination\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  ).not.toBeNull();
+  return recoveryPath!;
 }
 
 async function terminateGatewayIdentity(
@@ -301,13 +309,13 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-test("connect-driven gateway recovery restores the guard chain and keeps the recovered process identity for 15 seconds (#2478)", {
+test("gateway recovery restores the guard chain and keeps the recovered process identity for 15 seconds (#2478)", {
   meta: {
     e2ePhases: [
       "start the compatible endpoint and confirm host readiness",
       "onboard the guarded OpenClaw sandbox",
       "confirm initial gateway and inference health",
-      "terminate one live gateway and recover it through the production connect path",
+      "terminate one live gateway and verify production recovery",
       "verify the recovered process identity remains unchanged for 15 seconds",
     ],
   },
@@ -354,14 +362,18 @@ test("connect-driven gateway recovery restores the guard chain and keeps the rec
     initialIdentity,
   );
 
-  progress.phase("terminate one live gateway and recover it through the production connect path");
+  progress.phase("terminate one live gateway and verify production recovery");
   await terminateGatewayIdentity(
     sandbox,
     instance.sandboxName,
     preRecoveryIdentity!,
     "functional-recovery-terminate-gateway",
   );
-  await runProbeOnly(host, instance.sandboxName, "functional-recovery-connect-probe-only");
+  const recoveryPath = await runProbeOnly(
+    host,
+    instance.sandboxName,
+    "functional-recovery-connect-probe-only",
+  );
   const recoveredIdentity = await waitForGatewayIdentity(gateway, instance, 45_000);
   expect(
     recoveredIdentity,
@@ -386,6 +398,7 @@ test("connect-driven gateway recovery restores the guard chain and keeps the rec
   await artifacts.writeJson("functional-recovery-summary.json", {
     initialIdentity,
     preRecoveryIdentity,
+    recoveryPath,
     recoveredIdentity,
     stableIdentity,
     stabilitySeconds: STABILITY_SECONDS,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The gateway-recovery live target now accepts either successful production recovery path after terminating the managed gateway. In [Actions run 31767577321](https://github.com/NVIDIA/NemoClaw/actions/runs/31767577321), PID 1 replaced the process before `connect --probe-only` completed, so the CLI correctly reported that the gateway was already running. The target rejected that result even though its deterministic CLI contract explicitly requires that output for an automatic supervisor replacement.

The live target still requires a different process identity, the complete guard chain, healthy inference, and 15 seconds of process stability.

## Changes

- Accept the controller-recovery and supervisor-recovery success messages.
- Record which recovery path won the race in the live evidence summary.
- Keep the existing process replacement, guard, inference, and stability assertions.
- Rename the target phase and title to describe the behavior it proves.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Production recovery behavior and CLI output do not change; this corrects one live E2E expectation.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing command, recovery, lifecycle-control, and troubleshooting pages already describe supervisor relaunch and successful already-running recovery. The docs do not promise which recovery actor appears in the success line.
- Agent: Codex documentation writer subagent
<!-- docs-review-head-sha: f5cc3207c -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; DGX Station preparation is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — deterministic connect recovery: 2 passed; live target collection: passed
- [x] Applicable broad gate passed — exact Vitest project membership, test-title style, targeted repository hooks, and diff validation passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved crash-loop recovery coverage to accept recovery through either supported production path.
  * Recovery test results now record and report which path successfully restored service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->