### PR TITLE
test(e2e): add weekly unit gap review

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:coverage:cli": "npm run clean:cli && npm run build:cli && tsx scripts/check-dist-sourcemaps.mts dist && vitest run --project cli --project integration --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/cli --coverage.include=\"bin/**/*.js\" --coverage.include=\"src/**/*.ts\" --coverage.exclude=\"test/**/*.js\" --coverage.exclude=\"test/**/*.ts\" && tsx scripts/check-coverage-ratchet.mts coverage/cli/coverage-summary.json ci/coverage-threshold-cli.json \"CLI coverage\"",
     "test:coverage:plugin": "vitest run --project plugin --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reportsDirectory=coverage/plugin --coverage.include=\"nemoclaw/src/**/*.ts\" --coverage.include=\"nemoclaw/src/**/*.cts\" --coverage.exclude=\"**/*.test.ts\" && tsx scripts/check-coverage-ratchet.mts coverage/plugin/coverage-summary.json ci/coverage-threshold-plugin.json \"Plugin coverage\"",
     "test:live-e2e": "npm run clean:cli && npm run build:cli && NEMOCLAW_RUN_LIVE_E2E=1 vitest run --project e2e-live",
+    "e2e:unit-gaps": "tsx tools/e2e/unit-test-gaps.mts",
     "test:imports:check": "tsx scripts/checks/no-test-dist-imports.mts",
     "test:projects:check": "tsx scripts/checks/vitest-project-overlap.mts",
     "test:titles:check": "tsx scripts/checks/test-title-style.mts",

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -668,6 +668,8 @@ reviews them; redaction reduces exposure but does not prove that a report is
 credential-free. The command exits nonzero when a selected run is unfinished or
 failed-run evidence is unavailable. Do not accept a partial report as the
 weekly ledger.
+The command also stops when a workflow reaches the 1,000-run collection limit.
+Narrow the selected range and retry so the report cannot omit older runs silently.
 
 Review one row per cause candidate instead of one row per failed job. Confirm
 the selected candidate against the first causal line and identify the owning

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -639,9 +639,64 @@ graph as the live targets:
   pass/fail/skip counts, failure rate, pass/fail flips, current failure streak,
   and the most common failed phase. The failure-rate denominator and
   pass/fail-flip count exclude skips.
+
 - Selective dispatches remain silent unless they run on `main` with
   `post_to_slack=true`, which uses the preview Slack route. Branch-dispatched
   runs never receive Slack webhook secrets.
+
+### Weekly unit-test gap review
+
+Treat every automatic `main` E2E failure as a test-gap review input. Generate a
+report for the preceding 168 hours with GitHub CLI authentication already
+configured:
+
+```bash
+evidence_dir="$(mktemp -d)"
+chmod 700 "$evidence_dir"
+npm run e2e:unit-gaps -- \
+  --days 7 \
+  --output "$evidence_dir/unit-test-gaps.md" \
+  --json-output "$evidence_dir/unit-test-gaps.json"
+```
+
+The command reads push runs from `e2e.yaml` and `portable-profile-e2e.yaml` on
+`main`. It keeps failed logs in memory, applies the shared full secret redactor,
+removes volatile identifiers, paths, URLs, sandbox names, and durations from
+each selected cause candidate, and writes report files with mode `0600` in the
+mode-`0700` directory. Treat the reports as credential-bearing until a human
+reviews them; redaction reduces exposure but does not prove that a report is
+credential-free. The command exits nonzero when a selected run is unfinished or
+failed-run evidence is unavailable. Do not accept a partial report as the
+weekly ledger.
+
+Review one row per cause candidate instead of one row per failed job. Confirm
+the selected candidate against the first causal line and identify the owning
+component before changing code. Then apply the row's test action:
+
+- For a deterministic product failure, add a unit or package-contract
+  regression test that fails for the observed behavior before changing the
+  product code.
+- For a harness failure, add an `e2e-support` test for the decision, cleanup
+  path, or diagnostic.
+- For an external failure, test NemoClaw's retry and diagnostic response with
+  fault injection. Do not reproduce the provider, registry, network, or runner
+  outage in a unit test.
+- For a row that needs triage, name the missing contract only after confirming
+  the cause from the linked run.
+
+The Markdown and JSON reports start each row with review status `open` and no
+regression test. During review, record the test file and complete test title in
+the row and change the status only after the test fails without the fix and
+passes with it. A cause candidate is complete when that test evidence and a
+later passing run of the linked E2E target are both recorded. Delete the report
+directory after publishing only the reviewed, credential-free conclusions in
+the owning issue or pull request. Raw logs remain in process memory only until
+the command exits. Remove the named directory and confirm its absence:
+
+```bash
+rm -rf -- "$evidence_dir"
+test ! -e "$evidence_dir"
+```
 
 A manual run with `jobs=staging-brev-launchable` runs only `Publish staging Brev Launchable image`.
 Push runs do not select this job.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -668,6 +668,8 @@ reviews them; redaction reduces exposure but does not prove that a report is
 credential-free. The command exits nonzero when a selected run is unfinished or
 failed-run evidence is unavailable. Do not accept a partial report as the
 weekly ledger.
+Every GitHub read names `NVIDIA/NemoClaw`, so a fork or different checkout remote
+cannot substitute another repository's run data.
 The command also stops when a workflow reaches the 1,000-run collection limit.
 Narrow the selected range and retry so the report cannot omit older runs silently.
 

--- a/test/e2e/support/e2e-unit-test-gaps.test.ts
+++ b/test/e2e/support/e2e-unit-test-gaps.test.ts
@@ -11,7 +11,7 @@ import {
   normalizeFailureSignature,
   type RunLogEvidence,
 } from "../../../tools/e2e/unit-test-gaps-core.mts";
