### PR TITLE
fix(e2e): fail an unknown live target instead of collecting nothing

### DIFF
--- a/test/e2e/docs/README.md
+++ b/test/e2e/docs/README.md
@@ -80,13 +80,17 @@ The `generate-matrix` job resolves dispatch input through `requireTargets`, so
 an unknown id fails there before any target job starts.
 
 `test/e2e/live/registry-targets.test.ts` resolves `TARGET_ID` through the same
-registry at module load, which covers a run that sets it another way. An id no
+registry at module load, which covers a run that sets it another way. An ID no
 target declares fails collection with `Unknown target '<id>'. Available
-targets: ...`, and an empty or otherwise unsafe id fails with `Selected target
-ID '<id>' is not safe ...`. Either id would otherwise build a selector that
-matches nothing and exit 0 having executed no target. The check applies to every
-`e2e-live` collection, so a stale `TARGET_ID` in the environment also fails
-`npm run test:live-e2e` and `npm run test:e2e-phases:check`.
+targets: ...`, and an empty ID fails with `Selected target ID '' is not safe
+...`. Without those checks, either ID would build a selector that matches
+nothing and can exit 0 without executing a target. An unsafe ID also fails with
+`Selected target ID '<id>' is not safe ...`; regex-shaped IDs can otherwise
+broaden the selector and run unintended live targets. This module-load guard
+protects the registry-target catalogue when collection includes
+`registry-targets.test.ts`. Both `npm run test:live-e2e` and
+`npm run test:e2e-phases:check` include that file, but a collection command that
+omits it does not run this guard.
 
 A declared target that is not wired for live fixtures still collects. The
 typed-registry matrix reports it as skipped with its `[not wired]` reason and

--- a/test/e2e/docs/README.md
+++ b/test/e2e/docs/README.md
@@ -69,6 +69,31 @@ harness or runner. Vitest remains the only test harness.
 `suiteIds` remain metadata for reporting and migration planning. They do not
 dispatch shell validation suites.
 
+## Selecting One Target
+
+`.github/workflows/e2e.yaml` runs one matrix target by passing its id through
+`TARGET_ID` and selecting the matching test with `-t "^${TARGET_ID}$"`. The
+selector performs the restriction; `TARGET_ID` alone does not limit which
+targets run.
+
+The `generate-matrix` job resolves dispatch input through `requireTargets`, so
+an unknown id fails there before any target job starts.
+
+`test/e2e/live/registry-targets.test.ts` resolves `TARGET_ID` through the same
+registry at module load, which covers a run that sets it another way. An id no
+target declares fails collection with `Unknown target '<id>'. Available
+targets: ...`, and an empty or otherwise unsafe id fails with `Selected target
+ID '<id>' is not safe ...`. Either id would otherwise build a selector that
+matches nothing and exit 0 having executed no target. The check applies to every
+`e2e-live` collection, so a stale `TARGET_ID` in the environment also fails
+`npm run test:live-e2e` and `npm run test:e2e-phases:check`.
+
+A declared target that is not wired for live fixtures still collects. The
+typed-registry matrix reports it as skipped with its `[not wired]` reason and
+exits 0. That exit-0 skip is specific to the typed-registry matrix; the
+catalogue path sets `NEMOCLAW_E2E_REQUIRE_EXECUTED_TEST=1` and exits nonzero
+when its selection runs no tests.
+
 ## How To Run
 
 ```bash

--- a/test/e2e/live/registry-targets.test.ts
+++ b/test/e2e/live/registry-targets.test.ts
@@ -12,7 +12,7 @@ import {
   type LifecycleProfile,
   readRegistrySandboxEntry,
 } from "../fixtures/phases/index.ts";
-import { listTargets } from "../registry/registry.ts";
+import { listTargets, requireTargets } from "../registry/registry.ts";
 import { liveTargetSupport, liveTargetTestName } from "../registry/runtime-support.ts";
 import { cloudExperimentalChecksForOnboarding } from "./cloud-experimental-check-list.ts";
 import { runE2eCloudExperimentalChecks } from "./cloud-experimental-checks.ts";
