### PR TITLE
test(e2e): accept current OpenClaw idle status

### DIFF
--- a/test/e2e/live/full-e2e.test.ts
+++ b/test/e2e/live/full-e2e.test.ts
@@ -148,7 +148,7 @@ async function runOpenClawLaunchTurnAfterRecovery(input: {
     env: env(PORTABLE_PROFILE ? { DOCKER_HOST: "" } : {}),
     exitCommand: "/exit",
     host: input.host,
-    postReplyReadyText: "connected | idle",
+    postReplyReadyText: "gateway connected | idle",
     readyText: "gateway connected | idle",
     redactionValues: input.redactionValues,
     sandboxName: SANDBOX_NAME,

--- a/test/e2e/live/launch-readiness-lease-acceptance.test.ts
+++ b/test/e2e/live/launch-readiness-lease-acceptance.test.ts
@@ -38,7 +38,7 @@ test.runIf(process.platform === "linux" && SANDBOX_NAME.length > 0)(
       env: process.env,
       exitCommand: "/exit",
       host,
-      postReplyReadyText: "connected | idle",
+      postReplyReadyText: "gateway connected | idle",
       readyText: "gateway connected | idle",
       redactionValues: [],
       sandboxName: SANDBOX_NAME,

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -88,7 +88,7 @@ it.runIf(process.platform === "linux")(
       env: {},
       exitCommand: "/exit",
       host: host as never,
-      postReplyReadyText: "connected | idle",
+      postReplyReadyText: "gateway connected | idle",
       readyText: "gateway connected | idle",
       redactionValues: [],
       sandboxName: "alpha",
@@ -116,12 +116,12 @@ it.runIf(process.platform === "linux")(
     ]);
     expect(
       calls.slice(1).map((call) => call.env?.NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT),
-    ).toEqual(["connected | idle", "connected | idle"]);
+    ).toEqual(["gateway connected | idle", "gateway connected | idle"]);
   },
 );
 
 it.runIf(process.platform !== "win32")(
-  "waits for 'gateway connected | idle' before the prompt and 'connected | idle' before exit (#9023)",
+  "requires the exact reply before the post-reply 'gateway connected | idle' line (#9023)",
   () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "nemoclaw-launch-turn-ready-"));
     const scriptStub = join(fixtureRoot, "script");
@@ -144,13 +144,18 @@ if IFS= read -r -t 1 -d $'\r' _; then
 fi
 printf 'gateway connected | idle\n' | tee -a "$capture"
 IFS= read -r -d $'\r' _
-printf 'PONG\n' | tee -a "$capture"
 printf 'gateway connected | idle\n' | tee -a "$capture"
 if IFS= read -r -t 1 -d $'\r' _; then
-  echo "exit arrived before post-reply readiness" >&2
+  echo "exit command arrived before the exact reply" >&2
   exit 1
 fi
-printf 'connected | idle\n' | tee -a "$capture"
+printf 'PONG\n' | tee -a "$capture"
+printf 'gateway connected | busy\n' | tee -a "$capture"
+if IFS= read -r -t 1 -d $'\r' _; then
+  echo "exit command arrived while the TUI reported 'gateway connected | busy'" >&2
+  exit 1
+fi
+printf 'gateway connected | idle\n' | tee -a "$capture"
 IFS= read -r -d $'\r' exit_command
 [[ "$exit_command" == "/exit" ]]
 exit 0
@@ -171,7 +176,7 @@ exit 0
           NEMOCLAW_LAUNCH_EXIT_COMMAND: "/exit",
           NEMOCLAW_LAUNCH_EXPECTED_REPLY: "PONG",
           NEMOCLAW_LAUNCH_PROMPT: "prompt",
-          NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT: "connected | idle",
+          NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT: "gateway connected | idle",
           NEMOCLAW_LAUNCH_READY_TEXT: "gateway connected | idle",
           NEMOCLAW_LAUNCH_SANDBOX: "sandbox",
           PATH: `${fixtureRoot}:${process.env.PATH ?? ""}`,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The OpenClaw live E2E jobs received the expected reply and then reported `gateway connected | idle`, but the launch helper still required the obsolete exact line `connected | idle`. This change aligns both live callers with the current exact terminal line while preserving reply-before-idle ordering.

## Changes

- Require `gateway connected | idle` after the exact OpenClaw reply in both live launch paths.
- Extend support coverage to reject an idle line before the reply and a busy line after the reply.
- Close the detection gap that let the support test validate an outdated terminal line.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal E2E terminal-line assertions only; commands, configuration, defaults, supported workflows, and product behavior are unchanged.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit `4a70d0d9d` changes only internal E2E expectations and regression coverage. No documentation contains the affected terminal strings, and no user-facing behavior changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4a70d0d9d -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/e2e/support/launch-agent-turn.test.ts` passed 6 tests with 1 platform-specific skip; `npm run test:titles:check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; the change is limited to two exact live-call expectations and their focused support test.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end readiness checks to expect the clearer “gateway connected | idle” status.
  * Strengthened launch-turn validation to ensure exit commands are sent only after the expected reply and idle signal.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->