### PR TITLE
ci(test): ratchet test loop growth

### DIFF
--- a/.github/workflows/codebase-growth-guardrails.yaml
+++ b/.github/workflows/codebase-growth-guardrails.yaml
@@ -139,3 +139,15 @@ jobs:
         run: |
           set -euo pipefail
           node --experimental-strip-types tools/growth-guardrails/test-conditionals.mts
+
+      - name: Require changed test files not to add table-test candidate loops
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          node --experimental-strip-types tools/growth-guardrails/test-loops.mts

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "source-shape:check": "tsx scripts/find-source-shape-tests.mts --check",
     "test-size:check": "tsx scripts/check-test-file-size-budget.mts",
     "test-conditionals:scan": "tsx scripts/find-test-conditionals.mts",
+    "test-loops:scan": "tsx scripts/growth-guardrails/find-test-loops.mts",
     "bump:version": "tsx scripts/bump-version.mts",
     "release:plan": "tsx scripts/release-plan.mts",
     "release:cut": "bash scripts/release-cut-tag.sh",

--- a/scripts/growth-guardrails/find-test-loops.mts
+++ b/scripts/growth-guardrails/find-test-loops.mts
@@ -4,7 +4,8 @@
 //
 // Finds `for` loops that make test cases or generated test definitions
 // iterative. Independent rows should use it.each or test.each so each failure
-// identifies one behavior. Required iteration can stay in a named helper.
+// identifies one behavior. Required iteration can stay in a named helper
+// outside the test callback.
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";

