### PR TITLE
fix(sandbox): preserve native Hermes GPU startup

### DIFF
--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -710,9 +710,43 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
     );
   });
 
-  it("does not replace a native GPU container solely to persist its startup command", async () => {
+  it("preserves a native non-terminal startup command after create ownership ends", async () => {
+    const input = createInput();
+    const patch = createPatch();
+    const order: string[] = [];
+    input.persistStartupCommand = true;
+    mocks.createDockerGpuSandboxCreatePatch.mockReturnValueOnce(patch);
+    mocks.streamSandboxCreate.mockImplementationOnce(async (...args) => {
+      order.push("poll");
+      args[3].onPoll();
+      order.push("create-complete");
+      return { status: 0, output: "Created sandbox: alpha", sawProgress: true };
+    });
+    patch.ensureApplied.mockImplementationOnce(() => {
+      order.push("ensure-applied");
+    });
+
+    await expect(runSandboxGpuCreateFlow(input, createDeps())).resolves.toMatchObject({
+      route: "native",
+    });
+
+    expect(mocks.createDockerGpuSandboxCreatePatch).toHaveBeenCalledWith(
+      expect.objectContaining({ route: "native", persistStartupCommand: true }),
+    );
+    expect(mocks.streamSandboxCreate).toHaveBeenCalledWith(
+      "openshell",
+      input.createArgv.slice(1),
+      input.sandboxEnv,
+      expect.objectContaining({ waitForReadyTermination: true }),
+    );
+    expect(patch.maybeApplyDuringCreate).not.toHaveBeenCalled();
+    expect(order).toEqual(["poll", "create-complete", "ensure-applied"]);
+  });
+
+  it("keeps a native terminal startup command on the create lifecycle", async () => {
     const input = createInput();
     input.persistStartupCommand = true;
+    input.terminalAgent = true;
 
     await expect(runSandboxGpuCreateFlow(input, createDeps())).resolves.toMatchObject({
       route: "native",
@@ -720,6 +754,12 @@ describe("runSandboxGpuCreateFlow native failure and readiness", () => {
 
     expect(mocks.createDockerGpuSandboxCreatePatch).toHaveBeenCalledWith(
       expect.objectContaining({ route: "native", persistStartupCommand: false }),
+    );
+    expect(mocks.streamSandboxCreate).toHaveBeenCalledWith(
+      "openshell",
+      input.createArgv.slice(1),
+      input.sandboxEnv,
+      expect.objectContaining({ waitForReadyTermination: false }),
     );
   });
 

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -188,16 +188,18 @@ export function createSandboxGpuCreateAttemptRunner(
         })
       : null;
     const persistRestartSafeStartup =
-      input.persistStartupCommand === true && (route !== "native" || hasRequiredUlimits);
+      input.persistStartupCommand === true &&
+      (route !== "native" || !input.terminalAgent || hasRequiredUlimits);
     const deferRestartSafeCutover =
       !managedLifecycle && !compatibility && persistRestartSafeStartup;
     const runtimePatch =
       managedLifecycle?.patch ??
       createDockerGpuSandboxCreatePatch({
         route,
-        // The startup clone preserves native CDI devices, so DCode can apply its
-        // exact required limits without replacing the native GPU envelope.
-        // Other native routes are not swapped solely to persist a command.
+        // The startup clone preserves native CDI devices, so non-terminal agents
+        // keep their selected command and DCode can apply its exact required limits
+        // without replacing the native GPU envelope. Native terminal agents without
+        // required limits retain their create-time command.
         persistStartupCommand: persistRestartSafeStartup,
         externalRecreation: false,
         sandboxName: input.sandboxName,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Native Docker GPU onboarding could report a `Ready` Hermes sandbox after the create process ended the selected startup command.
This change uses the existing restart-safe post-create cutover for native non-terminal startup commands.

## Changes

- Preserve the selected startup command when native GPU onboarding creates a non-terminal agent.
- Keep terminal agents on the create lifecycle unless required limits already require the post-create cutover.
- Preserve managed activation ordering, compatibility fallback, sandbox identity checks, rollback, readiness checks, and GPU verification.
- Replace the previous persistence assertion with regression coverage for cutover ordering and terminal behavior.
- Close the detection gap where the previous test asserted disabled native persistence without checking the non-terminal workload after create ownership ended.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This restores the documented Hermes startup lifecycle without changing commands, configuration, output, defaults, or user actions.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent review found no Critical, Major, or blocking findings across create, cutover, rollback, readiness, and GPU verification.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit under review `65463036d` restores the documented Hermes lifecycle contract. `docs/get-started/quickstart-hermes.mdx`, `docs/reference/architecture.mdx`, `docs/changelog/2026-07-12.mdx`, and `docs/reference/commands.mdx` already describe gateway startup, managed startup persistence, and native GPU injection.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 65463036d -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Local tests were not run at maintainer direction. Required PR CI will validate the change.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup handling for terminal and non-terminal agent configurations.
  - Terminal-agent runs now avoid unnecessary startup persistence and complete without waiting for termination.
  - Non-terminal runs correctly defer runtime updates until creation finishes.
  - Preserved GPU configuration and selected commands when applying required runtime limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->