### PR TITLE
refactor(runtime): share corporate CA merge helper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -561,6 +561,7 @@ COPY scripts/verify-wechat-runtime-lock.mts /usr/local/lib/nemoclaw/verify-wecha
 FROM scratch AS openclaw-runtime-payload
 
 COPY scripts/lib/sandbox-init.sh /usr/local/lib/nemoclaw/sandbox-init.sh
+COPY --chmod=0444 scripts/lib/corporate-ca-runtime.sh /usr/local/lib/nemoclaw/corporate-ca-runtime.sh
 COPY scripts/lib/entrypoint-env-wrapper.sh /usr/local/lib/nemoclaw/entrypoint-env-wrapper.sh
 COPY scripts/lib/gateway-supervisor.sh /usr/local/lib/nemoclaw/gateway-supervisor.sh
 COPY scripts/lib/sandbox-rlimits.sh /usr/local/lib/nemoclaw/sandbox-rlimits.sh

--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -96,6 +96,7 @@ FROM scratch AS hermes-runtime-payload
 COPY --from=mcp-tool-discovery-runtime /opt/mcp-tool-discovery-runtime/dist/ /usr/local/lib/nemoclaw/mcp-tool-discovery-runtime/
 COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/
 COPY scripts/lib/sandbox-init.sh /usr/local/lib/nemoclaw/sandbox-init.sh
+COPY --chmod=0444 scripts/lib/corporate-ca-runtime.sh /usr/local/lib/nemoclaw/corporate-ca-runtime.sh
 COPY scripts/lib/entrypoint-env-wrapper.sh /usr/local/lib/nemoclaw/entrypoint-env-wrapper.sh
 COPY scripts/lib/gateway-supervisor.sh /usr/local/lib/nemoclaw/gateway-supervisor.sh
 COPY scripts/lib/sandbox-rlimits.sh /usr/local/lib/nemoclaw/sandbox-rlimits.sh

--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -1829,134 +1829,26 @@ export no_proxy="$_NO_PROXY_VAL"
 # #1828 OpenShell CA behavior stays intact) — and repoint SSL_CERT_FILE at the
 # merged bundle before the CURL/REQUESTS/GIT derivation below picks it up.
 _NEMOCLAW_CORPORATE_CA_FILE="/usr/local/share/nemoclaw/corporate-ca.pem"