--- a/scripts/growth-guardrails/find-test-loops.mts
+++ b/scripts/growth-guardrails/find-test-loops.mts
@@ -1,0 +1,327 @@
+#!/usr/bin/env -S npx tsx
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Finds `for` loops that make test cases or generated test definitions
+// iterative. Independent rows should use it.each or test.each so each failure
+// identifies one behavior. Required iteration can stay in a named helper.
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+export type TestLoopContextKind = "test" | "hook" | "suite" | "helper" | "top-level";
+
+export type TestLoopKind = "for" | "for-await-of" | "for-in" | "for-of";
+
+export type TestLoopOccurrence = {
+  readonly file: string;
+  readonly line: number;
+  readonly column: number;
+  readonly kind: TestLoopKind;
+  readonly contextKind: TestLoopContextKind;
+  readonly contextName: string | null;
+};
+
+export type TestLoopFileSummary = {
+  readonly file: string;
+  readonly count: number;
+};
+
+export type TestLoopReport = {
+  readonly summary: {
+    readonly scannedFiles: number;
+    readonly filesWithLoops: number;
+    readonly loopCount: number;
+  };
+  readonly files: readonly TestLoopFileSummary[];
+  readonly occurrences: readonly TestLoopOccurrence[];
+};
+
+type CallbackContext = {
+  readonly kind: TestLoopContextKind;
+  readonly name: string | null;
+};
+
+type CliOptions = {
+  readonly json: boolean;
+  readonly top: number;
+  readonly roots: readonly string[];
+};
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const DEFAULT_SCAN_ROOTS = Object.freeze(["test", "src", "nemoclaw/src"]);
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:[cm]?[jt]s)$/;
+const TEST_CALL_NAMES = new Set(["it", "test"]);
+const HOOK_CALL_NAMES = new Set(["beforeEach", "afterEach", "beforeAll", "afterAll"]);
+const SUITE_CALL_NAMES = new Set(["describe"]);
+const SKIP_DIRS = new Set([
+  ".git",
+  ".venv",
+  "coverage",
+  "dist",
+  "docs/_build",
+  "nemoclaw/dist",
+  "nemoclaw/node_modules",
+  "node_modules",
+]);
+
+function toRepoPath(absPath: string): string {
+  return path.relative(REPO_ROOT, absPath).split(path.sep).join("/");
+}
+
+function isSkipped(absPath: string): boolean {
+  const rel = toRepoPath(absPath);
+  return [...SKIP_DIRS].some((skipDir) => rel === skipDir || rel.startsWith(`${skipDir}/`));
+}
+
+function* walkFiles(dir: string): Generator<string> {
+  if (!existsSync(dir) || isSkipped(dir)) return;
+
+  for (const entry of readdirSync(dir)) {
+    const absPath = path.join(dir, entry);
+    if (isSkipped(absPath)) continue;
+
+    const stats = statSync(absPath);
+    if (stats.isDirectory()) {
+      yield* walkFiles(absPath);
+    } else if (stats.isFile() && TEST_FILE_PATTERN.test(entry)) {
+      yield absPath;
+    }
+  }
+}
+
+function scriptKindFor(filePath: string): ts.ScriptKind {
+  return /\.[cm]?js$/i.test(filePath) ? ts.ScriptKind.JS : ts.ScriptKind.TS;
+}
+
+function rootCallName(expression: ts.Expression): string | null {
+  if (ts.isIdentifier(expression)) return expression.text;
+  if (ts.isPropertyAccessExpression(expression)) return rootCallName(expression.expression);
+  if (ts.isCallExpression(expression)) return rootCallName(expression.expression);
+  return null;
+}
+
+function firstStringArgument(call: ts.CallExpression): string | null {
+  const first = call.arguments[0];
+  if (first === undefined) return null;
+  if (ts.isStringLiteral(first) || ts.isNoSubstitutionTemplateLiteral(first)) return first.text;
+  return null;
+}
+
+function callbackContextForFunction(node: ts.Node): CallbackContext | null {
+  const parent = node.parent;
+  if (!ts.isCallExpression(parent)) return null;
+
+  const rootName = rootCallName(parent.expression);
+  if (rootName !== null && TEST_CALL_NAMES.has(rootName)) {
+    return { kind: "test", name: firstStringArgument(parent) };
+  }
+  if (rootName !== null && HOOK_CALL_NAMES.has(rootName)) {
+    return { kind: "hook", name: rootName };
+  }
+  if (rootName !== null && SUITE_CALL_NAMES.has(rootName)) {
+    return { kind: "suite", name: firstStringArgument(parent) };
+  }
+  return null;
+}
+
+function isFunctionLikeNode(node: ts.Node): node is ts.FunctionLikeDeclaration {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isConstructorDeclaration(node)
+  );
+}
+
+function classifyContext(
+  contexts: readonly CallbackContext[],
+  functionDepth: number,
+): CallbackContext {
+  const context = contexts.at(-1);
+  if (context !== undefined) return context;
+  if (functionDepth > 0) return { kind: "helper", name: null };
+  return { kind: "top-level", name: null };
+}
+
+function loopKind(node: ts.Node): TestLoopKind | null {
+  if (ts.isForStatement(node)) return "for";
+  if (ts.isForInStatement(node)) return "for-in";
+  if (ts.isForOfStatement(node))
+    return node.awaitModifier === undefined ? "for-of" : "for-await-of";
+  return null;
+}
+
+function containsTestDefinition(node: ts.Node): boolean {
+  let found = false;
+
+  function visit(child: ts.Node): void {
+    if (found) return;
+    if (ts.isCallExpression(child)) {
+      const rootName = rootCallName(child.expression);
+      if (rootName !== null && TEST_CALL_NAMES.has(rootName)) {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(child, visit);
+  }
+
+  ts.forEachChild(node, visit);
+  return found;
+}
+
+export function scanTextForTestLoops(file: string, sourceText: string): TestLoopOccurrence[] {
+  const sourceFile = ts.createSourceFile(
+    file,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(file),
+  );
+  const occurrences: TestLoopOccurrence[] = [];
+  const contexts: CallbackContext[] = [];
+  let functionDepth = 0;
+
+  function visit(node: ts.Node): void {
+    let pushedContext = false;
+    let enteredFunction = false;
+
+    if (isFunctionLikeNode(node)) {
+      functionDepth += 1;
+      enteredFunction = true;
+      const context = callbackContextForFunction(node);
+      if (context !== null) {
+        contexts.push(context);
+        pushedContext = true;
+      }
+    }
+
+    const kind = loopKind(node);
+    if (kind !== null) {
+      const context = classifyContext(contexts, functionDepth);
+      if (context.kind === "test" || containsTestDefinition(node)) {
+        const location = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+        occurrences.push({
+          file,
+          line: location.line + 1,
+          column: location.character + 1,
+          kind,
+          contextKind: context.kind,
+          contextName: context.name,
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+
+    if (pushedContext) contexts.pop();
+    if (enteredFunction) functionDepth -= 1;
+  }
+
+  visit(sourceFile);
+  return occurrences;
+}
+
+function summarizeFiles(occurrences: readonly TestLoopOccurrence[]): TestLoopFileSummary[] {
+  const counts = new Map<string, number>();
+  for (const occurrence of occurrences) {
+    counts.set(occurrence.file, (counts.get(occurrence.file) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([file, count]) => ({ file, count }))
+    .sort((a, b) => b.count - a.count || a.file.localeCompare(b.file));
+}
+
+export function collectTestLoops(roots = DEFAULT_SCAN_ROOTS): TestLoopReport {
+  const absFiles = roots.flatMap((root) => [...walkFiles(path.join(REPO_ROOT, root))]);
+  const occurrences = absFiles
+    .flatMap((absPath) => scanTextForTestLoops(toRepoPath(absPath), readFileSync(absPath, "utf-8")))
+    .sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line || a.column - b.column);
+  const files = summarizeFiles(occurrences);
+  return {
+    summary: {
+      scannedFiles: absFiles.length,
+      filesWithLoops: files.length,
+      loopCount: occurrences.length,
+    },
+    files,
+    occurrences,
+  };
+}
+
+function formatContext(occurrence: TestLoopOccurrence): string {
+  const name = occurrence.contextName === null ? "" : `: ${occurrence.contextName}`;
+  return `${occurrence.contextKind}${name}`;
+}
+
+export function formatReport(report: TestLoopReport, options: Pick<CliOptions, "top">): string {
+  const lines = [
+    `Scanned ${report.summary.scannedFiles} test files; found ${report.summary.loopCount} table-test candidate loop(s) in ${report.summary.filesWithLoops} file(s).`,
+    "",
+    "Top files by loop count:",
+  ];
+  for (const file of report.files.slice(0, options.top)) {
+    lines.push(`- ${file.file}: loops=${file.count}`);
+  }
+  lines.push("", "Table-test candidate loops:");
+  for (const occurrence of report.occurrences.slice(0, options.top)) {
+    lines.push(
+      `- ${occurrence.file}:${occurrence.line}:${occurrence.column} [${formatContext(occurrence)}] ${occurrence.kind}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function parsePositiveInt(value: string, flag: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0)
+    throw new Error(`${flag} must be a positive integer`);
+  return parsed;
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  const roots: string[] = [];
+  let json = false;
+  let top = 20;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--top") {
+      top = parsePositiveInt(argv[++index] ?? "", "--top");
+    } else if (arg === "--root") {
+      roots.push(argv[++index] ?? "");
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(
+        "Usage: tsx scripts/growth-guardrails/find-test-loops.mts [--top N] [--root PATH] [--json]\n\nScans test/spec files under test, src, and nemoclaw/src by default.",
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (roots.some((root) => root.trim() === "")) throw new Error("--root requires a path");
+  return { json, top, roots: roots.length > 0 ? roots : DEFAULT_SCAN_ROOTS };
+}
+
+function main(): void {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const report = collectTestLoops(options.roots);
+    console.log(options.json ? JSON.stringify(report, null, 2) : formatReport(report, options));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? "")) main();

--- a/test/growth-guardrails-entrypoints.test.ts
+++ b/test/growth-guardrails-entrypoints.test.ts
@@ -94,7 +94,7 @@ describe("growth-guardrails executable entrypoints (#6953)", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain(
-      "PASS: changed test files did not add table-test candidate loops (0 at PR head vs 0 at base).",
+      "PASS: changed test files did not add table-test candidate loops (0 at the latest PR commit vs 0 at base).",
     );
   });
 
@@ -107,7 +107,9 @@ describe("growth-guardrails executable entrypoints (#6953)", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("FAIL: changed test files add table-test candidate loops.");
-    expect(result.stderr).toContain("test/a.test.ts: 1 test loop(s), up from 0");
+    expect(result.stderr).toContain(
+      "test/a.test.ts: 1 table-test candidate loop(s), up from 0",
+    );
   });
 
   it("prints the size-budget guardrail PASS diagnostic", () => {

--- a/test/growth-guardrails-entrypoints.test.ts
+++ b/test/growth-guardrails-entrypoints.test.ts
@@ -89,6 +89,27 @@ describe("growth-guardrails executable entrypoints (#6953)", () => {
     expect(result.stderr).toContain("test/a.test.ts: 1 if statement(s), up from 0");
   });
 
+  it("prints the test-loop guardrail PASS diagnostic", () => {
+    const result = runEntrypoint("tools/growth-guardrails/test-loops.mts", [[]]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "PASS: changed test files did not add table-test candidate loops (0 at PR head vs 0 at base).",
+    );
+  });
+
+  it("prints the test-loop guardrail FAIL heading and file detail", () => {
+    const result = runEntrypoint("tools/growth-guardrails/test-loops.mts", [
+      [{ filename: "test/a.test.ts", status: "modified" }],
+      blobPayload("it('a', () => { expect(1).toBe(1); });"),
+      blobPayload("it('a', () => { for (const row of rows) expect(row).toBeDefined(); });"),
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("FAIL: changed test files add table-test candidate loops.");
+    expect(result.stderr).toContain("test/a.test.ts: 1 test loop(s), up from 0");
+  });
+
   it("prints the size-budget guardrail PASS diagnostic", () => {
     const result = runEntrypoint("tools/growth-guardrails/test-size-budget.mts", [
       [],

--- a/test/growth-guardrails-test-loops.test.ts
+++ b/test/growth-guardrails-test-loops.test.ts
@@ -67,7 +67,7 @@ describe("growth-guardrails test-loops: pure policy", () => {
       blobs({ "test/a.test.ts": NO_LOOP }),
       blobs({ "test/a.test.ts": ONE_LOOP }),
     );
-    expect(result.details).toEqual(["test/a.test.ts: 1 test loop(s), up from 0"]);
+    expect(result.details).toEqual(["test/a.test.ts: 1 table-test candidate loop(s), up from 0"]);
     expect([result.baseTotal, result.headTotal]).toEqual([0, 1]);
   });
 
@@ -102,11 +102,13 @@ describe("growth-guardrails test-loops: pure policy", () => {
       blobs({ "test/adder.test.ts": NO_LOOP, "test/remover.test.ts": TWO_LOOPS }),
       blobs({ "test/adder.test.ts": ONE_LOOP, "test/remover.test.ts": NO_LOOP }),
     );
-    expect(result.details).toEqual(["test/adder.test.ts: 1 test loop(s), up from 0"]);
+    expect(result.details).toEqual([
+      "test/adder.test.ts: 1 table-test candidate loop(s), up from 0",
+    ]);
     expect([result.baseTotal, result.headTotal]).toEqual([2, 1]);
   });
 
-  it("counts a removed test file as zero at the PR commit", () => {
+  it("counts a removed test file as zero at the latest PR commit", () => {
     const result = evaluateLoopViolations(
       [{ basePath: "test/gone.test.ts", headPath: null, displayName: "test/gone.test.ts" }],
       blobs({ "test/gone.test.ts": TWO_LOOPS }),
@@ -133,7 +135,7 @@ describe("growth-guardrails test-loops: orchestration", () => {
     });
     const result = await runTestLoops(client, ENV);
     expect(result.ok).toBe(false);
-    expect(result.details).toEqual(["test/a.test.ts: 1 test loop(s), up from 0"]);
+    expect(result.details).toEqual(["test/a.test.ts: 1 table-test candidate loop(s), up from 0"]);
   });
 
   it("ignores changed source files that are not tests", async () => {

--- a/test/growth-guardrails-test-loops.test.ts
+++ b/test/growth-guardrails-test-loops.test.ts
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { scanTextForTestLoops } from "../scripts/growth-guardrails/find-test-loops.mts";
+import type { PrBlobClient, PullRequestFile } from "../tools/growth-guardrails/pr-blob-client.mts";
+import {
+  countTestLoops,
+  evaluateLoopViolations,
+  type LoopChange,
+  runTestLoops,
+} from "../tools/growth-guardrails/test-loops.mts";
+
+const NO_LOOP = "it('a', () => { expect(1).toBe(1); });";
+const ONE_LOOP = "it('a', () => { for (const row of rows) expect(row).toBeDefined(); });";
+const TWO_LOOPS =
+  "it('a', () => { for (const row of rows) consume(row); for (const item of items) consume(item); });";
+
+function blobs(entries: Record<string, string | null>): Map<string, string | null> {
+  return new Map(Object.entries(entries));
+}
+
+type BlobFetchCall = {
+  readonly repo: string;
+  readonly oid: string;
+  readonly paths: readonly string[];
+};
+
+function fakeClient(
+  pullFiles: PullRequestFile[],
+  table: Record<string, string | null>,
+  fetchCalls: BlobFetchCall[] = [],
+): PrBlobClient {
+  return {
+    getPullFiles: async () => pullFiles,
+    fetchBlobs: async (repo, oid, paths) => {
+      fetchCalls.push({ repo, oid, paths: [...paths] });
+      return new Map(paths.map((path) => [path, table[`${repo} ${oid} ${path}`] ?? null]));
+    },
+  };
+}
+
+describe("growth-guardrails test-loops: AST parity", () => {
+  it.each([
+    ["no loops", NO_LOOP, 0],
+    ["one loop", ONE_LOOP, 1],
+    ["two loops", TWO_LOOPS, 2],
+  ])("countTestLoops matches the shared AST scanner: %s", (_label, source, expected) => {
+    expect(countTestLoops("test/x.test.ts", source)).toBe(expected);
+    expect(countTestLoops("test/x.test.ts", source)).toBe(
+      scanTextForTestLoops("test/x.test.ts", source).length,
+    );
+  });
+});
+
+describe("growth-guardrails test-loops: pure policy", () => {
+  const same = (path: string): LoopChange => ({
+    basePath: path,
+    headPath: path,
+    displayName: path,
+  });
+
+  it("flags a test file that adds a table-test candidate loop", () => {
+    const result = evaluateLoopViolations(
+      [same("test/a.test.ts")],
+      blobs({ "test/a.test.ts": NO_LOOP }),
+      blobs({ "test/a.test.ts": ONE_LOOP }),
+    );
+    expect(result.details).toEqual(["test/a.test.ts: 1 test loop(s), up from 0"]);
+    expect([result.baseTotal, result.headTotal]).toEqual([0, 1]);
+  });
+
+  it("passes a test file that removes table-test candidate loops", () => {
+    const result = evaluateLoopViolations(
+      [same("test/a.test.ts")],
+      blobs({ "test/a.test.ts": TWO_LOOPS }),
+      blobs({ "test/a.test.ts": ONE_LOOP }),
+    );
+    expect(result.details).toEqual([]);
+    expect([result.baseTotal, result.headTotal]).toEqual([2, 1]);
+  });
+
+  it("compares a renamed test with its previous path", () => {
+    const result = evaluateLoopViolations(
+      [
+        {
+          basePath: "test/old.test.ts",
+          headPath: "test/new.test.ts",
+          displayName: "test/new.test.ts",
+        },
+      ],
+      blobs({ "test/old.test.ts": ONE_LOOP }),
+      blobs({ "test/new.test.ts": ONE_LOOP }),
+    );
+    expect(result.details).toEqual([]);
+  });
+
+  it("flags a per-file increase when another test file removes loops", () => {
+    const result = evaluateLoopViolations(
+      [same("test/adder.test.ts"), same("test/remover.test.ts")],
+      blobs({ "test/adder.test.ts": NO_LOOP, "test/remover.test.ts": TWO_LOOPS }),
+      blobs({ "test/adder.test.ts": ONE_LOOP, "test/remover.test.ts": NO_LOOP }),
+    );
+    expect(result.details).toEqual(["test/adder.test.ts: 1 test loop(s), up from 0"]);
+    expect([result.baseTotal, result.headTotal]).toEqual([2, 1]);
+  });
+
+  it("counts a removed test file as zero at the PR commit", () => {
+    const result = evaluateLoopViolations(
+      [{ basePath: "test/gone.test.ts", headPath: null, displayName: "test/gone.test.ts" }],
+      blobs({ "test/gone.test.ts": TWO_LOOPS }),
+      blobs({}),
+    );
+    expect(result.details).toEqual([]);
+    expect([result.baseTotal, result.headTotal]).toEqual([2, 0]);
+  });
+});
+
+describe("growth-guardrails test-loops: orchestration", () => {
+  const ENV = {
+    BASE_SHA: "base",
+    HEAD_REPO: "fork/repo",
+    HEAD_SHA: "head",
+    PR_NUMBER: "1",
+    REPO: "NVIDIA/NemoClaw",
+  } as const;
+
+  it("fails a PR whose changed test adds a table-test candidate loop", async () => {
+    const client = fakeClient([{ filename: "test/a.test.ts", status: "modified" }], {
+      "NVIDIA/NemoClaw base test/a.test.ts": NO_LOOP,
+      "fork/repo head test/a.test.ts": ONE_LOOP,
+    });
+    const result = await runTestLoops(client, ENV);
+    expect(result.ok).toBe(false);
+    expect(result.details).toEqual(["test/a.test.ts: 1 test loop(s), up from 0"]);
+  });
+
+  it("ignores changed source files that are not tests", async () => {
+    const client = fakeClient([{ filename: "src/lib/foo.ts", status: "modified" }], {});
+    const result = await runTestLoops(client, ENV);
+    expect(result.ok).toBe(true);
+    expect([result.baseTotal, result.headTotal]).toEqual([0, 0]);
+  });
+
+  it("fetches each changed test path once per revision", async () => {
+    const fetchCalls: BlobFetchCall[] = [];
+    const client = fakeClient(
+      [
+        { filename: "test/a.test.ts", status: "modified" },
+        { filename: "test/b.test.ts", status: "modified" },
+        { filename: "test/a.test.ts", status: "modified" },
+      ],
+      {
+        "NVIDIA/NemoClaw base test/a.test.ts": NO_LOOP,
+        "NVIDIA/NemoClaw base test/b.test.ts": NO_LOOP,
+        "fork/repo head test/a.test.ts": NO_LOOP,
+        "fork/repo head test/b.test.ts": NO_LOOP,
+      },
+      fetchCalls,
+    );
+
+    const result = await runTestLoops(client, ENV);
+
+    expect(result.ok).toBe(true);
+    expect(fetchCalls).toEqual([
+      {
+        repo: "NVIDIA/NemoClaw",
+        oid: "base",
+        paths: ["test/a.test.ts", "test/b.test.ts"],
+      },
+      {
+        repo: "fork/repo",
+        oid: "head",
+        paths: ["test/a.test.ts", "test/b.test.ts"],
+      },
+    ]);
+  });
+});

--- a/test/growth-guardrails-workflow-boundary.test.ts
+++ b/test/growth-guardrails-workflow-boundary.test.ts
@@ -69,6 +69,15 @@ describe("growth-guardrails workflow trust boundary", () => {
       /must invoke the trusted tool: .*test-conditionals\.mts/,
     ],
     [
+      "a dropped test-loop tool invocation",
+      (s: string) =>
+        s.replace(
+          "node --experimental-strip-types tools/growth-guardrails/test-loops.mts",
+          "echo skip loops",
+        ),
+      /must invoke the trusted tool: .*test-loops\.mts/,
+    ],
+    [
       "a resurrected inline node heredoc",
       (s: string) =>
         s.replace(
@@ -102,7 +111,7 @@ describe("growth-guardrails workflow trust boundary", () => {
           "      - name: Check out the trusted base revision",
           "      - name: Execute an untrusted action\n        uses: attacker/payload@main\n\n      - name: Check out the trusted base revision",
         ),
-      /must contain exactly 6 approved steps, not 7/,
+      /must contain exactly 7 approved steps, not 8/,
     ],
     [
       "a non-approved shell field",

--- a/test/test-loops-scanner.test.ts
+++ b/test/test-loops-scanner.test.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { scanTextForTestLoops } from "../scripts/growth-guardrails/find-test-loops.mts";
+
+describe("test loop scanner", () => {
+  it("detects each for-loop form inside a test callback", () => {
+    const occurrences = scanTextForTestLoops(
+      "test/virtual-loops.test.ts",
+      `
+        it("iterates", async () => {
+          for (let index = 0; index < 2; index += 1) consume(index);
+          for (const key in record) consume(key);
+          for (const value of values) consume(value);
+          for await (const value of stream) consume(value);
+        });
+      `,
+    );
+
+    expect(occurrences.map((occurrence) => occurrence.kind)).toEqual([
+      "for",
+      "for-in",
+      "for-of",
+      "for-await-of",
+    ]);
+    expect(occurrences[0]).toMatchObject({
+      contextKind: "test",
+      contextName: "iterates",
+    });
+  });
+
+  it("detects a loop that generates test definitions", () => {
+    const occurrences = scanTextForTestLoops(
+      "test/virtual-generated-tests.test.ts",
+      `
+        describe("generated tests", () => {
+          for (const value of values) {
+            it(String(value), () => expect(value).toBeDefined());
+          }
+        });
+      `,
+    );
+
+    expect(occurrences).toHaveLength(1);
+    expect(occurrences[0]).toMatchObject({
+      kind: "for-of",
+      contextKind: "suite",
+      contextName: "generated tests",
+    });
+  });
+
+  it("ignores fixture text and loop forms that do not represent table-test candidates", () => {
+    const occurrences = scanTextForTestLoops(
+      "test/virtual-helper-loops.test.ts",
+      `
+        const fixture = \`for (const row of rows) { expect(row).toBeDefined(); }\`;
+        function collect(values) {
+          for (const value of values) consume(value);
+        }
+        afterEach(() => {
+          for (const resource of resources) resource.close();
+        });
+        it("waits", () => {
+          while (pending()) wait();
+          do { wait(); } while (pending());
+          values.forEach(consume);
+          collect(values);
+          expect(fixture).toContain("for");
+        });
+      `,
+    );
+
+    expect(occurrences).toEqual([]);
+  });
+
+  it("detects a for loop inside executable template interpolation", () => {
+    const occurrences = scanTextForTestLoops(
+      "test/virtual-template-loop.test.ts",
+      [
+        'it("iterates in interpolation", () => {',
+        "  const value = `${(() => {",
+        "    for (const item of items) consume(item);",
+        '    return "done";',
+        "  })()}`;",
+        '  expect(value).toBe("done");',
+        "});",
+      ].join("\n"),
+    );
+
+    expect(occurrences).toHaveLength(1);
+    expect(occurrences[0]).toMatchObject({
+      kind: "for-of",
+      contextKind: "test",
+      contextName: "iterates in interpolation",
+    });
+  });
+});

--- a/tools/growth-guardrails/test-loops.mts
+++ b/tools/growth-guardrails/test-loops.mts
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Trusted policy evaluator: a changed test file may not add table-test
+// candidate loops. The workflow reads pull-request blobs as data and parses
+// them with the TypeScript AST. It never executes pull-request code.
+
+import { scanTextForTestLoops } from "../../scripts/growth-guardrails/find-test-loops.mts";
+import {
+  assertRepositoryName,
+  type BlobMap,
+  createPrBlobClient,
+  type PrBlobClient,
+} from "./pr-blob-client.mts";
+
+const TEST_FILE_RE = /^(test|src|nemoclaw\/src)\/.*\.(test|spec)\.(?:[cm]?[jt]s)$/;
+
+export function countTestLoops(file: string, text: string): number {
+  return scanTextForTestLoops(file, text).length;
+}
+
+function countText(file: string, text: string | null | undefined): number {
+  return text == null ? 0 : countTestLoops(file, text);
+}
+
+export type LoopChange = {
+  readonly basePath: string;
+  readonly headPath: string | null;
+  readonly displayName: string;
+};
+
+export type LoopEvaluation = {
+  readonly details: string[];
+  readonly baseTotal: number;
+  readonly headTotal: number;
+};
+
+export function evaluateLoopViolations(
+  changes: readonly LoopChange[],
+  baseBlobs: BlobMap,
+  headBlobs: BlobMap,
+): LoopEvaluation {
+  const details: string[] = [];
+  let baseTotal = 0;
+  let headTotal = 0;
+
+  for (const change of changes) {
+    const baseCount = countText(change.basePath, baseBlobs.get(change.basePath) ?? null);
+    const headCount =
+      change.headPath === null
+        ? 0
+        : countText(change.headPath, headBlobs.get(change.headPath) ?? null);
+    baseTotal += baseCount;
+    headTotal += headCount;
+    if (headCount > baseCount) {
+      details.push(
+        `${change.headPath ?? change.displayName}: ${headCount} test loop(s), up from ${baseCount}`,
+      );
+    }
+  }
+
+  return { details, baseTotal, headTotal };
+}
+
+export type LoopEnv = {
+  readonly BASE_SHA: string;
+  readonly HEAD_REPO: string;
+  readonly HEAD_SHA: string;
+  readonly PR_NUMBER: string;
+  readonly REPO: string;
+};
+
+export type LoopResult = LoopEvaluation & { readonly ok: boolean };
+
+export async function runTestLoops(client: PrBlobClient, env: LoopEnv): Promise<LoopResult> {
+  assertRepositoryName(env.REPO, "REPO");
+  assertRepositoryName(env.HEAD_REPO, "HEAD_REPO");
+
+  const files = await client.getPullFiles(env.REPO, env.PR_NUMBER);
+  const changedTests = files.filter(
+    ({ filename, previous_filename }) =>
+      TEST_FILE_RE.test(filename) || TEST_FILE_RE.test(previous_filename ?? ""),
+  );
+
+  const changes: LoopChange[] = changedTests.map((file) => {
+    const basePath = TEST_FILE_RE.test(file.previous_filename ?? "")
+      ? (file.previous_filename as string)
+      : file.filename;
+    const headPath =
+      file.status === "removed" || !TEST_FILE_RE.test(file.filename) ? null : file.filename;
+    return { basePath, headPath, displayName: file.filename };
+  });
+
+  const basePaths = [...new Set(changes.map((change) => change.basePath))];
+  const headPaths = [
+    ...new Set(changes.map((change) => change.headPath).filter((p): p is string => p !== null)),
+  ];
+
+  const [baseBlobs, headBlobs] = await Promise.all([
+    client.fetchBlobs(env.REPO, env.BASE_SHA, basePaths),
+    client.fetchBlobs(env.HEAD_REPO, env.HEAD_SHA, headPaths),
+  ]);
+
+  const evaluation = evaluateLoopViolations(changes, baseBlobs, headBlobs);
+  return { ...evaluation, ok: evaluation.details.length === 0 };
+}
+
+function readEnv(): LoopEnv & { GH_TOKEN: string } {
+  const { BASE_SHA, GH_TOKEN, HEAD_REPO, HEAD_SHA, PR_NUMBER, REPO } = process.env;
+  if (!BASE_SHA || !GH_TOKEN || !HEAD_REPO || !HEAD_SHA || !PR_NUMBER || !REPO) {
+    throw new Error(
+      "Missing required environment: BASE_SHA GH_TOKEN HEAD_REPO HEAD_SHA PR_NUMBER REPO",
+    );
+  }
+  return { BASE_SHA, GH_TOKEN, HEAD_REPO, HEAD_SHA, PR_NUMBER, REPO };
+}
+
+async function main(): Promise<void> {
+  const env = readEnv();
+  const client = createPrBlobClient({ token: env.GH_TOKEN });
+  const result = await runTestLoops(client, env);
+  if (!result.ok) {
+    console.error("FAIL: changed test files add table-test candidate loops.");
+    console.error(
+      `Changed test files contain ${result.headTotal} test loop(s) at PR head vs ${result.baseTotal} at base.`,
+    );
+    console.error("");
+    console.error(
+      "Test cases should stay linear. Use it.each or test.each for independent cases. Move iteration that represents one behavior into a named helper.",
+    );
+    console.error("");
+    console.error("Files with increased test loop counts:");
+    for (const detail of result.details) console.error(`- ${detail}`);
+    console.error("");
+    console.error("Run locally: npm run test-loops:scan -- --top 25");
+    process.exit(1);
+  }
+  console.log(
+    `PASS: changed test files did not add table-test candidate loops (${result.headTotal} at PR head vs ${result.baseTotal} at base).`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/tools/growth-guardrails/test-loops.mts
+++ b/tools/growth-guardrails/test-loops.mts
@@ -54,7 +54,7 @@ export function evaluateLoopViolations(
     headTotal += headCount;
     if (headCount > baseCount) {
       details.push(
-        `${change.headPath ?? change.displayName}: ${headCount} test loop(s), up from ${baseCount}`,
+        `${change.headPath ?? change.displayName}: ${headCount} table-test candidate loop(s), up from ${baseCount}`,
       );
     }
   }
@@ -122,11 +122,11 @@ async function main(): Promise<void> {
   if (!result.ok) {
     console.error("FAIL: changed test files add table-test candidate loops.");
     console.error(
-      `Changed test files contain ${result.headTotal} test loop(s) at PR head vs ${result.baseTotal} at base.`,
+      `Changed test files contain ${result.headTotal} table-test candidate loop(s) at the latest PR commit vs ${result.baseTotal} at base.`,
     );
     console.error("");
     console.error(
-      "Test cases should stay linear. Use it.each or test.each for independent cases. Move iteration that represents one behavior into a named helper.",
+      "Test cases should stay linear. Use it.each or test.each for independent cases. Move iteration that represents one behavior into a named helper outside the test callback.",
     );
     console.error("");
     console.error("Files with increased test loop counts:");
@@ -136,7 +136,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
   console.log(
-    `PASS: changed test files did not add table-test candidate loops (${result.headTotal} at PR head vs ${result.baseTotal} at base).`,
+    `PASS: changed test files did not add table-test candidate loops (${result.headTotal} at the latest PR commit vs ${result.baseTotal} at base).`,
   );
 }
 

--- a/tools/growth-guardrails/workflow-boundary.mts
+++ b/tools/growth-guardrails/workflow-boundary.mts
@@ -22,6 +22,7 @@ export const TRUSTED_BASE_REF = "${{ github.event.pull_request.base.sha }}";
 export const REQUIRED_TOOL_INVOCATIONS = [
   "node --experimental-strip-types tools/growth-guardrails/test-size-budget.mts",
   "node --experimental-strip-types tools/growth-guardrails/test-conditionals.mts",
+  "node --experimental-strip-types tools/growth-guardrails/test-loops.mts",
 ] as const;
 
 const HEAD_REF_MARKERS = [
@@ -64,6 +65,10 @@ const APPROVED_STEP_SHAPES = [
   {
     name: "Require changed test files not to add if statements",
     sha256: "991a7036d27aeb45fde2f3178936fba6ac87b90200b79c933015f9d63525d3cf",
+  },
+  {
+    name: "Require changed test files not to add table-test candidate loops",
+    sha256: "6432b36d3c5ed34c648d782e5fc2302c15e76aea88b0ed319dca080ef6ef9431",
   },
 ] as const;
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds a per-file growth ratchet that rejects changed test files when they add `for` loops to test callbacks or generate tests from loops. The check preserves existing debt and directs independent cases to `it.each` or `test.each`.

## Changes

- Add an AST scanner and `npm run test-loops:scan` command for table-test candidate loops.
- Add a trusted base-versus-PR evaluator to the codebase growth workflow.
- Add focused scanner, policy, executable-diagnostic, and workflow trust-boundary tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This contributor CI guardrail does not change a user-facing NemoClaw command, configuration, runtime workflow, or supported behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The evaluator runs from the trusted base checkout, parses pull-request blobs as data, and passes the exact workflow trust-boundary contract.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The review covered all nine changed files. This internal contributor guardrail does not change public NemoClaw behavior or documentation.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b4f3c5d7a -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/test-loops-scanner.test.ts test/growth-guardrails-test-loops.test.ts test/growth-guardrails-entrypoints.test.ts test/growth-guardrails-workflow-boundary.test.ts` passed 34 tests in four files.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm run check` passed structural, repository, secret, and plugin checks. CLI coverage did not pass because unrelated host-state and Git-fixture tests failed in this worktree; CI will evaluate the branch in its clean environment.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated scanning to identify table-style test loops across JavaScript and TypeScript test files.
  - Added command-line reporting with text or JSON output and configurable scan locations.
  - Added pull request checks that compare revisions and flag newly introduced test-loop patterns.

- **Bug Fixes**
  - Improved validation and failure reporting for invalid scan inputs and detected violations.

- **Tests**
  - Added comprehensive coverage for loop detection, reporting, revision comparisons, workflow enforcement, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->