### PR TITLE
fix(sandbox): remove exact Docker orphan on destroy

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -2353,6 +2353,9 @@ If the initial inspection cannot complete, more than one container matches, a ma
 The identity checks still apply with `--force`, `--yes`, or `NEMOCLAW_NON_INTERACTIVE=1`; those controls authorize confirmation but do not authorize an unproven container identity.
 NemoClaw rechecks the exact identity after read-only preflight, before provider cleanup, and synchronously at the sandbox-deletion boundary.
 If a later recheck detects drift or fails, `destroy` refuses sandbox deletion, restores managed MCP preparation when possible, preserves local ownership state, and reports any earlier cleanup already performed.
+If OpenShell reports the sandbox absent after preflight captured one matching Docker container, `destroy` rechecks and removes only that exact container ID.
+If Docker reports another OpenShell-managed container, removal fails, or NemoClaw cannot confirm removal, `destroy` exits nonzero and preserves the registry entry.
+Correct the reported Docker state, then rerun `destroy`.
 If Docker cannot complete the inspection, correct the reported Docker error before you rerun `destroy`.
 For common recovery steps, refer to [Docker is not running](troubleshooting#docker-is-not-running) and [Docker permission denied on Linux](troubleshooting#docker-permission-denied-on-linux).
 

--- a/src/lib/actions/sandbox/destroy-execution.ts
+++ b/src/lib/actions/sandbox/destroy-execution.ts
@@ -16,6 +16,7 @@ import {
   prepareSandboxHostLocalInferenceDestroyAuthority,
   retirePreparedHostLocalInferenceAuthority,
 } from "../../onboard/runtime-provider/host-local-inference-lifecycle";
+import { removeExactOpenShellDockerSandboxContainer } from "../../onboard/openshell-docker-sandbox-containers";
 import {
   type DetachSandboxProvidersResult,
   runSandboxProviderPreDeleteCleanup,
@@ -511,6 +512,30 @@ export async function executeSandboxDestroy({
         mcpRecoveryFailure,
         shieldsRelockRequiresGateway: gatewayUnreachable && hardened.hardeningFailed,
       };
+    }
+
+    if (!forcedLocalCleanup && expectedContainerIdentity) {
+      try {
+        removeExactOpenShellDockerSandboxContainer(
+          sandboxName,
+          expectedContainerIdentity.id,
+          console.log,
+        );
+      } catch (error) {
+        const detail = redactDestroyError(error);
+        return {
+          ok: false as const,
+          deleteOutput:
+            `OpenShell reported sandbox '${sandboxName}' absent, but exact Docker container ` +
+            `cleanup failed: ${detail}. The local sandbox record was preserved for retry.`,
+          exitCode: 1,
+          gatewayUnreachable: false,
+          hostLocalInferenceOwnershipRequiresGateway: false,
+          mcpOwnershipRequiresGateway: false,
+          shieldsRelockRequiresGateway: false,
+          deleteConfirmed: true,
+        };
+      }
     }
 
     // The sandbox is confirmed gone, or --force is discarding only a local

--- a/src/lib/actions/sandbox/destroy-execution.ts
+++ b/src/lib/actions/sandbox/destroy-execution.ts
@@ -16,7 +16,6 @@ import {
   prepareSandboxHostLocalInferenceDestroyAuthority,
   retirePreparedHostLocalInferenceAuthority,
 } from "../../onboard/runtime-provider/host-local-inference-lifecycle";
-import { removeExactOpenShellDockerSandboxContainer } from "../../onboard/openshell-docker-sandbox-containers";
 import {
   type DetachSandboxProvidersResult,
   runSandboxProviderPreDeleteCleanup,
@@ -29,6 +28,7 @@ import {
   classifyDestroyContainerIdentity,
   isSameDestroyContainerIdentity,
   observeDestroyContainerIdentity,
+  removeExactDestroyContainerIdentity,
   type SandboxNameLabeledContainer,
 } from "./destroy-presence";
 import type { DestroyRunOpenshell } from "./destroy-gateway";
@@ -516,17 +516,13 @@ export async function executeSandboxDestroy({
 
     if (!forcedLocalCleanup && expectedContainerIdentity) {
       try {
-        removeExactOpenShellDockerSandboxContainer(
-          sandboxName,
-          expectedContainerIdentity.id,
-          console.log,
-        );
+        removeExactDestroyContainerIdentity(sandboxName, expectedContainerIdentity, console.log);
       } catch (error) {
         const detail = redactDestroyError(error);
         return {
           ok: false as const,
           deleteOutput:
-            `OpenShell reported sandbox '${sandboxName}' absent, but exact Docker container ` +
+            `OpenShell reported sandbox '${sandboxName}' absent, but exact runtime ` +
             `cleanup failed: ${detail}. The local sandbox record was preserved for retry.`,
           exitCode: 1,
           gatewayUnreachable: false,

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -646,6 +646,28 @@ describe("destroySandbox flow", () => {
     expect(harness.retirePortableLifecycleReceiptSpy).not.toHaveBeenCalled();
   });
 
+  it("does not remove the Docker container during forced local cleanup (#9073)", async () => {
+    const containerId = "a".repeat(64);
+    const harness = createDestroyHarness({
+      deleteStatus: 1,
+      deleteOutput: "error trying to connect: connection refused",
+      dockerOrphanIds: [containerId],
+      dockerRunResult: {
+        status: 0,
+        stdout: `${containerId}\topenshell\tdefault\tsb-alpha`,
+      },
+    });
+
+    await expect(harness.destroySandbox("alpha", { force: true })).resolves.toBeUndefined();
+
+    expect(harness.dockerRunSpy).not.toHaveBeenCalledWith(
+      ["rm", "-f", containerId],
+      expect.anything(),
+    );
+    expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
   it("does not stop shared host services when --force cleans up the last sandbox with the gateway down (#6046)", async () => {
     // Gateway-unreachable delete failure + --force triggers forcedLocalCleanup:
     // the local record is removed but the gateway-side delete was never

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -671,6 +671,7 @@ describe("destroySandbox flow", () => {
 
     await expect(harness.destroySandbox("alpha", { force: true })).resolves.toBeUndefined();
 
+    expect(harness.events).toContain("delete");
     expect(harness.dockerRunSpy).not.toHaveBeenCalledWith(
       ["rm", "-f", containerId],
       expect.anything(),

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -606,9 +606,9 @@ describe("destroySandbox flow", () => {
     expect(harness.retirePortableLifecycleReceiptSpy).not.toHaveBeenCalled();
   });
 
-  it("preserves registry state when exact Docker container removal fails (#9073)", async () => {
+  it("preserves registry state until exact Docker container removal succeeds on retry (#9073)", async () => {
     const containerId = "a".repeat(64);
-    const harness = createDestroyHarness({
+    const options = {
       sandboxPresent: false,
       dockerOrphanIds: [containerId],
       dockerRemoveStatus: 1,
@@ -616,12 +616,23 @@ describe("destroySandbox flow", () => {
         status: 0,
         stdout: `${containerId}\topenshell\tdefault\tsb-alpha`,
       },
-    });
+    };
+    const harness = createDestroyHarness(options);
 
     await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow("process.exit(1)");
 
     expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
     expect(harness.retirePortableLifecycleReceiptSpy).not.toHaveBeenCalled();
+
+    options.dockerRemoveStatus = 0;
+    await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
+
+    expect(harness.dockerRunSpy).toHaveBeenCalledWith(
+      ["rm", "-f", containerId],
+      expect.objectContaining({ ignoreError: true, suppressOutput: true }),
+    );
+    expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
+    expect(harness.retirePortableLifecycleReceiptSpy).toHaveBeenCalledWith("alpha");
   });
 
   it("preserves registry state when exact Docker container inspection fails (#9073)", async () => {

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -440,18 +440,19 @@ describe("destroySandbox flow", () => {
   it("keeps the final exact probe immediately adjacent to sandbox delete", async () => {
     const managed = { status: 0, stdout: "aaaa000000000000\topenshell\tdefault\tsb-alpha" };
     const trace: string[] = [];
+    let identityProbeCalls = 0;
     const harness = createDestroyHarness({
       dockerRunResult: managed,
-      onDockerRun: (call) => trace.push(`probe:${String(call)}`),
+      onDockerRun: (call) => {
+        identityProbeCalls = call;
+        trace.push(`probe:${String(call)}`);
+      },
     });
     traceDestroyBoundaryCalls(harness, trace);
 
     await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
 
-    expect(trace.slice(-2)).toEqual([
-      `probe:${String(harness.dockerRunSpy.mock.calls.length)}`,
-      "delete",
-    ]);
+    expect(trace.slice(-2)).toEqual([`probe:${String(identityProbeCalls)}`, "delete"]);
   });
 
   it("preserves provider and registry ownership when runtime authority is unknown", async () => {
@@ -561,6 +562,88 @@ describe("destroySandbox flow", () => {
     expect(harness.prepareMcpBridgesForAbsentSandboxDestroySpy).toHaveBeenCalledWith("alpha", {
       force: false,
     });
+  });
+
+  it("removes the exact Docker container when OpenShell reports the sandbox absent (#9073)", async () => {
+    const containerId = "a".repeat(64);
+    const harness = createDestroyHarness({
+      sandboxPresent: false,
+      dockerOrphanIds: [containerId],
+      dockerRunResult: {
+        status: 0,
+        stdout: `${containerId}\topenshell\tdefault\tsb-alpha`,
+      },
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
+
+    expect(harness.dockerRunSpy).toHaveBeenCalledWith(
+      ["rm", "-f", containerId],
+      expect.objectContaining({ ignoreError: true, suppressOutput: true }),
+    );
+    expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
+  });
+
+  it("preserves registry state when the absent sandbox has a replacement Docker identity (#9073)", async () => {
+    const expectedContainerId = "a".repeat(64);
+    const replacementContainerId = "b".repeat(64);
+    const harness = createDestroyHarness({
+      sandboxPresent: false,
+      dockerOrphanIds: [replacementContainerId],
+      dockerRunResult: {
+        status: 0,
+        stdout: `${expectedContainerId}\topenshell\tdefault\tsb-alpha`,
+      },
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow("process.exit(1)");
+
+    expect(harness.dockerRunSpy).not.toHaveBeenCalledWith(
+      ["rm", "-f", replacementContainerId],
+      expect.anything(),
+    );
+    expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
+    expect(harness.retirePortableLifecycleReceiptSpy).not.toHaveBeenCalled();
+  });
+
+  it("preserves registry state when exact Docker container removal fails (#9073)", async () => {
+    const containerId = "a".repeat(64);
+    const harness = createDestroyHarness({
+      sandboxPresent: false,
+      dockerOrphanIds: [containerId],
+      dockerRemoveStatus: 1,
+      dockerRunResult: {
+        status: 0,
+        stdout: `${containerId}\topenshell\tdefault\tsb-alpha`,
+      },
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow("process.exit(1)");
+
+    expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
+    expect(harness.retirePortableLifecycleReceiptSpy).not.toHaveBeenCalled();
+  });
+
+  it("preserves registry state when exact Docker container inspection fails (#9073)", async () => {
+    const containerId = "a".repeat(64);
+    const harness = createDestroyHarness({
+      sandboxPresent: false,
+      dockerOrphanIds: [containerId],
+      dockerOrphanQueryStatus: 1,
+      dockerRunResult: {
+        status: 0,
+        stdout: `${containerId}\topenshell\tdefault\tsb-alpha`,
+      },
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow("process.exit(1)");
+
+    expect(harness.dockerRunSpy).not.toHaveBeenCalledWith(
+      ["rm", "-f", containerId],
+      expect.anything(),
+    );
+    expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
+    expect(harness.retirePortableLifecycleReceiptSpy).not.toHaveBeenCalled();
   });
 
   it("does not stop shared host services when --force cleans up the last sandbox with the gateway down (#6046)", async () => {

--- a/src/lib/actions/sandbox/destroy-presence.ts
+++ b/src/lib/actions/sandbox/destroy-presence.ts
@@ -6,6 +6,7 @@ import {
   OPENSHELL_MANAGED_BY_VALUE,
   OPENSHELL_SANDBOX_ID_LABEL,
   OPENSHELL_SANDBOX_NAME_LABEL,
+  removeExactOpenShellDockerSandboxContainer,
 } from "../../onboard/openshell-docker-sandbox-containers";
 import { sanitizeReadinessText } from "../../readiness/sanitize";
 import {
@@ -64,6 +65,15 @@ export function observeDestroyContainerIdentity(
   sandboxName: string,
 ): DockerSandboxIdentityObservation {
   return observeDockerSandboxIdentities(sandboxName);
+}
+
+/** Retire only the provider runtime bound to the pre-destroy identity proof. */
+export function removeExactDestroyContainerIdentity(
+  sandboxName: string,
+  expectedIdentity: SandboxNameLabeledContainer,
+  log: (message: string) => void,
+): void {
+  removeExactOpenShellDockerSandboxContainer(sandboxName, expectedIdentity.id, log);
 }
 
 /**

--- a/src/lib/onboard/openshell-docker-sandbox-containers.test.ts
+++ b/src/lib/onboard/openshell-docker-sandbox-containers.test.ts
@@ -2,13 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it, vi } from "vitest";
-import { queryOpenShellDockerSandboxRuntimeSnapshot } from "./openshell-docker-sandbox-containers";
+import {
+  queryOpenShellDockerSandboxRuntimeSnapshot,
+  removeExactOpenShellDockerSandboxContainer,
+} from "./openshell-docker-sandbox-containers";
 
 const IMAGE_ID = `sha256:${"a".repeat(64)}`;
 const BOOKKEEPING_IMAGE_REF = "openshell/sandbox-from:alpha";
 const EMPTY_RUNTIME_FIELDS = [IMAGE_ID, BOOKKEEPING_IMAGE_REF, "", null, [], "runc"];
 const ACTIVATED_CONTAINER_ID = "b".repeat(64);
 const ROLLBACK_CONTAINER_ID = "c".repeat(64);
+
+describe("removeExactOpenShellDockerSandboxContainer", () => {
+  it("fails when Docker cannot confirm the exact container is absent after removal (#9073)", () => {
+    const expectedContainerId = "a".repeat(64);
+    const queryContainers = vi
+      .fn()
+      .mockReturnValueOnce({ ok: true, ids: [expectedContainerId] })
+      .mockReturnValueOnce({ ok: true, ids: [expectedContainerId] });
+    const forceRemove = vi.fn(() => ({ status: 0 }));
+
+    expect(() =>
+      removeExactOpenShellDockerSandboxContainer("alpha", expectedContainerId, vi.fn(), {
+        queryContainers,
+        forceRemove,
+      }),
+    ).toThrow("could not confirm exact Docker container removal");
+
+    expect(forceRemove).toHaveBeenCalledWith(expectedContainerId);
+  });
+});
 
 function querySnapshot(fields: unknown, nvidiaVisibleDevices?: string) {
   const dockerRun = vi

--- a/src/lib/onboard/openshell-docker-sandbox-containers.ts
+++ b/src/lib/onboard/openshell-docker-sandbox-containers.ts
@@ -87,6 +87,43 @@ type StaleDockerOrphanCleanupDeps = {
   forceRemove?: (containerId: string) => { status?: number | null };
 };
 
+/** Remove only the Docker container whose immutable ID passed the caller's authority check. */
+export function removeExactOpenShellDockerSandboxContainer(
+  sandboxName: string,
+  expectedContainerId: string,
+  log: (message: string) => void,
+  deps: StaleDockerOrphanCleanupDeps = {},
+): void {
+  const queryContainers = deps.queryContainers ?? queryOpenShellDockerSandboxContainers;
+  const initial = queryContainers(sandboxName);
+  if (!initial.ok) {
+    throw new Error(`could not inspect the exact Docker cleanup target: ${initial.error}`);
+  }
+  if (initial.ids.length === 0) return;
+  if (initial.ids.length !== 1 || initial.ids[0] !== expectedContainerId) {
+    throw new Error(
+      `expected exactly labeled Docker container '${expectedContainerId}', found ` +
+        `${initial.ids.length === 0 ? "none" : initial.ids.join(", ")}; refusing replacement cleanup`,
+    );
+  }
+
+  const removal = deps.forceRemove
+    ? deps.forceRemove(expectedContainerId)
+    : dockerRun(["rm", "-f", expectedContainerId], {
+        ignoreError: true,
+        suppressOutput: true,
+        timeout: STALE_DOCKER_ORPHAN_TIMEOUT_MS,
+      });
+  if (Number(removal.status ?? 1) !== 0) {
+    throw new Error(`could not remove exact Docker container '${expectedContainerId}'`);
+  }
+  const confirmed = queryContainers(sandboxName);
+  if (!confirmed.ok || confirmed.ids.length !== 0) {
+    throw new Error("could not confirm exact Docker container removal");
+  }
+  log(`Removed exact Docker container '${expectedContainerId}' after OpenShell sandbox deletion`);
+}
+
 /**
  * Remove one exact Docker-owned orphan when a registry row outlives its OpenShell sandbox.
  * Docker labels are the remaining authority in this invalid state; see the focused #8720 tests.

--- a/test/helpers/destroy-flow-test-harness.ts
+++ b/test/helpers/destroy-flow-test-harness.ts
@@ -57,6 +57,9 @@ type DestroyHarnessOptions = {
   deleteOutput?: string;
   deleteStatus?: number;
   dockerPsOutput?: string;
+  dockerOrphanIds?: string[];
+  dockerOrphanQueryStatus?: number | null;
+  dockerRemoveStatus?: number | null;
   dockerRunResult?: { status: number | null; stdout?: string; stderr?: string };
   dockerRunResultSequence?: Array<{
     status: number | null;
@@ -345,8 +348,28 @@ export function createDestroyHarness(options: DestroyHarnessOptions = {}): Destr
       return matchedNames.length > 0 ? `${matchedNames.join("\n")}\n` : "";
     });
   let identityProbeCall = 0;
+  let dockerOrphanIds = [...(options.dockerOrphanIds ?? [])];
   const dockerRunSpy = vi.spyOn(dockerRun, "dockerRun").mockImplementation((args: unknown) => {
     const argv = Array.isArray(args) ? args.map(String) : [];
+    const isDockerOrphanQuery =
+      argv[0] === "ps" &&
+      argv.includes("label=openshell.ai/managed-by=openshell") &&
+      argv.includes("label=openshell.ai/sandbox-name=alpha") &&
+      argv.at(-1) === "{{.ID}}";
+    if (isDockerOrphanQuery) {
+      return {
+        status: options.dockerOrphanQueryStatus ?? 0,
+        stdout: dockerOrphanIds.join("\n"),
+        stderr: "",
+      } as ReturnType<typeof dockerRun.dockerRun>;
+    }
+    if (argv[0] === "rm" && argv[1] === "-f") {
+      const status = options.dockerRemoveStatus ?? 0;
+      if (status === 0) {
+        dockerOrphanIds = dockerOrphanIds.filter((id) => id !== argv[2]);
+      }
+      return { status, stdout: "", stderr: "" } as ReturnType<typeof dockerRun.dockerRun>;
+    }
     const filterIndex = argv.indexOf("--filter");
     const isIdentityProbe =
       argv[0] === "ps" &&


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Before this change, `destroy` could accept OpenShell's already-absent result and delete local state while the preflight-bound Docker container remained. This change removes only that immutable container ID, confirms it is absent, and preserves recovery state on any inspection or removal mismatch.

## Related Issue

Fixes #9073

## Changes

- Remove only the Docker container ID captured by the destroy preflight after OpenShell confirms sandbox deletion or absence.
- Fail closed and preserve the registry entry when Docker inspection, identity continuity, removal, or confirmation fails.
- Cover success and failure paths, and document the cleanup and retry behavior.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security review passed at exact PR head `a3ed139d9`; no findings remain.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/commands.mdx` — documents exact-ID Docker orphan removal, fail-closed outcomes, registry preservation, and retry instructions.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a3ed139d9 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/runtime-provider-source-shape.test.ts src/lib/actions/sandbox/rebuild-gateway-drift.test.ts src/lib/actions/sandbox/destroy-flow.test.ts src/lib/onboard/openshell-docker-sandbox-containers.test.ts` passed 103 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable; this is a path-scoped destroy fix covered by the focused suite and `npm run validate:pr`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors and 2 existing hidden Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation: a dedicated Brev instance with Docker 29.7.2 removed the exact target container, preserved an unrelated control container, refused a same-name replacement, and was deleted after testing.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox destruction when OpenShell reports a sandbox as missing.
  * Safely removes only the previously identified orphaned container, preventing accidental removal of replacement or unrelated containers.
  * Preserves sandbox records when cleanup fails, allowing destruction to be retried.
  * Confirms container removal before reporting success.
  * Forced local cleanup now avoids unnecessary Docker removal.
  * Handles ambiguous container identities and Docker inspection failures safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->