### PR TITLE
test(skills): isolate triage subprocess options

### DIFF
--- a/test/skills/triage-runtime.test.ts
+++ b/test/skills/triage-runtime.test.ts
@@ -135,7 +135,11 @@ if (args[0] === "api" && args[1] === "--paginate" && args[2]?.startsWith("repos/
     return spawnSync(process.execPath, args, {
       cwd: process.cwd(),
       encoding: "utf-8",
-      env: { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}` },
+      env: {
+        ...process.env,
+        NODE_OPTIONS: "",
+        PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
     });
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
@@ -155,7 +159,7 @@ describe("maintainer triage runtime behavior", () => {
         .join("\n"),
     });
 
-    expect(result.status).toBe(0);
+    expect(result.status, result.stderr).toBe(0);
     const output = JSON.parse(result.stdout);
     expect(output.queue.map((item: { number: number }) => item.number)).toEqual([101, 102, 103]);
     expect(output.queue).toEqual(
@@ -174,7 +178,7 @@ describe("maintainer triage runtime behavior", () => {
       approvedOnly: true,
     });
 
-    expect(result.status).toBe(0);
+    expect(result.status, result.stderr).toBe(0);
     const output = JSON.parse(result.stdout);
     expect(output.scanned).toBe(3);
     expect(output.queue.map((item: { number: number }) => item.number)).toEqual([101]);
@@ -184,7 +188,7 @@ describe("maintainer triage runtime behavior", () => {
   it("reports malformed Project data and continues without priority boosts", () => {
     const result = runTriage({ projectOutput: "not-json" });
 
-    expect(result.status).toBe(0);
+    expect(result.status, result.stderr).toBe(0);
     expect(result.stderr).toContain(
       "Could not parse Project 199 item data; continuing without priority boosts.",
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The maintainer triage runtime test now isolates its standalone Node process from Vitest's inherited `NODE_OPTIONS`. This prevents the test runner's source-require hook from rewriting the script's `./shared.ts` import to missing `./shared.js` in CLI shard 12.

Affected evidence:

- PR #9199 [run 31871412202, job 94980566330](https://github.com/NVIDIA/NemoClaw/actions/runs/31871412202/job/94980566330)
- PR #9204 [run 31871885957, job 94981738690](https://github.com/NVIDIA/NemoClaw/actions/runs/31871885957/job/94981738690)

Both jobs failed the same three assertions in `test/skills/triage-runtime.test.ts`.

## Related Issue

No issue. This is a shared required-check blocker for #9199 and #9204.

## Changes

- Clear inherited `NODE_OPTIONS` only for the spawned standalone triage process, which already receives its required Node arguments explicitly.
- Include child stderr as assertion context when the spawned process exits unsuccessfully.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes only a test-owned subprocess environment and its failure diagnostics.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: the change is confined to test subprocess isolation and failure context; it changes no supported command, behavior, configuration, API, policy, or documentation contract.
- Agent: Codex Desktop (`/root/openclaw_docs_review`)
<!-- docs-review-head-sha: df3c9723 -->
<!-- docs-review-agents-blob-sha: e30afb27 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — the focused integration file failed 3/3 before the fix with missing `./shared.js` and passed 3/3 at commit under review `df3c9723`
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — full `npm run validate:pr` passed at commit under review `df3c9723`
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved diagnostics for runtime triage test failures by including captured error output in assertion messages.
  * Ensured test subprocesses run without inherited `NODE_OPTIONS` while preserving the mocked execution path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->