### PR TITLE
fix(e2e): strip private OpenShell launch authority

### DIFF
--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -135,21 +135,14 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const argv = process.argv.slice(2);
-// Direct CLI exec paths can inherit source names that filtered helpers omit.
-const authorityNames = [
-  "NEMOCLAW_OPENSHELL_COMMAND",
-  "NEMOCLAW_LAUNCH_SANDBOX",
-  "NEMOCLAW_LAUNCH_RUN_ID",
-  "NEMOCLAW_LAUNCH_INTERCEPT_PATH",
-  "NEMOCLAW_LAUNCH_PTY_RECORD_WRITER_SCRIPT",
-  "NEMOCLAW_LAUNCH_RUNTIME_ENV_SCRIPT",
-  "OPENSHELL_NEMOCLAW_LAUNCH_REAL_COMMAND",
-  "OPENSHELL_NEMOCLAW_LAUNCH_SANDBOX",
-  "OPENSHELL_NEMOCLAW_LAUNCH_RUN_ID",
-  "OPENSHELL_NEMOCLAW_LAUNCH_INTERCEPT_PATH",
-  "OPENSHELL_NEMOCLAW_LAUNCH_PTY_RECORD_WRITER_SCRIPT",
-  "OPENSHELL_NEMOCLAW_LAUNCH_RUNTIME_ENV_SCRIPT",
-];
+// Direct CLI exec paths can inherit launch authority that filtered helpers omit.
+const authorityNames = Object.keys(process.env).filter(
+  (name) =>
+    name === "NEMOCLAW_OPENSHELL_BIN" ||
+    name === "NEMOCLAW_OPENSHELL_COMMAND" ||
+    name.startsWith("NEMOCLAW_LAUNCH_") ||
+    name.startsWith("OPENSHELL_NEMOCLAW_LAUNCH_"),
+);
 const realOpenShell = process.env.OPENSHELL_NEMOCLAW_LAUNCH_REAL_COMMAND;
 const sandboxName = process.env.OPENSHELL_NEMOCLAW_LAUNCH_SANDBOX;
 const runId = process.env.OPENSHELL_NEMOCLAW_LAUNCH_RUN_ID;
@@ -728,6 +721,16 @@ umask 077
 command -v script >/dev/null 2>&1
 command -v timeout >/dev/null 2>&1
 
+openshell_command="$NEMOCLAW_OPENSHELL_COMMAND"
+openshell_environment=(env)
+while IFS= read -r authority_name; do
+  openshell_environment+=(-u "$authority_name")
+done < <(
+  printf '%s\n' NEMOCLAW_OPENSHELL_BIN NEMOCLAW_OPENSHELL_COMMAND
+  compgen -e NEMOCLAW_LAUNCH_ || true
+  compgen -e OPENSHELL_NEMOCLAW_LAUNCH_ || true
+)
+
 session_dir="$(mktemp -d "$NEMOCLAW_LAUNCH_HOST_TMP_ROOT/nemoclaw-launch-host.XXXXXX")"
 capture="$session_dir/terminal.log"
 driver_error="$session_dir/pty-driver.err"