@@ -42,6 +42,16 @@ process.env.NEMOCLAW_CLI_BIN ??= CLI_ENTRYPOINT;
 // targeted unsupported target at module load so the job log/summary
 // captures it before vitest reports the skipped test by id.
 const SELECTED_TARGET_ID = process.env.TARGET_ID;
+// That selector matches nothing when the id names no registered target, and an
+// empty id builds the selector `-t "^$"`, which also matches nothing. Vitest
+// then filters every test out and the run exits 0, reporting success for a run
+// that executed no target. `generate-matrix` already rejects an unknown id
+// before the dispatch reaches here, so this is the last-mile check for a run
+// that sets TARGET_ID some other way. Resolve the id through the registry and
+// let it name the registered choices (#8286).
+if (SELECTED_TARGET_ID !== undefined) {
+  requireTargets([SELECTED_TARGET_ID]);
+}
 const REGISTRY_TARGET_PHASES = [
   "resolve the target contract and run plan",
   "confirm the target environment is ready",

--- a/test/e2e/live/registry-targets.test.ts
+++ b/test/e2e/live/registry-targets.test.ts
@@ -37,21 +37,22 @@ const E2E_CLOUD_EXPERIMENTAL_CHECKS_DIR = path.join(
 );
 process.env.NEMOCLAW_CLI_BIN ??= CLI_ENTRYPOINT;
 
-// The workflow filters by exact target id via `-t "^${TARGET_ID}$"`.
+// The workflow filters by target ID via `-t "^${TARGET_ID}$"`.
 // When that env is set, surface the structured `[not wired]` reason for the
 // targeted unsupported target at module load so the job log/summary
-// captures it before vitest reports the skipped test by id.
+// captures it before Vitest reports the skipped test by ID.
 const SELECTED_TARGET_ID = process.env.TARGET_ID;
-// That selector matches nothing when the id names no registered target, and an
-// empty id builds the selector `-t "^$"`, which also matches nothing. Vitest
+// That selector matches nothing when the ID names no registered target, and an
+// empty ID builds the selector `-t "^$"`, which also matches nothing. Vitest
 // then filters every test out and the run exits 0, reporting success for a run
-// that executed no target. `generate-matrix` already rejects an unknown id
+// that executed no target. `generate-matrix` already rejects an unknown ID
 // before the dispatch reaches here, so this is the last-mile check for a run
-// that sets TARGET_ID some other way. Resolve the id through the registry and
+// that sets TARGET_ID some other way. Resolve the ID through the registry and
 // let it name the registered choices (#8286).
-if (SELECTED_TARGET_ID !== undefined) {
-  requireTargets([SELECTED_TARGET_ID]);
-}
+const SELECTED_TARGET_IDS = [SELECTED_TARGET_ID].filter(
+  (targetId): targetId is string => targetId !== undefined,
+);
+requireTargets(SELECTED_TARGET_IDS);
 const REGISTRY_TARGET_PHASES = [
   "resolve the target contract and run plan",
   "confirm the target environment is ready",

--- a/test/e2e/support/e2e-live-target-gating.test.ts
+++ b/test/e2e/support/e2e-live-target-gating.test.ts
@@ -9,6 +9,8 @@ import { describe, expect, it } from "vitest";
 
 import { testTimeoutOptions } from "../../helpers/timeouts.ts";
 import { LIVE_E2E_ROOT, REPO_ROOT } from "../fixtures/paths.ts";
+import { listTargets } from "../registry/registry.ts";
+import { liveTargetSupport } from "../registry/runtime-support.ts";
 
 const VITEST = path.join(REPO_ROOT, "node_modules", "vitest", "vitest.mjs");
 const SPECIAL_GATE_ENV = ["NEMOCLAW_ISSUE_4434_LIVE", "NEMOCLAW_MCP_BRIDGE_AGENT"] as const;
@@ -60,6 +62,20 @@ function listLiveTests(options: {
 
 function linesForFile(lines: readonly string[], file: string): string[] {
   return lines.filter((line) => line.startsWith(`[e2e-live] test/e2e/live/${file} >`));
+}
+
+/**
+ * A registered target id. `wired: true` selects one the live fixtures support;
+ * `wired: false` selects a declared placeholder the live matrix skips.
+ */
+function declaredTargetId({ wired }: { wired: boolean }): string {
+  const match = listTargets().find(
+    (registered) => liveTargetSupport(registered).supported === wired,
+  );
+  if (!match) {
+    throw new Error(`registry declares no ${wired ? "wired" : "not wired"} target`);
+  }
+  return match.id;
 }
 
 describe("live E2E target gating", () => {
@@ -166,6 +182,54 @@ describe("live E2E target gating", () => {
     expect(invalid.status).not.toBe(0);
     expect(invalid.stderr).toContain("Unsupported NEMOCLAW_MCP_BRIDGE_AGENT: all");
   });
+
+  it(
+    "rejects a TARGET_ID no registry target declares (#8286)",
+    testTimeoutOptions(30_000),
+    () => {
+      const file = "registry-targets.test.ts";
+
+      // The workflow selects one target with `-t "^${TARGET_ID}$"`. An id no
+      // target declares matches nothing, and an empty id builds `-t "^$"`,
+      // which also matches nothing, so the run would collect no test and
+      // exit 0 having executed no target.
+      const unknown = listLiveTests({
+        enabled: true,
+        env: { TARGET_ID: "does-not-exist" },
+        files: [file],
+      });
+
+      expect(unknown.status, unknown.stdout).not.toBe(0);
+      expect(`${unknown.stdout}${unknown.stderr}`).toContain("Unknown target 'does-not-exist'");
+
+      const empty = listLiveTests({ enabled: true, env: { TARGET_ID: "" }, files: [file] });
+
+      expect(empty.status, empty.stdout).not.toBe(0);
+      expect(`${empty.stdout}${empty.stderr}`).toContain("Selected target ID ''");
+    },
+  );
+
+  it(
+    "collects registry targets for any declared TARGET_ID (#8286)",
+    testTimeoutOptions(30_000),
+    () => {
+      const file = "registry-targets.test.ts";
+
+      // The check rejects only ids the registry does not declare, so a wired id
+      // and a declared placeholder both still collect. Collecting at least one
+      // test proves the file was evaluated rather than skipped outright.
+      for (const wired of [true, false]) {
+        const result = listLiveTests({
+          enabled: true,
+          env: { TARGET_ID: declaredTargetId({ wired }) },
+          files: [file],
+        });
+
+        expect(result.status, result.stderr || result.stdout).toBe(0);
+        expect(linesForFile(result.lines, file).length).toBeGreaterThan(0);
+      }
+    },
+  );
 
   it("applies Linux gates at real Vitest collection", () => {
     const linuxTests = [

--- a/test/e2e/support/e2e-live-target-gating.test.ts
+++ b/test/e2e/support/e2e-live-target-gating.test.ts
@@ -65,17 +65,18 @@ function linesForFile(lines: readonly string[], file: string): string[] {
 }
 
 /**
- * A registered target id. `wired: true` selects one the live fixtures support;
+ * A registered target ID. `wired: true` selects one the live fixtures support;
  * `wired: false` selects a declared placeholder the live matrix skips.
  */
 function declaredTargetId({ wired }: { wired: boolean }): string {
   const match = listTargets().find(
     (registered) => liveTargetSupport(registered).supported === wired,
   );
-  if (!match) {
-    throw new Error(`registry declares no ${wired ? "wired" : "not wired"} target`);
-  }
-  return match.id;
+  return match?.id ?? missingDeclaredTarget(wired);
+}
+
+function missingDeclaredTarget(wired: boolean): never {
+  throw new Error(`registry declares no ${wired ? "wired" : "not wired"} target`);
 }
 
 describe("live E2E target gating", () => {

--- a/test/e2e/support/e2e-live-target-gating.test.ts
+++ b/test/e2e/support/e2e-live-target-gating.test.ts
@@ -206,6 +206,15 @@ describe("live E2E target gating", () => {
 
       expect(empty.status, empty.stdout).not.toBe(0);
       expect(`${empty.stdout}${empty.stderr}`).toContain("Selected target ID ''");
+
+      const unsafe = listLiveTests({
+        enabled: true,
+        env: { TARGET_ID: "unsafe/id" },
+        files: [file],
+      });
+
+      expect(unsafe.status, unsafe.stdout).not.toBe(0);
+      expect(`${unsafe.stdout}${unsafe.stderr}`).toContain("Selected target ID 'unsafe/id'");
     },
   );
 


### PR DESCRIPTION
## Summary

`test/e2e/live/registry-targets.test.ts` runs one target when `TARGET_ID` names it, matching the workflow selector `-t "^${TARGET_ID}$"`. An id no target declares matched nothing, and an empty id built `-t "^$"`, which also matched nothing. Vitest filtered every target out and the run exited 0 having executed no target. Collection now resolves the id through the registry's existing `requireTargets()`, which names the unknown id and the registered choices.

## Related Issue

Refs: #8286

This delivers one of that issue's four acceptance criteria — "An unknown target fails with a specific error instead of an empty skipped test". The other three require deleting the 22 declared targets that are not wired for live fixtures, which the issue itself gates: "Complete the cross-runtime-foundation decision first. A maintainer must confirm that no placeholder represents accepted near-term product scope." I have no such confirmation, and several placeholders name areas with current open work (Hermes, Brev, GPU), so every declaration is left in place. The issue stays open for that work.

## Changes

- `test/e2e/live/registry-targets.test.ts` — when `TARGET_ID` is set, resolve it through `requireTargets()` at module load. An unknown id fails collection with `Unknown target '<id>'. Available targets: ...`; an empty or otherwise unsafe id fails with `Selected target ID '<id>' is not safe ...`. A declared target that is not wired still collects and skips, so the 22 placeholders keep their current behavior.
- `test/e2e/support/e2e-live-target-gating.test.ts` — two tests, added to the file that already spawns `vitest list --project e2e-live` and owns collection-gating coverage. They reuse its `listLiveTests`/`linesForFile` helpers and its `testTimeoutOptions` budget. `list` collects without running, so the module-load check is exercised while no live target body executes and no host, Docker, or sandbox state changes.
- `test/e2e/docs/README.md` — a "Selecting One Target" section recording the selection contract and the new failure.

No new abstraction, configuration, fallback, or compatibility path, and no new test harness: the check reuses `requireTargets()`, which already produces this error for the matrix emitter, and the tests reuse the existing gating harness.

### Where this is and is not reachable

`generate-matrix` already rejects an unknown dispatch id. `tools/e2e/workflow-plan.mts` routes the `targets` input into `test/e2e/registry/run.ts`, which calls `requireTargets` and fails the dispatch before any target job starts, so `matrix.id` at `.github/workflows/e2e.yaml:1020` is always a registered id. **This PR does not fix a hole in the automatic dispatch path.** It is the last-mile check in the file that consumes `TARGET_ID`, for a run that sets it another way — a direct `tools/e2e/live-vitest-invocation.mts` invocation, a local debugging run, or drift between the planner and a hand-edited workflow step. Before it, any of those exited 0 having run nothing.

### Why not `NEMOCLAW_E2E_REQUIRE_EXECUTED_TEST=1`

The repo already has a general fail-closed mechanism for "the selection ran no tests": `failClosedWhenNoTestsRan` in `test/e2e/risk-signal-reporter.ts`, attached by `buildLiveVitestArgs`, which `tools/e2e/target-catalogue.mts` enables for the catalogue path. Setting that one env key on the registry matrix step would be more general. I did not, for two reasons: it would fail every dispatch of the 22 declared-but-unwired placeholders, which are exactly what #8286's blocked criteria must preserve until a maintainer rules on them; and it lives in `.github/workflows/**`, which I cannot modify. If maintainers would rather take that route after the placeholders are resolved, this check is a two-line revert.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging) — no source under those areas changed; the diff resolves an E2E target id at test-collection time.
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Codex Desktop independently reviewed the completed three-file diff at the latest PR commit. `test/e2e/docs/README.md` distinguishes unknown and empty IDs that match no target from unsafe regex-shaped IDs that can broaden live selection. It limits the module-load guard to collection commands that include `test/e2e/live/registry-targets.test.ts`. The final setup linearization preserves unset, invalid, and declared-ID behavior. The test-conditionals scan passed, and the affected focused test passed 7/7.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 284e47c3b -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: see below
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable; this is a bounded change to one file's collection check. The owning Vitest project ran in full, below.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — not applicable; Fern builds `docs/`, and the changed page is `test/e2e/docs/README.md`. No `docs/` page changed.
- [ ] Doc pages follow the style guide (doc changes only) — not applicable; no Fern page changed.
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### The defect, before the change

Against unmodified `main`, with the workflow's own selector:

```
$ NEMOCLAW_RUN_LIVE_E2E=1 TARGET_ID=totally-bogus-target npx vitest run --project e2e-live \
    test/e2e/live/registry-targets.test.ts -t '^totally-bogus-target$'
 Test Files  1 skipped (1)
      Tests  26 skipped (26)
EXIT=0
```

The registry declares 26 targets; 4 are wired for live fixtures. An unknown id skips all 26 and exits 0. An empty `TARGET_ID` reproduces it through `-t "^$"`.

### Red, then green

The new tests against the unmodified file (`git stash push -- test/e2e/live/registry-targets.test.ts`):

```
 × rejects a TARGET_ID no registry target declares (#8286)
 Tests  1 failed | 6 passed (7)
```

With the change:

```
$ npx vitest run --project e2e-support test/e2e/support/e2e-live-target-gating.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

The second new test — "collects registry targets for any declared TARGET_ID" — passes in both directions by design. It is the control that proves the check rejects only undeclared ids, and it asserts collected test lines rather than exit status alone, so it fails if collection stops producing tests.

### Behavior after the change

```
# unknown id
$ NEMOCLAW_RUN_LIVE_E2E=1 TARGET_ID=stale-value npx vitest list --project e2e-live
Unknown target 'stale-value'. Available targets: brev-launchable-cloud-openclaw, ...
EXIT=1

# declared but not wired — still collects and skips, unchanged
[not wired] macos-repo-cloud-openclaw: platform 'macos-local' is not wired for live fixtures; ...
EXIT=0
```

A stale ambient `TARGET_ID` also fails `npm run test:e2e-phases:check`, with the `Unknown target` line first in its output. The README records that.

### Owning project and repository checks

```
npx vitest run --project e2e-support
 Test Files  9 failed | 199 passed | 3 skipped (211)
      Tests  13 failed | 2435 passed | 26 skipped (2474)
```

Those failures are pre-existing on this macOS host, not from this change. The same project on the unmodified base commit fails the same way, and the count moves between runs on this host while the failing set stays constant: `lifecycle-user-service`, `standard-profile-workflow-boundary`, `compatible-anthropic-switch`, `cli-artifact-workflow-boundary`, `managed-image-protected-runtime-readiness` — systemd user-service, login-shell, and Docker paths this host cannot satisfy. `e2e-live-target-gating.test.ts` passes in every run.

```
npm run checks:repository       # passed, including the live-E2E unit-block guard, the
                                # test registration boundary, and the source-shape budget
npm run typecheck:cli           # clean
npm run test:e2e-phases:check   # semantic E2E phase coverage: 127 tests across 83 files
npm run validate:pr             # passed after pointing origin/main at the true base
```

### Limits

- Every command above ran on macOS against test collection only. No live target body executed and no sandbox, gateway, Docker, or host state was created, so this change is not exercised against a real live E2E run here. CI owns that.
- The change alters when a live E2E run fails, not what a target does. The 22 unwired declarations are untouched.

---

Signed-off-by: Kushagar Garg <dreamstick909@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for selecting a single test target with `TARGET_ID`.
  * Documented validation for unknown, empty, and unsafe values, including wired and unwired targets.

* **Tests**
  * Added coverage ensuring invalid target selections fail clearly during test collection.
  * Verified that valid targets and declared placeholders collect the expected end-to-end tests.
  * Improved safeguards against reporting successful runs when no tests are selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