-# Concise, secret-free warning when a baked corporate CA fails to merge at
-# runtime. Names the failed step + target path only (never certificate bytes)
-# so an operator can distinguish "no CA was baked" from "runtime merge failed".
-_nemoclaw_ca_merge_warn() {
-  echo "[nemoclaw] WARNING: corporate proxy CA merge failed at ${1}; keeping OpenShell-only trust — external TLS through the corporate proxy may fail (#6210)" >&2
-}
-merge_corporate_proxy_ca() {
-  # Trust-anchor tampering (#8650): replacing the baked corporate CA file with a
-  # symlink makes the merge below read the link target instead, adding
-  # attacker-selected bytes to the trust bundle that curl, python, git, and node
-  # verify against. The image bakes this path as a root-owned 0444 regular file,
-  # so a symlink here is never a legitimate state. This is not the recoverable
-  # "merge failed" case below, which safely keeps OpenShell-only trust, so it
-  # fails closed instead of warning.
-  if [ -L "$_NEMOCLAW_CORPORATE_CA_FILE" ]; then
-    echo "[nemoclaw] refusing symlinked corporate CA at ${_NEMOCLAW_CORPORATE_CA_FILE}; expected a regular file (#8650)" >&2
-    exit 1
+_NEMOCLAW_CORPORATE_CA_HELPER="/usr/local/lib/nemoclaw/corporate-ca-runtime.sh"
+if [ ! -f "$_NEMOCLAW_CORPORATE_CA_HELPER" ]; then
+  _HERMES_START_SOURCE="${BASH_SOURCE[0]}"
+  _HERMES_START_DIR="${_HERMES_START_SOURCE%/*}"
+  if [ "$_HERMES_START_DIR" = "$_HERMES_START_SOURCE" ]; then
+    _HERMES_START_DIR="."
   fi
-  [ -s "$_NEMOCLAW_CORPORATE_CA_FILE" ] || return 0
-  _base_bundle=""
-  if [ -n "${SSL_CERT_FILE:-}" ] && [ -f "${SSL_CERT_FILE}" ]; then
-    _base_bundle="$SSL_CERT_FILE"
-  elif [ -f /etc/ssl/certs/ca-certificates.crt ]; then
-    _base_bundle="/etc/ssl/certs/ca-certificates.crt"
-  fi
-  _merged="/tmp/nemoclaw-ca-bundle.pem"
-  # Trust-anchor path safety (#6210): in the normal container start this
-  # entrypoint runs as root (the step-down prefix wraps only the later agent
-  # commands, not this top-level merge), so the merged bundle is written
-  # root-owned 0444 — the non-root sandbox user that the agent later runs as
-  # inherits SSL_CERT_FILE but cannot rewrite it. The predictable /tmp path is
-  # still handled safely: it is built in a fresh mktemp sibling and atomically
-  # renamed into place; a pre-planted symlink at the target is dropped first
-  # (below); and rename(2) replaces the target link/file rather than writing
-  # through it, so a pre-planted symlink or file cannot redirect the write. On a
-  # non-root start the whole entrypoint (and the agent) is the same sandbox user,
-  # so there is no privilege boundary to cross.
-  # Build the bundle in a private temp file next to the target, verifying every
-  # write, then atomically rename into place. If any step fails we bail without
-  # exporting anything, leaving the OpenShell-only trust intact rather than
-  # pointing tools at a partial/empty bundle.
-  _tmp="$(mktemp "${_merged}.XXXXXX" 2>/dev/null)" || {
-    _nemoclaw_ca_merge_warn "create temp bundle (${_merged})"
-    return 0
-  }
-  if [ -n "$_base_bundle" ]; then
-    cat "$_base_bundle" >>"$_tmp" 2>/dev/null || {
-      rm -f "$_tmp"
-      _nemoclaw_ca_merge_warn "append OpenShell bundle"
-      return 0
-    }
-    printf '\n' >>"$_tmp" 2>/dev/null || {
-      rm -f "$_tmp"
-      _nemoclaw_ca_merge_warn "append OpenShell bundle"
-      return 0
-    }
-  fi
-  # Append through a descriptor opened with O_NOFOLLOW and verified as a regular
-  # file (#8650). The check above rejects a planted symlink; this rejects one
-  # swapped in afterwards, because the type check and the read share one
-  # descriptor and no path is resolved twice. Status 2 means the source was
-  # rejected as a trust anchor; any other non-zero status is an ordinary read
-  # failure that keeps the existing warn-and-continue behavior.
-  _ca_append_status=0
-  python3 -I - "$_NEMOCLAW_CORPORATE_CA_FILE" "$_tmp" <<'PY_APPEND_CORPORATE_CA' || _ca_append_status=$?
-import errno
-import os
-import stat
-import sys
-
-source, target = sys.argv[1], sys.argv[2]
-try:
-    descriptor = os.open(source, os.O_RDONLY | os.O_NOFOLLOW)
-except OSError as error:
-    raise SystemExit(2 if error.errno == errno.ELOOP else 3)
-try:
-    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-        raise SystemExit(2)
-    with open(target, "ab") as merged:
-        while True:
-            chunk = os.read(descriptor, 65536)
-            if not chunk:
-                break
-            merged.write(chunk)
-finally:
-    os.close(descriptor)
-PY_APPEND_CORPORATE_CA
-  if [ "$_ca_append_status" -eq 2 ]; then
-    rm -f "$_tmp"
-    echo "[nemoclaw] refusing corporate CA at ${_NEMOCLAW_CORPORATE_CA_FILE}; expected a regular file, not a symlink (#8650)" >&2
-    exit 1
-  fi
-  if [ "$_ca_append_status" -ne 0 ]; then
-    rm -f "$_tmp"
-    _nemoclaw_ca_merge_warn "append corporate CA"
-    return 0
-  fi
-  chmod 0444 "$_tmp" 2>/dev/null || {
-    rm -f "$_tmp"
-    _nemoclaw_ca_merge_warn "set merged bundle permissions (${_merged})"
-    return 0
-  }
-  # Defense-in-depth for the predictable /tmp path (#6210): if a co-tenant
-  # pre-planted a symlink at the target, drop it first so we rename into a fresh
-  # regular file we own rather than through an attacker-controlled link.
-  if [ -L "$_merged" ]; then
-    rm -f "$_merged" 2>/dev/null || true
-  fi
-  mv -f "$_tmp" "$_merged" 2>/dev/null || {
-    rm -f "$_tmp"
-    _nemoclaw_ca_merge_warn "install merged bundle (${_merged})"
-    return 0
-  }
-  # Export all CA env vars explicitly (not via the ${VAR:-…} defaulting below,
-  # which would keep an OpenShell-preset CURL/REQUESTS/GIT value pointing at the
-  # OpenShell-only bundle instead of the merged one).
-  export SSL_CERT_FILE="$_merged"
-  export CURL_CA_BUNDLE="$_merged"
-  export REQUESTS_CA_BUNDLE="$_merged"
-  export GIT_SSL_CAINFO="$_merged"
-  export NODE_EXTRA_CA_CERTS="$_merged"
-  export _NEMOCLAW_CORPORATE_CA_MERGED=1
-  echo "[nemoclaw] merged corporate proxy CA into sandbox trust bundle (#6210)" >&2
-}
+  _NEMOCLAW_CORPORATE_CA_HELPER="$(cd "$_HERMES_START_DIR" && pwd)/../../scripts/lib/corporate-ca-runtime.sh"
+  unset _HERMES_START_SOURCE _HERMES_START_DIR
+fi
+if [ ! -f "$_NEMOCLAW_CORPORATE_CA_HELPER" ] || [ -L "$_NEMOCLAW_CORPORATE_CA_HELPER" ]; then
+  echo "[nemoclaw] required corporate CA runtime helper is missing or unsafe" >&2
+  exit 1
+fi
+# shellcheck source=scripts/lib/corporate-ca-runtime.sh
+source "$_NEMOCLAW_CORPORATE_CA_HELPER"
 if [ "${NEMOCLAW_MANAGED_STARTUP_APPLIED:-0}" != "1" ]; then
   merge_corporate_proxy_ca
 fi
