### PR TITLE
fix(inference): accept a reply that lists no tool calls

### DIFF
--- a/src/lib/actions/sandbox/inference-invocation-probe.test.ts
+++ b/src/lib/actions/sandbox/inference-invocation-probe.test.ts
@@ -74,6 +74,22 @@ describe("sandbox inference invocation probe", () => {
     expect(probeSandboxInferenceInvocation(input, { execute })).toEqual({ ok: true });
   });
 
+  it("accepts a served response body that serializes an empty tool call list (#9108)", () => {
+    const body = JSON.stringify({
+      object: "chat.completion",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", reasoning_content: null, content: "OK", tool_calls: [] },
+          finish_reason: "stop",
+        },
+      ],
+    });
+    const execute = vi.fn(() => ({ status: 0, stdout: `200\n${body}`, stderr: "" }));
+
+    expect(probeSandboxInferenceInvocation(input, { execute })).toEqual({ ok: true });
+  });
+
   it.each([
     ["openai-completions", '{"choices":[{"message":{"content":"OK"}}]}'],
     [

--- a/src/lib/inference/health.test.ts
+++ b/src/lib/inference/health.test.ts
@@ -289,6 +289,10 @@ describe("inference health", () => {
         "malformed tool call",
         '{"choices":[{"message":{"tool_calls":[{"type":"function","function":{"name":"probe","arguments":7}}]}}]}',
       ],
+      [
+        "a tool_calls value that is not a list (#9108)",
+        '{"choices":[{"message":{"content":"OK","tool_calls":"none"}}]}',
+      ],
       ["numeric streaming delta", 'data: {"choices":[{"delta":{"content":123}}]}\n'],
     ])("rejects a Chat Completions response with %s", (_description, body) => {
       const result = probeRemoteProviderHealth("openai-api", {
@@ -301,6 +305,81 @@ describe("inference health", () => {
       expect(result?.probed).toBe(true);
       expect(result?.failureLabel).toBe("unhealthy");
       expect(result?.detail).toContain("not a Chat Completions result");
+    });
+
+    it.each([
+      ["an empty tool call list", []],
+      ["a null tool call list", null],
+    ])("reports a hosted response that carries %s as healthy (#9108)", (_description, toolCalls) => {
+      const result = probeRemoteProviderHealth("nvidia-prod", {
+        model: "nvidia/llama-3.3-nemotron-super-49b-v1",
+        getCredentialImpl: () => "nvapi-test",
+        runCurlProbeImpl: () =>
+          httpOk(
+            JSON.stringify({
+              object: "chat.completion",
+              model: "nvidia/llama-3.3-nemotron-super-49b-v1",
+              choices: [
+                {
+                  index: 0,
+                  message: {
+                    role: "assistant",
+                    reasoning_content: null,
+                    content: "OK",
+                    refusal: null,
+                    tool_calls: toolCalls,
+                  },
+                  finish_reason: "stop",
+                },
+              ],
+            }),
+          ),
+      });
+
+      expect(result?.ok).toBe(true);
+      expect(result?.probed).toBe(true);
+      expect(result?.failureLabel).toBeUndefined();
+      expect(result?.detail).toContain("succeeded");
+    });
+
+    it("reports what an HTTP 200 body lacked and omits the connection advice (#9108)", () => {
+      const result = probeRemoteProviderHealth("nvidia-prod", {
+        model: "meta/llama-3.3-70b-instruct",
+        getCredentialImpl: () => "nvapi-test",
+        runCurlProbeImpl: () =>
+          httpOk('{"object":"chat.completion","choices":[{"message":{"role":"assistant"}}]}'),
+      });
+
+      expect(result?.ok).toBe(false);
+      expect(result?.probed).toBe(true);
+      expect(result?.failureLabel).toBe("unhealthy");
+      expect(result?.detail).toContain("was answered");
+      expect(result?.detail).toContain("no choice carried a message");
+      expect(result?.detail).not.toContain("Check your network connection");
+    });
+
+    it("names an HTTP 200 reply that carried no choices (#9108)", () => {
+      const result = probeRemoteProviderHealth("nvidia-prod", {
+        model: "meta/llama-3.3-70b-instruct",
+        getCredentialImpl: () => "nvapi-test",
+        runCurlProbeImpl: () => httpOk('{"object":"chat.completion","choices":[]}'),
+      });
+
+      expect(result?.ok).toBe(false);
+      expect(result?.detail).toContain("carried no choices");
+    });
+
+    it("keeps the connection and credential advice when the route returns HTTP 500 (#9108)", () => {
+      const result = probeRemoteProviderHealth("nvidia-prod", {
+        model: "meta/llama-3.3-70b-instruct",
+        getCredentialImpl: () => "nvapi-test",
+        runCurlProbeImpl: () => httpServerError(),
+      });
+
+      expect(result?.ok).toBe(false);
+      expect(result?.detail).toContain("Check your network connection");
+      expect(result?.detail).toContain("NVIDIA_INFERENCE_API_KEY");
+      expect(result?.detail).not.toContain("was answered");
     });
 
     it("reports a provider error envelope returned with HTTP 200 as unhealthy", () => {

--- a/src/lib/inference/health.ts
+++ b/src/lib/inference/health.ts
@@ -225,12 +225,13 @@ function hasValidChatMessageFields(
     if (!valid) return false;
   }
   if ("tool_calls" in message) {
-    recognizedField = true;
-    if (
-      !Array.isArray(message.tool_calls) ||
-      message.tool_calls.length === 0 ||
-      !message.tool_calls.every(isValidChatToolCall)
-    ) {
+    const toolCalls = message.tool_calls;
+    if (Array.isArray(toolCalls)) {
+      if (toolCalls.length > 0) {
+        if (!toolCalls.every(isValidChatToolCall)) return false;
+        recognizedField = true;
+      }
+    } else if (toolCalls !== null && toolCalls !== undefined) {
       return false;
     }
   }
@@ -272,24 +273,35 @@ function isValidAnthropicContentBlock(value: unknown): boolean {
   return false;
 }
 
+function notChatCompletionsResult(observed: string): InferenceResponseValidation {
+  return { ok: false, reason: `response was not a Chat Completions result: ${observed}` };
+}
+
 function validateChatCompletionsResponse(body: string): InferenceResponseValidation {
   const parsed = parseJsonRecord(body);
   if (parsed) {
     if (hasProviderErrorEnvelope(parsed)) {
       return { ok: false, reason: "provider returned an error envelope" };
     }
+    if (!Array.isArray(parsed.choices) || parsed.choices.length === 0) {
+      return notChatCompletionsResult("the JSON body carried no choices");
+    }
     return hasChatCompletionsChoice(parsed, false)
       ? { ok: true }
-      : { ok: false, reason: "response was not a Chat Completions result" };
+      : notChatCompletionsResult(
+          "no choice carried a message with text content, a refusal, or tool calls",
+        );
   }
 
   // DeepSeek V4 Pro's model-specific probe requests streaming output. Accept
   // only a stream containing at least one structured Chat Completions chunk;
   // a bare 2xx, malformed SSE, or an SSE error envelope is not health proof.
   let hasValidChunk = false;
+  let hasStreamData = false;
   for (const line of body.split("\n")) {
     const match = /^data:\s*(.+)$/i.exec(line.trim());
     if (!match) continue;
+    hasStreamData = true;
     const data = match[1].trim();
     if (data === "[DONE]") continue;
     const event = parseJsonRecord(data);
@@ -299,9 +311,12 @@ function validateChatCompletionsResponse(body: string): InferenceResponseValidat
     }
     if (hasChatCompletionsChoice(event, true)) hasValidChunk = true;
   }
-  return hasValidChunk
-    ? { ok: true }
-    : { ok: false, reason: "response was not a Chat Completions result" };
+  if (hasValidChunk) return { ok: true };
+  return notChatCompletionsResult(
+    hasStreamData
+      ? "the stream carried no Chat Completions chunk"
+      : "the body was neither JSON nor a Chat Completions stream",
+  );
 }
 
 function isValidResponsesContentBlock(value: unknown): boolean {
@@ -393,10 +408,17 @@ function buildInvocationProbeDetail(
   credentialEnv: string,
   healthy: boolean,
   result: CurlProbeResult,
+  responseUnread: boolean,
 ): string {
   const route = `${providerLabel} model-invocation probe`;
   if (healthy) {
     return `${route} succeeded at ${endpoint}.`;
+  }
+  if (responseUnread) {
+    return (
+      `${route} at ${endpoint} was answered, but the probe could not read the response ` +
+      `as proof that the model ran. (${result.message})`
+    );
   }
   return (
     `${route} at ${endpoint} did not succeed. ` +
@@ -511,7 +533,14 @@ function probeChatCompletionsProviderHealth(
     probed: true,
     providerLabel,
     endpoint,
-    detail: buildInvocationProbeDetail(providerLabel, endpoint, credentialEnv, healthy, result),
+    detail: buildInvocationProbeDetail(
+      providerLabel,
+      endpoint,
+      credentialEnv,
+      healthy,
+      result,
+      rawResult.ok && !healthy,
+    ),
     ...(healthy ? {} : { failureLabel: classifyHealthProbeFailureLabel(result) }),
   };
 }
@@ -571,7 +600,14 @@ function probeAnthropicMessagesProviderHealth(
     probed: true,
     providerLabel,
     endpoint,
-    detail: buildInvocationProbeDetail(providerLabel, endpoint, credentialEnv, healthy, result),
+    detail: buildInvocationProbeDetail(
+      providerLabel,
+      endpoint,
+      credentialEnv,
+      healthy,
+      result,
+      rawResult.ok && !healthy,
+    ),
     ...(healthy ? {} : { failureLabel: classifyHealthProbeFailureLabel(result) }),
   };
 }


### PR DESCRIPTION
## Summary

The health validator treated the presence of a `tool_calls` key as a claim that had to validate on its own, so a hosted OpenAI-compatible runtime that serializes `"tool_calls": []` on every message had its replies rejected even when they carried real content. `status` reported an NVIDIA Endpoints route as unhealthy while the same request returned a well-formed Chat Completions object in under a second, and the failure text told the operator to check a network connection and an API key that were both working. An empty or null tool call list now proves nothing and vetoes nothing, and a probe that cannot classify a 2xx response reports what the response carried.

## Related Issue

Fixes #9108

## Changes

- `src/lib/inference/health.ts`: `hasValidChatMessageFields` treats an empty or null `tool_calls` list as "this reply called no tool". A non-empty list must still be well formed, and a `tool_calls` value that is not a list at all is still malformed. The same validator gates the host-side upstream probe and the in-sandbox served-request probe in `src/lib/actions/sandbox/inference-invocation-probe.ts`, so both hops were affected.
- `src/lib/inference/health.ts`: the Chat Completions failure reasons name what arrived — `the JSON body carried no choices`, `no choice carried a message with text content, a refusal, or tool calls`, `the stream carried no Chat Completions chunk`, and `the body was neither JSON nor a Chat Completions stream` — which answers the second request in the issue.
- `src/lib/inference/health.ts`: `buildInvocationProbeDetail` no longer advises checking the network connection and the credential env when the endpoint answered with a 2xx. That path now reports that the probe was answered but could not read the response as proof that the model ran. Transport and auth failures keep the original advice.
- `src/lib/inference/health.test.ts`: cases cover a hosted response carrying an empty and a null tool call list, the detail text for an unclassifiable 2xx, a body with no choices, and the HTTP 500 path that must keep the connection and credential advice. A `tool_calls` value that is not a list joins the existing rejection table.
- `src/lib/actions/sandbox/inference-invocation-probe.test.ts`: one case covers the same response shape through the `inference.local` served route.

Two items in the issue are deliberately not addressed here. The 5-second probe budget and the `probed: false` handling are a maintainer decision about the diagnostic hop, not a defect in this validator, and the documentation already describes that hop as non-authoritative. `isValidChatToolCall` remains stricter than the onboarding validator in `src/lib/inference/onboard-probes.ts`, which requires no `id`; no evidence in this report exercises that difference, and loosening it without one would weaken what a health result proves.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no page quotes a string this change rewrites. `docs/reference/commands.mdx` line 1889 already states that the probe accepts a recognized Chat Completions, streaming Chat Completions, or Anthropic Messages response, and lines 1813, 1824, and 1881 already scope an `unhealthy` 2xx verdict to an empty body, malformed JSON, a provider-error envelope, or the wrong response shape. A message carrying content alongside an empty tool call list was never one of those, so this change removes a contradiction between the documented behavior and the code.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: the reviewer read `docs/reference/commands.mdx`, `docs/inference/verify-inference-route.mdx`, `docs/inference/understand-provider-validation.mdx`, `docs/reference/troubleshooting.mdx`, `docs/monitoring/monitor-sandbox-activity.mdx`, and `docs/deployment/deploy-to-headless-server.mdx`, and searched `docs/` for every rewritten probe string and for `Inference (upstream)`, `tool_calls`, and `NVIDIA_INFERENCE_API_KEY`. It found no page that this change contradicts and applied the Product Scope Gate, recording that the change corrects an already-documented surface rather than establishing a new one. Its one required finding, a test title that named the transport path while exercising an HTTP 500 response, and its four optional wording findings were all applied in this commit; `npm run docs` completed with 0 errors and 2 pre-existing warnings during that review. The review was not run a second time afterwards.
- Agent: Claude Code
<!-- docs-review-head-sha: 1b0c6e483 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/inference src/lib/actions/sandbox/inference-invocation-probe.test.ts src/lib/actions/sandbox/status-snapshot-inference-health.test.ts` — 100 files, 1941 passed, run after the review edits. `npm run typecheck:cli`, `npm run checks:repository`, and `npm run build:cli` all clean.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inference health checks for Chat Completions and Anthropic responses.
  - More accurately identifies missing, empty, malformed, or unreadable response data.
  - Correctly handles empty or null tool-call lists as healthy responses.
  - Preserves connection and credential guidance for hosted-provider HTTP errors.
  - Improved validation of streaming responses, including empty streams and missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->