### PR TITLE
fix(e2e): bound unit gap evidence collection

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -655,19 +655,32 @@ evidence_dir="$(mktemp -d)"
 chmod 700 "$evidence_dir"
 npm run e2e:unit-gaps -- \
   --days 7 \
+  --cache-dir "$evidence_dir/cache" \
   --output "$evidence_dir/unit-test-gaps.md" \
   --json-output "$evidence_dir/unit-test-gaps.json"
 ```
 
 The command reads push runs from `e2e.yaml` and `portable-profile-e2e.yaml` on
-`main`. It keeps failed logs in memory, applies the shared full secret redactor,
-removes volatile identifiers, paths, URLs, sandbox names, and durations from
-each selected cause candidate, and writes report files with mode `0600` in the
-mode-`0700` directory. Treat the reports as credential-bearing until a human
-reviews them; redaction reduces exposure but does not prove that a report is
-credential-free. The command exits nonzero when a selected run is unfinished or
-failed-run evidence is unavailable. Do not accept a partial report as the
-weekly ledger.
+`main`. Online collection requires `--cache-dir`. The command creates the cache
+directory with mode `0700` and writes normalized job-and-signature JSON files
+with mode `0600`. Each cache entry binds sanitized evidence to one GitHub run ID
+and attempt. A later seven-day run with the same cache directory reuses matching
+entries. Each invocation reads logs for at most 50 uncached failed runs. When
+more failed runs remain, the command saves the sanitized evidence from that
+batch, exits nonzero, and asks you to rerun the same command with the same cache
+directory. Repeat until the command completes; each rerun reuses prior batches
+and collects the next one. The command reports cache hits and planned failed-log
+reads.
+
+The command extracts signatures in memory and does not retain raw GitHub logs.
+It applies the shared full secret redactor and removes volatile identifiers,
+paths, URLs, sandbox names, and durations from each selected cause candidate.
+Treat the cache and reports as credential-bearing until a human reviews them;
+redaction reduces exposure but does not prove that a file is credential-free.
+
+The command stops on GitHub authentication, authorization, and rate-limit
+failures. It exits nonzero when a selected run is unfinished or failed-run
+evidence is unavailable. Do not accept a partial report as the weekly ledger.
 Every GitHub read names `NVIDIA/NemoClaw`, so a fork or different checkout remote
 cannot substitute another repository's run data.
 The command also stops when a workflow reaches the 1,000-run collection limit.
@@ -692,10 +705,10 @@ The Markdown and JSON reports start each row with review status `open` and no
 regression test. During review, record the test file and complete test title in
 the row and change the status only after the test fails without the fix and
 passes with it. A cause candidate is complete when that test evidence and a
-later passing run of the linked E2E target are both recorded. Delete the report
-directory after publishing only the reviewed, credential-free conclusions in
-the owning issue or pull request. Raw logs remain in process memory only until
-the command exits. Remove the named directory and confirm its absence:
+later passing run of the linked E2E target are both recorded. Delete the
+evidence directory after publishing only the reviewed, credential-free
+conclusions in the owning issue or pull request. Remove the named directory and
+confirm its absence:
 
 ```bash
 rm -rf -- "$evidence_dir"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -666,11 +666,11 @@ directory with mode `0700` and writes normalized job-and-signature JSON files
 with mode `0600`. Each cache entry binds sanitized evidence to one GitHub run ID
 and attempt. A later seven-day run with the same cache directory reuses matching
 entries. Each invocation reads logs for at most 50 uncached failed runs. When
-more failed runs remain, the command saves the sanitized evidence from that
-batch, exits nonzero, and asks you to rerun the same command with the same cache
-directory. Repeat until the command completes; each rerun reuses prior batches
-and collects the next one. The command reports cache hits and planned failed-log
-reads.
+more failed runs remain, the command saves normalized job names and sanitized
+signatures for that batch. The command then exits nonzero. Rerun the command
+with the same cache directory. Repeat until the command completes; each rerun
+reuses prior batches and collects the next one. The command reports cache hits
+and planned failed-log reads.
 
 The command extracts signatures in memory and does not retain raw GitHub logs.
 It applies the shared full secret redactor and removes volatile identifiers,

--- a/test/e2e/support/e2e-unit-test-gaps.test.ts
+++ b/test/e2e/support/e2e-unit-test-gaps.test.ts
@@ -1,6 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -9,14 +15,20 @@ import {
   extractJobSignatures,
   formatUnitGapReport,
   normalizeFailureSignature,
+  type E2ERunRecord,
   type RunLogEvidence,
 } from "../../../tools/e2e/unit-test-gaps-core.mts";
 import {
+  classifyGitHubEvidenceReadError,
+  collectEvidence,
   failedRunLogArgs,
   listRunsArgs,
+  main,
   requireCompleteRunSelection,
   rollingRange,
 } from "../../../tools/e2e/unit-test-gaps.mts";
