### PR TITLE
ci(e2e): decouple Launchable from base publication

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -186,14 +186,11 @@ jobs:
         run: node --experimental-strip-types --no-warnings tools/e2e/dcode-base-image-contract.mts "${RUNNER_TEMP}/dcode-base-contract/contract.json"
 
   generate-matrix:
-    needs: base-image-publication
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       cli_artifact_provenance: ${{ steps.record_cli_artifact.outputs.provenance }}
       e2e_credentials_allowed: ${{ steps.e2e_credentials.outputs.allowed }}
-      dcode_base_contract: ${{ needs.base-image-publication.outputs.dcode_base_contract }}
-      dcode_base_ref: ${{ needs.base-image-publication.outputs.dcode_base_ref }}
       matrix: ${{ steps.matrix.outputs.matrix }}
       test_matrix: ${{ steps.matrix.outputs.test_matrix }}
       hermes_selected: ${{ steps.matrix.outputs.hermes_selected }}
@@ -907,7 +904,7 @@ jobs:
             ${{ steps.workspace.outputs.work_dir }}/cleanup.json
 
   live:
-    needs: generate-matrix
+    needs: [base-image-publication, generate-matrix]
     if: ${{ needs.generate-matrix.outputs.matrix != '[]' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
@@ -917,7 +914,7 @@ jobs:
         include: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     env:
       E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/live
-      NEMOCLAW_LANGCHAIN_DEEPAGENTS_CODE_SANDBOX_BASE_IMAGE_REF: ${{ needs.generate-matrix.outputs.dcode_base_ref }}
+      NEMOCLAW_LANGCHAIN_DEEPAGENTS_CODE_SANDBOX_BASE_IMAGE_REF: ${{ needs.base-image-publication.outputs.dcode_base_ref }}
       NEMOCLAW_CLI_BIN: ${{ github.workspace }}/bin/nemoclaw.js
       NEMOCLAW_RUN_LIVE_E2E: "1"
       NEMOCLAW_E2E_USE_HOSTED_INFERENCE: "1"
@@ -974,7 +971,7 @@ jobs:
       - name: Record immutable Deep Agents Code base evidence
         if: ${{ matrix.id == 'ubuntu-repo-cloud-langchain-deepagents-code' }}
         env:
-          BASE_CONTRACT: ${{ needs.generate-matrix.outputs.dcode_base_contract }}
+          BASE_CONTRACT: ${{ needs.base-image-publication.outputs.dcode_base_contract }}
           CANDIDATE_SHA: ${{ inputs.checkout_sha || github.sha }}
           TARGET_ID: ${{ matrix.id }}
         shell: bash

--- a/test/e2e/support/base-image-publication-workflow-boundary.test.ts
+++ b/test/e2e/support/base-image-publication-workflow-boundary.test.ts
@@ -93,6 +93,15 @@ function runClassifier(environment: {
 }
 
 describe("base-image publication workflow boundary (#7372)", () => {
+  it("keeps Launchable off the base-image publication critical path", () => {
+    const value = workflow();
+
+    expect(value.jobs["generate-matrix"].needs).toBeUndefined();
+    expect(value.jobs["staging-brev-launchable"].needs).toBe("generate-matrix");
+    expect(value.jobs.live.needs).toEqual(["base-image-publication", "generate-matrix"]);
+    expect(validate(value)).toEqual([]);
+  });
+
   // source-shape-contract: security -- Immutable base contracts must outlive the qualification interval so later E2E cannot fall back to a mutable alias.
   it("retains immutable base contracts for later qualification (#9049)", () => {
     const action = YAML.parse(
@@ -209,7 +218,19 @@ describe("base-image publication workflow boundary (#7372)", () => {
         (gateSteps(value)[5].run = "node tools/e2e/dcode-base-image-contract.mts contract.json"),
     ],
     ["step count", (value) => gateSteps(value).push({ name: "Unreviewed step", run: "true" })],
-    ["fanout dependency", (value) => (value.jobs["generate-matrix"].needs = [])],
+    [
+      "matrix publication dependency",
+      (value) => (value.jobs["generate-matrix"].needs = "base-image-publication"),
+    ],
+    ["live publication dependency", (value) => (value.jobs.live.needs = ["generate-matrix"])],
+    [
+      "Launchable publication dependency",
+      (value) =>
+        (value.jobs["staging-brev-launchable"].needs = [
+          "base-image-publication",
+          "generate-matrix",
+        ]),
+    ],
     [
       "matrix base output",
       (value) => {

--- a/test/e2e/support/base-image-publication-workflow-boundary.test.ts
+++ b/test/e2e/support/base-image-publication-workflow-boundary.test.ts
@@ -96,9 +96,6 @@ describe("base-image publication workflow boundary (#7372)", () => {
   it("keeps Launchable off the base-image publication critical path", () => {
     const value = workflow();
 
-    expect(value.jobs["generate-matrix"].needs).toBeUndefined();
-    expect(value.jobs["staging-brev-launchable"].needs).toBe("generate-matrix");
-    expect(value.jobs.live.needs).toEqual(["base-image-publication", "generate-matrix"]);
     expect(validate(value)).toEqual([]);
   });
 

--- a/tools/e2e/cli-artifact-workflow-boundary.mts
+++ b/tools/e2e/cli-artifact-workflow-boundary.mts
@@ -340,10 +340,12 @@ function validateConsumer(
   job: WorkflowRecord,
   jobSteps: WorkflowStep[],
 ): void {
-  const expectedNeeds =
-    jobName === "mcp-bridge-dev"
-      ? [CLI_ARTIFACT_PRODUCER_JOB, "openshell-dev-artifact"]
-      : CLI_ARTIFACT_PRODUCER_JOB;
+  let expectedNeeds: string | string[] = CLI_ARTIFACT_PRODUCER_JOB;
+  if (jobName === "mcp-bridge-dev") {
+    expectedNeeds = [CLI_ARTIFACT_PRODUCER_JOB, "openshell-dev-artifact"];
+  } else if (jobName === "live") {
+    expectedNeeds = ["base-image-publication", CLI_ARTIFACT_PRODUCER_JOB];
+  }
   if (!isDeepStrictEqual(job.needs, expectedNeeds)) {
     errors.push(`${jobName} must depend directly on the CLI artifact producer`);
   }

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -578,21 +578,21 @@ export function validateBaseImagePublicationGate(workflow: OperationsWorkflow): 
       "base-image-publication job must preserve its exact trusted-mode classifier, minimal permissions, pinned checkout, and verifier boundary",
     );
   }
-  if (!needs(workflow.jobs["generate-matrix"] ?? {}).includes("base-image-publication")) {
-    errors.push("generate-matrix must wait for base-image-publication");
+  const matrix = workflow.jobs["generate-matrix"] ?? {};
+  if (needs(matrix).includes("base-image-publication")) {
+    errors.push("generate-matrix must not wait for base-image-publication");
   }
-  const matrixOutputs = workflow.jobs["generate-matrix"]?.outputs ?? {};
-  if (
-    matrixOutputs.dcode_base_contract !==
-      "${{ needs.base-image-publication.outputs.dcode_base_contract }}" ||
-    matrixOutputs.dcode_base_ref !== "${{ needs.base-image-publication.outputs.dcode_base_ref }}"
-  ) {
-    errors.push("generate-matrix must preserve the immutable Deep Agents Code base outputs");
+  const matrixOutputs = matrix.outputs ?? {};
+  if ("dcode_base_contract" in matrixOutputs || "dcode_base_ref" in matrixOutputs) {
+    errors.push("generate-matrix must not relay Deep Agents Code base outputs");
   }
   const live = workflow.jobs.live ?? {};
+  if (!sameMembers(needs(live), ["base-image-publication", "generate-matrix"])) {
+    errors.push("live E2E must wait for matrix generation and base-image publication");
+  }
   if (
     live.env?.NEMOCLAW_LANGCHAIN_DEEPAGENTS_CODE_SANDBOX_BASE_IMAGE_REF !==
-    "${{ needs.generate-matrix.outputs.dcode_base_ref }}"
+    "${{ needs.base-image-publication.outputs.dcode_base_ref }}"
   ) {
     errors.push("live DCode must use the selected immutable base reference");
   }
@@ -601,12 +601,16 @@ export function validateBaseImagePublicationGate(workflow: OperationsWorkflow): 
   const liveSteps = live.steps ?? [];
   if (
     evidence.if !== "${{ matrix.id == 'ubuntu-repo-cloud-langchain-deepagents-code' }}" ||
-    evidence.env?.BASE_CONTRACT !== "${{ needs.generate-matrix.outputs.dcode_base_contract }}" ||
+    evidence.env?.BASE_CONTRACT !==
+      "${{ needs.base-image-publication.outputs.dcode_base_contract }}" ||
     !String(evidence.run ?? "").includes("dcode-base-image.json") ||
     liveSteps.indexOf(evidence) >= liveSteps.indexOf(findStep(live, "Run live E2E tests")) ||
     !String(upload.with?.path ?? "").includes("dcode-base-image.json")
   ) {
     errors.push("live DCode must record its immutable base contract before E2E execution");
+  }
+  if (!sameMembers(needs(workflow.jobs["staging-brev-launchable"] ?? {}), ["generate-matrix"])) {
+    errors.push("staging-brev-launchable must wait only for generate-matrix");
   }
   return errors;
 }

--- a/tools/e2e/workflow-boundary.mts
+++ b/tools/e2e/workflow-boundary.mts
@@ -2443,8 +2443,10 @@ export function validateE2eWorkflow(workflowValue: unknown): string[] {
   if (liveTargets["runs-on"] !== "${{ matrix.runner }}") {
     errors.push("live job must run on the matrix runner");
   }
-  if (liveTargets.needs !== "generate-matrix") {
-    errors.push("live job must depend on generate-matrix");
+  if (
+    !isDeepStrictEqual(liveTargets.needs, ["base-image-publication", "generate-matrix"])
+  ) {
+    errors.push("live job must depend on base-image-publication and generate-matrix");
   }
   if (liveTargets.if !== "${{ needs.generate-matrix.outputs.matrix != '[]' }}") {
     errors.push("live job must run whenever the trusted planner emits typed targets");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The E2E workflow now schedules Launchable staging after matrix generation without waiting for base-image publication. Live E2E still waits for base-image publication and consumes its immutable Deep Agents Code contract directly.

## Changes

- Remove the `base-image-publication` dependency from `generate-matrix` so both jobs can run concurrently.
- Keep `staging-brev-launchable` dependent on `generate-matrix`. This preserves maintainer authorization and dispatch receipt gates.
- Make `live` depend on both jobs and consume immutable Deep Agents Code outputs directly from `base-image-publication`.
- Update E2E workflow boundary validation and regression tests to require the intended dependency set.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal E2E workflow scheduling. It does not change a public interface or documented user workflow.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent workflow review confirmed that maintainer authorization, dispatch receipts, credential guards, immutable base evidence, and cleanup ownership remain enforced.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The final diff changes internal E2E job scheduling and validator contracts. It does not change a public command, API, configuration, runtime behavior, or documented user workflow.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 3ecac161c -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: On commit `3ecac161c`, `npm exec -- vitest run --project e2e-support test/e2e/support/base-image-publication-workflow-boundary.test.ts` passed 1 file and 38 tests. On commit `59b8677fe`, the four affected E2E-support files passed 178 tests. On commit `9745eff4e`, `npm run checks:repository` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
