### PR TITLE
fix(readiness): name the process holding the gateway port

### DIFF
--- a/docs/reference/system-readiness.mdx
+++ b/docs/reference/system-readiness.mdx
@@ -253,6 +253,7 @@ Use finding IDs to handle gateway failures without parsing summaries:
 | `gateway.port.inconclusive` | Warning | NemoClaw could not establish gateway port ownership. |
 
 The report includes bounded evidence for the resolved owner and applicable attachment, port, collection, or stale-observation failures.
+Port-conflict evidence names each listener that holds the gateway port by process name and PID, and gives the command that stops those PIDs.
 It omits the gateway state directory, removes process environments, redacts credential-shaped content, bounds diagnostic length, and renders control characters visibly.
 
 Managed gateway metadata is reusable only when its endpoint is bound to loopback on the configured gateway port.

--- a/docs/reference/system-readiness.mdx
+++ b/docs/reference/system-readiness.mdx
@@ -253,7 +253,10 @@ Use finding IDs to handle gateway failures without parsing summaries:
 | `gateway.port.inconclusive` | Warning | NemoClaw could not establish gateway port ownership. |
 
 The report includes bounded evidence for the resolved owner and applicable attachment, port, collection, or stale-observation failures.
-Port-conflict evidence names each listener that holds the gateway port by process name and PID, and gives the command that stops those PIDs.
+When NemoClaw resolves the complete listener set, port-conflict evidence lists every listener by process name and PID, or by PID when no name is available.
+A stop command targets only listeners that fail ownership verification.
+NemoClaw does not provide a stop command for a verified managed listener.
+If NemoClaw resolves no listener, the diagnostic provides an `lsof` inspection command.
 It omits the gateway state directory, removes process environments, redacts credential-shaped content, bounds diagnostic length, and renders control characters visibly.
 
 Managed gateway metadata is reusable only when its endpoint is bound to loopback on the configured gateway port.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -318,6 +318,11 @@ If forwarding then fails, onboarding removes the new sandbox and tells you to re
 When a previous onboard, upgrade, or sandbox crash leaves a stale `openclaw-gateway` host process holding the dashboard port, `$$nemoclaw onboard --fresh`, `$$nemoclaw <name> destroy` (when destroying the last sandbox), and `$$nemoclaw uninstall` automatically sweep the dashboard port range and signal `SIGTERM` then `SIGKILL` to recover.
 The sweep only targets processes owned by the current user whose command line matches `openclaw-gateway` or `openshell forward` markers, and skips dashboard ports owned by other live sandboxes.
 
