### PR TITLE
fix(onboard): verify fresh sandbox execution readiness

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -5027,9 +5027,15 @@ Set the onboarding variables before running `$$nemoclaw onboard` if a slow conne
 |----------|---------|---------|
 | `NEMOCLAW_OLLAMA_PULL_TIMEOUT` | `1800` (30 minutes) | Wall-clock timeout for `ollama pull` during onboard, in seconds. Accepts integer or float values. Already-downloaded layers are kept; re-running the pull resumes them. |
 | `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` | `180` | Wall-clock timeout for the inference-server validation probe during onboard, in seconds. Raise on slow networks or for very large prompts. |
-| `NEMOCLAW_SANDBOX_READY_TIMEOUT` | `180` | Wall-clock timeout for post-create readiness, in seconds. Raise when the sandbox image build, gateway upload, or in-sandbox boot exceeds the default (typical on 70B+ models, first-time gateway uploads over slow links, or DGX Station / remote-VM first runs). Ordinary onboarding deletes the partially created sandbox when the deadline expires and prints the retry hint. Portable OpenClaw onboarding instead preserves the sandbox when NemoClaw cannot verify its exact runtime identity. |
+| `NEMOCLAW_SANDBOX_READY_TIMEOUT` | `180` | Wall-clock timeout for post-create readiness, in seconds. Raise the timeout when the sandbox image build, gateway upload, or in-sandbox boot exceeds the default (typical on 70B+ models, first-time gateway uploads over slow links, or DGX Station / remote-VM first runs). Ordinary onboarding deletes the partially created sandbox when the deadline expires and prints the retry hint. Portable OpenClaw onboarding instead preserves the sandbox when NemoClaw cannot verify its exact runtime identity. |
 | `NEMOCLAW_SANDBOX_READY_ERROR_DEBOUNCE` | `30` | Consecutive `Error`-phase polls the post-create readiness wait tolerates before treating `Error` as terminal. Polling starts at 250ms and backs off to a 2-second cap, while `NEMOCLAW_SANDBOX_READY_TIMEOUT` remains the overall deadline. The gateway can briefly report a just-created sandbox in `Error` while it re-registers the sandbox (seen on DGX Spark); the debounce lets that transient recover to `Ready`. `Failed` and `CrashLoopBackOff` always fail immediately. Set to `1` to restore fast-fail on the first `Error` poll. |
 | `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` | `30`, `90`, or `120`, depending on the recovery phase | Wall-clock timeout for OpenShell command re-registration after policy application, plus gateway health and re-registration during managed OpenClaw or Hermes recovery. A valid finite, nonnegative value overrides the internal budget for the current recovery phase. |
+
+<AgentOnly variant="openclaw,hermes">
+
+For newly created OpenClaw and Hermes sandboxes, `NEMOCLAW_SANDBOX_READY_TIMEOUT` also covers the durable sandbox ID and no-op command checks that follow the OpenShell `Ready` state.
+
+</AgentOnly>
 
 An unset, blank, invalid, or negative `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` value uses 30 seconds for OpenClaw gateway health and 90 seconds for Hermes gateway health.
 Recreated-sandbox OpenShell registration uses 120 seconds when the recovery path does not supply another budget.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2117,7 +2117,9 @@ It does not cover the inference probe.
 For a newly created OpenClaw or Hermes sandbox, `Ready` is not the final acceptance signal.
 Within this same budget, NemoClaw also requires OpenShell to return a durable sandbox ID and accept `openshell sandbox exec --name <sandbox> -- true`.
 NemoClaw keeps waiting only when OpenShell returns its exact `sandbox is not ready` response.
-A missing or malformed ID, or another command failure, stops the wait and follows the ordinary failed-creation cleanup path.
+A missing or malformed ID, or another command failure, stops the wait.
+Ordinary onboarding then follows the failed-creation cleanup path.
+Portable OpenClaw onboarding preserves the sandbox as described below.
 
 </AgentOnly>
 

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2111,6 +2111,16 @@ Onboarding ends with:
 This is a separate budget from `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT`.
 It covers the readiness wait that follows sandbox creation, including in-sandbox boot, OpenClaw start, and policy load.
 It does not cover the inference probe.
+
+<AgentOnly variant="openclaw,hermes">
+
+For a newly created OpenClaw or Hermes sandbox, `Ready` is not the final acceptance signal.
+Within this same budget, NemoClaw also requires OpenShell to return a durable sandbox ID and accept `openshell sandbox exec --name <sandbox> -- true`.
+NemoClaw keeps waiting only when OpenShell returns its exact `sandbox is not ready` response.
+A missing or malformed ID, or another command failure, stops the wait and follows the ordinary failed-creation cleanup path.
+
+</AgentOnly>
+
 The 180-second default fits typical workstations but can be exceeded when:
 
 - The host is building or uploading the sandbox image for the first time (cold caches, slow link).

--- a/src/lib/adapters/openshell/client.test.ts
+++ b/src/lib/adapters/openshell/client.test.ts
@@ -182,14 +182,26 @@ describe("openshell helpers", () => {
     expect(observedEnv?.PATH).toBe(process.env.PATH);
   });
 
