### PR TITLE
fix(onboard): preserve Spark Express session when vLLM substitution sets provider mid-step

### DIFF
--- a/src/lib/onboard/station-express-resume.test.ts
+++ b/src/lib/onboard/station-express-resume.test.ts
@@ -1178,8 +1178,12 @@ describe("DGX Spark managed-vLLM Express resume (#7231)", () => {
     expect(reloaded?.stationExpressIntent).toEqual(sparkIntent);
     // A spark Express run is inherently non-interactive.
     expect(normalizeSession({ ...base, mode: "interactive" } as never)).toBeNull();
-    // provider/model must stay null until provider_selection completes.
+    // Provider and model must remain complete and use the Spark Express provider.
     expect(normalizeSession({ ...base, provider: "vllm-local" } as never)).toBeNull();
+    expect(
+      normalizeSession({ ...base, provider: "ollama-local", model: "llama3.1" } as never),
+    ).toBeNull();
+    expect(normalizeSession({ ...base, provider: "vllm-local", model: "" } as never)).toBeNull();
   });
 
   it("carries the intent through capture, reload normalization, and resume restore", async () => {

--- a/src/lib/onboard/station-express-resume.test.ts
+++ b/src/lib/onboard/station-express-resume.test.ts
@@ -1180,10 +1180,12 @@ describe("DGX Spark managed-vLLM Express resume (#7231)", () => {
     expect(normalizeSession({ ...base, mode: "interactive" } as never)).toBeNull();
     // Provider and model must remain complete and use the Spark Express provider.
     expect(normalizeSession({ ...base, provider: "vllm-local" } as never)).toBeNull();
+    expect(normalizeSession({ ...base, model: "llama3.1" } as never)).toBeNull();
     expect(
       normalizeSession({ ...base, provider: "ollama-local", model: "llama3.1" } as never),
     ).toBeNull();
     expect(normalizeSession({ ...base, provider: "vllm-local", model: "" } as never)).toBeNull();
+    expect(normalizeSession({ ...base, provider: "vllm-local", model: "   " } as never)).toBeNull();
   });
 
   it("carries the intent through capture, reload normalization, and resume restore", async () => {

--- a/src/lib/state/onboard-session-station-express.test.ts
+++ b/src/lib/state/onboard-session-station-express.test.ts
@@ -172,6 +172,25 @@ describe("Station Express onboarding session state (#7048)", () => {
     expect(session.normalizeSession(candidate)).toBeNull();
   });
 
+  it("preserves the Spark Express vLLM selection during provider setup (#9103)", () => {
+    session.saveSession(
+      session.createSession({
+        mode: "non-interactive",
+        stationExpressIntent: { version: 1, kind: "spark", sandboxName: "my-assistant" },
+      }),
+    );
+    session.markStepStarted("provider_selection");
+    session.updateSession((state) => {
+      state.provider = "vllm-local";
+      state.model = "nvidia/Qwen3.6-35B-A3B-NVFP4";
+    });
+
+    expect(requireLoadedSession(session.loadSession())).toMatchObject({
+      provider: "vllm-local",
+      model: "nvidia/Qwen3.6-35B-A3B-NVFP4",
+    });
+  });
+
   it("clears resume intent only after successful completion", () => {
     const receipt = path.join(session.SESSION_DIR, "station-express-resume");
     session.saveSession(

--- a/src/lib/state/onboard-session.test.ts
+++ b/src/lib/state/onboard-session.test.ts
@@ -203,18 +203,6 @@ describe("onboard session", () => {
     expect(summary.endpointUrl).toBe(loaded.endpointUrl);
   });
 
-  it("preserves provider on session when spark Express vLLM substitution sets it mid-step (#9103)", () => {
-    session.saveSession(session.createSession({
-      mode: "non-interactive",
-      stationExpressIntent: { version: 1, kind: "spark", sandboxName: "my-assistant" },
-    }));
-    session.markStepStarted("provider_selection");
-    session.updateSession((s) => {
-      s.provider = "vllm-local";
-      s.model = "nvidia/Qwen3.6-35B-A3B-NVFP4";
-    });
-    expect(requireLoadedSession(session.loadSession()).provider).toBe("vllm-local");
-  });
   it("clears a spark Express intent once provider selection completes (#7231)", () => {
     session.saveSession(
       session.createSession({

--- a/src/lib/state/onboard-session.test.ts
+++ b/src/lib/state/onboard-session.test.ts
@@ -203,6 +203,18 @@ describe("onboard session", () => {
     expect(summary.endpointUrl).toBe(loaded.endpointUrl);
   });
 
+  it("preserves provider on session when spark Express vLLM substitution sets it mid-step (#9103)", () => {
+    session.saveSession(session.createSession({
+      mode: "non-interactive",
+      stationExpressIntent: { version: 1, kind: "spark", sandboxName: "my-assistant" },
+    }));
+    session.markStepStarted("provider_selection");
+    session.updateSession((s) => {
+      s.provider = "vllm-local";
+      s.model = "nvidia/Qwen3.6-35B-A3B-NVFP4";
+    });
+    expect(requireLoadedSession(session.loadSession()).provider).toBe("vllm-local");
+  });
   it("clears a spark Express intent once provider selection completes (#7231)", () => {
     session.saveSession(
       session.createSession({

--- a/src/lib/state/onboard-session.ts
+++ b/src/lib/state/onboard-session.ts
@@ -907,14 +907,19 @@ export function normalizeSession(data: Session | SessionJsonValue | undefined): 
     const providerBound = Boolean(
       intent.kind !== "spark" && intent.servedModel && intent.checkpointModel,
     );
+    const incompleteProviderStateValid =
+      (normalized.provider === null && normalized.model === null) ||
+      (intent.kind === "spark" &&
+        normalized.provider === "vllm-local" &&
+        normalized.model !== null &&
+        normalized.model.trim().length > 0);
     if (
       providerComplete !== providerBound ||
       (providerComplete &&
         (intent.kind === "spark" ||
           normalized.provider !== "vllm-local" ||
           normalized.model !== intent.servedModel)) ||
-      // Spark intents have no served-model binding, so provider/model may be set while in_progress.
-      (!providerComplete && intent.kind !== "spark" && (normalized.provider !== null || normalized.model !== null))
+      (!providerComplete && !incompleteProviderStateValid)
     ) {
       return null;
     }

--- a/src/lib/state/onboard-session.ts
+++ b/src/lib/state/onboard-session.ts
@@ -913,7 +913,8 @@ export function normalizeSession(data: Session | SessionJsonValue | undefined): 
         (intent.kind === "spark" ||
           normalized.provider !== "vllm-local" ||
           normalized.model !== intent.servedModel)) ||
-      (!providerComplete && (normalized.provider !== null || normalized.model !== null))
+      // Spark intents have no served-model binding, so provider/model may be set while in_progress.
+      (!providerComplete && intent.kind !== "spark" && (normalized.provider !== null || normalized.model !== null))
     ) {
       return null;
     }


### PR DESCRIPTION
## Summary

Fixes #9103.

On DGX Spark, substituting a running local vLLM instance records the provider and model while provider selection is still in progress. Session validation rejected that state, reset onboarding to `init`, and caused the next state transition to fail.

## Fix

An incomplete Spark Express provider-selection step now accepts only either of these states:

- Provider and model are both unset.
- Provider is `vllm-local` and the model is nonblank after trimming.

Partial provider state, a different provider, and a blank model remain invalid. DGX Station validation is unchanged.

## Test

The focused Spark Express session test preserves a complete `vllm-local` provider and model pair. It also denies provider-only and model-only states, a different provider, and empty or whitespace-only models. The test lives in `src/lib/state/onboard-session-station-express.test.ts` to keep the owning session test file within its size budget.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Docs not applicable: this restores the existing Spark Express provider-selection contract and changes no user command, option, or workflow.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing Spark Express provider-selection contract restored; no user command, option, or workflow changed
- Agent: Codex Desktop
<!-- docs-review-head-sha: 3931e6c4a4 -->
<!-- docs-review-agents-blob-sha: e30afb270b -->

## Verification

- [x] Normal pre-commit and commit-msg hooks passed.
- [x] `npx vitest run --project cli src/lib/state/onboard-session-station-express.test.ts src/lib/onboard/station-express-resume.test.ts`: 88 tests passed.
- [x] `npx vitest run --project cli src/lib/onboard/station-express-resume.test.ts`: 65 tests passed for the added denial cases.
- [x] No secrets, API keys, or credentials committed.

Signed-off-by: yanyunl1991 <yanyunl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Spark Express session handling so selected provider and model details are preserved during setup.
  - Allowed in-progress Spark sessions to retain valid provider/model selections before setup is complete.
  - Continued enforcing provider and model requirements for non-Spark sessions.

- **Tests**
  - Added coverage for local provider and model selections.
  - Expanded validation for incomplete, empty, or unsupported provider/model combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->