+When onboarding preflight blocks a gateway port conflict, it names each listener that holds the port by process name and PID.
+It prints a PID alone when it cannot read the process name, and an inspection command when it resolves no listener.
+Confirm that a named listener is not a second NemoClaw gateway environment before you stop it.
+Release that environment with `NEMOCLAW_GATEWAY_PORT=<port> $$nemoclaw uninstall` instead of stopping its process.
+
 If a non-NemoClaw process is already bound to the dashboard port or the gateway port, identify the conflicting process, verify it is safe to stop, and terminate it:
 
 ```bash

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -318,9 +318,12 @@ If forwarding then fails, onboarding removes the new sandbox and tells you to re
 When a previous onboard, upgrade, or sandbox crash leaves a stale `openclaw-gateway` host process holding the dashboard port, `$$nemoclaw onboard --fresh`, `$$nemoclaw <name> destroy` (when destroying the last sandbox), and `$$nemoclaw uninstall` automatically sweep the dashboard port range and signal `SIGTERM` then `SIGKILL` to recover.
 The sweep only targets processes owned by the current user whose command line matches `openclaw-gateway` or `openshell forward` markers, and skips dashboard ports owned by other live sandboxes.
 
-When onboarding preflight blocks a gateway port conflict, it names each listener that holds the port by process name and PID.
-It prints a PID alone when it cannot read the process name, and an inspection command when it resolves no listener.
-Confirm that a named listener is not a second NemoClaw gateway environment before you stop it.
+If onboarding preflight resolves the complete listener set for a gateway port conflict, the diagnostic lists every listener.
+Each entry contains the process name and PID, or only the PID when NemoClaw cannot read the process name.
+The stop command targets only listeners that fail ownership verification.
+It does not target a verified managed listener.
+If NemoClaw resolves no listener, the diagnostic provides an `lsof` inspection command.
+Before you run a stop command, confirm that each targeted listener is not part of a second NemoClaw gateway environment.
 Release that environment with `NEMOCLAW_GATEWAY_PORT=<port> $$nemoclaw uninstall` instead of stopping its process.
 
 If a non-NemoClaw process is already bound to the dashboard port or the gateway port, identify the conflicting process, verify it is safe to stop, and terminate it:

--- a/src/lib/readiness/gateway-production.test.ts
+++ b/src/lib/readiness/gateway-production.test.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import type { AddressInfo } from "node:net";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -33,6 +35,7 @@ import {
   classifyManagedGatewayVersionDrift,
   classifyManagedGatewayVersionSource,
   createProductionGatewayReadinessDependencies,
+  gatewayPortConflictDetail,
   gatewayProcessIdentityMatchesTrustedBinary,
   gatewayProcessSamplesMatchTrustedBinary,
   parseDarwinLsofExecutable,
@@ -492,5 +495,47 @@ describe("managed gateway port readiness (#7411)", () => {
       resetTraceForTests();
       fs.rmSync(traceDir, { force: true, recursive: true });
     }
+  });
+
+  it("names the foreign listener the unprivileged scan resolved and how to stop it (#9118)", async () => {
+    const foreignListener = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      foreignListener.once("error", reject);
+      foreignListener.listen(0, "127.0.0.1", resolve);
+    });
+    const gatewayPort = (foreignListener.address() as AddressInfo).port;
+    subprocess.spawnSync.mockImplementation((command: string, args: readonly string[] = []) => {
+      if (command === "lsof" && args.includes("-ti")) return commandResult(`${process.pid}\n`, 0);
+      if (command === "ps" && args.includes("comm=")) return commandResult("python3\n", 0);
+      return commandResult();
+    });
+
+    try {
+      const deps = createProductionGatewayReadinessDependencies({
+        gatewayName: () => "nemoclaw-readiness-test",
+        gatewayPort: () => gatewayPort,
+      });
+
+      const observed = await deps.observeManagedGateway(managedOwner(gatewayPort));
+
+      expect(observed.portConflictState).not.toBe("none");
+      expect(observed.portConflictDetail).toContain(`python3 (PID ${process.pid})`);
+      expect(observed.portConflictDetail).toContain(`sudo kill ${process.pid}`);
+      expect(observed.portConflictDetail).not.toContain("occupied by unknown");
+    } finally {
+      await new Promise<void>((resolve) => foreignListener.close(() => resolve()));
+    }
+  });
+
+  it("offers an inspection command when no listener could be resolved (#9118)", () => {
+    const detail = gatewayPortConflictDetail(
+      8080,
+      { ok: false, process: "unknown", pid: null, reason: "port 8080 is in use (EADDRINUSE)" },
+      "occupied",
+      { pids: [], text: null },
+    );
+
+    expect(detail).toContain("is occupied by an unknown listener");
+    expect(detail).toContain("sudo lsof -i :8080 -sTCP:LISTEN -P -n");
   });
 });

--- a/src/lib/readiness/gateway-production.test.ts
+++ b/src/lib/readiness/gateway-production.test.ts
@@ -582,4 +582,22 @@ describe("managed gateway port readiness (#7411)", () => {
     expect(detail).toContain("NEMOCLAW_GATEWAY_PORT=8080 nemoclaw uninstall");
     expect(detail).not.toContain("sudo kill");
   });
+
+  it("uses the invoked CLI name in verified gateway release guidance (#9118)", () => {
+    vi.stubEnv("NEMOCLAW_INVOKED_AS", "nemohermes");
+    const owners = describeGatewayPortOwners(
+      { pids: [100], unverifiedPids: [] },
+      () => "openshell-gateway",
+    );
+
+    const detail = gatewayPortConflictDetail(
+      8080,
+      { ok: false, process: "unknown", pid: null, reason: "port 8080 is in use (EADDRINUSE)" },
+      "owner-mismatch",
+      owners,
+    );
+
+    expect(detail).toContain("NEMOCLAW_GATEWAY_PORT=8080 nemohermes uninstall");
+    expect(detail).not.toContain("nemoclaw uninstall");
+  });
 });

--- a/src/lib/readiness/gateway-production.test.ts
+++ b/src/lib/readiness/gateway-production.test.ts
@@ -35,6 +35,7 @@ import {
   classifyManagedGatewayVersionDrift,
   classifyManagedGatewayVersionSource,
   createProductionGatewayReadinessDependencies,
+  describeGatewayPortOwners,
   gatewayPortConflictDetail,
   gatewayProcessIdentityMatchesTrustedBinary,
   gatewayProcessSamplesMatchTrustedBinary,
@@ -505,9 +506,13 @@ describe("managed gateway port readiness (#7411)", () => {
     });
     const gatewayPort = (foreignListener.address() as AddressInfo).port;
     subprocess.spawnSync.mockImplementation((command: string, args: readonly string[] = []) => {
-      if (command === "lsof" && args.includes("-ti")) return commandResult(`${process.pid}\n`, 0);
-      if (command === "ps" && args.includes("comm=")) return commandResult("python3\n", 0);
-      return commandResult();
+      const resolvesListener = command === "lsof" && args.includes("-ti");
+      const resolvesName = command === "ps" && args.includes("comm=");
+      return resolvesListener
+        ? commandResult(`${process.pid}\n`, 0)
+        : resolvesName
+          ? commandResult("python3\n", 0)
+          : commandResult();
     });
 
     try {
@@ -532,10 +537,49 @@ describe("managed gateway port readiness (#7411)", () => {
       8080,
       { ok: false, process: "unknown", pid: null, reason: "port 8080 is in use (EADDRINUSE)" },
       "occupied",
-      { pids: [], text: null },
+      { stopPids: [], text: null },
     );
 
     expect(detail).toContain("is occupied by an unknown listener");
     expect(detail).toContain("sudo lsof -i :8080 -sTCP:LISTEN -P -n");
+  });
+
+  it("lists every listener and limits the stop command to the unverified listener (#9118)", () => {
+    const processNames = new Map([
+      [100, "openshell-gateway"],
+      [200, "python3"],
+    ]);
+    const owners = describeGatewayPortOwners(
+      { pids: [100], unverifiedPids: [200] },
+      (pid) => processNames.get(pid) ?? null,
+    );
+    const detail = gatewayPortConflictDetail(
+      8080,
+      { ok: false, process: "unknown", pid: null, reason: "port 8080 is in use (EADDRINUSE)" },
+      "multiple-owners",
+      owners,
+    );
+
+    expect(detail).toContain("openshell-gateway (PID 100), python3 (PID 200)");
+    expect(detail).toContain("Confirm PID 200 is not another NemoClaw gateway");
+    expect(detail).toContain("sudo kill 200");
+    expect(detail).not.toContain("sudo kill 100");
+  });
+
+  it("recommends releasing a verified gateway environment without a process stop command (#9118)", () => {
+    const owners = describeGatewayPortOwners(
+      { pids: [100], unverifiedPids: [] },
+      () => "openshell-gateway",
+    );
+    const detail = gatewayPortConflictDetail(
+      8080,
+      { ok: false, process: "unknown", pid: null, reason: "port 8080 is in use (EADDRINUSE)" },
+      "owner-mismatch",
+      owners,
+    );
+
+    expect(detail).toContain("openshell-gateway (PID 100)");
+    expect(detail).toContain("NEMOCLAW_GATEWAY_PORT=8080 nemoclaw uninstall");
+    expect(detail).not.toContain("sudo kill");
   });
 });

--- a/src/lib/readiness/gateway-production.ts
+++ b/src/lib/readiness/gateway-production.ts
@@ -261,6 +261,13 @@ function readLinuxProcessExecutable(pid: number): string | null {
   }
 }
 
+function readProcessName(pid: number, env: NodeJS.ProcessEnv): string | null {
+  const result = captureReadonly(["ps", "-p", String(pid), "-o", "comm="], env);
+  if (result.exitCode !== 0) return null;
+  const name = result.stdout.split(/\r?\n/)[0]?.trim();
+  return name ? path.basename(name) : null;
+}
+
 export function parseDarwinLsofExecutable(output: string): string | null {
   // macOS reports the process executable first, followed by other text vnodes
   // such as /usr/lib/dyld. Selecting the first record prevents a process from
@@ -520,25 +527,64 @@ export function classifyManagedGatewayVersionSource(
   return null;
 }
 
-function gatewayPortConflictDetail(
+export interface GatewayPortOwners {
+  pids: number[];
+  text: string | null;
+}
+
+export function describeGatewayPortOwners(
+  listenerScan: { pids: readonly number[]; unverifiedPids: readonly number[] },
+  describeProcess: (pid: number) => string | null,
+): GatewayPortOwners {
+  const pids =
+    listenerScan.unverifiedPids.length > 0
+      ? [...listenerScan.unverifiedPids]
+      : [...listenerScan.pids];
+  if (pids.length === 0) return { pids, text: null };
+  const text = pids
+    .map((pid) => {
+      const name = describeProcess(pid);
+      return name ? `${name} (PID ${pid})` : `PID ${pid}`;
+    })
+    .join(", ");
+  return { pids, text };
+}
+
+function gatewayPortConflictRemediation(gatewayPort: number, ownerPids: readonly number[]): string {
+  if (ownerPids.length === 0) {
+    return `Identify its listener before retrying: sudo lsof -i :${gatewayPort} -sTCP:LISTEN -P -n`;
+  }
+  const subject = ownerPids.length === 1 ? "that process is" : "those processes are";
+  const object = ownerPids.length === 1 ? "it" : "them";
+  return (
+    `Confirm ${subject} not another NemoClaw gateway, then stop only ${object} before retrying: ` +
+    `sudo kill ${ownerPids.join(" ")}`
+  );
+}
+
+export function gatewayPortConflictDetail(
   gatewayPort: number,
   portCheck: Awaited<ReturnType<typeof checkPortAvailable>>,
   state: GatewayPortConflictState,
+  owners: GatewayPortOwners = { pids: [], text: null },
 ): string | undefined {
   if (state === "none") return undefined;
-  const owner = portCheck.process
-    ? `${portCheck.process}${portCheck.pid ? ` (PID ${portCheck.pid})` : ""}`
-    : "an unknown listener";
+  const probedOwner =
+    portCheck.process && portCheck.process !== "unknown"
+      ? `${portCheck.process}${portCheck.pid ? ` (PID ${portCheck.pid})` : ""}`
+      : null;
+  const owner = owners.text ?? probedOwner ?? "an unknown listener";
   const condition =
     state === "multiple-owners"
-      ? "has multiple listeners"
+      ? `has multiple listeners: ${owner}`
       : state === "unknown"
         ? "could not be observed completely"
         : `is occupied by ${owner}`;
-  return (
-    `Gateway port ${gatewayPort} ${condition}. ` +
-    `Inspect port ${gatewayPort} and stop only its owning process before retrying.`
+  const remediation = gatewayPortConflictRemediation(
+    gatewayPort,
+    state === "unknown" ? [] : owners.pids,
   );
+  return `Gateway port ${gatewayPort} ${condition}. ${remediation}`;
 }
 
 function rejectUnexpectedGatewayEffect(): never {
@@ -782,11 +828,20 @@ export function createProductionGatewayReadinessDependencies(
       endpointBinding,
       listenerScan.pids.length === 1 && trustedTargetBoundPids.has(listenerScan.pids[0] ?? -1),
     );
+    const portConflictOwners =
+      portConflictState === "none"
+        ? { pids: [], text: null }
+        : describeGatewayPortOwners(listenerScan, (pid) => readProcessName(pid, probeEnv));
     return {
       reuseState,
       driftState,
       portConflictState,
-      portConflictDetail: gatewayPortConflictDetail(gatewayPort, portCheck, portConflictState),
+      portConflictDetail: gatewayPortConflictDetail(
+        gatewayPort,
+        portCheck,
+        portConflictState,
+        portConflictOwners,
+      ),
     };
   }
 

--- a/src/lib/readiness/gateway-production.ts
+++ b/src/lib/readiness/gateway-production.ts
@@ -17,6 +17,7 @@ import {
   parseVersionFromText,
   stripAnsi,
 } from "../adapters/openshell/gateway-drift";
+import { cliName as resolveCliName } from "../onboard/branding";
 import {
   getConfiguredGatewayPort,
   getDockerDriverGatewayEndpoint,
@@ -558,9 +559,10 @@ function gatewayPortConflictRemediation(
     return `Identify its listener before retrying: sudo lsof -i :${gatewayPort} -sTCP:LISTEN -P -n`;
   }
   if (stopPids.length === 0) {
+    const cliName = resolveCliName();
     return (
       "Confirm which managed gateway environment owns the verified listener, then release that " +
-      `environment with \`NEMOCLAW_GATEWAY_PORT=${gatewayPort} nemoclaw uninstall\` before retrying.`
+      `environment with \`NEMOCLAW_GATEWAY_PORT=${gatewayPort} ${cliName} uninstall\` before retrying.`
     );
   }
   const subject =