-  it("passes timeout and maxBuffer options through to OpenShell spawn calls", () => {
-    const observedOptions: Array<{ timeout?: number; maxBuffer?: number }> = [];
+  it("passes timeout, kill signal, and maxBuffer options through to OpenShell spawn calls", () => {
+    const observedOptions: Array<{
+      timeout?: number;
+      killSignal?: NodeJS.Signals | number;
+      maxBuffer?: number;
+    }> = [];
     const spawnSyncImpl: OpenshellSpawnSync = (_command, _args, options) => {
-      observedOptions.push({ timeout: options.timeout, maxBuffer: options.maxBuffer });
+      observedOptions.push({
+        timeout: options.timeout,
+        killSignal: options.killSignal,
+        maxBuffer: options.maxBuffer,
+      });
       return makeSpawnResult({ status: 0, stdout: "ok\n", stderr: "" });
     };
 
-    runOpenshellCommand("openshell", ["status"], { timeout: 4321, spawnSyncImpl });
+    runOpenshellCommand("openshell", ["status"], {
+      timeout: 4321,
+      killSignal: "SIGKILL",
+      spawnSyncImpl,
+    });
     captureOpenshellCommand("openshell", ["status"], {
       timeout: 9876,
       maxBuffer: 123456,
@@ -197,8 +209,8 @@ describe("openshell helpers", () => {
     });
 
     expect(observedOptions).toEqual([
-      { timeout: 4321, maxBuffer: undefined },
-      { timeout: 9876, maxBuffer: 123456 },
+      { timeout: 4321, killSignal: "SIGKILL", maxBuffer: undefined },
+      { timeout: 9876, killSignal: undefined, maxBuffer: 123456 },
     ]);
   });
 

--- a/src/lib/adapters/openshell/client.ts
+++ b/src/lib/adapters/openshell/client.ts
@@ -13,10 +13,7 @@ import {
 import { redirectInheritedChildStdoutToStderr } from "../../cli/stdout-guard";
 import { buildSubprocessEnv } from "../../subprocess-env";
 
-export {
-  openshellSandboxSshHost,
-  resolveOpenshellSandboxSshHost,
-} from "./sandbox-ssh-host";
+export { openshellSandboxSshHost, resolveOpenshellSandboxSshHost } from "./sandbox-ssh-host";
 
 export type OpenshellSpawnSync = (
   command: string,
@@ -49,6 +46,7 @@ function openshellSpawnEnv(opts: OpenshellSpawnOptions): NodeJS.ProcessEnv {
 export interface RunOpenshellOptions extends OpenshellSpawnOptions {
   stdio?: SpawnSyncOptions["stdio"];
   input?: string;
+  killSignal?: SpawnSyncOptions["killSignal"];
 }
 
 export interface CaptureOpenshellOptions extends OpenshellSpawnOptions {
@@ -208,6 +206,7 @@ export function runOpenshellCommand(
     stdio: redirectInheritedChildStdoutToStderr(opts.stdio ?? "inherit"),
     input: opts.input,
     timeout: opts.timeout,
+    killSignal: opts.killSignal,
   });
   if (result.error) {
     if (isIgnoredTimeout(result.error, opts)) {

--- a/src/lib/adapters/openshell/runtime.test.ts
+++ b/src/lib/adapters/openshell/runtime.test.ts
@@ -4,9 +4,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { captureResolvedOpenshell } from "./runtime";
+import { captureResolvedOpenshell, runOpenshell } from "./runtime";
 
 const directories: string[] = [];
 
@@ -18,10 +18,38 @@ function executable(name: string, output: string): string {
   return filePath;
 }
 
+function blockingExecutable(name: string): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-openshell-runtime-test-"));
+  directories.push(directory);
+  const filePath = path.join(directory, name);
+  fs.writeFileSync(
+    filePath,
+    `#!${process.execPath}\nconst lock = new Int32Array(new SharedArrayBuffer(4));\nAtomics.wait(lock, 0, 0, 10_000);\n`,
+    { mode: 0o755 },
+  );
+  return filePath;
+}
+
 afterEach(() => {
+  vi.unstubAllEnvs();
   for (const directory of directories.splice(0)) {
     fs.rmSync(directory, { recursive: true, force: true });
   }
+});
+
+describe("runOpenshell", () => {
+  it("forwards SIGKILL to a timed-out OpenShell command (#9050)", () => {
+    vi.stubEnv("NEMOCLAW_OPENSHELL_BIN", blockingExecutable("openshell"));
+
+    const result = runOpenshell([], {
+      ignoreError: true,
+      timeout: 100,
+      killSignal: "SIGKILL",
+    });
+
+    expect((result.error as NodeJS.ErrnoException | undefined)?.code).toBe("ETIMEDOUT");
+    expect(result.signal).toBe("SIGKILL");
+  });
 });
 
 describe("captureResolvedOpenshell", () => {

--- a/src/lib/adapters/openshell/runtime.ts
+++ b/src/lib/adapters/openshell/runtime.ts
@@ -28,6 +28,7 @@ type RunnerOptions = {
   includeStderr?: boolean;
   includeStreams?: boolean;
   timeout?: number;
+  killSignal?: NodeJS.Signals;
   maxBuffer?: number;
 };
 
@@ -55,6 +56,7 @@ export function runOpenshell(args: CommandArgs, opts: RunnerOptions = {}) {
     input: opts.input,
     ignoreError: opts.ignoreError,
     timeout: opts.timeout,
+    killSignal: opts.killSignal,
     errorLine: console.error,
     exit: (code: number) => process.exit(code),
   });

--- a/src/lib/onboard/sandbox-fresh-readiness.test.ts
+++ b/src/lib/onboard/sandbox-fresh-readiness.test.ts
@@ -54,6 +54,10 @@ import { runSandboxGpuCreateFlow, type SandboxGpuCreateFlowDeps } from "./sandbo
 
 type OpenShellResult = ReturnType<SandboxGpuCreateFlowDeps["runOpenshell"]>;
 
+const SANDBOX_NOT_READY_OUTPUT =
+  `Error:   × code: 'The system is not in a state required for the operation's\n` +
+  '  │ execution\', message: "sandbox is not ready"\n';
+
 function readySandboxGetResult(): OpenShellResult {
   return {
     status: 0,
@@ -76,13 +80,13 @@ function mockExit() {
   });
 }
 
-function timedOutOpenShellResult(): OpenShellResult {
+function timedOutOpenShellResult(stderr = ""): OpenShellResult {
   const error = new Error("spawn openshell timed out") as NodeJS.ErrnoException;
   error.code = "ETIMEDOUT";
   return {
     status: null,
     stdout: "",
-    stderr: "",
+    stderr,
     error,
     signal: "SIGKILL",
   } as OpenShellResult;
@@ -103,9 +107,7 @@ describe("fresh sandbox executable readiness", () => {
             {
               status: 1,
               stdout: "",
-              stderr:
-                `Error:   × code: 'The system is not in a state required for the operation's\n` +
-                '  │ execution\', message: "sandbox is not ready"\n',
+              stderr: SANDBOX_NOT_READY_OUTPUT,
             },
             { status: 0, stdout: "", stderr: "" },
           ],
@@ -152,7 +154,28 @@ describe("fresh sandbox executable readiness", () => {
     });
   });
 
-  it("bounds a stalled executable readiness probe and cleans up the fresh sandbox (#9050)", async () => {
+  it("fails when the identity probe times out after emitting not-ready output (#9050)", async () => {
+    const deps = createDeps();
+    vi.mocked(deps.runOpenshell).mockImplementation(
+      createSequencedOpenShellRunner([
+        ["sandbox get alpha", [timedOutOpenShellResult(SANDBOX_NOT_READY_OUTPUT)]],
+      ]),
+    );
+    mockExit();
+
+    await expect(runSandboxGpuCreateFlow(createInput(), deps)).rejects.toThrow("process.exit:1");
+
+    expect(deps.runOpenshell).not.toHaveBeenCalledWith(
+      ["sandbox", "exec", "--name", "alpha", "--", "true"],
+      expect.anything(),
+    );
+    expect(deps.runOpenshell).toHaveBeenCalledWith(
+      ["sandbox", "delete", "alpha"],
+      expect.objectContaining({ ignoreError: true }),
+    );
+  });
+
+  it("fails when the executable probe times out after emitting not-ready output (#9050)", async () => {
     const deps = createDeps();
     const input = createInput();
     input.sandboxReadyTimeoutSecs = 0.5;
@@ -161,7 +184,7 @@ describe("fresh sandbox executable readiness", () => {
         ["sandbox get alpha", [readySandboxGetResult()]],
         [
           ["sandbox", "exec", "--name", "alpha", "--", "true"].join(" "),
-          [timedOutOpenShellResult()],
+          [timedOutOpenShellResult(SANDBOX_NOT_READY_OUTPUT)],
         ],
       ]),
     );

--- a/src/lib/onboard/sandbox-fresh-readiness.test.ts
+++ b/src/lib/onboard/sandbox-fresh-readiness.test.ts
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  streamSandboxCreate: vi.fn(),
+  waitForCreatedSandboxReadyWithTrace: vi.fn(),
+  printReadinessFailure: vi.fn(),
+  enforceDockerGpuPatchPreserveNetwork: vi.fn(),
+  verifyGpuSandboxAccessAfterReady: vi.fn(),
+  createDockerGpuSandboxCreatePatch: vi.fn(),
+  printSandboxCreateFailureDiagnostics: vi.fn(),
+  collectDockerGpuPatchDiagnostics: vi.fn(),
+  queryOpenShellDockerSandboxContainers: vi.fn(),
+  queryOpenShellDockerSandboxRuntimeSnapshot: vi.fn(),
+}));
+
+vi.mock("../sandbox/create-stream", () => ({
+  streamSandboxCreate: mocks.streamSandboxCreate,
+}));
+
+vi.mock("./docker-gpu-local-inference", () => ({
+  enforceDockerGpuPatchPreserveNetwork: mocks.enforceDockerGpuPatchPreserveNetwork,
+  verifyGpuSandboxAccessAfterReady: mocks.verifyGpuSandboxAccessAfterReady,
+}));
+
+vi.mock("./docker-gpu-sandbox-create", () => ({
+  createDockerGpuSandboxCreatePatch: mocks.createDockerGpuSandboxCreatePatch,
+}));
+
+vi.mock("./sandbox-create-failure", () => ({
+  printSandboxCreateFailureDiagnostics: mocks.printSandboxCreateFailureDiagnostics,
+}));
+
+vi.mock("./docker-gpu-patch", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./docker-gpu-patch")>()),
+  collectDockerGpuPatchDiagnostics: mocks.collectDockerGpuPatchDiagnostics,
+}));
+
+vi.mock("./openshell-docker-sandbox-containers", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./openshell-docker-sandbox-containers")>()),
+  queryOpenShellDockerSandboxContainers: mocks.queryOpenShellDockerSandboxContainers,
+  queryOpenShellDockerSandboxRuntimeSnapshot: mocks.queryOpenShellDockerSandboxRuntimeSnapshot,
+}));
+
+import {
+  createGpuFlowDeps as createDeps,
+  createGpuFlowInput as createInput,
+  resetGpuFlowMocks,
+  setupGpuFlowMocks,
+} from "./__test-helpers__/sandbox-gpu-create-flow";
+import { runSandboxGpuCreateFlow, type SandboxGpuCreateFlowDeps } from "./sandbox-gpu-create-flow";
+
+type OpenShellResult = ReturnType<SandboxGpuCreateFlowDeps["runOpenshell"]>;
+
+function readySandboxGetResult(): OpenShellResult {
+  return {
+    status: 0,
+    stdout: "Name: alpha\nId: alpha-sandbox-id\nState: Ready\n",
+    stderr: "",
+  };
+}
+
+function createSequencedOpenShellRunner(
+  entries: Array<[string, OpenShellResult[]]>,
+): SandboxGpuCreateFlowDeps["runOpenshell"] {
+  const resultsByCommand = new Map(entries);
+  return (args) =>
+    resultsByCommand.get(args.join(" "))?.shift() ?? { status: 0, stdout: "", stderr: "" };
+}
+
+function mockExit() {
+  return vi.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("process.exit:1");
+  });
+}
+
+function timedOutOpenShellResult(): OpenShellResult {
+  const error = new Error("spawn openshell timed out") as NodeJS.ErrnoException;
+  error.code = "ETIMEDOUT";
+  return {
+    status: null,
+    stdout: "",
+    stderr: "",
+    error,
+    signal: "SIGKILL",
+  } as OpenShellResult;
+}
+
+beforeEach(() => setupGpuFlowMocks(mocks));
+afterEach(resetGpuFlowMocks);
+
+describe("fresh sandbox executable readiness", () => {
+  it("keeps a transient executable not-ready response inside the bounded wait (#9050)", async () => {
+    const deps = createDeps();
+    vi.mocked(deps.runOpenshell).mockImplementation(
+      createSequencedOpenShellRunner([
+        ["sandbox get alpha", [readySandboxGetResult(), readySandboxGetResult()]],
+        [
+          "sandbox exec --name alpha -- true",
+          [
+            {
+              status: 1,
+              stdout: "",
+              stderr:
+                `Error:   × code: 'The system is not in a state required for the operation's\n` +
+                '  │ execution\', message: "sandbox is not ready"\n',
+            },
+            { status: 0, stdout: "", stderr: "" },
+          ],
+        ],
+      ]),
+    );
+
+    await expect(runSandboxGpuCreateFlow(createInput(), deps)).resolves.toMatchObject({
+      route: "native",
+    });
+
+    expect(
+      vi
+        .mocked(deps.runOpenshell)
+        .mock.calls.filter(([args]) => args.join(" ") === "sandbox exec --name alpha -- true"),
+    ).toHaveLength(2);
+    expect(deps.runOpenshell).not.toHaveBeenCalledWith(
+      ["sandbox", "delete", "alpha"],
+      expect.anything(),
+    );
+  });
+
+  it("fails when the executable readiness probe is terminal (#9050)", async () => {
+    const deps = createDeps();
+    vi.mocked(deps.runOpenshell).mockImplementation(
+      createSequencedOpenShellRunner([
+        ["sandbox get alpha", [readySandboxGetResult()]],
+        [
+          "sandbox exec --name alpha -- true",
+          [{ status: 1, stdout: "", stderr: "permission denied" }],
+        ],
+      ]),
+    );
+    mockExit();
+
+    await expect(runSandboxGpuCreateFlow(createInput(), deps)).rejects.toThrow("process.exit:1");
+
+    expect(deps.runOpenshell).toHaveBeenCalledWith(
+      ["sandbox", "delete", "alpha"],
+      expect.objectContaining({ ignoreError: true }),
+    );
+    expect(mocks.printSandboxCreateFailureDiagnostics).toHaveBeenCalledWith("alpha", {
+      backupPath: null,
+    });
+  });
+
+  it("bounds a stalled executable readiness probe and cleans up the fresh sandbox (#9050)", async () => {
+    const deps = createDeps();
+    const input = createInput();
+    input.sandboxReadyTimeoutSecs = 0.5;
+    vi.mocked(deps.runOpenshell).mockImplementation(
+      createSequencedOpenShellRunner([
+        ["sandbox get alpha", [readySandboxGetResult()]],
+        [
+          ["sandbox", "exec", "--name", "alpha", "--", "true"].join(" "),
+          [timedOutOpenShellResult()],
+        ],
+      ]),
+    );
+    mockExit();
+
+    await expect(runSandboxGpuCreateFlow(input, deps)).rejects.toThrow("process.exit:1");
+
+    const identityOptions = vi
+      .mocked(deps.runOpenshell)
+      .mock.calls.find(([args]) => args.join(" ") === "sandbox get alpha")?.[1];
+    const executableOptions = vi
+      .mocked(deps.runOpenshell)
+      .mock.calls.find(([args]) => args.join(" ") === "sandbox exec --name alpha -- true")?.[1];
+    expect(identityOptions).toMatchObject({ killSignal: "SIGKILL" });
+    expect(executableOptions).toMatchObject({ killSignal: "SIGKILL" });
+    expect(identityOptions?.timeout).toBeGreaterThan(0);
+    expect(identityOptions?.timeout).toBeLessThanOrEqual(500);
+    expect(executableOptions?.timeout).toBeGreaterThan(0);
+    expect(executableOptions?.timeout).toBeLessThanOrEqual(500);
+    expect(deps.runOpenshell).toHaveBeenCalledWith(
+      ["sandbox", "delete", "alpha"],
+      expect.objectContaining({ ignoreError: true }),
+    );
+    expect(mocks.printSandboxCreateFailureDiagnostics).toHaveBeenCalledWith("alpha", {
+      backupPath: null,
+    });
+  });
+});

--- a/src/lib/onboard/sandbox-fresh-readiness.test.ts
+++ b/src/lib/onboard/sandbox-fresh-readiness.test.ts
@@ -154,6 +154,33 @@ describe("fresh sandbox executable readiness", () => {
     });
   });
 
+  it("removes a fresh sandbox when sandbox get omits a durable ID (#9050)", async () => {
+    const deps = createDeps();
+    vi.mocked(deps.runOpenshell).mockImplementation(
+      createSequencedOpenShellRunner([
+        ["sandbox get alpha", [{ status: 0, stdout: "Name: alpha\nState: Ready\n", stderr: "" }]],
+      ]),
+    );
+    mockExit();
+
+    await expect(runSandboxGpuCreateFlow(createInput(), deps)).rejects.toThrow("process.exit:1");
+
+    expect(deps.runOpenshell).not.toHaveBeenCalledWith(
+      ["sandbox", "exec", "--name", "alpha", "--", "true"],
+      expect.anything(),
+    );
+    expect(deps.runOpenshell).toHaveBeenCalledWith(
+      ["sandbox", "delete", "alpha"],
+      expect.objectContaining({ ignoreError: true, suppressOutput: true }),
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      "  NemoClaw could not verify that sandbox 'alpha' returned a durable ID and accepted commands.",
+    );
+    expect(mocks.printSandboxCreateFailureDiagnostics).toHaveBeenCalledWith("alpha", {
+      backupPath: null,
+    });
+  });
+
   it("fails when the identity probe times out after emitting not-ready output (#9050)", async () => {
     const deps = createDeps();
     vi.mocked(deps.runOpenshell).mockImplementation(

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -133,7 +133,9 @@ function probeExactOpenShellSandboxId(
     const sandboxId = parseOpenShellSandboxId(String(result.stdout ?? ""));
     return sandboxId ? { state: "identified", sandboxId } : { state: "failed" };
   }
-  if (result.error || result.signal || result.status === null) return { state: "failed" };
+  if (result.error || result.status === null || ("signal" in result && result.signal)) {
+    return { state: "failed" };
+  }
   return OPENSHELL_SANDBOX_NOT_READY.test(normalizedOpenShellCommandOutput(result))
     ? { state: "not_ready" }
     : { state: "failed" };
@@ -177,7 +179,9 @@ function checkSandboxExecutableReadiness(
     killSignal: "SIGKILL",
   });
   if (result.status === 0 && !result.error) return "ready";
-  if (result.error || result.signal || result.status === null) return "probe_failed";
+  if (result.error || result.status === null || ("signal" in result && result.signal)) {
+    return "probe_failed";
+  }
   return OPENSHELL_SANDBOX_NOT_READY.test(normalizedOpenShellCommandOutput(result))
     ? "not_ready"
     : "probe_failed";

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -133,6 +133,7 @@ function probeExactOpenShellSandboxId(
     const sandboxId = parseOpenShellSandboxId(String(result.stdout ?? ""));
     return sandboxId ? { state: "identified", sandboxId } : { state: "failed" };
   }
+  if (result.error || result.signal || result.status === null) return { state: "failed" };
   return OPENSHELL_SANDBOX_NOT_READY.test(normalizedOpenShellCommandOutput(result))
     ? { state: "not_ready" }
     : { state: "failed" };
@@ -176,6 +177,7 @@ function checkSandboxExecutableReadiness(
     killSignal: "SIGKILL",
   });
   if (result.status === 0 && !result.error) return "ready";
+  if (result.error || result.signal || result.status === null) return "probe_failed";
   return OPENSHELL_SANDBOX_NOT_READY.test(normalizedOpenShellCommandOutput(result))
     ? "not_ready"
     : "probe_failed";

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -34,6 +34,7 @@ import type {
   SandboxGpuCreateFlowInput,
 } from "./sandbox-gpu-create-flow";
 import * as sandboxGpuPreflight from "./sandbox-gpu-preflight";
+import { SANDBOX_RECREATE_PROBE_TIMEOUT_MS } from "./sandbox-recreate-probe";
 import type { CreatedSandboxReadyIdentityCheck } from "./sandbox-readiness-tracing";
 import * as sandboxReadinessTracing from "./sandbox-readiness-tracing";
 import { addTraceEvent } from "./tracing";
@@ -110,13 +111,23 @@ type OpenShellSandboxIdentityProbe =
   | { state: "not_ready" }
   | { state: "failed" };
 
+function remainingReadinessProbeTimeout(getRemainingMs: () => number): number | null {
+  const remainingMs = Math.floor(getRemainingMs());
+  return remainingMs > 0 ? Math.min(SANDBOX_RECREATE_PROBE_TIMEOUT_MS, remainingMs) : null;
+}
+
 function probeExactOpenShellSandboxId(
   sandboxName: string,
   deps: SandboxGpuCreateFlowDeps,
+  getRemainingMs: () => number = () => SANDBOX_RECREATE_PROBE_TIMEOUT_MS,
 ): OpenShellSandboxIdentityProbe {
+  const timeout = remainingReadinessProbeTimeout(getRemainingMs);
+  if (timeout === null) return { state: "not_ready" };
   const result = deps.runOpenshell(["sandbox", "get", sandboxName], {
     ignoreError: true,
     suppressOutput: true,
+    timeout,
+    killSignal: "SIGKILL",
   });
   if (result.status === 0 && !result.error) {
     const sandboxId = parseOpenShellSandboxId(String(result.stdout ?? ""));
@@ -131,14 +142,38 @@ function checkRecreatedSandboxReadyIdentity(
   sandboxName: string,
   expectedSandboxId: string,
   deps: SandboxGpuCreateFlowDeps,
+  getRemainingMs: () => number,
 ): ReturnType<CreatedSandboxReadyIdentityCheck> {
-  const identity = probeExactOpenShellSandboxId(sandboxName, deps);
+  const identity = probeExactOpenShellSandboxId(sandboxName, deps, getRemainingMs);
   if (identity.state === "not_ready") return "not_ready";
   if (identity.state === "failed") return "probe_failed";
   if (identity.sandboxId !== expectedSandboxId) return "identity_changed";
+  return checkSandboxExecutableReadiness(sandboxName, deps, getRemainingMs);
+}
+
+function checkCreatedSandboxReadyIdentity(
+  sandboxName: string,
+  deps: SandboxGpuCreateFlowDeps,
+  getRemainingMs: () => number,
+): ReturnType<CreatedSandboxReadyIdentityCheck> {
+  const identity = probeExactOpenShellSandboxId(sandboxName, deps, getRemainingMs);
+  if (identity.state === "not_ready") return "not_ready";
+  if (identity.state === "failed") return "probe_failed";
+  return checkSandboxExecutableReadiness(sandboxName, deps, getRemainingMs);
+}
+
+function checkSandboxExecutableReadiness(
+  sandboxName: string,
+  deps: SandboxGpuCreateFlowDeps,
+  getRemainingMs: () => number,
+): ReturnType<CreatedSandboxReadyIdentityCheck> {
+  const timeout = remainingReadinessProbeTimeout(getRemainingMs);
+  if (timeout === null) return "not_ready";
   const result = deps.runOpenshell(["sandbox", "exec", "--name", sandboxName, "--", "true"], {
     ignoreError: true,
     suppressOutput: true,
+    timeout,
+    killSignal: "SIGKILL",
   });
   if (result.status === 0 && !result.error) return "ready";
   return OPENSHELL_SANDBOX_NOT_READY.test(normalizedOpenShellCommandOutput(result))
@@ -489,9 +524,17 @@ export function createSandboxGpuCreateAttemptRunner(
           ? REPLACEMENT_STABLE_READY_POLLS
           : 1,
       checkReadyIdentity: expectedRecreatedSandboxId
-        ? () =>
-            checkRecreatedSandboxReadyIdentity(input.sandboxName, expectedRecreatedSandboxId, deps)
-        : undefined,
+        ? (getRemainingMs = () => SANDBOX_RECREATE_PROBE_TIMEOUT_MS) =>
+            checkRecreatedSandboxReadyIdentity(
+              input.sandboxName,
+              expectedRecreatedSandboxId,
+              deps,
+              getRemainingMs,
+            )
+        : input.terminalAgent
+          ? undefined
+          : (getRemainingMs = () => SANDBOX_RECREATE_PROBE_TIMEOUT_MS) =>
+              checkCreatedSandboxReadyIdentity(input.sandboxName, deps, getRemainingMs),
       sleep: deps.sleep,
     });
     if (!readiness.ready) {

--- a/src/lib/onboard/sandbox-readiness-tracing.test.ts
+++ b/src/lib/onboard/sandbox-readiness-tracing.test.ts
@@ -123,23 +123,25 @@ describe("waitForCreatedSandboxReadyWithTrace terminal-phase handling", () => {
     expect(sleep).not.toHaveBeenCalled();
   });
 
-  it("stops after an unknown recreated-runtime probe failure (#9050)", () => {
+  it("stops after an unknown durable-identity probe failure (#9050)", () => {
     const { runCaptureOpenshell, sleep } = replay([`${NAME}   Ready`]);
 
-    expect(
-      waitForCreatedSandboxReadyWithTrace({
-        sandboxName: NAME,
-        timeoutSecs: 30,
-        runCaptureOpenshell,
-        isSandboxReady,
-        checkReadyIdentity: () => "probe_failed",
-        sleep,
-      }),
-    ).toEqual({
+    const readiness = waitForCreatedSandboxReadyWithTrace({
+      sandboxName: NAME,
+      timeoutSecs: 30,
+      runCaptureOpenshell,
+      isSandboxReady,
+      checkReadyIdentity: () => "probe_failed",
+      sleep,
+    });
+    expect(readiness).toEqual({
       ready: false,
       reason: "identity_probe_failed",
       failurePhase: null,
     });
+    expect(formatCreatedSandboxReadinessFailureMessage(NAME, readiness, 30)).toBe(
+      `  NemoClaw could not verify that sandbox '${NAME}' returned a durable ID and accepted commands.`,
+    );
     expect(runCaptureOpenshell).toHaveBeenCalledOnce();
     expect(sleep).not.toHaveBeenCalled();
   });

--- a/src/lib/onboard/sandbox-readiness-tracing.ts
+++ b/src/lib/onboard/sandbox-readiness-tracing.ts
@@ -85,11 +85,9 @@ export type CreatedSandboxReadinessResult =
   | { ready: false; reason: "identity_probe_failed"; failurePhase: null }
   | { ready: false; reason: "timeout"; failurePhase: null };
 
-export type CreatedSandboxReadyIdentityCheck = () =>
-  | "ready"
-  | "not_ready"
-  | "identity_changed"
-  | "probe_failed";
+export type CreatedSandboxReadyIdentityCheck = (
+  getRemainingMs?: () => number,
+) => "ready" | "not_ready" | "identity_changed" | "probe_failed";
 
 export interface SandboxReadyWaitDeps {
   runCaptureOpenshell: RunCaptureOpenshell;
@@ -213,10 +211,11 @@ export function waitForCreatedSandboxReadyWithTrace(options: {
    */
   stableReadyPolls?: number;
   /**
-   * Optional exact-identity and executability proof for a sandbox whose
-   * runtime was replaced after OpenShell first reported Ready. A transient
-   * not-ready result stays inside this bounded wait. Identity changes and
-   * all other probe failures remain terminal.
+   * Optional durable-identity and executability proof after OpenShell first
+   * reports Ready. A transient not-ready result stays inside this bounded
+   * wait. Recreated sandboxes also compare the durable identity with the
+   * pre-recreate value. Identity changes and all other probe failures remain
+   * terminal.
    */
   checkReadyIdentity?: CreatedSandboxReadyIdentityCheck;
   /**
@@ -273,6 +272,12 @@ export function waitForCreatedSandboxReadyWithTrace(options: {
       addTraceEvent("not_ready", { attempts: 0, deadline_ms: budgetMs });
       return { ready: false, reason: "timeout", failurePhase: null };
     }
+    const readinessDeadlineMs = waitOptions.deadlineMs;
+    const readinessNow = waitOptions.now;
+    if (readinessDeadlineMs === undefined || readinessNow === undefined) {
+      throw new Error("Created sandbox readiness requires a deadline and clock.");
+    }
+    const getRemainingMs = () => Math.max(0, readinessDeadlineMs - readinessNow());
     let consecutiveReadyPolls = 0;
     let consecutiveFailurePolls = 0;
     let lastFailurePhase: string | null = null;
@@ -282,7 +287,7 @@ export function waitForCreatedSandboxReadyWithTrace(options: {
       attempt += 1;
       const list = runCaptureOpenshell(["sandbox", "list"], { ignoreError: true });
       if (isSandboxReady(list, sandboxName)) {
-        const identity = options.checkReadyIdentity?.() ?? "ready";
+        const identity = options.checkReadyIdentity?.(getRemainingMs) ?? "ready";
         if (identity === "identity_changed") {
           addTraceEvent("identity_changed", { attempt });
           result = {
@@ -407,7 +412,7 @@ export function formatCreatedSandboxReadinessFailureMessage(
     return `  Sandbox '${sandboxName}' changed identity before its recreated runtime became ready.`;
   }
   if (readiness.reason === "identity_probe_failed") {
-    return `  NemoClaw could not verify that sandbox '${sandboxName}' still had the expected ID and accepted commands.`;
+    return `  NemoClaw could not verify that sandbox '${sandboxName}' returned a durable ID and accepted commands.`;
   }
   return `  Sandbox '${sandboxName}' was created but did not become ready within ${timeoutSecs}s.`;
 }

--- a/test/helpers/managed-image-buildless-e2e.ts
+++ b/test/helpers/managed-image-buildless-e2e.ts
@@ -407,6 +407,11 @@ runner.run = (command, options = {}) => {
   if (/(?:^|\s)docker(?:\s+buildx)?\s+build(?:\s|$)/u.test(normalized)) {
     return poison("docker build");
   }
+  if (normalized.includes("sandbox get " + sandboxName)) {
+    return sandboxCreated
+      ? { status: 0, stdout: "Name: " + sandboxName + "\nId: sbx-managed-fixture\n", stderr: "" }
+      : { status: 1, stdout: "", stderr: "sandbox not found" };
+  }
   return { status: 0, stdout: "", stderr: "" };
 };
 runner.runFile = (file, args = []) => runner.run([file, ...args]);
@@ -678,6 +683,20 @@ function assertManagedLaunch(
     expect(result.payload.runnerCommands.every((command) => !command.includes("/health"))).toBe(
       true,
     );
+    expect(
+      result.payload.runnerCommands.every((command) => !command.includes("sandbox exec --name")),
+    ).toBe(true);
+  } else {
+    expect(
+      result.payload.runnerCommands.some((command) =>
+        command.includes(`sandbox get ${bootstrapRequest?.sandboxName}`),
+      ),
+    ).toBe(true);
+    expect(
+      result.payload.runnerCommands.some((command) =>
+        command.includes(`sandbox exec --name ${bootstrapRequest?.sandboxName} -- true`),
+      ),
+    ).toBe(true);
   }
   expect(createArgs.filter((arg) => arg.startsWith("NEMOCLAW_CORPORATE_CA_B64="))).toEqual([]);
   expect(profile.proxy).toMatchObject({

--- a/test/onboard-messaging.test.ts
+++ b/test/onboard-messaging.test.ts
@@ -347,7 +347,7 @@ runner.run = (command, opts = {}) => {
   const normalized = _n(command);
   commands.push({ command: normalized, env: opts.env || null });
   if (normalized.includes("provider get")) return { status: 1 };
-  return { status: 0 };
+  return normalized.includes("sandbox get") && normalized.includes("my-assistant") ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
 };
 runner.runCapture = (command) => {
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return "";

--- a/test/onboard-sandbox-build.test.ts
+++ b/test/onboard-sandbox-build.test.ts
@@ -278,8 +278,9 @@ agentOnboard.createAgentSandbox = () => {
 };
 
 runner.run = (command, opts = {}) => {
-  commands.push({ command: _n(command), env: opts.env || null });
-  return { status: 0 };
+  const normalized = _n(command);
+  commands.push({ command: normalized, env: opts.env || null });
+  return normalized.includes("sandbox get hermes-sandbox") ? { status: 0, stdout: Buffer.from("Name: hermes-sandbox\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
 };
 runner.runFile = (file, args = [], opts = {}) => {
   commands.push({ command: _n([file, ...args]), env: opts.env || null });

--- a/test/shellquote-sandbox.test.ts
+++ b/test/shellquote-sandbox.test.ts
@@ -86,7 +86,15 @@ process.env.NEMOCLAW_OPENSHELL_BIN = ${JSON.stringify(path.join(fakeBin, "opensh
 const commands = [];
 const asText = (command) => Array.isArray(command) ? command.join(" ") : String(command);
 runner.run = (command, opts = {}) => {
-  commands.push({ type: "run", command: asText(command), env: opts.env || null });
+  const text = asText(command);
+  commands.push({ type: "run", command: text, env: opts.env || null });
+  if (text.includes("sandbox get") && text.includes("my-assistant")) {
+    return {
+      status: 0,
+      stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"),
+      stderr: Buffer.alloc(0),
+    };
+  }
   return { status: 0 };
 };
 runner.runFile = (file, args = [], opts = {}) => {
@@ -175,6 +183,16 @@ try {
         "my-assistant",
       ]);
       expect(dnsCommand.command).not.toContain("bash -c");
+      expect(
+        payload.commands.some((entry: { command: string }) =>
+          entry.command.includes("sandbox get my-assistant"),
+        ),
+      ).toBe(true);
+      expect(
+        payload.commands.some((entry: { command: string }) =>
+          entry.command.includes("sandbox exec --name my-assistant -- true"),
+        ),
+      ).toBe(true);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fresh non-terminal sandbox creation previously advanced when OpenShell listed the sandbox as
Ready even if sandbox execution and dashboard forwarding were still rejected as not ready. This
change keeps that transient state inside the existing bounded readiness wait and advances only
after OpenShell returns a durable sandbox identity and accepts a no-op sandbox command.

Affected evidence: automatic main E2E run `31903730854`, job `95060230330`.

## Related Issue

Refs #9050

## Changes

- Reuse the existing sandbox executability probe after both recreated and ordinary fresh
  non-terminal sandbox creation.
- Bound durable-ID and no-op probes by the live readiness deadline and the existing 15-second
  probe cap, with `SIGKILL` termination.
- Treat only a completed OpenShell `sandbox is not ready` result as pending; malformed identity,
  timeout, spawn error, termination signal, and every other execution failure remain terminal.
- Keep terminal-agent creation unchanged because it does not start dashboard forwarding.
- Add focused coverage for transient execution readiness, terminal permission failures, bounded
  stalled probes, timeout results that retain not-ready output, successful identity responses that
  omit a durable ID, and the wrapper-level `killSignal` contract.
- Document the fresh OpenClaw and Hermes readiness contract and keep Deep Agents variant output
  unchanged.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference,
  runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded —
  reviewer/approval link/justification: independent nine-category security review passed with no
  findings for exact head `289045940`; commands use fixed argv, child lifetimes are bounded,
  output is suppressed, error/null-status/signal results fail closed before text classification,
  and missing durable IDs cannot reach the executable probe.
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link,
  and follow-up issue: in [run 31923423974](https://github.com/NVIDIA/NemoClaw/actions/runs/31923423974),
  Nemotron was unavailable during inference configuration and produced no analysis; GPT stopped
  after a partial review, while the publisher retained the canonical information-only result with
  0 blockers, 0 warnings, and 0 suggestions. CLI shard 9 timed out at the unchanged fixed 15-second
  boundary in `src/lib/actions/sandbox/start.test.ts` test `#8662`; the file is outside this PR and
  the other 11 CLI shards passed. These are accepted operational/load exceptions with no
  candidate finding. The still-running all-agent managed activation job is not waived and remains
  a merge gate.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Updated `docs/reference/commands.mdx` and
  `docs/reference/troubleshooting.mdx` for the fresh OpenClaw and Hermes durable-ID and no-op
  readiness checks. The troubleshooting page distinguishes ordinary failed-creation cleanup from
  Portable OpenClaw sandbox preservation. The generated OpenClaw and Hermes variants include the
  behavior, and the Deep Agents variants omit it. The complete 13-file diff, including the
  missing-durable-ID and wrapper-level termination regressions, has no documentation findings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 289045940 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in
  GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr`
  passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable
  above — exact head `289045940` passed the focused runtime regression 2/2, the current-main owner
  CLI group 60 tests with 1 intentional platform skip, integration 26/26, CLI typecheck,
  repository checks, docs, and normal pre-commit, commit-msg, and pre-push hooks.
- [ ] Applicable broad gate passed — exact-head static/build/type/plugin/installer/docs/security,
  self-hosted E2E, managed-image startup, and 11 of 12 CLI shards passed. The accepted
  non-candidate exceptions are recorded above, and the all-agent managed activation job remains
  in progress and required before merge.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the
  [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
