### PR TITLE
fix(e2e): retry transient OpenClaw TUI lookup

### DIFF
--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -78,7 +78,8 @@ function qualifyTuiInputMode() {
   let ttyPath;
   try {
     ttyPath = fs.realpathSync(path.join("/proc", pids[0], "fd", "0"));
-  } catch {
+  } catch (error) {
+    if (error && ["ENOENT", "ESRCH"].includes(error.code)) finish(1);
     finish(2, "tui_stdin_unavailable");
   }
   if (!/^\/dev\/pts\/\d+$/.test(ttyPath)) finish(2, "tui_stdin_not_pty");

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -23,6 +23,8 @@ import {
   runOpenClawLaunchReadinessLeaseTurns,
 } from "../live/launch-agent-turn.ts";
 
+const PROCESS_EXIT_WAIT = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+
 type SessionRecords = Record<string, string[]>;
 type FixtureMode =
   | "cleanup-failure"
@@ -365,7 +367,7 @@ exec "$@"
       tuiProcessIds.some((pid) => existsSync(`/proc/${pid}`)) &&
       Date.now() < processExitDeadline
     ) {
-      spawnSync(process.execPath, ["-e", "setTimeout(() => {}, 25)"], { timeout: 100 });
+      Atomics.wait(PROCESS_EXIT_WAIT, 0, 0, 25);
     }
     return {
       baselineRemoved: !existsSync(baselinePath),

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -35,6 +35,7 @@ type FixtureMode =
   | "nonzero"
   | "nonzero-cleanup-failure"
   | "recording-timeout"
+  | "transient-tui-stdin"
   | "valid";
 
 function message(role: "assistant" | "user", content = "nonempty"): string {
@@ -140,6 +141,8 @@ function runLaunchSessionFixture(mode: FixtureMode, terminalCopy: "absent" | "an
   const sessionRoot = join(fixtureRoot, "sessions");
   const tuiInputMarkerRoot = join(fixtureRoot, "tui-input");
   const tuiPidsPath = join(fixtureRoot, "tui-pids");
+  const tuiStdinRetryMarker = join(fixtureRoot, "tui-stdin-retry");
+  const tuiStdinUnavailableMarker = join(fixtureRoot, "tui-stdin-unavailable");
   const ttyMarker = join(fixtureRoot, "tty-observed");
   const runId = basename(fixtureRoot).replaceAll(/[^a-zA-Z0-9]/gu, "");
   const baselinePath = `/tmp/nemoclaw-launch-session-${runId}.json`;
@@ -156,34 +159,65 @@ const childProcess = require("node:child_process");
 
 const mode = process.env.NEMOCLAW_FIXTURE_MODE;
 if (process.argv[2] !== "tui") {
-  if (mode !== "multiple-tui-processes") {
+  if (mode === "transient-tui-stdin") {
+    const transient = childProcess.spawn(
+      process.execPath,
+      [__filename, "tui", "stdin-unavailable"],
+      { stdio: "inherit" },
+    );
+    fs.writeFileSync(process.env.NEMOCLAW_FIXTURE_TUI_PIDS, transient.pid + "\n");
+    const stopTransient = () => {
+      try { transient.kill("SIGTERM"); } catch {}
+      setTimeout(() => process.exit(0), 100);
+    };
+    for (const signal of ["SIGHUP", "SIGINT", "SIGTERM"]) {
+      process.once(signal, stopTransient);
+    }
+    transient.once("exit", async (status) => {
+      for (const signal of ["SIGHUP", "SIGINT", "SIGTERM"]) {
+        process.removeListener(signal, stopTransient);
+      }
+      if (status !== 0) process.exit(status ?? 66);
+      const processExitDeadline = Date.now() + 1_000;
+      while (fs.existsSync("/proc/" + transient.pid) && Date.now() < processExitDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      if (fs.existsSync("/proc/" + transient.pid)) process.exit(69);
+      const child = childProcess.spawnSync(process.execPath, [__filename, "tui"], {
+        stdio: "inherit",
+      });
+      fs.appendFileSync(process.env.NEMOCLAW_FIXTURE_TUI_PIDS, child.pid + "\n");
+      process.exit(child.status ?? 66);
+    });
+  } else if (mode !== "multiple-tui-processes") {
     const child = childProcess.spawnSync(process.execPath, [__filename, "tui"], { stdio: "inherit" });
     process.exit(child.status ?? 66);
-  }
-  const children = Array.from({ length: 2 }, () =>
-    childProcess.spawn(process.execPath, [__filename, "tui"], { stdio: "inherit" }),
-  );
-  fs.writeFileSync(
-    process.env.NEMOCLAW_FIXTURE_TUI_PIDS,
-    children.map((child) => child.pid).join("\n") + "\n",
-  );
-  const stopChildren = () => {
-    for (const child of children) {
-      try { child.kill("SIGTERM"); } catch {}
+  } else {
+    const children = Array.from({ length: 2 }, () =>
+      childProcess.spawn(process.execPath, [__filename, "tui"], { stdio: "inherit" }),
+    );
+    fs.writeFileSync(
+      process.env.NEMOCLAW_FIXTURE_TUI_PIDS,
+      children.map((child) => child.pid).join("\n") + "\n",
+    );
+    const stopChildren = () => {
+      for (const child of children) {
+        try { child.kill("SIGTERM"); } catch {}
+      }
+    };
+    for (const signal of ["SIGHUP", "SIGINT", "SIGTERM"]) {
+      process.once(signal, () => {
+        stopChildren();
+        setTimeout(() => process.exit(0), 100);
+      });
     }
-  };
-  for (const signal of ["SIGHUP", "SIGINT", "SIGTERM"]) {
-    process.once(signal, () => {
-      stopChildren();
-      setTimeout(() => process.exit(0), 100);
-    });
-  }
-  let activeChildren = children.length;
-  for (const child of children) {
-    child.once("exit", () => {
-      activeChildren -= 1;
-      if (activeChildren === 0) process.exit(0);
-    });
+    let activeChildren = children.length;
+    for (const child of children) {
+      child.once("exit", () => {
+        activeChildren -= 1;
+        if (activeChildren === 0) process.exit(0);
+      });
+    }
   }
 }
 
@@ -196,7 +230,10 @@ if (process.argv[2] === "tui") (async () => {
     sessionFile,
     JSON.stringify({ message: { content: [{ text: content, type: "text" }], role }, type: "message" }) + "\n",
   );
-  if (mode === "multiple-tui-processes") {
+  if (
+    mode === "multiple-tui-processes" ||
+    (mode === "transient-tui-stdin" && process.argv[3] !== "stdin-unavailable")
+  ) {
     let observedPtyInput = "";
     process.stdin.on("data", (chunk) => {
       observedPtyInput += chunk.toString();
@@ -204,6 +241,18 @@ if (process.argv[2] === "tui") (async () => {
         fs.writeFileSync(process.env.NEMOCLAW_FIXTURE_TUI_INPUT_MARKER_ROOT + "/" + process.pid, "");
       }
     });
+  }
+  if (mode === "transient-tui-stdin" && process.argv[3] === "stdin-unavailable") {
+    fs.closeSync(0);
+    fs.writeFileSync(process.env.NEMOCLAW_FIXTURE_TUI_STDIN_UNAVAILABLE, "");
+    const deadline = Date.now() + 5_000;
+    while (
+      !fs.existsSync(process.env.NEMOCLAW_FIXTURE_TUI_STDIN_RETRY) &&
+      Date.now() < deadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    process.exit(fs.existsSync(process.env.NEMOCLAW_FIXTURE_TUI_STDIN_RETRY) ? 0 : 68);
   }
   if (mode === "delayed-input-attachment" || mode === "input-mode-timeout") {
     let inputBeforeAttachment = false;
@@ -263,6 +312,16 @@ fi
 while [[ "$#" -gt 0 && "$1" != "--" ]]; do shift; done
 [[ "$#" -gt 0 ]]
 shift
+if [[ "$NEMOCLAW_FIXTURE_MODE" == "transient-tui-stdin" && "$4" == "input-mode" ]]; then
+  set +e
+  "$@"
+  status=$?
+  set -e
+  if [[ "$status" == 1 && -f "$NEMOCLAW_FIXTURE_TUI_STDIN_UNAVAILABLE" ]]; then
+    : >"$NEMOCLAW_FIXTURE_TUI_STDIN_RETRY"
+  fi
+  exit "$status"
+fi
 exec "$@"
 `,
     );
@@ -279,6 +338,8 @@ exec "$@"
         NEMOCLAW_FIXTURE_TERMINAL_COPY: terminalCopy,
         NEMOCLAW_FIXTURE_TUI_INPUT_MARKER_ROOT: tuiInputMarkerRoot,
         NEMOCLAW_FIXTURE_TUI_PIDS: tuiPidsPath,
+        NEMOCLAW_FIXTURE_TUI_STDIN_RETRY: tuiStdinRetryMarker,
+        NEMOCLAW_FIXTURE_TUI_STDIN_UNAVAILABLE: tuiStdinUnavailableMarker,
         NEMOCLAW_FIXTURE_TTY_MARKER: ttyMarker,
         NEMOCLAW_LAUNCH_COMMAND: fakeLaunch,
         NEMOCLAW_LAUNCH_ENTRYPOINT: "",
@@ -313,6 +374,7 @@ exec "$@"
         existsSync(join(tuiInputMarkerRoot, pid)),
       ),
       result,
+      tuiStdinUnavailableObserved: existsSync(tuiStdinUnavailableMarker),
       tuiProcessIds,
       ttyObserved: existsSync(ttyMarker),
     };
@@ -434,6 +496,30 @@ it.runIf(process.platform === "linux")(
     expect(baselineRemoved).toBe(true);
     expect(result.signal).toBeNull();
     expect(result.status).toBe(0);
+  },
+);
+
+it.runIf(process.platform === "linux")(
+  "retries when a matching OpenClaw TUI process closes standard input (#9160)",
+  () => {
+    const {
+      baselineRemoved,
+      orphanedTuiProcessIds,
+      recordedTuiInputProcessIds,
+      result,
+      tuiProcessIds,
+      tuiStdinUnavailableObserved,
+      ttyObserved,
+    } = runLaunchSessionFixture("transient-tui-stdin", "absent");
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(ttyObserved).toBe(true);
+    expect(tuiProcessIds).toHaveLength(2);
+    expect(tuiStdinUnavailableObserved).toBe(true);
+    expect(recordedTuiInputProcessIds).toEqual([tuiProcessIds[1]]);
+    expect(orphanedTuiProcessIds).toEqual([]);
+    expect(baselineRemoved).toBe(true);
+    expect(result.signal).toBeNull();
   },
 );
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The live OpenClaw E2E verifier now retries when its single matching TUI process disappears while descriptor 0 is being resolved. Stable input errors remain fatal, and the regression test proves that input reaches only the replacement TUI.

## Related Issue

Related to #9160. Ownership for main run `31892326555`, job `95031519568`, is recorded in [the claim comment](https://github.com/NVIDIA/NemoClaw/issues/9160#issuecomment-5302979302).

## Changes

- Treat only `ENOENT` and `ESRCH` from the single matching TUI descriptor-0 lookup as pending; keep multiple processes, stable non-PTY input, permission or unknown lookup errors, terminal-mode errors, and fatal structured evidence fatal.
- Add a deterministic Linux regression in which one real matching TUI closes descriptor 0, the actual input-mode probe observes the retry boundary, and only a later replacement receives the prompt.
- Replace the cleanup poll's sleep-only Node child with a bounded in-process `Atomics.wait` while preserving its one-second liveness deadline.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this changes only the internal live E2E verifier and its support fixture; supported product behavior and user-visible surfaces are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent security review passed all nine categories for `9291e388d` with no findings; retryable errors remain bounded and cannot qualify without structured session evidence.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: at commit under review `9291e388d`, the complete diff changes only `test/e2e/live/launch-agent-turn.ts` and `test/e2e/support/launch-agent-turn.test.ts`; the follow-up replaces a test-only cleanup-poll child process with a bounded in-process wait and does not change supported product behavior or a user-visible surface.
- Agent: Codex Desktop (`/root/openclaw_docs_review`)
<!-- docs-review-head-sha: 9291e388d -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — Linux `e2e-support` focused file: 19/19 passed; macOS: 6 passed and 13 Linux-only skipped. Archive SHA-256: `93a22b850fddca0eeea5ecaaf044893f002283c73a597ce23384dfdbf952a20b`; Linux JSON SHA-256: `e2ac8d5a739340fe39f3685fc5f6b58631eb5cfcc8d9b889f20f87b9d12a7658`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this two-file E2E-support correction; CLI typecheck, Oxfmt, Oxlint, repository checks, `git diff --check`, and `npm run validate:pr` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Independent code review passed with no findings for `9291e388d`. Independent security review passed all nine categories with no findings.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transient TUI input closure during launch sessions.
  * Launches now retry with a replacement TUI process when the initial process exits unexpectedly.
  * Unrelated input-resolution failures continue to report an appropriate error.

* **Tests**
  * Added Linux coverage for retry behavior and confirmed that no orphan processes remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->