--- a/src/lib/readiness/gateway-production.ts
+++ b/src/lib/readiness/gateway-production.ts
@@ -528,7 +528,7 @@ export function classifyManagedGatewayVersionSource(
 }
 
 export interface GatewayPortOwners {
-  pids: number[];
+  stopPids: number[];
   text: string | null;
 }
 
@@ -536,29 +536,39 @@ export function describeGatewayPortOwners(
   listenerScan: { pids: readonly number[]; unverifiedPids: readonly number[] },
   describeProcess: (pid: number) => string | null,
 ): GatewayPortOwners {
-  const pids =
-    listenerScan.unverifiedPids.length > 0
-      ? [...listenerScan.unverifiedPids]
-      : [...listenerScan.pids];
-  if (pids.length === 0) return { pids, text: null };
-  const text = pids
+  const allPids = [...new Set([...listenerScan.pids, ...listenerScan.unverifiedPids])];
+  const stopPids = [...listenerScan.unverifiedPids];
+  if (allPids.length === 0) return { stopPids, text: null };
+  const text = allPids
     .map((pid) => {
       const name = describeProcess(pid);
       return name ? `${name} (PID ${pid})` : `PID ${pid}`;
     })
     .join(", ");
-  return { pids, text };
+  return { stopPids, text };
 }
 
