### PR TITLE
feat(runtime): preserve host-local inference lifecycle

### DIFF
--- a/src/lib/actions/sandbox/destroy-execution.ts
+++ b/src/lib/actions/sandbox/destroy-execution.ts
@@ -11,6 +11,7 @@ import {
   requireRuntimeProviderDestructiveCleanupAuthority,
 } from "../../onboard/runtime-provider/access";
 import {
+  type HostLocalInferenceLifecycleOptions,
   type PreparedHostLocalInferenceAuthority,
   prepareSandboxHostLocalInferenceDestroyAuthority,
   retirePreparedHostLocalInferenceAuthority,
@@ -64,6 +65,7 @@ type SandboxDestroyExecutionInput = {
   stopInferenceResources: () => void;
   runtimeProviders?: RuntimeProviderBundleRegistry;
   deps?: {
+    hostLocalInferenceLifecycleOptions?: HostLocalInferenceLifecycleOptions;
     readTimerMarker?: typeof readTimerMarker;
     wipeSandboxState?: typeof wipeSandboxState;
   };
@@ -77,6 +79,8 @@ export type SandboxDestroyExecutionResult =
       deleteResult: ReturnType<DestroyRunOpenshell>;
       detachOutcome: DetachSandboxProvidersResult;
       forcedLocalCleanup: boolean;
+      /** Common lifecycle conclusively retired this row's explicit llama.cpp claim. */
+      commonLlamaCppAuthorityRetired?: true;
     }
   | {
       ok: false;
@@ -327,14 +331,13 @@ export async function executeSandboxDestroy({
     if (initialContinuity.status !== "match") {
       return identityRefusalResult("before destroy preparation", initialContinuity);
     }
-    // The durable-receipt gate also covers dedicated llama.cpp authority. Its
-    // established cleanup runs after confirmed deletion, while the B4-E1
-    // lifecycle helper below intentionally prepares only Ollama, NIM, and
-    // vLLM. Neither path may fall back to convention-named inference cleanup.
-    const hasHostLocalInferenceOwnership =
-      typeof sandbox?.hostLocalInferenceReceipt === "string";
+    // A receipt alone is not a llama.cpp lifecycle discriminator. Explicit
+    // provenance selects the common coordinator; an unmarked schema-v1 receipt
+    // remains on its established cleanup path.
+    const hasHostLocalInferenceOwnership = typeof sandbox?.hostLocalInferenceReceipt === "string";
     let runtimeProvider: RuntimeProviderBundle | null = null;
     let hostLocalInferenceAuthority: PreparedHostLocalInferenceAuthority | null = null;
+    let commonLlamaCppAuthorityRetired = false;
     if (sandbox) {
       try {
         runtimeProvider = requireRuntimeProviderDestructiveCleanupAuthority(
@@ -345,6 +348,7 @@ export async function executeSandboxDestroy({
         hostLocalInferenceAuthority = prepareSandboxHostLocalInferenceDestroyAuthority(
           runtimeProvider,
           sandbox,
+          deps.hostLocalInferenceLifecycleOptions,
         );
         if (hasHostLocalInferenceOwnership && (!getSandbox || !listSandboxes)) {
           throw new Error(
@@ -548,7 +552,10 @@ export async function executeSandboxDestroy({
           current,
           hostLocalInferenceAuthority,
           listSandboxes!().sandboxes,
+          deps.hostLocalInferenceLifecycleOptions,
         );
+        commonLlamaCppAuthorityRetired =
+          hostLocalInferenceAuthority.receipt.service === "llama-cpp";
       } catch (error) {
         return {
           ok: false as const,
@@ -570,6 +577,7 @@ export async function executeSandboxDestroy({
       deleteResult,
       alreadyGone,
       forcedLocalCleanup,
+      ...(commonLlamaCppAuthorityRetired ? { commonLlamaCppAuthorityRetired: true as const } : {}),
     };
   });
 }

--- a/src/lib/actions/sandbox/destroy-execution.ts
+++ b/src/lib/actions/sandbox/destroy-execution.ts
@@ -11,6 +11,11 @@ import {
   requireRuntimeProviderDestructiveCleanupAuthority,
 } from "../../onboard/runtime-provider/access";
 import {
+  type PreparedHostLocalInferenceAuthority,
+  prepareSandboxHostLocalInferenceDestroyAuthority,
+  retirePreparedHostLocalInferenceAuthority,
+} from "../../onboard/runtime-provider/host-local-inference-lifecycle";
+import {
   type DetachSandboxProvidersResult,
   runSandboxProviderPreDeleteCleanup,
 } from "../../onboard/sandbox-provider-cleanup";
@@ -46,6 +51,8 @@ export function retirePortableLifecycleAuthority(sandboxName: string): void {
 type SandboxDestroyExecutionInput = {
   cleanupShieldsArtifacts: (sandboxName: string) => void;
   force: boolean;
+  getSandbox?: (sandboxName: string) => SandboxEntry | null;
+  listSandboxes?: () => { sandboxes: SandboxEntry[] };
   runOpenshell: DestroyRunOpenshell;
   sandbox: SandboxEntry | null;
   sandboxConfirmedAbsent: boolean;
@@ -76,9 +83,12 @@ export type SandboxDestroyExecutionResult =
       deleteOutput: string;
       exitCode: number;
       gatewayUnreachable: boolean;
+      hostLocalInferenceOwnershipRequiresGateway: boolean;
       mcpOwnershipRequiresGateway: boolean;
       mcpRecoveryFailure?: string;
       shieldsRelockRequiresGateway: boolean;
+      hostLocalInferenceCleanupFailure?: string;
+      deleteConfirmed?: boolean;
     };
 
 type HardenedDeleteState = {
@@ -259,6 +269,8 @@ async function finalizeMcpDestroy(
 export async function executeSandboxDestroy({
   cleanupShieldsArtifacts,
   force,
+  getSandbox,
+  listSandboxes,
   runOpenshell,
   sandbox,
   sandboxConfirmedAbsent,
@@ -306,6 +318,7 @@ export async function executeSandboxDestroy({
             : `Container identity changed ${phase}; no sandbox delete was attempted.${earlierCleanupDetail}`,
       exitCode: 1,
       gatewayUnreachable: false,
+      hostLocalInferenceOwnershipRequiresGateway: false,
       mcpOwnershipRequiresGateway: false,
       mcpRecoveryFailure,
       shieldsRelockRequiresGateway: false,
@@ -314,7 +327,14 @@ export async function executeSandboxDestroy({
     if (initialContinuity.status !== "match") {
       return identityRefusalResult("before destroy preparation", initialContinuity);
     }
+    // The durable-receipt gate also covers dedicated llama.cpp authority. Its
+    // established cleanup runs after confirmed deletion, while the B4-E1
+    // lifecycle helper below intentionally prepares only Ollama, NIM, and
+    // vLLM. Neither path may fall back to convention-named inference cleanup.
+    const hasHostLocalInferenceOwnership =
+      typeof sandbox?.hostLocalInferenceReceipt === "string";
     let runtimeProvider: RuntimeProviderBundle | null = null;
+    let hostLocalInferenceAuthority: PreparedHostLocalInferenceAuthority | null = null;
     if (sandbox) {
       try {
         runtimeProvider = requireRuntimeProviderDestructiveCleanupAuthority(
@@ -322,12 +342,22 @@ export async function executeSandboxDestroy({
           sandbox,
           runtimeProviders,
         ).provider;
+        hostLocalInferenceAuthority = prepareSandboxHostLocalInferenceDestroyAuthority(
+          runtimeProvider,
+          sandbox,
+        );
+        if (hasHostLocalInferenceOwnership && (!getSandbox || !listSandboxes)) {
+          throw new Error(
+            "Exact registry readers are required to retire durable host-local inference authority.",
+          );
+        }
       } catch (error) {
         return {
           ok: false as const,
           deleteOutput: redactDestroyError(error),
           exitCode: 1,
           gatewayUnreachable: false,
+          hostLocalInferenceOwnershipRequiresGateway: false,
           mcpOwnershipRequiresGateway: false,
           shieldsRelockRequiresGateway: false,
         };
@@ -343,6 +373,7 @@ export async function executeSandboxDestroy({
           deleteOutput: redactDestroyError(error),
           exitCode: error.exitCode,
           gatewayUnreachable: false,
+          hostLocalInferenceOwnershipRequiresGateway: false,
           mcpOwnershipRequiresGateway: false,
           shieldsRelockRequiresGateway: false,
         };
@@ -372,21 +403,24 @@ export async function executeSandboxDestroy({
         mcpRecoveryFailure,
       );
     }
-    try {
-      stopInferenceResources();
-    } catch (error) {
-      const mcpRecoveryFailure = await restoreMcpForAbort(notHardened);
-      return {
-        ok: false,
-        deleteOutput:
-          `Could not stop managed inference resources before sandbox deletion: ${redactDestroyError(error)}. ` +
-          "No workspace wipe, provider cleanup, or sandbox deletion was attempted.",
-        exitCode: 1,
-        gatewayUnreachable: false,
-        mcpOwnershipRequiresGateway: false,
-        mcpRecoveryFailure,
-        shieldsRelockRequiresGateway: false,
-      };
+    if (!hasHostLocalInferenceOwnership) {
+      try {
+        stopInferenceResources();
+      } catch (error) {
+        const mcpRecoveryFailure = await restoreMcpForAbort(notHardened);
+        return {
+          ok: false,
+          deleteOutput:
+            `Could not stop managed inference resources before sandbox deletion: ${redactDestroyError(error)}. ` +
+            "No workspace wipe, provider cleanup, or sandbox deletion was attempted.",
+          exitCode: 1,
+          gatewayUnreachable: false,
+          hostLocalInferenceOwnershipRequiresGateway: false,
+          mcpOwnershipRequiresGateway: false,
+          mcpRecoveryFailure,
+          shieldsRelockRequiresGateway: false,
+        };
+      }
     }
     const postInferenceContinuity = inspectIdentityContinuity();
     if (postInferenceContinuity.status !== "match") {
@@ -445,14 +479,17 @@ export async function executeSandboxDestroy({
     // #7727: a failed pre-delete re-lock leaves the auto-restore timer as the
     // only authority that can lock the config again. Discarding the local
     // record here would revoke it for a sandbox the gateway never confirmed
-    // deleting, so --force must not take the local-cleanup shortcut until the
-    // gateway is back and deletion is confirmed.
+    // deleting. The same applies to an exact host-local inference receipt: it
+    // is the only durable authority that can retire the managed runtime. Thus
+    // --force must not take the local-cleanup shortcut until the gateway is
+    // back and deletion is confirmed.
     const forcedLocalCleanup =
       deleteResult.status !== 0 &&
       !alreadyGone &&
       gatewayUnreachable &&
       force &&
       !hasMcpOwnership &&
+      !hasHostLocalInferenceOwnership &&
       !hardened.hardeningFailed;
 
     if (deleteResult.status !== 0 && !alreadyGone && !forcedLocalCleanup) {
@@ -464,6 +501,8 @@ export async function executeSandboxDestroy({
         deleteOutput,
         exitCode: deleteResult.status || 1,
         gatewayUnreachable,
+        hostLocalInferenceOwnershipRequiresGateway:
+          gatewayUnreachable && hasHostLocalInferenceOwnership,
         mcpOwnershipRequiresGateway: gatewayUnreachable && hasMcpOwnership,
         mcpRecoveryFailure,
         shieldsRelockRequiresGateway: gatewayUnreachable && hardened.hardeningFailed,
@@ -471,8 +510,9 @@ export async function executeSandboxDestroy({
     }
 
     // The sandbox is confirmed gone, or --force is discarding only a local
-    // record that has no MCP ownership. Keep this under the lifecycle lock so
-    // stale timer state cannot target a same-name replacement.
+    // record that has no retained exact ownership. Keep this under the
+    // lifecycle lock so stale timer state cannot target a same-name
+    // replacement.
     cleanupShieldsArtifacts(sandboxName);
     if (!forcedLocalCleanup) {
       try {
@@ -484,11 +524,43 @@ export async function executeSandboxDestroy({
             deleteOutput: redactDestroyError(error),
             exitCode: error.exitCode,
             gatewayUnreachable: false,
+            hostLocalInferenceOwnershipRequiresGateway: false,
             mcpOwnershipRequiresGateway: false,
             shieldsRelockRequiresGateway: false,
           };
         }
         throw error;
+      }
+    }
+    if (!forcedLocalCleanup && runtimeProvider && sandbox && hostLocalInferenceAuthority) {
+      // Keep retirement after confirmed sandbox deletion: retiring first could
+      // leave a still-live sandbox without inference when its delete fails.
+      // The registry row is the durable cleanup journal. A retirement failure
+      // returns before that row is removed, and a retry takes the already-gone
+      // path to converge the provider's idempotent exact-runtime teardown.
+      try {
+        const current = getSandbox!(sandboxName);
+        if (!current) {
+          throw new Error(`sandbox '${sandboxName}' is no longer registered`);
+        }
+        retirePreparedHostLocalInferenceAuthority(
+          runtimeProvider,
+          current,
+          hostLocalInferenceAuthority,
+          listSandboxes!().sandboxes,
+        );
+      } catch (error) {
+        return {
+          ok: false as const,
+          deleteOutput,
+          exitCode: 1,
+          gatewayUnreachable: false,
+          hostLocalInferenceOwnershipRequiresGateway: false,
+          mcpOwnershipRequiresGateway: false,
+          shieldsRelockRequiresGateway: false,
+          hostLocalInferenceCleanupFailure: redactDestroyError(error),
+          deleteConfirmed: true,
+        };
       }
     }
     return {

--- a/src/lib/actions/sandbox/destroy-host-local-inference.test.ts
+++ b/src/lib/actions/sandbox/destroy-host-local-inference.test.ts
@@ -1,0 +1,372 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createInMemoryRuntimeProviderBundle } from "../../../../test/helpers/runtime-provider-bundle";
+import type { HostLocalInferenceOperation } from "../../onboard/runtime-provider/host-local-inference";
+import {
+  type HostLocalInferenceDestroyResult,
+  type HostLocalInferenceReceipt,
+  type HostLocalInferenceRuntime,
+  serializeHostLocalInferenceReceipt,
+} from "../../onboard/runtime-provider/host-local-inference";
+import type { SandboxEntry } from "../../state/registry";
+import { executeSandboxDestroy } from "./destroy-execution";
+
+const AUTHORITY_ID = `mxc-endpoint:${"a".repeat(64)}`;
+const BINDING_SHA256 = "d".repeat(64);
+const MODEL = "qwen3.5-9b";
+
+function receipt(
+  service: "ollama" | "nim" | "vllm" = "vllm",
+  publicationTransactionId = "1".repeat(64),
+): HostLocalInferenceReceipt {
+  const port = service === "ollama" ? 11434 : service === "nim" ? 8001 : 8000;
+  return {
+    schemaVersion: 2,
+    providerId: "mxc",
+    service,
+    engineAuthority: {
+      schemaVersion: 1,
+      providerId: "mxc",
+      operation: "host-local-inference",
+      engineId: "memory",
+      authorityId: AUTHORITY_ID,
+      bindingSha256: BINDING_SHA256,
+    },
+    endpoint: {
+      host: "host.openshell.internal",
+      port,
+      networkName: "mxc-runtime-network",
+      networkId: "2".repeat(64),
+      networkGatewayIp: "10.89.0.1",
+      networkAuthoritySha256: "3".repeat(64),
+    },
+    inference: {
+      protocol: "openai-chat-completions",
+      model: service === "ollama" ? `${MODEL}:latest` : MODEL,
+      toolCallingRequired: true,
+    },
+    publication: {
+      transactionId: publicationTransactionId,
+      targetSha256: "4".repeat(64),
+      priorState: service === "ollama" ? "host-process" : "absent",
+    },
+    runtime:
+      service === "ollama"
+        ? {
+            kind: "host",
+            probeImageRef: `quay.io/curl/curl@sha256:${"5".repeat(64)}`,
+            acceleration: "nvidia-gpu",
+            modelDigest: `sha256:${"6".repeat(64)}`,
+          }
+        : {
+            kind: "container",
+            runtimeId: `mxc-runtime:${service}`,
+            name: `nemoclaw-${service}`,
+            imageRef: `nvcr.io/nvidia/${service}@sha256:${"7".repeat(64)}`,
+            probeImageRef: `quay.io/curl/curl@sha256:${"5".repeat(64)}`,
+            specSha256: "8".repeat(64),
+            launchSha256: "9".repeat(64),
+            gpu: { vendor: "nvidia", devices: ["nvidia.com/gpu=all"] },
+          },
+  };
+}
+
+function sandbox(
+  name = "alpha",
+  value = receipt(),
+  overrides: Partial<SandboxEntry> = {},
+): SandboxEntry {
+  return {
+    name,
+    agent: "openclaw",
+    openshellDriver: "mxc",
+    provider: value.service === "ollama" ? "ollama-local" : "vllm-local",
+    model: value.inference?.model ?? MODEL,
+    endpointUrl: "https://inference.local/v1",
+    gatewayName: "nemoclaw",
+    lifecycleGeneration: `${name}-generation-1`,
+    hostLocalInferenceReceipt: serializeHostLocalInferenceReceipt(value),
+    ...overrides,
+  };
+}
+
+function provider(
+  options: {
+    prepareDestroy?: (value: HostLocalInferenceReceipt) => HostLocalInferenceReceipt;
+    destroy?: (value: HostLocalInferenceReceipt) => HostLocalInferenceDestroyResult;
+  } = {},
+) {
+  const events: string[] = [];
+  const prepareDestroy = vi.fn((value: HostLocalInferenceReceipt) => {
+    events.push("runtime prepare destroy");
+    return options.prepareDestroy?.(value) ?? value;
+  });
+  const destroy = vi.fn((value: HostLocalInferenceReceipt) => {
+    events.push("runtime destroy");
+    return options.destroy?.(value) ?? { status: "removed" as const, receipt: value };
+  });
+  const runtime: HostLocalInferenceRuntime = {
+    providerId: "mxc",
+    authorityId: AUTHORITY_ID,
+    services: ["ollama", "nim", "vllm"],
+    translateContainerArgs: (args) => args,
+    qualifyOllama: vi.fn(),
+    startManaged: vi.fn(),
+    inspectManaged: vi.fn((value) => ({ running: true, receipt: value })),
+    stopManaged: vi.fn((value) => ({ running: false, receipt: value })),
+    preserveForRebuild: vi.fn((value) => value),
+    prepareDestroy,
+    destroy,
+  };
+  const operation: HostLocalInferenceOperation = {
+    providerId: "mxc",
+    engine: {
+      operation: "host-local-inference",
+      engineId: "memory",
+      displayName: "In-memory",
+      authorityId: AUTHORITY_ID,
+      capture: vi.fn(),
+      captureHost: vi.fn(),
+    },
+    bindingSha256: BINDING_SHA256,
+    assertAuthority: vi.fn(),
+    spawn: vi.fn() as HostLocalInferenceOperation["spawn"],
+    createLlamaCppLifecycle: vi.fn() as HostLocalInferenceOperation["createLlamaCppLifecycle"],
+    managedRuntime: runtime,
+  };
+  const createOperation = vi.fn(() => operation);
+  const bundle = createInMemoryRuntimeProviderBundle({
+    providerId: "mxc",
+    workloadProfile: {
+      support: null,
+      hostArchitectures: ["x64"],
+      managedImageSelectionPolicy: "prefer-managed",
+      legacyDockerfileBuilds: false,
+    },
+    hostLocalInference: {
+      services: ["ollama", "nim", "vllm"],
+      createOperation,
+    },
+    recordEvent: (event) => events.push(event),
+  });
+  return { bundle, createOperation, destroy, events, prepareDestroy };
+}
+
+async function runDestroy(
+  runtimeProvider: ReturnType<typeof provider>,
+  options: {
+    entry?: SandboxEntry;
+    peers?: SandboxEntry[];
+    currentAfterDelete?: SandboxEntry | null;
+    deleteResult?: { status: number; stdout: string; stderr: string };
+    sandboxConfirmedAbsent?: boolean;
+    force?: boolean;
+    includeRegistryReaders?: boolean;
+  } = {},
+) {
+  const entry = options.entry ?? sandbox();
+  const peers = options.peers ?? [];
+  const afterDelete = Object.hasOwn(options, "currentAfterDelete")
+    ? (options.currentAfterDelete ?? null)
+    : entry;
+  let current: SandboxEntry | null = entry;
+  const getSandbox = vi.fn(() => current);
+  const listSandboxes = vi.fn(() => ({
+    sandboxes: [...(current ? [current] : []), ...peers],
+  }));
+  const stopInferenceResources = vi.fn(() => {
+    runtimeProvider.events.push("legacy inference cleanup");
+  });
+  const runOpenshell = vi.fn((args: string[]) => {
+    const command = args.join(" ");
+    runtimeProvider.events.push(command);
+    if (command === "sandbox delete alpha") current = afterDelete;
+    return (
+      options.deleteResult ?? {
+        status: 0,
+        stdout: "",
+        stderr: "",
+      }
+    );
+  });
+  const result = await executeSandboxDestroy({
+    cleanupShieldsArtifacts: () => runtimeProvider.events.push("cleanup"),
+    force: options.force ?? false,
+    ...(options.includeRegistryReaders === false ? {} : { getSandbox, listSandboxes }),
+    runOpenshell,
+    sandbox: entry,
+    sandboxConfirmedAbsent: options.sandboxConfirmedAbsent ?? false,
+    sandboxName: "alpha",
+    stopInferenceResources,
+    runtimeProviders: { mxc: runtimeProvider.bundle },
+    deps: {
+      readTimerMarker: () => null,
+      wipeSandboxState: () => undefined,
+    },
+  });
+  return { getSandbox, listSandboxes, result, runOpenshell, stopInferenceResources };
+}
+
+describe("sandbox destroy host-local inference transaction", () => {
+  it("retires the exact unshared runtime only after confirmed sandbox deletion", async () => {
+    const runtimeProvider = provider();
+    const { result, stopInferenceResources } = await runDestroy(runtimeProvider);
+
+    expect(result).toMatchObject({ ok: true });
+    expect(runtimeProvider.events.indexOf("runtime destroy")).toBeGreaterThan(
+      runtimeProvider.events.indexOf("sandbox delete alpha"),
+    );
+    expect(runtimeProvider.prepareDestroy).toHaveBeenCalledTimes(2);
+    expect(runtimeProvider.destroy).toHaveBeenCalledOnce();
+    expect(stopInferenceResources).not.toHaveBeenCalled();
+  });
+
+  it("keeps an exact runtime referenced by another sandbox", async () => {
+    const runtimeProvider = provider();
+    const entry = sandbox();
+    const peer = sandbox("beta", receipt());
+    const { result } = await runDestroy(runtimeProvider, { entry, peers: [peer] });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("retains externally owned Ollama instead of removing its host process", async () => {
+    const value = receipt("ollama");
+    const runtimeProvider = provider({
+      destroy: (current) => ({ status: "retained", reason: "host-process", receipt: current }),
+    });
+    const { result, stopInferenceResources } = await runDestroy(runtimeProvider, {
+      entry: sandbox("alpha", value),
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(runtimeProvider.destroy).toHaveBeenCalledWith(value);
+    expect(stopInferenceResources).not.toHaveBeenCalled();
+  });
+
+  it("redacts provider-native preflight failures and fails closed before legacy cleanup", async () => {
+    const runtimeProvider = provider({
+      prepareDestroy: () => {
+        throw new Error("provider failed with OPENAI_API_KEY=super-secret");
+      },
+    });
+    const { result, runOpenshell, stopInferenceResources } = await runDestroy(runtimeProvider);
+
+    expect(result).toMatchObject({ ok: false });
+    expect(JSON.stringify(result)).not.toContain("super-secret");
+    expect(JSON.stringify(result)).toContain("<REDACTED>");
+    expect(runOpenshell).not.toHaveBeenCalled();
+    expect(stopInferenceResources).not.toHaveBeenCalled();
+  });
+
+  it("requires exact registry readers before deleting a sandbox with durable authority", async () => {
+    const runtimeProvider = provider();
+    const { result, runOpenshell, stopInferenceResources } = await runDestroy(runtimeProvider, {
+      includeRegistryReaders: false,
+    });
+
+    expect(result).toMatchObject({ ok: false });
+    expect(runOpenshell).not.toHaveBeenCalled();
+    expect(stopInferenceResources).not.toHaveBeenCalled();
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("preserves authority when the registry row is missing or reused after deletion", async () => {
+    const missingProvider = provider();
+    const missing = await runDestroy(missingProvider, { currentAfterDelete: null });
+    expect(missing.result).toMatchObject({
+      ok: false,
+      deleteConfirmed: true,
+      hostLocalInferenceCleanupFailure: expect.stringContaining("no longer registered"),
+    });
+    expect(missingProvider.destroy).not.toHaveBeenCalled();
+
+    const reusedProvider = provider();
+    const reused = await runDestroy(reusedProvider, {
+      currentAfterDelete: sandbox("alpha", receipt(), {
+        lifecycleGeneration: "alpha-generation-reused",
+      }),
+    });
+    expect(reused.result).toMatchObject({
+      ok: false,
+      deleteConfirmed: true,
+      hostLocalInferenceCleanupFailure: expect.any(String),
+    });
+    expect(reusedProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on ambiguous peer authority for the same immutable runtime", async () => {
+    const runtimeProvider = provider();
+    const peer = sandbox("beta", receipt("vllm", "a".repeat(64)));
+    const { result } = await runDestroy(runtimeProvider, { peers: [peer] });
+
+    expect(result).toMatchObject({
+      ok: false,
+      deleteConfirmed: true,
+      hostLocalInferenceCleanupFailure: expect.any(String),
+    });
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("preserves local authority when exact runtime retirement is indeterminate", async () => {
+    const runtimeProvider = provider({
+      destroy: () => {
+        throw new Error("cleanup failed with NVIDIA_API_KEY=super-secret");
+      },
+    });
+    const { result } = await runDestroy(runtimeProvider);
+
+    expect(result).toMatchObject({
+      ok: false,
+      deleteConfirmed: true,
+      hostLocalInferenceCleanupFailure: expect.stringContaining("<REDACTED>"),
+    });
+    expect(JSON.stringify(result)).not.toContain("super-secret");
+  });
+
+  it("does not discard durable authority when --force cannot reach the gateway", async () => {
+    const runtimeProvider = provider();
+    const { result, stopInferenceResources } = await runDestroy(runtimeProvider, {
+      deleteResult: {
+        status: 1,
+        stdout: "",
+        stderr: "tcp connect error: Connection refused (os error 61)",
+      },
+      force: true,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      gatewayUnreachable: true,
+      hostLocalInferenceOwnershipRequiresGateway: true,
+    });
+    expect(runtimeProvider.events).not.toContain("cleanup");
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+    expect(stopInferenceResources).not.toHaveBeenCalled();
+  });
+
+  it("reconciles retained authority only after stable sandbox absence", async () => {
+    let destroyAttempts = 0;
+    const runtimeProvider = provider({
+      destroy: (value) => {
+        destroyAttempts += 1;
+        if (destroyAttempts === 1) throw new Error("injected runtime removal failure");
+        return { status: "already-absent", receipt: value };
+      },
+    });
+
+    const first = await runDestroy(runtimeProvider);
+    const retry = await runDestroy(runtimeProvider, {
+      deleteResult: { status: 1, stdout: "", stderr: "Error: sandbox alpha not found" },
+      sandboxConfirmedAbsent: true,
+    });
+
+    expect(first.result).toMatchObject({ ok: false, deleteConfirmed: true });
+    expect(retry.result).toMatchObject({ ok: true, alreadyGone: true });
+    expect(runtimeProvider.destroy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/actions/sandbox/destroy-host-local-inference.test.ts
+++ b/src/lib/actions/sandbox/destroy-host-local-inference.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createInMemoryRuntimeProviderBundle } from "../../../../test/helpers/runtime-provider-bundle";
+import { llamaCppHostLocalInferenceReceipt } from "../../../../test/helpers/host-local-inference-receipt";
 import type { HostLocalInferenceOperation } from "../../onboard/runtime-provider/host-local-inference";
 import {
   type HostLocalInferenceDestroyResult,
@@ -12,6 +13,7 @@ import {
   serializeHostLocalInferenceReceipt,
 } from "../../onboard/runtime-provider/host-local-inference";
 import type { SandboxEntry } from "../../state/registry";
+import { createSandboxHostLocalInferenceProvenance } from "../../state/registry/host-local-inference";
 import { executeSandboxDestroy } from "./destroy-execution";
 
 const AUTHORITY_ID = `mxc-endpoint:${"a".repeat(64)}`;
@@ -165,6 +167,11 @@ async function runDestroy(
     sandboxConfirmedAbsent?: boolean;
     force?: boolean;
     includeRegistryReaders?: boolean;
+    lifecycleOptions?: NonNullable<
+      NonNullable<
+        Parameters<typeof executeSandboxDestroy>[0]["deps"]
+      >["hostLocalInferenceLifecycleOptions"]
+    >;
   } = {},
 ) {
   const entry = options.entry ?? sandbox();
@@ -183,7 +190,7 @@ async function runDestroy(
   const runOpenshell = vi.fn((args: string[]) => {
     const command = args.join(" ");
     runtimeProvider.events.push(command);
-    if (command === "sandbox delete alpha") current = afterDelete;
+    current = command === "sandbox delete alpha" ? afterDelete : current;
     return (
       options.deleteResult ?? {
         status: 0,
@@ -203,19 +210,194 @@ async function runDestroy(
     stopInferenceResources,
     runtimeProviders: { mxc: runtimeProvider.bundle },
     deps: {
+      ...(options.lifecycleOptions
+        ? { hostLocalInferenceLifecycleOptions: options.lifecycleOptions }
+        : {}),
       readTimerMarker: () => null,
       wipeSandboxState: () => undefined,
     },
   });
-  return { getSandbox, listSandboxes, result, runOpenshell, stopInferenceResources };
+  return {
+    getSandbox,
+    listSandboxes,
+    result,
+    runOpenshell,
+    stopInferenceResources,
+  };
 }
 
 describe("sandbox destroy host-local inference transaction", () => {
+  function explicitLlamaReceipt(): HostLocalInferenceReceipt {
+    const value = llamaCppHostLocalInferenceReceipt();
+    return {
+      ...value,
+      engineAuthority: {
+        ...value.engineAuthority,
+        engineId: "memory",
+      },
+    };
+  }
+
+  function explicitLlamaSandbox(value = explicitLlamaReceipt()): SandboxEntry {
+    const serialized = serializeHostLocalInferenceReceipt(value);
+    return {
+      name: "alpha",
+      agent: "openclaw",
+      openshellDriver: "docker",
+      provider: "llama-cpp-local",
+      model: "llama-cpp-model",
+      endpointUrl: "https://inference.local/v1",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      lifecycleGeneration: "alpha-generation-1",
+      hostLocalInferenceReceipt: serialized,
+      hostLocalInferenceProvenance: createSandboxHostLocalInferenceProvenance("alpha", serialized),
+    };
+  }
+
+  function explicitLlamaProvider(options: { readonly failDestroy?: boolean } = {}) {
+    const value = explicitLlamaReceipt();
+    const prepareDestroy = vi.fn((receiptValue: HostLocalInferenceReceipt) => receiptValue);
+    const destroy = options.failDestroy
+      ? vi.fn((_receiptValue: HostLocalInferenceReceipt) => {
+          throw new Error("injected exact llama.cpp cleanup failure");
+        })
+      : vi.fn((receiptValue: HostLocalInferenceReceipt) => ({
+          status: "removed" as const,
+          receipt: receiptValue,
+        }));
+    const runtime: HostLocalInferenceRuntime = {
+      providerId: "docker",
+      authorityId: value.engineAuthority.authorityId,
+      services: ["llama-cpp"],
+      translateContainerArgs: (args) => args,
+      qualifyOllama: vi.fn(),
+      startManaged: vi.fn(),
+      inspectManaged: vi.fn((receiptValue) => ({
+        running: true,
+        receipt: receiptValue,
+      })),
+      stopManaged: vi.fn((receiptValue) => ({
+        running: false,
+        receipt: receiptValue,
+      })),
+      preserveForRebuild: vi.fn((receiptValue) => receiptValue),
+      prepareDestroy,
+      destroy,
+    };
+    const operation: HostLocalInferenceOperation = {
+      providerId: "docker",
+      engine: {
+        operation: "host-local-inference",
+        engineId: "memory",
+        displayName: "In-memory",
+        authorityId: value.engineAuthority.authorityId,
+        capture: vi.fn(),
+        captureHost: vi.fn(),
+      },
+      bindingSha256: value.engineAuthority.bindingSha256,
+      assertAuthority: vi.fn(),
+      spawn: vi.fn() as HostLocalInferenceOperation["spawn"],
+      createLlamaCppLifecycle: vi.fn() as HostLocalInferenceOperation["createLlamaCppLifecycle"],
+    };
+    const bundle = createInMemoryRuntimeProviderBundle({
+      providerId: "docker",
+      workloadProfile: {
+        support: null,
+        hostArchitectures: ["x64"],
+        managedImageSelectionPolicy: "prefer-managed",
+        legacyDockerfileBuilds: false,
+      },
+      hostLocalInference: {
+        services: ["llama-cpp"],
+        createOperation: () => operation,
+      },
+    });
+    const createLlamaCppAdapter = vi.fn((adapterOptions) => ({
+      gatewayPort: adapterOptions.gatewayPort ?? 8080,
+      runtimeOwnerSandboxName: adapterOptions.runtimeOwnerSandboxName,
+      model: adapterOptions.expectedModel,
+      operation: adapterOptions.operation!,
+      receipt: adapterOptions.expectedReceipt,
+      runtime,
+      prepareStartup: vi.fn(),
+    }));
+    return { bundle, createLlamaCppAdapter, destroy, prepareDestroy };
+  }
+
+  it("marks explicit llama.cpp authority retired only after one conclusive common cleanup", async () => {
+    const runtimeProvider = explicitLlamaProvider();
+    const entry = explicitLlamaSandbox();
+    let current: SandboxEntry | null = entry;
+    const stopInferenceResources = vi.fn();
+    const result = await executeSandboxDestroy({
+      cleanupShieldsArtifacts: vi.fn(),
+      force: false,
+      getSandbox: () => current,
+      listSandboxes: () => ({ sandboxes: current ? [current] : [] }),
+      runOpenshell: vi.fn(() => ({ status: 0, stdout: "", stderr: "" })),
+      sandbox: entry,
+      sandboxConfirmedAbsent: false,
+      sandboxName: "alpha",
+      stopInferenceResources,
+      runtimeProviders: { docker: runtimeProvider.bundle },
+      deps: {
+        hostLocalInferenceLifecycleOptions: {
+          createLlamaCppAdapter: runtimeProvider.createLlamaCppAdapter,
+        },
+        readTimerMarker: () => null,
+        wipeSandboxState: () => undefined,
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      commonLlamaCppAuthorityRetired: true,
+    });
+    expect(runtimeProvider.prepareDestroy).toHaveBeenCalledTimes(2);
+    expect(runtimeProvider.destroy).toHaveBeenCalledOnce();
+    expect(stopInferenceResources).not.toHaveBeenCalled();
+  });
+
+  it("retains explicit llama.cpp retry authority when common cleanup fails", async () => {
+    const runtimeProvider = explicitLlamaProvider({ failDestroy: true });
+    const entry = explicitLlamaSandbox();
+    const stopInferenceResources = vi.fn();
+    const result = await executeSandboxDestroy({
+      cleanupShieldsArtifacts: vi.fn(),
+      force: false,
+      getSandbox: () => entry,
+      listSandboxes: () => ({ sandboxes: [entry] }),
+      runOpenshell: vi.fn(() => ({ status: 0, stdout: "", stderr: "" })),
+      sandbox: entry,
+      sandboxConfirmedAbsent: false,
+      sandboxName: "alpha",
+      stopInferenceResources,
+      runtimeProviders: { docker: runtimeProvider.bundle },
+      deps: {
+        hostLocalInferenceLifecycleOptions: {
+          createLlamaCppAdapter: runtimeProvider.createLlamaCppAdapter,
+        },
+        readTimerMarker: () => null,
+        wipeSandboxState: () => undefined,
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      deleteConfirmed: true,
+      hostLocalInferenceCleanupFailure: expect.stringContaining("injected exact llama.cpp"),
+    });
+    expect(runtimeProvider.destroy).toHaveBeenCalledOnce();
+    expect(stopInferenceResources).not.toHaveBeenCalled();
+  });
+
   it("retires the exact unshared runtime only after confirmed sandbox deletion", async () => {
     const runtimeProvider = provider();
     const { result, stopInferenceResources } = await runDestroy(runtimeProvider);
 
     expect(result).toMatchObject({ ok: true });
+    expect(result).not.toHaveProperty("commonLlamaCppAuthorityRetired");
     expect(runtimeProvider.events.indexOf("runtime destroy")).toBeGreaterThan(
       runtimeProvider.events.indexOf("sandbox delete alpha"),
     );
@@ -350,18 +532,25 @@ describe("sandbox destroy host-local inference transaction", () => {
   });
 
   it("reconciles retained authority only after stable sandbox absence", async () => {
-    let destroyAttempts = 0;
+    const destroy = vi
+      .fn((value: HostLocalInferenceReceipt): HostLocalInferenceDestroyResult => ({
+        status: "already-absent",
+        receipt: value,
+      }))
+      .mockImplementationOnce(() => {
+        throw new Error("injected runtime removal failure");
+      });
     const runtimeProvider = provider({
-      destroy: (value) => {
-        destroyAttempts += 1;
-        if (destroyAttempts === 1) throw new Error("injected runtime removal failure");
-        return { status: "already-absent", receipt: value };
-      },
+      destroy,
     });
 
     const first = await runDestroy(runtimeProvider);
     const retry = await runDestroy(runtimeProvider, {
-      deleteResult: { status: 1, stdout: "", stderr: "Error: sandbox alpha not found" },
+      deleteResult: {
+        status: 1,
+        stdout: "",
+        stderr: "Error: sandbox alpha not found",
+      },
       sandboxConfirmedAbsent: true,
     });
 

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -565,8 +565,14 @@ async function destroySandboxUnlocked(
     }
     process.exit(destructiveResult.exitCode);
   }
-  const { detachOutcome, deleteResult, alreadyGone, forcedLocalCleanup, deleteOutput } =
-    destructiveResult;
+  const {
+    detachOutcome,
+    deleteResult,
+    alreadyGone,
+    forcedLocalCleanup,
+    deleteOutput,
+    commonLlamaCppAuthorityRetired,
+  } = destructiveResult;
 
   /**
    * SOURCE_OF_TRUTH
@@ -611,7 +617,7 @@ async function destroySandboxUnlocked(
   cleanupSandboxServices(sandboxName, {
     stopHostServices: shouldStopHostServices,
   });
-  if (deleteSucceededOrAlreadyGone) {
+  if (deleteSucceededOrAlreadyGone && commonLlamaCppAuthorityRetired !== true) {
     const managedLlamaCppCleanup = cleanupManagedLlamaCppRuntimeForSandbox(sandboxName, {
       ...(typeof sandbox?.gatewayPort === "number" ? { gatewayPort: sandbox.gatewayPort } : {}),
     });

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -502,6 +502,8 @@ async function destroySandboxUnlocked(
   const destructiveResult = await executeSandboxDestroy({
     cleanupShieldsArtifacts: cleanupShieldsDestroyArtifacts,
     force: normalized.force === true,
+    getSandbox: registry.getSandbox,
+    listSandboxes: registry.listSandboxes,
     runOpenshell,
     sandbox,
     sandboxConfirmedAbsent,
@@ -510,6 +512,14 @@ async function destroySandboxUnlocked(
     stopInferenceResources: () => stopSandboxInferenceResources(sandboxName, sandbox),
   });
   if (!destructiveResult.ok) {
+    if (destructiveResult.hostLocalInferenceCleanupFailure) {
+      console.error(
+        `  Sandbox '${sandboxName}' is gone, but its exact host-local inference cleanup failed: ${destructiveResult.hostLocalInferenceCleanupFailure}`,
+      );
+      console.error(
+        `  Local ownership state was preserved. Re-run '${CLI_NAME} ${sandboxName} destroy --yes' to reconcile only the recorded provider runtime.`,
+      );
+    }
     if (destructiveResult.deleteOutput) {
       console.error(`  ${destructiveResult.deleteOutput}`);
     }
@@ -529,6 +539,13 @@ async function destroySandboxUnlocked(
         );
         console.error(
           `  Start the gateway (run '${CLI_NAME} ${sandboxName} status'), then retry destroy; --force cannot safely discard a record whose config lock is unconfirmed.`,
+        );
+      } else if (destructiveResult.hostLocalInferenceOwnershipRequiresGateway) {
+        console.error(
+          `  The OpenShell gateway is unreachable. Local state was preserved because it contains the exact host-local inference ownership required to retire the managed runtime.`,
+        );
+        console.error(
+          `  Start the gateway (run '${CLI_NAME} ${sandboxName} status'), then retry destroy; --force cannot safely discard host-local inference ownership.`,
         );
       } else if (destructiveResult.mcpOwnershipRequiresGateway) {
         console.error(
@@ -556,8 +573,8 @@ async function destroySandboxUnlocked(
    * Invalid state: the OpenShell gateway is unreachable while a local sandbox
    * record still exists, so a normal destroy cannot confirm remote deletion.
    * Source boundary: destroySandbox -> executeSandboxDestroy -> `openshell
-   * sandbox delete`; only an explicit --force and no retained MCP ownership may
-   * select forcedLocalCleanup.
+   * sandbox delete`; only an explicit --force and no retained MCP or host-local
+   * inference ownership may select forcedLocalCleanup.
    * Source-fix constraint: NemoClaw cannot make an unreachable remote gateway
    * delete or attest the sandbox, so this path discards local state only.
    * Regression proof: destroy-flow.test.ts and the CLI integration test

--- a/src/lib/actions/sandbox/snapshot-auto-create-failure.test.ts
+++ b/src/lib/actions/sandbox/snapshot-auto-create-failure.test.ts
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { hostLocalInferenceReceipt } from "../../../../test/helpers/host-local-inference-receipt";
 import {
-  createInMemoryRuntimeProviderBundle,
-} from "../../../../test/helpers/runtime-provider-bundle";
-import {
-  resolveTestAgentBaselinePolicy,
-} from "../../../../test/support/snapshot-policy-test-fixture";
+  hostLocalInferenceReceipt,
+  serializedLlamaCppHostLocalInferenceReceipt,
+} from "../../../../test/helpers/host-local-inference-receipt";
+import { createInMemoryRuntimeProviderBundle } from "../../../../test/helpers/runtime-provider-bundle";
+import { resolveTestAgentBaselinePolicy } from "../../../../test/support/snapshot-policy-test-fixture";
 import {
   serializeHostLocalInferenceReceipt,
   type HostLocalInferenceOperation,
   type HostLocalInferenceRuntime,
 } from "../../onboard/runtime-provider/host-local-inference";
 import type { SnapshotStreamSandboxCreateMock } from "./snapshot-create-stream-test-types";
+import { createSandboxHostLocalInferenceProvenance } from "../../state/registry/host-local-inference";
 
 const harness = vi.hoisted(() => ({
   entries: new Map<string, Record<string, unknown>>(),
@@ -29,6 +29,14 @@ const captureOpenshellMock = vi.fn(() => ({
 const getSandboxMock = vi.fn((name?: string) => harness.entries.get(name ?? "") ?? null);
 const registerSandboxMock = vi.fn((entry: Record<string, unknown>) => {
   harness.entries.set(String(entry.name), entry);
+});
+const reserveSandboxInferenceRouteMock = vi.fn((name: string, route: Record<string, unknown>) => {
+  harness.entries.set(name, {
+    name,
+    pendingRouteReservation: true,
+    ...route,
+  });
+  return true;
 });
 const restoreSandboxStateMock = vi.fn();
 const captureSnapshotRestoreAuthorityMock = vi.fn();
@@ -201,6 +209,7 @@ vi.mock("../../state/registry", () => ({
     defaultSandbox: "alpha",
   })),
   registerSandbox: registerSandboxMock,
+  reserveSandboxInferenceRoute: reserveSandboxInferenceRouteMock,
   removeSandbox: vi.fn((name: string) => harness.entries.delete(name)),
   updateSandbox: vi.fn(),
 }));
@@ -266,6 +275,78 @@ describe("snapshot restore auto-create failures", () => {
     );
     expect(registerSandboxMock).not.toHaveBeenCalled();
     expect(restoreSandboxStateMock).not.toHaveBeenCalled();
+  });
+
+  it("releases an exact host-local clone reservation when auto-create fails", async () => {
+    const receipt = serializedLlamaCppHostLocalInferenceReceipt();
+    harness.entries.set("alpha", {
+      ...sourceEntry(),
+      openshellDriver: "docker",
+      provider: "llama-cpp-local",
+      model: "llama-cpp-model",
+      endpointUrl: "https://inference.local/v1",
+      endpointSource: "inference-set",
+      credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+      preferredInferenceApi: "openai-completions",
+      gatewayPort: 8080,
+      hostLocalInferenceReceipt: receipt,
+      hostLocalInferenceProvenance: createSandboxHostLocalInferenceProvenance("alpha", receipt),
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const { runSandboxSnapshot } = await import("./snapshot");
+
+    await expect(
+      runSandboxSnapshot("alpha", { kind: "restore", to: "beta" }),
+    ).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(reserveSandboxInferenceRouteMock).toHaveBeenCalledWith(
+      "beta",
+      expect.objectContaining({
+        hostLocalInferenceReceipt: receipt,
+        hostLocalInferenceProvenance: expect.objectContaining({
+          runtimeOwnerSandboxName: "alpha",
+        }),
+      }),
+    );
+    expect(getSandboxMock("beta")).toBeNull();
+    expect(registerSandboxMock).not.toHaveBeenCalled();
+  });
+
+  it("releases an exact host-local clone reservation when auto-create rejects", async () => {
+    const receipt = serializedLlamaCppHostLocalInferenceReceipt();
+    harness.entries.set("alpha", {
+      ...sourceEntry(),
+      openshellDriver: "docker",
+      provider: "llama-cpp-local",
+      model: "llama-cpp-model",
+      endpointUrl: "https://inference.local/v1",
+      endpointSource: "inference-set",
+      credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+      preferredInferenceApi: "openai-completions",
+      gatewayPort: 8080,
+      hostLocalInferenceReceipt: receipt,
+      hostLocalInferenceProvenance: createSandboxHostLocalInferenceProvenance("alpha", receipt),
+    });
+    streamSandboxCreateMock.mockRejectedValue(new Error("injected create rejection"));
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const { runSandboxSnapshot } = await import("./snapshot");
+
+    await expect(
+      runSandboxSnapshot("alpha", { kind: "restore", to: "beta" }),
+    ).rejects.toThrow("injected create rejection");
+
+    expect(reserveSandboxInferenceRouteMock).toHaveBeenCalledWith(
+      "beta",
+      expect.objectContaining({
+        hostLocalInferenceReceipt: receipt,
+        hostLocalInferenceProvenance: expect.objectContaining({
+          runtimeOwnerSandboxName: "alpha",
+        }),
+      }),
+    );
+    expect(getSandboxMock("beta")).toBeNull();
+    expect(registerSandboxMock).not.toHaveBeenCalled();
   });
 
   it("removes a registered clone when live inference re-proof fails", async () => {

--- a/src/lib/actions/sandbox/snapshot-auto-create-failure.test.ts
+++ b/src/lib/actions/sandbox/snapshot-auto-create-failure.test.ts
@@ -1,32 +1,114 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it, vi } from "vitest";
-import { resolveTestAgentBaselinePolicy } from "../../../../test/support/snapshot-policy-test-fixture";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { hostLocalInferenceReceipt } from "../../../../test/helpers/host-local-inference-receipt";
+import {
+  createInMemoryRuntimeProviderBundle,
+} from "../../../../test/helpers/runtime-provider-bundle";
+import {
+  resolveTestAgentBaselinePolicy,
+} from "../../../../test/support/snapshot-policy-test-fixture";
+import {
+  serializeHostLocalInferenceReceipt,
+  type HostLocalInferenceOperation,
+  type HostLocalInferenceRuntime,
+} from "../../onboard/runtime-provider/host-local-inference";
 import type { SnapshotStreamSandboxCreateMock } from "./snapshot-create-stream-test-types";
 
-const captureOpenshellMock = vi.fn(() => ({ status: 0, output: "alpha Ready\n" }));
-const getSandboxMock = vi.fn((name?: string) =>
-  name === "alpha"
-    ? {
-        name: "alpha",
-        agent: "openclaw",
-        gatewayName: "nemoclaw",
-        imageTag: "nemoclaw-alpha:test",
-        openshellDriver: "docker",
-        provider: "nvidia-nim",
-        model: "nvidia/model-a",
-      }
-    : null,
-);
-const registerSandboxMock = vi.fn();
+const harness = vi.hoisted(() => ({
+  entries: new Map<string, Record<string, unknown>>(),
+  preserveForRebuild: vi.fn((value: unknown) => value),
+  prepareDestroy: vi.fn((value: unknown) => value),
+  destroy: vi.fn((value: unknown) => ({ status: "removed", receipt: value })),
+}));
+const captureOpenshellMock = vi.fn(() => ({
+  status: 0,
+  output: "alpha Ready\nbeta Ready\nId: beta-runtime-id\n",
+}));
+const getSandboxMock = vi.fn((name?: string) => harness.entries.get(name ?? "") ?? null);
+const registerSandboxMock = vi.fn((entry: Record<string, unknown>) => {
+  harness.entries.set(String(entry.name), entry);
+});
 const restoreSandboxStateMock = vi.fn();
+const captureSnapshotRestoreAuthorityMock = vi.fn();
 const streamSandboxCreateMock = vi.fn<SnapshotStreamSandboxCreateMock>(async () => ({
   status: 7,
   output: "create failed before registry write",
   sawProgress: false,
   forcedReady: false,
 }));
+const removeSandboxRegistryEntryOutcomeMock = vi.fn((name: string) => {
+  const removed = harness.entries.delete(name);
+  return { status: removed ? ("complete" as const) : ("not-found" as const), removed };
+});
+
+const managedRuntime: HostLocalInferenceRuntime = {
+  providerId: "mxc",
+  authorityId: "mxc:host-local",
+  services: ["ollama", "nim", "vllm"],
+  translateContainerArgs: (args) => args,
+  qualifyOllama: vi.fn(),
+  startManaged: vi.fn(),
+  inspectManaged: vi.fn((value) => ({ running: true, receipt: value })),
+  stopManaged: vi.fn((value) => ({ running: false, receipt: value })),
+  preserveForRebuild:
+    harness.preserveForRebuild as HostLocalInferenceRuntime["preserveForRebuild"],
+  prepareDestroy: harness.prepareDestroy as HostLocalInferenceRuntime["prepareDestroy"],
+  destroy: harness.destroy as HostLocalInferenceRuntime["destroy"],
+};
+const operation: HostLocalInferenceOperation = {
+  providerId: "mxc",
+  engine: {
+    operation: "host-local-inference",
+    engineId: "memory",
+    displayName: "In-memory",
+    authorityId: "mxc:host-local",
+    capture: vi.fn(),
+    captureHost: vi.fn(),
+  },
+  bindingSha256: "a".repeat(64),
+  assertAuthority: vi.fn(),
+  spawn: vi.fn() as HostLocalInferenceOperation["spawn"],
+  createLlamaCppLifecycle: vi.fn() as HostLocalInferenceOperation["createLlamaCppLifecycle"],
+  managedRuntime,
+};
+const runtimeProvider = createInMemoryRuntimeProviderBundle({
+  providerId: "mxc",
+  workloadProfile: {
+    support: null,
+    hostArchitectures: ["x64"],
+    managedImageSelectionPolicy: "prefer-managed",
+    legacyDockerfileBuilds: false,
+  },
+  hostLocalInference: {
+    services: ["ollama", "nim", "vllm"],
+    createOperation: () => operation,
+  },
+});
+
+function managedHostLocalReceipt(): string {
+  const receipt = hostLocalInferenceReceipt("mxc");
+  return serializeHostLocalInferenceReceipt({
+    ...receipt,
+    engineAuthority: { ...receipt.engineAuthority, engineId: "memory" },
+  });
+}
+
+function sourceEntry(receipt?: string): Record<string, unknown> {
+  return {
+    name: "alpha",
+    agent: "openclaw",
+    gatewayName: "nemoclaw",
+    imageTag: "nemoclaw-alpha:test",
+    openshellDriver: receipt ? "mxc" : "docker",
+    provider: "vllm-local",
+    model: "model-a",
+    endpointUrl: "https://inference.local/v1",
+    lifecycleGeneration: "alpha-generation-1",
+    ...(receipt ? { hostLocalInferenceReceipt: receipt } : {}),
+  };
+}
 
 vi.mock("../../adapters/docker", () => ({
   dockerCapture: vi.fn(() => ""),
@@ -114,13 +196,17 @@ vi.mock("../../state/mcp-lifecycle-lock", () => ({
 }));
 vi.mock("../../state/registry", () => ({
   getSandbox: getSandboxMock,
-  listSandboxes: vi.fn(() => ({ sandboxes: [getSandboxMock("alpha")], defaultSandbox: "alpha" })),
+  listSandboxes: vi.fn(() => ({
+    sandboxes: [...harness.entries.values()],
+    defaultSandbox: "alpha",
+  })),
   registerSandbox: registerSandboxMock,
-  removeSandbox: vi.fn(),
+  removeSandbox: vi.fn((name: string) => harness.entries.delete(name)),
   updateSandbox: vi.fn(),
 }));
 vi.mock("../../state/sandbox", () => ({
   backupSandboxState: vi.fn(),
+  captureSnapshotRestoreAuthority: captureSnapshotRestoreAuthorityMock,
   findBackup: vi.fn(() => ({ match: null })),
   getLatestBackup: vi.fn(() => ({
     timestamp: "2026-06-15T00:00:00.000Z",
@@ -131,17 +217,36 @@ vi.mock("../../state/sandbox", () => ({
 }));
 vi.mock("./destroy", () => ({
   cleanupShieldsDestroyArtifacts: vi.fn(),
-  removeSandboxRegistryEntry: vi.fn(),
+  removeSandboxRegistryEntryOutcome: removeSandboxRegistryEntryOutcomeMock,
+  requireSandboxDestructiveCleanupAuthority: vi.fn(() => ({ provider: runtimeProvider })),
+}));
+vi.mock("./restore-gateway-pairing", () => ({
+  establishRestoredSandboxGatewayPairing: vi.fn(),
+  waitForRestoredSandboxGatewaySupervisor: vi.fn(() => true),
 }));
 vi.mock("./sandbox-gateway-routing", () => ({
   probeGatewayRunning: vi.fn(() => true),
   selectSandboxGatewayIfRegistered: vi.fn(() => true),
-  usesGatewayMetadataProbe: vi.fn(
-    (driver?: string | null) => driver === "docker" || driver === "vm",
-  ),
+  usesGatewayMetadataProbe: vi.fn(() => true),
+}));
+vi.mock("./snapshot/dependencies", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./snapshot/dependencies")>()),
+  requireCurrentSnapshotRuntimeProvider: vi.fn(() => runtimeProvider),
 }));
 
 describe("snapshot restore auto-create failures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.entries.clear();
+    harness.entries.set("alpha", sourceEntry());
+    streamSandboxCreateMock.mockResolvedValue({
+      status: 7,
+      output: "create failed before registry write",
+      sawProgress: false,
+      forcedReady: false,
+    });
+  });
+
   it("does not register a ghost sandbox when auto-create fails", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
@@ -160,6 +265,54 @@ describe("snapshot restore auto-create failures", () => {
       expect.objectContaining({ initialPhase: "create" }),
     );
     expect(registerSandboxMock).not.toHaveBeenCalled();
+    expect(restoreSandboxStateMock).not.toHaveBeenCalled();
+  });
+
+  it("removes a registered clone when live inference re-proof fails", async () => {
+    const receipt = managedHostLocalReceipt();
+    harness.entries.set("alpha", sourceEntry(receipt));
+    harness.preserveForRebuild
+      .mockImplementationOnce((value) => value)
+      .mockImplementationOnce(() => {
+        throw new Error("injected live route failure");
+      });
+    streamSandboxCreateMock.mockResolvedValue({
+      status: 0,
+      output: "beta Ready",
+      sawProgress: true,
+      forcedReady: false,
+    });
+    const { getLatestBackup } = await import("../../state/sandbox");
+    vi.mocked(getLatestBackup).mockReturnValue({
+      timestamp: "2026-08-02T00-00-00-000Z",
+      backupPath: "/tmp/backup-alpha",
+      hostLocalInferenceReceipt: receipt,
+    } as ReturnType<typeof getLatestBackup>);
+    captureSnapshotRestoreAuthorityMock.mockReturnValue({
+      schemaVersion: 1,
+      backupPath: "/tmp/backup-alpha",
+      contentSha256: "e".repeat(64),
+    });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const { runSandboxSnapshot } = await import("./snapshot");
+
+    await expect(
+      runSandboxSnapshot("alpha", { kind: "restore", to: "beta" }),
+    ).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(harness.preserveForRebuild).toHaveBeenCalledTimes(2);
+    expect(registerSandboxMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "beta", hostLocalInferenceReceipt: receipt }),
+    );
+    expect(harness.prepareDestroy).toHaveBeenCalledTimes(2);
+    expect(harness.destroy).not.toHaveBeenCalled();
+    const nimRuntime = await import("../../inference/nim");
+    expect(nimRuntime.stopNimContainer).not.toHaveBeenCalled();
+    expect(nimRuntime.stopNimContainerByName).not.toHaveBeenCalled();
+    expect(removeSandboxRegistryEntryOutcomeMock).toHaveBeenCalledWith("beta");
+    expect(getSandboxMock("beta")).toBeNull();
+    expect(consoleError.mock.calls.flat().join("\n")).toContain("injected live route failure");
     expect(restoreSandboxStateMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/actions/sandbox/snapshot-command-host-local-authority.test.ts
+++ b/src/lib/actions/sandbox/snapshot-command-host-local-authority.test.ts
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { hostLocalInferenceReceipt } from "../../../../test/helpers/host-local-inference-receipt";
+import { createInMemoryRuntimeProviderBundle } from "../../../../test/helpers/runtime-provider-bundle";
+import {
+  type HostLocalInferenceOperation,
+  type HostLocalInferenceRuntime,
+  serializeHostLocalInferenceReceipt,
+} from "../../onboard/runtime-provider/host-local-inference";
+import type { SandboxEntry } from "../../state/registry/types";
+import type { RebuildManifest, RestoreResult, SnapshotRestoreOptions } from "../../state/sandbox";
+import { runSandboxSnapshot } from "./snapshot";
+
+const harness = vi.hoisted(() => {
+  let registryEntry: unknown = null;
+  const events: string[] = [];
+  return {
+    events,
+    getSandbox: vi.fn(() => registryEntry),
+    setRegistryEntry: (entry: unknown) => {
+      registryEntry = entry;
+    },
+    getLatestBackup: vi.fn(),
+    captureSnapshotRestoreAuthority: vi.fn(),
+    restoreSandboxState: vi.fn(),
+    preserveForRebuild: vi.fn((receipt: unknown) => {
+      events.push("reprove");
+      return receipt;
+    }),
+  };
+});
+
+const managedRuntime: HostLocalInferenceRuntime = {
+  providerId: "docker",
+  authorityId: "docker:host-local",
+  services: ["vllm"],
+  translateContainerArgs: (args) => args,
+  qualifyOllama: vi.fn(),
+  startManaged: vi.fn(),
+  inspectManaged: vi.fn((value) => ({ running: true, receipt: value })),
+  stopManaged: vi.fn((value) => ({ running: false, receipt: value })),
+  preserveForRebuild: harness.preserveForRebuild as HostLocalInferenceRuntime["preserveForRebuild"],
+  prepareDestroy: vi.fn((value) => value),
+  destroy: vi.fn((value) => ({ status: "removed" as const, receipt: value })),
+};
+const operation: HostLocalInferenceOperation = {
+  providerId: "docker",
+  engine: {
+    operation: "host-local-inference",
+    engineId: "memory",
+    displayName: "In-memory",
+    authorityId: "docker:host-local",
+    capture: vi.fn(),
+    captureHost: vi.fn(),
+  },
+  bindingSha256: "a".repeat(64),
+  assertAuthority: vi.fn(),
+  spawn: vi.fn() as HostLocalInferenceOperation["spawn"],
+  createLlamaCppLifecycle: vi.fn() as HostLocalInferenceOperation["createLlamaCppLifecycle"],
+  managedRuntime,
+};
+const provider = createInMemoryRuntimeProviderBundle({
+  providerId: "docker",
+  workloadProfile: {
+    support: null,
+    hostArchitectures: ["x64"],
+    managedImageSelectionPolicy: "prefer-managed",
+    legacyDockerfileBuilds: true,
+  },
+  hostLocalInference: { services: ["vllm"], createOperation: () => operation },
+});
+
+vi.mock("../../adapters/openshell/runtime", () => ({
+  captureOpenshell: vi.fn(() => ({ status: 0, output: "alpha Ready\n" })),
+  getOpenshellBinary: vi.fn(() => "openshell"),
+  runOpenshell: vi.fn(() => ({ status: 0, output: "" })),
+}));
+
+vi.mock("../../policy", () => ({
+  applyPreset: vi.fn(() => true),
+  applyPresetContent: vi.fn(() => true),
+  getAppliedPresets: vi.fn(() => []),
+  getPresetContentGatewayState: vi.fn(() => "absent"),
+  loadPresetForSandbox: vi.fn(() => null),
+  removePreset: vi.fn(() => true),
+}));
+
+vi.mock("../../runtime-recovery", () => ({
+  parseLiveSandboxNames: vi.fn(() => new Set(["alpha"])),
+}));
+
+vi.mock("../../shields", () => ({
+  isShieldsDown: vi.fn(() => true),
+  repairMutableConfigPerms: vi.fn(() => ({ applied: true, verified: true, errors: [] })),
+}));
+
+vi.mock("../../shields/timer-bound-lock", () => ({
+  withTimerBoundShieldsMutationLock: vi.fn(
+    (_name: string, _operation: string, callback: () => unknown) => callback(),
+  ),
+}));
+
+vi.mock("../../state/mcp-lifecycle-lock", () => ({
+  withSandboxMutationLock: vi.fn((_name: string, callback: () => Promise<unknown>) => callback()),
+}));
+
+vi.mock("../../state/registry", () => ({
+  getBaselineExclusions: vi.fn(() => []),
+  getCustomPolicies: vi.fn(() => []),
+  getSandbox: harness.getSandbox,
+  listSandboxes: vi.fn(() => ({
+    sandboxes: [harness.getSandbox()].filter(Boolean),
+    defaultSandbox: "alpha",
+  })),
+  updateSandbox: vi.fn(),
+}));
+
+vi.mock("../../state/sandbox", () => ({
+  captureSnapshotRestoreAuthority: harness.captureSnapshotRestoreAuthority,
+  findBackup: vi.fn(() => ({ match: null })),
+  getLatestBackup: harness.getLatestBackup,
+  listBackups: vi.fn(() => []),
+  restoreSandboxState: harness.restoreSandboxState,
+}));
+
+vi.mock("./sandbox-gateway-routing", () => ({
+  probeGatewayRunning: vi.fn(() => true),
+  selectSandboxGatewayIfRegistered: vi.fn(() => true),
+  usesGatewayMetadataProbe: vi.fn(() => false),
+}));
+
+vi.mock("./snapshot/dependencies", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./snapshot/dependencies")>()),
+  requireCurrentSnapshotRuntimeProvider: vi.fn(() => provider),
+}));
+
+function receiptAtPort(port: number): string {
+  const receipt = hostLocalInferenceReceipt("docker");
+  return serializeHostLocalInferenceReceipt({
+    ...receipt,
+    engineAuthority: { ...receipt.engineAuthority, engineId: "memory" },
+    endpoint: { ...receipt.endpoint, port },
+  });
+}
+
+function manifest(receipt: string): RebuildManifest {
+  return {
+    version: 1,
+    sandboxName: "alpha",
+    timestamp: "2026-08-02T00-00-00-000Z",
+    agentType: "openclaw",
+    agentVersion: null,
+    expectedVersion: null,
+    stateDirs: [],
+    dir: "/sandbox",
+    backupPath: "/tmp/backup-alpha",
+    blueprintDigest: null,
+    hostLocalInferenceReceipt: receipt,
+  };
+}
+
+function sandbox(receipt: string): SandboxEntry {
+  return {
+    name: "alpha",
+    agent: "openclaw",
+    openshellDriver: "docker",
+    provider: "vllm-local",
+    model: "model-a",
+    endpointUrl: "https://inference.local/v1",
+    gatewayName: "nemoclaw",
+    gatewayPort: 8080,
+    lifecycleGeneration: "11111111-1111-4111-8111-111111111111",
+    lifecycleLiveIdentityFingerprint: "f".repeat(64),
+    hostLocalInferenceReceipt: receipt,
+  };
+}
+
+function successfulRestore(
+  _name: string,
+  _path: string,
+  options: SnapshotRestoreOptions = {},
+): RestoreResult {
+  harness.events.push("restore-start");
+  options.validateBeforeMutation?.();
+  harness.events.push("restore-complete");
+  return {
+    success: true,
+    restoredDirs: [],
+    failedDirs: [],
+    restoredFiles: [],
+    failedFiles: [],
+  };
+}
+
+describe("snapshot command host-local inference authority", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.events.length = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("re-proves authority before restore, at the mutation fence, and after success", async () => {
+    const receipt = receiptAtPort(8000);
+    harness.setRegistryEntry(sandbox(receipt));
+    harness.getLatestBackup.mockReturnValue(manifest(receipt));
+    harness.captureSnapshotRestoreAuthority.mockReturnValue({
+      schemaVersion: 1,
+      backupPath: "/tmp/backup-alpha",
+      contentSha256: "e".repeat(64),
+    });
+    harness.restoreSandboxState.mockImplementation(successfulRestore);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await runSandboxSnapshot("alpha", { kind: "restore" });
+
+    expect(harness.preserveForRebuild).toHaveBeenCalledTimes(4);
+    expect(harness.events).toEqual([
+      "reprove",
+      "reprove",
+      "restore-start",
+      "reprove",
+      "restore-complete",
+      "reprove",
+    ]);
+    expect(harness.restoreSandboxState).toHaveBeenCalledWith(
+      "alpha",
+      "/tmp/backup-alpha",
+      expect.objectContaining({
+        authority: expect.objectContaining({ contentSha256: "e".repeat(64) }),
+        validateBeforeMutation: expect.any(Function),
+      }),
+    );
+  });
+
+  it("rejects mismatched target authority before filesystem restore", async () => {
+    const snapshotReceipt = receiptAtPort(8000);
+    harness.setRegistryEntry(sandbox(receiptAtPort(8001)));
+    harness.getLatestBackup.mockReturnValue(manifest(snapshotReceipt));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(runSandboxSnapshot("alpha", { kind: "restore" })).rejects.toMatchObject({
+      exitCode: 1,
+    });
+
+    expect(harness.restoreSandboxState).not.toHaveBeenCalled();
+    expect(consoleError.mock.calls.flat().join("\n")).toContain(
+      "different host-local inference authority",
+    );
+  });
+});

--- a/src/lib/actions/sandbox/snapshot-restore-test-fixture.ts
+++ b/src/lib/actions/sandbox/snapshot-restore-test-fixture.ts
@@ -3,7 +3,11 @@
 
 import { vi } from "vitest";
 import { resolveTestAgentBaselinePolicy } from "../../../../test/support/snapshot-policy-test-fixture";
-import type { SandboxWorkloadReceipt } from "../../state/registry/types";
+import type {
+  SandboxEntry,
+  SandboxHostLocalInferenceProvenance,
+  SandboxWorkloadReceipt,
+} from "../../state/registry/types";
 import { dcodeProbeOutput } from "./dcode-probe-test-fixture";
 import { SANDBOX_EXEC_STARTED_MARKER } from "./sandbox-exec-output";
 import type { SnapshotStreamSandboxCreateMock } from "./snapshot-create-stream-test-types";
@@ -50,6 +54,13 @@ export type SandboxRecord = {
   observabilityEnabled?: boolean;
   provider?: string | null;
   model?: string | null;
+  endpointUrl?: string | null;
+  endpointSource?: SandboxEntry["endpointSource"];
+  credentialEnv?: string | null;
+  preferredInferenceApi?: string | null;
+  lifecycleGeneration?: string;
+  hostLocalInferenceReceipt?: string | null;
+  hostLocalInferenceProvenance?: SandboxHostLocalInferenceProvenance;
   dashboardPort?: number | null;
   hermesDashboardEnabled?: boolean;
   hermesDashboardPort?: number | null;
@@ -186,6 +197,7 @@ export const prepareInitialSandboxCreatePolicyMock = vi.fn(
   }),
 );
 export const registerSandboxMock = vi.fn();
+export const reserveSandboxInferenceRouteMock = vi.fn(() => true);
 export const updateSandboxMock = vi.fn();
 export const restoreSandboxStateMock = vi.fn();
 export const removeSandboxRegistryEntryOutcomeMock = vi.fn<
@@ -310,6 +322,7 @@ vi.mock("../../state/registry", () => ({
     defaultSandbox: "alpha",
   }),
   registerSandbox: registerSandboxMock,
+  reserveSandboxInferenceRoute: reserveSandboxInferenceRouteMock,
   removeSandbox: vi.fn(),
   updateSandbox: updateSandboxMock,
 }));
@@ -384,6 +397,7 @@ export function resetSnapshotRestoreMocks(): void {
     appliedPresets: [],
   }));
   registerSandboxMock.mockReset();
+  reserveSandboxInferenceRouteMock.mockReset().mockReturnValue(true);
   removeSandboxRegistryEntryOutcomeMock.mockReturnValue({ status: "complete", removed: true });
   updateSandboxMock.mockReset();
   restoreSandboxStateMock.mockReturnValue({

--- a/src/lib/actions/sandbox/snapshot.test.ts
+++ b/src/lib/actions/sandbox/snapshot.test.ts
@@ -5,6 +5,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { serializedLlamaCppHostLocalInferenceReceipt } from "../../../../test/helpers/host-local-inference-receipt";
+import { createSandboxHostLocalInferenceProvenance } from "../../state/registry/host-local-inference";
 import {
   type DcodeProbeState,
   dcodeProbeOutput,
@@ -742,6 +744,101 @@ describe("runSandboxSnapshot", () => {
       }),
     );
     expect(f.applyPresetMock).toHaveBeenCalledTimes(enabled ? 1 : 0);
+    },
+  );
+
+  it("reserves an explicit llama.cpp clone with the original owner and exact gateway authority", async () => {
+    const hostLocalInferenceReceipt = serializedLlamaCppHostLocalInferenceReceipt("docker");
+    const hostLocalInferenceProvenance = createSandboxHostLocalInferenceProvenance(
+      "alpha",
+      hostLocalInferenceReceipt,
+    );
+    let registeredClone: f.SandboxRecord | null = null;
+    f.registerSandboxMock.mockImplementation(
+      (entry) => (registeredClone = entry as f.SandboxRecord),
+    );
+    const source: f.SandboxRecord = {
+      name: "alpha",
+      agent: "openclaw",
+      imageTag: "nemoclaw-alpha:test",
+      openshellDriver: "docker",
+      provider: "llama-cpp-local",
+      model: "nemotron-llama-cpp",
+      endpointUrl: "https://inference.local/v1",
+      endpointSource: "inference-set",
+      credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+      preferredInferenceApi: "openai-completions",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      lifecycleGeneration: "alpha-generation-1",
+      hostLocalInferenceReceipt,
+      hostLocalInferenceProvenance,
+    };
+    f.getSandboxMock.mockImplementation((name) => (name === "alpha" ? source : registeredClone));
+    f.getLatestBackupMock.mockReturnValue({
+      ...f.latestBackupFixture,
+      agentType: "openclaw",
+      hostLocalInferenceReceipt,
+      hostLocalInferenceProvenance,
+    });
+    f.restoreSandboxStateMock.mockImplementation((_name, _path, options) => {
+      options?.validateBeforeMutation?.();
+      return {
+        success: true,
+        restoredDirs: [],
+        restoredFiles: [],
+        failedDirs: [],
+        failedFiles: [],
+      };
+    });
+    f.captureOpenshellMock.mockImplementation((args) =>
+      f.openshellResponses(args, {
+        "sandbox exec": { status: 0, output: dcodeProbeOutput("no-runtime") },
+        "sandbox list": { status: 0, output: "alpha Ready\nbeta Ready\n" },
+      }),
+    );
+    const dependencies = await import("./snapshot/dependencies");
+    const prepare = vi.spyOn(dependencies, "prepareHostLocalInferenceAuthority").mockImplementation(
+      (_provider, candidate, serializedReceipt) =>
+        ({
+          providerId: "docker",
+          sandboxName: candidate.name,
+          serializedReceipt,
+        }) as never,
+    );
+    const confirm = vi
+      .spyOn(dependencies, "confirmHostLocalInferenceAuthority")
+      .mockImplementation(() => undefined);
+    const { runSandboxSnapshot } = await import("./snapshot");
+
+    await runSandboxSnapshot("alpha", { kind: "restore", to: "beta" });
+
+    expect(f.reserveSandboxInferenceRouteMock).toHaveBeenCalledWith("beta", {
+      provider: "llama-cpp-local",
+      model: "nemotron-llama-cpp",
+      endpointUrl: "https://inference.local/v1",
+      endpointSource: "inference-set",
+      credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+      preferredInferenceApi: "openai-completions",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      openshellDriver: "docker",
+      hostLocalInferenceReceipt,
+      hostLocalInferenceProvenance,
+    });
+    expect(registeredClone).toMatchObject({
+      name: "beta",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      hostLocalInferenceReceipt,
+      hostLocalInferenceProvenance,
+    });
+    expect(
+      (registeredClone as f.SandboxRecord | null)?.hostLocalInferenceProvenance
+        ?.runtimeOwnerSandboxName,
+    ).toBe("alpha");
+    expect(prepare).toHaveBeenCalledTimes(2);
+    expect(confirm).toHaveBeenCalledTimes(2);
   });
 
   it.each([

--- a/src/lib/actions/sandbox/snapshot.ts
+++ b/src/lib/actions/sandbox/snapshot.ts
@@ -3,6 +3,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { dockerCapture } from "../../adapters/docker";
 import {
   captureOpenshell,
@@ -448,6 +449,25 @@ async function autoCreateSandboxFromSource(
   ];
   const createEnv = { ...process.env };
   delete createEnv.NEMOCLAW_OBSERVABILITY;
+  let cloneHostLocalReservation: Pick<
+    SandboxEntry,
+    "hostLocalInferenceReceipt" | "hostLocalInferenceProvenance"
+  > | null = null;
+  const releaseCloneHostLocalReservation = (): void => {
+    if (!cloneHostLocalReservation) return;
+    const current = registry.getSandbox(dstName);
+    if (
+      current?.pendingRouteReservation === true &&
+      current.hostLocalInferenceReceipt === cloneHostLocalReservation.hostLocalInferenceReceipt &&
+      isDeepStrictEqual(
+        current.hostLocalInferenceProvenance,
+        cloneHostLocalReservation.hostLocalInferenceProvenance,
+      )
+    ) {
+      registry.removeSandbox(dstName);
+    }
+    cloneHostLocalReservation = null;
+  };
 
   const command = openshellBin;
   const commandArgs = [
@@ -464,22 +484,66 @@ async function autoCreateSandboxFromSource(
     ...startupCommand,
   ];
 
+  const sourceAuthority = srcEntry as SandboxEntry;
+  if (sourceAuthority.hostLocalInferenceProvenance) {
+    if (
+      typeof sourceAuthority.hostLocalInferenceReceipt !== "string" ||
+      typeof sourceAuthority.provider !== "string" ||
+      typeof sourceAuthority.model !== "string" ||
+      !isValidForwardPort(sourceAuthority.gatewayPort) ||
+      typeof sourceAuthority.openshellDriver !== "string"
+    ) {
+      throw new SnapshotCommandError(
+        "Source host-local inference lifecycle authority is incomplete.",
+      );
+    }
+    const reserved = registry.reserveSandboxInferenceRoute(dstName, {
+      provider: sourceAuthority.provider,
+      model: sourceAuthority.model,
+      endpointUrl: sourceAuthority.endpointUrl ?? null,
+      endpointSource: sourceAuthority.endpointSource ?? null,
+      credentialEnv: sourceAuthority.credentialEnv ?? null,
+      preferredInferenceApi: sourceAuthority.preferredInferenceApi ?? null,
+      gatewayName: sourceGatewayName,
+      gatewayPort: sourceAuthority.gatewayPort,
+      openshellDriver: sourceAuthority.openshellDriver,
+      hostLocalInferenceReceipt: sourceAuthority.hostLocalInferenceReceipt,
+      hostLocalInferenceProvenance: sourceAuthority.hostLocalInferenceProvenance,
+    });
+    if (!reserved) {
+      throw new SnapshotCommandError(
+        "Could not reserve the clone's exact host-local inference authority.",
+      );
+    }
+    cloneHostLocalReservation = {
+      hostLocalInferenceReceipt: sourceAuthority.hostLocalInferenceReceipt,
+      hostLocalInferenceProvenance: sourceAuthority.hostLocalInferenceProvenance,
+    };
+  }
+
   console.log(`  '${dstName}' does not exist. Creating from '${srcName}' image (${fromImage})...`);
 
-  const createResult = await streamSandboxCreate(command, commandArgs, createEnv, {
-    // Use a pre-built image, so skip build+push and jump to pod creation.
-    initialPhase: "create",
-    // Wait until the sandbox actually reaches Ready state, not just appears in the list.
-    readyCheck: () => {
-      const list = captureOpenshell(["sandbox", "list", "-g", sourceGatewayName], {
-        ignoreError: true,
-      });
-      if (list.status !== 0) return false;
-      return isSandboxReady(list.output || "", dstName);
-    },
-  });
+  let createResult: Awaited<ReturnType<typeof streamSandboxCreate>>;
+  try {
+    createResult = await streamSandboxCreate(command, commandArgs, createEnv, {
+      // Use a pre-built image, so skip build+push and jump to pod creation.
+      initialPhase: "create",
+      // Wait until the sandbox actually reaches Ready state, not just appears in the list.
+      readyCheck: () => {
+        const list = captureOpenshell(["sandbox", "list", "-g", sourceGatewayName], {
+          ignoreError: true,
+        });
+        if (list.status !== 0) return false;
+        return isSandboxReady(list.output || "", dstName);
+      },
+    });
+  } catch (error) {
+    releaseCloneHostLocalReservation();
+    throw error;
+  }
 
   if (createResult.status !== 0 && !createResult.forcedReady) {
+    releaseCloneHostLocalReservation();
     console.error(`  Failed to create sandbox '${dstName}' (exit ${createResult.status}).`);
     const tail = (createResult.output || "").slice(-600);
     if (tail) console.error(tail);
@@ -491,12 +555,14 @@ async function autoCreateSandboxFromSource(
     ignoreError: true,
   });
   if (verify.status !== 0 || !isSandboxReady(verify.output || "", dstName)) {
+    releaseCloneHostLocalReservation();
     failUnregisteredSnapshotClone(dstName, sourceGatewayName);
   }
   let lifecycleRegistration: ReturnType<typeof cloneLifecycle.capture>;
   try {
     lifecycleRegistration = cloneLifecycle.capture();
   } catch {
+    releaseCloneHostLocalReservation();
     failUnregisteredSnapshotClone(dstName, sourceGatewayName);
   }
 
@@ -517,38 +583,45 @@ async function autoCreateSandboxFromSource(
   try {
     finalLifecycleRegistration = cloneLifecycle.revalidate(lifecycleRegistration);
   } catch {
+    releaseCloneHostLocalReservation();
     failUnregisteredSnapshotClone(dstName, sourceGatewayName);
   }
-  registry.registerSandbox({
-    ...srcEntry,
-    name: dstName,
-    createdAt: new Date().toISOString(),
-    policies: [],
-    observabilityEnabled: sourceObservabilityEnabled,
-    // dst has its own lifecycle; don't inherit src's local NIM container
-    // reference, or destroying dst would stop src's NIM.
-    nimContainer: null,
-    // No CUDA proof has run for dst (this auto-create path passes no GPU flags),
-    // so clear src's proof rather than inheriting it — otherwise dst could show
-    // `Sandbox GPU: enabled (CUDA verified)` based on another sandbox's run (#4231).
-    sandboxGpuProof: null,
-    dashboardPort: dstDashboardPort,
-    // The spread above carries the source's API port; the clone owns its own.
-    hermesApiPort: dstHermesApiPort,
-    // The shared image keeps Hermes' image-baked internal listener port, but
-    // the public WebUI port is a per-sandbox host resource and must follow the
-    // clone's newly allocated dashboard port so rebuild validation converges.
-    hermesDashboardPort:
-      (srcEntry as SandboxEntry).hermesDashboardEnabled === true
-        ? dstDashboardPort
-        : (srcEntry as SandboxEntry).hermesDashboardPort,
-    // A legacy source may have only a gateway name (or neither binding
-    // field). Register the new clone with the complete canonical binding so
-    // stop/start, recovery, and later snapshots can address its gateway.
-    gatewayName: sourceGatewayName,
-    gatewayPort: sourceGatewayPort,
-    ...finalLifecycleRegistration,
-  });
+  try {
+    registry.registerSandbox({
+      ...srcEntry,
+      name: dstName,
+      createdAt: new Date().toISOString(),
+      policies: [],
+      observabilityEnabled: sourceObservabilityEnabled,
+      // dst has its own lifecycle; don't inherit src's local NIM container
+      // reference, or destroying dst would stop src's NIM.
+      nimContainer: null,
+      // No CUDA proof has run for dst (this auto-create path passes no GPU flags),
+      // so clear src's proof rather than inheriting it — otherwise dst could show
+      // `Sandbox GPU: enabled (CUDA verified)` based on another sandbox's run (#4231).
+      sandboxGpuProof: null,
+      dashboardPort: dstDashboardPort,
+      // The spread above carries the source's API port; the clone owns its own.
+      hermesApiPort: dstHermesApiPort,
+      // The shared image keeps Hermes' image-baked internal listener port, but
+      // the public WebUI port is a per-sandbox host resource and must follow the
+      // clone's newly allocated dashboard port so rebuild validation converges.
+      hermesDashboardPort:
+        (srcEntry as SandboxEntry).hermesDashboardEnabled === true
+          ? dstDashboardPort
+          : (srcEntry as SandboxEntry).hermesDashboardPort,
+      // A legacy source may have only a gateway name (or neither binding
+      // field). Register the new clone with the complete canonical binding so
+      // stop/start, recovery, and later snapshots can address its gateway.
+      gatewayName: sourceGatewayName,
+      gatewayPort: sourceGatewayPort,
+      ...finalLifecycleRegistration,
+    });
+    cloneHostLocalReservation = null;
+  } catch {
+    releaseCloneHostLocalReservation();
+    failUnregisteredSnapshotClone(dstName, sourceGatewayName);
+  }
 
   const sourceAgent = (srcEntry as SandboxEntry).agent || "openclaw";
   if (sourceAgent === "openclaw" && !waitForRestoredSandboxGatewaySupervisor(dstName)) {
@@ -1224,6 +1297,7 @@ async function runSnapshotRestoreUnlocked(
   const currentSourceEntry = registry.getSandbox(sandboxName);
   let hasManagedProfileAuthority = false;
   const hostLocalInferenceReceipt = resolvedSnapshot.hostLocalInferenceReceipt;
+  const hostLocalInferenceProvenance = resolvedSnapshot.hostLocalInferenceProvenance;
   let snapshotRestoreAuthority: sandboxState.SnapshotRestoreAuthority | null = null;
   try {
     const snapshotAuthority = readManagedSnapshotProfileAuthority(snapshotProfileSource);
@@ -1248,6 +1322,14 @@ async function runSnapshotRestoreUnlocked(
       if (!currentSourceEntry) {
         throw new Error("host-local inference snapshot source is no longer registered");
       }
+      if (
+        !isDeepStrictEqual(
+          currentSourceEntry.hostLocalInferenceProvenance,
+          hostLocalInferenceProvenance,
+        )
+      ) {
+        throw new Error("snapshot inference provenance differs from the registered source");
+      }
       const sourceProvider = requireCurrentSnapshotRuntimeProvider(currentSourceEntry);
       const preparedSource = prepareHostLocalInferenceAuthority(
         sourceProvider,
@@ -1255,7 +1337,7 @@ async function runSnapshotRestoreUnlocked(
         hostLocalInferenceReceipt,
       );
       if (!preparedSource) {
-        throw new Error("snapshot inference receipt has no B4-E1 lifecycle authority");
+        throw new Error("snapshot inference receipt has no common lifecycle authority");
       }
     }
     if (hasManagedProfileAuthority || typeof hostLocalInferenceReceipt === "string") {
@@ -1335,7 +1417,7 @@ async function runSnapshotRestoreUnlocked(
           hostLocalInferenceReceipt,
         );
         if (!preparedHostLocalInferenceRestore) {
-          throw new Error("snapshot inference receipt has no B4-E1 lifecycle authority");
+          throw new Error("snapshot inference receipt has no common lifecycle authority");
         }
       } catch (error) {
         console.error(
@@ -1513,7 +1595,7 @@ async function runSnapshotRestoreUnlocked(
           hostLocalInferenceReceipt,
         );
         if (!preparedHostLocalInferenceRestore) {
-          throw new Error("snapshot inference receipt has no B4-E1 lifecycle authority");
+          throw new Error("snapshot inference receipt has no common lifecycle authority");
         }
       } catch (error) {
         console.error(

--- a/src/lib/actions/sandbox/snapshot.ts
+++ b/src/lib/actions/sandbox/snapshot.ts
@@ -86,15 +86,21 @@ import {
 } from "./sandbox-gateway-routing";
 import {
   backupSandboxStateWithManagedAuthority,
+  confirmHostLocalInferenceAuthority,
   createSnapshotCloneLifecycle,
-  fingerprintSandboxLiveIdentity,
   confirmSandboxRuntimeRestore,
+  fingerprintSandboxLiveIdentity,
+  type PreparedHostLocalInferenceAuthority,
   type PreparedSandboxRuntimeRestore,
+  prepareHostLocalInferenceAuthority,
   prepareManagedSnapshotProfileRestore,
+  prepareSandboxHostLocalInferenceDestroyAuthority,
   prepareSandboxRuntimeRestore,
   readManagedSnapshotProfileAuthority,
   rejectManagedSnapshotCloneUntilRebind,
   requireCurrentSnapshotRuntimeProvider,
+  retirePreparedHostLocalInferenceAuthority,
+  type RuntimeProviderBundle,
 } from "./snapshot/dependencies";
 import { formatSnapshotBaselineExclusionSummary } from "./snapshot-baseline-exclusion-summary";
 import { printHermesGatewayRestoreHint } from "./snapshot-hermes-gateway-hint";
@@ -578,8 +584,14 @@ function deleteSandboxForRestore(name: string): void {
       );
       snapshotExit(1);
     }
+    let runtimeProvider: RuntimeProviderBundle;
+    let hostLocalInferenceAuthority: PreparedHostLocalInferenceAuthority | null;
     try {
-      requireSandboxDestructiveCleanupAuthority(name, sbMeta);
+      runtimeProvider = requireSandboxDestructiveCleanupAuthority(name, sbMeta).provider;
+      hostLocalInferenceAuthority = prepareSandboxHostLocalInferenceDestroyAuthority(
+        runtimeProvider,
+        sbMeta,
+      );
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       console.error(
@@ -590,10 +602,12 @@ function deleteSandboxForRestore(name: string): void {
       );
       snapshotExit(1);
     }
-    if (sbMeta.nimContainer) {
-      nim.stopNimContainerByName(sbMeta.nimContainer);
-    } else {
-      nim.stopNimContainer(name, { silent: true });
+    if (!hostLocalInferenceAuthority) {
+      if (sbMeta.nimContainer) {
+        nim.stopNimContainerByName(sbMeta.nimContainer);
+      } else {
+        nim.stopNimContainer(name, { silent: true });
+      }
     }
     console.log(`  Deleting existing destination '${name}' before restore...`);
     if (readTimerMarker(name)) {
@@ -614,6 +628,25 @@ function deleteSandboxForRestore(name: string): void {
         `  Failed to delete '${name}' (exit ${deleteResult.status}). Aborting restore.`,
       );
       snapshotExit(1);
+    }
+    if (hostLocalInferenceAuthority) {
+      try {
+        const current = registry.getSandbox(name);
+        if (!current) throw new Error(`sandbox '${name}' is no longer registered`);
+        retirePreparedHostLocalInferenceAuthority(
+          runtimeProvider,
+          current,
+          hostLocalInferenceAuthority,
+          registry.listSandboxes().sandboxes,
+        );
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        console.error(
+          `  Destination '${name}' is gone, but its host-local inference cleanup failed: ${detail}`,
+        );
+        console.error("  Local ownership state was preserved; retry the restore to reconcile it.");
+        snapshotExit(1);
+      }
     }
     // Destination-only cleanup so the recreated sandbox does not inherit stale
     // host-side state or hit provider-name conflicts (Codex #3796 P2):
@@ -1190,6 +1223,7 @@ async function runSnapshotRestoreUnlocked(
   };
   const currentSourceEntry = registry.getSandbox(sandboxName);
   let hasManagedProfileAuthority = false;
+  const hostLocalInferenceReceipt = resolvedSnapshot.hostLocalInferenceReceipt;
   let snapshotRestoreAuthority: sandboxState.SnapshotRestoreAuthority | null = null;
   try {
     const snapshotAuthority = readManagedSnapshotProfileAuthority(snapshotProfileSource);
@@ -1210,7 +1244,21 @@ async function runSnapshotRestoreUnlocked(
     if (isCrossSandboxRestore && hasManagedProfileAuthority) {
       rejectManagedSnapshotCloneUntilRebind(snapshotProfileSource, targetSandbox);
     }
-    if (hasManagedProfileAuthority) {
+    if (typeof hostLocalInferenceReceipt === "string") {
+      if (!currentSourceEntry) {
+        throw new Error("host-local inference snapshot source is no longer registered");
+      }
+      const sourceProvider = requireCurrentSnapshotRuntimeProvider(currentSourceEntry);
+      const preparedSource = prepareHostLocalInferenceAuthority(
+        sourceProvider,
+        currentSourceEntry,
+        hostLocalInferenceReceipt,
+      );
+      if (!preparedSource) {
+        throw new Error("snapshot inference receipt has no B4-E1 lifecycle authority");
+      }
+    }
+    if (hasManagedProfileAuthority || typeof hostLocalInferenceReceipt === "string") {
       snapshotRestoreAuthority = sandboxState.captureSnapshotRestoreAuthority(
         backupPath,
         resolvedSnapshot,
@@ -1221,7 +1269,7 @@ async function runSnapshotRestoreUnlocked(
     }
   } catch (error) {
     console.error(
-      `  Cannot restore managed snapshot authority: ${
+      `  Cannot restore provider snapshot authority: ${
         error instanceof Error ? error.message : String(error)
       }.`,
     );
@@ -1230,6 +1278,7 @@ async function runSnapshotRestoreUnlocked(
   }
 
   let preparedRuntimeRestore: PreparedSandboxRuntimeRestore | null = null;
+  let preparedHostLocalInferenceRestore: PreparedHostLocalInferenceAuthority | null = null;
   if (!isCrossSandboxRestore) {
     // Self-restore: target is `sandboxName`. Cannot auto-create; the
     // source pod is the target, so it must already be live.
@@ -1264,6 +1313,33 @@ async function runSnapshotRestoreUnlocked(
       } catch (error) {
         console.error(
           `  Cannot preflight managed snapshot restore: ${
+            error instanceof Error ? error.message : String(error)
+          }.`,
+        );
+        snapshotExit(1);
+      }
+    }
+    if (typeof hostLocalInferenceReceipt === "string") {
+      const currentTarget = registry.getSandbox(targetSandbox);
+      if (!currentTarget) {
+        console.error(
+          `  Cannot restore host-local inference snapshot '${sandboxName}': target authority is missing.`,
+        );
+        snapshotExit(1);
+      }
+      try {
+        const provider = requireCurrentSnapshotRuntimeProvider(currentTarget);
+        preparedHostLocalInferenceRestore = prepareHostLocalInferenceAuthority(
+          provider,
+          currentTarget,
+          hostLocalInferenceReceipt,
+        );
+        if (!preparedHostLocalInferenceRestore) {
+          throw new Error("snapshot inference receipt has no B4-E1 lifecycle authority");
+        }
+      } catch (error) {
+        console.error(
+          `  Cannot preflight host-local inference snapshot restore: ${
             error instanceof Error ? error.message : String(error)
           }.`,
         );
@@ -1421,73 +1497,126 @@ async function runSnapshotRestoreUnlocked(
     await withDashboardPortReservationLock(() =>
       withGatewayRouteMutationLock(sourceGatewayName, createAndRegisterClone),
     );
+    if (typeof hostLocalInferenceReceipt === "string") {
+      const currentTarget = registry.getSandbox(targetSandbox);
+      if (!currentTarget) {
+        console.error(
+          `  Clone '${targetSandbox}' was created without durable host-local inference authority.`,
+        );
+        snapshotExit(1);
+      }
+      try {
+        const provider = requireCurrentSnapshotRuntimeProvider(currentTarget);
+        preparedHostLocalInferenceRestore = prepareHostLocalInferenceAuthority(
+          provider,
+          currentTarget,
+          hostLocalInferenceReceipt,
+        );
+        if (!preparedHostLocalInferenceRestore) {
+          throw new Error("snapshot inference receipt has no B4-E1 lifecycle authority");
+        }
+      } catch (error) {
+        console.error(
+          `  Cannot re-prove clone '${targetSandbox}' against snapshot inference authority: ${
+            error instanceof Error ? error.message : String(error)
+          }.`,
+        );
+        console.error(
+          `  Removing incomplete clone '${targetSandbox}' while its exact provider ownership is still registered.`,
+        );
+        deleteSandboxForRestore(targetSandbox);
+        snapshotExit(1);
+      }
+    }
   }
   withTimerBoundShieldsMutationLock(targetSandbox, "restore sandbox snapshot", () => {
     // Serialize filesystem restore, mutable-permission repair, and policy
     // reconciliation under the active timer generation. At the absolute
     // deadline, auto-restore keeps the outer lifecycle gate closed and waits
     // for this exact owner to finish before restoring lockdown.
-    const validateManagedRestoreBeforeMutation = preparedRuntimeRestore
-      ? () => {
-          const currentTarget = registry.getSandbox(targetSandbox);
-          if (!currentTarget) {
-            throw new Error(`target '${targetSandbox}' is no longer registered`);
+    const validateProviderRestoreBeforeMutation =
+      preparedRuntimeRestore || preparedHostLocalInferenceRestore
+        ? () => {
+            const currentTarget = registry.getSandbox(targetSandbox);
+            if (!currentTarget) {
+              throw new Error(`target '${targetSandbox}' is no longer registered`);
+            }
+            const provider = requireCurrentSnapshotRuntimeProvider(currentTarget);
+            if (preparedRuntimeRestore) {
+              const profileRestore = prepareManagedSnapshotProfileRestore(
+                snapshotProfileSource,
+                currentTarget,
+                provider,
+              );
+              if (!profileRestore) {
+                throw new Error("managed profile restore authority is missing");
+              }
+              const prepared = preparedRuntimeRestore;
+              if (!prepared) throw new Error("managed runtime restore authority is missing");
+              // The state layer invokes this after local tar staging and
+              // immediately before its first remote filesystem mutation.
+              preparedRuntimeRestore = prepareSandboxRuntimeRestore(
+                provider,
+                currentTarget,
+                prepared.source,
+                profileRestore.providerRestoreAuthority,
+              );
+            }
+            if (typeof hostLocalInferenceReceipt === "string") {
+              if (!preparedHostLocalInferenceRestore) {
+                throw new Error("host-local inference restore authority is missing");
+              }
+              confirmHostLocalInferenceAuthority(
+                provider,
+                currentTarget,
+                preparedHostLocalInferenceRestore,
+              );
+            }
           }
-          const provider = requireCurrentSnapshotRuntimeProvider(currentTarget);
-          const profileRestore = prepareManagedSnapshotProfileRestore(
-            snapshotProfileSource,
-            currentTarget,
-            provider,
-          );
-          if (!profileRestore) {
-            throw new Error("managed profile restore authority is missing");
-          }
-          const prepared = preparedRuntimeRestore;
-          if (!prepared) throw new Error("managed runtime restore authority is missing");
-          // The state layer invokes this after local tar staging and
-          // immediately before its first remote filesystem mutation.
-          preparedRuntimeRestore = prepareSandboxRuntimeRestore(
-            provider,
-            currentTarget,
-            prepared.source,
-            profileRestore.providerRestoreAuthority,
-          );
-        }
-      : null;
+        : null;
     if (targetSandbox !== sandboxName) {
       console.log(`  Restoring snapshot from '${sandboxName}' into '${targetSandbox}'...`);
     } else {
       console.log(`  Restoring snapshot into '${sandboxName}'...`);
     }
-    if (Boolean(snapshotRestoreAuthority) !== Boolean(validateManagedRestoreBeforeMutation)) {
+    if (Boolean(snapshotRestoreAuthority) !== Boolean(validateProviderRestoreBeforeMutation)) {
       console.error(
-        `  Cannot restore managed snapshot '${sandboxName}': content authority and the runtime mutation fence must both be present.`,
+        `  Cannot restore provider snapshot '${sandboxName}': content authority and the runtime mutation fence must both be present.`,
       );
       console.error(`  Destination '${targetSandbox}' was not changed.`);
       snapshotExit(1);
     }
     const result =
-      snapshotRestoreAuthority && validateManagedRestoreBeforeMutation
+      snapshotRestoreAuthority && validateProviderRestoreBeforeMutation
         ? sandboxState.restoreSandboxState(targetSandbox, backupPath, {
             authority: snapshotRestoreAuthority,
-            validateBeforeMutation: validateManagedRestoreBeforeMutation,
+            validateBeforeMutation: validateProviderRestoreBeforeMutation,
           })
         : sandboxState.restoreSandboxState(targetSandbox, backupPath);
     if (result.success) {
-      if (preparedRuntimeRestore) {
+      if (preparedRuntimeRestore || preparedHostLocalInferenceRestore) {
         const currentTarget = registry.getSandbox(targetSandbox);
         if (!currentTarget) {
           console.error(
-            `  Managed snapshot state was restored, but target '${targetSandbox}' is no longer registered.`,
+            `  Provider snapshot state was restored, but target '${targetSandbox}' is no longer registered.`,
           );
           snapshotExit(1);
         }
         try {
           const provider = requireCurrentSnapshotRuntimeProvider(currentTarget);
-          confirmSandboxRuntimeRestore(provider, currentTarget, preparedRuntimeRestore);
+          if (preparedRuntimeRestore) {
+            confirmSandboxRuntimeRestore(provider, currentTarget, preparedRuntimeRestore);
+          }
+          if (preparedHostLocalInferenceRestore) {
+            confirmHostLocalInferenceAuthority(
+              provider,
+              currentTarget,
+              preparedHostLocalInferenceRestore,
+            );
+          }
         } catch (error) {
           console.error(
-            `  Managed snapshot state was restored, but provider restore proof failed: ${
+            `  Provider snapshot state was restored, but provider restore proof failed: ${
               error instanceof Error ? error.message : String(error)
             }.`,
           );

--- a/src/lib/actions/sandbox/snapshot/backup-authority.test.ts
+++ b/src/lib/actions/sandbox/snapshot/backup-authority.test.ts
@@ -7,6 +7,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import { managedStartupE2eProfile } from "../../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
 import {
+  serializedHostLocalInferenceReceipt,
+} from "../../../../../test/helpers/host-local-inference-receipt";
+import {
   MANAGED_IMAGE_REPOSITORIES,
   type ShippedManagedImageAgent,
 } from "../../../onboard/managed-image/contract";
@@ -121,6 +124,24 @@ function successfulBackup(options: BackupOptions): BackupResult {
   };
 }
 
+function hostLocalSandbox(
+  agent: "openclaw" | "hermes" | "langchain-deepagents-code",
+  overrides: Partial<SandboxEntry> = {},
+): SandboxEntry {
+  return {
+    name: "alpha",
+    agent,
+    openshellDriver: "mxc",
+    provider: "vllm-local",
+    model: "model-a",
+    endpointUrl: "https://inference.local/v1",
+    gatewayName: "nemoclaw",
+    lifecycleGeneration: "alpha-generation-1",
+    hostLocalInferenceReceipt: serializedHostLocalInferenceReceipt("mxc"),
+    ...overrides,
+  };
+}
+
 describe("managed snapshot backup authority", () => {
   it.each([
     "openclaw",
@@ -180,6 +201,104 @@ describe("managed snapshot backup authority", () => {
     expect(backup).toHaveBeenCalledWith("alpha", { name: "legacy" });
     expect(requireProvider).not.toHaveBeenCalled();
     expect(captureRuntime).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "openclaw",
+    "hermes",
+    "langchain-deepagents-code",
+  ] as const)("captures and confirms exact %s host-local inference authority", (agent) => {
+    const entry = hostLocalSandbox(agent);
+    const prepared = {
+      providerId: "mxc",
+      sandboxName: "alpha",
+      serializedReceipt: entry.hostLocalInferenceReceipt,
+      sandboxAuthority: { model: entry.model },
+    };
+    const prepareHostLocalInference = vi.fn(() => prepared);
+    const confirmHostLocalInference = vi.fn();
+    const backup = vi.fn((_name: string, options: BackupOptions = {}) => successfulBackup(options));
+
+    const result = backupSandboxStateWithManagedAuthority(
+      "alpha",
+      { name: "host-local" },
+      {
+        getSandbox: () => entry,
+        requireProvider: () => provider(),
+        captureRuntime: vi.fn() as never,
+        prepareHostLocalInference: prepareHostLocalInference as never,
+        confirmHostLocalInference: confirmHostLocalInference as never,
+        backup,
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(backup).toHaveBeenCalledWith(
+      "alpha",
+      expect.objectContaining({
+        name: "host-local",
+        hostLocalInferenceReceipt: entry.hostLocalInferenceReceipt,
+        validateBeforePublish: expect.any(Function),
+      }),
+    );
+    expect(prepareHostLocalInference).toHaveBeenCalledWith(expect.anything(), entry);
+    expect(confirmHostLocalInference).toHaveBeenCalledWith(
+      expect.anything(),
+      entry,
+      prepared,
+    );
+  });
+
+  it.each([
+    ["agent", { agent: "hermes" }],
+    ["runtime provider", { openshellDriver: "docker" }],
+    ["route provider", { provider: "ollama-local" }],
+    ["model", { model: "model-b" }],
+    ["endpoint", { endpointUrl: "https://inference.local/v1/" }],
+    ["gateway", { gatewayName: "nemoclaw-8081" }],
+    ["lifecycle generation", { lifecycleGeneration: "alpha-generation-2" }],
+  ] as const)("rejects host-local %s drift before manifest publication", (_label, drift) => {
+    const initial = hostLocalSandbox("openclaw");
+    const current = hostLocalSandbox("openclaw", drift);
+    const entries = [initial, current];
+    const prepared = {
+      providerId: "mxc",
+      sandboxName: "alpha",
+      serializedReceipt: initial.hostLocalInferenceReceipt,
+    };
+    const confirmHostLocalInference = vi.fn((_provider, candidate: SandboxEntry) => {
+      const fields = [
+        "agent",
+        "openshellDriver",
+        "provider",
+        "model",
+        "endpointUrl",
+        "gatewayName",
+        "lifecycleGeneration",
+      ] as const;
+      if (fields.some((field) => candidate[field] !== initial[field])) {
+        throw new Error("sandbox authority changed after lifecycle preparation");
+      }
+    });
+    const backup = vi.fn((_name: string, options: BackupOptions = {}) => successfulBackup(options));
+
+    const result = backupSandboxStateWithManagedAuthority(
+      "alpha",
+      {},
+      {
+        getSandbox: vi.fn(() => entries.shift() ?? null),
+        requireProvider: () => provider(),
+        captureRuntime: vi.fn() as never,
+        prepareHostLocalInference: vi.fn(() => prepared) as never,
+        confirmHostLocalInference: confirmHostLocalInference as never,
+        backup,
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("sandbox authority changed"),
+    });
   });
 
   it("fails before filesystem capture when the provider rejects managed authority", () => {

--- a/src/lib/actions/sandbox/snapshot/backup-authority.test.ts
+++ b/src/lib/actions/sandbox/snapshot/backup-authority.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import { managedStartupE2eProfile } from "../../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
 import {
   serializedHostLocalInferenceReceipt,
+  serializedLlamaCppHostLocalInferenceReceipt,
 } from "../../../../../test/helpers/host-local-inference-receipt";
 import {
   MANAGED_IMAGE_REPOSITORIES,
@@ -16,6 +17,7 @@ import {
 import { encodeManagedStartupProfile } from "../../../onboard/managed-startup/profile";
 import type { RuntimeProviderBundle } from "../../../onboard/runtime-provider/contract";
 import type { SandboxEntry, SandboxWorkloadReceipt } from "../../../state/registry/types";
+import { createSandboxHostLocalInferenceProvenance } from "../../../state/registry/host-local-inference";
 import type { BackupOptions, BackupResult } from "../../../state/sandbox";
 import { backupSandboxStateWithManagedAuthority } from "./backup-authority";
 
@@ -142,17 +144,38 @@ function hostLocalSandbox(
   };
 }
 
+function explicitLlamaSandbox(agent: "openclaw" | "hermes" | "langchain-deepagents-code") {
+  const hostLocalInferenceReceipt = serializedLlamaCppHostLocalInferenceReceipt("mxc");
+  return {
+    name: "alpha",
+    agent,
+    openshellDriver: "mxc",
+    provider: "llama-cpp-local",
+    model: "llama-cpp-model",
+    endpointUrl: "https://inference.local/v1",
+    endpointSource: "inference-set",
+    gatewayName: "nemoclaw",
+    gatewayPort: 8080,
+    lifecycleGeneration: "alpha-generation-1",
+    hostLocalInferenceReceipt,
+    hostLocalInferenceProvenance: createSandboxHostLocalInferenceProvenance(
+      "alpha",
+      hostLocalInferenceReceipt,
+    ),
+  } satisfies SandboxEntry;
+}
+
 describe("managed snapshot backup authority", () => {
-  it.each([
-    "openclaw",
-    "hermes",
-    "langchain-deepagents-code",
-  ] as const)("captures and republishes exact %s provider authority", (agent) => {
+  it.each(["openclaw", "hermes", "langchain-deepagents-code"] as const)(
+    "captures and republishes exact %s provider authority",
+    (agent) => {
     const entry = sandbox(agent);
     const getSandbox = vi.fn(() => entry);
     const requireProvider = vi.fn(() => provider());
     const captureRuntime = vi.fn(() => runtime());
-    const backup = vi.fn((_name: string, options: BackupOptions = {}) => successfulBackup(options));
+      const backup = vi.fn((_name: string, options: BackupOptions = {}) =>
+        successfulBackup(options),
+      );
 
     const result = backupSandboxStateWithManagedAuthority(
       "alpha",
@@ -173,6 +196,72 @@ describe("managed snapshot backup authority", () => {
     expect(getSandbox).toHaveBeenCalledTimes(2);
     expect(requireProvider).toHaveBeenCalledTimes(2);
     expect(captureRuntime).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each(["openclaw", "hermes", "langchain-deepagents-code"] as const)(
+    "carries exact explicit llama.cpp authority through %s backup",
+    (agent) => {
+      const entry = explicitLlamaSandbox(agent);
+      const prepared = {
+        providerId: "mxc",
+        sandboxName: entry.name,
+        serializedReceipt: entry.hostLocalInferenceReceipt,
+      };
+      const prepareHostLocalInference = vi.fn(() => prepared);
+      const confirmHostLocalInference = vi.fn();
+      const backup = vi.fn((_name: string, options: BackupOptions = {}) =>
+        successfulBackup(options),
+      );
+
+      const result = backupSandboxStateWithManagedAuthority(
+        entry.name,
+        { name: "llama" },
+        {
+          getSandbox: () => entry,
+          requireProvider: () => provider(),
+          captureRuntime: vi.fn() as never,
+          prepareHostLocalInference: prepareHostLocalInference as never,
+          confirmHostLocalInference: confirmHostLocalInference as never,
+          backup,
+        },
+      );
+
+      expect(result.success).toBe(true);
+      expect(backup).toHaveBeenCalledWith(
+        entry.name,
+        expect.objectContaining({
+          hostLocalInferenceReceipt: entry.hostLocalInferenceReceipt,
+          hostLocalInferenceProvenance: entry.hostLocalInferenceProvenance,
+          validateBeforePublish: expect.any(Function),
+        }),
+      );
+      expect(prepareHostLocalInference).toHaveBeenCalledOnce();
+      expect(confirmHostLocalInference).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("fails before backup when explicit llama.cpp authority cannot be reconstructed", () => {
+    const entry = explicitLlamaSandbox("openclaw");
+    const backup = vi.fn();
+
+    const result = backupSandboxStateWithManagedAuthority(
+      entry.name,
+      {},
+      {
+        getSandbox: () => entry,
+        requireProvider: () => provider(),
+        captureRuntime: vi.fn() as never,
+        prepareHostLocalInference: vi.fn(() => null),
+        backup,
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("explicit host-local inference lifecycle authority"),
+    });
+    expect(backup).not.toHaveBeenCalled();
   });
 
   it("keeps explicit Dockerfile backups on the legacy state-only path", () => {
@@ -276,9 +365,8 @@ describe("managed snapshot backup authority", () => {
         "gatewayName",
         "lifecycleGeneration",
       ] as const;
-      if (fields.some((field) => candidate[field] !== initial[field])) {
+      expect(fields.some((field) => candidate[field] !== initial[field])).toBe(true);
         throw new Error("sandbox authority changed after lifecycle preparation");
-      }
     });
     const backup = vi.fn((_name: string, options: BackupOptions = {}) => successfulBackup(options));
 

--- a/src/lib/actions/sandbox/snapshot/backup-authority.ts
+++ b/src/lib/actions/sandbox/snapshot/backup-authority.ts
@@ -5,6 +5,10 @@ import { isDeepStrictEqual } from "node:util";
 
 import type { RuntimeProviderBundle } from "../../../onboard/runtime-provider/contract";
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "../../../onboard/runtime-provider/current";
+import {
+  confirmHostLocalInferenceAuthority,
+  prepareSandboxHostLocalInferenceAuthority,
+} from "../../../onboard/runtime-provider/host-local-inference-lifecycle";
 import { requireRuntimeProviderBundleForSandbox } from "../../../onboard/runtime-provider/registry";
 import type { SandboxEntry } from "../../../state/registry/types";
 import * as sandboxState from "../../../state/sandbox";
@@ -13,13 +17,15 @@ import { captureSandboxRuntimeSnapshot } from "./provider-lifecycle";
 
 type SnapshotBackupAuthority = Pick<
   sandboxState.BackupOptions,
-  "runtimeSnapshot" | "workload" | "validateBeforePublish"
+  "runtimeSnapshot" | "workload" | "hostLocalInferenceReceipt" | "validateBeforePublish"
 >;
 
 interface SnapshotBackupAuthorityDependencies {
   readonly getSandbox: (sandboxName: string) => SandboxEntry | null;
   readonly requireProvider: (sandbox: SandboxEntry) => RuntimeProviderBundle;
   readonly captureRuntime: typeof captureSandboxRuntimeSnapshot;
+  readonly prepareHostLocalInference: typeof prepareSandboxHostLocalInferenceAuthority;
+  readonly confirmHostLocalInference: typeof confirmHostLocalInferenceAuthority;
   readonly backup: typeof sandboxState.backupSandboxState;
 }
 
@@ -27,6 +33,8 @@ const defaultDependencies: Omit<SnapshotBackupAuthorityDependencies, "getSandbox
   requireProvider: (sandbox) =>
     requireRuntimeProviderBundleForSandbox(sandbox, CURRENT_RUNTIME_PROVIDER_BUNDLES),
   captureRuntime: captureSandboxRuntimeSnapshot,
+  prepareHostLocalInference: prepareSandboxHostLocalInferenceAuthority,
+  confirmHostLocalInference: confirmHostLocalInferenceAuthority,
   // Keep the call late-bound so tests and alternative state stores can replace
   // the module export without this adapter retaining an import-time reference.
   backup: (...args) => sandboxState.backupSandboxState(...args),
@@ -40,7 +48,7 @@ function failure(error: unknown): sandboxState.BackupResult {
     failedDirs: [],
     backedUpFiles: [],
     failedFiles: [],
-    error: `Cannot capture managed snapshot authority: ${detail}.`,
+    error: `Cannot capture provider snapshot authority: ${detail}.`,
   };
 }
 
@@ -106,10 +114,57 @@ function captureManagedAuthority(
   };
 }
 
+function captureHostLocalInferenceAuthority(
+  entry: SandboxEntry,
+  dependencies: SnapshotBackupAuthorityDependencies,
+): Pick<sandboxState.BackupOptions, "hostLocalInferenceReceipt" | "validateBeforePublish"> | null {
+  const receipt = entry.hostLocalInferenceReceipt;
+  if (typeof receipt !== "string") return null;
+  const provider = dependencies.requireProvider(entry);
+  const prepared = dependencies.prepareHostLocalInference(provider, entry);
+  if (!prepared) return null;
+  return {
+    hostLocalInferenceReceipt: prepared.serializedReceipt,
+    validateBeforePublish: () => {
+      const current = dependencies.getSandbox(entry.name);
+      if (!current) throw new Error(`sandbox '${entry.name}' is no longer registered`);
+      if (current.hostLocalInferenceReceipt !== receipt) {
+        throw new Error(`sandbox '${entry.name}' host-local inference changed during backup`);
+      }
+      const currentProvider = dependencies.requireProvider(current);
+      if (currentProvider.identity.id !== provider.identity.id) {
+        throw new Error(`sandbox '${entry.name}' runtime provider changed during backup`);
+      }
+      dependencies.confirmHostLocalInference(currentProvider, current, prepared);
+    },
+  };
+}
+
+function captureSnapshotAuthority(
+  entry: SandboxEntry,
+  dependencies: SnapshotBackupAuthorityDependencies,
+): SnapshotBackupAuthority | null {
+  const managed = captureManagedAuthority(entry, dependencies);
+  const hostLocal = captureHostLocalInferenceAuthority(entry, dependencies);
+  if (!managed && !hostLocal) return null;
+  return {
+    ...(managed?.runtimeSnapshot === undefined ? {} : { runtimeSnapshot: managed.runtimeSnapshot }),
+    ...(managed?.workload === undefined ? {} : { workload: managed.workload }),
+    ...(hostLocal?.hostLocalInferenceReceipt === undefined
+      ? {}
+      : { hostLocalInferenceReceipt: hostLocal.hostLocalInferenceReceipt }),
+    validateBeforePublish: () => {
+      managed?.validateBeforePublish?.();
+      hostLocal?.validateBeforePublish?.();
+    },
+  };
+}
+
 /**
- * Capture one managed workload and runtime authority pair around the complete
- * filesystem copy. The state layer publishes the manifest only after the
- * final callback confirms that the same provider authority remains live.
+ * Capture the provider-owned workload, runtime, and host-local inference
+ * authority around the complete filesystem copy. The state layer publishes
+ * the manifest only after the final callback confirms the same full sandbox
+ * binding and provider proof remain live.
  */
 export function backupSandboxStateWithManagedAuthority(
   sandboxName: string,
@@ -123,7 +178,7 @@ export function backupSandboxStateWithManagedAuthority(
 
   let authority: SnapshotBackupAuthority | null;
   try {
-    authority = captureManagedAuthority(entry, dependencies);
+    authority = captureSnapshotAuthority(entry, dependencies);
   } catch (error) {
     return failure(error);
   }

--- a/src/lib/actions/sandbox/snapshot/backup-authority.ts
+++ b/src/lib/actions/sandbox/snapshot/backup-authority.ts
@@ -17,7 +17,11 @@ import { captureSandboxRuntimeSnapshot } from "./provider-lifecycle";
 
 type SnapshotBackupAuthority = Pick<
   sandboxState.BackupOptions,
-  "runtimeSnapshot" | "workload" | "hostLocalInferenceReceipt" | "validateBeforePublish"
+  | "runtimeSnapshot"
+  | "workload"
+  | "hostLocalInferenceReceipt"
+  | "hostLocalInferenceProvenance"
+  | "validateBeforePublish"
 >;
 
 interface SnapshotBackupAuthorityDependencies {
@@ -117,19 +121,37 @@ function captureManagedAuthority(
 function captureHostLocalInferenceAuthority(
   entry: SandboxEntry,
   dependencies: SnapshotBackupAuthorityDependencies,
-): Pick<sandboxState.BackupOptions, "hostLocalInferenceReceipt" | "validateBeforePublish"> | null {
+): Pick<
+  sandboxState.BackupOptions,
+  "hostLocalInferenceReceipt" | "hostLocalInferenceProvenance" | "validateBeforePublish"
+> | null {
   const receipt = entry.hostLocalInferenceReceipt;
   if (typeof receipt !== "string") return null;
   const provider = dependencies.requireProvider(entry);
   const prepared = dependencies.prepareHostLocalInference(provider, entry);
-  if (!prepared) return null;
+  if (!prepared) {
+    if (entry.hostLocalInferenceProvenance) {
+      throw new Error("explicit host-local inference lifecycle authority cannot be reconstructed");
+    }
+    return null;
+  }
   return {
     hostLocalInferenceReceipt: prepared.serializedReceipt,
+    ...(entry.hostLocalInferenceProvenance
+      ? { hostLocalInferenceProvenance: entry.hostLocalInferenceProvenance }
+      : {}),
     validateBeforePublish: () => {
       const current = dependencies.getSandbox(entry.name);
       if (!current) throw new Error(`sandbox '${entry.name}' is no longer registered`);
       if (current.hostLocalInferenceReceipt !== receipt) {
         throw new Error(`sandbox '${entry.name}' host-local inference changed during backup`);
+      }
+      if (
+        !isDeepStrictEqual(current.hostLocalInferenceProvenance, entry.hostLocalInferenceProvenance)
+      ) {
+        throw new Error(
+          `sandbox '${entry.name}' host-local inference provenance changed during backup`,
+        );
       }
       const currentProvider = dependencies.requireProvider(current);
       if (currentProvider.identity.id !== provider.identity.id) {
@@ -153,6 +175,9 @@ function captureSnapshotAuthority(
     ...(hostLocal?.hostLocalInferenceReceipt === undefined
       ? {}
       : { hostLocalInferenceReceipt: hostLocal.hostLocalInferenceReceipt }),
+    ...(hostLocal?.hostLocalInferenceProvenance === undefined
+      ? {}
+      : { hostLocalInferenceProvenance: hostLocal.hostLocalInferenceProvenance }),
     validateBeforePublish: () => {
       managed?.validateBeforePublish?.();
       hostLocal?.validateBeforePublish?.();

--- a/src/lib/actions/sandbox/snapshot/dependencies.ts
+++ b/src/lib/actions/sandbox/snapshot/dependencies.ts
@@ -6,6 +6,13 @@ import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "../../../onboard/runtime-provi
 import { requireRuntimeProviderBundleForSandbox } from "../../../onboard/runtime-provider/registry";
 import type { SandboxEntry } from "../../../state/registry/types";
 
+export {
+  confirmHostLocalInferenceAuthority,
+  type PreparedHostLocalInferenceAuthority,
+  prepareHostLocalInferenceAuthority,
+  prepareSandboxHostLocalInferenceDestroyAuthority,
+  retirePreparedHostLocalInferenceAuthority,
+} from "../../../onboard/runtime-provider/host-local-inference-lifecycle";
 export type {
   ManagedWorkloadCloneSnapshot,
   PreparedManagedWorkloadCloneHandoff,
@@ -39,6 +46,7 @@ export {
   prepareSandboxRuntimeRestore,
   SandboxSnapshotProviderError,
 } from "./provider-lifecycle";
+export type { RuntimeProviderBundle };
 
 /**
  * Resolve the one already-registered provider bundle for a durable sandbox.

--- a/src/lib/actions/sandbox/snapshot/restore-authority.ts
+++ b/src/lib/actions/sandbox/snapshot/restore-authority.ts
@@ -3,6 +3,11 @@
 
 import type { RuntimeProviderBundle } from "../../../onboard/runtime-provider/contract";
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "../../../onboard/runtime-provider/current";
+import {
+  confirmHostLocalInferenceAuthority,
+  type PreparedHostLocalInferenceAuthority,
+  prepareHostLocalInferenceAuthority,
+} from "../../../onboard/runtime-provider/host-local-inference-lifecycle";
 import { requireRuntimeProviderBundleForSandbox } from "../../../onboard/runtime-provider/registry";
 import type { SandboxEntry } from "../../../state/registry/types";
 import * as sandboxState from "../../../state/sandbox";
@@ -16,14 +21,14 @@ import {
   prepareSandboxRuntimeRestore,
 } from "./provider-lifecycle";
 
-interface ManagedRestoreAuthorityDependencies {
+interface ProviderRestoreAuthorityDependencies {
   readonly getSandbox: (sandboxName: string) => SandboxEntry | null;
   readonly requireProvider: (sandbox: SandboxEntry) => RuntimeProviderBundle;
   readonly captureContentAuthority: typeof sandboxState.captureSnapshotRestoreAuthority;
   readonly restore: typeof sandboxState.restoreRecreatedSandboxState;
 }
 
-const defaultDependencies: Omit<ManagedRestoreAuthorityDependencies, "getSandbox"> = {
+const defaultDependencies: Omit<ProviderRestoreAuthorityDependencies, "getSandbox"> = {
   requireProvider: (sandbox) =>
     requireRuntimeProviderBundleForSandbox(sandbox, CURRENT_RUNTIME_PROVIDER_BUNDLES),
   captureContentAuthority: (...args) => sandboxState.captureSnapshotRestoreAuthority(...args),
@@ -38,21 +43,21 @@ function failure(error: unknown): sandboxState.RestoreResult {
     failedDirs: ["manifest"],
     restoredFiles: [],
     failedFiles: [],
-    error: `Cannot restore managed snapshot authority: ${detail}.`,
+    error: `Cannot restore provider snapshot authority: ${detail}.`,
   };
 }
 
 /**
- * Restore a rebuild backup through the same provider and content authority
- * boundary as an explicit snapshot restore. Legacy/custom-image manifests
- * retain their existing state-only path.
+ * Restore a rebuild backup through its provider runtime and content authority.
+ * Legacy/custom-image manifests without provider-backed state retain the
+ * existing state-only path.
  */
 export function restoreRecreatedSandboxStateWithManagedAuthority(
   sandboxName: string,
   manifest: sandboxState.RebuildManifest,
   options: sandboxState.RecreatedSandboxRestoreOptions,
-  overrides: Pick<ManagedRestoreAuthorityDependencies, "getSandbox"> &
-    Partial<Omit<ManagedRestoreAuthorityDependencies, "getSandbox">>,
+  overrides: Pick<ProviderRestoreAuthorityDependencies, "getSandbox"> &
+    Partial<Omit<ProviderRestoreAuthorityDependencies, "getSandbox">>,
 ): sandboxState.RestoreResult {
   const dependencies = { ...defaultDependencies, ...overrides };
   let snapshotProfile;
@@ -65,14 +70,16 @@ export function restoreRecreatedSandboxStateWithManagedAuthority(
   } catch (error) {
     return failure(error);
   }
-  if (!snapshotProfile) {
+  const hostLocalInferenceReceipt = manifest.hostLocalInferenceReceipt;
+  if (!snapshotProfile && typeof hostLocalInferenceReceipt !== "string") {
     return dependencies.restore(sandboxName, manifest.backupPath, options);
   }
-  if (!manifest.runtimeSnapshot) {
+  if (snapshotProfile && !manifest.runtimeSnapshot) {
     return failure("managed snapshot is missing provider runtime authority");
   }
 
-  let prepared: PreparedSandboxRuntimeRestore;
+  let preparedRuntime: PreparedSandboxRuntimeRestore | null = null;
+  let preparedHostLocal: PreparedHostLocalInferenceAuthority | null = null;
   let providerId: string;
   let contentAuthority: sandboxState.SnapshotRestoreAuthority;
   try {
@@ -80,25 +87,37 @@ export function restoreRecreatedSandboxStateWithManagedAuthority(
     if (!target) throw new Error(`target '${sandboxName}' is not registered`);
     const provider = dependencies.requireProvider(target);
     providerId = provider.identity.id;
-    const profileRestore = prepareManagedSnapshotProfileRestore(
-      {
-        sandboxName: manifest.sandboxName,
-        agentType: manifest.agentType,
-        workload: manifest.workload,
-      },
-      target,
-      provider,
-    );
-    if (!profileRestore) throw new Error("managed profile restore authority is missing");
+    if (snapshotProfile) {
+      const profileRestore = prepareManagedSnapshotProfileRestore(
+        {
+          sandboxName: manifest.sandboxName,
+          agentType: manifest.agentType,
+          workload: manifest.workload,
+        },
+        target,
+        provider,
+      );
+      if (!profileRestore) throw new Error("managed profile restore authority is missing");
+      preparedRuntime = prepareSandboxRuntimeRestore(
+        provider,
+        target,
+        manifest.runtimeSnapshot!,
+        profileRestore.providerRestoreAuthority,
+      );
+    }
+    if (typeof hostLocalInferenceReceipt === "string") {
+      preparedHostLocal = prepareHostLocalInferenceAuthority(
+        provider,
+        target,
+        hostLocalInferenceReceipt,
+      );
+      if (!preparedHostLocal) {
+        throw new Error("snapshot inference receipt has no B4-E1 lifecycle authority");
+      }
+    }
     const captured = dependencies.captureContentAuthority(manifest.backupPath, manifest);
     if (!captured) throw new Error("selected snapshot content changed during restore preflight");
     contentAuthority = captured;
-    prepared = prepareSandboxRuntimeRestore(
-      provider,
-      target,
-      manifest.runtimeSnapshot,
-      profileRestore.providerRestoreAuthority,
-    );
   } catch (error) {
     return failure(error);
   }
@@ -113,22 +132,31 @@ export function restoreRecreatedSandboxStateWithManagedAuthority(
       if (provider.identity.id !== providerId) {
         throw new Error(`target '${sandboxName}' runtime provider changed before restore`);
       }
-      const profileRestore = prepareManagedSnapshotProfileRestore(
-        {
-          sandboxName: manifest.sandboxName,
-          agentType: manifest.agentType,
-          workload: manifest.workload,
-        },
-        current,
-        provider,
-      );
-      if (!profileRestore) throw new Error("managed profile restore authority is missing");
-      prepared = prepareSandboxRuntimeRestore(
-        provider,
-        current,
-        prepared.source,
-        profileRestore.providerRestoreAuthority,
-      );
+      if (snapshotProfile) {
+        const profileRestore = prepareManagedSnapshotProfileRestore(
+          {
+            sandboxName: manifest.sandboxName,
+            agentType: manifest.agentType,
+            workload: manifest.workload,
+          },
+          current,
+          provider,
+        );
+        if (!profileRestore) throw new Error("managed profile restore authority is missing");
+        if (!preparedRuntime) throw new Error("managed runtime restore authority is missing");
+        preparedRuntime = prepareSandboxRuntimeRestore(
+          provider,
+          current,
+          preparedRuntime.source,
+          profileRestore.providerRestoreAuthority,
+        );
+      }
+      if (typeof hostLocalInferenceReceipt === "string") {
+        if (!preparedHostLocal) {
+          throw new Error("host-local inference restore authority is missing");
+        }
+        confirmHostLocalInferenceAuthority(provider, current, preparedHostLocal);
+      }
     },
   });
   if (!restore.success) return restore;
@@ -140,7 +168,10 @@ export function restoreRecreatedSandboxStateWithManagedAuthority(
     if (provider.identity.id !== providerId) {
       throw new Error(`target '${sandboxName}' runtime provider changed during restore`);
     }
-    confirmSandboxRuntimeRestore(provider, current, prepared);
+    if (preparedRuntime) confirmSandboxRuntimeRestore(provider, current, preparedRuntime);
+    if (preparedHostLocal) {
+      confirmHostLocalInferenceAuthority(provider, current, preparedHostLocal);
+    }
     return restore;
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
@@ -148,7 +179,7 @@ export function restoreRecreatedSandboxStateWithManagedAuthority(
       ...restore,
       success: false,
       error:
-        `State was restored, but managed runtime proof failed: ${detail}. ` +
+        `State was restored, but provider runtime proof failed: ${detail}. ` +
         `Retry this exact snapshot after the runtime stabilizes.`,
     };
   }

--- a/src/lib/actions/sandbox/snapshot/restore-authority.ts
+++ b/src/lib/actions/sandbox/snapshot/restore-authority.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { RuntimeProviderBundle } from "../../../onboard/runtime-provider/contract";
+import { isDeepStrictEqual } from "node:util";
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "../../../onboard/runtime-provider/current";
 import {
   confirmHostLocalInferenceAuthority,
@@ -25,6 +26,8 @@ interface ProviderRestoreAuthorityDependencies {
   readonly getSandbox: (sandboxName: string) => SandboxEntry | null;
   readonly requireProvider: (sandbox: SandboxEntry) => RuntimeProviderBundle;
   readonly captureContentAuthority: typeof sandboxState.captureSnapshotRestoreAuthority;
+  readonly prepareHostLocalInference: typeof prepareHostLocalInferenceAuthority;
+  readonly confirmHostLocalInference: typeof confirmHostLocalInferenceAuthority;
   readonly restore: typeof sandboxState.restoreRecreatedSandboxState;
 }
 
@@ -32,6 +35,8 @@ const defaultDependencies: Omit<ProviderRestoreAuthorityDependencies, "getSandbo
   requireProvider: (sandbox) =>
     requireRuntimeProviderBundleForSandbox(sandbox, CURRENT_RUNTIME_PROVIDER_BUNDLES),
   captureContentAuthority: (...args) => sandboxState.captureSnapshotRestoreAuthority(...args),
+  prepareHostLocalInference: prepareHostLocalInferenceAuthority,
+  confirmHostLocalInference: confirmHostLocalInferenceAuthority,
   restore: (...args) => sandboxState.restoreRecreatedSandboxState(...args),
 };
 
@@ -106,13 +111,21 @@ export function restoreRecreatedSandboxStateWithManagedAuthority(
       );
     }
     if (typeof hostLocalInferenceReceipt === "string") {
-      preparedHostLocal = prepareHostLocalInferenceAuthority(
+      if (
+        !isDeepStrictEqual(
+          target.hostLocalInferenceProvenance,
+          manifest.hostLocalInferenceProvenance,
+        )
+      ) {
+        throw new Error("snapshot inference provenance differs from the target lifecycle");
+      }
+      preparedHostLocal = dependencies.prepareHostLocalInference(
         provider,
         target,
         hostLocalInferenceReceipt,
       );
       if (!preparedHostLocal) {
-        throw new Error("snapshot inference receipt has no B4-E1 lifecycle authority");
+        throw new Error("snapshot inference receipt has no common lifecycle authority");
       }
     }
     const captured = dependencies.captureContentAuthority(manifest.backupPath, manifest);
@@ -155,7 +168,15 @@ export function restoreRecreatedSandboxStateWithManagedAuthority(
         if (!preparedHostLocal) {
           throw new Error("host-local inference restore authority is missing");
         }
-        confirmHostLocalInferenceAuthority(provider, current, preparedHostLocal);
+        if (
+          !isDeepStrictEqual(
+            current.hostLocalInferenceProvenance,
+            manifest.hostLocalInferenceProvenance,
+          )
+        ) {
+          throw new Error("snapshot inference provenance changed before restore");
+        }
+        dependencies.confirmHostLocalInference(provider, current, preparedHostLocal);
       }
     },
   });
@@ -170,7 +191,7 @@ export function restoreRecreatedSandboxStateWithManagedAuthority(
     }
     if (preparedRuntime) confirmSandboxRuntimeRestore(provider, current, preparedRuntime);
     if (preparedHostLocal) {
-      confirmHostLocalInferenceAuthority(provider, current, preparedHostLocal);
+      dependencies.confirmHostLocalInference(provider, current, preparedHostLocal);
     }
     return restore;
   } catch (error) {

--- a/src/lib/actions/sandbox/snapshot/restore-host-local-authority.test.ts
+++ b/src/lib/actions/sandbox/snapshot/restore-host-local-authority.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createInMemoryRuntimeProviderBundle } from "../../../../../test/helpers/runtime-provider-bundle";
+import { createSandboxHostLocalInferenceProvenance } from "../../../state/registry/host-local-inference";
 import {
   type HostLocalInferenceOperation,
   type HostLocalInferenceReceipt,
@@ -313,9 +314,95 @@ describe("host-local inference snapshot restore authority", () => {
 
     expect(result).toMatchObject({
       success: false,
-      error: expect.stringContaining("no B4-E1 lifecycle authority"),
+      error: expect.stringContaining("no common lifecycle authority"),
     });
     expect(captureContentAuthority).not.toHaveBeenCalled();
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it.each(["openclaw", "hermes", "langchain-deepagents-code"] as const)(
+    "re-proves explicit llama.cpp authority throughout %s restore",
+    (agent) => {
+      const serialized = llamaCppReceipt();
+      const provenance = createSandboxHostLocalInferenceProvenance("alpha", serialized);
+      const target: SandboxEntry = {
+        ...sandbox(agent, "vllm"),
+        provider: "llama-cpp-local",
+        model: "llama-cpp-model",
+        gatewayPort: 8080,
+        hostLocalInferenceReceipt: serialized,
+        hostLocalInferenceProvenance: provenance,
+      };
+      const prepared = {
+        providerId: "mxc",
+        sandboxName: "alpha",
+        serializedReceipt: serialized,
+      };
+      const prepareHostLocalInference = vi.fn(() => prepared);
+      const confirmHostLocalInference = vi.fn();
+      const restore = vi.fn((_name, _path, options: RecreatedSandboxRestoreOptions) =>
+        successfulRestore(options),
+      );
+
+      const result = restoreRecreatedSandboxStateWithManagedAuthority(
+        "alpha",
+        {
+          ...manifest(agent, "vllm"),
+          hostLocalInferenceReceipt: serialized,
+          hostLocalInferenceProvenance: provenance,
+        },
+        { targetAgentType: agent },
+        {
+          getSandbox: () => target,
+          requireProvider: () => provider().bundle,
+          prepareHostLocalInference: prepareHostLocalInference as never,
+          confirmHostLocalInference: confirmHostLocalInference as never,
+          captureContentAuthority: () => ({
+            schemaVersion: 1,
+            backupPath: "/tmp/alpha",
+            contentSha256: "f".repeat(64),
+          }),
+          restore,
+        },
+      );
+
+      expect(result.success).toBe(true);
+      expect(prepareHostLocalInference).toHaveBeenCalledWith(expect.anything(), target, serialized);
+      expect(confirmHostLocalInference).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("rejects a manifest that omits explicit llama.cpp provenance", () => {
+    const serialized = llamaCppReceipt();
+    const target: SandboxEntry = {
+      ...sandbox("openclaw", "vllm"),
+      provider: "llama-cpp-local",
+      model: "llama-cpp-model",
+      gatewayPort: 8080,
+      hostLocalInferenceReceipt: serialized,
+      hostLocalInferenceProvenance: createSandboxHostLocalInferenceProvenance("alpha", serialized),
+    };
+    const prepareHostLocalInference = vi.fn();
+    const restore = vi.fn();
+
+    const result = restoreRecreatedSandboxStateWithManagedAuthority(
+      "alpha",
+      { ...manifest("openclaw", "vllm"), hostLocalInferenceReceipt: serialized },
+      { targetAgentType: "openclaw" },
+      {
+        getSandbox: () => target,
+        requireProvider: () => provider().bundle,
+        prepareHostLocalInference: prepareHostLocalInference as never,
+        captureContentAuthority: vi.fn(),
+        restore,
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("provenance differs"),
+    });
+    expect(prepareHostLocalInference).not.toHaveBeenCalled();
     expect(restore).not.toHaveBeenCalled();
   });
 

--- a/src/lib/actions/sandbox/snapshot/restore-host-local-authority.test.ts
+++ b/src/lib/actions/sandbox/snapshot/restore-host-local-authority.test.ts
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createInMemoryRuntimeProviderBundle } from "../../../../../test/helpers/runtime-provider-bundle";
+import {
+  type HostLocalInferenceOperation,
+  type HostLocalInferenceReceipt,
+  type HostLocalInferenceRuntime,
+  serializeHostLocalInferenceReceipt,
+} from "../../../onboard/runtime-provider/host-local-inference";
+import type { SandboxEntry } from "../../../state/registry/types";
+import type {
+  RebuildManifest,
+  RecreatedSandboxRestoreOptions,
+  RestoreResult,
+} from "../../../state/sandbox";
+import { restoreRecreatedSandboxStateWithManagedAuthority } from "./restore-authority";
+
+type Agent = "openclaw" | "hermes" | "langchain-deepagents-code";
+type Service = "ollama" | "nim" | "vllm";
+
+const AUTHORITY_ID = `mxc-endpoint:${"a".repeat(64)}`;
+const BINDING_SHA256 = "d".repeat(64);
+const MODEL = "qwen3.5-9b";
+
+function receipt(service: Service, port = 8000): HostLocalInferenceReceipt {
+  return {
+    schemaVersion: 2,
+    providerId: "mxc",
+    service,
+    engineAuthority: {
+      schemaVersion: 1,
+      providerId: "mxc",
+      operation: "host-local-inference",
+      engineId: "memory",
+      authorityId: AUTHORITY_ID,
+      bindingSha256: BINDING_SHA256,
+    },
+    endpoint: {
+      host: "host.openshell.internal",
+      port,
+      networkName: "mxc-runtime-network",
+      networkId: "2".repeat(64),
+      networkGatewayIp: "10.89.0.1",
+      networkAuthoritySha256: "3".repeat(64),
+    },
+    inference: {
+      protocol: "openai-chat-completions",
+      model: service === "ollama" ? `${MODEL}:latest` : MODEL,
+      toolCallingRequired: true,
+    },
+    publication: {
+      transactionId: "4".repeat(64),
+      targetSha256: "5".repeat(64),
+      priorState: service === "ollama" ? "host-process" : "absent",
+    },
+    runtime:
+      service === "ollama"
+        ? {
+            kind: "host",
+            probeImageRef: `quay.io/curl/curl@sha256:${"6".repeat(64)}`,
+            acceleration: "nvidia-gpu",
+            modelDigest: `sha256:${"7".repeat(64)}`,
+          }
+        : {
+            kind: "container",
+            runtimeId: `mxc-runtime:${service}`,
+            name: `nemoclaw-${service}`,
+            imageRef: `nvcr.io/nvidia/${service}@sha256:${"8".repeat(64)}`,
+            probeImageRef: `quay.io/curl/curl@sha256:${"6".repeat(64)}`,
+            specSha256: "9".repeat(64),
+            launchSha256: "b".repeat(64),
+            gpu: { vendor: "nvidia", devices: ["nvidia.com/gpu=all"] },
+          },
+  };
+}
+
+function llamaCppReceipt(): string {
+  return serializeHostLocalInferenceReceipt({
+    schemaVersion: 1,
+    providerId: "mxc",
+    service: "llama-cpp",
+    engineAuthority: {
+      schemaVersion: 1,
+      providerId: "mxc",
+      operation: "host-local-inference",
+      engineId: "memory",
+      authorityId: AUTHORITY_ID,
+      bindingSha256: BINDING_SHA256,
+    },
+    endpoint: {
+      host: "host.openshell.internal",
+      port: 8081,
+      networkName: "mxc-runtime-network",
+    },
+    runtime: {
+      kind: "container",
+      runtimeId: "c".repeat(64),
+      name: "nemoclaw-llama-cpp",
+      imageRef: `ghcr.io/nvidia/llama-cpp@sha256:${"d".repeat(64)}`,
+      probeImageRef: `quay.io/curl/curl@sha256:${"e".repeat(64)}`,
+      specSha256: "f".repeat(64),
+      model: {
+        planDigest: `sha256:${"1".repeat(64)}`,
+        recipeId: "llama-cpp.test.v1",
+        generation: "2".repeat(64),
+        digest: `sha256:${"3".repeat(64)}`,
+        sizeBytes: 64,
+      },
+      gpu: { vendor: "nvidia", count: 1 },
+    },
+  });
+}
+
+function manifest(agent: Agent, service: Service, port = 8000): RebuildManifest {
+  return {
+    version: 1,
+    sandboxName: "alpha",
+    timestamp: "2026-08-02T00-00-00-000Z",
+    agentType: agent,
+    agentVersion: null,
+    expectedVersion: null,
+    stateDirs: [],
+    dir: "/sandbox",
+    backupPath: "/tmp/alpha",
+    blueprintDigest: null,
+    hostLocalInferenceReceipt: serializeHostLocalInferenceReceipt(receipt(service, port)),
+  };
+}
+
+function sandbox(
+  agent: Agent,
+  service: Service,
+  port = 8000,
+  overrides: Partial<SandboxEntry> = {},
+): SandboxEntry {
+  const value = receipt(service, port);
+  return {
+    name: "alpha",
+    agent,
+    openshellDriver: "mxc",
+    provider: service === "ollama" ? "ollama-local" : "vllm-local",
+    model: value.inference?.model ?? MODEL,
+    endpointUrl: "https://inference.local/v1",
+    gatewayName: "nemoclaw",
+    lifecycleGeneration: "alpha-generation-1",
+    hostLocalInferenceReceipt: serializeHostLocalInferenceReceipt(value),
+    ...overrides,
+  };
+}
+
+function provider() {
+  const preserveForRebuild = vi.fn((value: HostLocalInferenceReceipt) => value);
+  const runtime: HostLocalInferenceRuntime = {
+    providerId: "mxc",
+    authorityId: AUTHORITY_ID,
+    services: ["ollama", "nim", "vllm"],
+    translateContainerArgs: (args) => args,
+    qualifyOllama: vi.fn(),
+    startManaged: vi.fn(),
+    inspectManaged: vi.fn((value) => ({ running: true, receipt: value })),
+    stopManaged: vi.fn((value) => ({ running: false, receipt: value })),
+    preserveForRebuild,
+    prepareDestroy: vi.fn((value) => value),
+    destroy: vi.fn((value) => ({ status: "removed" as const, receipt: value })),
+  };
+  const operation: HostLocalInferenceOperation = {
+    providerId: "mxc",
+    engine: {
+      operation: "host-local-inference",
+      engineId: "memory",
+      displayName: "In-memory",
+      authorityId: AUTHORITY_ID,
+      capture: vi.fn(),
+      captureHost: vi.fn(),
+    },
+    bindingSha256: BINDING_SHA256,
+    assertAuthority: vi.fn(),
+    spawn: vi.fn() as HostLocalInferenceOperation["spawn"],
+    createLlamaCppLifecycle: vi.fn() as HostLocalInferenceOperation["createLlamaCppLifecycle"],
+    managedRuntime: runtime,
+  };
+  const bundle = createInMemoryRuntimeProviderBundle({
+    providerId: "mxc",
+    workloadProfile: {
+      support: null,
+      hostArchitectures: ["x64"],
+      managedImageSelectionPolicy: "prefer-managed",
+      legacyDockerfileBuilds: false,
+    },
+    hostLocalInference: {
+      services: ["ollama", "nim", "vllm"],
+      createOperation: () => operation,
+    },
+  });
+  return { bundle, preserveForRebuild };
+}
+
+function successfulRestore(options: RecreatedSandboxRestoreOptions): RestoreResult {
+  try {
+    options.validateBeforeMutation?.();
+    return {
+      success: true,
+      restoredDirs: ["workspace"],
+      failedDirs: [],
+      restoredFiles: [],
+      failedFiles: [],
+    };
+  } catch (error) {
+    return {
+      success: false,
+      restoredDirs: [],
+      failedDirs: ["workspace"],
+      restoredFiles: [],
+      failedFiles: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+describe("host-local inference snapshot restore authority", () => {
+  it.each([
+    ["openclaw", "ollama"],
+    ["openclaw", "nim"],
+    ["openclaw", "vllm"],
+    ["hermes", "ollama"],
+    ["hermes", "nim"],
+    ["hermes", "vllm"],
+    ["langchain-deepagents-code", "ollama"],
+    ["langchain-deepagents-code", "nim"],
+    ["langchain-deepagents-code", "vllm"],
+  ] as const)("re-proves exact %s %s authority before, at, and after restore", (agent, service) => {
+    const target = sandbox(agent, service);
+    const runtimeProvider = provider();
+    const restore = vi.fn((_name, _path, options: RecreatedSandboxRestoreOptions) =>
+      successfulRestore(options),
+    );
+
+    const result = restoreRecreatedSandboxStateWithManagedAuthority(
+      "alpha",
+      manifest(agent, service),
+      { targetAgentType: agent },
+      {
+        getSandbox: () => target,
+        requireProvider: () => runtimeProvider.bundle,
+        captureContentAuthority: () => ({
+          schemaVersion: 1,
+          backupPath: "/tmp/alpha",
+          contentSha256: "e".repeat(64),
+        }),
+        restore,
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(runtimeProvider.preserveForRebuild).toHaveBeenCalledTimes(3);
+    expect(restore).toHaveBeenCalledWith(
+      "alpha",
+      "/tmp/alpha",
+      expect.objectContaining({
+        authority: expect.objectContaining({ contentSha256: "e".repeat(64) }),
+        validateBeforeMutation: expect.any(Function),
+      }),
+    );
+  });
+
+  it("fails before mutation when the target route differs from the manifest", () => {
+    const runtimeProvider = provider();
+    const restore = vi.fn();
+    const result = restoreRecreatedSandboxStateWithManagedAuthority(
+      "alpha",
+      manifest("hermes", "vllm"),
+      { targetAgentType: "hermes" },
+      {
+        getSandbox: () => sandbox("hermes", "vllm", 8001),
+        requireProvider: () => runtimeProvider.bundle,
+        captureContentAuthority: vi.fn(),
+        restore,
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("different host-local inference authority"),
+    });
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("rejects a dedicated llama.cpp receipt instead of skipping provider confirmation", () => {
+    const runtimeProvider = provider();
+    const serialized = llamaCppReceipt();
+    const target = {
+      ...sandbox("openclaw", "vllm"),
+      model: "llama-cpp-model",
+      hostLocalInferenceReceipt: serialized,
+    };
+    const restore = vi.fn();
+    const captureContentAuthority = vi.fn();
+
+    const result = restoreRecreatedSandboxStateWithManagedAuthority(
+      "alpha",
+      { ...manifest("openclaw", "vllm"), hostLocalInferenceReceipt: serialized },
+      { targetAgentType: "openclaw" },
+      {
+        getSandbox: () => target,
+        requireProvider: () => runtimeProvider.bundle,
+        captureContentAuthority,
+        restore,
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("no B4-E1 lifecycle authority"),
+    });
+    expect(captureContentAuthority).not.toHaveBeenCalled();
+    expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when sandbox authority changes at the filesystem mutation fence", () => {
+    const runtimeProvider = provider();
+    const initial = sandbox("openclaw", "ollama");
+    const changed = sandbox("openclaw", "ollama", 8000, {
+      lifecycleGeneration: "alpha-generation-2",
+    });
+    const getSandbox = vi
+      .fn<() => SandboxEntry | null>()
+      .mockReturnValueOnce(initial)
+      .mockReturnValueOnce(changed);
+
+    const result = restoreRecreatedSandboxStateWithManagedAuthority(
+      "alpha",
+      manifest("openclaw", "ollama"),
+      { targetAgentType: "openclaw" },
+      {
+        getSandbox,
+        requireProvider: () => runtimeProvider.bundle,
+        captureContentAuthority: () => ({
+          schemaVersion: 1,
+          backupPath: "/tmp/alpha",
+          contentSha256: "f".repeat(64),
+        }),
+        restore: (_name, _path, options) => successfulRestore(options),
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("sandbox authority changed"),
+    });
+  });
+});

--- a/src/lib/inference/llama-cpp/managed-installer.test.ts
+++ b/src/lib/inference/llama-cpp/managed-installer.test.ts
@@ -19,6 +19,10 @@ import {
   dockerLlamaCppBindingSha256 as managedLlamaCppBindingSha256,
 } from "../../onboard/runtime-provider/docker-llama-cpp-operation";
 import {
+  createHostLocalCreateJournalStore,
+  HOST_LOCAL_CREATE_JOURNAL_DIRECTORY,
+} from "../../onboard/runtime-provider/host-local-create-journal";
+import {
   type HostLocalInferenceOperation,
   type HostLocalInferenceReceipt,
   type HostLocalLlamaCppLifecycle,
@@ -32,6 +36,7 @@ import {
   inspectManagedLlamaCppRuntimeExact,
   installManagedLlamaCpp,
   MANAGED_LLAMA_CPP_NETWORK_NAME,
+  rehydrateManagedLlamaCppLifecycle,
   resumeManagedLlamaCppRuntime,
 } from "./managed-installer";
 import {
@@ -41,6 +46,7 @@ import {
 } from "./managed-installer.test-support";
 import {
   createManagedLlamaCppReceiptWriter,
+  loadOrCreateManagedLlamaCppApiKey,
   managedLlamaCppStatePaths,
   reserveManagedLlamaCppOwner,
 } from "./managed-state";
@@ -663,6 +669,134 @@ describe("managed llama.cpp installer", () => {
       }),
     );
     expect(inspectManaged).toHaveBeenCalledWith(receipt);
+  });
+
+  it("rehydrates the exact lifecycle without rewriting owner, journal, API key, or receipt", () => {
+    const selected = selection();
+    const homeDir = temporaryHome();
+    const paths = managedLlamaCppStatePaths(homeDir);
+    const source = selected.recipe.spec.model;
+    const file = source.files[0]!;
+    const modelPath = path.join(
+      homeDir,
+      ".cache",
+      "huggingface",
+      "hub",
+      `models--${source.id.replaceAll("/", "--")}`,
+      "snapshots",
+      source.revision,
+      file.path,
+    );
+    fs.mkdirSync(path.dirname(modelPath), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(modelPath, "rehydration-fixture", { mode: 0o600 });
+    reserveManagedLlamaCppOwner(paths, {
+      schemaVersion: 1,
+      sandboxName: "spark-agent",
+      catalogDigest: selected.catalogDigest,
+      presetDigest: selected.presetDigest,
+      recipeDigest: selected.recipeDigest,
+      recipeId: selected.recipe.metadata.id,
+    });
+    loadOrCreateManagedLlamaCppApiKey(paths);
+    const harness = engineHarness();
+    const transactionId = "a".repeat(64);
+    const engineAuthority = {
+      schemaVersion: 1 as const,
+      providerId: "docker",
+      operation: "host-local-inference" as const,
+      engineId: harness.engine.engineId,
+      authorityId: harness.engine.authorityId,
+      bindingSha256: managedLlamaCppBindingSha256(harness.engine),
+    };
+    const receipt = {
+      schemaVersion: 1,
+      providerId: "docker",
+      service: "llama-cpp",
+      engineAuthority,
+      endpoint: {
+        host: "host.openshell.internal",
+        port: 8081,
+        networkName: MANAGED_LLAMA_CPP_NETWORK_NAME,
+      },
+      runtime: {
+        kind: "container",
+        runtimeId: "b".repeat(64),
+        name: "nemoclaw-llama-cpp",
+        imageRef: selected.recipe.spec.runtime.image,
+        probeImageRef: selected.recipe.spec.readiness.probeImage,
+        specSha256: "c".repeat(64),
+        model: {
+          planDigest: `sha256:${"d".repeat(64)}`,
+          recipeId: selected.recipe.metadata.id,
+          generation: transactionId,
+          digest: file.digest,
+          sizeBytes: file.sizeBytes,
+        },
+        gpu: { vendor: "nvidia", count: 1 },
+      },
+    } as const satisfies HostLocalInferenceReceipt;
+    const writer = createManagedLlamaCppReceiptWriter(paths, transactionId);
+    writer.writeExact(serializeHostLocalInferenceReceipt(receipt));
+    createHostLocalCreateJournalStore(paths.stateDir).create({
+      schemaVersion: 1,
+      transactionId,
+      phase: "prepared",
+      providerId: "docker",
+      service: "llama-cpp",
+      containerName: "nemoclaw-llama-cpp",
+      runtimeId: null,
+      createIntentUnixMs: null,
+      specSha256: receipt.runtime.specSha256,
+      networkId: "e".repeat(64),
+      apiKeyIdentitySha256: "f".repeat(64),
+      apiKeyRootIdentitySha256: "1".repeat(64),
+      engineAuthority,
+      receiptTargetSha256: writer.targetSha256,
+      serializedReceipt: null,
+      receiptSha256: null,
+    });
+    const journalDirectory = path.join(paths.stateDir, HOST_LOCAL_CREATE_JOURNAL_DIRECTORY);
+    const protectedFiles = [
+      paths.ownerPath,
+      paths.apiKeyPath,
+      paths.receiptPath,
+      ...fs.readdirSync(journalDirectory).map((entry) => path.join(journalDirectory, entry)),
+    ];
+    const before = new Map(protectedFiles.map((target) => [target, fs.readFileSync(target)]));
+    const lifecycle = {
+      recoverUnfinished: vi.fn(() => ({ recovered: [], failures: [] })),
+      resume: vi.fn(() => receipt),
+      runtime: {} as DockerLlamaCppManagedLifecycle["runtime"],
+      start: vi.fn(() => receipt),
+    } satisfies DockerLlamaCppManagedLifecycle;
+    const createLifecycle = vi.fn(() => lifecycle);
+    const operation = managedOperation(harness.engine, createLifecycle);
+    const runtimeProvider = managedRuntimeProvider(harness.engine, createLifecycle);
+
+    const rehydrated = rehydrateManagedLlamaCppLifecycle({
+      runtimeProvider,
+      runtimeOwnerSandboxName: "spark-agent",
+      homeDir,
+      operation,
+    });
+
+    expect(rehydrated.lifecycle).toBe(lifecycle);
+    expect(rehydrated.operation).toBe(operation);
+    expect(rehydrated.receipt).toEqual(receipt);
+    expect(rehydrated.owner.sandboxName).toBe("spark-agent");
+    expect(rehydrated.selection.recipe.metadata.id).toBe(selected.recipe.metadata.id);
+    expect(createLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKeyRootHostPath: paths.stateDir,
+        bindings: expect.objectContaining({
+          apiKeyHostPath: paths.apiKeyPath,
+          model: expect.objectContaining({ hostPath: fs.realpathSync(modelPath) }),
+        }),
+      }),
+    );
+    for (const [target, contents] of before) {
+      expect(fs.readFileSync(target)).toEqual(contents);
+    }
   });
 
   it("reuses YAML-pinned images, the shared Hugging Face cache, and the durable lifecycle", async () => {

--- a/src/lib/inference/llama-cpp/managed-installer.ts
+++ b/src/lib/inference/llama-cpp/managed-installer.ts
@@ -89,6 +89,24 @@ export interface ManagedLlamaCppExactInspectionOptions {
   readonly selection: ResolvedLlamaCppInferenceSelection;
 }
 
+export interface ManagedLlamaCppLifecycleRehydrationOptions {
+  readonly runtimeProvider: RuntimeProviderBundle;
+  readonly runtimeOwnerSandboxName: string;
+  readonly gatewayPort?: number;
+  readonly homeDir?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly operation?: HostLocalInferenceOperation;
+}
+
+export interface ManagedLlamaCppLifecycleRehydration {
+  readonly lifecycle: HostLocalLlamaCppLifecycle;
+  readonly operation: HostLocalInferenceOperation;
+  readonly owner: NonNullable<ReturnType<typeof loadManagedLlamaCppOwner>>;
+  readonly paths: ManagedLlamaCppStatePaths;
+  readonly receipt: HostLocalInferenceReceipt;
+  readonly selection: ResolvedLlamaCppInferenceSelection;
+}
+
 interface DockerNetworkInspection {
   readonly kind: "absent" | "owned";
   readonly id?: string;
@@ -475,6 +493,49 @@ function currentManagedLlamaCppArtifact(
       sizeBytes: source.file.sizeBytes,
     },
   };
+}
+
+/**
+ * Reconstruct the existing private llama.cpp lifecycle without changing its
+ * owner, journal, API key, or receipt. The caller supplies durable explicit
+ * lifecycle provenance before this seam is reached.
+ */
+export function rehydrateManagedLlamaCppLifecycle(
+  options: ManagedLlamaCppLifecycleRehydrationOptions,
+): ManagedLlamaCppLifecycleRehydration {
+  const homeDir = fs.realpathSync(options.homeDir ?? os.homedir());
+  const paths = managedLlamaCppStatePaths(homeDir, options.gatewayPort);
+  const owner = loadManagedLlamaCppOwner(paths);
+  if (!owner || owner.sandboxName !== options.runtimeOwnerSandboxName) {
+    throw new Error("Managed llama.cpp private owner differs from lifecycle provenance.");
+  }
+  const receipt = loadManagedLlamaCppReceipt(paths);
+  if (!receipt) throw new Error("Managed llama.cpp private receipt is unavailable.");
+  const selection = resolveManagedLlamaCppOwnerSelection(owner);
+  const operation =
+    options.operation ??
+    requireRuntimeProviderHostLocalInferenceOperation(options.runtimeProvider, "llama-cpp", {
+      env: options.env ?? process.env,
+    });
+  operation.assertAuthority();
+  if (operation.providerId !== options.runtimeProvider.identity.id) {
+    throw new Error("Managed llama.cpp runtime provider changed during lifecycle rehydration.");
+  }
+  const current = currentManagedLlamaCppArtifact(selection, homeDir);
+  return Object.freeze({
+    lifecycle: lifecycleFor({
+      selection,
+      paths,
+      cacheRoot: current.cacheRoot,
+      artifact: current.artifact,
+      operation,
+    }),
+    operation,
+    owner,
+    paths,
+    receipt,
+    selection,
+  });
 }
 
 /** Reconstruct current declarative and filesystem authority, then use the lifecycle's exact inspector. */

--- a/src/lib/inference/llama-cpp/managed-lifecycle-adapter.test.ts
+++ b/src/lib/inference/llama-cpp/managed-lifecycle-adapter.test.ts
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createInMemoryRuntimeProviderBundle } from "../../../../test/helpers/runtime-provider-bundle";
+import { privateBridgeFixture } from "../../onboard/runtime-provider/docker-llama-cpp-private-bridge.test-support";
+import type { RuntimeProviderWorkloadProfile } from "../../onboard/runtime-provider/contract";
+import type {
+  HostLocalInferenceOperation,
+  HostLocalInferenceRuntime,
+} from "../../onboard/runtime-provider/host-local-inference";
+import {
+  createManagedState,
+  engineHarness,
+  NETWORK_ID,
+  RUNTIME_ID,
+} from "../local-model-profile/cleanup.test-support";
+import { finalizeManagedLlamaCppLifecycleCleanup } from "../local-model-profile/cleanup";
+import { createManagedLlamaCppLifecycleAdapter } from "./managed-lifecycle-adapter";
+import { loadManagedLlamaCppReceipt, managedLlamaCppStatePaths } from "./managed-state";
+
+const TEST_WORKLOAD_PROFILE = {
+  support: null,
+  hostArchitectures: ["arm64"],
+  managedImageSelectionPolicy: "prefer-managed",
+  legacyDockerfileBuilds: false,
+} as const satisfies RuntimeProviderWorkloadProfile;
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+function temporaryHome(): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-llama-lifecycle-adapter-"));
+  const canonicalHome = fs.realpathSync(home);
+  temporaryDirectories.push(canonicalHome);
+  return canonicalHome;
+}
+
+describe("managed llama.cpp lifecycle adapter", () => {
+  it("uses one exact operation and exposes rollback only before publication", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine);
+    const receipt = loadManagedLlamaCppReceipt(managedLlamaCppStatePaths(homeDir))!;
+    const operation: HostLocalInferenceOperation = {
+      providerId: "docker",
+      engine: harness.engine,
+      bindingSha256: receipt.engineAuthority.bindingSha256,
+      assertAuthority: vi.fn(),
+      spawn: vi.fn(),
+      createLlamaCppLifecycle: vi.fn(),
+    };
+    const inspectManaged = vi.fn((value) => ({
+      running: false,
+      receipt: value,
+    }));
+    const stopManaged = vi.fn((value) => ({ running: false, receipt: value }));
+    const preserveForRebuild = vi.fn((value) => value);
+    const runtime: HostLocalInferenceRuntime = {
+      providerId: "docker",
+      authorityId: harness.engine.authorityId,
+      services: ["llama-cpp"],
+      translateContainerArgs: (args) => args,
+      qualifyOllama: vi.fn(),
+      startManaged: vi.fn(),
+      inspectManaged,
+      stopManaged,
+      preserveForRebuild,
+      prepareDestroy: vi.fn((value) => value),
+      destroy: vi.fn((value) => ({ status: "removed", receipt: value })),
+    };
+    const resume = vi.fn((value) => value);
+    const runtimeProvider = createInMemoryRuntimeProviderBundle({
+      providerId: "docker",
+      workloadProfile: TEST_WORKLOAD_PROFILE,
+      hostLocalInference: {
+        services: ["llama-cpp"],
+        createOperation: () => operation,
+      },
+    });
+    const adapter = createManagedLlamaCppLifecycleAdapter({
+      runtimeProvider,
+      runtimeOwnerSandboxName: "spark-agent",
+      expectedModel: "llama-cpp-model",
+      expectedReceipt: receipt,
+      gatewayPort: 8080,
+      homeDir,
+      operation,
+      rehydrate: vi.fn(
+        () =>
+          ({
+            lifecycle: { resume, runtime },
+            operation,
+            receipt,
+            selection: {
+              recipe: { spec: { model: { servedName: "llama-cpp-model" } } },
+            },
+          }) as never,
+      ),
+    });
+
+    expect(adapter.operation).toBe(operation);
+    const committed = adapter.prepareStartup();
+    expect(committed.publicationState()).toBe("unpublished");
+    expect(committed.validateBeforeCommit()).toEqual(receipt);
+    expect(committed.publicationState()).toBe("unpublished");
+    expect(committed.commit()).toEqual(receipt);
+    expect(committed.publicationState()).toBe("published");
+    expect(() => committed.rollback()).toThrow("terminal state 'committed'");
+
+    const rolledBack = adapter.prepareStartup();
+    expect(rolledBack.rollback()).toEqual({
+      status: "restored",
+      priorState: "stopped",
+      receipt,
+    });
+    expect(rolledBack.publicationState()).toBe("unpublished");
+    expect(stopManaged).toHaveBeenCalledWith(receipt);
+    expect(resume).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses the retained receipt for an idempotent destroy retry after private state is gone", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine);
+    const paths = managedLlamaCppStatePaths(homeDir);
+    const receipt = loadManagedLlamaCppReceipt(paths)!;
+    fs.rmSync(paths.stateDir, { recursive: true });
+    const operation: HostLocalInferenceOperation = {
+      providerId: "docker",
+      engine: harness.engine,
+      bindingSha256: receipt.engineAuthority.bindingSha256,
+      assertAuthority: vi.fn(),
+      spawn: vi.fn(),
+      createLlamaCppLifecycle: () => {
+        throw new Error("destroy retry must not reconstruct a missing private lifecycle");
+      },
+    };
+    const runtimeProvider = createInMemoryRuntimeProviderBundle({
+      providerId: "docker",
+      workloadProfile: TEST_WORKLOAD_PROFILE,
+      hostLocalInference: {
+        services: ["llama-cpp"],
+        createOperation: () => operation,
+      },
+    });
+    const privateBridge = privateBridgeFixture();
+    const adapter = createManagedLlamaCppLifecycleAdapter({
+      runtimeProvider,
+      runtimeOwnerSandboxName: "spark-agent",
+      expectedModel: "llama-cpp-model",
+      expectedReceipt: receipt,
+      gatewayPort: 8080,
+      homeDir,
+      operation,
+      finalizeCleanup: (owner, expected, options) =>
+        finalizeManagedLlamaCppLifecycleCleanup(owner, expected, {
+          ...options,
+          privateBridge,
+        }),
+    });
+
+    expect(() => adapter.prepareStartup()).toThrow("private lifecycle state is unavailable");
+    expect(adapter.runtime.prepareDestroy(receipt)).toEqual(receipt);
+    expect(adapter.runtime.destroy(receipt)).toEqual({
+      status: "removed",
+      receipt,
+    });
+    expect(adapter.runtime.destroy(receipt)).toEqual({
+      status: "already-absent",
+      receipt,
+    });
+    expect(harness.capture).toHaveBeenCalledWith(["rm", "--force", RUNTIME_ID], expect.any(Number));
+    expect(harness.capture).toHaveBeenCalledWith(["network", "rm", NETWORK_ID], expect.any(Number));
+  });
+});

--- a/src/lib/inference/llama-cpp/managed-lifecycle-adapter.test.ts
+++ b/src/lib/inference/llama-cpp/managed-lifecycle-adapter.test.ts
@@ -76,7 +76,7 @@ describe("managed llama.cpp lifecycle adapter", () => {
       stopManaged,
       preserveForRebuild,
       prepareDestroy: vi.fn((value) => value),
-      destroy: vi.fn((value) => ({ status: "removed", receipt: value })),
+      destroy: vi.fn((value) => ({ status: "removed" as const, receipt: value })),
     };
     const resume = vi.fn((value) => value);
     const runtimeProvider = createInMemoryRuntimeProviderBundle({

--- a/src/lib/inference/llama-cpp/managed-lifecycle-adapter.ts
+++ b/src/lib/inference/llama-cpp/managed-lifecycle-adapter.ts
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+
+import type { RuntimeProviderBundle } from "../../onboard/runtime-provider/contract";
+import type {
+  HostLocalInferenceOperation,
+  HostLocalInferencePreparedStartup,
+  HostLocalInferenceReceipt,
+  HostLocalInferenceRuntime,
+} from "../../onboard/runtime-provider/host-local-inference";
+import {
+  normalizeHostLocalInferenceReceipt,
+  serializeHostLocalInferenceReceipt,
+} from "../../onboard/runtime-provider/host-local-inference";
+import {
+  finalizeManagedLlamaCppLifecycleCleanup,
+  prepareManagedLlamaCppLifecycleCleanup,
+} from "../local-model-profile/cleanup";
+import { rehydrateManagedLlamaCppLifecycle } from "./managed-installer";
+import { managedLlamaCppStatePaths } from "./managed-state";
+
+export interface ManagedLlamaCppLifecycleAdapterOptions {
+  readonly runtimeProvider: RuntimeProviderBundle;
+  readonly runtimeOwnerSandboxName: string;
+  readonly expectedModel: string;
+  readonly expectedReceipt: HostLocalInferenceReceipt;
+  readonly gatewayPort: number;
+  readonly homeDir?: string;
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly operation?: HostLocalInferenceOperation;
+  readonly finalizeCleanup?: typeof finalizeManagedLlamaCppLifecycleCleanup;
+  readonly prepareCleanup?: typeof prepareManagedLlamaCppLifecycleCleanup;
+  readonly rehydrate?: typeof rehydrateManagedLlamaCppLifecycle;
+}
+
+/** One provider-specific seam consumed by the common host-local lifecycle coordinator. */
+export interface ManagedLlamaCppLifecycleAdapter {
+  readonly gatewayPort: number;
+  readonly runtimeOwnerSandboxName: string;
+  readonly model: string;
+  readonly operation: HostLocalInferenceOperation;
+  readonly receipt: HostLocalInferenceReceipt;
+  readonly runtime: HostLocalInferenceRuntime;
+  prepareStartup(): HostLocalInferencePreparedStartup;
+}
+
+function requireExactReceipt(
+  expected: string,
+  value: HostLocalInferenceReceipt,
+  message: string,
+): HostLocalInferenceReceipt {
+  const normalized = normalizeHostLocalInferenceReceipt(value);
+  if (serializeHostLocalInferenceReceipt(normalized) !== expected) throw new Error(message);
+  return normalized;
+}
+
+/**
+ * Rehydrate the existing managed llama.cpp internals only after the caller has
+ * selected the hidden lifecycle and supplied its durable original owner.
+ */
+export function createManagedLlamaCppLifecycleAdapter(
+  options: ManagedLlamaCppLifecycleAdapterOptions,
+): ManagedLlamaCppLifecycleAdapter {
+  const expected = serializeHostLocalInferenceReceipt(
+    normalizeHostLocalInferenceReceipt(options.expectedReceipt),
+  );
+  const normalizedReceipt = normalizeHostLocalInferenceReceipt(options.expectedReceipt);
+  if (normalizedReceipt.service !== "llama-cpp" || normalizedReceipt.schemaVersion !== 1) {
+    throw new Error(
+      "Managed llama.cpp lifecycle authority requires its canonical schema-v1 receipt.",
+    );
+  }
+  const gatewayPort = options.gatewayPort;
+  if (!Number.isSafeInteger(gatewayPort) || gatewayPort < 1 || gatewayPort > 65_535) {
+    throw new Error("Managed llama.cpp lifecycle authority requires its exact gateway port.");
+  }
+  const homeDir = fs.realpathSync(options.homeDir ?? os.homedir());
+  const paths = managedLlamaCppStatePaths(homeDir, gatewayPort);
+  const finalizeCleanup = options.finalizeCleanup ?? finalizeManagedLlamaCppLifecycleCleanup;
+  const prepareCleanup = options.prepareCleanup ?? prepareManagedLlamaCppLifecycleCleanup;
+  if (!fs.existsSync(paths.stateDir)) {
+    const operation =
+      options.operation ??
+      (() => {
+        throw new Error("Managed llama.cpp cleanup retry requires its exact provider operation.");
+      })();
+    const prepareExactCleanup = (value: HostLocalInferenceReceipt): HostLocalInferenceReceipt => {
+      const receipt = requireExactReceipt(
+        expected,
+        value,
+        "Managed llama.cpp cleanup retry changed registry receipt authority.",
+      );
+      return requireExactReceipt(
+        expected,
+        prepareCleanup(options.runtimeOwnerSandboxName, receipt, {
+          gatewayPort,
+          homeDir,
+          ...(options.environment === undefined ? {} : { env: options.environment }),
+          engine: operation.engine,
+        }),
+        "Managed llama.cpp cleanup retry could not re-prove registry receipt authority.",
+      );
+    };
+    const unavailable = (): never => {
+      throw new Error("Managed llama.cpp private lifecycle state is unavailable.");
+    };
+    const runtime: HostLocalInferenceRuntime = Object.freeze({
+      providerId: operation.providerId,
+      authorityId: operation.engine.authorityId,
+      services: Object.freeze(["llama-cpp"] as const),
+      translateContainerArgs: (args: readonly string[]) => args,
+      qualifyOllama: unavailable,
+      startManaged: unavailable,
+      inspectManaged: unavailable,
+      stopManaged: unavailable,
+      preserveForRebuild: unavailable,
+      prepareDestroy: prepareExactCleanup,
+      destroy(value: HostLocalInferenceReceipt) {
+        const receipt = prepareExactCleanup(value);
+        const finalized = finalizeCleanup(options.runtimeOwnerSandboxName, receipt, {
+          gatewayPort,
+          homeDir,
+          ...(options.environment === undefined ? {} : { env: options.environment }),
+          engine: operation.engine,
+        });
+        if (!finalized.ok) throw new Error(finalized.reason);
+        return Object.freeze({
+          status: finalized.removed.length > 0 ? ("removed" as const) : ("already-absent" as const),
+          receipt,
+        });
+      },
+    });
+    return Object.freeze({
+      gatewayPort,
+      runtimeOwnerSandboxName: options.runtimeOwnerSandboxName,
+      model: options.expectedModel,
+      operation,
+      receipt: normalizedReceipt,
+      runtime,
+      prepareStartup: unavailable,
+    });
+  }
+
+  const rehydrated = (options.rehydrate ?? rehydrateManagedLlamaCppLifecycle)({
+    runtimeProvider: options.runtimeProvider,
+    runtimeOwnerSandboxName: options.runtimeOwnerSandboxName,
+    gatewayPort,
+    ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
+    ...(options.environment === undefined ? {} : { env: options.environment }),
+    ...(options.operation === undefined ? {} : { operation: options.operation }),
+  });
+  const receipt = requireExactReceipt(
+    expected,
+    rehydrated.receipt,
+    "Managed llama.cpp private receipt differs from registry lifecycle authority.",
+  );
+  if (rehydrated.selection.recipe.spec.model.servedName !== options.expectedModel) {
+    throw new Error("Managed llama.cpp private model differs from registry lifecycle authority.");
+  }
+  const providerRuntime = rehydrated.lifecycle.runtime;
+  if (
+    providerRuntime.providerId !== options.runtimeProvider.identity.id ||
+    providerRuntime.authorityId !== rehydrated.operation.engine.authorityId ||
+    !providerRuntime.services.includes("llama-cpp")
+  ) {
+    throw new Error("Managed llama.cpp adapter reconstructed a different runtime authority.");
+  }
+  const runtime: HostLocalInferenceRuntime = Object.freeze({
+    ...providerRuntime,
+    destroy(value: HostLocalInferenceReceipt) {
+      const destroyed = providerRuntime.destroy(value);
+      requireExactReceipt(
+        expected,
+        destroyed.receipt,
+        "Managed llama.cpp destroy changed registry receipt authority.",
+      );
+      const finalized = finalizeCleanup(options.runtimeOwnerSandboxName, receipt, {
+        gatewayPort,
+        ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
+        ...(options.environment === undefined ? {} : { env: options.environment }),
+        engine: rehydrated.operation.engine,
+      });
+      if (!finalized.ok) throw new Error(finalized.reason);
+      return Object.freeze({
+        status:
+          destroyed.status === "removed" || finalized.removed.length > 0
+            ? ("removed" as const)
+            : ("already-absent" as const),
+        receipt,
+      });
+    },
+  });
+
+  return Object.freeze({
+    gatewayPort,
+    runtimeOwnerSandboxName: options.runtimeOwnerSandboxName,
+    model: rehydrated.selection.recipe.spec.model.servedName,
+    operation: rehydrated.operation,
+    receipt,
+    runtime,
+    prepareStartup(): HostLocalInferencePreparedStartup {
+      const atEntry = runtime.inspectManaged(receipt);
+      requireExactReceipt(
+        expected,
+        atEntry.receipt,
+        "Managed llama.cpp inspection changed registry receipt authority.",
+      );
+      const resumed = requireExactReceipt(
+        expected,
+        rehydrated.lifecycle.resume(receipt),
+        "Managed llama.cpp resume changed registry receipt authority.",
+      );
+      const rollbackPriorState = atEntry.running ? ("running" as const) : ("stopped" as const);
+      let state:
+        | "prepared"
+        | "validated"
+        | "committing"
+        | "committed"
+        | "rolling-back"
+        | "rolled-back"
+        | "indeterminate" = "prepared";
+      const requireRollbackSafe = (action: string): void => {
+        if (state !== "prepared" && state !== "validated") {
+          throw new Error(
+            `Managed llama.cpp startup cannot ${action} from terminal state '${state}'.`,
+          );
+        }
+      };
+      return Object.freeze({
+        receipt: resumed,
+        rollbackPriorState,
+        publicationState() {
+          if (state === "committed") return "published" as const;
+          if (state === "prepared" || state === "validated" || state === "rolled-back") {
+            return "unpublished" as const;
+          }
+          return "indeterminate" as const;
+        },
+        validateBeforeCommit() {
+          requireRollbackSafe("validate before commit");
+          try {
+            const validated = requireExactReceipt(
+              expected,
+              runtime.preserveForRebuild(receipt),
+              "Managed llama.cpp validation changed registry receipt authority.",
+            );
+            state = "validated";
+            return validated;
+          } catch (error) {
+            state = "prepared";
+            throw error;
+          }
+        },
+        commit() {
+          if (state !== "validated") {
+            throw new Error(
+              `Managed llama.cpp startup cannot commit without fresh validation from state '${state}'.`,
+            );
+          }
+          state = "committing";
+          try {
+            const committed = requireExactReceipt(
+              expected,
+              runtime.preserveForRebuild(receipt),
+              "Managed llama.cpp commit changed registry receipt authority.",
+            );
+            state = "committed";
+            return committed;
+          } catch (error) {
+            state = "indeterminate";
+            throw error;
+          }
+        },
+        rollback: () => {
+          requireRollbackSafe("roll back");
+          state = "rolling-back";
+          try {
+            const restored = atEntry.running
+              ? runtime.preserveForRebuild(receipt)
+              : runtime.stopManaged(receipt).receipt;
+            const result = Object.freeze({
+              status: "restored" as const,
+              priorState: rollbackPriorState,
+              receipt: requireExactReceipt(
+                expected,
+                restored,
+                "Managed llama.cpp rollback changed registry receipt authority.",
+              ),
+            });
+            state = "rolled-back";
+            return result;
+          } catch (error) {
+            state = "indeterminate";
+            throw error;
+          }
+        },
+      });
+    },
+  });
+}

--- a/src/lib/inference/local-model-profile/cleanup.test.ts
+++ b/src/lib/inference/local-model-profile/cleanup.test.ts
@@ -7,8 +7,9 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { privateBridgeFixture } from "../../onboard/runtime-provider/docker-llama-cpp-private-bridge.test-support";
 import { createHostLocalCreateJournalStore } from "../../onboard/runtime-provider/host-local-create-journal";
-import { managedLlamaCppStatePaths } from "../llama-cpp/managed-state";
+import { loadManagedLlamaCppReceipt, managedLlamaCppStatePaths } from "../llama-cpp/managed-state";
 import { runtimeAuthFingerprint } from "../serving/runtime-auth-fingerprint";
 import {
   HOST_LOCAL_VLLM_AUTH_LABEL,
@@ -27,6 +28,8 @@ import {
   cleanupHuggingFaceCacheData,
   cleanupLocalModelRuntimes,
   cleanupManagedLlamaCppRuntimeForSandbox,
+  finalizeManagedLlamaCppLifecycleCleanup,
+  prepareManagedLlamaCppLifecycleCleanup,
   resolveManagedLlamaCppCleanupTarget,
 } from "./cleanup";
 import {
@@ -381,6 +384,76 @@ describe("host-local model cleanup", () => {
     );
     expect(result.removed).not.toContain(`cache-contents:${cache}`);
     expect(result.preserved).toContain(cache);
+  });
+
+  it("finishes common-lifecycle llama.cpp cleanup and preserves the shared model cache", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine);
+    const paths = managedLlamaCppStatePaths(homeDir);
+    const receipt = loadManagedLlamaCppReceipt(paths)!;
+    createHostLocalCreateJournalStore(paths.stateDir).retire(TRANSACTION_ID);
+    const cache = path.join(homeDir, ".cache", "huggingface");
+    fs.mkdirSync(cache, { recursive: true });
+    fs.writeFileSync(path.join(cache, "shared-model"), "keep");
+    const privateBridge = privateBridgeFixture();
+
+    expect(
+      prepareManagedLlamaCppLifecycleCleanup("spark-agent", receipt, {
+        homeDir,
+        engine: harness.engine,
+      }),
+    ).toEqual(receipt);
+    expect(harness.capture).not.toHaveBeenCalledWith(
+      ["rm", "--force", RUNTIME_ID],
+      expect.any(Number),
+    );
+
+    const result = finalizeManagedLlamaCppLifecycleCleanup("spark-agent", receipt, {
+      homeDir,
+      engine: harness.engine,
+      privateBridge,
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(privateBridge.stopTransaction).toHaveBeenCalledWith(TRANSACTION_ID);
+    expect(privateBridge.assertStopped).toHaveBeenCalledWith(TRANSACTION_ID);
+    expect(harness.capture).toHaveBeenCalledWith(["rm", "--force", RUNTIME_ID], expect.any(Number));
+    expect(harness.capture).toHaveBeenCalledWith(["network", "rm", NETWORK_ID], expect.any(Number));
+    expect(fs.existsSync(paths.stateDir)).toBe(false);
+    expect(fs.readFileSync(path.join(cache, "shared-model"), "utf8")).toBe("keep");
+    expect(result.preserved).toContain(cache);
+  });
+
+  it("retries exact common-lifecycle cleanup after private state is already absent", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine);
+    const paths = managedLlamaCppStatePaths(homeDir);
+    const receipt = loadManagedLlamaCppReceipt(paths)!;
+    fs.rmSync(paths.stateDir, { recursive: true });
+    const privateBridge = privateBridgeFixture();
+
+    expect(
+      prepareManagedLlamaCppLifecycleCleanup("spark-agent", receipt, {
+        homeDir,
+        engine: harness.engine,
+      }),
+    ).toEqual(receipt);
+    const first = finalizeManagedLlamaCppLifecycleCleanup("spark-agent", receipt, {
+      homeDir,
+      engine: harness.engine,
+      privateBridge,
+    });
+    const second = finalizeManagedLlamaCppLifecycleCleanup("spark-agent", receipt, {
+      homeDir,
+      engine: harness.engine,
+      privateBridge,
+    });
+
+    expect(first).toMatchObject({ ok: true });
+    expect(first.removed).toEqual([`container:${RUNTIME_ID}`, `network:${NETWORK_ID}`]);
+    expect(second).toEqual({ ok: true, removed: [], preserved: [] });
   });
 
   it("removes non-credential Hugging Face cache data without running runtime cleanup", () => {

--- a/src/lib/inference/local-model-profile/cleanup.ts
+++ b/src/lib/inference/local-model-profile/cleanup.ts
@@ -12,6 +12,10 @@ import {
   dockerLlamaCppBindingSha256,
 } from "../../onboard/runtime-provider/docker-llama-cpp-operation";
 import {
+  createDockerLlamaCppPrivateBridgeController,
+  type DockerLlamaCppPrivateBridgeController,
+} from "../../onboard/runtime-provider/docker-llama-cpp-private-bridge";
+import {
   createHostLocalCreateJournalStore,
   type HostLocalCreateJournalRecord,
 } from "../../onboard/runtime-provider/host-local-create-journal";
@@ -31,6 +35,11 @@ import {
   type ManagedLlamaCppStatePaths,
   managedLlamaCppStatePaths,
 } from "../llama-cpp/managed-state";
+import {
+  normalizeHostLocalInferenceReceipt,
+  serializeHostLocalInferenceReceipt,
+  type HostLocalInferenceReceipt,
+} from "../../onboard/runtime-provider/host-local-inference";
 import {
   DUAL_STATION_VLLM_RUNTIME_RECEIPT_FILE,
   MANAGED_CLUSTER_VLLM_RUNTIME_RECEIPT_FILE,
@@ -619,6 +628,227 @@ export interface ManagedLlamaCppSandboxCleanupOptions {
   readonly env?: NodeJS.ProcessEnv;
   readonly engine?: ContainerEngine;
   readonly deps?: Partial<CleanupDeps>;
+}
+
+export interface ManagedLlamaCppLifecycleCleanupOptions extends ManagedLlamaCppSandboxCleanupOptions {
+  readonly privateBridge?: DockerLlamaCppPrivateBridgeController;
+}
+
+function requireManagedLlamaCppLifecycleCleanupReceipt(
+  expectedReceipt: HostLocalInferenceReceipt,
+): HostLocalInferenceReceipt & {
+  readonly runtime: Extract<
+    HostLocalInferenceReceipt["runtime"],
+    { readonly kind: "container" }
+  > & {
+    readonly model: NonNullable<
+      Extract<HostLocalInferenceReceipt["runtime"], { readonly kind: "container" }>["model"]
+    >;
+  };
+} {
+  const receipt = normalizeHostLocalInferenceReceipt(expectedReceipt);
+  if (
+    receipt.service !== "llama-cpp" ||
+    receipt.schemaVersion !== 1 ||
+    receipt.runtime.kind !== "container" ||
+    receipt.runtime.model === undefined
+  ) {
+    throw new Error("managed llama.cpp lifecycle cleanup receipt is invalid");
+  }
+  return receipt as HostLocalInferenceReceipt & {
+    readonly runtime: Extract<
+      HostLocalInferenceReceipt["runtime"],
+      { readonly kind: "container" }
+    > & {
+      readonly model: NonNullable<
+        Extract<HostLocalInferenceReceipt["runtime"], { readonly kind: "container" }>["model"]
+      >;
+    };
+  };
+}
+
+/** Re-prove exact cleanup authority without changing the runtime or private state. */
+export function prepareManagedLlamaCppLifecycleCleanup(
+  runtimeOwnerSandboxName: string,
+  expectedReceipt: HostLocalInferenceReceipt,
+  options: ManagedLlamaCppLifecycleCleanupOptions = {},
+): HostLocalInferenceReceipt {
+  const receipt = requireManagedLlamaCppLifecycleCleanupReceipt(expectedReceipt);
+  const homeDir = canonicalCleanupHomeDir(options.homeDir ?? os.homedir());
+  const paths = managedLlamaCppStatePaths(homeDir, options.gatewayPort);
+  const engine = options.engine ?? createManagedLlamaCppEngine(options.env ?? process.env);
+  requireQualifiedEngine(receipt.engineAuthority, engine);
+  requireEngineSuccess(
+    "engine availability check",
+    engine.capture(["info"], DOCKER_INSPECT_TIMEOUT_MS),
+  );
+  const transactionId = receipt.runtime.model.generation;
+  const container = inspectOwnedLlamaResource(
+    engine,
+    "container",
+    receipt.runtime.runtimeId,
+    {
+      [LLAMA_MANAGED_LABEL]: "true",
+      [LLAMA_PROVIDER_LABEL]: "docker",
+      [LLAMA_SERVICE_LABEL]: "llama-cpp",
+      [LLAMA_SPEC_LABEL]: receipt.runtime.specSha256,
+      [LLAMA_TRANSACTION_LABEL]: transactionId,
+    },
+    receipt.runtime.name,
+  );
+  if (container.kind === "foreign") {
+    throw new Error("managed llama.cpp lifecycle container authority changed");
+  }
+  const network = inspectOwnedLlamaResource(engine, "network", receipt.endpoint.networkName, {
+    [LLAMA_NETWORK_TRANSACTION_LABEL]: transactionId,
+  });
+  if (network.kind === "foreign") {
+    throw new Error("managed llama.cpp lifecycle network authority changed");
+  }
+  if (statePathExists(paths.stateDir)) {
+    requirePrivateManagedState(
+      paths,
+      options.deps?.currentUserId === undefined
+        ? typeof process.getuid === "function"
+          ? process.getuid()
+          : null
+        : options.deps.currentUserId,
+    );
+    const owner = loadManagedLlamaCppOwner(paths);
+    const privateReceipt = loadManagedLlamaCppReceipt(paths);
+    if (
+      owner?.sandboxName !== runtimeOwnerSandboxName ||
+      privateReceipt === null ||
+      serializeHostLocalInferenceReceipt(privateReceipt) !==
+        serializeHostLocalInferenceReceipt(receipt)
+    ) {
+      throw new Error("managed llama.cpp private lifecycle authority changed during cleanup");
+    }
+  }
+  return receipt;
+}
+
+/**
+ * Complete a common-lifecycle llama.cpp retirement after its provider runtime
+ * has stopped the bridge, removed the exact container, and retired the journal.
+ * The registry receipt remains the retry authority if this final phase fails.
+ */
+export function finalizeManagedLlamaCppLifecycleCleanup(
+  runtimeOwnerSandboxName: string,
+  expectedReceipt: HostLocalInferenceReceipt,
+  options: ManagedLlamaCppLifecycleCleanupOptions = {},
+): LocalModelRuntimeCleanupResult {
+  const removed: string[] = [];
+  const preserved: string[] = [];
+  try {
+    const receipt = requireManagedLlamaCppLifecycleCleanupReceipt(expectedReceipt);
+    const homeDir = canonicalCleanupHomeDir(options.homeDir ?? os.homedir());
+    const paths = managedLlamaCppStatePaths(homeDir, options.gatewayPort);
+    const engine = options.engine ?? createManagedLlamaCppEngine(options.env ?? process.env);
+    requireQualifiedEngine(receipt.engineAuthority, engine);
+    requireEngineSuccess(
+      "engine availability check",
+      engine.capture(["info"], DOCKER_INSPECT_TIMEOUT_MS),
+    );
+    const transactionId = receipt.runtime.model.generation;
+    const privateBridge = options.privateBridge ?? createDockerLlamaCppPrivateBridgeController();
+    privateBridge.stopTransaction(transactionId);
+    privateBridge.assertStopped(transactionId);
+
+    const expectedContainerLabels = {
+      [LLAMA_MANAGED_LABEL]: "true",
+      [LLAMA_PROVIDER_LABEL]: "docker",
+      [LLAMA_SERVICE_LABEL]: "llama-cpp",
+      [LLAMA_SPEC_LABEL]: receipt.runtime.specSha256,
+      [LLAMA_TRANSACTION_LABEL]: transactionId,
+    };
+    let container = inspectOwnedLlamaResource(
+      engine,
+      "container",
+      receipt.runtime.runtimeId,
+      expectedContainerLabels,
+      receipt.runtime.name,
+    );
+    if (container.kind === "foreign") {
+      throw new Error("managed llama.cpp lifecycle container authority changed");
+    }
+    if (container.kind === "owned") {
+      requireEngineSuccess(
+        "container removal",
+        engine.capture(["rm", "--force", container.id], DOCKER_MUTATION_TIMEOUT_MS),
+      );
+      removed.push(`container:${container.id}`);
+    }
+    container = inspectOwnedLlamaResource(
+      engine,
+      "container",
+      receipt.runtime.name,
+      expectedContainerLabels,
+    );
+    if (container.kind !== "absent") {
+      throw new Error("managed llama.cpp lifecycle container absence is unproven");
+    }
+
+    const expectedNetworkLabels = { [LLAMA_NETWORK_TRANSACTION_LABEL]: transactionId };
+    let network = inspectOwnedLlamaResource(
+      engine,
+      "network",
+      receipt.endpoint.networkName,
+      expectedNetworkLabels,
+    );
+    if (network.kind === "foreign") {
+      throw new Error("managed llama.cpp lifecycle network authority changed");
+    }
+    if (network.kind === "owned") {
+      requireEngineSuccess(
+        "network removal",
+        engine.capture(["network", "rm", network.id], DOCKER_MUTATION_TIMEOUT_MS),
+      );
+      removed.push(`network:${network.id}`);
+    }
+    network = inspectOwnedLlamaResource(
+      engine,
+      "network",
+      receipt.endpoint.networkName,
+      expectedNetworkLabels,
+    );
+    if (network.kind !== "absent") {
+      throw new Error("managed llama.cpp lifecycle network absence is unproven");
+    }
+
+    if (statePathExists(paths.stateDir)) {
+      requirePrivateManagedState(
+        paths,
+        options.deps?.currentUserId === undefined
+          ? typeof process.getuid === "function"
+            ? process.getuid()
+            : null
+          : options.deps.currentUserId,
+      );
+      const owner = loadManagedLlamaCppOwner(paths);
+      const privateReceipt = loadManagedLlamaCppReceipt(paths);
+      if (
+        owner?.sandboxName !== runtimeOwnerSandboxName ||
+        privateReceipt === null ||
+        serializeHostLocalInferenceReceipt(privateReceipt) !==
+          serializeHostLocalInferenceReceipt(receipt) ||
+        createHostLocalCreateJournalStore(paths.stateDir).list().length !== 0
+      ) {
+        throw new Error("managed llama.cpp private lifecycle authority changed during cleanup");
+      }
+      fs.rmSync(paths.stateDir, { recursive: true });
+      removed.push(`state:${paths.stateDir}`);
+    }
+    preserveSharedHuggingFaceCache(homeDir, preserved);
+    return { ok: true, removed, preserved };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : String(error),
+      removed,
+      preserved,
+    };
+  }
 }
 
 export interface ManagedLlamaCppCleanupTarget {

--- a/src/lib/onboard/machine/handlers/provider-inference-host-local-startup.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference-host-local-startup.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 
+import { llamaCppHostLocalInferenceReceipt } from "../../../../../test/helpers/host-local-inference-receipt";
 import { createSession } from "../../../state/onboard-session";
 import type { HostLocalInferenceReceipt } from "../../runtime-provider/host-local-inference";
 import type {
@@ -144,12 +145,10 @@ function hostLocalPublishedResumeSelection(
   recoveredToolCallingRequired = true,
 ): HostLocalInferenceStartupSelection {
   const selected = hostLocalStartupSelection(input, service, recoveredToolCallingRequired);
-  const managedRequest =
-    selected.request.service === "ollama"
-      ? (() => {
-          throw new Error("managed published-resume test selection unexpectedly resolved Ollama");
-        })()
-      : selected.request;
+  const managedRequest = selected.request as Extract<
+    HostLocalInferenceStartupSelection["request"],
+    { service: "nim" | "vllm" }
+  >;
   return {
     ...selected,
     request: {
@@ -173,7 +172,156 @@ function expectedOllamaSelection(
   >;
 }
 
+function llamaCppLifecycleSelection(
+  input: HostLocalInferenceStartupSelectionInput,
+  publishedRoute: boolean,
+): HostLocalInferenceStartupSelection {
+  const value = llamaCppHostLocalInferenceReceipt("mxc");
+  return {
+    runtimeProviderId: "mxc",
+    request: {
+      application: input.application,
+      service: "llama-cpp",
+      adapter: {
+        gatewayPort: 8080,
+        runtimeOwnerSandboxName: "llama-owner",
+        model: input.model,
+        operation: {} as never,
+        receipt: value,
+        runtime: {} as never,
+        prepareStartup: vi.fn() as never,
+      },
+      requireToolCalling: input.requireToolCalling ?? true,
+      publishedRoute,
+    },
+    resolveRuntimeProvider: () => null,
+    prepareGatewayMutation: async () => ({
+      commit: () => {},
+      rollback: () => {},
+    }),
+  };
+}
+
 describe("provider inference host-local startup selection", () => {
+  it.each(["openclaw", "hermes", "langchain-deepagents-code"] as const)(
+    "dispatches a published %s llama.cpp route through the common lifecycle exactly once",
+    async (application) => {
+      const model = "llama-cpp-model";
+      const session = createSession({
+        provider: "llama-cpp-local",
+        model,
+        endpointUrl: "https://inference.local/v1",
+        credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+        preferredInferenceApi: "openai-completions",
+      });
+      session.steps.provider_selection.status = "complete";
+      const resolver = vi.fn((input: HostLocalInferenceStartupSelectionInput) =>
+        llamaCppLifecycleSelection(input, true),
+      );
+      const { deps, calls } = createDeps({
+        isInferenceRouteReady: vi.fn(() => true),
+        resolveHostLocalInferenceStartupSelection: resolver,
+      });
+      const options = baseOptions(deps, session);
+
+      const result = await handleProviderInferenceState({
+        ...options,
+        agent: { name: application },
+        initial: { ...options.initial, endpointSource: "inference-set" },
+        resume: true,
+        sandboxName: `${application}-sandbox`,
+      });
+
+      expect(resolver).toHaveBeenCalledOnce();
+      expect(calls.recoverManagedLlamaCpp).not.toHaveBeenCalled();
+      expect(calls.setupInference).toHaveBeenCalledOnce();
+      expect(calls.setupInference.mock.calls[0]?.[7]).toEqual(
+        expect.objectContaining({
+          hostLocalInference: expect.objectContaining({
+            request: expect.objectContaining({
+              service: "llama-cpp",
+              publishedRoute: true,
+            }),
+          }),
+        }),
+      );
+      expect(result.hostLocalInferenceSandboxProofAuthority).toEqual(
+        expect.objectContaining({ service: "llama-cpp", directHostPort: 8081 }),
+      );
+    },
+  );
+
+  it("keeps an unselected managed llama.cpp resume on the unchanged legacy dispatcher", async () => {
+    const model = "llama-cpp-model";
+    const session = createSession({
+      provider: "llama-cpp-local",
+      model,
+      endpointUrl: "http://127.0.0.1:8081/v1",
+      credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+      preferredInferenceApi: "openai-completions",
+    });
+    session.steps.provider_selection.status = "complete";
+    const { deps, calls } = createDeps({
+      isInferenceRouteReady: vi.fn(() => true),
+      resolveHostLocalInferenceStartupSelection: vi.fn(() => null),
+    });
+
+    await handleProviderInferenceState({
+      ...baseOptions(deps, session),
+      resume: true,
+      sandboxName: "legacy-llama",
+    });
+
+    expect(calls.recoverManagedLlamaCpp).toHaveBeenCalledOnce();
+    expect(calls.setupInference).not.toHaveBeenCalled();
+  });
+
+  it.each(["openclaw", "hermes", "langchain-deepagents-code"] as const)(
+    "dispatches an authoritative %s llama.cpp rebuild through the common lifecycle exactly once",
+    async (application) => {
+      const model = "llama-cpp-model";
+      const session = createSession({
+        provider: "llama-cpp-local",
+        model,
+        endpointUrl: "https://inference.local/v1",
+        credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+        preferredInferenceApi: "openai-completions",
+      });
+      session.steps.provider_selection.status = "pending";
+      const resolver = vi.fn((input: HostLocalInferenceStartupSelectionInput) =>
+        llamaCppLifecycleSelection(input, true),
+      );
+      const { deps, calls } = createDeps({
+        isInferenceRouteReady: vi.fn(() => true),
+        resolveHostLocalInferenceStartupSelection: resolver,
+      });
+      const options = baseOptions(deps, session);
+
+      await handleProviderInferenceState({
+        ...options,
+        agent: { name: application },
+        authoritativeResumeConfig: true,
+        initial: { ...options.initial, endpointSource: "inference-set" },
+        resume: true,
+        sandboxName: `${application}-sandbox`,
+      });
+
+      expect(resolver).toHaveBeenCalledOnce();
+      expect(calls.recoverManagedLlamaCpp).not.toHaveBeenCalled();
+      expect(calls.setupInference).toHaveBeenCalledOnce();
+      expect(calls.setupInference.mock.calls[0]?.[7]).toEqual(
+        expect.objectContaining({
+          hostLocalInference: expect.objectContaining({
+            request: expect.objectContaining({
+              service: "llama-cpp",
+              publishedRoute: true,
+            }),
+          }),
+        }),
+      );
+    },
+  );
+
   it("rejects reuse of cached startup authority for a different sandbox", () => {
     const resolver = vi.fn((input: HostLocalInferenceStartupSelectionInput) =>
       hostLocalStartupSelection(input),

--- a/src/lib/onboard/machine/handlers/provider-inference.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.ts
@@ -39,6 +39,9 @@ import {
   type HostLocalInferenceSandboxProofAuthority,
   type HostLocalInferenceStartupSelection,
   type HostLocalInferenceStartupSelectionResolver,
+  hostLocalInferenceGatewayProvider,
+  hostLocalInferenceRequestModel,
+  hostLocalInferenceRequestToolCalling,
   hostLocalInferenceSandboxProofAuthority,
 } from "../../runtime-provider/host-local-inference-routing";
 import { withInferenceTrace, withProviderSelectionTrace } from "../../tracing";
@@ -354,7 +357,7 @@ type HostLocalInferenceSetupOptions = {
 };
 
 function isHostLocalInferenceProvider(provider: string): boolean {
-  return provider === "ollama-local" || provider === "vllm-local";
+  return provider === "ollama-local" || provider === "vllm-local" || provider === "llama-cpp-local";
 }
 
 function isCanonicalHostLocalResume(input: {
@@ -382,9 +385,13 @@ export function createCachedHostLocalInferenceSetupResolver(input: {
   allowPublishedResume: boolean;
   recover: boolean;
   recordToolCallingRequirement(requireToolCalling: boolean): void;
+  initial?: {
+    readonly sandboxName: string;
+    readonly setupOptions: HostLocalInferenceSetupOptions;
+  };
 }): (sandboxName: string) => HostLocalInferenceSetupOptions {
-  let cached: HostLocalInferenceSetupOptions | null = null;
-  let cachedSandboxName: string | null = null;
+  let cached: HostLocalInferenceSetupOptions | null = input.initial?.setupOptions ?? null;
+  let cachedSandboxName: string | null = input.initial?.sandboxName ?? null;
   return (sandboxName) => {
     if (cached === null) {
       cached = hostLocalInferenceSetupOptions(input.resolver, {
@@ -404,8 +411,7 @@ export function createCachedHostLocalInferenceSetupResolver(input: {
     }
     const request = cached.hostLocalInference?.request;
     if (request) {
-      const providerInput = request.service === "ollama" ? request.endpoint : request.managed;
-      input.recordToolCallingRequirement(providerInput.requireToolCalling);
+      input.recordToolCallingRequirement(hostLocalInferenceRequestToolCalling(request));
     }
     return cached;
   };
@@ -536,14 +542,13 @@ function hostLocalInferenceSetupOptions(
         "Host-local inference startup selection drifted from the accepted application.",
       );
     }
-    const expectedProvider = selected.request.service === "ollama" ? "ollama-local" : "vllm-local";
+    const expectedProvider = hostLocalInferenceGatewayProvider(selected.request);
     if (input.provider !== expectedProvider) {
       throw new Error("Host-local inference startup selection drifted from the accepted provider.");
     }
-    const providerInput =
-      selected.request.service === "ollama" ? selected.request.endpoint : selected.request.managed;
     if (
       selected.request.service !== "ollama" &&
+      selected.request.service !== "llama-cpp" &&
       selected.request.recover !== undefined &&
       typeof selected.request.recover !== "boolean"
     ) {
@@ -552,14 +557,13 @@ function hostLocalInferenceSetupOptions(
     const hasDurableToolCallingAuthority =
       selected.request.service === "ollama"
         ? input.recover
+        : selected.request.service === "llama-cpp"
+          ? selected.request.publishedRoute
         : selected.request.resumeReceipt !== undefined || selected.request.recover === true;
     const expectedToolCalling =
       input.requireToolCalling ??
       (hasDurableToolCallingAuthority ? null : input.freshRequireToolCalling);
-    const selectedModel =
-      selected.request.service === "ollama"
-        ? normalizeHostLocalOllamaModelRef(providerInput.model)
-        : providerInput.model;
+    const selectedModel = hostLocalInferenceRequestModel(selected.request);
     const acceptedModel =
       selected.request.service === "ollama"
         ? normalizeHostLocalOllamaModelRef(input.model)
@@ -568,13 +572,21 @@ function hostLocalInferenceSetupOptions(
       selectedModel !== acceptedModel ||
       (selected.request.service === "ollama" &&
         selected.request.endpoint.acceleration !== input.acceleration) ||
-      (expectedToolCalling !== null && providerInput.requireToolCalling !== expectedToolCalling)
+      (expectedToolCalling !== null &&
+        hostLocalInferenceRequestToolCalling(selected.request) !== expectedToolCalling)
     ) {
       throw new Error(
         "Host-local inference startup selection drifted from the accepted model proof.",
       );
     }
-    if (selected.request.service !== "ollama") {
+    if (selected.request.service === "llama-cpp") {
+      if (
+        input.acceleration !== "nvidia-gpu" ||
+        selected.request.publishedRoute !== input.allowPublishedResume
+      ) {
+        throw new Error("Managed llama.cpp startup selection drifted from recovery authority.");
+      }
+    } else if (selected.request.service !== "ollama") {
       if (input.acceleration !== "nvidia-gpu") {
         throw new Error(
           "Managed host-local inference requires accepted NVIDIA GPU passthrough authority.",
@@ -596,6 +608,65 @@ function hostLocalInferenceSetupOptions(
     }
   }
   return selected ? { hostLocalInference: selected } : {};
+}
+
+type EarlyManagedLlamaLifecycleSelection = {
+  readonly sandboxName: string;
+  readonly setupOptions: HostLocalInferenceSetupOptions;
+};
+
+function resolveEarlyManagedLlamaLifecycleSelection(input: {
+  readonly resumeProviderSelection: boolean;
+  readonly provider: string | null;
+  readonly model: string | null;
+  readonly sandboxName: string | null;
+  readonly application: string;
+  readonly acceleration: HostLocalOllamaAccelerationAuthority;
+  readonly effectiveResume: boolean;
+  readonly endpointUrl: string | null;
+  readonly endpointSource: InferenceEndpointSource | null;
+  readonly resolver: HostLocalInferenceStartupSelectionResolver;
+}): EarlyManagedLlamaLifecycleSelection | null {
+  if (
+    !input.resumeProviderSelection ||
+    input.provider !== "llama-cpp-local" ||
+    typeof input.model !== "string" ||
+    typeof input.sandboxName !== "string"
+  ) {
+    return null;
+  }
+  return {
+    sandboxName: input.sandboxName,
+    setupOptions: hostLocalInferenceSetupOptions(input.resolver, {
+      application: input.application,
+      sandboxName: input.sandboxName,
+      provider: input.provider,
+      model: input.model,
+      acceleration: input.acceleration,
+      requireToolCalling: null,
+      freshRequireToolCalling: true,
+      allowPublishedResume: true,
+      recover: isCanonicalHostLocalResume({
+        effectiveResume: input.effectiveResume,
+        provider: "llama-cpp-local",
+        endpointUrl: input.endpointUrl,
+        endpointSource: input.endpointSource,
+      }),
+    }),
+  };
+}
+
+async function ensureLegacyManagedLlamaCppResumeReady(
+  selection: EarlyManagedLlamaLifecycleSelection | null,
+  provider: string | null,
+  sandboxName: string | null,
+  ensure: (
+    provider: string | null | undefined,
+    sandboxName: string | null | undefined,
+  ) => Promise<boolean>,
+): Promise<void> {
+  if (selection?.setupOptions.hostLocalInference?.request.service === "llama-cpp") return;
+  await ensure(provider, sandboxName);
 }
 
 function endpointSourceForCurrentUrl(
@@ -918,6 +989,18 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
       provider,
       model,
     );
+    const earlyManagedLlamaLifecycleSelection = resolveEarlyManagedLlamaLifecycleSelection({
+      resumeProviderSelection,
+      provider,
+      model,
+      sandboxName,
+      application: agentName(agent),
+      acceleration: selectedHostLocalOllamaAcceleration(gpu, gpuPassthrough),
+      effectiveResume,
+      endpointUrl,
+      endpointSource,
+      resolver: deps.resolveHostLocalInferenceStartupSelection,
+    });
     let shouldRecordProviderSelection = false;
     // A review interruption selected a provider but did not configure its
     // route. Do not let a coincidentally ready gateway route skip setup.
@@ -937,7 +1020,12 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
       // gateway-owned llama.cpp lifecycle before the selection shortcut can
       // skip setup. The dependency is a no-op for operator-attached llama.cpp
       // routes because those routes have no matching managed owner state.
-      await deps.ensureManagedLlamaCppResumeReady(provider, sandboxName);
+      await ensureLegacyManagedLlamaCppResumeReady(
+        earlyManagedLlamaLifecycleSelection,
+        provider,
+        sandboxName,
+        deps.ensureManagedLlamaCppResumeReady,
+      );
       const recovery = await deps.ensureResumeProviderReady(gatewayName, provider, credentialEnv);
       forceInferenceSetup ||= recovery.forceInferenceSetup;
       credentialEnv = recovery.credentialEnv;
@@ -1190,6 +1278,7 @@ export async function handleProviderInferenceState<Gpu, Agent, Host>({
         recordToolCallingRequirement: (required) => {
           allowToolsIncompatible = !required;
         },
+        initial: earlyManagedLlamaLifecycleSelection ?? undefined,
       },
     );
     const hostLocalResume = await resolveHostLocalResumeSetup({

--- a/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.test.ts
@@ -1,0 +1,478 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createInMemoryRuntimeProviderBundle } from "../../../../test/helpers/runtime-provider-bundle";
+import type { SandboxEntry } from "../../state/registry/types";
+import type {
+  HostLocalInferenceDestroyResult,
+  HostLocalInferenceOperation,
+  HostLocalInferenceOperationInput,
+  HostLocalInferenceReceipt,
+  HostLocalInferenceRuntime,
+} from "./host-local-inference";
+import { serializeHostLocalInferenceReceipt } from "./host-local-inference";
+import {
+  confirmHostLocalInferenceAuthority,
+  type ManagedHostLocalInferenceService,
+  type PreparedHostLocalInferenceAuthority,
+  prepareSandboxHostLocalInferenceAuthority,
+  prepareSandboxHostLocalInferenceDestroyAuthority,
+  retirePreparedHostLocalInferenceAuthority,
+} from "./host-local-inference-lifecycle";
+
+const AUTHORITY_ID = `mxc-endpoint:${"a".repeat(64)}`;
+const BINDING_SHA256 = "b".repeat(64);
+const PROBE_IMAGE = `quay.io/curl/curl@sha256:${"c".repeat(64)}`;
+const AGENTS = ["openclaw", "hermes", "langchain-deepagents-code"] as const;
+const SERVICES = ["ollama", "nim", "vllm"] as const;
+
+function receipt(
+  service: ManagedHostLocalInferenceService = "vllm",
+  options: {
+    readonly acceleration?: "cpu" | "nvidia-gpu";
+    readonly runtimeId?: string;
+    readonly targetSha256?: string;
+  } = {},
+): HostLocalInferenceReceipt {
+  const model = service === "ollama" ? "nemotron:latest" : `${service}-model`;
+  return {
+    schemaVersion: 2,
+    providerId: "mxc",
+    service,
+    engineAuthority: {
+      schemaVersion: 1,
+      providerId: "mxc",
+      operation: "host-local-inference",
+      engineId: "memory",
+      authorityId: AUTHORITY_ID,
+      bindingSha256: BINDING_SHA256,
+    },
+    endpoint: {
+      host: "host.openshell.internal",
+      port: service === "ollama" ? 11434 : service === "nim" ? 8001 : 8000,
+      networkName: "mxc-runtime-network",
+      networkId: "d".repeat(64),
+      networkGatewayIp: "10.89.0.1",
+      networkAuthoritySha256: "e".repeat(64),
+    },
+    inference: {
+      protocol: "openai-chat-completions",
+      model,
+      toolCallingRequired: true,
+    },
+    publication: {
+      transactionId: "f".repeat(64),
+      targetSha256: options.targetSha256 ?? "1".repeat(64),
+      priorState: service === "ollama" ? "host-process" : "absent",
+    },
+    runtime:
+      service === "ollama"
+        ? {
+            kind: "host",
+            probeImageRef: PROBE_IMAGE,
+            acceleration: options.acceleration ?? "nvidia-gpu",
+            modelDigest: `sha256:${"2".repeat(64)}`,
+          }
+        : {
+            kind: "container",
+            runtimeId: options.runtimeId ?? `${"3".repeat(63)}${service === "nim" ? "4" : "5"}`,
+            name: `nemoclaw-${service}`,
+            imageRef: `nvcr.io/nvidia/${service}@sha256:${"6".repeat(64)}`,
+            probeImageRef: PROBE_IMAGE,
+            specSha256: "7".repeat(64),
+            launchSha256: "8".repeat(64),
+            gpu: {
+              vendor: "nvidia",
+              devices: ["nvidia.com/gpu=GPU-12345678-1234-1234-1234-123456789abc"],
+            },
+          },
+  };
+}
+
+function sandbox(
+  name = "alpha",
+  value = receipt(),
+  overrides: Partial<SandboxEntry> = {},
+): SandboxEntry {
+  return {
+    name,
+    agent: "openclaw",
+    openshellDriver: "mxc",
+    provider: value.service === "ollama" ? "ollama-local" : "vllm-local",
+    model: value.inference?.model,
+    endpointUrl: "https://inference.local/v1",
+    gatewayName: "nemoclaw",
+    lifecycleGeneration: `${name}-generation-1`,
+    hostLocalInferenceReceipt: serializeHostLocalInferenceReceipt(value),
+    ...overrides,
+  };
+}
+
+function requiredPrepared(
+  value: PreparedHostLocalInferenceAuthority | null,
+): PreparedHostLocalInferenceAuthority {
+  expect(value).not.toBeNull();
+  if (!value) throw new Error("test expected managed lifecycle authority");
+  return value;
+}
+
+function provider(
+  options: {
+    readonly authorityId?: string;
+    readonly bindingSha256?: string;
+    readonly engineId?: string;
+    readonly preserveForRebuild?: (value: HostLocalInferenceReceipt) => HostLocalInferenceReceipt;
+    readonly prepareDestroy?: (value: HostLocalInferenceReceipt) => HostLocalInferenceReceipt;
+    readonly destroy?: (value: HostLocalInferenceReceipt) => HostLocalInferenceDestroyResult;
+  } = {},
+) {
+  const operationInputs: HostLocalInferenceOperationInput[] = [];
+  const preserveForRebuild = vi.fn(
+    (value: HostLocalInferenceReceipt) => options.preserveForRebuild?.(value) ?? value,
+  );
+  const prepareDestroy = vi.fn(
+    (value: HostLocalInferenceReceipt) => options.prepareDestroy?.(value) ?? value,
+  );
+  let present = true;
+  const destroy = vi.fn((value: HostLocalInferenceReceipt): HostLocalInferenceDestroyResult => {
+    if (options.destroy) return options.destroy(value);
+    if (value.runtime.kind === "host") {
+      return { status: "retained", reason: "host-process", receipt: value };
+    }
+    const status = present ? "removed" : "already-absent";
+    present = false;
+    return { status, receipt: value };
+  });
+  const runtime: HostLocalInferenceRuntime = {
+    providerId: "mxc",
+    authorityId: options.authorityId ?? AUTHORITY_ID,
+    services: SERVICES,
+    translateContainerArgs: (args) => args,
+    qualifyOllama: vi.fn(),
+    startManaged: vi.fn(),
+    inspectManaged: vi.fn((value) => ({ running: true, receipt: value })),
+    stopManaged: vi.fn((value) => ({ running: false, receipt: value })),
+    preserveForRebuild,
+    prepareDestroy,
+    destroy,
+  };
+  const assertAuthority = vi.fn();
+  const operation: HostLocalInferenceOperation = {
+    providerId: "mxc",
+    engine: {
+      operation: "host-local-inference",
+      engineId: options.engineId ?? "memory",
+      displayName: "In-memory",
+      authorityId: options.authorityId ?? AUTHORITY_ID,
+    } as HostLocalInferenceOperation["engine"],
+    bindingSha256: options.bindingSha256 ?? BINDING_SHA256,
+    assertAuthority,
+    spawn: vi.fn() as HostLocalInferenceOperation["spawn"],
+    createLlamaCppLifecycle: vi.fn() as HostLocalInferenceOperation["createLlamaCppLifecycle"],
+    managedRuntime: runtime,
+  };
+  const createOperation = vi.fn((input?: HostLocalInferenceOperationInput) => {
+    if (input) operationInputs.push(input);
+    return operation;
+  });
+  const bundle = createInMemoryRuntimeProviderBundle({
+    providerId: "mxc",
+    workloadProfile: {
+      support: null,
+      hostArchitectures: ["x64"],
+      managedImageSelectionPolicy: "prefer-managed",
+      legacyDockerfileBuilds: false,
+    },
+    hostLocalInference: { services: SERVICES, createOperation },
+  });
+  return {
+    assertAuthority,
+    bundle,
+    createOperation,
+    destroy,
+    operationInputs,
+    prepareDestroy,
+    preserveForRebuild,
+  };
+}
+
+const AGENT_SERVICE_CASES = AGENTS.flatMap((agent) =>
+  SERVICES.map((service) => [agent, service] as const),
+);
+
+describe("host-local inference lifecycle authority", () => {
+  it.each(AGENT_SERVICE_CASES)(
+    "re-proves complete %s sandbox authority for %s",
+    (agent, service) => {
+      const value = receipt(service);
+      const entry = sandbox("alpha", value, { agent });
+      const runtimeProvider = provider();
+      const prepared = requiredPrepared(
+        prepareSandboxHostLocalInferenceAuthority(runtimeProvider.bundle, entry),
+      );
+
+      expect(prepared.sandboxAuthority).toMatchObject({
+        sandboxName: "alpha",
+        agent,
+        providerId: "mxc",
+        routeProvider: service === "ollama" ? "ollama-local" : "vllm-local",
+        model: value.inference?.model,
+        endpointUrl: "https://inference.local/v1",
+        gatewayName: "nemoclaw",
+        lifecycleGeneration: "alpha-generation-1",
+        serializedReceipt: entry.hostLocalInferenceReceipt,
+      });
+      confirmHostLocalInferenceAuthority(runtimeProvider.bundle, entry, prepared);
+      expect(runtimeProvider.preserveForRebuild).toHaveBeenCalledTimes(2);
+      expect(runtimeProvider.operationInputs).toEqual([
+        expect.objectContaining({
+          acceleration: value.runtime.kind === "host" ? value.runtime.acceleration : "nvidia-gpu",
+        }),
+        expect.objectContaining({
+          acceleration: value.runtime.kind === "host" ? value.runtime.acceleration : "nvidia-gpu",
+        }),
+      ]);
+    },
+  );
+
+  it("reconstructs a CPU Ollama operation from the durable acceleration authority", () => {
+    const value = receipt("ollama", { acceleration: "cpu" });
+    const entry = sandbox("alpha", value);
+    const runtimeProvider = provider();
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceAuthority(runtimeProvider.bundle, entry),
+    );
+
+    confirmHostLocalInferenceAuthority(runtimeProvider.bundle, entry, prepared);
+
+    expect(runtimeProvider.operationInputs).toHaveLength(2);
+    expect(runtimeProvider.operationInputs.every((input) => input.acceleration === "cpu")).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    ["sandbox name", (entry: SandboxEntry): SandboxEntry => ({ ...entry, name: "beta" })],
+    ["agent", (entry: SandboxEntry): SandboxEntry => ({ ...entry, agent: "hermes" })],
+    [
+      "runtime provider",
+      (entry: SandboxEntry): SandboxEntry => ({ ...entry, openshellDriver: "podman" }),
+    ],
+    [
+      "route provider",
+      (entry: SandboxEntry): SandboxEntry => ({ ...entry, provider: "ollama-local" }),
+    ],
+    ["model", (entry: SandboxEntry): SandboxEntry => ({ ...entry, model: "other-model" })],
+    [
+      "endpoint",
+      (entry: SandboxEntry): SandboxEntry => ({
+        ...entry,
+        endpointUrl: "http://127.0.0.1:8000/v1",
+      }),
+    ],
+    [
+      "gateway",
+      (entry: SandboxEntry): SandboxEntry => ({ ...entry, gatewayName: "other-gateway" }),
+    ],
+    [
+      "lifecycle generation",
+      (entry: SandboxEntry): SandboxEntry => ({
+        ...entry,
+        lifecycleGeneration: "alpha-generation-2",
+      }),
+    ],
+    [
+      "receipt",
+      (entry: SandboxEntry): SandboxEntry => ({
+        ...entry,
+        hostLocalInferenceReceipt: serializeHostLocalInferenceReceipt(receipt("nim")),
+      }),
+    ],
+  ] as const)("rejects %s drift after preparation", (_label, drift) => {
+    const entry = sandbox();
+    const runtimeProvider = provider();
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceAuthority(runtimeProvider.bundle, entry),
+    );
+
+    expect(() =>
+      confirmHostLocalInferenceAuthority(runtimeProvider.bundle, drift(entry), prepared),
+    ).toThrow("Host-local inference lifecycle authority is invalid");
+    expect(runtimeProvider.preserveForRebuild).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["engine", { engineId: "other-engine" }],
+    ["authority", { authorityId: `other:${"9".repeat(64)}` }],
+    ["binding", { bindingSha256: "9".repeat(64) }],
+  ] as const)("rejects operation-scoped %s drift before runtime proof", (_label, options) => {
+    const runtimeProvider = provider(options);
+
+    expect(() =>
+      prepareSandboxHostLocalInferenceAuthority(runtimeProvider.bundle, sandbox()),
+    ).toThrow();
+    expect(runtimeProvider.preserveForRebuild).not.toHaveBeenCalled();
+  });
+
+  it.each(SERVICES)("retires exact unshared %s authority", (service) => {
+    const value = receipt(service);
+    const entry = sandbox("alpha", value);
+    const runtimeProvider = provider();
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(runtimeProvider.bundle, entry),
+    );
+
+    expect(
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, entry, prepared, [entry])
+        .status,
+    ).toBe(service === "ollama" ? "retained" : "removed");
+    expect(runtimeProvider.destroy).toHaveBeenCalledOnce();
+    expect(runtimeProvider.prepareDestroy).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains an exact runtime referenced by a coherent peer sandbox", () => {
+    const value = receipt();
+    const alpha = sandbox("alpha", value);
+    const beta = sandbox("beta", value, { agent: "hermes" });
+    const runtimeProvider = provider();
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(runtimeProvider.bundle, alpha),
+    );
+
+    expect(
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, alpha, prepared, [
+        beta,
+        alpha,
+      ]).status,
+    ).toBe("shared");
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a shared receipt whose peer row is not coherently bound", () => {
+    const value = receipt();
+    const alpha = sandbox("alpha", value);
+    const beta = sandbox("beta", value, { model: "other-model" });
+    const runtimeProvider = provider();
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(runtimeProvider.bundle, alpha),
+    );
+
+    expect(() =>
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, alpha, prepared, [
+        beta,
+        alpha,
+      ]),
+    ).toThrow("sandbox model differs");
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("rejects conflicting receipts for the same immutable provider runtime", () => {
+    const value = receipt("vllm", { targetSha256: "1".repeat(64) });
+    const conflict = receipt("vllm", { targetSha256: "2".repeat(64) });
+    const alpha = sandbox("alpha", value);
+    const beta = sandbox("beta", conflict);
+    const runtimeProvider = provider();
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(runtimeProvider.bundle, alpha),
+    );
+
+    expect(() =>
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, alpha, prepared, [
+        beta,
+        alpha,
+      ]),
+    ).toThrow("conflicting registry authority");
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("scans the complete peer snapshot and rejects malformed ownership", () => {
+    const value = receipt();
+    const alpha = sandbox("alpha", value);
+    const beta = sandbox("beta", value);
+    const malformed = {
+      ...sandbox("gamma", receipt("nim")),
+      hostLocalInferenceReceipt: "{",
+    };
+    const runtimeProvider = provider();
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(runtimeProvider.bundle, alpha),
+    );
+
+    expect(() =>
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, alpha, prepared, [
+        beta,
+        alpha,
+        malformed,
+      ]),
+    ).toThrow("malformed or indeterminate");
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("requires one full-matching target row in the peer snapshot", () => {
+    const value = receipt();
+    const alpha = sandbox("alpha", value);
+    const runtimeProvider = provider();
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(runtimeProvider.bundle, alpha),
+    );
+
+    expect(() =>
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, alpha, prepared, [
+        sandbox("beta", value),
+      ]),
+    ).toThrow("exactly one target sandbox authority");
+    expect(() =>
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, alpha, prepared, [
+        { ...alpha, agent: "hermes" },
+      ]),
+    ).toThrow("different target sandbox authority");
+    expect(() =>
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, alpha, prepared, [
+        alpha,
+        { ...alpha },
+      ]),
+    ).toThrow("duplicate sandbox identities");
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("does not retain an unrelated immutable runtime", () => {
+    const value = receipt("vllm", { runtimeId: "4".repeat(64) });
+    const alpha = sandbox("alpha", value);
+    const beta = sandbox("beta", receipt("vllm", { runtimeId: "5".repeat(64) }));
+    const runtimeProvider = provider();
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(runtimeProvider.bundle, alpha),
+    );
+
+    expect(
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, alpha, prepared, [
+        beta,
+        alpha,
+      ]).status,
+    ).toBe("removed");
+    expect(runtimeProvider.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("reconciles exact retirement idempotently from the durable row", () => {
+    const entry = sandbox();
+    const runtimeProvider = provider();
+    const first = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(runtimeProvider.bundle, entry),
+    );
+
+    expect(
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, entry, first, [entry])
+        .status,
+    ).toBe("removed");
+    const retry = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(runtimeProvider.bundle, entry),
+    );
+    expect(
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, entry, retry, [entry])
+        .status,
+    ).toBe("already-absent");
+    expect(runtimeProvider.destroy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createInMemoryRuntimeProviderBundle } from "../../../../test/helpers/runtime-provider-bundle";
+import { createSandboxHostLocalInferenceProvenance } from "../../state/registry/host-local-inference";
 import type { SandboxEntry } from "../../state/registry/types";
 import type {
   HostLocalInferenceDestroyResult,
@@ -27,6 +28,7 @@ const BINDING_SHA256 = "b".repeat(64);
 const PROBE_IMAGE = `quay.io/curl/curl@sha256:${"c".repeat(64)}`;
 const AGENTS = ["openclaw", "hermes", "langchain-deepagents-code"] as const;
 const SERVICES = ["ollama", "nim", "vllm"] as const;
+const PROVIDER_SERVICES = [...SERVICES, "llama-cpp"] as const;
 
 function receipt(
   service: ManagedHostLocalInferenceService = "vllm",
@@ -91,6 +93,43 @@ function receipt(
   };
 }
 
+function llamaCppReceipt(): HostLocalInferenceReceipt {
+  return {
+    schemaVersion: 1,
+    providerId: "mxc",
+    service: "llama-cpp",
+    engineAuthority: {
+      schemaVersion: 1,
+      providerId: "mxc",
+      operation: "host-local-inference",
+      engineId: "memory",
+      authorityId: AUTHORITY_ID,
+      bindingSha256: BINDING_SHA256,
+    },
+    endpoint: {
+      host: "host.openshell.internal",
+      port: 8081,
+      networkName: "nemoclaw-llama-cpp-internal",
+    },
+    runtime: {
+      kind: "container",
+      runtimeId: "9".repeat(64),
+      name: "nemoclaw-llama-cpp",
+      imageRef: `nvcr.io/nvidia/llama-cpp@sha256:${"a".repeat(64)}`,
+      probeImageRef: PROBE_IMAGE,
+      specSha256: "d".repeat(64),
+      model: {
+        planDigest: `sha256:${"e".repeat(64)}`,
+        recipeId: "llama-cpp-model",
+        generation: "f".repeat(64),
+        digest: `sha256:${"1".repeat(64)}`,
+        sizeBytes: 1024,
+      },
+      gpu: { vendor: "nvidia", count: 1 },
+    },
+  };
+}
+
 function sandbox(
   name = "alpha",
   value = receipt(),
@@ -100,10 +139,19 @@ function sandbox(
     name,
     agent: "openclaw",
     openshellDriver: "mxc",
-    provider: value.service === "ollama" ? "ollama-local" : "vllm-local",
-    model: value.inference?.model,
+    provider:
+      value.service === "ollama"
+        ? "ollama-local"
+        : value.service === "llama-cpp"
+          ? "llama-cpp-local"
+          : "vllm-local",
+    model: value.service === "llama-cpp" ? "llama-cpp-model" : value.inference?.model,
     endpointUrl: "https://inference.local/v1",
+    endpointSource: "inference-set",
+    credentialEnv: value.service === "llama-cpp" ? "NEMOCLAW_LLAMACPP_LOCAL_TOKEN" : null,
+    preferredInferenceApi: "openai-completions",
     gatewayName: "nemoclaw",
+    gatewayPort: 8080,
     lifecycleGeneration: `${name}-generation-1`,
     hostLocalInferenceReceipt: serializeHostLocalInferenceReceipt(value),
     ...overrides,
@@ -114,8 +162,7 @@ function requiredPrepared(
   value: PreparedHostLocalInferenceAuthority | null,
 ): PreparedHostLocalInferenceAuthority {
   expect(value).not.toBeNull();
-  if (!value) throw new Error("test expected managed lifecycle authority");
-  return value;
+  return value!;
 }
 
 function provider(
@@ -136,19 +183,20 @@ function provider(
     (value: HostLocalInferenceReceipt) => options.prepareDestroy?.(value) ?? value,
   );
   let present = true;
-  const destroy = vi.fn((value: HostLocalInferenceReceipt): HostLocalInferenceDestroyResult => {
-    if (options.destroy) return options.destroy(value);
-    if (value.runtime.kind === "host") {
-      return { status: "retained", reason: "host-process", receipt: value };
-    }
+  const destroyContainer = (value: HostLocalInferenceReceipt): HostLocalInferenceDestroyResult => {
     const status = present ? "removed" : "already-absent";
     present = false;
     return { status, receipt: value };
-  });
+  };
+  const defaultDestroy = (value: HostLocalInferenceReceipt): HostLocalInferenceDestroyResult =>
+    value.runtime.kind === "host"
+      ? { status: "retained", reason: "host-process", receipt: value }
+      : destroyContainer(value);
+  const destroy = vi.fn(options.destroy ?? defaultDestroy);
   const runtime: HostLocalInferenceRuntime = {
     providerId: "mxc",
     authorityId: options.authorityId ?? AUTHORITY_ID,
-    services: SERVICES,
+    services: PROVIDER_SERVICES,
     translateContainerArgs: (args) => args,
     qualifyOllama: vi.fn(),
     startManaged: vi.fn(),
@@ -174,7 +222,7 @@ function provider(
     managedRuntime: runtime,
   };
   const createOperation = vi.fn((input?: HostLocalInferenceOperationInput) => {
-    if (input) operationInputs.push(input);
+    operationInputs.push(...(input === undefined ? [] : [input]));
     return operation;
   });
   const bundle = createInMemoryRuntimeProviderBundle({
@@ -185,7 +233,7 @@ function provider(
       managedImageSelectionPolicy: "prefer-managed",
       legacyDockerfileBuilds: false,
     },
-    hostLocalInference: { services: SERVICES, createOperation },
+    hostLocalInference: { services: PROVIDER_SERVICES, createOperation },
   });
   return {
     assertAuthority,
@@ -195,7 +243,17 @@ function provider(
     operationInputs,
     prepareDestroy,
     preserveForRebuild,
+    runtime,
   };
+}
+
+function explicitLlamaSandbox(name = "alpha", agent = "openclaw"): SandboxEntry {
+  const value = llamaCppReceipt();
+  const serialized = serializeHostLocalInferenceReceipt(value);
+  return sandbox(name, value, {
+    agent,
+    hostLocalInferenceProvenance: createSandboxHostLocalInferenceProvenance("alpha", serialized),
+  });
 }
 
 const AGENT_SERVICE_CASES = AGENTS.flatMap((agent) =>
@@ -220,6 +278,8 @@ describe("host-local inference lifecycle authority", () => {
         routeProvider: service === "ollama" ? "ollama-local" : "vllm-local",
         model: value.inference?.model,
         endpointUrl: "https://inference.local/v1",
+        endpointSource: "inference-set",
+        preferredInferenceApi: "openai-completions",
         gatewayName: "nemoclaw",
         lifecycleGeneration: "alpha-generation-1",
         serializedReceipt: entry.hostLocalInferenceReceipt,
@@ -236,6 +296,216 @@ describe("host-local inference lifecycle authority", () => {
       ]);
     },
   );
+
+  it.each(AGENTS)(
+    "routes explicitly provenanced llama.cpp for %s through the common coordinator",
+    (agent) => {
+      const entry = explicitLlamaSandbox("alpha", agent);
+      const runtimeProvider = provider();
+      const createLlamaCppAdapter = vi.fn((options) => ({
+        gatewayPort: options.gatewayPort ?? 8080,
+        runtimeOwnerSandboxName: options.runtimeOwnerSandboxName,
+        model: "llama-cpp-model",
+        operation: options.operation!,
+        receipt: options.expectedReceipt,
+        runtime: runtimeProvider.runtime,
+        prepareStartup: vi.fn(),
+      }));
+
+      const prepared = requiredPrepared(
+        prepareSandboxHostLocalInferenceAuthority(runtimeProvider.bundle, entry, {
+          createLlamaCppAdapter,
+        }),
+      );
+
+      expect(prepared.serializedReceipt).toBe(entry.hostLocalInferenceReceipt);
+      expect(prepared.sandboxAuthority).toMatchObject({
+        agent,
+        routeProvider: "llama-cpp-local",
+        gatewayName: "nemoclaw",
+        gatewayPort: 8080,
+        hostLocalInferenceProvenance: entry.hostLocalInferenceProvenance,
+      });
+      expect(createLlamaCppAdapter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runtimeOwnerSandboxName: "alpha",
+          gatewayPort: 8080,
+          expectedReceipt: llamaCppReceipt(),
+        }),
+      );
+      expect(runtimeProvider.preserveForRebuild).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("keeps an unmarked schema-v1 llama.cpp receipt on the dedicated legacy lifecycle", () => {
+    const runtimeProvider = provider();
+    const entry = sandbox("alpha", llamaCppReceipt());
+
+    expect(prepareSandboxHostLocalInferenceAuthority(runtimeProvider.bundle, entry)).toBeNull();
+    expect(runtimeProvider.createOperation).not.toHaveBeenCalled();
+    expect(runtimeProvider.preserveForRebuild).not.toHaveBeenCalled();
+  });
+
+  it("rejects changed explicit llama.cpp provenance before provider mutation", () => {
+    const runtimeProvider = provider();
+    const entry = explicitLlamaSandbox();
+    const drifted = {
+      ...entry,
+      hostLocalInferenceProvenance: {
+        ...entry.hostLocalInferenceProvenance!,
+        receiptSha256: "0".repeat(64),
+      },
+    };
+
+    expect(() =>
+      prepareSandboxHostLocalInferenceAuthority(runtimeProvider.bundle, drifted, {
+        createLlamaCppAdapter: vi.fn(),
+      }),
+    ).toThrow(/provenance does not match its receipt/);
+    expect(runtimeProvider.createOperation).not.toHaveBeenCalled();
+  });
+
+  it("retains an exact same-gateway llama.cpp runtime while a provenanced clone remains", () => {
+    const runtimeProvider = provider();
+    const alpha = explicitLlamaSandbox("alpha");
+    const beta = explicitLlamaSandbox("beta", "hermes");
+    const createLlamaCppAdapter = vi.fn((options) => ({
+      gatewayPort: options.gatewayPort ?? 8080,
+      runtimeOwnerSandboxName: options.runtimeOwnerSandboxName,
+      model: "llama-cpp-model",
+      operation: options.operation!,
+      receipt: options.expectedReceipt,
+      runtime: runtimeProvider.runtime,
+      prepareStartup: vi.fn(),
+    }));
+    const lifecycleOptions = { createLlamaCppAdapter };
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(
+        runtimeProvider.bundle,
+        alpha,
+        lifecycleOptions,
+      ),
+    );
+
+    expect(
+      retirePreparedHostLocalInferenceAuthority(
+        runtimeProvider.bundle,
+        alpha,
+        prepared,
+        [beta, alpha],
+        lifecycleOptions,
+      ).status,
+    ).toBe("shared");
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a llama.cpp peer on a different gateway before retirement", () => {
+    const runtimeProvider = provider();
+    const alpha = explicitLlamaSandbox("alpha");
+    const beta = { ...explicitLlamaSandbox("beta"), gatewayPort: 8090 };
+    const createLlamaCppAdapter = vi.fn((options) => ({
+      gatewayPort: options.gatewayPort ?? 8080,
+      runtimeOwnerSandboxName: options.runtimeOwnerSandboxName,
+      model: "llama-cpp-model",
+      operation: options.operation!,
+      receipt: options.expectedReceipt,
+      runtime: runtimeProvider.runtime,
+      prepareStartup: vi.fn(),
+    }));
+    const lifecycleOptions = { createLlamaCppAdapter };
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(
+        runtimeProvider.bundle,
+        alpha,
+        lifecycleOptions,
+      ),
+    );
+
+    expect(() =>
+      retirePreparedHostLocalInferenceAuthority(
+        runtimeProvider.bundle,
+        alpha,
+        prepared,
+        [alpha, beta],
+        lifecycleOptions,
+      ),
+    ).toThrow(/conflicting gateway, route, or provenance authority/);
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a llama.cpp peer with different route authority before retirement", () => {
+    const runtimeProvider = provider();
+    const alpha = explicitLlamaSandbox("alpha");
+    const beta = {
+      ...explicitLlamaSandbox("beta"),
+      credentialEnv: "DIFFERENT_TOKEN",
+    };
+    const createLlamaCppAdapter = vi.fn((options) => ({
+      gatewayPort: options.gatewayPort ?? 8080,
+      runtimeOwnerSandboxName: options.runtimeOwnerSandboxName,
+      model: "llama-cpp-model",
+      operation: options.operation!,
+      receipt: options.expectedReceipt,
+      runtime: runtimeProvider.runtime,
+      prepareStartup: vi.fn(),
+    }));
+    const lifecycleOptions = { createLlamaCppAdapter };
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(
+        runtimeProvider.bundle,
+        alpha,
+        lifecycleOptions,
+      ),
+    );
+
+    expect(() =>
+      retirePreparedHostLocalInferenceAuthority(
+        runtimeProvider.bundle,
+        alpha,
+        prepared,
+        [alpha, beta],
+        lifecycleOptions,
+      ),
+    ).toThrow(/conflicting gateway, route, or provenance authority/);
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a llama.cpp peer with different model authority before retirement", () => {
+    const runtimeProvider = provider();
+    const alpha = explicitLlamaSandbox("alpha");
+    const beta = {
+      ...explicitLlamaSandbox("beta"),
+      model: "different-model",
+    };
+    const createLlamaCppAdapter = vi.fn((options) => ({
+      gatewayPort: options.gatewayPort ?? 8080,
+      runtimeOwnerSandboxName: options.runtimeOwnerSandboxName,
+      model: "llama-cpp-model",
+      operation: options.operation!,
+      receipt: options.expectedReceipt,
+      runtime: runtimeProvider.runtime,
+      prepareStartup: vi.fn(),
+    }));
+    const lifecycleOptions = { createLlamaCppAdapter };
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(
+        runtimeProvider.bundle,
+        alpha,
+        lifecycleOptions,
+      ),
+    );
+
+    expect(() =>
+      retirePreparedHostLocalInferenceAuthority(
+        runtimeProvider.bundle,
+        alpha,
+        prepared,
+        [alpha, beta],
+        lifecycleOptions,
+      ),
+    ).toThrow(/conflicting gateway, route, or provenance authority/);
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
 
   it("reconstructs a CPU Ollama operation from the durable acceleration authority", () => {
     const value = receipt("ollama", { acceleration: "cpu" });
@@ -258,13 +528,25 @@ describe("host-local inference lifecycle authority", () => {
     ["agent", (entry: SandboxEntry): SandboxEntry => ({ ...entry, agent: "hermes" })],
     [
       "runtime provider",
-      (entry: SandboxEntry): SandboxEntry => ({ ...entry, openshellDriver: "podman" }),
+      (entry: SandboxEntry): SandboxEntry => ({
+        ...entry,
+        openshellDriver: "podman",
+      }),
     ],
     [
       "route provider",
-      (entry: SandboxEntry): SandboxEntry => ({ ...entry, provider: "ollama-local" }),
+      (entry: SandboxEntry): SandboxEntry => ({
+        ...entry,
+        provider: "ollama-local",
+      }),
     ],
-    ["model", (entry: SandboxEntry): SandboxEntry => ({ ...entry, model: "other-model" })],
+    [
+      "model",
+      (entry: SandboxEntry): SandboxEntry => ({
+        ...entry,
+        model: "other-model",
+      }),
+    ],
     [
       "endpoint",
       (entry: SandboxEntry): SandboxEntry => ({
@@ -273,8 +555,32 @@ describe("host-local inference lifecycle authority", () => {
       }),
     ],
     [
+      "endpoint source",
+      (entry: SandboxEntry): SandboxEntry => ({
+        ...entry,
+        endpointSource: "onboard",
+      }),
+    ],
+    [
+      "credential",
+      (entry: SandboxEntry): SandboxEntry => ({
+        ...entry,
+        credentialEnv: "DIFFERENT_TOKEN",
+      }),
+    ],
+    [
+      "inference API",
+      (entry: SandboxEntry): SandboxEntry => ({
+        ...entry,
+        preferredInferenceApi: "openai-responses",
+      }),
+    ],
+    [
       "gateway",
-      (entry: SandboxEntry): SandboxEntry => ({ ...entry, gatewayName: "other-gateway" }),
+      (entry: SandboxEntry): SandboxEntry => ({
+        ...entry,
+        gatewayName: "other-gateway",
+      }),
     ],
     [
       "lifecycle generation",

--- a/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.ts
@@ -3,6 +3,12 @@
 
 import { createHash } from "node:crypto";
 
+import {
+  createManagedLlamaCppLifecycleAdapter,
+  type ManagedLlamaCppLifecycleAdapter,
+  type ManagedLlamaCppLifecycleAdapterOptions,
+} from "../../inference/llama-cpp/managed-lifecycle-adapter";
+import { requireSandboxHostLocalInferenceProvenance } from "../../state/registry/host-local-inference";
 import type { SandboxEntry } from "../../state/registry/types";
 import type { RuntimeProviderBundle } from "./contract";
 import {
@@ -15,18 +21,23 @@ import {
 import { HOST_LOCAL_INFERENCE_APPLICATION_BASE_URL } from "./host-local-inference-routing";
 import { requireRuntimeProviderHostLocalInferenceOperation } from "./registry";
 
-export type ManagedHostLocalInferenceService = "ollama" | "nim" | "vllm";
+export type ManagedHostLocalInferenceService = "ollama" | "nim" | "vllm" | "llama-cpp";
 
 export type HostLocalInferenceLifecycleSandbox = Pick<
   SandboxEntry,
   | "agent"
+  | "credentialEnv"
+  | "endpointSource"
   | "endpointUrl"
   | "gatewayName"
+  | "gatewayPort"
   | "hostLocalInferenceReceipt"
+  | "hostLocalInferenceProvenance"
   | "lifecycleGeneration"
   | "model"
   | "name"
   | "openshellDriver"
+  | "preferredInferenceApi"
   | "provider"
 >;
 
@@ -35,12 +46,17 @@ export interface HostLocalInferenceSandboxAuthority {
   readonly sandboxName: string;
   readonly agent: string;
   readonly providerId: string;
-  readonly routeProvider: "ollama-local" | "vllm-local";
+  readonly routeProvider: "ollama-local" | "vllm-local" | "llama-cpp-local";
   readonly model: string;
   readonly endpointUrl: string;
+  readonly endpointSource: SandboxEntry["endpointSource"];
+  readonly credentialEnv: string | null;
+  readonly preferredInferenceApi: string | null;
   readonly gatewayName: string;
+  readonly gatewayPort?: number;
   readonly lifecycleGeneration: string;
   readonly serializedReceipt: string;
+  readonly hostLocalInferenceProvenance?: NonNullable<SandboxEntry["hostLocalInferenceProvenance"]>;
 }
 
 export interface PreparedHostLocalInferenceAuthority {
@@ -63,6 +79,10 @@ export type HostLocalInferenceRetirementResult =
 
 export interface HostLocalInferenceLifecycleOptions {
   readonly environment?: NodeJS.ProcessEnv;
+  readonly homeDir?: string;
+  readonly createLlamaCppAdapter?: (
+    options: ManagedLlamaCppLifecycleAdapterOptions,
+  ) => ManagedLlamaCppLifecycleAdapter;
 }
 
 type ManagedHostLocalInferenceReceipt = HostLocalInferenceReceipt & {
@@ -89,14 +109,27 @@ function exactText(value: unknown, label: string, maxBytes = 512): string {
   return value;
 }
 
-function parseManagedReceipt(serialized: string): ManagedHostLocalInferenceReceipt | null {
+function parseManagedReceipt(
+  serialized: string,
+  sandbox?: HostLocalInferenceLifecycleSandbox,
+): ManagedHostLocalInferenceReceipt | null {
   const receipt = parseHostLocalInferenceReceipt(serialized);
-  return MANAGED_SERVICES.has(receipt.service as ManagedHostLocalInferenceService)
-    ? (receipt as ManagedHostLocalInferenceReceipt)
-    : null;
+  if (MANAGED_SERVICES.has(receipt.service as ManagedHostLocalInferenceService)) {
+    if (sandbox?.hostLocalInferenceProvenance) {
+      requireSandboxHostLocalInferenceProvenance(sandbox.hostLocalInferenceProvenance, serialized);
+    }
+    return receipt as ManagedHostLocalInferenceReceipt;
+  }
+  if (receipt.service !== "llama-cpp") {
+    if (sandbox?.hostLocalInferenceProvenance) fail("provenance names an unsupported service");
+    return null;
+  }
+  if (!sandbox?.hostLocalInferenceProvenance) return null;
+  requireSandboxHostLocalInferenceProvenance(sandbox.hostLocalInferenceProvenance, serialized);
+  return receipt as ManagedHostLocalInferenceReceipt;
 }
 
-/** True only for the Ollama, NIM, and vLLM lifecycle owned by this B4-E1 helper. */
+/** True only for receipts already handled by the common host-local lifecycle. */
 export function isManagedHostLocalInferenceLifecycleReceipt(serialized: string): boolean {
   return parseManagedReceipt(serialized) !== null;
 }
@@ -118,17 +151,32 @@ function captureSandboxAuthority(
   if (providerId !== provider.identity.id) {
     fail("sandbox runtime provider differs from the selected provider");
   }
-  const routeProvider = receipt.service === "ollama" ? "ollama-local" : "vllm-local";
+  const routeProvider =
+    receipt.service === "ollama"
+      ? "ollama-local"
+      : receipt.service === "llama-cpp"
+        ? "llama-cpp-local"
+        : "vllm-local";
   if (sandbox.provider !== routeProvider) {
     fail("sandbox route provider differs from the receipt service");
   }
   if (sandbox.endpointUrl !== HOST_LOCAL_INFERENCE_APPLICATION_BASE_URL) {
     fail("sandbox inference endpoint is outside the canonical local route");
   }
-  const receiptModel = receipt.inference?.model;
+  const receiptModel = receipt.service === "llama-cpp" ? sandbox.model : receipt.inference?.model;
   if (typeof receiptModel !== "string" || sandbox.model !== receiptModel) {
     fail("sandbox model differs from the provider inference proof");
   }
+  const provenance = sandbox.hostLocalInferenceProvenance
+    ? requireSandboxHostLocalInferenceProvenance(sandbox.hostLocalInferenceProvenance, serialized)
+    : undefined;
+  if (receipt.service === "llama-cpp" && !provenance) {
+    fail("llama.cpp is missing explicit lifecycle provenance");
+  }
+  const gatewayPort = sandbox.gatewayPort;
+  const hasGatewayPort =
+    Number.isSafeInteger(gatewayPort) && Number(gatewayPort) >= 1 && Number(gatewayPort) <= 65_535;
+  if (provenance && !hasGatewayPort) fail("sandbox gateway port is missing or malformed");
   return Object.freeze({
     schemaVersion: 1 as const,
     sandboxName: exactText(sandbox.name, "sandbox name"),
@@ -137,15 +185,21 @@ function captureSandboxAuthority(
     routeProvider,
     model: exactText(receiptModel, "sandbox model"),
     endpointUrl: HOST_LOCAL_INFERENCE_APPLICATION_BASE_URL,
+    endpointSource: sandbox.endpointSource ?? null,
+    credentialEnv: sandbox.credentialEnv ?? null,
+    preferredInferenceApi: sandbox.preferredInferenceApi ?? null,
     gatewayName: exactText(sandbox.gatewayName, "sandbox gateway"),
+    ...(hasGatewayPort ? { gatewayPort: Number(gatewayPort) } : {}),
     lifecycleGeneration: exactText(sandbox.lifecycleGeneration, "sandbox lifecycle generation"),
     serializedReceipt: serialized,
+    ...(provenance ? { hostLocalInferenceProvenance: provenance } : {}),
   });
 }
 
 function requireRuntime(
   provider: RuntimeProviderBundle,
   receipt: ManagedHostLocalInferenceReceipt,
+  sandbox: HostLocalInferenceLifecycleSandbox,
   options: HostLocalInferenceLifecycleOptions,
 ): HostLocalInferenceRuntime {
   const acceleration =
@@ -164,6 +218,26 @@ function requireRuntime(
     operation.bindingSha256 !== receipt.engineAuthority.bindingSha256
   ) {
     fail("receipt differs from the operation-scoped provider engine authority");
+  }
+  if (receipt.service === "llama-cpp") {
+    const provenance = requireSandboxHostLocalInferenceProvenance(
+      sandbox.hostLocalInferenceProvenance,
+      sandbox.hostLocalInferenceReceipt ?? "",
+    );
+    const adapter = (options.createLlamaCppAdapter ?? createManagedLlamaCppLifecycleAdapter)({
+      runtimeProvider: provider,
+      runtimeOwnerSandboxName: provenance.runtimeOwnerSandboxName,
+      expectedModel: exactText(sandbox.model, "sandbox model"),
+      expectedReceipt: receipt,
+      gatewayPort: sandbox.gatewayPort!,
+      ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
+      ...(options.environment === undefined ? {} : { environment: options.environment }),
+      operation,
+    });
+    if (adapter.model !== sandbox.model) {
+      fail("sandbox model differs from reconstructed llama.cpp authority");
+    }
+    return adapter.runtime;
   }
   const runtime = operation.managedRuntime;
   if (
@@ -196,10 +270,10 @@ function prepare(
   mode: PreparedHostLocalInferenceAuthority["mode"],
   options: HostLocalInferenceLifecycleOptions,
 ): PreparedHostLocalInferenceAuthority | null {
-  const receipt = parseManagedReceipt(serialized);
+  const receipt = parseManagedReceipt(serialized, sandbox);
   if (!receipt) return null;
   const sandboxAuthority = captureSandboxAuthority(provider, sandbox, serialized, receipt);
-  const runtime = requireRuntime(provider, receipt, options);
+  const runtime = requireRuntime(provider, receipt, sandbox, options);
   const reproved =
     mode === "destroy" ? runtime.prepareDestroy(receipt) : runtime.preserveForRebuild(receipt);
   requireExactReceipt(
@@ -272,7 +346,7 @@ function requireCurrentSandboxAuthority(
   if (prepared.mode !== mode || prepared.providerId !== provider.identity.id) {
     fail("prepared authority has a different lifecycle intent or provider");
   }
-  const receipt = parseManagedReceipt(prepared.serializedReceipt);
+  const receipt = parseManagedReceipt(prepared.serializedReceipt, sandbox);
   if (!receipt) fail("prepared receipt no longer has a managed lifecycle");
   const current = captureSandboxAuthority(provider, sandbox, prepared.serializedReceipt, receipt);
   if (
@@ -290,9 +364,9 @@ export function confirmHostLocalInferenceAuthority(
   options: HostLocalInferenceLifecycleOptions = {},
 ): void {
   requireCurrentSandboxAuthority(provider, sandbox, prepared, "preserve");
-  const receipt = parseManagedReceipt(prepared.serializedReceipt);
+  const receipt = parseManagedReceipt(prepared.serializedReceipt, sandbox);
   if (!receipt) fail("prepared receipt no longer has a managed lifecycle");
-  const runtime = requireRuntime(provider, receipt, options);
+  const runtime = requireRuntime(provider, receipt, sandbox, options);
   requireExactReceipt(
     prepared.serializedReceipt,
     runtime.preserveForRebuild(receipt),
@@ -307,9 +381,9 @@ function confirmHostLocalInferenceDestroyAuthority(
   options: HostLocalInferenceLifecycleOptions,
 ): HostLocalInferenceRuntime {
   requireCurrentSandboxAuthority(provider, sandbox, prepared, "destroy");
-  const receipt = parseManagedReceipt(prepared.serializedReceipt);
+  const receipt = parseManagedReceipt(prepared.serializedReceipt, sandbox);
   if (!receipt) fail("prepared receipt no longer has a managed lifecycle");
-  const runtime = requireRuntime(provider, receipt, options);
+  const runtime = requireRuntime(provider, receipt, sandbox, options);
   requireExactReceipt(
     prepared.serializedReceipt,
     runtime.prepareDestroy(receipt),
@@ -349,7 +423,7 @@ function sharedPeerStatus(
   peers: readonly HostLocalInferenceLifecycleSandbox[],
 ): "exclusive" | "shared" {
   const names = new Set<string>();
-  const preparedReceipt = parseManagedReceipt(prepared.serializedReceipt);
+  const preparedReceipt = parseManagedReceipt(prepared.serializedReceipt, sandbox);
   if (!preparedReceipt) fail("prepared receipt no longer has a managed lifecycle");
   let targetCount = 0;
   let shared = false;
@@ -384,9 +458,27 @@ function sharedPeerStatus(
     if (peer.hostLocalInferenceReceipt !== prepared.serializedReceipt) {
       fail("the same immutable provider runtime has conflicting registry authority");
     }
-    const managedPeerReceipt = parseManagedReceipt(peer.hostLocalInferenceReceipt);
+    const managedPeerReceipt = parseManagedReceipt(peer.hostLocalInferenceReceipt, peer);
     if (!managedPeerReceipt) fail("peer runtime ownership is malformed or indeterminate");
-    captureSandboxAuthority(provider, peer, peer.hostLocalInferenceReceipt, managedPeerReceipt);
+    const peerAuthority = captureSandboxAuthority(
+      provider,
+      peer,
+      peer.hostLocalInferenceReceipt,
+      managedPeerReceipt,
+    );
+    if (
+      prepared.receipt.service === "llama-cpp" &&
+      (peerAuthority.model !== prepared.sandboxAuthority.model ||
+        peerAuthority.gatewayName !== prepared.sandboxAuthority.gatewayName ||
+        peerAuthority.gatewayPort !== prepared.sandboxAuthority.gatewayPort ||
+        peerAuthority.endpointSource !== prepared.sandboxAuthority.endpointSource ||
+        peerAuthority.credentialEnv !== prepared.sandboxAuthority.credentialEnv ||
+        peerAuthority.preferredInferenceApi !== prepared.sandboxAuthority.preferredInferenceApi ||
+        JSON.stringify(peerAuthority.hostLocalInferenceProvenance) !==
+          JSON.stringify(prepared.sandboxAuthority.hostLocalInferenceProvenance))
+    ) {
+      fail("the same llama.cpp runtime has conflicting gateway, route, or provenance authority");
+    }
     shared = true;
   }
   if (targetCount !== 1) {

--- a/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.ts
@@ -1,0 +1,427 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+import type { SandboxEntry } from "../../state/registry/types";
+import type { RuntimeProviderBundle } from "./contract";
+import {
+  type HostLocalInferenceDestroyResult,
+  type HostLocalInferenceReceipt,
+  type HostLocalInferenceRuntime,
+  parseHostLocalInferenceReceipt,
+  serializeHostLocalInferenceReceipt,
+} from "./host-local-inference";
+import { HOST_LOCAL_INFERENCE_APPLICATION_BASE_URL } from "./host-local-inference-routing";
+import { requireRuntimeProviderHostLocalInferenceOperation } from "./registry";
+
+export type ManagedHostLocalInferenceService = "ollama" | "nim" | "vllm";
+
+export type HostLocalInferenceLifecycleSandbox = Pick<
+  SandboxEntry,
+  | "agent"
+  | "endpointUrl"
+  | "gatewayName"
+  | "hostLocalInferenceReceipt"
+  | "lifecycleGeneration"
+  | "model"
+  | "name"
+  | "openshellDriver"
+  | "provider"
+>;
+
+export interface HostLocalInferenceSandboxAuthority {
+  readonly schemaVersion: 1;
+  readonly sandboxName: string;
+  readonly agent: string;
+  readonly providerId: string;
+  readonly routeProvider: "ollama-local" | "vllm-local";
+  readonly model: string;
+  readonly endpointUrl: string;
+  readonly gatewayName: string;
+  readonly lifecycleGeneration: string;
+  readonly serializedReceipt: string;
+}
+
+export interface PreparedHostLocalInferenceAuthority {
+  readonly providerId: string;
+  readonly sandboxName: string;
+  readonly serializedReceipt: string;
+  readonly receipt: HostLocalInferenceReceipt;
+  readonly mode: "preserve" | "destroy";
+  readonly sandboxAuthority: HostLocalInferenceSandboxAuthority;
+  /** Stable compare-and-swap identity for the complete outer registry binding. */
+  readonly sandboxAuthoritySha256: string;
+}
+
+export type HostLocalInferenceRetirementResult =
+  | HostLocalInferenceDestroyResult
+  | {
+      readonly status: "shared";
+      readonly receipt: HostLocalInferenceReceipt;
+    };
+
+export interface HostLocalInferenceLifecycleOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+type ManagedHostLocalInferenceReceipt = HostLocalInferenceReceipt & {
+  readonly service: ManagedHostLocalInferenceService;
+};
+
+const MANAGED_SERVICES = new Set<ManagedHostLocalInferenceService>(["ollama", "nim", "vllm"]);
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/u;
+
+function fail(message: string): never {
+  throw new Error(`Host-local inference lifecycle authority is invalid: ${message}`);
+}
+
+function exactText(value: unknown, label: string, maxBytes = 512): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value !== value.trim() ||
+    CONTROL_CHARACTERS.test(value) ||
+    Buffer.byteLength(value, "utf8") > maxBytes
+  ) {
+    fail(`${label} is missing or malformed`);
+  }
+  return value;
+}
+
+function parseManagedReceipt(serialized: string): ManagedHostLocalInferenceReceipt | null {
+  const receipt = parseHostLocalInferenceReceipt(serialized);
+  return MANAGED_SERVICES.has(receipt.service as ManagedHostLocalInferenceService)
+    ? (receipt as ManagedHostLocalInferenceReceipt)
+    : null;
+}
+
+/** True only for the Ollama, NIM, and vLLM lifecycle owned by this B4-E1 helper. */
+export function isManagedHostLocalInferenceLifecycleReceipt(serialized: string): boolean {
+  return parseManagedReceipt(serialized) !== null;
+}
+
+function sandboxAuthoritySha256(authority: HostLocalInferenceSandboxAuthority): string {
+  return createHash("sha256").update(JSON.stringify(authority)).digest("hex");
+}
+
+function captureSandboxAuthority(
+  provider: RuntimeProviderBundle,
+  sandbox: HostLocalInferenceLifecycleSandbox,
+  serialized: string,
+  receipt: ManagedHostLocalInferenceReceipt,
+): HostLocalInferenceSandboxAuthority {
+  if (sandbox.hostLocalInferenceReceipt !== serialized) {
+    fail(`target '${sandbox.name}' has different host-local inference authority`);
+  }
+  const providerId = exactText(sandbox.openshellDriver, "sandbox runtime provider");
+  if (providerId !== provider.identity.id) {
+    fail("sandbox runtime provider differs from the selected provider");
+  }
+  const routeProvider = receipt.service === "ollama" ? "ollama-local" : "vllm-local";
+  if (sandbox.provider !== routeProvider) {
+    fail("sandbox route provider differs from the receipt service");
+  }
+  if (sandbox.endpointUrl !== HOST_LOCAL_INFERENCE_APPLICATION_BASE_URL) {
+    fail("sandbox inference endpoint is outside the canonical local route");
+  }
+  const receiptModel = receipt.inference?.model;
+  if (typeof receiptModel !== "string" || sandbox.model !== receiptModel) {
+    fail("sandbox model differs from the provider inference proof");
+  }
+  return Object.freeze({
+    schemaVersion: 1 as const,
+    sandboxName: exactText(sandbox.name, "sandbox name"),
+    agent: exactText(sandbox.agent, "sandbox agent"),
+    providerId,
+    routeProvider,
+    model: exactText(receiptModel, "sandbox model"),
+    endpointUrl: HOST_LOCAL_INFERENCE_APPLICATION_BASE_URL,
+    gatewayName: exactText(sandbox.gatewayName, "sandbox gateway"),
+    lifecycleGeneration: exactText(sandbox.lifecycleGeneration, "sandbox lifecycle generation"),
+    serializedReceipt: serialized,
+  });
+}
+
+function requireRuntime(
+  provider: RuntimeProviderBundle,
+  receipt: ManagedHostLocalInferenceReceipt,
+  options: HostLocalInferenceLifecycleOptions,
+): HostLocalInferenceRuntime {
+  const acceleration =
+    receipt.runtime.kind === "host" ? receipt.runtime.acceleration : "nvidia-gpu";
+  const operation = requireRuntimeProviderHostLocalInferenceOperation(provider, receipt.service, {
+    env: options.environment ?? process.env,
+    acceleration,
+  });
+  operation.assertAuthority();
+  if (
+    receipt.providerId !== provider.identity.id ||
+    receipt.engineAuthority.providerId !== provider.identity.id ||
+    operation.providerId !== provider.identity.id ||
+    operation.engine.engineId !== receipt.engineAuthority.engineId ||
+    operation.engine.authorityId !== receipt.engineAuthority.authorityId ||
+    operation.bindingSha256 !== receipt.engineAuthority.bindingSha256
+  ) {
+    fail("receipt differs from the operation-scoped provider engine authority");
+  }
+  const runtime = operation.managedRuntime;
+  if (
+    !runtime ||
+    runtime.providerId !== provider.identity.id ||
+    runtime.authorityId !== operation.engine.authorityId ||
+    !runtime.services.includes(receipt.service) ||
+    typeof runtime.preserveForRebuild !== "function" ||
+    typeof runtime.prepareDestroy !== "function" ||
+    typeof runtime.destroy !== "function"
+  ) {
+    fail("provider returned an incomplete managed inference lifecycle");
+  }
+  return runtime;
+}
+
+function requireExactReceipt(
+  expected: string,
+  receipt: HostLocalInferenceReceipt,
+  message: string,
+): HostLocalInferenceReceipt {
+  if (serializeHostLocalInferenceReceipt(receipt) !== expected) fail(message);
+  return receipt;
+}
+
+function prepare(
+  provider: RuntimeProviderBundle,
+  sandbox: HostLocalInferenceLifecycleSandbox,
+  serialized: string,
+  mode: PreparedHostLocalInferenceAuthority["mode"],
+  options: HostLocalInferenceLifecycleOptions,
+): PreparedHostLocalInferenceAuthority | null {
+  const receipt = parseManagedReceipt(serialized);
+  if (!receipt) return null;
+  const sandboxAuthority = captureSandboxAuthority(provider, sandbox, serialized, receipt);
+  const runtime = requireRuntime(provider, receipt, options);
+  const reproved =
+    mode === "destroy" ? runtime.prepareDestroy(receipt) : runtime.preserveForRebuild(receipt);
+  requireExactReceipt(
+    serialized,
+    reproved,
+    mode === "destroy"
+      ? "provider authority changed during destroy preflight"
+      : "provider authority changed while it was being preserved",
+  );
+  return Object.freeze({
+    providerId: provider.identity.id,
+    sandboxName: sandboxAuthority.sandboxName,
+    serializedReceipt: serialized,
+    receipt,
+    mode,
+    sandboxAuthority,
+    sandboxAuthoritySha256: sandboxAuthoritySha256(sandboxAuthority),
+  });
+}
+
+/** Re-prove a canonical receipt only while it remains bound to the complete sandbox row. */
+export function reproveHostLocalInferenceReceipt(
+  provider: RuntimeProviderBundle,
+  sandbox: HostLocalInferenceLifecycleSandbox,
+  serialized: string,
+  options: HostLocalInferenceLifecycleOptions = {},
+): string {
+  const prepared = prepareHostLocalInferenceAuthority(provider, sandbox, serialized, options);
+  if (!prepared) fail("receipt uses the dedicated llama.cpp lifecycle");
+  return prepared.serializedReceipt;
+}
+
+export function prepareHostLocalInferenceAuthority(
+  provider: RuntimeProviderBundle,
+  sandbox: HostLocalInferenceLifecycleSandbox,
+  serialized: string,
+  options: HostLocalInferenceLifecycleOptions = {},
+): PreparedHostLocalInferenceAuthority | null {
+  return prepare(provider, sandbox, serialized, "preserve", options);
+}
+
+export function prepareSandboxHostLocalInferenceAuthority(
+  provider: RuntimeProviderBundle,
+  sandbox: HostLocalInferenceLifecycleSandbox,
+  options: HostLocalInferenceLifecycleOptions = {},
+): PreparedHostLocalInferenceAuthority | null {
+  const serialized = sandbox.hostLocalInferenceReceipt;
+  return typeof serialized === "string"
+    ? prepareHostLocalInferenceAuthority(provider, sandbox, serialized, options)
+    : null;
+}
+
+export function prepareSandboxHostLocalInferenceDestroyAuthority(
+  provider: RuntimeProviderBundle,
+  sandbox: HostLocalInferenceLifecycleSandbox,
+  options: HostLocalInferenceLifecycleOptions = {},
+): PreparedHostLocalInferenceAuthority | null {
+  const serialized = sandbox.hostLocalInferenceReceipt;
+  return typeof serialized === "string"
+    ? prepare(provider, sandbox, serialized, "destroy", options)
+    : null;
+}
+
+function requireCurrentSandboxAuthority(
+  provider: RuntimeProviderBundle,
+  sandbox: HostLocalInferenceLifecycleSandbox,
+  prepared: PreparedHostLocalInferenceAuthority,
+  mode: PreparedHostLocalInferenceAuthority["mode"],
+): void {
+  if (prepared.mode !== mode || prepared.providerId !== provider.identity.id) {
+    fail("prepared authority has a different lifecycle intent or provider");
+  }
+  const receipt = parseManagedReceipt(prepared.serializedReceipt);
+  if (!receipt) fail("prepared receipt no longer has a managed lifecycle");
+  const current = captureSandboxAuthority(provider, sandbox, prepared.serializedReceipt, receipt);
+  if (
+    JSON.stringify(current) !== JSON.stringify(prepared.sandboxAuthority) ||
+    sandboxAuthoritySha256(current) !== prepared.sandboxAuthoritySha256
+  ) {
+    fail("sandbox authority changed after lifecycle preparation");
+  }
+}
+
+export function confirmHostLocalInferenceAuthority(
+  provider: RuntimeProviderBundle,
+  sandbox: HostLocalInferenceLifecycleSandbox,
+  prepared: PreparedHostLocalInferenceAuthority,
+  options: HostLocalInferenceLifecycleOptions = {},
+): void {
+  requireCurrentSandboxAuthority(provider, sandbox, prepared, "preserve");
+  const receipt = parseManagedReceipt(prepared.serializedReceipt);
+  if (!receipt) fail("prepared receipt no longer has a managed lifecycle");
+  const runtime = requireRuntime(provider, receipt, options);
+  requireExactReceipt(
+    prepared.serializedReceipt,
+    runtime.preserveForRebuild(receipt),
+    "provider authority changed during lifecycle confirmation",
+  );
+}
+
+function confirmHostLocalInferenceDestroyAuthority(
+  provider: RuntimeProviderBundle,
+  sandbox: HostLocalInferenceLifecycleSandbox,
+  prepared: PreparedHostLocalInferenceAuthority,
+  options: HostLocalInferenceLifecycleOptions,
+): HostLocalInferenceRuntime {
+  requireCurrentSandboxAuthority(provider, sandbox, prepared, "destroy");
+  const receipt = parseManagedReceipt(prepared.serializedReceipt);
+  if (!receipt) fail("prepared receipt no longer has a managed lifecycle");
+  const runtime = requireRuntime(provider, receipt, options);
+  requireExactReceipt(
+    prepared.serializedReceipt,
+    runtime.prepareDestroy(receipt),
+    "provider authority changed before destroy mutation",
+  );
+  return runtime;
+}
+
+function sameImmutableRuntimeAuthority(
+  left: HostLocalInferenceReceipt,
+  right: HostLocalInferenceReceipt,
+): boolean {
+  if (
+    left.providerId !== right.providerId ||
+    left.service !== right.service ||
+    left.engineAuthority.engineId !== right.engineAuthority.engineId ||
+    left.engineAuthority.authorityId !== right.engineAuthority.authorityId ||
+    left.runtime.kind !== right.runtime.kind
+  ) {
+    return false;
+  }
+  if (left.runtime.kind === "container" && right.runtime.kind === "container") {
+    return left.runtime.runtimeId === right.runtime.runtimeId;
+  }
+  return (
+    left.runtime.kind === "host" &&
+    right.runtime.kind === "host" &&
+    left.endpoint.host === right.endpoint.host &&
+    left.endpoint.port === right.endpoint.port
+  );
+}
+
+function sharedPeerStatus(
+  provider: RuntimeProviderBundle,
+  sandbox: HostLocalInferenceLifecycleSandbox,
+  prepared: PreparedHostLocalInferenceAuthority,
+  peers: readonly HostLocalInferenceLifecycleSandbox[],
+): "exclusive" | "shared" {
+  const names = new Set<string>();
+  const preparedReceipt = parseManagedReceipt(prepared.serializedReceipt);
+  if (!preparedReceipt) fail("prepared receipt no longer has a managed lifecycle");
+  let targetCount = 0;
+  let shared = false;
+  for (const peer of peers) {
+    const peerName = exactText(peer.name, "peer sandbox name");
+    if (names.has(peerName)) fail("peer registry contains duplicate sandbox identities");
+    names.add(peerName);
+    if (peerName === sandbox.name) {
+      targetCount += 1;
+      const current = captureSandboxAuthority(
+        provider,
+        peer,
+        prepared.serializedReceipt,
+        preparedReceipt,
+      );
+      if (
+        JSON.stringify(current) !== JSON.stringify(prepared.sandboxAuthority) ||
+        sandboxAuthoritySha256(current) !== prepared.sandboxAuthoritySha256
+      ) {
+        fail("peer registry contains a different target sandbox authority");
+      }
+      continue;
+    }
+    if (typeof peer.hostLocalInferenceReceipt !== "string") continue;
+    let peerReceipt: HostLocalInferenceReceipt;
+    try {
+      peerReceipt = parseHostLocalInferenceReceipt(peer.hostLocalInferenceReceipt);
+    } catch {
+      fail("peer runtime ownership is malformed or indeterminate");
+    }
+    if (!sameImmutableRuntimeAuthority(prepared.receipt, peerReceipt)) continue;
+    if (peer.hostLocalInferenceReceipt !== prepared.serializedReceipt) {
+      fail("the same immutable provider runtime has conflicting registry authority");
+    }
+    const managedPeerReceipt = parseManagedReceipt(peer.hostLocalInferenceReceipt);
+    if (!managedPeerReceipt) fail("peer runtime ownership is malformed or indeterminate");
+    captureSandboxAuthority(provider, peer, peer.hostLocalInferenceReceipt, managedPeerReceipt);
+    shared = true;
+  }
+  if (targetCount !== 1) {
+    fail("peer registry does not contain exactly one target sandbox authority");
+  }
+  return shared ? "shared" : "exclusive";
+}
+
+/**
+ * Retire one exact managed runtime after the caller has confirmed sandbox
+ * deletion. The durable row remains the retry journal until this returns.
+ */
+export function retirePreparedHostLocalInferenceAuthority(
+  provider: RuntimeProviderBundle,
+  sandbox: HostLocalInferenceLifecycleSandbox,
+  prepared: PreparedHostLocalInferenceAuthority,
+  peers: readonly HostLocalInferenceLifecycleSandbox[],
+  options: HostLocalInferenceLifecycleOptions = {},
+): HostLocalInferenceRetirementResult {
+  const runtime = confirmHostLocalInferenceDestroyAuthority(provider, sandbox, prepared, options);
+  if (sharedPeerStatus(provider, sandbox, prepared, peers) === "shared") {
+    return Object.freeze({ status: "shared" as const, receipt: prepared.receipt });
+  }
+  const result = runtime.destroy(prepared.receipt);
+  requireExactReceipt(
+    prepared.serializedReceipt,
+    result.receipt,
+    "destroy returned different runtime authority",
+  );
+  if (
+    (prepared.receipt.runtime.kind === "host" &&
+      (result.status !== "retained" || result.reason !== "host-process")) ||
+    (prepared.receipt.runtime.kind === "container" && result.status === "retained")
+  ) {
+    fail("destroy returned a result incompatible with exact runtime ownership");
+  }
+  return result;
+}

--- a/src/lib/onboard/runtime-provider/host-local-inference-routing.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-routing.test.ts
@@ -81,6 +81,43 @@ function receipt(service: "ollama" | "nim" | "vllm"): HostLocalInferenceReceipt 
   };
 }
 
+function llamaCppReceipt(): HostLocalInferenceReceipt {
+  return {
+    schemaVersion: 1,
+    providerId: "mxc",
+    service: "llama-cpp",
+    engineAuthority: {
+      schemaVersion: 1,
+      providerId: "mxc",
+      operation: "host-local-inference",
+      engineId: "mxc",
+      authorityId: AUTHORITY_ID,
+      bindingSha256: "d".repeat(64),
+    },
+    endpoint: {
+      host: "host.openshell.internal",
+      port: 8081,
+      networkName: "nemoclaw-llama-cpp-internal",
+    },
+    runtime: {
+      kind: "container",
+      runtimeId: "6".repeat(64),
+      name: "nemoclaw-llama-cpp",
+      imageRef: MANAGED_IMAGE,
+      probeImageRef: PROBE_IMAGE,
+      specSha256: "7".repeat(64),
+      model: {
+        planDigest: `sha256:${"8".repeat(64)}`,
+        recipeId: "llama-cpp-model",
+        generation: "9".repeat(64),
+        digest: `sha256:${"a".repeat(64)}`,
+        sizeBytes: 1024,
+      },
+      gpu: { vendor: "nvidia", count: 1 },
+    },
+  };
+}
+
 function prepared(value: HostLocalInferenceReceipt) {
   const rollbackPriorState = value.publication?.priorState ?? "absent";
   return {
@@ -101,7 +138,7 @@ function runtime(): HostLocalInferenceRuntime {
   return {
     providerId: "mxc",
     authorityId: AUTHORITY_ID,
-    services: ["ollama", "nim", "vllm"],
+    services: ["ollama", "nim", "vllm", "llama-cpp"],
     translateContainerArgs: (args) => args,
     qualifyOllama: vi.fn(() => prepared(receipt("ollama"))),
     startManaged: vi.fn((input) => prepared(receipt(input.service))),
@@ -175,7 +212,41 @@ describe("provider-neutral host-local inference startup routing", () => {
     });
     expect(Object.keys(hostLocalInferenceOperationEnvironment("ollama", source))).toEqual([]);
     expect(Object.keys(hostLocalInferenceOperationEnvironment("vllm", source))).toEqual([]);
+    expect(Object.keys(hostLocalInferenceOperationEnvironment("llama-cpp", source))).toEqual([]);
   });
+
+  it.each(HOST_LOCAL_INFERENCE_APPLICATIONS)(
+    "resumes explicitly selected llama.cpp for %s through the same route transaction",
+    (application) => {
+      const value = llamaCppReceipt();
+      const providerRuntime = runtime();
+      const providerOperation = operation(providerRuntime);
+      const prepareStartup = vi.fn(() => prepared(value));
+      const route = prepareHostLocalInferenceStartup(providerOperation, {
+        application,
+        service: "llama-cpp",
+        adapter: {
+          gatewayPort: 8080,
+          runtimeOwnerSandboxName: "llama-owner",
+          model: "llama-cpp-model",
+          operation: providerOperation,
+          receipt: value,
+          runtime: providerRuntime,
+          prepareStartup,
+        },
+        requireToolCalling: true,
+        publishedRoute: true,
+  });
+
+      expect(route.gatewayProvider).toBe("llama-cpp-local");
+      expect(route.gatewayProviderBaseUrl).toBe("http://host.openshell.internal:8081/v1");
+      expect(route.applicationBaseUrl).toBe("https://inference.local/v1");
+      expect(route.receipt).toEqual(value);
+      expect(prepareStartup).toHaveBeenCalledOnce();
+      expect(providerRuntime.startManaged).not.toHaveBeenCalled();
+      expect(providerRuntime.qualifyOllama).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     ["ollama", "ollama-local", "http://host.openshell.internal:11434/v1"],

--- a/src/lib/onboard/runtime-provider/host-local-inference-routing.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-routing.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { RuntimeProviderBundle } from "./contract";
+import type { ManagedLlamaCppLifecycleAdapter } from "../../inference/llama-cpp/managed-lifecycle-adapter";
 import {
   HOST_LOCAL_INFERENCE_SANDBOX_HOST,
   type HostLocalInferenceOperation,
@@ -30,7 +31,7 @@ export const HOST_LOCAL_INFERENCE_APPLICATIONS = [
 export type HostLocalInferenceApplication = (typeof HOST_LOCAL_INFERENCE_APPLICATIONS)[number];
 
 export function hostLocalInferenceOperationEnvironment(
-  service: "ollama" | "nim" | "vllm",
+  service: "ollama" | "nim" | "vllm" | "llama-cpp",
   source: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
   const operationEnv = Object.create(null) as NodeJS.ProcessEnv;
@@ -45,7 +46,7 @@ export function hostLocalInferenceOperationEnvironment(
 export interface HostLocalInferenceGatewayMutationInput {
   readonly gatewayName: string;
   readonly sandboxName: string;
-  readonly provider: "ollama-local" | "vllm-local";
+  readonly provider: "ollama-local" | "vllm-local" | "llama-cpp-local";
   readonly model: string;
   readonly providerBaseUrl: string;
 }
@@ -75,6 +76,16 @@ export type HostLocalInferenceStartupRequest =
       /** Recover only an interrupted, not-yet-published same-transaction start. */
       readonly recover?: boolean;
       readonly receiptWriter: HostLocalInferenceReceiptWriter;
+    }
+  | {
+      readonly application: HostLocalInferenceApplication;
+      readonly service: "llama-cpp";
+      /** Rehydrated only by the hidden operation-scoped lifecycle resolver. */
+      readonly adapter: ManagedLlamaCppLifecycleAdapter;
+      /** Accepted sandbox proof requirement; schema-v1 receipts intentionally omit it. */
+      readonly requireToolCalling: boolean;
+      /** True only when the registry route was already durably published. */
+      readonly publishedRoute: boolean;
     };
 
 /** Operation-scoped selection injected by the qualification caller. */
@@ -108,7 +119,7 @@ export type HostLocalInferenceStartupSelectionResolver = (
 ) => HostLocalInferenceStartupSelection | null;
 
 export interface HostLocalInferenceSandboxProofAuthority {
-  readonly service: "ollama" | "nim" | "vllm";
+  readonly service: "ollama" | "nim" | "vllm" | "llama-cpp";
   readonly directHostPort: number;
   readonly directHealthPath: "/api/tags" | "/v1/health/ready" | "/health";
   readonly toolCallingRequired: boolean;
@@ -117,7 +128,12 @@ export interface HostLocalInferenceSandboxProofAuthority {
 export function hostLocalInferenceSandboxProofAuthority(
   request: HostLocalInferenceStartupRequest,
 ): HostLocalInferenceSandboxProofAuthority {
-  const input = request.service === "ollama" ? request.endpoint : request.managed;
+  const input =
+    request.service === "ollama"
+      ? request.endpoint
+      : request.service === "llama-cpp"
+        ? null
+        : request.managed;
   const directHealthPath =
     request.service === "ollama"
       ? "/api/tags"
@@ -126,16 +142,52 @@ export function hostLocalInferenceSandboxProofAuthority(
         : "/health";
   return Object.freeze({
     service: request.service,
-    directHostPort: input.hostPort,
+    directHostPort:
+      request.service === "llama-cpp" ? request.adapter.receipt.endpoint.port : input!.hostPort,
     directHealthPath,
-    toolCallingRequired: input.requireToolCalling,
+    toolCallingRequired:
+      request.service === "llama-cpp" ? request.requireToolCalling : input!.requireToolCalling,
   });
+}
+
+export function hostLocalInferenceRequestModel(request: HostLocalInferenceStartupRequest): string {
+  if (request.service === "ollama") return normalizeHostLocalOllamaModelRef(request.endpoint.model);
+  return request.service === "llama-cpp" ? request.adapter.model : request.managed.model;
+}
+
+export function hostLocalInferenceRequestToolCalling(
+  request: HostLocalInferenceStartupRequest,
+): boolean {
+  if (request.service === "ollama") return request.endpoint.requireToolCalling;
+  return request.service === "llama-cpp"
+    ? request.requireToolCalling
+    : request.managed.requireToolCalling;
+}
+
+export function hostLocalInferenceRuntimeOwnerSandboxName(
+  request: HostLocalInferenceStartupRequest,
+  sandboxName: string,
+): string {
+  return request.service === "llama-cpp" ? request.adapter.runtimeOwnerSandboxName : sandboxName;
+}
+
+export function hostLocalInferenceGatewayPort(
+  request: HostLocalInferenceStartupRequest,
+): number | undefined {
+  return request.service === "llama-cpp" ? request.adapter.gatewayPort : undefined;
+}
+
+export function hostLocalInferenceGatewayProvider(
+  request: HostLocalInferenceStartupRequest,
+): "ollama-local" | "vllm-local" | "llama-cpp-local" {
+  if (request.service === "ollama") return "ollama-local";
+  return request.service === "llama-cpp" ? "llama-cpp-local" : "vllm-local";
 }
 
 export interface HostLocalInferenceStartupRoute {
   readonly prepared: HostLocalInferencePreparedStartup;
   readonly receipt: HostLocalInferenceReceipt;
-  readonly gatewayProvider: "ollama-local" | "vllm-local";
+  readonly gatewayProvider: "ollama-local" | "vllm-local" | "llama-cpp-local";
   /** Provider registration target visible inside the OpenShell gateway. */
   readonly gatewayProviderBaseUrl: string;
   /** Stable inference route shared by OpenClaw, Hermes, and Deep Agents Code. */
@@ -159,6 +211,26 @@ function normalizeStartupReceipt(
   receipt: HostLocalInferenceReceipt,
 ): HostLocalInferenceReceipt {
   const normalized = normalizeHostLocalInferenceReceipt(receipt);
+  if (request.service === "llama-cpp") {
+    if (
+      normalized.schemaVersion !== 1 ||
+      normalized.service !== "llama-cpp" ||
+      normalized.providerId !== operation.providerId ||
+      normalized.providerId !== runtime.providerId ||
+      normalized.engineAuthority.providerId !== operation.providerId ||
+      normalized.engineAuthority.engineId !== operation.engine.engineId ||
+      normalized.engineAuthority.authorityId !== operation.engine.authorityId ||
+      normalized.engineAuthority.authorityId !== runtime.authorityId ||
+      normalized.engineAuthority.bindingSha256 !== operation.bindingSha256 ||
+      serializeHostLocalInferenceReceipt(normalized) !==
+        serializeHostLocalInferenceReceipt(request.adapter.receipt)
+    ) {
+      throw new Error(
+        "Host-local llama.cpp startup returned a different runtime or receipt authority.",
+      );
+    }
+    return normalized;
+  }
   const model =
     request.service === "ollama"
       ? normalizeHostLocalOllamaModelRef(request.endpoint.model)
@@ -265,7 +337,8 @@ export function prepareHostLocalInferenceStartup(
 ): HostLocalInferenceStartupRoute {
   requireApplication(request.application);
   operation.assertAuthority();
-  const runtime: HostLocalInferenceRuntime | undefined = operation.managedRuntime;
+  const runtime: HostLocalInferenceRuntime | undefined =
+    request.service === "llama-cpp" ? request.adapter.runtime : operation.managedRuntime;
   if (!runtime) {
     throw new Error(
       `Runtime provider '${operation.providerId}' does not provide managed host-local inference.`,
@@ -283,7 +356,12 @@ export function prepareHostLocalInferenceStartup(
     );
   }
   let prepared: HostLocalInferencePreparedStartup;
-  if (request.service === "ollama") {
+  if (request.service === "llama-cpp") {
+    if (request.publishedRoute !== true && request.publishedRoute !== false) {
+      throw new Error("Managed llama.cpp route publication authority is invalid.");
+    }
+    prepared = request.adapter.prepareStartup();
+  } else if (request.service === "ollama") {
     prepared = runtime.qualifyOllama(request.endpoint, request.receiptWriter);
   } else {
     if (request.managed.service !== request.service) {
@@ -336,16 +414,20 @@ export function prepareHostLocalInferenceStartup(
     throw error;
   }
   const expectedRollbackPriorState =
-    request.service !== "ollama" && request.resumeReceipt !== undefined
+    request.service === "llama-cpp"
+      ? prepared.rollbackPriorState
+      : request.service !== "ollama" && request.resumeReceipt !== undefined
       ? prepared.rollbackPriorState
       : receipt.publication?.priorState;
   if (
     prepared.rollbackPriorState !== expectedRollbackPriorState ||
     (request.service !== "ollama" &&
+      request.service !== "llama-cpp" &&
       request.resumeReceipt !== undefined &&
       prepared.rollbackPriorState !== "running" &&
       prepared.rollbackPriorState !== "stopped") ||
     (request.service !== "ollama" &&
+      request.service !== "llama-cpp" &&
       request.resumeReceipt !== undefined &&
       serializeHostLocalInferenceReceipt(
         normalizeHostLocalInferenceReceipt(request.resumeReceipt),
@@ -363,7 +445,7 @@ export function prepareHostLocalInferenceStartup(
   return Object.freeze({
     prepared,
     receipt,
-    gatewayProvider: request.service === "ollama" ? "ollama-local" : "vllm-local",
+    gatewayProvider: hostLocalInferenceGatewayProvider(request),
     gatewayProviderBaseUrl: providerBaseUrl(receipt),
     applicationBaseUrl: HOST_LOCAL_INFERENCE_APPLICATION_BASE_URL,
   });

--- a/src/lib/onboard/runtime-provider/podman-host-local-inference-destroy.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference-destroy.test.ts
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { createPodmanHostLocalInferenceTestHarness } from "../../../../test/helpers/podman-host-local-inference-test-harness";
+import { createPodmanHostLocalInferenceOperation } from "./podman-host-local-inference";
+
+describe("Podman host-local inference destroy", () => {
+  it("retains externally owned Ollama without issuing a Podman remove", () => {
+    const harness = createPodmanHostLocalInferenceTestHarness();
+    const operation = createPodmanHostLocalInferenceOperation({
+      engine: harness.engine,
+      env: harness.env,
+      acceleration: harness.operationAcceleration,
+      authorityStore: harness.authorityStore,
+      routeAuthorityStore: harness.routeAuthorityStore,
+      onFailureEvidence: harness.onFailureEvidence,
+      redactSensitive: harness.redactSensitive,
+    });
+    const runtime = operation.managedRuntime;
+    if (!runtime) throw new Error("test operation lacks managed runtime");
+    const prepared = runtime.qualifyOllama(
+      {
+        acceleration: "nvidia-gpu",
+        networkName: harness.input.networkName,
+        networkId: harness.input.networkId,
+        networkGatewayIp: harness.input.networkGatewayIp,
+        hostPort: 11434,
+        probeImageRef: harness.input.probeImageRef,
+        model: "nemotron:latest",
+        requireToolCalling: true,
+      },
+      harness.writer,
+    );
+    prepared.validateBeforeCommit();
+    const receipt = prepared.commit();
+    harness.state.probeFailure = "ready";
+    harness.events.length = 0;
+
+    expect(runtime.prepareDestroy(receipt)).toEqual(receipt);
+    expect(runtime.destroy(receipt)).toEqual({
+      status: "retained",
+      reason: "host-process",
+      receipt,
+    });
+    expect(harness.events.some((event) => event.startsWith("podman:rm "))).toBe(false);
+  });
+});

--- a/src/lib/onboard/runtime-provider/podman-host-local-inference-destroy.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference-destroy.test.ts
@@ -18,8 +18,8 @@ describe("Podman host-local inference destroy", () => {
       onFailureEvidence: harness.onFailureEvidence,
       redactSensitive: harness.redactSensitive,
     });
-    const runtime = operation.managedRuntime;
-    if (!runtime) throw new Error("test operation lacks managed runtime");
+    const runtime = operation.managedRuntime!;
+    expect(runtime, "test operation lacks managed runtime").toBeDefined();
     const prepared = runtime.qualifyOllama(
       {
         acceleration: "nvidia-gpu",

--- a/src/lib/onboard/sandbox-recreate-transaction.test.ts
+++ b/src/lib/onboard/sandbox-recreate-transaction.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { serializedHostLocalInferenceReceipt } from "../../../test/helpers/host-local-inference-receipt";
 import { managedStartupE2eProfile } from "../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
 import { decisionSelected } from "../state/onboard-checkpoint-decision";
 import { deriveCheckpointFromSession } from "../state/onboard-checkpoint-migrate";
@@ -830,6 +831,7 @@ describe("source registry fingerprint", () => {
       const journaled = fingerprintSandboxRegistryEntry(
         registry.getSandbox("alpha") as SandboxEntry,
       );
+      const hostLocalInferenceReceipt = serializedHostLocalInferenceReceipt("podman");
 
       expect(
         registry.reserveSandboxInferenceRoute("alpha", {
@@ -841,11 +843,12 @@ describe("source registry fingerprint", () => {
           preferredInferenceApi: "openai-responses",
           gatewayName: "nemoclaw",
           reservationSessionId: "session-9",
+          hostLocalInferenceReceipt,
         }),
       ).toBe(true);
-      expect(fingerprintSandboxRegistryEntry(registry.getSandbox("alpha") as SandboxEntry)).toBe(
-        journaled,
-      );
+      const reserved = registry.getSandbox("alpha") as SandboxEntry;
+      expect(reserved.hostLocalInferenceReceipt).toBe(hostLocalInferenceReceipt);
+      expect(fingerprintSandboxRegistryEntry(reserved)).toBe(journaled);
     } finally {
       await fs.rm(home, { recursive: true, force: true });
     }

--- a/src/lib/onboard/sandbox-recreate-transaction.test.ts
+++ b/src/lib/onboard/sandbox-recreate-transaction.test.ts
@@ -6,7 +6,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { serializedHostLocalInferenceReceipt } from "../../../test/helpers/host-local-inference-receipt";
+import {
+  serializedHostLocalInferenceReceipt,
+  serializedLlamaCppHostLocalInferenceReceipt,
+} from "../../../test/helpers/host-local-inference-receipt";
 import { managedStartupE2eProfile } from "../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
 import { decisionSelected } from "../state/onboard-checkpoint-decision";
 import { deriveCheckpointFromSession } from "../state/onboard-checkpoint-migrate";
@@ -16,6 +19,7 @@ import type {
 } from "../state/onboard-checkpoint-types";
 import { createSession } from "../state/onboard-session";
 import type { SandboxEntry } from "../state/registry";
+import { createSandboxHostLocalInferenceProvenance } from "../state/registry/host-local-inference";
 import { encodeManagedStartupProfile } from "./managed-startup/profile";
 import { createDockerRuntimeProviderBundle } from "./runtime-provider/docker";
 import { createRuntimeProviderBundleRegistry } from "./runtime-provider/registry";
@@ -848,6 +852,60 @@ describe("source registry fingerprint", () => {
       ).toBe(true);
       const reserved = registry.getSandbox("alpha") as SandboxEntry;
       expect(reserved.hostLocalInferenceReceipt).toBe(hostLocalInferenceReceipt);
+      expect(fingerprintSandboxRegistryEntry(reserved)).toBe(journaled);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("survives exact explicit llama.cpp route reservation during rebuild", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "nemoclaw-recreate-journal-"));
+    vi.stubEnv("HOME", home);
+    vi.resetModules();
+    try {
+      const registry = await import("../state/registry");
+      const hostLocalInferenceReceipt = serializedLlamaCppHostLocalInferenceReceipt("docker");
+      const hostLocalInferenceProvenance = createSandboxHostLocalInferenceProvenance(
+        "alpha",
+        hostLocalInferenceReceipt,
+      );
+      const route = {
+        provider: "llama-cpp-local",
+        model: "llama-cpp-model",
+        endpointUrl: "https://inference.local/v1",
+        endpointSource: "inference-set" as const,
+        credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+        preferredInferenceApi: "openai-completions",
+        gatewayName: "nemoclaw",
+        gatewayPort: 8080,
+        openshellDriver: "docker",
+        hostLocalInferenceReceipt,
+        hostLocalInferenceProvenance,
+      };
+      registry.reserveSandboxInferenceRoute("alpha", route);
+      registry.registerSandbox({
+        name: "alpha",
+        agent: "openclaw",
+        agentVersion: "2026.3.11",
+        createdAt: ISO,
+        imageTag: "nemoclaw/openclaw:2026.3.11",
+        lifecycleGeneration: "alpha-generation-1",
+        ...route,
+      });
+      const journaled = fingerprintSandboxRegistryEntry(
+        registry.getSandbox("alpha") as SandboxEntry,
+      );
+
+      expect(
+        registry.reserveSandboxInferenceRoute("alpha", {
+          ...route,
+          reservationSessionId: "session-llama-rebuild",
+        }),
+      ).toBe(true);
+      const reserved = registry.getSandbox("alpha") as SandboxEntry;
+
+      expect(reserved.hostLocalInferenceReceipt).toBe(hostLocalInferenceReceipt);
+      expect(reserved.hostLocalInferenceProvenance).toEqual(hostLocalInferenceProvenance);
       expect(fingerprintSandboxRegistryEntry(reserved)).toBe(journaled);
     } finally {
       await fs.rm(home, { recursive: true, force: true });

--- a/src/lib/onboard/sandbox-recreate-transaction.ts
+++ b/src/lib/onboard/sandbox-recreate-transaction.ts
@@ -194,6 +194,7 @@ const ROUTE_RESERVATION_FIELDS: readonly (keyof SandboxEntry)[] = [
   "credentialEnv",
   "preferredInferenceApi",
   "hostLocalInferenceReceipt",
+  "hostLocalInferenceProvenance",
   "gatewayName",
   "gatewayPort",
 ];

--- a/src/lib/onboard/sandbox-recreate-transaction.ts
+++ b/src/lib/onboard/sandbox-recreate-transaction.ts
@@ -193,6 +193,7 @@ const ROUTE_RESERVATION_FIELDS: readonly (keyof SandboxEntry)[] = [
   "endpointSource",
   "credentialEnv",
   "preferredInferenceApi",
+  "hostLocalInferenceReceipt",
   "gatewayName",
   "gatewayPort",
 ];

--- a/src/lib/onboard/sandbox-registration.test.ts
+++ b/src/lib/onboard/sandbox-registration.test.ts
@@ -4,6 +4,8 @@
 import { createRequire } from "node:module";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { serializedHostLocalInferenceReceipt } from "../../../test/helpers/host-local-inference-receipt";
+
 const requireDist = createRequire(import.meta.url);
 const onboardSession = requireDist("../state/onboard-session.js");
 const {
@@ -546,6 +548,12 @@ describe("registerCreatedSandbox", () => {
 
   it("passes the built entry to the supplied registry writer", () => {
     const registerSandbox = vi.fn();
+    const hostLocalInferenceReceipt = serializedHostLocalInferenceReceipt("docker");
+    const registry = requireDist("../state/registry.js") as typeof import("../state/registry");
+    const getSandbox = vi.spyOn(registry, "getSandbox").mockReturnValue({
+      name: "demo",
+      hostLocalInferenceReceipt,
+    });
 
     const input = {
       sandboxName: "demo",
@@ -585,13 +593,21 @@ describe("registerCreatedSandbox", () => {
     expect(entry.name).toBe("demo");
     expect(entry.openclawImagePluginInstalls).toEqual([]);
     expect(entry.workload).toEqual(input.workload);
+    expect(entry.hostLocalInferenceReceipt).toBe(hostLocalInferenceReceipt);
+    const clearedEntry = registerCreatedSandbox({
+      ...input,
+      hostLocalInferenceReceipt: null,
+    });
+    expect(clearedEntry.hostLocalInferenceReceipt).toBeNull();
+    expect(registerSandbox).toHaveBeenLastCalledWith(clearedEntry);
     expect(() =>
       registerCreatedSandbox({
         ...input,
         workload: { ...input.workload, reference: "" },
       }),
     ).toThrow(/workload ownership receipt failed closed validation/u);
-    expect(registerSandbox).toHaveBeenCalledTimes(1);
+    expect(registerSandbox).toHaveBeenCalledTimes(2);
+    getSandbox.mockRestore();
   });
 
   it("fails before registry mutation for an unknown durable provider identity", () => {

--- a/src/lib/onboard/sandbox-registration.test.ts
+++ b/src/lib/onboard/sandbox-registration.test.ts
@@ -4,7 +4,11 @@
 import { createRequire } from "node:module";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { serializedHostLocalInferenceReceipt } from "../../../test/helpers/host-local-inference-receipt";
+import {
+  serializedHostLocalInferenceReceipt,
+  serializedLlamaCppHostLocalInferenceReceipt,
+} from "../../../test/helpers/host-local-inference-receipt";
+import { createSandboxHostLocalInferenceProvenance } from "../state/registry/host-local-inference";
 
 const requireDist = createRequire(import.meta.url);
 const onboardSession = requireDist("../state/onboard-session.js");
@@ -608,6 +612,65 @@ describe("registerCreatedSandbox", () => {
     ).toThrow(/workload ownership receipt failed closed validation/u);
     expect(registerSandbox).toHaveBeenCalledTimes(2);
     getSandbox.mockRestore();
+  });
+
+  it("inherits exact llama.cpp lifecycle provenance from the pending route reservation", () => {
+    const registerSandbox = vi.fn();
+    const hostLocalInferenceReceipt = serializedLlamaCppHostLocalInferenceReceipt("docker");
+    const hostLocalInferenceProvenance = createSandboxHostLocalInferenceProvenance(
+      "original-owner",
+      hostLocalInferenceReceipt,
+    );
+    const registry = requireDist("../state/registry.js") as typeof import("../state/registry");
+    const getSandbox = vi.spyOn(registry, "getSandbox").mockReturnValue({
+      name: "demo",
+      pendingRouteReservation: true,
+      provider: "llama-cpp-local",
+      model: "llama-cpp-model",
+      endpointUrl: "https://inference.local/v1",
+      endpointSource: "inference-set",
+      credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+      preferredInferenceApi: "openai-completions",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      openshellDriver: "docker",
+      hostLocalInferenceReceipt,
+      hostLocalInferenceProvenance,
+    });
+    try {
+      const entry = registerCreatedSandbox({
+        sandboxName: "demo",
+        inferenceSelection: {
+          model: "llama-cpp-model",
+          provider: "llama-cpp-local",
+          endpointUrl: "https://inference.local/v1",
+          endpointSource: "inference-set",
+          credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+          preferredInferenceApi: "openai-completions",
+          compatibleEndpointReasoning: null,
+          compatibleEndpointReasoningEffort: null,
+          nimContainer: null,
+        },
+        runtimeFields,
+        agent: null,
+        agentVersionKnown: true,
+        imageTag: null,
+        appliedPolicies: [],
+        plannedMessagingState: undefined,
+        hermesToolGateways: [],
+        hermesDashboardState: { enabled: false, config: null },
+        dashboardPort: 18789,
+        gatewayName: "nemoclaw",
+        gatewayPort: 8080,
+        registerSandbox,
+      });
+
+      expect(entry.hostLocalInferenceReceipt).toBe(hostLocalInferenceReceipt);
+      expect(entry.hostLocalInferenceProvenance).toEqual(hostLocalInferenceProvenance);
+      expect(registerSandbox).toHaveBeenCalledExactlyOnceWith(entry);
+    } finally {
+      getSandbox.mockRestore();
+    }
   });
 
   it("fails before registry mutation for an unknown durable provider identity", () => {

--- a/src/lib/onboard/sandbox-registration.ts
+++ b/src/lib/onboard/sandbox-registration.ts
@@ -16,6 +16,7 @@ import type {
   SandboxMessagingState,
 } from "../state/registry";
 import * as registry from "../state/registry";
+import { cloneSandboxHostLocalInferenceReceipt } from "../state/registry/host-local-inference";
 import { cloneSandboxWorkloadReceipt } from "../state/registry/workload";
 import { DEFAULT_TOOL_DISCLOSURE, type ToolDisclosure } from "../tool-disclosure";
 import type { DcodeAutoApprovalMode } from "./dcode-auto-approval";
@@ -54,6 +55,7 @@ export interface CreatedSandboxRegistryEntryInput {
   agentVersionKnown: boolean;
   imageTag: string | null;
   workload?: SandboxEntry["workload"];
+  hostLocalInferenceReceipt?: SandboxEntry["hostLocalInferenceReceipt"];
   openclawImagePluginInstalls?: readonly OpenClawImagePluginInstall[];
   appliedPolicies: string[];
   toolDisclosure?: ToolDisclosure;
@@ -192,6 +194,14 @@ export function buildCreatedSandboxRegistryEntry(
       "Sandbox workload ownership receipt failed closed validation.",
     );
   }
+  const hostLocalInferenceReceipt = cloneSandboxHostLocalInferenceReceipt(
+    input.hostLocalInferenceReceipt,
+  );
+  if (input.hostLocalInferenceReceipt !== undefined && hostLocalInferenceReceipt === undefined) {
+    throw new RuntimeProviderSelectionError(
+      "Sandbox host-local inference receipt failed closed validation.",
+    );
+  }
 
   return {
     name: input.sandboxName,
@@ -201,6 +211,7 @@ export function buildCreatedSandboxRegistryEntry(
     ...getSandboxAgentRegistryFields(input.agent, input.agentVersionKnown),
     imageTag: input.imageTag,
     workload,
+    ...(hostLocalInferenceReceipt !== undefined ? { hostLocalInferenceReceipt } : {}),
     ...(input.openclawImagePluginInstalls !== undefined
       ? {
           openclawImagePluginInstalls: input.openclawImagePluginInstalls.map((install) => ({
@@ -256,7 +267,16 @@ export function loadServingProfileResumeSession(): {
 }
 
 export function registerCreatedSandbox(input: CreatedSandboxRegistrationInput): SandboxEntry {
-  const entry = buildCreatedSandboxRegistryEntry(input);
+  const pendingHostLocalInferenceReceipt =
+    input.hostLocalInferenceReceipt !== undefined
+      ? input.hostLocalInferenceReceipt
+      : registry.getSandbox(input.sandboxName)?.hostLocalInferenceReceipt;
+  const entry = buildCreatedSandboxRegistryEntry({
+    ...input,
+    ...(pendingHostLocalInferenceReceipt === undefined
+      ? {}
+      : { hostLocalInferenceReceipt: pendingHostLocalInferenceReceipt }),
+  });
   const provider = requireRuntimeProviderBundleForSandbox(
     entry,
     input.runtimeProviders ?? CURRENT_RUNTIME_PROVIDER_BUNDLES,

--- a/src/lib/onboard/sandbox-registration.ts
+++ b/src/lib/onboard/sandbox-registration.ts
@@ -16,7 +16,11 @@ import type {
   SandboxMessagingState,
 } from "../state/registry";
 import * as registry from "../state/registry";
-import { cloneSandboxHostLocalInferenceReceipt } from "../state/registry/host-local-inference";
+import {
+  cloneSandboxHostLocalInferenceProvenance,
+  cloneSandboxHostLocalInferenceReceipt,
+  requireSandboxHostLocalInferenceProvenance,
+} from "../state/registry/host-local-inference";
 import { cloneSandboxWorkloadReceipt } from "../state/registry/workload";
 import { DEFAULT_TOOL_DISCLOSURE, type ToolDisclosure } from "../tool-disclosure";
 import type { DcodeAutoApprovalMode } from "./dcode-auto-approval";
@@ -56,6 +60,7 @@ export interface CreatedSandboxRegistryEntryInput {
   imageTag: string | null;
   workload?: SandboxEntry["workload"];
   hostLocalInferenceReceipt?: SandboxEntry["hostLocalInferenceReceipt"];
+  hostLocalInferenceProvenance?: SandboxEntry["hostLocalInferenceProvenance"];
   openclawImagePluginInstalls?: readonly OpenClawImagePluginInstall[];
   appliedPolicies: string[];
   toolDisclosure?: ToolDisclosure;
@@ -202,6 +207,23 @@ export function buildCreatedSandboxRegistryEntry(
       "Sandbox host-local inference receipt failed closed validation.",
     );
   }
+  const hostLocalInferenceProvenance = cloneSandboxHostLocalInferenceProvenance(
+    input.hostLocalInferenceProvenance,
+  );
+  if (
+    input.hostLocalInferenceProvenance !== undefined &&
+    (!hostLocalInferenceProvenance || typeof hostLocalInferenceReceipt !== "string")
+  ) {
+    throw new RuntimeProviderSelectionError(
+      "Sandbox host-local inference provenance failed closed validation.",
+    );
+  }
+  if (hostLocalInferenceProvenance && typeof hostLocalInferenceReceipt === "string") {
+    requireSandboxHostLocalInferenceProvenance(
+      hostLocalInferenceProvenance,
+      hostLocalInferenceReceipt,
+    );
+  }
 
   return {
     name: input.sandboxName,
@@ -212,6 +234,7 @@ export function buildCreatedSandboxRegistryEntry(
     imageTag: input.imageTag,
     workload,
     ...(hostLocalInferenceReceipt !== undefined ? { hostLocalInferenceReceipt } : {}),
+    ...(hostLocalInferenceProvenance ? { hostLocalInferenceProvenance } : {}),
     ...(input.openclawImagePluginInstalls !== undefined
       ? {
           openclawImagePluginInstalls: input.openclawImagePluginInstalls.map((install) => ({
@@ -267,15 +290,23 @@ export function loadServingProfileResumeSession(): {
 }
 
 export function registerCreatedSandbox(input: CreatedSandboxRegistrationInput): SandboxEntry {
+  const pending = registry.getSandbox(input.sandboxName);
   const pendingHostLocalInferenceReceipt =
     input.hostLocalInferenceReceipt !== undefined
       ? input.hostLocalInferenceReceipt
-      : registry.getSandbox(input.sandboxName)?.hostLocalInferenceReceipt;
+      : pending?.hostLocalInferenceReceipt;
+  const pendingHostLocalInferenceProvenance =
+    input.hostLocalInferenceProvenance !== undefined
+      ? input.hostLocalInferenceProvenance
+      : pending?.hostLocalInferenceProvenance;
   const entry = buildCreatedSandboxRegistryEntry({
     ...input,
     ...(pendingHostLocalInferenceReceipt === undefined
       ? {}
       : { hostLocalInferenceReceipt: pendingHostLocalInferenceReceipt }),
+    ...(pendingHostLocalInferenceProvenance === undefined
+      ? {}
+      : { hostLocalInferenceProvenance: pendingHostLocalInferenceProvenance }),
   });
   const provider = requireRuntimeProviderBundleForSandbox(
     entry,

--- a/src/lib/onboard/setup-inference-route-containment.test.ts
+++ b/src/lib/onboard/setup-inference-route-containment.test.ts
@@ -442,6 +442,7 @@ describe("onboard shared gateway route containment", () => {
       preferredInferenceApi: null,
       gatewayName: "nemoclaw",
       reservationSessionId: undefined,
+      hostLocalInferenceReceipt: null,
     });
     expect(reservations).toHaveLength(2);
     expect(updateSandbox).toHaveBeenCalledTimes(2);

--- a/src/lib/onboard/setup-inference.ts
+++ b/src/lib/onboard/setup-inference.ts
@@ -549,7 +549,7 @@ export function createSetupInference(
             preferredInferenceApi: options.preferredInferenceApi ?? null,
             gatewayName,
             reservationSessionId: options.reservationSessionId,
-            ...(hostLocalInferenceReceipt === null ? {} : { hostLocalInferenceReceipt }),
+            hostLocalInferenceReceipt,
           });
           routeReserved = reserved;
           return reserved;

--- a/src/lib/onboard/setup-inference.ts
+++ b/src/lib/onboard/setup-inference.ts
@@ -28,6 +28,7 @@ import {
 } from "../openshell-gateway-endpoint-guard";
 import { withSandboxMutationLock } from "../state/mcp-lifecycle-lock";
 import type { Session } from "../state/onboard-session";
+import { createSandboxHostLocalInferenceProvenance } from "../state/registry/host-local-inference";
 import { shouldFrontOllamaWithProxy } from "./local-inference-topology";
 
 export { assertNoOpenShellGatewayEndpointOverride };
@@ -119,8 +120,13 @@ import {
 import {
   type HostLocalInferenceGatewayMutation,
   type HostLocalInferenceStartupRoute,
+  hostLocalInferenceGatewayPort,
+  hostLocalInferenceGatewayProvider,
   hostLocalInferenceOperationEnvironment,
   prepareHostLocalInferenceStartup,
+  hostLocalInferenceRequestModel,
+  hostLocalInferenceRequestToolCalling,
+  hostLocalInferenceRuntimeOwnerSandboxName,
 } from "./runtime-provider/host-local-inference-routing";
 import { requireRuntimeProviderHostLocalInferenceOperation } from "./runtime-provider/registry";
 
@@ -388,7 +394,7 @@ function resolveHostLocalInferenceRoute(
   selection: NonNullable<ProviderInferenceSetupOptions["hostLocalInference"]>,
 ): HostLocalInferenceStartupRoute {
   const { request } = selection;
-  const expectedProvider = request.service === "ollama" ? "ollama-local" : "vllm-local";
+  const expectedProvider = hostLocalInferenceGatewayProvider(request);
   if (expectedProvider !== provider) {
     throw new Error(`Host-local ${request.service} cannot configure provider '${provider}'.`);
   }
@@ -398,14 +404,13 @@ function resolveHostLocalInferenceRoute(
   if (!RUNTIME_PROVIDER_ID.test(selection.runtimeProviderId)) {
     throw new Error("Host-local inference selected a malformed runtime-provider identity.");
   }
-  const providerInput = request.service === "ollama" ? request.endpoint : request.managed;
   const selectedModel =
     request.service === "ollama" ? normalizeHostLocalOllamaModelRef(model) : model;
-  const requestedModel =
-    request.service === "ollama"
-      ? normalizeHostLocalOllamaModelRef(providerInput.model)
-      : providerInput.model;
-  if (requestedModel !== selectedModel || providerInput.requireToolCalling !== requireToolCalling) {
+  const requestedModel = hostLocalInferenceRequestModel(request);
+  if (
+    requestedModel !== selectedModel ||
+    hostLocalInferenceRequestToolCalling(request) !== requireToolCalling
+  ) {
     throw new Error("Host-local inference request drifted from the accepted model proof.");
   }
   const providerBundle = selection.resolveRuntimeProvider(sandboxName);
@@ -415,14 +420,14 @@ function resolveHostLocalInferenceRoute(
   if (providerBundle.identity.id !== selection.runtimeProviderId) {
     throw new Error("Sandbox-bound host-local inference runtime-provider identity drifted.");
   }
-  const operation = requireRuntimeProviderHostLocalInferenceOperation(
-    providerBundle,
-    request.service,
-    {
-      env: hostLocalInferenceOperationEnvironment(request.service),
-      acceleration: request.service === "ollama" ? request.endpoint.acceleration : "nvidia-gpu",
-    },
-  );
+  const operation =
+    request.service === "llama-cpp"
+      ? request.adapter.operation
+      : requireRuntimeProviderHostLocalInferenceOperation(providerBundle, request.service, {
+          env: hostLocalInferenceOperationEnvironment(request.service),
+          acceleration:
+            request.service === "ollama" ? request.endpoint.acceleration : "nvidia-gpu",
+        });
   return prepareHostLocalInferenceStartup(operation, request);
 }
 
@@ -538,6 +543,11 @@ export function createSetupInference(
         const hostLocalSelection = options.hostLocalInference;
         let routeReserved = false;
         let hostLocalInferenceReceipt: string | null = null;
+        let hostLocalInferenceProvenance:
+          | import("../state/registry/types").SandboxEntry["hostLocalInferenceProvenance"]
+          | undefined;
+        let hostLocalInferenceGatewayPortAuthority: number | undefined;
+        let hostLocalInferenceRuntimeProviderId: string | undefined;
         const reserveRoute = (name: string, selectedProvider: string, selectedModel: string) => {
           if (routeReserved) return true;
           const reserved = deps.updateSandbox(name, {
@@ -550,6 +560,13 @@ export function createSetupInference(
             gatewayName,
             reservationSessionId: options.reservationSessionId,
             hostLocalInferenceReceipt,
+            ...(hostLocalInferenceProvenance ? { hostLocalInferenceProvenance } : {}),
+            ...(hostLocalInferenceProvenance && hostLocalInferenceGatewayPortAuthority !== undefined
+              ? { gatewayPort: hostLocalInferenceGatewayPortAuthority }
+              : {}),
+            ...(hostLocalInferenceProvenance && hostLocalInferenceRuntimeProviderId
+              ? { openshellDriver: hostLocalInferenceRuntimeProviderId }
+              : {}),
           });
           routeReserved = reserved;
           return reserved;
@@ -600,6 +617,19 @@ export function createSetupInference(
               options.hostLocalInference,
             );
             hostLocalInferenceReceipt = serializeHostLocalInferenceReceipt(hostLocalRoute.receipt);
+            if (options.hostLocalInference.request.service === "llama-cpp") {
+              hostLocalInferenceProvenance = createSandboxHostLocalInferenceProvenance(
+                hostLocalInferenceRuntimeOwnerSandboxName(
+                  options.hostLocalInference.request,
+                  sandboxName!,
+                ),
+                hostLocalInferenceReceipt,
+              );
+              hostLocalInferenceGatewayPortAuthority = hostLocalInferenceGatewayPort(
+                options.hostLocalInference.request,
+              );
+              hostLocalInferenceRuntimeProviderId = options.hostLocalInference.runtimeProviderId;
+            }
             hostLocalGatewayMutation = await options.hostLocalInference.prepareGatewayMutation({
               gatewayName,
               sandboxName: sandboxName!,

--- a/src/lib/onboard/setup-inference.ts
+++ b/src/lib/onboard/setup-inference.ts
@@ -537,6 +537,7 @@ export function createSetupInference(
         const hostLocalProviderErrors: string[] = [];
         const hostLocalSelection = options.hostLocalInference;
         let routeReserved = false;
+        let hostLocalInferenceReceipt: string | null = null;
         const reserveRoute = (name: string, selectedProvider: string, selectedModel: string) => {
           if (routeReserved) return true;
           const reserved = deps.updateSandbox(name, {
@@ -548,6 +549,7 @@ export function createSetupInference(
             preferredInferenceApi: options.preferredInferenceApi ?? null,
             gatewayName,
             reservationSessionId: options.reservationSessionId,
+            ...(hostLocalInferenceReceipt === null ? {} : { hostLocalInferenceReceipt }),
           });
           routeReserved = reserved;
           return reserved;
@@ -597,6 +599,7 @@ export function createSetupInference(
               options.allowToolsIncompatible !== true,
               options.hostLocalInference,
             );
+            hostLocalInferenceReceipt = serializeHostLocalInferenceReceipt(hostLocalRoute.receipt);
             hostLocalGatewayMutation = await options.hostLocalInference.prepareGatewayMutation({
               gatewayName,
               sandboxName: sandboxName!,

--- a/src/lib/state/registry-route-reservation.test.ts
+++ b/src/lib/state/registry-route-reservation.test.ts
@@ -168,6 +168,43 @@ describe("sandbox inference route reservation", () => {
     }
   });
 
+  it("removes a persisted host-local receipt when reserving a remote route", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "nemoclaw-route-reservation-"));
+    vi.stubEnv("HOME", home);
+    vi.resetModules();
+    try {
+      const registry = await import("./registry");
+      const receipt = serializedHostLocalInferenceReceipt("docker");
+      registry.registerSandbox({
+        name: "alpha",
+        provider: "ollama-local",
+        model: "local-model",
+        hostLocalInferenceReceipt: receipt,
+      });
+
+      registry.reserveSandboxInferenceRoute("alpha", {
+        provider: "compatible-endpoint",
+        model: "remote-model",
+        endpointUrl: "https://api.example.test/v1",
+        credentialEnv: "REMOTE_API_KEY",
+        preferredInferenceApi: "openai-responses",
+        gatewayName: "nemoclaw",
+        hostLocalInferenceReceipt: null,
+      });
+
+      expect(registry.getSandbox("alpha")).toMatchObject({
+        provider: "compatible-endpoint",
+        model: "remote-model",
+        hostLocalInferenceReceipt: null,
+      });
+      vi.resetModules();
+      const reloadedRegistry = await import("./registry");
+      expect(reloadedRegistry.getSandbox("alpha")?.hostLocalInferenceReceipt).toBeNull();
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("stamps the owning onboard session on the reservation (#6562)", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "nemoclaw-route-reservation-"));
     vi.stubEnv("HOME", home);

--- a/src/lib/state/registry-route-reservation.test.ts
+++ b/src/lib/state/registry-route-reservation.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { serializedHostLocalInferenceReceipt } from "../../../test/helpers/host-local-inference-receipt";
 
 describe("sandbox inference route reservation", () => {
   afterEach(() => {
@@ -91,6 +92,77 @@ describe("sandbox inference route reservation", () => {
       expect(retargetedEntry.createdAt).toEqual(expect.any(String));
       expect(retargetedEntry.gatewayPort).toBeUndefined();
       expect(registry.isRouteOnlySandboxReservation(retargetedEntry)).toBe(false);
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves an omitted host-local receipt through creation registration", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "nemoclaw-route-reservation-"));
+    vi.stubEnv("HOME", home);
+    vi.resetModules();
+    try {
+      const registry = await import("./registry");
+      const { registerCreatedSandbox } = await import("../onboard/sandbox-registration");
+      const receipt = serializedHostLocalInferenceReceipt("docker");
+      const route = {
+        provider: "compatible-endpoint",
+        model: "model-a",
+        endpointUrl: "https://api.example.test/v1",
+        credentialEnv: "CUSTOM_API_KEY",
+        preferredInferenceApi: "openai-responses",
+        gatewayName: "nemoclaw-9090",
+      } as const;
+
+      registry.reserveSandboxInferenceRoute("alpha", {
+        ...route,
+        hostLocalInferenceReceipt: receipt,
+      });
+      registry.reserveSandboxInferenceRoute("alpha", { ...route, model: "model-b" });
+
+      expect(registry.getSandbox("alpha")?.hostLocalInferenceReceipt).toBe(receipt);
+      const entry = registerCreatedSandbox({
+        sandboxName: "alpha",
+        inferenceSelection: {
+          provider: route.provider,
+          model: "model-b",
+          endpointUrl: route.endpointUrl,
+          endpointSource: null,
+          credentialEnv: route.credentialEnv,
+          preferredInferenceApi: route.preferredInferenceApi,
+          compatibleEndpointReasoning: null,
+          compatibleEndpointReasoningEffort: null,
+          nimContainer: null,
+        },
+        runtimeFields: {
+          gpuEnabled: false,
+          hostGpuDetected: false,
+          sandboxGpuEnabled: false,
+          sandboxGpuMode: "auto",
+          sandboxGpuDevice: null,
+          openshellDriver: "docker",
+          openshellVersion: "0.1.2",
+        },
+        agent: null,
+        agentVersionKnown: true,
+        imageTag: null,
+        workload: {
+          schemaVersion: 1,
+          kind: "legacy-dockerfile",
+          reference: null,
+          shared: false,
+        },
+        appliedPolicies: [],
+        plannedMessagingState: undefined,
+        hermesToolGateways: [],
+        hermesDashboardState: { enabled: false, config: null },
+        dashboardPort: 18789,
+        gatewayName: route.gatewayName,
+        gatewayPort: 9090,
+      });
+
+      expect(entry.hostLocalInferenceReceipt).toBe(receipt);
+      expect(registry.getSandbox("alpha")?.hostLocalInferenceReceipt).toBe(receipt);
     } finally {
       await fs.rm(home, { recursive: true, force: true });
     }

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -17,7 +17,11 @@ import {
   isValidExtraProviderName,
   readExtraProviders,
 } from "./extra-providers";
-import { cloneSandboxHostLocalInferenceReceipt } from "./registry/host-local-inference";
+import {
+  cloneSandboxHostLocalInferenceProvenance,
+  cloneSandboxHostLocalInferenceReceipt,
+  requireSandboxHostLocalInferenceProvenance,
+} from "./registry/host-local-inference";
 import { withLock } from "./registry/lock";
 import {
   discardOpaqueCuaRuntimeReadiness,
@@ -41,7 +45,11 @@ export {
   type SandboxEntryDisplayInference,
   type SandboxEntryInference,
 } from "./registry-entry-view";
-export { cloneSandboxHostLocalInferenceReceipt };
+export {
+  cloneSandboxHostLocalInferenceProvenance,
+  cloneSandboxHostLocalInferenceReceipt,
+  requireSandboxHostLocalInferenceProvenance,
+};
 
 import { isDcodeAutoApprovalMode } from "../onboard/dcode-auto-approval";
 import { cloneSandboxHostMounts, hasUnsafeHostMountTerminalText } from "./registry/host-mount";
@@ -133,6 +141,40 @@ export function registerSandbox(entry: SandboxEntry): void {
     if (entry.hostLocalInferenceReceipt !== undefined && hostLocalInferenceReceipt === undefined) {
       throw new Error("Cannot register a sandbox with an invalid host-local inference receipt");
     }
+    const hostLocalInferenceProvenance = cloneSandboxHostLocalInferenceProvenance(
+      entry.hostLocalInferenceProvenance,
+    );
+    if (
+      entry.hostLocalInferenceProvenance !== undefined &&
+      (!hostLocalInferenceProvenance || typeof hostLocalInferenceReceipt !== "string")
+    ) {
+      throw new Error("Cannot register a sandbox with invalid host-local inference provenance");
+    }
+    if (hostLocalInferenceProvenance && typeof hostLocalInferenceReceipt === "string") {
+      requireSandboxHostLocalInferenceProvenance(
+        hostLocalInferenceProvenance,
+        hostLocalInferenceReceipt,
+      );
+      const reserved = data.sandboxes[entry.name];
+      if (
+        reserved?.pendingRouteReservation !== true ||
+        reserved.hostLocalInferenceReceipt !== hostLocalInferenceReceipt ||
+        !isDeepStrictEqual(reserved.hostLocalInferenceProvenance, hostLocalInferenceProvenance) ||
+        reserved.provider !== entry.provider ||
+        reserved.model !== entry.model ||
+        reserved.endpointUrl !== entry.endpointUrl ||
+        reserved.endpointSource !== entry.endpointSource ||
+        reserved.credentialEnv !== entry.credentialEnv ||
+        reserved.preferredInferenceApi !== entry.preferredInferenceApi ||
+        reserved.openshellDriver !== entry.openshellDriver ||
+        reserved.gatewayName !== entry.gatewayName ||
+        reserved.gatewayPort !== entry.gatewayPort
+      ) {
+        throw new Error(
+          "Cannot register a sandbox after its host-local inference reservation changed",
+        );
+      }
+    }
     data.sandboxes[entry.name] = {
       name: entry.name,
       createdAt: entry.createdAt || new Date().toISOString(),
@@ -193,6 +235,7 @@ export function registerSandbox(entry: SandboxEntry): void {
       imageTag: entry.imageTag || null,
       workload: cloneSandboxWorkloadReceipt(entry.workload),
       ...(hostLocalInferenceReceipt !== undefined ? { hostLocalInferenceReceipt } : {}),
+      ...(hostLocalInferenceProvenance ? { hostLocalInferenceProvenance } : {}),
       lifecycleGeneration: entry.lifecycleGeneration,
       lifecycleLiveIdentityFingerprint: entry.lifecycleLiveIdentityFingerprint,
       messaging: cloneSandboxMessagingState(entry.messaging),
@@ -228,8 +271,11 @@ type SandboxInferenceRouteReservation = Pick<
   | "preferredInferenceApi"
 > & {
   gatewayName: string;
+  gatewayPort?: number;
+  openshellDriver?: string;
   reservationSessionId?: string;
   hostLocalInferenceReceipt?: string | null;
+  hostLocalInferenceProvenance?: SandboxEntry["hostLocalInferenceProvenance"];
 };
 
 /**
@@ -245,6 +291,46 @@ export function reserveSandboxInferenceRoute(
     const data = load();
     const existing = data.sandboxes[name];
     const normalized = normalizeInferenceSelection(route);
+    const provenance = cloneSandboxHostLocalInferenceProvenance(route.hostLocalInferenceProvenance);
+    if (
+      route.hostLocalInferenceProvenance !== undefined &&
+      (!provenance || typeof route.hostLocalInferenceReceipt !== "string")
+    ) {
+      throw new Error("Cannot reserve invalid host-local inference provenance");
+    }
+    if (provenance && typeof route.hostLocalInferenceReceipt === "string") {
+      requireSandboxHostLocalInferenceProvenance(provenance, route.hostLocalInferenceReceipt);
+      if (
+        !Number.isSafeInteger(route.gatewayPort) ||
+        Number(route.gatewayPort) < 1 ||
+        Number(route.gatewayPort) > 65_535 ||
+        typeof route.openshellDriver !== "string" ||
+        route.openshellDriver.length === 0
+      ) {
+        throw new Error(
+          "Cannot reserve host-local inference provenance without exact runtime and gateway authority",
+        );
+      }
+    }
+    if (existing?.hostLocalInferenceProvenance !== undefined) {
+      if (
+        !provenance ||
+        typeof route.hostLocalInferenceReceipt !== "string" ||
+        existing.hostLocalInferenceReceipt !== route.hostLocalInferenceReceipt ||
+        !isDeepStrictEqual(existing.hostLocalInferenceProvenance, provenance) ||
+        existing.provider !== normalized.provider ||
+        existing.model !== normalized.model ||
+        existing.endpointUrl !== normalized.endpointUrl ||
+        existing.endpointSource !== normalized.endpointSource ||
+        existing.credentialEnv !== normalized.credentialEnv ||
+        existing.preferredInferenceApi !== normalized.preferredInferenceApi ||
+        existing.gatewayName !== route.gatewayName ||
+        existing.gatewayPort !== route.gatewayPort ||
+        existing.openshellDriver !== route.openshellDriver
+      ) {
+        throw new Error("Cannot change an explicit host-local inference lifecycle reservation");
+      }
+    }
     const next: SandboxEntry = {
       ...(existing ?? { name, pendingRouteReservation: true as const }),
       pendingRouteReservation: true,
@@ -258,8 +344,10 @@ export function reserveSandboxInferenceRoute(
       ...(route.hostLocalInferenceReceipt !== undefined
         ? { hostLocalInferenceReceipt: route.hostLocalInferenceReceipt }
         : {}),
+      ...(provenance ? { hostLocalInferenceProvenance: provenance } : {}),
       gatewayName: route.gatewayName,
-      gatewayPort: undefined,
+      gatewayPort: route.gatewayPort,
+      ...(route.openshellDriver === undefined ? {} : { openshellDriver: route.openshellDriver }),
     };
     if (existing?.cuaRuntimeReadiness || hasOpaqueCuaRuntimeReadiness(data, name)) {
       delete next.cuaRuntimeReadiness;
@@ -296,6 +384,37 @@ export function isPendingReservationForSession(
   );
 }
 
+const HOST_LOCAL_INFERENCE_LIFECYCLE_AUTHORITY_FIELDS = new Set<keyof SandboxEntry>([
+  "credentialEnv",
+  "endpointSource",
+  "endpointUrl",
+  "gatewayName",
+  "gatewayPort",
+  "hostLocalInferenceReceipt",
+  "model",
+  "openshellDriver",
+  "preferredInferenceApi",
+  "provider",
+]);
+
+function changesHostLocalInferenceLifecycleAuthority(
+  current: SandboxEntry,
+  updates: Partial<SandboxEntry>,
+): boolean {
+  if (
+    Object.prototype.hasOwnProperty.call(updates, "hostLocalInferenceProvenance") &&
+    !isDeepStrictEqual(updates.hostLocalInferenceProvenance, current.hostLocalInferenceProvenance)
+  ) {
+    return true;
+  }
+  if (!current.hostLocalInferenceProvenance) return false;
+  return Object.entries(updates).some(
+    ([field, value]) =>
+      HOST_LOCAL_INFERENCE_LIFECYCLE_AUTHORITY_FIELDS.has(field as keyof SandboxEntry) &&
+      !isDeepStrictEqual(value, current[field as keyof SandboxEntry]),
+  );
+}
+
 export function updateSandbox(name: string, updates: Partial<SandboxEntry>): boolean {
   return withLock(() => {
     const data = load();
@@ -314,6 +433,7 @@ export function updateSandbox(name: string, updates: Partial<SandboxEntry>): boo
     ) {
       return false;
     }
+    if (changesHostLocalInferenceLifecycleAuthority(current, updates)) return false;
     const { cuaRuntimeReadiness: _ignoredReadiness, ...ordinaryUpdates } = updates;
     const next = { ...current, ...ordinaryUpdates };
     if (

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -41,6 +41,7 @@ export {
   type SandboxEntryDisplayInference,
   type SandboxEntryInference,
 } from "./registry-entry-view";
+export { cloneSandboxHostLocalInferenceReceipt };
 
 import { isDcodeAutoApprovalMode } from "../onboard/dcode-auto-approval";
 import { cloneSandboxHostMounts, hasUnsafeHostMountTerminalText } from "./registry/host-mount";

--- a/src/lib/state/registry.ts
+++ b/src/lib/state/registry.ts
@@ -17,6 +17,7 @@ import {
   isValidExtraProviderName,
   readExtraProviders,
 } from "./extra-providers";
+import { cloneSandboxHostLocalInferenceReceipt } from "./registry/host-local-inference";
 import { withLock } from "./registry/lock";
 import {
   discardOpaqueCuaRuntimeReadiness,
@@ -125,6 +126,12 @@ export function registerSandbox(entry: SandboxEntry): void {
     if (retainedDefaultSandbox(data.defaultSandbox, data.sandboxes) === null) {
       data.defaultSandbox = null;
     }
+    const hostLocalInferenceReceipt = cloneSandboxHostLocalInferenceReceipt(
+      entry.hostLocalInferenceReceipt,
+    );
+    if (entry.hostLocalInferenceReceipt !== undefined && hostLocalInferenceReceipt === undefined) {
+      throw new Error("Cannot register a sandbox with an invalid host-local inference receipt");
+    }
     data.sandboxes[entry.name] = {
       name: entry.name,
       createdAt: entry.createdAt || new Date().toISOString(),
@@ -184,6 +191,7 @@ export function registerSandbox(entry: SandboxEntry): void {
           : null,
       imageTag: entry.imageTag || null,
       workload: cloneSandboxWorkloadReceipt(entry.workload),
+      ...(hostLocalInferenceReceipt !== undefined ? { hostLocalInferenceReceipt } : {}),
       lifecycleGeneration: entry.lifecycleGeneration,
       lifecycleLiveIdentityFingerprint: entry.lifecycleLiveIdentityFingerprint,
       messaging: cloneSandboxMessagingState(entry.messaging),
@@ -220,6 +228,7 @@ type SandboxInferenceRouteReservation = Pick<
 > & {
   gatewayName: string;
   reservationSessionId?: string;
+  hostLocalInferenceReceipt?: string | null;
 };
 
 /**
@@ -245,6 +254,9 @@ export function reserveSandboxInferenceRoute(
       endpointSource: normalized.endpointSource,
       credentialEnv: normalized.credentialEnv,
       preferredInferenceApi: normalized.preferredInferenceApi,
+      ...(route.hostLocalInferenceReceipt !== undefined
+        ? { hostLocalInferenceReceipt: route.hostLocalInferenceReceipt }
+        : {}),
       gatewayName: route.gatewayName,
       gatewayPort: undefined,
     };

--- a/src/lib/state/registry/host-local-inference.test.ts
+++ b/src/lib/state/registry/host-local-inference.test.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { serializedHostLocalInferenceReceipt } from "../../../../test/helpers/host-local-inference-receipt";
+import { cloneSandboxHostLocalInferenceReceipt } from "./host-local-inference";
+
+describe("sandbox host-local inference receipt transport", () => {
+  it("clones only complete canonical receipt transports", () => {
+    const valid = serializedHostLocalInferenceReceipt();
+
+    expect(cloneSandboxHostLocalInferenceReceipt(valid)).toBe(valid);
+    expect(cloneSandboxHostLocalInferenceReceipt(null)).toBeNull();
+    expect(cloneSandboxHostLocalInferenceReceipt(undefined)).toBeUndefined();
+    expect(cloneSandboxHostLocalInferenceReceipt(valid.trimEnd())).toBeUndefined();
+    expect(cloneSandboxHostLocalInferenceReceipt("[]\n")).toBeUndefined();
+    expect(cloneSandboxHostLocalInferenceReceipt('{"providerId": "mxc"}\n')).toBeUndefined();
+    expect(
+      cloneSandboxHostLocalInferenceReceipt('{"apiKey":"must-not-persist"}\n'),
+    ).toBeUndefined();
+    expect(
+      cloneSandboxHostLocalInferenceReceipt(`{"value":"${"a".repeat(33 * 1024)}"}\n`),
+    ).toBeUndefined();
+  });
+});

--- a/src/lib/state/registry/host-local-inference.ts
+++ b/src/lib/state/registry/host-local-inference.ts
@@ -1,10 +1,22 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
+
 import {
+  type HostLocalInferenceReceipt,
   parseHostLocalInferenceReceipt,
   serializeHostLocalInferenceReceipt,
 } from "../../onboard/runtime-provider/host-local-inference";
+import type { SandboxHostLocalInferenceProvenance } from "./types";
+
+const SHA256 = /^[a-f0-9]{64}$/u;
+const SAFE_SANDBOX_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
+
+function receiptTransactionId(receipt: HostLocalInferenceReceipt): string | null {
+  if (receipt.schemaVersion === 2) return receipt.publication?.transactionId ?? null;
+  return receipt.runtime.kind === "container" ? (receipt.runtime.model?.generation ?? null) : null;
+}
 
 /**
  * Clone a canonical, secret-free provider-neutral receipt. The state boundary
@@ -19,4 +31,73 @@ export function cloneSandboxHostLocalInferenceReceipt(
   } catch {
     return undefined;
   }
+}
+
+/** Clone and strictly validate the private durable lifecycle discriminator. */
+export function cloneSandboxHostLocalInferenceProvenance(
+  value: unknown,
+): SandboxHostLocalInferenceProvenance | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    Object.keys(record).sort().join(",") !==
+      ["origin", "receiptSha256", "runtimeOwnerSandboxName", "schemaVersion", "transactionId"].join(
+        ",",
+      ) ||
+    record.schemaVersion !== 1 ||
+    record.origin !== "startup-selection" ||
+    typeof record.runtimeOwnerSandboxName !== "string" ||
+    !SAFE_SANDBOX_NAME.test(record.runtimeOwnerSandboxName) ||
+    typeof record.transactionId !== "string" ||
+    !SHA256.test(record.transactionId) ||
+    typeof record.receiptSha256 !== "string" ||
+    !SHA256.test(record.receiptSha256)
+  ) {
+    return undefined;
+  }
+  return Object.freeze({
+    schemaVersion: 1 as const,
+    origin: "startup-selection" as const,
+    runtimeOwnerSandboxName: record.runtimeOwnerSandboxName,
+    transactionId: record.transactionId,
+    receiptSha256: record.receiptSha256,
+  });
+}
+
+/** Build provenance only at the operation-scoped startup-selection boundary. */
+export function createSandboxHostLocalInferenceProvenance(
+  runtimeOwnerSandboxName: string,
+  serializedReceipt: string,
+): SandboxHostLocalInferenceProvenance {
+  const receipt = parseHostLocalInferenceReceipt(serializedReceipt);
+  const transactionId = receiptTransactionId(receipt);
+  if (!transactionId || !SHA256.test(transactionId)) {
+    throw new Error("Host-local inference receipt has no durable create transaction");
+  }
+  const provenance = cloneSandboxHostLocalInferenceProvenance({
+    schemaVersion: 1,
+    origin: "startup-selection",
+    runtimeOwnerSandboxName,
+    transactionId,
+    receiptSha256: createHash("sha256").update(serializedReceipt).digest("hex"),
+  });
+  if (!provenance) throw new Error("Host-local inference lifecycle provenance is malformed");
+  return provenance;
+}
+
+/** Require a provenance record to remain paired with the exact receipt bytes and transaction. */
+export function requireSandboxHostLocalInferenceProvenance(
+  value: unknown,
+  serializedReceipt: string,
+): SandboxHostLocalInferenceProvenance {
+  const provenance = cloneSandboxHostLocalInferenceProvenance(value);
+  const receipt = parseHostLocalInferenceReceipt(serializedReceipt);
+  if (
+    !provenance ||
+    provenance.receiptSha256 !== createHash("sha256").update(serializedReceipt).digest("hex") ||
+    provenance.transactionId !== receiptTransactionId(receipt)
+  ) {
+    throw new Error("Host-local inference lifecycle provenance does not match its receipt");
+  }
+  return provenance;
 }

--- a/src/lib/state/registry/host-local-inference.ts
+++ b/src/lib/state/registry/host-local-inference.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  parseHostLocalInferenceReceipt,
+  serializeHostLocalInferenceReceipt,
+} from "../../onboard/runtime-provider/host-local-inference";
+
+/**
+ * Clone a canonical, secret-free provider-neutral receipt. The state boundary
+ * validates the complete schema before accepting durable authority.
+ */
+export function cloneSandboxHostLocalInferenceReceipt(
+  value: string | null | undefined,
+): string | null | undefined {
+  if (value === undefined || value === null) return value;
+  try {
+    return serializeHostLocalInferenceReceipt(parseHostLocalInferenceReceipt(value));
+  } catch {
+    return undefined;
+  }
+}

--- a/src/lib/state/registry/persistence.ts
+++ b/src/lib/state/registry/persistence.ts
@@ -23,7 +23,11 @@ import {
 } from "../registry-normalization";
 import * as reversibleRemoval from "../registry-reversible-removal";
 import { nemoclawStateRoot } from "../state-root";
-import { cloneSandboxHostLocalInferenceReceipt } from "./host-local-inference";
+import {
+  cloneSandboxHostLocalInferenceProvenance,
+  cloneSandboxHostLocalInferenceReceipt,
+  requireSandboxHostLocalInferenceProvenance,
+} from "./host-local-inference";
 import type { SandboxEntry, SandboxRegistry } from "./types";
 import { cloneSandboxWorkloadReceipt } from "./workload";
 
@@ -69,6 +73,27 @@ function cloneHostLocalInferenceReceiptOrThrow(
     );
   }
   return receipt;
+}
+
+function cloneHostLocalInferenceProvenanceOrThrow(
+  value: SandboxEntry["hostLocalInferenceProvenance"],
+  receipt: SandboxEntry["hostLocalInferenceReceipt"],
+  operation: "load" | "save",
+): SandboxEntry["hostLocalInferenceProvenance"] {
+  if (value === undefined) return undefined;
+  const provenance = cloneSandboxHostLocalInferenceProvenance(value);
+  if (!provenance || typeof receipt !== "string") {
+    throw new Error(
+      `Cannot ${operation} a sandbox entry with invalid host-local inference provenance`,
+    );
+  }
+  try {
+    return requireSandboxHostLocalInferenceProvenance(provenance, receipt);
+  } catch {
+    throw new Error(
+      `Cannot ${operation} a sandbox entry with invalid host-local inference provenance`,
+    );
+  }
 }
 
 function cloneServingProfileProvenanceOrThrow(
@@ -186,6 +211,11 @@ function normalizeSandboxEntryForRuntime(
     entry.hostLocalInferenceReceipt,
     "load",
   );
+  const hostLocalInferenceProvenance = cloneHostLocalInferenceProvenanceOrThrow(
+    entry.hostLocalInferenceProvenance,
+    hostLocalInferenceReceipt,
+    "load",
+  );
   const servingProfileProvenance = cloneServingProfileProvenanceOrThrow(
     entry.servingProfileProvenance,
     "load",
@@ -203,6 +233,7 @@ function normalizeSandboxEntryForRuntime(
     messaging: _messaging,
     workload: _workload,
     hostLocalInferenceReceipt: _hostLocalInferenceReceipt,
+    hostLocalInferenceProvenance: _hostLocalInferenceProvenance,
     servingProfileProvenance: _servingProfileProvenance,
     mcp: _mcp,
     baselineExclusions: _baselineExclusions,
@@ -215,6 +246,7 @@ function normalizeSandboxEntryForRuntime(
     ...rest,
     ...(workload ? { workload } : {}),
     ...(hostLocalInferenceReceipt !== undefined ? { hostLocalInferenceReceipt } : {}),
+    ...(hostLocalInferenceProvenance ? { hostLocalInferenceProvenance } : {}),
     ...(servingProfileProvenance ? { servingProfileProvenance } : {}),
     ...(messaging ? { messaging } : {}),
     ...(mcp ? { mcp } : {}),
@@ -254,6 +286,11 @@ function serializeSandboxEntryForDisk(
     durable.hostLocalInferenceReceipt,
     "save",
   );
+  const hostLocalInferenceProvenance = cloneHostLocalInferenceProvenanceOrThrow(
+    durable.hostLocalInferenceProvenance,
+    hostLocalInferenceReceipt,
+    "save",
+  );
   const servingProfileProvenance = cloneServingProfileProvenanceOrThrow(
     durable.servingProfileProvenance,
     "save",
@@ -271,6 +308,7 @@ function serializeSandboxEntryForDisk(
     messaging: _messaging,
     workload: _workload,
     hostLocalInferenceReceipt: _hostLocalInferenceReceipt,
+    hostLocalInferenceProvenance: _hostLocalInferenceProvenance,
     servingProfileProvenance: _servingProfileProvenance,
     mcp: _mcp,
     baselineExclusions: _baselineExclusions,
@@ -284,6 +322,7 @@ function serializeSandboxEntryForDisk(
     ...(rest.dashboardPort === 0 ? { dashboardPort: null } : {}),
     ...(workload ? { workload } : {}),
     ...(hostLocalInferenceReceipt !== undefined ? { hostLocalInferenceReceipt } : {}),
+    ...(hostLocalInferenceProvenance ? { hostLocalInferenceProvenance } : {}),
     ...(servingProfileProvenance ? { servingProfileProvenance } : {}),
     ...(messaging ? { messaging } : {}),
     ...(mcp ? { mcp } : {}),

--- a/src/lib/state/registry/persistence.ts
+++ b/src/lib/state/registry/persistence.ts
@@ -23,6 +23,7 @@ import {
 } from "../registry-normalization";
 import * as reversibleRemoval from "../registry-reversible-removal";
 import { nemoclawStateRoot } from "../state-root";
+import { cloneSandboxHostLocalInferenceReceipt } from "./host-local-inference";
 import type { SandboxEntry, SandboxRegistry } from "./types";
 import { cloneSandboxWorkloadReceipt } from "./workload";
 
@@ -55,6 +56,19 @@ function cloneSandboxWorkloadReceiptOrThrow(
     throw new Error(`Cannot ${operation} a sandbox entry with an invalid workload receipt`);
   }
   return workload;
+}
+
+function cloneHostLocalInferenceReceiptOrThrow(
+  value: SandboxEntry["hostLocalInferenceReceipt"],
+  operation: "load" | "save",
+): SandboxEntry["hostLocalInferenceReceipt"] {
+  const receipt = cloneSandboxHostLocalInferenceReceipt(value);
+  if (value !== undefined && receipt === undefined) {
+    throw new Error(
+      `Cannot ${operation} a sandbox entry with an invalid host-local inference receipt`,
+    );
+  }
+  return receipt;
 }
 
 function cloneServingProfileProvenanceOrThrow(
@@ -168,6 +182,10 @@ function normalizeSandboxEntryForRuntime(
 ): SandboxEntry {
   const messaging = cloneSandboxMessagingState(entry.messaging);
   const workload = cloneSandboxWorkloadReceiptOrThrow(entry.workload, "load");
+  const hostLocalInferenceReceipt = cloneHostLocalInferenceReceiptOrThrow(
+    entry.hostLocalInferenceReceipt,
+    "load",
+  );
   const servingProfileProvenance = cloneServingProfileProvenanceOrThrow(
     entry.servingProfileProvenance,
     "load",
@@ -184,6 +202,7 @@ function normalizeSandboxEntryForRuntime(
   const {
     messaging: _messaging,
     workload: _workload,
+    hostLocalInferenceReceipt: _hostLocalInferenceReceipt,
     servingProfileProvenance: _servingProfileProvenance,
     mcp: _mcp,
     baselineExclusions: _baselineExclusions,
@@ -195,6 +214,7 @@ function normalizeSandboxEntryForRuntime(
   return {
     ...rest,
     ...(workload ? { workload } : {}),
+    ...(hostLocalInferenceReceipt !== undefined ? { hostLocalInferenceReceipt } : {}),
     ...(servingProfileProvenance ? { servingProfileProvenance } : {}),
     ...(messaging ? { messaging } : {}),
     ...(mcp ? { mcp } : {}),
@@ -230,6 +250,10 @@ function serializeSandboxEntryForDisk(
   };
   const messaging = serializeSandboxMessagingStateForDisk(durable.messaging);
   const workload = cloneSandboxWorkloadReceiptOrThrow(durable.workload, "save");
+  const hostLocalInferenceReceipt = cloneHostLocalInferenceReceiptOrThrow(
+    durable.hostLocalInferenceReceipt,
+    "save",
+  );
   const servingProfileProvenance = cloneServingProfileProvenanceOrThrow(
     durable.servingProfileProvenance,
     "save",
@@ -246,6 +270,7 @@ function serializeSandboxEntryForDisk(
   const {
     messaging: _messaging,
     workload: _workload,
+    hostLocalInferenceReceipt: _hostLocalInferenceReceipt,
     servingProfileProvenance: _servingProfileProvenance,
     mcp: _mcp,
     baselineExclusions: _baselineExclusions,
@@ -258,6 +283,7 @@ function serializeSandboxEntryForDisk(
     ...rest,
     ...(rest.dashboardPort === 0 ? { dashboardPort: null } : {}),
     ...(workload ? { workload } : {}),
+    ...(hostLocalInferenceReceipt !== undefined ? { hostLocalInferenceReceipt } : {}),
     ...(servingProfileProvenance ? { servingProfileProvenance } : {}),
     ...(messaging ? { messaging } : {}),
     ...(mcp ? { mcp } : {}),

--- a/src/lib/state/registry/types.ts
+++ b/src/lib/state/registry/types.ts
@@ -148,6 +148,8 @@ export interface SandboxEntry extends Partial<InferenceSelection> {
    * through per-sandbox image deletion.
    */
   workload?: SandboxWorkloadReceipt;
+  /** Canonical provider-neutral receipt for an out-of-sandbox inference runtime. */
+  hostLocalInferenceReceipt?: string | null;
   messaging?: SandboxMessagingState;
   mcp?: SandboxMcpState;
   hermesToolGateways?: string[];

--- a/src/lib/state/registry/types.ts
+++ b/src/lib/state/registry/types.ts
@@ -86,6 +86,22 @@ export interface SandboxHostMount {
   };
 }
 
+/**
+ * Durable proof that one host-local runtime was explicitly admitted through
+ * the hidden provider lifecycle selection. Legacy routes never receive this
+ * record, even when they carry the same provider name or receipt schema.
+ */
+export interface SandboxHostLocalInferenceProvenance {
+  readonly schemaVersion: 1;
+  readonly origin: "startup-selection";
+  /** Original private-state owner retained when exact same-gateway clones share a runtime. */
+  readonly runtimeOwnerSandboxName: string;
+  /** Provider create transaction bound to the canonical receipt. */
+  readonly transactionId: string;
+  /** Digest of the exact serialized receipt bytes carried by this row. */
+  readonly receiptSha256: string;
+}
+
 export interface SandboxEntry extends Partial<InferenceSelection> {
   name: string;
   /** Route-only placeholder created before sandbox creation; never eligible as the default. */
@@ -150,6 +166,8 @@ export interface SandboxEntry extends Partial<InferenceSelection> {
   workload?: SandboxWorkloadReceipt;
   /** Canonical provider-neutral receipt for an out-of-sandbox inference runtime. */
   hostLocalInferenceReceipt?: string | null;
+  /** Explicit hidden-lifecycle provenance; absence keeps llama.cpp on its legacy path. */
+  hostLocalInferenceProvenance?: SandboxHostLocalInferenceProvenance;
   messaging?: SandboxMessagingState;
   mcp?: SandboxMcpState;
   hermesToolGateways?: string[];

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -91,6 +91,8 @@ export const OPENCLAW_IMAGE_PLUGIN_PROVENANCE_RESTORE_ERROR =
   "custom-image OpenClaw plugin provenance is missing or invalid";
 export const MANAGED_SNAPSHOT_RESTORE_AUTHORITY_ERROR =
   "managed snapshot restore requires exact content and runtime authority";
+export const HOST_LOCAL_INFERENCE_SNAPSHOT_RESTORE_AUTHORITY_ERROR =
+  "host-local inference snapshot restore requires exact content and runtime authority";
 
 function parseJson<T>(text: string): T {
   return JSON.parse(text);
@@ -143,6 +145,8 @@ export interface RebuildManifest {
    * snapshot. Older and explicit Dockerfile snapshots omit this field.
    */
   workload?: SandboxWorkloadReceipt;
+  /** Exact provider-neutral authority for out-of-sandbox inference. */
+  hostLocalInferenceReceipt?: string;
   instances?: InstanceBackup[];
   // Optional user-provided label for `snapshot restore <name>`.
   name?: string;
@@ -157,6 +161,7 @@ export interface BackupOptions {
   name?: string | null;
   runtimeSnapshot?: SandboxRuntimeSnapshot;
   workload?: SandboxWorkloadReceipt;
+  hostLocalInferenceReceipt?: string;
   /**
    * Internal publication fence for provider-backed backups. The callback
    * runs after data capture and sanitization but before the manifest becomes
@@ -327,6 +332,9 @@ function isRebuildManifest(value: unknown): value is RebuildManifest {
       : cloneSandboxRuntimeSnapshot(value.runtimeSnapshot);
   const workload =
     value.workload === undefined ? undefined : cloneSandboxWorkloadReceipt(value.workload as never);
+  const hostLocalInferenceReceipt = registry.cloneSandboxHostLocalInferenceReceipt(
+    value.hostLocalInferenceReceipt as string | null | undefined,
+  );
   return (
     typeof value.version === "number" &&
     typeof value.sandboxName === "string" &&
@@ -357,6 +365,8 @@ function isRebuildManifest(value: unknown): value is RebuildManifest {
         validatePreservedEnvFiles(value.preservedEnv, HERMES_PRESERVED_ENV_INVENTORY))) &&
     (value.runtimeSnapshot === undefined || runtimeSnapshot !== undefined) &&
     (value.workload === undefined || workload !== undefined) &&
+    (value.hostLocalInferenceReceipt === undefined ||
+      (typeof hostLocalInferenceReceipt === "string" && hostLocalInferenceReceipt.length > 0)) &&
     (workload?.kind !== "managed-image" || runtimeSnapshot !== undefined) &&
     (value.instances === undefined ||
       (Array.isArray(value.instances) &&
@@ -1097,6 +1107,7 @@ export { isSshTransportFailure };
 function normalizeSnapshotBackupAuthority(options: BackupOptions): {
   readonly runtimeSnapshot?: SandboxRuntimeSnapshot;
   readonly workload?: SandboxWorkloadReceipt;
+  readonly hostLocalInferenceReceipt?: string;
   readonly error?: string;
 } {
   const runtimeSnapshot =
@@ -1105,11 +1116,20 @@ function normalizeSnapshotBackupAuthority(options: BackupOptions): {
       : cloneSandboxRuntimeSnapshot(options.runtimeSnapshot);
   const workload =
     options.workload === undefined ? undefined : cloneSandboxWorkloadReceipt(options.workload);
+  const hostLocalInferenceReceipt = registry.cloneSandboxHostLocalInferenceReceipt(
+    options.hostLocalInferenceReceipt,
+  );
   if (options.runtimeSnapshot !== undefined && runtimeSnapshot === undefined) {
     return { error: "snapshot runtime state is invalid or cannot be represented" };
   }
   if (options.workload !== undefined && workload === undefined) {
     return { error: "snapshot workload authority is invalid" };
+  }
+  if (
+    options.hostLocalInferenceReceipt !== undefined &&
+    typeof hostLocalInferenceReceipt !== "string"
+  ) {
+    return { error: "snapshot host-local inference authority is invalid" };
   }
   if (workload?.kind === "managed-image" && runtimeSnapshot === undefined) {
     return { error: "managed snapshot is missing provider runtime state" };
@@ -1117,6 +1137,7 @@ function normalizeSnapshotBackupAuthority(options: BackupOptions): {
   return {
     ...(runtimeSnapshot === undefined ? {} : { runtimeSnapshot }),
     ...(workload === undefined ? {} : { workload }),
+    ...(typeof hostLocalInferenceReceipt === "string" ? { hostLocalInferenceReceipt } : {}),
   };
 }
 
@@ -1956,11 +1977,13 @@ function restoreSandboxStateInternal(
       error,
     };
   };
-  if (
-    manifest.workload?.kind === "managed-image" &&
-    (!options.authority || !options.validateBeforeMutation)
-  ) {
-    return failRestoreContract(MANAGED_SNAPSHOT_RESTORE_AUTHORITY_ERROR);
+  if (!options.authority || !options.validateBeforeMutation) {
+    if (manifest.workload?.kind === "managed-image") {
+      return failRestoreContract(MANAGED_SNAPSHOT_RESTORE_AUTHORITY_ERROR);
+    }
+    if (typeof manifest.hostLocalInferenceReceipt === "string") {
+      return failRestoreContract(HOST_LOCAL_INFERENCE_SNAPSHOT_RESTORE_AUTHORITY_ERROR);
+    }
   }
   if (options.targetAgentType !== manifest.agentType) {
     return failRestoreContract(
@@ -2393,6 +2416,9 @@ function readManifest(backupPath: string): RebuildManifest | null {
         : cloneSandboxRuntimeSnapshot(manifest.runtimeSnapshot);
     const workload =
       manifest.workload === undefined ? undefined : cloneSandboxWorkloadReceipt(manifest.workload);
+    const hostLocalInferenceReceipt = registry.cloneSandboxHostLocalInferenceReceipt(
+      manifest.hostLocalInferenceReceipt,
+    );
     return {
       ...manifest,
       dir,
@@ -2402,6 +2428,7 @@ function readManifest(backupPath: string): RebuildManifest | null {
       blueprintDigest: manifest.blueprintDigest ?? null,
       ...(runtimeSnapshot === undefined ? {} : { runtimeSnapshot }),
       ...(workload === undefined ? {} : { workload }),
+      ...(typeof hostLocalInferenceReceipt === "string" ? { hostLocalInferenceReceipt } : {}),
     };
   } catch {
     return null;

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -74,7 +74,11 @@ import {
   cloneSandboxRuntimeSnapshot,
   type SandboxRuntimeSnapshot,
 } from "./registry/runtime-snapshot.js";
-import type { SandboxEntry, SandboxWorkloadReceipt } from "./registry/types.js";
+import type {
+  SandboxEntry,
+  SandboxHostLocalInferenceProvenance,
+  SandboxWorkloadReceipt,
+} from "./registry/types.js";
 import { cloneSandboxWorkloadReceipt } from "./registry/workload.js";
 import type { CustomPolicyEntry } from "./registry.js";
 import * as registry from "./registry.js";
@@ -147,6 +151,8 @@ export interface RebuildManifest {
   workload?: SandboxWorkloadReceipt;
   /** Exact provider-neutral authority for out-of-sandbox inference. */
   hostLocalInferenceReceipt?: string;
+  /** Explicit hidden-lifecycle provenance paired with the exact receipt. */
+  hostLocalInferenceProvenance?: SandboxHostLocalInferenceProvenance;
   instances?: InstanceBackup[];
   // Optional user-provided label for `snapshot restore <name>`.
   name?: string;
@@ -162,6 +168,7 @@ export interface BackupOptions {
   runtimeSnapshot?: SandboxRuntimeSnapshot;
   workload?: SandboxWorkloadReceipt;
   hostLocalInferenceReceipt?: string;
+  hostLocalInferenceProvenance?: SandboxHostLocalInferenceProvenance;
   /**
    * Internal publication fence for provider-backed backups. The callback
    * runs after data capture and sanitization but before the manifest becomes
@@ -335,6 +342,23 @@ function isRebuildManifest(value: unknown): value is RebuildManifest {
   const hostLocalInferenceReceipt = registry.cloneSandboxHostLocalInferenceReceipt(
     value.hostLocalInferenceReceipt as string | null | undefined,
   );
+  const hostLocalInferenceProvenance = registry.cloneSandboxHostLocalInferenceProvenance(
+    value.hostLocalInferenceProvenance,
+  );
+  const validHostLocalInferenceProvenance = (() => {
+    if (value.hostLocalInferenceProvenance === undefined) return true;
+    if (!hostLocalInferenceProvenance || typeof hostLocalInferenceReceipt !== "string")
+      return false;
+    try {
+      registry.requireSandboxHostLocalInferenceProvenance(
+        hostLocalInferenceProvenance,
+        hostLocalInferenceReceipt,
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  })();
   return (
     typeof value.version === "number" &&
     typeof value.sandboxName === "string" &&
@@ -367,6 +391,7 @@ function isRebuildManifest(value: unknown): value is RebuildManifest {
     (value.workload === undefined || workload !== undefined) &&
     (value.hostLocalInferenceReceipt === undefined ||
       (typeof hostLocalInferenceReceipt === "string" && hostLocalInferenceReceipt.length > 0)) &&
+    validHostLocalInferenceProvenance &&
     (workload?.kind !== "managed-image" || runtimeSnapshot !== undefined) &&
     (value.instances === undefined ||
       (Array.isArray(value.instances) &&
@@ -1108,6 +1133,7 @@ function normalizeSnapshotBackupAuthority(options: BackupOptions): {
   readonly runtimeSnapshot?: SandboxRuntimeSnapshot;
   readonly workload?: SandboxWorkloadReceipt;
   readonly hostLocalInferenceReceipt?: string;
+  readonly hostLocalInferenceProvenance?: SandboxHostLocalInferenceProvenance;
   readonly error?: string;
 } {
   const runtimeSnapshot =
@@ -1118,6 +1144,9 @@ function normalizeSnapshotBackupAuthority(options: BackupOptions): {
     options.workload === undefined ? undefined : cloneSandboxWorkloadReceipt(options.workload);
   const hostLocalInferenceReceipt = registry.cloneSandboxHostLocalInferenceReceipt(
     options.hostLocalInferenceReceipt,
+  );
+  const hostLocalInferenceProvenance = registry.cloneSandboxHostLocalInferenceProvenance(
+    options.hostLocalInferenceProvenance,
   );
   if (options.runtimeSnapshot !== undefined && runtimeSnapshot === undefined) {
     return { error: "snapshot runtime state is invalid or cannot be represented" };
@@ -1131,6 +1160,19 @@ function normalizeSnapshotBackupAuthority(options: BackupOptions): {
   ) {
     return { error: "snapshot host-local inference authority is invalid" };
   }
+  if (options.hostLocalInferenceProvenance !== undefined) {
+    if (!hostLocalInferenceProvenance || typeof hostLocalInferenceReceipt !== "string") {
+      return { error: "snapshot host-local inference provenance is invalid" };
+    }
+    try {
+      registry.requireSandboxHostLocalInferenceProvenance(
+        hostLocalInferenceProvenance,
+        hostLocalInferenceReceipt,
+      );
+    } catch {
+      return { error: "snapshot host-local inference provenance is invalid" };
+    }
+  }
   if (workload?.kind === "managed-image" && runtimeSnapshot === undefined) {
     return { error: "managed snapshot is missing provider runtime state" };
   }
@@ -1138,6 +1180,7 @@ function normalizeSnapshotBackupAuthority(options: BackupOptions): {
     ...(runtimeSnapshot === undefined ? {} : { runtimeSnapshot }),
     ...(workload === undefined ? {} : { workload }),
     ...(typeof hostLocalInferenceReceipt === "string" ? { hostLocalInferenceReceipt } : {}),
+    ...(hostLocalInferenceProvenance ? { hostLocalInferenceProvenance } : {}),
   };
 }
 
@@ -2419,6 +2462,9 @@ function readManifest(backupPath: string): RebuildManifest | null {
     const hostLocalInferenceReceipt = registry.cloneSandboxHostLocalInferenceReceipt(
       manifest.hostLocalInferenceReceipt,
     );
+    const hostLocalInferenceProvenance = registry.cloneSandboxHostLocalInferenceProvenance(
+      manifest.hostLocalInferenceProvenance,
+    );
     return {
       ...manifest,
       dir,
@@ -2429,6 +2475,7 @@ function readManifest(backupPath: string): RebuildManifest | null {
       ...(runtimeSnapshot === undefined ? {} : { runtimeSnapshot }),
       ...(workload === undefined ? {} : { workload }),
       ...(typeof hostLocalInferenceReceipt === "string" ? { hostLocalInferenceReceipt } : {}),
+      ...(hostLocalInferenceProvenance ? { hostLocalInferenceProvenance } : {}),
     };
   } catch {
     return null;

--- a/test/helpers/host-local-inference-receipt.ts
+++ b/test/helpers/host-local-inference-receipt.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  type HostLocalInferenceReceipt,
+  serializeHostLocalInferenceReceipt,
+} from "../../src/lib/onboard/runtime-provider/host-local-inference";
+
+export function hostLocalInferenceReceipt(providerId = "mxc"): HostLocalInferenceReceipt {
+  return {
+    schemaVersion: 2,
+    providerId,
+    service: "vllm",
+    engineAuthority: {
+      schemaVersion: 1,
+      providerId,
+      operation: "host-local-inference",
+      engineId: providerId,
+      authorityId: `${providerId}:host-local`,
+      bindingSha256: "a".repeat(64),
+    },
+    endpoint: {
+      host: `${providerId}.internal`,
+      port: 8000,
+      networkName: `${providerId}-network`,
+      networkId: "e".repeat(64),
+      networkGatewayIp: "10.89.0.1",
+      networkAuthoritySha256: "f".repeat(64),
+    },
+    inference: {
+      protocol: "openai-chat-completions",
+      model: "model-a",
+      toolCallingRequired: true,
+    },
+    publication: {
+      transactionId: "1".repeat(64),
+      targetSha256: "2".repeat(64),
+      priorState: "absent",
+    },
+    runtime: {
+      kind: "container",
+      runtimeId: `${providerId}-vllm`,
+      name: "nemoclaw-vllm",
+      imageRef: `nvcr.io/nvidia/vllm@sha256:${"b".repeat(64)}`,
+      probeImageRef: `quay.io/curl/curl@sha256:${"c".repeat(64)}`,
+      specSha256: "d".repeat(64),
+      launchSha256: "3".repeat(64),
+      gpu: { vendor: "nvidia", devices: ["nvidia.com/gpu=all"] },
+    },
+  };
+}
+
+export function serializedHostLocalInferenceReceipt(providerId = "mxc"): string {
+  return serializeHostLocalInferenceReceipt(hostLocalInferenceReceipt(providerId));
+}

--- a/test/helpers/host-local-inference-receipt.ts
+++ b/test/helpers/host-local-inference-receipt.ts
@@ -53,3 +53,46 @@ export function hostLocalInferenceReceipt(providerId = "mxc"): HostLocalInferenc
 export function serializedHostLocalInferenceReceipt(providerId = "mxc"): string {
   return serializeHostLocalInferenceReceipt(hostLocalInferenceReceipt(providerId));
 }
+
+export function llamaCppHostLocalInferenceReceipt(
+  providerId = "docker",
+): HostLocalInferenceReceipt {
+  return {
+    schemaVersion: 1,
+    providerId,
+    service: "llama-cpp",
+    engineAuthority: {
+      schemaVersion: 1,
+      providerId,
+      operation: "host-local-inference",
+      engineId: providerId,
+      authorityId: `${providerId}:host-local`,
+      bindingSha256: "4".repeat(64),
+    },
+    endpoint: {
+      host: "host.openshell.internal",
+      port: 8081,
+      networkName: "nemoclaw-llama-cpp-internal",
+    },
+    runtime: {
+      kind: "container",
+      runtimeId: "5".repeat(64),
+      name: "nemoclaw-llama-cpp",
+      imageRef: `nvcr.io/nvidia/llama-cpp@sha256:${"6".repeat(64)}`,
+      probeImageRef: `quay.io/curl/curl@sha256:${"7".repeat(64)}`,
+      specSha256: "8".repeat(64),
+      model: {
+        planDigest: `sha256:${"9".repeat(64)}`,
+        recipeId: "nemotron-llama-cpp",
+        generation: "a".repeat(64),
+        digest: `sha256:${"b".repeat(64)}`,
+        sizeBytes: 1024,
+      },
+      gpu: { vendor: "nvidia", count: 1 },
+    },
+  };
+}
+
+export function serializedLlamaCppHostLocalInferenceReceipt(providerId = "docker"): string {
+  return serializeHostLocalInferenceReceipt(llamaCppHostLocalInferenceReceipt(providerId));
+}

--- a/test/onboard-host-local-inference-routing.test.ts
+++ b/test/onboard-host-local-inference-routing.test.ts
@@ -21,6 +21,7 @@ import type { SetupInference, SetupInferenceDeps } from "../src/lib/onboard/setu
 import { createPodmanHostLocalInferenceTestHarness } from "./helpers/podman-host-local-inference-test-harness.js";
 import { createInMemoryRuntimeProviderBundle } from "./helpers/runtime-provider-bundle.js";
 import { createDirectSetupInferenceHarnessFactory } from "./support/setup-inference-test-harness.js";
+import { llamaCppHostLocalInferenceReceipt } from "./helpers/host-local-inference-receipt.js";
 
 const onboard = require("../src/lib/onboard") as {
   createSetupInference: (overrides?: Partial<SetupInferenceDeps>) => SetupInference;
@@ -333,6 +334,93 @@ function fixture(
   };
 }
 
+function llamaFixture(application: HostLocalInferenceApplication) {
+  const events: string[] = [];
+  const baseReceipt = llamaCppHostLocalInferenceReceipt("mxc");
+  const value: HostLocalInferenceReceipt = {
+    ...baseReceipt,
+    engineAuthority: {
+      ...baseReceipt.engineAuthority,
+      engineId: "memory",
+      authorityId: AUTHORITY_ID,
+      bindingSha256: "d".repeat(64),
+    },
+  };
+  const providerRuntime: HostLocalInferenceRuntime = {
+    providerId: "mxc",
+    authorityId: AUTHORITY_ID,
+    services: ["llama-cpp"],
+    translateContainerArgs: (args) => args,
+    qualifyOllama: vi.fn(),
+    startManaged: vi.fn(),
+    inspectManaged: vi.fn((current) => ({ running: true, receipt: current })),
+    stopManaged: vi.fn((current) => ({ running: false, receipt: current })),
+    preserveForRebuild: vi.fn((current) => current),
+    prepareDestroy: vi.fn((current) => current),
+    destroy: vi.fn((current) => ({
+      status: "removed" as const,
+      receipt: current,
+    })),
+  };
+  const providerOperation = operation(providerRuntime);
+  const bundle = createInMemoryRuntimeProviderBundle({
+    providerId: "mxc",
+    workloadProfile: {
+      support: null,
+      hostArchitectures: ["x64"],
+      managedImageSelectionPolicy: "prefer-managed",
+      legacyDockerfileBuilds: false,
+    },
+    hostLocalInference: {
+      services: ["llama-cpp"],
+      createOperation: () => providerOperation,
+    },
+  });
+  const prepareStartup = vi.fn(() => {
+    events.push("provider-ready-proof");
+    return prepared(value, events);
+  });
+  const gatewayCommit = vi.fn(() => {
+    events.push("gateway-commit");
+  });
+  const gatewayRollback = vi.fn(() => {
+    events.push("gateway-rollback");
+  });
+  const prepareGatewayMutation = vi.fn(() => {
+    events.push("gateway-snapshot");
+    return { commit: gatewayCommit, rollback: gatewayRollback };
+  });
+  const selection: HostLocalInferenceStartupSelection = {
+    runtimeProviderId: "mxc",
+    request: {
+      application,
+      service: "llama-cpp",
+      adapter: {
+        gatewayPort: 8080,
+        runtimeOwnerSandboxName: SANDBOX,
+        model: MODEL,
+        operation: providerOperation,
+        receipt: value,
+        runtime: providerRuntime,
+        prepareStartup,
+      },
+      requireToolCalling: true,
+      publishedRoute: false,
+    },
+    resolveRuntimeProvider: (sandboxName) => (sandboxName === SANDBOX ? bundle : null),
+    prepareGatewayMutation,
+  };
+  return {
+    events,
+    gatewayCommit,
+    gatewayRollback,
+    prepareGatewayMutation,
+    prepareStartup,
+    selection,
+    value,
+  };
+}
+
 describe("onboard host-local inference routing", () => {
   it("explicitly clears stale host-local ownership for a remote route", async () => {
     const harness = createHarness({
@@ -385,10 +473,15 @@ describe("onboard host-local inference routing", () => {
       const smoke = vi.fn(() => {
         route.events.push("gateway-smoke");
       });
-      const reserve = vi.fn(() => {
+      const reserve = vi.fn(
+        (
+          _sandboxName: string,
+          _reservation: Parameters<SetupInferenceDeps["updateSandbox"]>[1],
+        ) => {
         route.events.push("sandbox-reserve");
         return true;
-      });
+        },
+      );
       const harness = createHarness({
         runOpenshell: (args) =>
           args.slice(0, 2).join(" ") === "provider get" ? { status: 1 } : undefined,
@@ -414,10 +507,17 @@ describe("onboard host-local inference routing", () => {
 
       const reservation = (
         reserve.mock.calls.at(-1) as unknown as
-          | [string, { hostLocalInferenceReceipt?: string }]
+          | [
+              string,
+              {
+                hostLocalInferenceReceipt?: string;
+                hostLocalInferenceProvenance?: unknown;
+              },
+            ]
           | undefined
       )?.[1];
       expect(reservation?.hostLocalInferenceReceipt).toEqual(expect.any(String));
+      expect(reservation?.hostLocalInferenceProvenance).toBeUndefined();
       expect(
         parseHostLocalInferenceReceipt(reservation?.hostLocalInferenceReceipt ?? ""),
       ).toMatchObject({
@@ -474,6 +574,76 @@ describe("onboard host-local inference routing", () => {
       expect(legacyWarmup).not.toHaveBeenCalled();
       expect(legacyOllamaProof).not.toHaveBeenCalled();
       expect(route.gatewayRollback).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(APPLICATIONS)(
+    "registers explicitly selected llama.cpp for %s with exact private provenance",
+    async (application) => {
+      const route = llamaFixture(application);
+      const legacyRun = vi.fn();
+      const legacyValidate = vi.fn();
+      const reserve = vi.fn(
+        (
+          _sandboxName: string,
+          _reservation: Parameters<SetupInferenceDeps["updateSandbox"]>[1],
+        ) => {
+          route.events.push("sandbox-reserve");
+          return true;
+        },
+      );
+      const harness = createHarness({
+        runOpenshell: (args) =>
+          args.slice(0, 2).join(" ") === "provider get" ? { status: 1 } : undefined,
+        overrides: {
+          applyLocalInferenceRoute: undefined,
+          run: legacyRun,
+          validateLocalProvider: legacyValidate,
+          hydrateCredentialEnv: vi.fn(() => "test-llama-secret"),
+          updateSandbox: reserve,
+        },
+      });
+
+      const result = await harness.setupInference(
+        SANDBOX,
+        MODEL,
+        "llama-cpp-local",
+        null,
+        "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+        null,
+        [],
+        {
+          gatewayName: "nemoclaw",
+          hostLocalInference: route.selection,
+        },
+      );
+      expect(harness.errors).toEqual([]);
+      expect(result).toEqual({ ok: true });
+
+      const reservation = reserve.mock.calls.at(-1)?.[1];
+      expect(reservation).toMatchObject({
+        provider: "llama-cpp-local",
+        model: MODEL,
+        endpointUrl: "https://inference.local/v1",
+        endpointSource: "inference-set",
+        gatewayName: "nemoclaw",
+        gatewayPort: 8080,
+        openshellDriver: "mxc",
+        hostLocalInferenceProvenance: {
+          runtimeOwnerSandboxName: SANDBOX,
+          transactionId:
+            route.value.runtime.kind === "container"
+              ? route.value.runtime.model?.generation
+              : undefined,
+          receiptSha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+        },
+      });
+      expect(reservation?.hostLocalInferenceReceipt).toEqual(expect.any(String));
+      expect(route.prepareStartup).toHaveBeenCalledOnce();
+      expect(route.gatewayCommit).toHaveBeenCalledOnce();
+      expect(route.gatewayRollback).not.toHaveBeenCalled();
+      expect(legacyRun).not.toHaveBeenCalled();
+      expect(legacyValidate).not.toHaveBeenCalled();
     },
   );
 

--- a/test/onboard-host-local-inference-routing.test.ts
+++ b/test/onboard-host-local-inference-routing.test.ts
@@ -11,6 +11,7 @@ import type {
   HostLocalInferenceRuntime,
   HostLocalInferenceService,
 } from "../src/lib/onboard/runtime-provider/host-local-inference.js";
+import { parseHostLocalInferenceReceipt } from "../src/lib/onboard/runtime-provider/host-local-inference.js";
 import type {
   HostLocalInferenceApplication,
   HostLocalInferenceStartupSelection,
@@ -373,6 +374,20 @@ describe("onboard host-local inference routing", () => {
           hostLocalInference: route.selection,
         }),
       ).resolves.toEqual({ ok: true });
+
+      const reservation = (
+        reserve.mock.calls.at(-1) as unknown as
+          | [string, { hostLocalInferenceReceipt?: string }]
+          | undefined
+      )?.[1];
+      expect(reservation?.hostLocalInferenceReceipt).toEqual(expect.any(String));
+      expect(
+        parseHostLocalInferenceReceipt(reservation?.hostLocalInferenceReceipt ?? ""),
+      ).toMatchObject({
+        providerId: "mxc",
+        service: "ollama",
+        endpoint: { port: 11434, networkName: "mxc-runtime-network" },
+      });
 
       expect(route.prepareGatewayMutation).toHaveBeenCalledWith({
         gatewayName: "nemoclaw",

--- a/test/onboard-host-local-inference-routing.test.ts
+++ b/test/onboard-host-local-inference-routing.test.ts
@@ -334,6 +334,43 @@ function fixture(
 }
 
 describe("onboard host-local inference routing", () => {
+  it("explicitly clears stale host-local ownership for a remote route", async () => {
+    const harness = createHarness({
+      overrides: {
+        isRoutedInferenceProvider: () => true,
+        reconcileModelRouter: vi.fn(async () => undefined),
+        routedInference: {
+          upsertRoutedProvider: vi.fn(() => ({
+            ok: true,
+            endpointUrl: "https://api.example.test/v1",
+            result: { message: "configured" },
+          })),
+        },
+      },
+    });
+
+    await expect(
+      harness.setupInference(
+        "sandbox-a",
+        "remote-model",
+        "nvidia-router",
+        "https://api.example.test/v1",
+        "REMOTE_API_KEY",
+        null,
+        [],
+      ),
+    ).resolves.toEqual({ ok: true });
+
+    expect(harness.updateSandbox).toHaveBeenCalledWith(
+      "sandbox-a",
+      expect.objectContaining({
+        provider: "nvidia-router",
+        model: "remote-model",
+        hostLocalInferenceReceipt: null,
+      }),
+    );
+  });
+
   it.each(APPLICATIONS)(
     "routes %s through inference.local without legacy host probes",
     async (application) => {

--- a/test/onboard-inference-failure-paths.test.ts
+++ b/test/onboard-inference-failure-paths.test.ts
@@ -1082,6 +1082,7 @@ describe("setupInference dependency failures", () => {
       credentialEnv: "NVIDIA_INFERENCE_API_KEY",
       preferredInferenceApi: null,
       gatewayName: "nemoclaw",
+      hostLocalInferenceReceipt: null,
     });
     expect(harness.logs).toEqual(["  ✓ Inference route set: nvidia-router / router/model"]);
     expect(harness.errors).toEqual([]);

--- a/test/onboard-inference-gateway-scope.test.ts
+++ b/test/onboard-inference-gateway-scope.test.ts
@@ -104,6 +104,7 @@ describe("onboarding inference gateway scope", () => {
           preferredInferenceApi: null,
           gatewayName: GATEWAY,
           reservationSessionId: undefined,
+          hostLocalInferenceReceipt: null,
         });
         expectCommandsTargetOnly(harness.commands);
       },

--- a/test/onboard-inference-reconciliation.test.ts
+++ b/test/onboard-inference-reconciliation.test.ts
@@ -149,7 +149,7 @@ describe("onboard helpers", () => {
         commands.at(-1)?.command || "",
         /inference set -g nemoclaw --no-verify --provider compatible-anthropic-endpoint --model anthropic\.claude-3-5-sonnet-20240620-v1:0/,
       );
-      expect(updateSandbox).toHaveBeenCalledWith("test-box", { model: "anthropic.claude-3-5-sonnet-20240620-v1:0", provider: "compatible-anthropic-endpoint", endpointUrl: "https://bedrock-runtime.us-east-1.amazonaws.com", endpointSource: "onboard", credentialEnv: "COMPATIBLE_ANTHROPIC_API_KEY", preferredInferenceApi: null, gatewayName: "nemoclaw" });
+      expect(updateSandbox).toHaveBeenCalledWith("test-box", { model: "anthropic.claude-3-5-sonnet-20240620-v1:0", provider: "compatible-anthropic-endpoint", endpointUrl: "https://bedrock-runtime.us-east-1.amazonaws.com", endpointSource: "onboard", credentialEnv: "COMPATIBLE_ANTHROPIC_API_KEY", preferredInferenceApi: null, gatewayName: "nemoclaw", hostLocalInferenceReceipt: null });
     });
   });
   it("resolves a sandbox name before reconciling Hermes Provider on resume", {

--- a/test/registry-host-local-inference.test.ts
+++ b/test/registry-host-local-inference.test.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { serializedHostLocalInferenceReceipt } from "./helpers/host-local-inference-receipt";
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-local-registry-test-"));
+process.env.HOME = tmpDir;
+
+const require = createRequire(import.meta.url);
+const registry = require("../src/lib/state/registry");
+const regFile = path.join(tmpDir, ".nemoclaw", "sandboxes.json");
+
+beforeEach(() => {
+  if (fs.existsSync(regFile)) fs.unlinkSync(regFile);
+});
+
+describe("registry host-local inference authority", () => {
+  it("round-trips a canonical receipt without rewriting it", () => {
+    const receipt = serializedHostLocalInferenceReceipt();
+    registry.registerSandbox({
+      name: "host-local",
+      hostLocalInferenceReceipt: receipt,
+    });
+
+    expect(registry.getSandbox("host-local").hostLocalInferenceReceipt).toBe(receipt);
+    const data = JSON.parse(fs.readFileSync(regFile, "utf-8"));
+    expect(data.sandboxes["host-local"].hostLocalInferenceReceipt).toBe(receipt);
+  });
+
+  it("rejects malformed receipt transports on load and save", () => {
+    fs.mkdirSync(path.dirname(regFile), { recursive: true });
+    fs.writeFileSync(
+      regFile,
+      JSON.stringify({
+        defaultSandbox: "alpha",
+        sandboxes: {
+          alpha: { name: "alpha", hostLocalInferenceReceipt: '{"providerId": "mxc"}\n' },
+        },
+      }),
+    );
+    expect(() => registry.getSandbox("alpha")).toThrow(/invalid host-local inference receipt/);
+
+    fs.rmSync(regFile, { force: true });
+    expect(() =>
+      registry.save({
+        defaultSandbox: "alpha",
+        sandboxes: {
+          alpha: { name: "alpha", hostLocalInferenceReceipt: "not-json\n" },
+        },
+      }),
+    ).toThrow(/invalid host-local inference receipt/);
+    expect(fs.existsSync(regFile)).toBe(false);
+  });
+});

--- a/test/registry-host-local-inference.test.ts
+++ b/test/registry-host-local-inference.test.ts
@@ -2,22 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { serializedHostLocalInferenceReceipt } from "./helpers/host-local-inference-receipt";
+import {
+  serializedHostLocalInferenceReceipt,
+  serializedLlamaCppHostLocalInferenceReceipt,
+} from "./helpers/host-local-inference-receipt";
+import { createSandboxHostLocalInferenceProvenance } from "../src/lib/state/registry/host-local-inference";
 
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-host-local-registry-test-"));
 process.env.HOME = tmpDir;
 
-const require = createRequire(import.meta.url);
-const registry = require("../src/lib/state/registry");
+const registry = await import("../src/lib/state/registry");
 const regFile = path.join(tmpDir, ".nemoclaw", "sandboxes.json");
 
 beforeEach(() => {
-  if (fs.existsSync(regFile)) fs.unlinkSync(regFile);
+  fs.rmSync(regFile, { force: true });
 });
 
 describe("registry host-local inference authority", () => {
@@ -28,7 +30,7 @@ describe("registry host-local inference authority", () => {
       hostLocalInferenceReceipt: receipt,
     });
 
-    expect(registry.getSandbox("host-local").hostLocalInferenceReceipt).toBe(receipt);
+    expect(registry.getSandbox("host-local")?.hostLocalInferenceReceipt).toBe(receipt);
     const data = JSON.parse(fs.readFileSync(regFile, "utf-8"));
     expect(data.sandboxes["host-local"].hostLocalInferenceReceipt).toBe(receipt);
   });
@@ -56,5 +58,198 @@ describe("registry host-local inference authority", () => {
       }),
     ).toThrow(/invalid host-local inference receipt/);
     expect(fs.existsSync(regFile)).toBe(false);
+  });
+
+  it("round-trips explicit llama.cpp lifecycle provenance only through its exact reservation", () => {
+    const receipt = serializedLlamaCppHostLocalInferenceReceipt();
+    const provenance = createSandboxHostLocalInferenceProvenance("llama-owner", receipt);
+    registry.reserveSandboxInferenceRoute("llama-clone", {
+      provider: "llama-cpp-local",
+      model: "nemotron-llama-cpp",
+      endpointUrl: "https://inference.local/v1",
+      endpointSource: "inference-set" as const,
+      credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+      preferredInferenceApi: "openai-completions",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      openshellDriver: "docker",
+      hostLocalInferenceReceipt: receipt,
+      hostLocalInferenceProvenance: provenance,
+    });
+    registry.registerSandbox({
+      name: "llama-clone",
+      openshellDriver: "docker",
+      provider: "llama-cpp-local",
+      model: "nemotron-llama-cpp",
+      endpointUrl: "https://inference.local/v1",
+      endpointSource: "inference-set" as const,
+      credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+      preferredInferenceApi: "openai-completions",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      hostLocalInferenceReceipt: receipt,
+      hostLocalInferenceProvenance: provenance,
+    });
+
+    expect(registry.getSandbox("llama-clone")).toMatchObject({
+      hostLocalInferenceReceipt: receipt,
+      hostLocalInferenceProvenance: provenance,
+    });
+  });
+
+  it.each([
+    ["runtime provider", { openshellDriver: "mxc" }],
+    ["route provider", { provider: "vllm-local" }],
+    ["model", { model: "different-model" }],
+    ["endpoint", { endpointUrl: "https://inference.local/v1/" }],
+    ["endpoint source", { endpointSource: "onboard" }],
+    ["credential", { credentialEnv: "DIFFERENT_TOKEN" }],
+    ["inference API", { preferredInferenceApi: "openai-responses" }],
+    ["gateway", { gatewayName: "nemoclaw-8090" }],
+    ["gateway port", { gatewayPort: 8090 }],
+  ] as const)("rejects %s drift at explicit llama.cpp registration CAS", (_label, drift) => {
+    const receipt = serializedLlamaCppHostLocalInferenceReceipt();
+    const provenance = createSandboxHostLocalInferenceProvenance("llama-owner", receipt);
+    const route = {
+      provider: "llama-cpp-local",
+      model: "nemotron-llama-cpp",
+      endpointUrl: "https://inference.local/v1",
+      endpointSource: "inference-set" as const,
+      credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+      preferredInferenceApi: "openai-completions",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      openshellDriver: "docker",
+      hostLocalInferenceReceipt: receipt,
+      hostLocalInferenceProvenance: provenance,
+    };
+    registry.reserveSandboxInferenceRoute("llama-drift", route);
+
+    expect(() =>
+      registry.registerSandbox({
+        name: "llama-drift",
+        ...route,
+        ...drift,
+      }),
+    ).toThrow(/reservation changed/);
+  });
+
+  it("rejects receipt or original-owner drift at explicit llama.cpp registration CAS", () => {
+    const receipt = serializedLlamaCppHostLocalInferenceReceipt();
+    const provenance = createSandboxHostLocalInferenceProvenance("llama-owner", receipt);
+    const route = {
+      provider: "llama-cpp-local",
+      model: "nemotron-llama-cpp",
+      endpointUrl: "https://inference.local/v1",
+      endpointSource: "inference-set" as const,
+      credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+      preferredInferenceApi: "openai-completions",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      openshellDriver: "docker",
+      hostLocalInferenceReceipt: receipt,
+      hostLocalInferenceProvenance: provenance,
+    };
+    registry.reserveSandboxInferenceRoute("llama-owner-drift", route);
+    expect(() =>
+      registry.registerSandbox({
+        name: "llama-owner-drift",
+        ...route,
+        hostLocalInferenceProvenance: createSandboxHostLocalInferenceProvenance(
+          "different-owner",
+          receipt,
+        ),
+      }),
+    ).toThrow(/reservation changed/);
+
+    fs.rmSync(regFile, { force: true });
+    registry.reserveSandboxInferenceRoute("llama-receipt-drift", route);
+    const changedReceipt = serializedLlamaCppHostLocalInferenceReceipt("mxc");
+    expect(() =>
+      registry.registerSandbox({
+        name: "llama-receipt-drift",
+        ...route,
+        hostLocalInferenceReceipt: changedReceipt,
+        hostLocalInferenceProvenance: createSandboxHostLocalInferenceProvenance(
+          "llama-owner",
+          changedReceipt,
+        ),
+      }),
+    ).toThrow(/reservation changed/);
+  });
+
+  it("keeps an explicit llama.cpp reservation immutable across repeated route writes", () => {
+    const receipt = serializedLlamaCppHostLocalInferenceReceipt();
+    const provenance = createSandboxHostLocalInferenceProvenance("llama-owner", receipt);
+    const route = {
+      provider: "llama-cpp-local",
+      model: "nemotron-llama-cpp",
+      endpointUrl: "https://inference.local/v1",
+      endpointSource: "inference-set" as const,
+      credentialEnv: "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+      preferredInferenceApi: "openai-completions",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      openshellDriver: "docker",
+      hostLocalInferenceReceipt: receipt,
+      hostLocalInferenceProvenance: provenance,
+    };
+    registry.reserveSandboxInferenceRoute("llama-stable", route);
+    expect(registry.reserveSandboxInferenceRoute("llama-stable", route)).toBe(true);
+
+    expect(() =>
+      registry.reserveSandboxInferenceRoute("llama-stable", {
+        ...route,
+        model: "different-model",
+      }),
+    ).toThrow(/Cannot change an explicit host-local inference lifecycle reservation/);
+    const { hostLocalInferenceProvenance: _provenance, ...unmarkedRoute } = route;
+    expect(() => registry.reserveSandboxInferenceRoute("llama-stable", unmarkedRoute)).toThrow(
+      /Cannot change an explicit host-local inference lifecycle reservation/,
+    );
+    expect(registry.updateSandbox("llama-stable", { model: "different-model" })).toBe(false);
+    expect(
+      registry.updateSandbox("llama-stable", {
+        hostLocalInferenceProvenance: undefined,
+      }),
+    ).toBe(false);
+    expect(registry.updateSandbox("llama-stable", { policies: ["baseline"] })).toBe(true);
+    expect(registry.getSandbox("llama-stable")).toMatchObject(route);
+  });
+
+  it("admits provenance creation through reservation rather than a generic row update", () => {
+    const receipt = serializedLlamaCppHostLocalInferenceReceipt();
+    registry.registerSandbox({
+      name: "legacy-llama",
+      hostLocalInferenceReceipt: receipt,
+    });
+
+    expect(
+      registry.updateSandbox("legacy-llama", {
+        hostLocalInferenceProvenance: createSandboxHostLocalInferenceProvenance(
+          "legacy-llama",
+          receipt,
+        ),
+      }),
+    ).toBe(false);
+    expect(registry.getSandbox("legacy-llama")?.hostLocalInferenceProvenance).toBeUndefined();
+  });
+
+  it("rejects provenance whose receipt bytes changed", () => {
+    const receipt = serializedLlamaCppHostLocalInferenceReceipt();
+    const provenance = createSandboxHostLocalInferenceProvenance("llama-owner", receipt);
+    expect(() =>
+      registry.reserveSandboxInferenceRoute("drifted", {
+        provider: "vllm-local",
+        model: "model-a",
+        endpointUrl: "https://inference.local/v1",
+        endpointSource: "inference-set",
+        credentialEnv: null,
+        preferredInferenceApi: "openai-completions",
+        gatewayName: "nemoclaw",
+        hostLocalInferenceReceipt: serializedHostLocalInferenceReceipt(),
+        hostLocalInferenceProvenance: provenance,
+      }),
+    ).toThrow(/provenance does not match its receipt/);
   });
 });

--- a/test/runtime-provider-source-shape.test.ts
+++ b/test/runtime-provider-source-shape.test.ts
@@ -175,6 +175,7 @@ describe("runtime provider central source boundary", () => {
       "src/lib/onboard/runtime-provider/docker-state-mutation.ts",
       "src/lib/onboard/runtime-provider/docker.ts",
       "src/lib/onboard/runtime-provider/host-local-create-journal.ts",
+      "src/lib/onboard/runtime-provider/host-local-inference-lifecycle.ts",
       "src/lib/onboard/runtime-provider/host-local-inference-routing.ts",
       "src/lib/onboard/runtime-provider/host-local-inference.ts",
       "src/lib/onboard/runtime-provider/mxc.ts",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Before B4-E1, host-local inference authority did not survive every registry and sandbox lifecycle transition. This change persists and re-proves the exact authority through registration, reconciliation, recovery, snapshot, restore, rebuild, clone, backup, and destroy without activating a new provider or public support surface.

## Related Issue

Closes #9141

Part of #7744

## Changes

- Persist and validate the canonical, secret-free host-local inference receipt at registry read, write, route reservation, and sandbox registration boundaries.
- Bind lifecycle authority to the sandbox, agent, runtime provider, inference provider, model, endpoint, gateway, lifecycle generation, runtime engine, image, network, and NVIDIA CDI evidence.
- Add the provider-neutral lifecycle authority required by B4-E1 so lifecycle operations validate the same receipt instead of separate command-local identities.
- Re-prove authority before and after lifecycle mutations, and reject missing, changed, reused, ambiguous, or conflicting ownership.
- Retire an exact managed runtime only after confirmed sandbox deletion, retain shared runtimes, and preserve the registry row when cleanup must be retried.
- Add focused coverage for OpenClaw, Hermes, LangChain Deep Agents Code, Ollama, NVIDIA NIM, vLLM, shared-runtime retention, cleanup retries, and current provider boundaries.
- Keep Podman absent from the production runtime-provider registry. Keep `--temp-managed-runtime` hidden, default-off, and undocumented.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: B4-E1 adds dormant lifecycle authority and persistence. It changes no CLI command, flag, default, supported workflow, or public support claim.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The completed implementation review covered receipt validation, registry compare-and-swap behavior, lifecycle fences, shared-runtime retention, cleanup retries, and current-provider boundaries. No waiver was used.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: B4-E1 adds dormant provider-neutral host-local inference lifecycle authority and persistence. It does not activate a supported workflow, change CLI behavior or defaults, or register Podman. The hidden, default-off `--temp-managed-runtime` experiment remains undocumented.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a0fedd98b -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — `npm run validate:pr` exited 0. Repository checks, CLI typecheck, formatting, test-size, source architecture, source-shape, secret scan, commitlint, and `git diff --check` passed. The normal new-branch push also passed the pre-push hooks.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — Focused Vitest runs passed: CLI product matrix 248/248, lifecycle tests 32/32, Podman destroy regression 1/1, and hidden-flag/current-provider checks 2/2 with 58 skipped.
- [ ] Applicable broad gate passed — `npm test` and `npm run check` are not claimed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle tracking for host-local inference runtimes, including Ollama, NIM, vLLM, and llama.cpp.
  * Sandbox creation, routing, backups, and restores now preserve validated inference ownership records.
  * Snapshot operations now verify inference authority before and after changes.
  * Shared runtimes are retained while exclusively owned runtimes can be safely removed.

* **Bug Fixes**
  * Improved sandbox deletion safeguards to prevent accidental runtime removal.
  * Added clearer failure handling and retry support for cleanup and ownership validation.
  * Invalid, incomplete, or inconsistent inference ownership data is rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