+
+const execFileAsync = promisify(execFile);
 
 function evidence(overrides: Partial<RunLogEvidence> = {}): RunLogEvidence {
   return {
@@ -35,6 +47,20 @@ function evidence(overrides: Partial<RunLogEvidence> = {}): RunLogEvidence {
     },
     ...overrides,
   };
+}
+
+function failedRun(databaseId: number, attempt = 1): E2ERunRecord {
+  return {
+    ...evidence().run,
+    attempt,
+    databaseId,
+    url: `https://github.com/NVIDIA/NemoClaw/actions/runs/${String(databaseId)}`,
+  };
+}
+
+function withTemporaryDirectory<T>(action: (directory: string) => Promise<T>): Promise<T> {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-unit-gaps-test-"));
+  return action(directory).finally(() => fs.rmSync(directory, { force: true, recursive: true }));
 }
 
 describe("weekly E2E unit-test gap analysis", () => {
@@ -228,5 +254,225 @@ describe("weekly E2E unit-test gap analysis", () => {
         url: "https://github.com/NVIDIA/NemoClaw/actions/runs/12345678",
       },
     ]);
+  });
+
+  it.each([
+    ["HTTP 403: API rate limit exceeded", "rate-limit"],
+    ["HTTP 429: secondary rate limit", "rate-limit"],
+    ["HTTP 401: Requires authentication", "access"],
+    ["HTTP 403: Resource not accessible by integration", "access"],
+    ["HTTP 502: upstream failure", null],
+  ] as const)("classifies GitHub read failure %s as %s", (message, classification) => {
+    expect(classifyGitHubEvidenceReadError(Object.assign(new Error(message), { stderr: message }))).toBe(
+      classification,
+    );
+  });
+
+  it("stores normalized signatures and reuses them for the same run attempt", async () => {
+    await withTemporaryDirectory(async (directory) => {
+      const cacheDir = path.join(directory, "evidence");
+      const run = failedRun(34567890, 2);
+      const plans: Array<{ cachedRuns: number; deferredRuns: number; failedLogReads: number }> = [];
+      let reads = 0;
+      const runGh = async (): Promise<string> => {
+        reads += 1;
+        return "job\tstep\t2026-08-16T10:00:00Z Error: Authorization: Bearer ghp_EXAMPLE012345678901234\n";
+      };
+
+      const first = await collectEvidence([run], cacheDir, runGh, 1, (plan) => plans.push(plan));
+      const cacheFile = path.join(cacheDir, "34567890-attempt-2.json");
+      const cached = fs.readFileSync(cacheFile, "utf8");
+      expect(first[0]!.log).toContain("Authorization: Bearer <REDACTED>");
+      expect(cached).toContain("Authorization: Bearer <REDACTED>");
+      expect(cached).not.toContain("ghp_EXAMPLE");
+      expect(fs.statSync(cacheDir).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(cacheFile).mode & 0o777).toBe(0o600);
+
+      const second = await collectEvidence(
+        [run],
+        cacheDir,
+        async () => {
+          throw new Error("cached evidence must prevent this GitHub read");
+        },
+        1,
+        (plan) => plans.push(plan),
+      );
+
+      expect(second).toEqual(first);
+      expect(reads).toBe(1);
+      expect(plans).toEqual([
+        { cachedRuns: 0, deferredRuns: 0, failedLogReads: 1 },
+        { cachedRuns: 1, deferredRuns: 0, failedLogReads: 0 },
+      ]);
+    });
+  });
+
+  it.each([
+    ["rate-limit", "HTTP 403: API rate limit exceeded"],
+    ["access", "HTTP 403: Resource not accessible by integration"],
+  ] as const)("stops new failed-log reads after a GitHub %s failure", async (kind, message) => {
+    await withTemporaryDirectory(async (directory) => {
+      const runs = [failedRun(45678901), failedRun(45678902), failedRun(45678903)];
+      let reads = 0;
+      const result = collectEvidence(
+        runs,
+        path.join(directory, "evidence"),
+        async () => {
+          reads += 1;
+          throw Object.assign(new Error(message), { stderr: message });
+        },
+        1,
+      );
+
+      await expect(result).rejects.toEqual(
+        expect.objectContaining({ kind, runId: 45678901 }),
+      );
+      expect(reads).toBe(1);
+    });
+  });
+
+  it("collects 300 failures in 50-log batches and then reuses the cache", async () => {
+    await withTemporaryDirectory(async (directory) => {
+      const cacheDir = path.join(directory, "evidence");
+      const runs = Array.from({ length: 300 }, (_, index) => failedRun(50000000 + index));
+      let reads = 0;
+      const runGh = async (): Promise<string> => {
+        reads += 1;
+        return "job\tstep\tError: cached high-volume failure\n";
+      };
+
+      for (const deferredRuns of [250, 200, 150, 100, 50]) {
+        await expect(collectEvidence(runs, cacheDir, runGh)).rejects.toEqual(
+          expect.objectContaining({ deferredRuns }),
+        );
+      }
+      await collectEvidence(runs, cacheDir, runGh);
+      expect(reads).toBe(300);
+      reads = 0;
+      let plan:
+        | { cachedRuns: number; deferredRuns: number; failedLogReads: number }
+        | undefined;
+      const result = await collectEvidence(runs, cacheDir, runGh, 2, (value) => {
+        plan = value;
+      });
+
+      expect(result).toHaveLength(300);
+      expect(reads).toBe(0);
+      expect(plan).toEqual({ cachedRuns: 300, deferredRuns: 0, failedLogReads: 0 });
+    });
+  });
+
+  it("rejects cached evidence for another run before a GitHub read", async () => {
+    await withTemporaryDirectory(async (directory) => {
+      const cacheDir = path.join(directory, "evidence");
+      fs.mkdirSync(cacheDir, { mode: 0o700 });
+      fs.writeFileSync(
+        path.join(cacheDir, "56789012-attempt-1.json"),
+        '{"attempt":1,"runId":99999999,"signatures":[],"version":1}\n',
+        { mode: 0o600 },
+      );
+      let reads = 0;
+
+      await expect(
+        collectEvidence([failedRun(56789012)], cacheDir, async () => {
+          reads += 1;
+          return "";
+        }),
+      ).rejects.toThrow("Cached evidence for run 56789012 does not match the run.");
+      expect(reads).toBe(0);
+    });
+  });
+
+  it("rejects a cached job name that can create another log row", async () => {
+    await withTemporaryDirectory(async (directory) => {
+      const cacheDir = path.join(directory, "evidence");
+      fs.mkdirSync(cacheDir, { mode: 0o700 });
+      fs.writeFileSync(
+        path.join(cacheDir, "56789013-attempt-1.json"),
+        '{"attempt":1,"runId":56789013,"signatures":[{"job":"job\\tforged","signature":"Error: failure"}],"version":1}\n',
+        { mode: 0o600 },
+      );
+
+      await expect(
+        collectEvidence([failedRun(56789013)], cacheDir, async () => ""),
+      ).rejects.toThrow("Cached evidence for run 56789013 does not match the run.");
+    });
+  });
+
+  it("stops workflow-run listing when GitHub reports a rate limit", async () => {
+    await withTemporaryDirectory(async (directory) => {
+      const markdownFile = path.join(directory, "report.md");
+      const jsonFile = path.join(directory, "report.json");
+      let reads = 0;
+      const result = main(
+        [
+          "--days",
+          "7",
+          "--cache-dir",
+          path.join(directory, "evidence"),
+          "--output",
+          markdownFile,
+          "--json-output",
+          jsonFile,
+        ],
+        {
+          now: new Date("2026-08-16T20:00:00.000Z"),
+          runGh: async () => {
+            reads += 1;
+            throw Object.assign(new Error("HTTP 403: API rate limit exceeded"), {
+              stderr: "HTTP 403: API rate limit exceeded",
+            });
+          },
+        },
+      );
+
+      await expect(result).rejects.toEqual(
+        expect.objectContaining({ kind: "rate-limit", runId: null }),
+      );
+      expect(reads).toBe(1);
+      expect(fs.existsSync(markdownFile)).toBe(false);
+      expect(fs.existsSync(jsonFile)).toBe(false);
+    });
+  });
+
+  it("runs the npm collector entry point with offline evidence", async () => {
+    await withTemporaryDirectory(async (directory) => {
+      const logsDir = path.join(directory, "logs");
+      const runsFile = path.join(directory, "runs.json");
+      const markdownFile = path.join(directory, "report.md");
+      const jsonFile = path.join(directory, "report.json");
+      fs.mkdirSync(logsDir, { mode: 0o700 });
+      fs.writeFileSync(runsFile, `${JSON.stringify([failedRun(67890123)])}\n`, { mode: 0o600 });
+      fs.writeFileSync(
+        path.join(logsDir, "67890123.log"),
+        "job\tstep\tError: offline entry-point failure\n",
+        { mode: 0o600 },
+      );
+
+      const { stdout } = await execFileAsync(
+        "npm",
+        [
+          "run",
+          "e2e:unit-gaps",
+          "--",
+          "--runs-file",
+          runsFile,
+          "--logs-dir",
+          logsDir,
+          "--output",
+          markdownFile,
+          "--json-output",
+          jsonFile,
+        ],
+        { cwd: process.cwd(), encoding: "utf8" },
+      );
+
+      expect(stdout).toContain("Wrote 1 cause candidates from 1 runs");
+      expect(fs.existsSync(markdownFile)).toBe(true);
+      expect(JSON.parse(fs.readFileSync(jsonFile, "utf8"))).toMatchObject({
+        incompleteRuns: [],
+        runCounts: { failure: 1 },
+      });
+    });
   });
 });

