### PR TITLE
fix(e2e): qualify OpenClaw PTY input structurally

### DIFF
--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -137,7 +137,7 @@ function appendedMessages(fileName, baseline) {
   return messages;
 }
 
-function qualifyTurns() {
+function qualifyTurns(requireAssistant) {
   const expectedTurns = Number(expectedTurnsText);
   if (!Number.isSafeInteger(expectedTurns) || expectedTurns < 1) {
     finish(2, "expected_turn_count_invalid");
@@ -169,13 +169,15 @@ function qualifyTurns() {
     }
     if (!message.hasStructuredContent) finish(2, "message_content_empty", { sessionId });
   }
-  if (messages.length < expectedRoles.length) finish(1);
+  const requiredMessages = expectedRoles.length - (requireAssistant ? 0 : 1);
+  if (messages.length < requiredMessages) finish(1);
   finish(0);
 }
 
 try {
   if (mode === "baseline") recordBaseline();
-  if (mode === "qualify") qualifyTurns();
+  if (mode === "qualify") qualifyTurns(true);
+  if (mode === "qualify-input") qualifyTurns(false);
 } catch {
   finish(2, "verifier_failed");
 }
@@ -280,17 +282,33 @@ wait_for_turn_count() {
   fail_launch_session "launch did not record the required structured session turns"
 }
 
-wait_for_launch_readiness() {
-  for _ in {1..1800}; do
-    if grep -Fq -- "gateway connected | idle" "$capture"; then
-      return 0
-    fi
+submit_turn() {
+  local expected_turns="$1"
+  local content="$2"
+  local evidence_status
+  for _ in {1..90}; do
     if ! kill -0 "$session_pid" 2>/dev/null; then
       break
     fi
-    sleep 0.1
+    if ! printf '%s\r' "$content" >&3; then
+      break
+    fi
+    for _ in {1..2}; do
+      if session_evidence qualify-input "$expected_turns" >/dev/null 2>"$evidence_error"; then
+        return 0
+      else
+        evidence_status=$?
+      fi
+      if [[ "$evidence_status" != 1 ]]; then
+        fail_launch_session "structured session input evidence was invalid or unavailable (status $evidence_status)"
+      fi
+      if ! kill -0 "$session_pid" 2>/dev/null; then
+        break 2
+      fi
+      sleep 1
+    done
   done
-  fail_launch_session "launch did not report OpenClaw readiness"
+  fail_launch_session "launch did not record PTY input in the structured session"
 }
 
 if ! session_evidence baseline >/dev/null 2>"$evidence_error"; then
@@ -328,10 +346,9 @@ if [[ "$capture_ready" != 1 ]]; then
   fail_launch_session "launch did not create a PTY diagnostic capture"
 fi
 
-wait_for_launch_readiness
-printf '%s\r' "$NEMOCLAW_LAUNCH_FIRST_INPUT" >&3
+submit_turn 1 "$NEMOCLAW_LAUNCH_FIRST_INPUT"
 wait_for_turn_count 1
-printf '%s\r' "$NEMOCLAW_LAUNCH_SECOND_INPUT" >&3
+submit_turn 2 "$NEMOCLAW_LAUNCH_SECOND_INPUT"
 wait_for_turn_count 2
 
 if [[ -n "$NEMOCLAW_LAUNCH_EXIT_COMMAND" ]]; then

--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -16,7 +16,7 @@ const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
 
-const [mode, sessionRoot, baselinePath, expectedTurnsText] = process.argv.slice(1);
+const [mode, sessionRoot, baselinePath, expectedTurnsText, expectedInput] = process.argv.slice(1);
 
 function finish(exitCode, reason, detail = {}) {
   if (reason) process.stderr.write(JSON.stringify({ reason, ...detail }) + "\n");
@@ -108,6 +108,13 @@ function hasStructuredContent(message) {
   return Array.isArray(message.content) && message.content.length > 0;
 }
 
+function containsExactInput(message, input) {
+  if (typeof message.content === "string") return message.content === input;
+  return Array.isArray(message.content) && message.content.some((part) =>
+    part && typeof part === "object" && typeof part.text === "string" && part.text === input
+  );
+}
+
 function appendedMessages(fileName, baseline) {
   const { offset, complete, raw } = readCompleteSession(fileName);
   const prior = baseline[fileName];
@@ -132,7 +139,11 @@ function appendedMessages(fileName, baseline) {
     if (!record || record.type !== "message" || !record.message) continue;
     const role = record.message.role;
     if (role !== "user" && role !== "assistant") continue;
-    messages.push({ role, hasStructuredContent: hasStructuredContent(record.message) });
+    messages.push({
+      role,
+      hasStructuredContent: hasStructuredContent(record.message),
+      containsExpectedInput: containsExactInput(record.message, expectedInput),
+    });
   }
   return messages;
 }
@@ -141,6 +152,9 @@ function qualifyTurns(requireAssistant) {
   const expectedTurns = Number(expectedTurnsText);
   if (!Number.isSafeInteger(expectedTurns) || expectedTurns < 1) {
     finish(2, "expected_turn_count_invalid");
+  }
+  if (!requireAssistant && (!expectedInput || expectedInput.includes("\n") || expectedInput.includes("\r"))) {
+    finish(2, "expected_input_invalid");
   }
 
   const baseline = readBaseline();
@@ -171,6 +185,9 @@ function qualifyTurns(requireAssistant) {
   }
   const requiredMessages = expectedRoles.length - (requireAssistant ? 0 : 1);
   if (messages.length < requiredMessages) finish(1);
+  if (!requireAssistant && !messages[requiredMessages - 1].containsExpectedInput) {
+    finish(2, "input_content_mismatch", { sessionId });
+  }
   finish(0);
 }
 
@@ -250,8 +267,12 @@ fail_launch_session() {
 session_evidence() {
   local mode="$1"
   local expected_turns=""
+  local expected_input=""
   if [[ "$#" -gt 1 ]]; then
     expected_turns="$2"
+  fi
+  if [[ "$#" -gt 2 ]]; then
+    expected_input="$3"
   fi
   "$NEMOCLAW_OPENSHELL_COMMAND" sandbox exec \
     --name "$NEMOCLAW_LAUNCH_SANDBOX" -- \
@@ -259,7 +280,8 @@ session_evidence() {
     "$mode" \
     "$NEMOCLAW_LAUNCH_SESSION_ROOT" \
     "$baseline_path" \
-    "$expected_turns"
+    "$expected_turns" \
+    "$expected_input"
 }
 
 wait_for_turn_count() {
@@ -294,7 +316,7 @@ submit_turn() {
       break
     fi
     for _ in {1..2}; do
-      if session_evidence qualify-input "$expected_turns" >/dev/null 2>"$evidence_error"; then
+      if session_evidence qualify-input "$expected_turns" "$content" >/dev/null 2>"$evidence_error"; then
         return 0
       else
         evidence_status=$?

--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -280,6 +280,19 @@ wait_for_turn_count() {
   fail_launch_session "launch did not record the required structured session turns"
 }
 
+wait_for_launch_readiness() {
+  for _ in {1..1800}; do
+    if grep -Fq -- "gateway connected | idle" "$capture"; then
+      return 0
+    fi
+    if ! kill -0 "$session_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+  fail_launch_session "launch did not report OpenClaw readiness"
+}
+
 if ! session_evidence baseline >/dev/null 2>"$evidence_error"; then
   fail_launch_session "launch could not record the structured session baseline"
 fi
@@ -315,6 +328,7 @@ if [[ "$capture_ready" != 1 ]]; then
   fail_launch_session "launch did not create a PTY diagnostic capture"
 fi
 
+wait_for_launch_readiness
 printf '%s\r' "$NEMOCLAW_LAUNCH_FIRST_INPUT" >&3
 wait_for_turn_count 1
 printf '%s\r' "$NEMOCLAW_LAUNCH_SECOND_INPUT" >&3

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -26,6 +26,7 @@ import {
 type SessionRecords = Record<string, string[]>;
 type FixtureMode =
   | "cleanup-failure"
+  | "delayed-ready"
   | "invalid-order"
   | "nonzero"
   | "nonzero-cleanup-failure"
@@ -157,6 +158,19 @@ const append = (role, content) => fs.appendFileSync(
 );
 
 (async () => {
+  if (mode === "delayed-ready") {
+    process.stdout.write("starting gateway\n");
+    let inputBeforeReadiness = false;
+    const recordEarlyInput = () => { inputBeforeReadiness = true; };
+    process.stdin.on("data", recordEarlyInput);
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    process.stdin.off("data", recordEarlyInput);
+    process.stdout.write("gateway connected | idle\n");
+    if (inputBeforeReadiness) process.exit(67);
+  } else {
+    process.stdout.write("gateway connected | idle\n");
+  }
+
   const first = await ask();
   if (mode === "invalid-order") {
     append("assistant", "response before input");
@@ -324,6 +338,21 @@ it.runIf(process.platform === "linux")(
       expect(result.signal).toBeNull();
       expect(result.status).toBe(0);
     }
+  },
+);
+
+it.runIf(process.platform === "linux")(
+  "waits for OpenClaw readiness before sending PTY input (#9160)",
+  () => {
+    const { baselineRemoved, result, ttyObserved } = runLaunchSessionFixture(
+      "delayed-ready",
+      "plain",
+    );
+
+    expect(ttyObserved).toBe(true);
+    expect(baselineRemoved).toBe(true);
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
   },
 );
 

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -211,6 +211,7 @@ exec "$@"
 
     const result = spawnSync("bash", ["-c", LAUNCH_TURN_SCRIPT], {
       encoding: "utf8",
+      killSignal: "SIGKILL",
       env: {
         ...process.env,
         NEMOCLAW_FIXTURE_MODE: mode,

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -26,6 +26,7 @@ import {
 type SessionRecords = Record<string, string[]>;
 type FixtureMode =
   | "cleanup-failure"
+  | "delayed-duplicate"
   | "delayed-input"
   | "invalid-order"
   | "nonzero"
@@ -61,6 +62,7 @@ function runEvidenceFixture(input: {
   after: SessionRecords;
   afterFinalNewline?: boolean;
   before?: SessionRecords;
+  expectedInput?: string;
   expectedTurns: number;
   mode?: "qualify" | "qualify-input";
 }) {
@@ -85,6 +87,7 @@ function runEvidenceFixture(input: {
         sessionRoot,
         baselinePath,
         String(input.expectedTurns),
+        input.expectedInput ?? "",
       ],
       { encoding: "utf8" },
     );
@@ -160,7 +163,7 @@ const append = (role, content) => fs.appendFileSync(
 
 (async () => {
   if (mode === "delayed-input") {
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await ask();
   }
 
   const first = await ask();
@@ -171,6 +174,13 @@ const append = (role, content) => fs.appendFileSync(
     append("user", first);
     process.stdout.write(terminalCopy === "ansi" ? "\u001b[2Kignored repaint\r" : "ignored plain copy\n");
     append("assistant", "first response");
+  }
+
+  if (mode === "delayed-duplicate") {
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    append("user", first);
+    await new Promise((resolve) => setTimeout(resolve, 10000));
+    return;
   }
 
   const second = await ask();
@@ -263,12 +273,14 @@ it("keeps a partial structured turn pending (#9160)", () => {
 
 it("qualifies PTY input from the structured user record before the assistant reply (#9160)", () => {
   const accepted = runEvidenceFixture({
-    after: { "session-a": [message("user")] },
+    after: { "session-a": [message("user", "first input")] },
+    expectedInput: "first input",
     expectedTurns: 1,
     mode: "qualify-input",
   });
   const pending = runEvidenceFixture({
     after: { "session-a": [message("user"), message("assistant")] },
+    expectedInput: "second input",
     expectedTurns: 2,
     mode: "qualify-input",
   });
@@ -277,6 +289,25 @@ it("qualifies PTY input from the structured user record before the assistant rep
   expect(accepted.qualification.status).toBe(0);
   expect(pending.baseline.status).toBe(0);
   expect(pending.qualification.status).toBe(1);
+});
+
+it("rejects a prior turn duplicate as evidence for the next PTY input (#9160)", () => {
+  const { baseline, qualification } = runEvidenceFixture({
+    after: {
+      "session-a": [
+        message("user", "first input"),
+        message("assistant"),
+        message("user", "first input"),
+      ],
+    },
+    expectedInput: "second input",
+    expectedTurns: 2,
+    mode: "qualify-input",
+  });
+
+  expect(baseline.status).toBe(0);
+  expect(qualification.status).toBe(2);
+  expect(qualification.stderr).toContain('"reason":"input_content_mismatch"');
 });
 
 it("does not qualify structured turns recorded before the baseline (#9160)", () => {
@@ -363,6 +394,22 @@ it.runIf(process.platform === "linux")(
     expect(baselineRemoved).toBe(true);
     expect(result.signal).toBeNull();
     expect(result.status).toBe(0);
+  },
+);
+
+it.runIf(process.platform === "linux")(
+  "rejects a delayed duplicate before recording the distinct second PTY input (#9160)",
+  () => {
+    const { baselineRemoved, result, ttyObserved } = runLaunchSessionFixture(
+      "delayed-duplicate",
+      "plain",
+    );
+
+    expect(ttyObserved).toBe(true);
+    expect(baselineRemoved).toBe(true);
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('"reason":"input_content_mismatch"');
   },
 );
 

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -26,7 +26,7 @@ import {
 type SessionRecords = Record<string, string[]>;
 type FixtureMode =
   | "cleanup-failure"
-  | "delayed-ready"
+  | "delayed-input"
   | "invalid-order"
   | "nonzero"
   | "nonzero-cleanup-failure"
@@ -62,6 +62,7 @@ function runEvidenceFixture(input: {
   afterFinalNewline?: boolean;
   before?: SessionRecords;
   expectedTurns: number;
+  mode?: "qualify" | "qualify-input";
 }) {
   const fixtureRoot = mkdtempSync(join(tmpdir(), "nemoclaw-launch-evidence-"));
   const baselinePath = join(fixtureRoot, "baseline.json");
@@ -80,7 +81,7 @@ function runEvidenceFixture(input: {
       [
         "-e",
         OPENCLAW_SESSION_EVIDENCE_SCRIPT,
-        "qualify",
+        input.mode ?? "qualify",
         sessionRoot,
         baselinePath,
         String(input.expectedTurns),
@@ -158,17 +159,8 @@ const append = (role, content) => fs.appendFileSync(
 );
 
 (async () => {
-  if (mode === "delayed-ready") {
-    process.stdout.write("starting gateway\n");
-    let inputBeforeReadiness = false;
-    const recordEarlyInput = () => { inputBeforeReadiness = true; };
-    process.stdin.on("data", recordEarlyInput);
-    await new Promise((resolve) => setTimeout(resolve, 1_500));
-    process.stdin.off("data", recordEarlyInput);
-    process.stdout.write("gateway connected | idle\n");
-    if (inputBeforeReadiness) process.exit(67);
-  } else {
-    process.stdout.write("gateway connected | idle\n");
+  if (mode === "delayed-input") {
+    await new Promise((resolve) => setTimeout(resolve, 500));
   }
 
   const first = await ask();
@@ -269,6 +261,24 @@ it("keeps a partial structured turn pending (#9160)", () => {
   expect(qualification.status).toBe(1);
 });
 
+it("qualifies PTY input from the structured user record before the assistant reply (#9160)", () => {
+  const accepted = runEvidenceFixture({
+    after: { "session-a": [message("user")] },
+    expectedTurns: 1,
+    mode: "qualify-input",
+  });
+  const pending = runEvidenceFixture({
+    after: { "session-a": [message("user"), message("assistant")] },
+    expectedTurns: 2,
+    mode: "qualify-input",
+  });
+
+  expect(accepted.baseline.status).toBe(0);
+  expect(accepted.qualification.status).toBe(0);
+  expect(pending.baseline.status).toBe(0);
+  expect(pending.qualification.status).toBe(1);
+});
+
 it("does not qualify structured turns recorded before the baseline (#9160)", () => {
   const { baseline, qualification } = runEvidenceFixture({
     before: { "session-a": [message("user"), message("assistant")] },
@@ -342,10 +352,10 @@ it.runIf(process.platform === "linux")(
 );
 
 it.runIf(process.platform === "linux")(
-  "waits for OpenClaw readiness before sending PTY input (#9160)",
+  "retries PTY input until structured user evidence is recorded (#9160)",
   () => {
     const { baselineRemoved, result, ttyObserved } = runLaunchSessionFixture(
-      "delayed-ready",
+      "delayed-input",
       "plain",
     );
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

OpenClaw launch qualification now retries real-PTY input until the in-sandbox structured session records the expected user turn with the submitted input, then waits for the assistant turn. This fixes main E2E run 31862560250, job 94959342356, where one-shot input was sent before the TUI accepted it, without using terminal copy as behavioral evidence.

## Related Issue

Related to #9160.

## Changes

- Add a `qualify-input` evidence mode that binds structured user-turn acceptance to the submitted input.
- Retry PTY input only while structured user evidence remains pending, while preserving fail-closed handling for invalid evidence and process exit.
- Add portable duplicate-input coverage and Linux regression fixtures that discard the first submitted line before accepting a later submission and reject a delayed prior-turn duplicate.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only the internal live E2E PTY driver and does not change a supported user command, flag, configuration, API, policy, default, or runtime behavior.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The final diff changes only `test/e2e/live/launch-agent-turn.ts` and `test/e2e/support/launch-agent-turn.test.ts`; repository documentation does not describe this internal input qualification sequence.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5d88c38f -->
<!-- docs-review-agents-blob-sha: e30afb27 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/launch-agent-turn.test.ts` completed with 8 passed and 8 Linux-only skipped on macOS at latest PR commit `5d88c38f`; the Linux PTY regressions await CI.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this focused two-file E2E driver fix; Oxfmt, Oxlint, and normal path-scoped hooks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end validation of interactive input submission.
  * Added coverage for delayed prompts, delayed responses, and retrying input until it is recorded.
  * Added validation that submitted input matches the expected content.
  * Added support for confirming input before an assistant response is available.
  * Strengthened checks to prevent duplicate or stale turn evidence from being accepted.
  * Updated turn handling to confirm each submission is captured before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