-import { rollingRange } from "../../../tools/e2e/unit-test-gaps.mts";
+import { requireCompleteRunSelection, rollingRange } from "../../../tools/e2e/unit-test-gaps.mts";
 
 function evidence(overrides: Partial<RunLogEvidence> = {}): RunLogEvidence {
   return {
@@ -60,6 +60,13 @@ describe("weekly E2E unit-test gap analysis", () => {
       from: "2026-08-09T19:30:00.000Z",
       to: "2026-08-16T19:30:00.000Z",
     });
+  });
+
+  it("rejects a run selection that may have reached the collection limit", () => {
+    expect(() => requireCompleteRunSelection("e2e.yaml", 999)).not.toThrow();
+    expect(() => requireCompleteRunSelection("e2e.yaml", 1000)).toThrow(
+      "e2e.yaml reached the 1000-run collection limit, so the selected range may be incomplete. Narrow --since or --days and retry.",
+    );
   });
 
   it("groups volatile BuildKit references under the missing build-input contract", () => {

--- a/test/e2e/support/e2e-unit-test-gaps.test.ts
+++ b/test/e2e/support/e2e-unit-test-gaps.test.ts
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildUnitGapReport,
+  classifyFailureSignature,
+  extractJobSignatures,
+  formatUnitGapReport,
+  normalizeFailureSignature,
+  type RunLogEvidence,
+} from "../../../tools/e2e/unit-test-gaps-core.mts";
+import { rollingRange } from "../../../tools/e2e/unit-test-gaps.mts";
+
+function evidence(overrides: Partial<RunLogEvidence> = {}): RunLogEvidence {
+  return {
+    log: "job\tstep\t2026-08-12T10:00:00.0000000Z AssertionError: expected UPGRADE, received 400\n",
+    run: {
+      attempt: 1,
+      conclusion: "failure",
+      createdAt: "2026-08-12T10:00:00Z",
+      databaseId: 12345678,
+      event: "push",
+      headBranch: "main",
+      headSha: "1234567890abcdef1234567890abcdef12345678",
+      name: "E2E main",
+      status: "completed",
+      url: "https://github.com/NVIDIA/NemoClaw/actions/runs/12345678",
+    },
+    ...overrides,
+  };
+}
+
+describe("weekly E2E unit-test gap analysis", () => {
+  it("redacts volatile identifiers, paths, URLs, sandboxes, and durations", () => {
+    const signature = normalizeFailureSignature(
+      "Error: sandbox e2e-sbx-a at /home/runner/work/NemoClaw failed after 180000ms for 1234567890abcdef1234567890abcdef12345678 via https://example.test/path?token=secret",
+    );
+
+    expect(signature).toBe(
+      "Error: sandbox <sandbox> at <path> failed after <duration> for <sha> via <url>",
+    );
+    expect(signature).not.toContain("secret");
+  });
+
+  it("redacts credential-shaped values before writing a cause candidate", () => {
+    const signature = normalizeFailureSignature(
+      "Error: Authorization: Bearer ghp_EXAMPLE012345678901234 AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE session=eyJhbGciOiJIUzI1NiJ9.cGF5bG9hZA.c2lnbmF0dXJl",
+    );
+
+    expect(signature).toBe(
+      "Error: Authorization: Bearer <REDACTED> AWS_ACCESS_KEY_ID=<REDACTED> session=<REDACTED>",
+    );
+    expect(signature).not.toContain("EXAMPLE");
+  });
+
+  it("uses an exact rolling window for --days", () => {
+    expect(rollingRange(7, new Date("2026-08-16T19:30:00.000Z"))).toEqual({
+      from: "2026-08-09T19:30:00.000Z",
+      to: "2026-08-16T19:30:00.000Z",
+    });
+  });
+
+  it("groups volatile BuildKit references under the missing build-input contract", () => {
+    expect(
+      normalizeFailureSignature(
+        'ERROR: failed to build: failed to solve: failed to compute cache key: failed to calculate checksum of ref 12345678-1234-4234-9234-123456789abc::sztmu18osbm95fj41qvxlgdie: "/tools/mcp-tool-discovery-runtime/reviewed-runtime-bundle/mcp-tool-discovery/mcp-tool-discovery.bundle": not found',
+      ),
+    ).toBe("ERROR: reviewed runtime bundle is missing from the image build context");
+  });
+
+  it("uses the earliest high-specificity causal line and ignores wrappers and echoed shell", () => {
+    const signatures = extractJobSignatures(
+      [
+        "portable-launch\tstep\t2026-08-12T10:00:00.0000000Z ##[error]Process completed with exit code 1.",
+        'portable-launch\tstep\t2026-08-12T10:00:00.5000000Z echo "::error::a shell guard failed"',
+        "portable-launch\tstep\t2026-08-12T10:00:01.0000000Z Error: Portable Podman readiness failed at service activation",
+        "rootless-linux\tstep\t2026-08-12T10:00:02.0000000Z npm error code EAI_AGAIN",
+      ].join("\n"),
+    );
+
+    expect(signatures).toEqual([
+      {
+        job: "portable-launch",
+        signature: "Error: Portable Podman readiness failed at service activation",
+      },
+      { job: "rootless-linux", signature: "npm error code EAI_AGAIN" },
+    ]);
+  });
+
+  it("keeps a failed job in the queue when its causal line needs manual review", () => {
+    expect(
+      extractJobSignatures(
+        "job\tstep\t2026-08-12T10:00:00.0000000Z ##[error]Process completed with exit code 1.\n",
+      ),
+    ).toEqual([{ job: "job", signature: "Failed job log requires manual causal-line review" }]);
+  });
+
+  it.each([
+    ["AssertionError: expected UPGRADE, received 400", "deterministic"],
+    ["npm error code EAI_AGAIN", "external"],
+    ["Error: E2E cleanup failed: gateway unavailable", "harness"],
+    ["Error: Local BuildKit build failed", "needs-triage"],
+  ] as const)("classifies %s as %s", (signature, classification) => {
+    expect(classifyFailureSignature(signature)).toBe(classification);
+  });
+
+  it("groups the same normalized cause across runs and keeps the required test action", () => {
+    const first = evidence();
+    const second = evidence({
+      run: {
+        ...evidence().run,
+        databaseId: 23456789,
+        url: "https://github.com/NVIDIA/NemoClaw/actions/runs/23456789",
+      },
+    });
+    const report = buildUnitGapReport(
+      [first, second],
+      { from: "2026-08-09", to: "2026-08-16" },
+      "2026-08-16T20:00:00.000Z",
+    );
+
+    expect(report.groups).toHaveLength(1);
+    expect(report.groups[0]).toMatchObject({
+      classification: "deterministic",
+      regressionTest: null,
+      reviewStatus: "open",
+      runCount: 2,
+      runIds: [12345678, 23456789],
+    });
+    expect(report.groups[0]!.requiredAction).toContain("unit or package-contract regression test");
+  });
+
+  it("fails the evidence ledger visibly when a failed log is unavailable", () => {
+    const report = buildUnitGapReport(
+      [evidence({ error: "too many API requests needed to fetch logs", log: undefined })],
+      { from: "2026-08-09", to: "2026-08-16" },
+      "2026-08-16T20:00:00.000Z",
+    );
+    const markdown = formatUnitGapReport(report);
+
+    expect(report.incompleteRuns).toEqual([
+      {
+        error: "too many API requests needed to fetch logs",
+        runId: 12345678,
+        url: "https://github.com/NVIDIA/NemoClaw/actions/runs/12345678",
+      },
+    ]);
+    expect(markdown).toContain("The report is incomplete.");
+  });
+
+  it("keeps a run active at the cutoff from producing a complete ledger", () => {
+    const active = evidence({
+      log: undefined,
+      run: { ...evidence().run, conclusion: "", status: "in_progress" },
+    });
+    const report = buildUnitGapReport(
+      [active],
+      { from: "2026-08-09T20:00:00.000Z", to: "2026-08-16T20:00:00.000Z" },
+      "2026-08-16T20:00:00.000Z",
+    );
+
+    expect(report.incompleteRuns).toEqual([
+      {
+        error: "run was in_progress at the collection cutoff",
+        runId: 12345678,
+        url: "https://github.com/NVIDIA/NemoClaw/actions/runs/12345678",
+      },
+    ]);
+  });
+});

--- a/test/e2e/support/e2e-unit-test-gaps.test.ts
+++ b/test/e2e/support/e2e-unit-test-gaps.test.ts
@@ -11,7 +11,12 @@ import {
   normalizeFailureSignature,
   type RunLogEvidence,
 } from "../../../tools/e2e/unit-test-gaps-core.mts";
-import { requireCompleteRunSelection, rollingRange } from "../../../tools/e2e/unit-test-gaps.mts";
+import {
+  failedRunLogArgs,
+  listRunsArgs,
+  requireCompleteRunSelection,
+  rollingRange,
+} from "../../../tools/e2e/unit-test-gaps.mts";
 
 function evidence(overrides: Partial<RunLogEvidence> = {}): RunLogEvidence {
   return {
@@ -69,6 +74,23 @@ describe("weekly E2E unit-test gap analysis", () => {
     );
   });
 
+  it("binds workflow and failed-log reads to the canonical repository", () => {
+    expect(
+      listRunsArgs("e2e.yaml", {
+        from: "2026-08-09T20:00:00.000Z",
+        to: "2026-08-16T20:00:00.000Z",
+      }),
+    ).toEqual(expect.arrayContaining(["--repo", "NVIDIA/NemoClaw", "--workflow", "e2e.yaml"]));
+    expect(failedRunLogArgs(12345678)).toEqual([
+      "run",
+      "view",
+      "12345678",
+      "--repo",
+      "NVIDIA/NemoClaw",
+      "--log-failed",
+    ]);
+  });
+
   it("groups volatile BuildKit references under the missing build-input contract", () => {
     expect(
       normalizeFailureSignature(
@@ -93,6 +115,20 @@ describe("weekly E2E unit-test gap analysis", () => {
         signature: "Error: Portable Podman readiness failed at service activation",
       },
       { job: "rootless-linux", signature: "npm error code EAI_AGAIN" },
+    ]);
+  });
+
+  it("strips terminal controls after a timestamp and preserves an unprefixed message", () => {
+    expect(
+      extractJobSignatures(
+        [
+          "online\tstep\t2026-08-12T10:00:00.0000000Z \u001b[31mError: colored failure\u001b[0m",
+          "offline\tstep\tError: offline evidence failed",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      { job: "online", signature: "Error: colored failure" },
+      { job: "offline", signature: "Error: offline evidence failed" },
     ]);
   });
 

--- a/test/e2e/support/e2e-unit-test-gaps.test.ts
+++ b/test/e2e/support/e2e-unit-test-gaps.test.ts
@@ -80,7 +80,24 @@ describe("weekly E2E unit-test gap analysis", () => {
         from: "2026-08-09T20:00:00.000Z",
         to: "2026-08-16T20:00:00.000Z",
       }),
-    ).toEqual(expect.arrayContaining(["--repo", "NVIDIA/NemoClaw", "--workflow", "e2e.yaml"]));
+    ).toEqual([
+      "run",
+      "list",
+      "--repo",
+      "NVIDIA/NemoClaw",
+      "--workflow",
+      "e2e.yaml",
+      "--branch",
+      "main",
+      "--event",
+      "push",
+      "--created",
+      "2026-08-09T20:00:00.000Z..2026-08-16T20:00:00.000Z",
+      "--limit",
+      "1000",
+      "--json",
+      "attempt,conclusion,createdAt,databaseId,event,headBranch,headSha,name,status,url",
+    ]);
     expect(failedRunLogArgs(12345678)).toEqual([
       "run",
       "view",

--- a/tools/e2e/unit-test-gaps-core.mts
+++ b/tools/e2e/unit-test-gaps-core.mts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { stripVTControlCharacters } from "node:util";
+
 type SanitizationModule = typeof import("../../src/lib/readiness/sanitize.ts");
 
 const loadedSanitization = (await import("../../src/lib/readiness/sanitize.ts")) as unknown as {
@@ -56,7 +58,6 @@ export interface UnitGapReport {
   groups: UnitGapGroup[];
 }
 
-const ANSI_PATTERN = /\u001b\[[0-9;]*[A-Za-z]/gu;
 const TIMESTAMP_PATTERN = /^\uFEFF?\d{4}-\d{2}-\d{2}T\S+Z\s+/u;
 const UUID_PATTERN =
   /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/giu;
@@ -84,11 +85,9 @@ function stripLogPrefix(line: string): { job: string; message: string } | null {
   const fields = line.split("\t");
   if (fields.length < 3) return null;
   const job = fields[0]!.trim();
-  const message = fields
-    .slice(2)
-    .join("\t")
-    .replace(ANSI_PATTERN, "")
-    .replace(TIMESTAMP_PATTERN, "");
+  const message = stripVTControlCharacters(
+    fields.slice(2).join("\t").replace(TIMESTAMP_PATTERN, ""),
+  );
   return job.length === 0 ? null : { job, message: message.trim() };
 }
 

--- a/tools/e2e/unit-test-gaps-core.mts
+++ b/tools/e2e/unit-test-gaps-core.mts
@@ -1,0 +1,346 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+type SanitizationModule = typeof import("../../src/lib/readiness/sanitize.ts");
+
+const loadedSanitization = (await import("../../src/lib/readiness/sanitize.ts")) as unknown as {
+  default?: SanitizationModule;
+  sanitizeReadinessText?: SanitizationModule["sanitizeReadinessText"];
+};
+function resolveSanitizeText(): SanitizationModule["sanitizeReadinessText"] {
+  const candidate =
+    loadedSanitization.sanitizeReadinessText ?? loadedSanitization.default?.sanitizeReadinessText;
+  if (candidate === undefined) throw new Error("shared diagnostic sanitizer is unavailable");
+  return candidate;
+}
+const sanitizeText = resolveSanitizeText();
+
+export type UnitGapClass = "deterministic" | "external" | "harness" | "needs-triage";
+
+export interface E2ERunRecord {
+  attempt: number;
+  conclusion: string;
+  createdAt: string;
+  databaseId: number;
+  event: string;
+  headBranch: string;
+  headSha: string;
+  name: string;
+  status: string;
+  url: string;
+}
+
+export interface RunLogEvidence {
+  error?: string;
+  log?: string;
+  run: E2ERunRecord;
+}
+
+export interface UnitGapGroup {
+  classification: UnitGapClass;
+  failedJobs: string[];
+  requiredAction: string;
+  runCount: number;
+  runIds: number[];
+  sampleUrls: string[];
+  signature: string;
+  regressionTest: { file: string; title: string } | null;
+  reviewStatus: "open";
+}
+
+export interface UnitGapReport {
+  generatedAt: string;
+  incompleteRuns: Array<{ error: string; runId: number; url: string }>;
+  range: { from: string; to: string };
+  runCounts: Record<string, number>;
+  groups: UnitGapGroup[];
+}
+
+const ANSI_PATTERN = /\u001b\[[0-9;]*[A-Za-z]/gu;
+const TIMESTAMP_PATTERN = /^\uFEFF?\d{4}-\d{2}-\d{2}T\S+Z\s+/u;
+const UUID_PATTERN =
+  /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/giu;
+const SHA_PATTERN = /\b[0-9a-f]{40,64}\b/giu;
+const LONG_ID_PATTERN = /\b[0-9a-f]{12,39}\b/giu;
+const RUN_NUMBER_PATTERN = /\b\d{7,}\b/gu;
+const URL_PATTERN = /https?:\/\/[^\s)'"<>]+/giu;
+const PATH_PATTERN = /(?:\/(?:home|github|tmp|run|opt|usr|var)\/)[^\s)'"<>]+/gu;
+const SANDBOX_PATTERN = /\be2e-[a-z0-9][a-z0-9-]{1,63}\b/giu;
+const DURATION_PATTERN = /\b\d+(?:\.\d+)?(?:ms|s|m)\b/giu;
+
+const ACTIONS: Record<UnitGapClass, string> = {
+  deterministic:
+    "Add a unit or package-contract regression test that reproduces this cause before changing the product code.",
+  external:
+    "Verify the retry and diagnostic contract with a fault-injection unit test; do not imitate the external outage.",
+  harness:
+    "Add an e2e-support test for the harness decision, cleanup path, or diagnostic that failed.",
+  "needs-triage":
+    "Confirm the first causal line, assign the owning component, and name the missing unit-test contract.",
+};
+const MANUAL_CAUSAL_LINE_REVIEW = "Failed job log requires manual causal-line review";
+
+function stripLogPrefix(line: string): { job: string; message: string } | null {
+  const fields = line.split("\t");
+  if (fields.length < 3) return null;
+  const job = fields[0]!.trim();
+  const message = fields
+    .slice(2)
+    .join("\t")
+    .replace(ANSI_PATTERN, "")
+    .replace(TIMESTAMP_PATTERN, "");
+  return job.length === 0 ? null : { job, message: message.trim() };
+}
+
+export function normalizeFailureSignature(message: string): string {
+  const normalized = sanitizeText(message.replace(URL_PATTERN, "<url>"), Number.MAX_SAFE_INTEGER)
+    .replace(/^##\[error\]\s*/u, "")
+    .replace(PATH_PATTERN, "<path>")
+    .replace(UUID_PATTERN, "<uuid>")
+    .replace(SHA_PATTERN, "<sha>")
+    .replace(LONG_ID_PATTERN, "<id>")
+    .replace(RUN_NUMBER_PATTERN, "<number>")
+    .replace(SANDBOX_PATTERN, "<sandbox>")
+    .replace(DURATION_PATTERN, "<duration>")
+    .replace(/::<[a-z]+>|::[a-z0-9]{12,}/giu, "::<ref>")
+    .replace(/\s+/gu, " ")
+    .trim();
+  if (/failed to compute cache key:.*reviewed-runtime-bundle\/.*: not found/iu.test(normalized)) {
+    return "ERROR: reviewed runtime bundle is missing from the image build context";
+  }
+  if (/failed to build:.*security_inventory=/iu.test(normalized)) {
+    return "ERROR: sandbox security inventory verification failed during image build";
+  }
+  if (/Starting the managed portable registry failed: Unable to find image/iu.test(normalized)) {
+    return "Error: starting the managed portable registry failed while loading its pinned image";
+  }
+  return normalized.slice(0, 240);
+}
+
+function candidateScore(message: string): number {
+  if (/^##\[error\]Process completed with exit code/iu.test(message)) return 0;
+  if (
+    /^(?:\{\s*)?echo\b|^(?:if|set|test|printf|throw new Error)\b|^\[\[|^\w+=|^[❯×]\s|^⎯|^"(?:[a-z_]+_)?matrix"|^Tests?\s+\d+\s+failed|^\d+\||^#\d+\s|^Timeout:|^openshell CLI not found|^OpenShell gateway managed service failed.*using standalone fallback|^\[install\] gh CLI download failed.*falling back|^Onboarding did not finish|^AssertionError:\s*(?:\[|test\/e2e\/.*:\s.*OK)|^FAIL\s/iu.test(
+      message,
+    )
+  ) {
+    return 0;
+  }
+  if (
+    /(?:Release qualification did not pass|FAILED: producer run|\[e2e target=.*\]\s+\[phase|AssertionError:\s*\[non-interactive\] Agent|AssertionError:\s*✓ Active gateway|Error:.*failed:\s*[█▓]|Error:.*failed:\s*\[non-interactive\] Agent)/iu.test(
+      message,
+    )
+  ) {
+    return 30;
+  }
+  if (
+    /(?:EAI_AGAIN|ECONNRESET|ETIMEDOUT|CORPORATE_CA_PROBE_FAIL|WSServerHandshakeError|locked file seal|No space left|Docker Hub login failed|CreateArtifact.*ETIMEDOUT|docker: Error response)/iu.test(
+      message,
+    )
+  ) {
+    return 120;
+  }
+  if (/^##\[error\](?!Process completed)/iu.test(message)) return 110;
+  if (/^AssertionError:\s+\S/iu.test(message)) return 100;
+  if (/^(?:Error|ERROR):\s+\S/iu.test(message)) return 95;
+  if (/^npm error (?:code|request|403|404|5\d\d)/iu.test(message)) return 90;
+  if (/^\[nemoclaw\].*(?:exhausted|failed|missing|refus)/iu.test(message)) return 90;
+  if (/^curl:\s*\(\d+\)/iu.test(message)) return 85;
+  if (/\b(?:failed|timed out|timeout|not found|missing)\b/iu.test(message)) return 60;
+  return 0;
+}
+
+function selectJobSignature(messages: readonly string[]): string | null {
+  const candidates = messages
+    .map((message, index) => ({ index, message, score: candidateScore(message) }))
+    .filter((candidate) => candidate.score > 0);
+  const selected = candidates.sort(
+    (left, right) => right.score - left.score || left.index - right.index,
+  )[0];
+  if (selected === undefined || selected.score < 60) return null;
+  const signature = normalizeFailureSignature(selected.message);
+  return signature.length === 0 ? null : signature;
+}
+
+export function extractJobSignatures(log: string): Array<{ job: string; signature: string }> {
+  const messagesByJob = new Map<string, string[]>();
+  for (const line of log.split(/\r?\n/gu)) {
+    const parsed = stripLogPrefix(line);
+    if (parsed === null) continue;
+    const messages = messagesByJob.get(parsed.job) ?? [];
+    messages.push(parsed.message);
+    messagesByJob.set(parsed.job, messages);
+  }
+  return [...messagesByJob]
+    .map(([job, messages]) => ({
+      job,
+      signature:
+        selectJobSignature(messages) ??
+        (messages.some((message) =>
+          /(?:##\[error\]|AssertionError|Failed Tests|Tests?\s+\d+\s+failed|^FAIL\s)/iu.test(
+            message,
+          ),
+        )
+          ? MANUAL_CAUSAL_LINE_REVIEW
+          : null),
+    }))
+    .filter((entry): entry is { job: string; signature: string } => entry.signature !== null);
+}
+
+export function classifyFailureSignature(signature: string): UnitGapClass {
+  if (signature === MANUAL_CAUSAL_LINE_REVIEW) return "needs-triage";
+  if (
+    /\b(?:EAI_AGAIN|ECONNRESET|ETIMEDOUT|connection reset|temporary failure|rate limit|HTTP (?:408|429|5\d\d)|returned error: (?:408|429|5\d\d)|Docker Hub login failed|CreateArtifact.*ETIMEDOUT)\b/iu.test(
+      signature,
+    )
+  ) {
+    return "external";
+  }
+  if (/(?:CORPORATE_CA_PROBE_FAIL|WSServerHandshakeError|locked file seal)/iu.test(signature)) {
+    return "deterministic";
+  }
+  if (
+    /(?:E2E cleanup failed|Live E2E selection ran no tests|risk signal requires|workflow run total_count changed)/iu.test(
+      signature,
+    )
+  ) {
+    return "harness";
+  }
+  if (
+    /(?:AssertionError|\bexpected\b|\bmissing\b|\bnot found\b|\brequires\b|\binvalid\b|\bdid not\b|\bcannot\b|\bunsupported\b|owner-mode|locked file seal)/iu.test(
+      signature,
+    )
+  ) {
+    return "deterministic";
+  }
+  return "needs-triage";
+}
+
+function conclusionKey(run: E2ERunRecord): string {
+  if (run.status !== "completed") return run.status;
+  return run.conclusion || "unknown";
+}
+
+export function buildUnitGapReport(
+  evidence: readonly RunLogEvidence[],
+  range: UnitGapReport["range"],
+  generatedAt = new Date().toISOString(),
+): UnitGapReport {
+  const runCounts: Record<string, number> = {};
+  const incompleteRuns: UnitGapReport["incompleteRuns"] = [];
+  const grouped = new Map<
+    string,
+    {
+      classification: UnitGapClass;
+      jobs: Set<string>;
+      runIds: Set<number>;
+      signature: string;
+      urls: Set<string>;
+    }
+  >();
+
+  for (const item of evidence) {
+    const key = conclusionKey(item.run);
+    runCounts[key] = (runCounts[key] ?? 0) + 1;
+    if (item.run.status !== "completed") {
+      incompleteRuns.push({
+        error: `run was ${normalizeFailureSignature(item.run.status)} at the collection cutoff`,
+        runId: item.run.databaseId,
+        url: item.run.url,
+      });
+      continue;
+    }
+    if (item.run.conclusion !== "failure") continue;
+    if (item.log === undefined || item.error !== undefined) {
+      incompleteRuns.push({
+        error: normalizeFailureSignature(item.error ?? "failed log unavailable"),
+        runId: item.run.databaseId,
+        url: item.run.url,
+      });
+      continue;
+    }
+    const signatures = extractJobSignatures(item.log);
+    if (signatures.length === 0) {
+      incompleteRuns.push({
+        error: "failed log contained no specific causal signature",
+        runId: item.run.databaseId,
+        url: item.run.url,
+      });
+      continue;
+    }
+    for (const { job, signature } of signatures) {
+      const classification = classifyFailureSignature(signature);
+      const groupKey = `${classification}\0${signature}`;
+      const group = grouped.get(groupKey) ?? {
+        classification,
+        jobs: new Set<string>(),
+        runIds: new Set<number>(),
+        signature,
+        urls: new Set<string>(),
+      };
+      group.jobs.add(job);
+      group.runIds.add(item.run.databaseId);
+      group.urls.add(item.run.url);
+      grouped.set(groupKey, group);
+    }
+  }
+
+  const groups = [...grouped.values()]
+    .map((group): UnitGapGroup => ({
+      classification: group.classification,
+      failedJobs: [...group.jobs].sort(),
+      requiredAction: ACTIONS[group.classification],
+      runCount: group.runIds.size,
+      runIds: [...group.runIds].sort((left, right) => left - right),
+      sampleUrls: [...group.urls].sort().slice(0, 3),
+      signature: group.signature,
+      regressionTest: null,
+      reviewStatus: "open",
+    }))
+    .sort(
+      (left, right) =>
+        right.runCount - left.runCount || left.signature.localeCompare(right.signature),
+    );
+
+  return { generatedAt, groups, incompleteRuns, range, runCounts };
+}
+
+function escapeCell(value: string): string {
+  return value.replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+export function formatUnitGapReport(report: UnitGapReport): string {
+  const counts = Object.entries(report.runCounts)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, count]) => `${name}: ${count}`)
+    .join(", ");
+  const lines = [
+    "# E2E unit-test gap report",
+    "",
+    `Range: ${report.range.from} through ${report.range.to}`,
+    "",
+    `Runs: ${counts || "none"}`,
+    "",
+    "Each row is a cause candidate, not a final root-cause decision. Review the linked runs before assigning the test contract.",
+    "",
+    "| Cause candidate | Class | Runs | Failed jobs | Review status | Regression test | Required test action | Evidence |",
+    "| --- | --- | ---: | --- | --- | --- | --- | --- |",
+  ];
+  for (const group of report.groups) {
+    const evidence = group.sampleUrls.map((url, index) => `[run ${index + 1}](${url})`).join(", ");
+    lines.push(
+      `| ${escapeCell(group.signature)} | ${group.classification} | ${group.runCount} | ${escapeCell(group.failedJobs.join(", "))} | ${group.reviewStatus} | — | ${escapeCell(group.requiredAction)} | ${evidence} |`,
+    );
+  }
+  if (report.groups.length === 0) {
+    lines.push("| No failed-job signatures found | — | 0 | — | — | — | — | — |");
+  }
+  lines.push("", `Incomplete selected runs: ${report.incompleteRuns.length}`, "");
+  if (report.incompleteRuns.length > 0) {
+    lines.push(
+      "The report is incomplete. Wait for unfinished runs and resolve unavailable failed logs before using it as a weekly test-gap ledger.",
+      "",
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/tools/e2e/unit-test-gaps.mts
+++ b/tools/e2e/unit-test-gaps.mts
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+
+import {
+  buildUnitGapReport,
+  type E2ERunRecord,
+  formatUnitGapReport,
+  type RunLogEvidence,
+} from "./unit-test-gaps-core.mts";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_WORKFLOWS = ["e2e.yaml", "portable-profile-e2e.yaml"];
+const MAX_GH_BUFFER_BYTES = 128 * 1024 * 1024;
+const DEFAULT_CONCURRENCY = 6;
+
+interface Options {
+  days: number;
+  jsonOutput: string;
+  logsDir?: string;
+  output: string;
+  runsFile?: string;
+  since?: string;
+  workflows: string[];
+}
+
+function usage(): never {
+  throw new Error(
+    "usage: unit-test-gaps.mts [--days 7 | --since YYYY-MM-DD] --output REPORT.md --json-output REPORT.json [--workflow FILE] [--runs-file RUNS.json --logs-dir DIR]",
+  );
+}
+
+function positiveInteger(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > 90) {
+    throw new Error(`${flag} must be an integer from 1 through 90`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv: readonly string[]): Options {
+  const options: Options = { days: 7, jsonOutput: "", output: "", workflows: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (flag === "--days" && value !== undefined) {
+      options.days = positiveInteger(value, flag);
+      index += 1;
+    } else if (flag === "--since" && value !== undefined) {
+      options.since = value;
+      index += 1;
+    } else if (flag === "--output" && value !== undefined) {
+      options.output = value;
+      index += 1;
+    } else if (flag === "--json-output" && value !== undefined) {
+      options.jsonOutput = value;
+      index += 1;
+    } else if (flag === "--workflow" && value !== undefined) {
+      options.workflows.push(value);
+      index += 1;
+    } else if (flag === "--runs-file" && value !== undefined) {
+      options.runsFile = value;
+      index += 1;
+    } else if (flag === "--logs-dir" && value !== undefined) {
+      options.logsDir = value;
+      index += 1;
+    } else {
+      usage();
+    }
+  }
+  if (options.output.length === 0 || options.jsonOutput.length === 0) usage();
+  if ((options.runsFile === undefined) !== (options.logsDir === undefined)) usage();
+  if (options.workflows.length === 0) options.workflows = [...DEFAULT_WORKFLOWS];
+  return options;
+}
+
+export function rollingRange(days: number, now = new Date()): { from: string; to: string } {
+  return {
+    from: new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString(),
+    to: now.toISOString(),
+  };
+}
+
+function rangeFromOptions(options: Options, now = new Date()): { from: string; to: string } {
+  if (options.since === undefined) return rollingRange(options.days, now);
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/u.test(options.since) ||
+    Number.isNaN(Date.parse(`${options.since}T00:00:00Z`))
+  ) {
+    throw new Error("--since must use YYYY-MM-DD");
+  }
+  return { from: `${options.since}T00:00:00.000Z`, to: now.toISOString() };
+}
+
+function normalizeRun(value: unknown): E2ERunRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("GitHub returned a malformed run record");
+  }
+  const run = value as Record<string, unknown>;
+  const requiredStrings = [
+    "conclusion",
+    "createdAt",
+    "event",
+    "headBranch",
+    "headSha",
+    "name",
+    "status",
+    "url",
+  ] as const;
+  if (
+    !Number.isSafeInteger(run.attempt) ||
+    !Number.isSafeInteger(run.databaseId) ||
+    (run.databaseId as number) < 1 ||
+    requiredStrings.some((key) => typeof run[key] !== "string")
+  ) {
+    throw new Error("GitHub returned a malformed run record");
+  }
+  return run as unknown as E2ERunRecord;
+}
+
+async function gh(args: readonly string[]): Promise<string> {
+  const result = await execFileAsync("gh", [...args], {
+    encoding: "utf8",
+    maxBuffer: MAX_GH_BUFFER_BYTES,
+    timeout: 10 * 60_000,
+  });
+  return result.stdout;
+}
+
+async function collectRuns(
+  workflows: readonly string[],
+  range: { from: string; to: string },
+): Promise<E2ERunRecord[]> {
+  const records = await Promise.all(
+    workflows.map(async (workflow) => {
+      const output = await gh([
+        "run",
+        "list",
+        "--workflow",
+        workflow,
+        "--branch",
+        "main",
+        "--event",
+        "push",
+        "--created",
+        `${range.from}..${range.to}`,
+        "--limit",
+        "1000",
+        "--json",
+        "attempt,conclusion,createdAt,databaseId,event,headBranch,headSha,name,status,url",
+      ]);
+      const parsed = JSON.parse(output) as unknown;
+      if (!Array.isArray(parsed)) throw new Error(`GitHub returned malformed runs for ${workflow}`);
+      return parsed.map(normalizeRun);
+    }),
+  );
+  const byId = new Map<number, E2ERunRecord>();
+  for (const run of records.flat()) byId.set(run.databaseId, run);
+  return [...byId.values()].sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+}
+
+async function parallelMap<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  action: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const output = new Array<R>(values.length);
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= values.length) return;
+      output[index] = await action(values[index]!);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, worker));
+  return output;
+}
+
+async function collectEvidence(runs: readonly E2ERunRecord[]): Promise<RunLogEvidence[]> {
+  const failures = runs.filter((run) => run.status === "completed" && run.conclusion === "failure");
+  const logs = new Map<number, RunLogEvidence>();
+  await parallelMap(failures, DEFAULT_CONCURRENCY, async (run) => {
+    try {
+      const log = await gh(["run", "view", String(run.databaseId), "--log-failed"]);
+      logs.set(run.databaseId, { log, run });
+    } catch (error) {
+      logs.set(run.databaseId, {
+        error: error instanceof Error ? error.message : "failed log unavailable",
+        run,
+      });
+    }
+  });
+  return runs.map((run) => logs.get(run.databaseId) ?? { run });
+}
+
+function readOfflineEvidence(runsFile: string, logsDir: string): RunLogEvidence[] {
+  const parsed = JSON.parse(fs.readFileSync(runsFile, "utf8")) as unknown;
+  if (!Array.isArray(parsed)) throw new Error("--runs-file must contain a JSON array");
+  return parsed.map(normalizeRun).map((run) => {
+    if (run.conclusion !== "failure") return { run };
+    const logPath = path.join(logsDir, `${run.databaseId}.log`);
+    const errorPath = path.join(logsDir, `${run.databaseId}.error`);
+    const error = fs.existsSync(errorPath) ? fs.readFileSync(errorPath, "utf8").trim() : "";
+    return {
+      ...(error.length > 0 ? { error } : {}),
+      ...(fs.existsSync(logPath) ? { log: fs.readFileSync(logPath, "utf8") } : {}),
+      run,
+    };
+  });
+}
+
+function writePrivate(file: string, contents: string): void {
+  fs.mkdirSync(path.dirname(path.resolve(file)), { mode: 0o700, recursive: true });
+  fs.writeFileSync(file, contents, { encoding: "utf8", mode: 0o600 });
+  fs.chmodSync(file, 0o600);
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const options = parseArgs(argv);
+  const range = rangeFromOptions(options);
+  const evidence =
+    options.runsFile !== undefined && options.logsDir !== undefined
+      ? readOfflineEvidence(options.runsFile, options.logsDir)
+      : await collectEvidence(await collectRuns(options.workflows, range));
+  const report = buildUnitGapReport(evidence, range);
+  writePrivate(options.output, formatUnitGapReport(report));
+  writePrivate(options.jsonOutput, `${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write(
+    `Wrote ${String(report.groups.length)} cause candidates from ${String(evidence.length)} runs; ${String(report.incompleteRuns.length)} selected runs need more evidence.\n`,
+  );
+  if (report.incompleteRuns.length > 0) process.exitCode = 1;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main();
+}

--- a/tools/e2e/unit-test-gaps.mts
+++ b/tools/e2e/unit-test-gaps.mts
@@ -17,6 +17,7 @@ import {
 const execFileAsync = promisify(execFile);
 const DEFAULT_WORKFLOWS = ["e2e.yaml", "portable-profile-e2e.yaml"];
 const MAX_GH_BUFFER_BYTES = 128 * 1024 * 1024;
+const MAX_RUNS_PER_WORKFLOW = 1000;
 const DEFAULT_CONCURRENCY = 6;
 
 interface Options {
@@ -132,6 +133,13 @@ async function gh(args: readonly string[]): Promise<string> {
   return result.stdout;
 }
 
+export function requireCompleteRunSelection(workflow: string, runCount: number): void {
+  if (runCount < MAX_RUNS_PER_WORKFLOW) return;
+  throw new Error(
+    `${workflow} reached the ${String(MAX_RUNS_PER_WORKFLOW)}-run collection limit, so the selected range may be incomplete. Narrow --since or --days and retry.`,
+  );
+}
+
 async function collectRuns(
   workflows: readonly string[],
   range: { from: string; to: string },
@@ -150,12 +158,13 @@ async function collectRuns(
         "--created",
         `${range.from}..${range.to}`,
         "--limit",
-        "1000",
+        String(MAX_RUNS_PER_WORKFLOW),
         "--json",
         "attempt,conclusion,createdAt,databaseId,event,headBranch,headSha,name,status,url",
       ]);
       const parsed = JSON.parse(output) as unknown;
       if (!Array.isArray(parsed)) throw new Error(`GitHub returned malformed runs for ${workflow}`);
+      requireCompleteRunSelection(workflow, parsed.length);
       return parsed.map(normalizeRun);
     }),
   );

--- a/tools/e2e/unit-test-gaps.mts
+++ b/tools/e2e/unit-test-gaps.mts
@@ -15,6 +15,7 @@ import {
 } from "./unit-test-gaps-core.mts";
 
 const execFileAsync = promisify(execFile);
+const NEMOCLAW_REPOSITORY = "NVIDIA/NemoClaw";
 const DEFAULT_WORKFLOWS = ["e2e.yaml", "portable-profile-e2e.yaml"];
 const MAX_GH_BUFFER_BYTES = 128 * 1024 * 1024;
 const MAX_RUNS_PER_WORKFLOW = 1000;
@@ -140,28 +141,38 @@ export function requireCompleteRunSelection(workflow: string, runCount: number):
   );
 }
 
+export function listRunsArgs(workflow: string, range: { from: string; to: string }): string[] {
+  return [
+    "run",
+    "list",
+    "--repo",
+    NEMOCLAW_REPOSITORY,
+    "--workflow",
+    workflow,
+    "--branch",
+    "main",
+    "--event",
+    "push",
+    "--created",
+    `${range.from}..${range.to}`,
+    "--limit",
+    String(MAX_RUNS_PER_WORKFLOW),
+    "--json",
+    "attempt,conclusion,createdAt,databaseId,event,headBranch,headSha,name,status,url",
+  ];
+}
+
+export function failedRunLogArgs(databaseId: number): string[] {
+  return ["run", "view", String(databaseId), "--repo", NEMOCLAW_REPOSITORY, "--log-failed"];
+}
+
 async function collectRuns(
   workflows: readonly string[],
   range: { from: string; to: string },
 ): Promise<E2ERunRecord[]> {
   const records = await Promise.all(
     workflows.map(async (workflow) => {
-      const output = await gh([
-        "run",
-        "list",
-        "--workflow",
-        workflow,
-        "--branch",
-        "main",
-        "--event",
-        "push",
-        "--created",
-        `${range.from}..${range.to}`,
-        "--limit",
-        String(MAX_RUNS_PER_WORKFLOW),
-        "--json",
-        "attempt,conclusion,createdAt,databaseId,event,headBranch,headSha,name,status,url",
-      ]);
+      const output = await gh(listRunsArgs(workflow, range));
       const parsed = JSON.parse(output) as unknown;
       if (!Array.isArray(parsed)) throw new Error(`GitHub returned malformed runs for ${workflow}`);
       requireCompleteRunSelection(workflow, parsed.length);
@@ -197,7 +208,7 @@ async function collectEvidence(runs: readonly E2ERunRecord[]): Promise<RunLogEvi
   const logs = new Map<number, RunLogEvidence>();
   await parallelMap(failures, DEFAULT_CONCURRENCY, async (run) => {
     try {
-      const log = await gh(["run", "view", String(run.databaseId), "--log-failed"]);
+      const log = await gh(failedRunLogArgs(run.databaseId));
       logs.set(run.databaseId, { log, run });
     } catch (error) {
       logs.set(run.databaseId, {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add a repeatable maintainer report that turns recent automatic E2E failures into reviewable unit-test gap candidates. The collector keeps failed logs in memory, redacts report text, marks incomplete evidence, and records the regression test required to close each candidate.

## Changes

- Add a `gh`-based collector bound to `NVIDIA/NemoClaw`, with a bounded rolling seven-day window, a truncation guard, and private report output.
- Group volatile failure logs into redacted cause candidates with explicit review and regression-test fields.
- Add focused E2E-support coverage for collection, redaction, classification, grouping, and incomplete evidence.
- Document the weekly review process and evidence-handling requirements in `test/e2e/README.md`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal maintainer analysis tooling, not supported product behavior. Its operating procedure is documented in `test/e2e/README.md`.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/README.md`
- Agent: Codex Desktop
<!-- docs-review-head-sha: b06532996 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/e2e-unit-test-gaps.test.ts` passed 16 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to analyze end-to-end test failures and identify unit-test coverage gaps.
  * Reports support Markdown and JSON output, failure grouping, classification, sanitized signatures, and incomplete-evidence tracking.
  * Added offline evidence support for analysis without retrieving live run data.
  * Added an npm script for running the analysis.

* **Documentation**
  * Added a weekly review procedure covering report generation, secure handling, review steps, and cleanup.

* **Tests**
  * Added comprehensive coverage for failure analysis, grouping, classification, date ranges, redaction, and incomplete runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->