### PR TITLE
fix(inference): replace subprocess sleep with Atomics.wait on Windows host

### DIFF
--- a/src/lib/inference/ollama/windows.test.ts
+++ b/src/lib/inference/ollama/windows.test.ts
@@ -5,9 +5,9 @@ import { createRequire } from "node:module";
 import { describe, expect, it, vi } from "vitest";
 
 const require = createRequire(import.meta.url);
+const childProcess = require("node:child_process");
 const WINDOWS_DIST_PATH = require.resolve("./windows");
 const RUNNER_PATH = require.resolve("../../runner");
-const childProcess = require("node:child_process");
 const WINDOWS_OLLAMA_TAGS_URL = "http://host.docker.internal:11434/api/tags";
 
 function commandText(command: string | string[]): string {
@@ -21,20 +21,28 @@ function loadWindowsOllamaWithMocks(
   const runner = require(RUNNER_PATH);
   const originalRun = runner.run;
   const originalRunCapture = runner.runCapture;
+  // Stub the blocking wait so this test does not spend time on retry delays.
+  const atomicsWaitSpy = vi.spyOn(Atomics, "wait").mockReturnValue("timed-out");
+  // Prove the retired subprocess-sleep path stays unused: the module must not
+  // call child_process.spawnSync for its fixed readiness delays.
   const originalSpawnSync = childProcess.spawnSync;
+  const spawnSyncSpy = vi.fn(() => ({ status: 0 }));
+  childProcess.spawnSync = spawnSyncSpy;
 
   delete require.cache[WINDOWS_DIST_PATH];
   runner.run = run;
   runner.runCapture = runCapture;
-  childProcess.spawnSync = vi.fn(() => ({ status: 0 }));
 
   return {
     windows: require(WINDOWS_DIST_PATH),
+    atomicsWaitSpy,
+    spawnSyncSpy,
     restore() {
       delete require.cache[WINDOWS_DIST_PATH];
       runner.run = originalRun;
       runner.runCapture = originalRunCapture;
       childProcess.spawnSync = originalSpawnSync;
+      atomicsWaitSpy.mockRestore();
     },
   };
 }
@@ -73,10 +81,24 @@ describe("Windows Ollama helper", () => {
     });
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const { windows, restore } = loadWindowsOllamaWithMocks(run, runCapture);
+    const { windows, restore, atomicsWaitSpy, spawnSyncSpy } = loadWindowsOllamaWithMocks(run, runCapture);
 
     try {
       expect(windows.setupWindowsOllamaWith0000Binding({ installedPath })).toBe(true);
+      // The blocking wait settles for 1s after the kill, pauses 1s between
+      // launch attempts, then polls readiness with a 2s delay.
+      expect(atomicsWaitSpy).toHaveBeenCalledTimes(3);
+      // The wait must target the module's shared backing store (a plain
+      // ArrayBuffer would be rejected by Atomics.wait).
+      for (const [array] of atomicsWaitSpy.mock.calls) {
+        expect(array).toBeInstanceOf(Int32Array);
+        expect(array.buffer).toBeInstanceOf(SharedArrayBuffer);
+      }
+      expect(atomicsWaitSpy).toHaveBeenNthCalledWith(1, expect.any(Int32Array), 0, 0, 1000);
+      expect(atomicsWaitSpy).toHaveBeenNthCalledWith(2, expect.any(Int32Array), 0, 0, 1000);
+      expect(atomicsWaitSpy).toHaveBeenNthCalledWith(3, expect.any(Int32Array), 0, 0, 2000);
+      // The retired subprocess-sleep path must not be exercised.
+      expect(spawnSyncSpy).not.toHaveBeenCalled();
     } finally {
       restore();
       logSpy.mockRestore();
@@ -107,5 +129,20 @@ describe("Windows Ollama helper", () => {
       ],
       { ignoreError: true },
     );
+  });
+
+  it("skips the blocking wait for non-positive delays", () => {
+    const run = vi.fn();
+    const runCapture = vi.fn();
+    const { windows, restore, atomicsWaitSpy, spawnSyncSpy } = loadWindowsOllamaWithMocks(run, runCapture);
+
+    try {
+      windows.sleep(0);
+      windows.sleep(-1);
+      expect(atomicsWaitSpy).not.toHaveBeenCalled();
+      expect(spawnSyncSpy).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
   });
 });

--- a/src/lib/inference/ollama/windows.ts
+++ b/src/lib/inference/ollama/windows.ts
@@ -5,7 +5,7 @@
 // Windows-host Ollama actions invoked from WSL via PowerShell interop.
 // Detection lives in onboard.ts; this module owns the action side.
 
-const { spawn, spawnSync } = require("child_process");
+const { spawn } = require("child_process");
 const { dockerCapture } = require("../../adapters/docker/command");
 const { run, runCapture } = require("../../runner");
 const {
@@ -15,8 +15,15 @@ const {
 } = require("../local");
 const { OLLAMA_PORT } = require("../../core/ports");
 
+// Avoid starting a subprocess for each fixed readiness delay.
+// The supported Windows-host Ollama path runs through WSL PowerShell interop.
+// Native Windows activation remains gated by #8178.
+const sleepBuffer = new SharedArrayBuffer(4);
+const sleepArray = new Int32Array(sleepBuffer);
+
 function sleep(seconds: number): void {
-  spawnSync("sleep", [String(seconds)]);
+  if (seconds <= 0) return;
+  Atomics.wait(sleepArray, 0, 0, seconds * 1000);
 }
 
 function psSingleQuote(value: string): string {
@@ -223,6 +230,7 @@ module.exports = {
   installOllamaOnWindowsHost,
   awaitWindowsOllamaReady,
   setupWindowsOllamaWith0000Binding,
+  sleep,
   switchToWindowsOllamaHost,
   printWindowsOllamaTimeoutDiagnostics,
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Replaces the Windows-host Ollama readiness delay's subprocess-based sleep with an in-process `Atomics.wait`. The supported Windows-host path (WSL + Docker Desktop) previously spawned a `sleep` subprocess for each fixed readiness delay; this avoids that process fork without changing the delay behavior.

## Changes

- `src/lib/inference/ollama/windows.ts`: block on `Atomics.wait` over a `SharedArrayBuffer` instead of spawning a `sleep` subprocess; export `sleep` so the test can exercise its non-positive-delay guard.
- `src/lib/inference/ollama/windows.test.ts`: assert the blocking wait requests the intended 1s settle/pause and 2s readiness poll on the module's shared backing store, cover the non-positive-delay no-op, and prove the retired `spawnSync` subprocess path is unused.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: no user-facing behavior change; internal implementation detail.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: inference path; mechanical replacement of a blocking sleep with an in-process wait, no behavior change.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: No documentation change needed: this swaps an internal blocking wait on the Windows-host Ollama readiness
  path for an in-process Atomics.wait, with no user-facing behavior change. AGENTS.md and all docs are unaffected.
- Agent: Claude Code
<!-- docs-review-head-sha: 8cb7a87 -->
<!-- docs-review-agents-blob-sha: e30afb2 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set — `npx vitest run src/lib/inference/ollama/windows.test.ts` → 2 passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Kuangyicheng <c8688rickowens@outlook.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup timing behavior for Windows-based Ollama inference.
  * Zero or negative delays now complete immediately.
  * Removed reliance on external sleep processes, improving reliability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->