### PR TITLE
fix(agents): fail closed on Pi shell limits

### DIFF
--- a/agents/pi/Dockerfile.base
+++ b/agents/pi/Dockerfile.base
@@ -316,8 +316,8 @@ COPY scripts/lib/sandbox-rlimits.sh /usr/local/lib/nemoclaw/sandbox-rlimits.sh
 # /etc/profile.d, interactive shells via /etc/bash.bashrc. OpenShell creates
 # these exec/connect processes outside the entrypoint tree, and this image
 # layer cannot make them inherit a child's lowered limits. Refuse the shell if
-# the helper is absent or either enforcement step fails so every Pi execution
-# path retains the reviewed limits. The managed entrypoint separately enforces
+# the helper is absent or either enforcement step fails so these Pi Bash shell
+# paths retain the reviewed limits. The managed entrypoint separately enforces
 # the same fail-closed contract. Ref: sandbox-rlimits.sh (#2173).
 # hadolint ignore=SC2028
 RUN chmod 444 /usr/local/lib/nemoclaw/sandbox-rlimits.sh \

--- a/agents/pi/Dockerfile.base
+++ b/agents/pi/Dockerfile.base
@@ -313,26 +313,22 @@ COPY scripts/lib/sandbox-rlimits.sh /usr/local/lib/nemoclaw/sandbox-rlimits.sh
 # non-root sandbox user and is reached through fresh `openshell sandbox exec` /
 # connect shells that do not inherit the entrypoint's lowered limits, so the
 # nproc/nofile caps are installed for every bash mode: login shells via
-# /etc/profile.d, interactive shells via /etc/bash.bashrc. A shell stays
-# available if enforcement fails, matching the established OpenClaw/Hermes
-# compatibility contract, but the hook must emit a visible security diagnostic.
-# OpenShell creates these exec/connect processes outside the entrypoint tree,
-# and this image layer cannot make them inherit a child's lowered limits.
-# Remove the warn-and-continue exception when OpenShell starts every
-# exec/connect process under enforced caps or exposes a fail-closed limit
-# contract. The managed entrypoint separately fails closed if the helper is
-# absent or the effective limits cannot be verified.
-# Mirrors the OpenClaw and Hermes base images. Ref: sandbox-rlimits.sh (#2173).
+# /etc/profile.d, interactive shells via /etc/bash.bashrc. OpenShell creates
+# these exec/connect processes outside the entrypoint tree, and this image
+# layer cannot make them inherit a child's lowered limits. Refuse the shell if
+# the helper is absent or either enforcement step fails so every Pi execution
+# path retains the reviewed limits. The managed entrypoint separately enforces
+# the same fail-closed contract. Ref: sandbox-rlimits.sh (#2173).
 # hadolint ignore=SC2028
 RUN chmod 444 /usr/local/lib/nemoclaw/sandbox-rlimits.sh \
     && printf '%s\n' \
         '# NemoClaw sandbox resource limits — see sandbox-rlimits.sh (#2173)' \
-        '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits_exact --quiet || { printf "%s\n" "[SECURITY] Sandbox resource limits were NOT hardened for this shell." >&2; true; }' \
+        '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits_exact --quiet || { printf "%s\n" "[SECURITY] Sandbox resource limits were NOT hardened for this shell; refusing shell startup." >&2; exit 1; }' \
         > /etc/profile.d/nemoclaw-rlimits.sh \
     && chmod 444 /etc/profile.d/nemoclaw-rlimits.sh \
     && { printf '%s\n' \
             '# NemoClaw sandbox resource limits — see sandbox-rlimits.sh (#2173)' \
-            '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits_exact --quiet || { printf "%s\n" "[SECURITY] Sandbox resource limits were NOT hardened for this shell." >&2; true; }' \
+            '[ -f /usr/local/lib/nemoclaw/sandbox-rlimits.sh ] && . /usr/local/lib/nemoclaw/sandbox-rlimits.sh && harden_resource_limits --quiet && verify_resource_limits_exact --quiet || { printf "%s\n" "[SECURITY] Sandbox resource limits were NOT hardened for this shell; refusing shell startup." >&2; exit 1; }' \
             ''; \
          cat /etc/bash.bashrc; \
        } > /etc/bash.bashrc.new \

--- a/test/sandbox-rlimit-hooks.test.ts
+++ b/test/sandbox-rlimit-hooks.test.ts
@@ -45,10 +45,6 @@ function dcodeRlimitShim(rlimitLib: string): string {
   return `[ -f ${rlimitLib} ] && . ${rlimitLib} && harden_resource_limits --quiet && verify_resource_limits_exact --quiet || { printf "%s\\n" "[SECURITY] Sandbox resource limits were NOT hardened for this shell." >&2; true; }`;
 }
 
