### PR TITLE
fix(sandbox): wait for agent startup before detach

### DIFF
--- a/src/lib/onboard/managed-bootstrap/docker-runtime.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-runtime.test.ts
@@ -5,7 +5,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { streamSandboxCreate } from "../../sandbox/create-stream";
+import {
+  dockerEnv,
+  FakeChild,
+  makePollingOptions,
+} from "../../sandbox/create-stream-test-fixtures";
+import { getReadyCheckOutputPatternsForAgent } from "../../sandbox/create-stream-ready-gate";
 
 const adapterMocks = vi.hoisted(() => ({
   activate: vi.fn<typeof import("./adapter").activateManagedBootstrapSequence>(),
@@ -31,7 +39,101 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("Docker managed-bootstrap lifecycle composition", () => {
+  it("activates a Ready managed hold before post-activation startup output", async () => {
+    vi.useFakeTimers();
+    const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-docker-runtime-"));
+    const seed = authority("hermes");
+    const prepared = Object.freeze({}) as ManagedBootstrapPreparedTransaction;
+    const activated = Object.freeze({
+      snapshot: { runtimeId: OLD_ID },
+      replacement: { replacementRuntimeId: NEW_ID },
+    }) as ManagedBootstrapActivatedTransaction;
+    const order: string[] = [];
+    adapterMocks.prepare.mockImplementation(async (_adapter, input) => {
+      order.push("prepare");
+      const receipt = await input.create.launch({
+        heldWorkloadArgv: seed.handle.heldWorkloadArgv,
+        bootstrapIdentity: IDENTITY,
+      });
+      order.push("create-returned");
+      expect(receipt).toEqual(seed.handle.createReceipt);
+      return prepared;
+    });
+    adapterMocks.activate.mockImplementation(async () => {
+      order.push("activate");
+      return activated;
+    });
+    const lifecycle = createDockerManagedBootstrapSurface().createLifecycle({
+      providerId: "docker",
+      stateRoot,
+      bootstrapIdentity: IDENTITY,
+      request: seed.request,
+      image: seed.plan.image,
+      agentIdentity: seed.plan.agentIdentity,
+      intendedWorkloadArgv: seed.plan.intendedWorkloadArgv,
+      expectedSupervisorArgv: seed.plan.expectedSupervisorArgv,
+      launchArgv: ["openshell", "sandbox", "create", "--name", "alpha"],
+      heldWorkloadArgv: seed.handle.heldWorkloadArgv,
+      authorityStore: {
+        recordPreparedAuthority: vi.fn(),
+      },
+      route: "none",
+      persistStartupCommand: false,
+      sandboxName: "alpha",
+      sandboxGpuConfig: {
+        mode: "0",
+        hostGpuDetected: false,
+        hostGpuPlatform: null,
+        sandboxGpuEnabled: false,
+        sandboxGpuDevice: null,
+        errors: [],
+      },
+      requiredLimits: [],
+      timeoutSecs: 30,
+      network: {
+        inferenceProvider: "openai",
+        gatewayUsesContainerBridge: false,
+        gatewayPort: 0,
+      },
+      dependencies: {},
+    });
+    const child = new FakeChild();
+    let ready = false;
+
+    try {
+      const result = lifecycle.runCreate(async () => {
+        order.push("stream-start");
+        const stream = streamSandboxCreate("openshell", ["sandbox", "create"], dockerEnv, {
+          ...makePollingOptions(child),
+          readyCheck: () => ready,
+          readyCheckOutputPatterns: getReadyCheckOutputPatternsForAgent({
+            isTerminalAgent: false,
+            startupRunsDuringCreate: false,
+            env: dockerEnv,
+          }),
+          initialPhase: "create",
+        });
+        child.stdout.emit("data", Buffer.from("Created sandbox: alpha\n"));
+        ready = true;
+        await vi.advanceTimersByTimeAsync(6);
+        expect(order).not.toContain("activate");
+        return { value: await stream, receipt: seed.handle.createReceipt };
+      });
+
+      await expect(result).resolves.toMatchObject({ status: 0, forcedReady: true });
+      expect(order).toEqual(["prepare", "stream-start", "create-returned", "activate"]);
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(adapterMocks.activate).toHaveBeenCalledOnce();
+    } finally {
+      fs.rmSync(stateRoot, { recursive: true, force: true });
+    }
+  });
+
   it("does not finalize rollback after a claimed commit loses acknowledgement", async () => {
     const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-docker-runtime-"));
     const seed = authority("openclaw");

--- a/src/lib/onboard/sandbox-create-step.test.ts
+++ b/src/lib/onboard/sandbox-create-step.test.ts
@@ -266,6 +266,10 @@ describe("runSandboxCreateStep", () => {
     await vi.advanceTimersByTimeAsync(6);
 
     expect(resolved).toBe(false);
+    expect(child.kill).not.toHaveBeenCalled();
+    child.stderr.emit("data", Buffer.from("Setting up NemoClaw...\n"));
+    await vi.advanceTimersByTimeAsync(6);
+
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
     expect(patch.maybeApplyDuringCreate).not.toHaveBeenCalled();
 
@@ -303,7 +307,6 @@ describe("runSandboxCreateStep", () => {
   it.each([
     ["terminal VM", true, vmEnv],
     ["terminal Docker", true, dockerEnv],
-    ["non-terminal Docker", false, dockerEnv],
   ])("detaches immediately for %s", async (_label, isTerminalAgent, env) => {
     vi.useFakeTimers();
 
@@ -342,14 +345,17 @@ describe("runSandboxCreateStep", () => {
     vi.useRealTimers();
   });
 
-  it("waits for startup output for non-terminal VM creates", async () => {
+  it.each([
+    ["VM", vmEnv],
+    ["Docker", dockerEnv],
+  ])("waits for startup output for non-terminal %s creates", async (_label, env) => {
     vi.useFakeTimers();
 
     const child = new FakeChild();
     const logLine = vi.fn();
     const streamOptions = makePollingOptions(child, { logLine });
     const deps = makeDeps(
-      makeLaunch({ sandboxEnv: vmEnv }),
+      makeLaunch({ sandboxEnv: env }),
       makePatch(),
       { status: 0, output: "" },
       {
@@ -404,9 +410,10 @@ describe("runSandboxCreateStep", () => {
     );
 
     const promise = runSandboxCreateStep(makeContext(), deps);
+    await vi.advanceTimersByTimeAsync(0);
     child.stdout.emit("data", Buffer.from("Created sandbox: alpha\n"));
+    child.stderr.emit("data", Buffer.from("Setting up NemoClaw...\n"));
     child.emit("close", 255);
-    await vi.runOnlyPendingTimersAsync();
 
     await expect(promise).resolves.toMatchObject({
       createResult: expect.objectContaining({ status: 0, forcedReady: true }),

--- a/src/lib/onboard/sandbox-create-step.ts
+++ b/src/lib/onboard/sandbox-create-step.ts
@@ -128,10 +128,11 @@ export async function runSandboxCreateStep(
       onPoll: () => {
         if (!deferRestartSafeCutover) dockerGpuCreatePatch.maybeApplyDuringCreate();
       },
-      readyCheckOutputPatterns: getReadyCheckOutputPatternsForAgent(
-        deps.isTerminalAgent(context.agent),
-        sandboxEnv,
-      ),
+      readyCheckOutputPatterns: getReadyCheckOutputPatternsForAgent({
+        isTerminalAgent: deps.isTerminalAgent(context.agent),
+        startupRunsDuringCreate: true,
+        env: sandboxEnv,
+      }),
       failureCheck: dockerGpuCreatePatch.createFailureMessage,
       traceEvent: deps.addTraceEvent,
       waitForReadyTermination: deferRestartSafeCutover,

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -723,6 +723,27 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
     );
   });
 
+  it("waits for native non-terminal startup output before detaching the create client", async () => {
+    const input = createInput();
+    input.sandboxEnv = { OPENSHELL_DRIVERS: "docker" };
+
+    await expect(runSandboxGpuCreateFlow(input, createDeps())).resolves.toMatchObject({
+      route: "native",
+    });
+
+    const streamOptions = mocks.streamSandboxCreate.mock.calls[0]?.[3];
+    expect(streamOptions).toEqual(
+      expect.objectContaining({
+        readyCheckOutputPatterns: [expect.any(RegExp)],
+      }),
+    );
+    expect(
+      streamOptions?.readyCheckOutputPatterns?.some((pattern: RegExp) =>
+        pattern.test("Setting up NemoClaw (Hermes)..."),
+      ),
+    ).toBe(true);
+  });
+
   it("applies exact required limits while preserving the native GPU route", async () => {
     const input = createInput();
     input.persistStartupCommand = true;

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -372,7 +372,7 @@ describe("runSandboxGpuCreateFlow provider-owned managed create", () => {
       "mxc-launch",
       input.createArgv.slice(1),
       input.sandboxEnv,
-      expect.anything(),
+      expect.objectContaining({ readyCheckOutputPatterns: [] }),
     );
     expect(recoverUnfinished.mock.invocationCallOrder[0]).toBeLessThan(
       prepareNetwork.mock.invocationCallOrder[0],

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -226,10 +226,11 @@ export function createSandboxGpuCreateAttemptRunner(
         onPoll: () => {
           if (!deferRestartSafeCutover) runtimePatch.maybeApplyDuringCreate();
         },
-        readyCheckOutputPatterns: getReadyCheckOutputPatternsForAgent(
-          input.terminalAgent,
-          input.sandboxEnv,
-        ),
+        readyCheckOutputPatterns: getReadyCheckOutputPatternsForAgent({
+          isTerminalAgent: input.terminalAgent,
+          startupRunsDuringCreate: managedLifecycle === null,
+          env: input.sandboxEnv,
+        }),
         failureCheck: runtimePatch.createFailureMessage,
         traceEvent: addTraceEvent,
         waitForReadyTermination: deferRestartSafeCutover,

--- a/src/lib/sandbox/create-stream-ready-gate.test.ts
+++ b/src/lib/sandbox/create-stream-ready-gate.test.ts
@@ -54,7 +54,11 @@ describe("sandbox-create-stream ready gate", () => {
     ["terminal Docker", true, dockerEnv],
     ["terminal VM", true, vmEnv],
   ])("keeps agent and env ready gates equivalent for %s", (_label, isTerminalAgent, env) => {
-    const explicitPatterns = getReadyCheckOutputPatternsForAgent(isTerminalAgent, env);
+    const explicitPatterns = getReadyCheckOutputPatternsForAgent({
+      isTerminalAgent,
+      startupRunsDuringCreate: true,
+      env,
+    });
     expect(getReadyCheckOutputPatterns(env, explicitPatterns)).toEqual(explicitPatterns);
   });
 
@@ -62,9 +66,26 @@ describe("sandbox-create-stream ready gate", () => {
     ["Docker", dockerEnv],
     ["VM", vmEnv],
   ])("requires startup output for a non-terminal %s agent", (_label, env) => {
-    const patterns = getReadyCheckOutputPatternsForAgent(false, env);
+    const patterns = getReadyCheckOutputPatternsForAgent({
+      isTerminalAgent: false,
+      startupRunsDuringCreate: true,
+      env,
+    });
     expect(patterns).toHaveLength(1);
     expect(patterns[0]?.test("Setting up NemoClaw (Hermes)...")).toBe(true);
+  });
+
+  it.each([
+    ["Docker", dockerEnv],
+    ["VM", vmEnv],
+  ])("does not wait when non-terminal %s startup follows create", (_label, env) => {
+    expect(
+      getReadyCheckOutputPatternsForAgent({
+        isTerminalAgent: false,
+        startupRunsDuringCreate: false,
+        env,
+      }),
+    ).toEqual([]);
   });
 
   it("ignores process env driver overrides when explicit env is supplied", () => {
@@ -77,7 +98,11 @@ describe("sandbox-create-stream ready gate", () => {
     [
       "non-terminal Docker agent gate",
       dockerEnv,
-      getReadyCheckOutputPatternsForAgent(false, dockerEnv),
+      getReadyCheckOutputPatternsForAgent({
+        isTerminalAgent: false,
+        startupRunsDuringCreate: true,
+        env: dockerEnv,
+      }),
     ],
   ])("waits for startup output before detaching with the %s", async (_label, env, patterns) => {
     vi.useFakeTimers();

--- a/src/lib/sandbox/create-stream-ready-gate.test.ts
+++ b/src/lib/sandbox/create-stream-ready-gate.test.ts
@@ -58,12 +58,28 @@ describe("sandbox-create-stream ready gate", () => {
     expect(getReadyCheckOutputPatterns(env, explicitPatterns)).toEqual(explicitPatterns);
   });
 
+  it.each([
+    ["Docker", dockerEnv],
+    ["VM", vmEnv],
+  ])("requires startup output for a non-terminal %s agent", (_label, env) => {
+    const patterns = getReadyCheckOutputPatternsForAgent(false, env);
+    expect(patterns).toHaveLength(1);
+    expect(patterns[0]?.test("Setting up NemoClaw (Hermes)...")).toBe(true);
+  });
+
   it("ignores process env driver overrides when explicit env is supplied", () => {
     vi.stubEnv("OPENSHELL_DRIVERS", "vm");
     expect(getReadyCheckOutputPatterns(dockerEnv, undefined)).toEqual([]);
   });
 
-  it("waits for startup output before detaching with the default VM gate", async () => {
+  it.each([
+    ["default VM gate", vmEnv, undefined],
+    [
+      "non-terminal Docker agent gate",
+      dockerEnv,
+      getReadyCheckOutputPatternsForAgent(false, dockerEnv),
+    ],
+  ])("waits for startup output before detaching with the %s", async (_label, env, patterns) => {
     vi.useFakeTimers();
 
     const child = new FakeChild();
@@ -71,8 +87,12 @@ describe("sandbox-create-stream ready gate", () => {
     let resolved = false;
     const promise = streamSandboxCreate(
       "echo create",
-      vmEnv,
-      makePollingOptions(child, { readyCheck: () => true, logLine }),
+      env,
+      makePollingOptions(child, {
+        readyCheck: () => true,
+        readyCheckOutputPatterns: patterns,
+        logLine,
+      }),
     ).then((result) => {
       resolved = true;
       return result;

--- a/src/lib/sandbox/create-stream-ready-gate.ts
+++ b/src/lib/sandbox/create-stream-ready-gate.ts
@@ -19,11 +19,12 @@ export function getReadyCheckOutputPatterns(
   return selectedDrivers(env).includes("vm") ? STARTUP_READY_DETACH_OUTPUT_PATTERNS : [];
 }
 
-export function getReadyCheckOutputPatternsForAgent(
-  isTerminalAgent: boolean,
-  env: NodeJS.ProcessEnv,
-): readonly RegExp[] {
-  return isTerminalAgent
+export function getReadyCheckOutputPatternsForAgent(input: {
+  readonly isTerminalAgent: boolean;
+  readonly startupRunsDuringCreate: boolean;
+  readonly env: NodeJS.ProcessEnv;
+}): readonly RegExp[] {
+  return input.isTerminalAgent || !input.startupRunsDuringCreate
     ? []
-    : getReadyCheckOutputPatterns(env, STARTUP_READY_DETACH_OUTPUT_PATTERNS);
+    : getReadyCheckOutputPatterns(input.env, STARTUP_READY_DETACH_OUTPUT_PATTERNS);
 }

--- a/src/lib/sandbox/create-stream-ready-gate.ts
+++ b/src/lib/sandbox/create-stream-ready-gate.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export const VM_READY_DETACH_OUTPUT_PATTERNS: readonly RegExp[] = [/Setting up NemoClaw/];
+export const STARTUP_READY_DETACH_OUTPUT_PATTERNS: readonly RegExp[] = [/Setting up NemoClaw/];
 
 function selectedDrivers(env: NodeJS.ProcessEnv): string[] {
   const raw = env.OPENSHELL_DRIVERS ?? (process.platform === "darwin" ? "vm" : "docker");
@@ -16,12 +16,14 @@ export function getReadyCheckOutputPatterns(
   patterns: readonly RegExp[] | undefined,
 ): readonly RegExp[] {
   if (patterns) return patterns;
-  return selectedDrivers(env).includes("vm") ? VM_READY_DETACH_OUTPUT_PATTERNS : [];
+  return selectedDrivers(env).includes("vm") ? STARTUP_READY_DETACH_OUTPUT_PATTERNS : [];
 }
 
 export function getReadyCheckOutputPatternsForAgent(
   isTerminalAgent: boolean,
   env: NodeJS.ProcessEnv,
 ): readonly RegExp[] {
-  return isTerminalAgent ? [] : getReadyCheckOutputPatterns(env, undefined);
+  return isTerminalAgent
+    ? []
+    : getReadyCheckOutputPatterns(env, STARTUP_READY_DETACH_OUTPUT_PATTERNS);
 }

--- a/test/onboard-sandbox-recreation.test.ts
+++ b/test/onboard-sandbox-recreation.test.ts
@@ -1352,6 +1352,7 @@ childProcess.spawn = (...args) => {
   commands.push({ command: _n([args[0], ...(Array.isArray(args[1]) ? args[1] : [])]), env: args[2]?.env || null, child });
   process.nextTick(() => {
     child.stdout.emit("data", Buffer.from("Created sandbox: my-assistant\n"));
+    child.stderr.emit("data", Buffer.from("Setting up NemoClaw...\n"));
   });
   return child;
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

OpenShell can report a non-terminal Docker sandbox as `Ready` before the agent startup process produces output. For unmanaged creates, the create stream now waits for the existing startup message before it stops the host create client, which prevents a native Hermes sandbox from remaining at `sleep infinity`. Managed-bootstrap creates still detach at authoritative `Ready` so activation can start the held agent workload.

## Changes

- Apply the startup-output gate to unmanaged non-terminal Docker and VM agents.
- Preserve immediate detach behavior for terminal agents, managed-bootstrap creates, and the existing generic create-stream default.
- Add regression coverage for the stream helper, onboarding create step, native GPU path, managed lifecycle ordering, and full onboarding fixture.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal create-stream sequencing. No command, configuration, default, error, or documented lifecycle contract changes; the existing startup-wait progress line can now appear for unmanaged Docker creates.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category review of the final eight-file change found no Critical, Major, or blocking findings and confirmed the managed-bootstrap ordering issue is resolved.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change corrects internal create-stream sequencing. Unmanaged Docker and VM creates now wait for the existing startup message before the host create client detaches. Managed-bootstrap creates still detach when OpenShell reports Ready so activation can start the agent. No command, configuration, default, error, or documented lifecycle contract changes. The OpenClaw and Hermes quickstarts already tell users to wait for the ready summary before checking sandbox status.
- Agent: Codex Desktop
<!-- docs-review-head-sha: ec61870cb -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: The four focused CLI files passed 72 tests, including production managed-lifecycle and create-stream composition. `test/onboard-sandbox-recreation.test.ts` passed all 11 integration tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this is a focused create-stream coordination change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox creation readiness detection across VM and Docker environments.
  * Ensured non-terminal sandboxes wait for NemoClaw startup output before detaching.
  * Improved activation sequencing so it occurs only after sandbox creation is ready.
  * Added recovery coverage for delayed startup output and SSH connection interruptions.

* **Tests**
  * Expanded coverage for terminal and non-terminal sandbox creation, GPU flows, managed providers, and recreation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->