### PR TITLE
feat(e2e): report same-commit reliability

### DIFF
--- a/.github/workflows/e2e-main-retry.yaml
+++ b/.github/workflows/e2e-main-retry.yaml
@@ -66,3 +66,57 @@ jobs:
           path: ${{ runner.temp }}/e2e-main-retry-evidence.json
           if-no-files-found: warn
           retention-days: 14
+
+  report-same-commit-reliability:
+    needs: evaluate
+    if: >-
+      ${{
+      always() &&
+      github.run_attempt == 1 &&
+      github.repository == 'NVIDIA/NemoClaw' &&
+      github.event.workflow_run.status == 'completed' &&
+      (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch') &&
+      github.event.workflow_run.path == '.github/workflows/e2e.yaml' &&
+      startsWith(github.event.workflow_run.display_title, 'E2E ') &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == 'NVIDIA/NemoClaw'
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout trusted reliability reporter
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - name: Build advisory same-commit reliability report
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELIABILITY_REPORT_PATH: ${{ runner.temp }}/same-commit-reliability.json
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --experimental-strip-types --no-warnings \
+            tools/e2e/same-commit-reliability.mts \
+            | tee "${RUNNER_TEMP}/same-commit-reliability.md"
+          cat "${RUNNER_TEMP}/same-commit-reliability.md" >>"${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload advisory reliability evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: same-commit-reliability-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          path: |
+            ${{ runner.temp }}/same-commit-reliability.json
+            ${{ runner.temp }}/same-commit-reliability.md
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/e2e-main-retry.yaml
+++ b/.github/workflows/e2e-main-retry.yaml
@@ -101,14 +101,15 @@ jobs:
       - name: Build advisory same-commit reliability report
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          RELIABILITY_REPORT_PATH: ${{ runner.temp }}/same-commit-reliability.json
           SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
         shell: bash
         run: |
           set -euo pipefail
           node --experimental-strip-types --no-warnings \
             tools/e2e/same-commit-reliability.mts \
-            | tee "${RUNNER_TEMP}/same-commit-reliability.md"
+            >"${RUNNER_TEMP}/same-commit-reliability.json" \
+            2>"${RUNNER_TEMP}/same-commit-reliability.md"
+          cat "${RUNNER_TEMP}/same-commit-reliability.md"
           cat "${RUNNER_TEMP}/same-commit-reliability.md" >>"${GITHUB_STEP_SUMMARY}"
 
       - name: Upload advisory reliability evidence

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -122,6 +122,11 @@
       "category": "security"
     },
     {
+      "file": "test/e2e/support/same-commit-reliability.test.ts",
+      "test": "locks the reporter to canonical source and trusted controller identities (#9168)",
+      "category": "security"
+    },
+    {
       "file": "test/e2e/support/e2e-expected-state.test.ts",
       "test": "compiles absence probes for every preflight failure contract",
       "category": "security"

--- a/scripts/scorecard/read-artifact-zip.mts
+++ b/scripts/scorecard/read-artifact-zip.mts
@@ -58,9 +58,11 @@ function isSafeExpectedFile(expectedFile: string): boolean {
 }
 
 /**
- * Lists safe regular-file entries from a GitHub artifact ZIP without
- * extracting or inflating their contents. Structural ambiguity, links,
- * encryption, split archives, ZIP64, duplicate names, and excess entries are
+ * Lists structurally validated regular-file entries from a GitHub artifact
+ * ZIP without extracting or inflating their contents. Relative names must not
+ * contain empty, dot, parent, backslash, NUL, absolute, or trailing-slash
+ * segments. Links, encryption, split archives, ZIP64, duplicate names,
+ * unsupported compression, inconsistent headers, and excess entries are
  * rejected before callers select an allowlisted evidence file.
  */
 export function listValidatedArtifactZipEntries(
@@ -155,9 +157,11 @@ export function listValidatedArtifactZipEntries(
 }
 
 /**
- * Reads the exact bytes of one safe relative file from a GitHub artifact ZIP
- * without extracting paths to disk. Duplicate targets, links, encryption,
- * split archives, ZIP64, excess entries, and oversized payloads are rejected.
+ * Reads the exact bytes of one structurally validated relative regular-file
+ * entry from a GitHub artifact ZIP without extracting paths to disk. The same
+ * name, archive-layout, file-type, encryption, split/ZIP64, compression,
+ * header-consistency, entry-count, compressed-size, inflated-size, and CRC
+ * constraints used by the entry validator are enforced before bytes return.
  */
 export function readValidatedArtifactZipEntryBytes(
   archive: Buffer,

--- a/scripts/scorecard/read-artifact-zip.mts
+++ b/scripts/scorecard/read-artifact-zip.mts
@@ -51,8 +51,107 @@ function isSafeExpectedFile(expectedFile: string): boolean {
     !expectedFile.endsWith("/") &&
     !expectedFile.includes("\\") &&
     !expectedFile.includes("\0") &&
-    segments.every((segment) => segment !== "" && segment !== "." && segment !== "..")
+    segments.every(
+      (segment) => segment !== "" && segment !== "." && segment !== "..",
+    )
   );
+}
+
+/**
+ * Lists safe regular-file entries from a GitHub artifact ZIP without
+ * extracting or inflating their contents. Structural ambiguity, links,
+ * encryption, split archives, ZIP64, duplicate names, and excess entries are
+ * rejected before callers select an allowlisted evidence file.
+ */
+export function listValidatedArtifactZipEntries(
+  archive: Buffer,
+  options: { maxEntries?: number },
+): string[] | null {
+  const maxEntries = options.maxEntries ?? 1000;
+  if (maxEntries < 1) return null;
+  const endOffset = findZipEndOfCentralDirectory(archive);
+  if (endOffset < 0) return null;
+  const entriesOnDisk = archive.readUInt16LE(endOffset + 8);
+  const totalEntries = archive.readUInt16LE(endOffset + 10);
+  const centralDirectorySize = archive.readUInt32LE(endOffset + 12);
+  const centralDirectoryOffset = archive.readUInt32LE(endOffset + 16);
+  if (
+    archive.readUInt16LE(endOffset + 4) !== 0 ||
+    archive.readUInt16LE(endOffset + 6) !== 0 ||
+    entriesOnDisk !== totalEntries ||
+    totalEntries < 1 ||
+    totalEntries > maxEntries ||
+    centralDirectoryOffset + centralDirectorySize !== endOffset
+  ) {
+    return null;
+  }
+
+  const names: string[] = [];
+  const seen = new Set<string>();
+  let offset = centralDirectoryOffset;
+  for (let index = 0; index < totalEntries; index += 1) {
+    if (
+      offset + 46 > endOffset ||
+      archive.readUInt32LE(offset) !== ZIP_CENTRAL_DIRECTORY_SIGNATURE
+    ) {
+      return null;
+    }
+    const creatorSystem = archive.readUInt8(offset + 5);
+    const flags = archive.readUInt16LE(offset + 8);
+    const compressionMethod = archive.readUInt16LE(offset + 10);
+    const compressedSize = archive.readUInt32LE(offset + 20);
+    const fileNameLength = archive.readUInt16LE(offset + 28);
+    const extraLength = archive.readUInt16LE(offset + 30);
+    const commentLength = archive.readUInt16LE(offset + 32);
+    const diskStart = archive.readUInt16LE(offset + 34);
+    const externalAttributes = archive.readUInt32LE(offset + 38);
+    const localHeaderOffset = archive.readUInt32LE(offset + 42);
+    const entryEnd = offset + 46 + fileNameLength + extraLength + commentLength;
+    if (entryEnd > endOffset) return null;
+    const nameBytes = archive.subarray(
+      offset + 46,
+      offset + 46 + fileNameLength,
+    );
+    let name: string;
+    try {
+      name = new TextDecoder("utf-8", { fatal: true }).decode(nameBytes);
+    } catch {
+      return null;
+    }
+    const unixFileType = (externalAttributes >>> 16) & 0xf000;
+    if (
+      !isSafeExpectedFile(name) ||
+      seen.has(name) ||
+      diskStart !== 0 ||
+      (flags & 0x1) !== 0 ||
+      (compressionMethod !== 0 && compressionMethod !== 8) ||
+      (creatorSystem !== 0 && creatorSystem !== 3) ||
+      (creatorSystem === 3 && unixFileType !== 0 && unixFileType !== 0x8000) ||
+      localHeaderOffset + 30 > centralDirectoryOffset ||
+      archive.readUInt32LE(localHeaderOffset) !== ZIP_LOCAL_FILE_SIGNATURE
+    ) {
+      return null;
+    }
+    const localFlags = archive.readUInt16LE(localHeaderOffset + 6);
+    const localCompressionMethod = archive.readUInt16LE(localHeaderOffset + 8);
+    const localNameLength = archive.readUInt16LE(localHeaderOffset + 26);
+    const localExtraLength = archive.readUInt16LE(localHeaderOffset + 28);
+    const localNameEnd = localHeaderOffset + 30 + localNameLength;
+    const dataEnd = localNameEnd + localExtraLength + compressedSize;
+    if (
+      localNameEnd > centralDirectoryOffset ||
+      dataEnd > centralDirectoryOffset ||
+      localFlags !== flags ||
+      localCompressionMethod !== compressionMethod ||
+      !archive.subarray(localHeaderOffset + 30, localNameEnd).equals(nameBytes)
+    ) {
+      return null;
+    }
+    seen.add(name);
+    names.push(name);
+    offset = entryEnd;
+  }
+  return offset === endOffset ? names.sort() : null;
 }
 
 /**
@@ -67,7 +166,11 @@ export function readValidatedArtifactZipEntryBytes(
 ): Buffer | null {
   const maxEntries = options.maxEntries ?? 1000;
   const expectedFileName = Buffer.from(expectedFile, "utf8");
-  if (!isSafeExpectedFile(expectedFile) || options.maxBytes < 1 || maxEntries < 1) {
+  if (
+    !isSafeExpectedFile(expectedFile) ||
+    options.maxBytes < 1 ||
+    maxEntries < 1
+  ) {
     return null;
   }
 
@@ -96,14 +199,16 @@ export function readValidatedArtifactZipEntryBytes(
   for (let entryIndex = 0; entryIndex < totalEntries; entryIndex += 1) {
     if (
       centralEntryOffset + 46 > endOffset ||
-      archive.readUInt32LE(centralEntryOffset) !== ZIP_CENTRAL_DIRECTORY_SIGNATURE
+      archive.readUInt32LE(centralEntryOffset) !==
+        ZIP_CENTRAL_DIRECTORY_SIGNATURE
     ) {
       return null;
     }
     const fileNameLength = archive.readUInt16LE(centralEntryOffset + 28);
     const extraLength = archive.readUInt16LE(centralEntryOffset + 30);
     const commentLength = archive.readUInt16LE(centralEntryOffset + 32);
-    const centralEntryEnd = centralEntryOffset + 46 + fileNameLength + extraLength + commentLength;
+    const centralEntryEnd =
+      centralEntryOffset + 46 + fileNameLength + extraLength + commentLength;
     if (centralEntryEnd > endOffset) return null;
     const fileName = archive.subarray(
       centralEntryOffset + 46,
@@ -164,23 +269,31 @@ export function readValidatedArtifactZipEntryBytes(
     localFileNameEnd > centralDirectoryOffset ||
     localFlags !== flags ||
     localCompressionMethod !== compressionMethod ||
-    !archive.subarray(localHeaderOffset + 30, localFileNameEnd).equals(expectedFileName) ||
+    !archive
+      .subarray(localHeaderOffset + 30, localFileNameEnd)
+      .equals(expectedFileName) ||
     compressedDataEnd > centralDirectoryOffset
   ) {
     return null;
   }
 
-  const compressedData = archive.subarray(compressedDataOffset, compressedDataEnd);
+  const compressedData = archive.subarray(
+    compressedDataOffset,
+    compressedDataEnd,
+  );
   let contents: Buffer;
   try {
     contents =
       compressionMethod === 0
         ? Buffer.from(compressedData)
-        : zlib.inflateRawSync(compressedData, { maxOutputLength: options.maxBytes });
+        : zlib.inflateRawSync(compressedData, {
+            maxOutputLength: options.maxBytes,
+          });
   } catch {
     return null;
   }
-  if (contents.length !== uncompressedSize || crc32(contents) !== expectedCrc) return null;
+  if (contents.length !== uncompressedSize || crc32(contents) !== expectedCrc)
+    return null;
   return contents;
 }
 
@@ -190,5 +303,11 @@ export function readValidatedArtifactZipEntry(
   expectedFile: string,
   options: { maxBytes: number; maxEntries?: number },
 ): string | null {
-  return readValidatedArtifactZipEntryBytes(archive, expectedFile, options)?.toString("utf8") ?? null;
+  return (
+    readValidatedArtifactZipEntryBytes(
+      archive,
+      expectedFile,
+      options,
+    )?.toString("utf8") ?? null
+  );
 }

--- a/src/lib/actions/sandbox/start.test.ts
+++ b/src/lib/actions/sandbox/start.test.ts
@@ -232,7 +232,7 @@ describe("startSandbox", () => {
 
   it(
     "retries startup after a structured recovery failure (#8662)",
-    testTimeoutOptions(15_000),
+    testTimeoutOptions(30_000),
     async () => {
       const h = harness();
       h.restoreStartupState.mockReturnValueOnce(FAILED_RECOVERY);

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -582,23 +582,25 @@ graph as the live targets:
 - GitHub Actions run history is the authoritative record for push and
   manual E2E results.
 - `E2E / Main Retry` publishes an advisory same-commit reliability table for
-  trusted-main and explicit manual qualification runs. It keeps first-pass
-  success, pass-after-retry, exhausted retries, and pass/fail flips distinct,
+  trusted pushes to `main` and explicit manual qualification runs. It keeps
+  first-pass success, pass-after-retry, exhausted retries, and pass/fail flips
+  distinct,
   and never treats retry records or runner-pressure classifications as proof
   that a manual run reached a terminal result. Manual identity comes from the
   run-bound dispatch receipt; its terminal result additionally requires at
   least one canonical `nemoclaw-e2e-evidence-v1` manifest bound to the same run,
   attempt, candidate SHA, trusted workflow repository, workflow SHA, and job
-  status. Trusted-main outcomes instead require the canonical retry-controller
-  artifact. Missing or malformed identity/outcome evidence leaves a run
-  unclassified. Retry and runner-pressure files contribute only fixed failure
-  classes: their complete, missing, or malformed state is reported separately,
-  so malformed classification data cannot erase an otherwise authenticated
-  outcome. Both evidence-state counts appear in the grouped JSON and Markdown
-  table. The table never changes a required check, release conclusion, or rerun
-  decision.
-- The report job appends the Markdown table to the GitHub Actions job summary
-  and uploads the bounded, allowlisted JSON and Markdown files as
+  status. Outcomes from trusted pushes to `main` instead require the canonical
+  retry-controller artifact. Missing or malformed identity/outcome evidence
+  leaves a run unclassified. Retry and runner-pressure files contribute only
+  allowlisted failure classes: their complete, missing, or malformed state is
+  reported separately, so malformed classification data cannot erase an
+  otherwise authenticated outcome. Both evidence-state counts appear in the
+  grouped JSON and Markdown table. The table never changes a required check,
+  release conclusion, or rerun decision.
+- The `report-same-commit-reliability` job appends the Markdown table to its
+  GitHub Actions job summary and uploads the bounded, allowlisted
+  `same-commit-reliability.json` and `same-commit-reliability.md` files as
   `same-commit-reliability-<source-run-id>-<attempt>` with 14-day retention.
   Artifact ZIP entries are structurally validated before an allowlisted file is
   read: ambiguous relative paths, links, encryption, split/ZIP64 archives,

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -584,9 +584,26 @@ graph as the live targets:
 - `E2E / Main Retry` publishes an advisory same-commit reliability table for
   trusted-main and explicit manual qualification runs. It keeps first-pass
   success, pass-after-retry, exhausted retries, and pass/fail flips distinct,
-  consumes only fixed retry and terminal runner classifications, and leaves
-  missing or malformed evidence unclassified. The table never changes a
-  required check, release conclusion, or rerun decision.
+  and never treats retry records or runner-pressure classifications as proof
+  that a manual run reached a terminal result. Manual identity comes from the
+  run-bound dispatch receipt; its terminal result additionally requires at
+  least one canonical `nemoclaw-e2e-evidence-v1` manifest bound to the same run,
+  attempt, candidate SHA, trusted workflow repository, workflow SHA, and job
+  status. Trusted-main outcomes instead require the canonical retry-controller
+  artifact. Missing or malformed identity/outcome evidence leaves a run
+  unclassified. Retry and runner-pressure files contribute only fixed failure
+  classes: their complete, missing, or malformed state is reported separately,
+  so malformed classification data cannot erase an otherwise authenticated
+  outcome. Both evidence-state counts appear in the grouped JSON and Markdown
+  table. The table never changes a required check, release conclusion, or rerun
+  decision.
+- The report job appends the Markdown table to the GitHub Actions job summary
+  and uploads the bounded, allowlisted JSON and Markdown files as
+  `same-commit-reliability-<source-run-id>-<attempt>` with 14-day retention.
+  Artifact ZIP entries are structurally validated before an allowlisted file is
+  read: ambiguous relative paths, links, encryption, split/ZIP64 archives,
+  duplicate names, unsupported compression, inconsistent headers, excess
+  entries, oversized contents, and CRC mismatches are rejected.
 - Automated issue routing and the workflow's `issues: write` capability are
   retired. Any future issue escalation should use a separately reviewed
   exceptional threshold, such as the same lane failing twice consecutively or

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -581,6 +581,12 @@ graph as the live targets:
 
 - GitHub Actions run history is the authoritative record for push and
   manual E2E results.
+- `E2E / Main Retry` publishes an advisory same-commit reliability table for
+  trusted-main and explicit manual qualification runs. It keeps first-pass
+  success, pass-after-retry, exhausted retries, and pass/fail flips distinct,
+  consumes only fixed retry and terminal runner classifications, and leaves
+  missing or malformed evidence unclassified. The table never changes a
+  required check, release conclusion, or rerun decision.
 - Automated issue routing and the workflow's `issues: write` capability are
   retired. Any future issue escalation should use a separately reviewed
   exceptional threshold, such as the same lane failing twice consecutively or

--- a/test/e2e/support/artifact-zip.test.ts
+++ b/test/e2e/support/artifact-zip.test.ts
@@ -4,13 +4,20 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  listValidatedArtifactZipEntries,
   readValidatedArtifactZipEntry,
   readValidatedArtifactZipEntryBytes,
 } from "../../../scripts/scorecard/read-artifact-zip.mts";
 import { artifactZip } from "../../helpers/artifact-zip";
 
-const structuralMutations: Array<[string, (archive: Buffer, centralOffset: number) => void]> = [
-  ["link", (archive, centralOffset) => archive.writeUInt32LE(0xa0000000, centralOffset + 38)],
+const structuralMutations: Array<
+  [string, (archive: Buffer, centralOffset: number) => void]
+> = [
+  [
+    "link",
+    (archive, centralOffset) =>
+      archive.writeUInt32LE(0xa0000000, centralOffset + 38),
+  ],
   [
     "encrypted",
     (archive, centralOffset) => {
@@ -22,6 +29,45 @@ const structuralMutations: Array<[string, (archive: Buffer, centralOffset: numbe
 ];
 
 describe("validated GitHub artifact ZIP reader", () => {
+  it("lists only structurally valid regular files", () => {
+    const archive = artifactZip([
+      { name: "e2e/runner-pressure-classification.jsonl", contents: "safe" },
+      { name: "e2e/retry/provider.json", contents: "{}" },
+    ]);
+
+    expect(
+      listValidatedArtifactZipEntries(archive, { maxEntries: 10 }),
+    ).toEqual([
+      "e2e/retry/provider.json",
+      "e2e/runner-pressure-classification.jsonl",
+    ]);
+    expect(
+      listValidatedArtifactZipEntries(archive, { maxEntries: 1 }),
+    ).toBeNull();
+  });
+
+  it("rejects duplicate, linked, and invalid UTF-8 names while listing", () => {
+    expect(
+      listValidatedArtifactZipEntries(
+        artifactZip([
+          { name: "same.json", contents: "one" },
+          { name: "same.json", contents: "two" },
+        ]),
+        {},
+      ),
+    ).toBeNull();
+    const linked = artifactZip([{ name: "summary.json", contents: "{}" }]);
+    linked.writeUInt32LE(
+      0xa0000000,
+      linked.readUInt32LE(linked.length - 6) + 38,
+    );
+    expect(listValidatedArtifactZipEntries(linked, {})).toBeNull();
+    const invalidUtf8 = artifactZip([{ name: "x.json", contents: "{}" }]);
+    invalidUtf8[30] = 0xff;
+    invalidUtf8[invalidUtf8.readUInt32LE(invalidUtf8.length - 6) + 46] = 0xff;
+    expect(listValidatedArtifactZipEntries(invalidUtf8, {})).toBeNull();
+  });
+
   it("reads only the exact safe relative entry from a multi-entry archive", () => {
     const archive = artifactZip([
       { name: "diagnostics/log.txt", contents: "ignored" },
@@ -29,16 +75,24 @@ describe("validated GitHub artifact ZIP reader", () => {
       { name: "résumé.json", contents: '{"utf8":true}' },
     ]);
 
-    expect(readValidatedArtifactZipEntry(archive, "summary.json", { maxBytes: 1_024 })).toBe(
-      '{"safe":true}',
-    );
-    expect(readValidatedArtifactZipEntry(archive, "résumé.json", { maxBytes: 1_024 })).toBe(
-      '{"utf8":true}',
-    );
     expect(
-      readValidatedArtifactZipEntryBytes(archive, "diagnostics/log.txt", { maxBytes: 1_024 }),
+      readValidatedArtifactZipEntry(archive, "summary.json", {
+        maxBytes: 1_024,
+      }),
+    ).toBe('{"safe":true}');
+    expect(
+      readValidatedArtifactZipEntry(archive, "résumé.json", {
+        maxBytes: 1_024,
+      }),
+    ).toBe('{"utf8":true}');
+    expect(
+      readValidatedArtifactZipEntryBytes(archive, "diagnostics/log.txt", {
+        maxBytes: 1_024,
+      }),
     ).toEqual(Buffer.from("ignored"));
-    expect(readValidatedArtifactZipEntry(archive, "log.txt", { maxBytes: 1_024 })).toBeNull();
+    expect(
+      readValidatedArtifactZipEntry(archive, "log.txt", { maxBytes: 1_024 }),
+    ).toBeNull();
   });
 
   it.each([
@@ -58,7 +112,9 @@ describe("validated GitHub artifact ZIP reader", () => {
     ]);
 
     expect(
-      readValidatedArtifactZipEntryBytes(archive, requestedPath, { maxBytes: 1_024 }),
+      readValidatedArtifactZipEntryBytes(archive, requestedPath, {
+        maxBytes: 1_024,
+      }),
     ).toBeNull();
   });
 
@@ -83,27 +139,44 @@ describe("validated GitHub artifact ZIP reader", () => {
   });
 
   it("reads deflated entries and rejects corrupt compressed data", () => {
-    const archive = artifactZip([{ name: "summary.json", contents: '{"compressed":true}' }], 8);
-
-    expect(readValidatedArtifactZipEntry(archive, "summary.json", { maxBytes: 1_024 })).toBe(
-      '{"compressed":true}',
+    const archive = artifactZip(
+      [{ name: "summary.json", contents: '{"compressed":true}' }],
+      8,
     );
+
+    expect(
+      readValidatedArtifactZipEntry(archive, "summary.json", {
+        maxBytes: 1_024,
+      }),
+    ).toBe('{"compressed":true}');
 
     const corruptArchive = Buffer.from(archive);
     const compressedDataOffset =
       30 + corruptArchive.readUInt16LE(26) + corruptArchive.readUInt16LE(28);
-    const compressedDataEnd = compressedDataOffset + corruptArchive.readUInt32LE(18);
+    const compressedDataEnd =
+      compressedDataOffset + corruptArchive.readUInt32LE(18);
     corruptArchive.fill(0, compressedDataOffset, compressedDataEnd);
     expect(
-      readValidatedArtifactZipEntry(corruptArchive, "summary.json", { maxBytes: 1_024 }),
+      readValidatedArtifactZipEntry(corruptArchive, "summary.json", {
+        maxBytes: 1_024,
+      }),
     ).toBeNull();
   });
 
-  it.each(structuralMutations)("rejects %s artifact entries", (_name, mutate) => {
-    const archive = artifactZip([{ name: "summary.json", contents: '{"safe":true}' }]);
-    const centralOffset = archive.readUInt32LE(archive.length - 6);
-    mutate(archive, centralOffset);
+  it.each(structuralMutations)(
+    "rejects %s artifact entries",
+    (_name, mutate) => {
+      const archive = artifactZip([
+        { name: "summary.json", contents: '{"safe":true}' },
+      ]);
+      const centralOffset = archive.readUInt32LE(archive.length - 6);
+      mutate(archive, centralOffset);
 
-    expect(readValidatedArtifactZipEntry(archive, "summary.json", { maxBytes: 1_024 })).toBeNull();
-  });
+      expect(
+        readValidatedArtifactZipEntry(archive, "summary.json", {
+          maxBytes: 1_024,
+        }),
+      ).toBeNull();
+    },
+  );
 });

--- a/test/e2e/support/same-commit-reliability.test.ts
+++ b/test/e2e/support/same-commit-reliability.test.ts
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  formatReliabilityReport,
+  normalizeReliabilityRun,
+  type ReliabilitySample,
+  summarizeReliability,
+} from "../../../tools/e2e/same-commit-reliability.mts";
+import { artifactZip } from "../../helpers/artifact-zip";
+
+const SHA_A = "a".repeat(40);
+const SHA_B = "b".repeat(40);
+const REPOSITORY = "NVIDIA/NemoClaw";
+
+function sample(
+  runId: number,
+  candidateSha: string,
+  source: ReliabilitySample["source"],
+  outcome: ReliabilitySample["outcome"],
+  failureClasses: ReliabilitySample["failureClasses"] = [],
+): ReliabilitySample {
+  return {
+    runId,
+    runAttempt: outcome === "passed-after-retry" || outcome === "exhausted" ? 2 : 1,
+    candidateSha,
+    source,
+    outcome,
+    failureClasses,
+    evidence: "complete",
+    url: `https://github.com/${REPOSITORY}/actions/runs/${runId}`,
+  };
+}
+
+function workflowRun(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 101,
+    run_attempt: 1,
+    status: "completed",
+    conclusion: "failure",
+    event: "workflow_dispatch",
+    path: ".github/workflows/e2e.yaml",
+    display_title: "E2E PR #7 (qualification)",
+    head_branch: "main",
+    head_sha: SHA_B,
+    html_url: `https://github.com/${REPOSITORY}/actions/runs/101`,
+    repository: { full_name: REPOSITORY },
+    head_repository: { full_name: REPOSITORY },
+    ...overrides,
+  };
+}
+
+describe("same-commit E2E reliability", () => {
+  it("keeps commits and run sources separate while reporting recovery and flips", () => {
+    const groups = summarizeReliability([
+      sample(1, SHA_A, "trusted-main", "failed-first-attempt", ["assertion"]),
+      sample(2, SHA_A, "trusted-main", "passed-after-retry", ["transient-external"]),
+      sample(3, SHA_A, "trusted-main", "exhausted", ["timeout"]),
+      sample(4, SHA_A, "trusted-main", "passed-first-attempt"),
+      sample(5, SHA_A, "manual-qualification", "passed-first-attempt"),
+      sample(6, SHA_B, "trusted-main", "passed-first-attempt"),
+      sample(7, SHA_A, "trusted-main", "superseded"),
+    ]);
+
+    expect(groups).toHaveLength(3);
+    expect(
+      groups.find((group) => group.source === "trusted-main" && group.candidateSha === SHA_A),
+    ).toMatchObject({
+      runs: 5,
+      passedFirstAttempt: 1,
+      passedAfterRetry: 1,
+      failedFirstAttempt: 1,
+      exhausted: 1,
+      superseded: 1,
+      passFailFlips: 3,
+      firstPassRate: 0.25,
+      recoveryRate: 0.5,
+      failureClasses: { assertion: 1, "transient-external": 1, timeout: 1 },
+    });
+  });
+
+  it("renders only normalized identities and fixed classes, never input credentials", () => {
+    const secret = "ghp_should-never-appear";
+    const report = formatReliabilityReport([
+      ...summarizeReliability([
+        sample(1, SHA_A, "trusted-main", "failed-first-attempt", ["authentication"]),
+      ]),
+    ]);
+
+    expect(report).toContain("authentication: 1");
+    expect(report).toContain(SHA_A.slice(0, 12));
+    expect(report).not.toContain(secret);
+  });
+
+  it("consumes dispatch, retry, and runner classifications without retaining payload text", async () => {
+    const secret = "sk-live-secret-output";
+    const dispatch = artifactZip([
+      {
+        name: "dispatch.json",
+        contents: JSON.stringify({
+          kind: "nemoclaw-e2e-dispatch-v2",
+          repository: REPOSITORY,
+          eventName: "workflow_dispatch",
+          workflowRunId: "101",
+          workflowRunAttempt: 1,
+          candidateSha: SHA_A,
+          ignoredCredential: secret,
+        }),
+      },
+    ]);
+    const evidence = artifactZip([
+      {
+        name: "e2e-artifacts/live/example/runner-pressure-classification.jsonl",
+        contents:
+          'E2E_TERMINAL_CLASSIFICATION {"v":1,"classification":"timeout","reason":"phase timed out"}\n',
+      },
+      {
+        name: "e2e-artifacts/live/example/retry/provider.json",
+        contents: JSON.stringify({
+          schemaVersion: 1,
+          operation: "provider.readiness",
+          owner: "provider",
+          idempotence: "read-only",
+          maxAttempts: 2,
+          outcome: "exhausted",
+          attempts: [
+            {
+              attempt: 1,
+              outcome: "failed",
+              failureClass: "transient-external",
+              retryScheduled: true,
+            },
+            {
+              attempt: 2,
+              outcome: "failed",
+              failureClass: "transient-external",
+              retryScheduled: false,
+            },
+          ],
+          ignoredCredential: secret,
+        }),
+      },
+    ]);
+    const archives = new Map([
+      [1, dispatch],
+      [2, evidence],
+    ]);
+    const result = await normalizeReliabilityRun(workflowRun(), {
+      requestJson: async () => ({
+        total_count: 2,
+        artifacts: [
+          {
+            id: 1,
+            name: "e2e-dispatch-101-1",
+            size_in_bytes: dispatch.length,
+            expired: false,
+          },
+          {
+            id: 2,
+            name: "e2e-example",
+            size_in_bytes: evidence.length,
+            expired: false,
+          },
+        ],
+      }),
+      requestArchive: async (artifactId) => archives.get(artifactId)!,
+    });
+
+    expect(result).toMatchObject({
+      candidateSha: SHA_A,
+      source: "manual-qualification",
+      outcome: "failed-first-attempt",
+      failureClasses: ["timeout", "transient-external"],
+      evidence: "complete",
+    });
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
+
+  it("keeps missing or malformed manual identity evidence unclassified", async () => {
+    const missing = await normalizeReliabilityRun(workflowRun({ conclusion: "success" }), {
+      requestJson: async () => ({ total_count: 0, artifacts: [] }),
+      requestArchive: async () => Buffer.alloc(0),
+    });
+    expect(missing).toMatchObject({
+      candidateSha: null,
+      outcome: "unclassified",
+      evidence: "missing",
+    });
+    expect(summarizeReliability([missing!])).toEqual([
+      expect.objectContaining({ candidateSha: null, runs: 1, unclassified: 1 }),
+    ]);
+
+    const malformedZip = artifactZip([{ name: "dispatch.json", contents: "{}" }]);
+    const malformed = await normalizeReliabilityRun(workflowRun({ conclusion: "success" }), {
+      requestJson: async () => ({
+        total_count: 1,
+        artifacts: [
+          {
+            id: 9,
+            name: "e2e-dispatch-101-1",
+            size_in_bytes: malformedZip.length,
+            expired: false,
+          },
+        ],
+      }),
+      requestArchive: async () => malformedZip,
+    });
+    expect(malformed).toMatchObject({
+      candidateSha: null,
+      outcome: "unclassified",
+      evidence: "malformed",
+    });
+  });
+});

--- a/test/e2e/support/same-commit-reliability.test.ts
+++ b/test/e2e/support/same-commit-reliability.test.ts
@@ -32,6 +32,7 @@ function sample(
     outcome,
     failureClasses,
     evidence: "complete",
+    failureClassEvidence: failureClasses.length > 0 ? "complete" : "missing",
     url: `https://github.com/${REPOSITORY}/actions/runs/${runId}`,
   };
 }
@@ -83,6 +84,37 @@ function retryEvidence(runId: number, sourceSha: string): Buffer {
       }),
     },
   ]);
+}
+
+function terminalEvidence(
+  candidateSha: string,
+  jobStatus: "failure" | "success",
+): { name: string; contents: string } {
+  return {
+    name: "e2e-artifacts/live/example/evidence-manifest.json",
+    contents: JSON.stringify({
+      kind: "nemoclaw-e2e-evidence-v1",
+      targetId: "example",
+      candidate: { repository: REPOSITORY, sha: candidateSha },
+      workflow: {
+        repository: REPOSITORY,
+        sha: SHA_B,
+        runId: "101",
+        runAttempt: "1",
+        jobStatus,
+      },
+      artifactDirectory: "e2e-artifacts/live/example",
+      productEvidenceFileCount: 1,
+    }),
+  };
+}
+
+function mappedRequest(entries: ReadonlyArray<readonly [string, unknown]>) {
+  const responses = new Map(entries);
+  return async (path: string): Promise<unknown> => {
+    expect(responses.has(path), `unexpected path ${path}`).toBe(true);
+    return responses.get(path);
+  };
 }
 
 function workflowStep(job: WorkflowJob, name: string): WorkflowStep {
@@ -138,7 +170,9 @@ describe("same-commit E2E reliability", () => {
 
   // source-shape-contract: security -- The reliability reporter must execute only from the trusted default-branch controller while authenticating the canonical E2E source repository and branch
   it("locks the reporter to canonical source and trusted controller identities (#9168)", () => {
-    type RetryWorkflow = { jobs: { "report-same-commit-reliability": WorkflowJob } };
+    type RetryWorkflow = {
+      jobs: { "report-same-commit-reliability": WorkflowJob };
+    };
     const reporter =
       readYaml<RetryWorkflow>(RETRY_WORKFLOW_PATH).jobs["report-same-commit-reliability"];
     const guard = reporter.if ?? "";
@@ -173,6 +207,7 @@ describe("same-commit E2E reliability", () => {
       },
     ]);
     const evidence = artifactZip([
+      terminalEvidence(SHA_A, "failure"),
       {
         name: "e2e-artifacts/live/example/runner-pressure-classification.jsonl",
         contents:
@@ -236,6 +271,7 @@ describe("same-commit E2E reliability", () => {
       outcome: "failed-first-attempt",
       failureClasses: ["timeout", "transient-external"],
       evidence: "complete",
+      failureClassEvidence: "complete",
     });
     expect(JSON.stringify(result)).not.toContain(secret);
   });
@@ -317,18 +353,132 @@ describe("same-commit E2E reliability", () => {
     });
   });
 
+  it("accepts authenticated terminal evidence for a passing manual run", async () => {
+    const dispatch = artifactZip([
+      {
+        name: "dispatch.json",
+        contents: JSON.stringify({
+          kind: "nemoclaw-e2e-dispatch-v2",
+          repository: REPOSITORY,
+          eventName: "workflow_dispatch",
+          workflowRunId: "101",
+          workflowRunAttempt: 1,
+          candidateSha: SHA_A,
+        }),
+      },
+    ]);
+    const terminal = artifactZip([terminalEvidence(SHA_A, "success")]);
+    const archives = new Map([
+      [1, dispatch],
+      [2, terminal],
+    ]);
+    const result = await normalizeReliabilityRun(workflowRun({ conclusion: "success" }), {
+      requestJson: async () => ({
+        total_count: 2,
+        artifacts: [
+          {
+            id: 1,
+            name: "e2e-dispatch-101-1",
+            size_in_bytes: dispatch.length,
+            expired: false,
+          },
+          {
+            id: 2,
+            name: "e2e-example",
+            size_in_bytes: terminal.length,
+            expired: false,
+          },
+        ],
+      }),
+      requestArchive: async (artifactId) => archives.get(artifactId)!,
+    });
+
+    expect(result).toMatchObject({
+      candidateSha: SHA_A,
+      source: "manual-qualification",
+      outcome: "passed-first-attempt",
+      evidence: "complete",
+      failureClassEvidence: "missing",
+    });
+  });
+
+  it("reports malformed failure-class evidence without discarding a terminal outcome", async () => {
+    const dispatch = artifactZip([
+      {
+        name: "dispatch.json",
+        contents: JSON.stringify({
+          kind: "nemoclaw-e2e-dispatch-v2",
+          repository: REPOSITORY,
+          eventName: "workflow_dispatch",
+          workflowRunId: "101",
+          workflowRunAttempt: 1,
+          candidateSha: SHA_A,
+        }),
+      },
+    ]);
+    const terminal = artifactZip([
+      terminalEvidence(SHA_A, "success"),
+      {
+        name: "e2e-artifacts/live/example/retry/provider.json",
+        contents: "{}",
+      },
+    ]);
+    const archives = new Map([
+      [1, dispatch],
+      [2, terminal],
+    ]);
+    const result = await normalizeReliabilityRun(workflowRun({ conclusion: "success" }), {
+      requestJson: async () => ({
+        total_count: 2,
+        artifacts: [
+          {
+            id: 1,
+            name: "e2e-dispatch-101-1",
+            size_in_bytes: dispatch.length,
+            expired: false,
+          },
+          {
+            id: 2,
+            name: "e2e-example",
+            size_in_bytes: terminal.length,
+            expired: false,
+          },
+        ],
+      }),
+      requestArchive: async (artifactId) => archives.get(artifactId)!,
+    });
+
+    expect(result).toMatchObject({
+      outcome: "passed-first-attempt",
+      evidence: "complete",
+      failureClassEvidence: "malformed",
+    });
+    const groups = summarizeReliability([result!]);
+    expect(groups[0]).toMatchObject({
+      evidence: { complete: 1, malformed: 0, missing: 0 },
+      failureClassEvidence: { complete: 0, malformed: 1, missing: 0 },
+    });
+    expect(formatReliabilityReport(groups)).toContain("complete: 0, malformed: 1, missing: 0");
+  });
+
   it("accepts trusted-main evidence only from the canonical retry controller", async () => {
     const archive = retryEvidence(101, SHA_B);
     const name = "e2e-main-retry-101-1";
     const result = await normalizeReliabilityRun(
-      workflowRun({ event: "push", conclusion: "success", display_title: "E2E main" }),
+      workflowRun({
+        event: "push",
+        conclusion: "success",
+        display_title: "E2E main",
+      }),
       {
-        requestJson: async (path) => {
-          if (path.includes("actions/runs/101/artifacts")) {
-            return { total_count: 0, artifacts: [] };
-          }
-          if (path.includes("actions/artifacts?")) {
-            return {
+        requestJson: mappedRequest([
+          [
+            `repos/${REPOSITORY}/actions/runs/101/artifacts?per_page=100`,
+            { total_count: 0, artifacts: [] },
+          ],
+          [
+            `repos/${REPOSITORY}/actions/artifacts?name=${name}&per_page=100`,
+            {
               total_count: 1,
               artifacts: [
                 {
@@ -339,11 +489,10 @@ describe("same-commit E2E reliability", () => {
                   workflow_run: { id: 202 },
                 },
               ],
-            };
-          }
-          if (path.endsWith("actions/runs/202")) return controllerRun(202);
-          throw new Error(`unexpected path ${path}`);
-        },
+            },
+          ],
+          [`repos/${REPOSITORY}/actions/runs/202`, controllerRun(202)],
+        ]),
         requestArchive: async () => archive,
       },
     );
@@ -360,14 +509,20 @@ describe("same-commit E2E reliability", () => {
     const archive = retryEvidence(101, SHA_B);
     const name = "e2e-main-retry-101-1";
     const result = await normalizeReliabilityRun(
-      workflowRun({ event: "push", conclusion: "success", display_title: "E2E main" }),
+      workflowRun({
+        event: "push",
+        conclusion: "success",
+        display_title: "E2E main",
+      }),
       {
-        requestJson: async (path) => {
-          if (path.includes("actions/runs/101/artifacts")) {
-            return { total_count: 0, artifacts: [] };
-          }
-          if (path.includes("actions/artifacts?")) {
-            return {
+        requestJson: mappedRequest([
+          [
+            `repos/${REPOSITORY}/actions/runs/101/artifacts?per_page=100`,
+            { total_count: 0, artifacts: [] },
+          ],
+          [
+            `repos/${REPOSITORY}/actions/artifacts?name=${name}&per_page=100`,
+            {
               total_count: 1,
               artifacts: [
                 {
@@ -378,13 +533,13 @@ describe("same-commit E2E reliability", () => {
                   workflow_run: { id: 203 },
                 },
               ],
-            };
-          }
-          if (path.endsWith("actions/runs/203")) {
-            return controllerRun(203, { path: ".github/workflows/other.yaml" });
-          }
-          throw new Error(`unexpected path ${path}`);
-        },
+            },
+          ],
+          [
+            `repos/${REPOSITORY}/actions/runs/203`,
+            controllerRun(203, { path: ".github/workflows/other.yaml" }),
+          ],
+        ]),
         requestArchive: async () => archive,
       },
     );
@@ -401,14 +556,20 @@ describe("same-commit E2E reliability", () => {
     const archive = retryEvidence(101, SHA_B);
     const name = "e2e-main-retry-101-1";
     const result = await normalizeReliabilityRun(
-      workflowRun({ event: "push", conclusion: "success", display_title: "E2E main" }),
+      workflowRun({
+        event: "push",
+        conclusion: "success",
+        display_title: "E2E main",
+      }),
       {
-        requestJson: async (path) => {
-          if (path.includes("actions/runs/101/artifacts")) {
-            return { total_count: 0, artifacts: [] };
-          }
-          if (path.includes("actions/artifacts?")) {
-            return {
+        requestJson: mappedRequest([
+          [
+            `repos/${REPOSITORY}/actions/runs/101/artifacts?per_page=100`,
+            { total_count: 0, artifacts: [] },
+          ],
+          [
+            `repos/${REPOSITORY}/actions/artifacts?name=${name}&per_page=100`,
+            {
               total_count: 2,
               artifacts: [202, 203].map((controllerId) => ({
                 id: controllerId,
@@ -417,10 +578,9 @@ describe("same-commit E2E reliability", () => {
                 expired: false,
                 workflow_run: { id: controllerId },
               })),
-            };
-          }
-          throw new Error(`artifact collision must fail before controller lookup: ${path}`);
-        },
+            },
+          ],
+        ]),
         requestArchive: async () => archive,
       },
     );

--- a/test/e2e/support/same-commit-reliability.test.ts
+++ b/test/e2e/support/same-commit-reliability.test.ts
@@ -10,10 +10,12 @@ import {
   summarizeReliability,
 } from "../../../tools/e2e/same-commit-reliability.mts";
 import { artifactZip } from "../../helpers/artifact-zip";
+import { readYaml, type WorkflowJob, type WorkflowStep } from "../../helpers/e2e-workflow-contract";
 
 const SHA_A = "a".repeat(40);
 const SHA_B = "b".repeat(40);
 const REPOSITORY = "NVIDIA/NemoClaw";
+const RETRY_WORKFLOW_PATH = ".github/workflows/e2e-main-retry.yaml";
 
 function sample(
   runId: number,
@@ -52,6 +54,43 @@ function workflowRun(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function controllerRun(id: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    status: "in_progress",
+    event: "workflow_run",
+    path: RETRY_WORKFLOW_PATH,
+    head_branch: "main",
+    head_sha: SHA_A,
+    html_url: `https://github.com/${REPOSITORY}/actions/runs/${id}`,
+    repository: { full_name: REPOSITORY },
+    head_repository: { full_name: REPOSITORY },
+    ...overrides,
+  };
+}
+
+function retryEvidence(runId: number, sourceSha: string): Buffer {
+  return artifactZip([
+    {
+      name: "e2e-main-retry-evidence.json",
+      contents: JSON.stringify({
+        schemaVersion: 1,
+        sourceRunId: runId,
+        sourceSha,
+        sourceAttempt: 1,
+        action: "passed-first-attempt",
+        reason: "source run passed",
+      }),
+    },
+  ]);
+}
+
+function workflowStep(job: WorkflowJob, name: string): WorkflowStep {
+  const found = job.steps?.find((step) => step.name === name);
+  expect(found, `missing workflow step ${name}`).toBeDefined();
+  return found!;
+}
+
 describe("same-commit E2E reliability", () => {
   it("keeps commits and run sources separate while reporting recovery and flips", () => {
     const groups = summarizeReliability([
@@ -85,13 +124,36 @@ describe("same-commit E2E reliability", () => {
     const secret = "ghp_should-never-appear";
     const report = formatReliabilityReport([
       ...summarizeReliability([
-        sample(1, SHA_A, "trusted-main", "failed-first-attempt", ["authentication"]),
+        sample(1, SHA_A, "trusted-main", "failed-first-attempt", [
+          "authentication",
+          secret as ReliabilitySample["failureClasses"][number],
+        ]),
       ]),
     ]);
 
     expect(report).toContain("authentication: 1");
     expect(report).toContain(SHA_A.slice(0, 12));
     expect(report).not.toContain(secret);
+  });
+
+  // source-shape-contract: security -- The reliability reporter must execute only from the trusted default-branch controller while authenticating the canonical E2E source repository and branch
+  it("locks the reporter to canonical source and trusted controller identities (#9168)", () => {
+    type RetryWorkflow = { jobs: { "report-same-commit-reliability": WorkflowJob } };
+    const reporter =
+      readYaml<RetryWorkflow>(RETRY_WORKFLOW_PATH).jobs["report-same-commit-reliability"];
+    const guard = reporter.if ?? "";
+    for (const fragment of [
+      "github.repository == 'NVIDIA/NemoClaw'",
+      "github.event.workflow_run.path == '.github/workflows/e2e.yaml'",
+      "github.event.workflow_run.head_branch == 'main'",
+      "github.event.workflow_run.head_repository.full_name == 'NVIDIA/NemoClaw'",
+    ]) {
+      expect(guard).toContain(fragment);
+    }
+    expect(workflowStep(reporter, "Checkout trusted reliability reporter").with).toEqual({
+      ref: "${{ github.workflow_sha }}",
+      "persist-credentials": false,
+    });
   });
 
   it("consumes dispatch, retry, and runner classifications without retaining payload text", async () => {
@@ -209,6 +271,163 @@ describe("same-commit E2E reliability", () => {
     });
     expect(malformed).toMatchObject({
       candidateSha: null,
+      outcome: "unclassified",
+      evidence: "malformed",
+    });
+  });
+
+  it("requires terminal evidence after authenticating a manual dispatch", async () => {
+    const dispatch = artifactZip([
+      {
+        name: "dispatch.json",
+        contents: JSON.stringify({
+          kind: "nemoclaw-e2e-dispatch-v2",
+          repository: REPOSITORY,
+          eventName: "workflow_dispatch",
+          workflowRunId: "101",
+          workflowRunAttempt: 1,
+          candidateSha: SHA_A,
+        }),
+      },
+    ]);
+    const result = await normalizeReliabilityRun(workflowRun({ conclusion: "success" }), {
+      requestJson: async () => ({
+        total_count: 1,
+        artifacts: [
+          {
+            id: 1,
+            name: "e2e-dispatch-101-1",
+            size_in_bytes: dispatch.length,
+            expired: false,
+          },
+        ],
+      }),
+      requestArchive: async () => dispatch,
+    });
+
+    expect(result).toMatchObject({
+      candidateSha: SHA_A,
+      source: "manual-qualification",
+      outcome: "unclassified",
+      evidence: "missing",
+    });
+    expect(summarizeReliability([result!])[0]).toMatchObject({
+      passedFirstAttempt: 0,
+      unclassified: 1,
+    });
+  });
+
+  it("accepts trusted-main evidence only from the canonical retry controller", async () => {
+    const archive = retryEvidence(101, SHA_B);
+    const name = "e2e-main-retry-101-1";
+    const result = await normalizeReliabilityRun(
+      workflowRun({ event: "push", conclusion: "success", display_title: "E2E main" }),
+      {
+        requestJson: async (path) => {
+          if (path.includes("actions/runs/101/artifacts")) {
+            return { total_count: 0, artifacts: [] };
+          }
+          if (path.includes("actions/artifacts?")) {
+            return {
+              total_count: 1,
+              artifacts: [
+                {
+                  id: 7,
+                  name,
+                  size_in_bytes: archive.length,
+                  expired: false,
+                  workflow_run: { id: 202 },
+                },
+              ],
+            };
+          }
+          if (path.endsWith("actions/runs/202")) return controllerRun(202);
+          throw new Error(`unexpected path ${path}`);
+        },
+        requestArchive: async () => archive,
+      },
+    );
+
+    expect(result).toMatchObject({
+      candidateSha: SHA_B,
+      source: "trusted-main",
+      outcome: "passed-first-attempt",
+      evidence: "complete",
+    });
+  });
+
+  it("rejects trusted-main evidence from an untrusted workflow", async () => {
+    const archive = retryEvidence(101, SHA_B);
+    const name = "e2e-main-retry-101-1";
+    const result = await normalizeReliabilityRun(
+      workflowRun({ event: "push", conclusion: "success", display_title: "E2E main" }),
+      {
+        requestJson: async (path) => {
+          if (path.includes("actions/runs/101/artifacts")) {
+            return { total_count: 0, artifacts: [] };
+          }
+          if (path.includes("actions/artifacts?")) {
+            return {
+              total_count: 1,
+              artifacts: [
+                {
+                  id: 8,
+                  name,
+                  size_in_bytes: archive.length,
+                  expired: false,
+                  workflow_run: { id: 203 },
+                },
+              ],
+            };
+          }
+          if (path.endsWith("actions/runs/203")) {
+            return controllerRun(203, { path: ".github/workflows/other.yaml" });
+          }
+          throw new Error(`unexpected path ${path}`);
+        },
+        requestArchive: async () => archive,
+      },
+    );
+
+    expect(result).toMatchObject({
+      candidateSha: SHA_B,
+      source: "trusted-main",
+      outcome: "unclassified",
+      evidence: "malformed",
+    });
+  });
+
+  it("fails closed when trusted-main artifact names collide", async () => {
+    const archive = retryEvidence(101, SHA_B);
+    const name = "e2e-main-retry-101-1";
+    const result = await normalizeReliabilityRun(
+      workflowRun({ event: "push", conclusion: "success", display_title: "E2E main" }),
+      {
+        requestJson: async (path) => {
+          if (path.includes("actions/runs/101/artifacts")) {
+            return { total_count: 0, artifacts: [] };
+          }
+          if (path.includes("actions/artifacts?")) {
+            return {
+              total_count: 2,
+              artifacts: [202, 203].map((controllerId) => ({
+                id: controllerId,
+                name,
+                size_in_bytes: archive.length,
+                expired: false,
+                workflow_run: { id: controllerId },
+              })),
+            };
+          }
+          throw new Error(`artifact collision must fail before controller lookup: ${path}`);
+        },
+        requestArchive: async () => archive,
+      },
+    );
+
+    expect(result).toMatchObject({
+      candidateSha: SHA_B,
+      source: "trusted-main",
       outcome: "unclassified",
       evidence: "malformed",
     });

--- a/test/e2e/support/same-commit-reliability.test.ts
+++ b/test/e2e/support/same-commit-reliability.test.ts
@@ -188,6 +188,13 @@ describe("same-commit E2E reliability", () => {
       ref: "${{ github.workflow_sha }}",
       "persist-credentials": false,
     });
+    const build = workflowStep(reporter, "Build advisory same-commit reliability report");
+    expect(build.env).toEqual({
+      GITHUB_TOKEN: "${{ github.token }}",
+      SOURCE_RUN_ID: "${{ github.event.workflow_run.id }}",
+    });
+    expect(build.run).toContain('>"${RUNNER_TEMP}/same-commit-reliability.json"');
+    expect(build.run).toContain('2>"${RUNNER_TEMP}/same-commit-reliability.md"');
   });
 
   it("consumes dispatch, retry, and runner classifications without retaining payload text", async () => {

--- a/test/onboard-selection-anthropic-retry.test.ts
+++ b/test/onboard-selection-anthropic-retry.test.ts
@@ -51,8 +51,17 @@ elif echo "$auth" | grep -q '${goodToken}' && echo "$url" | grep -q '/v1/message
     body='event: message_start
 data: {"type":"message_start","message":{"id":"msg_123"}}
 
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool_123","name":"emit_ok","input":{}}}
+
 event: content_block_delta
-data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"OK"}}
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}
 
 event: message_stop
 data: {"type":"message_stop"}

--- a/tools/e2e/same-commit-reliability.mts
+++ b/tools/e2e/same-commit-reliability.mts
@@ -11,10 +11,15 @@ import {
   readValidatedArtifactZipEntry,
 } from "../../scripts/scorecard/read-artifact-zip.mts";
 import type { RetryEvidence, RetryFailureClass } from "../../test/e2e/fixtures/retry-policy.ts";
-import { parseClassificationLine, type TerminalClassification } from "./runner-pressure-core.mts";
+import {
+  parseClassificationLine,
+  TERMINAL_CLASSIFICATIONS,
+  type TerminalClassification,
+} from "./runner-pressure-core.mts";
 
 const REPOSITORY = "NVIDIA/NemoClaw";
 const WORKFLOW_PATH = ".github/workflows/e2e.yaml";
+const CONTROLLER_WORKFLOW_PATH = ".github/workflows/e2e-main-retry.yaml";
 const DISPLAY_TITLE_PREFIX = "E2E ";
 const SHA = /^[a-f0-9]{40}$/u;
 const MAX_RUNS = 50;
@@ -31,6 +36,11 @@ const RETRY_FAILURE_CLASSES: readonly RetryFailureClass[] = [
   "transient-external",
   "ambiguous-mutation",
 ];
+const RELIABILITY_FAILURE_CLASSES = new Set<string>([
+  ...RETRY_FAILURE_CLASSES,
+  ...TERMINAL_CLASSIFICATIONS,
+  "unclassified",
+]);
 
 export type ReliabilitySource = "manual-qualification" | "trusted-main";
 export type ReliabilityOutcome =
@@ -92,6 +102,18 @@ type Artifact = {
   workflow_run?: { id?: number };
 };
 
+type ControllerRun = {
+  id: number;
+  status: string;
+  event: string;
+  path: string;
+  head_branch: string;
+  head_sha: string;
+  html_url: string;
+  repository: { full_name?: string };
+  head_repository: { full_name?: string } | null;
+};
+
 type JsonRequest = (path: string) => Promise<unknown>;
 type ArchiveRequest = (artifactId: number, maxBytes: number) => Promise<Buffer>;
 
@@ -133,6 +155,28 @@ function validateRun(value: unknown): WorkflowRun | null {
     return null;
   }
   return run as unknown as WorkflowRun;
+}
+
+function validateControllerRun(value: unknown, expectedId: number): ControllerRun | null {
+  const run = record(value);
+  const repository = record(run?.repository);
+  const headRepository = record(run?.head_repository);
+  if (
+    !run ||
+    run.id !== expectedId ||
+    (run.status !== "in_progress" && run.status !== "completed") ||
+    run.event !== "workflow_run" ||
+    run.path !== CONTROLLER_WORKFLOW_PATH ||
+    run.head_branch !== "main" ||
+    typeof run.head_sha !== "string" ||
+    !SHA.test(run.head_sha) ||
+    repository?.full_name !== REPOSITORY ||
+    headRepository?.full_name !== REPOSITORY ||
+    run.html_url !== `https://github.com/${REPOSITORY}/actions/runs/${run.id}`
+  ) {
+    return null;
+  }
+  return run as unknown as ControllerRun;
 }
 
 function validateArtifacts(value: unknown): Artifact[] | null {
@@ -283,9 +327,10 @@ async function identifyCandidateSha(
 async function collectFailureClasses(
   artifacts: Artifact[],
   requestArchive: ArchiveRequest,
-): Promise<{ classes: ReliabilityFailureClass[]; malformed: boolean }> {
+): Promise<{ classes: ReliabilityFailureClass[]; malformed: boolean; records: number }> {
   const classes = new Set<ReliabilityFailureClass>();
   let malformed = false;
+  let records = 0;
   let bytes = 0;
   for (const artifact of artifacts.filter((item) => item.name.startsWith("e2e-"))) {
     if (artifact.expired || artifact.size_in_bytes > MAX_ARTIFACT_BYTES) continue;
@@ -314,12 +359,14 @@ async function collectFailureClasses(
       try {
         if (entry.endsWith("/runner-pressure-classification.jsonl")) {
           classes.add(parseClassificationLine(text).classification);
+          records += 1;
         } else {
           const evidence = parseRetryEvidence(JSON.parse(text));
           if (evidence === null) {
             malformed = true;
             continue;
           }
+          records += 1;
           for (const attempt of evidence.attempts) {
             if (attempt.failureClass) classes.add(attempt.failureClass);
           }
@@ -329,7 +376,30 @@ async function collectFailureClasses(
       }
     }
   }
-  return { classes: [...classes].sort(), malformed };
+  return { classes: [...classes].sort(), malformed, records };
+}
+
+async function trustedMainRetryArtifact(
+  artifacts: Artifact[] | null,
+  expectedName: string,
+  requestJson: JsonRequest,
+): Promise<{ artifact: Artifact | null; evidence: "complete" | "malformed" | "missing" }> {
+  if (artifacts === null) return { artifact: null, evidence: "malformed" };
+  const matches = artifacts.filter((artifact) => artifact.name === expectedName);
+  if (matches.length === 0) return { artifact: null, evidence: "missing" };
+  if (matches.length !== 1) return { artifact: null, evidence: "malformed" };
+  const artifact = matches[0]!;
+  const controllerId = record(artifact.workflow_run)?.id;
+  if (!positiveInteger(controllerId)) return { artifact: null, evidence: "malformed" };
+  try {
+    const controller = await requestJson(`repos/${REPOSITORY}/actions/runs/${controllerId}`);
+    if (validateControllerRun(controller, controllerId) === null) {
+      return { artifact: null, evidence: "malformed" };
+    }
+  } catch {
+    return { artifact: null, evidence: "malformed" };
+  }
+  return { artifact, evidence: "complete" };
 }
 
 function deriveOutcome(run: WorkflowRun): ReliabilityOutcome {
@@ -385,15 +455,17 @@ export async function normalizeReliabilityRun(
       ),
     );
     const retryArtifacts = validateArtifacts(response);
-    const retryArtifact = retryArtifacts?.find(
-      (artifact) => artifact.name === `e2e-main-retry-${run.id}-${run.run_attempt}`,
+    const selected = await trustedMainRetryArtifact(
+      retryArtifacts,
+      `e2e-main-retry-${run.id}-${run.run_attempt}`,
+      services.requestJson,
     );
-    if (!retryArtifact) {
-      evidence = "missing";
+    if (!selected.artifact) {
+      evidence = selected.evidence;
       outcome = "unclassified";
     } else {
       const text = await readArtifactEntry(
-        retryArtifact,
+        selected.artifact,
         "e2e-main-retry-evidence.json",
         services.requestArchive,
       );
@@ -412,6 +484,10 @@ export async function normalizeReliabilityRun(
   }
   const classified = await collectFailureClasses(artifacts, services.requestArchive);
   if (classified.malformed) evidence = "malformed";
+  if (run.event === "workflow_dispatch" && candidateSha !== null && classified.records === 0) {
+    evidence = classified.malformed ? "malformed" : "missing";
+    outcome = "unclassified";
+  }
   const failed = outcome === "exhausted" || outcome === "failed-first-attempt";
   return {
     runId: run.id,
@@ -458,6 +534,7 @@ export function summarizeReliability(samples: readonly ReliabilitySample[]): Rel
       const classes: Record<string, number> = {};
       for (const sample of ordered) {
         for (const failureClass of sample.failureClasses) {
+          if (!RELIABILITY_FAILURE_CLASSES.has(failureClass)) continue;
           classes[failureClass] = (classes[failureClass] ?? 0) + 1;
         }
       }

--- a/tools/e2e/same-commit-reliability.mts
+++ b/tools/e2e/same-commit-reliability.mts
@@ -1,0 +1,614 @@
+#!/usr/bin/env node
+
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+import {
+  listValidatedArtifactZipEntries,
+  readValidatedArtifactZipEntry,
+} from "../../scripts/scorecard/read-artifact-zip.mts";
+import type { RetryEvidence, RetryFailureClass } from "../../test/e2e/fixtures/retry-policy.ts";
+import { parseClassificationLine, type TerminalClassification } from "./runner-pressure-core.mts";
+
+const REPOSITORY = "NVIDIA/NemoClaw";
+const WORKFLOW_PATH = ".github/workflows/e2e.yaml";
+const DISPLAY_TITLE_PREFIX = "E2E ";
+const SHA = /^[a-f0-9]{40}$/u;
+const MAX_RUNS = 50;
+const MAX_ARTIFACT_BYTES = 2 * 1024 * 1024;
+const MAX_RUN_ARTIFACT_BYTES = 8 * 1024 * 1024;
+
+const RETRY_FAILURE_CLASSES: readonly RetryFailureClass[] = [
+  "authentication",
+  "authorization",
+  "cleanup",
+  "deterministic",
+  "malformed-input",
+  "policy-denial",
+  "transient-external",
+  "ambiguous-mutation",
+];
+
+export type ReliabilitySource = "manual-qualification" | "trusted-main";
+export type ReliabilityOutcome =
+  | "exhausted"
+  | "failed-first-attempt"
+  | "passed-after-retry"
+  | "passed-first-attempt"
+  | "superseded"
+  | "unclassified";
+export type ReliabilityFailureClass = RetryFailureClass | TerminalClassification | "unclassified";
+
+export interface ReliabilitySample {
+  runId: number;
+  runAttempt: number;
+  candidateSha: string | null;
+  source: ReliabilitySource | null;
+  outcome: ReliabilityOutcome;
+  failureClasses: ReliabilityFailureClass[];
+  evidence: "complete" | "malformed" | "missing";
+  url: string;
+}
+
+export interface ReliabilityGroup {
+  candidateSha: string | null;
+  source: ReliabilitySource;
+  runs: number;
+  passedFirstAttempt: number;
+  passedAfterRetry: number;
+  failedFirstAttempt: number;
+  exhausted: number;
+  superseded: number;
+  unclassified: number;
+  passFailFlips: number;
+  firstPassRate: number;
+  recoveryRate: number | null;
+  failureClasses: Record<string, number>;
+}
+
+type WorkflowRun = {
+  id: number;
+  run_attempt: number;
+  status: string;
+  conclusion: string | null;
+  event: string;
+  path: string;
+  display_title: string;
+  head_branch: string;
+  head_sha: string;
+  html_url: string;
+  repository: { full_name?: string };
+  head_repository: { full_name?: string } | null;
+};
+
+type Artifact = {
+  id: number;
+  name: string;
+  size_in_bytes: number;
+  expired: boolean;
+  workflow_run?: { id?: number };
+};
+
+type JsonRequest = (path: string) => Promise<unknown>;
+type ArchiveRequest = (artifactId: number, maxBytes: number) => Promise<Buffer>;
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function positiveInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0;
+}
+
+function fixedRate(numerator: number, denominator: number): number {
+  return denominator === 0 ? 0 : Number((numerator / denominator).toFixed(4));
+}
+
+function validateRun(value: unknown): WorkflowRun | null {
+  const run = record(value);
+  const repository = record(run?.repository);
+  const headRepository = record(run?.head_repository);
+  if (
+    !run ||
+    !positiveInteger(run.id) ||
+    !positiveInteger(run.run_attempt) ||
+    run.status !== "completed" ||
+    typeof run.conclusion !== "string" ||
+    (run.event !== "push" && run.event !== "workflow_dispatch") ||
+    run.path !== WORKFLOW_PATH ||
+    typeof run.display_title !== "string" ||
+    !run.display_title.startsWith(DISPLAY_TITLE_PREFIX) ||
+    run.head_branch !== "main" ||
+    typeof run.head_sha !== "string" ||
+    !SHA.test(run.head_sha) ||
+    repository?.full_name !== REPOSITORY ||
+    headRepository?.full_name !== REPOSITORY ||
+    run.html_url !== `https://github.com/${REPOSITORY}/actions/runs/${run.id}`
+  ) {
+    return null;
+  }
+  return run as unknown as WorkflowRun;
+}
+
+function validateArtifacts(value: unknown): Artifact[] | null {
+  const response = record(value);
+  if (!response || !Array.isArray(response.artifacts) || response.artifacts.length > 100)
+    return null;
+  const artifacts: Artifact[] = [];
+  for (const value of response.artifacts) {
+    const artifact = record(value);
+    if (
+      !artifact ||
+      !positiveInteger(artifact.id) ||
+      typeof artifact.name !== "string" ||
+      !/^[A-Za-z0-9_.-]{1,256}$/u.test(artifact.name) ||
+      !Number.isSafeInteger(artifact.size_in_bytes) ||
+      (artifact.size_in_bytes as number) < 0 ||
+      typeof artifact.expired !== "boolean"
+    ) {
+      return null;
+    }
+    artifacts.push(artifact as unknown as Artifact);
+  }
+  return artifacts;
+}
+
+function parseDispatchReceipt(text: string | null, run: WorkflowRun): string | null {
+  if (text === null || Buffer.byteLength(text) > 16_384) return null;
+  try {
+    const receipt = record(JSON.parse(text));
+    if (
+      receipt?.kind !== "nemoclaw-e2e-dispatch-v2" ||
+      receipt.repository !== REPOSITORY ||
+      receipt.eventName !== "workflow_dispatch" ||
+      String(receipt.workflowRunId) !== String(run.id) ||
+      receipt.workflowRunAttempt !== run.run_attempt ||
+      typeof receipt.candidateSha !== "string" ||
+      !SHA.test(receipt.candidateSha)
+    ) {
+      return null;
+    }
+    return receipt.candidateSha;
+  } catch {
+    return null;
+  }
+}
+
+function parseRetryEvidence(value: unknown): RetryEvidence | null {
+  const evidence = record(value);
+  if (
+    evidence?.schemaVersion !== 1 ||
+    typeof evidence.operation !== "string" ||
+    !/^[a-z0-9][a-z0-9._-]{0,127}$/u.test(evidence.operation) ||
+    typeof evidence.owner !== "string" ||
+    !/^[a-z0-9][a-z0-9._-]{0,127}$/u.test(evidence.owner) ||
+    !["read-only", "idempotent", "reconciled-mutation"].includes(String(evidence.idempotence)) ||
+    !positiveInteger(evidence.maxAttempts) ||
+    (evidence.maxAttempts as number) > 10 ||
+    !["failed-no-retry", "exhausted", "passed-after-retry", "passed-first-attempt"].includes(
+      String(evidence.outcome),
+    ) ||
+    !Array.isArray(evidence.attempts) ||
+    evidence.attempts.length < 1 ||
+    evidence.attempts.length > (evidence.maxAttempts as number)
+  ) {
+    return null;
+  }
+  for (let index = 0; index < evidence.attempts.length; index += 1) {
+    const attempt = record(evidence.attempts[index]);
+    if (
+      attempt?.attempt !== index + 1 ||
+      (attempt.outcome !== "failed" && attempt.outcome !== "passed") ||
+      typeof attempt.retryScheduled !== "boolean" ||
+      (attempt.failureClass !== undefined &&
+        !RETRY_FAILURE_CLASSES.includes(attempt.failureClass as RetryFailureClass))
+    ) {
+      return null;
+    }
+  }
+  return evidence as unknown as RetryEvidence;
+}
+
+function parseMainRetryEvidence(
+  value: unknown,
+  run: WorkflowRun,
+): { valid: boolean; outcome: ReliabilityOutcome } {
+  const evidence = record(value);
+  if (
+    evidence?.schemaVersion !== 1 ||
+    evidence.sourceRunId !== run.id ||
+    evidence.sourceSha !== run.head_sha ||
+    evidence.sourceAttempt !== run.run_attempt ||
+    !["failed-no-retry", "ignored", "passed-after-retry", "passed-first-attempt"].includes(
+      String(evidence.action),
+    ) ||
+    typeof evidence.reason !== "string"
+  ) {
+    return { valid: false, outcome: "unclassified" };
+  }
+  if (evidence.action === "ignored" && evidence.reason === "a newer E2E main push exists") {
+    return { valid: true, outcome: "superseded" };
+  }
+  if (evidence.action === "passed-first-attempt") {
+    return { valid: true, outcome: "passed-first-attempt" };
+  }
+  if (evidence.action === "passed-after-retry") {
+    return { valid: true, outcome: "passed-after-retry" };
+  }
+  if (evidence.action === "failed-no-retry") {
+    return {
+      valid: true,
+      outcome: run.run_attempt === 1 ? "failed-first-attempt" : "exhausted",
+    };
+  }
+  return { valid: true, outcome: "unclassified" };
+}
+
+async function readArtifactEntry(
+  artifact: Artifact,
+  entry: string,
+  requestArchive: ArchiveRequest,
+): Promise<string | null> {
+  if (artifact.expired || artifact.size_in_bytes > MAX_ARTIFACT_BYTES) return null;
+  const archive = await requestArchive(artifact.id, MAX_ARTIFACT_BYTES);
+  return readValidatedArtifactZipEntry(archive, entry, { maxBytes: 64 * 1024 });
+}
+
+async function identifyCandidateSha(
+  value: unknown,
+  services: { requestJson: JsonRequest; requestArchive: ArchiveRequest },
+): Promise<string | null> {
+  const run = validateRun(value);
+  if (run === null) return null;
+  if (run.event === "push") return run.head_sha;
+  const artifacts = validateArtifacts(
+    await services.requestJson(`repos/${REPOSITORY}/actions/runs/${run.id}/artifacts?per_page=100`),
+  );
+  const receipt = artifacts?.find(
+    (artifact) => artifact.name === `e2e-dispatch-${run.id}-${run.run_attempt}`,
+  );
+  return receipt
+    ? parseDispatchReceipt(
+        await readArtifactEntry(receipt, "dispatch.json", services.requestArchive),
+        run,
+      )
+    : null;
+}
+
+async function collectFailureClasses(
+  artifacts: Artifact[],
+  requestArchive: ArchiveRequest,
+): Promise<{ classes: ReliabilityFailureClass[]; malformed: boolean }> {
+  const classes = new Set<ReliabilityFailureClass>();
+  let malformed = false;
+  let bytes = 0;
+  for (const artifact of artifacts.filter((item) => item.name.startsWith("e2e-"))) {
+    if (artifact.expired || artifact.size_in_bytes > MAX_ARTIFACT_BYTES) continue;
+    bytes += artifact.size_in_bytes;
+    if (bytes > MAX_RUN_ARTIFACT_BYTES) break;
+    const archive = await requestArchive(artifact.id, MAX_ARTIFACT_BYTES);
+    const entries = listValidatedArtifactZipEntries(archive, {
+      maxEntries: 1000,
+    });
+    if (entries === null) {
+      malformed = true;
+      continue;
+    }
+    for (const entry of entries.filter(
+      (name) =>
+        name.endsWith("/runner-pressure-classification.jsonl") ||
+        (name.includes("/retry/") && name.endsWith(".json")),
+    )) {
+      const text = readValidatedArtifactZipEntry(archive, entry, {
+        maxBytes: 64 * 1024,
+      });
+      if (text === null) {
+        malformed = true;
+        continue;
+      }
+      try {
+        if (entry.endsWith("/runner-pressure-classification.jsonl")) {
+          classes.add(parseClassificationLine(text).classification);
+        } else {
+          const evidence = parseRetryEvidence(JSON.parse(text));
+          if (evidence === null) {
+            malformed = true;
+            continue;
+          }
+          for (const attempt of evidence.attempts) {
+            if (attempt.failureClass) classes.add(attempt.failureClass);
+          }
+        }
+      } catch {
+        malformed = true;
+      }
+    }
+  }
+  return { classes: [...classes].sort(), malformed };
+}
+
+function deriveOutcome(run: WorkflowRun): ReliabilityOutcome {
+  if (run.conclusion === "success") {
+    return run.run_attempt === 1 ? "passed-first-attempt" : "passed-after-retry";
+  }
+  if (run.conclusion === "failure") {
+    return run.run_attempt === 1 ? "failed-first-attempt" : "exhausted";
+  }
+  return "unclassified";
+}
+
+export async function normalizeReliabilityRun(
+  value: unknown,
+  services: { requestJson: JsonRequest; requestArchive: ArchiveRequest },
+): Promise<ReliabilitySample | null> {
+  const run = validateRun(value);
+  if (run === null) return null;
+  const artifacts = validateArtifacts(
+    await services.requestJson(`repos/${REPOSITORY}/actions/runs/${run.id}/artifacts?per_page=100`),
+  );
+  if (artifacts === null) {
+    return {
+      runId: run.id,
+      runAttempt: run.run_attempt,
+      candidateSha: run.event === "push" ? run.head_sha : null,
+      source: run.event === "push" ? "trusted-main" : "manual-qualification",
+      outcome: "unclassified",
+      failureClasses: ["unclassified"],
+      evidence: "malformed",
+      url: run.html_url,
+    };
+  }
+  let candidateSha: string | null = run.head_sha;
+  let evidence: ReliabilitySample["evidence"] = "complete";
+  if (run.event === "workflow_dispatch") {
+    const receiptArtifact = artifacts.find(
+      (artifact) => artifact.name === `e2e-dispatch-${run.id}-${run.run_attempt}`,
+    );
+    candidateSha = receiptArtifact
+      ? parseDispatchReceipt(
+          await readArtifactEntry(receiptArtifact, "dispatch.json", services.requestArchive),
+          run,
+        )
+      : null;
+    if (candidateSha === null) evidence = receiptArtifact ? "malformed" : "missing";
+  }
+  let outcome = candidateSha === null ? "unclassified" : deriveOutcome(run);
+  if (run.event === "push") {
+    const response = record(
+      await services.requestJson(
+        `repos/${REPOSITORY}/actions/artifacts?name=e2e-main-retry-${run.id}-${run.run_attempt}&per_page=100`,
+      ),
+    );
+    const retryArtifacts = validateArtifacts(response);
+    const retryArtifact = retryArtifacts?.find(
+      (artifact) => artifact.name === `e2e-main-retry-${run.id}-${run.run_attempt}`,
+    );
+    if (!retryArtifact) {
+      evidence = "missing";
+      outcome = "unclassified";
+    } else {
+      const text = await readArtifactEntry(
+        retryArtifact,
+        "e2e-main-retry-evidence.json",
+        services.requestArchive,
+      );
+      try {
+        const parsed =
+          text === null
+            ? { valid: false, outcome: "unclassified" as const }
+            : parseMainRetryEvidence(JSON.parse(text), run);
+        outcome = parsed.outcome;
+        if (!parsed.valid) evidence = "malformed";
+      } catch {
+        evidence = "malformed";
+        outcome = "unclassified";
+      }
+    }
+  }
+  const classified = await collectFailureClasses(artifacts, services.requestArchive);
+  if (classified.malformed) evidence = "malformed";
+  const failed = outcome === "exhausted" || outcome === "failed-first-attempt";
+  return {
+    runId: run.id,
+    runAttempt: run.run_attempt,
+    candidateSha,
+    source: run.event === "push" ? "trusted-main" : "manual-qualification",
+    outcome,
+    failureClasses:
+      failed && classified.classes.length === 0 ? ["unclassified"] : classified.classes,
+    evidence,
+    url: run.html_url,
+  };
+}
+
+function passState(outcome: ReliabilityOutcome): boolean | null {
+  if (outcome === "passed-first-attempt" || outcome === "passed-after-retry") return true;
+  if (outcome === "failed-first-attempt" || outcome === "exhausted") return false;
+  return null;
+}
+
+export function summarizeReliability(samples: readonly ReliabilitySample[]): ReliabilityGroup[] {
+  const grouped = new Map<string, ReliabilitySample[]>();
+  for (const sample of samples) {
+    if (!sample.source) continue;
+    const key = `${sample.source}:${sample.candidateSha ?? `unknown-run-${sample.runId}`}`;
+    grouped.set(key, [...(grouped.get(key) ?? []), sample]);
+  }
+  return [...grouped.values()]
+    .map((values) => {
+      const ordered = [...values].sort((a, b) => a.runId - b.runId || a.runAttempt - b.runAttempt);
+      const count = (outcome: ReliabilityOutcome) =>
+        ordered.filter((sample) => sample.outcome === outcome).length;
+      const first = count("passed-first-attempt");
+      const recovered = count("passed-after-retry");
+      const exhausted = count("exhausted");
+      const failedFirst = count("failed-first-attempt");
+      const states = ordered
+        .map((sample) => passState(sample.outcome))
+        .filter((state) => state !== null);
+      let flips = 0;
+      for (let index = 1; index < states.length; index += 1) {
+        if (states[index] !== states[index - 1]) flips += 1;
+      }
+      const classes: Record<string, number> = {};
+      for (const sample of ordered) {
+        for (const failureClass of sample.failureClasses) {
+          classes[failureClass] = (classes[failureClass] ?? 0) + 1;
+        }
+      }
+      return {
+        candidateSha: ordered[0]!.candidateSha,
+        source: ordered[0]!.source!,
+        runs: ordered.length,
+        passedFirstAttempt: first,
+        passedAfterRetry: recovered,
+        failedFirstAttempt: failedFirst,
+        exhausted,
+        superseded: count("superseded"),
+        unclassified: count("unclassified"),
+        passFailFlips: flips,
+        firstPassRate: fixedRate(first, first + recovered + failedFirst + exhausted),
+        recoveryRate:
+          recovered + exhausted === 0 ? null : fixedRate(recovered, recovered + exhausted),
+        failureClasses: classes,
+      };
+    })
+    .sort((a, b) => {
+      const sourceOrder = a.source.localeCompare(b.source);
+      if (sourceOrder !== 0) return sourceOrder;
+      return (a.candidateSha ?? "").localeCompare(b.candidateSha ?? "");
+    });
+}
+
+export function formatReliabilityReport(groups: readonly ReliabilityGroup[]): string {
+  const lines = [
+    "## Same-commit E2E reliability",
+    "",
+    "Advisory history only; it does not change required checks, release conclusions, or rerun decisions.",
+    "",
+  ];
+  if (groups.length === 0)
+    return [...lines, "No authenticated same-commit history is available."].join("\n");
+  lines.push(
+    "| Source | Commit | Runs | First pass | After retry | Exhausted | Failed first | Flips | First-pass rate | Recovery rate | Failure classes |",
+    "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+  );
+  for (const group of groups) {
+    const classes = Object.entries(group.failureClasses)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, count]) => `${name}: ${count}`)
+      .join(", ");
+    lines.push(
+      `| ${group.source} | ${group.candidateSha ? `\`${group.candidateSha.slice(0, 12)}\`` : "unclassified"} | ${group.runs} | ${group.passedFirstAttempt} | ${group.passedAfterRetry} | ${group.exhausted} | ${group.failedFirstAttempt} | ${group.passFailFlips} | ${(group.firstPassRate * 100).toFixed(1)}% | ${group.recoveryRate === null ? "n/a" : `${(group.recoveryRate * 100).toFixed(1)}%`} | ${classes || "none"} |`,
+    );
+  }
+  return lines.join("\n");
+}
+
+async function githubJson(path: string, token: string): Promise<unknown> {
+  const response = await fetch(`https://api.github.com/${path}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!response.ok) throw new Error(`GitHub API ${path} failed with ${response.status}`);
+  return response.json();
+}
+
+async function githubArchive(artifactId: number, maxBytes: number, token: string): Promise<Buffer> {
+  const response = await fetch(
+    `https://api.github.com/repos/${REPOSITORY}/actions/artifacts/${artifactId}/zip`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!response.ok) throw new Error(`GitHub artifact ${artifactId} failed with ${response.status}`);
+  const length = Number(response.headers.get("content-length") ?? "0");
+  if (Number.isFinite(length) && length > maxBytes)
+    throw new Error("GitHub artifact exceeds bound");
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (bytes.length > maxBytes) throw new Error("GitHub artifact exceeds bound");
+  return bytes;
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function main(): Promise<void> {
+  const token = requiredEnvironment("GITHUB_TOKEN");
+  const currentRunId = Number(requiredEnvironment("SOURCE_RUN_ID"));
+  if (!positiveInteger(currentRunId)) throw new Error("SOURCE_RUN_ID must be a positive integer");
+  const requestJson = (path: string) => githubJson(path, token);
+  const requestArchive = (artifactId: number, maxBytes: number) =>
+    githubArchive(artifactId, maxBytes, token);
+  const response = record(
+    await requestJson(
+      `repos/${REPOSITORY}/actions/workflows/e2e.yaml/runs?status=completed&per_page=${MAX_RUNS}`,
+    ),
+  );
+  if (!response || !Array.isArray(response.workflow_runs)) {
+    throw new Error("GitHub returned no E2E workflow run history");
+  }
+  const current = response.workflow_runs.find((run) => record(run)?.id === currentRunId);
+  const currentSample = await normalizeReliabilityRun(current, {
+    requestJson,
+    requestArchive,
+  });
+  const samples: ReliabilitySample[] = [];
+  for (const run of response.workflow_runs) {
+    if (!currentSample?.candidateSha) break;
+    const candidateSha = await identifyCandidateSha(run, {
+      requestJson,
+      requestArchive,
+    });
+    if (candidateSha !== currentSample.candidateSha) continue;
+    const sample = await normalizeReliabilityRun(run, {
+      requestJson,
+      requestArchive,
+    });
+    if (sample && sample.candidateSha === currentSample.candidateSha) {
+      samples.push(sample);
+    }
+  }
+  if (currentSample && !samples.some((sample) => sample.runId === currentSample.runId)) {
+    samples.push(currentSample);
+  }
+  const groups = summarizeReliability(samples);
+  const report = {
+    schemaVersion: 1,
+    currentRunId,
+    candidateSha: currentSample?.candidateSha ?? null,
+    groups,
+  };
+  fs.writeFileSync(
+    requiredEnvironment("RELIABILITY_REPORT_PATH"),
+    `${JSON.stringify(report, null, 2)}\n`,
+    {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    },
+  );
+  console.log(formatReliabilityReport(groups));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/tools/e2e/same-commit-reliability.mts
+++ b/tools/e2e/same-commit-reliability.mts
@@ -3,7 +3,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import fs from "node:fs";
 import { pathToFileURL } from "node:url";
 
 import {
@@ -766,16 +765,8 @@ async function main(): Promise<void> {
     candidateSha: currentSample?.candidateSha ?? null,
     groups,
   };
-  fs.writeFileSync(
-    requiredEnvironment("RELIABILITY_REPORT_PATH"),
-    `${JSON.stringify(report, null, 2)}\n`,
-    {
-      encoding: "utf8",
-      mode: 0o600,
-      flag: "wx",
-    },
-  );
-  console.log(formatReliabilityReport(groups));
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.stderr.write(`${formatReliabilityReport(groups)}\n`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/tools/e2e/same-commit-reliability.mts
+++ b/tools/e2e/same-commit-reliability.mts
@@ -51,6 +51,7 @@ export type ReliabilityOutcome =
   | "superseded"
   | "unclassified";
 export type ReliabilityFailureClass = RetryFailureClass | TerminalClassification | "unclassified";
+export type EvidenceState = "complete" | "malformed" | "missing";
 
 export interface ReliabilitySample {
   runId: number;
@@ -59,7 +60,8 @@ export interface ReliabilitySample {
   source: ReliabilitySource | null;
   outcome: ReliabilityOutcome;
   failureClasses: ReliabilityFailureClass[];
-  evidence: "complete" | "malformed" | "missing";
+  evidence: EvidenceState;
+  failureClassEvidence: EvidenceState;
   url: string;
 }
 
@@ -77,6 +79,8 @@ export interface ReliabilityGroup {
   firstPassRate: number;
   recoveryRate: number | null;
   failureClasses: Record<string, number>;
+  evidence: Record<EvidenceState, number>;
+  failureClassEvidence: Record<EvidenceState, number>;
 }
 
 type WorkflowRun = {
@@ -223,6 +227,43 @@ function parseDispatchReceipt(text: string | null, run: WorkflowRun): string | n
   }
 }
 
+function parseTerminalEvidenceManifest(
+  text: string | null,
+  run: WorkflowRun,
+  candidateSha: string,
+): "cancelled" | "failure" | "success" | null {
+  if (text === null || Buffer.byteLength(text) > 16_384) return null;
+  try {
+    const manifest = record(JSON.parse(text));
+    const candidate = record(manifest?.candidate);
+    const workflow = record(manifest?.workflow);
+    const jobStatus = workflow?.jobStatus;
+    const valid =
+      manifest?.kind === "nemoclaw-e2e-evidence-v1" &&
+      typeof manifest.targetId === "string" &&
+      /^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(manifest.targetId) &&
+      candidate?.repository !== undefined &&
+      typeof candidate.repository === "string" &&
+      /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(candidate.repository) &&
+      candidate.sha === candidateSha &&
+      workflow?.repository === REPOSITORY &&
+      workflow.sha === run.head_sha &&
+      workflow.runId === String(run.id) &&
+      workflow.runAttempt === String(run.run_attempt) &&
+      (jobStatus === "cancelled" || jobStatus === "failure" || jobStatus === "success") &&
+      typeof manifest.artifactDirectory === "string" &&
+      /^e2e-artifacts\/live\/[a-z0-9]+(?:[_-][a-z0-9]+)*(?:\/[a-z0-9]+(?:[_-][a-z0-9]+)*)?$/u.test(
+        manifest.artifactDirectory,
+      ) &&
+      Number.isSafeInteger(manifest.productEvidenceFileCount) &&
+      (manifest.productEvidenceFileCount as number) >= (jobStatus === "success" ? 1 : 0);
+    if (!valid) return null;
+    return jobStatus as "cancelled" | "failure" | "success";
+  } catch {
+    return null;
+  }
+}
+
 function parseRetryEvidence(value: unknown): RetryEvidence | null {
   const evidence = record(value);
   if (
@@ -324,25 +365,52 @@ async function identifyCandidateSha(
     : null;
 }
 
-async function collectFailureClasses(
+async function collectRunEvidence(
   artifacts: Artifact[],
+  run: WorkflowRun,
+  candidateSha: string | null,
   requestArchive: ArchiveRequest,
-): Promise<{ classes: ReliabilityFailureClass[]; malformed: boolean; records: number }> {
+): Promise<{
+  classes: ReliabilityFailureClass[];
+  failureClassEvidence: EvidenceState;
+  terminalEvidence: EvidenceState;
+}> {
   const classes = new Set<ReliabilityFailureClass>();
-  let malformed = false;
-  let records = 0;
+  let failureClassMalformed = false;
+  let failureClassRecords = 0;
+  let terminalMalformed = false;
+  let terminalRecords = 0;
   let bytes = 0;
   for (const artifact of artifacts.filter((item) => item.name.startsWith("e2e-"))) {
     if (artifact.expired || artifact.size_in_bytes > MAX_ARTIFACT_BYTES) continue;
     bytes += artifact.size_in_bytes;
-    if (bytes > MAX_RUN_ARTIFACT_BYTES) break;
+    if (bytes > MAX_RUN_ARTIFACT_BYTES) {
+      terminalMalformed = true;
+      failureClassMalformed = true;
+      break;
+    }
     const archive = await requestArchive(artifact.id, MAX_ARTIFACT_BYTES);
     const entries = listValidatedArtifactZipEntries(archive, {
       maxEntries: 1000,
     });
     if (entries === null) {
-      malformed = true;
+      terminalMalformed = true;
+      failureClassMalformed = true;
       continue;
+    }
+    for (const entry of entries.filter(
+      (name) => name.endsWith("/evidence-manifest.json") || name === "evidence-manifest.json",
+    )) {
+      const text = readValidatedArtifactZipEntry(archive, entry, {
+        maxBytes: 16_384,
+      });
+      const jobStatus =
+        candidateSha === null ? null : parseTerminalEvidenceManifest(text, run, candidateSha);
+      if (jobStatus === null) {
+        terminalMalformed = true;
+      } else if (jobStatus === run.conclusion) {
+        terminalRecords += 1;
+      }
     }
     for (const entry of entries.filter(
       (name) =>
@@ -353,37 +421,52 @@ async function collectFailureClasses(
         maxBytes: 64 * 1024,
       });
       if (text === null) {
-        malformed = true;
+        failureClassMalformed = true;
         continue;
       }
       try {
         if (entry.endsWith("/runner-pressure-classification.jsonl")) {
           classes.add(parseClassificationLine(text).classification);
-          records += 1;
+          failureClassRecords += 1;
         } else {
           const evidence = parseRetryEvidence(JSON.parse(text));
           if (evidence === null) {
-            malformed = true;
+            failureClassMalformed = true;
             continue;
           }
-          records += 1;
+          failureClassRecords += 1;
           for (const attempt of evidence.attempts) {
             if (attempt.failureClass) classes.add(attempt.failureClass);
           }
         }
       } catch {
-        malformed = true;
+        failureClassMalformed = true;
       }
     }
   }
-  return { classes: [...classes].sort(), malformed, records };
+  return {
+    classes: [...classes].sort(),
+    failureClassEvidence: failureClassMalformed
+      ? "malformed"
+      : failureClassRecords > 0
+        ? "complete"
+        : "missing",
+    terminalEvidence: terminalMalformed
+      ? "malformed"
+      : terminalRecords > 0
+        ? "complete"
+        : "missing",
+  };
 }
 
 async function trustedMainRetryArtifact(
   artifacts: Artifact[] | null,
   expectedName: string,
   requestJson: JsonRequest,
-): Promise<{ artifact: Artifact | null; evidence: "complete" | "malformed" | "missing" }> {
+): Promise<{
+  artifact: Artifact | null;
+  evidence: "complete" | "malformed" | "missing";
+}> {
   if (artifacts === null) return { artifact: null, evidence: "malformed" };
   const matches = artifacts.filter((artifact) => artifact.name === expectedName);
   if (matches.length === 0) return { artifact: null, evidence: "missing" };
@@ -430,6 +513,7 @@ export async function normalizeReliabilityRun(
       outcome: "unclassified",
       failureClasses: ["unclassified"],
       evidence: "malformed",
+      failureClassEvidence: "malformed",
       url: run.html_url,
     };
   }
@@ -482,11 +566,10 @@ export async function normalizeReliabilityRun(
       }
     }
   }
-  const classified = await collectFailureClasses(artifacts, services.requestArchive);
-  if (classified.malformed) evidence = "malformed";
-  if (run.event === "workflow_dispatch" && candidateSha !== null && classified.records === 0) {
-    evidence = classified.malformed ? "malformed" : "missing";
-    outcome = "unclassified";
+  const collected = await collectRunEvidence(artifacts, run, candidateSha, services.requestArchive);
+  if (run.event === "workflow_dispatch" && candidateSha !== null) {
+    evidence = collected.terminalEvidence;
+    if (evidence !== "complete") outcome = "unclassified";
   }
   const failed = outcome === "exhausted" || outcome === "failed-first-attempt";
   return {
@@ -495,9 +578,9 @@ export async function normalizeReliabilityRun(
     candidateSha,
     source: run.event === "push" ? "trusted-main" : "manual-qualification",
     outcome,
-    failureClasses:
-      failed && classified.classes.length === 0 ? ["unclassified"] : classified.classes,
+    failureClasses: failed && collected.classes.length === 0 ? ["unclassified"] : collected.classes,
     evidence,
+    failureClassEvidence: collected.failureClassEvidence,
     url: run.html_url,
   };
 }
@@ -538,6 +621,12 @@ export function summarizeReliability(samples: readonly ReliabilitySample[]): Rel
           classes[failureClass] = (classes[failureClass] ?? 0) + 1;
         }
       }
+      const evidence = { complete: 0, malformed: 0, missing: 0 };
+      const failureClassEvidence = { complete: 0, malformed: 0, missing: 0 };
+      for (const sample of ordered) {
+        evidence[sample.evidence] += 1;
+        failureClassEvidence[sample.failureClassEvidence] += 1;
+      }
       return {
         candidateSha: ordered[0]!.candidateSha,
         source: ordered[0]!.source!,
@@ -553,6 +642,8 @@ export function summarizeReliability(samples: readonly ReliabilitySample[]): Rel
         recoveryRate:
           recovered + exhausted === 0 ? null : fixedRate(recovered, recovered + exhausted),
         failureClasses: classes,
+        evidence,
+        failureClassEvidence,
       };
     })
     .sort((a, b) => {
@@ -572,8 +663,8 @@ export function formatReliabilityReport(groups: readonly ReliabilityGroup[]): st
   if (groups.length === 0)
     return [...lines, "No authenticated same-commit history is available."].join("\n");
   lines.push(
-    "| Source | Commit | Runs | First pass | After retry | Exhausted | Failed first | Flips | First-pass rate | Recovery rate | Failure classes |",
-    "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    "| Source | Commit | Runs | First pass | After retry | Exhausted | Failed first | Superseded | Unclassified | Flips | First-pass rate | Recovery rate | Failure classes | Outcome evidence | Failure-class evidence |",
+    "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | --- |",
   );
   for (const group of groups) {
     const classes = Object.entries(group.failureClasses)
@@ -581,10 +672,14 @@ export function formatReliabilityReport(groups: readonly ReliabilityGroup[]): st
       .map(([name, count]) => `${name}: ${count}`)
       .join(", ");
     lines.push(
-      `| ${group.source} | ${group.candidateSha ? `\`${group.candidateSha.slice(0, 12)}\`` : "unclassified"} | ${group.runs} | ${group.passedFirstAttempt} | ${group.passedAfterRetry} | ${group.exhausted} | ${group.failedFirstAttempt} | ${group.passFailFlips} | ${(group.firstPassRate * 100).toFixed(1)}% | ${group.recoveryRate === null ? "n/a" : `${(group.recoveryRate * 100).toFixed(1)}%`} | ${classes || "none"} |`,
+      `| ${group.source} | ${group.candidateSha ? `\`${group.candidateSha.slice(0, 12)}\`` : "unclassified"} | ${group.runs} | ${group.passedFirstAttempt} | ${group.passedAfterRetry} | ${group.exhausted} | ${group.failedFirstAttempt} | ${group.superseded} | ${group.unclassified} | ${group.passFailFlips} | ${(group.firstPassRate * 100).toFixed(1)}% | ${group.recoveryRate === null ? "n/a" : `${(group.recoveryRate * 100).toFixed(1)}%`} | ${classes || "none"} | ${formatEvidenceCounts(group.evidence)} | ${formatEvidenceCounts(group.failureClassEvidence)} |`,
     );
   }
   return lines.join("\n");
+}
+
+function formatEvidenceCounts(counts: Record<EvidenceState, number>): string {
+  return `complete: ${counts.complete}, malformed: ${counts.malformed}, missing: ${counts.missing}`;
 }
 
 async function githubJson(path: string, token: string): Promise<unknown> {


### PR DESCRIPTION
## Summary

Add an advisory same-commit E2E reliability report that separates trusted main pushes from manual qualification runs and measures first-pass, retry-recovery, exhausted, superseded, flip, and fixed failure-class outcomes without exposing artifact payloads.

## Related Issue

Closes #9168.

## Changes

- Add a post-evaluation workflow job that writes a Markdown step summary and uploads bounded JSON and Markdown reports with 14-day retention.
- Stream bounded JSON and Markdown through separate workflow channels into the documented artifact files and job summary.
- Align the existing Anthropic retry fixture with the native tool-call contract already documented by #9236.
- Add a reporter that groups completed E2E history by candidate commit and provenance and emits only allowlisted aggregate fields.
- Authenticate manual-run identity with the run-bound dispatch receipt and terminal outcome with canonical run-, attempt-, candidate-, workflow-, and job-status-bound evidence manifests.
- Keep retry and runner-pressure evidence as narrower failure-class evidence, expose complete/missing/malformed states separately, and prevent malformed classification data from erasing an authenticated outcome.
- Bind trusted-main retry artifacts to a validated `NVIDIA/NemoClaw` controller run from `.github/workflows/e2e-main-retry.yaml`, rejecting missing provenance and duplicate artifact names.
- Lock the reporter job to the canonical source repository, E2E workflow, main branch, and trusted `github.workflow_sha` checkout with an executable source-shape contract.
- Structurally validate artifact ZIP entries against ambiguous paths, duplicates, links, encryption, ZIP64/split archives, invalid UTF-8, unsupported compression, inconsistent headers, excess entries, size bounds, and CRC mismatches.
- Add synthetic coverage for authenticated passing and failing terminal evidence, missing terminal evidence, malformed failure classes, same-commit grouping, retries, exhaustion, flips, controller provenance, artifact-name collisions, fixed classes, and credential-negative output.
- Document identity, outcome, failure-class, job-summary, artifact, retention, and ZIP validation semantics in `test/e2e/README.md`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: https://github.com/NVIDIA/NemoClaw/pull/9237#pullrequestreview-4945393809 records the complete security review through `790ab125c`. https://github.com/NVIDIA/NemoClaw/pull/9237#pullrequestreview-4945652587 confirms that the stream-capture repair at `4aa14aa39` aligns the publication contract and adds no security blocker. The timeout correction at `411dff12c` and Anthropic fixture correction at `1e9a971da` are test-only.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/README.md`; the prior complete-PR review through `790ab125c` remains valid. Extended review through commit under review `1e9a971da` confirmed that `4aa14aa39` preserves the documented JSON artifact, Markdown artifact, job-summary table, allowlisted contents, and retention behavior while changing only stream capture. `411dff12c` changes only a test timeout. `1e9a971da` changes only the Anthropic retry fixture to match #9236’s documented native tool-call contract; the identical #9219 correction passed GitHub shard 3 at `9df0ac820`. No additional documentation is needed. The prior Markdownlint, format check, and docs build evidence remains applicable because the later commits do not change documentation.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 1e9a971da -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or applicable local gates passed after refreshing `origin/main`
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 28 E2E-support tests passed at `790ab125c`; `4aa14aa39` adds seven assertions to the existing reliability test, and `411dff12c` changes only a test timeout. The startup test command in the fresh fork checkout stopped before running tests because the shared plugin artifact was not built. The identical Anthropic fixture correction passed #9219 GitHub shard 3 at `9df0ac820`. Current GitHub CI provides revision-bound validation.
- [x] Applicable broad gate passed — GitHub CI and managed-runtime qualification passed for PR commit `1e9a971da`; the primary advisor and publisher reported no findings, while the second-opinion lane repeated an advisor protocol fault after one retry
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

The repository-wide test wrapper stopped before running tests because the existing local `nemoclaw` package installation lacks `json5` and `tar`; the directly applicable E2E support tests and root typecheck above completed successfully.

The documentation-only repair at `790ab125c` passed `npm exec markdownlint-cli2 -- test/e2e/README.md`, `npm run format:check`, and `npm run docs`; Fern reported 0 errors and 2 non-blocking warnings.

---
Signed-off-by: Ho Lim <subhoya@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added same-commit E2E reliability reporting for eligible main-branch runs.
  * Reports summarize retries, recoveries, failures, runner pressure, and evidence status.
  * Workflow summaries now include Markdown reports with downloadable JSON and evidence artifacts.
  * Added secure validation for artifact ZIP contents, including duplicate, linked, malformed, and unsafe entries.

* **Documentation**
  * Expanded guidance on reliability outcomes, evidence requirements, artifact handling, and report limitations.

* **Tests**
  * Added comprehensive coverage for reliability reporting and ZIP validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




