### PR TITLE
fix(sandbox): unload Ollama models when a sandbox stops

### DIFF
--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -297,7 +297,7 @@ This retry also applies to tight-VRAM hosts where model warm-up can spill from G
 ## Release GPU Memory
 
 When you destroy an Ollama-backed sandbox or stop host services, NemoClaw asks Ollama to unload each currently loaded model by sending `keep_alive: 0`.
-When you stop a single Ollama-backed sandbox, NemoClaw unloads only that sandbox's own model, and keeps it loaded while another Ollama-backed sandbox that uses the same model is still running.
+When you stop a single Ollama-backed sandbox, NemoClaw unloads only that sandbox's own model, and leaves it loaded when another Ollama-backed sandbox uses the same model.
 This cleanup runs on a best-effort basis and does not delete downloaded model files.
 
 ## Related Topics

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -297,7 +297,7 @@ This retry also applies to tight-VRAM hosts where model warm-up can spill from G
 ## Release GPU Memory
 
 When you destroy an Ollama-backed sandbox or stop host services, NemoClaw asks Ollama to unload each currently loaded model by sending `keep_alive: 0`.
-When you stop a single Ollama-backed sandbox, NemoClaw unloads only that sandbox's own model, and leaves it loaded when another Ollama-backed sandbox uses the same model.
+When you stop a single Ollama-backed sandbox, NemoClaw unloads only that sandbox's own model, and keeps it loaded while another Ollama-backed sandbox that uses the same model is still running.
 This cleanup runs on a best-effort basis and does not delete downloaded model files.
 
 ## Related Topics

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -296,7 +296,7 @@ This retry also applies to tight-VRAM hosts where model warm-up can spill from G
 
 ## Release GPU Memory
 
-When you switch away from Ollama, stop host services, or destroy an Ollama-backed sandbox, NemoClaw asks Ollama to unload each currently loaded model by sending `keep_alive: 0`.
+When you stop or destroy an Ollama-backed sandbox, or stop host services, NemoClaw asks Ollama to unload each currently loaded model by sending `keep_alive: 0`.
 This cleanup runs on a best-effort basis and does not delete downloaded model files.
 
 ## Related Topics

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -296,7 +296,8 @@ This retry also applies to tight-VRAM hosts where model warm-up can spill from G
 
 ## Release GPU Memory
 
-When you stop or destroy an Ollama-backed sandbox, or stop host services, NemoClaw asks Ollama to unload each currently loaded model by sending `keep_alive: 0`.
+When you destroy an Ollama-backed sandbox or stop host services, NemoClaw asks Ollama to unload each currently loaded model by sending `keep_alive: 0`.
+When you stop a single Ollama-backed sandbox, NemoClaw unloads only that sandbox's own model, and leaves it loaded when another Ollama-backed sandbox uses the same model.
 This cleanup runs on a best-effort basis and does not delete downloaded model files.
 
 ## Related Topics

--- a/src/lib/actions/sandbox/stop.test.ts
+++ b/src/lib/actions/sandbox/stop.test.ts
@@ -467,3 +467,70 @@ describe("stopSandbox", () => {
     ]);
   });
 });
