### PR TITLE
fix: resolve Hermes restore and GPU regressions

### DIFF
--- a/src/lib/actions/sandbox/rebuild-hermes-cron-restore.test.ts
+++ b/src/lib/actions/sandbox/rebuild-hermes-cron-restore.test.ts
@@ -234,8 +234,7 @@ describe("Hermes cron rebuild restore contract", () => {
       "41",
       "--start-time",
       "902",
-      "--drain-token",
-      "restore-token",
+      "--drain-token=restore-token",
     ]);
   });
 
@@ -251,7 +250,23 @@ describe("Hermes cron rebuild restore contract", () => {
     validateHermesCronRestore("alpha", identity);
 
     const validateArgv = processMocks.privilegedSandboxExecArgv.mock.calls[1]?.[1];
-    expect(validateArgv?.at(-1)).toBe(untrustedToken);
+    expect(validateArgv?.at(-1)).toBe(`--drain-token=${untrustedToken}`);
+  });
+
+  it("keeps a leading-hyphen drain token attached to its option", () => {
+    const leadingHyphenToken = "-restore-token";
+    processMocks.dockerSpawnSync.mockImplementation((argv: string[]) => ({
+      status: 0,
+      stdout: receipt(argv.includes("validate") ? "validate" : "begin", 41, 902, leadingHyphenToken),
+      stderr: "",
+    }));
+
+    const identity = beginHermesCronRestore("alpha");
+    validateHermesCronRestore("alpha", identity);
+
+    expect(processMocks.privilegedSandboxExecArgv.mock.calls[1]?.[1]).toContain(
+      "--drain-token=-restore-token",
+    );
   });
 
   it("keeps dispatch drained when state restore is incomplete", () => {
@@ -321,8 +336,7 @@ describe("Hermes cron rebuild restore contract", () => {
         "41",
         "--start-time",
         "902",
-        "--drain-token",
-        "restore-token",
+        "--drain-token=restore-token",
         "--replacement-pid",
         "77",
         "--replacement-start-time",
@@ -447,8 +461,7 @@ describe("Hermes cron rebuild restore contract", () => {
       "41",
       "--start-time",
       "902",
-      "--drain-token",
-      "restore-token",
+      "--drain-token=restore-token",
     ]);
   });
 

--- a/src/lib/actions/sandbox/rebuild-hermes-post-restore.ts
+++ b/src/lib/actions/sandbox/rebuild-hermes-post-restore.ts
@@ -523,7 +523,7 @@ function executeCronRestoreControl(
   const command = [HERMES_PYTHON, "-I", HERMES_CRON_CONTROL, action];
   if (identity) {
     command.push("--pid", String(identity.pid), "--start-time", String(identity.start_time));
-    if (identity.drain_token) command.push("--drain-token", identity.drain_token);
+    if (identity.drain_token) command.push(`--drain-token=${identity.drain_token}`);
   }
   if (replacementIdentity) {
     command.push(

--- a/src/lib/onboard/managed-bootstrap/docker-runtime.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-runtime.test.ts
@@ -20,12 +20,20 @@ const adapterMocks = vi.hoisted(() => ({
   finalize: vi.fn<typeof import("./adapter").finalizeManagedBootstrapSequence>(),
   prepare: vi.fn<typeof import("./adapter").prepareManagedBootstrapSequence>(),
 }));
+const runtimeSnapshotMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
 
 vi.mock("./adapter", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./adapter")>()),
   activateManagedBootstrapSequence: adapterMocks.activate,
   finalizeManagedBootstrapSequence: adapterMocks.finalize,
   prepareManagedBootstrapSequence: adapterMocks.prepare,
+}));
+
+vi.mock("../openshell-docker-sandbox-containers", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../openshell-docker-sandbox-containers")>()),
+  queryOpenShellDockerSandboxRuntimeSnapshot: runtimeSnapshotMocks.query,
 }));
 
 import type {
@@ -37,6 +45,18 @@ import { authority, IDENTITY, NEW_ID, OLD_ID } from "./docker-test-fixture";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  runtimeSnapshotMocks.query.mockReturnValue({
+    ok: true,
+    imageId: `sha256:${"a".repeat(64)}`,
+    bookkeepingImageRef: "openshell/sandbox-from:alpha",
+    stateError: "",
+    deviceRequests: null,
+    devices: [],
+    runtime: "runc",
+    nvidiaVisibleDevices: null,
+    nativeGpuAttachmentState: "absent",
+    containerId: NEW_ID,
+  });
 });
 
 afterEach(() => {
@@ -129,6 +149,17 @@ describe("Docker managed-bootstrap lifecycle composition", () => {
       expect(order).toEqual(["prepare", "stream-start", "create-returned", "activate"]);
       expect(child.kill).toHaveBeenCalledWith("SIGTERM");
       expect(adapterMocks.activate).toHaveBeenCalledOnce();
+      expect(lifecycle.inspectNativeRuntime?.()).toEqual({
+        imageId: `sha256:${"a".repeat(64)}`,
+        bookkeepingImageRef: "openshell/sandbox-from:alpha",
+        stateError: "",
+        nativeGpuAttachmentState: "absent",
+      });
+      expect(runtimeSnapshotMocks.query).toHaveBeenCalledWith(
+        "alpha",
+        {},
+        { expectedContainerId: NEW_ID },
+      );
     } finally {
       fs.rmSync(stateRoot, { recursive: true, force: true });
     }

--- a/src/lib/onboard/managed-bootstrap/docker-runtime.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-runtime.ts
@@ -138,10 +138,27 @@ function createDockerLifecycle(
     metadata: {},
   } as const;
   const replacementOptions = dockerReplacementOptions(mode, input);
+  let activatedRuntimeId: string | null = null;
 
   return {
     launchArgv: input.launchArgv,
     patch,
+    inspectNativeRuntime() {
+      if (activatedRuntimeId === null) return undefined;
+      const snapshot = queryOpenShellDockerSandboxRuntimeSnapshot(
+        input.sandboxName,
+        {},
+        { expectedContainerId: activatedRuntimeId },
+      );
+      return snapshot.ok
+        ? {
+            imageId: snapshot.imageId,
+            bookkeepingImageRef: snapshot.bookkeepingImageRef,
+            stateError: snapshot.stateError,
+            nativeGpuAttachmentState: snapshot.nativeGpuAttachmentState,
+          }
+        : null;
+    },
     async recoverUnfinished() {
       return recoverManagedBootstrapTransactions(adapter);
     },
@@ -187,6 +204,7 @@ function createDockerLifecycle(
         authorityStore: input.authorityStore,
         timeoutSecs: input.timeoutSecs,
       });
+      activatedRuntimeId = activated.replacement.replacementRuntimeId;
       const launched = launchState.value;
       if (!launched) {
         await finalizeManagedBootstrapSequence(adapter, {

--- a/src/lib/onboard/managed-bootstrap/runtime-create.ts
+++ b/src/lib/onboard/managed-bootstrap/runtime-create.ts
@@ -130,6 +130,11 @@ export function createManagedBootstrapTerminalFinalizer(
 export interface ManagedBootstrapRuntimeCreateLifecycle {
   readonly launchArgv: readonly string[];
   readonly patch: ManagedBootstrapRuntimePatch;
+  /**
+   * Inspect the exact activated native runtime when provider authority is available.
+   * `undefined` means activation has not selected a runtime yet; `null` fails closed.
+   */
+  inspectNativeRuntime?(): ManagedBootstrapRuntimeSnapshot | null | undefined;
   recoverUnfinished(): Promise<ManagedBootstrapRecoveryReport>;
   prepareNetwork(): Promise<void>;
   runCreate<T>(

--- a/src/lib/onboard/openshell-docker-sandbox-containers.test.ts
+++ b/src/lib/onboard/openshell-docker-sandbox-containers.test.ts
@@ -7,6 +7,8 @@ import { queryOpenShellDockerSandboxRuntimeSnapshot } from "./openshell-docker-s
 const IMAGE_ID = `sha256:${"a".repeat(64)}`;
 const BOOKKEEPING_IMAGE_REF = "openshell/sandbox-from:alpha";
 const EMPTY_RUNTIME_FIELDS = [IMAGE_ID, BOOKKEEPING_IMAGE_REF, "", null, [], "runc"];
+const ACTIVATED_CONTAINER_ID = "b".repeat(64);
+const ROLLBACK_CONTAINER_ID = "c".repeat(64);
 
 function querySnapshot(fields: unknown, nvidiaVisibleDevices?: string) {
   const dockerRun = vi
@@ -232,6 +234,57 @@ describe("queryOpenShellDockerSandboxRuntimeSnapshot", () => {
     expect(queryOpenShellDockerSandboxRuntimeSnapshot("alpha", { dockerRun })).toEqual({
       ok: false,
       error: `expected one labeled sandbox container, found ${ids ? 2 : 0}`,
+    });
+    expect(dockerRun).toHaveBeenCalledOnce();
+  });
+
+  it("inspects the exact activated container while its rollback backup is retained", () => {
+    const dockerRun = vi
+      .fn()
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: `${ACTIVATED_CONTAINER_ID}\n${ROLLBACK_CONTAINER_ID}\n`,
+        stderr: "",
+      })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: JSON.stringify(EMPTY_RUNTIME_FIELDS),
+        stderr: "",
+      });
+
+    expect(
+      queryOpenShellDockerSandboxRuntimeSnapshot(
+        "alpha",
+        { dockerRun },
+        { expectedContainerId: ACTIVATED_CONTAINER_ID },
+      ),
+    ).toMatchObject({
+      ok: true,
+      containerId: ACTIVATED_CONTAINER_ID,
+      nativeGpuAttachmentState: "absent",
+    });
+    expect(dockerRun).toHaveBeenLastCalledWith(
+      expect.arrayContaining([ACTIVATED_CONTAINER_ID]),
+      expect.objectContaining({ suppressOutput: true }),
+    );
+  });
+
+  it("refuses when the expected activated container ID is absent from the labeled query", () => {
+    const dockerRun = vi.fn(() => ({
+      status: 0,
+      stdout: `${ROLLBACK_CONTAINER_ID}\n`,
+      stderr: "",
+    }));
+
+    expect(
+      queryOpenShellDockerSandboxRuntimeSnapshot(
+        "alpha",
+        { dockerRun },
+        { expectedContainerId: ACTIVATED_CONTAINER_ID },
+      ),
+    ).toEqual({
+      ok: false,
+      error: "expected activated sandbox container was not found among labeled containers",
     });
     expect(dockerRun).toHaveBeenCalledOnce();
   });

--- a/src/lib/onboard/openshell-docker-sandbox-containers.ts
+++ b/src/lib/onboard/openshell-docker-sandbox-containers.ts
@@ -170,6 +170,11 @@ export type OpenShellDockerSandboxRuntimeSnapshotQuery =
     }
   | { ok: false; error: string };
 
+export interface OpenShellDockerSandboxRuntimeSnapshotOptions {
+  /** Full transaction-owned container ID selected while a rollback backup is retained. */
+  readonly expectedContainerId?: string;
+}
+
 export function isImmutableDockerImageId(value: string): boolean {
   return /^sha256:[0-9a-f]{64}$/i.test(value);
 }
@@ -329,7 +334,10 @@ function parseNvidiaVisibleDevices(result: {
 }
 
 /**
- * Inspect the one exactly labeled native container before deletion.
+ * Inspect a native container before deletion. Default callers must resolve one
+ * labeled container. Managed-bootstrap callers may instead provide the full
+ * transaction-owned container ID, which must be present among the labeled
+ * replacement and retained rollback backup.
  *
  * Docker owns the fields returned here: `.Image` is the immutable retry
  * identity, `.Config.Image` is bookkeeping-only, and HostConfig supplies the
@@ -340,17 +348,27 @@ function parseNvidiaVisibleDevices(result: {
 export function queryOpenShellDockerSandboxRuntimeSnapshot(
   sandboxName: string,
   deps: DockerSandboxContainerQueryDeps = {},
+  options: OpenShellDockerSandboxRuntimeSnapshotOptions = {},
 ): OpenShellDockerSandboxRuntimeSnapshotQuery {
   const containers = queryOpenShellDockerSandboxContainers(sandboxName, deps);
   if (!containers.ok) return { ok: false, error: containers.error };
-  if (containers.ids.length !== 1) {
+  const expectedContainerId = options.expectedContainerId;
+  if (expectedContainerId !== undefined && !/^[a-f0-9]{64}$/u.test(expectedContainerId)) {
+    return { ok: false, error: "expected sandbox container ID is invalid" };
+  }
+  const selectedContainerIds = expectedContainerId
+    ? containers.ids.filter((containerId) => containerId === expectedContainerId)
+    : containers.ids;
+  if (selectedContainerIds.length !== 1) {
     return {
       ok: false,
-      error: `expected one labeled sandbox container, found ${containers.ids.length}`,
+      error: expectedContainerId
+        ? "expected activated sandbox container was not found among labeled containers"
+        : `expected one labeled sandbox container, found ${containers.ids.length}`,
     };
   }
   const run = deps.dockerRun ?? dockerRun;
-  const containerId = containers.ids[0];
+  const containerId = selectedContainerIds[0];
   const inspect = run(
     [
       "inspect",

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -134,12 +134,6 @@ export function createSandboxGpuCreateAttemptRunner(
   const nativeFallbackHasCleanBaseline =
     managedRouting?.nativeFallbackHasCleanBaseline ??
     (nativeFallbackBaseline?.ok === true && nativeFallbackBaseline.ids.length === 0);
-  const inspectNativeRuntime = (): NativeRuntimeSnapshot | null => {
-    if (managedRouting) return managedRouting.inspectNativeRuntime();
-    const snapshot = queryOpenShellDockerSandboxRuntimeSnapshot(input.sandboxName);
-    return snapshot.ok ? snapshot : null;
-  };
-
   const runAttempt = async (route: SelectedDockerGpuRoute) => {
     const compatibility = route === "compatibility";
     if (compatibility && input.initialGpuRoute === "native") {
@@ -187,6 +181,13 @@ export function createSandboxGpuCreateAttemptRunner(
           },
         })
       : null;
+    const inspectNativeRuntime = (): NativeRuntimeSnapshot | null => {
+      const lifecycleSnapshot = managedLifecycle?.inspectNativeRuntime?.();
+      if (lifecycleSnapshot !== undefined) return lifecycleSnapshot;
+      if (managedRouting) return managedRouting.inspectNativeRuntime();
+      const snapshot = queryOpenShellDockerSandboxRuntimeSnapshot(input.sandboxName);
+      return snapshot.ok ? snapshot : null;
+    };
     const persistRestartSafeStartup =
       input.persistStartupCommand === true &&
       (route !== "native" || !input.terminalAgent || hasRequiredUlimits);

--- a/test/e2e/live/hermes-gpu-startup-proof.ts
+++ b/test/e2e/live/hermes-gpu-startup-proof.ts
@@ -76,7 +76,12 @@ export async function assertHermesGpuStartupProof({
     expect(installText).not.toContain(
       "Recreating OpenShell Docker sandbox container with NVIDIA GPU access",
     );
-    expect(installText).not.toContain("Docker container mode selected:");
+    expect(installText).toContain(
+      "Recreating OpenShell Docker sandbox container with restart-safe startup",
+    );
+    expect(installText).toContain(
+      "Docker container mode selected: persistent sandbox startup command",
+    );
     for (const fragment of HERMES_GPU_FALLBACK_DISCLOSURE_FRAGMENTS) {
       expect(installText).not.toContain(fragment);
     }

--- a/test/e2e/live/hermes-gpu-startup-proof.ts
+++ b/test/e2e/live/hermes-gpu-startup-proof.ts
@@ -247,13 +247,8 @@ raise SystemExit(1)`,
     entrypoint: ["/opt/openshell/bin/openshell-sandbox"],
     has_openshell_sandbox_command: true,
   });
-  if (gpuRoute !== "native-success") {
-    expect(commandBoundary.command_ends_with_nemoclaw_start).toBe(true);
-    expect(commandBoundary.command_is_sleep_infinity).toBe(false);
-  } else {
-    expect(commandBoundary.command_is_sleep_infinity).toBe(true);
-    expect(commandBoundary.command_ends_with_nemoclaw_start).toBe(false);
-  }
+  expect(commandBoundary.command_ends_with_nemoclaw_start).toBe(true);
+  expect(commandBoundary.command_is_sleep_infinity).toBe(false);
 
   const containerState = await host.command(
     "docker",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The main E2E run exposed two deterministic Hermes GPU regressions and a restore bug whose trigger depends on random token content. This change restores native restart-safe startup proof, preserves exact host evidence for managed GPU fallback while its rollback backup exists, and makes every generated cron drain token parse as one option value.

## Changes

- Pass the Hermes cron drain token as `--drain-token=<value>` so a URL-safe token beginning with `-` cannot be parsed as another option.
- Carry managed-bootstrap authority into native GPU fallback inspection by selecting the full activated container ID and confirming that ID remains exactly labeled.
- Keep the default runtime snapshot rule unchanged: label-only callers still reject zero or multiple matching containers.
- Update the native Hermes GPU live proof to require the restart-safe recreation, persistent startup mode, and `nemoclaw-start` Docker command boundary introduced by #9147.
- Add positive and fail-closed regressions for a retained rollback backup, an absent activated ID, and a leading-hyphen drain token.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: These changes restore existing Hermes restore, managed GPU fallback, and restart-safe startup contracts without changing commands, configuration, defaults, or emitted output.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The full activated Docker ID must be 64 lowercase hexadecimal characters and remain in the exactly labeled result; label-only ambiguity still fails closed, and the drain token remains on the existing direct-argv transport.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Head commit `c24326fba` was independently reviewed across all nine changed files. Existing docs already describe retained rollback backups, exact-container fallback evidence, and the Hermes cron restore gate; the fixes restore those contracts.
- Agent: Codex Desktop
<!-- docs-review-head-sha: c24326fba -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Four focused CLI test files passed, 104 tests total; `npm run typecheck:cli` and `npm run test:projects:check` passed. A separate `npm run test:changed` attempt did not reach a terminal summary locally and was stopped after Vitest became idle; it is not used as evidence.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox runtime inspection during managed Docker activation and rollback scenarios.
  * Ensured inspection targets the correct activated container when multiple containers are present.
  * Kept drain tokens securely attached to their command-line option, including unusual token values.
  * Improved GPU sandbox startup validation for restart-safe behavior.

* **Tests**
  * Expanded coverage for runtime inspection, container selection, rollback handling, and drain-token edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->