### PR TITLE
fix(inference): fail incomplete Hermes route sync

### DIFF
--- a/docs/get-started/quickstart-hermes.mdx
+++ b/docs/get-started/quickstart-hermes.mdx
@@ -339,7 +339,7 @@ Use these details when your first-run path needs more control.
     nemohermes inference set --model <model> --provider <provider>
     ```
 
-    If the in-sandbox config write or integrity hash update fails, the command returns nonzero after committing the OpenShell route and registry.
+    If the in-sandbox config write or integrity hash update fails, `nemohermes inference set` exits with status `1` after committing the OpenShell route and NemoClaw registry.
     Run the printed `nemohermes <sandbox-name> rebuild` command to make the in-sandbox Hermes configuration match the committed route.
   </Accordion>
 </AccordionGroup>

--- a/docs/get-started/quickstart-hermes.mdx
+++ b/docs/get-started/quickstart-hermes.mdx
@@ -338,6 +338,9 @@ Use these details when your first-run path needs more control.
     ```bash
     nemohermes inference set --model <model> --provider <provider>
     ```
+
+    If the in-sandbox config write or integrity hash update fails, the command returns nonzero after committing the OpenShell route and registry.
+    Run the printed `nemohermes <sandbox-name> rebuild` command to make the in-sandbox Hermes configuration match the committed route.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -4094,7 +4094,12 @@ NemoClaw resolves the OpenShell gateway from the target sandbox's recorded gatew
 Do not run `openshell inference set` directly on a shared NemoClaw gateway because that bypasses registry compatibility checks and can break other sandboxes.
 When either flag is missing, `$$nemoclaw inference set` reports both required flags without suggesting a raw OpenShell command.
 The command updates the host registry immediately after the gateway route changes.
+<AgentOnly variant="openclaw">
 If the in-sandbox config sync fails, NemoClaw keeps the gateway and registry aligned, warns that the running image may still need a rebuild, and points you to `$$nemoclaw <name> rebuild`.
+</AgentOnly>
+<AgentOnly variant="hermes">
+If the in-sandbox config write or integrity hash update fails, the OpenShell route and NemoClaw registry remain committed, but the command exits with status `1` and points you to `$$nemoclaw <name> rebuild`.
+</AgentOnly>
 
 Supported provider names are `nvidia-prod`, `nvidia-nim`, `nvidia-router`, `openai-api`, `anthropic-prod`, `compatible-anthropic-endpoint`, `gemini-api`, `compatible-endpoint`, `hermes-provider`, `ollama-local`, and `vllm-local`.
 Use `--no-verify` only when OpenShell cannot verify the provider at switch time but you have already confirmed the provider and credential.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -4094,12 +4094,22 @@ NemoClaw resolves the OpenShell gateway from the target sandbox's recorded gatew
 Do not run `openshell inference set` directly on a shared NemoClaw gateway because that bypasses registry compatibility checks and can break other sandboxes.
 When either flag is missing, `$$nemoclaw inference set` reports both required flags without suggesting a raw OpenShell command.
 The command updates the host registry immediately after the gateway route changes.
+
+</AgentOnly>
+
 <AgentOnly variant="openclaw">
+
 If the in-sandbox config sync fails, NemoClaw keeps the gateway and registry aligned, warns that the running image may still need a rebuild, and points you to `$$nemoclaw <name> rebuild`.
+
 </AgentOnly>
+
 <AgentOnly variant="hermes">
+
 If the in-sandbox config write or integrity hash update fails, the OpenShell route and NemoClaw registry remain committed, but the command exits with status `1` and points you to `$$nemoclaw <name> rebuild`.
+
 </AgentOnly>
+
+<AgentOnly variant="openclaw,hermes">
 
 Supported provider names are `nvidia-prod`, `nvidia-nim`, `nvidia-router`, `openai-api`, `anthropic-prod`, `compatible-anthropic-endpoint`, `gemini-api`, `compatible-endpoint`, `hermes-provider`, `ollama-local`, and `vllm-local`.
 Use `--no-verify` only when OpenShell cannot verify the provider at switch time but you have already confirmed the provider and credential.

--- a/src/lib/actions/inference-set-hermes-run.test.ts
+++ b/src/lib/actions/inference-set-hermes-run.test.ts
@@ -243,7 +243,7 @@ describe("runInferenceSet Hermes routing", () => {
       message: expect.stringMatching(/Hermes inference route synchronization did not complete/),
     });
 
-    // A failed gateway-config write leaves the old config in place; re-seeding the
+    // A failed in-sandbox Hermes config write leaves the old config in place; re-seeding the
     // dashboard from it would be pointless. The host route remains committed, but
     // the command must fail so automation cannot accept a partial switch.
     expect(deps.calls.updateSandbox).toHaveBeenCalledWith(

--- a/src/lib/actions/inference-set-hermes-run.test.ts
+++ b/src/lib/actions/inference-set-hermes-run.test.ts
@@ -207,7 +207,7 @@ describe("runInferenceSet Hermes routing", () => {
     expect(seedOrder).toBeGreaterThan(writeOrder);
   });
 
-  it("does not re-seed the dashboard when the in-sandbox config write fails (#6893)", async () => {
+  it("fails after commit when the in-sandbox config write fails (#7083)", async () => {
     const config: ConfigObject = {
       model: { default: "moonshotai/kimi-k2.6", provider: "custom" },
     };
@@ -227,22 +227,32 @@ describe("runInferenceSet Hermes routing", () => {
       throw new Error("write failed");
     });
 
-    await runInferenceSet(
-      {
-        provider: "hermes-provider",
-        model: "openai/gpt-5.4-mini",
-        sandboxName: "hermes",
-        noVerify: true,
-      },
-      deps,
-    );
+    await expect(
+      runInferenceSet(
+        {
+          provider: "hermes-provider",
+          model: "openai/gpt-5.4-mini",
+          sandboxName: "hermes",
+          noVerify: true,
+        },
+        deps,
+      ),
+    ).rejects.toThrow(/Hermes inference route synchronization did not complete/);
 
     // A failed gateway-config write leaves the old config in place; re-seeding the
-    // dashboard from it would be pointless (and the guidance is to rebuild).
+    // dashboard from it would be pointless. The host route remains committed, but
+    // the command must fail so automation cannot accept a partial switch.
+    expect(deps.calls.updateSandbox).toHaveBeenCalledWith(
+      "hermes",
+      expect.objectContaining({
+        provider: "hermes-provider",
+        model: "openai/gpt-5.4-mini",
+      }),
+    );
     expect(deps.calls.seedHermesDashboardConfig).not.toHaveBeenCalled();
   });
 
-  it("does not re-seed or report synced when the config hash refresh fails (#6893)", async () => {
+  it("fails after commit when the config hash refresh fails (#7083)", async () => {
     const config: ConfigObject = {
       model: { default: "moonshotai/kimi-k2.6", provider: "custom" },
     };
@@ -262,15 +272,17 @@ describe("runInferenceSet Hermes routing", () => {
       throw new Error("hash refresh failed");
     });
 
-    await runInferenceSet(
-      {
-        provider: "hermes-provider",
-        model: "openai/gpt-5.4-mini",
-        sandboxName: "hermes",
-        noVerify: true,
-      },
-      deps,
-    );
+    await expect(
+      runInferenceSet(
+        {
+          provider: "hermes-provider",
+          model: "openai/gpt-5.4-mini",
+          sandboxName: "hermes",
+          noVerify: true,
+        },
+        deps,
+      ),
+    ).rejects.toThrow(/Hermes inference route synchronization did not complete/);
 
     expect(deps.calls.writeSandboxConfig).toHaveBeenCalledOnce();
     expect(deps.calls.seedHermesDashboardConfig).not.toHaveBeenCalled();

--- a/src/lib/actions/inference-set-hermes-run.test.ts
+++ b/src/lib/actions/inference-set-hermes-run.test.ts
@@ -237,7 +237,11 @@ describe("runInferenceSet Hermes routing", () => {
         },
         deps,
       ),
-    ).rejects.toThrow(/Hermes inference route synchronization did not complete/);
+    ).rejects.toMatchObject({
+      name: "InferenceSetError",
+      exitCode: 1,
+      message: expect.stringMatching(/Hermes inference route synchronization did not complete/),
+    });
 
     // A failed gateway-config write leaves the old config in place; re-seeding the
     // dashboard from it would be pointless. The host route remains committed, but
@@ -282,9 +286,20 @@ describe("runInferenceSet Hermes routing", () => {
         },
         deps,
       ),
-    ).rejects.toThrow(/Hermes inference route synchronization did not complete/);
+    ).rejects.toMatchObject({
+      name: "InferenceSetError",
+      exitCode: 1,
+      message: expect.stringMatching(/Hermes inference route synchronization did not complete/),
+    });
 
     expect(deps.calls.writeSandboxConfig).toHaveBeenCalledOnce();
+    expect(deps.calls.updateSandbox).toHaveBeenCalledWith(
+      "hermes",
+      expect.objectContaining({
+        provider: "hermes-provider",
+        model: "openai/gpt-5.4-mini",
+      }),
+    );
     expect(deps.calls.seedHermesDashboardConfig).not.toHaveBeenCalled();
     const logs = deps.calls.log.mock.calls.map((call) => String(call[0]));
     expect(logs.some((line) => line.includes("failed to refresh its integrity hash"))).toBe(true);

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -1323,7 +1323,7 @@ async function runInferenceSetWithoutHostLock(
       throw new InferenceSetError(
         `Hermes inference route synchronization did not complete for '${sandboxName}'. ` +
           `The OpenShell route and NemoClaw registry remain committed, but the in-sandbox ` +
-          `Hermes config is stale. Run '${CLI_NAME} ${sandboxName} rebuild' to converge it.`,
+          `Hermes configuration did not fully converge. Run '${CLI_NAME} ${sandboxName} rebuild' to converge it.`,
       );
     }
     return mutation;

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -1239,8 +1239,9 @@ async function runInferenceSetWithoutHostLock(
         ? `  Syncing Hermes model route in sandbox '${sandboxName}'...`
         : `  Syncing OpenClaw model identity in sandbox '${sandboxName}'...`,
     );
-    // In-sandbox config is the last, crash-prone layer (gateway + registry already consistent):
-    //   - don't abort on failure; track whether it synced, never report a false "synced"
+    // In-sandbox config is the last, crash-prone layer (gateway + registry already consistent).
+    // OpenClaw keeps its existing degraded result on failure. Hermes finalizes the committed
+    // route and registry, then returns an error so automation cannot accept partial convergence.
     // Two degraded states, both fixed by `rebuild` (regenerates openclaw.json + .config-hash from registry):
     //   - write fails:           config left old (old .config-hash still matches it)
     //   - hash recompute fails:  config new but .config-hash stale -> integrity-guard mismatch

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -1299,7 +1299,7 @@ async function runInferenceSetWithoutHostLock(
       reasoningEffortRequest,
     );
 
-    return finalizeInferenceMutation(
+    const mutation = finalizeInferenceMutation(
       {
         agentName,
         configChanged: patched.changed,
@@ -1319,6 +1319,14 @@ async function runInferenceSetWithoutHostLock(
       },
       deps,
     );
+    if (agentName === "hermes" && !inSandboxConfigSynced) {
+      throw new InferenceSetError(
+        `Hermes inference route synchronization did not complete for '${sandboxName}'. ` +
+          `The OpenShell route and NemoClaw registry remain committed, but the in-sandbox ` +
+          `Hermes config is stale. Run '${CLI_NAME} ${sandboxName} rebuild' to converge it.`,
+      );
+    }
+    return mutation;
   } catch (error) {
     if (!providerMutation) throw error;
     if (restoredSelectionAfterProviderFailure) throw error;


### PR DESCRIPTION
## Summary

Return status `1` when a Hermes inference switch cannot finish its in-sandbox configuration sync. The command preserves the committed OpenShell route and NemoClaw registry, reports the partial state, and directs the user to rebuild the sandbox.

## Related Issue

Fixes #7083

## Changes

- Return `InferenceSetError` with status `1` after a Hermes config-write or integrity-hash failure.
- Preserve the committed route and registry while withholding dashboard re-seeding after the incomplete sync.
- Keep the existing OpenClaw degraded-result behavior unchanged.
- Document the Hermes result and recovery command in the quickstart and command reference.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer review covered all nine security categories at https://github.com/NVIDIA/NemoClaw/pull/9233#pullrequestreview-4946715964; subsequent commits address its documentation findings without changing the reviewed runtime behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/get-started/quickstart-hermes.mdx`, `docs/reference/commands.mdx`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6819caac6 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 184 focused inference tests passed for the runtime change; subsequent commits changed documentation only.
- [x] Applicable broad gate passed — not applicable; this is a bounded inference error-result change with focused tests.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — validation passed with no errors; Fern reported the existing unauthenticated redirect-check and accent-contrast warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ho Lim <subhoya@gmail.com>
