### PR TITLE
test(e2e): describe workflow checks plainly

### DIFF
--- a/test/e2e/support/e2e-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-operations-workflow-boundary.test.ts
@@ -27,28 +27,42 @@ function workflowScript(jobName: string, stepName: string): string {
   return step?.with?.script as string;
 }
 
-describe("E2E operations workflow boundary", testTimeoutOptions(15_000), () => {
-  it("accepts the checked-in workflow and rejects aggregation, permission, and secret-scope drift", () => {
+describe("E2E operations workflow", testTimeoutOptions(15_000), () => {
+  it("accepts the checked-in workflow", () => {
     expect(validateE2eOperationsWorkflowBoundary()).toEqual([]);
+  });
 
+  it("requires the scorecard to wait for every reporting dependency", () => {
     const workflow = readE2eOperationsWorkflow();
     workflow.jobs.scorecard.needs = [...(workflow.jobs.scorecard.needs as string[])];
     (workflow.jobs.scorecard.needs as string[]).pop();
+
+    expect(validateE2eOperationsWorkflow(workflow)).toContain(
+      "scorecard needs must exactly match report-to-pr needs",
+    );
+  });
+
+  it("limits scorecard permissions to read access", () => {
+    const workflow = readE2eOperationsWorkflow();
     workflow.jobs.scorecard.permissions = {
       actions: "read",
       contents: "read",
       issues: "write",
     };
+
+    expect(validateE2eOperationsWorkflow(workflow)).toContain(
+      "scorecard permissions must be actions: read and contents: read",
+    );
+  });
+
+  it("does not expose credentials to the scorecard job", () => {
+    const workflow = readE2eOperationsWorkflow();
     workflow.jobs.scorecard.env = {
       SLACK_WEBHOOK_URL_DAILY: "${{ secrets.SLACK_WEBHOOK_URL_DAILY }}",
     };
 
-    expect(validateE2eOperationsWorkflow(workflow)).toEqual(
-      expect.arrayContaining([
-        "scorecard needs must exactly match report-to-pr needs",
-        "scorecard permissions must be actions: read and contents: read",
-        "scorecard must not expose credentials at job scope",
-      ]),
+    expect(validateE2eOperationsWorkflow(workflow)).toContain(
+      "scorecard must not expose credentials at job scope",
     );
   });
 
@@ -67,7 +81,7 @@ describe("E2E operations workflow boundary", testTimeoutOptions(15_000), () => {
     );
   });
 
-  it("binds release qualification to the trusted full-run result set (#7912)", () => {
+  it("requires release qualification to evaluate every full-run result (#7912)", () => {
     const workflow = readE2eOperationsWorkflow();
     workflow.jobs["release-qualification"].if = "${{ always() }}";
     workflow.jobs["release-qualification"].needs = ["generate-matrix"];
@@ -97,7 +111,7 @@ describe("E2E operations workflow boundary", testTimeoutOptions(15_000), () => {
     );
   });
 
-  it("pins the relevant E2E aggregate to the trusted push result set (#7912)", () => {
+  it("requires the push summary to evaluate every selected E2E result (#7912)", () => {
     const workflow = readE2eOperationsWorkflow();
     const job = workflow.jobs["relevant-e2e"];
     job.if = "${{ always() }}";
@@ -230,7 +244,7 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
     );
   });
 
-  it("rejects manual PR authorization and checkout validation drift", () => {
+  it("validates manual PR dispatch inputs and the checked-out commit", () => {
     const workflow = readE2eOperationsWorkflow();
     delete workflow.on?.workflow_dispatch?.inputs?.review_reason;
     const authentication = workflow.jobs["generate-matrix"].steps!.find(
@@ -381,7 +395,7 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
     );
   });
 
-  it("rejects drift from the manual PR risk-signal identity inputs", () => {
+  it("passes the requested SHA and correlation ID to manual PR jobs", () => {
     const workflow = readE2eOperationsWorkflow();
     workflow.env!.NEMOCLAW_E2E_EXPECTED_SHA = "${{ inputs.checkout_sha || github.sha }}";
     workflow.env!.NEMOCLAW_E2E_CORRELATION_ID = "";
@@ -394,7 +408,7 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
     );
   });
 
-  it("limits manual PR runs to trusted controller selectors or opted-in Jetson dispatch", () => {
+  it("limits manual PR runs to controller-approved selectors or Jetson dispatch", () => {
     const workflow = readE2eOperationsWorkflow();
     const authentication = workflow.jobs["generate-matrix"].steps!.find(
       (step) => step.name === "Authenticate manual PR dispatch",
@@ -409,7 +423,7 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
     );
   });
 
-  it("keeps the controller selector cases equal to the Advisor planning contract", () => {
+  it("uses the same controller selectors as the PR Review Advisor", () => {
     const workflow = readE2eOperationsWorkflow();
     const authentication = workflow.jobs["generate-matrix"].steps!.find(
       (step) => step.name === "Authenticate manual PR dispatch",
@@ -500,7 +514,7 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
     }
   });
 
-  it("accepts the controller target matrix for the current PR head", () => {
+  it("accepts the controller target matrix for the commit under review", () => {
     const workflow = readE2eOperationsWorkflow();
     const generateMatrix = workflow.jobs["generate-matrix"];
     const controller = generateMatrix.steps!.find(
@@ -643,7 +657,7 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
     }
   });
 
-  it("keeps every planned job wired to bound evidence", () => {
+  it("reports a result for every planned job", () => {
     const workflow = readE2eOperationsWorkflow();
     const job = workflow.jobs["cloud-onboard"];
     job.env!.E2E_TARGET_ID = "different-job";
@@ -729,7 +743,7 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
     );
   });
 
-  it("requires prNumber and report to originate from the trusted resolveReportPr and renderE2eReport calls", () => {
+  it("derives the PR number and report text from the validated helper results", () => {
     const workflow = readE2eOperationsWorkflow();
     const report = workflow.jobs["report-to-pr"].steps!.find(
       (step) => step.name === "Post E2E target results to PR",
@@ -1143,7 +1157,7 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
     }
   });
 
-  it("rejects raw trace upload ordering and unified advisor auto-dispatch", () => {
+  it("sanitizes raw traces before cleanup", () => {
     const workflow = readE2eOperationsWorkflow();
     const cloudSteps = workflow.jobs["cloud-onboard"].steps!;
     const sanitize = cloudSteps.find(
@@ -1151,6 +1165,13 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
     )!;
     sanitize.run = "cp -R raw-traces e2e-artifacts";
 
+    expect(validateE2eOperationsWorkflow(workflow)).toContain(
+      "cloud-onboard trace sanitizer must retain scripts/e2e/sanitize-trace-timing.py",
+    );
+  });
+
+  it("prevents the PR Review Advisor from writing to Actions or dispatching workflows", () => {
+    const workflow = readE2eOperationsWorkflow();
     const directory = mkdtempSync(join(tmpdir(), "nemoclaw-e2e-operations-"));
     const advisorPath = join(directory, "advisor.yaml");
     try {
@@ -1165,7 +1186,6 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
       );
       expect(validateE2eOperationsWorkflow(workflow, advisorPath)).toEqual(
         expect.arrayContaining([
-          "cloud-onboard trace sanitizer must retain scripts/e2e/sanitize-trace-timing.py",
           "Unified advisor must not hold actions: write",
           "Unified advisor must not auto-dispatch workflows",
         ]),

--- a/test/e2e/support/e2e-trusted-dispatch-receipt-workflow.test.ts
+++ b/test/e2e/support/e2e-trusted-dispatch-receipt-workflow.test.ts
@@ -6,8 +6,8 @@ import { describe, expect, it } from "vitest";
 import { validateE2eWorkflow } from "../../../tools/e2e/workflow-boundary.mts";
 import { readWorkflow } from "../../helpers/e2e-workflow-contract";
 
-describe("trusted E2E dispatch receipt workflow boundary", () => {
-  it("rejects incomplete or mutable trusted PR dispatch receipts", () => {
+describe("manual PR dispatch receipt", () => {
+  it("rejects receipts with missing fields, changed schema, or mutable uploads", () => {
     const workflow = readWorkflow() as {
       jobs: Record<
         string,
@@ -44,7 +44,7 @@ describe("trusted E2E dispatch receipt workflow boundary", () => {
     );
   });
 
-  it("rejects candidate execution before the trusted PR dispatch receipt", () => {
+  it("records and uploads the receipt after authentication and before checkout", () => {
     const workflow = readWorkflow() as {
       jobs: Record<
         string,

--- a/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
+++ b/test/e2e/support/managed-image-protected-runtime-workflow.test.ts
@@ -38,19 +38,19 @@ function namedStep(value: WorkflowRecord, name: string): Record<string, unknown>
   return step as Record<string, unknown>;
 }
 
-describe("protected managed-image runtime workflow boundary", () => {
-  it("accepts the exact activated trusted runtime lane", () => {
+describe("protected managed-image runtime workflow", () => {
+  it("accepts the checked-in protected runtime job", () => {
     expect(validateManagedImageProtectedRuntimeWorkflow(workflow())).toEqual([]);
   });
 
-  it("accepts the exact hosted-build to protected-runtime cache handoff", () => {
+  it("accepts the hosted build-cache handoff to the protected runtime job", () => {
     const value = workflow();
 
     expect(validateManagedImageMultiarchWorkflow(value)).toEqual([]);
     expect(validateManagedImageProtectedRuntimeWorkflow(value)).toEqual([]);
   });
 
-  it("binds protected risk evidence to the isolated exact candidate checkout", () => {
+  it("runs protected runtime checks from .candidate-runtime", () => {
     const value = workflow();
     const jobEnv = runtimeJob(value).env as Record<string, unknown>;
     jobEnv.NEMOCLAW_E2E_TESTED_ROOT = "${{ github.workspace }}";
@@ -80,7 +80,7 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   });
 
-  it("binds protected candidate identity on ordinary main runs", () => {
+  it("uses github.sha for main pushes", () => {
     const value = workflow();
     const jobEnv = multiarchJob(value).env as Record<string, unknown>;
     jobEnv.NEMOCLAW_PROTECTED_MANAGED_IMAGE_HEAD_SHA = "${{ inputs.checkout_sha }}";
@@ -90,7 +90,7 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   });
 
-  it("ships the exact activation contract consumed by the trusted lane (#7744)", () => {
+  it("lists every supported agent and provider in the activation file (#7744)", () => {
     const activation = JSON.parse(
       fs.readFileSync(
         path.resolve(
@@ -122,7 +122,7 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   });
 
-  it("rejects checking candidate source out over trusted qualification code", () => {
+  it("does not replace workflow code with the source under test", () => {
     const value = workflow();
     const candidateCheckout = namedStep(value, "Checkout exact protected runtime candidate source");
     (candidateCheckout.with as Record<string, unknown>).path = ".";
@@ -132,7 +132,7 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   });
 
-  it("rejects exposing the NGC credential to candidate-controlled steps", () => {
+  it("passes the NGC credential only to the qualification step", () => {
     const value = workflow();
     namedStep(value, "Validate protected runtime activation contract").env = {
       NVIDIA_API_KEY: "${{ secrets.NVIDIA_API_KEY }}",
@@ -143,7 +143,7 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   });
 
-  it("rejects executing candidate checkout paths in the secret-bearing qualification step", () => {
+  it("prevents the credentialed qualification step from executing .candidate-runtime files", () => {
     const value = workflow();
     const qualification = namedStep(
       value,
@@ -156,7 +156,7 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   });
 
-  it("rejects removing NIM from the activation contract", () => {
+  it("requires NIM in the activation file", () => {
     const value = workflow();
     const step = namedStep(value, "Validate protected runtime activation contract");
     step.run = String(step.run).replace(
@@ -169,7 +169,7 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   });
 
-  it("rejects qualification before exact all-agent image construction", () => {
+  it("runs qualification only after every agent image is built", () => {
     const value = workflow();
     const job = runtimeJob(value);
     const workflowSteps = job.steps as Array<Record<string, unknown>>;
@@ -202,7 +202,7 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   });
 
-  it("rejects removing the exact protected runtime cache download", () => {
+  it("requires one protected runtime cache download", () => {
     const value = workflow();
     const job = runtimeJob(value);
     job.steps = (job.steps as Array<Record<string, unknown>>).filter(
@@ -230,7 +230,7 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   }, 15_000);
 
-  it("rejects a GPU rebuild that omits the exact hosted cache import", () => {
+  it("requires GPU rebuilds to import the hosted build cache", () => {
     const value = workflow();
     const build = namedStep(value, "Build exact all-agent protected runtime images");
     build.run = String(build.run).replace(
@@ -253,7 +253,7 @@ describe("protected managed-image runtime workflow boundary", () => {
     );
   });
 
-  it("rejects removing the exact amd64 build cache publication", () => {
+  it("requires one amd64 build-cache upload", () => {
     const value = workflow();
     const job = multiarchJob(value);
     job.steps = (job.steps as Array<Record<string, unknown>>).filter(

--- a/test/e2e/support/mcp-workflow-compatibility.test.ts
+++ b/test/e2e/support/mcp-workflow-compatibility.test.ts
@@ -12,7 +12,7 @@ import { validateMcpOpenShellWorkflowBoundary } from "../../../tools/e2e/mcp-wor
 import { requireFixture } from "./require-fixture";
 
 describe("MCP workflow runtime compatibility", () => {
-  it("accepts harmless classifier key reordering (#6426)", () => {
+  it("accepts compatibility-step keys in any order (#6426)", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-workflow-"));
     const workflowPath = path.join(directory, "e2e.yaml");
     try {
@@ -38,7 +38,7 @@ describe("MCP workflow runtime compatibility", () => {
     }
   });
 
-  it("gates the dev full lifecycle on the canonical runtime classifier (#6426)", () => {
+  it("runs the development MCP test only for the reviewed OpenShell version (#6426)", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-workflow-"));
     const workflowPath = path.join(directory, "e2e.yaml");
     try {
@@ -73,7 +73,7 @@ describe("MCP workflow runtime compatibility", () => {
     }
   });
 
-  it("rejects dev compatibility classifier identity or ordering drift (#6426)", () => {
+  it("pins the compatibility script and runs it before the development MCP test (#6426)", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-workflow-"));
     const workflowPath = path.join(directory, "e2e.yaml");
     try {
@@ -109,7 +109,7 @@ describe("MCP workflow runtime compatibility", () => {
     }
   });
 
-  it("rejects bypasses around the dev compatibility classifier (#6426)", () => {
+  it("does not skip or ignore compatibility-check failures (#6426)", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-workflow-"));
     const workflowPath = path.join(directory, "e2e.yaml");
     try {
@@ -145,7 +145,7 @@ describe("MCP workflow runtime compatibility", () => {
     }
   });
 
-  it("keeps the stable MCP lifecycle independent of dev compatibility branching (#6426)", () => {
+  it("runs the stable MCP test without the development compatibility check (#6426)", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-workflow-"));
     const workflowPath = path.join(directory, "e2e.yaml");
     try {

--- a/test/e2e/support/openshell-exact-main-driver-config.test.ts
+++ b/test/e2e/support/openshell-exact-main-driver-config.test.ts
@@ -26,8 +26,8 @@ afterEach(() => {
   restoreProofEnv();
 });
 
-describe("exact-main selected-driver config proof boundary", () => {
-  it("does not inject driver config outside the explicit candidate-main lane", async () => {
+describe("OpenShell driver configuration for main-branch E2E", () => {
+  it("does nothing when the driver configuration check is disabled", async () => {
     delete process.env[EXACT_MAIN_DRIVER_CONFIG_PROOF_ENV];
     const add = vi.fn();
 
@@ -38,7 +38,7 @@ describe("exact-main selected-driver config proof boundary", () => {
     expect(add).not.toHaveBeenCalled();
   });
 
-  it("injects only the reviewed structured tmpfs config on sandbox create", () => {
+  it("adds the tmpfs driver configuration only to sandbox create", () => {
     const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-exact-main-driver-wrapper-"));
     const delegate = path.join(fixture, "openshell-real");
     fs.writeFileSync(delegate, "#!/bin/sh\nprintf '%s\\n' \"$@\"\n", {
@@ -97,7 +97,7 @@ describe("exact-main selected-driver config proof boundary", () => {
     }
   });
 
-  it("preserves production driver config when the wrapper only delegates capabilities", () => {
+  it("passes through an existing driver configuration unchanged", () => {
     const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-exact-main-pass-through-"));
     const delegate = path.join(fixture, "openshell-real");
     fs.writeFileSync(delegate, "#!/bin/sh\nprintf '%s\\n' \"$@\"\n", {
@@ -128,7 +128,7 @@ describe("exact-main selected-driver config proof boundary", () => {
     }
   });
 
-  it("expects graceful gateway recovery to remount tmpfs while retaining durable state", () => {
+  it("expects gateway restart to empty tmpfs and preserve persistent files", () => {
     const source = fs.readFileSync(
       path.join("test", "e2e", "live", "openshell-exact-main-driver-config.ts"),
       "utf8",

--- a/test/e2e/support/standard-profile-workflow-boundary.test.ts
+++ b/test/e2e/support/standard-profile-workflow-boundary.test.ts
@@ -14,7 +14,7 @@ import { readWorkflow } from "../../helpers/e2e-workflow-contract";
 
 const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 
-describe("standard E2E execution profile boundary", () => {
+describe("standard E2E execution profile", () => {
   it("accepts the catalogue callers and reusable profile", () => {
     expect(validateStandardProfileWorkflowBoundary(readWorkflow())).toEqual([]);
   });
@@ -66,7 +66,7 @@ describe("standard E2E execution profile boundary", () => {
     );
   });
 
-  it("rejects catalogue callers without dispatch-bound manual PR risk-signal identity", () => {
+  it("passes checkout_sha and the correlation ID from the catalogue matrix", () => {
     const workflow = readWorkflow() as {
       jobs: Record<string, { with: Record<string, string> }>;
     };
@@ -83,22 +83,29 @@ describe("standard E2E execution profile boundary", () => {
     );
   });
 
-  it("rejects target display-name and credential-boundary drift", () => {
+  it("uses the planned target display name", () => {
     const workflow = readWorkflow() as {
       jobs: Record<string, { name: string; with: Record<string, string> }>;
     };
     workflow.jobs["catalogue-standard"]!.name = "${{ matrix.id }}";
-    workflow.jobs["catalogue-nvidia-api"]!.with.credential_boundary = "NVIDIA inference API key";
 
-    expect(validateStandardProfileWorkflowBoundary(workflow)).toEqual(
-      expect.arrayContaining([
-        "catalogue-standard must use the planned outcome-first display name",
-        "catalogue-nvidia-api must pass credential_boundary from the catalogue matrix",
-      ]),
+    expect(validateStandardProfileWorkflowBoundary(workflow)).toContain(
+      "catalogue-standard must use the planned outcome-first display name",
     );
   });
 
-  it("rejects shared host, telemetry, secret, and artifact drift", () => {
+  it("passes each profile's credential description from the catalogue matrix", () => {
+    const workflow = readWorkflow() as {
+      jobs: Record<string, { with: Record<string, string> }>;
+    };
+    workflow.jobs["catalogue-nvidia-api"]!.with.credential_boundary = "NVIDIA inference API key";
+
+    expect(validateStandardProfileWorkflowBoundary(workflow)).toContain(
+      "catalogue-nvidia-api must pass credential_boundary from the catalogue matrix",
+    );
+  });
+
+  it("rejects changes to shared setup, credentials, telemetry, and artifact paths", () => {
     const profile = YAML.parse(
       fs.readFileSync(
         path.join(REPO_ROOT, ".github", "workflows", "e2e-standard-profile.yaml"),
@@ -284,7 +291,7 @@ describe("standard E2E execution profile boundary", () => {
     }
   });
 
-  it("rejects checkout, credential guard, target execution, and cleanup drift", () => {
+  it("keeps checkout, credential cleanup, target execution, and artifact upload in order", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-standard-profile-"));
     const profilePath = path.join(tmp, "profile.yaml");
     const profile = YAML.parse(

--- a/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
+++ b/test/e2e/support/upload-e2e-artifacts-workflow-boundary.test.ts
@@ -76,19 +76,19 @@ function validateActionMutation(mutate: (action: MutableAction) => void): string
   });
 }
 
-describe("upload-e2e-artifacts workflow boundary", () => {
-  it("binds one canonical uploader to every E2E execution job", () => {
+describe("E2E artifact uploads", () => {
+  it("uses the shared uploader in every E2E execution job", () => {
     expect(validateUploadE2eArtifactsAction()).toEqual([]);
     expect(validateUploadE2eArtifactsInvocations(readWorkflow())).toEqual([]);
   });
 
-  it("rejects semantic-neutral action byte drift from the immutable provenance", () => {
+  it("rejects any change to the upload action pinned by the workflow", () => {
     expect(validateActionSourceMutation((source) => `${source}# unreviewed drift\n`)).toEqual([
       "upload-e2e-artifacts content must match the action reviewed at its immutable commit pin",
     ]);
   });
 
-  it("rejects action upload-policy and inner always drift", () => {
+  it("retains E2E artifacts for 14 days", () => {
     const policyErrors = validateActionMutation((action) => {
       action.runs.steps[0].with!["retention-days"] = 7;
     });
@@ -96,13 +96,16 @@ describe("upload-e2e-artifacts workflow boundary", () => {
       "upload-e2e-artifacts must preserve artifact defaults, hidden-file policy, missing-file behavior, and retention",
     );
 
-    const alwaysErrors = validateActionMutation((action) => {
-      action.runs.steps[0].if = "${{ success() }}";
-    });
-    expect(alwaysErrors).toContain("upload-e2e-artifacts inner step must run with always()");
   });
 
-  it("rejects checkout-local, direct, and unreviewed remote upload actions", () => {
+  it("uploads artifacts even when an earlier step fails", () => {
+    const errors = validateActionMutation((action) => {
+      action.runs.steps[0].if = "${{ success() }}";
+    });
+    expect(errors).toContain("upload-e2e-artifacts inner step must run with always()");
+  });
+
+  it("uses the pinned shared action for ordinary E2E result uploads", () => {
     const workflow = mutableWorkflow();
     uploadStep(workflow.jobs["messaging-providers"]).uses = LOCAL_UPLOAD_ACTION;
     uploadStep(workflow.jobs["openclaw-plugin-runtime-exdev"]).uses = DIRECT_UPLOAD_ACTION;
@@ -121,7 +124,7 @@ describe("upload-e2e-artifacts workflow boundary", () => {
     );
   });
 
-  it("rejects reusing the protected build-cache upload exception for another step", () => {
+  it("allows the named protected build-cache step to upload directly", () => {
     const workflow = mutableWorkflow();
     const job = workflow.jobs["managed-image-multiarch-startup"];
     const cacheUpload = job.steps?.find(
@@ -135,7 +138,7 @@ describe("upload-e2e-artifacts workflow boundary", () => {
     );
   });
 
-  it("rejects release qualification waiver upload drift", () => {
+  it("retains release waiver evidence for 30 days", () => {
     const workflow = mutableWorkflow();
     const upload = workflow.jobs["release-qualification"].steps?.find(
       (step) => step.name === "Upload release qualification waiver evidence",
@@ -151,7 +154,7 @@ describe("upload-e2e-artifacts workflow boundary", () => {
   it.each([
     ["name", "another-cache-artifact"],
     ["path", "another-cache-path/"],
-  ])("rejects protected build-cache upload %s drift", (input, value) => {
+  ])("uses the required protected build-cache upload %s", (input, value) => {
     const workflow = mutableWorkflow();
     const job = workflow.jobs["managed-image-multiarch-startup"];
     const cacheUpload = job.steps?.find(
@@ -168,7 +171,7 @@ describe("upload-e2e-artifacts workflow boundary", () => {
     );
   });
 
-  it("rejects duplicate exact protected build-cache upload steps", () => {
+  it("allows only one protected build-cache upload step", () => {
     const workflow = mutableWorkflow();
     const job = workflow.jobs["managed-image-multiarch-startup"];
     const cacheUpload = job.steps?.find(
@@ -199,7 +202,7 @@ describe("upload-e2e-artifacts workflow boundary", () => {
     );
   });
 
-  it("rejects scorecard push runtime summary drift", () => {
+  it("uploads the scorecard summary from its configured path", () => {
     const workflow = mutableWorkflow();
     uploadStep(workflow.jobs.scorecard).with!.path = "runtime-summary.json";
 
@@ -208,7 +211,7 @@ describe("upload-e2e-artifacts workflow boundary", () => {
     );
   });
 
-  it("rejects default, explicit-exception, caller-key, and caller-if drift", () => {
+  it("requires each caller to use its configured inputs and condition", () => {
     const workflow = mutableWorkflow();
     const defaultJob = workflow.jobs["messaging-providers"];
     uploadStep(defaultJob).with = { name: "e2e-messaging-providers" };

--- a/test/e2e/support/workflow-plan.test.ts
+++ b/test/e2e/support/workflow-plan.test.ts
@@ -129,7 +129,7 @@ describe("E2E workflow plan", () => {
     expect(selectedWorkflowJobs(plan)).toEqual(["catalogue-nvidia-inference"]);
   });
 
-  it("preserves the migrated retained-target execution contracts", () => {
+  it("preserves the profile, timeout, install mode, packages, and environment for migrated targets", () => {
     expect(catalogueTarget("gateway-guard-recovery")).toMatchObject({
       profile: "nvidia-inference",
       timeoutMinutes: 45,
@@ -449,7 +449,7 @@ describe("E2E workflow plan", () => {
     ).toThrow("invalid or duplicate display name");
   });
 
-  it("withholds credentialed catalogue profiles from PR candidate runs", () => {
+  it("omits credentialed catalogue profiles when checkout_sha is set", () => {
     const directory = mkdtempSync(path.join(tmpdir(), "nemoclaw-workflow-plan-pr-"));
     const output = path.join(directory, "github-output");
     const summary = path.join(directory, "summary.md");
@@ -477,7 +477,7 @@ describe("E2E workflow plan", () => {
     }
   });
 
-  it("defines PR candidate eligibility once for every catalogue profile", () => {
+  it("allows manual PR dispatch only for standard-profile targets", () => {
     expect(
       Object.fromEntries(
         E2E_TARGET_CATALOGUE.map((target) => [
@@ -531,7 +531,7 @@ describe("E2E workflow plan", () => {
     expect(selectedWorkflowJobs(plan)).toEqual(["catalogue-standard", "jetson-nvmap-gpu"]);
   });
 
-  it("selects the Jetson proof when no other retained E2E owns a changed file (#8142)", () => {
+  it("selects the Jetson test when no other E2E job owns a changed file (#8142)", () => {
     const plan = buildE2eWorkflowPlan({}, { changedFiles: ["docs/index.yml"] });
 
     expect(selectedWorkflowJobs(plan)).toEqual(["jetson-nvmap-gpu"]);
@@ -582,7 +582,7 @@ describe("E2E workflow plan", () => {
     expect(targetIds).toEqual(expect.arrayContaining(["onboard-repair", "onboard-resume"]));
   });
 
-  it("uses one risk rule for catalogue and retained workflow jobs", () => {
+  it("uses one risk rule for catalogue targets and workflow jobs", () => {
     const plan = buildE2eWorkflowPlan(
       {},
       { changedFiles: ["src/lib/messaging/applier/agent-config.ts"] },
@@ -661,7 +661,7 @@ describe("E2E workflow plan", () => {
     },
   );
 
-  it("maps the trusted-main bootstrap job during a PR controller checkout", () => {
+  it("maps launchable-smoke to bootstrap-install-smoke when checkout_sha is set", () => {
     const directory = mkdtempSync(path.join(tmpdir(), "nemoclaw-workflow-plan-cli-"));
     const output = path.join(directory, "github-output");
     const summary = path.join(directory, "summary.md");
@@ -691,7 +691,7 @@ describe("E2E workflow plan", () => {
     }
   });
 
-  it("plans active jobs while the candidate verifies retired controller selectors (#7616)", () => {
+  it("plans active jobs while checking retired controller selectors (#7616)", () => {
     const directory = mkdtempSync(path.join(tmpdir(), "nemoclaw-workflow-plan-cli-"));
     const output = path.join(directory, "github-output");
     const summary = path.join(directory, "summary.md");
@@ -988,7 +988,7 @@ describe("E2E workflow plan", () => {
     expect(output).toBe(`${JSON.stringify(parsed)}\n`);
   });
 
-  it("renders the selected matrix and retained jobs as a readable plan", () => {
+  it("renders the selected targets and workflow jobs as a readable plan", () => {
     const filtered = spawnSync(TSX, [PLANNER_CLI, "--summary", "--jobs", "hermes-e2e"], {
       cwd: REPO_ROOT,
       encoding: "utf8",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

E2E support tests now describe the input they change and the result they require. The previous titles combined terms such as `exact`, `candidate`, `trusted`, `boundary`, `contract`, and `drift` without stating the tested behavior.

## Changes

- Rewrite titles in eight workflow-focused E2E support suites with direct behavior language.
- Split combined scorecard, catalogue-profile, artifact-retention, raw-trace, and advisor checks so each title matches its assertions.
- Leave workflow definitions, validators, credentials, target selection, and runtime behavior unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This change renames and regroups existing tests without changing assertions or product behavior. GitHub CI will execute the edited suites; a duplicate local run was omitted at maintainer direction.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The changed text is internal test output and does not alter a public API, CLI, configuration, default, workflow, or documentation route.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Only internal E2E test titles and grouping changed. No workflow, validator, credential, selection, runtime, or user-visible behavior changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 30df5b5800 -->
<!-- docs-review-agents-blob-sha: e30afb270b -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — Tests are marked not applicable because this is a test-title and grouping change; GitHub CI will execute the edited suites.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — Not applicable; no runtime or shared test harness changed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Reorganized workflow boundary coverage into smaller, behavior-focused end-to-end tests.
  - Clarified validation for dispatch receipts, protected runtimes, artifact uploads, workflow plans, permissions, credentials, selectors, and release qualification.
  - Updated test descriptions to reflect current terminology and expected behavior.
  - Preserved existing assertions and workflow constraint coverage while improving test readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->