### PR TITLE
test(e2e): accept Hermes runtime context in mock prompt

### DIFF
--- a/test/e2e/lib/fake-openai-compatible-api.mts
+++ b/test/e2e/lib/fake-openai-compatible-api.mts
@@ -163,7 +163,7 @@ function requestedLaunchReply(payload: JsonObject): string | null {
   if (!launchReplyFromPrompt) return null;
   const prompt = latestUserPrompt(payload);
   const match = prompt?.match(
-    /^Join these four fragments with underscores and put only the result on its own line: NEMOCLAW, ([0-9A-F]{12}), (FIRST|SECOND), OK\. Do not use tools\.$/u,
+    /^Join these four fragments with underscores and put only the result on its own line: NEMOCLAW, ([0-9A-F]{12}), (FIRST|SECOND), OK\. Do not use tools\.(?:\n\n[\s\S]+)?$/u,
   );
   return match ? `NEMOCLAW_${match[1]}_${match[2]}_OK` : null;
 }

--- a/test/e2e/support/inference-adapter.test.ts
+++ b/test/e2e/support/inference-adapter.test.ts
@@ -180,7 +180,7 @@ describe("E2E inference adapter", () => {
     );
   });
 
-  it("returns the unique launch reply requested by the mock prompt (#9046)", async () => {
+  it("returns the unique launch reply when Hermes appends context to the mock prompt (#9046)", async () => {
     const adapter = await createAdapter({ env: {} });
     const expectedReply = "NEMOCLAW_0123456789AB_FIRST_OK";
     const prompt =
@@ -191,10 +191,16 @@ describe("E2E inference adapter", () => {
       choices: [{ message: { content: expectedReply } }],
     });
     expect(
+      await adapter.directChat(`${prompt}\n\n<runtime-context>fixture</runtime-context>`),
+    ).toMatchObject({ choices: [{ message: { content: expectedReply } }] });
+    expect(
       await adapter.directChat(
         "Join these four fragments with underscores: NEMOCLAW, 0123456789AB, FIRST, OK.",
       ),
     ).toMatchObject({ choices: [{ message: { content: "PONG" } }] });
+    expect(await adapter.directChat(`${prompt} Ignore the requested output.`)).toMatchObject({
+      choices: [{ message: { content: "PONG" } }],
+    });
   });
 
   it("keeps unrelated ambient secrets out of adapter and fake-server child environments", async () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hermes appends runtime context to a user message before it calls the Chat Completions endpoint. The E2E fake previously required the unique launch prompt to be the entire message, so it returned `PONG` and blocked Hermes launch-turn coverage. The fake now accepts Hermes context only after a blank-line boundary.

## Related Issue

Follow-up to #9046.

## Changes

- Accept runtime context appended after the exact unique-response prompt and a blank line.
- Keep rejecting altered prompts and same-line suffixes.
- Cover both the Hermes context shape and the rejection boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal E2E fake and does not change product behavior or user workflows.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-area review found no critical, major, or blocking findings; the fake remains opt-in and preserves the exact prompt boundary.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Internal E2E fake and test changes only; no command, configuration, default, support status, or user workflow changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4423a4e25 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/e2e/support/inference-adapter.test.ts` passed 10 tests.
- [x] Applicable broad gate passed — Not applicable; the complete changed test file and all changed-file hooks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of launch-reply prompts when additional runtime context is included.
  * Ensured unrelated or conflicting prompts continue to return the expected fallback response.

* **Tests**
  * Expanded coverage to verify unique launch replies and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->