### PR TITLE
fix(cli): accept repeated OpenClaw final sequence

### DIFF
--- a/src/lib/voice-gateway/openclaw-client.test.ts
+++ b/src/lib/voice-gateway/openclaw-client.test.ts
@@ -210,7 +210,7 @@ describe("OpenClaw voice gateway client", () => {
     const { result, events, socket } = await runTurn(
       replyHandlers([
         { seq: 2, state: "delta", deltaText: "world", message: assistantMessage("Hello world") },
-        { seq: 7, state: "delta", deltaText: "!", message: assistantMessage("Hello world!") },
+        { seq: 7, state: "delta", deltaText: "", message: assistantMessage("Hello world") },
         {
           sessionKey: "other-session",
           seq: 7,

--- a/src/lib/voice-gateway/openclaw-client.test.ts
+++ b/src/lib/voice-gateway/openclaw-client.test.ts
@@ -206,6 +206,32 @@ describe("OpenClaw voice gateway client", () => {
     expect(events).toEqual([{ type: "started" }, { type: "text", text: "Hello world" }]);
   });
 
+  it("accepts a final response that repeats the last sequence and contains assistant text (#9243)", async () => {
+    const { result, events, socket } = await runTurn(
+      replyHandlers([
+        { seq: 2, state: "delta", deltaText: "world", message: assistantMessage("Hello world") },
+        { seq: 7, state: "delta", deltaText: "!", message: assistantMessage("Hello world!") },
+        {
+          sessionKey: "other-session",
+          seq: 7,
+          state: "final",
+          message: assistantMessage("discarded session"),
+        },
+        {
+          runId: "other-run",
+          seq: 7,
+          state: "final",
+          message: assistantMessage("discarded run"),
+        },
+        { seq: 7, state: "final", message: assistantMessage("Hello world!") },
+      ]),
+    );
+
+    expect(result).toEqual({ outcome: "completed" });
+    expect(events).toEqual([{ type: "started" }, { type: "text", text: "Hello world!" }]);
+    expect(socket.closed).toBe(true);
+  });
+
   it("accepts schema-minimum deltas without optional messages (#8482)", async () => {
     const { result, events } = await runTurn(
       replyHandlers([
@@ -270,7 +296,7 @@ describe("OpenClaw voice gateway client", () => {
     ["duplicate", 1],
     ["decreasing", 0],
   ])("rejects a %s sequence before returning response text (#8482)", async (_name, sequence) => {
-    const { result, events } = await runTurn(
+    const { result, events, socket } = await runTurn(
       replyHandlers([
         { seq: 1, state: "delta", deltaText: "first" },
         { seq: sequence, state: "delta", deltaText: "second" },
@@ -279,6 +305,37 @@ describe("OpenClaw voice gateway client", () => {
 
     expect(result).toEqual({ outcome: "failed", reason: "agent_protocol_error" });
     expect(events).toEqual([{ type: "started" }]);
+    expect(socket.closed).toBe(true);
+  });
+
+  it("rejects a final response with a lower sequence (#9243)", async () => {
+    const { result, events, socket } = await runTurn(
+      replyHandlers([
+        { seq: 7, state: "delta", deltaText: "first" },
+        { seq: 6, state: "final", message: assistantMessage("complete") },
+      ]),
+    );
+
+    expect(result).toEqual({ outcome: "failed", reason: "agent_protocol_error" });
+    expect(events).toEqual([{ type: "started" }]);
+    expect(socket.closed).toBe(true);
+  });
+
+  it.each([
+    ["no message", undefined],
+    ["a user message", { role: "user", content: [{ type: "text", text: "untrusted" }] }],
+    ["non-text assistant content", { role: "assistant", content: [{ type: "image" }] }],
+  ])("rejects an equal-sequence final response with %s (#9243)", async (_name, message) => {
+    const { result, events, socket } = await runTurn(
+      replyHandlers([
+        { seq: 7, state: "delta", deltaText: "partial" },
+        { seq: 7, state: "final", message },
+      ]),
+    );
+
+    expect(result).toEqual({ outcome: "failed", reason: "agent_protocol_error" });
+    expect(events).toEqual([{ type: "started" }]);
+    expect(socket.closed).toBe(true);
   });
 
   it("discards malformed frames for another session or run before projection checks (#8482)", async () => {
@@ -311,6 +368,20 @@ describe("OpenClaw voice gateway client", () => {
 
     expect(result).toEqual({ outcome: "failed", reason: "response_too_large" });
     expect(events).toEqual([{ type: "started" }]);
+  });
+
+  it("rejects an oversized equal-sequence final response (#9243)", async () => {
+    const chunk = "x".repeat(VOICE_CHUNK_BYTES);
+    const { result, events, socket } = await runTurn(
+      replyHandlers([
+        { seq: 7, state: "delta", deltaText: "partial" },
+        { seq: 7, state: "final", message: assistantMessage(`${chunk}${chunk}`) },
+      ]),
+    );
+
+    expect(result).toEqual({ outcome: "failed", reason: "response_too_large" });
+    expect(events).toEqual([{ type: "started" }]);
+    expect(socket.closed).toBe(true);
   });
 
   it("rejects too many queued chat events before the run ID is admitted (#8482)", async () => {

--- a/src/lib/voice-gateway/openclaw-client.ts
+++ b/src/lib/voice-gateway/openclaw-client.ts
@@ -167,18 +167,21 @@ export class OpenClawVoiceClient implements AgentTurnClient {
       }
 
       const sequence = payload.seq;
+      const state = payload.state;
+      const finalSnapshot = state === "final" ? textFromAssistantMessage(payload.message) : null;
+      const repeatsLastSequence = lastSequence !== null && sequence === lastSequence;
       if (
         typeof sequence !== "number" ||
         !Number.isInteger(sequence) ||
         sequence < 0 ||
-        (lastSequence !== null && sequence <= lastSequence)
+        (lastSequence !== null && sequence < lastSequence) ||
+        (repeatsLastSequence && finalSnapshot === null)
       ) {
         finish({ outcome: "failed", reason: "agent_protocol_error" });
         return;
       }
       lastSequence = sequence;
 
-      const state = payload.state;
       if (state === "delta") {
         if (
           typeof payload.deltaText !== "string" ||
@@ -200,8 +203,7 @@ export class OpenClawVoiceClient implements AgentTurnClient {
       }
 
       if (state === "final") {
-        const snapshot = textFromAssistantMessage(payload.message);
-        if (snapshot !== null) projectedText = snapshot;
+        if (finalSnapshot !== null) projectedText = finalSnapshot;
         if (Buffer.byteLength(projectedText) > VOICE_GATEWAY_MAX_RESPONSE_BYTES) {
           finish({ outcome: "failed", reason: "response_too_large" });
           return;

--- a/test/fixtures/voice-gateway/pinned-openclaw-gateway.ts
+++ b/test/fixtures/voice-gateway/pinned-openclaw-gateway.ts
@@ -78,8 +78,8 @@ export class PinnedOpenClawGateway {
       runId: "pinned-openclaw-run",
       seq: 7,
       state: "delta",
-      deltaText: "!",
-      message: this.assistantMessage("Hello world!"),
+      deltaText: "",
+      message: this.assistantMessage("Hello world"),
     });
     this.chat({
       sessionKey,

--- a/test/fixtures/voice-gateway/pinned-openclaw-gateway.ts
+++ b/test/fixtures/voice-gateway/pinned-openclaw-gateway.ts
@@ -8,7 +8,7 @@ interface SentRequest {
   readonly params: Record<string, unknown>;
 }
 
-/** Emits the pinned OpenClaw v2026.7.1 chat shape after one omitted delta. */
+/** Emits chat events for pinned OpenClaw v2026.7.1, including a repeated final sequence. */
 export class PinnedOpenClawGateway {
   onopen: (() => void) | null = null;
   onmessage: ((event: { readonly data: unknown }) => void) | null = null;
@@ -76,9 +76,17 @@ export class PinnedOpenClawGateway {
     this.chat({
       sessionKey,
       runId: "pinned-openclaw-run",
-      seq: 3,
+      seq: 7,
+      state: "delta",
+      deltaText: "!",
+      message: this.assistantMessage("Hello world!"),
+    });
+    this.chat({
+      sessionKey,
+      runId: "pinned-openclaw-run",
+      seq: 7,
       state: "final",
-      message: this.assistantMessage("Hello world"),
+      message: this.assistantMessage("Hello world!"),
     });
   }
 

--- a/test/voice-gateway-integration.test.ts
+++ b/test/voice-gateway-integration.test.ts
@@ -119,7 +119,7 @@ afterEach(async () => {
 });
 
 describe("experimental voice gateway composed boundary", () => {
-  it("recovers an omitted OpenClaw delta before completing the pinned runtime turn (#8482)", async () => {
+  it("recovers an omitted delta when a final event repeats the last sequence (#9243)", async () => {
     let pinnedOpenClaw: PinnedOpenClawGateway | undefined;
     const diagnostics: object[] = [];
     const ids = ["voice-session", "agent-session", "turn", "response"];
@@ -156,7 +156,7 @@ describe("experimental voice gateway composed boundary", () => {
     const events = await runtime.commitTurn(session, "runtime-commit", "repository status");
     await runtime.closeSession(session);
 
-    expect(output).toEqual(["Hello world"]);
+    expect(output).toEqual(["Hello world!"]);
     expect(events.map((event) => (event as { type: string }).type)).toEqual([
       "response.started",
       "response.text.delta",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The experimental OpenClaw voice gateway now completes a turn when a correlated final event repeats the last delta sequence and contains recognized assistant text. It still rejects duplicate response parts, lower sequence numbers, final messages without recognized assistant text, and oversized responses.

## Related Issue

Fixes #9243

## Changes

- Allow one final OpenClaw event to repeat the last sequence after exact session and run filtering and assistant-text parsing.
- Preserve lower-sequence, duplicate-delta, malformed-message, response-size, terminal-event, and cleanup controls.
- Update the pinned OpenClaw fixture to emit `delta 2`, `delta 7`, and `final 7`, with focused positive and negative regression tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This change corrects internal native-event validation for the experimental adapter. The documented normalized response contract does not define OpenClaw sequence ordering and remains unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop reviewed the changed native-frame validation against the repository security rubric. Focused tests preserve exact session and run filtering, fail-closed ordering and message validation, response bounds, terminal-event uniqueness, cleanup, and diagnostic redaction.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing documentation defines normalized response events and identifies the hidden adapter as experimental. It does not define native OpenClaw sequence ordering. The review found no stale documentation or changed-text findings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 812810af6 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `./node_modules/.bin/vitest run --project cli src/lib/voice-gateway/openclaw-client.test.ts src/lib/voice-gateway/session-service.test.ts` passed 32 tests; `./node_modules/.bin/vitest run --project integration test/voice-gateway-integration.test.ts` passed 3 tests; `npm run typecheck:cli` and `npm run checks:repository` passed. A live turn on commit `6b20f0937` with OpenClaw `2026.7.1` emitted deltas `2`, `7`, `15`, then final `15`; NemoClaw returned one completion, no failure, non-empty normalized text, and redacted diagnostics.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — Not run; focused parser and composed-boundary tests cover the changed behavior.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved voice response recovery when a final event repeats the previous sequence number.
  - Ensured valid final assistant messages are reconciled correctly, including omitted text updates.
  - Continued rejecting invalid, decreasing, oversized, or mismatched response events.
  - Improved connection cleanup when protocol errors occur.

- **Tests**
  - Added coverage for repeated-sequence final responses and reconstructed voice output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->