+
+describe("stopSandbox Ollama GPU release", () => {
+  it("unloads Ollama models so a stop frees GPU memory (#9110)", () => {
+    const unloadOllamaModels = vi.fn();
+    const h = harness({ unloadOllamaModels });
+    h.getSandbox.mockReturnValue(sandbox({ provider: "ollama-local" }));
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(unloadOllamaModels).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases GPU memory on an already-stopped sandbox too (#9110)", () => {
+    const unloadOllamaModels = vi.fn();
+    const h = harness({
+      findLabeledSandboxContainers: () => [container("openshell-my-sandbox", false)],
+      unloadOllamaModels,
+    });
+    h.getSandbox.mockReturnValue(sandbox({ provider: "ollama-local" }));
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(unloadOllamaModels).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["nvidia-prod", sandbox({ provider: "nvidia-prod" })],
+    ["vllm-local", sandbox({ provider: "vllm-local" })],
+    ["an unrecorded provider", sandbox()],
+  ])("leaves %s sandboxes untouched (#9110)", (_label, entry) => {
+    const unloadOllamaModels = vi.fn();
+    const h = harness({ unloadOllamaModels });
+    h.getSandbox.mockReturnValue(entry);
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(unloadOllamaModels).not.toHaveBeenCalled();
+  });
+
+  it("keeps the stop successful and quiet when the unload throws (#9110)", () => {
+    const unloadOllamaModels = vi.fn(() => {
+      throw new Error("curl: command not found");
+    });
+    const h = harness({ unloadOllamaModels });
+    h.getSandbox.mockReturnValue(sandbox({ provider: "ollama-local" }));
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(h.warn).not.toHaveBeenCalled();
+  });
+
+  it("skips the unload when the stop itself failed (#9110)", () => {
+    const unloadOllamaModels = vi.fn();
+    const h = harness({ unloadOllamaModels });
+    h.getSandbox.mockReturnValue(sandbox({ provider: "ollama-local" }));
+    h.dockerStop.mockReturnValue({ status: 125 });
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(1);
+    expect(unloadOllamaModels).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/actions/sandbox/stop.test.ts
+++ b/src/lib/actions/sandbox/stop.test.ts
@@ -475,10 +475,6 @@ describe("stopSandbox Ollama GPU release", () => {
     return () => ({ sandboxes, defaultSandbox: null });
   }
 
-  const peerRunning = () => [{ running: true }];
-  const peerStopped = () => [{ running: false }];
-  const peerUnreported = () => [];
-
   it("unloads the sandbox's own model so a stop frees GPU memory (#9110)", () => {
     const unloadOllamaModels = vi.fn();
     const h = harness({ listSandboxes: registryOf(ollamaSandbox), unloadOllamaModels });
@@ -505,11 +501,10 @@ describe("stopSandbox Ollama GPU release", () => {
     expect(unloadOllamaModels).toHaveBeenCalledWith(["qwen2.5:7b"]);
   });
 
-  it("never unloads a model a running sibling Ollama sandbox also uses (#9110)", () => {
+  it("never unloads a model a sibling Ollama sandbox also uses (#9110)", () => {
     const unloadOllamaModels = vi.fn();
     const peer = sandbox({ model: "qwen2.5:7b", name: "peer", provider: "ollama-local" });
     const h = harness({
-      findSandboxContainers: peerRunning,
       listSandboxes: registryOf(ollamaSandbox, peer),
       unloadOllamaModels,
     });
@@ -528,42 +523,8 @@ describe("stopSandbox Ollama GPU release", () => {
     const unloadOllamaModels = vi.fn();
     const own = sandbox({ model: ownModel, provider: "ollama-local" });
     const peer = sandbox({ model: peerModel, name: "peer", provider: "ollama-local" });
-    const h = harness({
-      findSandboxContainers: peerRunning,
-      listSandboxes: registryOf(own, peer),
-      unloadOllamaModels,
-    });
+    const h = harness({ listSandboxes: registryOf(own, peer), unloadOllamaModels });
     h.getSandbox.mockReturnValue(own);
-
-    stopSandbox("my-sandbox", h.deps);
-
-    expect(unloadOllamaModels).not.toHaveBeenCalled();
-  });
-
-  it("releases the shared model once the last sibling using it is down (#9110)", () => {
-    const unloadOllamaModels = vi.fn();
-    const peer = sandbox({ model: "qwen2.5:7b", name: "peer", provider: "ollama-local" });
-    const h = harness({
-      findSandboxContainers: peerStopped,
-      listSandboxes: registryOf(ollamaSandbox, peer),
-      unloadOllamaModels,
-    });
-    h.getSandbox.mockReturnValue(ollamaSandbox);
-
-    stopSandbox("my-sandbox", h.deps);
-
-    expect(unloadOllamaModels).toHaveBeenCalledWith(["qwen2.5:7b"]);
-  });
-
-  it("keeps a shared model loaded when the sibling reports no containers (#9110)", () => {
-    const unloadOllamaModels = vi.fn();
-    const peer = sandbox({ model: "qwen2.5:7b", name: "peer", provider: "ollama-local" });
-    const h = harness({
-      findSandboxContainers: peerUnreported,
-      listSandboxes: registryOf(ollamaSandbox, peer),
-      unloadOllamaModels,
-    });
-    h.getSandbox.mockReturnValue(ollamaSandbox);
 
     stopSandbox("my-sandbox", h.deps);
 

--- a/src/lib/actions/sandbox/stop.test.ts
+++ b/src/lib/actions/sandbox/stop.test.ts
@@ -475,6 +475,10 @@ describe("stopSandbox Ollama GPU release", () => {
     return () => ({ sandboxes, defaultSandbox: null });
   }
 
+  const peerRunning = () => [{ running: true }];
+  const peerStopped = () => [{ running: false }];
+  const peerUnreported = () => [];
+
   it("unloads the sandbox's own model so a stop frees GPU memory (#9110)", () => {
     const unloadOllamaModels = vi.fn();
     const h = harness({ listSandboxes: registryOf(ollamaSandbox), unloadOllamaModels });
@@ -501,10 +505,11 @@ describe("stopSandbox Ollama GPU release", () => {
     expect(unloadOllamaModels).toHaveBeenCalledWith(["qwen2.5:7b"]);
   });
 
-  it("never unloads a model a sibling Ollama sandbox also uses (#9110)", () => {
+  it("never unloads a model a running sibling Ollama sandbox also uses (#9110)", () => {
     const unloadOllamaModels = vi.fn();
     const peer = sandbox({ model: "qwen2.5:7b", name: "peer", provider: "ollama-local" });
     const h = harness({
+      findSandboxContainers: peerRunning,
       listSandboxes: registryOf(ollamaSandbox, peer),
       unloadOllamaModels,
     });
@@ -523,8 +528,42 @@ describe("stopSandbox Ollama GPU release", () => {
     const unloadOllamaModels = vi.fn();
     const own = sandbox({ model: ownModel, provider: "ollama-local" });
     const peer = sandbox({ model: peerModel, name: "peer", provider: "ollama-local" });
-    const h = harness({ listSandboxes: registryOf(own, peer), unloadOllamaModels });
+    const h = harness({
+      findSandboxContainers: peerRunning,
+      listSandboxes: registryOf(own, peer),
+      unloadOllamaModels,
+    });
     h.getSandbox.mockReturnValue(own);
+
+    stopSandbox("my-sandbox", h.deps);
+
+    expect(unloadOllamaModels).not.toHaveBeenCalled();
+  });
+
+  it("releases the shared model once the last sibling using it is down (#9110)", () => {
+    const unloadOllamaModels = vi.fn();
+    const peer = sandbox({ model: "qwen2.5:7b", name: "peer", provider: "ollama-local" });
+    const h = harness({
+      findSandboxContainers: peerStopped,
+      listSandboxes: registryOf(ollamaSandbox, peer),
+      unloadOllamaModels,
+    });
+    h.getSandbox.mockReturnValue(ollamaSandbox);
+
+    stopSandbox("my-sandbox", h.deps);
+
+    expect(unloadOllamaModels).toHaveBeenCalledWith(["qwen2.5:7b"]);
+  });
+
+  it("keeps a shared model loaded when the sibling reports no containers (#9110)", () => {
+    const unloadOllamaModels = vi.fn();
+    const peer = sandbox({ model: "qwen2.5:7b", name: "peer", provider: "ollama-local" });
+    const h = harness({
+      findSandboxContainers: peerUnreported,
+      listSandboxes: registryOf(ollamaSandbox, peer),
+      unloadOllamaModels,
+    });
+    h.getSandbox.mockReturnValue(ollamaSandbox);
 
     stopSandbox("my-sandbox", h.deps);
 

--- a/src/lib/actions/sandbox/stop.test.ts
+++ b/src/lib/actions/sandbox/stop.test.ts
@@ -469,38 +469,75 @@ describe("stopSandbox", () => {
 });
 
 describe("stopSandbox Ollama GPU release", () => {
-  it("unloads Ollama models so a stop frees GPU memory (#9110)", () => {
+  const ollamaSandbox = sandbox({ model: "qwen2.5:7b", provider: "ollama-local" });
+
+  function registryOf(...sandboxes: SandboxEntry[]) {
+    return () => ({ sandboxes, defaultSandbox: null });
+  }
+
+  it("unloads the sandbox's own model so a stop frees GPU memory (#9110)", () => {
     const unloadOllamaModels = vi.fn();
-    const h = harness({ unloadOllamaModels });
-    h.getSandbox.mockReturnValue(sandbox({ provider: "ollama-local" }));
+    const h = harness({ listSandboxes: registryOf(ollamaSandbox), unloadOllamaModels });
+    h.getSandbox.mockReturnValue(ollamaSandbox);
 
     const result = stopSandbox("my-sandbox", h.deps);
 
     expect(result.exitCode).toBe(0);
-    expect(unloadOllamaModels).toHaveBeenCalledTimes(1);
+    expect(unloadOllamaModels).toHaveBeenCalledWith(["qwen2.5:7b"]);
   });
 
   it("releases GPU memory on an already-stopped sandbox too (#9110)", () => {
     const unloadOllamaModels = vi.fn();
     const h = harness({
       findLabeledSandboxContainers: () => [container("openshell-my-sandbox", false)],
+      listSandboxes: registryOf(ollamaSandbox),
       unloadOllamaModels,
     });
-    h.getSandbox.mockReturnValue(sandbox({ provider: "ollama-local" }));
+    h.getSandbox.mockReturnValue(ollamaSandbox);
 
     const result = stopSandbox("my-sandbox", h.deps);
 
     expect(result.exitCode).toBe(0);
-    expect(unloadOllamaModels).toHaveBeenCalledTimes(1);
+    expect(unloadOllamaModels).toHaveBeenCalledWith(["qwen2.5:7b"]);
+  });
+
+  it("never unloads a model a sibling Ollama sandbox also uses (#9110)", () => {
+    const unloadOllamaModels = vi.fn();
+    const peer = sandbox({ model: "qwen2.5:7b", name: "peer", provider: "ollama-local" });
+    const h = harness({
+      listSandboxes: registryOf(ollamaSandbox, peer),
+      unloadOllamaModels,
+    });
+    h.getSandbox.mockReturnValue(ollamaSandbox);
+
+    const result = stopSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(unloadOllamaModels).not.toHaveBeenCalled();
+  });
+
+  it("still releases its own model when a sibling holds a different one (#9110)", () => {
+    const unloadOllamaModels = vi.fn();
+    const peer = sandbox({ model: "llama3:8b", name: "peer", provider: "ollama-local" });
+    const h = harness({
+      listSandboxes: registryOf(ollamaSandbox, peer),
+      unloadOllamaModels,
+    });
+    h.getSandbox.mockReturnValue(ollamaSandbox);
+
+    stopSandbox("my-sandbox", h.deps);
+
+    expect(unloadOllamaModels).toHaveBeenCalledWith(["qwen2.5:7b"]);
   });
 
   it.each([
-    ["nvidia-prod", sandbox({ provider: "nvidia-prod" })],
-    ["vllm-local", sandbox({ provider: "vllm-local" })],
-    ["an unrecorded provider", sandbox()],
+    ["nvidia-prod", sandbox({ model: "qwen2.5:7b", provider: "nvidia-prod" })],
+    ["vllm-local", sandbox({ model: "qwen2.5:7b", provider: "vllm-local" })],
+    ["an unrecorded provider", sandbox({ model: "qwen2.5:7b" })],
+    ["an unrecorded model", sandbox({ provider: "ollama-local" })],
   ])("leaves %s sandboxes untouched (#9110)", (_label, entry) => {
     const unloadOllamaModels = vi.fn();
-    const h = harness({ unloadOllamaModels });
+    const h = harness({ listSandboxes: registryOf(entry), unloadOllamaModels });
     h.getSandbox.mockReturnValue(entry);
 
     const result = stopSandbox("my-sandbox", h.deps);
@@ -513,8 +550,8 @@ describe("stopSandbox Ollama GPU release", () => {
     const unloadOllamaModels = vi.fn(() => {
       throw new Error("curl: command not found");
     });
-    const h = harness({ unloadOllamaModels });
-    h.getSandbox.mockReturnValue(sandbox({ provider: "ollama-local" }));
+    const h = harness({ listSandboxes: registryOf(ollamaSandbox), unloadOllamaModels });
+    h.getSandbox.mockReturnValue(ollamaSandbox);
 
     const result = stopSandbox("my-sandbox", h.deps);
 
@@ -524,8 +561,8 @@ describe("stopSandbox Ollama GPU release", () => {
 
   it("skips the unload when the stop itself failed (#9110)", () => {
     const unloadOllamaModels = vi.fn();
-    const h = harness({ unloadOllamaModels });
-    h.getSandbox.mockReturnValue(sandbox({ provider: "ollama-local" }));
+    const h = harness({ listSandboxes: registryOf(ollamaSandbox), unloadOllamaModels });
+    h.getSandbox.mockReturnValue(ollamaSandbox);
     h.dockerStop.mockReturnValue({ status: 125 });
 
     const result = stopSandbox("my-sandbox", h.deps);

--- a/src/lib/actions/sandbox/stop.test.ts
+++ b/src/lib/actions/sandbox/stop.test.ts
@@ -516,6 +516,21 @@ describe("stopSandbox Ollama GPU release", () => {
     expect(unloadOllamaModels).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["an implicit latest tag", "llama3", "llama3:latest"],
+    ["an explicit latest tag", "llama3:latest", "llama3"],
+  ])("protects a sibling recorded with %s (#9110)", (_label, ownModel, peerModel) => {
+    const unloadOllamaModels = vi.fn();
+    const own = sandbox({ model: ownModel, provider: "ollama-local" });
+    const peer = sandbox({ model: peerModel, name: "peer", provider: "ollama-local" });
+    const h = harness({ listSandboxes: registryOf(own, peer), unloadOllamaModels });
+    h.getSandbox.mockReturnValue(own);
+
+    stopSandbox("my-sandbox", h.deps);
+
+    expect(unloadOllamaModels).not.toHaveBeenCalled();
+  });
+
   it("still releases its own model when a sibling holds a different one (#9110)", () => {
     const unloadOllamaModels = vi.fn();
     const peer = sandbox({ model: "llama3:8b", name: "peer", provider: "ollama-local" });

--- a/src/lib/actions/sandbox/stop.ts
+++ b/src/lib/actions/sandbox/stop.ts
@@ -27,11 +27,35 @@ function teardownDashboardForwardBestEffort(
   }
 }
 
-function defaultUnloadOllamaModels(): void {
+function defaultUnloadOllamaModels(onlyModels: readonly string[]): void {
   const { unloadOllamaModels } = require("../../inference/ollama/proxy") as {
-    unloadOllamaModels: () => void;
+    unloadOllamaModels: (onlyModels?: readonly string[]) => void;
   };
-  unloadOllamaModels();
+  unloadOllamaModels(onlyModels);
+}
+
+/**
+ * The Ollama model this sandbox alone is holding, or null when there is
+ * nothing safe to release.
+ *
+ * The Ollama daemon is host-global, so unloading everything would evict a
+ * model a sibling sandbox is still using. Release only this sandbox's own
+ * model, and only when no other Ollama-backed sandbox is registered against
+ * the same one.
+ */
+function exclusivelyHeldOllamaModel(
+  sandbox: registry.SandboxEntry,
+  peers: readonly registry.SandboxEntry[],
+): string | null {
+  const model = sandbox.model?.trim();
+  if (!model) return null;
+  const sharedWithPeer = peers.some(
+    (peer) =>
+      peer.name !== sandbox.name &&
+      !!peer.provider?.includes("ollama") &&
+      peer.model?.trim() === model,
+  );
+  return sharedWithPeer ? null : model;
 }
 
 /**
@@ -44,11 +68,14 @@ function defaultUnloadOllamaModels(): void {
  */
 function unloadOllamaModelsBestEffort(
   sandbox: registry.SandboxEntry,
-  unload: (() => void) | undefined,
+  deps: SandboxStopDeps,
 ): void {
   if (!sandbox.provider?.includes("ollama")) return;
   try {
-    (unload ?? defaultUnloadOllamaModels)();
+    const { sandboxes } = (deps.listSandboxes ?? registry.listSandboxes)();
+    const model = exclusivelyHeldOllamaModel(sandbox, sandboxes);
+    if (!model) return;
+    (deps.unloadOllamaModels ?? defaultUnloadOllamaModels)([model]);
   } catch {
     /* Best-effort: a failed unload must not fail the stop. */
   }
@@ -62,7 +89,8 @@ export interface SandboxStopDeps {
   runtimeProviders?: RuntimeProviderBundleRegistry;
   stopSandboxChannels?: typeof stopSandboxChannels;
   teardownSandboxDashboardForward?: typeof teardownSandboxDashboardForward;
-  unloadOllamaModels?: () => void;
+  listSandboxes?: typeof registry.listSandboxes;
+  unloadOllamaModels?: (onlyModels: readonly string[]) => void;
   log?: (message: string) => void;
   warn?: (message: string) => void;
 }
@@ -114,7 +142,7 @@ export function stopSandbox(
   });
   if (outcome.exitCode !== 0) return outcome;
 
-  unloadOllamaModelsBestEffort(resolved.sandbox, deps.unloadOllamaModels);
+  unloadOllamaModelsBestEffort(resolved.sandbox, deps);
 
   if (outcome.state === "already-stopped") {
     log(`  Sandbox '${sandboxName}' is already stopped.`);

--- a/src/lib/actions/sandbox/stop.ts
+++ b/src/lib/actions/sandbox/stop.ts
@@ -34,60 +34,33 @@ function defaultUnloadOllamaModels(onlyModels: readonly string[]): void {
   unloadOllamaModels(onlyModels);
 }
 
-function defaultFindSandboxContainers(sandboxName: string): readonly { running: boolean }[] {
-  const { findLabeledSandboxContainers } = require("../../onboard/docker-driver-sandbox-recovery") as {
-    findLabeledSandboxContainers: (name: string) => readonly { running: boolean }[];
-  };
-  return findLabeledSandboxContainers(sandboxName);
-}
-
-/**
- * A sibling still counts as a live user of its model unless its workload is
- * provably down. An empty container list is not proof: a non-Docker driver
- * reports nothing, and treating that as stopped would evict a model the
- * sibling is using.
- */
-function sandboxIsProvablyStopped(
-  sandboxName: string,
-  findSandboxContainers: (name: string) => readonly { running: boolean }[],
-): boolean {
-  const containers = findSandboxContainers(sandboxName);
-  return containers.length > 0 && containers.every((container) => !container.running);
-}
-
 /**
  * The Ollama model this sandbox alone is holding, or null when there is
  * nothing safe to release.
  *
  * The Ollama daemon is host-global, so unloading everything would evict a
  * model a sibling sandbox is still using. Release only this sandbox's own
- * model, and only once every sibling registered against that model is down —
- * stop preserves registry entries, so a registered sibling is not by itself
- * evidence of use, and requiring it to be gone would strand the model forever.
- * Peers are compared with Ollama's implicit `latest` tag semantics, so a
- * sibling recorded as `llama3` still protects `llama3:latest`.
+ * model, and only when no other Ollama-backed sandbox is registered against
+ * the same one. Peers are compared with Ollama's implicit `latest` tag
+ * semantics, so a sibling recorded as `llama3` still protects `llama3:latest`.
  */
 function exclusivelyHeldOllamaModel(
   sandbox: registry.SandboxEntry,
   peers: readonly registry.SandboxEntry[],
-  findSandboxContainers: (name: string) => readonly { running: boolean }[],
 ): string | null {
   const model = sandbox.model?.trim();
   if (!model) return null;
   const { ollamaModelRefsMatch } = require("../../inference/ollama/model-discovery") as {
     ollamaModelRefsMatch: (left: string, right: string) => boolean;
   };
-  const sharingPeers = peers.filter(
+  const sharedWithPeer = peers.some(
     (peer) =>
       peer.name !== sandbox.name &&
       !!peer.provider?.includes("ollama") &&
       !!peer.model &&
       ollamaModelRefsMatch(peer.model, model),
   );
-  const everySharingPeerIsDown = sharingPeers.every((peer) =>
-    sandboxIsProvablyStopped(peer.name, findSandboxContainers),
-  );
-  return everySharingPeerIsDown ? model : null;
+  return sharedWithPeer ? null : model;
 }
 
 /**
@@ -105,11 +78,7 @@ function unloadOllamaModelsBestEffort(
   if (!sandbox.provider?.includes("ollama")) return;
   try {
     const { sandboxes } = (deps.listSandboxes ?? registry.listSandboxes)();
-    const model = exclusivelyHeldOllamaModel(
-      sandbox,
-      sandboxes,
-      deps.findSandboxContainers ?? defaultFindSandboxContainers,
-    );
+    const model = exclusivelyHeldOllamaModel(sandbox, sandboxes);
     if (!model) return;
     (deps.unloadOllamaModels ?? defaultUnloadOllamaModels)([model]);
   } catch {
@@ -126,7 +95,6 @@ export interface SandboxStopDeps {
   stopSandboxChannels?: typeof stopSandboxChannels;
   teardownSandboxDashboardForward?: typeof teardownSandboxDashboardForward;
   listSandboxes?: typeof registry.listSandboxes;
-  findSandboxContainers?: (name: string) => readonly { running: boolean }[];
   unloadOllamaModels?: (onlyModels: readonly string[]) => void;
   log?: (message: string) => void;
   warn?: (message: string) => void;

--- a/src/lib/actions/sandbox/stop.ts
+++ b/src/lib/actions/sandbox/stop.ts
@@ -27,6 +27,33 @@ function teardownDashboardForwardBestEffort(
   }
 }
 
+function defaultUnloadOllamaModels(): void {
+  const { unloadOllamaModels } = require("../../inference/ollama/proxy") as {
+    unloadOllamaModels: () => void;
+  };
+  unloadOllamaModels();
+}
+
+/**
+ * Release the GPU memory an Ollama-backed sandbox left resident (#9110).
+ *
+ * `stopAll()` and `destroySandbox()` already unload; a plain stop did not, so
+ * the model stayed loaded until Ollama's own idle TTL expired. Best-effort:
+ * the sandbox is already stopped by this point, so GPU cleanup must never
+ * change the exit code.
+ */
+function unloadOllamaModelsBestEffort(
+  sandbox: registry.SandboxEntry,
+  unload: (() => void) | undefined,
+): void {
+  if (!sandbox.provider?.includes("ollama")) return;
+  try {
+    (unload ?? defaultUnloadOllamaModels)();
+  } catch {
+    /* Best-effort: a failed unload must not fail the stop. */
+  }
+}
+
 export type { SandboxLifecycleResult } from "./runtime/lifecycle-runtime";
 
 export interface SandboxStopDeps {
@@ -35,6 +62,7 @@ export interface SandboxStopDeps {
   runtimeProviders?: RuntimeProviderBundleRegistry;
   stopSandboxChannels?: typeof stopSandboxChannels;
   teardownSandboxDashboardForward?: typeof teardownSandboxDashboardForward;
+  unloadOllamaModels?: () => void;
   log?: (message: string) => void;
   warn?: (message: string) => void;
 }
@@ -85,6 +113,8 @@ export function stopSandbox(
     },
   });
   if (outcome.exitCode !== 0) return outcome;
+
+  unloadOllamaModelsBestEffort(resolved.sandbox, deps.unloadOllamaModels);
 
   if (outcome.state === "already-stopped") {
     log(`  Sandbox '${sandboxName}' is already stopped.`);

--- a/src/lib/actions/sandbox/stop.ts
+++ b/src/lib/actions/sandbox/stop.ts
@@ -41,7 +41,8 @@ function defaultUnloadOllamaModels(onlyModels: readonly string[]): void {
  * The Ollama daemon is host-global, so unloading everything would evict a
  * model a sibling sandbox is still using. Release only this sandbox's own
  * model, and only when no other Ollama-backed sandbox is registered against
- * the same one.
+ * the same one. Peers are compared with Ollama's implicit `latest` tag
+ * semantics, so a sibling recorded as `llama3` still protects `llama3:latest`.
  */
 function exclusivelyHeldOllamaModel(
   sandbox: registry.SandboxEntry,
@@ -49,11 +50,15 @@ function exclusivelyHeldOllamaModel(
 ): string | null {
   const model = sandbox.model?.trim();
   if (!model) return null;
+  const { ollamaModelRefsMatch } = require("../../inference/ollama/model-discovery") as {
+    ollamaModelRefsMatch: (left: string, right: string) => boolean;
+  };
   const sharedWithPeer = peers.some(
     (peer) =>
       peer.name !== sandbox.name &&
       !!peer.provider?.includes("ollama") &&
-      peer.model?.trim() === model,
+      !!peer.model &&
+      ollamaModelRefsMatch(peer.model, model),
   );
   return sharedWithPeer ? null : model;
 }

--- a/src/lib/actions/sandbox/stop.ts
+++ b/src/lib/actions/sandbox/stop.ts
@@ -34,33 +34,60 @@ function defaultUnloadOllamaModels(onlyModels: readonly string[]): void {
   unloadOllamaModels(onlyModels);
 }
 
+function defaultFindSandboxContainers(sandboxName: string): readonly { running: boolean }[] {
+  const { findLabeledSandboxContainers } = require("../../onboard/docker-driver-sandbox-recovery") as {
+    findLabeledSandboxContainers: (name: string) => readonly { running: boolean }[];
+  };
+  return findLabeledSandboxContainers(sandboxName);
+}
+
+/**
+ * A sibling still counts as a live user of its model unless its workload is
+ * provably down. An empty container list is not proof: a non-Docker driver
+ * reports nothing, and treating that as stopped would evict a model the
+ * sibling is using.
+ */
+function sandboxIsProvablyStopped(
+  sandboxName: string,
+  findSandboxContainers: (name: string) => readonly { running: boolean }[],
+): boolean {
+  const containers = findSandboxContainers(sandboxName);
+  return containers.length > 0 && containers.every((container) => !container.running);
+}
+
 /**
  * The Ollama model this sandbox alone is holding, or null when there is
  * nothing safe to release.
  *
  * The Ollama daemon is host-global, so unloading everything would evict a
  * model a sibling sandbox is still using. Release only this sandbox's own
- * model, and only when no other Ollama-backed sandbox is registered against
- * the same one. Peers are compared with Ollama's implicit `latest` tag
- * semantics, so a sibling recorded as `llama3` still protects `llama3:latest`.
+ * model, and only once every sibling registered against that model is down —
+ * stop preserves registry entries, so a registered sibling is not by itself
+ * evidence of use, and requiring it to be gone would strand the model forever.
+ * Peers are compared with Ollama's implicit `latest` tag semantics, so a
+ * sibling recorded as `llama3` still protects `llama3:latest`.
  */
 function exclusivelyHeldOllamaModel(
   sandbox: registry.SandboxEntry,
   peers: readonly registry.SandboxEntry[],
+  findSandboxContainers: (name: string) => readonly { running: boolean }[],
 ): string | null {
   const model = sandbox.model?.trim();
   if (!model) return null;
   const { ollamaModelRefsMatch } = require("../../inference/ollama/model-discovery") as {
     ollamaModelRefsMatch: (left: string, right: string) => boolean;
   };
-  const sharedWithPeer = peers.some(
+  const sharingPeers = peers.filter(
     (peer) =>
       peer.name !== sandbox.name &&
       !!peer.provider?.includes("ollama") &&
       !!peer.model &&
       ollamaModelRefsMatch(peer.model, model),
   );
-  return sharedWithPeer ? null : model;
+  const everySharingPeerIsDown = sharingPeers.every((peer) =>
+    sandboxIsProvablyStopped(peer.name, findSandboxContainers),
+  );
+  return everySharingPeerIsDown ? model : null;
 }
 
 /**
@@ -78,7 +105,11 @@ function unloadOllamaModelsBestEffort(
   if (!sandbox.provider?.includes("ollama")) return;
   try {
     const { sandboxes } = (deps.listSandboxes ?? registry.listSandboxes)();
-    const model = exclusivelyHeldOllamaModel(sandbox, sandboxes);
+    const model = exclusivelyHeldOllamaModel(
+      sandbox,
+      sandboxes,
+      deps.findSandboxContainers ?? defaultFindSandboxContainers,
+    );
     if (!model) return;
     (deps.unloadOllamaModels ?? defaultUnloadOllamaModels)([model]);
   } catch {
@@ -95,6 +126,7 @@ export interface SandboxStopDeps {
   stopSandboxChannels?: typeof stopSandboxChannels;
   teardownSandboxDashboardForward?: typeof teardownSandboxDashboardForward;
   listSandboxes?: typeof registry.listSandboxes;
+  findSandboxContainers?: (name: string) => readonly { running: boolean }[];
   unloadOllamaModels?: (onlyModels: readonly string[]) => void;
   log?: (message: string) => void;
   warn?: (message: string) => void;

--- a/src/lib/inference/ollama/proxy.ts
+++ b/src/lib/inference/ollama/proxy.ts
@@ -1217,9 +1217,14 @@ async function prepareOllamaModel(
  * leaving GPU memory reserved. Reverting to async HTTP would reintroduce
  * that race; keep it synchronous.
  *
+ * Pass `onlyModels` to unload just those models and leave every other loaded
+ * model alone. Callers that own the whole host (`stopAll`, `destroySandbox`)
+ * omit it and unload everything; a single-sandbox stop scopes the unload so it
+ * cannot evict a model another sandbox is still using (#9110).
+ *
  * Keep this logic in sync with `test/ollama-gpu-cleanup.test.ts`.
  */
-function unloadOllamaModels() {
+function unloadOllamaModels(onlyModels?: readonly string[]) {
   try {
     const psResult = spawnSync(
       "curl",
@@ -1232,9 +1237,11 @@ function unloadOllamaModels() {
 
     const parsed = JSON.parse(psResult.stdout || "{}");
     const models = Array.isArray(parsed.models) ? parsed.models : [];
+    const selected = onlyModels?.length ? new Set(onlyModels) : null;
 
     for (const entry of models) {
       if (!entry?.name) continue;
+      if (selected && !selected.has(entry.name)) continue;
       // `-sS` deliberately swallows HTTP 4xx/5xx; this path is best-effort
       // and `--fail` would only surface orphaned-GPU-memory failures into
       // unrelated CLI exit codes during destroy. If we ever want explicit

--- a/src/lib/inference/ollama/proxy.ts
+++ b/src/lib/inference/ollama/proxy.ts
@@ -1237,11 +1237,14 @@ function unloadOllamaModels(onlyModels?: readonly string[]) {
 
     const parsed = JSON.parse(psResult.stdout || "{}");
     const models = Array.isArray(parsed.models) ? parsed.models : [];
-    const selected = onlyModels?.length ? new Set(onlyModels) : null;
+    // Compare with Ollama's implicit `latest` tag semantics: a sandbox
+    // recorded as `llama3` must still match the `llama3:latest` that
+    // /api/ps reports, otherwise the scoped unload silently does nothing.
+    const selected = onlyModels?.length ? onlyModels : null;
 
     for (const entry of models) {
       if (!entry?.name) continue;
-      if (selected && !selected.has(entry.name)) continue;
+      if (selected && !selected.some((model) => ollamaModelRefsMatch(model, entry.name))) continue;
       // `-sS` deliberately swallows HTTP 4xx/5xx; this path is best-effort
       // and `--fail` would only surface orphaned-GPU-memory failures into
       // unrelated CLI exit codes during destroy. If we ever want explicit

--- a/test/ollama-gpu-cleanup.test.ts
+++ b/test/ollama-gpu-cleanup.test.ts
@@ -68,6 +68,20 @@ function respondWithLoadedModels(...names: string[]) {
       : ok();
 }
 
+/** The endpoint path and POST body of each unload request, in the order issued. */
+function unloadRequests(calls: readonly SpawnCall[]) {
+  return calls
+    .filter(({ args }) => args.includes("POST"))
+    .map(({ args }) => ({
+      target: new URL(args[args.length - 1]).pathname,
+      body: args[args.indexOf("-d") + 1],
+    }));
+}
+
+function unloadOf(model: string) {
+  return { target: "/api/generate", body: JSON.stringify({ model, keep_alive: 0 }) };
+}
+
 describe("Ollama GPU cleanup", () => {
   it("calls curl synchronously to unload every running model via /api/generate", () => {
     withMockedSpawnSync(
@@ -152,8 +166,7 @@ describe("Ollama GPU cleanup", () => {
 
         const curlCalls = calls.filter(({ command }) => command === "curl");
         expect(curlCalls).toHaveLength(2);
-        expect(curlCalls[1].args).toContain(JSON.stringify({ model: "drop-me:7b", keep_alive: 0 }));
-        expect(curlCalls[1].args[curlCalls[1].args.length - 1]).toMatch(/\/api\/generate$/);
+        expect(unloadRequests(curlCalls)).toEqual([unloadOf("drop-me:7b")]);
       },
     );
   });
@@ -165,7 +178,9 @@ describe("Ollama GPU cleanup", () => {
         const { unloadOllamaModels } = require(modulePath);
         unloadOllamaModels([]);
 
-        expect(calls.filter(({ command }) => command === "curl")).toHaveLength(3);
+        const curlCalls = calls.filter(({ command }) => command === "curl");
+        expect(curlCalls).toHaveLength(3);
+        expect(unloadRequests(curlCalls)).toEqual([unloadOf("one:7b"), unloadOf("two:7b")]);
       },
     );
   });

--- a/test/ollama-gpu-cleanup.test.ts
+++ b/test/ollama-gpu-cleanup.test.ts
@@ -171,6 +171,18 @@ describe("Ollama GPU cleanup", () => {
     );
   });
 
+  it.each([
+    ["an untagged filter against a tagged daemon entry", "llama3", "llama3:latest"],
+    ["a tagged filter against an untagged daemon entry", "llama3:latest", "llama3"],
+  ])("matches %s (#9110)", (_label, filterRef, loadedRef) => {
+    withMockedSpawnSync(respondWithLoadedModels(loadedRef), (calls) => {
+      const { unloadOllamaModels } = require(modulePath);
+      unloadOllamaModels([filterRef]);
+
+      expect(unloadRequests(calls)).toEqual([unloadOf(loadedRef)]);
+    });
+  });
+
   it("unloads every loaded model when the filter is empty (#9110)", () => {
     withMockedSpawnSync(
       respondWithLoadedModels("one:7b", "two:7b"),

--- a/test/ollama-gpu-cleanup.test.ts
+++ b/test/ollama-gpu-cleanup.test.ts
@@ -134,4 +134,41 @@ describe("Ollama GPU cleanup", () => {
       },
     );
   });
+
+  it("unloads only the named models when a filter is supplied (#9110)", () => {
+    withMockedSpawnSync(
+      ({ args }) => {
+        if (args.some((a) => a.endsWith("/api/ps"))) {
+          return ok(JSON.stringify({ models: [{ name: "keep-me:7b" }, { name: "drop-me:7b" }] }));
+        }
+        return ok();
+      },
+      (calls) => {
+        const { unloadOllamaModels } = require(modulePath);
+        unloadOllamaModels(["drop-me:7b"]);
+
+        const curlCalls = calls.filter(({ command }) => command === "curl");
+        expect(curlCalls).toHaveLength(2);
+        expect(curlCalls[1].args).toContain(JSON.stringify({ model: "drop-me:7b", keep_alive: 0 }));
+        expect(curlCalls[1].args[curlCalls[1].args.length - 1]).toMatch(/\/api\/generate$/);
+      },
+    );
+  });
+
+  it("unloads every loaded model when the filter is empty (#9110)", () => {
+    withMockedSpawnSync(
+      ({ args }) => {
+        if (args.some((a) => a.endsWith("/api/ps"))) {
+          return ok(JSON.stringify({ models: [{ name: "one:7b" }, { name: "two:7b" }] }));
+        }
+        return ok();
+      },
+      (calls) => {
+        const { unloadOllamaModels } = require(modulePath);
+        unloadOllamaModels([]);
+
+        expect(calls.filter(({ command }) => command === "curl")).toHaveLength(3);
+      },
+    );
+  });
 });

--- a/test/ollama-gpu-cleanup.test.ts
+++ b/test/ollama-gpu-cleanup.test.ts
@@ -60,6 +60,14 @@ function withMockedSpawnSync<T>(
   }
 }
 
+/** Answer /api/ps with the named models loaded, and every other call with an empty 200. */
+function respondWithLoadedModels(...names: string[]) {
+  return ({ args }: SpawnCall): SpawnSyncReturns<string> =>
+    args.some((a) => a.endsWith("/api/ps"))
+      ? ok(JSON.stringify({ models: names.map((name) => ({ name })) }))
+      : ok();
+}
+
 describe("Ollama GPU cleanup", () => {
   it("calls curl synchronously to unload every running model via /api/generate", () => {
     withMockedSpawnSync(
@@ -137,12 +145,7 @@ describe("Ollama GPU cleanup", () => {
 
   it("unloads only the named models when a filter is supplied (#9110)", () => {
     withMockedSpawnSync(
-      ({ args }) => {
-        if (args.some((a) => a.endsWith("/api/ps"))) {
-          return ok(JSON.stringify({ models: [{ name: "keep-me:7b" }, { name: "drop-me:7b" }] }));
-        }
-        return ok();
-      },
+      respondWithLoadedModels("keep-me:7b", "drop-me:7b"),
       (calls) => {
         const { unloadOllamaModels } = require(modulePath);
         unloadOllamaModels(["drop-me:7b"]);
@@ -157,12 +160,7 @@ describe("Ollama GPU cleanup", () => {
 
   it("unloads every loaded model when the filter is empty (#9110)", () => {
     withMockedSpawnSync(
-      ({ args }) => {
-        if (args.some((a) => a.endsWith("/api/ps"))) {
-          return ok(JSON.stringify({ models: [{ name: "one:7b" }, { name: "two:7b" }] }));
-        }
-        return ok();
-      },
+      respondWithLoadedModels("one:7b", "two:7b"),
       (calls) => {
         const { unloadOllamaModels } = require(modulePath);
         unloadOllamaModels([]);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`nemoclaw <name> stop` left an Ollama-backed sandbox's model resident in GPU memory. Before this change the model stayed loaded until Ollama's own idle TTL expired, so several GB of VRAM remained reserved after a stop reported success. After this change a successful stop asks Ollama to unload that sandbox's model, closing the same gap `destroy` and host-service stop already closed.

## Related Issue

Refs #9110

This PR fixes only the sandbox-stop symptom. #9110 also reports the provider-switch symptom, which is a separate code path and is left for a follow-up, so this does not close the issue.

## Changes

- `src/lib/actions/sandbox/stop.ts`: after a successful stop of an Ollama-backed sandbox, unload the model that sandbox alone is holding. No new capability is introduced — `unloadOllamaModels()` already exists in `src/lib/inference/ollama/proxy.ts` and was already wired into `stopAll()` (`src/lib/tunnel/services.ts`) and `cleanupSandboxServices()` (`src/lib/actions/sandbox/destroy.ts`); the plain stop path was the one lifecycle point it was never hooked into.
  - The provider gate is the existing `provider.includes("ollama")` test already used at `destroy.ts` and `destroy-preflight.ts`, reading the registry entry `stopSandbox` has already resolved. No new config or environment flag.
  - `exclusivelyHeldOllamaModel()` then resolves which model is safe to release: this sandbox's own recorded model, unless a sibling Ollama-backed sandbox declares the same one. Peers are compared with `ollamaModelRefsMatch`, so a sibling recorded as `llama3` still protects `llama3:latest`.
  - The call is placed after the `outcome.exitCode !== 0` guard, so it covers both terminal-success paths (normal stop and already-stopped) with one statement and never runs when the stop itself failed.
  - The default implementation is a lazy `require` inside a closure, copied from the same pattern in `destroy.ts`. This keeps the `@ts-nocheck` proxy module off `stop.ts`'s static load path, so no new static fan-out edge is added.
  - The call is wrapped best-effort: a failing or absent `curl` must not change the exit code of a stop that already succeeded.
- `src/lib/inference/ollama/proxy.ts`: `unloadOllamaModels()` takes an optional `onlyModels` filter. Existing no-argument callers keep the full host sweep. Filter entries are matched with `ollamaModelRefsMatch`, so a sandbox recorded as `llama3` still unloads the `llama3:latest` that `/api/ps` reports — an exact string match silently released nothing for any model pulled without a tag.
- `test/ollama-gpu-cleanup.test.ts`: four proxy-level cases pinning the filtered path, the unfiltered path, and implicit-tag matching in both directions.
- `src/lib/actions/sandbox/stop.test.ts`: twelve `#9110` cases via the new optional `unloadOllamaModels` and `listSandboxes` dependencies on `SandboxStopDeps`.
- `docs/inference/set-up-ollama.mdx`: correct the Release GPU Memory section. It claimed "switch away from Ollama" releases memory, which no code path implements, and omitted sandbox stop entirely. It now names the three implemented triggers and separates their scope: destroy and host-service stop unload every loaded model, while a single sandbox stop unloads only that sandbox's own model and leaves it loaded when another Ollama-backed sandbox uses the same one. See the notes below.

## Behavior notes for reviewers

- **This is the unfinished half of #2638.** That issue's acceptance criteria read "NemoClaw detects stale Ollama runners on provider switch **or sandbox stop**", and PR #2651's merged title was "unload Ollama models from GPU on provider switch and sandbox stop". #2651 hooked `cleanupSandboxServices()`, `sandboxDestroy()`, and `stopAll()` — none of which `nemoclaw <name> stop` reaches. `cleanupSandboxServices` has exactly one caller, `destroy.ts`.
- **The docs change removes a promise, deliberately.** `docs/inference/set-up-ollama.mdx` claimed provider switch releases GPU memory. It does not: `src/lib/onboard.ts` never imports `unloadOllamaModels`, and its only provider-switch teardown, `runSandboxProviderPreDeleteCleanup`, detaches messaging and search providers only. Rather than leave a documented behavior that does not exist, the line now states what is implemented. The clause should be restored when the provider-switch path is wired.
- **The stop-time unload is scoped to the stopping sandbox's own model** (advisor finding `PRA-1`, addressed in `7c3c13e959`). `unloadOllamaModels()` gained an optional model filter: `stopAll()` and `destroySandbox()` own the whole host, omit the filter, and keep unloading everything, so their behavior is byte-for-byte unchanged. Sandbox stop passes only its own recorded model, and skips the unload entirely when another registered Ollama-backed sandbox declares that same model, or when the sandbox has no recorded model. A single-sandbox stop can therefore never evict a model a sibling sandbox is using.
- **Known limitation — two sandboxes recording the same model.** Stop preserves registry entries, so the sibling check cannot tell a registered peer from a running one and suppresses the unload for both. Those sandboxes release nothing on stop and wait for Ollama's idle TTL. That is exactly today's behavior on `main`, so this PR does not regress it, and `destroy` and host-service stop still release. Fixing it properly needs a driver-neutral running-state query, which the runtime-provider contract does not expose: `RuntimeProviderLifecycleSurface` has `start`, `stop`, and `verifyStarted`, and `recovery` only offers `recover(sandbox)`. I attempted it in `caa0d4d5d9` by calling into the Docker recovery module and reverted it in `de4bfcd46f` — `src/lib/actions/sandbox/stop.ts` is contractually driver-neutral and `test/runtime-provider-source-shape.test.ts:111` enforces that. Adding the capability belongs in its own PR.
- **`nemoclaw <name> start` does not re-warm the model**, so the first inference after a stop/start pays a cold load. That is the intended trade for returning the VRAM.
- **Not covered:** `nemoclaw inference set` is a third path that switches providers without unloading. Out of scope here.
- `unloadOllamaModels()` targets `http://localhost:${OLLAMA_PORT}` directly rather than `getResolvedOllamaHost()`. On a remote-Ollama topology it no-ops — but it already no-ops identically in `destroy` today, so this PR neither introduces nor worsens that. Separate defect, not folded in.

## Type of Change

- [x] Code change with doc updates

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Docs updated for user-facing behavior changes
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:

Validation run locally on `de4bfcd46f`:

- `npx vitest run src/lib/actions/sandbox/stop.test.ts test/ollama-gpu-cleanup.test.ts test/destroy-cleanup-sandbox-services.test.ts` — 53 passed, up from 31 on main.
- `tools/growth-guardrails/test-conditionals.mts` — PASS (3 `if` at head vs 3 at base).
- `tools/growth-guardrails/test-size-budget.mts` — PASS.
- `npm run typecheck:cli` — clean.
- `npx oxlint` on both changed source files — clean.
- `npm run test-size:check` — passed (`stop.test.ts` is 588 lines against a 1500 budget).
- `npm run source-shape:check` — `source_shape_cases=0`.
- `npm run format:check` — neither changed file is flagged.
- `npm run docs:check-routes` — OK.

Test coverage added:

| Case | Asserts |
|---|---|
| Ollama-backed stop | unload called once, exit 0 |
| Already-stopped Ollama sandbox | unload called once, exit 0 |
| `nvidia-prod` / `vllm-local` / unrecorded provider | unload not called, exit 0 |
| Unload throws | exit 0 and no warning emitted |
| Docker stop fails | unload not called, exit 1 |
| Sibling Ollama sandbox on the **same** model | unload not called |
| Sibling Ollama sandbox on a **different** model | unload called with only this sandbox's model |
| Sandbox with no recorded model | unload not called |
| Sibling recorded with an implicit vs explicit `latest` tag | unload not called (both directions) |
| Proxy-level: filtered `unloadOllamaModels(["drop-me:7b"])` | one `keep_alive: 0` POST, for that model only |
| Proxy-level: empty filter | every loaded model unloaded |
| Proxy-level: filter `llama3` vs daemon `llama3:latest` | unloaded (both directions) |

Two commits in this branch are a revert pair (`caa0d4d5d9` / `de4bfcd46f`) and cancel out; the net diff is four files. See the known-limitation note above for why.

Branch selection is expressed by per-case fixtures rather than conditionals, so the file stays free of `if` statements and of source-text assertions.

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/inference/set-up-ollama.mdx`
- Agent: Claude Code

Signed-off-by: Dongni Yang <dongniy@nvidia.com>
