### PR TITLE
refactor(core): share service port catalog

### DIFF
--- a/src/lib/core/ports.ts
+++ b/src/lib/core/ports.ts
@@ -111,9 +111,9 @@ interface ServicePortDefinition {
 }
 
 /**
- * Services that participate in host-port collision validation. Dashboard and
- * gateway defaults remain reusable; inference and adapter defaults are
- * reserved even when their corresponding service is reconfigured.
+ * Services that participate in host-port collision validation. The gateway
+ * default is reusable after the gateway is reconfigured, while the dashboard
+ * allocation range and inference and adapter defaults remain reserved.
  */
 const SERVICE_PORT_CATALOG: readonly ServicePortDefinition[] = [
   {

--- a/src/lib/core/ports.ts
+++ b/src/lib/core/ports.ts
@@ -42,6 +42,11 @@ export interface RuntimeAdapterPortValidationOptions extends GatewayPortValidati
   gatewayPort: number;
 }
 
+type PortValidationOptions = GatewayPortValidationOptions | RuntimeAdapterPortValidationOptions;
+
+/** Default OpenShell gateway port when NEMOCLAW_GATEWAY_PORT is unset. */
+export const DEFAULT_GATEWAY_PORT = 8080;
+
 /**
  * The default port the OpenClaw dashboard listens on inside the sandbox.
  * The sandbox image is built with CHAT_UI_URL=http://127.0.0.1:SANDBOX_DASHBOARD_PORT
@@ -97,10 +102,90 @@ export const HTTPS_PIN_RUNTIME_ADAPTER_PORT = parsePort(
   11438,
 );
 
-export function validateGatewayPort(
+interface ServicePortDefinition {
+  readonly envVar: string | null;
+  readonly label: string;
+  readonly defaultPort: number;
+  readonly reserveDefault: boolean;
+  readonly configuredPort: (options: PortValidationOptions) => number | undefined;
+}
+
+/**
+ * Services that participate in host-port collision validation. Dashboard and
+ * gateway defaults remain reusable; inference and adapter defaults are
+ * reserved even when their corresponding service is reconfigured.
+ */
+const SERVICE_PORT_CATALOG: readonly ServicePortDefinition[] = [
+  {
+    envVar: "NEMOCLAW_GATEWAY_PORT",
+    label: "OpenShell gateway",
+    defaultPort: DEFAULT_GATEWAY_PORT,
+    reserveDefault: false,
+    configuredPort: (options) => ("gatewayPort" in options ? options.gatewayPort : undefined),
+  },
+  {
+    envVar: "NEMOCLAW_DASHBOARD_PORT",
+    label: "dashboard",
+    defaultPort: SANDBOX_DASHBOARD_PORT,
+    reserveDefault: false,
+    configuredPort: (options) => options.dashboardPort,
+  },
+  {
+    envVar: "NEMOCLAW_VLLM_PORT",
+    label: "vLLM / NIM inference",
+    defaultPort: 8000,
+    reserveDefault: true,
+    configuredPort: (options) => options.vllmPort,
+  },
+  {
+    envVar: null,
+    label: "llama.cpp inference",
+    defaultPort: LLAMA_CPP_PORT,
+    reserveDefault: true,
+    configuredPort: () => undefined,
+  },
+  {
+    envVar: "NEMOCLAW_OLLAMA_PORT",
+    label: "Ollama inference",
+    defaultPort: 11434,
+    reserveDefault: true,
+    configuredPort: (options) => options.ollamaPort,
+  },
+  {
+    envVar: "NEMOCLAW_OLLAMA_PROXY_PORT",
+    label: "Ollama auth proxy",
+    defaultPort: 11435,
+    reserveDefault: true,
+    configuredPort: (options) => options.ollamaProxyPort,
+  },
+  {
+    envVar: "NEMOCLAW_BEDROCK_RUNTIME_ADAPTER_PORT",
+    label: "Bedrock Runtime adapter",
+    defaultPort: 11436,
+    reserveDefault: true,
+    configuredPort: (options) => options.bedrockRuntimeAdapterPort,
+  },
+  {
+    envVar: "NEMOCLAW_OPENROUTER_RUNTIME_ADAPTER_PORT",
+    label: "OpenRouter Runtime adapter",
+    defaultPort: 11437,
+    reserveDefault: true,
+    configuredPort: (options) => options.openrouterRuntimeAdapterPort,
+  },
+  {
+    envVar: "NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_PORT",
+    label: "HTTPS Pin Runtime adapter",
+    defaultPort: 11438,
+    reserveDefault: true,
+    configuredPort: (options) => options.httpsPinRuntimeAdapterPort,
+  },
+];
+
+function validateServicePort(
   envVar: string,
   port: number,
-  options: GatewayPortValidationOptions,
+  options: PortValidationOptions,
+  serviceEnvVar: string,
 ): void {
   if (port >= options.dashboardRangeStart && port <= options.dashboardRangeEnd) {
     throw new Error(
@@ -108,46 +193,34 @@ export function validateGatewayPort(
     );
   }
 
-  const reservedDefaults = [
-    { label: "llama.cpp inference", port: LLAMA_CPP_PORT },
-    { label: "vLLM / NIM inference", port: 8000 },
-    { label: "Ollama inference", port: 11434 },
-    { label: "Ollama auth proxy", port: 11435 },
-    { label: "Bedrock Runtime adapter", port: 11436 },
-    { label: "OpenRouter Runtime adapter", port: 11437 },
-    { label: "HTTPS Pin Runtime adapter", port: 11438 },
-  ];
-  const reservedDefault = reservedDefaults.find((entry) => entry.port === port);
+  const reservedDefault = SERVICE_PORT_CATALOG.find(
+    (entry) => entry.reserveDefault && entry.envVar !== serviceEnvVar && entry.defaultPort === port,
+  );
   if (reservedDefault) {
     throw new Error(
-      `Invalid port: ${envVar}="${port}" — must not overlap the ${reservedDefault.label} default port (${reservedDefault.port})`,
+      `Invalid port: ${envVar}="${port}" — must not overlap the ${reservedDefault.label} default port (${reservedDefault.defaultPort})`,
     );
   }
 
-  const conflicts = [
-    { envVar: "NEMOCLAW_DASHBOARD_PORT", port: options.dashboardPort },
-    { envVar: "NEMOCLAW_VLLM_PORT", port: options.vllmPort },
-    { envVar: "NEMOCLAW_OLLAMA_PORT", port: options.ollamaPort },
-    { envVar: "NEMOCLAW_OLLAMA_PROXY_PORT", port: options.ollamaProxyPort },
-    {
-      envVar: "NEMOCLAW_BEDROCK_RUNTIME_ADAPTER_PORT",
-      port: options.bedrockRuntimeAdapterPort,
-    },
-    {
-      envVar: "NEMOCLAW_OPENROUTER_RUNTIME_ADAPTER_PORT",
-      port: options.openrouterRuntimeAdapterPort,
-    },
-    {
-      envVar: "NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_PORT",
-      port: options.httpsPinRuntimeAdapterPort,
-    },
-  ];
-  const conflict = conflicts.find((entry) => entry.port === port);
+  const conflict = SERVICE_PORT_CATALOG.find(
+    (entry) =>
+      entry.envVar !== null &&
+      entry.envVar !== serviceEnvVar &&
+      entry.configuredPort(options) === port,
+  );
   if (conflict) {
     throw new Error(
-      `Invalid port: ${envVar}="${port}" — conflicts with ${conflict.envVar} (${conflict.port})`,
+      `Invalid port: ${envVar}="${port}" — conflicts with ${conflict.envVar} (${port})`,
     );
   }
+}
+
+export function validateGatewayPort(
+  envVar: string,
+  port: number,
+  options: GatewayPortValidationOptions,
+): void {
+  validateServicePort(envVar, port, options, "NEMOCLAW_GATEWAY_PORT");
 }
 
 export function parseGatewayPort(
@@ -165,48 +238,7 @@ export function validateOpenRouterRuntimeAdapterPort(
   port: number,
   options: RuntimeAdapterPortValidationOptions,
 ): void {
-  if (port >= options.dashboardRangeStart && port <= options.dashboardRangeEnd) {
-    throw new Error(
-      `Invalid port: ${envVar}="${port}" — must not overlap the ${options.dashboardRangeStart}-${options.dashboardRangeEnd} dashboard port range`,
-    );
-  }
-
-  const reservedDefaults = [
-    { label: "llama.cpp inference", port: LLAMA_CPP_PORT },
-    { label: "vLLM / NIM inference", port: 8000 },
-    { label: "Ollama inference", port: 11434 },
-    { label: "Ollama auth proxy", port: 11435 },
-    { label: "Bedrock Runtime adapter", port: 11436 },
-    { label: "HTTPS Pin Runtime adapter", port: 11438 },
-  ];
-  const reservedDefault = reservedDefaults.find((entry) => entry.port === port);
-  if (reservedDefault) {
-    throw new Error(
-      `Invalid port: ${envVar}="${port}" — must not overlap the ${reservedDefault.label} default port (${reservedDefault.port})`,
-    );
-  }
-
-  const conflicts = [
-    { envVar: "NEMOCLAW_GATEWAY_PORT", port: options.gatewayPort },
-    { envVar: "NEMOCLAW_DASHBOARD_PORT", port: options.dashboardPort },
-    { envVar: "NEMOCLAW_VLLM_PORT", port: options.vllmPort },
-    { envVar: "NEMOCLAW_OLLAMA_PORT", port: options.ollamaPort },
-    { envVar: "NEMOCLAW_OLLAMA_PROXY_PORT", port: options.ollamaProxyPort },
-    {
-      envVar: "NEMOCLAW_BEDROCK_RUNTIME_ADAPTER_PORT",
-      port: options.bedrockRuntimeAdapterPort,
-    },
-    {
-      envVar: "NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_PORT",
-      port: options.httpsPinRuntimeAdapterPort,
-    },
-  ];
-  const conflict = conflicts.find((entry) => entry.port === port);
-  if (conflict) {
-    throw new Error(
-      `Invalid port: ${envVar}="${port}" — conflicts with ${conflict.envVar} (${conflict.port})`,
-    );
-  }
+  validateServicePort(envVar, port, options, "NEMOCLAW_OPENROUTER_RUNTIME_ADAPTER_PORT");
 }
 
 export function validateHttpsPinRuntimeAdapterPort(
@@ -214,52 +246,8 @@ export function validateHttpsPinRuntimeAdapterPort(
   port: number,
   options: RuntimeAdapterPortValidationOptions,
 ): void {
-  if (port >= options.dashboardRangeStart && port <= options.dashboardRangeEnd) {
-    throw new Error(
-      `Invalid port: ${envVar}="${port}" — must not overlap the ${options.dashboardRangeStart}-${options.dashboardRangeEnd} dashboard port range`,
-    );
-  }
-
-  const reservedDefaults = [
-    { label: "llama.cpp inference", port: LLAMA_CPP_PORT },
-    { label: "vLLM / NIM inference", port: 8000 },
-    { label: "Ollama inference", port: 11434 },
-    { label: "Ollama auth proxy", port: 11435 },
-    { label: "Bedrock Runtime adapter", port: 11436 },
-    { label: "OpenRouter Runtime adapter", port: 11437 },
-  ];
-  const reservedDefault = reservedDefaults.find((entry) => entry.port === port);
-  if (reservedDefault) {
-    throw new Error(
-      `Invalid port: ${envVar}="${port}" — must not overlap the ${reservedDefault.label} default port (${reservedDefault.port})`,
-    );
-  }
-
-  const conflicts = [
-    { envVar: "NEMOCLAW_GATEWAY_PORT", port: options.gatewayPort },
-    { envVar: "NEMOCLAW_DASHBOARD_PORT", port: options.dashboardPort },
-    { envVar: "NEMOCLAW_VLLM_PORT", port: options.vllmPort },
-    { envVar: "NEMOCLAW_OLLAMA_PORT", port: options.ollamaPort },
-    { envVar: "NEMOCLAW_OLLAMA_PROXY_PORT", port: options.ollamaProxyPort },
-    {
-      envVar: "NEMOCLAW_BEDROCK_RUNTIME_ADAPTER_PORT",
-      port: options.bedrockRuntimeAdapterPort,
-    },
-    {
-      envVar: "NEMOCLAW_OPENROUTER_RUNTIME_ADAPTER_PORT",
-      port: options.openrouterRuntimeAdapterPort,
-    },
-  ];
-  const conflict = conflicts.find((entry) => entry.port === port);
-  if (conflict) {
-    throw new Error(
-      `Invalid port: ${envVar}="${port}" — conflicts with ${conflict.envVar} (${conflict.port})`,
-    );
-  }
+  validateServicePort(envVar, port, options, "NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_PORT");
 }
-
-/** Default OpenShell gateway port when NEMOCLAW_GATEWAY_PORT is unset. */
-export const DEFAULT_GATEWAY_PORT = 8080;
 /** OpenShell gateway port (default 8080, override via NEMOCLAW_GATEWAY_PORT). */
 export const GATEWAY_PORT = parseGatewayPort("NEMOCLAW_GATEWAY_PORT", DEFAULT_GATEWAY_PORT, {
   dashboardPort: DASHBOARD_PORT,
@@ -277,26 +265,9 @@ export const GATEWAY_PORT = parseGatewayPort("NEMOCLAW_GATEWAY_PORT", DEFAULT_GA
 export function validateLlamaCppPortReservation(
   options: RuntimeAdapterPortValidationOptions,
 ): void {
-  const configuredPorts = [
-    { envVar: "NEMOCLAW_GATEWAY_PORT", port: options.gatewayPort },
-    { envVar: "NEMOCLAW_DASHBOARD_PORT", port: options.dashboardPort },
-    { envVar: "NEMOCLAW_VLLM_PORT", port: options.vllmPort },
-    { envVar: "NEMOCLAW_OLLAMA_PORT", port: options.ollamaPort },
-    { envVar: "NEMOCLAW_OLLAMA_PROXY_PORT", port: options.ollamaProxyPort },
-    {
-      envVar: "NEMOCLAW_BEDROCK_RUNTIME_ADAPTER_PORT",
-      port: options.bedrockRuntimeAdapterPort,
-    },
-    {
-      envVar: "NEMOCLAW_OPENROUTER_RUNTIME_ADAPTER_PORT",
-      port: options.openrouterRuntimeAdapterPort,
-    },
-    {
-      envVar: "NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_PORT",
-      port: options.httpsPinRuntimeAdapterPort,
-    },
-  ];
-  const conflict = configuredPorts.find(({ port }) => port === LLAMA_CPP_PORT);
+  const conflict = SERVICE_PORT_CATALOG.find(
+    (entry) => entry.envVar !== null && entry.configuredPort(options) === LLAMA_CPP_PORT,
+  );
   if (conflict) {
     throw new Error(
       `Invalid port: ${conflict.envVar}="${LLAMA_CPP_PORT}" — conflicts with the fixed llama.cpp inference port (${LLAMA_CPP_PORT})`,


### PR DESCRIPTION
## Summary

Consolidate NemoClaw's repeated host-service port defaults and collision checks behind one internal catalog. Public validators, environment overrides, rejection order, and error text remain unchanged while the duplicated policy shrinks by 29 lines.

## Related Issue

Contributes to #8292.

## Changes

- Add one internal catalog for the gateway, dashboard, vLLM/NIM, fixed llama.cpp, Ollama/proxy, Bedrock, OpenRouter, and HTTPS-pin ports.
- Route the gateway and runtime-adapter validators through one catalog-driven check while preserving the dashboard allocation range, reserved defaults, configured-port conflicts, validator self-exclusion, and the fixed llama.cpp port `8081` reservation.
- Keep the abstraction local to `src/lib/core/ports.ts`: these validators are the current consumers, and changing each validator directly would preserve the duplicated policy that #8292 asks to centralize. Existing `src/lib/core/ports.test.ts` coverage protects the public behavior and exact conflict messages.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: The refactor changes no public behavior. The 52 existing focused tests exercise parsing bounds, dashboard-range rejection, every reserved default, configured collisions, validator self-exclusion, and the fixed llama.cpp `8081` reservation.
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is an internal behavior-preserving refactor with no command, configuration, output, environment variable, default, or error-message change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex Desktop separately reviewed commit `740fb0d2b` against `origin/main`. The one-file diff preserves the public wrapper signatures, validation order, dashboard range, reserved defaults, configured collision labels, self-exclusions for the gateway/OpenRouter/HTTPS-pin validators, and fixed llama.cpp `8081` rejection; 52 focused tests and the full PR validation pass.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Codex Desktop reviewed commit `740fb0d2b`, the complete one-file diff, and current `AGENTS.md` blob `e30afb270`. The documented port names, environment variables, defaults, ranges, and error behavior are unchanged.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 740fb0d2b -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/core/ports.test.ts` (52 passed)
- [x] Applicable broad gate passed — `npm run validate:pr`
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Ho Lim <subhoya@gmail.com>