-
+unset _NEMOCLAW_CORPORATE_CA_HELPER
 # OpenShell injects SSL_CERT_FILE/CURL_CA_BUNDLE for its L7 proxy CA. Persist
 # them into connect-session shells so Python Slack probes and Hermes tools trust
 # the same proxy CA that the entrypoint received at startup.

--- a/scripts/lib/corporate-ca-runtime.sh
+++ b/scripts/lib/corporate-ca-runtime.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared fail-closed corporate-proxy CA merge used by the OpenClaw and Hermes
+# entrypoints. The caller owns _NEMOCLAW_CORPORATE_CA_FILE.
+_nemoclaw_ca_merge_warn() {
+  echo "[nemoclaw] WARNING: corporate proxy CA merge failed at ${1}; keeping OpenShell-only trust — external TLS through the corporate proxy may fail (#6210)" >&2
+}
+
+merge_corporate_proxy_ca() {
+  if [ -L "$_NEMOCLAW_CORPORATE_CA_FILE" ]; then
+    echo "[nemoclaw] refusing symlinked corporate CA at ${_NEMOCLAW_CORPORATE_CA_FILE}; expected a regular file (#8650)" >&2
+    exit 1
+  fi
+  [ -s "$_NEMOCLAW_CORPORATE_CA_FILE" ] || return 0
+  _base_bundle=""
+  if [ -n "${SSL_CERT_FILE:-}" ] && [ -f "${SSL_CERT_FILE}" ]; then
+    _base_bundle="$SSL_CERT_FILE"
+  elif [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+    _base_bundle="/etc/ssl/certs/ca-certificates.crt"
+  fi
+  _merged="/tmp/nemoclaw-ca-bundle.pem"
+  _tmp="$(mktemp "${_merged}.XXXXXX" 2>/dev/null)" || {
+    _nemoclaw_ca_merge_warn "create temp bundle (${_merged})"
+    return 0
+  }
+  if [ -n "$_base_bundle" ]; then
+    cat "$_base_bundle" >>"$_tmp" 2>/dev/null || {
+      rm -f "$_tmp"
+      _nemoclaw_ca_merge_warn "append OpenShell bundle"
+      return 0
+    }
+    printf '\n' >>"$_tmp" 2>/dev/null || {
+      rm -f "$_tmp"
+      _nemoclaw_ca_merge_warn "append OpenShell bundle"
+      return 0
+    }
+  fi
+
+  _ca_append_status=0
+  python3 -I - "$_NEMOCLAW_CORPORATE_CA_FILE" "$_tmp" <<'PY_APPEND_CORPORATE_CA' || _ca_append_status=$?
+import errno
+import os
+import stat
+import sys
+
+source, target = sys.argv[1], sys.argv[2]
+try:
+    descriptor = os.open(source, os.O_RDONLY | os.O_NOFOLLOW)
+except OSError as error:
+    raise SystemExit(2 if error.errno == errno.ELOOP else 3)
+try:
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        raise SystemExit(2)
+    with open(target, "ab") as merged:
+        while True:
+            chunk = os.read(descriptor, 65536)
+            if not chunk:
+                break
+            merged.write(chunk)
+finally:
+    os.close(descriptor)
+PY_APPEND_CORPORATE_CA
+  if [ "$_ca_append_status" -eq 2 ]; then
+    rm -f "$_tmp"
+    echo "[nemoclaw] refusing corporate CA at ${_NEMOCLAW_CORPORATE_CA_FILE}; expected a regular file, not a symlink (#8650)" >&2
+    exit 1
+  fi
+  if [ "$_ca_append_status" -ne 0 ]; then
+    rm -f "$_tmp"
+    _nemoclaw_ca_merge_warn "append corporate CA"
+    return 0
+  fi
+  chmod 0444 "$_tmp" 2>/dev/null || {
+    rm -f "$_tmp"
+    _nemoclaw_ca_merge_warn "set merged bundle permissions (${_merged})"
+    return 0
+  }
+  if [ -L "$_merged" ]; then
+    rm -f "$_merged" 2>/dev/null || true
+  fi
+  mv -f "$_tmp" "$_merged" 2>/dev/null || {
+    rm -f "$_tmp"
+    _nemoclaw_ca_merge_warn "install merged bundle (${_merged})"
+    return 0
+  }
+
+  export SSL_CERT_FILE="$_merged"
+  export CURL_CA_BUNDLE="$_merged"
+  export REQUESTS_CA_BUNDLE="$_merged"
+  export GIT_SSL_CAINFO="$_merged"
+  export NODE_EXTRA_CA_CERTS="$_merged"
+  export _NEMOCLAW_CORPORATE_CA_MERGED=1
+  echo "[nemoclaw] merged corporate proxy CA into sandbox trust bundle (#6210)" >&2
+}

--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -3200,131 +3200,20 @@ export no_proxy="$_NO_PROXY_VAL"
 # #1828 OpenShell CA behavior stays intact) — and repoint the CA env vars at
 # the merged bundle so curl/python/git/node all trust both roots.
 _NEMOCLAW_CORPORATE_CA_FILE="/usr/local/share/nemoclaw/corporate-ca.pem"
-# Concise, secret-free warning when a baked corporate CA fails to merge at
-# runtime. Names the failed step + target path only (never certificate bytes)
-# so an operator can distinguish "no CA was baked" from "runtime merge failed".
-_nemoclaw_ca_merge_warn() {
-  echo "[nemoclaw] WARNING: corporate proxy CA merge failed at ${1}; keeping OpenShell-only trust — external TLS through the corporate proxy may fail (#6210)" >&2
-}
-merge_corporate_proxy_ca() {
-  # Trust-anchor tampering (#8650): replacing the baked corporate CA file with a
-  # symlink makes the merge below read the link target instead, adding
-  # attacker-selected bytes to the trust bundle that curl, python, git, and node
-  # verify against. The image bakes this path as a root-owned 0444 regular file,
-  # so a symlink here is never a legitimate state. This is not the recoverable
-  # "merge failed" case below, which safely keeps OpenShell-only trust, so it
-  # fails closed instead of warning.
-  if [ -L "$_NEMOCLAW_CORPORATE_CA_FILE" ]; then
-    echo "[nemoclaw] refusing symlinked corporate CA at ${_NEMOCLAW_CORPORATE_CA_FILE}; expected a regular file (#8650)" >&2
-    exit 1
-  fi
-  [ -s "$_NEMOCLAW_CORPORATE_CA_FILE" ] || return 0
-  _base_bundle=""
-  if [ -n "${SSL_CERT_FILE:-}" ] && [ -f "${SSL_CERT_FILE}" ]; then
-    _base_bundle="$SSL_CERT_FILE"
-  elif [ -f /etc/ssl/certs/ca-certificates.crt ]; then
-    _base_bundle="/etc/ssl/certs/ca-certificates.crt"
-  fi
-  _merged="/tmp/nemoclaw-ca-bundle.pem"
-  # Trust-anchor path safety (#6210): in the normal container start this
-  # entrypoint runs as root (the step-down prefix wraps only the later agent
-  # commands, not this top-level merge), so the merged bundle is written
-  # root-owned 0444 — the non-root sandbox user that the agent later runs as
-  # inherits SSL_CERT_FILE but cannot rewrite it. The predictable /tmp path is
-  # still handled safely: it is built in a fresh mktemp sibling and atomically
-  # renamed into place; a pre-planted symlink at the target is dropped first
-  # (below); and rename(2) replaces the target link/file rather than writing
-  # through it, so a pre-planted symlink or file cannot redirect the write. On a
-  # non-root start the whole entrypoint (and the agent) is the same sandbox user,
-  # so there is no privilege boundary to cross.
-  # Build the bundle in a private temp file next to the target, verifying every
-  # write, then atomically rename into place. If any step fails we bail without
-  # exporting anything, leaving the OpenShell-only trust intact rather than
-  # pointing tools at a partial/empty bundle.
-  _tmp="$(mktemp "${_merged}.XXXXXX" 2>/dev/null)" || {
-    _nemoclaw_ca_merge_warn "create temp bundle (${_merged})"
-    return 0
-  }
-  if [ -n "$_base_bundle" ]; then
-    cat "$_base_bundle" >>"$_tmp" 2>/dev/null || {
-      rm -f "$_tmp"
-      _nemoclaw_ca_merge_warn "append OpenShell bundle"
-      return 0
-    }
-    printf '\n' >>"$_tmp" 2>/dev/null || {
-      rm -f "$_tmp"
-      _nemoclaw_ca_merge_warn "append OpenShell bundle"
-      return 0
-    }
-  fi
-  # Append through a descriptor opened with O_NOFOLLOW and verified as a regular
-  # file (#8650). The check above rejects a planted symlink; this rejects one
-  # swapped in afterwards, because the type check and the read share one
-  # descriptor and no path is resolved twice. Status 2 means the source was
-  # rejected as a trust anchor; any other non-zero status is an ordinary read
-  # failure that keeps the existing warn-and-continue behavior.
-  _ca_append_status=0
-  python3 -I - "$_NEMOCLAW_CORPORATE_CA_FILE" "$_tmp" <<'PY_APPEND_CORPORATE_CA' || _ca_append_status=$?
-import errno
-import os
-import stat
-import sys
-
-source, target = sys.argv[1], sys.argv[2]
-try:
-    descriptor = os.open(source, os.O_RDONLY | os.O_NOFOLLOW)
-except OSError as error:
-    raise SystemExit(2 if error.errno == errno.ELOOP else 3)
-try:
-    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-        raise SystemExit(2)
-    with open(target, "ab") as merged:
-        while True:
-            chunk = os.read(descriptor, 65536)
-            if not chunk:
-                break
-            merged.write(chunk)
-finally:
-    os.close(descriptor)
-PY_APPEND_CORPORATE_CA
-  if [ "$_ca_append_status" -eq 2 ]; then
-    rm -f "$_tmp"
-    echo "[nemoclaw] refusing corporate CA at ${_NEMOCLAW_CORPORATE_CA_FILE}; expected a regular file, not a symlink (#8650)" >&2
-    exit 1
-  fi
-  if [ "$_ca_append_status" -ne 0 ]; then
-    rm -f "$_tmp"
-    _nemoclaw_ca_merge_warn "append corporate CA"
-    return 0
-  fi
-  chmod 0444 "$_tmp" 2>/dev/null || {
-    rm -f "$_tmp"
-    _nemoclaw_ca_merge_warn "set merged bundle permissions (${_merged})"
-    return 0
-  }
-  # Defense-in-depth for the predictable /tmp path (#6210): if a co-tenant
-  # pre-planted a symlink at the target, drop it first so we rename into a fresh
-  # regular file we own rather than through an attacker-controlled link.
-  if [ -L "$_merged" ]; then
-    rm -f "$_merged" 2>/dev/null || true
-  fi
-  mv -f "$_tmp" "$_merged" 2>/dev/null || {
-    rm -f "$_tmp"
-    _nemoclaw_ca_merge_warn "install merged bundle (${_merged})"
-    return 0
-  }
-  export SSL_CERT_FILE="$_merged"
-  export CURL_CA_BUNDLE="$_merged"
-  export REQUESTS_CA_BUNDLE="$_merged"
-  export GIT_SSL_CAINFO="$_merged"
-  export NODE_EXTRA_CA_CERTS="$_merged"
-  export _NEMOCLAW_CORPORATE_CA_MERGED=1
-  echo "[nemoclaw] merged corporate proxy CA into sandbox trust bundle (#6210)" >&2
-}
+_NEMOCLAW_CORPORATE_CA_HELPER="/usr/local/lib/nemoclaw/corporate-ca-runtime.sh"
+if [ ! -f "$_NEMOCLAW_CORPORATE_CA_HELPER" ]; then
+  _NEMOCLAW_CORPORATE_CA_HELPER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/corporate-ca-runtime.sh"
+fi
+if [ ! -f "$_NEMOCLAW_CORPORATE_CA_HELPER" ] || [ -L "$_NEMOCLAW_CORPORATE_CA_HELPER" ]; then
+  echo "[nemoclaw] required corporate CA runtime helper is missing or unsafe" >&2
+  exit 1
+fi
+# shellcheck source=scripts/lib/corporate-ca-runtime.sh
+source "$_NEMOCLAW_CORPORATE_CA_HELPER"
 if [ "${NEMOCLAW_MANAGED_STARTUP_APPLIED:-0}" != "1" ]; then
   merge_corporate_proxy_ca
 fi
-
+unset _NEMOCLAW_CORPORATE_CA_HELPER
 # Git TLS CA bundle fix (NemoClaw#2270).
 # OpenShell's L7 proxy does MITM TLS termination and re-signs with its own CA.
 # OpenShell injects SSL_CERT_FILE and CURL_CA_BUNDLE pointing at the CA bundle,

--- a/test/corporate-ca-runtime-merge.test.ts
+++ b/test/corporate-ca-runtime-merge.test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { runShellLines, sliceBlock } from "./helpers/corporate-ca-support";
+import { runCorporateCaHelperGuard, runShellLines, sliceBlock } from "./helpers/corporate-ca-support";
 
 const OPENCLAW_START = join(import.meta.dirname, "../scripts/nemoclaw-start.sh");
 const HERMES_START = join(import.meta.dirname, "../agents/hermes/start.sh");
@@ -41,6 +41,21 @@ function mergeBlock(scriptPath: string, endMarker: string, corpCa: string, merge
 
 const OPENCLAW_END = "# Git TLS CA bundle fix (NemoClaw#2270).";
 const HERMES_END = "# OpenShell injects SSL_CERT_FILE/CURL_CA_BUNDLE for its L7 proxy CA.";
+
+describe("corporate proxy CA runtime helper guard (#8292)", () => {
+  it.each(["missing", "symlink"] as const)(
+    "exits before sourcing or merging when the deployed helper is %s and fallback is unavailable",
+    (deployedMode) => {
+      const dir = tmpDir(`nemoclaw-corp-helper-${deployedMode}-`);
+      const result = runCorporateCaHelperGuard(OPENCLAW_START, dir, deployedMode);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("required corporate CA runtime helper is missing or unsafe");
+      expect(result.stderr).not.toContain(result.secret);
+      expect(existsSync(result.mergedPath)).toBe(false);
+    },
+  );
+});
 
 /**
  * Run a merge block whose stderr is captured to a file, and return that

--- a/test/corporate-ca-runtime-merge.test.ts
+++ b/test/corporate-ca-runtime-merge.test.ts
@@ -43,11 +43,16 @@ const OPENCLAW_END = "# Git TLS CA bundle fix (NemoClaw#2270).";
 const HERMES_END = "# OpenShell injects SSL_CERT_FILE/CURL_CA_BUNDLE for its L7 proxy CA.";
 
 describe("corporate proxy CA runtime helper guard (#8292)", () => {
-  it.each(["missing", "symlink"] as const)(
-    "exits before sourcing or merging when the deployed helper is %s and fallback is unavailable",
-    (deployedMode) => {
-      const dir = tmpDir(`nemoclaw-corp-helper-${deployedMode}-`);
-      const result = runCorporateCaHelperGuard(OPENCLAW_START, dir, deployedMode);
+  it.each([
+    { agent: "OpenClaw", script: OPENCLAW_START, end: OPENCLAW_END, mode: "missing" as const },
+    { agent: "OpenClaw", script: OPENCLAW_START, end: OPENCLAW_END, mode: "symlink" as const },
+    { agent: "Hermes", script: HERMES_START, end: HERMES_END, mode: "missing" as const },
+    { agent: "Hermes", script: HERMES_START, end: HERMES_END, mode: "symlink" as const },
+  ])(
+    "exits $agent before sourcing or merging when the deployed helper is $mode and fallback is unavailable",
+    ({ agent, script, end, mode }) => {
+      const dir = tmpDir(`nemoclaw-${agent.toLowerCase()}-helper-${mode}-`);
+      const result = runCorporateCaHelperGuard(script, dir, mode, end);
 
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("required corporate CA runtime helper is missing or unsafe");

--- a/test/helpers/corporate-ca-support.ts
+++ b/test/helpers/corporate-ca-support.ts
@@ -334,11 +334,11 @@ export function runCorporateCaHelperGuard(
   scriptPath: string,
   dir: string,
   deployedMode: "missing" | "symlink",
+  endMarker: string,
 ): { status: number; stderr: string; mergedPath: string; secret: string } {
   const src = fs.readFileSync(scriptPath, "utf-8");
   const startMarker =
     '_NEMOCLAW_CORPORATE_CA_HELPER="/usr/local/lib/nemoclaw/corporate-ca-runtime.sh"';
-  const endMarker = "# Git TLS CA bundle fix (NemoClaw#2270).";
   const start = src.indexOf(startMarker);
   const end = src.indexOf(endMarker, start);
   if (start === -1 || end === -1 || end <= start) {

--- a/test/helpers/corporate-ca-support.ts
+++ b/test/helpers/corporate-ca-support.ts
@@ -19,7 +19,15 @@ export function sliceBlock(scriptPath: string, startMarker: string, endMarker: s
   if (start === -1 || end === -1 || end <= start) {
     throw new Error(`Failed to extract block [${startMarker} .. ${endMarker}] from ${scriptPath}`);
   }
-  return src.slice(start, end);
+  const block = src.slice(start, end);
+  const sourceCommand = 'source "$_NEMOCLAW_CORPORATE_CA_HELPER"';
+  if (!block.includes(sourceCommand)) return block;
+
+  const helperPath = path.join(import.meta.dirname, "../../scripts/lib/corporate-ca-runtime.sh");
+  const helperSource = fs.readFileSync(helperPath, "utf-8");
+  return block
+    .replaceAll("/usr/local/lib/nemoclaw/corporate-ca-runtime.sh", helperPath)
+    .replace(sourceCommand, helperSource);
 }
 
 export interface CaMaterial {

--- a/test/helpers/corporate-ca-support.ts
+++ b/test/helpers/corporate-ca-support.ts
@@ -328,3 +328,47 @@ export function runShellLines(dir: string, lines: string[]): string {
   });
   return execFileSync("bash", [script], { encoding: "utf-8" });
 }
+
+/** Execute the shipped helper guard with an unavailable fallback. */
+export function runCorporateCaHelperGuard(
+  scriptPath: string,
+  dir: string,
+  deployedMode: "missing" | "symlink",
+): { status: number; stderr: string; mergedPath: string; secret: string } {
+  const src = fs.readFileSync(scriptPath, "utf-8");
+  const startMarker =
+    '_NEMOCLAW_CORPORATE_CA_HELPER="/usr/local/lib/nemoclaw/corporate-ca-runtime.sh"';
+  const endMarker = "# Git TLS CA bundle fix (NemoClaw#2270).";
+  const start = src.indexOf(startMarker);
+  const end = src.indexOf(endMarker, start);
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(`Failed to extract corporate CA helper guard from ${scriptPath}`);
+  }
+
+  const deployedPath = path.join(dir, "deployed-corporate-ca-runtime.sh");
+  const mergedPath = path.join(dir, "merged-ca.pem");
+  const secret = "CA-MATERIAL-MUST-NOT-LEAK";
+  if (deployedMode === "symlink") {
+    const sentinelHelper = path.join(dir, "sentinel-helper.sh");
+    fs.writeFileSync(
+      sentinelHelper,
+      [
+        `printf '%s\\n' ${JSON.stringify(secret)} >&2`,
+        `printf 'sourced\\n' >${JSON.stringify(mergedPath)}`,
+        `merge_corporate_proxy_ca() { printf 'merged\\n' >${JSON.stringify(mergedPath)}; }`,
+      ].join("\n"),
+      { mode: 0o600 },
+    );
+    fs.symlinkSync(sentinelHelper, deployedPath);
+  }
+
+  const block = src
+    .slice(start, end)
+    .replaceAll("/usr/local/lib/nemoclaw/corporate-ca-runtime.sh", deployedPath);
+  const wrapper = path.join(dir, "helper-guard.sh");
+  fs.writeFileSync(wrapper, ["#!/usr/bin/env bash", "set -euo pipefail", block].join("\n"), {
+    mode: 0o700,
+  });
+  const result = spawnSync("bash", [wrapper], { encoding: "utf-8" });
+  return { status: result.status ?? -1, stderr: result.stderr ?? "", mergedPath, secret };
+}

--- a/test/hermes-final-image-layout.test.ts
+++ b/test/hermes-final-image-layout.test.ts
@@ -275,6 +275,7 @@ describe("Hermes final image layout", () => {
           "COPY --from=mcp-tool-discovery-runtime /opt/mcp-tool-discovery-runtime/dist/ /usr/local/lib/nemoclaw/mcp-tool-discovery-runtime/",
           "COPY nemoclaw-blueprint/ /opt/nemoclaw-blueprint/",
           "COPY scripts/lib/sandbox-init.sh /usr/local/lib/nemoclaw/sandbox-init.sh",
+          "COPY --chmod=0444 scripts/lib/corporate-ca-runtime.sh /usr/local/lib/nemoclaw/corporate-ca-runtime.sh",
           "COPY scripts/lib/entrypoint-env-wrapper.sh /usr/local/lib/nemoclaw/entrypoint-env-wrapper.sh",
           "COPY scripts/lib/gateway-supervisor.sh /usr/local/lib/nemoclaw/gateway-supervisor.sh",
           "COPY scripts/lib/sandbox-rlimits.sh /usr/local/lib/nemoclaw/sandbox-rlimits.sh",

--- a/test/openclaw-final-image-layout.test.ts
+++ b/test/openclaw-final-image-layout.test.ts
@@ -89,6 +89,7 @@ describe("OpenClaw final image layout", () => {
         stage: "openclaw-runtime-payload",
         copies: [
           "COPY scripts/lib/sandbox-init.sh /usr/local/lib/nemoclaw/sandbox-init.sh",
+          "COPY --chmod=0444 scripts/lib/corporate-ca-runtime.sh /usr/local/lib/nemoclaw/corporate-ca-runtime.sh",
           "COPY scripts/lib/entrypoint-env-wrapper.sh /usr/local/lib/nemoclaw/entrypoint-env-wrapper.sh",
           "COPY scripts/lib/gateway-supervisor.sh /usr/local/lib/nemoclaw/gateway-supervisor.sh",
           "COPY scripts/lib/sandbox-rlimits.sh /usr/local/lib/nemoclaw/sandbox-rlimits.sh",


### PR DESCRIPTION
## Summary

Share the fail-closed corporate-proxy CA runtime merge between the OpenClaw and Hermes entrypoints. Both images now project the same reviewed helper as a read-only file while preserving the existing trust-anchor, atomic-write, and environment contracts.

## Related Issue

Contributes to #8292.

## Changes

- Move the duplicated corporate-CA merge implementation into `scripts/lib/corporate-ca-runtime.sh` without changing its symlink rejection, descriptor-bound `O_NOFOLLOW` read, atomic installation, or five CA environment exports.
- Copy the helper into both runtime payloads with mode `0444` and keep repository-relative fallbacks only for source-tree execution.
- Keep the existing behavioral/TLS tests on the shipped helper, extend both image-layout contracts, and cover missing and symlinked deployed helpers in both OpenClaw and Hermes. The patch removes 111 net lines.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is an internal behavior-preserving extraction; the existing corporate-CA guide describes the runtime contract rather than its former inline location.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed latest PR commit `7f5af7506` and found no blocking security change. The complete nine-file diff preserves trust-anchor symlink/TOCTOU safety, root-owned `0444` image projection, atomic bundle installation, secret-free failure output, and OpenClaw/Hermes behavior; the final test-only delta adds the Hermes missing/symlink helper parity that the prior maintainer review identified as a non-blocking coverage improvement.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Codex Desktop reviewed latest PR commit `7f5af7506`, the complete nine-file diff, and current `AGENTS.md` blob `e30afb270`; `docs/security/configure-corporate-ca-trust.mdx` remains accurate because no user-visible behavior, command, or trust contract changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7f5af7506 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/corporate-ca-runtime-merge.test.ts test/corporate-ca-tls-e2e.test.ts test/openclaw-final-image-layout.test.ts test/hermes-final-image-layout.test.ts` (38 passed)
- [x] Applicable broad gate passed — `npm run validate:pr`
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ho Lim <subhoya@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved corporate certificate handling during application startup.
  * Startup now fails safely when certificate configuration is missing, invalid, or tampered with.
  * Certificate bundles are assembled securely and replaced only after successful completion.
  * Runtime images now include the shared certificate helper as a read-only file.

* **Tests**
  * Added coverage for helper safeguards, secret protection, and incomplete certificate prevention.
  * Verified secure inclusion and permissions in final runtime images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