--- a/test/e2e/support/e2e-unit-test-gaps.test.ts
+++ b/test/e2e/support/e2e-unit-test-gaps.test.ts
@@ -268,7 +268,7 @@ describe("weekly E2E unit-test gap analysis", () => {
     );
   });
 
-  it("stores normalized signatures and reuses them for the same run attempt", async () => {
+  it("reuses normalized signatures only for the same run attempt", async () => {
     await withTemporaryDirectory(async (directory) => {
       const cacheDir = path.join(directory, "evidence");
       const run = failedRun(34567890, 2);
@@ -300,9 +300,16 @@ describe("weekly E2E unit-test gap analysis", () => {
 
       expect(second).toEqual(first);
       expect(reads).toBe(1);
+
+      await collectEvidence([failedRun(34567890, 3)], cacheDir, runGh, 1, (plan) =>
+        plans.push(plan),
+      );
+      expect(reads).toBe(2);
+      expect(fs.existsSync(path.join(cacheDir, "34567890-attempt-3.json"))).toBe(true);
       expect(plans).toEqual([
         { cachedRuns: 0, deferredRuns: 0, failedLogReads: 1 },
         { cachedRuns: 1, deferredRuns: 0, failedLogReads: 0 },
+        { cachedRuns: 0, deferredRuns: 0, failedLogReads: 1 },
       ]);
     });
   });

--- a/test/e2e/support/e2e-unit-test-gaps.test.ts
+++ b/test/e2e/support/e2e-unit-test-gaps.test.ts
@@ -283,6 +283,7 @@ describe("weekly E2E unit-test gap analysis", () => {
       const cacheFile = path.join(cacheDir, "34567890-attempt-2.json");
       const cached = fs.readFileSync(cacheFile, "utf8");
       expect(first[0]!.log).toContain("Authorization: Bearer <REDACTED>");
+      expect(first[0]!.log).not.toContain("ghp_EXAMPLE");
       expect(cached).toContain("Authorization: Bearer <REDACTED>");
       expect(cached).not.toContain("ghp_EXAMPLE");
       expect(fs.statSync(cacheDir).mode & 0o777).toBe(0o700);
@@ -338,36 +339,40 @@ describe("weekly E2E unit-test gap analysis", () => {
     });
   });
 
-  it("collects 300 failures in 50-log batches and then reuses the cache", async () => {
-    await withTemporaryDirectory(async (directory) => {
-      const cacheDir = path.join(directory, "evidence");
-      const runs = Array.from({ length: 300 }, (_, index) => failedRun(50000000 + index));
-      let reads = 0;
-      const runGh = async (): Promise<string> => {
-        reads += 1;
-        return "job\tstep\tError: cached high-volume failure\n";
-      };
+  it(
+    "collects 300 failures in 50-log batches and then reuses the cache",
+    async () => {
+      await withTemporaryDirectory(async (directory) => {
+        const cacheDir = path.join(directory, "evidence");
+        const runs = Array.from({ length: 300 }, (_, index) => failedRun(50000000 + index));
+        let reads = 0;
+        const runGh = async (): Promise<string> => {
+          reads += 1;
+          return "job\tstep\tError: cached high-volume failure\n";
+        };
 
-      for (const deferredRuns of [250, 200, 150, 100, 50]) {
-        await expect(collectEvidence(runs, cacheDir, runGh)).rejects.toEqual(
-          expect.objectContaining({ deferredRuns }),
-        );
-      }
-      await collectEvidence(runs, cacheDir, runGh);
-      expect(reads).toBe(300);
-      reads = 0;
-      let plan:
-        | { cachedRuns: number; deferredRuns: number; failedLogReads: number }
-        | undefined;
-      const result = await collectEvidence(runs, cacheDir, runGh, 2, (value) => {
-        plan = value;
+        for (const deferredRuns of [250, 200, 150, 100, 50]) {
+          await expect(collectEvidence(runs, cacheDir, runGh)).rejects.toEqual(
+            expect.objectContaining({ deferredRuns }),
+          );
+        }
+        await collectEvidence(runs, cacheDir, runGh);
+        expect(reads).toBe(300);
+        reads = 0;
+        let plan:
+          | { cachedRuns: number; deferredRuns: number; failedLogReads: number }
+          | undefined;
+        const result = await collectEvidence(runs, cacheDir, runGh, 2, (value) => {
+          plan = value;
+        });
+
+        expect(result).toHaveLength(300);
+        expect(reads).toBe(0);
+        expect(plan).toEqual({ cachedRuns: 300, deferredRuns: 0, failedLogReads: 0 });
       });
-
-      expect(result).toHaveLength(300);
-      expect(reads).toBe(0);
-      expect(plan).toEqual({ cachedRuns: 300, deferredRuns: 0, failedLogReads: 0 });
-    });
-  });
+    },
+    30_000,
+  );
 
   it("rejects cached evidence for another run before a GitHub read", async () => {
     await withTemporaryDirectory(async (directory) => {
@@ -403,6 +408,24 @@ describe("weekly E2E unit-test gap analysis", () => {
       await expect(
         collectEvidence([failedRun(56789013)], cacheDir, async () => ""),
       ).rejects.toThrow("Cached evidence for run 56789013 does not match the run.");
+    });
+  });
+
+  it("rejects cached evidence that is a symbolic link", async () => {
+    await withTemporaryDirectory(async (directory) => {
+      const cacheDir = path.join(directory, "evidence");
+      fs.mkdirSync(cacheDir, { mode: 0o700 });
+      const target = path.join(directory, "outside.json");
+      fs.writeFileSync(
+        target,
+        '{"attempt":1,"runId":56789014,"signatures":[],"version":1}\n',
+        { mode: 0o600 },
+      );
+      fs.symlinkSync(target, path.join(cacheDir, "56789014-attempt-1.json"));
+
+      await expect(
+        collectEvidence([failedRun(56789014)], cacheDir, async () => ""),
+      ).rejects.toThrow("Cached evidence for run 56789014 is not a bounded regular file.");
     });
   });
 
@@ -442,44 +465,50 @@ describe("weekly E2E unit-test gap analysis", () => {
     });
   });
 
-  it("runs the npm collector entry point with offline evidence", async () => {
-    await withTemporaryDirectory(async (directory) => {
-      const logsDir = path.join(directory, "logs");
-      const runsFile = path.join(directory, "runs.json");
-      const markdownFile = path.join(directory, "report.md");
-      const jsonFile = path.join(directory, "report.json");
-      fs.mkdirSync(logsDir, { mode: 0o700 });
-      fs.writeFileSync(runsFile, `${JSON.stringify([failedRun(67890123)])}\n`, { mode: 0o600 });
-      fs.writeFileSync(
-        path.join(logsDir, "67890123.log"),
-        "job\tstep\tError: offline entry-point failure\n",
-        { mode: 0o600 },
-      );
+  it(
+    "runs the npm collector entry point with offline evidence",
+    async () => {
+      await withTemporaryDirectory(async (directory) => {
+        const logsDir = path.join(directory, "logs");
+        const runsFile = path.join(directory, "runs.json");
+        const markdownFile = path.join(directory, "report.md");
+        const jsonFile = path.join(directory, "report.json");
+        fs.mkdirSync(logsDir, { mode: 0o700 });
+        fs.writeFileSync(runsFile, `${JSON.stringify([failedRun(67890123)])}\n`, {
+          mode: 0o600,
+        });
+        fs.writeFileSync(
+          path.join(logsDir, "67890123.log"),
+          "job\tstep\tError: offline entry-point failure\n",
+          { mode: 0o600 },
+        );
 
-      const { stdout } = await execFileAsync(
-        "npm",
-        [
-          "run",
-          "e2e:unit-gaps",
-          "--",
-          "--runs-file",
-          runsFile,
-          "--logs-dir",
-          logsDir,
-          "--output",
-          markdownFile,
-          "--json-output",
-          jsonFile,
-        ],
-        { cwd: process.cwd(), encoding: "utf8" },
-      );
+        const { stdout } = await execFileAsync(
+          "npm",
+          [
+            "run",
+            "e2e:unit-gaps",
+            "--",
+            "--runs-file",
+            runsFile,
+            "--logs-dir",
+            logsDir,
+            "--output",
+            markdownFile,
+            "--json-output",
+            jsonFile,
+          ],
+          { cwd: process.cwd(), encoding: "utf8", maxBuffer: 8 * 1024 * 1024, timeout: 60_000 },
+        );
 
-      expect(stdout).toContain("Wrote 1 cause candidates from 1 runs");
-      expect(fs.existsSync(markdownFile)).toBe(true);
-      expect(JSON.parse(fs.readFileSync(jsonFile, "utf8"))).toMatchObject({
-        incompleteRuns: [],
-        runCounts: { failure: 1 },
+        expect(stdout).toContain("Wrote 1 cause candidates from 1 runs");
+        expect(fs.existsSync(markdownFile)).toBe(true);
+        expect(JSON.parse(fs.readFileSync(jsonFile, "utf8"))).toMatchObject({
+          incompleteRuns: [],
+          runCounts: { failure: 1 },
+        });
       });
-    });
-  });
+    },
+    90_000,
+  );
 });

--- a/test/e2e/support/e2e-unit-test-gaps.test.ts
+++ b/test/e2e/support/e2e-unit-test-gaps.test.ts
@@ -422,10 +422,15 @@ describe("weekly E2E unit-test gap analysis", () => {
         { mode: 0o600 },
       );
       fs.symlinkSync(target, path.join(cacheDir, "56789014-attempt-1.json"));
+      let reads = 0;
 
       await expect(
-        collectEvidence([failedRun(56789014)], cacheDir, async () => ""),
+        collectEvidence([failedRun(56789014)], cacheDir, async () => {
+          reads += 1;
+          return "";
+        }),
       ).rejects.toThrow("Cached evidence for run 56789014 is not a bounded regular file.");
+      expect(reads).toBe(0);
     });
   });
 

--- a/tools/e2e/unit-test-gaps.mts
+++ b/tools/e2e/unit-test-gaps.mts
@@ -5,10 +5,11 @@ import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 import {
   buildUnitGapReport,
+  extractJobSignatures,
   type E2ERunRecord,
   formatUnitGapReport,
   type RunLogEvidence,
@@ -19,9 +20,52 @@ const NEMOCLAW_REPOSITORY = "NVIDIA/NemoClaw";
 const DEFAULT_WORKFLOWS = ["e2e.yaml", "portable-profile-e2e.yaml"];
 const MAX_GH_BUFFER_BYTES = 128 * 1024 * 1024;
 const MAX_RUNS_PER_WORKFLOW = 1000;
-const DEFAULT_CONCURRENCY = 6;
+const MAX_CACHE_FILE_BYTES = 1024 * 1024;
+const MAX_FAILED_LOG_READS = 50;
+const DEFAULT_CONCURRENCY = 2;
+const CACHE_VERSION = 1;
+
+type GhRunner = (args: readonly string[]) => Promise<string>;
+
+interface CachedFailureEvidence {
+  attempt: number;
+  runId: number;
+  signatures: Array<{ job: string; signature: string }>;
+  version: typeof CACHE_VERSION;
+}
+
+export interface EvidenceCollectionPlan {
+  cachedRuns: number;
+  deferredRuns: number;
+  failedLogReads: number;
+}
+
+export class EvidenceBatchIncompleteError extends Error {
+  constructor(readonly deferredRuns: number) {
+    super(
+      `${String(deferredRuns)} failed runs remain after this 50-log batch. Rerun the command with the same cache directory.`,
+    );
+    this.name = "EvidenceBatchIncompleteError";
+  }
+}
+
+export class GitHubEvidenceReadError extends Error {
+  constructor(
+    readonly kind: "access" | "rate-limit",
+    readonly runId: number | null,
+  ) {
+    const resource = runId === null ? "the workflow run list" : `logs for run ${String(runId)}`;
+    super(
+      kind === "rate-limit"
+        ? `GitHub rate limit prevented reading ${resource}. Wait for the quota to reset, then reuse the same cache directory.`
+        : `GitHub denied access to ${resource}. Correct gh authentication or authorization before retrying with the same cache directory.`,
+    );
+    this.name = "GitHubEvidenceReadError";
+  }
+}
 
 interface Options {
+  cacheDir?: string;
   days: number;
   jsonOutput: string;
   logsDir?: string;
@@ -33,7 +77,7 @@ interface Options {
 
 function usage(): never {
   throw new Error(
-    "usage: unit-test-gaps.mts [--days 7 | --since YYYY-MM-DD] --output REPORT.md --json-output REPORT.json [--workflow FILE] [--runs-file RUNS.json --logs-dir DIR]",
+    "usage: unit-test-gaps.mts [--days 7 | --since YYYY-MM-DD] --output REPORT.md --json-output REPORT.json (--cache-dir DIR [--workflow FILE] | --runs-file RUNS.json --logs-dir DIR)",
   );
 }
 
@@ -62,6 +106,9 @@ function parseArgs(argv: readonly string[]): Options {
     } else if (flag === "--json-output" && value !== undefined) {
       options.jsonOutput = value;
       index += 1;
+    } else if (flag === "--cache-dir" && value !== undefined) {
+      options.cacheDir = value;
+      index += 1;
     } else if (flag === "--workflow" && value !== undefined) {
       options.workflows.push(value);
       index += 1;
@@ -77,6 +124,8 @@ function parseArgs(argv: readonly string[]): Options {
   }
   if (options.output.length === 0 || options.jsonOutput.length === 0) usage();
   if ((options.runsFile === undefined) !== (options.logsDir === undefined)) usage();
+  if (options.runsFile === undefined && options.cacheDir === undefined) usage();
+  if (options.runsFile !== undefined && options.cacheDir !== undefined) usage();
   if (options.workflows.length === 0) options.workflows = [...DEFAULT_WORKFLOWS];
   return options;
 }
@@ -169,16 +218,23 @@ export function failedRunLogArgs(databaseId: number): string[] {
 async function collectRuns(
   workflows: readonly string[],
   range: { from: string; to: string },
+  runGh: GhRunner,
 ): Promise<E2ERunRecord[]> {
-  const records = await Promise.all(
-    workflows.map(async (workflow) => {
-      const output = await gh(listRunsArgs(workflow, range));
-      const parsed = JSON.parse(output) as unknown;
-      if (!Array.isArray(parsed)) throw new Error(`GitHub returned malformed runs for ${workflow}`);
-      requireCompleteRunSelection(workflow, parsed.length);
-      return parsed.map(normalizeRun);
-    }),
-  );
+  const records: E2ERunRecord[][] = [];
+  for (const workflow of workflows) {
+    let output: string;
+    try {
+      output = await runGh(listRunsArgs(workflow, range));
+    } catch (error) {
+      const kind = classifyGitHubEvidenceReadError(error);
+      if (kind !== null) throw new GitHubEvidenceReadError(kind, null);
+      throw error;
+    }
+    const parsed = JSON.parse(output) as unknown;
+    if (!Array.isArray(parsed)) throw new Error(`GitHub returned malformed runs for ${workflow}`);
+    requireCompleteRunSelection(workflow, parsed.length);
+    records.push(parsed.map(normalizeRun));
+  }
   const byId = new Map<number, E2ERunRecord>();
   for (const run of records.flat()) byId.set(run.databaseId, run);
   return [...byId.values()].sort((left, right) => left.createdAt.localeCompare(right.createdAt));
@@ -203,20 +259,165 @@ async function parallelMap<T, R>(
   return output;
 }
 
-async function collectEvidence(runs: readonly E2ERunRecord[]): Promise<RunLogEvidence[]> {
+function signaturesToLog(
+  signatures: ReadonlyArray<{ job: string; signature: string }>,
+): string {
+  if (signatures.length === 0) return "";
+  return `${signatures.map(({ job, signature }) => `${job}\tstep\t${signature}`).join("\n")}\n`;
+}
+
+function cacheFile(cacheDir: string, run: E2ERunRecord): string {
+  return path.join(cacheDir, `${String(run.databaseId)}-attempt-${String(run.attempt)}.json`);
+}
+
+function ensurePrivateDirectory(directory: string): void {
+  if (fs.existsSync(directory)) {
+    const stat = fs.lstatSync(directory);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error("The evidence cache path must be a directory, not a symbolic link.");
+    }
+  } else {
+    fs.mkdirSync(directory, { mode: 0o700, recursive: true });
+  }
+  fs.chmodSync(directory, 0o700);
+}
+
+function parseCachedEvidence(contents: string, run: E2ERunRecord): CachedFailureEvidence {
+  const parsed = JSON.parse(contents) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Cached evidence for run ${String(run.databaseId)} is not a JSON object.`);
+  }
+  const record = parsed as Record<string, unknown>;
+  const signatures = record.signatures;
+  if (
+    record.version !== CACHE_VERSION ||
+    record.runId !== run.databaseId ||
+    record.attempt !== run.attempt ||
+    !Array.isArray(signatures) ||
+    signatures.some(
+      (entry) =>
+        !entry ||
+        typeof entry !== "object" ||
+        Array.isArray(entry) ||
+        typeof (entry as Record<string, unknown>).job !== "string" ||
+        typeof (entry as Record<string, unknown>).signature !== "string" ||
+        ((entry as Record<string, unknown>).job as string).length === 0 ||
+        ((entry as Record<string, unknown>).signature as string).length === 0 ||
+        ((entry as Record<string, unknown>).job as string).length > 512 ||
+        ((entry as Record<string, unknown>).signature as string).length > 240 ||
+        /[\r\n\t]/u.test((entry as Record<string, unknown>).job as string) ||
+        /[\r\n\t]/u.test((entry as Record<string, unknown>).signature as string),
+    )
+  ) {
+    throw new Error(`Cached evidence for run ${String(run.databaseId)} does not match the run.`);
+  }
+  return parsed as CachedFailureEvidence;
+}
+
+function readCachedEvidence(cacheDir: string, run: E2ERunRecord): CachedFailureEvidence | null {
+  const file = cacheFile(cacheDir, run);
+  if (!fs.existsSync(file)) return null;
+  const stat = fs.lstatSync(file);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_CACHE_FILE_BYTES) {
+    throw new Error(`Cached evidence for run ${String(run.databaseId)} is not a bounded regular file.`);
+  }
+  fs.chmodSync(file, 0o600);
+  return parseCachedEvidence(fs.readFileSync(file, "utf8"), run);
+}
+
+function writeCachedEvidence(
+  cacheDir: string,
+  run: E2ERunRecord,
+  signatures: CachedFailureEvidence["signatures"],
+): void {
+  const destination = cacheFile(cacheDir, run);
+  const temporary = `${destination}.${String(process.pid)}.tmp`;
+  try {
+    fs.writeFileSync(
+      temporary,
+      `${JSON.stringify(
+        { attempt: run.attempt, runId: run.databaseId, signatures, version: CACHE_VERSION },
+        null,
+        2,
+      )}\n`,
+      { encoding: "utf8", flag: "wx", mode: 0o600 },
+    );
+    fs.renameSync(temporary, destination);
+    fs.chmodSync(destination, 0o600);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+function commandErrorText(error: unknown): string {
+  if (error && typeof error === "object" && "stderr" in error) {
+    const stderr = (error as { stderr?: unknown }).stderr;
+    if (typeof stderr === "string") return stderr;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function classifyGitHubEvidenceReadError(error: unknown): "access" | "rate-limit" | null {
+  const message = commandErrorText(error);
+  if (/API rate limit exceeded|secondary rate limit|abuse detection|HTTP\s+429/iu.test(message)) {
+    return "rate-limit";
+  }
+  if (
+    /HTTP\s+(?:401|403)|authentication|authorization|resource not accessible|single sign-on|\bSSO\b|credential|permission denied/iu.test(
+      message,
+    )
+  ) {
+    return "access";
+  }
+  return null;
+}
+
+export async function collectEvidence(
+  runs: readonly E2ERunRecord[],
+  cacheDir: string,
+  runGh: GhRunner = gh,
+  concurrency = DEFAULT_CONCURRENCY,
+  reportPlan: (plan: EvidenceCollectionPlan) => void = () => undefined,
+): Promise<RunLogEvidence[]> {
+  ensurePrivateDirectory(cacheDir);
   const failures = runs.filter((run) => run.status === "completed" && run.conclusion === "failure");
   const logs = new Map<number, RunLogEvidence>();
-  await parallelMap(failures, DEFAULT_CONCURRENCY, async (run) => {
+  const missing: E2ERunRecord[] = [];
+  for (const run of failures) {
+    const cached = readCachedEvidence(cacheDir, run);
+    if (cached === null) {
+      missing.push(run);
+    } else {
+      logs.set(run.databaseId, { log: signaturesToLog(cached.signatures), run });
+    }
+  }
+  const scheduled = missing.slice(0, MAX_FAILED_LOG_READS);
+  const deferredRuns = missing.length - scheduled.length;
+  reportPlan({
+    cachedRuns: failures.length - missing.length,
+    deferredRuns,
+    failedLogReads: scheduled.length,
+  });
+
+  let fatalError: GitHubEvidenceReadError | null = null;
+  await parallelMap(scheduled, concurrency, async (run) => {
+    if (fatalError !== null) return;
     try {
-      const log = await gh(failedRunLogArgs(run.databaseId));
-      logs.set(run.databaseId, { log, run });
+      const rawLog = await runGh(failedRunLogArgs(run.databaseId));
+      const signatures = extractJobSignatures(rawLog);
+      writeCachedEvidence(cacheDir, run, signatures);
+      logs.set(run.databaseId, { log: signaturesToLog(signatures), run });
     } catch (error) {
-      logs.set(run.databaseId, {
-        error: error instanceof Error ? error.message : "failed log unavailable",
-        run,
-      });
+      const kind = classifyGitHubEvidenceReadError(error);
+      if (kind !== null) {
+        fatalError ??= new GitHubEvidenceReadError(kind, run.databaseId);
+      } else {
+        logs.set(run.databaseId, { error: "failed log unavailable", run });
+      }
     }
   });
+  if (fatalError !== null) throw fatalError;
+  if (deferredRuns > 0) throw new EvidenceBatchIncompleteError(deferredRuns);
   return runs.map((run) => logs.get(run.databaseId) ?? { run });
 }
 
@@ -230,7 +431,9 @@ function readOfflineEvidence(runsFile: string, logsDir: string): RunLogEvidence[
     const error = fs.existsSync(errorPath) ? fs.readFileSync(errorPath, "utf8").trim() : "";
     return {
       ...(error.length > 0 ? { error } : {}),
-      ...(fs.existsSync(logPath) ? { log: fs.readFileSync(logPath, "utf8") } : {}),
+      ...(fs.existsSync(logPath)
+        ? { log: signaturesToLog(extractJobSignatures(fs.readFileSync(logPath, "utf8"))) }
+        : {}),
       run,
     };
   });
@@ -242,13 +445,28 @@ function writePrivate(file: string, contents: string): void {
   fs.chmodSync(file, 0o600);
 }
 
-export async function main(argv = process.argv.slice(2)): Promise<void> {
+export async function main(
+  argv = process.argv.slice(2),
+  dependencies: { now?: Date; runGh?: GhRunner } = {},
+): Promise<void> {
   const options = parseArgs(argv);
-  const range = rangeFromOptions(options);
+  const range = rangeFromOptions(options, dependencies.now);
+  const runGh = dependencies.runGh ?? gh;
+  if (options.cacheDir !== undefined) ensurePrivateDirectory(options.cacheDir);
   const evidence =
     options.runsFile !== undefined && options.logsDir !== undefined
       ? readOfflineEvidence(options.runsFile, options.logsDir)
-      : await collectEvidence(await collectRuns(options.workflows, range));
+      : await collectEvidence(
+          await collectRuns(options.workflows, range, runGh),
+          options.cacheDir!,
+          runGh,
+          DEFAULT_CONCURRENCY,
+          ({ cachedRuns, deferredRuns, failedLogReads }) => {
+            process.stdout.write(
+              `Reusing ${String(cachedRuns)} cached failed runs; reading ${String(failedLogReads)} failed logs; deferring ${String(deferredRuns)} runs.\n`,
+            );
+          },
+        );
   const report = buildUnitGapReport(evidence, range);
   writePrivate(options.output, formatUnitGapReport(report));
   writePrivate(options.jsonOutput, `${JSON.stringify(report, null, 2)}\n`);
@@ -258,6 +476,6 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
   if (report.incompleteRuns.length > 0) process.exitCode = 1;
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? "")) {
   await main();
 }

--- a/tools/e2e/unit-test-gaps.mts
+++ b/tools/e2e/unit-test-gaps.mts
@@ -316,13 +316,35 @@ function parseCachedEvidence(contents: string, run: E2ERunRecord): CachedFailure
 
 function readCachedEvidence(cacheDir: string, run: E2ERunRecord): CachedFailureEvidence | null {
   const file = cacheFile(cacheDir, run);
-  if (!fs.existsSync(file)) return null;
-  const stat = fs.lstatSync(file);
-  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_CACHE_FILE_BYTES) {
-    throw new Error(`Cached evidence for run ${String(run.databaseId)} is not a bounded regular file.`);
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (typeof noFollow !== "number") {
+    throw new Error("O_NOFOLLOW is required for the evidence cache.");
   }
-  fs.chmodSync(file, 0o600);
-  return parseCachedEvidence(fs.readFileSync(file, "utf8"), run);
+  let descriptor: number;
+  try {
+    descriptor = fs.openSync(file, fs.constants.O_RDONLY | noFollow | fs.constants.O_NONBLOCK);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return null;
+    if (code === "ELOOP") {
+      throw new Error(
+        `Cached evidence for run ${String(run.databaseId)} is not a bounded regular file.`,
+      );
+    }
+    throw error;
+  }
+  try {
+    const stat = fs.fstatSync(descriptor);
+    if (!stat.isFile() || stat.size > MAX_CACHE_FILE_BYTES) {
+      throw new Error(
+        `Cached evidence for run ${String(run.databaseId)} is not a bounded regular file.`,
+      );
+    }
+    fs.fchmodSync(descriptor, 0o600);
+    return parseCachedEvidence(fs.readFileSync(descriptor, "utf8"), run);
+  } finally {
+    fs.closeSync(descriptor);
+  }
 }
 
 function writeCachedEvidence(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The weekly E2E unit-gap collector previously reread every failed log and continued after GitHub access failures. It now collects at most 50 uncached logs per invocation, reuses private sanitized evidence, and stops on authentication, authorization, or rate-limit failures.

## Changes

- Cache normalized job names and sanitized signatures by GitHub run ID and attempt with private filesystem modes.
- Limit each invocation to 50 uncached failed-log reads and direct the operator to reuse the cache for the next batch.
- Stop workflow-list and failed-log collection when GitHub rejects access or reports a rate limit.
- Sanitize logs before retention and correct the `npm run e2e:unit-gaps` entry point.
- Add regression tests for cache reuse, attempt separation, cache validation, access failures, high-volume batches, and executable invocation.
- Update the owning E2E guide with cache custody, rerun, and cleanup requirements.

The escaped defect came from an incomplete test boundary in #9256. Its tests covered parsing and report grouping but did not execute the npm entry point or model a high-volume seven-day collection.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer security review passed all nine rubric categories with no findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `test/e2e/README.md`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 133377a08 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/e2e-unit-test-gaps.test.ts`: 30 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — GitHub CI will run the broad checks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added resumable evidence collection with secure, reusable caching.
  * Added offline operation using previously collected runs and logs.
  * Added configurable cache location and collection concurrency.
  * Improved failed-run log processing with bounded batches and automatic retries.
  * Improved access and rate-limit error handling and reporting.
  * Normalized cached evidence and enforced private file permissions.
  * Added validation to prevent conflicting collection modes.
* **Documentation**
  * Updated guidance for cache management, cleanup, retries, and secure log handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->