### PR TITLE
fix(sandbox): report why a sandbox config read failed

### DIFF
--- a/src/lib/sandbox/config.ts
+++ b/src/lib/sandbox/config.ts
@@ -462,15 +462,25 @@ function readSandboxConfig(sandboxName: string, target: AgentConfigTarget): Conf
       },
     );
     if (result.error || result.signal || result.status !== 0) {
-      const detail = result.error?.message || result.stderr?.trim() || result.output;
-      configFail(
-        `  Cannot read ${target.agentName} config (${target.configPath})${detail ? `: ${detail}` : "."}`,
-      );
+      // Diagnostic channels only. `result.output` is stdout-first, and stdout
+      // here is the agent config `cat` printed, so echoing it would put config
+      // contents — credentials included — into a CLI error.
+      const detail = result.error?.message || result.stderr?.trim();
+      // Preserve a failed exec's detail. `configFail` throws, so it must not be
+      // caught and replaced with the generic stopped-sandbox message below.
+      if (detail) {
+        configFail(`  Cannot read ${target.agentName} config (${target.configPath}): ${detail}`);
+      }
+      raw = "";
+    } else {
+      // `output` is display-normalized with trim(); the transaction digest must
+      // bind the exact bytes returned by `cat`, including its final newline.
+      raw = result.stdout ?? result.output ?? "";
     }
-    // `output` is display-normalized with trim(); the transaction digest must
-    // bind the exact bytes returned by `cat`, including its final newline.
-    raw = result.stdout ?? result.output ?? "";
-  } catch {
+  } catch (error) {
+    // Only unexpected capture failures become empty reads. A diagnostic raised
+    // above already names the reason and must reach the caller (#9104).
+    if (error instanceof SandboxConfigError) throw error;
     raw = "";
   }
 

