### PR TITLE
fix(onboard): restore portable and legacy launch recovery

### DIFF
--- a/src/lib/actions/sandbox/connect-qualified-session-setup.test.ts
+++ b/src/lib/actions/sandbox/connect-qualified-session-setup.test.ts
@@ -3,13 +3,14 @@
 
 import { describe, expect, it, vi } from "vitest";
 
+import { loadAgent } from "../../agent/defs";
 import type { SandboxEntry } from "../../state/registry";
 import {
   completeInteractiveSessionSetup,
   completeReadinessQualifiedInteractiveSessionSetup,
 } from "./connect";
 
-function entry(agent: string): SandboxEntry {
+function entry(agent: string | null): SandboxEntry {
   return {
     name: "alpha",
     agent,
@@ -35,20 +36,58 @@ describe("readiness-qualified interactive session setup", () => {
   it("does not run the complete pairing path for qualified OpenClaw state (#9023)", () => {
     const runApprovalPass = vi.fn();
 
-    completeReadinessQualifiedInteractiveSessionSetup("alpha", entry("openclaw"), runApprovalPass);
+    completeReadinessQualifiedInteractiveSessionSetup(
+      "alpha",
+      loadAgent("openclaw"),
+      entry("openclaw"),
+      runApprovalPass,
+    );
 
     expect(runApprovalPass).not.toHaveBeenCalled();
   });
 
-  it.each(["hermes", "langchain-deepagents-code", "unknown-agent"])(
+  it("uses the qualified OpenClaw identity for a legacy registry entry (#9023)", () => {
+    const runApprovalPass = vi.fn();
+
+    completeReadinessQualifiedInteractiveSessionSetup(
+      "alpha",
+      loadAgent("openclaw"),
+      entry(null),
+      runApprovalPass,
+    );
+
+    expect(runApprovalPass).not.toHaveBeenCalled();
+  });
+
+  it.each(["hermes", "langchain-deepagents-code"])(
     "keeps the complete session path for %s (#9023)",
     (agent) => {
       const runApprovalPass = vi.fn();
 
-      completeReadinessQualifiedInteractiveSessionSetup("alpha", entry(agent), runApprovalPass);
+      completeReadinessQualifiedInteractiveSessionSetup(
+        "alpha",
+        loadAgent(agent),
+        entry(agent),
+        runApprovalPass,
+      );
 
       expect(runApprovalPass).toHaveBeenCalledOnce();
       expect(runApprovalPass).toHaveBeenCalledWith("alpha", "nemoclaw");
     },
   );
+
+  it("keeps the complete session path when sandbox state is unavailable (#9023)", () => {
+    const runApprovalPass = vi.fn();
+
+    completeReadinessQualifiedInteractiveSessionSetup(
+      "alpha",
+      loadAgent("openclaw"),
+      null,
+      runApprovalPass,
+      () => "nemoclaw",
+    );
+
+    expect(runApprovalPass).toHaveBeenCalledOnce();
+    expect(runApprovalPass).toHaveBeenCalledWith("alpha", "nemoclaw");
+  });
 });

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -1224,16 +1224,17 @@ export function completeInteractiveSessionSetup(
   runApprovalPass(sandboxName, gatewayName);
 }
 
-/** Preserve non-OpenClaw setup after current OpenClaw pairing qualification. */
+/** Preserve session setup after launch readiness accepts a trusted agent identity. */
 export function completeReadinessQualifiedInteractiveSessionSetup(
   sandboxName: string,
+  agent: AgentDefinition,
   sb: SandboxEntry | null,
   runApprovalPass = runConnectAutoPairApprovalPass,
+  resolveFallbackGateway = getSandboxTargetGatewayName,
 ): void {
   maybeEnsureHermesToolGatewayBroker(sb);
-  const agentName = String(sb?.agent ?? "").trim();
-  if (agentName === "openclaw") return;
-  const gatewayName = sb ? resolveSandboxGatewayName(sb) : getSandboxTargetGatewayName(sandboxName);
+  if (sb && agent.name === "openclaw") return;
+  const gatewayName = sb ? resolveSandboxGatewayName(sb) : resolveFallbackGateway(sandboxName);
   runApprovalPass(sandboxName, gatewayName);
 }
 

--- a/src/lib/actions/sandbox/launch.test.ts
+++ b/src/lib/actions/sandbox/launch.test.ts
@@ -48,7 +48,7 @@ vi.mock("./launch-readiness", () => ({
 
 import { launchSandbox } from "./launch";
 
-function sandboxEntry(agentName: string): SandboxEntry {
+function sandboxEntry(agentName: string | null): SandboxEntry {
   return {
     name: "alpha",
     agent: agentName,
@@ -335,6 +335,7 @@ describe("launchSandbox", () => {
     expect(mocks.printInteractiveSessionHints).toHaveBeenCalledWith("alpha");
     expect(mocks.completeReadinessQualifiedInteractiveSessionSetup).toHaveBeenCalledWith(
       "alpha",
+      openclaw,
       sb,
     );
     expect(mocks.completeInteractiveSessionSetup).not.toHaveBeenCalled();
@@ -346,6 +347,29 @@ describe("launchSandbox", () => {
       mocks.prepareHermesLightTerminalSkin,
     );
     expect(mocks.prepareHermesLightTerminalSkin).toHaveBeenCalledBefore(mocks.execSandbox);
+    expect(launchedCommand()).toEqual(["bash", "-lc", "openclaw tui"]);
+  });
+
+  it("passes the qualified OpenClaw identity for legacy registry state (#9023)", async () => {
+    const openclaw = loadAgent("openclaw");
+    const sb = sandboxEntry(null);
+    mocks.inspectLaunchReadiness.mockResolvedValue({
+      kind: "accepted",
+      category: "accepted",
+      agent: openclaw,
+      sb,
+    });
+
+    await launchSandbox("alpha");
+
+    expect(mocks.prepareInteractiveSession).not.toHaveBeenCalled();
+    expect(mocks.completeReadinessQualifiedInteractiveSessionSetup).toHaveBeenCalledWith(
+      "alpha",
+      openclaw,
+      sb,
+    );
+    expect(mocks.completeInteractiveSessionSetup).not.toHaveBeenCalled();
+    expect(mocks.publishLaunchReadiness).not.toHaveBeenCalled();
     expect(launchedCommand()).toEqual(["bash", "-lc", "openclaw tui"]);
   });
 
@@ -381,6 +405,7 @@ describe("launchSandbox", () => {
     );
     expect(mocks.completeReadinessQualifiedInteractiveSessionSetup).toHaveBeenCalledWith(
       "alpha",
+      openclaw,
       sb,
     );
     expect(mocks.execSandbox).toHaveBeenCalledOnce();

--- a/src/lib/actions/sandbox/launch.ts
+++ b/src/lib/actions/sandbox/launch.ts
@@ -82,7 +82,7 @@ export async function launchSandbox(
   while (true) {
     if (decision.kind === "accepted") {
       printInteractiveSessionHints(sandboxName);
-      completeReadinessQualifiedInteractiveSessionSetup(sandboxName, decision.sb);
+      completeReadinessQualifiedInteractiveSessionSetup(sandboxName, decision.agent, decision.sb);
       session = { agent: decision.agent, sb: decision.sb };
       break;
     }

--- a/src/lib/onboard/exit-step-failure.test.ts
+++ b/src/lib/onboard/exit-step-failure.test.ts
@@ -104,7 +104,7 @@ describe("terminal step failure helper", () => {
     complete = false;
     listeners[0](1);
     errorSpy.mockRestore();
-    expect(errors.join("\n")).toContain("onboard --resume");
+    expect(errors.join("\n")).toContain("onboard --resume --name <sandbox>");
     expect(errors.join("\n")).toContain("onboard --experimental-profile portable --fresh");
 
     const loaded = requireLoadedSession();
@@ -222,7 +222,16 @@ describe("incomplete-onboard --resume backstop (#6003)", () => {
 
   it("prints the resume hint when a step was in progress at exit", () => {
     session.saveSession(session.createSession({ lastStepStarted: "inference" }));
-    expect(runExitHandler(1)).toContain("onboard --resume");
+    expect(runExitHandler(1)).toContain("onboard --resume --name <sandbox>");
+  });
+
+  it("keeps the short resume hint when the sandbox name was recorded", () => {
+    session.saveSession(
+      session.createSession({ lastStepStarted: "inference", sandboxName: "alpha" }),
+    );
+    const output = runExitHandler(1);
+    expect(output).toContain("onboard --resume");
+    expect(output).not.toContain("--name <sandbox>");
   });
 
   it("stays silent when no step had started", () => {

--- a/src/lib/onboard/exit-step-failure.ts
+++ b/src/lib/onboard/exit-step-failure.ts
@@ -56,7 +56,7 @@ export function registerIncompleteOnboardExitFailureHandler(
     // printOnboardResumeHint also self-dedupes against tailored hints.
     const interrupted = markLastStartedStepFailed(deps, message, true);
     if (!interrupted) return;
-    printOnboardResumeHint(portable);
+    printOnboardResumeHint(portable, undefined, interrupted.sandboxName);
   };
 
   processLike.once("exit", (code) => {

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -167,6 +167,30 @@ describe("isSandboxBridgeGatewayReachable", () => {
     },
   );
 
+  it("does not expose rejected runtime JSON in the rendered daemon diagnostic", async () => {
+    vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
+    const credential = "https://proxy-user:proxy-secret@proxy.example:8443";
+
+    const result = await isSandboxBridgeGatewayReachable({
+      inspectNetworkImpl: () => undefined,
+      runtimeProbeImpl: () => ({
+        status: 0,
+        stdout: JSON.stringify({ HttpProxy: credential, ServerVersion: "" }),
+      }),
+      usesHostGatewayRouteImpl: () => false,
+    });
+    const message = formatSandboxBridgeUnreachableMessage(result);
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "docker_daemon_unreachable",
+      detail: "Docker-compatible runtime info did not contain a recognized daemon version",
+    });
+    expect(message).not.toContain(credential);
+    expect(message).not.toContain("proxy-secret");
+    expect(message).not.toContain("HttpProxy");
+  });
+
   it("classifies an unavailable portable daemon before route inspection completes", async () => {
     vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
     const runtimeProbeImpl = vi.fn(() => ({
@@ -185,7 +209,7 @@ describe("isSandboxBridgeGatewayReachable", () => {
       reason: "docker_daemon_unreachable",
       networkName: "openshell-docker",
     });
-    expect(result.detail).toContain("Cannot connect to Podman");
+    expect(result.detail).toBe("Docker-compatible runtime info probe exited with status 1");
     expect(runtimeProbeImpl).toHaveBeenCalledOnce();
   });
 

--- a/src/lib/onboard/gateway-sandbox-reachability.test.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.test.ts
@@ -123,6 +123,50 @@ describe("isSandboxBridgeGatewayReachable", () => {
     expect(result.detail).toContain("not found");
   });
 
+  it.each([
+    ["Docker", '{"ServerVersion":"29.7.0"}'],
+    ["Podman", '{"version":{"Version":"5.7.0"}}'],
+  ])(
+    "accepts %s JSON when the portable runtime is reachable but its network is not inspectable",
+    async (_runtime, stdout) => {
+      vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
+      const runtimeProbeImpl = vi.fn(() => ({ status: 0, stdout }));
+
+      const result = await isSandboxBridgeGatewayReachable({
+        inspectNetworkImpl: () => undefined,
+        runtimeProbeImpl,
+        timeoutSec: 7,
+        usesHostGatewayRouteImpl: () => false,
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "probe_unavailable",
+        networkName: "openshell-docker",
+      });
+      expect(runtimeProbeImpl).toHaveBeenCalledWith(["info", "--format", "{{json .}}"], 17_000);
+    },
+  );
+
+  it.each(["", "not JSON", "{}"])(
+    "rejects an exit-zero portable runtime response without valid daemon JSON: %j",
+    async (stdout) => {
+      vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
+
+      const result = await isSandboxBridgeGatewayReachable({
+        inspectNetworkImpl: () => undefined,
+        runtimeProbeImpl: () => ({ status: 0, stdout }),
+        usesHostGatewayRouteImpl: () => false,
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        reason: "docker_daemon_unreachable",
+        networkName: "openshell-docker",
+      });
+    },
+  );
+
   it("classifies an unavailable portable daemon before route inspection completes", async () => {
     vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
     const runtimeProbeImpl = vi.fn(() => ({

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -15,6 +15,7 @@ import os from "node:os";
 import { dockerCapture, dockerRun } from "../adapters/docker/run";
 import { failLine, warnLine } from "../cli/terminal-style";
 import { GATEWAY_PORT } from "../core/ports";
+import { parseDockerDaemonObservation } from "../domain/docker-host";
 import { cliDisplayName, cliName } from "./branding";
 import {
   isPortableExperimentalProfile,
@@ -94,7 +95,7 @@ export interface SandboxBridgeReachabilityOptions {
   inspectNetworkImpl?: (networkName: string) => DockerBridgeNetworkInfo | undefined;
   usesHostGatewayRouteImpl?: () => boolean;
 
-  runtimeProbeImpl?: () => SandboxBridgeProbeRunResult;
+  runtimeProbeImpl?: (args: readonly string[], timeoutMs: number) => SandboxBridgeProbeRunResult;
   /** Inject a precomputed image-cache result; bypasses real pre-pull. */
   ensureImageCachedOverride?: import("./preflight").EnsureProbeImageCachedResult;
 }
@@ -205,11 +206,27 @@ function buildOpenShellDockerRoute(
   };
 }
 
-function outputTail(value: unknown): string | undefined {
+function outputText(value: unknown): string | undefined {
   if (value === undefined || value === null) return undefined;
   const raw = Buffer.isBuffer(value) ? value.toString("utf8") : String(value);
   const text = raw.trim();
-  return text ? text.slice(-400) : undefined;
+  return text || undefined;
+}
+
+function outputTail(value: unknown): string | undefined {
+  return outputText(value)?.slice(-400);
+}
+
+function isReachableRuntimeInfo(result: SandboxBridgeProbeRunResult): boolean {
+  if (result.status !== 0) return false;
+  const stdout = outputText(result.stdout);
+  if (!stdout) return false;
+  try {
+    JSON.parse(stdout);
+  } catch {
+    return false;
+  }
+  return parseDockerDaemonObservation(stdout).reachable;
 }
 
 function summarizeProbeResult(result: SandboxBridgeProbeRunResult): string {
@@ -286,13 +303,7 @@ export async function isSandboxBridgeGatewayReachable(
   const runImpl = opts.runImpl ?? defaultRunImpl;
 
   const portableProfile = isPortableExperimentalProfile();
-  const runtimeProbe =
-    opts.runtimeProbeImpl ??
-    (() =>
-      defaultRunImpl(
-        ["info", "--format", "{{.ServerVersion}}"],
-        timeoutSec * 1000 + PROBE_RUN_OVERHEAD_MS,
-      ));
+  const runtimeProbe = opts.runtimeProbeImpl ?? defaultRunImpl;
 
   const network = inspectNetwork(networkName);
   const route = buildOpenShellDockerRoute(
@@ -303,8 +314,11 @@ export async function isSandboxBridgeGatewayReachable(
   );
   if (!route) {
     if (portableProfile) {
-      const runtimeResult = runtimeProbe();
-      if (runtimeResult.status !== 0) {
+      const runtimeResult = runtimeProbe(
+        ["info", "--format", "{{json .}}"],
+        timeoutSec * 1000 + PROBE_RUN_OVERHEAD_MS,
+      );
+      if (!isReachableRuntimeInfo(runtimeResult)) {
         return {
           ok: false,
           reason: "docker_daemon_unreachable",

--- a/src/lib/onboard/gateway-sandbox-reachability.ts
+++ b/src/lib/onboard/gateway-sandbox-reachability.ts
@@ -240,6 +240,22 @@ function summarizeProbeResult(result: SandboxBridgeProbeRunResult): string {
   return details.length > 0 ? details.join(" | ") : "docker run did not complete the probe";
 }
 
+function summarizeRuntimeInfoProbeResult(result: SandboxBridgeProbeRunResult): string {
+  if (isProbeTimeout(result)) {
+    return "Docker-compatible runtime info probe timed out";
+  }
+  if (result.status === 0) {
+    return "Docker-compatible runtime info did not contain a recognized daemon version";
+  }
+  if (result.signal) {
+    return `Docker-compatible runtime info probe ended with signal ${result.signal}`;
+  }
+  if (result.status !== null) {
+    return `Docker-compatible runtime info probe exited with status ${result.status}`;
+  }
+  return "Docker-compatible runtime info probe did not complete";
+}
+
 function isNameResolutionFailure(detail: string): boolean {
   return /bad address|name or service not known|temporary failure in name resolution|could not resolve|getaddrinfo/i.test(
     detail,
@@ -323,7 +339,7 @@ export async function isSandboxBridgeGatewayReachable(
           ok: false,
           reason: "docker_daemon_unreachable",
           networkName,
-          detail: summarizeProbeResult(runtimeResult),
+          detail: summarizeRuntimeInfoProbeResult(runtimeResult),
         };
       }
     }

--- a/src/lib/onboard/resume-hint.test.ts
+++ b/src/lib/onboard/resume-hint.test.ts
@@ -23,14 +23,29 @@ describe("onboard resume hint", () => {
     expect(text).toContain("--fresh");
   });
 
+  it("includes the required name argument when no sandbox name was recorded", () => {
+    const lines: string[] = [];
+    printOnboardResumeHint(false, (message) => lines.push(message), null);
+
+    expect(lines).toContain("    nemoclaw onboard --resume --name <sandbox>");
+  });
+
+  it("keeps the short resume command when the sandbox name was recorded", () => {
+    const lines: string[] = [];
+    printOnboardResumeHint(false, (message) => lines.push(message), "alpha");
+
+    expect(lines).toContain("    nemoclaw onboard --resume");
+    expect(lines.join("\n")).not.toContain("--name <sandbox>");
+  });
+
   it("prints portable resume recovery guidance when the portable env is set (#9035)", () => {
     const prev = process.env[portableEnv];
     process.env[portableEnv] = "portable";
     try {
       const lines: string[] = [];
-      printOnboardResumeHint(undefined, (message) => lines.push(message));
+      printOnboardResumeHint(undefined, (message) => lines.push(message), null);
       const text = lines.join("\n");
-      expect(text).toContain("onboard --resume");
+      expect(text).toContain("onboard --resume --name <sandbox>");
       expect(text).toContain("restored from the checkpoint");
       expect(text).toContain("onboard --experimental-profile portable --fresh");
     } finally {

--- a/src/lib/onboard/resume-hint.ts
+++ b/src/lib/onboard/resume-hint.ts
@@ -4,13 +4,12 @@
 import { CLI_NAME } from "../cli/branding";
 import { isPortableExperimentalProfile } from "./experimental/portable-profile";
 
-export function onboardResumeRecoveryCommand(): string {
-  return `${CLI_NAME} onboard --resume`;
+export function onboardResumeRecoveryCommand(sandboxName?: string | null): string {
+  const nameArg = sandboxName === null ? " --name <sandbox>" : "";
+  return `${CLI_NAME} onboard --resume${nameArg}`;
 }
 
-export function onboardFreshRecoveryCommand(
-  portable = isPortableExperimentalProfile(),
-): string {
+export function onboardFreshRecoveryCommand(portable = isPortableExperimentalProfile()): string {
   return portable
     ? `${CLI_NAME} onboard --experimental-profile portable --fresh`
     : `${CLI_NAME} onboard --fresh`;
@@ -35,19 +34,20 @@ let resumeHintShown = false;
 export function printOnboardResumeHint(
   portable = isPortableExperimentalProfile(),
   log: (message: string) => void = (message) => console.error(message),
+  sandboxName?: string | null,
 ): void {
   if (resumeHintShown) return;
   resumeHintShown = true;
   log("");
   if (portable) {
     log("  Onboarding did not finish. Resume from the step that failed with:");
-    log(`    ${onboardResumeRecoveryCommand()}`);
+    log(`    ${onboardResumeRecoveryCommand(sandboxName)}`);
     log("  The portable profile and rootless Podman authority are restored from the checkpoint.");
     log("  To start over instead, run:");
     log(`    ${onboardFreshRecoveryCommand(true)}`);
   } else {
     log("  Onboarding did not finish. Resume from the step that failed with:");
-    log(`    ${onboardResumeRecoveryCommand()}`);
+    log(`    ${onboardResumeRecoveryCommand(sandboxName)}`);
     log("  Completed steps are skipped; pass --fresh instead to start over.");
   }
 }


### PR DESCRIPTION
## Summary

Prevent portable onboarding from reporting a healthy rootless Podman runtime as unreachable when the OpenShell network is not yet inspectable. Restore the qualified-launch contract for legacy OpenClaw registry entries and print an actionable resume command when onboarding failed before recording a sandbox name.

## Related Issue

Related to #9006.
Follow-up to #9023.

## Changes

- Probe the Docker-compatible runtime with JSON output and validate both Docker and native Podman daemon schemas with the shared parser.
- Keep rejected runtime-info stdout and stderr outside the rendered failure diagnostic while reporting bounded status, signal, timeout, or version-observation outcomes.
- Pass the launch-readiness decision's trusted agent identity into session completion so a legacy `agent: null` OpenClaw entry does not repeat the complete pairing path.
- Preserve complete session setup for non-OpenClaw agents and missing sandbox state.
- Add `--name <sandbox>` to the incomplete-onboarding resume hint when no sandbox name was checkpointed.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing command, troubleshooting, recovery, portable-profile, and gateway-authentication docs already describe these contracts; this PR restores their implementation.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact launch-readiness qualification remains authoritative; only accepted OpenClaw state skips approval, while non-OpenClaw and missing-sandbox states retain complete setup. The runtime probe requires exit-zero, valid Docker or Podman daemon JSON, rejects malformed, empty, or unreachable results, and never renders captured runtime-info output.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing docs already own the unchanged `--resume`/`--name`, portable runtime, and lease-qualified OpenClaw pairing contracts. The review covered the complete 10-file diff, including the bounded user-visible runtime diagnostic and its credential-bearing regression.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5fc6746bf -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## Brev Exact-Head Validation

- Candidate: `5fc6746bf34c38d4c93ef72489a07d5de62f83ba`; causal control: `cc89a7d6fe701845b00f379902c0cfa2888c9fc9`.
- Environment: Brev `nc-1l40sgpu-aug13`, Node 22.23.2, OpenShell 0.0.101, portable rootless Podman through `unix:///run/user/1000/podman/podman.sock`, and the preserved `my-assistant` registry entry with `agent: null`.
- Candidate launch-to-first exact `gateway connected | idle`: 5.228s, 5.265s, 5.428s, and 5.324s; mean 5.311s and median 5.295s. The complete pairing fallback was absent in all four runs.
- Control launch time: 11.364s, 9.788s, and 9.755s; mean 10.302s. The complete pairing fallback ran in all three controls and averaged 4.391s.
- Observed end-to-end mean improvement: 4.991s (48.4%). Probe-only exact-head status was 0 in 1.127s.
- Registry and readiness-receipt hashes remained unchanged. The exact test processes were removed after capture; older pre-existing sessions were preserved.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli` on the five affected test files: 108 passed
- [ ] Applicable broad gate passed — not required for this narrow change; an informational `npm run test:fast` attempt produced 19,730 passes and 16 unrelated host-sensitive failures on macOS temporary-path, filesystem, GNU utility, and timing assumptions
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved sandbox session setup for qualified OpenClaw launches while preserving support for legacy and other supported agent configurations.
  * Enhanced Docker and Podman reachability checks with clearer diagnostics for unavailable, incomplete, timed-out, or unsuccessful probes.
  * Resume guidance now includes the relevant sandbox name and a recovery command when needed.

* **Tests**
  * Added coverage for qualified launches, legacy sandbox records, reachability outcomes, and onboarding recovery hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
