### PR TITLE
test(e2e): wait for selected Hermes route

### DIFF
--- a/test/e2e/live/hermes-inference-switch-helpers.ts
+++ b/test/e2e/live/hermes-inference-switch-helpers.ts
@@ -139,6 +139,26 @@ export function expectAuthenticatedProxyResolutionRequests(
   }
 }
 
+export function hasAuthenticatedProxyResolutionRequest(
+  baseline: Pick<FakeOpenAiCompatibleServer, "requests"> | undefined,
+  requestOffset: number,
+  expectedModel: string,
+): boolean {
+  if (!baseline) return true;
+  return baseline
+    .requests()
+    .slice(requestOffset)
+    .some(
+      (request) =>
+        request.method === "POST" &&
+        ["/v1/chat/completions", "/chat/completions"].includes(request.path) &&
+        request.auth === "ok" &&
+        request.authorizationSent === true &&
+        request.model === expectedModel &&
+        (request.forbiddenMarkerMatches ?? 0) === 0,
+    );
+}
+
 export function hostedInstallModel(runtimeEnv: NodeJS.ProcessEnv = process.env): string {
   return (
     runtimeEnv.NEMOCLAW_MODEL ?? runtimeEnv.NEMOCLAW_COMPAT_MODEL ?? DEFAULT_HOSTED_INFERENCE_MODEL
@@ -339,6 +359,7 @@ export async function runHermesPongWithRetry(options: {
 }
 
 export async function runHermesCliPongWithRetry(options: {
+  accept?: (result: ShellProbeResult, attempt: number) => boolean;
   attempts?: number;
   delay?: (milliseconds: number) => Promise<void>;
   run: (attempt: number) => Promise<ShellProbeResult>;
@@ -350,7 +371,8 @@ export async function runHermesCliPongWithRetry(options: {
   let last: ShellProbeResult | undefined;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     last = await options.run(attempt);
-    if ((last.exitCode === 0 && /\bPONG\b/iu.test(last.stdout)) || attempt === attempts)
+    const accepted = options.accept?.(last, attempt) ?? true;
+    if ((last.exitCode === 0 && /\bPONG\b/iu.test(last.stdout) && accepted) || attempt === attempts)
       return last;
     await delay(5_000);
   }

--- a/test/e2e/live/hermes-inference-switch.test.ts
+++ b/test/e2e/live/hermes-inference-switch.test.ts
@@ -20,6 +20,7 @@ import {
   expectedApiMode,
   expectedBaseUrl,
   expectOpenAiProvider,
+  hasAuthenticatedProxyResolutionRequest,
   hashCheck,
   hermesApiCommand,
   hermesGatewayPid,
@@ -428,6 +429,8 @@ test("Hermes inference set updates route/config and preserves live runtime", {
   });
 
   const proxyResolutionCli = await runHermesCliPongWithRetry({
+    accept: () =>
+      hasAuthenticatedProxyResolutionRequest(mockBaseline, requestOffset, proxyResolutionModel),
     run: (attempt) =>
       sandbox.exec(
         SANDBOX_NAME,

--- a/test/e2e/support/hermes-inference-switch-command-shape.test.ts
+++ b/test/e2e/support/hermes-inference-switch-command-shape.test.ts
@@ -18,6 +18,7 @@ import {
   compatibleAnthropicMetadataArgs,
   expectAuthenticatedBaselineInventoryRequest,
   expectAuthenticatedProxyResolutionRequests,
+  hasAuthenticatedProxyResolutionRequest,
   hostedInstallModel,
   inferenceLocalMaxTokens,
   installHermes,
@@ -27,6 +28,7 @@ import {
   openshellGatewayName,
   parseInferenceRoute,
   runHermesInferenceSetWithRetry,
+  runHermesCliPongWithRetry,
   runHermesPongWithRetry,
   SANDBOX_NAME,
 } from "../live/hermes-inference-switch-helpers.ts";
@@ -224,6 +226,45 @@ describe("Hermes inference switch command shape", () => {
     await expect(
       runHermesPongWithRetry({ delay, expectedModel: "target-model", run }),
     ).resolves.toMatchObject({ exitCode: 0 });
+    expect(run.mock.calls).toEqual([[1], [2]]);
+    expect(delay).toHaveBeenCalledWith(5_000);
+  });
+
+  it("retries a Hermes CLI PONG until the selected route receives it", async () => {
+    const requests: Array<{
+      auth: string;
+      authorizationSent: boolean;
+      bodyBytes: number;
+      forbiddenMarkerMatches: number;
+      method: string;
+      model: string;
+      path: string;
+    }> = [];
+    const baseline = { requests: () => requests };
+    const result = { exitCode: 0, stderr: "", stdout: "PONG\n" } as ShellProbeResult;
+    const run = vi.fn(async (attempt: number) => {
+      if (attempt === 2) {
+        requests.push({
+          auth: "ok",
+          authorizationSent: true,
+          bodyBytes: 64,
+          forbiddenMarkerMatches: 0,
+          method: "POST",
+          model: "selected-model",
+          path: "/v1/chat/completions",
+        });
+      }
+      return result;
+    });
+    const delay = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      runHermesCliPongWithRetry({
+        accept: () => hasAuthenticatedProxyResolutionRequest(baseline, 0, "selected-model"),
+        delay,
+        run,
+      }),
+    ).resolves.toBe(result);
     expect(run.mock.calls).toEqual([[1], [2]]);
     expect(delay).toHaveBeenCalledWith(5_000);
   });

--- a/test/e2e/support/hermes-inference-switch-command-shape.test.ts
+++ b/test/e2e/support/hermes-inference-switch-command-shape.test.ts
@@ -242,19 +242,24 @@ describe("Hermes inference switch command shape", () => {
     }> = [];
     const baseline = { requests: () => requests };
     const result = { exitCode: 0, stderr: "", stdout: "PONG\n" } as ShellProbeResult;
-    const recordSelectedRouteAndReturnPong = (_attempt: number): Promise<ShellProbeResult> => {
-      requests.push({
-        auth: "ok",
-        authorizationSent: true,
-        bodyBytes: 64,
-        forbiddenMarkerMatches: 0,
-        method: "POST",
-        model: "selected-model",
-        path: "/v1/chat/completions",
-      });
-      return Promise.resolve(result);
-    };
-    const run = vi.fn(recordSelectedRouteAndReturnPong).mockResolvedValueOnce(result);
+    const authenticatedRequest = (model: string) => ({
+      auth: "ok",
+      authorizationSent: true,
+      bodyBytes: 64,
+      forbiddenMarkerMatches: 0,
+      method: "POST",
+      model,
+      path: "/v1/chat/completions",
+    });
+    const recordRouteAndReturnPong =
+      (model: string) =>
+      (_attempt: number): Promise<ShellProbeResult> => {
+        requests.push(authenticatedRequest(model));
+        return Promise.resolve(result);
+      };
+    const run = vi
+      .fn(recordRouteAndReturnPong("selected-model"))
+      .mockImplementationOnce(recordRouteAndReturnPong("stale-model"));
     const delay = vi.fn().mockResolvedValue(undefined);
 
     await expect(
@@ -264,6 +269,10 @@ describe("Hermes inference switch command shape", () => {
         run,
       }),
     ).resolves.toBe(result);
+    expect(requests).toEqual([
+      authenticatedRequest("stale-model"),
+      authenticatedRequest("selected-model"),
+    ]);
     expect(run.mock.calls).toEqual([[1], [2]]);
     expect(delay).toHaveBeenCalledWith(5_000);
   });

--- a/test/e2e/support/hermes-inference-switch-command-shape.test.ts
+++ b/test/e2e/support/hermes-inference-switch-command-shape.test.ts
@@ -242,20 +242,19 @@ describe("Hermes inference switch command shape", () => {
     }> = [];
     const baseline = { requests: () => requests };
     const result = { exitCode: 0, stderr: "", stdout: "PONG\n" } as ShellProbeResult;
-    const run = vi.fn(async (attempt: number) => {
-      if (attempt === 2) {
-        requests.push({
-          auth: "ok",
-          authorizationSent: true,
-          bodyBytes: 64,
-          forbiddenMarkerMatches: 0,
-          method: "POST",
-          model: "selected-model",
-          path: "/v1/chat/completions",
-        });
-      }
-      return result;
-    });
+    const recordSelectedRouteAndReturnPong = (_attempt: number): Promise<ShellProbeResult> => {
+      requests.push({
+        auth: "ok",
+        authorizationSent: true,
+        bodyBytes: 64,
+        forbiddenMarkerMatches: 0,
+        method: "POST",
+        model: "selected-model",
+        path: "/v1/chat/completions",
+      });
+      return Promise.resolve(result);
+    };
+    const run = vi.fn(recordSelectedRouteAndReturnPong).mockResolvedValueOnce(result);
     const delay = vi.fn().mockResolvedValue(undefined);
 
     await expect(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Hermes proxy-resolution E2E probe could receive `PONG` from the previous route before the selected endpoint began receiving traffic, causing the later strict endpoint check to fail. The probe now keeps retrying until the selected endpoint records an authenticated request for the expected model, while the unchanged final assertion continues to reject credential exposure and incorrect traffic.

## Changes

- Add an optional acceptance condition to the Hermes CLI retry helper.
- Require an authenticated chat request for the expected model before accepting the proxy-resolution `PONG`.
- Add regression coverage for a stale first response followed by selected-route convergence.
- Preserve the final request-set assertion, including its forbidden-marker checks.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal E2E orchestration and regression coverage only; commands, configuration, defaults, supported workflows, and product behavior are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: An independent nine-category security review passed with no findings. Authentication, expected-model, forbidden-marker, and final request-set assertions remain enforced.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Candidate `f4c5dcf80` contains current main and changes only Hermes live E2E orchestration and its support test. The test rejects an authenticated stale-model response, and the final authenticated-request, expected-model, and forbidden-marker assertion remains unchanged.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f4c5dcf80 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: The focused E2E-support suite passed 21/21 tests. CLI build and typecheck, Oxlint, project-membership, source-shape, E2E-phase, and test-title checks also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; the change is limited to one live retry acceptance condition and its focused support coverage.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>
