### PR TITLE
docs: document Google Gemini embedding-model filtering and troubleshooting (#8971)

### DIFF
--- a/docs/inference/use-google-gemini.mdx
+++ b/docs/inference/use-google-gemini.mdx
@@ -45,7 +45,11 @@ NemoClaw validates Gemini inference through its OpenAI-compatible Chat Completio
 When you enter a custom Gemini model ID, NemoClaw checks Google's native model catalog and accepts IDs with or without the `models/` prefix.
 It skips the Responses API probe because Gemini does not support `/v1/responses`.
 
+Google's native model catalog also lists embedding-only models, which do not support chat completions.
+NemoClaw filters these out of the catalog before matching your selection, so embedding-only models are never offered during onboarding and always fail validation if entered manually.
+
 ## Related Topics
 
 - [Choose a Model](../learn-and-choose/choose-model) compares the curated Gemini models by task fit.
 - [Understand Provider Validation](../validate-inference/understand-provider-validation) describes provider validation behavior.
+- [Troubleshooting](../reference/troubleshooting#google-gemini-rejects-a-curated-or-custom-model) lists the error messages produced when a Gemini model fails validation.

--- a/docs/inference/use-google-gemini.mdx
+++ b/docs/inference/use-google-gemini.mdx
@@ -52,4 +52,4 @@ NemoClaw filters these out of the catalog before matching your selection, so emb
 
 - [Choose a Model](../learn-and-choose/choose-model) compares the curated Gemini models by task fit.
 - [Understand Provider Validation](../validate-inference/understand-provider-validation) describes provider validation behavior.
-- [Troubleshooting](../reference/troubleshooting#google-gemini-rejects-a-curated-or-custom-model) lists the error messages produced when a Gemini model fails validation.
+- [Troubleshooting](../../reference/troubleshooting#google-gemini-rejects-a-curated-or-custom-model) lists the error messages produced when a Gemini model fails validation.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1275,7 +1275,7 @@ Model '{model}' is not available from Google Gemini. Checked https://generativel
 ```
 
 This means the model ID is either misspelled, not available to your API key or account tier, or is an embedding-only model (for example, an `embedding-*` or `text-embedding-*` model) that Google's catalog does not list under `generateContent`.
-NemoClaw accepts the model ID with or without the `models/` prefix, so re-check the ID against the [curated Gemini models](../inference/use-google-gemini#model-choices) or Google's published model list rather than the prefix form.
+NemoClaw accepts the model ID with or without the `models/` prefix. Verify the model name against the [curated Gemini models](../inference/use-google-gemini#model-choices) or Google's published model list. Do not treat the optional prefix as a different model.
 
 ## Runtime
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1254,6 +1254,29 @@ bash uninstall.sh --yes
 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
+### Google Gemini rejects a curated or custom model
+
+NemoClaw validates a selected Google Gemini model against Google's native model catalog (`https://generativelanguage.googleapis.com/v1beta/models`) before it creates the sandbox.
+That catalog includes embedding-only models, which do not support chat completions.
+NemoClaw filters out any model whose `supportedGenerationMethods` does not include `generateContent`, so embedding-only models never appear as selectable and always fail validation if entered manually.
+
+If the catalog request itself fails (invalid API key, network error, rate limit, or an outage), onboarding reports:
+
+```text
+Could not validate model against https://generativelanguage.googleapis.com/v1beta/models: {reason}
+```
+
+Check that `GEMINI_API_KEY` is set and valid, and that the host can reach `generativelanguage.googleapis.com`, then retry onboarding.
+
+If the catalog request succeeds but the selected model is not present in the filtered results, onboarding reports:
+
+```text
+Model '{model}' is not available from Google Gemini. Checked https://generativelanguage.googleapis.com/v1beta/models.
+```
+
+This means the model ID is either misspelled, not available to your API key or account tier, or is an embedding-only model (for example, an `embedding-*` or `text-embedding-*` model) that Google's catalog does not list under `generateContent`.
+NemoClaw accepts the model ID with or without the `models/` prefix, so re-check the ID against the [curated Gemini models](../inference/use-google-gemini#model-choices) or Google's published model list rather than the prefix form.
+
 ## Runtime
 
 <AgentOnly variant="openclaw">

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1275,7 +1275,7 @@ Model '{model}' is not available from Google Gemini. Checked https://generativel
 ```
 
 This means the model ID is either misspelled, not available to your API key or account tier, or is an embedding-only model (for example, an `embedding-*` or `text-embedding-*` model) that Google's catalog does not list under `generateContent`.
-NemoClaw accepts the model ID with or without the `models/` prefix. Verify the model name against the [curated Gemini models](../inference/use-google-gemini#model-choices) or Google's published model list. Do not treat the optional prefix as a different model.
+NemoClaw accepts the model ID with or without the `models/` prefix. Verify the model name against the [curated Gemini models](../inference/hosted-inference/use-google-gemini#model-choices) or Google's published model list. Do not treat the optional prefix as a different model.
 
 ## Runtime
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The Google Gemini provider documentation did not state that NemoClaw filters embedding-only models (no `generateContent` support) out of the model catalog, and had no troubleshooting entry for the resulting validation error messages. This adds that statement to the Validation section and adds a new Troubleshooting entry documenting both error strings.

## Related Issue
Fixes #8971

## Changes
- `docs/inference/use-google-gemini.mdx`: state in the Validation section that embedding-only models are filtered out of Google's native model catalog before matching, and link to the new troubleshooting entry.
- `docs/reference/troubleshooting.mdx`: add a "Google Gemini rejects a curated or custom model" entry under Onboarding, documenting the `Could not validate model against ...` and `Model '{model}' is not available from Google Gemini ...` error strings and their causes, verified against `src/lib/inference/provider-models.ts` (`validateGeminiModel`, `parseGeminiModelCatalogPage`).

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: docs-only change, no code behavior changed.
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/inference/use-google-gemini.mdx`, `docs/reference/troubleshooting.mdx`. An independent Codex Desktop review covered the writing rules and documentation style. Both reciprocal links resolve in the generated OpenClaw, Deep Agents, and Hermes routes. `npm run docs:check-routes` and `npm run docs` passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 50d97e1b4 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## Verification
- [ ] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub — commit `a947d72db3e6e7e5c48be801cc300e2e2177196a` is not verified (`no_user`)
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm run docs:check-routes` passed for 68 guarded pages
- [ ] Applicable broad gate passed — not run because this pull request changes documentation only
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — the command exited 0 with 0 errors; two existing warnings report missing Fern authentication for redirects and the repository light-mode accent contrast
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — N/A, no new pages

---
Signed-off-by: wakqasahmed <wakqasahmed@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented that Gemini embedding-only models are excluded from available catalog results and rejected during manual validation.
  - Added troubleshooting guidance for catalog request failures and invalid, unavailable, inaccessible, or unsupported model IDs.
  - Clarified that only models supporting content generation are available for matching.
  - Linked model validation troubleshooting from the Gemini integration documentation, including recovery guidance for curated and custom configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

