### PR TITLE
fix(hermes): seed pip for Hindsight lazy install

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -1150,7 +1150,50 @@ RUN set -eu; \
 # gateway must retain import access after the lock while both runtime identities
 # remain unable to mutate the dependency tree. Remove the probe install so the
 # published image still performs installation only when Hindsight is selected.
-RUN test "$(stat -c '%U:%G %a' /sandbox/.hermes/lazy-packages)" = "sandbox:sandbox 750" \
+# uv creates the Hermes virtual environment without pip. Seed pip from Python's
+# bundled ensurepip payload while this layer is still root, then verify the
+# sandbox can read but cannot modify the virtual environment used by the lazy
+# installer. The Hermes lazy installer still installs the approved dependency
+# as the sandbox user.
+RUN /opt/hermes/.venv/bin/python -I -m ensurepip --upgrade --default-pip \
+    && /opt/hermes/.venv/bin/python -I -m pip --version \
+    && chmod 644 /opt/hermes/.venv/.lock \
+    && test "$(stat -c '%U:%G %a' /opt/hermes/.venv/.lock)" = "root:root 644" \
+    && test "$(stat -c '%U:%G %a' /opt/hermes/.venv/bin/pip)" = "root:root 755" \
+    && venv_violation="$(find -P /opt/hermes/.venv ! -type l \( ! -user root -o ! -group root -o -perm /022 \) -print -quit)" \
+    && test -z "$venv_violation" \
+    && venv_link_owner_violation="$(find -P /opt/hermes/.venv -type l \( ! -user root -o ! -group root \) -print -quit)" \
+    && test -z "$venv_link_owner_violation" \
+    && venv_links_file="$(mktemp)" \
+    && find -P /opt/hermes/.venv -type l -printf '%P -> %l\n' > "$venv_links_file" \
+    && LC_ALL=C sort -o "$venv_links_file" "$venv_links_file" \
+    && venv_links="$(cat "$venv_links_file")" \
+    && rm -f "$venv_links_file" \
+    && expected_venv_links="$(printf '%s\n' \
+        'bin/python -> /usr/bin/python3' \
+        'bin/python3 -> python' \
+        'bin/python3.13 -> python' \
+        'lib64 -> lib')" \
+    && test "$venv_links" = "$expected_venv_links" \
+    && test "$(readlink -e /opt/hermes/.venv/bin/python)" = "/usr/bin/python3.13" \
+    && test "$(readlink -e /opt/hermes/.venv/bin/python3)" = "/usr/bin/python3.13" \
+    && test "$(readlink -e /opt/hermes/.venv/bin/python3.13)" = "/usr/bin/python3.13" \
+    && test "$(readlink -e /opt/hermes/.venv/lib64)" = "/opt/hermes/.venv/lib" \
+    && test "$(stat -Lc '%U:%G %a %F' /opt/hermes/.venv/bin/python)" = "root:root 755 regular file" \
+    && test "$(stat -Lc '%U:%G %a %F' /opt/hermes/.venv/bin/python3)" = "root:root 755 regular file" \
+    && test "$(stat -Lc '%U:%G %a %F' /opt/hermes/.venv/bin/python3.13)" = "root:root 755 regular file" \
+    && test "$(stat -Lc '%U:%G %a %F' /opt/hermes/.venv/lib64)" = "root:root 755 directory" \
+    && /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- \
+        sh -eu -c '\
+            /opt/hermes/.venv/bin/python -I -m pip --version >/dev/null; \
+            if printf '' >> /opt/hermes/.venv/.lock 2>/dev/null; then exit 1; fi; \
+            if printf '' >> /opt/hermes/.venv/bin/pip 2>/dev/null; then exit 1; fi; \
+            if printf '' >> /opt/hermes/.venv/lib/python3.13/site-packages/pip/__init__.py 2>/dev/null; then exit 1; fi; \
+            if printf '' >> /opt/hermes/.venv/bin/python 2>/dev/null; then exit 1; fi; \
+            if printf '' > /opt/hermes/.venv/lib64/.nemoclaw-sandbox-write-probe 2>/dev/null; then exit 1; fi; \
+            if ln -sf /usr/bin/false /opt/hermes/.venv/bin/python 2>/dev/null; then exit 1; fi' \
+    && test ! -e /opt/hermes/.venv/lib/.nemoclaw-sandbox-write-probe \
+    && test "$(stat -c '%U:%G %a' /sandbox/.hermes/lazy-packages)" = "sandbox:sandbox 750" \
     && HOME=/sandbox \
         UV_CACHE_DIR=/sandbox/.hermes/cache/uv \
         UV_NO_CACHE=1 \

