### PR TITLE
fix(e2e): retry unstable publication pagination

### DIFF
--- a/test/e2e/support/base-image-publication.test.ts
+++ b/test/e2e/support/base-image-publication.test.ts
@@ -396,6 +396,53 @@ describe("base-image publication evidence", () => {
     ).rejects.toThrow(/duplicate id/u);
   });
 
+  it("restarts collection after a concurrent workflow-run count change", async () => {
+    const entries = Array.from({ length: 102 }, (_, index) => ({ id: index + 1 }));
+    const pages = [
+      { total_count: 101, workflow_runs: entries.slice(0, 100) },
+      { total_count: 102, workflow_runs: entries.slice(100) },
+      { total_count: 102, workflow_runs: entries.slice(0, 100) },
+      { total_count: 102, workflow_runs: entries.slice(100) },
+    ];
+    const requests: string[] = [];
+
+    await expect(
+      collectPaginated(
+        async (requestPath) => {
+          requests.push(requestPath);
+          return pages.shift();
+        },
+        "/runs?per_page=100",
+        "workflow_runs",
+      ),
+    ).resolves.toMatchObject({ total_count: 102, workflow_runs: entries });
+    expect(requests).toEqual([
+      "/runs?per_page=100&page=1",
+      "/runs?per_page=100&page=2",
+      "/runs?per_page=100&page=1",
+      "/runs?per_page=100&page=2",
+    ]);
+  });
+
+  it("fails closed after three unstable pagination attempts", async () => {
+    const entries = Array.from({ length: 101 }, (_, index) => ({ id: index + 1 }));
+    let requests = 0;
+
+    await expect(
+      collectPaginated(
+        async (requestPath) => {
+          requests += 1;
+          return requestPath.endsWith("page=1")
+            ? { total_count: 101, workflow_runs: entries.slice(0, 100) }
+            : { total_count: 102, workflow_runs: entries.slice(100) };
+        },
+        "/runs?per_page=100",
+        "workflow_runs",
+      ),
+    ).rejects.toThrow(/total_count changed during 3 pagination attempts/u);
+    expect(requests).toBe(6);
+  });
+
   it("accepts a batch-push tip that descends from the newest changed input (#7372)", () => {
     const selection = selectPublicationRun(
       runsPayload([workflowRun({ head_sha: EXPECTED_SHA })]),

--- a/tools/e2e/base-image-publication.mts
+++ b/tools/e2e/base-image-publication.mts
@@ -17,6 +17,7 @@ const RUN_URL_ROOT = `https://github.com/${REPOSITORY}/actions/runs`;
 const WORKFLOW_URL = `https://github.com/${REPOSITORY}/blob/${MAIN_BRANCH}/${WORKFLOW_PATH}`;
 const PAGE_SIZE = 100;
 const MAX_API_PAGES = 10;
+const PAGINATION_ATTEMPTS = 3;
 const REQUEST_ATTEMPTS = 3;
 const REQUEST_TIMEOUT_MS = 20_000;
 const MAX_RETRY_DELAY_MS = 10_000;
@@ -516,16 +517,13 @@ export function validateBoundRun(payload: unknown, expected: PublicationRun): vo
   }
 }
 
-export async function collectPaginated(
+async function collectPaginationAttempt(
   request: (path: string) => Promise<unknown>,
   basePath: string,
   collectionKey: "workflow_runs" | "jobs",
-  maxPages = MAX_API_PAGES,
-): Promise<JsonRecord> {
-  if (!Number.isSafeInteger(maxPages) || maxPages < 1) {
-    throw new Error("pagination page cap must be a positive integer");
-  }
-  const label = collectionKey === "workflow_runs" ? "workflow run" : "publisher job";
+  maxPages: number,
+  label: string,
+): Promise<JsonRecord | undefined> {
   const values: unknown[] = [];
   const ids = new Set<number>();
   let totalCount: number | undefined;
@@ -539,7 +537,7 @@ export async function collectPaginated(
     }
     if (totalCount === undefined) totalCount = pageTotal;
     if (pageTotal !== totalCount) {
-      throw new Error(`${label} total_count changed during pagination`);
+      return undefined;
     }
     const pageValues = response[collectionKey];
     if (!Array.isArray(pageValues) || pageValues.length > PAGE_SIZE) {
@@ -561,6 +559,29 @@ export async function collectPaginated(
   }
 
   throw new Error(`${label} pagination exceeded the ${maxPages}-page safety cap`);
+}
+
+export async function collectPaginated(
+  request: (path: string) => Promise<unknown>,
+  basePath: string,
+  collectionKey: "workflow_runs" | "jobs",
+  maxPages = MAX_API_PAGES,
+): Promise<JsonRecord> {
+  if (!Number.isSafeInteger(maxPages) || maxPages < 1) {
+    throw new Error("pagination page cap must be a positive integer");
+  }
+  const label = collectionKey === "workflow_runs" ? "workflow run" : "publisher job";
+  for (let attempt = 1; attempt <= PAGINATION_ATTEMPTS; attempt += 1) {
+    const result = await collectPaginationAttempt(
+      request,
+      basePath,
+      collectionKey,
+      maxPages,
+      label,
+    );
+    if (result) return result;
+  }
+  throw new Error(`${label} total_count changed during ${PAGINATION_ATTEMPTS} pagination attempts`);
 }
 
 function annotationValue(value: string): string {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The E2E publication gate now discards a partial workflow-run traversal and restarts from page 1 when GitHub reports a concurrent count change. This fixes main E2E run 31865751841, jobs 94966592045 and 94967770635, while still accepting evidence only from a complete stable traversal.

## Changes

- Retry publication pagination from page 1 after a workflow-run or publisher-job count change.
- Bound collection to three attempts and preserve fail-closed handling for duplicate, incomplete, malformed, or over-cap evidence.
- Cover recovery from one concurrent count change and rejection after persistent instability.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only the internal trusted E2E publication collector and does not change a supported user command, flag, configuration, API, policy, default, or runtime behavior.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The final diff changes only the internal E2E publication collector and its focused tests; repository documentation does not describe this GitHub evidence-pagination algorithm.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 45247a29 -->
<!-- docs-review-agents-blob-sha: e30afb27 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `./node_modules/.bin/vitest run --project e2e-support test/e2e/support/base-image-publication.test.ts --reporter=verbose` completed with 42 passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: The host aggregate E2E-support run completed with 2,393 passed, 18 skipped, and 8 unrelated macOS/BSD or timing failures; the changed publication suite passed. `npm run validate:pr` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow-run pagination when result counts change during retrieval.
  * Automatically retries inconsistent pagination results up to three times.
  * Reports a clear failure when pagination remains unstable after all retries.

* **Tests**
  * Added coverage for successful retries, stable complete results, and repeated pagination failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->