### PR TITLE
fix(hermes): resolve MCP port from managed relay

### DIFF
--- a/agents/hermes/mcp-config-transaction.py
+++ b/agents/hermes/mcp-config-transaction.py
@@ -95,8 +95,11 @@ MAX_ERROR_MESSAGE_LENGTH = 512
 MAX_GATEWAY_PID_RECORD_BYTES = 4096
 MCP_RACE_RECOVERY_ATTEMPTS = 3
 MAX_GATEWAY_PUBLIC_PORT_RECORD_BYTES = 16
-MAX_GATEWAY_ENVIRONMENT_BYTES = 64 * 1024
 GATEWAY_INTERNAL_PORT = 18642
+GATEWAY_NOT_READY_MESSAGE = "Hermes gateway is not running for managed MCP reload"
+MANAGED_API_RELAY_TARGET = f"TCP:127.0.0.1:{GATEWAY_INTERNAL_PORT}".encode()
+MANAGED_API_RELAY_LISTEN_PREFIX = b"TCP-LISTEN:"
+MANAGED_API_RELAY_LISTEN_SUFFIX = b",bind=0.0.0.0,fork,reuseaddr"
 
 
 def _parse_gateway_public_port(raw: str) -> int:
@@ -884,8 +887,7 @@ def _process_parent_pid(pid: int) -> int | None:
     return None
 
 
-def _is_service_manager_process(pid: int) -> bool:
-    arguments = _process_arguments(pid)
+def _is_service_manager_arguments(arguments: list[bytes]) -> bool:
     if not arguments:
         return False
     if arguments == [SERVICE_MANAGER_PATH]:
@@ -895,6 +897,10 @@ def _is_service_manager_process(pid: int) -> bool:
         and len(arguments) == 2
         and arguments[1] == SERVICE_MANAGER_PATH
     )
+
+
+def _is_service_manager_process(pid: int) -> bool:
+    return _is_service_manager_arguments(_process_arguments(pid))
 
 
 def _gateway_has_managed_parent(pid: int) -> bool:
@@ -1040,40 +1046,148 @@ def _gateway_identity() -> tuple[int, object] | None:
     return numeric_pid, start_time
 
 
-def _read_gateway_environment(pid: int) -> bytes:
+def _process_start_identity(pid: int) -> object | None:
+    os.environ["HERMES_HOME"] = HERMES_DIR
+    from gateway.status import get_process_start_time
+
+    return get_process_start_time(pid)
+
+
+def _managed_api_relay_port(arguments: list[bytes]) -> int | None:
+    if (
+        len(arguments) != 3
+        or os.path.basename(arguments[0]) != b"socat"
+        or arguments[2] != MANAGED_API_RELAY_TARGET
+    ):
+        return None
+
+    listen = arguments[1]
+    if not (
+        listen.startswith(MANAGED_API_RELAY_LISTEN_PREFIX)
+        and listen.endswith(MANAGED_API_RELAY_LISTEN_SUFFIX)
+    ):
+        raise PermissionError("Hermes managed API relay arguments are malformed")
+    raw_port = listen[
+        len(MANAGED_API_RELAY_LISTEN_PREFIX) : -len(MANAGED_API_RELAY_LISTEN_SUFFIX)
+    ]
     try:
-        with open(f"/proc/{pid}/environ", "rb") as environment_file:
-            raw = environment_file.read(MAX_GATEWAY_ENVIRONMENT_BYTES + 1)
-    except OSError as error:
-        raise PermissionError("Hermes gateway environment is unavailable") from error
-    if len(raw) > MAX_GATEWAY_ENVIRONMENT_BYTES:
-        raise PermissionError("Hermes gateway environment is too large")
-    return raw
+        decoded = raw_port.decode("ascii")
+    except UnicodeDecodeError as error:
+        raise PermissionError("Hermes managed API relay port is malformed") from error
+    return _parse_gateway_public_port(decoded)
 
 
-def _gateway_environment_public_port(
+def _managed_api_relay_public_port(
     identity: tuple[int, object],
 ) -> int:
+    """Resolve the public port from the service manager's API relay child."""
     gateway_pid = identity[0]
-    environment = _read_gateway_environment(gateway_pid)
-    if _gateway_identity() != identity:
-        raise PermissionError("Hermes gateway identity changed while reading")
+    manager_pid = _process_parent_pid(gateway_pid)
+    if manager_pid is None:
+        raise PermissionError(
+            "Hermes gateway is not running under the managed service lifecycle"
+        )
 
-    prefix = b"NEMOCLAW_HERMES_API_PORT="
-    values = [
-        entry[len(prefix) :]
-        for entry in environment.split(b"\0")
-        if entry.startswith(prefix)
-    ]
-    if len(values) > 1:
-        raise PermissionError("Hermes gateway API port is ambiguous")
-    if not values or not values[0]:
-        return 8642
+    expected_uid = os.geteuid()
     try:
-        decoded = values[0].decode("ascii")
-    except UnicodeDecodeError as error:
-        raise PermissionError("Hermes gateway API port is malformed") from error
-    return _parse_gateway_public_port(decoded)
+        manager_uid = os.stat(f"/proc/{manager_pid}").st_uid
+        manager_arguments = _process_arguments(manager_pid)
+        manager_start = _process_start_identity(manager_pid)
+    except FileNotFoundError:
+        raise RuntimeError(GATEWAY_NOT_READY_MESSAGE) from None
+    except OSError as error:
+        raise PermissionError(
+            "Hermes service manager identity is unavailable"
+        ) from error
+    if (
+        manager_uid != expected_uid
+        or not _is_service_manager_arguments(manager_arguments)
+        or manager_start is None
+    ):
+        raise PermissionError(
+            "Hermes gateway is not running under the managed service lifecycle"
+        )
+
+    # The sandbox user can rewrite same-UID files. An unrelated sandbox process
+    # cannot choose the validated service manager as its parent.
+    candidates: list[tuple[int, object, int, list[bytes]]] = []
+    try:
+        with os.scandir("/proc") as process_entries:
+            process_names = [process_entry.name for process_entry in process_entries]
+    except OSError as error:
+        raise PermissionError("Hermes process table is unavailable") from error
+
+    for name in process_names:
+        if not name.isascii() or not name.isdigit():
+            continue
+        pid = int(name, 10)
+        if pid <= 1 or pid == gateway_pid:
+            continue
+        try:
+            owner_uid = os.stat(f"/proc/{pid}").st_uid
+            parent_pid = _process_parent_pid(pid)
+        except OSError:
+            continue
+        if owner_uid != expected_uid or parent_pid != manager_pid:
+            continue
+        try:
+            arguments = _process_arguments(pid)
+        except OSError as error:
+            raise PermissionError(
+                "Hermes managed API relay identity is unavailable"
+            ) from error
+        port = _managed_api_relay_port(arguments)
+        if port is None:
+            continue
+        try:
+            start_identity = _process_start_identity(pid)
+        except OSError as error:
+            raise PermissionError(
+                "Hermes managed API relay identity is unavailable"
+            ) from error
+        if start_identity is not None:
+            candidates.append((pid, start_identity, port, arguments))
+
+    if not candidates:
+        raise RuntimeError(GATEWAY_NOT_READY_MESSAGE)
+    if len(candidates) != 1:
+        raise PermissionError("Hermes managed API relay identity is ambiguous")
+
+    relay_pid, relay_start, port, relay_arguments = candidates[0]
+    try:
+        relay_owner_uid = os.stat(f"/proc/{relay_pid}").st_uid
+    except FileNotFoundError:
+        raise RuntimeError(GATEWAY_NOT_READY_MESSAGE) from None
+    except OSError as error:
+        raise PermissionError(
+            "Hermes managed API relay identity is unavailable"
+        ) from error
+    try:
+        relay_parent_pid = _process_parent_pid(relay_pid)
+        current_arguments = _process_arguments(relay_pid)
+        current_start = _process_start_identity(relay_pid)
+        current_manager_uid = os.stat(f"/proc/{manager_pid}").st_uid
+        current_manager_arguments = _process_arguments(manager_pid)
+        current_manager_start = _process_start_identity(manager_pid)
+    except FileNotFoundError:
+        raise RuntimeError(GATEWAY_NOT_READY_MESSAGE) from None
+    except OSError as error:
+        raise PermissionError(
+            "Hermes managed API relay identity is unavailable"
+        ) from error
+    if (
+        relay_owner_uid != expected_uid
+        or relay_parent_pid != manager_pid
+        or current_arguments != relay_arguments
+        or current_start != relay_start
+        or current_manager_uid != manager_uid
+        or current_manager_arguments != manager_arguments
+        or current_manager_start != manager_start
+        or _process_parent_pid(gateway_pid) != manager_pid
+        or _gateway_identity() != identity
+    ):
+        raise RuntimeError(GATEWAY_NOT_READY_MESSAGE)
+    return port
 
 
 def _resolve_gateway_public_port() -> int:
@@ -1084,8 +1198,8 @@ def _resolve_gateway_public_port() -> int:
         raise PermissionError("Hermes root API port marker is unavailable")
     identity = _gateway_identity()
     if identity is None:
-        raise PermissionError("Hermes gateway identity is unavailable")
-    return _gateway_environment_public_port(identity)
+        raise RuntimeError(GATEWAY_NOT_READY_MESSAGE)
+    return _managed_api_relay_public_port(identity)
 
 
 def _configure_gateway_public_port() -> None:
@@ -1247,13 +1361,13 @@ def _assert_non_root_lifecycle_identity() -> None:
         )
     identity = _gateway_identity()
     if identity is None:
-        raise RuntimeError("Hermes gateway is not running for managed MCP reload")
+        raise RuntimeError(GATEWAY_NOT_READY_MESSAGE)
     if not _gateway_has_managed_parent(identity[0]):
         raise RuntimeError(
             "Hermes gateway is not running under the managed service lifecycle"
         )
     if _gateway_identity() != identity:
-        raise RuntimeError("Hermes gateway is not running for managed MCP reload")
+        raise RuntimeError(GATEWAY_NOT_READY_MESSAGE)
 
 
 def probe() -> dict[str, object]:

--- a/agents/hermes/mcp-config-transaction.py
+++ b/agents/hermes/mcp-config-transaction.py
@@ -1132,6 +1132,8 @@ def _managed_api_relay_public_port(
             continue
         try:
             arguments = _process_arguments(pid)
+        except FileNotFoundError:
+            continue
         except OSError as error:
             raise PermissionError(
                 "Hermes managed API relay identity is unavailable"
@@ -1141,6 +1143,8 @@ def _managed_api_relay_public_port(
             continue
         try:
             start_identity = _process_start_identity(pid)
+        except FileNotFoundError:
+            continue
         except OSError as error:
             raise PermissionError(
                 "Hermes managed API relay identity is unavailable"

--- a/src/lib/actions/sandbox/openshell-child-visible-credentials.v0.0.101.json
+++ b/src/lib/actions/sandbox/openshell-child-visible-credentials.v0.0.101.json
@@ -41,7 +41,7 @@
       },
       {
         "path": "agents/hermes/mcp-config-transaction.py",
-        "sha256": "08949acbd2394a1191c359ed6745be7bdca0f38026a62a733b9dbb97a519f728"
+        "sha256": "dd150dd66c2afb2136cb3424c3e1e98f598e08b2b5082375138ac050c1bd85e5"
       }
     ]
   },

--- a/src/lib/actions/sandbox/openshell-child-visible-credentials.v0.0.101.json
+++ b/src/lib/actions/sandbox/openshell-child-visible-credentials.v0.0.101.json
@@ -41,7 +41,7 @@
       },
       {
         "path": "agents/hermes/mcp-config-transaction.py",
-        "sha256": "e3e51798c242b7ed54c1dff8203d3e73dbc2b9fcb8c7d271292f6b41f08bdd90"
+        "sha256": "08949acbd2394a1191c359ed6745be7bdca0f38026a62a733b9dbb97a519f728"
       }
     ]
   },

