### PR TITLE
fix(inference): validate injected llama lifecycle authority

### DIFF
--- a/src/lib/actions/sandbox/destroy-host-local-inference.test.ts
+++ b/src/lib/actions/sandbox/destroy-host-local-inference.test.ts
@@ -457,6 +457,19 @@ describe("sandbox destroy host-local inference transaction", () => {
     expect(runtimeProvider.destroy).not.toHaveBeenCalled();
   });
 
+  it("rejects a malformed durable receipt before sandbox deletion", async () => {
+    const runtimeProvider = provider();
+    const entry = sandbox("alpha", receipt(), { hostLocalInferenceReceipt: "not-json" });
+    const { result, runOpenshell, stopInferenceResources } = await runDestroy(runtimeProvider, {
+      entry,
+    });
+
+    expect(result).toMatchObject({ ok: false });
+    expect(runOpenshell).not.toHaveBeenCalled();
+    expect(stopInferenceResources).not.toHaveBeenCalled();
+    expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
   it("preserves authority when the registry row is missing or reused after deletion", async () => {
     const missingProvider = provider();
     const missing = await runDestroy(missingProvider, { currentAfterDelete: null });

--- a/src/lib/actions/sandbox/snapshot-command-host-local-authority.test.ts
+++ b/src/lib/actions/sandbox/snapshot-command-host-local-authority.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { hostLocalInferenceReceipt } from "../../../../test/helpers/host-local-inference-receipt";
 import { createInMemoryRuntimeProviderBundle } from "../../../../test/helpers/runtime-provider-bundle";
@@ -197,12 +197,7 @@ function successfulRestore(
 
 describe("snapshot command host-local inference authority", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     harness.events.length = 0;
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   it("re-proves authority before restore, at the mutation fence, and after success", async () => {

--- a/src/lib/inference/llama-cpp/managed-installer.test.ts
+++ b/src/lib/inference/llama-cpp/managed-installer.test.ts
@@ -772,6 +772,20 @@ describe("managed llama.cpp installer", () => {
     const createLifecycle = vi.fn(() => lifecycle);
     const operation = managedOperation(harness.engine, createLifecycle);
     const runtimeProvider = managedRuntimeProvider(harness.engine, createLifecycle);
+    const mismatchedOperation = managedOperation(
+      { ...harness.engine, engineId: "other-engine" },
+      createLifecycle,
+    );
+
+    expect(() =>
+      rehydrateManagedLlamaCppLifecycle({
+        runtimeProvider,
+        runtimeOwnerSandboxName: "spark-agent",
+        homeDir,
+        operation: mismatchedOperation,
+      }),
+    ).toThrow("returned mismatched host-local-inference authority");
+    expect(createLifecycle).not.toHaveBeenCalled();
 
     const rehydrated = rehydrateManagedLlamaCppLifecycle({
       runtimeProvider,

--- a/src/lib/inference/llama-cpp/managed-installer.ts
+++ b/src/lib/inference/llama-cpp/managed-installer.ts
@@ -512,15 +512,13 @@ export function rehydrateManagedLlamaCppLifecycle(
   const receipt = loadManagedLlamaCppReceipt(paths);
   if (!receipt) throw new Error("Managed llama.cpp private receipt is unavailable.");
   const selection = resolveManagedLlamaCppOwnerSelection(owner);
-  const operation =
-    options.operation ??
-    requireRuntimeProviderHostLocalInferenceOperation(options.runtimeProvider, "llama-cpp", {
-      env: options.env ?? process.env,
-    });
+  const operation = requireRuntimeProviderHostLocalInferenceOperation(
+    options.runtimeProvider,
+    "llama-cpp",
+    { env: options.env ?? process.env },
+    options.operation,
+  );
   operation.assertAuthority();
-  if (operation.providerId !== options.runtimeProvider.identity.id) {
-    throw new Error("Managed llama.cpp runtime provider changed during lifecycle rehydration.");
-  }
   const current = currentManagedLlamaCppArtifact(selection, homeDir);
   return Object.freeze({
     lifecycle: lifecycleFor({

--- a/src/lib/inference/llama-cpp/managed-lifecycle-adapter.test.ts
+++ b/src/lib/inference/llama-cpp/managed-lifecycle-adapter.test.ts
@@ -48,9 +48,10 @@ function temporaryHome(): string {
 describe("managed llama.cpp lifecycle adapter", () => {
   it("uses one exact operation and exposes rollback only before publication", () => {
     const homeDir = temporaryHome();
+    const gatewayPort = 8080;
     const harness = engineHarness();
-    createManagedState(homeDir, harness.engine);
-    const receipt = loadManagedLlamaCppReceipt(managedLlamaCppStatePaths(homeDir))!;
+    createManagedState(homeDir, harness.engine, { gatewayPort });
+    const receipt = loadManagedLlamaCppReceipt(managedLlamaCppStatePaths(homeDir, gatewayPort))!;
     const operation: HostLocalInferenceOperation = {
       providerId: "docker",
       engine: harness.engine,
@@ -92,7 +93,7 @@ describe("managed llama.cpp lifecycle adapter", () => {
       runtimeOwnerSandboxName: "spark-agent",
       expectedModel: "llama-cpp-model",
       expectedReceipt: receipt,
-      gatewayPort: 8080,
+      gatewayPort,
       homeDir,
       operation,
       rehydrate: vi.fn(
@@ -130,9 +131,10 @@ describe("managed llama.cpp lifecycle adapter", () => {
 
   it("uses the retained receipt for an idempotent destroy retry after private state is gone", () => {
     const homeDir = temporaryHome();
+    const gatewayPort = 8080;
     const harness = engineHarness();
-    createManagedState(homeDir, harness.engine);
-    const paths = managedLlamaCppStatePaths(homeDir);
+    createManagedState(homeDir, harness.engine, { gatewayPort });
+    const paths = managedLlamaCppStatePaths(homeDir, gatewayPort);
     const receipt = loadManagedLlamaCppReceipt(paths)!;
     fs.rmSync(paths.stateDir, { recursive: true });
     const operation: HostLocalInferenceOperation = {
@@ -159,7 +161,7 @@ describe("managed llama.cpp lifecycle adapter", () => {
       runtimeOwnerSandboxName: "spark-agent",
       expectedModel: "llama-cpp-model",
       expectedReceipt: receipt,
-      gatewayPort: 8080,
+      gatewayPort,
       homeDir,
       operation,
       finalizeCleanup: (owner, expected, options) =>

--- a/src/lib/onboard/runtime-provider/registry.ts
+++ b/src/lib/onboard/runtime-provider/registry.ts
@@ -730,6 +730,7 @@ export function requireRuntimeProviderHostLocalInferenceOperation(
   bundle: RuntimeProviderBundle,
   service: HostLocalInferenceService,
   input: HostLocalInferenceOperationInput,
+  candidate?: HostLocalInferenceOperation,
 ): HostLocalInferenceOperation {
   const surface = bundle.hostLocalInference;
   if (
@@ -749,7 +750,7 @@ export function requireRuntimeProviderHostLocalInferenceOperation(
       `Runtime provider '${bundle.identity.id}' does not provide an operation-scoped host-local-inference engine for ${service}.`,
     );
   }
-  const operation = surface.createOperation(input);
+  const operation = candidate ?? surface.createOperation(input);
   if (
     operation.providerId !== bundle.identity.id ||
     operation.engine.operation !== "host-local-inference" ||

--- a/src/lib/onboard/setup-inference.ts
+++ b/src/lib/onboard/setup-inference.ts
@@ -422,7 +422,12 @@ function resolveHostLocalInferenceRoute(
   }
   const operation =
     request.service === "llama-cpp"
-      ? request.adapter.operation
+      ? requireRuntimeProviderHostLocalInferenceOperation(
+          providerBundle,
+          request.service,
+          { env: hostLocalInferenceOperationEnvironment(request.service) },
+          request.adapter.operation,
+        )
       : requireRuntimeProviderHostLocalInferenceOperation(providerBundle, request.service, {
           env: hostLocalInferenceOperationEnvironment(request.service),
           acceleration:

--- a/test/onboard-host-local-inference-routing.test.ts
+++ b/test/onboard-host-local-inference-routing.test.ts
@@ -647,6 +647,39 @@ describe("onboard host-local inference routing", () => {
     },
   );
 
+  it("rejects injected llama.cpp engine drift before startup", async () => {
+    const route = llamaFixture("openclaw");
+    const request = route.selection.request as Extract<
+      HostLocalInferenceStartupSelection["request"],
+      { service: "llama-cpp" }
+    >;
+    const selection: HostLocalInferenceStartupSelection = {
+      ...route.selection,
+      request: {
+        ...request,
+        adapter: {
+          ...request.adapter,
+          operation: {
+            ...request.adapter.operation,
+            engine: { ...request.adapter.operation.engine, engineId: "other-engine" },
+          },
+        },
+      },
+    };
+    const harness = createHarness();
+
+    await expect(
+      harness.setupInference(SANDBOX, MODEL, "llama-cpp-local", null, null, null, [], {
+        hostLocalInference: selection,
+      }),
+    ).rejects.toThrow("EXIT_CALLED:1");
+
+    expect(route.prepareStartup).not.toHaveBeenCalled();
+    expect(route.prepareGatewayMutation).not.toHaveBeenCalled();
+    expect(harness.commands).toEqual([]);
+    expect(harness.errors.join(" ")).toContain("mismatched host-local-inference authority");
+  });
+
   it.each([
     ["nim", 8001],
     ["vllm", 8000],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This follow-up completes the outstanding actionable review feedback from #9123. Injected llama.cpp lifecycle operations are now revalidated against the sandbox-bound runtime provider before rehydration or startup, while unchanged legacy receipt dispatch remains intact.

## Related Issue

Follow-up to #9123 and #7744.

## Changes

- Reuse the runtime-provider operation validator for injected operations at both llama.cpp rehydration and onboarding startup boundaries.
- Reject same-provider operations whose engine operation, ID, or display name differs from the provider bundle, with focused rehydration and onboarding regression coverage.
- Prove malformed durable receipts already fail before sandbox deletion, without changing legacy llama.cpp dispatch.
- Bind lifecycle-adapter fixtures to one explicit gateway port and remove redundant Vitest mock teardown hooks.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Internal authority validation and test-fixture corrections do not change commands, configuration, defaults, output, or documented lifecycle selection.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Follow-up validates the engine-authority findings from https://github.com/NVIDIA/NemoClaw/pull/9123#discussion_r3786304102 and https://github.com/NVIDIA/NemoClaw/pull/9123#discussion_r3786304119 at both production boundaries.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Internal provider-authority validation and test-only corrections; no command, setting, default, output, installation step, or documented behavior changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 836ef45ba -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run build:cli && npm run typecheck:cli`; focused Vitest projects passed 45 CLI tests and 52 integration tests; `npm run checks:repository` and `npm run test-size:check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented sandbox deletion and cleanup when host-local inference receipts are malformed.
  - Rejected host-local inference operations with mismatched engine authorities before startup or lifecycle changes.
  - Improved operation routing consistency during inference setup and rehydration.
  - Ensured lifecycle state and retry handling use the correct gateway-specific paths.

- **Tests**
  - Added regression coverage for invalid receipts, authority mismatches, routing, startup, rollback, and destroy-retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->