### PR TITLE
fix(inference): reject flattened Anthropic tool calls

### DIFF
--- a/docs/inference/set-up-anthropic-compatible-endpoint.mdx
+++ b/docs/inference/set-up-anthropic-compatible-endpoint.mdx
@@ -32,12 +32,17 @@ OpenClaw uses the native Anthropic Messages frontend for this provider.
 NemoClaw validates the endpoint with a non-streaming `/v1/messages` request and then a `stream: true` request to the same path.
 
 The streaming check requires exactly one `message_start`, at least one `content_block_delta`, and one `message_stop` in a well-formed server-sent event sequence.
+It also forces the endpoint to call the `emit_ok` validation tool.
+The stream must contain a native `tool_use` content block named `emit_ok` and finish the request with `stop_reason: tool_use`.
+JSON-shaped assistant text does not satisfy either requirement, even when it names `emit_ok` and contains valid JSON.
+NemoClaw reports `anthropic-streaming-missing-tool-use` when the native block is absent and `anthropic-streaming-missing-tool-use-stop-reason` when the matching stop reason is absent.
 An endpoint whose non-streaming response works but whose streaming response is malformed fails during onboarding.
 
-Set `NEMOCLAW_REASONING=true` to skip the streaming check for a reasoning-only model.
-Agent runs still use streaming, so this setting moves any streaming defect to runtime.
+Set `NEMOCLAW_REASONING=true` to skip both the streaming sequence and forced tool-call checks for a reasoning-only model.
+Agent runs still use streaming and native tool calls, so this setting moves either defect to runtime.
 
 Refer to [Onboarding fails with duplicate Anthropic message_start events](../../reference/troubleshooting#onboarding-fails-with-duplicate-anthropic-message_start-events) when the streaming validation fails with duplicate start events.
+Refer to [Onboarding rejects an Anthropic-compatible tool call](../../reference/troubleshooting#onboarding-rejects-an-anthropic-compatible-tool-call) when the endpoint returns a tool request as assistant text or omits the tool-use stop reason.
 
 </AgentOnly>
 
@@ -48,6 +53,7 @@ Refer to [Onboarding fails with duplicate Anthropic message_start events](../../
 Hermes uses the managed OpenAI Chat Completions frontend at `https://inference.local/v1` for this provider.
 NemoClaw validates `/v1/chat/completions`, verifies the same path during inference setup, and registers it with OpenShell as `type=openai` using `OPENAI_BASE_URL`.
 The route keeps `COMPATIBLE_ANTHROPIC_API_KEY` as its credential binding.
+The OpenClaw-only native Anthropic `emit_ok` streaming check does not run on this route.
 
 This path avoids duplicate Anthropic SSE `message_start` events.
 If the endpoint only implements Anthropic Messages, onboarding stops instead of creating a Hermes sandbox with an unusable runtime route.
@@ -63,6 +69,7 @@ AWS Bedrock routes keep their existing OpenAI-compatible adapter behavior.
 
 Deep Agents Code supports only OpenAI-compatible inference for this provider.
 NemoClaw validates `/v1/chat/completions`, coerces the route to `openai-completions`, and writes `https://inference.local/v1` as the provider base URL in `/sandbox/.deepagents/config.toml`.
+The OpenClaw-only native Anthropic `emit_ok` streaming check does not run on this route.
 
 If the endpoint implements only Anthropic Messages, onboarding stops instead of creating a Deep Agents sandbox with an unusable runtime route.
 

--- a/docs/inference/understand-provider-validation.mdx
+++ b/docs/inference/understand-provider-validation.mdx
@@ -60,9 +60,13 @@ The managed Deep Agents runtime keeps `use_responses_api = false` and uses Chat 
 
 For OpenClaw, NemoClaw sends a non-streaming request to `/v1/messages`, then sends a streaming request to the same path.
 The streaming check requires exactly one `message_start`, at least one `content_block_delta`, and one `message_stop` event.
+The streaming request also forces the `emit_ok` tool through Anthropic's `tool_choice` field.
+Validation requires a native `tool_use` content block named `emit_ok` and a later `message_delta` with `stop_reason: tool_use`.
+Text that merely contains JSON shaped like a tool request remains assistant text and fails validation.
+The corresponding diagnostics are `anthropic-streaming-missing-tool-use` and `anthropic-streaming-missing-tool-use-stop-reason`.
 
-Set `NEMOCLAW_REASONING=true` to skip the streaming check for a reasoning-only endpoint.
-Agent runs still use streaming, so this setting moves a streaming defect from onboarding to runtime.
+Set `NEMOCLAW_REASONING=true` to skip both the streaming sequence and forced tool-call checks for a reasoning-only endpoint.
+Agent runs still use streaming and native tool calls, so this setting moves either defect from onboarding to runtime.
 
 </AgentOnly>
 
@@ -70,6 +74,7 @@ Agent runs still use streaming, so this setting moves a streaming defect from on
 
 For Hermes and other agents that use only OpenAI-compatible inference, NemoClaw validates `/v1/chat/completions` for a custom Anthropic selection.
 This is the API surface that the managed OpenAI frontend uses at runtime.
+These routes keep their existing Chat Completions tool-call validation and do not run the OpenClaw native Anthropic `emit_ok` streaming check.
 
 </AgentOnly>
 
@@ -104,5 +109,6 @@ Verify that route from inside the sandbox after onboarding.
 - [Verify the Sandbox Inference Route](verify-inference-route) to test the route the agent uses.
 <AgentOnly variant="openclaw">
 - [Troubleshooting](../../reference/troubleshooting#tool-calls-appear-as-assistant-text) when a local server returns tool calls as text.
+- [Troubleshooting Anthropic-compatible tool-call validation](../../reference/troubleshooting#onboarding-rejects-an-anthropic-compatible-tool-call) when the forced native tool probe fails during onboarding.
 </AgentOnly>
 - [Set Up an OpenAI-Compatible Endpoint](../custom-endpoints/set-up-openai-compatible-endpoint) for custom endpoint setup.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2261,6 +2261,27 @@ If JSON still appears as text, confirm that vLLM started with automatic tool cho
 
 <AgentOnly variant="openclaw">
 
+### Onboarding rejects an Anthropic-compatible tool call
+
+Validation for an OpenClaw **Other Anthropic-compatible endpoint** selection can fail with either of these diagnostics:
+
+```text
+anthropic-streaming-missing-tool-use
+anthropic-streaming-missing-tool-use-stop-reason
+```
+
+After an ordinary `/v1/messages` request succeeds, NemoClaw sends a streaming request that forces the endpoint to call the `emit_ok` validation tool.
+The response must include a native Anthropic `tool_use` content block named `emit_ok` and a later `message_delta` with `stop_reason: tool_use`.
+NemoClaw checks these observations independently: the first diagnostic means the named native block is absent, and the second means the stream does not finish the tool request with the required stop reason.
+
+A text delta containing JSON such as `{"name":"emit_ok","arguments":{"value":"OK"}}` is still assistant text.
+NemoClaw rejects it instead of treating it as a tool call because OpenClaw cannot dispatch text as a native Anthropic tool request.
+Fix the endpoint's Anthropic tool parser or chat template so it emits native protocol events, then run onboarding again.
+
+This check applies only to OpenClaw custom Anthropic routes.
+Hermes and Deep Agents Code keep their existing `/v1/chat/completions` validation and do not run the native Anthropic `emit_ok` probe.
+For a reasoning-only endpoint, `NEMOCLAW_REASONING=true` skips the streaming sequence and forced tool-call checks; OpenClaw still needs streaming and native tool calls at runtime, so use this only when the selected model cannot complete the onboarding probe.
+
 ### Onboarding fails with duplicate Anthropic message_start events
 
 Validation for an OpenClaw **Other Anthropic-compatible endpoint** selection ends with an error like:
@@ -2270,6 +2291,7 @@ Anthropic Messages API (streaming): duplicate message_start
 ```
 
 For OpenClaw custom Anthropic routes, NemoClaw sends a `stream: true` request to `/v1/messages` and validates the SSE event sequence (exactly one `message_start`, at least one `content_block_delta`, and a `message_stop`).
+The same request forces the `emit_ok` tool and separately requires a native `tool_use` block plus `stop_reason: tool_use`; JSON-shaped assistant text does not satisfy that tool-call contract.
 This error means the streaming layer on the endpoint or gateway is malformed even though its non-streaming responses are valid.
 A working non-streaming response does not imply that streaming works.
 Some inference gateways proxy plain requests correctly but corrupt the SSE stream, for example by emitting `message_start` twice for one request.
@@ -2282,8 +2304,8 @@ An older Hermes sandbox that still uses native Anthropic Messages can report tha
 Fix the streaming layer on the endpoint or gateway, or onboard with a different Anthropic-compatible endpoint.
 The official Anthropic provider does not run this check and is not affected.
 If an OpenClaw sandbox created by an older release fails at runtime with an empty final response on an Anthropic-compatible endpoint, re-run `$$nemoclaw onboard` so the streaming check can diagnose the endpoint.
-If the endpoint serves a reasoning-only model, set `NEMOCLAW_REASONING=true` to skip the streaming check.
-Streaming defects then surface at runtime instead of during onboarding.
+If the endpoint serves a reasoning-only model, set `NEMOCLAW_REASONING=true` to skip the streaming sequence and forced tool-call checks.
+Streaming or native tool-call defects then surface at runtime instead of during onboarding.
 
 ### `NEMOCLAW_DISABLE_DEVICE_AUTH=1` does not change an existing sandbox
 

--- a/src/lib/adapters/http/probe.test.ts
+++ b/src/lib/adapters/http/probe.test.ts
@@ -1031,6 +1031,75 @@ describe("runAnthropicStreamingEventProbe", () => {
     expect(result.missingEvents).toEqual([]);
     expect(result.duplicateEvents).toEqual([]);
     expect(result.sequenceErrors).toEqual([]);
+    expect(result.toolCallErrors).toEqual([]);
+  });
+
+  it("passes when the stream emits the required native tool call", () => {
+    const nativeToolStream = [
+      "event: message_start",
+      'data: {"type":"message_start","message":{"id":"msg_1"}}',
+      "",
+      "event: content_block_start",
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"emit_ok","input":{}}}',
+      "",
+      "event: content_block_delta",
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"value\\":\\"OK\\"}"}}',
+      "",
+      "event: content_block_stop",
+      'data: {"type":"content_block_stop","index":0}',
+      "",
+      "event: message_delta",
+      'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}',
+      "",
+      "event: message_stop",
+      'data: {"type":"message_stop"}',
+      "",
+    ].join("\n");
+
+    const result = runAnthropicStreamingEventProbe(
+      ["-sS", "--max-time", "15", "https://example.test/v1/messages"],
+      { spawnSyncImpl: mockStreaming(nativeToolStream) },
+      { expectedToolName: "emit_ok" },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.toolCallErrors).toEqual([]);
+  });
+
+  it("rejects JSON-shaped assistant text instead of a native tool call (#7967)", () => {
+    const flattenedToolStream = [
+      "event: message_start",
+      'data: {"type":"message_start","message":{"id":"msg_1"}}',
+      "",
+      "event: content_block_start",
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+      "",
+      "event: content_block_delta",
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\\"name\\":\\"emit_ok\\",\\"arguments\\":{\\"value\\":\\"OK\\"}}"}}',
+      "",
+      "event: content_block_stop",
+      'data: {"type":"content_block_stop","index":0}',
+      "",
+      "event: message_delta",
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}',
+      "",
+      "event: message_stop",
+      'data: {"type":"message_stop"}',
+      "",
+    ].join("\n");
+
+    const result = runAnthropicStreamingEventProbe(
+      ["-sS", "--max-time", "15", "https://example.test/v1/messages"],
+      { spawnSyncImpl: mockStreaming(flattenedToolStream) },
+      { expectedToolName: "emit_ok" },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.toolCallErrors).toEqual([
+      "missing-expected-tool-use",
+      "missing-tool-use-stop-reason",
+    ]);
+    expect(result.message).toContain("required structured tool_use content block");
   });
 
   it("rejects a non-2xx response even when its body looks like valid SSE", () => {

--- a/src/lib/adapters/http/probe.ts
+++ b/src/lib/adapters/http/probe.ts
@@ -560,6 +560,8 @@ interface SseEventCaptureResult {
   eventCounts: Map<string, number>;
   /** SSE `event:` types in stream order, for sequence validation. */
   eventSequence: string[];
+  /** Captured response body, retained only for protocol-specific validation. */
+  body: string;
 }
 
 /**
@@ -614,6 +616,7 @@ function captureSseEventCounts(
         detail,
         eventCounts: new Map(),
         eventSequence: [],
+        body: "",
       };
     }
 
@@ -632,6 +635,7 @@ function captureSseEventCounts(
         ),
         eventCounts: new Map(),
         eventSequence: [],
+        body: "",
       };
     }
 
@@ -654,6 +658,7 @@ function captureSseEventCounts(
       detail: "",
       eventCounts,
       eventSequence,
+      body,
     };
   } finally {
     cleanupTempDir(bodyFile, tempPrefix);
@@ -753,7 +758,18 @@ export interface AnthropicStreamingProbeResult {
   duplicateEvents: string[];
   /** Order violations, e.g. content deltas before message_start or after message_stop. */
   sequenceErrors: string[];
+  /** Structured tool-call contract violations when a named tool is required. */
+  toolCallErrors: AnthropicStreamingToolCallError[];
   message: string;
+}
+
+export type AnthropicStreamingToolCallError =
+  | "missing-expected-tool-use"
+  | "missing-tool-use-stop-reason";
+
+export interface AnthropicStreamingExpectations {
+  /** Require one structured `tool_use` content block for this exact tool name. */
+  expectedToolName?: string;
 }
 
 /**
@@ -791,6 +807,51 @@ function anthropicSequenceErrors(eventSequence: string[]): string[] {
   return errors;
 }
 
+function anthropicToolCallErrors(
+  body: string,
+  expectedToolName: string | undefined,
+): AnthropicStreamingToolCallError[] {
+  if (!expectedToolName) return [];
+  let hasExpectedToolUse = false;
+  let hasToolUseStopReason = false;
+
+  for (const eventBlock of body.split(/\r?\n\r?\n/)) {
+    const data = eventBlock
+      .split(/\r?\n/)
+      .flatMap((line) => {
+        const match = /^data:\s?(.*)$/i.exec(line);
+        return match ? [match[1]] : [];
+      })
+      .join("\n");
+    if (!data || data === "[DONE]") continue;
+    try {
+      const payload = JSON.parse(data) as {
+        type?: unknown;
+        content_block?: { type?: unknown; name?: unknown };
+        delta?: { stop_reason?: unknown };
+      };
+      if (
+        payload.type === "content_block_start" &&
+        payload.content_block?.type === "tool_use" &&
+        payload.content_block.name === expectedToolName
+      ) {
+        hasExpectedToolUse = true;
+      }
+      if (payload.type === "message_delta" && payload.delta?.stop_reason === "tool_use") {
+        hasToolUseStopReason = true;
+      }
+    } catch {
+      // Malformed data remains covered by the required structured observations
+      // below; never interpret JSON-shaped assistant text as a tool call.
+    }
+  }
+
+  return [
+    ...(hasExpectedToolUse ? [] : (["missing-expected-tool-use"] as const)),
+    ...(hasToolUseStopReason ? [] : (["missing-tool-use-stop-reason"] as const)),
+  ];
+}
+
 /**
  * Send a streaming request to an Anthropic-compatible `/v1/messages`
  * endpoint and verify the SSE event stream is well formed: the required
@@ -805,17 +866,19 @@ function anthropicSequenceErrors(eventSequence: string[]): string[] {
 export function runAnthropicStreamingEventProbe(
   argv: string[],
   opts: CurlProbeOptions = {},
+  expectations: AnthropicStreamingExpectations = {},
 ): AnthropicStreamingProbeResult {
   return withTraceSpan(
     "nemoclaw.inference.curl_anthropic_streaming_probe",
     getCurlProbeTraceAttributes(argv, opts),
-    () => runAnthropicStreamingEventProbeImpl(argv, opts),
+    () => runAnthropicStreamingEventProbeImpl(argv, opts, expectations),
   );
 }
 
 function runAnthropicStreamingEventProbeImpl(
   argv: string[],
   opts: CurlProbeOptions = {},
+  expectations: AnthropicStreamingExpectations = {},
 ): AnthropicStreamingProbeResult {
   try {
     const capture = captureSseEventCounts(argv, opts, "nemoclaw-anthropic-streaming-probe", true);
@@ -835,6 +898,7 @@ function runAnthropicStreamingEventProbeImpl(
         missingEvents: REQUIRED_ANTHROPIC_STREAMING_EVENTS,
         duplicateEvents: [],
         sequenceErrors: [],
+        toolCallErrors: [],
         message: `Streaming probe failed: ${compactText(capture.detail).slice(0, 200)}`,
       };
     }
@@ -847,7 +911,16 @@ function runAnthropicStreamingEventProbeImpl(
     );
     const sequenceErrors =
       missing.length === 0 ? anthropicSequenceErrors(capture.eventSequence) : [];
-    if (missing.length > 0 || duplicates.length > 0 || sequenceErrors.length > 0) {
+    const toolCallErrors =
+      missing.length === 0
+        ? anthropicToolCallErrors(capture.body, expectations.expectedToolName)
+        : [];
+    if (
+      missing.length > 0 ||
+      duplicates.length > 0 ||
+      sequenceErrors.length > 0 ||
+      toolCallErrors.length > 0
+    ) {
       const problems: string[] = [];
       if (duplicates.length > 0) {
         const detail = duplicates
@@ -861,12 +934,19 @@ function runAnthropicStreamingEventProbeImpl(
       if (sequenceErrors.length > 0) {
         problems.push(`emits events out of order (${sequenceErrors.join("; ")})`);
       }
+      if (toolCallErrors.includes("missing-expected-tool-use")) {
+        problems.push("does not emit the required structured tool_use content block");
+      }
+      if (toolCallErrors.includes("missing-tool-use-stop-reason")) {
+        problems.push("does not finish the tool request with stop_reason tool_use");
+      }
       emitCurlResultTraceEvent({
         ok: false,
         http_status: capture.httpStatus,
         missing_events_count: missing.length,
         duplicate_events_count: duplicates.length,
         sequence_errors_count: sequenceErrors.length,
+        tool_call_errors_count: toolCallErrors.length,
         curl_status: capture.curlStatus,
       });
       return {
@@ -876,9 +956,10 @@ function runAnthropicStreamingEventProbeImpl(
         missingEvents: missing,
         duplicateEvents: duplicates,
         sequenceErrors,
+        toolCallErrors,
         message:
           `Anthropic Messages streaming on this endpoint ${problems.join(" and ")}. ` +
-          "Agent runs use the streaming path and would fail with an empty final response.",
+          "Agent runs use the streaming path and require native protocol events.",
       };
     }
 
@@ -888,6 +969,7 @@ function runAnthropicStreamingEventProbeImpl(
       missing_events_count: 0,
       duplicate_events_count: 0,
       sequence_errors_count: 0,
+      tool_call_errors_count: 0,
       curl_status: capture.curlStatus,
     });
     return {
@@ -897,6 +979,7 @@ function runAnthropicStreamingEventProbeImpl(
       missingEvents: [],
       duplicateEvents: [],
       sequenceErrors: [],
+      toolCallErrors: [],
       message: "",
     };
   } catch (error) {
@@ -918,6 +1001,7 @@ function runAnthropicStreamingEventProbeImpl(
       missingEvents: REQUIRED_ANTHROPIC_STREAMING_EVENTS,
       duplicateEvents: [],
       sequenceErrors: [],
+      toolCallErrors: [],
       message: `Streaming probe error: ${detail}`,
     };
   }

--- a/src/lib/inference/probe-anthropic.test.ts
+++ b/src/lib/inference/probe-anthropic.test.ts
@@ -94,6 +94,7 @@ describe("probeAnthropicEndpoint", () => {
       missingEvents: [],
       duplicateEvents: [],
       sequenceErrors: [],
+      toolCallErrors: [],
       message: "",
     });
 
@@ -130,6 +131,7 @@ describe("probeAnthropicEndpoint", () => {
           missingEvents: [],
           duplicateEvents: [],
           sequenceErrors: [],
+          toolCallErrors: [],
           message: "",
         };
       });
@@ -156,6 +158,77 @@ describe("probeAnthropicEndpoint", () => {
     expect(fs.existsSync(configPath)).toBe(false);
   });
 
+  it("forces and validates a native streaming tool call when requested (#7967)", () => {
+    vi.spyOn(probe, "runCurlProbe").mockReturnValue({
+      ok: true,
+      httpStatus: 200,
+      curlStatus: 0,
+      body: "{}",
+      stderr: "",
+      message: "HTTP 200",
+    });
+    const streamSpy = vi.spyOn(probe, "runAnthropicStreamingEventProbe").mockReturnValue({
+      ok: true,
+      httpStatus: 200,
+      curlStatus: 0,
+      missingEvents: [],
+      duplicateEvents: [],
+      sequenceErrors: [],
+      toolCallErrors: [],
+      message: "",
+    });
+
+    const result = probeAnthropicEndpoint(
+      "https://custom.endpoint.test",
+      "nvidia/nemotron-3-super-v3",
+      "sk-custom-secret",
+      { probeStreaming: true, requireStreamingToolCalling: true },
+    );
+
+    expect(result.ok).toBe(true);
+    const [streamingArgv, , expectations] = streamSpy.mock.calls[0];
+    const payload = JSON.parse(streamingArgv[streamingArgv.indexOf("-d") + 1]);
+    expect(payload).toMatchObject({
+      stream: true,
+      tools: [{ name: "emit_ok" }],
+      tool_choice: { type: "tool", name: "emit_ok" },
+    });
+    expect(expectations).toEqual({ expectedToolName: "emit_ok" });
+  });
+
+  it("reports native tool-call protocol violations as diagnostics (#7967)", () => {
+    vi.spyOn(probe, "runCurlProbe").mockReturnValue({
+      ok: true,
+      httpStatus: 200,
+      curlStatus: 0,
+      body: "{}",
+      stderr: "",
+      message: "HTTP 200",
+    });
+    vi.spyOn(probe, "runAnthropicStreamingEventProbe").mockReturnValue({
+      ok: false,
+      httpStatus: 200,
+      curlStatus: 0,
+      missingEvents: [],
+      duplicateEvents: [],
+      sequenceErrors: [],
+      toolCallErrors: ["missing-expected-tool-use", "missing-tool-use-stop-reason"],
+      message: "Missing native Anthropic tool call.",
+    });
+
+    const result = probeAnthropicEndpoint(
+      "https://custom.endpoint.test",
+      "nvidia/nemotron-3-super-v3",
+      "sk-custom-secret",
+      { probeStreaming: true, requireStreamingToolCalling: true },
+    );
+
+    expect(result.failures?.[0]?.diagnosticCodes).toEqual([
+      "anthropic-streaming-missing-tool-use",
+      "anthropic-streaming-missing-tool-use-stop-reason",
+    ]);
+  });
+
   it("fails validation when the streaming event sequence is malformed", () => {
     vi.spyOn(probe, "runCurlProbe").mockReturnValue({
       ok: true,
@@ -172,6 +245,7 @@ describe("probeAnthropicEndpoint", () => {
       missingEvents: [],
       duplicateEvents: ["message_start"],
       sequenceErrors: [],
+      toolCallErrors: [],
       message:
         "Anthropic Messages streaming on this endpoint emits duplicate message_start " +
         "(2 events for one request). Agent runs use the streaming path and would fail " +
@@ -211,6 +285,7 @@ describe("probeAnthropicEndpoint", () => {
       missingEvents: ["message_stop"],
       duplicateEvents: [],
       sequenceErrors: [],
+      toolCallErrors: [],
       message: "Anthropic Messages streaming is missing required events: message_stop.",
     });
 
@@ -249,6 +324,7 @@ describe("probeAnthropicEndpoint", () => {
       missingEvents: [],
       duplicateEvents: [],
       sequenceErrors: [],
+      toolCallErrors: [],
       message: "",
     });
 

--- a/src/lib/inference/probe-anthropic.ts
+++ b/src/lib/inference/probe-anthropic.ts
@@ -26,7 +26,9 @@ export type AnthropicStreamingDiagnosticCode =
   | "anthropic-streaming-duplicate-message-stop"
   | "anthropic-streaming-missing-content-block-delta"
   | "anthropic-streaming-missing-message-start"
-  | "anthropic-streaming-missing-message-stop";
+  | "anthropic-streaming-missing-message-stop"
+  | "anthropic-streaming-missing-tool-use"
+  | "anthropic-streaming-missing-tool-use-stop-reason";
 
 export interface AnthropicProbeFailureDetail {
   name: string;
@@ -55,6 +57,12 @@ export interface AnthropicProbeOptions {
    */
   probeStreaming?: boolean;
   /**
+   * Require the streaming request to return a native Anthropic `tool_use`
+   * block. This detects gateways that flatten tool calls into assistant text
+   * even though ordinary Messages and non-streaming requests succeed (#7967).
+   */
+  requireStreamingToolCalling?: boolean;
+  /**
    * SSRF-preflight-validated address(es) to pin the probe curl to via
    * `--resolve`, so a second DNS lookup here cannot rebind the endpoint host to
    * a private/internal address after the public preflight (TOCTOU — #6293).
@@ -71,6 +79,7 @@ export interface AnthropicProbeOptions {
 // tolerated by the streaming probe when the required events were already
 // collected before the cap.
 const STREAMING_PROBE_TIMING_ARGS = ["--connect-timeout", "10", "--max-time", "15"];
+const STREAMING_TOOL_PROBE_NAME = "emit_ok";
 
 function anthropicFailureFromError(error: unknown): AnthropicProbeResult {
   const message = error instanceof Error ? error.message : String(error);
@@ -81,12 +90,40 @@ function anthropicFailureFromError(error: unknown): AnthropicProbeResult {
   };
 }
 
-function anthropicMessagesPayload(model: string, stream: boolean): string {
+function anthropicMessagesPayload(
+  model: string,
+  stream: boolean,
+  requireToolCalling = false,
+): string {
   return JSON.stringify({
     model,
-    max_tokens: 16,
+    max_tokens: requireToolCalling ? 64 : 16,
     ...(stream ? { stream: true } : {}),
-    messages: [{ role: "user", content: "Reply with exactly: OK" }],
+    messages: [
+      {
+        role: "user",
+        content: requireToolCalling
+          ? `Call ${STREAMING_TOOL_PROBE_NAME} with value OK. Do not answer with text.`
+          : "Reply with exactly: OK",
+      },
+    ],
+    ...(requireToolCalling
+      ? {
+          tools: [
+            {
+              name: STREAMING_TOOL_PROBE_NAME,
+              description: "Return the supplied validation value.",
+              input_schema: {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            },
+          ],
+          tool_choice: { type: "tool", name: STREAMING_TOOL_PROBE_NAME },
+        }
+      : {}),
   });
 }
 
@@ -109,7 +146,7 @@ const SEQUENCE_ERROR_DIAGNOSTICS: Record<string, AnthropicStreamingDiagnosticCod
 function anthropicStreamingDiagnosticCodes(
   result: Pick<
     AnthropicStreamingProbeResult,
-    "duplicateEvents" | "missingEvents" | "sequenceErrors"
+    "duplicateEvents" | "missingEvents" | "sequenceErrors" | "toolCallErrors"
   >,
 ): AnthropicStreamingDiagnosticCode[] {
   return [
@@ -121,6 +158,11 @@ function anthropicStreamingDiagnosticCodes(
     ),
     ...result.sequenceErrors.flatMap((error) =>
       SEQUENCE_ERROR_DIAGNOSTICS[error] ? [SEQUENCE_ERROR_DIAGNOSTICS[error]] : [],
+    ),
+    ...result.toolCallErrors.map((error) =>
+      error === "missing-expected-tool-use"
+        ? ("anthropic-streaming-missing-tool-use" as const)
+        : ("anthropic-streaming-missing-tool-use-stop-reason" as const),
     ),
   ];
 }
@@ -183,7 +225,7 @@ export function probeAnthropicEndpoint(
           "-H",
           "content-type: application/json",
           "-d",
-          anthropicMessagesPayload(model, true),
+          anthropicMessagesPayload(model, true, options.requireStreamingToolCalling === true),
           messagesUrl,
         ],
         {
@@ -191,6 +233,9 @@ export function probeAnthropicEndpoint(
           pinnedAddresses: options.pinnedAddresses,
           trustedPrivateCapability: options.trustedPrivateCapability,
         },
+        options.requireStreamingToolCalling === true
+          ? { expectedToolName: STREAMING_TOOL_PROBE_NAME }
+          : {},
       );
       if (!streamResult.ok) {
         return {

--- a/src/lib/onboard/inference-selection-validation.test.ts
+++ b/src/lib/onboard/inference-selection-validation.test.ts
@@ -619,7 +619,11 @@ describe("inference selection validation", () => {
         "https://compatible.example",
         "nvidia/nemotron-3-super-v3",
         "test-key",
-        { probeStreaming: true, pinnedAddresses: ["93.184.216.34"] },
+        {
+          probeStreaming: true,
+          requireStreamingToolCalling: true,
+          pinnedAddresses: ["93.184.216.34"],
+        },
       );
     } finally {
       log.mockRestore();
@@ -714,7 +718,11 @@ describe("inference selection validation", () => {
         "https://compatible.example",
         "reasoning-model",
         "test-key",
-        { probeStreaming: false, pinnedAddresses: ["93.184.216.34"] },
+        {
+          probeStreaming: false,
+          requireStreamingToolCalling: false,
+          pinnedAddresses: ["93.184.216.34"],
+        },
       );
     } finally {
       log.mockRestore();

--- a/src/lib/onboard/inference-selection-validation.ts
+++ b/src/lib/onboard/inference-selection-validation.ts
@@ -14,6 +14,7 @@ const { probeAnthropicEndpoint, probeOpenAiLikeEndpointOptimized } =
       apiKey: string | null | undefined,
       options?: {
         probeStreaming?: boolean;
+        requireStreamingToolCalling?: boolean;
         pinnedAddresses?: readonly string[];
         trustedPrivateCapability?: TrustedPrivateEndpointCapability;
       },
@@ -463,7 +464,8 @@ export function createInferenceSelectionValidationHelpers(
     // Validate the protocol surface that the selected agent will actually use.
     // Hermes routes custom Anthropic providers through the managed OpenAI
     // frontend, while native Anthropic consumers require strict SSE validation
-    // for duplicate/missing/out-of-order events (#6289).
+    // for duplicate/missing/out-of-order events (#6289) and a native tool_use
+    // result rather than JSON-shaped assistant text (#7967).
     const probe =
       intendedApi === "openai-completions"
         ? await runOpenAiLikeProbe(
@@ -481,6 +483,7 @@ export function createInferenceSelectionValidationHelpers(
             // Reasoning-only compatible endpoints often reject streaming probes,
             // so mirror the custom OpenAI-compatible path and skip streaming.
             probeStreaming: !reasoningEnabled,
+            requireStreamingToolCalling: !reasoningEnabled,
             pinnedAddresses,
             trustedPrivateCapability,
           });


### PR DESCRIPTION
## Summary

Custom Anthropic-compatible endpoints can pass ordinary Messages and SSE sequencing checks while flattening a requested tool call into JSON-shaped assistant text. This change makes OpenClaw onboarding force one streaming tool call and rejects endpoints unless they emit a native `tool_use` block with the matching `tool_use` stop reason.

## Related Issue

Closes #7967.

## Changes

- extend the existing Anthropic streaming probe to inspect its captured SSE data for a named native `tool_use` block and matching stop reason
- force the existing custom Anthropic onboarding probe to call a strict `emit_ok` tool
- preserve the reasoning-mode exception and the existing Hermes and Deep Agents Code Chat Completions routes
- add positive native-tool-call and negative flattened-text coverage, plus onboarding and diagnostic mapping tests
- document the forced OpenClaw probe, native protocol requirements, diagnostics, reasoning exception, and agent-specific routing boundaries

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [senthilr-nv reviewed commit `72711d8f8`](https://github.com/NVIDIA/NemoClaw/pull/9236#pullrequestreview-4945216976) and confirmed the inference, onboarding, SSRF, credential, reasoning, and focused test boundaries; the requested documentation update is included in `6a42e44e9`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/inference/set-up-anthropic-compatible-endpoint.mdx`, `docs/inference/understand-provider-validation.mdx`, `docs/reference/troubleshooting.mdx`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6a42e44e9 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/adapters/http/probe.test.ts src/lib/inference/probe-anthropic.test.ts src/lib/onboard/inference-selection-validation.test.ts` (107 passed)
- [x] Applicable broad gate passed — `npm run typecheck:cli`, `npm run checks:repository`, `npm run source-shape:check`, and `npm run test-size:check`
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors; Fern reported an unauthenticated redirect-check warning and the existing light-theme contrast warning.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional documentation validation:

- `npm run docs:sync-agent-variants` passed and preserved the OpenClaw, Hermes, and Deep Agents Code behavior boundaries.
- `npm run docs` passed with 0 errors.

---

Signed-off-by: Ho Lim <subhoya@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for native tool calls in Anthropic streaming responses.
  * Added checks for expected tool names and required `tool_use` stop reasons.
  * Added clear diagnostics for missing tool-use blocks and invalid streaming tool-call sequences.
  * Added an option to require streaming tool-call validation during inference setup.

* **Bug Fixes**
  * Prevented JSON-formatted assistant text from being mistaken for a native tool call.

* **Documentation**
  * Added troubleshooting guidance for Anthropic-compatible tool-call validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