@@ -817,7 +820,7 @@ session_evidence() {
     fi
   fi
   timeout --kill-after=1s "$command_timeout"s \
-    "$NEMOCLAW_OPENSHELL_COMMAND" sandbox exec \
+    "${"$"}{openshell_environment[@]}" "$openshell_command" sandbox exec \
     --name "$NEMOCLAW_LAUNCH_SANDBOX" -- \
     node -e "$NEMOCLAW_LAUNCH_SESSION_EVIDENCE_SCRIPT" \
     "$mode" \

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -243,13 +243,14 @@ function runLaunchSessionFixture(mode: FixtureMode, terminalCopy: "absent" | "an
   const sessionRoot = join(fixtureRoot, "sessions");
   const tuiPidsPath = join(fixtureRoot, "tui-pids");
   const ttyMarker = join(fixtureRoot, "tty-observed");
-  const openshellCallsPath = join(fixtureRoot, "openshell-calls.jsonl");
+  const openshellCallsRoot = join(fixtureRoot, "openshell-calls");
   const pendingQualificationMarker = join(fixtureRoot, "pending-qualification-observed");
   const ptyRecordReceiptPath = join(fixtureRoot, "pty-record-receipt.json");
   const runId = randomUUID().replaceAll("-", "");
   const baselinePath = `/tmp/nemoclaw-launch-session-${runId}.json`;
   const ptyRecordRoot = `/tmp/nemoclaw-launch-turn-${runId}`;
   mkdirSync(sessionRoot);
+  mkdirSync(openshellCallsRoot, { mode: 0o700 });
   writeFileSync(
     join(fixtureRoot, ".bash_profile"),
     'export PATH="$NEMOCLAW_FIXTURE_BIN_ROOT:$PATH"\n',
@@ -406,7 +407,9 @@ if (process.argv[2] !== "tui") {
       String.raw`#!/usr/bin/env bash
 set -euo pipefail
 node -e '
+const crypto = require("node:crypto");
 const fs = require("node:fs");
+const path = require("node:path");
 const authorityNames = Object.keys(process.env)
   .filter(
     (name) =>
@@ -416,9 +419,13 @@ const authorityNames = Object.keys(process.env)
       name.startsWith("OPENSHELL_NEMOCLAW_LAUNCH_"),
   )
   .sort();
-fs.appendFileSync(
-  process.env.NEMOCLAW_FIXTURE_OPENSHELL_CALLS,
-  JSON.stringify({ argv: process.argv.slice(1), authorityNames }) + "\\n",
+fs.writeFileSync(
+  path.join(
+    process.env.NEMOCLAW_FIXTURE_OPENSHELL_CALLS,
+    process.pid + "-" + crypto.randomUUID() + ".json",
+  ),
+  JSON.stringify({ argv: process.argv.slice(1), authorityNames }),
+  { flag: "wx", mode: 0o600 },
 );
 ' "$@"
 while [[ "$#" -gt 0 && "$1" != "--" ]]; do shift; done
@@ -456,7 +463,7 @@ exec "$@"
         HOME: fixtureRoot,
         NEMOCLAW_FIXTURE_BIN_ROOT: fixtureRoot,
         NEMOCLAW_FIXTURE_MODE: mode,
-        NEMOCLAW_FIXTURE_OPENSHELL_CALLS: openshellCallsPath,
+        NEMOCLAW_FIXTURE_OPENSHELL_CALLS: openshellCallsRoot,
         NEMOCLAW_FIXTURE_PENDING_QUALIFICATION_MARKER: pendingQualificationMarker,
         NEMOCLAW_FIXTURE_PTY_RECORD_ROOT: ptyRecordRoot,
         NEMOCLAW_FIXTURE_SESSION_FILE: join(sessionRoot, "session-a.jsonl"),
@@ -502,13 +509,15 @@ exec "$@"
         name.startsWith("nemoclaw-launch-host."),
       ),
       orphanedTuiProcessIds: tuiProcessIds.filter((pid) => existsSync(`/proc/${pid}`)),
-      openshellCalls: existsSync(openshellCallsPath)
-        ? readFileSync(openshellCallsPath, "utf8")
-            .trim()
-            .split("\n")
-            .filter(Boolean)
-            .map((line) => JSON.parse(line) as { argv: string[]; authorityNames: string[] })
-        : [],
+      openshellCalls: readdirSync(openshellCallsRoot)
+        .sort()
+        .map(
+          (name) =>
+            JSON.parse(readFileSync(join(openshellCallsRoot, name), "utf8")) as {
+              argv: string[];
+              authorityNames: string[];
+            },
+        ),
       pendingQualificationObserved: existsSync(pendingQualificationMarker),
       ptyRecordRemoved: !existsSync(ptyRecordRoot),
       ptyRecordReceipt: existsSync(ptyRecordReceiptPath)

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -324,7 +324,6 @@ if (process.argv[2] !== "tui") {
 (async () => {
   if (!process.stdin.isTTY || !process.stdout.isTTY) process.exit(64);
   fs.appendFileSync(process.env.NEMOCLAW_FIXTURE_TUI_PIDS, process.pid + "\n");
-  fs.writeFileSync(process.env.NEMOCLAW_FIXTURE_TTY_MARKER, "");
   const recordPath = process.env.NEMOCLAW_FIXTURE_PTY_RECORD_ROOT + "/pty-record.json";
   const record = JSON.parse(fs.readFileSync(recordPath, "utf8"));
   const recordStats = fs.lstatSync(recordPath);
@@ -347,6 +346,7 @@ if (process.argv[2] !== "tui") {
   if (mode === "pty-cleanup-unknown-entry") {
     fs.writeFileSync(process.env.NEMOCLAW_FIXTURE_PTY_RECORD_ROOT + "/unexpected", "owned test residue");
   }
+  fs.writeFileSync(process.env.NEMOCLAW_FIXTURE_TTY_MARKER, "");
   const sessionFile = process.env.NEMOCLAW_FIXTURE_SESSION_FILE;
   const terminalCopy = process.env.NEMOCLAW_FIXTURE_TERMINAL_COPY;
   const append = (role, content) => fs.appendFileSync(
@@ -431,6 +431,11 @@ fs.writeFileSync(
 while [[ "$#" -gt 0 && "$1" != "--" ]]; do shift; done
 [[ "$#" -gt 0 ]]
 shift
+case "$NEMOCLAW_FIXTURE_MODE:$4" in
+  pty-record-invalid:input-mode|pty-record-permission:input-mode|pty-record-identity:input-mode)
+    [[ -e "$NEMOCLAW_FIXTURE_TTY_MARKER" ]] || exit 1
+    ;;
+esac
 if [[ "$NEMOCLAW_FIXTURE_MODE" == "cleanup-failure" && "$4" == "cleanup-baseline" ]]; then
   exit 71
 fi

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -243,6 +243,7 @@ function runLaunchSessionFixture(mode: FixtureMode, terminalCopy: "absent" | "an
   const sessionRoot = join(fixtureRoot, "sessions");
   const tuiPidsPath = join(fixtureRoot, "tui-pids");
   const ttyMarker = join(fixtureRoot, "tty-observed");
+  const openshellCallsPath = join(fixtureRoot, "openshell-calls.jsonl");
   const pendingQualificationMarker = join(fixtureRoot, "pending-qualification-observed");
   const ptyRecordReceiptPath = join(fixtureRoot, "pty-record-receipt.json");
   const runId = randomUUID().replaceAll("-", "");
@@ -404,6 +405,22 @@ if (process.argv[2] !== "tui") {
       fakeOpenshell,
       String.raw`#!/usr/bin/env bash
 set -euo pipefail
+node -e '
+const fs = require("node:fs");
+const authorityNames = Object.keys(process.env)
+  .filter(
+    (name) =>
+      name === "NEMOCLAW_OPENSHELL_BIN" ||
+      name === "NEMOCLAW_OPENSHELL_COMMAND" ||
+      name.startsWith("NEMOCLAW_LAUNCH_") ||
+      name.startsWith("OPENSHELL_NEMOCLAW_LAUNCH_"),
+  )
+  .sort();
+fs.appendFileSync(
+  process.env.NEMOCLAW_FIXTURE_OPENSHELL_CALLS,
+  JSON.stringify({ argv: process.argv.slice(1), authorityNames }) + "\\n",
+);
+' "$@"
 while [[ "$#" -gt 0 && "$1" != "--" ]]; do shift; done
 [[ "$#" -gt 0 ]]
 shift
@@ -439,6 +456,7 @@ exec "$@"
         HOME: fixtureRoot,
         NEMOCLAW_FIXTURE_BIN_ROOT: fixtureRoot,
         NEMOCLAW_FIXTURE_MODE: mode,
+        NEMOCLAW_FIXTURE_OPENSHELL_CALLS: openshellCallsPath,
         NEMOCLAW_FIXTURE_PENDING_QUALIFICATION_MARKER: pendingQualificationMarker,
         NEMOCLAW_FIXTURE_PTY_RECORD_ROOT: ptyRecordRoot,
         NEMOCLAW_FIXTURE_SESSION_FILE: join(sessionRoot, "session-a.jsonl"),
@@ -484,6 +502,13 @@ exec "$@"
         name.startsWith("nemoclaw-launch-host."),
       ),
       orphanedTuiProcessIds: tuiProcessIds.filter((pid) => existsSync(`/proc/${pid}`)),
+      openshellCalls: existsSync(openshellCallsPath)
+        ? readFileSync(openshellCallsPath, "utf8")
+            .trim()
+            .split("\n")
+            .filter(Boolean)
+            .map((line) => JSON.parse(line) as { argv: string[]; authorityNames: string[] })
+        : [],
       pendingQualificationObserved: existsSync(pendingQualificationMarker),
       ptyRecordRemoved: !existsSync(ptyRecordRoot),
       ptyRecordReceipt: existsSync(ptyRecordReceiptPath)
@@ -539,14 +564,6 @@ function runOpenShellShimFixture(gatewayArgs: string[]) {
   writeFileSync(
     realOpenShell,
     String.raw`#!/usr/bin/env node
-const authorityNames = new Set([
-  "NEMOCLAW_OPENSHELL_COMMAND",
-  "NEMOCLAW_LAUNCH_SANDBOX",
-  "NEMOCLAW_LAUNCH_RUN_ID",
-  "NEMOCLAW_LAUNCH_INTERCEPT_PATH",
-  "NEMOCLAW_LAUNCH_PTY_RECORD_WRITER_SCRIPT",
-  "NEMOCLAW_LAUNCH_RUNTIME_ENV_SCRIPT",
-]);
 require("node:fs").appendFileSync(
   ${JSON.stringify(callsPath)},
   JSON.stringify({
@@ -554,7 +571,10 @@ require("node:fs").appendFileSync(
     authorityNames: Object.keys(process.env)
       .filter(
         (name) =>
-          authorityNames.has(name) || name.startsWith("OPENSHELL_NEMOCLAW_LAUNCH_"),
+          name === "NEMOCLAW_OPENSHELL_BIN" ||
+          name === "NEMOCLAW_OPENSHELL_COMMAND" ||
+          name.startsWith("NEMOCLAW_LAUNCH_") ||
+          name.startsWith("OPENSHELL_NEMOCLAW_LAUNCH_"),
       )
       .sort(),
   }) + "\n",
@@ -566,11 +586,15 @@ require("node:fs").appendFileSync(
   chmodSync(shim, 0o755);
   const hostEnv = {
     ...process.env,
+    NEMOCLAW_LAUNCH_COMMAND: "nemoclaw",
+    NEMOCLAW_LAUNCH_FIRST_INPUT: "fixture input",
     NEMOCLAW_LAUNCH_INTERCEPT_PATH: interceptPath,
     NEMOCLAW_LAUNCH_PTY_RECORD_WRITER_SCRIPT: OPENCLAW_PTY_RECORD_WRITER_SCRIPT,
     NEMOCLAW_LAUNCH_RUN_ID: runId,
     NEMOCLAW_LAUNCH_RUNTIME_ENV_SCRIPT: OPENCLAW_LAUNCH_RUNTIME_ENV_SCRIPT,
     NEMOCLAW_LAUNCH_SANDBOX: sandboxName,
+    NEMOCLAW_LAUNCH_SESSION_EVIDENCE_SCRIPT: OPENCLAW_SESSION_EVIDENCE_SCRIPT,
+    NEMOCLAW_OPENSHELL_BIN: shim,
     NEMOCLAW_OPENSHELL_COMMAND: realOpenShell,
     OPENSHELL_NEMOCLAW_LAUNCH_INTERCEPT_PATH: interceptPath,
     OPENSHELL_NEMOCLAW_LAUNCH_PTY_RECORD_WRITER_SCRIPT: OPENCLAW_PTY_RECORD_WRITER_SCRIPT,
@@ -783,12 +807,13 @@ it.runIf(process.platform === "linux")(
 );
 
 it.runIf(process.platform === "linux")(
-  "sends two inputs and exit through a real PTY without using terminal copy as evidence (#9160)",
+  "sends two inputs and /exit through a real PTY, strips launch authority from OpenShell calls, and ignores terminal copy evidence (#9160)",
   () => {
     for (const terminalCopy of ["absent", "ansi", "reordered"] as const) {
       const {
         baselineRemoved,
         hostSessionResidue,
+        openshellCalls,
         orphanedTuiProcessIds,
         ptyRecordReceipt,
         ptyRecordRemoved,
@@ -801,6 +826,12 @@ it.runIf(process.platform === "linux")(
       expect(baselineRemoved).toBe(true);
       expect(ptyRecordRemoved).toBe(true);
       expect(hostSessionResidue).toEqual([]);
+      expect(openshellCalls.length).toBeGreaterThan(3);
+      expect(openshellCalls.every((call) => call.authorityNames.length === 0)).toBe(true);
+      expect(openshellCalls.some((call) => call.argv.includes("baseline"))).toBe(true);
+      expect(
+        openshellCalls.some((call) => call.argv.includes(OPENCLAW_PTY_RECORD_WRITER_SCRIPT)),
+      ).toBe(true);
       expect(tuiProcessIds).toHaveLength(1);
       expect(orphanedTuiProcessIds).toEqual([]);
       expect(ptyRecordReceipt).toMatchObject({


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The merged OpenClaw E2E shim filter removes only selected launch variables. This follow-up removes every private launch-authority variable before shim-mediated and direct session-evidence calls reach the pinned OpenShell binary.

## Related Issue

Relates #9200.

E2E root cause: OpenClaw launch evidence / real OpenShell execution / private launch authority remains in child environments

Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/31969859118 (run `31969859118`, attempt 1)

Failed job: OpenClaw security posture (`95220668388`)

Source artifact: `9269583761`, digest `sha256:8cccd5b85af7614c68228df3a37153c1271deb6ac4f8967c4ae8cdd01d797161`

Scope: one root cause

## Changes

- Remove `NEMOCLAW_OPENSHELL_BIN`, `NEMOCLAW_OPENSHELL_COMMAND`, `NEMOCLAW_LAUNCH_*`, and `OPENSHELL_NEMOCLAW_LAUNCH_*` before every real OpenShell call.
- Capture the pinned OpenShell command before the direct session-evidence path constructs its sanitized environment.
- Record shim and session-evidence OpenShell calls and require that each child receives no launch-authority variable.
- Store concurrent OpenShell call evidence in exclusive mode-0600 per-call records under a fixture-owned mode-0700 directory.
- Publish intentional PTY-record mutations before input-mode evidence can qualify them.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change affects internal E2E launch evidence and does not change a supported product surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent code and nine-category security reviews passed for commit `c0b9d3060b0555f31795909bb3564039891c603a` with no findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change only synchronizes an internal Linux E2E fixture so PTY-record mutations precede input-mode evidence. It changes no user-visible or supported product surface.
- Agent: Codex Desktop
<!-- docs-review-head-sha: c0b9d3060 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — on current main, `npx vitest run --project e2e-support test/e2e/support/launch-agent-turn.test.ts` passed 8 tests with 20 intentional Linux-only skips on macOS; exact-head Linux selection is pending automatic CI.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launch-session handling by filtering authority-related environment variables before starting OpenShell.
  * Enhanced PTY readiness validation to prevent sessions from proceeding until required launch evidence is available.
  * Added broader validation for launch-related environment variables and OpenShell invocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->