### PR TITLE
fix(hermes): correct pip environment validation

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -1173,6 +1173,7 @@ RUN /opt/hermes/.venv/bin/python -I -m ensurepip --upgrade --default-pip \
         'bin/python -> /usr/bin/python3' \
         'bin/python3 -> python' \
         'bin/python3.13 -> python' \
+        "lib/python3.13/site-packages/certifi/cacert.pem -> $SSL_CERT_FILE" \
         'lib64 -> lib')" \
     && test "$venv_links" = "$expected_venv_links" \
     && test "$(readlink -e /opt/hermes/.venv/bin/python)" = "/usr/bin/python3.13" \
@@ -1186,11 +1187,11 @@ RUN /opt/hermes/.venv/bin/python -I -m ensurepip --upgrade --default-pip \
     && /usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups -- \
         sh -eu -c '\
             /opt/hermes/.venv/bin/python -I -m pip --version >/dev/null; \
-            if printf '' >> /opt/hermes/.venv/.lock 2>/dev/null; then exit 1; fi; \
-            if printf '' >> /opt/hermes/.venv/bin/pip 2>/dev/null; then exit 1; fi; \
-            if printf '' >> /opt/hermes/.venv/lib/python3.13/site-packages/pip/__init__.py 2>/dev/null; then exit 1; fi; \
-            if printf '' >> /opt/hermes/.venv/bin/python 2>/dev/null; then exit 1; fi; \
-            if printf '' > /opt/hermes/.venv/lib64/.nemoclaw-sandbox-write-probe 2>/dev/null; then exit 1; fi; \
+            if printf "" >> /opt/hermes/.venv/.lock 2>/dev/null; then exit 1; fi; \
+            if printf "" >> /opt/hermes/.venv/bin/pip 2>/dev/null; then exit 1; fi; \
+            if printf "" >> /opt/hermes/.venv/lib/python3.13/site-packages/pip/__init__.py 2>/dev/null; then exit 1; fi; \
+            if printf "" >> /opt/hermes/.venv/bin/python 2>/dev/null; then exit 1; fi; \
+            if printf "" > /opt/hermes/.venv/lib64/.nemoclaw-sandbox-write-probe 2>/dev/null; then exit 1; fi; \
             if ln -sf /usr/bin/false /opt/hermes/.venv/bin/python 2>/dev/null; then exit 1; fi' \
     && test ! -e /opt/hermes/.venv/lib/.nemoclaw-sandbox-write-probe \
     && test "$(stat -c '%U:%G %a' /sandbox/.hermes/lazy-packages)" = "sandbox:sandbox 750" \

--- a/test/hermes-dependency-review.test.ts
+++ b/test/hermes-dependency-review.test.ts
@@ -274,6 +274,7 @@ describe("Hermes 0.19.0 dependency review", () => {
       "'bin/python -> /usr/bin/python3'",
       "'bin/python3 -> python'",
       "'bin/python3.13 -> python'",
+      `"lib/python3.13/site-packages/certifi/cacert.pem -> $SSL_CERT_FILE"`,
       "'lib64 -> lib'",
       `test "$venv_links" = "$expected_venv_links"`,
       `test "$(readlink -e /opt/hermes/.venv/bin/python)" = "/usr/bin/python3.13"`,
@@ -283,11 +284,11 @@ describe("Hermes 0.19.0 dependency review", () => {
       "/usr/bin/setpriv --reuid=sandbox --regid=sandbox --init-groups --",
       "sh -eu -c",
       "/opt/hermes/.venv/bin/python -I -m pip --version >/dev/null",
-      `if printf '' >> /opt/hermes/.venv/.lock 2>/dev/null; then exit 1; fi`,
-      `if printf '' >> /opt/hermes/.venv/bin/pip 2>/dev/null; then exit 1; fi`,
-      `if printf '' >> /opt/hermes/.venv/lib/python3.13/site-packages/pip/__init__.py 2>/dev/null; then exit 1; fi`,
-      `if printf '' >> /opt/hermes/.venv/bin/python 2>/dev/null; then exit 1; fi`,
-      `if printf '' > /opt/hermes/.venv/lib64/.nemoclaw-sandbox-write-probe 2>/dev/null; then exit 1; fi`,
+      `if printf "" >> /opt/hermes/.venv/.lock 2>/dev/null; then exit 1; fi`,
+      `if printf "" >> /opt/hermes/.venv/bin/pip 2>/dev/null; then exit 1; fi`,
+      `if printf "" >> /opt/hermes/.venv/lib/python3.13/site-packages/pip/__init__.py 2>/dev/null; then exit 1; fi`,
+      `if printf "" >> /opt/hermes/.venv/bin/python 2>/dev/null; then exit 1; fi`,
+      `if printf "" > /opt/hermes/.venv/lib64/.nemoclaw-sandbox-write-probe 2>/dev/null; then exit 1; fi`,
       `if ln -sf /usr/bin/false /opt/hermes/.venv/bin/python 2>/dev/null; then exit 1; fi`,
       `test ! -e /opt/hermes/.venv/lib/.nemoclaw-sandbox-write-probe`,
       `test "$(stat -c '%U:%G %a' /sandbox/.hermes/lazy-packages)" = "sandbox:sandbox 750"`,
@@ -304,6 +305,7 @@ describe("Hermes 0.19.0 dependency review", () => {
     }
     expect(layer).toContain("-perm /022");
     expect(layer).not.toContain(`test -z "$(find -P /opt/hermes/.venv`);
+    expect(layer).not.toContain(`printf ''`);
 
     const activeUser = instructions
       .filter(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hermes managed-image validation now recognizes the certificate bundle link that the image creates before checking the virtual environment. The sandbox write probes now pass a valid empty format string, so each denial check tests filesystem permissions instead of shell parsing.

## Related Issue

Follow-up to #9094.

## Changes

- Add the certifi certificate bundle link, with its target from `SSL_CERT_FILE`, to the exact sorted link inventory.
- Keep rejecting links outside the approved inventory.
- Correct the five sandbox write probes so they execute the intended empty write.
- Extend the source contract test to cover both corrections.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This corrects internal image-build validation; the existing Hermes plugin and corporate certificate-trust pages already describe the user contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Focused review found no Critical, Major, or blocking gaps.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `docs/manage-sandboxes/install-plugins-hermes.mdx` and `docs/security/configure-corporate-ca-trust.mdx` already cover the user contract; no documentation files changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 346f66eb5c -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration` passed 23 tests across five targeted files; the cached-image probe also passed the corrected link inventory and sandbox denial checks.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual environment validation to ensure certificate configuration is correctly linked.
  * Updated sandbox write checks while preserving existing behavior.
* **Tests**
  * Strengthened lazy-install verification for certificate setup.
  * Added validation to prevent outdated command formatting in sandbox checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->