### PR TITLE
test: convert loop-generated cases to tables

### DIFF
--- a/nemoclaw/src/onboard/config.test.ts
+++ b/nemoclaw/src/onboard/config.test.ts
@@ -105,24 +105,25 @@ describe("onboard/config", () => {
       expect(describeOnboardProvider(config)).toBe("My Custom Provider");
     });
 
-    const endpointCases: [EndpointType, string][] = [
-      ["build", "NVIDIA Endpoints"],
-      ["openai", "OpenAI"],
-      ["anthropic", "Anthropic"],
-      ["gemini", "Google Gemini"],
-      ["ollama", "Local Ollama"],
-      ["vllm", "Local vLLM"],
-      ["nim-local", "Local NVIDIA NIM"],
-      ["ncp", "NVIDIA Cloud Partner"],
-      ["custom", "Other OpenAI-compatible endpoint"],
+    const endpointCases: Array<{ endpointType: EndpointType; expected: string }> = [
+      { endpointType: "build", expected: "NVIDIA Endpoints" },
+      { endpointType: "openai", expected: "OpenAI" },
+      { endpointType: "anthropic", expected: "Anthropic" },
+      { endpointType: "gemini", expected: "Google Gemini" },
+      { endpointType: "ollama", expected: "Local Ollama" },
+      { endpointType: "vllm", expected: "Local vLLM" },
+      { endpointType: "nim-local", expected: "Local NVIDIA NIM" },
+      { endpointType: "ncp", expected: "NVIDIA Cloud Partner" },
+      { endpointType: "custom", expected: "Other OpenAI-compatible endpoint" },
     ];
 
-    for (const [endpointType, expected] of endpointCases) {
-      it(`returns "${expected}" for endpoint type "${endpointType}"`, () => {
+    it.each(endpointCases)(
+      'returns "$expected" for endpoint type "$endpointType"',
+      ({ endpointType, expected }) => {
         const config = makeConfig({ endpointType, providerLabel: undefined });
         expect(describeOnboardProvider(config)).toBe(expected);
-      });
-    }
+      },
+    );
 
     it("returns Unknown for unsupported endpoint types", () => {
       const config = makeConfig({

--- a/src/lib/actions/sandbox/host-aliases.test.ts
+++ b/src/lib/actions/sandbox/host-aliases.test.ts
@@ -40,8 +40,9 @@ function expectHostAliasError(action: () => void): HostAliasesCommandError {
 }
 
 describe("host alias legacy gateway support checks", () => {
-  for (const driver of ["docker", "vm"] as const) {
-    it(`rejects ${driver} driver sandboxes before probing Docker`, () => {
+  it.each(["docker", "vm"] as const)(
+    "rejects %s driver sandboxes before probing Docker",
+    (driver) => {
       const probeLegacyGatewayContainer = vi.fn(() => ({ state: "present" as const }));
 
       const error = expectHostAliasError(() =>
@@ -56,8 +57,8 @@ describe("host alias legacy gateway support checks", () => {
       );
       expect(error.message).toContain(`which the ${driver} driver does not run`);
       expect(probeLegacyGatewayContainer).not.toHaveBeenCalled();
-    });
-  }
+    },
+  );
 
   it("reports a missing legacy gateway distinctly from Docker probe failures", () => {
     const error = expectHostAliasError(() =>

--- a/src/lib/messaging/channels/slack/hooks/status-health.test.ts
+++ b/src/lib/messaging/channels/slack/hooks/status-health.test.ts
@@ -116,9 +116,9 @@ describe("slack.statusHealth hook", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
-  for (const [name, account, inputs, expected, signal] of [
+  it.each([
     [
-      "classifies unavailable Slack credentials as terminal (#7383)",
+      "unavailable Slack credentials",
       {
         running: false,
         connected: false,
@@ -130,14 +130,15 @@ describe("slack.statusHealth hook", () => {
       { label: "Account probe", severity: "fail" },
     ],
     [
-      "classifies a Slack plugin probe failure as terminal (#7383)",
+      "a Slack plugin probe failure",
       { probe: { ok: false, error: "plugin failed to load" } },
       {},
       ["terminal", "plugin", "plugin_probe_failed", false],
       { label: "Account probe", severity: "warn" },
     ],
-  ] as const) {
-    it(name, () => {
+  ] as const)(
+    "classifies %s as terminal (#7383)",
+    (_condition, account, inputs, expected, signal) => {
       const [state, category, reason, retryable] = expected;
       const report = runProbe(account, inputs).report;
       expect(report.readiness).toMatchObject({
@@ -147,8 +148,8 @@ describe("slack.statusHealth hook", () => {
         retryable,
       } satisfies Partial<ChannelReadiness>);
       expect(report.signals).toContainEqual(expect.objectContaining(signal));
-    });
-  }
+    },
+  );
 
   it("returns a null transition time for an out-of-range Slack timestamp (#7383)", () => {
     expect(

--- a/src/lib/onboard/vllm-menu.test.ts
+++ b/src/lib/onboard/vllm-menu.test.ts
@@ -36,26 +36,24 @@ describe("buildVllmMenuEntries", () => {
     assert.match(entries[0].label, /running/);
   });
 
-  for (const [platform, hostLabel] of [
-    ["spark", "Spark"],
-    ["station", "Station"],
-  ] as const) {
-    it(`does not mark the running entry experimental on DGX ${hostLabel}`, () => {
-      const entries = buildVllmMenuEntries({
-        vllmRunning: true,
-        vllmProfile: null,
-        experimental: false,
-        platform,
-        hasVllmImage: false,
-        log: () => {},
-        env: {},
-      });
-      assert.equal(entries.length, 1);
-      assert.equal(entries[0].key, "vllm");
-      assert.doesNotMatch(entries[0].label, /experimental/);
-      assert.match(entries[0].label, /running/);
+  it.each([
+    { platform: "spark", hostLabel: "Spark" },
+    { platform: "station", hostLabel: "Station" },
+  ] as const)("does not mark the running entry experimental on DGX $hostLabel", ({ platform }) => {
+    const entries = buildVllmMenuEntries({
+      vllmRunning: true,
+      vllmProfile: null,
+      experimental: false,
+      platform,
+      hasVllmImage: false,
+      log: () => {},
+      env: {},
     });
-  }
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].key, "vllm");
+    assert.doesNotMatch(entries[0].label, /experimental/);
+    assert.match(entries[0].label, /running/);
+  });
 
   it("returns the install entry when a profile matches and EXPERIMENTAL is set", () => {
     const entries = buildVllmMenuEntries({

--- a/src/lib/openshell-sandbox-list.test.ts
+++ b/src/lib/openshell-sandbox-list.test.ts
@@ -76,22 +76,20 @@ describe("sandbox list gateway preflight and recovery (#6237)", () => {
     vi.restoreAllMocks();
   });
 
-  for (const [name, issue] of [
-    ["gateway image drift", imageDriftIssue],
-    ["host-process gateway drift", hostProcessDriftIssue],
-  ] as const) {
-    it(`exits before querying sandbox state for ${name}`, async () => {
-      mocks.detectPreflightIssue.mockReturnValueOnce(issue);
+  it.each([
+    { name: "gateway image drift", issue: imageDriftIssue },
+    { name: "host-process gateway drift", issue: hostProcessDriftIssue },
+  ])("exits before querying sandbox state for $name", async ({ issue }) => {
+    mocks.detectPreflightIssue.mockReturnValueOnce(issue);
 
-      await expect(captureSandboxListWithGatewayPreflightOrExit(context)).rejects.toThrow(
-        "process.exit(1)",
-      );
+    await expect(captureSandboxListWithGatewayPreflightOrExit(context)).rejects.toThrow(
+      "process.exit(1)",
+    );
 
-      expect(mocks.printIssue).toHaveBeenCalledWith(issue, context);
-      expect(mocks.captureOpenshell).not.toHaveBeenCalled();
-      expect(mocks.recoverNamedGatewayRuntime).not.toHaveBeenCalled();
-    });
-  }
+    expect(mocks.printIssue).toHaveBeenCalledWith(issue, context);
+    expect(mocks.captureOpenshell).not.toHaveBeenCalled();
+    expect(mocks.recoverNamedGatewayRuntime).not.toHaveBeenCalled();
+  });
 
   it("returns the successful sandbox list without gateway recovery", async () => {
     const result = await captureSandboxListWithGatewayPreflightOrExit(context);

--- a/src/lib/policy/host-redaction.test.ts
+++ b/src/lib/policy/host-redaction.test.ts
@@ -88,11 +88,9 @@ describe("isInternalHost", () => {
     "w.localdomain",
   ];
 
-  for (const host of internal) {
-    it(`treats ${host} as internal`, () => {
-      expect(isInternalHost(host)).toBe(true);
-    });
-  }
+  it.each(internal)("treats %s as internal", (host) => {
+    expect(isInternalHost(host)).toBe(true);
+  });
 
   const external = [
     "api.slack.com",
@@ -107,11 +105,9 @@ describe("isInternalHost", () => {
     "fec0::1",
     "2001:db8::1",
   ];
-  for (const host of external) {
-    it(`treats ${host} as external`, () => {
-      expect(isInternalHost(host)).toBe(false);
-    });
-  }
+  it.each(external)("treats %s as external", (host) => {
+    expect(isInternalHost(host)).toBe(false);
+  });
 });
 
 describe("hostStemsFromEndpoints", () => {

--- a/src/lib/sandbox/hermes-upstream-header.parity.test.ts
+++ b/src/lib/sandbox/hermes-upstream-header.parity.test.ts
@@ -50,13 +50,11 @@ const FIXTURES: Array<{ name: string; config: Record<string, unknown> }> = [
 ];
 
 describe("buildHermesUpstreamHeader parity", () => {
-  for (const fixture of FIXTURES) {
-    it(`agent and host helpers produce identical output for: ${fixture.name}`, () => {
-      const agent = buildAgentHeader(fixture.config);
-      const host = buildHostHeader(fixture.config);
-      expect(host).toBe(agent);
-    });
-  }
+  it.each(FIXTURES)("agent and host helpers produce identical output for: $name", ({ config }) => {
+    const agent = buildAgentHeader(config);
+    const host = buildHostHeader(config);
+    expect(host).toBe(agent);
+  });
 
   it("strips newlines and control characters so the comment cannot escape into YAML", () => {
     const malicious = {

--- a/test/canonical-credential-resolution.test.ts
+++ b/test/canonical-credential-resolution.test.ts
@@ -99,8 +99,9 @@ describe("resolveProviderCredential — canonical credential resolution (#2306)"
     },
   ];
 
-  for (const { name, credentialEnv, value } of providers) {
-    it(`resolves ${credentialEnv} (${name}) from credentials.json when not in env`, async () => {
+  it.each(providers)(
+    "resolves $credentialEnv ($name) from credentials.json when not in env",
+    async ({ credentialEnv, value }) => {
       const tmpDir = createFixtureHome(credentialEnv, value);
       // Ensure env does NOT have the key
       vi.stubEnv(credentialEnv, "");
@@ -111,8 +112,8 @@ describe("resolveProviderCredential — canonical credential resolution (#2306)"
 
       expect(result).toBe(value);
       expect(process.env[credentialEnv]).toBe(value);
-    });
-  }
+    },
+  );
 
   it("returns env value when only in process.env", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-2306-envonly-"));

--- a/test/channels-add-preset.test.ts
+++ b/test/channels-add-preset.test.ts
@@ -402,8 +402,9 @@ describe("channels add applies a matching policy preset (#3437)", () => {
     );
   });
 
-  for (const channel of ["telegram", "slack", "discord"]) {
-    it(`applies the '${channel}' preset before triggering rebuild`, async () => {
+  it.each(["telegram", "slack", "discord"])(
+    "applies the '%s' preset before triggering rebuild",
+    async (channel) => {
       await addSandboxChannel("test-sb", { channel });
 
       expect(applyPresetSpy).toHaveBeenCalledOnce();
@@ -414,8 +415,8 @@ describe("channels add applies a matching policy preset (#3437)", () => {
       expect(callOrder.indexOf(`applyPreset:${channel}`)).toBeLessThan(
         callOrder.indexOf("promptAndRebuild"),
       );
-    });
-  }
+    },
+  );
 
   it("applies the tokenless WhatsApp preset for Hermes before triggering rebuild", async () => {
     sandboxAgent = "hermes";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Convert 10 loop-generated test groups to Vitest `it.each` tables. This keeps the existing cases and assertions while making each candidate explicit in the test runner and reducing the test-loop growth baseline from 1,377 to 1,367.

## Changes

- Convert host redaction, endpoint label, header parity, credential resolution, channel preset, DGX platform, host alias, sandbox drift, and Slack readiness cases to table tests.
- Preserve the existing inputs, assertions, setup, cleanup, and behavior-oriented test names.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This is a test-only registration refactor with no user-facing behavior or supported product change.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The change only replaces suite-level test generation with `it.each`; sensitive inputs, assertions, state isolation, and production controls are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed all nine changed test files and all 10 conversions from suite-level generated tests to `it.each`. The conversions preserve behavior-oriented test titles and do not change user-facing NemoClaw behavior or documentation.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 15b5d3066 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [ ] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run` for the nine changed files passed 198 tests; `npm run test:titles:check` passed; the scanner reports 1,367 loops, 10 fewer than the baseline.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