--- a/test/hermes-dependency-review.test.ts
+++ b/test/hermes-dependency-review.test.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
+import { dockerfileInstructions } from "./helpers/dockerfile-run-commands";
 
 const root = path.join(import.meta.dirname, "..");
 const dockerfileBase = fs.readFileSync(
@@ -240,5 +241,77 @@ describe("Hermes 0.19.0 dependency review", () => {
     expect(review).toContain("`tornado==6.5.7`");
     expect(review).toContain("checksum-pinned Node.js `24.18.1`");
     expect(review).toContain("exact uv `0.11.33`");
+  });
+
+  it("seeds root-owned pip before the sandbox user installs a lazy dependency", () => {
+    const instructions = dockerfileInstructions(dockerfile);
+    const lazyInstallLayer = instructions.find(
+      (instruction) =>
+        instruction.keyword === "RUN" &&
+        instruction.body.includes(
+          "from tools.lazy_deps import ensure; ensure('memory.hindsight', prompt=False)",
+        ),
+    );
+    expect(lazyInstallLayer).toBeDefined();
+
+    const layer = lazyInstallLayer?.body ?? "";
+    const orderedContracts = [
+      "/opt/hermes/.venv/bin/python -I -m ensurepip --upgrade --default-pip",
+      "/opt/hermes/.venv/bin/python -I -m pip --version",
+      "chmod 644 /opt/hermes/.venv/.lock",
+      `test "$(stat -c '%U:%G %a' /opt/hermes/.venv/.lock)" = "root:root 644"`,
+      `test "$(stat -c '%U:%G %a' /opt/hermes/.venv/bin/pip)" = "root:root 755"`,
+      `venv_violation="$(find -P /opt/hermes/.venv ! -type l`,
+      `test -z "$venv_violation"`,
+      `venv_link_owner_violation="$(find -P /opt/hermes/.venv -type l`,
+      `test -z "$venv_link_owner_violation"`,
+      `venv_links_file="$(mktemp)"`,
+      `find -P /opt/hermes/.venv -type l -printf '%P -> %l\\n' > "$venv_links_file"`,
+      `LC_ALL=C sort -o "$venv_links_file" "$venv_links_file"`,
+      `venv_links="$(cat "$venv_links_file")"`,
+      `rm -f "$venv_links_file"`,
+      `expected_venv_links="$(printf '%s\\n'`,
+      "'bin/python -> /usr/bin/python3'",
+      "'bin/python3 -> python'",
+      "'bin/python3.13 -> python'",
+      "'lib64 -> lib'",
+      `test "$venv_links" = "$expected_venv_links"`,
+      `test "$(readlink -e /opt/hermes/.venv/bin/python)" = "/usr/bin/python3.13"`,
+      `test "$(readlink -e /opt/hermes/.venv/lib64)" = "/opt/hermes/.venv/lib"`,
+      `test "$(stat -Lc '%U:%G %a %F' /opt/hermes/.venv/bin/python)" = "root:root 755 regular file"`,
+      `test "$(stat -Lc '%U:%G %a %F' /opt/hermes/.venv/lib64)" = "root:root 755 directory"`,
+      "/usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups --",
+      "sh -eu -c",
+      "/opt/hermes/.venv/bin/python -I -m pip --version >/dev/null",
+      `if printf '' >> /opt/hermes/.venv/.lock 2>/dev/null; then exit 1; fi`,
+      `if printf '' >> /opt/hermes/.venv/bin/pip 2>/dev/null; then exit 1; fi`,
+      `if printf '' >> /opt/hermes/.venv/lib/python3.13/site-packages/pip/__init__.py 2>/dev/null; then exit 1; fi`,
+      `if printf '' >> /opt/hermes/.venv/bin/python 2>/dev/null; then exit 1; fi`,
+      `if printf '' > /opt/hermes/.venv/lib64/.nemoclaw-sandbox-write-probe 2>/dev/null; then exit 1; fi`,
+      `if ln -sf /usr/bin/false /opt/hermes/.venv/bin/python 2>/dev/null; then exit 1; fi`,
+      `test ! -e /opt/hermes/.venv/lib/.nemoclaw-sandbox-write-probe`,
+      `test "$(stat -c '%U:%G %a' /sandbox/.hermes/lazy-packages)" = "sandbox:sandbox 750"`,
+      "from tools.lazy_deps import ensure; ensure('memory.hindsight', prompt=False)",
+    ];
+    let previousIndex = -1;
+    for (const contract of orderedContracts) {
+      const contractIndex = layer.indexOf(contract);
+      expect(
+        contractIndex,
+        `Missing or misordered lazy-install contract: ${contract}`,
+      ).toBeGreaterThan(previousIndex);
+      previousIndex = contractIndex;
+    }
+    expect(layer).toContain("-perm /022");
+    expect(layer).not.toContain(`test -z "$(find -P /opt/hermes/.venv`);
+
+    const activeUser = instructions
+      .filter(
+        (instruction) =>
+          instruction.keyword === "USER" &&
+          instruction.start < (lazyInstallLayer?.start ?? Number.POSITIVE_INFINITY),
+      )
+      .at(-1);
+    expect(activeUser?.body.trim()).toBe("root");
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Hermes Hindsight lazy installer runs as the sandbox user and installs into `/sandbox/.hermes/lazy-packages`. The uv-created Hermes virtual environment did not include pip, so the installer tried to create it in the read-only root environment and failed. The image now provides bundled pip before the sandbox-owned lazy install while preserving the virtual environment's security boundary.

## Related Issue

Follow-up to #8613.

## Changes

- Seed pip from Python's bundled `ensurepip` payload during the root image-build layer without a network request.
- Normalize uv's lock file to a root-owned, non-writable mode.
- Fail the image build unless the virtual-environment tree and its exact link targets remain root-owned and non-writable.
- Prove that the sandbox user can run pip but cannot modify the lock, launchers, modules, interpreter target, library target, or links before the real lazy-install probe runs.
- Add a source contract test for the enforcement order and fail-closed scans.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing Hermes documentation already describes sandbox-owned lazy packages and the read-only `/opt/hermes` boundary; commands and user workflows do not change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-area review passed after fail-closed scan, exact link-target, and real sandbox write-denial controls were added.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing Hermes MCP and security pages already describe the unchanged user workflow, sandbox lazy-install location, and read-only root environment.
- Agent: Codex Desktop
<!-- docs-review-head-sha: bb4a24a90 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — Three focused files passed 21 tests; changed-file hooks passed.
- [ ] Applicable broad gate passed — The exact arm64 image could not be unpacked locally because Docker storage was full, so the managed-image build remains for CI. Immutable layer metadata and the cached same-version runtime passed the security preflight.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual environment setup and integrity checks during image builds.
  * Confirmed sandboxed processes can read dependencies without modifying the environment.
  * Ensured lazy dependency installation occurs with the required permissions and command order.

* **Tests**
  * Added coverage for ownership, permissions, symlinks, interpreter targets, and active build user validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->