-function piRlimitShim(rlimitLib: string): string {
-  return `[ -f ${rlimitLib} ] && . ${rlimitLib} && harden_resource_limits --quiet && verify_resource_limits_exact --quiet || { printf "%s\\n" "[SECURITY] Sandbox resource limits were NOT hardened for this shell; refusing shell startup." >&2; exit 1; }`;
-}
-
 type ProbeValues = Record<string, string | undefined>;
 
 function parseProbeOutput(stdout: string): ProbeValues {
@@ -205,57 +201,30 @@ function expectDcodeRlimitHookWarnsWhenHelperIsMissing(hookPath: string, rlimitL
 
 function expectPiRlimitHooksRejectFailedEnforcement(
   hookPaths: Array<{ mode: "interactive" | "login"; path: string }>,
-  rlimitLib: string,
+  failure: string,
 ): void {
-  const failures: Array<{ body?: string; name: string }> = [
-    { name: "missing helper" },
-    {
-      body: [
-        "harden_resource_limits() { return 1; }",
-        "verify_resource_limits_exact() { :; }",
-      ].join("\n"),
-      name: "failed hardening",
-    },
-    {
-      body: [
-        "harden_resource_limits() { :; }",
-        "verify_resource_limits_exact() { return 1; }",
-      ].join("\n"),
-      name: "failed verification",
-    },
-  ];
+  for (const hook of hookPaths) {
+    const args =
+      hook.mode === "login"
+        ? [
+            "--noprofile",
+            "--norc",
+            "-lc",
+            'source "$1"; printf "UNREACHABLE\\n"',
+            "pi-login",
+            hook.path,
+          ]
+        : ["--noprofile", "--rcfile", hook.path, "-ic", 'printf "UNREACHABLE\\n"'];
+    const result = spawnSync("bash", args, {
+      encoding: "utf-8",
+      timeout: 5000,
+    });
 
-  for (const failure of failures) {
-    if (failure.body === undefined) {
-      fs.rmSync(rlimitLib, { force: true });
-    } else {
-      fs.writeFileSync(rlimitLib, `${failure.body}\n`, { mode: 0o644 });
-      fs.chmodSync(rlimitLib, 0o644);
-    }
-
-    for (const hook of hookPaths) {
-      const args =
-        hook.mode === "login"
-          ? [
-              "--noprofile",
-              "--norc",
-              "-lc",
-              'source "$1"; printf "UNREACHABLE\\n"',
-              "pi-login",
-              hook.path,
-            ]
-          : ["--noprofile", "--rcfile", hook.path, "-ic", 'printf "UNREACHABLE\\n"'];
-      const result = spawnSync("bash", args, {
-        encoding: "utf-8",
-        timeout: 5000,
-      });
-
-      expect(result.status, `${hook.mode}: ${failure.name}\n${result.stderr}`).not.toBe(0);
-      expect(result.stdout).not.toContain("UNREACHABLE");
-      expect(result.stderr).toContain(
-        "[SECURITY] Sandbox resource limits were NOT hardened for this shell; refusing shell startup.",
-      );
-    }
+    expect(result.status, `${hook.mode}: ${failure}\n${result.stderr}`).not.toBe(0);
+    expect(result.stdout).not.toContain("UNREACHABLE");
+    expect(result.stderr).toContain(
+      "[SECURITY] Sandbox resource limits were NOT hardened for this shell; refusing shell startup.",
+    );
   }
 }
 
@@ -489,7 +458,6 @@ describe("sandbox rlimit system hooks (#2173)", () => {
     const rlimitHook = path.join(tmp, "profile.d", "nemoclaw-rlimits.sh");
     const rlimitLib = path.join(tmp, "sandbox-rlimits.sh");
     const bashrc = path.join(tmp, "bash.bashrc");
-    const expectedRlimitShim = piRlimitShim(rlimitLib);
 
     try {
       fs.mkdirSync(path.dirname(rlimitHook), { recursive: true });
@@ -506,16 +474,36 @@ describe("sandbox rlimit system hooks (#2173)", () => {
 
       const { result } = runLoggedDockerShell(command, tmp);
       expect(result.status, result.stderr).toBe(0);
-      expect(fs.readFileSync(rlimitHook, "utf-8")).toContain(expectedRlimitShim);
-      expect(fs.readFileSync(bashrc, "utf-8")).toContain(expectedRlimitShim);
       expect(fs.readFileSync(bashrc, "utf-8")).toContain("# existing Pi bashrc");
-      expectPiRlimitHooksRejectFailedEnforcement(
-        [
-          { mode: "login", path: rlimitHook },
-          { mode: "interactive", path: bashrc },
-        ],
+      const hooks: Array<{ mode: "interactive" | "login"; path: string }> = [
+        { mode: "login", path: rlimitHook },
+        { mode: "interactive", path: bashrc },
+      ];
+
+      fs.rmSync(rlimitLib, { force: true });
+      expectPiRlimitHooksRejectFailedEnforcement(hooks, "missing helper");
+
+      fs.writeFileSync(
         rlimitLib,
+        [
+          "harden_resource_limits() { return 1; }",
+          "verify_resource_limits() { :; }",
+          "verify_resource_limits_exact() { :; }",
+        ].join("\n"),
+        { mode: 0o644 },
       );
+      expectPiRlimitHooksRejectFailedEnforcement(hooks, "failed hardening");
+
+      fs.writeFileSync(
+        rlimitLib,
+        [
+          "harden_resource_limits() { :; }",
+          "verify_resource_limits() { :; }",
+          "verify_resource_limits_exact() { return 1; }",
+        ].join("\n"),
+        { mode: 0o644 },
+      );
+      expectPiRlimitHooksRejectFailedEnforcement(hooks, "failed exact verification");
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/sandbox-rlimit-hooks.test.ts
+++ b/test/sandbox-rlimit-hooks.test.ts
@@ -11,6 +11,7 @@ import { dockerRunCommandBetween, runLoggedDockerShell } from "./helpers/dockerf
 const ROOT = path.resolve(import.meta.dirname, "..");
 const DOCKERFILE = path.join(ROOT, "Dockerfile");
 const DOCKERFILE_BASE = path.join(ROOT, "Dockerfile.base");
+const PI_DOCKERFILE_BASE = path.join(ROOT, "agents", "pi", "Dockerfile.base");
 const HERMES_DOCKERFILE = path.join(ROOT, "agents", "hermes", "Dockerfile");
 const DCODE_DOCKERFILE_BASE = path.join(
   ROOT,
@@ -42,6 +43,10 @@ function rlimitShim(rlimitLib: string): string {
 
 function dcodeRlimitShim(rlimitLib: string): string {
   return `[ -f ${rlimitLib} ] && . ${rlimitLib} && harden_resource_limits --quiet && verify_resource_limits_exact --quiet || { printf "%s\\n" "[SECURITY] Sandbox resource limits were NOT hardened for this shell." >&2; true; }`;
+}
+
+function piRlimitShim(rlimitLib: string): string {
+  return `[ -f ${rlimitLib} ] && . ${rlimitLib} && harden_resource_limits --quiet && verify_resource_limits_exact --quiet || { printf "%s\\n" "[SECURITY] Sandbox resource limits were NOT hardened for this shell; refusing shell startup." >&2; exit 1; }`;
 }
 
 type ProbeValues = Record<string, string | undefined>;
@@ -196,6 +201,62 @@ function expectDcodeRlimitHookWarnsWhenHelperIsMissing(hookPath: string, rlimitL
   expect(result.stderr).toContain(
     "[SECURITY] Sandbox resource limits were NOT hardened for this shell.",
   );
+}
+
+function expectPiRlimitHooksRejectFailedEnforcement(
+  hookPaths: Array<{ mode: "interactive" | "login"; path: string }>,
+  rlimitLib: string,
+): void {
+  const failures: Array<{ body?: string; name: string }> = [
+    { name: "missing helper" },
+    {
+      body: [
+        "harden_resource_limits() { return 1; }",
+        "verify_resource_limits_exact() { :; }",
+      ].join("\n"),
+      name: "failed hardening",
+    },
+    {
+      body: [
+        "harden_resource_limits() { :; }",
+        "verify_resource_limits_exact() { return 1; }",
+      ].join("\n"),
+      name: "failed verification",
+    },
+  ];
+
+  for (const failure of failures) {
+    if (failure.body === undefined) {
+      fs.rmSync(rlimitLib, { force: true });
+    } else {
+      fs.writeFileSync(rlimitLib, `${failure.body}\n`, { mode: 0o644 });
+      fs.chmodSync(rlimitLib, 0o644);
+    }
+
+    for (const hook of hookPaths) {
+      const args =
+        hook.mode === "login"
+          ? [
+              "--noprofile",
+              "--norc",
+              "-lc",
+              'source "$1"; printf "UNREACHABLE\\n"',
+              "pi-login",
+              hook.path,
+            ]
+          : ["--noprofile", "--rcfile", hook.path, "-ic", 'printf "UNREACHABLE\\n"'];
+      const result = spawnSync("bash", args, {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+
+      expect(result.status, `${hook.mode}: ${failure.name}\n${result.stderr}`).not.toBe(0);
+      expect(result.stdout).not.toContain("UNREACHABLE");
+      expect(result.stderr).toContain(
+        "[SECURITY] Sandbox resource limits were NOT hardened for this shell; refusing shell startup.",
+      );
+    }
+  }
 }
 
 function expectRlimitLibIsPosixShSafe(rlimitLib: string): void {
@@ -417,6 +478,44 @@ describe("sandbox rlimit system hooks (#2173)", () => {
       expectSystemRlimitHookEnforcesLimits(bashrc);
       expectSystemRlimitHookBypassesShadowedUlimit(rlimitHook);
       expectSystemRlimitHookIsSilentWhenVerificationFails(rlimitHook, rlimitLib);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("Pi login and interactive hooks reject shells when exact limit enforcement fails", () => {
+    const dockerfile = fs.readFileSync(PI_DOCKERFILE_BASE, "utf-8");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-pi-rlimit-hooks-"));
+    const rlimitHook = path.join(tmp, "profile.d", "nemoclaw-rlimits.sh");
+    const rlimitLib = path.join(tmp, "sandbox-rlimits.sh");
+    const bashrc = path.join(tmp, "bash.bashrc");
+    const expectedRlimitShim = piRlimitShim(rlimitLib);
+
+    try {
+      fs.mkdirSync(path.dirname(rlimitHook), { recursive: true });
+      copyRlimitFixture(rlimitLib);
+      fs.writeFileSync(bashrc, "# existing Pi bashrc\n");
+      const command = dockerRunCommandBetween(
+        dockerfile,
+        "# System-wide RLIMIT hooks for Pi connect and login shells",
+        "COPY agents/pi/pi-runtime/package.json",
+      )
+        .replaceAll("/usr/local/lib/nemoclaw/sandbox-rlimits.sh", rlimitLib)
+        .replaceAll("/etc/profile.d/nemoclaw-rlimits.sh", rlimitHook)
+        .replaceAll("/etc/bash.bashrc", bashrc);
+
+      const { result } = runLoggedDockerShell(command, tmp);
+      expect(result.status, result.stderr).toBe(0);
+      expect(fs.readFileSync(rlimitHook, "utf-8")).toContain(expectedRlimitShim);
+      expect(fs.readFileSync(bashrc, "utf-8")).toContain(expectedRlimitShim);
+      expect(fs.readFileSync(bashrc, "utf-8")).toContain("# existing Pi bashrc");
+      expectPiRlimitHooksRejectFailedEnforcement(
+        [
+          { mode: "login", path: rlimitHook },
+          { mode: "interactive", path: bashrc },
+        ],
+        rlimitLib,
+      );
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Pi login and interactive Bash shells previously continued when resource-limit enforcement failed. This change rejects shell startup and reports the failed security control.

## Related Issue

Follow-up to #7925 and #9100.

## Changes

- Make both Pi system-wide Bash hooks exit when the resource-limit helper is missing or enforcement fails.
- Add regression coverage for missing-helper, hardening-failure, and verification-failure paths in login and interactive shells.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Pi remains outside the supported and selectable agent inventory. This change affects only a fail-closed image control and its regression tests.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Codex Desktop review passed all nine security categories for commit under review `e1947a586036b0f7577ce43e842888fe0e09ea33`. Both Bash hooks fail closed when the helper is absent or hardening or exact verification fails. The tests exercise each failure through shell behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `agents/pi/Dockerfile.base` makes the Pi candidate image reject Bash login and interactive shell startup when the resource-limit helper is missing. The same hooks reject startup when hardening or exact verification fails. `test/sandbox-rlimit-hooks.test.ts` covers these paths. Pi remains outside `SHIPPED_MANAGED_IMAGE_AGENTS` and the public supported-agent inventory, so no public documentation changes are required.
- Agent: Codex Desktop
<!-- docs-review-head-sha: e1947a586 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/sandbox-rlimit-hooks.test.ts` — 9 tests passed at `ffa50eb05874153d020d4ca33a5621d7d197eee1`; `npm run validate:pr` passed at the same commit.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell startup security by stopping startup when resource-limit hardening or verification fails.
  * Missing security helpers now prevent shell sessions from continuing instead of allowing startup with only a warning.

* **Tests**
  * Added coverage verifying secure behavior for login and interactive shells, including missing helpers, hardening failures, and verification failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
