### PR TITLE
fix(onboard): capture Docker probe responses through stdout

### DIFF
--- a/src/lib/adapters/http/container-curl-probe.test.ts
+++ b/src/lib/adapters/http/container-curl-probe.test.ts
@@ -123,6 +123,7 @@ describe("container curl probe", () => {
   it("returns an unchanged nonzero Docker probe result without creating the response file (#9116)", () => {
     const dockerFailure = successfulSpawn("partial response");
     dockerFailure.status = 7;
+    const expectedFailure = { ...dockerFailure, output: [...dockerFailure.output] };
     const spawn = vi.fn(() => dockerFailure);
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-probe-test-"));
     const outputPath = path.join(tempDir, "response.json");
@@ -135,6 +136,7 @@ describe("container curl probe", () => {
       );
 
       expect(result).toBe(dockerFailure);
+      expect(result).toEqual(expectedFailure);
       expect(fs.existsSync(outputPath)).toBe(false);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });

--- a/src/lib/adapters/http/container-curl-probe.test.ts
+++ b/src/lib/adapters/http/container-curl-probe.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SpawnSyncOptionsWithStringEncoding, SpawnSyncReturns } from "node:child_process";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -10,11 +11,11 @@ import {
   createContainerCurlProbeSpawn,
 } from "./container-curl-probe";
 
-function successfulSpawn(): SpawnSyncReturns<string> {
+function successfulSpawn(stdout = "200"): SpawnSyncReturns<string> {
   return {
     pid: 123,
-    output: ["200", ""],
-    stdout: "200",
+    output: [stdout, ""],
+    stdout,
     stderr: "",
     status: 0,
     signal: null,
@@ -22,28 +23,39 @@ function successfulSpawn(): SpawnSyncReturns<string> {
 }
 
 describe("container curl probe", () => {
-  it("mounts only the temporary output directory and preserves curl arguments", () => {
+  it("writes the response body and returns the HTTP status without a WSL bind mount (#9116)", () => {
+    const responseBody = '{"choices":[{"message":{"tool_calls":[{}]}}]}';
     const spawn = vi.fn(
-      (_command: string, _args: readonly string[], _options: SpawnSyncOptionsWithStringEncoding) =>
-        successfulSpawn(),
+      (_command: string, args: readonly string[], _options: SpawnSyncOptionsWithStringEncoding) => {
+        const writeOutIndex = args.indexOf("-w");
+        const writeOut = args[writeOutIndex + 1];
+        return successfulSpawn(`${responseBody}${writeOut.replace("%{http_code}", "200")}`);
+      },
     );
-    const outputPath = path.join(os.tmpdir(), "nemoclaw-curl-probe-test", "response.json");
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-probe-test-"));
+    const outputPath = path.join(tempDir, "response.json");
+    fs.writeFileSync(outputPath, "");
     const args = ["-sS", "-o", outputPath, "-w", "%{http_code}", "http://example.test/v1"];
 
-    createContainerCurlProbeSpawn(spawn)("curl", args, { encoding: "utf8" });
+    try {
+      const result = createContainerCurlProbeSpawn(spawn)("curl", args, { encoding: "utf8" });
 
-    expect(spawn).toHaveBeenCalledWith(
-      "docker",
-      expect.arrayContaining([
-        "run",
-        "--rm",
-        "--volume",
-        `${path.dirname(outputPath)}:${path.dirname(outputPath)}`,
-        CONTAINER_REACHABILITY_IMAGE,
-        ...args,
-      ]),
-      { encoding: "utf8" },
-    );
+      expect(result.stdout).toBe("200");
+      expect(fs.readFileSync(outputPath, "utf8")).toBe(responseBody);
+      const containerArgs = spawn.mock.calls[0][1];
+      expect(containerArgs).toEqual(
+        expect.arrayContaining([
+          "run",
+          "--rm",
+          CONTAINER_REACHABILITY_IMAGE,
+          "http://example.test/v1",
+        ]),
+      );
+      expect(containerArgs).not.toContain("--volume");
+      expect(containerArgs).not.toContain(outputPath);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("rejects credential configs and output paths outside the temporary directory", () => {
@@ -60,5 +72,25 @@ describe("container curl probe", () => {
       run("curl", ["-o", path.join(process.cwd(), "response.json")], { encoding: "utf8" }),
     ).toThrow(/must stay inside the temporary directory/);
     expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("rejects container curl output without the HTTP status marker (#9116)", () => {
+    const spawn = vi.fn(() => successfulSpawn("{}"));
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-probe-test-"));
+    const outputPath = path.join(tempDir, "response.json");
+    fs.writeFileSync(outputPath, "");
+
+    try {
+      expect(() =>
+        createContainerCurlProbeSpawn(spawn)(
+          "curl",
+          ["-sS", "-o", outputPath, "-w", "%{http_code}", "http://example.test/v1"],
+          { encoding: "utf8" },
+        ),
+      ).toThrow(/did not return the HTTP status write-out/);
+      expect(fs.readFileSync(outputPath, "utf8")).toBe("");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/lib/adapters/http/container-curl-probe.test.ts
+++ b/src/lib/adapters/http/container-curl-probe.test.ts
@@ -34,7 +34,6 @@ describe("container curl probe", () => {
     );
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-probe-test-"));
     const outputPath = path.join(tempDir, "response.json");
-    fs.writeFileSync(outputPath, "");
     const args = ["-sS", "-o", outputPath, "-w", "%{http_code}", "http://example.test/v1"];
 
     try {
@@ -78,7 +77,6 @@ describe("container curl probe", () => {
     const spawn = vi.fn(() => successfulSpawn("{}"));
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-probe-test-"));
     const outputPath = path.join(tempDir, "response.json");
-    fs.writeFileSync(outputPath, "");
 
     try {
       expect(() =>
@@ -88,7 +86,35 @@ describe("container curl probe", () => {
           { encoding: "utf8" },
         ),
       ).toThrow(/did not return the HTTP status write-out/);
-      expect(fs.readFileSync(outputPath, "utf8")).toBe("");
+      expect(fs.existsSync(outputPath)).toBe(false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not follow a replacement output symlink (#9116)", () => {
+    const spawn = vi.fn(
+      (_command: string, args: readonly string[]) => {
+        const writeOutIndex = args.indexOf("-w");
+        const writeOut = args[writeOutIndex + 1];
+        return successfulSpawn(`replacement${writeOut.replace("%{http_code}", "200")}`);
+      },
+    );
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-probe-test-"));
+    const targetPath = path.join(tempDir, "target.json");
+    const outputPath = path.join(tempDir, "response.json");
+    fs.writeFileSync(targetPath, "original");
+    fs.symlinkSync(targetPath, outputPath);
+
+    try {
+      expect(() =>
+        createContainerCurlProbeSpawn(spawn)(
+          "curl",
+          ["-sS", "-o", outputPath, "-w", "%{http_code}", "http://example.test/v1"],
+          { encoding: "utf8" },
+        ),
+      ).toThrow();
+      expect(fs.readFileSync(targetPath, "utf8")).toBe("original");
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/lib/adapters/http/container-curl-probe.test.ts
+++ b/src/lib/adapters/http/container-curl-probe.test.ts
@@ -92,6 +92,34 @@ describe("container curl probe", () => {
     }
   });
 
+  it.each(["20x", "200 extra"])(
+    "rejects a malformed HTTP status write-out without creating the response file: %s (#9116)",
+    (httpStatus) => {
+      const spawn = vi.fn(
+        (_command: string, args: readonly string[]) => {
+          const writeOutIndex = args.indexOf("-w");
+          const writeOut = args[writeOutIndex + 1];
+          return successfulSpawn(`{}${writeOut.replace("%{http_code}", httpStatus)}`);
+        },
+      );
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-probe-test-"));
+      const outputPath = path.join(tempDir, "response.json");
+
+      try {
+        expect(() =>
+          createContainerCurlProbeSpawn(spawn)(
+            "curl",
+            ["-sS", "-o", outputPath, "-w", "%{http_code}", "http://example.test/v1"],
+            { encoding: "utf8" },
+          ),
+        ).toThrow(/invalid HTTP status write-out/);
+        expect(fs.existsSync(outputPath)).toBe(false);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("does not follow a replacement output symlink (#9116)", () => {
     const spawn = vi.fn(
       (_command: string, args: readonly string[]) => {

--- a/src/lib/adapters/http/container-curl-probe.test.ts
+++ b/src/lib/adapters/http/container-curl-probe.test.ts
@@ -120,6 +120,27 @@ describe("container curl probe", () => {
     },
   );
 
+  it("does not create the response file after a Docker failure (#9116)", () => {
+    const dockerFailure = successfulSpawn("partial response");
+    dockerFailure.status = 7;
+    const spawn = vi.fn(() => dockerFailure);
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-curl-probe-test-"));
+    const outputPath = path.join(tempDir, "response.json");
+
+    try {
+      const result = createContainerCurlProbeSpawn(spawn)(
+        "curl",
+        ["-sS", "-o", outputPath, "-w", "%{http_code}", "http://example.test/v1"],
+        { encoding: "utf8" },
+      );
+
+      expect(result).toBe(dockerFailure);
+      expect(fs.existsSync(outputPath)).toBe(false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not follow a replacement output symlink (#9116)", () => {
     const spawn = vi.fn(
       (_command: string, args: readonly string[]) => {

--- a/src/lib/adapters/http/container-curl-probe.test.ts
+++ b/src/lib/adapters/http/container-curl-probe.test.ts
@@ -120,7 +120,7 @@ describe("container curl probe", () => {
     },
   );
 
-  it("does not create the response file after a Docker failure (#9116)", () => {
+  it("returns an unchanged nonzero Docker probe result without creating the response file (#9116)", () => {
     const dockerFailure = successfulSpawn("partial response");
     dockerFailure.status = 7;
     const spawn = vi.fn(() => dockerFailure);

--- a/src/lib/adapters/http/container-curl-probe.ts
+++ b/src/lib/adapters/http/container-curl-probe.ts
@@ -66,6 +66,15 @@ function splitContainerOutput(
   return { body: stdout.slice(0, markerIndex), httpStatus };
 }
 
+function writeProbeOutput(outputPath: string, body: string): void {
+  const fileDescriptor = fs.openSync(outputPath, "wx", 0o600);
+  try {
+    fs.writeFileSync(fileDescriptor, body, "utf8");
+  } finally {
+    fs.closeSync(fileDescriptor);
+  }
+}
+
 /** Run a credential-free curl probe from Docker Desktop's network context. */
 export function createContainerCurlProbeSpawn(
   spawnSyncImpl: CurlProbeSpawn = spawnSync,
@@ -93,7 +102,7 @@ export function createContainerCurlProbeSpawn(
     if (result.error || result.status !== 0) return result;
 
     const output = splitContainerOutput(String(result.stdout || ""), prepared.statusMarker);
-    fs.writeFileSync(prepared.outputPath, output.body, "utf8");
+    writeProbeOutput(prepared.outputPath, output.body);
     return { ...result, stdout: output.httpStatus };
   };
 }

--- a/src/lib/adapters/http/container-curl-probe.ts
+++ b/src/lib/adapters/http/container-curl-probe.ts
@@ -6,10 +6,14 @@ import {
   type SpawnSyncReturns,
   spawnSync,
 } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 export const CONTAINER_REACHABILITY_IMAGE = "curlimages/curl:8.10.1";
+const MAX_CONTAINER_CURL_STDOUT_BYTES = 8 * 1024 * 1024 + 256;
+const HTTP_STATUS_MARKER_PREFIX = "\n__NEMOCLAW_CONTAINER_HTTP_STATUS_";
 
 type CurlProbeSpawn = (
   command: string,
@@ -30,6 +34,38 @@ function curlOutputPath(args: readonly string[]): string {
   return outputPath;
 }
 
+function prepareContainerArgs(args: readonly string[]): {
+  args: string[];
+  outputPath: string;
+  statusMarker: string;
+} {
+  const outputPath = curlOutputPath(args);
+  const outputIndex = args.indexOf("-o");
+  const containerArgs = [...args.slice(0, outputIndex), ...args.slice(outputIndex + 2)];
+  const writeOutIndex = containerArgs.indexOf("-w");
+  if (writeOutIndex < 0 || containerArgs[writeOutIndex + 1] !== "%{http_code}") {
+    throw new Error("container curl probe requires the HTTP status write-out");
+  }
+  const statusMarker = `${HTTP_STATUS_MARKER_PREFIX}${randomUUID()}__:`;
+  containerArgs[writeOutIndex + 1] = `${statusMarker}%{http_code}`;
+  return { args: containerArgs, outputPath, statusMarker };
+}
+
+function splitContainerOutput(
+  stdout: string,
+  statusMarker: string,
+): { body: string; httpStatus: string } {
+  const markerIndex = stdout.lastIndexOf(statusMarker);
+  if (markerIndex < 0) {
+    throw new Error("container curl probe did not return the HTTP status write-out");
+  }
+  const httpStatus = stdout.slice(markerIndex + statusMarker.length).trim();
+  if (!/^\d{3}$/.test(httpStatus)) {
+    throw new Error("container curl probe returned an invalid HTTP status write-out");
+  }
+  return { body: stdout.slice(0, markerIndex), httpStatus };
+}
+
 /** Run a credential-free curl probe from Docker Desktop's network context. */
 export function createContainerCurlProbeSpawn(
   spawnSyncImpl: CurlProbeSpawn = spawnSync,
@@ -46,23 +82,18 @@ export function createContainerCurlProbeSpawn(
     ) {
       throw new Error("container curl probe does not accept credential config files");
     }
-    const outputPath = curlOutputPath(args);
-    const outputDir = path.dirname(outputPath);
-    const uid = typeof process.getuid === "function" ? process.getuid() : 0;
-    const gid = typeof process.getgid === "function" ? process.getgid() : 0;
-    return spawnSyncImpl(
+    // Docker Desktop containers may not share the WSL filesystem that owns this temporary path.
+    // Capture the response on stdout so the host process writes the body to the WSL file.
+    const prepared = prepareContainerArgs(args);
+    const result = spawnSyncImpl(
       "docker",
-      [
-        "run",
-        "--rm",
-        "--user",
-        `${uid}:${gid}`,
-        "--volume",
-        `${outputDir}:${outputDir}`,
-        CONTAINER_REACHABILITY_IMAGE,
-        ...args,
-      ],
-      options,
+      ["run", "--rm", CONTAINER_REACHABILITY_IMAGE, ...prepared.args],
+      { ...options, maxBuffer: options.maxBuffer ?? MAX_CONTAINER_CURL_STDOUT_BYTES },
     );
+    if (result.error || result.status !== 0) return result;
+
+    const output = splitContainerOutput(String(result.stdout || ""), prepared.statusMarker);
+    fs.writeFileSync(prepared.outputPath, output.body, "utf8");
+    return { ...result, stdout: output.httpStatus };
   };
 }

--- a/src/lib/inference/onboard-host-docker-internal.test.ts
+++ b/src/lib/inference/onboard-host-docker-internal.test.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SpawnSyncReturns } from "node:child_process";
-import fs from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const { isHijackedDockerInternalUrl } = require("./onboard-host-docker-internal");
@@ -47,37 +46,35 @@ describe("host.docker.internal onboarding inference policy", () => {
     expect(result.message).toMatch(/host\.openshell\.internal:11435/);
   });
 
-  it("validates Windows-host Ollama from Docker for strict and compatibility paths (#8127)", async () => {
+  it("recognizes Windows-host Ollama tool calls returned through Docker stdout (#9116)", async () => {
     const seenCommands: Array<{ command: string; args: readonly string[] }> = [];
     const containerProbeSpawnSyncImpl = (
       command: string,
       args: readonly string[],
     ): SpawnSyncReturns<string> => {
       seenCommands.push({ command, args });
-      const outputIndex = args.indexOf("-o");
-      const outputPath = args[outputIndex + 1];
-      fs.writeFileSync(
-        outputPath,
-        JSON.stringify({
-          choices: [
-            {
-              message: {
-                tool_calls: [
-                  {
-                    id: "call_1",
-                    type: "function",
-                    function: { name: "sessions_send", arguments: '{"message":"hello"}' },
-                  },
-                ],
-              },
+      const body = JSON.stringify({
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                {
+                  id: "call_1",
+                  type: "function",
+                  function: { name: "sessions_send", arguments: '{"message":"hello"}' },
+                },
+              ],
             },
-          ],
-        }),
-      );
+          },
+        ],
+      });
+      const writeOutIndex = args.indexOf("-w");
+      const writeOut = args[writeOutIndex + 1];
+      const stdout = `${body}${writeOut.replace("%{http_code}", "200")}`;
       return {
         pid: 123,
-        output: ["200", ""],
-        stdout: "200",
+        output: [stdout, ""],
+        stdout,
         stderr: "",
         status: 0,
         signal: null,
@@ -108,6 +105,7 @@ describe("host.docker.internal onboarding inference policy", () => {
       expect(command).toBe("docker");
       expect(args).toContain("curlimages/curl:8.10.1");
       expect(args).toContain("http://host.docker.internal:11434/v1/chat/completions");
+      expect(args).not.toContain("--volume");
     }
   });
 
@@ -127,22 +125,21 @@ describe("host.docker.internal onboarding inference policy", () => {
       apiKey: "",
       extraHeaders: ["Authorization: Bearer not-a-real-secret"],
     },
-  ])("refuses credentials and non-canonical Windows-host Ollama routes in Docker-context validation (#8127)", ({
-    endpointUrl,
-    apiKey,
-    extraHeaders,
-  }) => {
-    const result = probeOpenAiLikeEndpoint(endpointUrl, "openai/nemotron-mini", apiKey, {
-      skipResponsesProbe: true,
-      requireChatCompletionsToolCalling: true,
-      allowHostDockerInternal: true,
-      probeFromDocker: { expectedPort: 11434 },
-      extraHeaders,
-    });
+  ])(
+    "refuses credentials and non-canonical Windows-host Ollama routes in Docker-context validation (#8127)",
+    ({ endpointUrl, apiKey, extraHeaders }) => {
+      const result = probeOpenAiLikeEndpoint(endpointUrl, "openai/nemotron-mini", apiKey, {
+        skipResponsesProbe: true,
+        requireChatCompletionsToolCalling: true,
+        allowHostDockerInternal: true,
+        probeFromDocker: { expectedPort: 11434 },
+        extraHeaders,
+      });
 
-    expect(result).toMatchObject({
-      ok: false,
-      failures: [expect.objectContaining({ name: "Docker-context validation boundary" })],
-    });
-  });
+      expect(result).toMatchObject({
+        ok: false,
+        failures: [expect.objectContaining({ name: "Docker-context validation boundary" })],
+      });
+    },
+  );
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Windows-host Ollama validation on WSL previously asked a Docker container to write the response body through a bind-mounted temporary file, but Docker Desktop could resolve that path outside the WSL filesystem. Onboarding could then read an empty body and report a missing structured tool call. The container now emits the body and marked HTTP status on stdout, and the WSL host writes the body before validation.

## Related Issue

Fixes #9116

## Changes

- Replace the Docker Desktop bind mount with bounded stdout capture and a randomized HTTP status marker.
- Write the response body from the host process into the existing temporary file before the shared parser reads it.
- Keep Docker-context validation restricted to the exact credential-free Windows-host Ollama route.
- Add regression tests for response transport and missing status output.
- Exercise strict and compatibility validation paths.
- Preserve route-validation and credential-rejection coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Existing Windows preparation, Ollama setup, provider validation, troubleshooting, and platform support pages already describe the restored behavior. The command, endpoint, validation contract, and operator workflow do not change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed the changed process and filesystem boundary. The Docker path remains credential-free, rejects alternate routes and headers, bounds stdout, validates a randomized status marker, and fails closed before writing ambiguous output.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing Windows preparation and Ollama validation pages already document the supported Windows-host Ollama route and structured tool-call requirement. Commit `fac59f389` includes the completed Docker response transport hardening and regression coverage. The independent review found no documentation or changed-text findings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: fac59f389 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/adapters/http/container-curl-probe.test.ts src/lib/inference/onboard-host-docker-internal.test.ts src/lib/inference/onboard-probes.test.ts src/lib/inference/onboard-probes-tool-call-retry.test.ts src/lib/inference/local.test.ts src/lib/onboard/inference-selection-validation.test.ts` passed 163 tests with 1 skipped. A post-review rerun of the two changed test files passed 10 tests. The compiled adapter also returned HTTP 200 and the `sessions_send` tool call through a real Docker container on macOS. The change has not yet been tested on WSL2.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run because the change is limited to the Windows-host Ollama Docker response boundary and has focused source and runtime evidence.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when retrieving HTTP responses through Docker-based probes.
  - Added clearer handling for missing or malformed HTTP status information.
  - Improved response output handling with safer temporary-file creation.
  - Removed unnecessary container volume mounts during HTTP checks.
  - Preserved meaningful Docker and HTTP errors for easier troubleshooting.

- **Tests**
  - Expanded coverage for response bodies, status extraction, container arguments, output files, and error conditions.
  - Updated Docker probe validation to confirm responses are returned correctly without volume mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->