### PR TITLE
test(e2e): assert visible terminal behavior

### DIFF
--- a/test/e2e/live/full-e2e.test.ts
+++ b/test/e2e/live/full-e2e.test.ts
@@ -148,8 +148,8 @@ async function runOpenClawLaunchTurnAfterRecovery(input: {
     env: env(PORTABLE_PROFILE ? { DOCKER_HOST: "" } : {}),
     exitCommand: "/exit",
     host: input.host,
-    postReplyReadyText: "gateway connected | idle",
-    readyText: "gateway connected | idle",
+    postReplyReadyState: "idle",
+    readyState: "idle",
     redactionValues: input.redactionValues,
     sandboxName: SANDBOX_NAME,
   });

--- a/test/e2e/live/gateway-guard-recovery.test.ts
+++ b/test/e2e/live/gateway-guard-recovery.test.ts
@@ -370,9 +370,6 @@ test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)
   });
   expect(trustedRecovery.timedOut, resultText(trustedRecovery)).toBe(false);
   expect(trustedRecovery.exitCode, resultText(trustedRecovery)).toBe(0);
-  expect(resultText(trustedRecovery)).toMatch(
-    /Probe complete: (?:recovered OpenClaw gateway|OpenClaw gateway is running)/,
-  );
   const restartStateLockPlan = await sandbox.exec(
     instance.sandboxName,
     ["python3", "-c", OPENCLAW_STATE_LOCK_PLAN_PROBE],
@@ -501,7 +498,6 @@ test("gateway recovery restores /tmp guard chain after pod-recreate wipe (#2701)
   });
   expect(legacyRecovery.timedOut, resultText(legacyRecovery)).toBe(false);
   expect(legacyRecovery.exitCode, resultText(legacyRecovery)).toBe(0);
