### PR TITLE
test(e2e): parse release waiver actor correctly

### DIFF
--- a/test/e2e/support/e2e-workflow.test.ts
+++ b/test/e2e/support/e2e-workflow.test.ts
@@ -45,7 +45,8 @@ function runReleaseWaiverAuthorization(
     `#!/usr/bin/env bash
 set -euo pipefail
 url="\${!#}"
-administrator="\${url##*/}"
+administrator="\${url%/permission}"
+administrator="\${administrator##*/}"
 printf '%s\n' "$administrator" >>"$CURL_LOG"
 case "$administrator" in
   maintainer) role=maintain ;;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The release-waiver authorization fixture now extracts the collaborator identity from GitHub's permission route. Previously, it treated the final route segment as the actor and caused every authorization case to fail on `main`.

## Changes

- Remove the trailing `/permission` route segment before extracting the collaborator identity.
- Preserve the existing administrator, maintainer, and identity-mismatch scenarios.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This only corrects a test fixture; production behavior and user workflows do not change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent review found no critical, major, or blocking security findings; the production authorization workflow is unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Test-only fixture change with no user-visible behavior, command, configuration, or support-status change.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 8aabd151d -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/e2e/support/e2e-workflow.test.ts` passed 38 tests.
- [x] Applicable broad gate passed — Not applicable; the complete changed test file passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved release-waiver authorization test coverage to correctly identify the administrator associated with an API request.
  * Increased confidence that authorization workflows are validated against the correct administrator identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->