### PR TITLE
test(uninstall): align post-merge portable fixtures

### DIFF
--- a/test/e2e/live/podman-portable-uninstall.test.ts
+++ b/test/e2e/live/podman-portable-uninstall.test.ts
@@ -334,7 +334,8 @@ test(
         .filter((entry) => entry.isFile() || entry.isSymbolicLink())
         .map((entry) => path.join(entry.parentPath, entry.name));
       expect(residualFiles).toEqual([retirementRecord]);
-      expect(fs.existsSync(configDir)).toBe(false);
+      expect(fs.readdirSync(path.dirname(expectedContainersConf))).toEqual([]);
+      expect(fs.statSync(path.dirname(expectedContainersConf)).mode & 0o777).toBe(0o700);
       const managerEnvironment = await runCommand(
         shellProbe,
         "systemctl",

--- a/test/uninstall.test.ts
+++ b/test/uninstall.test.ts
@@ -278,6 +278,7 @@ exit 0
       path.join(fakeBin, "openshell"),
       `#!/usr/bin/env bash
 case "$*" in
+  "status -g nemoclaw") printf 'Status: Connected\\nGateway: nemoclaw\\n' ;;
   "gateway list -o json") printf '[{"name":"nemoclaw"},{"name":"nemoclaw-9124"}]\\n' ;;
   "sandbox delete -g nemoclaw my-assistant")
     printf "Error: status: NotFound, sandbox 'my-assistant' not found\\n" >&2


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This post-merge follow-up aligns two uninstall fixtures with the behavior shipped by #9209 for #9189. The latest PR commit verifies the retained private portable-config directory instead of requiring its parent to disappear, and makes the public-wrapper fixture prove that the selected gateway is connected before accepting structured sandbox absence.

## Related Issue

Follow-up regression evidence for #9189 and merged PR #9209.

## Changes

- Verify that `~/.config/nemoclaw/portable/` remains safe-empty with mode `0700` after exact `containers.conf` retirement.
- Return the exact connected `nemoclaw` gateway status in the public uninstall-wrapper fixture before its existing structured sandbox-absence response.

These are test-fixture corrections only. Production behavior, commands, workflows, dependencies, timeouts, architecture, and documentation are unchanged.

The review of PR #9232 at https://github.com/NVIDIA/NemoClaw/pull/9232#pullrequestreview-4946794713 independently reproduced the same post-uninstall `configDir` expectation failure on its latest reviewed commit. This PR uses that result only as cross-PR regression evidence and does not claim that PR #9232's other workflow, documentation, or evidence findings are resolved.

The branch was constructed and validated from GitHub-verified base `d315374228ab9b642fba9ca41d9883f3c7cd381c`. Before publication, `main` advanced through verified, path-disjoint voice-gateway, Hermes-route, and credential-filter changes to `0db288e27b9d80ce2abbe24d08bff1afe4d28317`. Those changes do not alter either changed test, their uninstall behavior, or their E2E workflow routing; the signed candidate merges cleanly with that main tree.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: the patch changes only test fixtures to match already-documented uninstall and gateway behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent nine-category Codex Desktop review passed with no findings.
- [x] Non-success, skipped, or missing CI check accepted by maintainer:
  - The [first Nemotron advisor job](https://github.com/NVIDIA/NemoClaw/actions/runs/31963775743/job/95205667487) and its [single retry](https://github.com/NVIDIA/NemoClaw/actions/runs/31963775743/job/95206650679) failed because the model omitted required review-tool results. The failures are unrelated to this two-fixture diff.
  - The [advisor publisher job](https://github.com/NVIDIA/NemoClaw/actions/runs/31964436108/job/95207894082) rejected stale base evidence after #9242 advanced `main` from `0db288e27` to `13c11e8ad`.
  - The [current-base manual advisor run](https://github.com/NVIDIA/NemoClaw/actions/runs/31965325301) evaluated latest PR commit `bd393f9d9` against base SHA `13c11e8ad`. Terra reported no findings; Nemotron repeated the unrelated review-tool failure.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The two test-only corrections align with existing documentation for exact `containers.conf` retirement, retained owner-only state, and named-gateway reachability. The reviewer also checked the adjacent d315 E2E target-selection documentation and found no conflict.
- Agent: Codex Desktop
<!-- docs-review-head-sha: bd393f9d9 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: wrapper owner 7/7; portable cleanup owners 94/94; protected workflow routing owners 93/93; d315 live-target gating and registry owners 76/76; non-executing live-registry collection passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable to this two-fixture correction; `npm run test:changed` exited 0 with no selected CLI, plugin, or E2E-support file, and both changed lanes ran explicitly above.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — not applicable; no documentation changed.
- [ ] Doc pages follow the style guide (doc changes only) — not applicable; no documentation changed.
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — not applicable.

Additional checks on the latest PR commit: `npm run build:cli`, `npm run typecheck:cli`, `npm run checks:repository`, `npm run test-conditionals:scan`, `npm run source-shape:check`, `npm run test-size:check`, `git diff --check`, normal staged pre-commit, and normal pre-push all passed. Independent security review passed all nine categories with no findings.

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated uninstall coverage to verify the portable runtime configuration directory is empty and retains secure `0700` permissions.
  * Improved gateway uninstall test coverage by simulating a successful connected status for the selected gateway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