--- a/test/sandbox-config-read-failure-diagnostic.test.ts
+++ b/test/sandbox-config-read-failure-diagnostic.test.ts
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression for #9104.
+ *
+ * `readSandboxConfig` runs `openshell sandbox exec -- cat <configPath>` and, on
+ * a failed exec, raises a diagnostic carrying the reason OpenShell reported.
+ * That diagnostic was raised inside a `try` whose `catch` discarded every
+ * error, so the reason never reached the user: every failed read reported the
+ * generic "Is the sandbox running?" text instead. A reporter watching a Ready
+ * sandbox was told it was not running.
+ *
+ * These tests drive the real read path — real `spawnSync`, real
+ * `captureOpenshellCommand` — against a stub OpenShell binary selected through
+ * `NEMOCLAW_OPENSHELL_BIN`, so they fail if the reason is discarded again.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_AGENT_CONFIG,
+  readSandboxConfig,
+  SandboxConfigError,
+} from "../src/lib/sandbox/config";
+
+const EXEC_FAILURE_REASON = "exec session setup failed: container not ready";
+
+let home: string;
+
+/**
+ * Install a stub `openshell` whose `sandbox exec` fails, writing `stderr` to
+ * stderr and `stdout` to stdout — the two channels the diagnostic chooses
+ * between.
+ */
+function stubOpenshell(stderr: string, stdout = ""): void {
+  const binary = path.join(home, "openshell");
+  fs.writeFileSync(
+    binary,
+    [
+      "#!/usr/bin/env bash",
+      `printf '%s' ${JSON.stringify(stdout)}`,
+      `printf '%s' ${JSON.stringify(stderr)} >&2`,
+      "exit 1",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  vi.stubEnv("NEMOCLAW_OPENSHELL_BIN", binary);
+}
+
+/** Read the config and return the diagnostic lines the CLI would print. */
+function readAndCaptureLines(): string {
+  const error = (() => {
+    try {
+      readSandboxConfig("alpha", DEFAULT_AGENT_CONFIG);
+      return null;
+    } catch (thrown) {
+      return thrown;
+    }
+  })();
+
+  expect(error).toBeInstanceOf(SandboxConfigError);
+  return (error as SandboxConfigError).lines.join("\n");
+}
+
+describe("failed sandbox config reads report OpenShell failures (#9104)", () => {
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-9104-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("reports the reason OpenShell gave for the failed read", () => {
+    stubOpenshell(EXEC_FAILURE_REASON);
+
+    const lines = readAndCaptureLines();
+
+    // The operator needs the actual reason to act on: the read failed because
+    // the exec session could not be set up, not because the sandbox is stopped.
+    expect(lines).toContain(EXEC_FAILURE_REASON);
+    expect(lines).toContain("Cannot read openclaw config (/sandbox/.openclaw/openclaw.json)");
+  });
+
+  it("does not blame a stopped sandbox when OpenShell reported another reason", () => {
+    stubOpenshell(EXEC_FAILURE_REASON);
+
+    const lines = readAndCaptureLines();
+
+    // #9104: the sandbox was Ready. Claiming otherwise sends the operator to
+    // the wrong remedy, and `readInSandboxConfigOrFail` appends "Start the
+    // sandbox and retry." to any message carrying this question.
+    expect(lines).not.toContain("Is the sandbox running?");
+  });
+
+  it("keeps the stopped-sandbox question when OpenShell reported no reason", () => {
+    stubOpenshell("");
+
+    const lines = readAndCaptureLines();
+
+    // With nothing to report, the stopped sandbox stays the best guess — this
+    // is the pre-existing text and it must survive the fix above.
+    expect(lines).toContain("Is the sandbox running?");
+  });
+
+  it("never echoes the partial config a failed read printed", () => {
+    // A read that fails partway still puts config bytes on stdout. Those bytes
+    // are the agent config, so the diagnostic must come from stderr alone.
+    stubOpenshell("", '{"agents":{"apiKey":"sk-secret-9104"}}');
+
+    const lines = readAndCaptureLines();
+
+    expect(lines).not.toContain("sk-secret-9104");
+    expect(lines).toContain("Is the sandbox running?");
+  });
+});


### PR DESCRIPTION
## Summary

`nemoclaw inference set` told a reporter "Is the sandbox running?" about a sandbox that was Phase Ready. It says that about every failed config read, because the diagnostic naming the real reason was thrown inside a `try` whose `catch` discarded it. This lets that reason reach the user.

Before: `Cannot read openclaw config (/sandbox/.openclaw/openclaw.json). / Is the sandbox running? / Start the sandbox and retry.`
After: `Cannot read openclaw config (/sandbox/.openclaw/openclaw.json): exec session setup failed: container not ready`

## Related Issue

Refs: #9104

## Changes

- `src/lib/sandbox/config.ts` — `readSandboxConfig` runs `openshell sandbox exec -- cat <configPath>`. On a failed exec it built a diagnostic carrying OpenShell's reason and threw it through `configFail`, but the enclosing `catch { raw = ""; }` swallowed it unconditionally, so execution always fell through to the generic stopped-sandbox message below. That made the detailed branch dead code. `SandboxConfigError` now escapes the catch; unexpected errors still become an empty read.
- The reason is taken from the spawn error and stderr only. It previously also fell back to `result.output`, which is stdout-first (`captureOutput`, `adapters/openshell/client.ts:161`) — and stdout here is the agent config the `cat` printed. Surfacing a diagnostic that could carry it would put config contents, credentials included, into a CLI error.
- When OpenShell reports no reason at all, nothing changes: the read stays empty and the existing "Is the sandbox running?" text stands as the best remaining guess.
- `test/sandbox-config-read-failure-diagnostic.test.ts` — new. Drives the real read path (real `spawnSync`, real `captureOpenshellCommand`) against a stub OpenShell binary selected with `NEMOCLAW_OPENSHELL_BIN`.

No new abstraction, configuration, fallback, or compatibility path.

### On the exit code, which is the issue's headline

**I could not reproduce exit 0, and this PR does not claim to fix it.** Driving the real binary with a stub OpenShell whose `sandbox exec -- cat` fails, both grammars exit **1** on current `main`:

```
$ nemoclaw inference set --provider nvidia-prod --model … --sandbox test-sb --no-verify
  Cannot read openclaw config (/sandbox/.openclaw/openclaw.json).
  Is the sandbox running?
  Start the sandbox and retry.
exit=1
```

The contract holds in source too: `configFail` throws `SandboxConfigError` with exit code 1, `readInSandboxConfigOrFail` carries it into `InferenceSetError`, and both `inference:set` and `sandbox:inference:set` call `failWithLines(…, error.exitCode)`. The three sibling `sandbox config` commands do the same. No commit has touched these files since `v0.0.108`, the reported version.

What I did reproduce is the issue's other stated expectation — "the message should say so accurately" — so that is what this fixes. If the reporter can still see `exit=0`, the wrapper and shell around the invocation are worth capturing, since the CLI itself returns 1 here.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no page documents this diagnostic. `grep -rn "Is the sandbox running\|Cannot read" docs/ fern/` returns only one unrelated line (`docs/reference/commands.mdx:2558`, prose about policy presets). No flag, command surface, or documented output changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: requested — this touches the sandbox config read, and the `result.output` change above is the part worth a second pair of eyes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed `src/lib/sandbox/config.ts`, `test/sandbox-config-read-failure-diagnostic.test.ts`, linked issue #9104, and the owning inference and sandbox-configuration guides. The merge with current main preserves both reviewed PR-owned blobs. The change replaces an undocumented generic fallback with OpenShell's available stderr or spawn-error diagnostic, preserves the generic fallback when no diagnostic exists, and does not change commands, flags, configuration, defaults, exit behavior, or a documented recovery procedure. No documentation page contains the old fallback or the new transport-specific example, and the diagnostic does not include partial stdout or sandbox configuration content.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 9eb62a99b -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: see below
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable; this is a bounded change to one function, not a runtime or test-harness change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Red, then green

The new test against **unmodified `origin/main` sources** (`git checkout origin/main -- src/lib/sandbox/config.ts`):

```
 × reports the reason OpenShell gave for the failed read
 × does not blame a stopped sandbox when OpenShell reported another reason
 Tests  2 failed | 1 passed (3)
```

With the fix:

```
npx vitest run --project integration test/sandbox-config-read-failure-diagnostic.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

### Real behavior, through the real CLI

Stub OpenShell on `PATH`, isolated `HOME`, one registered sandbox; `sandbox exec -- cat` fails with `exec session setup failed: container not ready`. Only one OpenShell call is made — the read is the pre-flight gate (#6997), so nothing is mutated either way.

```
$ nemoclaw inference set --provider nvidia-prod --model … --sandbox bug9104-alpha --no-verify

# origin/main
  Cannot read openclaw config (/sandbox/.openclaw/openclaw.json).
  Is the sandbox running?
  Start the sandbox and retry.
exit=1

# this branch
  Cannot read openclaw config (/sandbox/.openclaw/openclaw.json): exec session setup failed: container not ready
exit=1
```

The "Start the sandbox and retry." hint correctly disappears: `readInSandboxConfigOrFail` appends it only to a message asking whether the sandbox is running.

### Blast radius

`readSandboxConfig` feeds `config get`, `config set`, `config rotate-token`, `inference set`, and the tunnel allowed-origins reader. All of them already route `SandboxConfigError` to a non-zero exit, so each gets the same better diagnostic and nothing else changes. Found by grepping the symbol and the changed literals repo-wide, not by picking adjacent directories.

```
npx vitest run --project cli src/lib/sandbox/ src/lib/actions/inference-set
 Test Files  35 passed (35)   Tests  403 passed (403)

npx vitest run --project integration \
  test/openclaw-config-transaction-wiring.test.ts test/hermes-config-transaction-wiring.test.ts \
  test/inference-set-preflight.test.ts test/config-set.test.ts test/config-set-prompt-error.test.ts \
  test/config-set-nested-ssrf.test.ts test/policy-mutation-read-failure.test.ts \
  test/openclaw-config-restore.test.ts test/exit-code-user-error-surfaces.test.ts
 Test Files  9 passed (9)    Tests  142 passed (142)

npm run typecheck:cli        # clean
npm run checks:repository    # all checks passed
```

### Limits

- The reporter's platform is Ubuntu 24.04 with live OpenShell 0.0.101; everything above ran on macOS against a stub OpenShell binary. The failure is in NemoClaw's host-side read, which is platform-independent, but no live sandbox was involved.
- Exit code 0 is unreproduced, as described above. The issue stays open for it.

---

Signed-off-by: harjoth <harjoth.khara@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox configuration error messages by showing relevant command errors or diagnostics without exposing sensitive configuration output.
  * Preserved clearer failure guidance, including accurate messaging for stopped sandboxes.
  * Explicit configuration read failures now report their original error details.

* **Tests**
  * Added regression coverage for diagnostic preservation, fallback guidance, and prevention of sensitive output disclosure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->