### PR TITLE
fix(hermes): normalize managed relay process name

### DIFF
--- a/agents/hermes/mcp-config-transaction.py
+++ b/agents/hermes/mcp-config-transaction.py
@@ -874,7 +874,7 @@ def _process_name(pid: int) -> bytes | None:
             for line in status_file:
                 if line.startswith(b"Name:"):
                     fields = line.split(maxsplit=1)
-                    return fields[1] if len(fields) == 2 else None
+                    return fields[1].removesuffix(b"\n") if len(fields) == 2 else None
     except FileNotFoundError:
         return None
     return None

--- a/src/lib/actions/sandbox/openshell-child-visible-credentials.v0.0.101.json
+++ b/src/lib/actions/sandbox/openshell-child-visible-credentials.v0.0.101.json
@@ -41,7 +41,7 @@
       },
       {
         "path": "agents/hermes/mcp-config-transaction.py",
-        "sha256": "1d9905cee4879c21aa2df85895e331ed7cd841fcf2d5a375696e251d0c0600b4"
+        "sha256": "88988d567fd297a1d37919ad269181a7b42059c5f80cf840477322252fc89351"
       }
     ]
   },

--- a/test/openshell-0.0.101-migration-review.test.ts
+++ b/test/openshell-0.0.101-migration-review.test.ts
@@ -230,7 +230,7 @@ describe("OpenShell 0.0.101 migration review", () => {
         },
         {
           path: "agents/hermes/mcp-config-transaction.py",
-          sha256: "1d9905cee4879c21aa2df85895e331ed7cd841fcf2d5a375696e251d0c0600b4",
+          sha256: "88988d567fd297a1d37919ad269181a7b42059c5f80cf840477322252fc89351",
         },
       ],
     });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Follow-up to #9148. Normalize the `/proc/<pid>/status` process name before the managed Hermes relay identity comparison. The legitimate `socat` relay is now discoverable while every existing ownership, ancestry, argument, port, and process-lifetime check remains enforced.

## Changes

- Remove exactly one terminal line feed from the kernel process-name record.
- Refresh the reviewed security digests for the corrected Hermes transaction source.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the Hermes MCP port test reads a realistic `/proc/<pid>/status` record with its terminal line feed and exercises relay discovery.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this restores the existing managed MCP behavior without changing commands, configuration, defaults, output, remediation, or credential handling.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent Codex Desktop review passed all nine security categories; exact relay identity and lifetime checks remain fail-closed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Internal Hermes relay identity normalization only; existing managed MCP setup and troubleshooting documentation remains accurate. No user-visible command, configuration, default, output, remediation, credential-flow, or supported-workflow change.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5479e8b2c -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/hermes-mcp-api-port.test.ts test/openshell-0.0.101-migration-review.test.ts`: 2 files and 12 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process name handling by removing trailing newline characters from reported process names.

* **Tests**
  * Updated credential configuration integrity evidence and validation checks to reflect the corrected process-name handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->