### PR TITLE
fix(install): keep the interrupt status when onboarding is interrupted

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -149,6 +149,15 @@ The hosted installer's equivalent environment-variable form requires both `NEMOC
 Use the installer flag unless an automation boundary cannot pass installer arguments.
 For prerequisites, effects, verification, and recovery, refer to [Choose a Local Inference Server](../inference/local-inference/choose-local-inference-server#install-a-fixed-vllm-profile).
 
+## Hosted Installer Exit Statuses
+
+The hosted installer reports how a run stopped through its exit status.
+When you interrupt it at a prompt, it exits `130`, the same status that `$$nemoclaw onboard` reports for that interrupt.
+An interrupted onboarding run still prints `[ERROR] Onboarding did not complete successfully.` before it exits, so read the exit status rather than that line.
+The installer preserves no other signal status, and a progress step stopped by `SIGTERM` also exits `130`, so a script that stops the installer itself cannot read `130` as a deliberate interrupt.
+DGX Station host preparation exits `10` when it requires a reboot and `11` when it requires a new login session, and prints the command that resumes the install.
+Treat every other non-zero status as a failure.
+
 ## Standalone Host Commands
 
 The CLI handles host-side operations that run outside the selected agent runtime.
@@ -834,6 +843,7 @@ If the container is running but the upstream is still warming up (for example, i
 On the Docker-driver gateway path, preflight stays read-only when it detects a stale gateway (for example, a Docker-driver runtime env hash drift).
 It prints a `⚠ Gateway will be recreated when sandbox creation starts` notice and defers the actual teardown to step `[2/8] Starting OpenShell gateway`.
 This means pressing `Ctrl+C` between preflight and step `[2/8]` leaves the running gateway and existing sandbox containers untouched, so `$$nemoclaw onboard` is safe to run just to check preflight output.
+An interrupted run prints the resume command and exits with status `130` for `Ctrl+C` or `143` for `SIGTERM`.
 For Linux Docker-driver gateways, onboarding also checks that a helper container on the OpenShell Docker network can reach `host.openshell.internal:<gateway-port>`.
 If a host firewall blocks that sandbox path, onboarding exits with a `sudo ufw allow from <subnet> to <gateway-ip> port <gateway-port> proto tcp` command before it reports the gateway healthy.
 Set `NEMOCLAW_AUTO_FIX_FIREWALL=1` to opt in to automatic UFW remediation for this specific failure: NemoClaw uses `sudo -n` only, validates the Docker bridge subnet/gateway/port, applies the narrow UFW rule only after a proven TCP reachability failure, and re-probes before continuing.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -206,10 +206,13 @@ fi
 # ---------------------------------------------------------------------------
 info() { printf "${C_CYAN}[INFO]${C_RESET}  %s\n" "$*"; }
 warn() { printf "${C_YELLOW}[WARN]${C_RESET}  %s\n" "$*"; }
-error() {
+error_with_status() {
+  local status="$1"
+  shift
   printf "${C_RED}[ERROR]${C_RESET} %s\n" "$*" >&2
-  exit 1
+  exit "$status"
 }
+error() { error_with_status 1 "$@"; }
 ok() { printf "  ${C_GREEN}✓${C_RESET}  %s\n" "$*"; }
 
 resolve_nemoclaw_gateway_port() {
@@ -3950,6 +3953,14 @@ run_onboard() {
   return "$status"
 }
 
+fail_onboarding() {
+  local status="${1:-1}"
+  if [ "$status" -ne 130 ]; then
+    status=1
+  fi
+  error_with_status "$status" "Onboarding did not complete successfully."
+}
+
 station_express_receipt_retirement_pending() {
   command_exists node || return 1
   local session_file
@@ -6092,13 +6103,13 @@ main() {
           || [[ "${_STATION_EXPRESS_RESUME_LOADED:-}" == "1" ]] \
           || station_express_receipt_retirement_pending; then
           info "Existing sandboxes recovered; reconciling DGX Station Express onboarding state."
-          run_onboard || error "Onboarding did not complete successfully."
+          run_onboard || fail_onboarding "$?"
           ONBOARD_RAN=true
         else
           info "Existing sandboxes recovered; skipping generic onboarding."
         fi
       else
-        run_onboard || error "Onboarding did not complete successfully."
+        run_onboard || fail_onboarding "$?"
         ONBOARD_RAN=true
         restore_onboard_forward_after_post_checks || error "Hermes host forward restore failed."
       fi

--- a/test/install-onboard-exit.test.ts
+++ b/test/install-onboard-exit.test.ts
@@ -22,11 +22,11 @@ function installerTestEnv(home: string, env: Record<string, string> = {}): Recor
   };
 }
 
-function runOnboardExitStatus(env: Record<string, string>, stubExitCode: number): number | null {
+function runOnboardStub(env: Record<string, string>, stubScript: string): number | null {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-onboard-exit-"));
   const stubBin = path.join(tmp, "stub-cli");
 
-  fs.writeFileSync(stubBin, `#!/usr/bin/env bash\nexit ${stubExitCode}\n`, { mode: 0o755 });
+  fs.writeFileSync(stubBin, stubScript, { mode: 0o755 });
 
   const snippet = `
     set -e
@@ -47,14 +47,21 @@ function runOnboardExitStatus(env: Record<string, string>, stubExitCode: number)
   return result.status;
 }
 
+function runOnboardExitStatus(env: Record<string, string>, stubExitCode: number): number | null {
+  return runOnboardStub(env, `#!/usr/bin/env bash\nexit ${stubExitCode}\n`);
+}
+
+function runOnboardInterruptedStatus(env: Record<string, string>): number | null {
+  return runOnboardStub(env, `#!/usr/bin/env bash\ntrap - INT\nkill -INT $$\nsleep 5\n`);
+}
+
 function runMainOnboardGate(stubExitCode: number): number | null {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-onboard-gate-"));
   const snippet = `
     set -e
     source "${INSTALLER_PAYLOAD}" >/dev/null 2>&1 || true
     run_onboard() { return ${stubExitCode}; }
-    error() { exit 1; }
-    run_onboard || error "Onboarding did not complete successfully."
+    run_onboard || fail_onboarding "$?"
   `;
 
   const result = spawnSync("bash", ["-c", snippet], {
@@ -79,5 +86,17 @@ describe("install.sh run_onboard exit propagation (#5029)", () => {
 
   it("main onboarding gate continues when run_onboard succeeds", () => {
     expect(runMainOnboardGate(0)).toBe(0);
+  });
+
+  it("reports 130 when nemoclaw onboard is terminated by an interrupt (#9121)", () => {
+    expect(runOnboardInterruptedStatus(ACCEPTED_NON_INTERACTIVE_ENV)).toBe(130);
+  });
+
+  it("main onboarding gate keeps the interrupt status instead of reporting a failed install (#9121)", () => {
+    expect(runMainOnboardGate(130)).toBe(130);
+  });
+
+  it("main onboarding gate reports every other failure as 1 (#9121)", () => {
+    expect(runMainOnboardGate(2)).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Interrupting the hosted installer at the NVIDIA API Key prompt exited `1`, the same status as a failed install, while `nemoclaw onboard` interrupted at that same prompt exits `130`. A script wrapping the installer therefore could not tell a deliberate interrupt from a failure. The installer now keeps `130` and still normalises every other non-zero status to `1`.

## Related Issue

Fixes #9121

## Changes

- `scripts/install.sh`: `error_with_status` prints the existing `[ERROR]` line and exits with a caller-supplied status; `error` delegates to it with `1`, so its callers are unchanged. `fail_onboarding` keeps `130` and reports every other non-zero status as `1`, and both `run_onboard ||` gates call it. No abstraction, configuration, fallback, or compatibility path is added: `error_with_status` has one other consumer, `fail_onboarding`, and the gate behaviour is protected by the tests below.
- `test/install-onboard-exit.test.ts`: the existing `runMainOnboardGate` mirrored the retired `|| error` expression, so the gate could lose the interrupt status without failing. It now mirrors the real expression and calls the real `fail_onboarding`. The stub-CLI helper was split so a stub body can be supplied. Three cases added: a stub CLI that genuinely dies from `SIGINT` is observed as `130` by `run_onboard`; the gate keeps `130`; the gate reports `2` as `1`.
- `docs/reference/commands.mdx`: a new `Hosted Installer Exit Statuses` section records the interrupt status, the `[ERROR]` line the installer still prints on an interrupt, the `SIGTERM` limitation below, and the already-documented DGX Station statuses `10` and `11`. The `$$nemoclaw onboard` section now states the `130` and `143` statuses that the new section compares against.

Why the fix is at the gate rather than at the prompt. The masked credential prompt puts the terminal in raw mode, so Ctrl+C arrives as byte `0x03` and the terminal never raises `SIGINT` on the foreground process group. The installer's shell is therefore never signalled: the CLI alone re-raises `SIGINT` on itself, dies from it, and the shell computes `130`. `run_onboard` propagated that status correctly; only the gate discarded it.

Deliberately unchanged, and recorded in the new documentation rather than fixed here:

- `SIGTERM` is not preserved. `spin` maps both `INT` and `TERM` to `exit 130` for the duration of a progress step, and a `SIGTERM` that reaches the CLI alone normalises to `1` at the gate. `SIGTERM` is never generated by the terminal, so it is not reachable from the reported defect, and changing it would alter installer behaviour without a defect that calls for it.
- The other installer stages. `ensure_docker` exits `0` when Docker group membership is not yet active and prints a rerun command, and `spin` returns a failed step's own status. Both predate this issue and are not reachable from the reported defect.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: the changed documentation path is `docs/reference/commands.mdx`. The reviewer read `docs/AGENTS.md`, `docs/CONTRIBUTING.md`, `WRITING.md`, the controlled word list, the shared documentation writing and review contract, the changed page, `docs/reference/system-readiness.mdx`, `docs/get-started/quickstart.mdx`, `docs/get-started/dgx-station-preparation.mdx`, `docs/deployment/deploy-to-headless-server.mdx`, `docs/inference/set-up-vllm-on-two-dgx-stations.mdx`, `docs/reference/troubleshooting.mdx`, and `docs/resources/engineer-agentic-documentation.mdx`, and searched `docs/` for every exit-status, interrupt, `SIGINT`, reboot-required, and hosted-installer string. It applied the Product Scope Gate and recorded that this corrects an already-documented surface. Its required findings were applied in this commit: the original prose claimed that the installer exits `1` for any failure, which contradicts `docs/get-started/dgx-station-preparation.mdx` and `docs/inference/set-up-vllm-on-two-dgx-stations.mdx`, both of which already document status `10`; it claimed that `130` identifies a deliberate interrupt, which the `spin` trap breaks for `SIGTERM`; it scoped the interrupt status to onboarding prompts when the installer's own prompts report it too; it omitted the `[ERROR]` line that an interrupted run still prints; and the section sat at the wrong heading level under `Hosted Installer Options`, whose other entries are all option names. Its `SIGTERM` finding was applied in the narrower form above after I probed the behaviour directly: a `SIGTERM` that reaches only the CLI does normalise to `1`, but the group case exits `143` before the gate runs, so the broader wording the reviewer proposed would have overclaimed. Two optional findings were not applied: a full exit-status table would document the `exit 0` Docker-group path and the `SIGTERM`-to-`130` mapping as intended contract rather than as the current behaviour, and a cross-link from `docs/deployment/deploy-to-headless-server.mdx` adds link surface this change does not require. `npm run docs` reported 0 errors and 2 warnings after the review edits; both predate this change and are environmental, one an unauthenticated missing-redirects check and one a light-mode accent contrast ratio. The review ran once, against the working tree that became this commit, and was not rerun afterwards.
- Agent: Claude Code
<!-- docs-review-head-sha: eab0434de -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/install-onboard-exit.test.ts` — 7 passed, rerun after the documentation review edits. `npx vitest run --project integration test/install-` — 25 files, 276 passed. `npm run typecheck:cli`, `npm run checks:repository`, and `npm run build:cli` all clean. Non-vacuity was checked rather than assumed: sourcing the unmodified installer and running the retired gate expression with a `130` stub exits `1`, while the new gate exits `130`. `npx vitest run --project installer-integration` reported 9 failed of 564; all 9 are DGX Station host-preparation cases failing on `A reboot is pending on the Station factory image` because the test host carries `/var/run/reboot-required`, and `scripts/prepare-dgx-station-host.sh` is untouched by this change.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented hosted installer exit statuses, including interruption, termination, reboot, and login requirements.
  - Clarified that onboarding interruption returns status `130` for `Ctrl+C` and `143` for `SIGTERM`.
  - Explained that other non-zero statuses indicate onboarding failures.

- **Bug Fixes**
  - Installer onboarding now preserves interruption statuses while consistently reporting other failures with status `1`.
  - Improved error handling across standard and recovery onboarding flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->