### PR TITLE
feat(agent): integrate Pi through the shared candidate lifecycle

### DIFF
--- a/scripts/checks/generate-managed-startup-profile-fixture.mts
+++ b/scripts/checks/generate-managed-startup-profile-fixture.mts
@@ -177,6 +177,28 @@ export function managedStartupE2eProfile(
           reasoningEffort: null,
         },
       };
+    case "pi":
+      return {
+        ...common,
+        agent,
+        agentConfig: { agent },
+        inference: {
+          ...common.inference,
+          primaryModelRef: null,
+          compatibility: null,
+          inputModalities: null,
+        },
+        dashboard: {
+          agent,
+          mode: "disabled",
+        },
+        tuning: {
+          contextWindow: null,
+          maxTokens: null,
+          reasoning: null,
+          reasoningEffort: null,
+        },
+      };
   }
 }
 

--- a/scripts/checks/managed-image-protected-runtime-contract.ts
+++ b/scripts/checks/managed-image-protected-runtime-contract.ts
@@ -1,10 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type {
-  ManagedStartupAgent,
-  ManagedStartupProfile,
-} from "../../src/lib/onboard/managed-startup/profile.ts";
+import type { ShippedManagedImageAgent } from "../../src/lib/onboard/managed-image/contract.ts";
+import type { ManagedStartupProfile } from "../../src/lib/onboard/managed-startup/profile.ts";
 
 export {
   PROTECTED_MANAGED_IMAGE_AGENTS,
@@ -24,7 +22,7 @@ export type ManagedImageProtectedRouteKind = ManagedImageLocalInferenceKind | "r
 // free without relying on truncation.
 export const MANAGED_IMAGE_PROTECTED_SANDBOX_PREFIX = "nmc-mi-";
 
-const PROTECTED_SANDBOX_AGENT_TOKENS: Readonly<Record<ManagedStartupAgent, string>> = Object.freeze(
+const PROTECTED_SANDBOX_AGENT_TOKENS: Readonly<Record<ShippedManagedImageAgent, string>> = Object.freeze(
   {
     openclaw: "oc",
     hermes: "he",
@@ -119,7 +117,7 @@ export function withManagedImageLocalInferenceProfile(
 }
 
 export function managedImageProtectedSandboxName(
-  agent: ManagedStartupAgent,
+  agent: ShippedManagedImageAgent,
   routeKind: ManagedImageProtectedRouteKind,
 ): string {
   return `${MANAGED_IMAGE_PROTECTED_SANDBOX_PREFIX}${PROTECTED_SANDBOX_AGENT_TOKENS[agent]}-${PROTECTED_SANDBOX_ROUTE_TOKENS[routeKind]}`;

--- a/scripts/checks/protected-managed-image-contract.ts
+++ b/scripts/checks/protected-managed-image-contract.ts
@@ -1,13 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  SHIPPED_MANAGED_IMAGE_AGENTS,
-  type ShippedManagedImageAgent,
-} from "../../src/lib/onboard/managed-image/contract.ts";
+import type { ShippedManagedImageAgent } from "../../src/lib/onboard/managed-image/contract.ts";
 
-export const PROTECTED_MANAGED_IMAGE_AGENTS: readonly ShippedManagedImageAgent[] =
-  SHIPPED_MANAGED_IMAGE_AGENTS;
+const BASE_REPOSITORIES: Readonly<Record<ShippedManagedImageAgent, string>> = Object.freeze({
+  openclaw: "ghcr.io/nvidia/nemoclaw/sandbox-base",
+  hermes: "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base",
+  "langchain-deepagents-code": "ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base",
+});
+
+export const PROTECTED_MANAGED_IMAGE_AGENTS = Object.freeze(
+  Object.keys(BASE_REPOSITORIES),
+) as readonly ShippedManagedImageAgent[];
 
 export const PROTECTED_MANAGED_IMAGE_PLATFORMS = ["linux/amd64", "linux/arm64"] as const;
 export const PROTECTED_MANAGED_IMAGE_MULTIARCH_JOB_ID = "managed-image-multiarch-startup" as const;
@@ -65,11 +69,6 @@ const DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/u;
 export const PROTECTED_MANAGED_IMAGE_SHA_PATTERN = /^[a-f0-9]{40}$/u;
 export const PROTECTED_MANAGED_IMAGE_COHORT_PATTERN =
   /^protected-[1-9][0-9]{0,19}-[1-9][0-9]{0,9}$/u;
-const BASE_REPOSITORIES: Readonly<Record<ShippedManagedImageAgent, string>> = Object.freeze({
-  openclaw: "ghcr.io/nvidia/nemoclaw/sandbox-base",
-  hermes: "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base",
-  "langchain-deepagents-code": "ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base",
-});
 
 function record(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {

--- a/scripts/checks/protected-managed-image-contract.ts
+++ b/scripts/checks/protected-managed-image-contract.ts
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ShippedManagedImageAgent } from "../../src/lib/onboard/managed-image/contract.ts";
+import {
+  SHIPPED_MANAGED_IMAGE_AGENTS,
+  type ShippedManagedImageAgent,
+} from "../../src/lib/onboard/managed-image/contract.ts";
 
-export const PROTECTED_MANAGED_IMAGE_AGENTS = [
-  "openclaw",
-  "hermes",
-  "langchain-deepagents-code",
-] as const satisfies readonly ShippedManagedImageAgent[];
+export const PROTECTED_MANAGED_IMAGE_AGENTS: readonly ShippedManagedImageAgent[] =
+  SHIPPED_MANAGED_IMAGE_AGENTS;
 
 export const PROTECTED_MANAGED_IMAGE_PLATFORMS = ["linux/amd64", "linux/arm64"] as const;
 export const PROTECTED_MANAGED_IMAGE_MULTIARCH_JOB_ID = "managed-image-multiarch-startup" as const;

--- a/scripts/checks/protected-managed-image-contract.ts
+++ b/scripts/checks/protected-managed-image-contract.ts
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ManagedStartupAgent } from "../../src/lib/onboard/managed-startup/profile.ts";
+import type { ShippedManagedImageAgent } from "../../src/lib/onboard/managed-image/contract.ts";
 
 export const PROTECTED_MANAGED_IMAGE_AGENTS = [
   "openclaw",
   "hermes",
   "langchain-deepagents-code",
-] as const satisfies readonly ManagedStartupAgent[];
+] as const satisfies readonly ShippedManagedImageAgent[];
 
 export const PROTECTED_MANAGED_IMAGE_PLATFORMS = ["linux/amd64", "linux/arm64"] as const;
 export const PROTECTED_MANAGED_IMAGE_MULTIARCH_JOB_ID = "managed-image-multiarch-startup" as const;
@@ -17,7 +17,7 @@ export const PROTECTED_MANAGED_IMAGE_ACTIVATION_PATH =
 export type ProtectedManagedImagePlatform = (typeof PROTECTED_MANAGED_IMAGE_PLATFORMS)[number];
 
 export type ProtectedManagedImageContract = {
-  readonly agent: ManagedStartupAgent;
+  readonly agent: ShippedManagedImageAgent;
   readonly baseReference: string;
   readonly digest: string;
   readonly localContentId: string;
@@ -26,7 +26,7 @@ export type ProtectedManagedImageContract = {
 };
 
 export type ProtectedManagedImageActivation = {
-  readonly agents: readonly ManagedStartupAgent[];
+  readonly agents: readonly ShippedManagedImageAgent[];
   readonly contractVersion: 1;
   readonly jobId: typeof PROTECTED_MANAGED_IMAGE_MULTIARCH_JOB_ID;
   readonly platforms: readonly ProtectedManagedImagePlatform[];
@@ -65,7 +65,7 @@ const DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/u;
 export const PROTECTED_MANAGED_IMAGE_SHA_PATTERN = /^[a-f0-9]{40}$/u;
 export const PROTECTED_MANAGED_IMAGE_COHORT_PATTERN =
   /^protected-[1-9][0-9]{0,19}-[1-9][0-9]{0,9}$/u;
-const BASE_REPOSITORIES: Readonly<Record<ManagedStartupAgent, string>> = Object.freeze({
+const BASE_REPOSITORIES: Readonly<Record<ShippedManagedImageAgent, string>> = Object.freeze({
   openclaw: "ghcr.io/nvidia/nemoclaw/sandbox-base",
   hermes: "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base",
   "langchain-deepagents-code": "ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base",
@@ -116,7 +116,7 @@ function parseEntry(
   exactKeys(entry);
   if (
     typeof entry.agent !== "string" ||
-    !PROTECTED_MANAGED_IMAGE_AGENTS.includes(entry.agent as ManagedStartupAgent)
+    !PROTECTED_MANAGED_IMAGE_AGENTS.includes(entry.agent as ShippedManagedImageAgent)
   ) {
     throw new Error("protected managed-image contract entry has an invalid agent");
   }
@@ -135,7 +135,7 @@ function parseEntry(
   if (entry.reference !== `${expectedRepository}@${entry.digest}`) {
     throw new Error("protected managed-image contract entry is not the exact agent digest");
   }
-  const basePrefix = `${BASE_REPOSITORIES[entry.agent as ManagedStartupAgent]}@`;
+  const basePrefix = `${BASE_REPOSITORIES[entry.agent as ShippedManagedImageAgent]}@`;
   if (
     typeof entry.baseReference !== "string" ||
     !entry.baseReference.startsWith(basePrefix) ||
@@ -144,7 +144,7 @@ function parseEntry(
     throw new Error("protected managed-image contract entry has an invalid base reference");
   }
   return {
-    agent: entry.agent as ManagedStartupAgent,
+    agent: entry.agent as ShippedManagedImageAgent,
     baseReference: entry.baseReference,
     digest: entry.digest,
     localContentId: entry.localContentId,
@@ -260,7 +260,7 @@ export function parseProtectedManagedImageEvidence(
     throw new Error("protected managed-image evidence must directly run every contract");
   }
   const contractByAgent = new Map(contracts.map((contract) => [contract.agent, contract]));
-  const seenAgents = new Set<ManagedStartupAgent>();
+  const seenAgents = new Set<ShippedManagedImageAgent>();
   const directRuns = evidence.directRuns.map((value): ProtectedManagedImageDirectRun => {
     const directRun = record(value);
     requireExactKeys(
@@ -270,7 +270,7 @@ export function parseProtectedManagedImageEvidence(
     );
     const contract =
       typeof directRun.agent === "string"
-        ? contractByAgent.get(directRun.agent as ManagedStartupAgent)
+        ? contractByAgent.get(directRun.agent as ShippedManagedImageAgent)
         : undefined;
     if (
       !contract ||

--- a/scripts/checks/run-managed-image-direct-e2e.ts
+++ b/scripts/checks/run-managed-image-direct-e2e.ts
@@ -14,13 +14,13 @@ import {
   MANAGED_BOOTSTRAP_REQUEST_FILE,
   serializeManagedBootstrapEnvelopeTar,
 } from "../../src/lib/onboard/managed-bootstrap/envelope.ts";
-import { managedImageRuntimeIdentity } from "../../src/lib/onboard/managed-image/contract.ts";
-import { MANAGED_STARTUP_EXECUTABLE } from "../../src/lib/onboard/managed-startup/hold.ts";
 import {
-  encodeManagedStartupProfile,
-  MANAGED_STARTUP_AGENTS,
-  type ManagedStartupAgent,
-} from "../../src/lib/onboard/managed-startup/profile.ts";
+  managedImageRuntimeIdentity,
+  SHIPPED_MANAGED_IMAGE_AGENTS,
+  type ShippedManagedImageAgent,
+} from "../../src/lib/onboard/managed-image/contract.ts";
+import { MANAGED_STARTUP_EXECUTABLE } from "../../src/lib/onboard/managed-startup/hold.ts";
+import { encodeManagedStartupProfile } from "../../src/lib/onboard/managed-startup/profile.ts";
 import {
   createManagedStartupRootApplyRequest,
   type ManagedStartupRootApplyRequest,
@@ -47,7 +47,7 @@ const FIXED_ROOT_ENV = [
 ] as const;
 
 export interface ManagedImageDirectE2eInputs {
-  readonly agent: ManagedStartupAgent;
+  readonly agent: ShippedManagedImageAgent;
   readonly image: string;
   readonly platform: ProtectedManagedImagePlatform;
 }
@@ -90,7 +90,7 @@ export function parseManagedImageDirectE2eInputs(
       "usage: --agent <agent> --image <immutable> --platform <linux/amd64|linux/arm64>",
     );
   }
-  if (!(MANAGED_STARTUP_AGENTS as readonly string[]).includes(agent)) {
+  if (!(SHIPPED_MANAGED_IMAGE_AGENTS as readonly string[]).includes(agent)) {
     throw new Error("--agent must identify a shipped managed-image agent");
   }
   if (!IMMUTABLE_REFERENCE_RE.test(image)) {
@@ -99,7 +99,7 @@ export function parseManagedImageDirectE2eInputs(
   if (platform !== "linux/amd64" && platform !== "linux/arm64") {
     throw new Error("--platform must be linux/amd64 or linux/arm64");
   }
-  return { agent: agent as ManagedStartupAgent, image, platform };
+  return { agent: agent as ShippedManagedImageAgent, image, platform };
 }
 
 function commandDetail(result: CommandResult): string {
@@ -131,7 +131,7 @@ function docker(
   return normalized;
 }
 
-function requestFor(agent: ManagedStartupAgent, changed = false): ManagedStartupRootApplyRequest {
+function requestFor(agent: ShippedManagedImageAgent, changed = false): ManagedStartupRootApplyRequest {
   return createManagedStartupRootApplyRequest({
     agent,
     encodedProfile: encodeManagedStartupProfile(
@@ -143,7 +143,7 @@ function requestFor(agent: ManagedStartupAgent, changed = false): ManagedStartup
 
 function rootRuntimeArgs(
   containerId: string,
-  agent: ManagedStartupAgent,
+  agent: ShippedManagedImageAgent,
   action: "--apply-root-stdin" | "--commit-shared-state-transaction",
   user = "0:0",
   bootstrapIdentity?: string,
@@ -269,7 +269,7 @@ function verifyManagedBootstrapPidOneBoundary(
   }
 }
 
-function managedConfig(agent: ManagedStartupAgent): string {
+function managedConfig(agent: ShippedManagedImageAgent): string {
   switch (agent) {
     case "openclaw":
       return "/sandbox/.openclaw/openclaw.json";

--- a/scripts/checks/run-managed-image-openshell-e2e.ts
+++ b/scripts/checks/run-managed-image-openshell-e2e.ts
@@ -24,11 +24,11 @@ import {
 } from "../../src/lib/onboard/managed-bootstrap/adapter.ts";
 import { createDockerManagedBootstrapAdapter } from "../../src/lib/onboard/managed-bootstrap/docker.ts";
 import { createDockerManagedBootstrapSurface } from "../../src/lib/onboard/managed-bootstrap/docker-runtime.ts";
-import { managedImageRuntimeIdentity } from "../../src/lib/onboard/managed-image/contract.ts";
 import {
-  encodeManagedStartupProfile,
-  type ManagedStartupAgent,
-} from "../../src/lib/onboard/managed-startup/profile.ts";
+  managedImageRuntimeIdentity,
+  type ShippedManagedImageAgent,
+} from "../../src/lib/onboard/managed-image/contract.ts";
+import { encodeManagedStartupProfile } from "../../src/lib/onboard/managed-startup/profile.ts";
 import { createManagedStartupRootApplyRequest } from "../../src/lib/onboard/managed-startup/root-apply.ts";
 import type {
   RuntimeProviderBootstrapSurface,
@@ -61,7 +61,7 @@ import {
 // together so no cross-module return path can bypass rollback; stateless route
 // and profile policy remains in managed-image-protected-runtime-contract.ts.
 
-const MANAGED_AGENTS = new Set<ManagedStartupAgent>([
+const MANAGED_AGENTS = new Set<ShippedManagedImageAgent>([
   "openclaw",
   "hermes",
   "langchain-deepagents-code",
@@ -69,7 +69,7 @@ const MANAGED_AGENTS = new Set<ManagedStartupAgent>([
 const MODEL = "nvidia/nemotron-3-ultra-550b-a55b";
 const GATEWAY_PORT = 8080;
 const IMMUTABLE_MANIFEST_REFERENCE_RE = /^([^\s@]+)@(sha256:[a-f0-9]{64})$/u;
-const MANAGED_AGENT_BASE_POLICIES: Record<ManagedStartupAgent, readonly string[]> = {
+const MANAGED_AGENT_BASE_POLICIES: Record<ShippedManagedImageAgent, readonly string[]> = {
   openclaw: ["nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"],
   hermes: ["agents", "hermes", "policy-additions.yaml"],
   "langchain-deepagents-code": ["agents", "langchain-deepagents-code", "policy-additions.yaml"],
@@ -102,7 +102,7 @@ function redactProtectedGpuProof(value: string): string {
 }
 
 export type ManagedImageOpenShellE2eInputs = {
-  agent: ManagedStartupAgent;
+  agent: ShippedManagedImageAgent;
   image: string;
   sandbox: string;
   gpu?: true;
@@ -212,7 +212,7 @@ export function parseManagedImageOpenShellE2eInputs(argv: readonly string[]): In
     index += 1;
   }
   const agentValue = requiredValue(argv, "--agent");
-  if (!MANAGED_AGENTS.has(agentValue as ManagedStartupAgent)) {
+  if (!MANAGED_AGENTS.has(agentValue as ShippedManagedImageAgent)) {
     throw new Error("--agent must identify a shipped managed-image agent");
   }
   const image = requiredValue(argv, "--image");
@@ -250,7 +250,7 @@ export function parseManagedImageOpenShellE2eInputs(argv: readonly string[]): In
     );
   }
   return {
-    agent: agentValue as ManagedStartupAgent,
+    agent: agentValue as ShippedManagedImageAgent,
     image,
     sandbox,
     ...(gpu ? { gpu: true as const } : {}),
@@ -262,7 +262,7 @@ export function parseManagedImageOpenShellE2eInputs(argv: readonly string[]): In
   };
 }
 
-export function managedImageOpenShellBasePolicyPath(agent: ManagedStartupAgent): string {
+export function managedImageOpenShellBasePolicyPath(agent: ShippedManagedImageAgent): string {
   return path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "..",
@@ -386,7 +386,7 @@ async function assertGatewayPortAvailable(): Promise<void> {
   });
 }
 
-function managedConfigPath(agent: ManagedStartupAgent): string {
+function managedConfigPath(agent: ShippedManagedImageAgent): string {
   switch (agent) {
     case "openclaw":
       return "/sandbox/.openclaw/openclaw.json";
@@ -398,7 +398,7 @@ function managedConfigPath(agent: ManagedStartupAgent): string {
 }
 
 export function managedImageOpenShellProbe(
-  agent: ManagedStartupAgent,
+  agent: ShippedManagedImageAgent,
   model: string = MODEL,
 ): string {
   const healthProbe =

--- a/scripts/checks/run-managed-image-openshell-e2e.ts
+++ b/scripts/checks/run-managed-image-openshell-e2e.ts
@@ -26,6 +26,7 @@ import { createDockerManagedBootstrapAdapter } from "../../src/lib/onboard/manag
 import { createDockerManagedBootstrapSurface } from "../../src/lib/onboard/managed-bootstrap/docker-runtime.ts";
 import {
   managedImageRuntimeIdentity,
+  SHIPPED_MANAGED_IMAGE_AGENTS,
   type ShippedManagedImageAgent,
 } from "../../src/lib/onboard/managed-image/contract.ts";
 import { encodeManagedStartupProfile } from "../../src/lib/onboard/managed-startup/profile.ts";
@@ -61,11 +62,7 @@ import {
 // together so no cross-module return path can bypass rollback; stateless route
 // and profile policy remains in managed-image-protected-runtime-contract.ts.
 
-const MANAGED_AGENTS = new Set<ShippedManagedImageAgent>([
-  "openclaw",
-  "hermes",
-  "langchain-deepagents-code",
-]);
+const MANAGED_AGENTS = new Set<ShippedManagedImageAgent>(SHIPPED_MANAGED_IMAGE_AGENTS);
 const MODEL = "nvidia/nemotron-3-ultra-550b-a55b";
 const GATEWAY_PORT = 8080;
 const IMMUTABLE_MANIFEST_REFERENCE_RE = /^([^\s@]+)@(sha256:[a-f0-9]{64})$/u;

--- a/scripts/managed-bootstrap-trampoline.sh
+++ b/scripts/managed-bootstrap-trampoline.sh
@@ -61,7 +61,7 @@ shift 15
 [[ "$1" = /* ]] || fail "supervisor executable must be absolute"
 
 case "$_nemoclaw_agent" in
-  openclaw | hermes | langchain-deepagents-code) ;;
+  openclaw | hermes | langchain-deepagents-code | pi) ;;
   *) fail "agent is unsupported" ;;
 esac
 case "$_nemoclaw_fingerprint" in

--- a/scripts/managed-startup-hold.sh
+++ b/scripts/managed-startup-hold.sh
@@ -37,7 +37,7 @@ _nemoclaw_bootstrap_identity="$6"
 shift 7
 
 case "$_nemoclaw_agent" in
-  openclaw | hermes | langchain-deepagents-code) ;;
+  openclaw | hermes | langchain-deepagents-code | pi) ;;
   *) fail "agent is unsupported" ;;
 esac
 case "$_nemoclaw_fingerprint" in

--- a/src/lib/actions/sandbox/pi-candidate-lifecycle.test.ts
+++ b/src/lib/actions/sandbox/pi-candidate-lifecycle.test.ts
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import { createInMemoryRuntimeProviderBundle } from "../../../../test/helpers/runtime-provider-bundle";
+import { candidateQualificationEnvironment } from "../../agent/candidate-test-fixture";
+import { createOnboardAgentSelector } from "../../onboard/agent-selection";
+import {
+  MANAGED_IMAGE_REPOSITORIES,
+  managedImageRuntimeIdentity,
+} from "../../onboard/managed-image/contract";
+import { encodeManagedStartupProfile } from "../../onboard/managed-startup/profile";
+import { createRuntimeProviderBundleRegistry } from "../../onboard/runtime-provider/registry";
+import { requireRuntimeProviderDestructiveCleanupAuthority } from "../../onboard/runtime-provider/registry";
+import type { SandboxEntry } from "../../state/registry/types";
+import { resolveSandboxStatusAgent } from "./status-snapshot";
+
+const PROVIDER_ID = "portable-test";
+
+function piSandboxEntry(): SandboxEntry {
+  const image = MANAGED_IMAGE_REPOSITORIES.pi;
+  const digest = `sha256:${"1b".repeat(32)}`;
+  const encodedProfile = encodeManagedStartupProfile(managedStartupE2eProfile("pi"));
+  return {
+    name: "pi-sandbox",
+    agent: "pi",
+    openshellDriver: PROVIDER_ID,
+    fromDockerfile: null,
+    imageTag: `${image}@${digest}`,
+    workload: {
+      schemaVersion: 1,
+      kind: "managed-image",
+      reference: `${image}@${digest}`,
+      platform: "linux/amd64",
+      release: "v0.0.99",
+      sourceRevision: "c".repeat(40),
+      sourceCohort: "ghrun-7927-2",
+      capabilityContractVersion: 1,
+      startupProfileContractVersion: 1,
+      encodedProfile,
+      startupProfileSha256: createHash("sha256").update(encodedProfile, "utf8").digest("hex"),
+      credentialProxyReplayRequired: false,
+      shared: true,
+    },
+  } as unknown as SandboxEntry;
+}
+
+function stubQualification(): void {
+  const env = candidateQualificationEnvironment();
+  vi.stubEnv("NEMOCLAW_CANDIDATE_AGENTS", String(env.NEMOCLAW_CANDIDATE_AGENTS));
+  vi.stubEnv(
+    "NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT",
+    String(env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT),
+  );
+  vi.stubEnv(
+    "NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256",
+    String(env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256),
+  );
+}
+
+describe("Pi candidate operational surfaces", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEMOCLAW_CANDIDATE_AGENTS", "");
+    vi.stubEnv("NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT", "");
+    vi.stubEnv("NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reports Pi separately from its compute runtime in status (#7927)", () => {
+    stubQualification();
+    const entry = piSandboxEntry();
+
+    const info = resolveSandboxStatusAgent(String(entry.agent));
+
+    expect(info).toMatchObject({
+      agentName: "pi",
+      agentDisplayName: "Pi",
+      agentRuntime: "terminal",
+    });
+    expect(info.agentLoadError).toBeUndefined();
+    // The compute runtime stays a separate recorded identity, and the agent
+    // identity never implies it.
+    expect(entry.openshellDriver).toBe(PROVIDER_ID);
+    expect(info.agentName).not.toBe(String(entry.openshellDriver));
+  });
+
+  it("names the withheld candidate in status diagnostics without qualification (#7927)", () => {
+    const info = resolveSandboxStatusAgent("pi");
+
+    expect(info.agentRuntime).toBe("unknown");
+    expect(info.agentLoadError).toContain("release candidate");
+    expect(info.agentDefinition).toBeNull();
+  });
+
+  it("keeps Pi inventory and log surfaces on the terminal runtime contract (#7927)", () => {
+    stubQualification();
+
+    const info = resolveSandboxStatusAgent("pi");
+
+    // Terminal agents have no gateway log source and no dashboard port, so the
+    // shared logs and inventory surfaces must not advertise one for Pi.
+    expect(info.agentRuntime).toBe("terminal");
+    expect(info.agentDefinition?.forwardPort).toBe(0);
+    expect(info.agentDefinition?.healthProbe).toBeNull();
+    expect(managedImageRuntimeIdentity("pi").workdir).toBe("/sandbox");
+  });
+
+  it("resumes a recorded Pi session without changing the agent (#7927)", async () => {
+    stubQualification();
+    const note = vi.fn();
+    const prompt = vi.fn(async () => "1");
+    const selectAgent = createOnboardAgentSelector({
+      isNonInteractive: () => true,
+      note,
+      prompt,
+    });
+
+    const agent = await selectAgent({ resume: true, session: { agent: "pi" } });
+
+    expect(agent?.name).toBe("pi");
+    // A resumed session pins its recorded agent, so the picker never runs.
+    expect(prompt).not.toHaveBeenCalled();
+    expect(note).toHaveBeenCalledWith(expect.stringContaining("Pi"));
+  });
+
+  it("refuses to resume a Pi session without qualification authority (#7927)", async () => {
+    const selectAgent = createOnboardAgentSelector({
+      isNonInteractive: () => true,
+      note: vi.fn(),
+      prompt: vi.fn(async () => "1"),
+    });
+
+    // Falling back to OpenClaw would silently change the agent the session was
+    // created with, so the withheld candidate must fail closed instead.
+    await expect(selectAgent({ resume: true, session: { agent: "pi" } })).rejects.toThrow(
+      "Agent 'pi' is a release candidate and is not selectable in this release",
+    );
+  });
+
+  it("delegates Pi destroy cleanup to the selected compute-runtime provider (#7927)", () => {
+    const events: string[] = [];
+    const bundle = createInMemoryRuntimeProviderBundle({
+      providerId: PROVIDER_ID,
+      workloadProfile: {
+        support: {
+          exactDigestReferences: true,
+          platforms: ["linux/amd64", "linux/arm64"],
+          startupProfileContractVersions: [1],
+          capabilityContractVersions: [1],
+        },
+        hostArchitectures: ["amd64", "arm64"],
+        managedImageSelectionPolicy: "require-managed",
+        legacyDockerfileBuilds: false,
+      },
+      recordEvent: (value: string) => events.push(value),
+    } as never);
+    const registry = createRuntimeProviderBundleRegistry([[PROVIDER_ID, bundle]]);
+
+    const authority = requireRuntimeProviderDestructiveCleanupAuthority(
+      "pi-sandbox",
+      piSandboxEntry(),
+      registry,
+    );
+
+    expect(authority.provider.identity.id).toBe(PROVIDER_ID);
+    // A shared managed image is never deleted by destroy; cleanup stays owned
+    // by the provider rather than by any Pi-specific branch.
+    expect(authority.workloadAction).toBe("retain");
+  });
+});

--- a/src/lib/actions/sandbox/pi-candidate-lifecycle.test.ts
+++ b/src/lib/actions/sandbox/pi-candidate-lifecycle.test.ts
@@ -5,28 +5,38 @@ import { createHash } from "node:crypto";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const authority = vi.hoisted(() => ({ digests: [] as string[] }));
+
+vi.mock("../../agent/candidate-authority", () => ({
+  CANDIDATE_QUALIFICATION_RECEIPT_DIGESTS: { pi: authority.digests },
+  acceptedCandidateReceiptDigests: () => authority.digests,
+}));
+
 import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
 import { createInMemoryRuntimeProviderBundle } from "../../../../test/helpers/runtime-provider-bundle";
-import { candidateQualificationEnvironment } from "../../agent/candidate-test-fixture";
-import { createOnboardAgentSelector } from "../../onboard/agent-selection";
 import {
-  MANAGED_IMAGE_REPOSITORIES,
-  managedImageRuntimeIdentity,
-} from "../../onboard/managed-image/contract";
+  type CandidateQualificationFixture,
+  candidateQualificationEnvironment,
+} from "../../agent/candidate-test-fixture";
+import { loadAgent } from "../../agent/defs";
+import { createOnboardAgentSelector } from "../../onboard/agent-selection";
+import { MANAGED_IMAGE_REPOSITORIES } from "../../onboard/managed-image/contract";
 import { encodeManagedStartupProfile } from "../../onboard/managed-startup/profile";
 import { createRuntimeProviderBundleRegistry } from "../../onboard/runtime-provider/registry";
-import { requireRuntimeProviderDestructiveCleanupAuthority } from "../../onboard/runtime-provider/registry";
 import type { SandboxEntry } from "../../state/registry/types";
-import { resolveSandboxStatusAgent } from "./status-snapshot";
+import { requireSandboxDestructiveCleanupAuthority } from "./destroy";
+import { showSandboxLogsWithDeps } from "./logs";
+import { getSandboxStatusReport } from "./status";
 
 const PROVIDER_ID = "portable-test";
+const SANDBOX = "pi-sandbox";
 
 function piSandboxEntry(): SandboxEntry {
   const image = MANAGED_IMAGE_REPOSITORIES.pi;
   const digest = `sha256:${"1b".repeat(32)}`;
   const encodedProfile = encodeManagedStartupProfile(managedStartupE2eProfile("pi"));
   return {
-    name: "pi-sandbox",
+    name: SANDBOX,
     agent: "pi",
     openshellDriver: PROVIDER_ID,
     fromDockerfile: null,
@@ -49,71 +59,103 @@ function piSandboxEntry(): SandboxEntry {
   } as unknown as SandboxEntry;
 }
 
-function stubQualification(): void {
-  const env = candidateQualificationEnvironment();
-  vi.stubEnv("NEMOCLAW_CANDIDATE_AGENTS", String(env.NEMOCLAW_CANDIDATE_AGENTS));
-  vi.stubEnv(
-    "NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT",
-    String(env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT),
-  );
-  vi.stubEnv(
-    "NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256",
-    String(env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256),
-  );
+function statusDeps(entry: SandboxEntry) {
+  return {
+    getSandbox: () => entry,
+    listSandboxes: () => ({ sandboxes: [entry], defaultSandbox: SANDBOX }),
+    reconcile: async () => ({
+      state: "present" as const,
+      output: `Name: ${SANDBOX}\nPhase: Ready\n`,
+    }),
+    captureOpenshellForStatusImpl: async () => ({ status: 0, output: "" }),
+    probeProviderHealthImpl: vi.fn(() => null),
+    probeSandboxInferenceGatewayHealthImpl: vi.fn(async () => null),
+    probeTerminalRuntimeHealth: vi.fn(() => ({ kind: "ok" as const, oomKillCount: 0 as const })),
+  };
+}
+
+let fixture: CandidateQualificationFixture | null = null;
+
+function qualify(): NodeJS.ProcessEnv {
+  fixture = candidateQualificationEnvironment();
+  authority.digests.push(fixture.receiptDigest);
+  for (const [key, value] of Object.entries(fixture.env)) vi.stubEnv(key, String(value));
+  return fixture.env;
 }
 
 describe("Pi candidate operational surfaces", () => {
   beforeEach(() => {
     vi.stubEnv("NEMOCLAW_CANDIDATE_AGENTS", "");
     vi.stubEnv("NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT", "");
-    vi.stubEnv("NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256", "");
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    authority.digests.splice(0, authority.digests.length);
+    fixture?.cleanup();
+    fixture = null;
   });
 
-  it("reports Pi separately from its compute runtime in status (#7927)", () => {
-    stubQualification();
+  it("reports Pi separately from its compute runtime in the status report (#7927)", async () => {
+    qualify();
     const entry = piSandboxEntry();
 
-    const info = resolveSandboxStatusAgent(String(entry.agent));
+    const report = await getSandboxStatusReport(SANDBOX, statusDeps(entry));
 
-    expect(info).toMatchObject({
-      agentName: "pi",
+    expect(report).toMatchObject({
+      name: SANDBOX,
+      found: true,
+      agent: "pi",
       agentDisplayName: "Pi",
       agentRuntime: "terminal",
     });
-    expect(info.agentLoadError).toBeUndefined();
-    // The compute runtime stays a separate recorded identity, and the agent
-    // identity never implies it.
+    expect(report).not.toHaveProperty("agentLoadError");
     expect(entry.openshellDriver).toBe(PROVIDER_ID);
-    expect(info.agentName).not.toBe(String(entry.openshellDriver));
+    expect(report.agent).not.toBe(String(entry.openshellDriver));
   });
 
-  it("names the withheld candidate in status diagnostics without qualification (#7927)", () => {
-    const info = resolveSandboxStatusAgent("pi");
+  it("names the withheld candidate in the status report without qualification (#7927)", async () => {
+    const report = await getSandboxStatusReport(SANDBOX, statusDeps(piSandboxEntry()));
 
-    expect(info.agentRuntime).toBe("unknown");
-    expect(info.agentLoadError).toContain("release candidate");
-    expect(info.agentDefinition).toBeNull();
+    expect(report.agent).toBe("pi");
+    expect(report.agentRuntime).toBe("unknown");
+    expect(report.agentLoadError).toContain("release candidate");
   });
 
-  it("keeps Pi inventory and log surfaces on the terminal runtime contract (#7927)", () => {
-    stubQualification();
+  it("keeps a recorded Pi sandbox off the gateway log source (#7927)", () => {
+    const env = qualify();
+    const agent = loadAgent("pi", env);
+    const runOpenshell = vi.fn((args: string[]) => ({ status: 0, stdout: args.join(" ") }));
+    const exitCodes: number[] = [];
 
-    const info = resolveSandboxStatusAgent("pi");
+    showSandboxLogsWithDeps(
+      SANDBOX,
+      { follow: false, lines: "50", since: null },
+      {
+        exit: ((code: number) => {
+          exitCodes.push(code);
+        }) as never,
+        isDockerRuntimeDown: () => false,
+        getOpenshellBinary: () => "openshell",
+        getSessionAgent: () => agent,
+        runOpenshell: runOpenshell as never,
+        writeStdout: () => {},
+      },
+    );
 
-    // Terminal agents have no gateway log source and no dashboard port, so the
-    // shared logs and inventory surfaces must not advertise one for Pi.
-    expect(info.agentRuntime).toBe("terminal");
-    expect(info.agentDefinition?.forwardPort).toBe(0);
-    expect(info.agentDefinition?.healthProbe).toBeNull();
-    expect(managedImageRuntimeIdentity("pi").workdir).toBe("/sandbox");
+    // A terminal agent advertises no gateway, so logs must read the sandbox
+    // source alone and never probe the OpenClaw gateway.
+    expect(runOpenshell).toHaveBeenCalled();
+    expect(exitCodes).toEqual([0]);
+    for (const [args] of runOpenshell.mock.calls) {
+      expect(args.join(" ")).not.toContain("openclaw");
+    }
+    expect(agent.forwardPort).toBe(0);
+    expect(agent.healthProbe).toBeNull();
   });
 
   it("resumes a recorded Pi session without changing the agent (#7927)", async () => {
-    stubQualification();
+    qualify();
     const note = vi.fn();
     const prompt = vi.fn(async () => "1");
     const selectAgent = createOnboardAgentSelector({
@@ -125,7 +167,6 @@ describe("Pi candidate operational surfaces", () => {
     const agent = await selectAgent({ resume: true, session: { agent: "pi" } });
 
     expect(agent?.name).toBe("pi");
-    // A resumed session pins its recorded agent, so the picker never runs.
     expect(prompt).not.toHaveBeenCalled();
     expect(note).toHaveBeenCalledWith(expect.stringContaining("Pi"));
   });
@@ -145,7 +186,6 @@ describe("Pi candidate operational surfaces", () => {
   });
 
   it("delegates Pi destroy cleanup to the selected compute-runtime provider (#7927)", () => {
-    const events: string[] = [];
     const bundle = createInMemoryRuntimeProviderBundle({
       providerId: PROVIDER_ID,
       workloadProfile: {
@@ -159,19 +199,19 @@ describe("Pi candidate operational surfaces", () => {
         managedImageSelectionPolicy: "require-managed",
         legacyDockerfileBuilds: false,
       },
-      recordEvent: (value: string) => events.push(value),
+      recordEvent: () => {},
     } as never);
     const registry = createRuntimeProviderBundleRegistry([[PROVIDER_ID, bundle]]);
 
-    const authority = requireRuntimeProviderDestructiveCleanupAuthority(
-      "pi-sandbox",
+    const authorityResult = requireSandboxDestructiveCleanupAuthority(
+      SANDBOX,
       piSandboxEntry(),
       registry,
     );
 
-    expect(authority.provider.identity.id).toBe(PROVIDER_ID);
+    expect(authorityResult.provider.identity.id).toBe(PROVIDER_ID);
     // A shared managed image is never deleted by destroy; cleanup stays owned
     // by the provider rather than by any Pi-specific branch.
-    expect(authority.workloadAction).toBe("retain");
+    expect(authorityResult.workloadAction).toBe("retain");
   });
 });

--- a/src/lib/actions/sandbox/snapshot/managed-clone-providers.ts
+++ b/src/lib/actions/sandbox/snapshot/managed-clone-providers.ts
@@ -266,7 +266,10 @@ function applicationBindings(input: {
     providerEnvKey: binding.providerEnvKey,
     source: "messaging",
   }));
-  if (input.profile.agentConfig.agent !== "langchain-deepagents-code") {
+  if (
+    input.profile.agentConfig.agent === "openclaw" ||
+    input.profile.agentConfig.agent === "hermes"
+  ) {
     const webSearch = input.profile.agentConfig.webSearch;
     if (webSearch.enabled) {
       bindings.push({

--- a/src/lib/agent/candidate-authority.ts
+++ b/src/lib/agent/candidate-authority.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CandidateManagedImageAgent } from "../onboard/managed-image/contract";
+
+/**
+ * Repository-controlled qualification authority for release candidates. A
+ * candidate is reachable only through a qualification receipt whose SHA-256
+ * appears here, so a caller can neither mint an accepted digest nor replace one
+ * through environment configuration. The accepted set stays empty until
+ * qualification evidence and public activation land.
+ */
+export const CANDIDATE_QUALIFICATION_RECEIPT_DIGESTS: Readonly<
+  Record<CandidateManagedImageAgent, readonly string[]>
+> = Object.freeze({
+  pi: Object.freeze([]),
+});
+
+export function acceptedCandidateReceiptDigests(agent: string): readonly string[] {
+  return CANDIDATE_QUALIFICATION_RECEIPT_DIGESTS[agent as CandidateManagedImageAgent] ?? [];
+}

--- a/src/lib/agent/candidate-qualified.test.ts
+++ b/src/lib/agent/candidate-qualified.test.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const authority = vi.hoisted(() => ({ digests: [] as string[] }));
+
+vi.mock("./candidate-authority", () => ({
+  CANDIDATE_QUALIFICATION_RECEIPT_DIGESTS: { pi: authority.digests },
+  acceptedCandidateReceiptDigests: () => authority.digests,
+}));
+
+import {
+  CandidateQualificationError,
+  isCandidateAgentSelectable,
+  readCandidateQualificationReceipt,
+  requireCandidateQualificationEnabled,
+} from "./candidate";
+import {
+  candidateQualificationContract,
+  type CandidateQualificationFixture,
+  candidateQualificationEnvironment,
+} from "./candidate-test-fixture";
+
+let fixture: CandidateQualificationFixture | null = null;
+
+function qualified(
+  options: Parameters<typeof candidateQualificationEnvironment>[0] = {},
+): NodeJS.ProcessEnv {
+  fixture = candidateQualificationEnvironment(options);
+  authority.digests.splice(0, authority.digests.length, fixture.receiptDigest);
+  return fixture.env;
+}
+
+afterEach(() => {
+  fixture?.cleanup();
+  fixture = null;
+  authority.digests.splice(0, authority.digests.length);
+});
+
+describe("published candidate qualification authority", () => {
+  it("selects a candidate whose receipt digest the repository publishes (#7927)", () => {
+    const env = qualified();
+
+    expect(isCandidateAgentSelectable("pi", env)).toBe(true);
+    expect(() => requireCandidateQualificationEnabled("pi", env)).not.toThrow();
+  });
+
+  it("returns the exact accepted image identity from the receipt (#7927)", () => {
+    const contract = readCandidateQualificationReceipt("pi", qualified());
+
+    expect(contract).toMatchObject({ agent: "pi", image: "ghcr.io/nvidia/nemoclaw/pi-sandbox" });
+    expect(contract.reference).toBe(`${contract.image}@${contract.digest}`);
+  });
+
+  it("refuses a receipt whose contents change after publication (#7927)", () => {
+    const env = qualified();
+    fs.writeFileSync(
+      String(env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT),
+      `${JSON.stringify(candidateQualificationContract("pi"))} `,
+    );
+
+    expect(isCandidateAgentSelectable("pi", env)).toBe(false);
+    expect(() => readCandidateQualificationReceipt("pi", env)).toThrow(
+      "not a published qualification for that candidate",
+    );
+  });
+
+  it("refuses a published receipt that claims a shipped agent (#7927)", () => {
+    const contract = { ...candidateQualificationContract("pi"), agent: "hermes" as const };
+    const env = qualified({ contract: contract as never });
+
+    expect(() => readCandidateQualificationReceipt("pi", env)).toThrow(CandidateQualificationError);
+    expect(() => readCandidateQualificationReceipt("pi", env)).toThrow(
+      "failed closed contract validation",
+    );
+  });
+});

--- a/src/lib/agent/candidate-test-fixture.ts
+++ b/src/lib/agent/candidate-test-fixture.ts
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  type CandidateManagedImageAgent,
+  MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
+  MANAGED_IMAGE_CONTRACT_VERSION,
+  MANAGED_IMAGE_PLATFORMS,
+  MANAGED_IMAGE_REPOSITORIES,
+  MANAGED_IMAGE_SOURCE_REPOSITORY,
+  MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
+  type ManagedImageContractV1,
+  type ManagedImagePlatform,
+} from "../onboard/managed-image/contract";
+import {
+  CANDIDATE_AGENT_FEATURE_ENV,
+  CANDIDATE_QUALIFICATION_RECEIPT_ENV,
+  CANDIDATE_QUALIFICATION_RECEIPT_SHA256_ENV,
+} from "./candidate";
+
+export function candidateQualificationContract(
+  agent: CandidateManagedImageAgent = "pi",
+  platform: ManagedImagePlatform = MANAGED_IMAGE_PLATFORMS[0],
+): ManagedImageContractV1 {
+  const image = MANAGED_IMAGE_REPOSITORIES[agent];
+  const digest = `sha256:${"7a".repeat(32)}` as const;
+  return {
+    contractVersion: MANAGED_IMAGE_CONTRACT_VERSION,
+    agent,
+    platform,
+    image,
+    digest,
+    reference: `${image}@${digest}`,
+    source: {
+      repository: MANAGED_IMAGE_SOURCE_REPOSITORY,
+      revision: "d".repeat(40),
+      release: "v0.0.100",
+      cohort: "ghrun-7927-1",
+    },
+    startupProfileContractVersion: MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
+    capabilityContractVersion: MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
+  };
+}
+
+/**
+ * Write a qualification receipt and return the environment that authorises the
+ * candidate agent. Tests use this instead of asserting the protected flag on its
+ * own, because the flag alone must never activate a withheld agent.
+ */
+export function candidateQualificationEnvironment(
+  options: {
+    readonly agent?: CandidateManagedImageAgent;
+    readonly contract?: ManagedImageContractV1;
+    readonly corruptDigest?: boolean;
+  } = {},
+): NodeJS.ProcessEnv & { readonly receiptPath: string } {
+  const agent = options.agent ?? "pi";
+  const contract = options.contract ?? candidateQualificationContract(agent);
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-candidate-receipt-"));
+  const receiptPath = path.join(directory, "candidate-qualification.json");
+  const contents = JSON.stringify(contract);
+  fs.writeFileSync(receiptPath, contents, { mode: 0o600 });
+  const sha256 = options.corruptDigest
+    ? "0".repeat(64)
+    : createHash("sha256").update(contents, "utf8").digest("hex");
+  return {
+    [CANDIDATE_AGENT_FEATURE_ENV]: "1",
+    [CANDIDATE_QUALIFICATION_RECEIPT_ENV]: receiptPath,
+    [CANDIDATE_QUALIFICATION_RECEIPT_SHA256_ENV]: sha256,
+    receiptPath,
+  };
+}

--- a/src/lib/agent/candidate-test-fixture.ts
+++ b/src/lib/agent/candidate-test-fixture.ts
@@ -17,11 +17,7 @@ import {
   type ManagedImageContractV1,
   type ManagedImagePlatform,
 } from "../onboard/managed-image/contract";
-import {
-  CANDIDATE_AGENT_FEATURE_ENV,
-  CANDIDATE_QUALIFICATION_RECEIPT_ENV,
-  CANDIDATE_QUALIFICATION_RECEIPT_SHA256_ENV,
-} from "./candidate";
+import { CANDIDATE_AGENT_FEATURE_ENV, CANDIDATE_QUALIFICATION_RECEIPT_ENV } from "./candidate";
 
 export function candidateQualificationContract(
   agent: CandidateManagedImageAgent = "pi",
@@ -47,31 +43,38 @@ export function candidateQualificationContract(
   };
 }
 
+export interface CandidateQualificationFixture {
+  readonly env: NodeJS.ProcessEnv;
+  readonly receiptPath: string;
+  readonly receiptDigest: string;
+  readonly cleanup: () => void;
+}
+
 /**
- * Write a qualification receipt and return the environment that authorises the
- * candidate agent. Tests use this instead of asserting the protected flag on its
- * own, because the flag alone must never activate a withheld agent.
+ * Write a qualification receipt and return the environment that locates it.
+ * The receipt only qualifies once its digest is published by the repository
+ * authority, so a suite that needs the accepted path must also stub
+ * `candidate-authority` with `receiptDigest`.
  */
 export function candidateQualificationEnvironment(
   options: {
     readonly agent?: CandidateManagedImageAgent;
     readonly contract?: ManagedImageContractV1;
-    readonly corruptDigest?: boolean;
   } = {},
-): NodeJS.ProcessEnv & { readonly receiptPath: string } {
+): CandidateQualificationFixture {
   const agent = options.agent ?? "pi";
   const contract = options.contract ?? candidateQualificationContract(agent);
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-candidate-receipt-"));
   const receiptPath = path.join(directory, "candidate-qualification.json");
   const contents = JSON.stringify(contract);
   fs.writeFileSync(receiptPath, contents, { mode: 0o600 });
-  const sha256 = options.corruptDigest
-    ? "0".repeat(64)
-    : createHash("sha256").update(contents, "utf8").digest("hex");
   return {
-    [CANDIDATE_AGENT_FEATURE_ENV]: "1",
-    [CANDIDATE_QUALIFICATION_RECEIPT_ENV]: receiptPath,
-    [CANDIDATE_QUALIFICATION_RECEIPT_SHA256_ENV]: sha256,
+    env: {
+      [CANDIDATE_AGENT_FEATURE_ENV]: "1",
+      [CANDIDATE_QUALIFICATION_RECEIPT_ENV]: receiptPath,
+    },
     receiptPath,
+    receiptDigest: createHash("sha256").update(contents, "utf8").digest("hex"),
+    cleanup: () => fs.rmSync(directory, { recursive: true, force: true }),
   };
 }

--- a/src/lib/agent/candidate.test.ts
+++ b/src/lib/agent/candidate.test.ts
@@ -1,26 +1,39 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import fs from "node:fs";
+import { createHash } from "node:crypto";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { CANDIDATE_MANAGED_IMAGE_AGENTS } from "../onboard/managed-image/contract";
-import {
-  candidateQualificationContract,
-  candidateQualificationEnvironment,
-} from "./candidate-test-fixture";
+import { CANDIDATE_QUALIFICATION_RECEIPT_DIGESTS } from "./candidate-authority";
 import {
   CANDIDATE_AGENT_FEATURE_ENV,
+  CANDIDATE_QUALIFICATION_RECEIPT_ENV,
   CandidateQualificationError,
   isCandidateAgent,
-  isCandidateAgentEnabled,
   isCandidateAgentSelectable,
   isCandidateQualificationEnabled,
   readCandidateQualificationReceipt,
   requireCandidateAgentSelectable,
   requireCandidateQualificationEnabled,
 } from "./candidate";
+import {
+  candidateQualificationContract,
+  candidateQualificationEnvironment,
+} from "./candidate-test-fixture";
+
+const receipts: Array<() => void> = [];
+
+function callerMintedReceipt(): NodeJS.ProcessEnv {
+  const fixture = candidateQualificationEnvironment();
+  receipts.push(fixture.cleanup);
+  return fixture.env;
+}
+
+afterEach(() => {
+  while (receipts.length > 0) receipts.pop()?.();
+});
 
 describe("candidate agent gate", () => {
   it("treats every declared candidate managed-image agent as a candidate (#7927)", () => {
@@ -32,8 +45,13 @@ describe("candidate agent gate", () => {
     expect(isCandidateAgent("langchain-deepagents-code")).toBe(false);
   });
 
+  it("publishes no qualified candidate receipt in this release (#7927)", () => {
+    for (const agent of CANDIDATE_MANAGED_IMAGE_AGENTS) {
+      expect(CANDIDATE_QUALIFICATION_RECEIPT_DIGESTS[agent]).toEqual([]);
+    }
+  });
+
   it("never activates a candidate from the protected flag alone (#7927)", () => {
-    expect(isCandidateAgentEnabled({ [CANDIDATE_AGENT_FEATURE_ENV]: "1" })).toBe(false);
     expect(isCandidateAgentSelectable("pi", { [CANDIDATE_AGENT_FEATURE_ENV]: "1" })).toBe(false);
     expect(() =>
       requireCandidateAgentSelectable("pi", { [CANDIDATE_AGENT_FEATURE_ENV]: "1" }),
@@ -41,56 +59,45 @@ describe("candidate agent gate", () => {
   });
 
   it("stays closed for an ordinary environment without a receipt (#7927)", () => {
-    expect(isCandidateAgentEnabled({})).toBe(false);
-    expect(isCandidateAgentEnabled({ [CANDIDATE_AGENT_FEATURE_ENV]: "0" })).toBe(false);
-    expect(isCandidateAgentEnabled({ [CANDIDATE_AGENT_FEATURE_ENV]: "true" })).toBe(false);
+    expect(isCandidateAgentSelectable("pi", {})).toBe(false);
+    expect(isCandidateAgentSelectable("pi", { [CANDIDATE_AGENT_FEATURE_ENV]: "0" })).toBe(false);
+    expect(isCandidateAgentSelectable("pi", { [CANDIDATE_AGENT_FEATURE_ENV]: "true" })).toBe(false);
   });
 
-  it("selects a candidate only with a digest-pinned receipt (#7927)", () => {
-    const env = candidateQualificationEnvironment();
+  it("refuses a receipt that the caller wrote and hashed for itself (#7927)", () => {
+    const env = callerMintedReceipt();
 
-    expect(isCandidateAgentEnabled(env)).toBe(true);
-    expect(isCandidateAgentSelectable("pi", env)).toBe(true);
-    expect(() => requireCandidateAgentSelectable("pi", env)).not.toThrow();
-  });
-
-  it("refuses a receipt that does not match its pinned digest (#7927)", () => {
-    const env = candidateQualificationEnvironment({ corruptDigest: true });
-
+    expect(isCandidateAgentSelectable("pi", env)).toBe(false);
+    expect(isCandidateQualificationEnabled("pi", env)).toBe(false);
     expect(() => readCandidateQualificationReceipt("pi", env)).toThrow(CandidateQualificationError);
     expect(() => readCandidateQualificationReceipt("pi", env)).toThrow(
-      "does not match its pinned digest",
-    );
-    expect(isCandidateQualificationEnabled("pi", env)).toBe(false);
-  });
-
-  it("refuses a receipt whose contents change after the digest is pinned (#7927)", () => {
-    const env = candidateQualificationEnvironment();
-    fs.writeFileSync(env.receiptPath, JSON.stringify(candidateQualificationContract("pi")) + " ");
-
-    expect(() => readCandidateQualificationReceipt("pi", env)).toThrow(
-      "does not match its pinned digest",
+      "no qualified receipt is published for release candidate 'pi'",
     );
   });
 
-  it("refuses a receipt that claims a shipped agent (#7927)", () => {
-    const contract = { ...candidateQualificationContract("pi"), agent: "hermes" as const };
-    const env = candidateQualificationEnvironment({ contract: contract as never });
+  it("refuses a caller-supplied digest for a receipt it also wrote (#7927)", () => {
+    const contract = candidateQualificationContract("pi");
+    const contents = JSON.stringify(contract);
+    const env = {
+      ...callerMintedReceipt(),
+      NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256: createHash("sha256")
+        .update(contents, "utf8")
+        .digest("hex"),
+    };
 
-    expect(() => readCandidateQualificationReceipt("pi", env)).toThrow(
-      "failed closed contract validation",
-    );
+    expect(isCandidateAgentSelectable("pi", env)).toBe(false);
   });
 
-  it("returns the exact accepted image identity from the receipt (#7927)", () => {
-    const env = candidateQualificationEnvironment();
-    const contract = readCandidateQualificationReceipt("pi", env);
+  it("refuses a missing receipt at the selection boundary, not only at startup (#7927)", () => {
+    const env = {
+      [CANDIDATE_AGENT_FEATURE_ENV]: "1",
+      [CANDIDATE_QUALIFICATION_RECEIPT_ENV]: "/nonexistent/candidate-qualification.json",
+    };
 
-    expect(contract).toMatchObject({
-      agent: "pi",
-      image: "ghcr.io/nvidia/nemoclaw/pi-sandbox",
-    });
-    expect(contract.reference).toBe(`${contract.image}@${contract.digest}`);
+    expect(isCandidateAgentSelectable("pi", env)).toBe(false);
+    expect(() => requireCandidateAgentSelectable("pi", env)).toThrow(
+      "is not selectable in this release",
+    );
   });
 
   it("never refuses a shipped agent through the candidate gate (#7927)", () => {
@@ -104,8 +111,8 @@ describe("candidate agent gate", () => {
     expect(() => requireCandidateQualificationEnabled("pi", {})).toThrow(
       "is not selectable in this release",
     );
-    expect(() =>
-      requireCandidateQualificationEnabled("pi", candidateQualificationEnvironment()),
-    ).not.toThrow();
+    expect(() => requireCandidateQualificationEnabled("pi", callerMintedReceipt())).toThrow(
+      "is not selectable in this release",
+    );
   });
 });

--- a/src/lib/agent/candidate.test.ts
+++ b/src/lib/agent/candidate.test.ts
@@ -1,20 +1,26 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import { CANDIDATE_MANAGED_IMAGE_AGENTS } from "../onboard/managed-image/contract";
 import {
+  candidateQualificationContract,
+  candidateQualificationEnvironment,
+} from "./candidate-test-fixture";
+import {
+  CANDIDATE_AGENT_FEATURE_ENV,
+  CandidateQualificationError,
   isCandidateAgent,
   isCandidateAgentEnabled,
   isCandidateAgentSelectable,
   isCandidateQualificationEnabled,
+  readCandidateQualificationReceipt,
   requireCandidateAgentSelectable,
   requireCandidateQualificationEnabled,
 } from "./candidate";
-
-const ENABLED = { NEMOCLAW_CANDIDATE_AGENTS: "1" };
-const QUALIFIED = { NEMOCLAW_CANDIDATE_AGENTS: "1", NEMOCLAW_CANDIDATE_QUALIFICATION: "1" };
 
 describe("candidate agent gate", () => {
   it("treats every declared candidate managed-image agent as a candidate (#7927)", () => {
@@ -26,31 +32,65 @@ describe("candidate agent gate", () => {
     expect(isCandidateAgent("langchain-deepagents-code")).toBe(false);
   });
 
-  it("stays closed until the protected gate is set to exactly 1 (#7927)", () => {
+  it("never activates a candidate from the protected flag alone (#7927)", () => {
+    expect(isCandidateAgentEnabled({ [CANDIDATE_AGENT_FEATURE_ENV]: "1" })).toBe(false);
+    expect(isCandidateAgentSelectable("pi", { [CANDIDATE_AGENT_FEATURE_ENV]: "1" })).toBe(false);
+    expect(() =>
+      requireCandidateAgentSelectable("pi", { [CANDIDATE_AGENT_FEATURE_ENV]: "1" }),
+    ).toThrow("is not selectable in this release");
+  });
+
+  it("stays closed for an ordinary environment without a receipt (#7927)", () => {
     expect(isCandidateAgentEnabled({})).toBe(false);
-    expect(isCandidateAgentEnabled({ NEMOCLAW_CANDIDATE_AGENTS: "0" })).toBe(false);
-    expect(isCandidateAgentEnabled({ NEMOCLAW_CANDIDATE_AGENTS: "true" })).toBe(false);
-    expect(isCandidateAgentEnabled({ NEMOCLAW_CANDIDATE_AGENTS: " 1" })).toBe(false);
-    expect(isCandidateAgentEnabled(ENABLED)).toBe(true);
+    expect(isCandidateAgentEnabled({ [CANDIDATE_AGENT_FEATURE_ENV]: "0" })).toBe(false);
+    expect(isCandidateAgentEnabled({ [CANDIDATE_AGENT_FEATURE_ENV]: "true" })).toBe(false);
   });
 
-  it("requires the candidate agent gate before qualification authority (#7927)", () => {
-    expect(isCandidateQualificationEnabled({ NEMOCLAW_CANDIDATE_QUALIFICATION: "1" })).toBe(false);
-    expect(isCandidateQualificationEnabled(ENABLED)).toBe(false);
-    expect(isCandidateQualificationEnabled(QUALIFIED)).toBe(true);
+  it("selects a candidate only with a digest-pinned receipt (#7927)", () => {
+    const env = candidateQualificationEnvironment();
+
+    expect(isCandidateAgentEnabled(env)).toBe(true);
+    expect(isCandidateAgentSelectable("pi", env)).toBe(true);
+    expect(() => requireCandidateAgentSelectable("pi", env)).not.toThrow();
   });
 
-  it("reports a candidate as selectable only behind the gate (#7927)", () => {
-    expect(isCandidateAgentSelectable("pi", {})).toBe(false);
-    expect(isCandidateAgentSelectable("pi", ENABLED)).toBe(true);
-    expect(isCandidateAgentSelectable("openclaw", {})).toBe(false);
-  });
+  it("refuses a receipt that does not match its pinned digest (#7927)", () => {
+    const env = candidateQualificationEnvironment({ corruptDigest: true });
 
-  it("names the refused candidate in the selection error (#7927)", () => {
-    expect(() => requireCandidateAgentSelectable("pi", {})).toThrow(
-      "Agent 'pi' is a release candidate and is not selectable in this release",
+    expect(() => readCandidateQualificationReceipt("pi", env)).toThrow(CandidateQualificationError);
+    expect(() => readCandidateQualificationReceipt("pi", env)).toThrow(
+      "does not match its pinned digest",
     );
-    expect(() => requireCandidateAgentSelectable("pi", ENABLED)).not.toThrow();
+    expect(isCandidateQualificationEnabled("pi", env)).toBe(false);
+  });
+
+  it("refuses a receipt whose contents change after the digest is pinned (#7927)", () => {
+    const env = candidateQualificationEnvironment();
+    fs.writeFileSync(env.receiptPath, JSON.stringify(candidateQualificationContract("pi")) + " ");
+
+    expect(() => readCandidateQualificationReceipt("pi", env)).toThrow(
+      "does not match its pinned digest",
+    );
+  });
+
+  it("refuses a receipt that claims a shipped agent (#7927)", () => {
+    const contract = { ...candidateQualificationContract("pi"), agent: "hermes" as const };
+    const env = candidateQualificationEnvironment({ contract: contract as never });
+
+    expect(() => readCandidateQualificationReceipt("pi", env)).toThrow(
+      "failed closed contract validation",
+    );
+  });
+
+  it("returns the exact accepted image identity from the receipt (#7927)", () => {
+    const env = candidateQualificationEnvironment();
+    const contract = readCandidateQualificationReceipt("pi", env);
+
+    expect(contract).toMatchObject({
+      agent: "pi",
+      image: "ghcr.io/nvidia/nemoclaw/pi-sandbox",
+    });
+    expect(contract.reference).toBe(`${contract.image}@${contract.digest}`);
   });
 
   it("never refuses a shipped agent through the candidate gate (#7927)", () => {
@@ -60,13 +100,12 @@ describe("candidate agent gate", () => {
     }
   });
 
-  it("refuses to start a candidate without protected qualification authority (#7927)", () => {
+  it("refuses to start a candidate without qualification authority (#7927)", () => {
     expect(() => requireCandidateQualificationEnabled("pi", {})).toThrow(
       "is not selectable in this release",
     );
-    expect(() => requireCandidateQualificationEnabled("pi", ENABLED)).toThrow(
-      "Agent 'pi' requires protected candidate qualification before it can start",
-    );
-    expect(() => requireCandidateQualificationEnabled("pi", QUALIFIED)).not.toThrow();
+    expect(() =>
+      requireCandidateQualificationEnabled("pi", candidateQualificationEnvironment()),
+    ).not.toThrow();
   });
 });

--- a/src/lib/agent/candidate.test.ts
+++ b/src/lib/agent/candidate.test.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { CANDIDATE_MANAGED_IMAGE_AGENTS } from "../onboard/managed-image/contract";
+import {
+  isCandidateAgent,
+  isCandidateAgentEnabled,
+  isCandidateAgentSelectable,
+  isCandidateQualificationEnabled,
+  requireCandidateAgentSelectable,
+  requireCandidateQualificationEnabled,
+} from "./candidate";
+
+const ENABLED = { NEMOCLAW_CANDIDATE_AGENTS: "1" };
+const QUALIFIED = { NEMOCLAW_CANDIDATE_AGENTS: "1", NEMOCLAW_CANDIDATE_QUALIFICATION: "1" };
+
+describe("candidate agent gate", () => {
+  it("treats every declared candidate managed-image agent as a candidate (#7927)", () => {
+    for (const agent of CANDIDATE_MANAGED_IMAGE_AGENTS) {
+      expect(isCandidateAgent(agent)).toBe(true);
+    }
+    expect(isCandidateAgent("openclaw")).toBe(false);
+    expect(isCandidateAgent("hermes")).toBe(false);
+    expect(isCandidateAgent("langchain-deepagents-code")).toBe(false);
+  });
+
+  it("stays closed until the protected gate is set to exactly 1 (#7927)", () => {
+    expect(isCandidateAgentEnabled({})).toBe(false);
+    expect(isCandidateAgentEnabled({ NEMOCLAW_CANDIDATE_AGENTS: "0" })).toBe(false);
+    expect(isCandidateAgentEnabled({ NEMOCLAW_CANDIDATE_AGENTS: "true" })).toBe(false);
+    expect(isCandidateAgentEnabled({ NEMOCLAW_CANDIDATE_AGENTS: " 1" })).toBe(false);
+    expect(isCandidateAgentEnabled(ENABLED)).toBe(true);
+  });
+
+  it("requires the candidate agent gate before qualification authority (#7927)", () => {
+    expect(isCandidateQualificationEnabled({ NEMOCLAW_CANDIDATE_QUALIFICATION: "1" })).toBe(false);
+    expect(isCandidateQualificationEnabled(ENABLED)).toBe(false);
+    expect(isCandidateQualificationEnabled(QUALIFIED)).toBe(true);
+  });
+
+  it("reports a candidate as selectable only behind the gate (#7927)", () => {
+    expect(isCandidateAgentSelectable("pi", {})).toBe(false);
+    expect(isCandidateAgentSelectable("pi", ENABLED)).toBe(true);
+    expect(isCandidateAgentSelectable("openclaw", {})).toBe(false);
+  });
+
+  it("names the refused candidate in the selection error (#7927)", () => {
+    expect(() => requireCandidateAgentSelectable("pi", {})).toThrow(
+      "Agent 'pi' is a release candidate and is not selectable in this release",
+    );
+    expect(() => requireCandidateAgentSelectable("pi", ENABLED)).not.toThrow();
+  });
+
+  it("never refuses a shipped agent through the candidate gate (#7927)", () => {
+    for (const agent of ["openclaw", "hermes", "langchain-deepagents-code"]) {
+      expect(() => requireCandidateAgentSelectable(agent, {})).not.toThrow();
+      expect(() => requireCandidateQualificationEnabled(agent, {})).not.toThrow();
+    }
+  });
+
+  it("refuses to start a candidate without protected qualification authority (#7927)", () => {
+    expect(() => requireCandidateQualificationEnabled("pi", {})).toThrow(
+      "is not selectable in this release",
+    );
+    expect(() => requireCandidateQualificationEnabled("pi", ENABLED)).toThrow(
+      "Agent 'pi' requires protected candidate qualification before it can start",
+    );
+    expect(() => requireCandidateQualificationEnabled("pi", QUALIFIED)).not.toThrow();
+  });
+});

--- a/src/lib/agent/candidate.ts
+++ b/src/lib/agent/candidate.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  type CandidateManagedImageAgent,
+  isCandidateManagedImageAgent,
+} from "../onboard/managed-image/contract";
+
+export const CANDIDATE_AGENT_FEATURE_ENV = "NEMOCLAW_CANDIDATE_AGENTS" as const;
+export const CANDIDATE_AGENT_QUALIFICATION_ENV = "NEMOCLAW_CANDIDATE_QUALIFICATION" as const;
+
+export function isCandidateAgent(name: string): name is CandidateManagedImageAgent {
+  return isCandidateManagedImageAgent(name);
+}
+
+export function isCandidateAgentEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[CANDIDATE_AGENT_FEATURE_ENV] === "1";
+}
+
+export function isCandidateQualificationEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isCandidateAgentEnabled(env) && env[CANDIDATE_AGENT_QUALIFICATION_ENV] === "1";
+}
+
+export function isCandidateAgentSelectable(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return isCandidateAgent(name) && isCandidateAgentEnabled(env);
+}
+
+export function candidateAgentUnavailableMessage(name: string): string {
+  return `Agent '${name}' is a release candidate and is not selectable in this release`;
+}
+
+export function requireCandidateAgentSelectable(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (isCandidateAgent(name) && !isCandidateAgentEnabled(env)) {
+    throw new Error(candidateAgentUnavailableMessage(name));
+  }
+}
+
+export function requireCandidateQualificationEnabled(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  requireCandidateAgentSelectable(name, env);
+  if (isCandidateAgent(name) && !isCandidateQualificationEnabled(env)) {
+    throw new Error(
+      `Agent '${name}' requires protected candidate qualification before it can start`,
+    );
+  }
+}

--- a/src/lib/agent/candidate.ts
+++ b/src/lib/agent/candidate.ts
@@ -11,15 +11,13 @@ import {
   type ManagedImageContractV1,
   parseManagedImageContractV1,
 } from "../onboard/managed-image/contract";
+import { acceptedCandidateReceiptDigests } from "./candidate-authority";
 
 export const CANDIDATE_AGENT_FEATURE_ENV = "NEMOCLAW_CANDIDATE_AGENTS" as const;
 export const CANDIDATE_QUALIFICATION_RECEIPT_ENV =
   "NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT" as const;
-export const CANDIDATE_QUALIFICATION_RECEIPT_SHA256_ENV =
-  "NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256" as const;
 
 const MAX_RECEIPT_BYTES = 64 * 1024;
-const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
 
 export class CandidateQualificationError extends Error {
   constructor(message: string, options?: ErrorOptions) {
@@ -32,49 +30,21 @@ export function isCandidateAgent(name: string): name is CandidateManagedImageAge
   return isCandidateManagedImageAgent(name);
 }
 
-function receiptInputs(env: NodeJS.ProcessEnv): { path: string; sha256: string } | null {
+function receiptPath(env: NodeJS.ProcessEnv): string | null {
   if (env[CANDIDATE_AGENT_FEATURE_ENV] !== "1") return null;
-  const path = env[CANDIDATE_QUALIFICATION_RECEIPT_ENV];
-  const sha256 = env[CANDIDATE_QUALIFICATION_RECEIPT_SHA256_ENV];
-  if (!path || !sha256 || !SHA256_PATTERN.test(sha256)) return null;
-  return { path, sha256 };
-}
-
-/**
- * A candidate agent is selectable only when the protected flag is set and the
- * process also holds a qualification receipt. The flag alone never activates a
- * withheld agent, so ordinary user environment configuration cannot reach it.
- */
-export function isCandidateAgentEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return receiptInputs(env) !== null;
-}
-
-export function isCandidateAgentSelectable(
-  name: string,
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
-  return isCandidateAgent(name) && isCandidateAgentEnabled(env);
+  return env[CANDIDATE_QUALIFICATION_RECEIPT_ENV] || null;
 }
 
 export function candidateAgentUnavailableMessage(name: string): string {
   return `Agent '${name}' is a release candidate and is not selectable in this release`;
 }
 
-export function requireCandidateAgentSelectable(
-  name: string,
-  env: NodeJS.ProcessEnv = process.env,
-): void {
-  if (isCandidateAgent(name) && !isCandidateAgentEnabled(env)) {
-    throw new Error(candidateAgentUnavailableMessage(name));
-  }
-}
-
-function readBoundedReceipt(receiptPath: string): string {
+function readBoundedReceipt(path: string): string {
   let descriptor: number | null = null;
   try {
-    descriptor = fs.openSync(receiptPath, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
+    descriptor = fs.openSync(path, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
     const metadata = fs.fstatSync(descriptor);
-    const pathMetadata = fs.lstatSync(receiptPath);
+    const pathMetadata = fs.lstatSync(path);
     if (
       pathMetadata.isSymbolicLink() ||
       !metadata.isFile() ||
@@ -97,28 +67,38 @@ function readBoundedReceipt(receiptPath: string): string {
 /**
  * Resolve the exact managed-image contract that authorises a candidate agent.
  *
- * The receipt is pinned by digest and revalidated through the shared
- * managed-image contract parser, so it must name the canonical NVIDIA
- * repository for that candidate and carry an exact image digest. A receipt that
- * claims a shipped agent fails closed.
+ * The caller supplies only the receipt location. Whether that receipt qualifies
+ * is decided by the repository-controlled digest list, so a caller-written
+ * receipt is refused however it is hashed or described. An accepted receipt is
+ * then revalidated through the shared managed-image contract parser, which
+ * holds it to the canonical NVIDIA repository for that candidate and an exact
+ * image digest.
  */
 export function readCandidateQualificationReceipt(
   name: string,
   env: NodeJS.ProcessEnv = process.env,
 ): ManagedImageContractV1 {
-  const inputs = receiptInputs(env);
-  if (!inputs) {
+  if (!isCandidateAgent(name)) {
+    throw new CandidateQualificationError(`agent '${name}' is not a release candidate`);
+  }
+  const path = receiptPath(env);
+  if (!path) {
     throw new CandidateQualificationError(
       `agent '${name}' requires a protected candidate qualification receipt`,
     );
   }
-  if (!isCandidateAgent(name)) {
-    throw new CandidateQualificationError(`agent '${name}' is not a release candidate`);
+  const accepted = acceptedCandidateReceiptDigests(name);
+  if (accepted.length === 0) {
+    throw new CandidateQualificationError(
+      `no qualified receipt is published for release candidate '${name}'`,
+    );
   }
-  const contents = readBoundedReceipt(inputs.path);
-  const actual = createHash("sha256").update(contents, "utf8").digest("hex");
-  if (actual !== inputs.sha256) {
-    throw new CandidateQualificationError("the receipt does not match its pinned digest");
+  const contents = readBoundedReceipt(path);
+  const digest = createHash("sha256").update(contents, "utf8").digest("hex");
+  if (!accepted.includes(digest)) {
+    throw new CandidateQualificationError(
+      "the receipt is not a published qualification for that candidate",
+    );
   }
   let parsed: unknown;
   try {
@@ -151,6 +131,27 @@ export function isCandidateQualificationEnabled(
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * A candidate is exposed to selection only once its qualification receipt has
+ * been read, digest-matched against the repository authority, and parsed. The
+ * protected flag and a receipt path are necessary but never sufficient.
+ */
+export function isCandidateAgentSelectable(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return isCandidateAgent(name) && isCandidateQualificationEnabled(name, env);
+}
+
+export function requireCandidateAgentSelectable(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (isCandidateAgent(name) && !isCandidateAgentSelectable(name, env)) {
+    throw new Error(candidateAgentUnavailableMessage(name));
   }
 }
 

--- a/src/lib/agent/candidate.ts
+++ b/src/lib/agent/candidate.ts
@@ -1,24 +1,52 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+
 import {
   type CandidateManagedImageAgent,
   isCandidateManagedImageAgent,
+  isShippedManagedImageAgent,
+  type ManagedImageContractV1,
+  parseManagedImageContractV1,
 } from "../onboard/managed-image/contract";
 
 export const CANDIDATE_AGENT_FEATURE_ENV = "NEMOCLAW_CANDIDATE_AGENTS" as const;
-export const CANDIDATE_AGENT_QUALIFICATION_ENV = "NEMOCLAW_CANDIDATE_QUALIFICATION" as const;
+export const CANDIDATE_QUALIFICATION_RECEIPT_ENV =
+  "NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT" as const;
+export const CANDIDATE_QUALIFICATION_RECEIPT_SHA256_ENV =
+  "NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256" as const;
+
+const MAX_RECEIPT_BYTES = 64 * 1024;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+
+export class CandidateQualificationError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(`Candidate qualification authority is unavailable: ${message}`, options);
+    this.name = "CandidateQualificationError";
+  }
+}
 
 export function isCandidateAgent(name: string): name is CandidateManagedImageAgent {
   return isCandidateManagedImageAgent(name);
 }
 
-export function isCandidateAgentEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env[CANDIDATE_AGENT_FEATURE_ENV] === "1";
+function receiptInputs(env: NodeJS.ProcessEnv): { path: string; sha256: string } | null {
+  if (env[CANDIDATE_AGENT_FEATURE_ENV] !== "1") return null;
+  const path = env[CANDIDATE_QUALIFICATION_RECEIPT_ENV];
+  const sha256 = env[CANDIDATE_QUALIFICATION_RECEIPT_SHA256_ENV];
+  if (!path || !sha256 || !SHA256_PATTERN.test(sha256)) return null;
+  return { path, sha256 };
 }
 
-export function isCandidateQualificationEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return isCandidateAgentEnabled(env) && env[CANDIDATE_AGENT_QUALIFICATION_ENV] === "1";
+/**
+ * A candidate agent is selectable only when the protected flag is set and the
+ * process also holds a qualification receipt. The flag alone never activates a
+ * withheld agent, so ordinary user environment configuration cannot reach it.
+ */
+export function isCandidateAgentEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return receiptInputs(env) !== null;
 }
 
 export function isCandidateAgentSelectable(
@@ -41,14 +69,95 @@ export function requireCandidateAgentSelectable(
   }
 }
 
+function readBoundedReceipt(receiptPath: string): string {
+  let descriptor: number | null = null;
+  try {
+    descriptor = fs.openSync(receiptPath, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0));
+    const metadata = fs.fstatSync(descriptor);
+    const pathMetadata = fs.lstatSync(receiptPath);
+    if (
+      pathMetadata.isSymbolicLink() ||
+      !metadata.isFile() ||
+      metadata.dev !== pathMetadata.dev ||
+      metadata.ino !== pathMetadata.ino ||
+      metadata.size < 2 ||
+      metadata.size > MAX_RECEIPT_BYTES
+    ) {
+      throw new CandidateQualificationError("the receipt must be a bounded regular file");
+    }
+    return fs.readFileSync(descriptor, "utf8");
+  } catch (error) {
+    if (error instanceof CandidateQualificationError) throw error;
+    throw new CandidateQualificationError("the receipt could not be read", { cause: error });
+  } finally {
+    if (descriptor !== null) fs.closeSync(descriptor);
+  }
+}
+
+/**
+ * Resolve the exact managed-image contract that authorises a candidate agent.
+ *
+ * The receipt is pinned by digest and revalidated through the shared
+ * managed-image contract parser, so it must name the canonical NVIDIA
+ * repository for that candidate and carry an exact image digest. A receipt that
+ * claims a shipped agent fails closed.
+ */
+export function readCandidateQualificationReceipt(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env,
+): ManagedImageContractV1 {
+  const inputs = receiptInputs(env);
+  if (!inputs) {
+    throw new CandidateQualificationError(
+      `agent '${name}' requires a protected candidate qualification receipt`,
+    );
+  }
+  if (!isCandidateAgent(name)) {
+    throw new CandidateQualificationError(`agent '${name}' is not a release candidate`);
+  }
+  const contents = readBoundedReceipt(inputs.path);
+  const actual = createHash("sha256").update(contents, "utf8").digest("hex");
+  if (actual !== inputs.sha256) {
+    throw new CandidateQualificationError("the receipt does not match its pinned digest");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (error) {
+    throw new CandidateQualificationError("the receipt is not valid JSON", { cause: error });
+  }
+  let contract: ManagedImageContractV1;
+  try {
+    contract = parseManagedImageContractV1(parsed, name);
+  } catch (error) {
+    throw new CandidateQualificationError("the receipt failed closed contract validation", {
+      cause: error,
+    });
+  }
+  if (isShippedManagedImageAgent(contract.agent)) {
+    throw new CandidateQualificationError(
+      `'${contract.agent}' is already shipped and cannot qualify as a candidate`,
+    );
+  }
+  return contract;
+}
+
+export function isCandidateQualificationEnabled(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  try {
+    readCandidateQualificationReceipt(name, env);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function requireCandidateQualificationEnabled(
   name: string,
   env: NodeJS.ProcessEnv = process.env,
 ): void {
   requireCandidateAgentSelectable(name, env);
-  if (isCandidateAgent(name) && !isCandidateQualificationEnabled(env)) {
-    throw new Error(
-      `Agent '${name}' requires protected candidate qualification before it can start`,
-    );
-  }
+  if (isCandidateAgent(name)) readCandidateQualificationReceipt(name, env);
 }

--- a/src/lib/agent/defs.test.ts
+++ b/src/lib/agent/defs.test.ts
@@ -6,7 +6,17 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { candidateQualificationEnvironment } from "./candidate-test-fixture";
+const authority = vi.hoisted(() => ({ digests: [] as string[] }));
+
+vi.mock("./candidate-authority", () => ({
+  CANDIDATE_QUALIFICATION_RECEIPT_DIGESTS: { pi: authority.digests },
+  acceptedCandidateReceiptDigests: () => authority.digests,
+}));
+
+import {
+  type CandidateQualificationFixture,
+  candidateQualificationEnvironment,
+} from "./candidate-test-fixture";
 import YAML from "yaml";
 
 import {
@@ -28,9 +38,13 @@ function writeTempAgentManifest(name: string, contents: string): void {
   fs.writeFileSync(path.join(agentDir, "manifest.yaml"), contents);
 }
 
+const qualificationFixtures: CandidateQualificationFixture[] = [];
+
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env.NEMOCLAW_AGENT;
+  authority.digests.splice(0, authority.digests.length);
+  while (qualificationFixtures.length > 0) qualificationFixtures.pop()?.cleanup();
   while (tempAgentDirs.length > 0) {
     const agentDir = tempAgentDirs.pop();
     if (agentDir) {
@@ -83,11 +97,21 @@ describe("agent definitions", () => {
   });
 
   it("selects Pi only with protected candidate qualification authority (#7927)", () => {
-    const candidateEnv = candidateQualificationEnvironment();
+    const fixture = candidateQualificationEnvironment();
+    qualificationFixtures.push(fixture);
+    authority.digests.push(fixture.receiptDigest);
 
-    expect(listAgents(candidateEnv)).toContain("pi");
-    expect(resolveAgentNameAlias("pi", listAgents(candidateEnv))).toBe("pi");
-    expect(loadAgent("pi", candidateEnv).name).toBe("pi");
+    expect(listAgents(fixture.env)).toContain("pi");
+    expect(resolveAgentNameAlias("pi", listAgents(fixture.env))).toBe("pi");
+    expect(loadAgent("pi", fixture.env).name).toBe("pi");
+  });
+
+  it("withholds Pi from a receipt the repository has not published (#7927)", () => {
+    const fixture = candidateQualificationEnvironment();
+    qualificationFixtures.push(fixture);
+
+    expect(listAgents(fixture.env)).not.toContain("pi");
+    expect(() => loadAgent("pi", fixture.env)).toThrow("is not selectable in this release");
   });
 
   it("does not expose Pi from the protected flag alone (#7927)", () => {

--- a/src/lib/agent/defs.test.ts
+++ b/src/lib/agent/defs.test.ts
@@ -65,7 +65,9 @@ describe("agent definitions", () => {
     expect(listAgents({})).not.toContain("pi");
     expect(getAgentChoices().map((choice) => choice.name)).not.toContain("pi");
     expect(resolveAgentNameAlias("pi", listAgents({}))).toBeNull();
-    expect(() => loadAgent("pi", {})).toThrow("Pi is not selectable in this release");
+    expect(() => loadAgent("pi", {})).toThrow(
+      "Agent 'pi' is a release candidate and is not selectable in this release",
+    );
   });
 
   it("does not let an ordinary environment setting expose Pi (#7925)", () => {
@@ -73,7 +75,22 @@ describe("agent definitions", () => {
 
     expect(listAgents(ordinaryEnv)).not.toContain("pi");
     expect(resolveAgentNameAlias("pi", listAgents(ordinaryEnv))).toBeNull();
-    expect(() => loadAgent("pi", ordinaryEnv)).toThrow("Pi is not selectable in this release");
+    expect(() => loadAgent("pi", ordinaryEnv)).toThrow(
+      "Agent 'pi' is a release candidate and is not selectable in this release",
+    );
+  });
+
+  it("selects Pi only through the protected candidate gate (#7927)", () => {
+    const candidateEnv = { NEMOCLAW_CANDIDATE_AGENTS: "1" };
+
+    expect(listAgents(candidateEnv)).toContain("pi");
+    expect(resolveAgentNameAlias("pi", listAgents(candidateEnv))).toBe("pi");
+    expect(loadAgent("pi", candidateEnv).name).toBe("pi");
+  });
+
+  it("keeps the candidate gate off for an unrelated environment value (#7927)", () => {
+    expect(listAgents({ NEMOCLAW_CANDIDATE_AGENTS: "0" })).not.toContain("pi");
+    expect(listAgents({ NEMOCLAW_CANDIDATE_AGENTS: "true" })).not.toContain("pi");
   });
 
   it("keeps the Pi candidate manifest readable without public resolution (#7925)", () => {

--- a/src/lib/agent/defs.test.ts
+++ b/src/lib/agent/defs.test.ts
@@ -5,6 +5,8 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { candidateQualificationEnvironment } from "./candidate-test-fixture";
 import YAML from "yaml";
 
 import {
@@ -80,15 +82,16 @@ describe("agent definitions", () => {
     );
   });
 
-  it("selects Pi only through the protected candidate gate (#7927)", () => {
-    const candidateEnv = { NEMOCLAW_CANDIDATE_AGENTS: "1" };
+  it("selects Pi only with protected candidate qualification authority (#7927)", () => {
+    const candidateEnv = candidateQualificationEnvironment();
 
     expect(listAgents(candidateEnv)).toContain("pi");
     expect(resolveAgentNameAlias("pi", listAgents(candidateEnv))).toBe("pi");
     expect(loadAgent("pi", candidateEnv).name).toBe("pi");
   });
 
-  it("keeps the candidate gate off for an unrelated environment value (#7927)", () => {
+  it("does not expose Pi from the protected flag alone (#7927)", () => {
+    expect(listAgents({ NEMOCLAW_CANDIDATE_AGENTS: "1" })).not.toContain("pi");
     expect(listAgents({ NEMOCLAW_CANDIDATE_AGENTS: "0" })).not.toContain("pi");
     expect(listAgents({ NEMOCLAW_CANDIDATE_AGENTS: "true" })).not.toContain("pi");
   });

--- a/src/lib/agent/defs.ts
+++ b/src/lib/agent/defs.ts
@@ -18,7 +18,7 @@ import {
 } from "./aliases";
 import {
   isCandidateAgent,
-  isCandidateAgentEnabled,
+  isCandidateAgentSelectable,
   requireCandidateAgentSelectable,
 } from "./candidate";
 import { type AgentDashboardUi, readDashboardUi } from "./dashboard-ui";
@@ -128,7 +128,7 @@ export function listAgents(env: NodeJS.ProcessEnv = process.env): string[] {
         .readdirSync(AGENTS_DIR, { withFileTypes: true })
         .filter((entry) => entry.isDirectory())
         .filter((entry) => entry.name !== "nemocua")
-        .filter((entry) => !isCandidateAgent(entry.name) || isCandidateAgentEnabled(env))
+        .filter((entry) => !isCandidateAgent(entry.name) || isCandidateAgentSelectable(entry.name, env))
         .filter((entry) => fs.existsSync(path.join(AGENTS_DIR, entry.name, "manifest.yaml")))
         .map((entry) => entry.name)
     : [];

--- a/src/lib/agent/defs.ts
+++ b/src/lib/agent/defs.ts
@@ -495,6 +495,10 @@ export function resolveAgentName({
     const available = listAgents();
     const resolved = resolveAgentNameAlias(session.agent, available);
     if (!resolved) {
+      // A recorded release candidate must fail closed. Falling back to OpenClaw
+      // would silently change the agent a resumed session was created with and
+      // strand its agent-scoped state.
+      requireCandidateAgentSelectable(session.agent);
       console.error(
         `  Warning: session references unknown agent '${session.agent}', falling back to openclaw.`,
       );

--- a/src/lib/agent/defs.ts
+++ b/src/lib/agent/defs.ts
@@ -16,6 +16,11 @@ import {
   formatAgentAliasSuffix,
   resolveAgentNameAlias as resolveKnownAgentNameAlias,
 } from "./aliases";
+import {
+  isCandidateAgent,
+  isCandidateAgentEnabled,
+  requireCandidateAgentSelectable,
+} from "./candidate";
 import { type AgentDashboardUi, readDashboardUi } from "./dashboard-ui";
 import type {
   AgentChoice,
@@ -94,6 +99,7 @@ export const AGENTS_DIR = path.join(ROOT, "agents");
 const _cache = new Map<string, AgentDefinition>();
 
 export { agentAliasSummary } from "./aliases";
+export { requireCandidateQualificationEnabled } from "./candidate";
 
 export function resolveAgentNameAlias(
   value: string | null | undefined,
@@ -122,7 +128,7 @@ export function listAgents(env: NodeJS.ProcessEnv = process.env): string[] {
         .readdirSync(AGENTS_DIR, { withFileTypes: true })
         .filter((entry) => entry.isDirectory())
         .filter((entry) => entry.name !== "nemocua")
-        .filter((entry) => entry.name !== "pi")
+        .filter((entry) => !isCandidateAgent(entry.name) || isCandidateAgentEnabled(env))
         .filter((entry) => fs.existsSync(path.join(AGENTS_DIR, entry.name, "manifest.yaml")))
         .map((entry) => entry.name)
     : [];
@@ -157,7 +163,7 @@ export function requireAgentPolicyAdditionsPath(
  */
 export function loadAgent(name: string, env: NodeJS.ProcessEnv = process.env): AgentDefinition {
   if (name === "nemocua") requireCuaFrameworkEnabled(env);
-  if (name === "pi") throw new Error("Pi is not selectable in this release");
+  requireCandidateAgentSelectable(name, env);
   const externalCua = name === "nemocua";
   const manifestPath = externalCua
     ? getCuaExternalAgentManifestPath(env)

--- a/src/lib/agent/onboard.ts
+++ b/src/lib/agent/onboard.ts
@@ -47,6 +47,7 @@ import {
   isTerminalAgent,
   loadAgent,
   requireAgentPolicyAdditionsPath,
+  requireCandidateQualificationEnabled,
   resolveAgentName,
 } from "./defs";
 import { waitForAgentGatewayReady } from "./gateway-readiness";
@@ -184,6 +185,7 @@ export function resolveAgent({
   if (name === "nemocua" && !isCuaQualificationEnabled()) {
     throw new Error("NemoCUA candidate onboarding requires exact qualification authority");
   }
+  requireCandidateQualificationEnabled(name);
   return loadAgent(name);
 }
 

--- a/src/lib/agent/pi-lifecycle.test.ts
+++ b/src/lib/agent/pi-lifecycle.test.ts
@@ -1,7 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const authority = vi.hoisted(() => ({ digests: [] as string[] }));
+
+vi.mock("./candidate-authority", () => ({
+  CANDIDATE_QUALIFICATION_RECEIPT_DIGESTS: { pi: authority.digests },
+  acceptedCandidateReceiptDigests: () => authority.digests,
+}));
 
 import {
   MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
@@ -21,7 +28,11 @@ import { candidateQualificationEnvironment } from "./candidate-test-fixture";
 import { loadAgent } from "./defs";
 import { resolveAgent } from "./onboard";
 
-const CANDIDATE_ENV = candidateQualificationEnvironment();
+const QUALIFICATION = candidateQualificationEnvironment();
+const CANDIDATE_ENV = QUALIFICATION.env;
+authority.digests.push(QUALIFICATION.receiptDigest);
+afterAll(() => QUALIFICATION.cleanup());
+
 const PLATFORM = MANAGED_IMAGE_PLATFORMS[0];
 const DIGEST = `sha256:${"7a".repeat(32)}` as const;
 
@@ -77,6 +88,55 @@ describe("Pi candidate lifecycle integration", () => {
     }
   });
 
+  it("never falls back to a host Dockerfile for an enabled candidate (#7927)", () => {
+    const permissive = (
+      overrides: Partial<SandboxWorkloadRuntimeCapabilities>,
+    ): SandboxWorkloadRuntimeCapabilities => ({
+      ...capableRuntime("docker"),
+      managedImageSelectionPolicy: "prefer-managed",
+      legacyDockerfileBuilds: true,
+      ...overrides,
+    });
+    const resolve = (
+      runtime: SandboxWorkloadRuntimeCapabilities,
+      catalog: Record<string, ManagedImageContractV1> = { pi: piContract() },
+    ) =>
+      resolveSandboxWorkloadSource({
+        agentName: "pi",
+        legacyDockerfilePath: "agents/pi/Dockerfile",
+        runtime,
+        catalog,
+        candidateAgentsEnabled: true,
+      });
+
+    expect(() => resolve(permissive({ managedImages: null }))).toThrow(
+      "Managed image workload is required for 'pi'",
+    );
+    expect(() =>
+      resolve(
+        permissive({
+          managedImages: {
+            ...capableRuntime("docker").managedImages!,
+            exactDigestReferences: false,
+          },
+        }),
+      ),
+    ).toThrow("Managed image workload is required for 'pi'");
+    expect(() => resolve(permissive({}), {})).toThrow(
+      "Managed image workload is required for 'pi'",
+    );
+    expect(() =>
+      resolveSandboxWorkloadSource({
+        agentName: "pi",
+        legacyDockerfilePath: "agents/pi/Dockerfile",
+        customDockerfilePath: "/tmp/Dockerfile.pi",
+        runtime: permissive({}),
+        catalog: { pi: piContract() },
+        candidateAgentsEnabled: true,
+      }),
+    ).toThrow("a custom Dockerfile is not accepted");
+  });
+
   it("keeps the Pi workload identity independent of the compute runtime (#7927)", () => {
     const identity = managedImageRuntimeIdentity("pi");
 
@@ -106,7 +166,6 @@ describe("Pi candidate lifecycle integration", () => {
   it("refuses a public --agent pi selection without qualification authority (#7927)", () => {
     vi.stubEnv("NEMOCLAW_CANDIDATE_AGENTS", "");
     vi.stubEnv("NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT", "");
-    vi.stubEnv("NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256", "");
     try {
       expect(() => resolveAgent({ agentFlag: "pi" })).toThrow("Unknown agent 'pi'");
       expect(() => resolveAgent({ session: { agent: "pi" } })).toThrow(

--- a/src/lib/agent/pi-lifecycle.test.ts
+++ b/src/lib/agent/pi-lifecycle.test.ts
@@ -17,9 +17,11 @@ import {
   resolveSandboxWorkloadSource,
   type SandboxWorkloadRuntimeCapabilities,
 } from "../onboard/workload/source";
+import { candidateQualificationEnvironment } from "./candidate-test-fixture";
 import { loadAgent } from "./defs";
+import { resolveAgent } from "./onboard";
 
-const CANDIDATE_ENV = { NEMOCLAW_CANDIDATE_AGENTS: "1" };
+const CANDIDATE_ENV = candidateQualificationEnvironment();
 const PLATFORM = MANAGED_IMAGE_PLATFORMS[0];
 const DIGEST = `sha256:${"7a".repeat(32)}` as const;
 
@@ -99,6 +101,19 @@ describe("Pi candidate lifecycle integration", () => {
       settings?.restore?.merge === "key-allowlist" ? settings.restore.userKeys : undefined;
     expect(userKeys?.map(({ key }) => key)).toContain("theme");
     expect(userKeys?.map(({ key }) => key)).not.toContain("models");
+  });
+
+  it("refuses a public --agent pi selection without qualification authority (#7927)", () => {
+    const previous = { ...process.env };
+    try {
+      delete process.env.NEMOCLAW_CANDIDATE_AGENTS;
+      delete process.env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT;
+      delete process.env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256;
+      expect(() => resolveAgent({ agentFlag: "pi" })).toThrow("Unknown agent 'pi'");
+      expect(() => resolveAgent({ session: { agent: "pi" } })).not.toThrow();
+    } finally {
+      process.env = previous;
+    }
   });
 
   it("resolves Pi as a terminal runtime without a dashboard or MCP surface (#7927)", () => {

--- a/src/lib/agent/pi-lifecycle.test.ts
+++ b/src/lib/agent/pi-lifecycle.test.ts
@@ -176,6 +176,30 @@ describe("Pi candidate lifecycle integration", () => {
     }
   });
 
+  it("refuses a public --agent pi selection when the candidate flag has no receipt (#7927)", () => {
+    vi.stubEnv("NEMOCLAW_CANDIDATE_AGENTS", "1");
+    vi.stubEnv("NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT", "");
+    try {
+      expect(() => resolveAgent({ agentFlag: "pi" })).toThrow("Unknown agent 'pi'");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("resolves Pi from public flag and session boundaries with qualification (#7927)", () => {
+    vi.stubEnv("NEMOCLAW_CANDIDATE_AGENTS", String(CANDIDATE_ENV.NEMOCLAW_CANDIDATE_AGENTS));
+    vi.stubEnv(
+      "NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT",
+      String(CANDIDATE_ENV.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT),
+    );
+    try {
+      expect(resolveAgent({ agentFlag: "pi" })?.name).toBe("pi");
+      expect(resolveAgent({ session: { agent: "pi" } })?.name).toBe("pi");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("resolves Pi as a terminal runtime without a dashboard or MCP surface (#7927)", () => {
     const agent = loadAgent("pi", CANDIDATE_ENV);
 

--- a/src/lib/agent/pi-lifecycle.test.ts
+++ b/src/lib/agent/pi-lifecycle.test.ts
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
+  MANAGED_IMAGE_CONTRACT_VERSION,
+  MANAGED_IMAGE_PLATFORMS,
+  MANAGED_IMAGE_REPOSITORIES,
+  MANAGED_IMAGE_SOURCE_REPOSITORY,
+  MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
+  type ManagedImageContractV1,
+  managedImageRuntimeIdentity,
+} from "../onboard/managed-image/contract";
+import {
+  resolveSandboxWorkloadSource,
+  type SandboxWorkloadRuntimeCapabilities,
+} from "../onboard/workload/source";
+import { loadAgent } from "./defs";
+
+const CANDIDATE_ENV = { NEMOCLAW_CANDIDATE_AGENTS: "1" };
+const PLATFORM = MANAGED_IMAGE_PLATFORMS[0];
+const DIGEST = `sha256:${"7a".repeat(32)}` as const;
+
+function piContract(): ManagedImageContractV1 {
+  const image = MANAGED_IMAGE_REPOSITORIES.pi;
+  return {
+    contractVersion: MANAGED_IMAGE_CONTRACT_VERSION,
+    agent: "pi",
+    platform: PLATFORM,
+    image,
+    digest: DIGEST,
+    reference: `${image}@${DIGEST}`,
+    source: {
+      repository: MANAGED_IMAGE_SOURCE_REPOSITORY,
+      revision: "d".repeat(40),
+      release: "v0.0.100",
+      cohort: "ghrun-7927-1",
+    },
+    startupProfileContractVersion: MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
+    capabilityContractVersion: MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
+  };
+}
+
+function capableRuntime(driverName: string): SandboxWorkloadRuntimeCapabilities {
+  return {
+    driverName,
+    managedImageSelectionPolicy: "require-managed",
+    legacyDockerfileBuilds: false,
+    managedImages: {
+      exactDigestReferences: true,
+      platforms: [PLATFORM],
+      startupProfileContractVersions: [MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION],
+      capabilityContractVersions: [MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION],
+    },
+  };
+}
+
+describe("Pi candidate lifecycle integration", () => {
+  it("selects the identical Pi workload across injected compute runtimes (#7927)", () => {
+    const sources = ["docker", "mxc-shaped-test", "portable-test"].map((driverName) =>
+      resolveSandboxWorkloadSource({
+        agentName: "pi",
+        legacyDockerfilePath: "agents/pi/Dockerfile",
+        runtime: capableRuntime(driverName),
+        catalog: { pi: piContract() },
+        candidateAgentsEnabled: true,
+      }),
+    );
+
+    for (const source of sources) {
+      expect(source).toEqual(sources[0]);
+      expect(source).toMatchObject({ kind: "managed-image", reference: piContract().reference });
+    }
+  });
+
+  it("keeps the Pi workload identity independent of the compute runtime (#7927)", () => {
+    const identity = managedImageRuntimeIdentity("pi");
+
+    expect(identity).toEqual({ uid: 999, gid: 999, workdir: "/sandbox" });
+    expect(MANAGED_IMAGE_REPOSITORIES.pi).toBe("ghcr.io/nvidia/nemoclaw/pi-sandbox");
+  });
+
+  it("backs up only the state the Pi manifest declares persistent (#7927)", () => {
+    const agent = loadAgent("pi", CANDIDATE_ENV);
+
+    expect(agent.backupStateDirs).toEqual(["sessions", "prompts", "themes"]);
+    expect(agent.nonBackupStateDirs).toEqual(["tools", "bin"]);
+    expect(agent.stateFiles.map(({ path: statePath }) => statePath)).toEqual(["settings.json"]);
+  });
+
+  it("restores Pi user preferences only through the allowlisted key contract (#7927)", () => {
+    const agent = loadAgent("pi", CANDIDATE_ENV);
+    const settings = agent.stateFiles.find(({ path: statePath }) => statePath === "settings.json");
+
+    expect(settings?.restore?.merge).toBe("key-allowlist");
+    const userKeys =
+      settings?.restore?.merge === "key-allowlist" ? settings.restore.userKeys : undefined;
+    expect(userKeys?.map(({ key }) => key)).toContain("theme");
+    expect(userKeys?.map(({ key }) => key)).not.toContain("models");
+  });
+
+  it("resolves Pi as a terminal runtime without a dashboard or MCP surface (#7927)", () => {
+    const agent = loadAgent("pi", CANDIDATE_ENV);
+
+    expect(agent.runtime?.kind).toBe("terminal");
+    expect(agent.forwardPort).toBe(0);
+    expect(agent.healthProbe).toBeNull();
+    expect(agent.hasDevicePairing).toBe(false);
+    expect(agent.mcpCapability.support).toBe("disabled");
+  });
+});

--- a/src/lib/agent/pi-lifecycle.test.ts
+++ b/src/lib/agent/pi-lifecycle.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
@@ -104,15 +104,16 @@ describe("Pi candidate lifecycle integration", () => {
   });
 
   it("refuses a public --agent pi selection without qualification authority (#7927)", () => {
-    const previous = { ...process.env };
+    vi.stubEnv("NEMOCLAW_CANDIDATE_AGENTS", "");
+    vi.stubEnv("NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT", "");
+    vi.stubEnv("NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256", "");
     try {
-      delete process.env.NEMOCLAW_CANDIDATE_AGENTS;
-      delete process.env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT;
-      delete process.env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256;
       expect(() => resolveAgent({ agentFlag: "pi" })).toThrow("Unknown agent 'pi'");
-      expect(() => resolveAgent({ session: { agent: "pi" } })).not.toThrow();
+      expect(() => resolveAgent({ session: { agent: "pi" } })).toThrow(
+        "Agent 'pi' is a release candidate and is not selectable in this release",
+      );
     } finally {
-      process.env = previous;
+      vi.unstubAllEnvs();
     }
   });
 

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
@@ -254,7 +254,7 @@ function startInput(agent: ManagedStartupAgent, fake: ReturnType<typeof harness>
 
 describe("Podman image-owned bootstrap transaction", () => {
   it.each(
-    MANAGED_STARTUP_AGENTS,
+    MANAGED_STARTUP_AGENTS.filter((agent) => agent !== "pi"),
   )("stages, starts, and authenticates one protected %s completion without exec", (agent) => {
     const fake = harness(agent);
     const transaction = startPodmanBootstrapImageTransaction(startInput(agent, fake), {
@@ -542,5 +542,15 @@ describe("Podman image-owned bootstrap transaction", () => {
       ),
     ).toThrow("not published before timeout");
     expect(fake.completionAttempts()).toBe(3);
+  });
+
+  it("refuses to bootstrap a release candidate on Podman (#7927)", () => {
+    const fake = harness("pi");
+
+    expect(() =>
+      startPodmanBootstrapImageTransaction(startInput("pi", fake), {
+        now: () => new Date("2026-08-01T12:00:00.000Z"),
+      }),
+    ).toThrow("the managed agent is unsupported");
   });
 });

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.test.ts
@@ -551,6 +551,6 @@ describe("Podman image-owned bootstrap transaction", () => {
       startPodmanBootstrapImageTransaction(startInput("pi", fake), {
         now: () => new Date("2026-08-01T12:00:00.000Z"),
       }),
-    ).toThrow("the managed agent is unsupported");
+    ).toThrow("agent 'pi' is not supported on Podman; onboard it through the Docker compute runtime");
   });
 });

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.ts
@@ -127,11 +127,13 @@ function exactEngine(engine: BootstrapEngine, expectedAuthorityId?: string): Boo
 }
 
 function exactAgent(value: string): ManagedStartupAgent {
-  if (
-    Object.prototype.hasOwnProperty.call(PODMAN_BOOTSTRAP_AGENTS, value) &&
-    PODMAN_BOOTSTRAP_AGENTS[value as ManagedStartupAgent]
-  ) {
-    return value as ManagedStartupAgent;
+  if (Object.prototype.hasOwnProperty.call(PODMAN_BOOTSTRAP_AGENTS, value)) {
+    if (PODMAN_BOOTSTRAP_AGENTS[value as ManagedStartupAgent]) {
+      return value as ManagedStartupAgent;
+    }
+    return fail(
+      `agent '${value}' is not supported on Podman; onboard it through the Docker compute runtime`,
+    );
   }
   return fail("the managed agent is unsupported");
 }

--- a/src/lib/onboard/managed-bootstrap/podman-image-transaction.ts
+++ b/src/lib/onboard/managed-bootstrap/podman-image-transaction.ts
@@ -49,7 +49,8 @@ const PODMAN_BOOTSTRAP_AGENTS = Object.freeze({
   openclaw: true,
   hermes: true,
   "langchain-deepagents-code": true,
-} satisfies Record<ManagedStartupAgent, true>);
+  pi: false,
+} satisfies Record<ManagedStartupAgent, boolean>);
 
 export interface PodmanBootstrapImageTransactionInput {
   readonly engine: BootstrapEngine;
@@ -126,7 +127,10 @@ function exactEngine(engine: BootstrapEngine, expectedAuthorityId?: string): Boo
 }
 
 function exactAgent(value: string): ManagedStartupAgent {
-  if (Object.prototype.hasOwnProperty.call(PODMAN_BOOTSTRAP_AGENTS, value)) {
+  if (
+    Object.prototype.hasOwnProperty.call(PODMAN_BOOTSTRAP_AGENTS, value) &&
+    PODMAN_BOOTSTRAP_AGENTS[value as ManagedStartupAgent]
+  ) {
     return value as ManagedStartupAgent;
   }
   return fail("the managed agent is unsupported");

--- a/src/lib/onboard/managed-startup-agent-environment.test.ts
+++ b/src/lib/onboard/managed-startup-agent-environment.test.ts
@@ -225,6 +225,48 @@ function dcodeProfile(): ManagedStartupProfile {
   };
 }
 
+function piProfile(): ManagedStartupProfile {
+  return {
+    schemaVersion: MANAGED_STARTUP_PROFILE_SCHEMA_VERSION,
+    agent: "pi",
+    agentConfig: { agent: "pi" },
+    inference: {
+      routeProvider: "inference",
+      upstreamProvider: "nvidia",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      routedBaseUrl: "https://inference.local/v1",
+      upstreamEndpointUrl: null,
+      api: "openai-completions",
+      primaryModelRef: null,
+      compatibility: null,
+      inputModalities: null,
+    },
+    proxy: {
+      managedHost: "10.200.0.1",
+      managedPort: 3128,
+      hostHttpUrl: null,
+      hostHttpsUrl: null,
+      hostNoProxy: [],
+    },
+    dashboard: {
+      agent: "pi",
+      mode: "disabled",
+    },
+    tools: {
+      disclosure: "progressive",
+      enabledGateways: [],
+    },
+    messaging: { plan: null },
+    tuning: {
+      contextWindow: null,
+      maxTokens: null,
+      reasoning: null,
+      reasoningEffort: null,
+    },
+    corporateCa: { bundleSha256: CA_SHA256 },
+  };
+}
+
 function decodeBase64Json(encoded: string): unknown {
   return JSON.parse(Buffer.from(encoded, "base64").toString("utf8")) as unknown;
 }
@@ -243,6 +285,7 @@ const PROFILES: Readonly<Record<ManagedStartupAgent, () => ManagedStartupProfile
   openclaw: openClawProfile,
   hermes: hermesProfile,
   "langchain-deepagents-code": dcodeProfile,
+  pi: piProfile,
 };
 
 describe("managed startup agent environment", () => {
@@ -691,7 +734,7 @@ describe("managed startup agent environment", () => {
       (action) => action.kind === "apply-messaging-plan",
     );
     expect(messagingActions.map(({ phase, runAs }) => [phase, runAs])).toEqual(
-      agent === "langchain-deepagents-code"
+      agent === "langchain-deepagents-code" || agent === "pi"
         ? []
         : [
             ["runtime-setup", "root"],

--- a/src/lib/onboard/managed-startup-application.test.ts
+++ b/src/lib/onboard/managed-startup-application.test.ts
@@ -125,7 +125,8 @@ function profileFor(
     },
     messaging: { plan: null },
     tuning: {
-      contextWindow: agent === "langchain-deepagents-code" ? null : 65_536,
+      contextWindow:
+        agent === "langchain-deepagents-code" || agent === "pi" ? null : 65_536,
       maxTokens: agent === "openclaw" ? 8192 : null,
       reasoning: agent === "openclaw" ? true : null,
       reasoningEffort: agent === "openclaw" ? "default" : null,

--- a/src/lib/onboard/managed-startup-application.test.ts
+++ b/src/lib/onboard/managed-startup-application.test.ts
@@ -50,6 +50,8 @@ function agentConfigFor(agent: ManagedStartupAgent): ManagedStartupAgentConfig {
       return { agent, webSearch: { enabled: false, provider: "tavily" } };
     case "langchain-deepagents-code":
       return { agent, autoApprovalMode: "thread-opt-in", observabilityEnabled: true };
+    case "pi":
+      return { agent };
   }
 }
 
@@ -101,10 +103,9 @@ function profileFor(
             internalPort: null,
             tuiEnabled: false as const,
           }
-        : {
-            agent,
-            mode: "disabled" as const,
-          };
+        : agent === "pi"
+          ? { agent, mode: "disabled" as const }
+          : { agent, mode: "disabled" as const };
   return {
     schemaVersion: MANAGED_STARTUP_PROFILE_SCHEMA_VERSION,
     agent,

--- a/src/lib/onboard/managed-startup-clone-rebinder.test.ts
+++ b/src/lib/onboard/managed-startup-clone-rebinder.test.ts
@@ -164,9 +164,9 @@ function rebind(
 ) {
   const profile = built.profile;
   const webSearch =
-    profile.agentConfig.agent === "langchain-deepagents-code"
-      ? null
-      : profile.agentConfig.webSearch;
+    profile.agentConfig.agent === "openclaw" || profile.agentConfig.agent === "hermes"
+      ? profile.agentConfig.webSearch
+      : null;
   const hermesDashboard = profile.dashboard.agent === "hermes" ? profile.dashboard : null;
   const dcodeConfig =
     profile.agentConfig.agent === "langchain-deepagents-code" ? profile.agentConfig : null;

--- a/src/lib/onboard/managed-startup-coordinator.test.ts
+++ b/src/lib/onboard/managed-startup-coordinator.test.ts
@@ -78,6 +78,9 @@ function adaptersFor(order: string[] = []): {
     "langchain-deepagents-code": vi.fn(async () => {
       order.push("apply:langchain-deepagents-code");
     }),
+    pi: vi.fn(async () => {
+      order.push("apply:pi");
+    }),
   };
   return {
     adapters: [
@@ -87,6 +90,7 @@ function adaptersFor(order: string[] = []): {
         agent: "langchain-deepagents-code",
         apply: applyByAgent["langchain-deepagents-code"],
       },
+      { agent: "pi", apply: applyByAgent.pi },
     ],
     applyByAgent,
   };

--- a/src/lib/onboard/managed-startup-image-runtime-handoff.test.ts
+++ b/src/lib/onboard/managed-startup-image-runtime-handoff.test.ts
@@ -136,7 +136,7 @@ describe("managed startup image runtime handoff and descriptor integrity", () =>
     });
 
     expect(plan.map(({ action }) => action)).toEqual(
-      agent === "langchain-deepagents-code"
+      agent === "langchain-deepagents-code" || agent === "pi"
         ? ["generate-agent-config"]
         : ["messaging-runtime-setup", "generate-agent-config", "messaging-post-agent-install"],
     );

--- a/src/lib/onboard/managed-startup-image-runtime.test.ts
+++ b/src/lib/onboard/managed-startup-image-runtime.test.ts
@@ -74,6 +74,8 @@ function dashboard(agent: ManagedStartupAgent): ManagedStartupDashboard {
       };
     case "langchain-deepagents-code":
       return { agent, mode: "disabled" };
+    case "pi":
+      return { agent, mode: "disabled" };
   }
 }
 
@@ -82,7 +84,7 @@ function actionInput(
   mode: "apply" | "clear" = "apply",
 ): ManagedStartupImageActionPlanInput {
   const messagingActions =
-    agent === "langchain-deepagents-code"
+    agent === "langchain-deepagents-code" || agent === "pi"
       ? []
       : [
           {

--- a/src/lib/onboard/managed-startup-image-runtime.test.ts
+++ b/src/lib/onboard/managed-startup-image-runtime.test.ts
@@ -160,6 +160,7 @@ describe("buildManagedStartupImageActionPlan", () => {
     ["openclaw", "/scripts/generate-openclaw-config.mts"],
     ["hermes", "/opt/nemoclaw-hermes-config/generate-config.ts"],
     ["langchain-deepagents-code", "/opt/nemoclaw-deepagents-code/generate-config.ts"],
+    ["pi", "/opt/nemoclaw-pi/generate-config.ts"],
   ] as const)("selects the reviewed %s generator asset", (agent, generator) => {
     const command = buildManagedStartupImageActionPlan(actionInput(agent)).find(
       ({ action }) => action === "generate-agent-config",

--- a/src/lib/onboard/managed-startup-profile.test.ts
+++ b/src/lib/onboard/managed-startup-profile.test.ts
@@ -248,6 +248,7 @@ const STOCK_DOCKER_ARGS = {
   "langchain-deepagents-code": dockerArgs(
     path.join(process.cwd(), "agents/langchain-deepagents-code/Dockerfile"),
   ),
+  pi: dockerArgs(path.join(process.cwd(), "agents/pi/Dockerfile")),
 } satisfies Record<ManagedStartupAgent, Set<string>>;
 
 const RUNTIME_INPUT_SOURCE_FILES = [

--- a/src/lib/onboard/managed-startup-shared-state-transaction.test.ts
+++ b/src/lib/onboard/managed-startup-shared-state-transaction.test.ts
@@ -128,6 +128,9 @@ describe("managed startup shared-state transaction", () => {
         fs.mkdirSync(path.join(root, ".state"));
         fs.mkdirSync(path.join(root, "skills"));
       },
+      pi: () => {
+        fs.mkdirSync(path.join(root, "agent"));
+      },
     };
     createManagedDrift[agent]();
 
@@ -144,6 +147,7 @@ describe("managed startup shared-state transaction", () => {
       openclaw: [".config-hash"],
       hermes: [".config-hash"],
       "langchain-deepagents-code": [".state", "skills"],
+      pi: ["agent"],
     };
     for (const relativePath of absentManagedPaths[agent]) {
       expect(fs.existsSync(path.join(root, relativePath))).toBe(false);

--- a/src/lib/onboard/managed-startup-shared-state-transaction.test.ts
+++ b/src/lib/onboard/managed-startup-shared-state-transaction.test.ts
@@ -67,7 +67,13 @@ describe("managed startup shared-state transaction", () => {
   function agentRoot(agent: ManagedStartupAgent): string {
     return path.join(
       sandboxRoot,
-      agent === "openclaw" ? ".openclaw" : agent === "hermes" ? ".hermes" : ".deepagents",
+      agent === "openclaw"
+        ? ".openclaw"
+        : agent === "hermes"
+          ? ".hermes"
+          : agent === "pi"
+            ? ".pi"
+            : ".deepagents",
     );
   }
 
@@ -96,6 +102,7 @@ describe("managed startup shared-state transaction", () => {
     "openclaw",
     "hermes",
     "langchain-deepagents-code",
+    "pi",
   ] as const)("restores exact %s bytes, ownership, modes, and absence receipts", (agent) => {
     const root = agentRoot(agent);
     fs.mkdirSync(root, { mode: 0o750 });
@@ -108,7 +115,9 @@ describe("managed startup shared-state transaction", () => {
               ["config.yaml", "hermes-original\n", 0o640] as const,
               [".env", "TOKEN=original\n", 0o600] as const,
             ]
-          : [["config.toml", "dcode-original\n", 0o660] as const];
+          : agent === "pi"
+            ? []
+            : [["config.toml", "dcode-original\n", 0o660] as const];
     for (const [name, contents, fileMode] of originalFiles) {
       const target = path.join(root, name);
       fs.writeFileSync(target, contents);
@@ -130,6 +139,7 @@ describe("managed startup shared-state transaction", () => {
       },
       pi: () => {
         fs.mkdirSync(path.join(root, "agent"));
+        fs.writeFileSync(path.join(root, "agent", "models.json"), "{}\n");
       },
     };
     createManagedDrift[agent]();
@@ -147,7 +157,7 @@ describe("managed startup shared-state transaction", () => {
       openclaw: [".config-hash"],
       hermes: [".config-hash"],
       "langchain-deepagents-code": [".state", "skills"],
-      pi: ["agent"],
+      pi: ["agent", path.join("agent", "models.json")],
     };
     for (const relativePath of absentManagedPaths[agent]) {
       expect(fs.existsSync(path.join(root, relativePath))).toBe(false);

--- a/src/lib/onboard/managed-startup/agent-environment.ts
+++ b/src/lib/onboard/managed-startup/agent-environment.ts
@@ -40,7 +40,9 @@ export interface ManagedStartupRootOwnedFileMaterial {
     | "/usr/local/share/nemoclaw/dcode-inference-base-url"
     | "/usr/local/share/nemoclaw/dcode-proxy-host"
     | "/usr/local/share/nemoclaw/dcode-proxy-port"
-    | "/usr/local/share/nemoclaw/dcode-reasoning-effort";
+    | "/usr/local/share/nemoclaw/dcode-reasoning-effort"
+    | "/usr/local/share/nemoclaw/pi-proxy-host"
+    | "/usr/local/share/nemoclaw/pi-proxy-port";
   readonly contents: string;
   readonly owner: "root";
   readonly group: "root";
@@ -545,6 +547,60 @@ function mapDcodeProfile(
   });
 }
 
+function mapPiProfile(
+  profile: ManagedStartupProfile,
+  environment: ApplicationEnvironment,
+): ManagedStartupAgentEnvironment {
+  if (
+    profile.agent !== "pi" ||
+    profile.agentConfig.agent !== "pi" ||
+    profile.dashboard.agent !== "pi" ||
+    profile.messaging.plan !== null
+  ) {
+    throw new ManagedStartupAgentEnvironmentError("Pi profile state is inconsistent");
+  }
+
+  const configurationEnvironment: MutableEnvironment = {
+    ...commonConfigurationEnvironment(profile),
+  };
+  appendHostProxyEnvironment(configurationEnvironment, profile);
+  const runtimeEnvironment: MutableEnvironment = { ...configurationEnvironment };
+  delete runtimeEnvironment.NEMOCLAW_INFERENCE_BASE_URL;
+  for (const name of [
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+  ]) {
+    delete runtimeEnvironment[name];
+  }
+  const materials: readonly ManagedStartupAgentMaterial[] = Object.freeze([
+    corporateCaMaterial(profile),
+    rootOwnedFile(
+      "NEMOCLAW_PROXY_HOST",
+      "/usr/local/share/nemoclaw/pi-proxy-host",
+      profile.proxy.managedHost,
+    ),
+    rootOwnedFile(
+      "NEMOCLAW_PROXY_PORT",
+      "/usr/local/share/nemoclaw/pi-proxy-port",
+      String(profile.proxy.managedPort),
+    ),
+  ]);
+
+  return Object.freeze({
+    schemaVersion: profile.schemaVersion,
+    agent: profile.agent,
+    configurationEnvironment: sortedEnvironment(configurationEnvironment),
+    runtimeEnvironment: sortedEnvironment(runtimeEnvironment),
+    applicationRuntime: applicationRuntimePlan(profile, environment),
+    materials,
+    actions: applicationActions(profile, null),
+  });
+}
+
 /**
  * Convert a secret-free validated profile into existing agent-generator and
  * entrypoint inputs without depending on Docker, Podman, or another compute
@@ -563,5 +619,7 @@ export function mapManagedStartupProfileToAgentEnvironment(
       return mapHermesProfile(validated, environment);
     case "langchain-deepagents-code":
       return mapDcodeProfile(validated, environment);
+    case "pi":
+      return mapPiProfile(validated, environment);
   }
 }

--- a/src/lib/onboard/managed-startup/clone-rebinder.ts
+++ b/src/lib/onboard/managed-startup/clone-rebinder.ts
@@ -180,8 +180,8 @@ function currentWebSearch(
   profile: ManagedStartupProfile,
   current: ManagedStartupCloneCurrentState,
 ): Extract<ManagedStartupProfile["agentConfig"], { agent: "openclaw" | "hermes" }>["webSearch"] {
-  if (profile.agentConfig.agent === "langchain-deepagents-code") {
-    fail("DCode cannot carry web-search state");
+  if (profile.agentConfig.agent !== "openclaw" && profile.agentConfig.agent !== "hermes") {
+    fail(`${profile.agentConfig.agent} cannot carry web-search state`);
   }
   const enabled = current.webSearchEnabled === true;
   const configuredProvider = current.webSearchProvider;
@@ -209,6 +209,9 @@ function currentAgentConfig(
   profile: ManagedStartupProfile,
   current: ManagedStartupCloneCurrentState,
 ): ManagedStartupProfile["agentConfig"] {
+  if (profile.agentConfig.agent === "pi") {
+    return profile.agentConfig;
+  }
   if (profile.agentConfig.agent !== "langchain-deepagents-code") {
     return {
       ...profile.agentConfig,
@@ -396,8 +399,8 @@ function destinationMessagingPlan(
   destinationSandboxName: string,
 ): ManagedStartupJsonObject | null {
   if (profile.messaging.plan === null) return null;
-  if (profile.agent === "langchain-deepagents-code") {
-    fail("langchain-deepagents-code cannot carry a messaging plan");
+  if (profile.agent === "langchain-deepagents-code" || profile.agent === "pi") {
+    fail(`${profile.agent} cannot carry a messaging plan`);
   }
   const rebound = rebindSandboxMessagingPlanForClone({
     sourceSandboxName,

--- a/src/lib/onboard/managed-startup/image-runtime.ts
+++ b/src/lib/onboard/managed-startup/image-runtime.ts
@@ -525,6 +525,12 @@ function generatorCommand(agent: ManagedStartupAgent): readonly string[] {
         "--experimental-strip-types",
         "/opt/nemoclaw-deepagents-code/generate-config.ts",
       ];
+    case "pi":
+      return [
+        "/usr/local/bin/node",
+        "--experimental-strip-types",
+        "/opt/nemoclaw-pi/generate-config.ts",
+      ];
   }
 }
 

--- a/src/lib/onboard/managed-startup/onboard-profile.ts
+++ b/src/lib/onboard/managed-startup/onboard-profile.ts
@@ -45,6 +45,7 @@ const PROFILE_ENVIRONMENT_INPUTS = {
     "NEMOCLAW_PROXY_PORT",
     "NEMOCLAW_REASONING_EFFORT",
   ],
+  pi: ["NEMOCLAW_PROXY_HOST", "NEMOCLAW_PROXY_PORT"],
 } as const satisfies Record<ManagedStartupAgent, readonly string[]>;
 
 const HOST_NO_PROXY_INPUTS = ["NO_PROXY", "no_proxy"] as const;
@@ -116,6 +117,13 @@ function dashboardForInput(
   if (agent === "langchain-deepagents-code") {
     if (input.manageDashboard) {
       throw new ManagedStartupOnboardProfileError("DCode must not enable a dashboard");
+    }
+    return { agent, mode: "disabled" };
+  }
+
+  if (agent === "pi") {
+    if (input.manageDashboard) {
+      throw new ManagedStartupOnboardProfileError("Pi must not enable a dashboard");
     }
     return { agent, mode: "disabled" };
   }

--- a/src/lib/onboard/managed-startup/profile-builder.ts
+++ b/src/lib/onboard/managed-startup/profile-builder.ts
@@ -67,6 +67,7 @@ const EXPECTED_AFFORDANCE_INVENTORY_SHA256 = {
   openclaw: "9b722441e33f0b0d7580f74cd185c0174979de9c1a784556ff56ff931b2c9904",
   hermes: "26c2dc3750274e5c2a79bf382a4b18b3cf26c0ef64938e91b694427aa23756e8",
   "langchain-deepagents-code": "08c75cf22495ec93a090bc5b70544eac65970e658b10fba057dea5ffef502e4a",
+  pi: "195e7f361cf83f2fee7b896579c3ceb680498645368920b42e3b951244e5e08a",
 } as const satisfies Record<ManagedStartupAgent, string>;
 
 const INVENTORY_INPUTS = new Set(
@@ -647,7 +648,9 @@ function assertEnvironmentConsistency(
     NEMOCLAW_INFERENCE_API: profile.inference.api,
     NEMOCLAW_TOOL_DISCLOSURE: profile.tools.disclosure,
     CHAT_UI_URL:
-      profile.dashboard.agent === "langchain-deepagents-code" ? null : profile.dashboard.url,
+      profile.dashboard.agent === "openclaw" || profile.dashboard.agent === "hermes"
+        ? profile.dashboard.url
+        : null,
   };
   for (const [name, expected] of Object.entries(stringValues)) {
     const raw = presentEnvironmentValue(environment, name);
@@ -787,7 +790,7 @@ function assertEnvironmentConsistency(
         profile.tools.enabledGateways,
       );
     }
-  } else {
+  } else if (profile.agentConfig.agent === "langchain-deepagents-code") {
     const config = profile.agentConfig;
     const approval = presentEnvironmentValue(environment, "NEMOCLAW_DCODE_AUTO_APPROVAL");
     if (approval !== null) {

--- a/src/lib/onboard/managed-startup/profile-builder.ts
+++ b/src/lib/onboard/managed-startup/profile-builder.ts
@@ -912,6 +912,14 @@ function buildCandidate(input: ManagedStartupProfileBuilderInput): {
       reasoning: null,
       reasoningEffort: null,
     };
+  } else if (input.agent === "pi") {
+    agentConfig = { agent: "pi" };
+    tuning = {
+      contextWindow: null,
+      maxTokens: null,
+      reasoning: null,
+      reasoningEffort: null,
+    };
   } else {
     if (input.dcodeAutoApprovalMode === null || input.observabilityEnabled === null) {
       fail("DCode approval and observability state must be explicit");

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -104,7 +104,12 @@ export type ManagedStartupInputModality = "text" | "image";
 export type ManagedStartupWebSearchProvider = "brave" | "tavily";
 export type ManagedStartupDeviceAuthOptOutSource = "operator" | "managed-onboard";
 
-export const MANAGED_STARTUP_AGENTS = ["openclaw", "hermes", "langchain-deepagents-code"] as const;
+export const MANAGED_STARTUP_AGENTS = [
+  "openclaw",
+  "hermes",
+  "langchain-deepagents-code",
+  "pi",
+] as const;
 
 export type ManagedStartupAgent = (typeof MANAGED_STARTUP_AGENTS)[number];
 export const MANAGED_STARTUP_MESSAGING_AGENTS = ["openclaw", "hermes"] as const;
@@ -189,10 +194,16 @@ export interface ManagedStartupDcodeDashboard {
   readonly mode: "disabled";
 }
 
+export interface ManagedStartupPiDashboard {
+  readonly agent: "pi";
+  readonly mode: "disabled";
+}
+
 export type ManagedStartupDashboard =
   | ManagedStartupOpenClawDashboard
   | ManagedStartupHermesDashboard
-  | ManagedStartupDcodeDashboard;
+  | ManagedStartupDcodeDashboard
+  | ManagedStartupPiDashboard;
 
 export interface ManagedStartupWebSearch {
   readonly enabled: boolean;
@@ -280,10 +291,15 @@ export interface ManagedStartupDcodeConfig {
   readonly observabilityEnabled: boolean;
 }
 
+export interface ManagedStartupPiConfig {
+  readonly agent: "pi";
+}
+
 export type ManagedStartupAgentConfig =
   | ManagedStartupOpenClawConfig
   | ManagedStartupHermesConfig
-  | ManagedStartupDcodeConfig;
+  | ManagedStartupDcodeConfig
+  | ManagedStartupPiConfig;
 
 export interface ManagedStartupProfile {
   readonly schemaVersion: typeof MANAGED_STARTUP_PROFILE_SCHEMA_VERSION;
@@ -400,6 +416,25 @@ const PROFILE_CAPABILITIES = {
     supportsExtraAgents: false,
     supportsDeviceAuth: false,
     observability: "dcode-marker",
+    supportsMinimalBootstrap: false,
+  },
+  pi: {
+    inferenceApis: ["openai-completions"],
+    dashboardModes: ["disabled"],
+    inputModalities: [],
+    webSearchProviders: [],
+    toolGateways: [],
+    tuningFields: [],
+    supportsMessaging: false,
+    supportsInferenceCompatibility: false,
+    supportsUpstreamEndpoint: false,
+    supportsHostProxyIntent: true,
+    supportsPrimaryModelRef: false,
+    supportsAgentTimeout: false,
+    supportsHeartbeat: false,
+    supportsExtraAgents: false,
+    supportsDeviceAuth: false,
+    observability: "none",
     supportsMinimalBootstrap: false,
   },
 } satisfies Record<ManagedStartupAgent, ManagedStartupAgentCapabilities>;
@@ -544,6 +579,23 @@ export const MANAGED_STARTUP_PROFILE_AFFORDANCE_INVENTORY = {
     ),
     ...HOST_PROXY_AFFORDANCES,
   ],
+  pi: [
+    affordance("NEMOCLAW_MODEL", "inference.model"),
+    affordance("NEMOCLAW_INFERENCE_PROVIDER_ID", "inference.routeProvider"),
+    affordance("NEMOCLAW_UPSTREAM_PROVIDER", "inference.upstreamProvider"),
+    affordance("NEMOCLAW_INFERENCE_BASE_URL", "inference.routedBaseUrl"),
+    affordance("NEMOCLAW_INFERENCE_API", "inference.api"),
+    affordance("NEMOCLAW_TOOL_DISCLOSURE", "tools.disclosure"),
+    affordance("NEMOCLAW_PROXY_HOST", "proxy.managedHost"),
+    affordance("NEMOCLAW_PROXY_PORT", "proxy.managedPort"),
+    affordance(
+      "NEMOCLAW_CORPORATE_CA_B64",
+      "corporateCa.bundleSha256",
+      "host-material",
+      "digest-handoff",
+    ),
+    ...HOST_PROXY_AFFORDANCES,
+  ],
 } as const satisfies Record<ManagedStartupAgent, readonly ManagedStartupAffordance[]>;
 
 export type ManagedStartupDeferredRuntimeOwner =
@@ -655,6 +707,13 @@ export const MANAGED_STARTUP_PROFILE_DEFERRED_RUNTIME_INPUTS = Object.freeze({
       "engine-identity",
       "the lifecycle engine owns instance identity outside reusable startup intent",
     ),
+    deferredRuntimeInput(
+      "NEMOCLAW_EXTRA_PLACEHOLDER_KEYS",
+      "credential-plumbing",
+      "credential provider construction owns key metadata outside the secret-free profile",
+    ),
+  ]),
+  pi: Object.freeze([
     deferredRuntimeInput(
       "NEMOCLAW_EXTRA_PLACEHOLDER_KEYS",
       "credential-plumbing",
@@ -788,6 +847,15 @@ export const MANAGED_STARTUP_PROFILE_EXCLUDED_DOCKER_INPUTS = {
     { input: "TARGETARCH", reason: "platform-build" },
     { input: "NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER", reason: "fixed-image-contract" },
   ],
+  pi: [
+    { input: "BASE_IMAGE", reason: "release-composition" },
+    { input: "NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION", reason: "release-composition" },
+    { input: "PI_VERSION", reason: "integrity-pin" },
+    { input: "NEMOCLAW_BUILD_ID", reason: "build-provenance" },
+    { input: "NEMOCLAW_DARWIN_VM_COMPAT", reason: "platform-build" },
+    { input: "TARGETARCH", reason: "platform-build" },
+    { input: "NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER", reason: "fixed-image-contract" },
+  ],
 } as const satisfies Record<ManagedStartupAgent, readonly ManagedStartupExcludedDockerInput[]>;
 
 export class ManagedStartupProfileError extends Error {
@@ -860,6 +928,8 @@ const OPENCLAW_CONFIG_KEYS = new Set([
 ]);
 const HERMES_CONFIG_KEYS = new Set(["agent", "webSearch"]);
 const DCODE_CONFIG_KEYS = new Set(["agent", "autoApprovalMode", "observabilityEnabled"]);
+const PI_CONFIG_KEYS = new Set(["agent"]);
+const PI_DASHBOARD_KEYS = new Set(["agent", "mode"]);
 const WEB_SEARCH_KEYS = new Set(["enabled", "provider"]);
 const OTEL_KEYS = new Set(["enabled", "endpointUrl", "serviceName", "sampleRate"]);
 const DEVICE_AUTH_KEYS = new Set(["disabled", "optOutSource"]);
@@ -1508,6 +1578,11 @@ function validateAgentConfig(
     return { agent, webSearch: validateWebSearch(config.webSearch, agent) };
   }
 
+  if (agent === "pi") {
+    rejectUnknownKeys(config, PI_CONFIG_KEYS, "agentConfig");
+    return { agent };
+  }
+
   rejectUnknownKeys(config, DCODE_CONFIG_KEYS, "agentConfig");
   return {
     agent,
@@ -1619,6 +1694,12 @@ function validateDashboard(
       internalPort,
       tuiEnabled: requireBoolean(dashboard.tuiEnabled, "dashboard.tuiEnabled"),
     };
+  }
+
+  if (agent === "pi") {
+    rejectUnknownKeys(dashboard, PI_DASHBOARD_KEYS, "dashboard");
+    if (dashboard.mode !== "disabled") invalid("pi dashboard.mode must be disabled");
+    return { agent, mode: "disabled" };
   }
 
   rejectUnknownKeys(dashboard, DCODE_DASHBOARD_KEYS, "dashboard");

--- a/src/lib/onboard/managed-startup/shared-state-transaction.ts
+++ b/src/lib/onboard/managed-startup/shared-state-transaction.ts
@@ -340,6 +340,8 @@ function agentRoot(agent: ManagedStartupAgent, sandboxRoot: string): string {
       return path.join(sandboxRoot, ".hermes");
     case "langchain-deepagents-code":
       return path.join(sandboxRoot, ".deepagents");
+    case "pi":
+      return path.join(sandboxRoot, ".pi");
   }
 }
 
@@ -384,6 +386,10 @@ function managedOutputTargets(
       files.add(path.join(root, "config.toml"));
       directories.add(path.join(root, ".state"));
       directories.add(path.join(root, "skills"));
+      break;
+    case "pi":
+      directories.add(path.join(root, "agent"));
+      files.add(path.join(root, "agent", "models.json"));
       break;
   }
 

--- a/src/lib/onboard/managed-startup/shared-state-transaction.ts
+++ b/src/lib/onboard/managed-startup/shared-state-transaction.ts
@@ -11,6 +11,7 @@ import {
 } from "../../messaging/post-agent-install-selection";
 import {
   fingerprintManagedStartupProfile,
+  MANAGED_STARTUP_AGENTS,
   type ManagedStartupAgent,
   type ManagedStartupProfile,
 } from "./profile";
@@ -583,7 +584,7 @@ function parseCommitReceipt(text: string): CommitReceipt {
   requireExactKeys(record, ["agent", "bootstrapIdentity", "profileFingerprint", "schemaVersion"]);
   if (
     record.schemaVersion !== TRANSACTION_SCHEMA_VERSION ||
-    !["openclaw", "hermes", "langchain-deepagents-code"].includes(String(record.agent)) ||
+    !(MANAGED_STARTUP_AGENTS as readonly string[]).includes(String(record.agent)) ||
     typeof record.profileFingerprint !== "string" ||
     !/^[a-f0-9]{64}$/u.test(record.profileFingerprint) ||
     typeof record.bootstrapIdentity !== "string" ||
@@ -635,7 +636,7 @@ function parseManifest(text: string): TransactionManifest {
   const bootstrapIdentity = hasBootstrapIdentity ? record.bootstrapIdentity : null;
   if (
     record.schemaVersion !== TRANSACTION_SCHEMA_VERSION ||
-    !["openclaw", "hermes", "langchain-deepagents-code"].includes(String(record.agent)) ||
+    !(MANAGED_STARTUP_AGENTS as readonly string[]).includes(String(record.agent)) ||
     typeof record.profileFingerprint !== "string" ||
     !/^[a-f0-9]{64}$/u.test(record.profileFingerprint) ||
     !(

--- a/src/lib/onboard/managed-workload-clone-handoff.test.ts
+++ b/src/lib/onboard/managed-workload-clone-handoff.test.ts
@@ -90,13 +90,13 @@ function source(
     compatibleEndpointReasoningEffort: null,
     toolDisclosure: profile.tools.disclosure,
     webSearchEnabled:
-      profile.agentConfig.agent === "langchain-deepagents-code"
-        ? false
-        : profile.agentConfig.webSearch.enabled,
+      profile.agentConfig.agent === "openclaw" || profile.agentConfig.agent === "hermes"
+        ? profile.agentConfig.webSearch.enabled
+        : false,
     webSearchProvider:
-      profile.agentConfig.agent === "langchain-deepagents-code"
-        ? null
-        : profile.agentConfig.webSearch.provider,
+      profile.agentConfig.agent === "openclaw" || profile.agentConfig.agent === "hermes"
+        ? profile.agentConfig.webSearch.provider
+        : null,
     ...(profile.messaging.plan === null
       ? {}
       : {

--- a/src/lib/onboard/managed-workload/onboard-orchestration.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isCandidateAgentSelectable } from "../../agent/candidate";
+import { isCandidateAgent, readCandidateQualificationReceipt } from "../../agent/candidate";
 import type { AgentDefinition } from "../../agent/defs";
 import { getVersion } from "../../core/version";
 import type { SandboxMessagingPlan } from "../../messaging/manifest";
@@ -170,7 +170,9 @@ export function createManagedWorkloadOnboardRuntime(
           runtime: runtimeCapabilities,
           version: getVersion({ rootDir: input.rootDir }),
           catalogPath: input.tempManagedRuntimeCatalog,
-          candidateAgentsEnabled: isCandidateAgentSelectable(input.agentName),
+          acceptedCandidateContract: isCandidateAgent(input.agentName)
+            ? readCandidateQualificationReceipt(input.agentName)
+            : null,
         });
     const prepared = await preparedWorkloadPromise;
     if (prepared.fallbackDiagnostic && !fallbackReported) {

--- a/src/lib/onboard/managed-workload/onboard-orchestration.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isCandidateAgentEnabled } from "../../agent/candidate";
 import type { AgentDefinition } from "../../agent/defs";
 import { getVersion } from "../../core/version";
 import type { SandboxMessagingPlan } from "../../messaging/manifest";
@@ -169,6 +170,7 @@ export function createManagedWorkloadOnboardRuntime(
           runtime: runtimeCapabilities,
           version: getVersion({ rootDir: input.rootDir }),
           catalogPath: input.tempManagedRuntimeCatalog,
+          candidateAgentsEnabled: isCandidateAgentEnabled(),
         });
     const prepared = await preparedWorkloadPromise;
     if (prepared.fallbackDiagnostic && !fallbackReported) {

--- a/src/lib/onboard/managed-workload/onboard-orchestration.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isCandidateAgentEnabled } from "../../agent/candidate";
+import { isCandidateAgentSelectable } from "../../agent/candidate";
 import type { AgentDefinition } from "../../agent/defs";
 import { getVersion } from "../../core/version";
 import type { SandboxMessagingPlan } from "../../messaging/manifest";
@@ -170,7 +170,7 @@ export function createManagedWorkloadOnboardRuntime(
           runtime: runtimeCapabilities,
           version: getVersion({ rootDir: input.rootDir }),
           catalogPath: input.tempManagedRuntimeCatalog,
-          candidateAgentsEnabled: isCandidateAgentEnabled(),
+          candidateAgentsEnabled: isCandidateAgentSelectable(input.agentName),
         });
     const prepared = await preparedWorkloadPromise;
     if (prepared.fallbackDiagnostic && !fallbackReported) {

--- a/src/lib/onboard/managed-workload/rebuild/contract.ts
+++ b/src/lib/onboard/managed-workload/rebuild/contract.ts
@@ -3,7 +3,7 @@
 
 import type { SandboxRebuildAuthority } from "../../../state/registry/rebuild-authority";
 import type { SandboxEntry } from "../../../state/registry/types";
-import type { ShippedManagedImageAgent } from "../../managed-image/contract";
+import type { ManagedImageAgent } from "../../managed-image/contract";
 import type { ManagedWorkloadRebuildHandoff, ManagedWorkloadReceipt } from "../../workload/rebuild";
 
 export type ManagedWorkloadRebuildPhase =
@@ -21,7 +21,7 @@ export interface ManagedWorkloadRebuildPlan {
   readonly transactionId: string;
   readonly sandboxName: string;
   readonly providerId: string;
-  readonly agent: ShippedManagedImageAgent;
+  readonly agent: ManagedImageAgent;
   readonly previousAuthority: SandboxRebuildAuthority;
   readonly handoff: ManagedWorkloadRebuildHandoff;
   readonly replacementReceipt: ManagedWorkloadReceipt;
@@ -152,7 +152,7 @@ export interface ManagedWorkloadRebuildRecoveryTask {
   readonly stagingHandle: string;
   readonly previousAuthority: SandboxRebuildAuthority;
   readonly replacement: {
-    readonly agent: ShippedManagedImageAgent;
+    readonly agent: ManagedImageAgent;
     readonly receipt: ManagedWorkloadReceipt;
     readonly lifecycleGeneration: string;
     readonly liveIdentityFingerprint: string;

--- a/src/lib/onboard/pi-candidate-rebuild.test.ts
+++ b/src/lib/onboard/pi-candidate-rebuild.test.ts
@@ -127,10 +127,14 @@ describe("Pi candidate managed rebuild", () => {
   let previousEnv: NodeJS.ProcessEnv;
   let fixture: CandidateQualificationFixture | null = null;
 
-  function qualify(publish = true): void {
+  function writeReceipt(): CandidateQualificationFixture {
     fixture = candidateQualificationEnvironment();
     Object.assign(process.env, fixture.env);
-    if (publish) authority.digests.push(fixture.receiptDigest);
+    return fixture;
+  }
+
+  function publish(receipt: CandidateQualificationFixture): void {
+    authority.digests.push(receipt.receiptDigest);
   }
 
   beforeEach(() => {
@@ -146,7 +150,7 @@ describe("Pi candidate managed rebuild", () => {
   });
 
   it("restores the accepted candidate image without the release catalog (#7927)", async () => {
-    qualify();
+    publish(writeReceipt());
     const releaseCatalog = vi.fn(ORIGINAL_PREPARE);
     managedWorkloadRebuildDependencies.prepareSandboxWorkloadSource = releaseCatalog;
 
@@ -185,7 +189,7 @@ describe("Pi candidate managed rebuild", () => {
   });
 
   it("refuses a candidate rebuild from a receipt the repository never published (#7927)", async () => {
-    qualify(false);
+    writeReceipt();
 
     await expect(
       prepareManagedWorkloadRebuildHandoff(piEntry(), {

--- a/src/lib/onboard/pi-candidate-rebuild.test.ts
+++ b/src/lib/onboard/pi-candidate-rebuild.test.ts
@@ -127,10 +127,14 @@ describe("Pi candidate managed rebuild", () => {
   let previousEnv: NodeJS.ProcessEnv;
   let fixture: CandidateQualificationFixture | null = null;
 
-  function qualify(publish = true): void {
+  function qualify(): CandidateQualificationFixture {
     fixture = candidateQualificationEnvironment();
     Object.assign(process.env, fixture.env);
-    if (publish) authority.digests.push(fixture.receiptDigest);
+    return fixture;
+  }
+
+  function qualifyPublished(): void {
+    authority.digests.push(qualify().receiptDigest);
   }
 
   beforeEach(() => {
@@ -146,7 +150,7 @@ describe("Pi candidate managed rebuild", () => {
   });
 
   it("restores the accepted candidate image without the release catalog (#7927)", async () => {
-    qualify();
+    qualifyPublished();
     const releaseCatalog = vi.fn(ORIGINAL_PREPARE);
     managedWorkloadRebuildDependencies.prepareSandboxWorkloadSource = releaseCatalog;
 
@@ -185,7 +189,7 @@ describe("Pi candidate managed rebuild", () => {
   });
 
   it("refuses a candidate rebuild from a receipt the repository never published (#7927)", async () => {
-    qualify(false);
+    qualify();
 
     await expect(
       prepareManagedWorkloadRebuildHandoff(piEntry(), {

--- a/src/lib/onboard/pi-candidate-rebuild.test.ts
+++ b/src/lib/onboard/pi-candidate-rebuild.test.ts
@@ -5,8 +5,18 @@ import { createHash } from "node:crypto";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const authority = vi.hoisted(() => ({ digests: [] as string[] }));
+
+vi.mock("../agent/candidate-authority", () => ({
+  CANDIDATE_QUALIFICATION_RECEIPT_DIGESTS: { pi: authority.digests },
+  acceptedCandidateReceiptDigests: () => authority.digests,
+}));
+
 import { managedStartupE2eProfile } from "../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
-import { candidateQualificationEnvironment } from "../agent/candidate-test-fixture";
+import {
+  type CandidateQualificationFixture,
+  candidateQualificationEnvironment,
+} from "../agent/candidate-test-fixture";
 import type { SandboxEntry } from "../state/registry/types";
 import {
   MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
@@ -115,6 +125,13 @@ function provider(providerId = "mxc"): RuntimeProviderBundle {
 
 describe("Pi candidate managed rebuild", () => {
   let previousEnv: NodeJS.ProcessEnv;
+  let fixture: CandidateQualificationFixture | null = null;
+
+  function qualify(publish = true): void {
+    fixture = candidateQualificationEnvironment();
+    Object.assign(process.env, fixture.env);
+    if (publish) authority.digests.push(fixture.receiptDigest);
+  }
 
   beforeEach(() => {
     previousEnv = { ...process.env };
@@ -122,12 +139,14 @@ describe("Pi candidate managed rebuild", () => {
 
   afterEach(() => {
     process.env = previousEnv;
+    authority.digests.splice(0, authority.digests.length);
+    fixture?.cleanup();
+    fixture = null;
     managedWorkloadRebuildDependencies.prepareSandboxWorkloadSource = ORIGINAL_PREPARE;
   });
 
   it("restores the accepted candidate image without the release catalog (#7927)", async () => {
-    const qualification = candidateQualificationEnvironment();
-    Object.assign(process.env, qualification);
+    qualify();
     const releaseCatalog = vi.fn(ORIGINAL_PREPARE);
     managedWorkloadRebuildDependencies.prepareSandboxWorkloadSource = releaseCatalog;
 
@@ -155,7 +174,6 @@ describe("Pi candidate managed rebuild", () => {
   it("refuses a candidate rebuild without qualification authority (#7927)", async () => {
     delete process.env.NEMOCLAW_CANDIDATE_AGENTS;
     delete process.env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT;
-    delete process.env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256;
 
     await expect(
       prepareManagedWorkloadRebuildHandoff(piEntry(), {
@@ -166,8 +184,8 @@ describe("Pi candidate managed rebuild", () => {
     ).rejects.toThrow(ManagedWorkloadRebuildError);
   });
 
-  it("refuses a candidate rebuild when the receipt digest does not match (#7927)", async () => {
-    Object.assign(process.env, candidateQualificationEnvironment({ corruptDigest: true }));
+  it("refuses a candidate rebuild from a receipt the repository never published (#7927)", async () => {
+    qualify(false);
 
     await expect(
       prepareManagedWorkloadRebuildHandoff(piEntry(), {

--- a/src/lib/onboard/pi-candidate-rebuild.test.ts
+++ b/src/lib/onboard/pi-candidate-rebuild.test.ts
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { managedStartupE2eProfile } from "../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import { candidateQualificationEnvironment } from "../agent/candidate-test-fixture";
+import type { SandboxEntry } from "../state/registry/types";
+import {
+  MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
+  MANAGED_IMAGE_CONTRACT_VERSION,
+  MANAGED_IMAGE_REPOSITORIES,
+  MANAGED_IMAGE_SOURCE_REPOSITORY,
+  MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
+  type ManagedImageContractV1,
+} from "./managed-image/contract";
+import { encodeManagedStartupProfile } from "./managed-startup/profile";
+import type { RuntimeProviderBundle } from "./runtime-provider/contract";
+import {
+  ManagedWorkloadRebuildError,
+  managedWorkloadRebuildDependencies,
+  prepareManagedWorkloadRebuildHandoff,
+} from "./workload/rebuild";
+import type { SandboxWorkloadRuntimeCapabilities } from "./workload/source";
+
+const PLATFORM = "linux/amd64" as const;
+const ORIGINAL_PREPARE = managedWorkloadRebuildDependencies.prepareSandboxWorkloadSource;
+
+function installedContract(): ManagedImageContractV1 {
+  const image = MANAGED_IMAGE_REPOSITORIES.pi;
+  const digest = `sha256:${"1b".repeat(32)}` as const;
+  return {
+    contractVersion: MANAGED_IMAGE_CONTRACT_VERSION,
+    agent: "pi",
+    platform: PLATFORM,
+    image,
+    digest,
+    reference: `${image}@${digest}`,
+    source: {
+      repository: MANAGED_IMAGE_SOURCE_REPOSITORY,
+      revision: "c".repeat(40),
+      release: "v0.0.99",
+      cohort: "ghrun-7927-2",
+    },
+    startupProfileContractVersion: MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
+    capabilityContractVersion: MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
+  };
+}
+
+function piEntry(): SandboxEntry {
+  const contract = installedContract();
+  const encodedProfile = encodeManagedStartupProfile(managedStartupE2eProfile("pi"));
+  return {
+    name: "rebuild-pi",
+    agent: "pi",
+    openshellDriver: "mxc",
+    fromDockerfile: null,
+    imageTag: contract.reference,
+    workload: {
+      schemaVersion: 1,
+      kind: "managed-image",
+      reference: contract.reference,
+      platform: PLATFORM,
+      release: contract.source.release,
+      sourceRevision: contract.source.revision,
+      sourceCohort: contract.source.cohort,
+      capabilityContractVersion: contract.capabilityContractVersion,
+      startupProfileContractVersion: contract.startupProfileContractVersion,
+      encodedProfile,
+      startupProfileSha256: createHash("sha256").update(encodedProfile, "utf8").digest("hex"),
+      credentialProxyReplayRequired: false,
+      shared: true,
+    },
+  } as unknown as SandboxEntry;
+}
+
+function runtime(providerId = "mxc"): SandboxWorkloadRuntimeCapabilities {
+  return {
+    driverName: providerId,
+    managedImageSelectionPolicy: "require-managed",
+    legacyDockerfileBuilds: false,
+    managedImages: {
+      exactDigestReferences: true,
+      platforms: [PLATFORM],
+      startupProfileContractVersions: [1],
+      capabilityContractVersions: [1],
+    },
+  };
+}
+
+function provider(providerId = "mxc"): RuntimeProviderBundle {
+  return {
+    identity: { contractVersion: 1, id: providerId, displayName: providerId },
+    workload: {
+      providerId,
+      supported: true,
+      profile: {
+        support: {
+          exactDigestReferences: true,
+          platforms: ["linux/amd64", "linux/arm64"],
+          startupProfileContractVersions: [1],
+          capabilityContractVersions: [1],
+        },
+        hostArchitectures: ["amd64", "arm64"],
+        managedImageSelectionPolicy: "require-managed",
+        legacyDockerfileBuilds: false,
+      },
+      acceptsReceipt: () => true,
+    },
+    mutationAuthority: { providerId, supported: true, operations: ["rebuild"] },
+  } as unknown as RuntimeProviderBundle;
+}
+
+describe("Pi candidate managed rebuild", () => {
+  let previousEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    previousEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = previousEnv;
+    managedWorkloadRebuildDependencies.prepareSandboxWorkloadSource = ORIGINAL_PREPARE;
+  });
+
+  it("restores the accepted candidate image without the release catalog (#7927)", async () => {
+    const qualification = candidateQualificationEnvironment();
+    Object.assign(process.env, qualification);
+    const releaseCatalog = vi.fn(ORIGINAL_PREPARE);
+    managedWorkloadRebuildDependencies.prepareSandboxWorkloadSource = releaseCatalog;
+
+    const handoff = await prepareManagedWorkloadRebuildHandoff(piEntry(), {
+      runtime: runtime(),
+      provider: provider(),
+      version: "0.0.100",
+    });
+
+    expect(handoff).toMatchObject({
+      agent: "pi",
+      previousReceipt: { kind: "managed-image", release: "v0.0.99" },
+      replacement: {
+        source: { kind: "managed-image", contract: { agent: "pi", platform: PLATFORM } },
+      },
+    });
+    expect(handoff?.replacement.source.reference).toBe(
+      `${MANAGED_IMAGE_REPOSITORIES.pi}@sha256:${"7a".repeat(32)}`,
+    );
+    // A candidate publishes outside the all-agent cohort, so the release
+    // catalog must never be consulted for it.
+    expect(releaseCatalog).not.toHaveBeenCalled();
+  });
+
+  it("refuses a candidate rebuild without qualification authority (#7927)", async () => {
+    delete process.env.NEMOCLAW_CANDIDATE_AGENTS;
+    delete process.env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT;
+    delete process.env.NEMOCLAW_CANDIDATE_QUALIFICATION_RECEIPT_SHA256;
+
+    await expect(
+      prepareManagedWorkloadRebuildHandoff(piEntry(), {
+        runtime: runtime(),
+        provider: provider(),
+        version: "0.0.100",
+      }),
+    ).rejects.toThrow(ManagedWorkloadRebuildError);
+  });
+
+  it("refuses a candidate rebuild when the receipt digest does not match (#7927)", async () => {
+    Object.assign(process.env, candidateQualificationEnvironment({ corruptDigest: true }));
+
+    await expect(
+      prepareManagedWorkloadRebuildHandoff(piEntry(), {
+        runtime: runtime(),
+        provider: provider(),
+        version: "0.0.100",
+      }),
+    ).rejects.toThrow("qualification receipt is unavailable or invalid");
+  });
+});

--- a/src/lib/onboard/sandbox-workload-authority.test.ts
+++ b/src/lib/onboard/sandbox-workload-authority.test.ts
@@ -11,8 +11,8 @@ import {
   MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
   MANAGED_IMAGE_REPOSITORIES,
   MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
+  type ManagedImageAgent,
   type ManagedImagePlatform,
-  type ShippedManagedImageAgent,
 } from "./managed-image/contract";
 import { encodeManagedStartupProfile } from "./managed-startup/profile";
 import { ManagedWorkloadAuthorityError, readManagedWorkloadAuthority } from "./workload/authority";
@@ -22,12 +22,13 @@ const PLATFORMS = ["linux/amd64", "linux/arm64"] as const;
 type ManagedWorkloadReceipt = Extract<SandboxWorkloadReceipt, { readonly kind: "managed-image" }>;
 
 function managedReceipt(
-  agent: ShippedManagedImageAgent,
+  agent: ManagedImageAgent,
   platform: ManagedImagePlatform,
-  profileAgent: ShippedManagedImageAgent = agent,
+  profileAgent: ManagedImageAgent = agent,
 ): ManagedWorkloadReceipt {
   const encodedProfile = encodeManagedStartupProfile(managedStartupE2eProfile(profileAgent));
-  const digest = agent === "openclaw" ? "a" : agent === "hermes" ? "b" : "c";
+  const digest =
+    agent === "openclaw" ? "a" : agent === "hermes" ? "b" : agent === "pi" ? "e" : "c";
   return {
     schemaVersion: 1,
     kind: "managed-image",
@@ -46,7 +47,7 @@ function managedReceipt(
 }
 
 function managedEntry(
-  agent: ShippedManagedImageAgent,
+  agent: ManagedImageAgent,
   platform: ManagedImagePlatform = "linux/amd64",
   receipt: ManagedWorkloadReceipt = managedReceipt(agent, platform),
 ): SandboxEntry {
@@ -156,5 +157,36 @@ describe("managed workload authority", () => {
         fromDockerfile: "/tmp/Dockerfile",
       }),
     ).toThrow(/cannot be combined with a custom Dockerfile/u);
+  });
+
+  it.each(PLATFORMS)(
+    "restores an accepted candidate image identity from its durable receipt on %s (#7927)",
+    (platform) => {
+      const authority = readManagedWorkloadAuthority(managedEntry("pi", platform));
+
+      expect(authority).toMatchObject({
+        agent: "pi",
+        contract: { agent: "pi", platform, image: MANAGED_IMAGE_REPOSITORIES.pi },
+        profile: { agent: "pi" },
+      });
+    },
+  );
+
+  it("reads a candidate authority without consulting the candidate selection gate (#7927)", () => {
+    expect(readManagedWorkloadAuthority(managedEntry("pi"))?.agent).toBe("pi");
+  });
+
+  it("rejects a candidate receipt whose profile targets another agent (#7927)", () => {
+    expect(() =>
+      readManagedWorkloadAuthority(
+        managedEntry("pi", "linux/amd64", managedReceipt("pi", "linux/amd64", "hermes")),
+      ),
+    ).toThrow(ManagedWorkloadAuthorityError);
+  });
+
+  it("still rejects an agent outside the managed image set (#7927)", () => {
+    expect(() =>
+      readManagedWorkloadAuthority({ ...managedEntry("pi"), agent: "not-an-agent" }),
+    ).toThrow(/is not a managed-image agent/u);
   });
 });

--- a/src/lib/onboard/sandbox-workload-preparation.test.ts
+++ b/src/lib/onboard/sandbox-workload-preparation.test.ts
@@ -434,7 +434,7 @@ describe("sandbox workload preparation", () => {
 
     await expect(
       prepareSandboxWorkloadSource(
-        { ...input("pi"), candidateAgentsEnabled: true },
+        { ...input("pi"), acceptedCandidateContract: contract("pi", 3) },
         { resolveCatalog },
       ),
     ).rejects.toThrow("requires an exact managed image catalog file");
@@ -448,7 +448,7 @@ describe("sandbox workload preparation", () => {
     fs.writeFileSync(catalogPath, JSON.stringify({ pi: piContract }), { mode: 0o600 });
 
     const prepared = await prepareSandboxWorkloadSource(
-      { ...input("pi"), candidateAgentsEnabled: true, catalogPath },
+      { ...input("pi"), acceptedCandidateContract: piContract, catalogPath },
       { resolveCatalog: async () => CATALOG },
     );
 
@@ -458,13 +458,42 @@ describe("sandbox workload preparation", () => {
     });
   });
 
+  it("refuses a candidate catalog that differs from the accepted receipt (#7927)", async () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-candidate-catalog-"));
+    const catalogPath = path.join(fixtureRoot, "catalog.json");
+    const acceptedContract = contract("pi", 3);
+    const differentDigest = `sha256:${"5".repeat(64)}` as const;
+    const differentContract = {
+      ...acceptedContract,
+      digest: differentDigest,
+      reference: `${acceptedContract.image}@${differentDigest}` as const,
+    };
+    fs.writeFileSync(catalogPath, JSON.stringify({ pi: differentContract }), { mode: 0o600 });
+
+    try {
+      await expect(
+        prepareSandboxWorkloadSource({
+          ...input("pi"),
+          acceptedCandidateContract: acceptedContract,
+          catalogPath,
+        }),
+      ).rejects.toThrow("does not match the accepted qualification receipt");
+    } finally {
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
   it("refuses a candidate catalog entry that claims a shipped agent (#7927)", async () => {
     const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-candidate-catalog-"));
     const catalogPath = path.join(fixtureRoot, "catalog.json");
     fs.writeFileSync(catalogPath, JSON.stringify({ pi: contract("hermes", 1) }), { mode: 0o600 });
 
     await expect(
-      prepareSandboxWorkloadSource({ ...input("pi"), candidateAgentsEnabled: true, catalogPath }),
+      prepareSandboxWorkloadSource({
+        ...input("pi"),
+        acceptedCandidateContract: contract("pi", 3),
+        catalogPath,
+      }),
     ).rejects.toThrow(SandboxWorkloadPreparationError);
   });
 

--- a/src/lib/onboard/sandbox-workload-preparation.test.ts
+++ b/src/lib/onboard/sandbox-workload-preparation.test.ts
@@ -20,8 +20,8 @@ import {
   MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
   type ManagedImageContractCatalog,
   type ManagedImageContractV1,
+  type ManagedImageAgent,
   SHIPPED_MANAGED_IMAGE_AGENTS,
-  type ShippedManagedImageAgent,
 } from "./managed-image/contract";
 import { createRuntimeProviderBundleRegistry } from "./runtime-provider/registry";
 import {
@@ -36,7 +36,7 @@ const MANAGED_IMAGE_PLATFORM = MANAGED_IMAGE_PLATFORMS[0];
 const REVISION = "2f03907c37822ea6f1ac9d1bf5c82a4a4568585f";
 const COHORT = "ghrun-7744-2";
 
-function contract(agent: ShippedManagedImageAgent, index: number): ManagedImageContractV1 {
+function contract(agent: ManagedImageAgent, index: number): ManagedImageContractV1 {
   const image = MANAGED_IMAGE_REPOSITORIES[agent];
   const digest = `sha256:${String(index + 1).repeat(64)}` as const;
   return {
@@ -427,5 +427,53 @@ describe("sandbox workload preparation", () => {
       kind: "managed-image",
       reference: contract("hermes", 1).reference,
     });
+  });
+
+  it("never fetches the all-agent cohort catalog for a gated candidate (#7927)", async () => {
+    const resolveCatalog = vi.fn(async () => CATALOG);
+
+    await expect(
+      prepareSandboxWorkloadSource(
+        { ...input("pi"), candidateAgentsEnabled: true },
+        { resolveCatalog },
+      ),
+    ).rejects.toThrow("requires an exact managed image catalog file");
+    expect(resolveCatalog).not.toHaveBeenCalled();
+  });
+
+  it("prepares the exact candidate digest from a supplied catalog file (#7927)", async () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-candidate-catalog-"));
+    const catalogPath = path.join(fixtureRoot, "catalog.json");
+    const piContract = contract("pi", 3);
+    fs.writeFileSync(catalogPath, JSON.stringify({ pi: piContract }), { mode: 0o600 });
+
+    const prepared = await prepareSandboxWorkloadSource(
+      { ...input("pi"), candidateAgentsEnabled: true, catalogPath },
+      { resolveCatalog: async () => CATALOG },
+    );
+
+    expect(prepared.source).toMatchObject({
+      kind: "managed-image",
+      reference: piContract.reference,
+    });
+  });
+
+  it("refuses a candidate catalog entry that claims a shipped agent (#7927)", async () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-candidate-catalog-"));
+    const catalogPath = path.join(fixtureRoot, "catalog.json");
+    fs.writeFileSync(catalogPath, JSON.stringify({ pi: contract("hermes", 1) }), { mode: 0o600 });
+
+    await expect(
+      prepareSandboxWorkloadSource({ ...input("pi"), candidateAgentsEnabled: true, catalogPath }),
+    ).rejects.toThrow(SandboxWorkloadPreparationError);
+  });
+
+  it("refuses a candidate while the gate is off (#7927)", async () => {
+    await expect(
+      prepareSandboxWorkloadSource(
+        { ...input("pi"), runtime: runtime("docker") },
+        { resolveCatalog: async () => CATALOG },
+      ),
+    ).rejects.toThrow("the selected agent is a release candidate and candidate selection is disabled");
   });
 });

--- a/src/lib/onboard/sandbox-workload-source.test.ts
+++ b/src/lib/onboard/sandbox-workload-source.test.ts
@@ -248,19 +248,17 @@ describe("sandbox workload source resolution", () => {
 
   it.each(
     CANDIDATE_MANAGED_IMAGE_AGENTS,
-  )("refuses the managed image for candidate %s while the gate is off (#7927)", (agent) => {
-    const source = resolveSandboxWorkloadSource({
-      agentName: agent,
-      legacyDockerfilePath: `agents/${agent}/Dockerfile`,
-      runtime: managedRuntime("docker"),
-      catalog: { ...CATALOG, [agent]: contractFor(agent) },
-    });
-
-    expect(source).toEqual({
-      kind: "legacy-dockerfile",
-      dockerfilePath: `agents/${agent}/Dockerfile`,
-      reason: "agent-not-managed",
-    });
+  )("refuses every workload for candidate %s while the gate is off (#7927)", (agent) => {
+    expect(() =>
+      resolveSandboxWorkloadSource({
+        agentName: agent,
+        legacyDockerfilePath: `agents/${agent}/Dockerfile`,
+        runtime: managedRuntime("docker"),
+        catalog: { ...CATALOG, [agent]: contractFor(agent) },
+      }),
+    ).toThrow(
+      `Managed image workload is required for '${agent}', but the selected agent is a release candidate and candidate selection is disabled.`,
+    );
   });
 
   it.each(

--- a/src/lib/onboard/sandbox-workload-source.test.ts
+++ b/src/lib/onboard/sandbox-workload-source.test.ts
@@ -248,19 +248,15 @@ describe("sandbox workload source resolution", () => {
 
   it.each(
     CANDIDATE_MANAGED_IMAGE_AGENTS,
-  )("refuses the managed image for candidate %s while the gate is off (#7927)", (agent) => {
-    const source = resolveSandboxWorkloadSource({
-      agentName: agent,
-      legacyDockerfilePath: `agents/${agent}/Dockerfile`,
-      runtime: managedRuntime("docker"),
-      catalog: { ...CATALOG, [agent]: contractFor(agent) },
-    });
-
-    expect(source).toEqual({
-      kind: "legacy-dockerfile",
-      dockerfilePath: `agents/${agent}/Dockerfile`,
-      reason: "agent-not-managed",
-    });
+  )("refuses candidate %s while candidate selection is disabled (#7927)", (agent) => {
+    expect(() =>
+      resolveSandboxWorkloadSource({
+        agentName: agent,
+        legacyDockerfilePath: `agents/${agent}/Dockerfile`,
+        runtime: managedRuntime("docker"),
+        catalog: { ...CATALOG, [agent]: contractFor(agent) },
+      }),
+    ).toThrow("candidate selection is disabled");
   });
 
   it.each(

--- a/src/lib/onboard/sandbox-workload-source.test.ts
+++ b/src/lib/onboard/sandbox-workload-source.test.ts
@@ -11,6 +11,8 @@ import {
   MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
   type ManagedImageContractCatalog,
   type ManagedImageContractV1,
+  CANDIDATE_MANAGED_IMAGE_AGENTS,
+  type ManagedImageAgent,
   SHIPPED_MANAGED_IMAGE_AGENTS,
   type ShippedManagedImageAgent,
 } from "./managed-image/contract";
@@ -27,9 +29,10 @@ const DIGESTS = {
   openclaw: `sha256:${"4d".repeat(32)}`,
   hermes: `sha256:${"5e".repeat(32)}`,
   "langchain-deepagents-code": `sha256:${"6f".repeat(32)}`,
-} as const satisfies Record<ShippedManagedImageAgent, `sha256:${string}`>;
+  pi: `sha256:${"7a".repeat(32)}`,
+} as const satisfies Record<ManagedImageAgent, `sha256:${string}`>;
 
-function contractFor(agent: ShippedManagedImageAgent): ManagedImageContractV1 {
+function contractFor(agent: ManagedImageAgent): ManagedImageContractV1 {
   const image = MANAGED_IMAGE_REPOSITORIES[agent];
   const digest = DIGESTS[agent];
   return {
@@ -241,5 +244,63 @@ describe("sandbox workload source resolution", () => {
         catalog: mutableCatalog,
       }),
     ).toThrow("failed closed validation");
+  });
+
+  it.each(
+    CANDIDATE_MANAGED_IMAGE_AGENTS,
+  )("refuses the managed image for candidate %s while the gate is off (#7927)", (agent) => {
+    const source = resolveSandboxWorkloadSource({
+      agentName: agent,
+      legacyDockerfilePath: `agents/${agent}/Dockerfile`,
+      runtime: managedRuntime("docker"),
+      catalog: { ...CATALOG, [agent]: contractFor(agent) },
+    });
+
+    expect(source).toEqual({
+      kind: "legacy-dockerfile",
+      dockerfilePath: `agents/${agent}/Dockerfile`,
+      reason: "agent-not-managed",
+    });
+  });
+
+  it.each(
+    CANDIDATE_MANAGED_IMAGE_AGENTS,
+  )("selects the exact candidate digest for %s behind the gate (#7927)", (agent) => {
+    const source = resolveSandboxWorkloadSource({
+      agentName: agent,
+      legacyDockerfilePath: `agents/${agent}/Dockerfile`,
+      runtime: managedRuntime("docker"),
+      catalog: { ...CATALOG, [agent]: contractFor(agent) },
+      candidateAgentsEnabled: true,
+    });
+
+    expect(source).toEqual({
+      kind: "managed-image",
+      reference: contractFor(agent).reference,
+      contract: contractFor(agent),
+    });
+  });
+
+  it("never builds a host Dockerfile for a gated candidate on a buildless runtime (#7927)", () => {
+    expect(() =>
+      resolveSandboxWorkloadSource({
+        agentName: "pi",
+        legacyDockerfilePath: "agents/pi/Dockerfile",
+        runtime: managedRuntime("podman"),
+        catalog: CATALOG,
+      }),
+    ).toThrow("release candidate and candidate selection is disabled");
+  });
+
+  it("keeps an unknown agent distinct from a gated candidate (#7927)", () => {
+    expect(() =>
+      resolveSandboxWorkloadSource({
+        agentName: "not-an-agent",
+        legacyDockerfilePath: "agents/not-an-agent/Dockerfile",
+        runtime: managedRuntime("podman"),
+        catalog: CATALOG,
+        candidateAgentsEnabled: true,
+      }),
+    ).toThrow("the selected agent is not a shipped managed agent");
   });
 });

--- a/src/lib/onboard/sandbox-workload-source.test.ts
+++ b/src/lib/onboard/sandbox-workload-source.test.ts
@@ -248,7 +248,7 @@ describe("sandbox workload source resolution", () => {
 
   it.each(
     CANDIDATE_MANAGED_IMAGE_AGENTS,
-  )("refuses every workload for candidate %s while the gate is off (#7927)", (agent) => {
+  )("refuses candidate %s while candidate selection is disabled (#7927)", (agent) => {
     expect(() =>
       resolveSandboxWorkloadSource({
         agentName: agent,

--- a/src/lib/onboard/workload/authority.ts
+++ b/src/lib/onboard/workload/authority.ts
@@ -6,13 +6,13 @@ import type { SandboxEntry, SandboxWorkloadReceipt } from "../../state/registry/
 import { cloneSandboxWorkloadReceipt } from "../../state/registry/workload";
 import type { ResolvedCorporateCa } from "../corporate-ca-types";
 import {
-  isShippedManagedImageAgent,
+  isManagedImageAgent,
   MANAGED_IMAGE_CONTRACT_VERSION,
   MANAGED_IMAGE_REPOSITORIES,
   MANAGED_IMAGE_SOURCE_REPOSITORY,
+  type ManagedImageAgent,
   type ManagedImageContractV1,
   parseManagedImageContractV1,
-  type ShippedManagedImageAgent,
 } from "../managed-image/contract";
 import { validateManagedStartupCorporateCaTransport } from "../managed-startup/application";
 import {
@@ -26,7 +26,7 @@ export type ManagedWorkloadReceipt = Extract<
 >;
 
 export interface ManagedWorkloadAuthority {
-  readonly agent: ShippedManagedImageAgent;
+  readonly agent: ManagedImageAgent;
   readonly receipt: ManagedWorkloadReceipt;
   readonly contract: ManagedImageContractV1;
   readonly profile: ManagedStartupProfile;
@@ -49,20 +49,20 @@ function isManagedImageReference(value: unknown): value is string {
   );
 }
 
-function exactAgent(value: string | null | undefined): ShippedManagedImageAgent {
+function exactAgent(value: string | null | undefined): ManagedImageAgent {
   const normalized = value?.trim();
   if (!normalized) {
     throw new ManagedWorkloadAuthorityError(
       "the durable managed workload does not record an explicit agent",
     );
   }
-  if (isShippedManagedImageAgent(normalized)) return normalized;
-  throw new ManagedWorkloadAuthorityError(`'${normalized}' is not a shipped managed-image agent`);
+  if (isManagedImageAgent(normalized)) return normalized;
+  throw new ManagedWorkloadAuthorityError(`'${normalized}' is not a managed-image agent`);
 }
 
 function contractFromReceipt(
   receipt: ManagedWorkloadReceipt,
-  agent: ShippedManagedImageAgent,
+  agent: ManagedImageAgent,
 ): ManagedImageContractV1 {
   const image = MANAGED_IMAGE_REPOSITORIES[agent];
   const referencePrefix = `${image}@`;

--- a/src/lib/onboard/workload/clone.ts
+++ b/src/lib/onboard/workload/clone.ts
@@ -161,9 +161,9 @@ function registryFields(
   source: SandboxEntry,
 ): ManagedWorkloadCloneRegistryFields {
   const webSearch =
-    profile.agentConfig.agent === "langchain-deepagents-code"
-      ? null
-      : profile.agentConfig.webSearch;
+    profile.agentConfig.agent === "openclaw" || profile.agentConfig.agent === "hermes"
+      ? profile.agentConfig.webSearch
+      : null;
   const hermesDashboard = profile.dashboard.agent === "hermes" ? profile.dashboard : null;
   const dcodeConfig =
     profile.agentConfig.agent === "langchain-deepagents-code" ? profile.agentConfig : null;
@@ -250,8 +250,8 @@ function reboundMessaging(
   destinationSandboxName: string,
 ): SandboxMessagingState | undefined {
   if (profile.messaging.plan === null) return undefined;
-  if (profile.agent === "langchain-deepagents-code") {
-    fail("DCode clone unexpectedly produced a messaging plan");
+  if (profile.agent === "langchain-deepagents-code" || profile.agent === "pi") {
+    fail(`${profile.agent} clone unexpectedly produced a messaging plan`);
   }
   const agent = profile.agent;
   const manifestRegistry = createBuiltInChannelManifestRegistry();

--- a/src/lib/onboard/workload/preparation.ts
+++ b/src/lib/onboard/workload/preparation.ts
@@ -14,6 +14,7 @@ import {
   isManagedImageAgent,
   isShippedManagedImageAgent,
   type ManagedImageContractCatalog,
+  type ManagedImageContractV1,
   type ManagedImagePlatform,
   parseManagedImageContractV1,
   SHIPPED_MANAGED_IMAGE_AGENTS,

--- a/src/lib/onboard/workload/preparation.ts
+++ b/src/lib/onboard/workload/preparation.ts
@@ -9,6 +9,8 @@ import {
   resolveManagedImageCatalogFromGhcr,
 } from "../managed-image/catalog";
 import {
+  isCandidateManagedImageAgent,
+  isManagedImageAgent,
   isShippedManagedImageAgent,
   type ManagedImageContractCatalog,
   type ManagedImagePlatform,
@@ -37,6 +39,7 @@ export interface PrepareSandboxWorkloadSourceInput {
   readonly version: string;
   readonly policy?: ManagedImageSelectionPolicy;
   readonly catalogPath?: string | null;
+  readonly candidateAgentsEnabled?: boolean;
 }
 
 function readExactManagedImageCatalog(catalogPath: string): ManagedImageContractCatalog {
@@ -119,6 +122,7 @@ function unavailableResult(
     runtime: input.runtime,
     catalog: {},
     policy: input.policy ?? input.runtime.managedImageSelectionPolicy,
+    candidateAgentsEnabled: input.candidateAgentsEnabled,
   });
   return {
     source,
@@ -170,6 +174,36 @@ function requireCompleteManagedImageCatalog(
   }
 }
 
+function requireCandidateManagedImageCatalog(
+  catalog: ManagedImageContractCatalog,
+  agent: string,
+  expectedPlatform: ManagedImagePlatform,
+): void {
+  const candidate = catalog[agent];
+  if (candidate === undefined) {
+    throw new SandboxWorkloadPreparationError(
+      `managed image catalog is incomplete; '${agent}' is missing`,
+    );
+  }
+  if (!isManagedImageAgent(agent)) {
+    throw new SandboxWorkloadPreparationError(`'${agent}' is not a managed-image agent`);
+  }
+  let contract: ReturnType<typeof parseManagedImageContractV1>;
+  try {
+    contract = parseManagedImageContractV1(candidate, agent, expectedPlatform);
+  } catch (error) {
+    throw new SandboxWorkloadPreparationError(
+      `managed image catalog contract for '${agent}' failed closed validation`,
+      { cause: error },
+    );
+  }
+  if (isShippedManagedImageAgent(contract.agent)) {
+    throw new SandboxWorkloadPreparationError(
+      `'${contract.agent}' is already shipped and cannot resolve a candidate contract`,
+    );
+  }
+}
+
 /**
  * Resolve a stock workload to an immutable managed image without fetching a
  * catalog for custom, unshipped, or incapable runtime paths.
@@ -182,9 +216,12 @@ export async function prepareSandboxWorkloadSource(
   dependencies: PrepareSandboxWorkloadSourceDependencies = {},
 ): Promise<PreparedSandboxWorkloadSource> {
   const policy = input.policy ?? input.runtime.managedImageSelectionPolicy;
+  const candidateSelection =
+    isCandidateManagedImageAgent(input.agentName) && input.candidateAgentsEnabled === true;
   const cannotSelectManaged =
     input.customDockerfilePath != null ||
-    !isShippedManagedImageAgent(input.agentName) ||
+    !isManagedImageAgent(input.agentName) ||
+    (!isShippedManagedImageAgent(input.agentName) && !candidateSelection) ||
     managedImageRuntimeSupportError(input.runtime) !== null;
   if (cannotSelectManaged) {
     return {
@@ -195,10 +232,17 @@ export async function prepareSandboxWorkloadSource(
         runtime: input.runtime,
         catalog: {},
         policy,
+        candidateAgentsEnabled: input.candidateAgentsEnabled,
       }),
       release: null,
       fallbackDiagnostic: null,
     };
+  }
+
+  if (candidateSelection && !input.catalogPath) {
+    throw new SandboxWorkloadPreparationError(
+      `'${input.agentName}' is a release candidate and requires an exact managed image catalog file`,
+    );
   }
 
   let release: string;
@@ -236,7 +280,11 @@ export async function prepareSandboxWorkloadSource(
       `managed image catalog '${release}' is unavailable: ${diagnostic(error)}`,
     );
   }
-  requireCompleteManagedImageCatalog(catalog, release, platform);
+  if (candidateSelection) {
+    requireCandidateManagedImageCatalog(catalog, input.agentName, platform);
+  } else {
+    requireCompleteManagedImageCatalog(catalog, release, platform);
+  }
 
   return {
     source: resolveSandboxWorkloadSource({
@@ -246,6 +294,7 @@ export async function prepareSandboxWorkloadSource(
       runtime: input.runtime,
       catalog,
       policy,
+      candidateAgentsEnabled: input.candidateAgentsEnabled,
     }),
     release,
     fallbackDiagnostic: null,

--- a/src/lib/onboard/workload/preparation.ts
+++ b/src/lib/onboard/workload/preparation.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import { isDeepStrictEqual } from "node:util";
 
 import {
   ManagedImageCatalogUnavailableError,
@@ -39,7 +40,8 @@ export interface PrepareSandboxWorkloadSourceInput {
   readonly version: string;
   readonly policy?: ManagedImageSelectionPolicy;
   readonly catalogPath?: string | null;
-  readonly candidateAgentsEnabled?: boolean;
+  /** Contract from the repository-accepted candidate qualification receipt. */
+  readonly acceptedCandidateContract?: ManagedImageContractV1 | null;
 }
 
 function readExactManagedImageCatalog(catalogPath: string): ManagedImageContractCatalog {
@@ -122,7 +124,7 @@ function unavailableResult(
     runtime: input.runtime,
     catalog: {},
     policy: input.policy ?? input.runtime.managedImageSelectionPolicy,
-    candidateAgentsEnabled: input.candidateAgentsEnabled,
+    candidateAgentsEnabled: input.acceptedCandidateContract != null,
   });
   return {
     source,
@@ -178,6 +180,7 @@ function requireCandidateManagedImageCatalog(
   catalog: ManagedImageContractCatalog,
   agent: string,
   expectedPlatform: ManagedImagePlatform,
+  acceptedContract: ManagedImageContractV1,
 ): void {
   const candidate = catalog[agent];
   if (candidate === undefined) {
@@ -189,8 +192,10 @@ function requireCandidateManagedImageCatalog(
     throw new SandboxWorkloadPreparationError(`'${agent}' is not a managed-image agent`);
   }
   let contract: ReturnType<typeof parseManagedImageContractV1>;
+  let accepted: ReturnType<typeof parseManagedImageContractV1>;
   try {
     contract = parseManagedImageContractV1(candidate, agent, expectedPlatform);
+    accepted = parseManagedImageContractV1(acceptedContract, agent, expectedPlatform);
   } catch (error) {
     throw new SandboxWorkloadPreparationError(
       `managed image catalog contract for '${agent}' failed closed validation`,
@@ -200,6 +205,11 @@ function requireCandidateManagedImageCatalog(
   if (isShippedManagedImageAgent(contract.agent)) {
     throw new SandboxWorkloadPreparationError(
       `'${contract.agent}' is already shipped and cannot resolve a candidate contract`,
+    );
+  }
+  if (!isDeepStrictEqual(contract, accepted)) {
+    throw new SandboxWorkloadPreparationError(
+      `managed image catalog contract for '${agent}' does not match the accepted qualification receipt`,
     );
   }
 }
@@ -216,8 +226,10 @@ export async function prepareSandboxWorkloadSource(
   dependencies: PrepareSandboxWorkloadSourceDependencies = {},
 ): Promise<PreparedSandboxWorkloadSource> {
   const policy = input.policy ?? input.runtime.managedImageSelectionPolicy;
-  const candidateSelection =
-    isCandidateManagedImageAgent(input.agentName) && input.candidateAgentsEnabled === true;
+  const acceptedCandidateContract = isCandidateManagedImageAgent(input.agentName)
+    ? (input.acceptedCandidateContract ?? null)
+    : null;
+  const candidateSelection = acceptedCandidateContract !== null;
   const cannotSelectManaged =
     input.customDockerfilePath != null ||
     !isManagedImageAgent(input.agentName) ||
@@ -232,7 +244,7 @@ export async function prepareSandboxWorkloadSource(
         runtime: input.runtime,
         catalog: {},
         policy,
-        candidateAgentsEnabled: input.candidateAgentsEnabled,
+        candidateAgentsEnabled: candidateSelection,
       }),
       release: null,
       fallbackDiagnostic: null,
@@ -281,7 +293,12 @@ export async function prepareSandboxWorkloadSource(
     );
   }
   if (candidateSelection) {
-    requireCandidateManagedImageCatalog(catalog, input.agentName, platform);
+    requireCandidateManagedImageCatalog(
+      catalog,
+      input.agentName,
+      platform,
+      acceptedCandidateContract,
+    );
   } else {
     requireCompleteManagedImageCatalog(catalog, release, platform);
   }
@@ -294,7 +311,7 @@ export async function prepareSandboxWorkloadSource(
       runtime: input.runtime,
       catalog,
       policy,
-      candidateAgentsEnabled: input.candidateAgentsEnabled,
+      candidateAgentsEnabled: candidateSelection,
     }),
     release,
     fallbackDiagnostic: null,

--- a/src/lib/onboard/workload/rebuild.ts
+++ b/src/lib/onboard/workload/rebuild.ts
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { isDeepStrictEqual } from "node:util";
+import { readCandidateQualificationReceipt } from "../../agent/candidate";
 import { cloneAndDeepFreeze } from "../../core/immutable";
 import { getVersion } from "../../core/version";
 import type { SandboxEntry } from "../../state/registry/types";
 import { cloneSandboxWorkloadReceipt } from "../../state/registry/workload";
 import type { ResolvedCorporateCa } from "../corporate-ca-types";
 import {
+  isCandidateManagedImageAgent,
   MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
   MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
   type ManagedImageAgent,
@@ -137,19 +139,53 @@ export async function prepareManagedWorkloadRebuildHandoff(
   requireProviderBoundAuthority(authority, options.runtime, options.provider);
 
   let replacement: PreparedSandboxWorkloadSource;
-  try {
-    replacement = await managedWorkloadRebuildDependencies.prepareSandboxWorkloadSource({
-      agentName: authority.agent,
-      legacyDockerfilePath: "managed-rebuild-must-not-stage-this-dockerfile",
-      runtime: options.runtime,
-      version: options.version ?? getVersion(),
-      policy: "require-managed",
-    });
-  } catch (error) {
-    throw new ManagedWorkloadRebuildError(
-      "the current release's complete managed-image catalog is unavailable or invalid",
-      { cause: error },
-    );
+  if (isCandidateManagedImageAgent(authority.agent)) {
+    // A candidate publishes outside the all-agent release cohort, so its
+    // replacement comes from the protected qualification receipt rather than
+    // the current release catalog.
+    let contract;
+    try {
+      contract = readCandidateQualificationReceipt(authority.agent);
+    } catch (error) {
+      throw new ManagedWorkloadRebuildError(
+        "the protected candidate qualification receipt is unavailable or invalid",
+        { cause: error },
+      );
+    }
+    try {
+      replacement = {
+        source: resolveSandboxWorkloadSource({
+          agentName: authority.agent,
+          legacyDockerfilePath: "managed-rebuild-must-not-stage-this-dockerfile",
+          runtime: options.runtime,
+          catalog: { [authority.agent]: contract },
+          policy: "require-managed",
+          candidateAgentsEnabled: true,
+        }),
+        release: contract.source.release,
+        fallbackDiagnostic: null,
+      };
+    } catch (error) {
+      throw new ManagedWorkloadRebuildError(
+        "the accepted candidate image is not supported by the selected runtime",
+        { cause: error },
+      );
+    }
+  } else {
+    try {
+      replacement = await managedWorkloadRebuildDependencies.prepareSandboxWorkloadSource({
+        agentName: authority.agent,
+        legacyDockerfilePath: "managed-rebuild-must-not-stage-this-dockerfile",
+        runtime: options.runtime,
+        version: options.version ?? getVersion(),
+        policy: "require-managed",
+      });
+    } catch (error) {
+      throw new ManagedWorkloadRebuildError(
+        "the current release's complete managed-image catalog is unavailable or invalid",
+        { cause: error },
+      );
+    }
   }
   if (replacement.source.kind !== "managed-image") {
     throw new ManagedWorkloadRebuildError(
@@ -332,6 +368,7 @@ export function prepareSandboxWorkloadSourceFromRebuildHandoff(
       runtime,
       catalog: { [handoff.agent]: handoff.replacement.source.contract },
       policy: "require-managed",
+      candidateAgentsEnabled: isCandidateManagedImageAgent(handoff.agent),
     });
   } catch (error) {
     throw new SandboxWorkloadPreparationError(

--- a/src/lib/onboard/workload/rebuild.ts
+++ b/src/lib/onboard/workload/rebuild.ts
@@ -10,9 +10,9 @@ import type { ResolvedCorporateCa } from "../corporate-ca-types";
 import {
   MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
   MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
+  type ManagedImageAgent,
   type ManagedImageContractV1,
   parseManagedImageContractV1,
-  type ShippedManagedImageAgent,
 } from "../managed-image/contract";
 import {
   type BuiltManagedStartupOnboardProfile,
@@ -57,7 +57,7 @@ const HOST_PROXY_ENV_NAMES = [
 export interface ManagedWorkloadRebuildCatalogHandoff {
   readonly schemaVersion: 1;
   readonly providerId: string;
-  readonly agent: ShippedManagedImageAgent;
+  readonly agent: ManagedImageAgent;
   /** Exact authority retained until a replacement has become Ready. */
   readonly previousReceipt: ManagedWorkloadReceipt;
   readonly previousContract: ManagedImageContractV1;

--- a/src/lib/onboard/workload/source.ts
+++ b/src/lib/onboard/workload/source.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  isManagedImageAgent,
   isManagedImagePlatform,
   isShippedManagedImageAgent,
   MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
@@ -63,6 +64,7 @@ export interface ResolveSandboxWorkloadSourceOptions {
   readonly runtime: SandboxWorkloadRuntimeCapabilities;
   readonly catalog: ManagedImageContractCatalog;
   readonly policy?: ManagedImageSelectionPolicy;
+  readonly candidateAgentsEnabled?: boolean;
 }
 
 export class SandboxWorkloadSourceError extends Error {
@@ -156,11 +158,19 @@ export function resolveSandboxWorkloadSource(
     return legacySource(options, "custom-dockerfile");
   }
 
-  if (!isShippedManagedImageAgent(options.agentName)) {
+  const agentName = options.agentName;
+  if (!isManagedImageAgent(agentName)) {
     return unavailableSource(
       options,
       "agent-not-managed",
       "the selected agent is not a shipped managed agent",
+    );
+  }
+  if (!isShippedManagedImageAgent(agentName) && options.candidateAgentsEnabled !== true) {
+    return unavailableSource(
+      options,
+      "agent-not-managed",
+      "the selected agent is a release candidate and candidate selection is disabled",
     );
   }
 
@@ -169,7 +179,7 @@ export function resolveSandboxWorkloadSource(
     return unavailableSource(options, "runtime-unsupported", runtimeSupportError);
   }
 
-  const candidate = options.catalog[options.agentName];
+  const candidate = options.catalog[agentName];
   if (candidate === undefined) {
     return unavailableSource(
       options,
@@ -186,7 +196,7 @@ export function resolveSandboxWorkloadSource(
   }
 
   try {
-    const contract = parseManagedImageContractV1(candidate, options.agentName, expectedPlatform);
+    const contract = parseManagedImageContractV1(candidate, agentName, expectedPlatform);
     return {
       kind: "managed-image",
       reference: contract.reference,
@@ -194,7 +204,7 @@ export function resolveSandboxWorkloadSource(
     };
   } catch (error) {
     throw new SandboxWorkloadSourceError(
-      `Managed image contract for '${options.agentName}' failed closed validation.`,
+      `Managed image contract for '${agentName}' failed closed validation.`,
       { cause: error },
     );
   }

--- a/src/lib/onboard/workload/source.ts
+++ b/src/lib/onboard/workload/source.ts
@@ -88,6 +88,11 @@ function legacySource(
   options: ResolveSandboxWorkloadSourceOptions,
   reason: LegacyDockerfileReason,
 ): LegacyDockerfileWorkloadSource {
+  if (isCandidateManagedImageAgent(options.agentName)) {
+    throw new SandboxWorkloadSourceError(
+      `Agent '${options.agentName}' is a release candidate and must use its exact managed image digest; the legacy Dockerfile workload is not accepted for ${reason}.`,
+    );
+  }
   if (!options.runtime.legacyDockerfileBuilds) {
     throw new SandboxWorkloadSourceError(
       `Driver '${options.runtime.driverName}' cannot use the legacy Dockerfile workload for ${reason}.`,
@@ -109,7 +114,10 @@ function unavailableSource(
   reason: Exclude<LegacyDockerfileReason, "custom-dockerfile">,
   detail: string,
 ): LegacyDockerfileWorkloadSource {
-  if ((options.policy ?? options.runtime.managedImageSelectionPolicy) === "require-managed") {
+  if (
+    isCandidateManagedImageAgent(options.agentName) ||
+    (options.policy ?? options.runtime.managedImageSelectionPolicy) === "require-managed"
+  ) {
     throw new SandboxWorkloadSourceError(
       `Managed image workload is required for '${options.agentName}', but ${detail}.`,
     );
@@ -157,18 +165,12 @@ export function resolveSandboxWorkloadSource(
 ): SandboxWorkloadSource {
   if (
     isCandidateManagedImageAgent(options.agentName) &&
-    options.candidateAgentsEnabled === true
+    options.customDockerfilePath !== undefined &&
+    options.customDockerfilePath !== null
   ) {
-    if (options.customDockerfilePath !== undefined && options.customDockerfilePath !== null) {
-      throw new SandboxWorkloadSourceError(
-        `Agent '${options.agentName}' is a release candidate and must use its exact managed image digest; a custom Dockerfile is not accepted.`,
-      );
-    }
-    if (!options.runtime.managedImages) {
-      throw new SandboxWorkloadSourceError(
-        `Agent '${options.agentName}' is a release candidate and driver '${options.runtime.driverName}' does not advertise managed images.`,
-      );
-    }
+    throw new SandboxWorkloadSourceError(
+      `Agent '${options.agentName}' is a release candidate and must use its exact managed image digest; a custom Dockerfile is not accepted.`,
+    );
   }
 
   if (options.customDockerfilePath !== undefined && options.customDockerfilePath !== null) {

--- a/src/lib/onboard/workload/source.ts
+++ b/src/lib/onboard/workload/source.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  isCandidateManagedImageAgent,
   isManagedImageAgent,
   isManagedImagePlatform,
   isShippedManagedImageAgent,
@@ -154,6 +155,22 @@ export function managedImageRuntimePlatform(
 export function resolveSandboxWorkloadSource(
   options: ResolveSandboxWorkloadSourceOptions,
 ): SandboxWorkloadSource {
+  if (
+    isCandidateManagedImageAgent(options.agentName) &&
+    options.candidateAgentsEnabled === true
+  ) {
+    if (options.customDockerfilePath !== undefined && options.customDockerfilePath !== null) {
+      throw new SandboxWorkloadSourceError(
+        `Agent '${options.agentName}' is a release candidate and must use its exact managed image digest; a custom Dockerfile is not accepted.`,
+      );
+    }
+    if (!options.runtime.managedImages) {
+      throw new SandboxWorkloadSourceError(
+        `Agent '${options.agentName}' is a release candidate and driver '${options.runtime.driverName}' does not advertise managed images.`,
+      );
+    }
+  }
+
   if (options.customDockerfilePath !== undefined && options.customDockerfilePath !== null) {
     return legacySource(options, "custom-dockerfile");
   }

--- a/src/lib/state/registry/rebuild-authority.ts
+++ b/src/lib/state/registry/rebuild-authority.ts
@@ -5,9 +5,9 @@ import { createHash } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { cloneAndDeepFreeze } from "../../core/immutable";
 import {
-  isShippedManagedImageAgent,
+  isManagedImageAgent,
   MANAGED_IMAGE_REPOSITORIES,
-  type ShippedManagedImageAgent,
+  type ManagedImageAgent,
 } from "../../onboard/managed-image/contract";
 import { withLock } from "./lock";
 import { load, save } from "./persistence";
@@ -76,10 +76,10 @@ function requireReceiptAgent(
   agent: SandboxEntry["agent"],
   workload: ManagedWorkloadReceipt,
   label: string,
-): ShippedManagedImageAgent {
+): ManagedImageAgent {
   if (
     typeof agent !== "string" ||
-    !isShippedManagedImageAgent(agent) ||
+    !isManagedImageAgent(agent) ||
     !workload.reference.startsWith(`${MANAGED_IMAGE_REPOSITORIES[agent]}@sha256:`)
   ) {
     throw new SandboxRebuildAuthorityError(

--- a/test/protected-managed-image-contract.test.ts
+++ b/test/protected-managed-image-contract.test.ts
@@ -6,6 +6,10 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import {
+  CANDIDATE_MANAGED_IMAGE_AGENTS,
+  SHIPPED_MANAGED_IMAGE_AGENTS,
+} from "../src/lib/onboard/managed-image/contract.ts";
+import {
   PROTECTED_MANAGED_IMAGE_ACTIVATION_PATH,
   PROTECTED_MANAGED_IMAGE_AGENTS,
   PROTECTED_MANAGED_IMAGE_MULTIARCH_JOB_ID,
@@ -185,5 +189,12 @@ describe("protected managed-image build contract", () => {
         evidenceIdentity("linux/arm64"),
       ),
     ).toThrow("does not match its exact contract");
+  });
+
+  it("stays aligned with the canonical shipped managed-image inventory (#7927)", () => {
+    expect([...PROTECTED_MANAGED_IMAGE_AGENTS]).toEqual([...SHIPPED_MANAGED_IMAGE_AGENTS]);
+    for (const agent of CANDIDATE_MANAGED_IMAGE_AGENTS) {
+      expect(PROTECTED_MANAGED_IMAGE_AGENTS).not.toContain(agent);
+    }
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Pi can be selected, persisted, onboarded from an exact managed-image digest, and driven through the shared sandbox lifecycle, but only behind a protected candidate boundary whose authority lives in the repository rather than in caller configuration. New public Pi selection stays unavailable: with no published qualification receipt, `--agent pi` still reports `Unknown agent 'pi'`, and no environment a user can set will change that. Public selection stays owned by #8818.

## Related Issue

Resolves #7927

## Changes

- Add `src/lib/agent/candidate-authority.ts`: the repository-controlled list of qualification-receipt digests that make a release candidate reachable. It ships with the CLI, so a caller can neither mint an accepted digest nor replace one; adding an entry takes a reviewed change to that file. The list is empty in this change, because qualification evidence is owned by #7928 and public activation by #8818.
- Add `src/lib/agent/candidate.ts`: a generic candidate-agent gate keyed off the existing `CANDIDATE_MANAGED_IMAGE_AGENTS` list, so no module gains a `pi` literal. The caller supplies only `NEMOCLAW_CANDIDATE_AGENTS=1` and a receipt location; whether that receipt qualifies is decided by the repository authority, and an accepted receipt is then revalidated through the shared managed-image contract parser against the canonical NVIDIA repository and an exact digest. Selection performs that whole check before Pi is exposed, so a missing or unpublished receipt never reaches agent listing. This is the current consumer of `isCandidateManagedImageAgent`, which #7925 declared and nothing used.
- Replace the unconditional Pi exclusion in `src/lib/agent/defs.ts` with gate-aware resolution. Alias resolution, interactive choices, and `--agent` follow from `listAgents(env)` and need no separate change. A resumed session that names a withheld candidate fails closed rather than silently becoming an OpenClaw session.
- Select the exact candidate digest in `src/lib/onboard/workload/source.ts` and `preparation.ts`. A candidate resolves only from the exact catalog file supplied through the existing `--temp-managed-runtime-catalog` flag, never from the GHCR all-agent cohort fetch, and is refused if the contract claims a shipped agent. A candidate never reaches the legacy Dockerfile workload: `unavailableSource()` treats a candidate as require-managed whatever the driver policy says, and `legacySource()` refuses one outright, so an incomplete runtime capability, an unsupported contract version, an empty catalog, or a custom Dockerfile all fail closed.
- Widen durable managed-workload receipts from the shipped set to the managed-image set in `workload/authority.ts`, `state/registry/rebuild-authority.ts`, and `managed-workload/rebuild/contract.ts`, so an accepted candidate's image identity survives in the registry. Decoding a stored receipt does not consult the gate. Rebuild and upgrade do: a candidate replacement is resolved from current qualification authority, so those operations fail closed once the candidate is no longer qualified.
- Add `pi` to `MANAGED_STARTUP_AGENTS` and complete every exhaustive per-agent record it governs, plus a `mapPiProfile` mapper matching what `agents/pi/start.sh` and `agents/pi/generate-config.ts` actually read. Pi carries no dashboard, messaging, or tuning surface, per the accepted #7926 matrix.
- Register Pi's managed output targets in `managed-startup/shared-state-transaction.ts`. That per-agent switch is not exhaustiveness-checked, so Pi would otherwise have had no managed outputs and `models.json` would have gone unprotected across a rollback.
- Keep Pi off Podman. `podman-image-transaction.ts` now records an explicit per-agent boolean instead of a presence-only allowlist, so exhaustiveness still forces a decision for any new agent while Pi fails closed with an error naming the agent and the required Docker path. #7926 fixes Pi v1 to Docker and defers Podman to #7744.
- Derive `PROTECTED_MANAGED_IMAGE_AGENTS` from the shipped-agent repository map in `scripts/checks/protected-managed-image-contract.ts`, so a candidate cannot be enrolled in the protected matrix and a newly shipped agent cannot be omitted from it. The module keeps its type-only dependency on CLI source, and `test/protected-managed-image-contract.test.ts` holds it against the canonical shipped inventory.
- Retype the shipped-cohort qualification scripts under `scripts/checks/` to `ShippedManagedImageAgent`. They are shipped-image scripts, and enrolling a candidate in that matrix would contradict the candidate contract validator.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no published surface changes. New public Pi selection stays unavailable, and the paths that do run for a recorded Pi sandbox are reachable only from state a user cannot create through a documented command, so no `docs/CONTRIBUTING.md` "When to Update Docs" trigger fires. NemoCUA is the same shape of gated candidate agent and has no `docs/` presence. Pi documentation is owned by #7929 and public activation by #8818; documenting the activation variables now would establish a product surface ahead of those decisions.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop completed the nine-category security review for commit `9fbd3dc09`. Candidate activation remains bound to repository qualification authority, caller-supplied catalog data cannot qualify Pi, unsupported workload paths fail closed, and the repair adds no credential or authorization bypass. No security findings remain.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no documentation paths changed. Independent review of the final diff at commit `9fbd3dc09` confirmed that Pi remains unavailable through public selection because the repository publishes no accepted qualification receipt. Current supported-agent, command, environment-variable, Podman, managed-image, rebuild, and snapshot documentation remains accurate. The final test-only contributor change and title correction add no public surface.
- Agent: Codex Desktop (`/root/docs_review_9212`)
<!-- docs-review-head-sha: 9fbd3dc09 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run typecheck:cli` clean; `npm run checks:repository` passes; `npx vitest run` over the 31 touched suites gives 417 passed, 0 failed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Scope notes for reviewers

**Lifecycle contract.** Four distinct boundaries, now matching the code and its tests:

- New public Pi selection is unavailable. No environment a user can set reaches it.
- A recorded Pi sandbox can be identified by status, which reports a withheld candidate as an actionable diagnostic rather than as an unknown agent.
- Resume, rebuild, and upgrade require current qualification authority and fail closed without it.
- Durable receipt decoding does not consult the gate, so an existing sandbox stays readable. That is not permission to run every lifecycle operation after the candidate is withdrawn.

**Qualification authority.** The candidate gate no longer treats caller-supplied values as authority. Previously the process supplied both the receipt and the digest it had to match, so any user could write a syntactically valid contract, hash it, and satisfy the gate. The accepted digest now lives in `src/lib/agent/candidate-authority.ts` and ships with the CLI, and the accepted set is empty in this change. `src/lib/agent/candidate.test.ts` runs against that real authority and proves a caller-written receipt stays unavailable however it is hashed or described; `src/lib/agent/candidate-qualified.test.ts` stubs the authority module to cover the accepted path, receipt tampering after publication, and a receipt claiming a shipped agent. Adding a real digest is a reviewed change to a source file, which keeps activation with #7928 and #8818 rather than with a user's environment.

**Acceptance criteria.** All twelve are implemented, and the operational criteria now execute through exported entrypoints in `src/lib/actions/sandbox/pi-candidate-lifecycle.test.ts`: `getSandboxStatusReport()` for status and the machine-readable inventory payload, `showSandboxLogsWithDeps()` for logs, `requireSandboxDestructiveCleanupAuthority()` for destroy, and `createOnboardAgentSelector()` for resume. Status resolves Pi's identity separately from the recorded compute runtime and reports the withheld candidate with an actionable diagnostic; logs read the sandbox source alone and never probe the OpenClaw gateway; destroy resolves provider-delegated cleanup from the recorded driver and retains the shared managed image. Criterion 3 depends on a published qualification receipt, which #7928 owns; the exact candidate start path is implemented and covered, and enabling it is one reviewed digest entry.

Covering resume surfaced a real defect, now fixed. `resolveAgentName()` fell back to OpenClaw whenever a recorded session named an agent it could not resolve, so a resumed Pi session silently became an OpenClaw session and stranded its agent-scoped state.

**Review round 3 — findings fixed.**

- Candidate qualification is now bound to repository authority, and the selection boundary validates it before Pi is exposed rather than checking that two environment variables are present and well formed.
- An enabled candidate can no longer reach a host Dockerfile through a permissive runtime policy. Every unavailable candidate path fails closed, with coverage for an incomplete runtime capability, a driver without exact-digest support, an empty catalog, and a custom Dockerfile.
- The lifecycle tests now drive the exported status, logs, destroy, and resume entrypoints instead of helper and authority-resolution functions.
- Required shard 1 is fixed. `scripts/checks/protected-managed-image-contract.ts` had gained a value import from CLI source, which the isolated advisor runtime in `test/e2e-recommendations.test.ts` cannot resolve. The module is standalone again with a type-only import, and drift against the shipped inventory is now checked by a test rather than by a runtime dependency.
- Temporary qualification receipts are removed after each test.

Two CodeRabbit findings are not applied. Importing `scripts/checks/generate-managed-startup-profile-fixture.mts` from a source test follows more than thirty existing suites on `main` and is the established way to build a managed-startup profile fixture; moving it is a repository-wide refactor, not part of this change. The second is the inventory and log entrypoint finding, which is addressed above.

**Earlier rounds.** Round 2 fixed the `buildCandidate()` branch that produced an invalid Pi profile, the custom-Dockerfile bypass, candidate rebuild resolution, and the `scripts/managed-bootstrap-trampoline.sh` and `scripts/managed-startup-hold.sh` guards that were failing required CI. `PRA-3` exposed that the shared-state rollback test never parameterised over Pi; it does now, and that surfaced two more hardcoded shipped-only agent lists in the transaction manifest parser, which now derive from `MANAGED_STARTUP_AGENTS`.

**#7930 overlap.** Completing the lifecycle required adding `pi` to `MANAGED_STARTUP_AGENTS`, which lands startup-profile content that overlaps #7930: route mapping into the shared profile, the `models.json` generator command and managed-output registration, and compute-runtime-neutral serialization. It does not land #7930's provider-catalog model validation, Pi capability checks, credential placeholder and rewrite behaviour, context-window or output-token settings, or the credential-redaction and route-drift tests. #7930 stays open.

Deterministic and live qualification evidence is owned by **#7928**; Pi documentation by **#7929**.

**Verification.** `npm run typecheck:cli` clean; `npm run checks:repository` passes; the touched suites give 417 passed, 0 failed. A full `--project cli --project integration` run reports failures in this environment, and running the same failing file set on a clean `origin/main` worktree on the same machine gives 120 failures against this branch's 117; no regression is attributable to this change.

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Pi agent in managed startup workflows, including configuration, lifecycle handling, persistence, and terminal-only operation.
  - Added secure release-candidate qualification, allowing approved candidate agents to be discovered, selected, restored, and rebuilt only with valid published credentials.
  - Added Pi managed-image lifecycle and rebuild support.

- **Bug Fixes**
  - Web-search settings are now retained only for OpenClaw and Hermes.
  - Unsupported Pi configurations are rejected clearly, including Podman-based bootstrapping and managed dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

