### PR TITLE
fix(hermes): skip unrelated relay children

### DIFF
--- a/agents/hermes/mcp-config-transaction.py
+++ b/agents/hermes/mcp-config-transaction.py
@@ -98,6 +98,7 @@ MAX_GATEWAY_PUBLIC_PORT_RECORD_BYTES = 16
 GATEWAY_INTERNAL_PORT = 18642
 GATEWAY_NOT_READY_MESSAGE = "Hermes gateway is not running for managed MCP reload"
 MANAGED_API_RELAY_TARGET = f"TCP:127.0.0.1:{GATEWAY_INTERNAL_PORT}".encode()
+MANAGED_API_RELAY_PROCESS_NAME = b"socat"
 MANAGED_API_RELAY_LISTEN_PREFIX = b"TCP-LISTEN:"
 MANAGED_API_RELAY_LISTEN_SUFFIX = b",bind=0.0.0.0,fork,reuseaddr"
 
@@ -867,6 +868,18 @@ def _process_arguments(pid: int) -> list[bytes]:
         return []
 
 
+def _process_name(pid: int) -> bytes | None:
+    try:
+        with open(f"/proc/{pid}/status", "rb") as status_file:
+            for line in status_file:
+                if line.startswith(b"Name:"):
+                    fields = line.split(maxsplit=1)
+                    return fields[1] if len(fields) == 2 else None
+    except FileNotFoundError:
+        return None
+    return None
+
+
 def _is_trusted_gateway_process(pid: int) -> bool:
     arguments = _process_arguments(pid)
     return any(
@@ -1056,7 +1069,7 @@ def _process_start_identity(pid: int) -> object | None:
 def _managed_api_relay_port(arguments: list[bytes]) -> int | None:
     if (
         len(arguments) != 3
-        or os.path.basename(arguments[0]) != b"socat"
+        or os.path.basename(arguments[0]) != MANAGED_API_RELAY_PROCESS_NAME
         or arguments[2] != MANAGED_API_RELAY_TARGET
     ):
         return None
@@ -1126,9 +1139,14 @@ def _managed_api_relay_public_port(
         try:
             owner_uid = os.stat(f"/proc/{pid}").st_uid
             parent_pid = _process_parent_pid(pid)
+            process_name = _process_name(pid)
         except OSError:
             continue
-        if owner_uid != expected_uid or parent_pid != manager_pid:
+        if (
+            owner_uid != expected_uid
+            or parent_pid != manager_pid
+            or process_name != MANAGED_API_RELAY_PROCESS_NAME
+        ):
             continue
         try:
             arguments = _process_arguments(pid)
@@ -1168,6 +1186,7 @@ def _managed_api_relay_public_port(
         ) from error
     try:
         relay_parent_pid = _process_parent_pid(relay_pid)
+        relay_process_name = _process_name(relay_pid)
         current_arguments = _process_arguments(relay_pid)
         current_start = _process_start_identity(relay_pid)
         current_manager_uid = os.stat(f"/proc/{manager_pid}").st_uid
@@ -1182,6 +1201,7 @@ def _managed_api_relay_public_port(
     if (
         relay_owner_uid != expected_uid
         or relay_parent_pid != manager_pid
+        or relay_process_name != MANAGED_API_RELAY_PROCESS_NAME
         or current_arguments != relay_arguments
         or current_start != relay_start
         or current_manager_uid != manager_uid

--- a/src/lib/actions/sandbox/openshell-child-visible-credentials.v0.0.101.json
+++ b/src/lib/actions/sandbox/openshell-child-visible-credentials.v0.0.101.json
@@ -41,7 +41,7 @@
       },
       {
         "path": "agents/hermes/mcp-config-transaction.py",
-        "sha256": "dd150dd66c2afb2136cb3424c3e1e98f598e08b2b5082375138ac050c1bd85e5"
+        "sha256": "1d9905cee4879c21aa2df85895e331ed7cd841fcf2d5a375696e251d0c0600b4"
       }
     ]
   },

--- a/test/hermes-mcp-api-port.test.ts
+++ b/test/hermes-mcp-api-port.test.ts
@@ -45,6 +45,7 @@ module.os.geteuid = lambda: 1000
 module.os.scandir = lambda path: ProcessEntries()
 module.os.stat = lambda path: types.SimpleNamespace(st_uid=owners[int(path.rsplit("/", 1)[1])])
 module._process_parent_pid = lambda pid: manager_pid
+module._process_name = lambda pid: module.MANAGED_API_RELAY_PROCESS_NAME
 module._process_arguments = lambda pid: [module.SERVICE_MANAGER_PATH] if pid == manager_pid else relay_arguments
 module._process_start_identity = lambda pid: 101 if pid == manager_pid else 202
 module._gateway_identity = lambda: identity
@@ -72,6 +73,102 @@ print(json.dumps({"port": port, "environment_reads": environment_reads}))
 
     expect(result.status, result.stderr).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({ port: 8645, environment_reads: [] });
+  });
+
+  it("skips unreadable unrelated children but rejects unreadable relay arguments (#9044)", () => {
+    const result = spawnSync(
+      "python3",
+      [
+        "-c",
+        `
+import builtins, importlib.util, io, json, sys, types
+sys.modules["yaml"] = types.SimpleNamespace(YAMLError=type("YAMLError", (Exception,), {}))
+spec = importlib.util.spec_from_file_location("mcp_tx", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+identity = (41, 333)
+manager_pid = 40
+helper_pid = 42
+relay_pid = 43
+relay_arguments = [
+    b"socat",
+    b"TCP-LISTEN:8645,bind=0.0.0.0,fork,reuseaddr",
+    b"TCP:127.0.0.1:18642",
+]
+
+class ProcessEntries:
+    def __enter__(self):
+        return iter(types.SimpleNamespace(name=str(pid)) for pid in (41, helper_pid, relay_pid))
+    def __exit__(self, *_args):
+        return False
+
+def run_case(helper_name):
+    process_names = {
+        manager_pid: "bash",
+        41: "python3",
+        helper_pid: helper_name,
+        relay_pid: "socat",
+    }
+    parents = {41: manager_pid, helper_pid: manager_pid, relay_pid: manager_pid}
+    command_lines = {
+        manager_pid: module.SERVICE_MANAGER_PATH + b"\\0",
+        relay_pid: b"\\0".join(relay_arguments) + b"\\0",
+    }
+    command_line_reads = []
+    real_open = builtins.open
+
+    def fake_open(path, mode="r", *args, **kwargs):
+        raw_path = str(path)
+        fields = raw_path.split("/")
+        if len(fields) == 4 and fields[1] == "proc":
+            pid = int(fields[2])
+            if fields[3] == "status":
+                status = f"Name:\\t{process_names[pid]}\\nPPid:\\t{parents[pid]}\\n"
+                if "b" in mode:
+                    return io.BytesIO(status.encode("utf-8"))
+                return io.StringIO(status)
+            if fields[3] == "cmdline":
+                command_line_reads.append(pid)
+                if pid == helper_pid:
+                    raise PermissionError("helper arguments denied")
+                return io.BytesIO(command_lines[pid])
+        return real_open(path, mode, *args, **kwargs)
+
+    module.os.geteuid = lambda: 1000
+    module.os.scandir = lambda path: ProcessEntries()
+    module.os.stat = lambda path: types.SimpleNamespace(st_uid=1000)
+    module._process_start_identity = lambda pid: 101 if pid == manager_pid else 200 + pid
+    module._gateway_identity = lambda: identity
+    builtins.open = fake_open
+    try:
+        try:
+            outcome = {"port": module._managed_api_relay_public_port(identity)}
+        except Exception as error:
+            outcome = {"error": [type(error).__name__, str(error)]}
+    finally:
+        builtins.open = real_open
+    outcome["helper_arguments_read"] = helper_pid in command_line_reads
+    return outcome
+
+print(json.dumps({
+    "unrelated_child": run_case("sleep"),
+    "relay_named_child": run_case("socat"),
+}, sort_keys=True))
+`,
+        TRANSACTION,
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      relay_named_child: {
+        error: ["PermissionError", "Hermes managed API relay identity is unavailable"],
+        helper_arguments_read: true,
+      },
+      unrelated_child: { helper_arguments_read: false, port: 8645 },
+    });
   });
 
   it("accepts allocated relay ports and rejects forged relay topology (#9044)", () => {
@@ -114,6 +211,7 @@ def run_candidate(owner=1000, parent=manager_pid, arguments=exact_arguments):
     module.os.scandir = lambda path: ProcessEntries()
     module.os.stat = lambda path: types.SimpleNamespace(st_uid=owners[int(path.rsplit("/", 1)[1])])
     module._process_parent_pid = lambda pid: manager_pid if pid == 41 else parent
+    module._process_name = lambda pid: module.MANAGED_API_RELAY_PROCESS_NAME
     module._process_arguments = lambda pid: [module.SERVICE_MANAGER_PATH] if pid == manager_pid else arguments
     module._process_start_identity = lambda pid: 101 if pid == manager_pid else 202
     module._gateway_identity = lambda: identity
@@ -200,7 +298,7 @@ def run_case(mutation):
         []
         if mutation == "missing"
         else [42, 43]
-        if mutation in ("ambiguous", "candidate_arguments_exit", "candidate_start_exit")
+        if mutation in ("ambiguous", "candidate_start_exit")
         else [42]
     )
     counters = {
@@ -208,7 +306,6 @@ def run_case(mutation):
         "manager_arguments": 0,
         "manager_start": 0,
         "manager_stat": 0,
-        "relay_arguments": 0,
         "relay_start": 0,
     }
     module.os.geteuid = lambda: 1000
@@ -239,11 +336,6 @@ def run_case(mutation):
             if mutation == "manager_arguments" and counters["manager_arguments"] > 1:
                 return [b"/tmp/unmanaged-start"]
             return [module.SERVICE_MANAGER_PATH]
-        counters["relay_arguments"] += 1
-        if mutation == "candidate_arguments_exit" and counters["relay_arguments"] == 1:
-            raise FileNotFoundError("relay exited")
-        if mutation == "candidate_arguments_denied":
-            raise PermissionError("relay arguments denied")
         return relay_arguments
 
     def process_start(pid):
@@ -263,6 +355,7 @@ def run_case(mutation):
 
     module.os.stat = process_stat
     module._process_parent_pid = parent_pid
+    module._process_name = lambda pid: module.MANAGED_API_RELAY_PROCESS_NAME
     module._process_arguments = process_arguments
     module._process_start_identity = process_start
     module._gateway_identity = lambda: identity
@@ -270,14 +363,12 @@ def run_case(mutation):
         port = module._managed_api_relay_public_port(identity)
     except Exception as error:
         return type(error).__name__, str(error)
-    if mutation in ("candidate_arguments_exit", "candidate_start_exit"):
+    if mutation == "candidate_start_exit":
         return port
     raise AssertionError("unstable relay topology was accepted")
 
 results = {case: run_case(case) for case in (
     "missing",
-    "candidate_arguments_exit",
-    "candidate_arguments_denied",
     "candidate_start_exit",
     "candidate_start_denied",
     "relay_start",
@@ -298,11 +389,6 @@ print(json.dumps(results, sort_keys=True))
     expect(result.status, result.stderr).toBe(0);
     expect(JSON.parse(result.stdout)).toEqual({
       ambiguous: ["PermissionError", "Hermes managed API relay identity is ambiguous"],
-      candidate_arguments_denied: [
-        "PermissionError",
-        "Hermes managed API relay identity is unavailable",
-      ],
-      candidate_arguments_exit: 8645,
       candidate_start_denied: [
         "PermissionError",
         "Hermes managed API relay identity is unavailable",

--- a/test/openshell-0.0.101-migration-review.test.ts
+++ b/test/openshell-0.0.101-migration-review.test.ts
@@ -230,7 +230,7 @@ describe("OpenShell 0.0.101 migration review", () => {
         },
         {
           path: "agents/hermes/mcp-config-transaction.py",
-          sha256: "dd150dd66c2afb2136cb3424c3e1e98f598e08b2b5082375138ac050c1bd85e5",
+          sha256: "1d9905cee4879c21aa2df85895e331ed7cd841fcf2d5a375696e251d0c0600b4",
         },
       ],
     });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Concurrent Hermes MCP mutations could reject a valid operation when relay discovery read a short-lived unrelated service-manager child.
Relay discovery now filters unrelated children before command-line inspection without weakening exact relay validation.

## Changes

- Read each same-owner manager child's process name before reading its command line.
- Inspect command-line arguments only for possible `socat` relay children.
- Retain same-UID, managed-parent, exact-argument, start-identity, unique-selection, manager, gateway, and final stability checks for possible relays.
- Add real-reader regression coverage that skips an unreadable unrelated child and rejects unreadable possible-relay arguments.
- Update the OpenShell security evidence digest for the reviewed Hermes transaction helper.
- Close the detection gap where the previous test replaced the command-line reader and did not exercise the live disappearing-process behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This fixes internal Hermes MCP relay discovery without changing commands, configuration, defaults, protocols, documented errors, or user actions.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent review found no Critical, Major, or blocking findings. Possible relays retain all authoritative identity, topology, ambiguity, and stability checks, and unreadable possible-relay arguments fail closed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit under review `faffc7c16` fixes internal relay discovery. `docs/deployment/set-up-mcp-bridge.mdx`, `docs/manage-sandboxes/add-mcp-server.mdx`, `docs/manage-sandboxes/manage-mcp-servers.mdx`, `docs/reference/troubleshoot-mcp-servers.mdx`, and `docs/index.yml` already own the unchanged public behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: faffc7c16 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Local tests were not run at maintainer direction. Required PR CI will validate the change.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed relay detection by verifying the expected relay process identity.
  - Prevented unrelated or unreadable processes from being selected as the API relay.
  - Strengthened relay identity revalidation for more reliable API port resolution.

- **Tests**
  - Expanded coverage for process-name validation, unreadable process information, and relay topology stability.
  - Updated configuration integrity checks for the latest relay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->