-function gatewayPortConflictRemediation(gatewayPort: number, ownerPids: readonly number[]): string {
-  if (ownerPids.length === 0) {
+function gatewayPortConflictRemediation(
+  gatewayPort: number,
+  stopPids: readonly number[],
+  hasResolvedOwner: boolean,
+  state: GatewayPortConflictState,
+): string {
+  if (state === "unknown" || !hasResolvedOwner) {
     return `Identify its listener before retrying: sudo lsof -i :${gatewayPort} -sTCP:LISTEN -P -n`;
   }
-  const subject = ownerPids.length === 1 ? "that process is" : "those processes are";
-  const object = ownerPids.length === 1 ? "it" : "them";
+  if (stopPids.length === 0) {
+    return (
+      "Confirm which managed gateway environment owns the verified listener, then release that " +
+      `environment with \`NEMOCLAW_GATEWAY_PORT=${gatewayPort} nemoclaw uninstall\` before retrying.`
+    );
+  }
+  const subject =
+    stopPids.length === 1 ? `PID ${stopPids[0]} is` : `PIDs ${stopPids.join(", ")} are`;
+  const object = stopPids.length === 1 ? "it" : "them";
   return (
     `Confirm ${subject} not another NemoClaw gateway, then stop only ${object} before retrying: ` +
-    `sudo kill ${ownerPids.join(" ")}`
+    `sudo kill ${stopPids.join(" ")}`
   );
 }
 
@@ -566,7 +576,7 @@ export function gatewayPortConflictDetail(
   gatewayPort: number,
   portCheck: Awaited<ReturnType<typeof checkPortAvailable>>,
   state: GatewayPortConflictState,
-  owners: GatewayPortOwners = { pids: [], text: null },
+  owners: GatewayPortOwners = { stopPids: [], text: null },
 ): string | undefined {
   if (state === "none") return undefined;
   const probedOwner =
@@ -582,7 +592,9 @@ export function gatewayPortConflictDetail(
         : `is occupied by ${owner}`;
   const remediation = gatewayPortConflictRemediation(
     gatewayPort,
-    state === "unknown" ? [] : owners.pids,
+    owners.stopPids,
+    owners.text !== null,
+    state,
   );
   return `Gateway port ${gatewayPort} ${condition}. ${remediation}`;
 }
@@ -830,7 +842,7 @@ export function createProductionGatewayReadinessDependencies(
     );
     const portConflictOwners =
       portConflictState === "none"
-        ? { pids: [], text: null }
+        ? { stopPids: [], text: null }
         : describeGatewayPortOwners(listenerScan, (pid) => readProcessName(pid, probeEnv));
     return {
       reuseState,

--- a/test/onboard-gateway-port-conflict-fast-fail.test.ts
+++ b/test/onboard-gateway-port-conflict-fast-fail.test.ts
@@ -116,6 +116,9 @@ describe("onboard gateway port conflict readiness (#6752)", () => {
       expect(combined).toMatch(
         /The gateway port is held by an incompatible or ambiguous owner|OpenShell gateway needs this port/,
       );
+      expect(combined).not.toMatch(/occupied by unknown/);
+      expect(combined).toMatch(/\(PID \d+\)/);
+      expect(combined).toMatch(/sudo kill \d+/);
     },
   );
 


### PR DESCRIPTION
## Summary

The public gateway readiness collector probes the gateway port with `lsof` skipped, so its conflict message read an owner of `unknown` from the bind probe and offered no way to act on it, even though the collector's own unprivileged listener scan had already resolved the owning PID. An operator whose port was held by an ordinary process was told the owner was `unknown` and left to rediscover it by hand. The diagnostic now names each listener by process name and PID, separates verified gateway listeners from unverified listeners, and limits process-stop guidance to the exact unverified PID or PIDs. Verified gateway listeners receive a port-scoped `nemoclaw uninstall` command, while unresolved listeners receive an `lsof` inspection command.

## Related Issue

Fixes #9118

## Changes

- `src/lib/readiness/gateway-production.ts`: the listener scan retains verified gateway PIDs and unverified PIDs as disjoint sets. `gatewayPortConflictDetail` names every resolved listener, but process-stop authority comes only from the unverified set. The bind probe's `unknown` sentinel is treated as the absence of a name. Owners are resolved only when a conflict exists, so a healthy port starts no extra child process.
- `src/lib/readiness/gateway-production.ts`: `describeGatewayPortOwners` reads process names through `ps -p <pid> -o comm=` on the existing read-only capture, alongside the `ps -o args=` call already used for identity evidence. A name that cannot be read degrades to the PID alone.
- `src/lib/readiness/gateway-production.ts`: mixed conflicts list every listener, name the exact unverified PID or PIDs the operator must confirm, and generate `sudo kill` only for those PIDs. A verified-only conflict recommends `NEMOCLAW_GATEWAY_PORT=<port> nemoclaw uninstall`; an unresolved conflict recommends `sudo lsof -i :<port> -sTCP:LISTEN -P -n`.
- `test/onboard-gateway-port-conflict-fast-fail.test.ts`: the two existing assertions accepted either message wording, so the process name, PID, and remediation command could all disappear without failing. The case now requires an owner PID, a stop command, and the absence of `occupied by unknown`.
- `src/lib/readiness/gateway-production.test.ts`: coverage includes a real occupied port, unresolved ownership, mixed verified and unverified listeners, and verified-only ownership. It proves verified gateway PIDs never enter `sudo kill`, exact unverified PIDs are named before stopping, and verified-only conflicts use port-scoped environment release guidance.
- `docs/reference/troubleshooting.mdx`: the section that already documents manual `lsof` and `kill` recovery now states what preflight reports, what it reports when a name or a listener cannot be resolved, and that a second NemoClaw gateway environment is released with `uninstall` rather than stopped.
- `docs/reference/system-readiness.mdx`: the readiness evidence description records that port-conflict evidence carries the listener name, PID, and stop command, because `host probe` surfaces the same evidence entry.

No abstraction, configuration, fallback, or compatibility path is added. The `unknown` sentinel in `src/lib/onboard/preflight.ts` and the matching branch in `couldBeNemoClawGatewayPortListener` are deliberately unchanged: neither is reachable in this failure, since readiness admission exits first, and narrowing them would change fail-fast behavior for genuinely unidentified listeners without a defect that calls for it.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: review of the latest PR commit confirmed that discovery is read-only, verified and unverified listener sets are disjoint, `sudo kill` contains only unverified numeric PIDs, verified listeners use port-scoped uninstall guidance, unresolved ownership fails closed to `lsof`, and focused tests cover each authority branch.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated `docs/reference/system-readiness.mdx` and `docs/reference/troubleshooting.mdx`. The independent reviewer verified the complete effective diff, applicable OpenClaw, Hermes, and Deep Agents guide variants, user-visible diagnostics, terminology, structure, voice, command presentation, process-safety wording, and variant-aware uninstall guidance. Focused CLI tests passed (55), focused integration tests passed (2), and the docs build reported 0 errors and 2 pre-existing warnings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7593744bdb -->
<!-- docs-review-agents-blob-sha: e30afb270b -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: the final safety-wording change passed all 55 tests in `src/lib/readiness/gateway-production.test.ts` and `npm run typecheck:cli`; the complete change set also passed 21 focused integration/documentation-variant tests, `npm run checks:repository`, `npm run build:cli`, and `git diff --check`. Pre-commit checks passed for the follow-up repair. GitHub CI will provide the unavailable local commitlint and oxlint checks.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Gateway port-conflict diagnostics now identify listening processes by name and PID when available.
  - Added PID-specific commands for stopping unverified conflicting processes.
  - Added inspection guidance when process details cannot be determined.
  - Improved handling of multiple listeners and verified managed gateway environments.
  - Added port-scoped cleanup guidance for conflicting environments.

- **Documentation**
  - Expanded system-readiness and troubleshooting guidance for gateway port conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