-  expect(resultText(legacyRecovery)).toContain("Probe complete: recovered OpenClaw gateway");
   const legacyStateLockPlan = await sandbox.exec(
     instance.sandboxName,
     ["python3", "-c", OPENCLAW_STATE_LOCK_PLAN_PROBE],

--- a/test/e2e/live/issue-2478-crash-loop-recovery.test.ts
+++ b/test/e2e/live/issue-2478-crash-loop-recovery.test.ts
@@ -229,7 +229,7 @@ async function runProbeOnly(
   },
   sandboxName: string,
   artifactName: string,
-): Promise<"connect" | "supervisor"> {
+): Promise<void> {
   const result = await host.nemoclaw([sandboxName, "connect", "--probe-only"], {
     artifactName,
     env: probeEnv(),
@@ -239,18 +239,6 @@ async function runProbeOnly(
     result.exitCode,
     `${artifactName} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
   ).toBe(0);
-  const connectRecovery = `Probe complete: recovered OpenClaw gateway in '${sandboxName}'.`;
-  const supervisorRecovery = `Probe complete: OpenClaw gateway is running in '${sandboxName}'.`;
-  const recoveryPath = result.stdout.includes(connectRecovery)
-    ? "connect"
-    : result.stdout.includes(supervisorRecovery)
-      ? "supervisor"
-      : null;
-  expect(
-    recoveryPath,
-    `${artifactName} did not observe a healthy gateway after termination\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
-  ).not.toBeNull();
-  return recoveryPath!;
 }
 
 async function terminateGatewayIdentity(
@@ -369,7 +357,7 @@ test("gateway recovery restores the guard chain and keeps the recovered process 
     preRecoveryIdentity!,
     "functional-recovery-terminate-gateway",
   );
-  const recoveryPath = await runProbeOnly(
+  await runProbeOnly(
     host,
     instance.sandboxName,
     "functional-recovery-connect-probe-only",
@@ -398,7 +386,6 @@ test("gateway recovery restores the guard chain and keeps the recovered process 
   await artifacts.writeJson("functional-recovery-summary.json", {
     initialIdentity,
     preRecoveryIdentity,
-    recoveryPath,
     recoveredIdentity,
     stableIdentity,
     stabilitySeconds: STABILITY_SECONDS,

--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -67,9 +67,9 @@ fi
 
 render_terminal() {
   sed -E $'s/\x1B][^\x07\x1B]*(\x07|\x1B\\\\)//g' \
-    | sed -E $'s|\x1B\\[[0-?]*[ -/]*[@-~]||g' \
     | LC_ALL=C awk '
       BEGIN {
+        escape = sprintf("%c", 27)
         carriage_return = sprintf("%c", 13)
         backspace = sprintf("%c", 8)
         cursor = 0
@@ -88,6 +88,25 @@ render_terminal() {
       {
         for (character_index = 1; character_index <= length($0); character_index++) {
           character = substr($0, character_index, 1)
+          if (character == escape && substr($0, character_index + 1, 1) == "[") {
+            csi_end = 0
+            for (csi_index = character_index + 2; csi_index <= length($0); csi_index++) {
+              csi_character = substr($0, csi_index, 1)
+              if (csi_character ~ /[@-~]/) {
+                csi_end = csi_index
+                break
+              }
+            }
+            if (csi_end > 0) {
+              csi_parameters = substr($0, character_index + 2, csi_end - character_index - 2)
+              if (csi_character == "K" && csi_parameters == "2") {
+                rendered_line = ""
+                cursor = 0
+              }
+              character_index = csi_end
+              continue
+            }
+          }
           if (character == carriage_return) {
             cursor = 0
           } else if (character == backspace) {

--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -65,10 +65,63 @@ if [[ "$capture_ready" != 1 ]]; then
   exit 1
 fi
 
-if [[ -n "$NEMOCLAW_LAUNCH_READY_TEXT" ]]; then
+render_terminal() {
+  sed -E $'s/\x1B][^\x07\x1B]*(\x07|\x1B\\\\)//g' \
+    | sed -E $'s|\x1B\\[[0-?]*[ -/]*[@-~]||g' \
+    | LC_ALL=C awk '
+      BEGIN {
+        carriage_return = sprintf("%c", 13)
+        backspace = sprintf("%c", 8)
+        cursor = 0
+      }
+      function write_character(character, prefix, suffix) {
+        prefix = substr(rendered_line, 1, cursor)
+        suffix = cursor < length(rendered_line) ? substr(rendered_line, cursor + 2) : ""
+        rendered_line = prefix character suffix
+        cursor++
+      }
+      function emit_line() {
+        print rendered_line
+        rendered_line = ""
+        cursor = 0
+      }
+      {
+        for (character_index = 1; character_index <= length($0); character_index++) {
+          character = substr($0, character_index, 1)
+          if (character == carriage_return) {
+            cursor = 0
+          } else if (character == backspace) {
+            if (cursor > 0) cursor--
+          } else if (character !~ /[[:cntrl:]]/) {
+            write_character(character)
+          }
+        }
+        emit_line()
+      }
+    '
+}
+normalized_capture() {
+  render_terminal <"$capture"
+}
+has_ready_state() {
+  normalized_capture | awk -v expected="$NEMOCLAW_LAUNCH_READY_STATE" '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+    {
+      field_count = split($0, fields, /\|/)
+      if (trim(fields[field_count]) == expected) found = 1
+    }
+    END { exit found ? 0 : 1 }
+  '
+}
+
+if [[ -n "$NEMOCLAW_LAUNCH_READY_STATE" ]]; then
   ready_seen=0
   for _ in {1..60}; do
-    if grep -Fq -- "$NEMOCLAW_LAUNCH_READY_TEXT" "$capture"; then
+    if has_ready_state; then
       ready_seen=1
       break
     fi
@@ -90,11 +143,7 @@ printf '%s\r' "$NEMOCLAW_LAUNCH_PROMPT" >&3
 
 reply_seen=0
 normalized_response() {
-  tail -c "+$((response_start + 1))" "$capture" \
-    | sed -E $'s/\x1B][^\x07\x1B]*(\x07|\x1B\\\\)//g' \
-    | sed -E $'s|\x1B\\[[0-?]*[ -/]*[@-~]||g' \
-    | tr '\r' '\n' \
-    | LC_ALL=C tr -d '\000-\010\013\014\016-\037\177'
+  tail -c "+$((response_start + 1))" "$capture" | render_terminal
 }
 has_exact_reply() {
   normalized_response | awk -v expected="$NEMOCLAW_LAUNCH_EXPECTED_REPLY" '
@@ -110,13 +159,17 @@ has_exact_reply() {
 has_post_reply_ready() {
   normalized_response | awk \
     -v expected="$NEMOCLAW_LAUNCH_EXPECTED_REPLY" \
-    -v ready="$NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT" '
+    -v ready="$NEMOCLAW_LAUNCH_POST_REPLY_READY_STATE" '
+      function trim(value) {
+        sub(/^[[:space:]]+/, "", value)
+        sub(/[[:space:]]+$/, "", value)
+        return value
+      }
       {
-        line = $0
-        sub(/^[[:space:]]+/, "", line)
-        sub(/[[:space:]]+$/, "", line)
+        line = trim($0)
         if (line == expected) reply = 1
-        if (reply && line == ready) found = 1
+        field_count = split(line, fields, /\|/)
+        if (reply && trim(fields[field_count]) == ready) found = 1
       }
       END { exit found ? 0 : 1 }
     '
@@ -132,7 +185,7 @@ for _ in {1..180}; do
   sleep 1
 done
 
-if [[ "$reply_seen" = 1 && -n "$NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT" ]]; then
+if [[ "$reply_seen" = 1 && -n "$NEMOCLAW_LAUNCH_POST_REPLY_READY_STATE" ]]; then
   post_reply_ready_seen=0
   for _ in {1..60}; do
     if has_post_reply_ready; then
@@ -187,8 +240,8 @@ export interface LaunchAgentTurnOptions {
   env: NodeJS.ProcessEnv;
   exitCommand?: string;
   host: HostCliClient;
-  postReplyReadyText?: string;
-  readyText?: string;
+  postReplyReadyState?: string;
+  readyState?: string;
   redactionValues: string[];
   sandboxName: string;
   expectedReply?: string;
@@ -211,8 +264,8 @@ export async function runLaunchAgentTurn(
       NEMOCLAW_LAUNCH_EXIT_COMMAND: options.exitCommand ?? "",
       NEMOCLAW_LAUNCH_EXPECTED_REPLY: options.expectedReply ?? EXPECTED_REPLY,
       NEMOCLAW_LAUNCH_PROMPT: options.prompt ?? PROMPT,
-      NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT: options.postReplyReadyText ?? "",
-      NEMOCLAW_LAUNCH_READY_TEXT: options.readyText ?? "",
+      NEMOCLAW_LAUNCH_POST_REPLY_READY_STATE: options.postReplyReadyState ?? "",
+      NEMOCLAW_LAUNCH_READY_STATE: options.readyState ?? "",
       NEMOCLAW_LAUNCH_SANDBOX: options.sandboxName,
       TERM: "xterm-256color",
     },

--- a/test/e2e/live/launch-readiness-lease-acceptance.test.ts
+++ b/test/e2e/live/launch-readiness-lease-acceptance.test.ts
@@ -38,8 +38,8 @@ test.runIf(process.platform === "linux" && SANDBOX_NAME.length > 0)(
       env: process.env,
       exitCommand: "/exit",
       host,
-      postReplyReadyText: "gateway connected | idle",
-      readyText: "gateway connected | idle",
+      postReplyReadyState: "idle",
+      readyState: "idle",
       redactionValues: [],
       sandboxName: SANDBOX_NAME,
       beforeLaunchTurns: () => {

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -221,6 +221,28 @@ exit 0
 );
 
 it.runIf(process.platform !== "win32")(
+  "renders controlled startup readiness before sending the prompt (#9160)",
+  () => {
+    for (const initialOutput of [
+      "idleXYZ\ridle   ",
+      "busyXYZ\r\u001b[2Kidle",
+      "idlX\be",
+      "\u0001idle\u0002",
+    ]) {
+      const result = runLaunchTurnFixture({
+        exitStatus: 0,
+        initialOutput,
+        readyState: "idle",
+      });
+
+      expect(result.signal, result.stderr).toBeNull();
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("NEMOCLAW_LAUNCH_TURN_OK");
+    }
+  },
+);
+
+it.runIf(process.platform !== "win32")(
   "records a successful reply and exit status 0 after the TUI exit command (#8584)",
   () => {
     const result = runLaunchTurnFixture({ exitStatus: 0 });

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -9,7 +9,26 @@ import { join } from "node:path";
 import { expect, it } from "vitest";
 import { LAUNCH_TURN_SCRIPT, runLaunchReadinessLeaseTurns } from "../live/launch-agent-turn.ts";
 
-function runLaunchTurnFixture(exitStatus: number, reply = "PONG", closeAfterReply = false) {
+interface LaunchTurnFixtureOptions {
+  closeAfterReply?: boolean;
+  exitStatus: number;
+  initialOutput?: string;
+  postReplyOutput?: string;
+  postReplyReadyState?: string;
+  readyState?: string;
+  reply?: string;
+}
+
+function runLaunchTurnFixture(options: LaunchTurnFixtureOptions) {
+  const {
+    closeAfterReply = false,
+    exitStatus,
+    initialOutput = "",
+    postReplyOutput = "",
+    postReplyReadyState = "",
+    readyState = "",
+    reply = "PONG",
+  } = options;
   const fixtureRoot = mkdtempSync(join(tmpdir(), "nemoclaw-launch-turn-"));
   const scriptStub = join(fixtureRoot, "script");
   const sleepStub = join(fixtureRoot, "sleep");
@@ -25,8 +44,14 @@ for argument in "$@"; do
   capture="$argument"
 done
 : >"$capture"
+if [[ -n "$NEMOCLAW_FIXTURE_INITIAL_OUTPUT" ]]; then
+  printf '%s\n' "$NEMOCLAW_FIXTURE_INITIAL_OUTPUT" | tee -a "$capture"
+fi
 IFS= read -r -d $'\r' _
-printf '%s\n' "$NEMOCLAW_FIXTURE_REPLY" | tee "$capture"
+printf '%s\n' "$NEMOCLAW_FIXTURE_REPLY" | tee -a "$capture"
+if [[ -n "$NEMOCLAW_FIXTURE_POST_REPLY_OUTPUT" ]]; then
+  printf '%s\n' "$NEMOCLAW_FIXTURE_POST_REPLY_OUTPUT" | tee -a "$capture"
+fi
 ${
   closeAfterReply
     ? ""
@@ -50,10 +75,12 @@ exit ${exitStatus}
         NEMOCLAW_LAUNCH_ENTRYPOINT: "",
         NEMOCLAW_LAUNCH_EXIT_COMMAND: closeAfterReply ? "" : "/exit",
         NEMOCLAW_LAUNCH_EXPECTED_REPLY: "PONG",
+        NEMOCLAW_FIXTURE_INITIAL_OUTPUT: initialOutput,
+        NEMOCLAW_FIXTURE_POST_REPLY_OUTPUT: postReplyOutput,
         NEMOCLAW_FIXTURE_REPLY: reply,
-        NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT: "",
+        NEMOCLAW_LAUNCH_POST_REPLY_READY_STATE: postReplyReadyState,
         NEMOCLAW_LAUNCH_PROMPT: "prompt",
-        NEMOCLAW_LAUNCH_READY_TEXT: "",
+        NEMOCLAW_LAUNCH_READY_STATE: readyState,
         NEMOCLAW_LAUNCH_SANDBOX: "sandbox",
         PATH: `${fixtureRoot}:${process.env.PATH ?? ""}`,
       },
@@ -88,8 +115,8 @@ it.runIf(process.platform === "linux")(
       env: {},
       exitCommand: "/exit",
       host: host as never,
-      postReplyReadyText: "gateway connected | idle",
-      readyText: "gateway connected | idle",
+      postReplyReadyState: "idle",
+      readyState: "idle",
       redactionValues: [],
       sandboxName: "alpha",
       beforeLaunchTurns: () => {
@@ -110,18 +137,18 @@ it.runIf(process.platform === "linux")(
       "/exit",
       "/exit",
     ]);
-    expect(calls.slice(1).map((call) => call.env?.NEMOCLAW_LAUNCH_READY_TEXT)).toEqual([
-      "gateway connected | idle",
-      "gateway connected | idle",
+    expect(calls.slice(1).map((call) => call.env?.NEMOCLAW_LAUNCH_READY_STATE)).toEqual([
+      "idle",
+      "idle",
     ]);
     expect(
-      calls.slice(1).map((call) => call.env?.NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT),
-    ).toEqual(["gateway connected | idle", "gateway connected | idle"]);
+      calls.slice(1).map((call) => call.env?.NEMOCLAW_LAUNCH_POST_REPLY_READY_STATE),
+    ).toEqual(["idle", "idle"]);
   },
 );
 
 it.runIf(process.platform !== "win32")(
-  "requires the exact reply before the post-reply 'gateway connected | idle' line (#9023)",
+  "requires the exact reply before a post-reply idle state (#9023, #9160)",
   () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), "nemoclaw-launch-turn-ready-"));
     const scriptStub = join(fixtureRoot, "script");
@@ -142,7 +169,7 @@ if IFS= read -r -t 1 -d $'\r' _; then
   echo "prompt arrived before gateway readiness" >&2
   exit 1
 fi
-printf 'gateway connected | idle\n' | tee -a "$capture"
+printf 'connected | idle\n' | tee -a "$capture"
 IFS= read -r -d $'\r' _
 printf 'gateway connected | idle\n' | tee -a "$capture"
 if IFS= read -r -t 1 -d $'\r' _; then
@@ -150,12 +177,12 @@ if IFS= read -r -t 1 -d $'\r' _; then
   exit 1
 fi
 printf 'PONG\n' | tee -a "$capture"
-printf 'gateway connected | busy\n' | tee -a "$capture"
+printf 'runtime status | busy\n' | tee -a "$capture"
 if IFS= read -r -t 1 -d $'\r' _; then
-  echo "exit command arrived while the TUI reported 'gateway connected | busy'" >&2
+  echo "exit command arrived while the TUI reported a busy state" >&2
   exit 1
 fi
-printf 'gateway connected | idle\n' | tee -a "$capture"
+printf 'runtime status | idle\n' | tee -a "$capture"
 IFS= read -r -d $'\r' exit_command
 [[ "$exit_command" == "/exit" ]]
 exit 0
@@ -176,8 +203,8 @@ exit 0
           NEMOCLAW_LAUNCH_EXIT_COMMAND: "/exit",
           NEMOCLAW_LAUNCH_EXPECTED_REPLY: "PONG",
           NEMOCLAW_LAUNCH_PROMPT: "prompt",
-          NEMOCLAW_LAUNCH_POST_REPLY_READY_TEXT: "gateway connected | idle",
-          NEMOCLAW_LAUNCH_READY_TEXT: "gateway connected | idle",
+          NEMOCLAW_LAUNCH_POST_REPLY_READY_STATE: "idle",
+          NEMOCLAW_LAUNCH_READY_STATE: "idle",
           NEMOCLAW_LAUNCH_SANDBOX: "sandbox",
           PATH: `${fixtureRoot}:${process.env.PATH ?? ""}`,
         },
@@ -196,7 +223,7 @@ exit 0
 it.runIf(process.platform !== "win32")(
   "records a successful reply and exit status 0 after the TUI exit command (#8584)",
   () => {
-    const result = runLaunchTurnFixture(0);
+    const result = runLaunchTurnFixture({ exitStatus: 0 });
 
     expect(result.signal, result.stderr).toBeNull();
     expect(result.status, result.stderr).toBe(0);
@@ -211,7 +238,7 @@ it.runIf(process.platform !== "win32")(
       const reply =
         `\u001b]8;;https://example.invalid/reply${terminator}` +
         `PONG\u001b]8;;${terminator}`;
-      const result = runLaunchTurnFixture(0, reply);
+      const result = runLaunchTurnFixture({ exitStatus: 0, reply });
 
       expect(result.signal, result.stderr).toBeNull();
       expect(result.status, result.stderr).toBe(0);
@@ -221,13 +248,47 @@ it.runIf(process.platform !== "win32")(
 );
 
 it.runIf(process.platform !== "win32")(
-  "accepts an exact reply after a CSI erase-in-line sequence",
+  "accepts an exact reply after a CSI erase-in-line sequence (#9160)",
   () => {
-    const result = runLaunchTurnFixture(0, "\u001b[2KPONG");
+    const result = runLaunchTurnFixture({ exitStatus: 0, reply: "\u001b[2KPONG" });
 
     expect(result.signal, result.stderr).toBeNull();
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain("NEMOCLAW_LAUNCH_TURN_OK");
+  },
+);
+
+it.runIf(process.platform !== "win32")(
+  "preserves an exact visible reply through supported redraw controls (#9160)",
+  () => {
+    for (const reply of ["WAIT\rPONG", "PONX\bG", "\u0001PONG\u0002"]) {
+      const result = runLaunchTurnFixture({ exitStatus: 0, reply });
+
+      expect(result.signal, result.stderr).toBeNull();
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("NEMOCLAW_LAUNCH_TURN_OK");
+    }
+  },
+);
+
+it.runIf(process.platform !== "win32")(
+  "rejects busy readiness after an exact reply (#9160)",
+  () => {
+    const result = runLaunchTurnFixture({
+      closeAfterReply: true,
+      exitStatus: 0,
+      initialOutput: "connected | idle",
+      postReplyOutput: "gateway connected | busy",
+      postReplyReadyState: "idle",
+      readyState: "idle",
+    });
+
+    expect(result.signal, result.stderr).toBeNull();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "launch did not return to the expected TUI state after the reply",
+    );
+    expect(result.stdout).not.toContain("NEMOCLAW_LAUNCH_TURN_OK");
   },
 );
 
@@ -238,9 +299,8 @@ it.runIf(process.platform !== "win32")(
       "The answer is PONG, with extra prose.",
       "The answer is \u001b[31mPONG\u001b[0m, with extra prose.",
       "\u001b]8;;https://example.invalid/reply\u0007PONG with extra prose\u001b]8;;\u0007",
-      "\u001b]8;;https://example.invalid/replyPONG",
     ]) {
-      const result = runLaunchTurnFixture(0, reply, true);
+      const result = runLaunchTurnFixture({ closeAfterReply: true, exitStatus: 0, reply });
 
       expect(result.signal, result.stderr).toBeNull();
       expect(result.status).toBe(1);
@@ -251,9 +311,39 @@ it.runIf(process.platform !== "win32")(
 );
 
 it.runIf(process.platform !== "win32")(
+  "rejects stale or partial visible reply text (#9160)",
+  () => {
+    for (const reply of ["PON", "PONGX", "PONG\rWAIT"]) {
+      const result = runLaunchTurnFixture({ closeAfterReply: true, exitStatus: 0, reply });
+
+      expect(result.signal, result.stderr).toBeNull();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("launch did not produce the expected agent reply");
+      expect(result.stdout).not.toContain("NEMOCLAW_LAUNCH_TURN_OK");
+    }
+  },
+);
+
+it.runIf(process.platform !== "win32")(
+  "preserves an unrecognized terminal sequence in failed output (#9160)",
+  () => {
+    const result = runLaunchTurnFixture({
+      closeAfterReply: true,
+      exitStatus: 0,
+      reply: "\u001b]8;;https://example.invalid/replyPONG",
+    });
+
+    expect(result.signal, result.stderr).toBeNull();
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("https://example.invalid/replyPONG");
+    expect(result.stderr).toContain("launch did not produce the expected agent reply");
+  },
+);
+
+it.runIf(process.platform !== "win32")(
   "reports a nonzero TUI exit after recording a successful reply (#8584)",
   () => {
-    const result = runLaunchTurnFixture(23);
+    const result = runLaunchTurnFixture({ exitStatus: 23 });
 
     expect(result.signal, result.stderr).toBeNull();
     expect(result.status).toBe(23);

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -250,7 +250,7 @@ it.runIf(process.platform !== "win32")(
 it.runIf(process.platform !== "win32")(
   "accepts an exact reply after a CSI erase-in-line sequence (#9160)",
   () => {
-    const result = runLaunchTurnFixture({ exitStatus: 0, reply: "\u001b[2KPONG" });
+    const result = runLaunchTurnFixture({ exitStatus: 0, reply: "WAIT\u001b[2KPONG" });
 
     expect(result.signal, result.stderr).toBeNull();
     expect(result.status, result.stderr).toBe(0);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Launch-turn E2E now matches the exact visible reply and semantic `idle` state after terminal control sequences, instead of matching incidental TUI prefixes. Gateway recovery tests now rely on exit status and existing process, guard-chain, inference, health, and stability evidence instead of exact operator copy.

## Related Issue

Fixes #9160

## Changes

- Render visible output after terminated OSC sequences, CSI `2K`, carriage returns, backspaces, and nonprinting controls before matching launch-turn output.
- Pass semantic readiness state from OpenClaw callers and require it only after the exact reply appears.
- Remove exact gateway recovery sentence checks where stronger behavioral evidence already follows.
- Add deterministic support cases for accepted and rejected terminal output forms.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior, justification:
- [ ] Tests not applicable, justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable, justification: This changes only internal E2E support and live-test assertions. It does not change a user-facing product surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded, reviewer/approval link/justification: The change only replaces terminal-copy assertions. Existing process identity, guard-chain, health, inference, and stability evidence remains, and credential and policy behavior is unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer, check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit `d3d4a31df` changes only internal E2E tests and support code under `test/e2e/`. The final follow-up adds startup-readiness fixtures for terminal control sequences. It changes no user-facing product surface.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d3d4a31df -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above, command/result or justification: `npx vitest run --project e2e-support test/e2e/support/launch-agent-turn.test.ts` passed 11 tests and skipped 1 opt-in live test.
- [ ] Applicable broad gate passed, `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes, command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved launch readiness checks to recognize normalized terminal state values, including idle and busy states.
  * Added coverage for terminal redraws, control sequences, stale or partial responses, and unrecognized output.
  * Strengthened recovery validation using process identity, guard checks, inference, exit codes, and stability.
  * Removed brittle assertions tied to specific recovery messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->