--- a/test/hermes-mcp-api-port.test.ts
+++ b/test/hermes-mcp-api-port.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -12,43 +12,69 @@ const TRANSACTION = path.resolve(
 );
 
 describe("Hermes MCP API port resolution", () => {
-  it("reads the port from a same-identity gateway process environment (#9044)", () => {
-    const gateway = spawn(process.execPath, ["-e", "setTimeout(() => {}, 10000)"], {
-      env: { NEMOCLAW_HERMES_API_PORT: "8645", PATH: process.env.PATH },
-      stdio: "ignore",
-    });
-
-    try {
-      expect(gateway.pid).toBeTypeOf("number");
-      const result = spawnSync(
-        "python3",
-        [
-          "-c",
-          `
-import importlib.util, json, sys, types
+  it("resolves the port from the managed API relay without process environments (#9044)", () => {
+    const result = spawnSync(
+      "python3",
+      [
+        "-c",
+        `
+import builtins, importlib.util, json, sys, types
 sys.modules["yaml"] = types.SimpleNamespace(YAMLError=type("YAMLError", (Exception,), {}))
 spec = importlib.util.spec_from_file_location("mcp_tx", sys.argv[1])
 module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = module
 spec.loader.exec_module(module)
-identity = (int(sys.argv[2]), 333)
-module._gateway_identity = lambda: identity
-print(json.dumps({"port": module._gateway_environment_public_port(identity)}))
-`,
-          TRANSACTION,
-          String(gateway.pid),
-        ],
-        { encoding: "utf8" },
-      );
+identity = (41, 333)
+manager_pid = 40
+relay_pid = 42
+relay_arguments = [
+    b"socat",
+    b"TCP-LISTEN:8645,bind=0.0.0.0,fork,reuseaddr",
+    b"TCP:127.0.0.1:18642",
+]
 
-      expect(result.status, result.stderr).toBe(0);
-      expect(JSON.parse(result.stdout)).toEqual({ port: 8645 });
-    } finally {
-      gateway.kill("SIGKILL");
-    }
+class ProcessEntries:
+    def __enter__(self):
+        return iter(types.SimpleNamespace(name=name) for name in ("self", "1", "41", "42"))
+    def __exit__(self, *_args):
+        return False
+
+owners = {manager_pid: 1000, relay_pid: 1000}
+module._root_gateway_public_port_marker = lambda: None
+module.os.geteuid = lambda: 1000
+module.os.scandir = lambda path: ProcessEntries()
+module.os.stat = lambda path: types.SimpleNamespace(st_uid=owners[int(path.rsplit("/", 1)[1])])
+module._process_parent_pid = lambda pid: manager_pid
+module._process_arguments = lambda pid: [module.SERVICE_MANAGER_PATH] if pid == manager_pid else relay_arguments
+module._process_start_identity = lambda pid: 101 if pid == manager_pid else 202
+module._gateway_identity = lambda: identity
+
+environment_reads = []
+real_open = builtins.open
+def deny_environment(path, *args, **kwargs):
+    if str(path).endswith("/environ"):
+        environment_reads.append(str(path))
+        raise PermissionError("process environments are unavailable")
+    return real_open(path, *args, **kwargs)
+
+builtins.open = deny_environment
+try:
+    port = module._resolve_gateway_public_port()
+finally:
+    builtins.open = real_open
+
+print(json.dumps({"port": port, "environment_reads": environment_reads}))
+`,
+        TRANSACTION,
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ port: 8645, environment_reads: [] });
   });
 
-  it("reads allocated ports from the identity-bound gateway environment (#9044)", () => {
+  it("accepts allocated relay ports and rejects forged relay topology (#9044)", () => {
     const result = spawnSync(
       "python3",
       [
@@ -61,52 +87,63 @@ module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 identity = (41, 333)
-module._gateway_identity = lambda: identity
-opened = []
+manager_pid = 40
+relay_pid = 42
+exact_arguments = [
+    b"socat",
+    b"TCP-LISTEN:8645,bind=0.0.0.0,fork,reuseaddr",
+    b"TCP:127.0.0.1:18642",
+]
 
-accepted = []
-for raw in (b"8642", b"8645", b"8652"):
-    module._read_gateway_environment = (
-        lambda pid, value=raw: opened.append(pid)
-        or b"PATH=/usr/bin\\0NEMOCLAW_HERMES_API_PORT=" + value + b"\\0"
-    )
-    accepted.append(module._gateway_environment_public_port(identity))
+def relay_arguments(raw):
+    return [
+        b"socat",
+        module.MANAGED_API_RELAY_LISTEN_PREFIX + raw + module.MANAGED_API_RELAY_LISTEN_SUFFIX,
+        module.MANAGED_API_RELAY_TARGET,
+    ]
+
+class ProcessEntries:
+    def __enter__(self):
+        return iter((types.SimpleNamespace(name="41"), types.SimpleNamespace(name="42")))
+    def __exit__(self, *_args):
+        return False
+
+def run_candidate(owner=1000, parent=manager_pid, arguments=exact_arguments):
+    owners = {manager_pid: 1000, relay_pid: owner}
+    module.os.geteuid = lambda: 1000
+    module.os.scandir = lambda path: ProcessEntries()
+    module.os.stat = lambda path: types.SimpleNamespace(st_uid=owners[int(path.rsplit("/", 1)[1])])
+    module._process_parent_pid = lambda pid: manager_pid if pid == 41 else parent
+    module._process_arguments = lambda pid: [module.SERVICE_MANAGER_PATH] if pid == manager_pid else arguments
+    module._process_start_identity = lambda pid: 101 if pid == manager_pid else 202
+    module._gateway_identity = lambda: identity
+    try:
+        module._managed_api_relay_public_port(identity)
+    except Exception as error:
+        return type(error).__name__, str(error)
+    raise AssertionError("untrusted relay topology was accepted")
+
+accepted = [module._managed_api_relay_port(relay_arguments(raw)) for raw in (b"8642", b"8645", b"8652")]
 
 rejected = []
-for raw in (
-    b"8641",
-    b"8653",
-    "²".encode("utf-8"),
-    b"8645\\0NEMOCLAW_HERMES_API_PORT=8646",
+for arguments in (
+    relay_arguments(b"8641"),
+    relay_arguments(b"8653"),
+    relay_arguments("²".encode("utf-8")),
+    [b"socat", b"TCP-LISTEN:8645,reuseaddr", module.MANAGED_API_RELAY_TARGET],
 ):
-    module._read_gateway_environment = (
-        lambda pid, value=raw: opened.append(pid)
-        or b"NEMOCLAW_HERMES_API_PORT=" + value + b"\\0"
-    )
     try:
-        module._gateway_environment_public_port(identity)
+        module._managed_api_relay_port(arguments)
     except PermissionError as error:
         rejected.append(str(error))
-
-module._read_gateway_environment = lambda pid: opened.append(pid) or b"PATH=/usr/bin\\0"
-absent = module._gateway_environment_public_port(identity)
-
-module._gateway_identity = lambda: (41, 999)
-module._read_gateway_environment = (
-    lambda pid: opened.append(pid) or b"NEMOCLAW_HERMES_API_PORT=8645\\0"
-)
-identity_change = ""
-try:
-    module._gateway_environment_public_port(identity)
-except PermissionError as error:
-    identity_change = str(error)
 
 print(json.dumps({
     "accepted": accepted,
     "rejected": rejected,
-    "absent": absent,
-    "identity_change": identity_change,
-    "opened": opened,
+    "wrong_owner": run_candidate(owner=2000),
+    "wrong_parent": run_candidate(parent=99),
+    "wrong_executable": run_candidate(arguments=[b"fake-socat", *exact_arguments[1:]]),
+    "wrong_target": run_candidate(arguments=[*exact_arguments[:2], b"TCP:127.0.0.1:18780"]),
 }))
 `,
         TRANSACTION,
@@ -120,44 +157,116 @@ print(json.dumps({
       rejected: [
         "Hermes API port is outside the allocated range",
         "Hermes API port is outside the allocated range",
-        "Hermes gateway API port is malformed",
-        "Hermes gateway API port is ambiguous",
+        "Hermes managed API relay port is malformed",
+        "Hermes managed API relay arguments are malformed",
       ],
-      absent: 8642,
-      identity_change: "Hermes gateway identity changed while reading",
-      opened: Array(9).fill(41),
+      wrong_executable: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],
+      wrong_owner: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],
+      wrong_parent: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],
+      wrong_target: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],
     });
   });
 
-  it("rejects an unavailable gateway environment without using another identity (#9044)", () => {
+  it("classifies changed relay topology as not ready and rejects ambiguous or unreadable topology (#9044)", () => {
     const result = spawnSync(
       "python3",
       [
         "-c",
         `
-import builtins, importlib.util, json, sys, types
+import importlib.util, json, sys, types
 sys.modules["yaml"] = types.SimpleNamespace(YAMLError=type("YAMLError", (Exception,), {}))
 spec = importlib.util.spec_from_file_location("mcp_tx", sys.argv[1])
 module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = module
 spec.loader.exec_module(module)
+identity = (41, 333)
+manager_pid = 40
+relay_arguments = [
+    b"socat",
+    b"TCP-LISTEN:8645,bind=0.0.0.0,fork,reuseaddr",
+    b"TCP:127.0.0.1:18642",
+]
 
-opened = []
-real_open = builtins.open
-def denied(path, *args, **kwargs):
-    opened.append(path)
-    raise PermissionError("denied")
+class ProcessEntries:
+    def __init__(self, pids):
+        self.pids = pids
+    def __enter__(self):
+        return iter(types.SimpleNamespace(name=str(pid)) for pid in self.pids)
+    def __exit__(self, *_args):
+        return False
 
-builtins.open = denied
-message = ""
-try:
-    module._read_gateway_environment(41)
-except PermissionError as error:
-    message = str(error)
-finally:
-    builtins.open = real_open
+def run_case(mutation):
+    relay_pids = [] if mutation == "missing" else ([42, 43] if mutation == "ambiguous" else [42])
+    counters = {
+        "gateway_parent": 0,
+        "manager_arguments": 0,
+        "manager_start": 0,
+        "manager_stat": 0,
+        "relay_start": 0,
+    }
+    module.os.geteuid = lambda: 1000
 
-print(json.dumps({"message": message, "opened": opened}))
+    if mutation == "process_table":
+        module.os.scandir = lambda path: (_ for _ in ()).throw(PermissionError("denied"))
+    else:
+        module.os.scandir = lambda path: ProcessEntries([41, *relay_pids])
+
+    def process_stat(path):
+        pid = int(path.rsplit("/", 1)[1])
+        if pid == manager_pid:
+            counters["manager_stat"] += 1
+            changed = mutation == "manager_owner" and counters["manager_stat"] > 1
+            return types.SimpleNamespace(st_uid=1001 if changed else 1000)
+        return types.SimpleNamespace(st_uid=1000)
+
+    def parent_pid(pid):
+        if pid == 41:
+            counters["gateway_parent"] += 1
+            if mutation == "gateway_parent" and counters["gateway_parent"] > 1:
+                return 99
+        return manager_pid
+
+    def process_arguments(pid):
+        if pid == manager_pid:
+            counters["manager_arguments"] += 1
+            if mutation == "manager_arguments" and counters["manager_arguments"] > 1:
+                return [b"/tmp/unmanaged-start"]
+            return [module.SERVICE_MANAGER_PATH]
+        return relay_arguments
+
+    def process_start(pid):
+        if pid == manager_pid:
+            counters["manager_start"] += 1
+            if mutation == "manager_start" and counters["manager_start"] > 1:
+                return 102
+            return 101
+        counters["relay_start"] += 1
+        if mutation == "relay_start" and counters["relay_start"] > 1:
+            return 203
+        return 202 + (pid - 42)
+
+    module.os.stat = process_stat
+    module._process_parent_pid = parent_pid
+    module._process_arguments = process_arguments
+    module._process_start_identity = process_start
+    module._gateway_identity = lambda: identity
+    try:
+        module._managed_api_relay_public_port(identity)
+    except Exception as error:
+        return type(error).__name__, str(error)
+    raise AssertionError("unstable relay topology was accepted")
+
+results = {case: run_case(case) for case in (
+    "missing",
+    "relay_start",
+    "manager_owner",
+    "manager_arguments",
+    "manager_start",
+    "gateway_parent",
+    "ambiguous",
+    "process_table",
+)}
+print(json.dumps(results, sort_keys=True))
 `,
         TRANSACTION,
       ],
@@ -166,8 +275,14 @@ print(json.dumps({"message": message, "opened": opened}))
 
     expect(result.status, result.stderr).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({
-      message: "Hermes gateway environment is unavailable",
-      opened: ["/proc/41/environ"],
+      ambiguous: ["PermissionError", "Hermes managed API relay identity is ambiguous"],
+      gateway_parent: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],
+      manager_arguments: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],
+      manager_owner: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],
+      manager_start: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],
+      missing: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],
+      process_table: ["PermissionError", "Hermes process table is unavailable"],
+      relay_start: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],
     });
   });
 
@@ -306,7 +421,7 @@ print(json.dumps({
     });
   });
 
-  it("prefers the root marker over the gateway environment (#8543)", () => {
+  it("prefers the root marker over managed relay discovery (#8543)", () => {
     const result = spawnSync(
       "python3",
       [
@@ -320,7 +435,7 @@ sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 
 module._gateway_identity = lambda: (41, 333)
-module._gateway_environment_public_port = lambda identity: 8649
+module._managed_api_relay_public_port = lambda identity: 8649
 
 module._root_gateway_public_port_marker = lambda: 8647
 marker_wins = module._resolve_gateway_public_port()
@@ -336,13 +451,13 @@ except PermissionError as error:
     root_without_marker = str(error)
 
 module.os.geteuid = lambda: 1000
-same_uid_fallback = module._resolve_gateway_public_port()
+same_uid_relay = module._resolve_gateway_public_port()
 
 module._gateway_identity = lambda: None
 without_identity = ""
 try:
     module._resolve_gateway_public_port()
-except PermissionError as error:
+except RuntimeError as error:
     without_identity = str(error)
 
 module.os.geteuid = real_geteuid
@@ -350,7 +465,7 @@ module.os.geteuid = real_geteuid
 print(json.dumps({
     "marker_wins": marker_wins,
     "root_without_marker": root_without_marker,
-    "same_uid_fallback": same_uid_fallback,
+    "same_uid_relay": same_uid_relay,
     "without_identity": without_identity,
 }))
 `,
@@ -363,8 +478,8 @@ print(json.dumps({
     expect(JSON.parse(result.stdout)).toEqual({
       marker_wins: 8647,
       root_without_marker: "Hermes root API port marker is unavailable",
-      same_uid_fallback: 8649,
-      without_identity: "Hermes gateway identity is unavailable",
+      same_uid_relay: 8649,
+      without_identity: "Hermes gateway is not running for managed MCP reload",
     });
   });
 

--- a/test/hermes-mcp-api-port.test.ts
+++ b/test/hermes-mcp-api-port.test.ts
@@ -196,12 +196,19 @@ class ProcessEntries:
         return False
 
 def run_case(mutation):
-    relay_pids = [] if mutation == "missing" else ([42, 43] if mutation == "ambiguous" else [42])
+    relay_pids = (
+        []
+        if mutation == "missing"
+        else [42, 43]
+        if mutation in ("ambiguous", "candidate_arguments_exit", "candidate_start_exit")
+        else [42]
+    )
     counters = {
         "gateway_parent": 0,
         "manager_arguments": 0,
         "manager_start": 0,
         "manager_stat": 0,
+        "relay_arguments": 0,
         "relay_start": 0,
     }
     module.os.geteuid = lambda: 1000
@@ -232,6 +239,11 @@ def run_case(mutation):
             if mutation == "manager_arguments" and counters["manager_arguments"] > 1:
                 return [b"/tmp/unmanaged-start"]
             return [module.SERVICE_MANAGER_PATH]
+        counters["relay_arguments"] += 1
+        if mutation == "candidate_arguments_exit" and counters["relay_arguments"] == 1:
+            raise FileNotFoundError("relay exited")
+        if mutation == "candidate_arguments_denied":
+            raise PermissionError("relay arguments denied")
         return relay_arguments
 
     def process_start(pid):
@@ -241,6 +253,10 @@ def run_case(mutation):
                 return 102
             return 101
         counters["relay_start"] += 1
+        if mutation == "candidate_start_exit" and counters["relay_start"] == 1:
+            raise FileNotFoundError("relay exited")
+        if mutation == "candidate_start_denied":
+            raise PermissionError("relay start identity denied")
         if mutation == "relay_start" and counters["relay_start"] > 1:
             return 203
         return 202 + (pid - 42)
@@ -251,13 +267,19 @@ def run_case(mutation):
     module._process_start_identity = process_start
     module._gateway_identity = lambda: identity
     try:
-        module._managed_api_relay_public_port(identity)
+        port = module._managed_api_relay_public_port(identity)
     except Exception as error:
         return type(error).__name__, str(error)
+    if mutation in ("candidate_arguments_exit", "candidate_start_exit"):
+        return port
     raise AssertionError("unstable relay topology was accepted")
 
 results = {case: run_case(case) for case in (
     "missing",
+    "candidate_arguments_exit",
+    "candidate_arguments_denied",
+    "candidate_start_exit",
+    "candidate_start_denied",
     "relay_start",
     "manager_owner",
     "manager_arguments",
@@ -276,6 +298,16 @@ print(json.dumps(results, sort_keys=True))
     expect(result.status, result.stderr).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({
       ambiguous: ["PermissionError", "Hermes managed API relay identity is ambiguous"],
+      candidate_arguments_denied: [
+        "PermissionError",
+        "Hermes managed API relay identity is unavailable",
+      ],
+      candidate_arguments_exit: 8645,
+      candidate_start_denied: [
+        "PermissionError",
+        "Hermes managed API relay identity is unavailable",
+      ],
+      candidate_start_exit: 8645,
       gateway_parent: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],
       manager_arguments: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],
       manager_owner: ["RuntimeError", "Hermes gateway is not running for managed MCP reload"],

--- a/test/openshell-0.0.101-migration-review.test.ts
+++ b/test/openshell-0.0.101-migration-review.test.ts
@@ -230,7 +230,7 @@ describe("OpenShell 0.0.101 migration review", () => {
         },
         {
           path: "agents/hermes/mcp-config-transaction.py",
-          sha256: "08949acbd2394a1191c359ed6745be7bdca0f38026a62a733b9dbb97a519f728",
+          sha256: "dd150dd66c2afb2136cb3424c3e1e98f598e08b2b5082375138ac050c1bd85e5",
         },
       ],
     });

--- a/test/openshell-0.0.101-migration-review.test.ts
+++ b/test/openshell-0.0.101-migration-review.test.ts
@@ -230,7 +230,7 @@ describe("OpenShell 0.0.101 migration review", () => {
         },
         {
           path: "agents/hermes/mcp-config-transaction.py",
-          sha256: "e3e51798c242b7ed54c1dff8203d3e73dbc2b9fcb8c7d271292f6b41f08bdd90",
+          sha256: "08949acbd2394a1191c359ed6745be7bdca0f38026a62a733b9dbb97a519f728",
         },
       ],
     });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

OpenShell denies the Hermes sandbox user access to the gateway process environment, so managed MCP mutations could not recover the allocated API port. The transaction helper now resolves that port from the service manager's exact `socat` API relay and revalidates the gateway, manager, and relay identities before accepting it.

## Changes

- Remove gateway `/proc/*/environ` reads from managed MCP port resolution.
- Accept only one same-owner relay with the expected parent, executable, listen range, and internal API target.
- Revalidate process ownership, parentage, arguments, and start identities before using the port.
- Treat missing or changing topology as transient while malformed, unreadable, or ambiguous topology fails closed.
- Continue scanning when a candidate relay exits during argument or start-identity reads, while preserving fail-closed handling for other access errors.
- Refresh the reviewed OpenShell integrity evidence and add regression coverage for forged and changing relay topology.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This restores internal managed MCP port discovery without changing commands, configuration, defaults, or documented workflows.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent review of the final four-file change found no Critical, Major, or blocking findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed `docs/deployment/set-up-mcp-bridge.mdx`, `docs/manage-sandboxes/gateway-lifecycle-control.mdx`, `docs/reference/troubleshoot-mcp-servers.mdx`, and `docs/index.yml` against the final Hermes transaction helper, integrity manifest, port regression tests, and migration integrity test. The change restores internal managed MCP port discovery and treats candidate exits as transient without changing commands, configuration, defaults, success criteria, recovery steps, or supported workflows. No Critical, Major, or blocking writing findings remain.
- Agent: Codex Desktop
<!-- docs-review-head-sha: df16c2a9c -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: The four focused integration files passed all 37 tests, covering relay discovery, startup recovery, credential boundaries, and OpenShell integrity evidence.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this is a focused Hermes transaction-helper correction.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway relay discovery and validation for more reliable public MCP API port detection.
  * Gateway state now consistently reports a clear “not ready” condition when the relay is missing, ambiguous, or unstable.

* **Tests**
  * Expanded coverage for relay validation, fallback resolution, missing gateway state, and ambiguous relays.
  * Updated credential metadata integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->