### PR TITLE
fix(e2e): use isolated gateway state for inference switch

### DIFF
--- a/test/e2e/fixtures/compatible-anthropic-switch.ts
+++ b/test/e2e/fixtures/compatible-anthropic-switch.ts
@@ -123,8 +123,8 @@ function readOwnedGatewayStateFile(filePath: string, currentUid: number): string
   }
 }
 
-function managedOpenShellGatewayPid(): number | null {
-  const stateDirectory = resolveDockerDriverGatewayStateDir(process.env, os.homedir());
+function managedOpenShellGatewayPid(homeDir: string): number | null {
+  const stateDirectory = resolveDockerDriverGatewayStateDir(process.env, homeDir);
   const pidPath = path.join(stateDirectory, "openshell-gateway.pid");
   const markerPath = path.join(stateDirectory, "runtime.json");
   const pidPathExists = pathExists(pidPath);
@@ -186,8 +186,8 @@ function managedOpenShellGatewayPid(): number | null {
   return pid;
 }
 
-async function activeOpenShellGatewayPid(host: HostCliClient): Promise<number> {
-  const managedPid = managedOpenShellGatewayPid();
+async function activeOpenShellGatewayPid(host: HostCliClient, homeDir: string): Promise<number> {
+  const managedPid = managedOpenShellGatewayPid(homeDir);
   if (managedPid !== null) return managedPid;
   for (const serviceName of GATEWAY_SERVICE_NAMES) {
     const result = await host.command(
@@ -219,11 +219,12 @@ async function activeOpenShellGatewayPid(host: HostCliClient): Promise<number> {
 export async function installGatewayHostVerificationAlias(
   host: HostCliClient,
   cleanup: { add(name: string, run: () => Promise<void> | void): void },
+  homeDir: string = os.homedir(),
 ): Promise<void> {
-  const gatewayPid = await activeOpenShellGatewayPid(host);
+  const gatewayPid = await activeOpenShellGatewayPid(host, homeDir);
   const ownerToken = randomBytes(16).toString("hex");
   const fixtureDirectory = fs.mkdtempSync(
-    path.join(os.homedir(), ".nemoclaw-gateway-resolver-"),
+    path.join(homeDir, ".nemoclaw-gateway-resolver-"),
   );
   const resolverSource = path.join(fixtureDirectory, "hosts");
   const ownedLine = `127.0.0.1 ${OPENSHELL_HOST_ALIAS} # nemoclaw-gateway-host-verifier:${ownerToken}`;

--- a/test/e2e/live/openclaw-inference-switch.test.ts
+++ b/test/e2e/live/openclaw-inference-switch.test.ts
@@ -1093,7 +1093,7 @@ test("openclaw-inference-switch: switches route and preserves live OpenClaw beha
 
   if (SWITCH_PROVIDER === "compatible-anthropic-endpoint" && SWITCH_MOCK_ANTHROPIC === "1") {
     mockProvider = await startMockAnthropicProvider();
-    await installGatewayHostVerificationAlias(host, cleanup);
+    await installGatewayHostVerificationAlias(host, cleanup, home);
     await artifacts.writeJson("mock-anthropic-provider.json", {
       endpointUrl: mockProvider.endpointUrl,
     });

--- a/test/e2e/support/compatible-anthropic-switch.test.ts
+++ b/test/e2e/support/compatible-anthropic-switch.test.ts
@@ -54,6 +54,20 @@ const INVALID_MANAGED_GATEWAY_STATE_CASES = [
   },
 ] as const;
 
+function mockGatewayProcess(pid: number, gatewayBin: string): void {
+  const statSync = fs.statSync;
+  vi.spyOn(fs, "statSync").mockImplementation(((target) =>
+    String(target) === `/proc/${pid}`
+      ? ({ uid: process.getuid?.() ?? 0 } as fs.Stats)
+      : statSync(target)) as typeof fs.statSync);
+  const realpathSync = fs.realpathSync;
+  const gatewayExecutablePaths = new Set([`/proc/${pid}/exe`, gatewayBin]);
+  vi.spyOn(fs, "realpathSync").mockImplementation(((target) =>
+    gatewayExecutablePaths.has(String(target))
+      ? gatewayBin
+      : realpathSync(target)) as typeof fs.realpathSync);
+}
+
 describe("compatible Anthropic inference switch setup", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -99,11 +113,19 @@ describe("compatible Anthropic inference switch setup", () => {
     expect(rewrite).not.toHaveBeenCalled();
   });
 
-  it("uses the managed Docker-driver gateway before the user service (#9166)", async () => {
-    const stateDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-managed-gateway-test-"));
+  it("uses managed Docker-driver gateway state from the target home before the user service (#9166)", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-target-home-gateway-test-"));
+    const stateDirectory = path.join(
+      home,
+      ".local",
+      "state",
+      "nemoclaw",
+      "openshell-docker-gateway",
+    );
     const pid = process.pid;
     const gatewayBin = "/usr/bin/openshell-gateway";
-    vi.stubEnv("NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR", stateDirectory);
+    fs.mkdirSync(stateDirectory, { recursive: true });
+    vi.stubEnv("NEMOCLAW_OPENSHELL_GATEWAY_STATE_DIR", "");
     writeDockerDriverGatewayPidFile(path.join(stateDirectory, "openshell-gateway.pid"), pid);
     writeDockerDriverGatewayRuntimeMarkerForStateDir(stateDirectory, {
       desiredEnv: {},
@@ -111,17 +133,16 @@ describe("compatible Anthropic inference switch setup", () => {
       gatewayBin,
       pid,
     });
-    const realpathSync = fs.realpathSync;
-    const gatewayExecutablePaths = new Set([`/proc/${pid}/exe`, gatewayBin]);
-    vi.spyOn(fs, "realpathSync").mockImplementation(
-      ((target) =>
-        gatewayExecutablePaths.has(String(target)) ? gatewayBin : realpathSync(target)) as typeof fs.realpathSync,
-    );
+    mockGatewayProcess(pid, gatewayBin);
     const command = vi.fn().mockResolvedValue({ exitCode: 0, stderr: "", stdout: "" });
     const add = vi.fn();
 
     try {
-      await installGatewayHostVerificationAlias({ command } as unknown as HostCliClient, { add });
+      await installGatewayHostVerificationAlias(
+        { command } as unknown as HostCliClient,
+        { add },
+        home,
+      );
       const cleanupMount = add.mock.calls[0]?.[1] as () => Promise<void>;
       await cleanupMount();
 
@@ -133,7 +154,7 @@ describe("compatible Anthropic inference switch setup", () => {
         );
       }
     } finally {
-      fs.rmSync(stateDirectory, { force: true, recursive: true });
+      fs.rmSync(home, { force: true, recursive: true });
     }
   });
 
@@ -153,7 +174,11 @@ describe("compatible Anthropic inference switch setup", () => {
     const add = vi.fn();
 
     try {
-      await installGatewayHostVerificationAlias({ command } as unknown as HostCliClient, { add });
+      await installGatewayHostVerificationAlias(
+        { command } as unknown as HostCliClient,
+        { add },
+        stateDirectory,
+      );
       const cleanupMount = add.mock.calls[0]?.[1] as () => Promise<void>;
       await cleanupMount();
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The OpenClaw inference-switch E2E target installed OpenShell under an isolated home but looked for managed gateway state under the test process's ambient home. Pass the target home to the existing owned gateway-state verifier so the target uses its recorded Docker-driver gateway instead of falling through to unavailable user-systemd services.

Failure evidence: E2E run 31895698451, job 95038810397. Ownership was claimed on #9166 before implementation: https://github.com/NVIDIA/NemoClaw/issues/9166#issuecomment-5303424854

## Related Issue

Related to #9166.

## Changes

- Thread the target home through managed gateway PID and runtime-marker discovery.
- Store the temporary host-verification resolver under the same isolated home.
- Pass the OpenClaw inference-switch target's installation home while preserving the existing default for other callers.
- Add support coverage proving target-home managed state is selected without probing the user service.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: this corrects internal E2E fixture state discovery and changes no supported command, configuration, API, policy, default, error, or runtime behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent Codex Desktop security review at commit under review `d47cc72d8` passed all nine required categories with no finding; the three reviewed file blobs are unchanged at latest PR commit `87a58c462`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: At commit under review `87a58c462`, the complete diff against base `de29c02a1` changes only internal E2E fixtures and tests. It passes the isolated test home to the existing owned gateway-state verifier and stores verifier artifacts under that home; it does not change supported product behavior or a user-visible surface.
- Agent: Codex Desktop (`/root/openclaw_docs_review`)
<!-- docs-review-head-sha: 87a58c462 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — at latest PR commit `87a58c462`, `npx vitest run --project e2e-support test/e2e/support/compatible-anthropic-switch.test.ts`: 11 passed, 1 Linux-only skipped on macOS.
- [ ] Applicable broad gate passed — not applicable to this three-file internal E2E fixture correction; `npm run validate:pr`, CLI typecheck, Oxfmt, Oxlint, repository checks, semantic-phase coverage, size/conditional checks, and `git diff --check` passed after merging main `de29c02a1`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for gateway behavior across custom home directories.
  * Improved validation of gateway process ownership, executable resolution, and state-directory handling.
  * Strengthened host-verification setup and cleanup checks across managed and active service scenarios.
  * Updated provider-switching tests to verify behavior in isolated environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
