### PR TITLE
fix(e2e): honor managed gateway unit path

### DIFF
--- a/test/e2e/fixtures/portable-profile-systemctl-shim.sh
+++ b/test/e2e/fixtures/portable-profile-systemctl-shim.sh
@@ -20,7 +20,7 @@ service_pid_file="${runtime_dir}/nemoclaw-podman-service.pid"
 log_file="${runtime_dir}/nemoclaw-podman-service.log"
 gateway_service_name="nemoclaw-openshell-gateway"
 gateway_unit_path="${config_home}/systemd/user/${gateway_service_name}.service"
-gateway_binary_path="${bin_home}/openshell-gateway"
+gateway_binary_path=""
 gateway_env_file="${config_home}/openshell/gateway.env"
 gateway_tls_dir="${state_home}/openshell/tls"
 gateway_state_dir="${state_home}/openshell/gateway"
@@ -460,6 +460,34 @@ stop_runtime() {
   rm -f "$socket_path" "$backend_socket_path"
 }
 
+gateway_binary_path_is_trusted() {
+  local candidate="$1"
+  local user_bin_home="${bin_home%/}"
+  case "$candidate" in
+    "${user_bin_home}/openshell-gateway" | /usr/local/bin/openshell-gateway | /usr/bin/openshell-gateway)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+read_managed_gateway_binary_path() {
+  local candidate="" count=0 line
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      ExecStart=*)
+        candidate="${line#ExecStart=}"
+        ((count += 1))
+        ;;
+    esac
+  done <"$gateway_unit_path"
+  [[ "$count" -eq 1 && "$candidate" == /* && "$candidate" != *[[:space:]]* ]] || return 1
+  gateway_binary_path_is_trusted "$candidate" || return 1
+  printf '%s\n' "$candidate"
+}
+
 validate_gateway_unit() {
   if [[ ! -f "$gateway_unit_path" || -L "$gateway_unit_path" || ! -r "$gateway_unit_path" ]]; then
     echo "Portable profile fixture requires the managed gateway user service at ${gateway_unit_path}." >&2
@@ -469,15 +497,21 @@ validate_gateway_unit() {
     echo "Portable profile fixture rejected the foreign gateway user service at ${gateway_unit_path}." >&2
     return 1
   fi
-  if [[ "$(grep -Fxc "ExecStart=${gateway_binary_path}" "$gateway_unit_path" || true)" -ne 1 ]] \
-    || [[ "$(grep -Fxc "ExecStartPre=${gateway_binary_path} generate-certs --output-dir \${OPENSHELL_LOCAL_TLS_DIR} --server-san host.openshell.internal" "$gateway_unit_path" || true)" -ne 1 ]] \
+  local unit_gateway_binary
+  unit_gateway_binary="$(read_managed_gateway_binary_path)" || {
+    echo "Portable profile fixture rejected the OpenShell gateway user service identity at ${gateway_unit_path}." >&2
+    return 1
+  }
+  if [[ "$(grep -Fxc "ExecStart=${unit_gateway_binary}" "$gateway_unit_path" || true)" -ne 1 ]] \
+    || [[ "$(grep -Fxc "ExecStartPre=${unit_gateway_binary} generate-certs --output-dir \${OPENSHELL_LOCAL_TLS_DIR} --server-san host.openshell.internal" "$gateway_unit_path" || true)" -ne 1 ]] \
     || [[ "$(grep -Fxc 'StateDirectory=openshell/gateway' "$gateway_unit_path" || true)" -ne 1 ]] \
     || [[ "$(grep -Fxc 'Environment=OPENSHELL_LOCAL_TLS_DIR=%S/openshell/tls' "$gateway_unit_path" || true)" -ne 1 ]] \
     || [[ "$(grep -Fxc 'EnvironmentFile=-%E/openshell/gateway.env' "$gateway_unit_path" || true)" -ne 1 ]] \
-    || [[ ! -x "$gateway_binary_path" || -L "$gateway_binary_path" ]]; then
-    echo "Portable profile fixture rejected the gateway user service identity at ${gateway_unit_path}." >&2
+    || [[ ! -f "$unit_gateway_binary" || ! -r "$unit_gateway_binary" || ! -x "$unit_gateway_binary" || -L "$unit_gateway_binary" ]]; then
+    echo "Portable profile fixture rejected the OpenShell gateway user service identity at ${gateway_unit_path}." >&2
     return 1
   fi
+  gateway_binary_path="$unit_gateway_binary"
 }
 
 load_gateway_environment() {

--- a/test/e2e/support/portable-profile-systemctl-shim.test.ts
+++ b/test/e2e/support/portable-profile-systemctl-shim.test.ts
@@ -241,6 +241,24 @@ function formatPsStartTime(scope: FixtureScope, startTime: string): ReturnType<t
   );
 }
 
+function readManagedGatewayBinaryPath(scope: FixtureScope): ReturnType<typeof spawnSync> {
+  return spawnSync(
+    "bash",
+    [
+      "-c",
+      'source "$1"\nread_managed_gateway_binary_path',
+      "portable-profile-gateway-binary",
+      scope.shim,
+    ],
+    {
+      encoding: "utf8",
+      env: scope.env,
+      killSignal: "SIGKILL",
+      timeout: 15_000,
+    },
+  );
+}
+
 function systemctlAsync(
   scope: FixtureScope,
   args: string[],
@@ -434,6 +452,37 @@ function portableLaunchStep(name: string): WorkflowStep {
 }
 
 describe("portable profile systemctl fixture", () => {
+  it.each(["/usr/local/bin/openshell-gateway", "/usr/bin/openshell-gateway"])(
+    "reads installer-selected OpenShell gateway binary %s from the managed user service (#9208)",
+    (gatewayBinary) => {
+      const scope = createFixture();
+      try {
+        fs.writeFileSync(scope.gatewayUnitPath, gatewayServiceUnit(gatewayBinary), { mode: 0o600 });
+        const result = readManagedGatewayBinaryPath(scope);
+        expect(result.status, String(result.stderr)).toBe(0);
+        expect(result.stdout).toBe(`${gatewayBinary}\n`);
+      } finally {
+        fs.rmSync(scope.directory, { force: true, recursive: true });
+      }
+    },
+  );
+
+  it("rejects a managed OpenShell gateway user service that names an untrusted binary path (#9208)", () => {
+    const scope = createFixture();
+    try {
+      fs.writeFileSync(
+        scope.gatewayUnitPath,
+        gatewayServiceUnit("/opt/openshell/bin/openshell-gateway"),
+        { mode: 0o600 },
+      );
+      const result = readManagedGatewayBinaryPath(scope);
+      expect(result.status).not.toBe(0);
+      expect(result.stdout).toBe("");
+    } finally {
+      fs.rmSync(scope.directory, { force: true, recursive: true });
+    }
+  });
+
   it("normalizes irregular ps fallback spacing to one process-start-time identity (#9006)", () => {
     const scope = createFixture();
     try {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The protected Portable Profile `systemctl` fixture now reads the OpenShell gateway binary selected by the managed user service instead of assuming the user XDG bin directory. It accepts only the three installer-owned locations and rejects ambiguous or untrusted service identities.

This restores the portable-launch fixture after automatic run `31969858915`, job `95220512323`, rejected a valid `/usr/local/bin/openshell-gateway` unit. The immutable artifact is `9269507500` with digest `sha256:2bc324b785af9d93abef8dc3a4bc4da38b4c2d30f51e7f88838e8cf0cd6315e0`.

## Related Issue

Relates #9208.

## Changes

- Read exactly one absolute `ExecStart` path from the managed OpenShell gateway user service.
- Accept only the installer-supported XDG user bin, `/usr/local/bin`, or `/usr/bin` gateway locations.
- Keep the exact `ExecStartPre`, unit marker, environment, file type, permission, and symlink checks fail closed.
- Cover both system locations and an untrusted path with deterministic fixture tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes only the protected Portable Profile E2E fixture and its deterministic support coverage; production and supported user behavior are unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security review of commit `6b8fc44b8` passed with no findings; the path allowlist matches installer authority and preserves existing unit, environment, process-identity, logging, and cleanup controls.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Independent Pi CLI review covered the complete two-file PR diff at latest PR commit `338dd2fd6`. The change is limited to an internal E2E fixture and support tests for installer-selected OpenShell gateway paths. It changes no public command, configuration, workflow, default, or supported behavior. The conflict-free main merge incorporates the terminal-test fix required by CI.
- Agent: Pi CLI
<!-- docs-review-head-sha: 338dd2fd6 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `./node_modules/.bin/vitest run --project e2e-support test/e2e/support/portable-profile-systemctl-shim.test.ts` passed 30/30 on exact current main.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this two-file fixture repair. Current-main `checks:repository`, CLI typecheck, source-shape, test-size, conditional, test-loop, and scoped normal hooks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of the managed gateway service configuration.
  * Gateway binaries must now use trusted system locations and be regular, readable executables.
  * Added checks to ensure service start commands consistently reference the configured gateway binary.
  * Improved error reporting when the gateway identity or executable configuration is invalid.

* **Tests**
  * Added coverage for valid gateway paths in trusted locations.
  * Added validation for rejecting untrusted paths and missing executable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->