### PR TITLE
fix(pairing): clear consecutive scope approvals

### DIFF
--- a/src/lib/actions/sandbox/connect-autopair-budget.ts
+++ b/src/lib/actions/sandbox/connect-autopair-budget.ts
@@ -6,7 +6,10 @@
 // so tests can import and assert the invariant on the real values without
 // pulling in connect.ts's heavy transitive requires (#4504).
 
-export const CONNECT_AUTO_PAIR_MAX_APPROVALS = 1;
+// Fresh OpenClaw finalization can observe the initial CLI pairing request and
+// its immediately following operator.write upgrade in the same pass. Keep the
+// budget at those two bounded transitions so neither request is left pending.
+export const CONNECT_AUTO_PAIR_MAX_APPROVALS = 2;
 // `openclaw devices list` budget (seconds), interpolated into the in-sandbox
 // script so the invariant below is asserted on real values, not source text.
 // A cold OpenClaw 2026.6.10 CLI can take just over 2s to load its runtime
@@ -30,4 +33,4 @@ export const CONNECT_AUTO_PAIR_POST_TIMEOUT_OBSERVE_S = 4;
 // sources the proxy environment and launches Python. Keep 10s beyond the longer
 // inner path so the outer timer cannot terminate a legitimate approval before
 // its fixed receipt is returned.
-export const CONNECT_AUTO_PAIR_TIMEOUT_MS = 25_000;
+export const CONNECT_AUTO_PAIR_TIMEOUT_MS = 35_000;

--- a/test/sandbox-connect-inference/auto-pair-approval.test.ts
+++ b/test/sandbox-connect-inference/auto-pair-approval.test.ts
@@ -115,10 +115,10 @@ describe("sandbox connect auto-pair approval pass (#4263)", () => {
       const script = extractApprovalPassScript(stateFile, sandboxName);
       // Disallowed/malformed/unknown requests are skipped by the policy before
       // an approve is even attempted (they `continue` before the attempt
-      // counter increments), so they do not consume the MAX_APPROVALS=1 budget
-      // (#4504). They are ordered first here to prove the rejection path runs;
-      // the single allowed request (`ok-cli`) is then approved and exhausts the
-      // one-attempt budget, so the trailing duplicate `ok-cli` is never reached.
+      // counter increments), so they do not consume the bounded approval
+      // budget (#4504). They are ordered first here to prove the rejection path
+      // runs. The initial CLI pairing and its write-scope upgrade are then both
+      // approved, while the trailing duplicate is never reached.
       const run = runApprovalPassScript(script, [
         {
           requestId: "admin-cli",
@@ -139,24 +139,28 @@ describe("sandbox connect auto-pair approval pass (#4263)", () => {
           scopes: ["operator.read"],
         },
         {
-          requestId: "ok-cli",
-          clientId: "openclaw-cli",
+          requestId: "initial-cli-pairing",
+          clientId: "cli",
           clientMode: "cli",
-          scopes: ["operator.read", "operator.write"],
+          scopes: ["operator.pairing"],
         },
         {
-          requestId: "ok-cli",
-          clientId: "openclaw-cli",
+          requestId: "cli-write-upgrade",
+          clientId: "cli",
           clientMode: "cli",
-          scopes: ["operator.read", "operator.write"],
+          scopes: ["operator.pairing", "operator.write"],
+        },
+        {
+          requestId: "cli-write-upgrade",
+          clientId: "cli",
+          clientMode: "cli",
+          scopes: ["operator.pairing", "operator.write"],
         },
       ]);
 
       expect(run.result.status).toBe(0);
-      // Only the first allowed request is approved — MAX_APPROVALS is 1 (#4504),
-      // the realistic single pending CLI/webchat scope upgrade.
-      expect(run.approvals).toEqual(["ok-cli"]);
-      expect(run.approvalEnv).toEqual(["unset:unset:unset"]);
+      expect(run.approvals).toEqual(["initial-cli-pairing", "cli-write-upgrade"]);
+      expect(run.approvalEnv).toEqual(["unset:unset:unset", "unset:unset:unset"]);
     },
   );
 

--- a/test/sandbox-connect-inference/auto-pair-approval.test.ts
+++ b/test/sandbox-connect-inference/auto-pair-approval.test.ts
@@ -118,7 +118,8 @@ describe("sandbox connect auto-pair approval pass (#4263)", () => {
       // counter increments), so they do not consume the bounded approval
       // budget (#4504). They are ordered first here to prove the rejection path
       // runs. The initial CLI pairing and its write-scope upgrade are then both
-      // approved, while the trailing duplicate is never reached.
+      // approved, while the trailing distinct request proves the two-approval
+      // cap stops the pass.
       const run = runApprovalPassScript(script, [
         {
           requestId: "admin-cli",
@@ -151,10 +152,10 @@ describe("sandbox connect auto-pair approval pass (#4263)", () => {
           scopes: ["operator.pairing", "operator.write"],
         },
         {
-          requestId: "cli-write-upgrade",
-          clientId: "cli",
-          clientMode: "cli",
-          scopes: ["operator.pairing", "operator.write"],
+          requestId: "later-webchat-upgrade",
+          clientId: "openclaw-control-ui",
+          clientMode: "webchat",
+          scopes: ["operator.read", "operator.write"],
         },
       ]);
 


### PR DESCRIPTION
## Summary
Fresh OpenClaw onboarding can produce an initial CLI pairing request followed by a write-scope upgrade. This change lets the bounded approval pass clear both allowlisted transitions instead of leaving the upgrade pending.

## E2E root cause

- Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/31608673742
- Failed job: `issue-4462-scope-upgrade-approval` (job 94154557147)
- Signature: fresh onboarding paired one CLI device but left one same-device request pending with only `operator.pairing` granted
- Scope: one root cause, the connect-time approval pass stopped after the initial pairing request

## Changes

- Raise the shared connect approval cap from one to two allowlisted requests.
- Preserve the 10-second outer timing margin for two approval commands.
- Model the initial pairing, write upgrade, and a third distinct allowlisted request so the test protects the two-request ceiling.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: restores the intended connect-time pairing sequence without changing commands, configuration, errors, or a documented product contract
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent Codex Desktop review confirmed that unknown clients and `operator.admin` remain denied and the distinct third request protects the two-approval ceiling
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change restores the intended connect-time pairing sequence without changing commands, configuration, errors, or a documented product contract.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 96a15dd5c -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/sandbox-connect-inference/auto-pair-approval.test.ts src/lib/actions/sandbox/connect-autopair-budget.test.ts` passed 13 tests; the later test correction passed 9 tests in the changed file
- [ ] Applicable broad gate passed — not applicable because this changes one bounded constant and its focused regression test
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the number of approvals available during automatic connection pairing from one to two.
  - Extended the connection operation timeout to better accommodate pairing and permission upgrades.

- **Tests**
  - Updated approval-flow coverage for multiple pairing approvals and capped subsequent upgrade requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->