### PR TITLE
fix(e2e): strip launch authority from OpenShell

### DIFF
--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -135,27 +135,21 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const argv = process.argv.slice(2);
-// Direct CLI exec paths can inherit source names that filtered helpers omit.
-const authorityNames = [
-  "NEMOCLAW_OPENSHELL_COMMAND",
-  "NEMOCLAW_LAUNCH_SANDBOX",
-  "NEMOCLAW_LAUNCH_RUN_ID",
-  "NEMOCLAW_LAUNCH_INTERCEPT_PATH",
-  "NEMOCLAW_LAUNCH_PTY_RECORD_WRITER_SCRIPT",
-  "NEMOCLAW_LAUNCH_RUNTIME_ENV_SCRIPT",
-  "OPENSHELL_NEMOCLAW_LAUNCH_REAL_COMMAND",
-  "OPENSHELL_NEMOCLAW_LAUNCH_SANDBOX",
-  "OPENSHELL_NEMOCLAW_LAUNCH_RUN_ID",
-  "OPENSHELL_NEMOCLAW_LAUNCH_INTERCEPT_PATH",
-  "OPENSHELL_NEMOCLAW_LAUNCH_PTY_RECORD_WRITER_SCRIPT",
-  "OPENSHELL_NEMOCLAW_LAUNCH_RUNTIME_ENV_SCRIPT",
-];
 const realOpenShell = process.env.OPENSHELL_NEMOCLAW_LAUNCH_REAL_COMMAND;
 const sandboxName = process.env.OPENSHELL_NEMOCLAW_LAUNCH_SANDBOX;
 const runId = process.env.OPENSHELL_NEMOCLAW_LAUNCH_RUN_ID;
 const interceptPath = process.env.OPENSHELL_NEMOCLAW_LAUNCH_INTERCEPT_PATH;
 const writerScript = process.env.OPENSHELL_NEMOCLAW_LAUNCH_PTY_RECORD_WRITER_SCRIPT;
 const runtimeEnvScript = process.env.OPENSHELL_NEMOCLAW_LAUNCH_RUNTIME_ENV_SCRIPT;
+
+function isLaunchAuthorityName(name) {
+  return (
+    name === "NEMOCLAW_OPENSHELL_BIN" ||
+    name === "NEMOCLAW_OPENSHELL_COMMAND" ||
+    name.startsWith("NEMOCLAW_LAUNCH_") ||
+    name.startsWith("OPENSHELL_NEMOCLAW_LAUNCH_")
+  );
+}
 
 function fail(reason) {
   process.stderr.write(JSON.stringify({ reason }) + "\n");
@@ -168,7 +162,9 @@ function arraysEqual(left, right) {
 
 function runRealOpenShell(nextArgv) {
   const env = { ...process.env };
-  for (const name of authorityNames) delete env[name];
+  for (const name of Object.keys(env)) {
+    if (isLaunchAuthorityName(name)) delete env[name];
+  }
   const result = childProcess.spawnSync(realOpenShell, nextArgv, {
     env,
     stdio: "inherit",
@@ -804,6 +800,12 @@ session_evidence() {
   local mode="$1"
   local expected_turns=""
   local command_timeout=10
+  local openshell_command="$NEMOCLAW_OPENSHELL_COMMAND"
+  local sandbox_name="$NEMOCLAW_LAUNCH_SANDBOX"
+  local evidence_script="$NEMOCLAW_LAUNCH_SESSION_EVIDENCE_SCRIPT"
+  local session_root="$NEMOCLAW_LAUNCH_SESSION_ROOT"
+  local run_id="$NEMOCLAW_LAUNCH_RUN_ID"
+  local name
   if [[ "$#" -gt 1 ]]; then
     expected_turns="$2"
   fi
@@ -816,16 +818,26 @@ session_evidence() {
       command_timeout="$remaining"
     fi
   fi
-  timeout --kill-after=1s "$command_timeout"s \
-    "$NEMOCLAW_OPENSHELL_COMMAND" sandbox exec \
-    --name "$NEMOCLAW_LAUNCH_SANDBOX" -- \
-    node -e "$NEMOCLAW_LAUNCH_SESSION_EVIDENCE_SCRIPT" \
-    "$mode" \
-    "$NEMOCLAW_LAUNCH_SESSION_ROOT" \
-    "$baseline_path" \
-    "$expected_turns" \
-    "$pty_record_root" \
-    "$NEMOCLAW_LAUNCH_RUN_ID"
+  (
+    set -- env
+    while IFS= read -r name; do
+      case "$name" in
+        NEMOCLAW_OPENSHELL_BIN|NEMOCLAW_OPENSHELL_COMMAND|NEMOCLAW_LAUNCH_*|OPENSHELL_NEMOCLAW_LAUNCH_*)
+          set -- "$@" -u "$name"
+          ;;
+      esac
+    done < <(compgen -e)
+    exec "$@" timeout --kill-after=1s "$command_timeout"s \
+      "$openshell_command" sandbox exec \
+      --name "$sandbox_name" -- \
+      node -e "$evidence_script" \
+      "$mode" \
+      "$session_root" \
+      "$baseline_path" \
+      "$expected_turns" \
+      "$pty_record_root" \
+      "$run_id"
+  )
 }
 
 wait_for_turn_count() {

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -258,17 +258,20 @@ function runLaunchSessionFixture(mode: FixtureMode, terminalCopy: "absent" | "an
   );
 
   try {
-    if (mode === "evidence-command-failure") {
-      writeFileSync(
-        fakeTimeout,
-        String.raw`#!/usr/bin/env bash
+    const setupFixtureMode: Partial<Record<FixtureMode, () => void>> = {
+      "evidence-command-failure": () => {
+        writeFileSync(
+          fakeTimeout,
+          String.raw`#!/usr/bin/env bash
 [[ "$1" == --kill-after=* ]] && shift
 shift
 exec "$@"
 `,
-      );
-      chmodSync(fakeTimeout, 0o755);
-    }
+        );
+        chmodSync(fakeTimeout, 0o755);
+      },
+    };
+    setupFixtureMode[mode]?.();
     writeFileSync(
       fakeStty,
       String.raw`#!/usr/bin/env bash

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -48,6 +48,7 @@ type FixtureMode =
   | "cleanup-failure"
   | "delayed-input-attachment"
   | "delayed-recording"
+  | "evidence-command-failure"
   | "input-mode-timeout"
   | "invalid-order"
   | "late-extra"
@@ -240,10 +241,12 @@ function runLaunchSessionFixture(mode: FixtureMode, terminalCopy: "absent" | "an
   const fakeLaunch = join(fixtureRoot, "openclaw");
   const fakeOpenshell = join(fixtureRoot, "openshell");
   const fakeStty = join(fixtureRoot, "stty");
+  const fakeTimeout = join(fixtureRoot, "timeout");
   const sessionRoot = join(fixtureRoot, "sessions");
   const tuiPidsPath = join(fixtureRoot, "tui-pids");
   const ttyMarker = join(fixtureRoot, "tty-observed");
   const pendingQualificationMarker = join(fixtureRoot, "pending-qualification-observed");
+  const openshellCallsPath = join(fixtureRoot, "openshell-calls.jsonl");
   const ptyRecordReceiptPath = join(fixtureRoot, "pty-record-receipt.json");
   const runId = randomUUID().replaceAll("-", "");
   const baselinePath = `/tmp/nemoclaw-launch-session-${runId}.json`;
@@ -255,6 +258,17 @@ function runLaunchSessionFixture(mode: FixtureMode, terminalCopy: "absent" | "an
   );
 
   try {
+    if (mode === "evidence-command-failure") {
+      writeFileSync(
+        fakeTimeout,
+        String.raw`#!/usr/bin/env bash
+[[ "$1" == --kill-after=* ]] && shift
+shift
+exec "$@"
+`,
+      );
+      chmodSync(fakeTimeout, 0o755);
+    }
     writeFileSync(
       fakeStty,
       String.raw`#!/usr/bin/env bash
@@ -404,6 +418,29 @@ if (process.argv[2] !== "tui") {
       fakeOpenshell,
       String.raw`#!/usr/bin/env bash
 set -euo pipefail
+node -e '
+const [callsPath, ...argv] = process.argv.slice(1);
+const authorityNames = Object.keys(process.env)
+  .filter(
+    (name) =>
+      name === "NEMOCLAW_OPENSHELL_BIN" ||
+      name === "NEMOCLAW_OPENSHELL_COMMAND" ||
+      name.startsWith("NEMOCLAW_LAUNCH_") ||
+      name.startsWith("OPENSHELL_NEMOCLAW_LAUNCH_"),
+  )
+  .sort();
+require("node:fs").appendFileSync(
+  callsPath,
+  JSON.stringify({
+    argv,
+    authorityNames,
+    route: argv.includes("--tty") ? "shim" : "evidence",
+  }) + "\n",
+);
+' "$NEMOCLAW_FIXTURE_OPENSHELL_CALLS" "$@"
+if [[ "$NEMOCLAW_FIXTURE_MODE" == "evidence-command-failure" ]]; then
+  exit 71
+fi
 while [[ "$#" -gt 0 && "$1" != "--" ]]; do shift; done
 [[ "$#" -gt 0 ]]
 shift
@@ -439,6 +476,7 @@ exec "$@"
         HOME: fixtureRoot,
         NEMOCLAW_FIXTURE_BIN_ROOT: fixtureRoot,
         NEMOCLAW_FIXTURE_MODE: mode,
+        NEMOCLAW_FIXTURE_OPENSHELL_CALLS: openshellCallsPath,
         NEMOCLAW_FIXTURE_PENDING_QUALIFICATION_MARKER: pendingQualificationMarker,
         NEMOCLAW_FIXTURE_PTY_RECORD_ROOT: ptyRecordRoot,
         NEMOCLAW_FIXTURE_SESSION_FILE: join(sessionRoot, "session-a.jsonl"),
@@ -451,6 +489,7 @@ exec "$@"
         NEMOCLAW_LAUNCH_ENTRYPOINT: "",
         NEMOCLAW_LAUNCH_EXIT_COMMAND: "/exit",
         NEMOCLAW_LAUNCH_FIRST_INPUT: "first input",
+        NEMOCLAW_LAUNCH_FUTURE_AUTHORITY: "private future authority",
         NEMOCLAW_LAUNCH_HOST_TMP_ROOT: fixtureRoot,
         NEMOCLAW_LAUNCH_OPENSHELL_SHIM_SCRIPT: OPENCLAW_LAUNCH_OPENSHELL_SHIM_SCRIPT,
         NEMOCLAW_LAUNCH_PTY_RECORD_WRITER_SCRIPT: OPENCLAW_PTY_RECORD_WRITER_SCRIPT,
@@ -462,6 +501,8 @@ exec "$@"
         NEMOCLAW_LAUNCH_SESSION_EVIDENCE_SCRIPT: OPENCLAW_SESSION_EVIDENCE_SCRIPT,
         NEMOCLAW_LAUNCH_SESSION_ROOT: sessionRoot,
         NEMOCLAW_OPENSHELL_COMMAND: fakeOpenshell,
+        NEMOCLAW_OPENSHELL_BIN: "private legacy binary",
+        OPENSHELL_NEMOCLAW_LAUNCH_FUTURE_AUTHORITY: "private alias authority",
         PATH: `${fixtureRoot}:${process.env.PATH ?? ""}`,
         TERM: "xterm-256color",
       },
@@ -484,6 +525,20 @@ exec "$@"
         name.startsWith("nemoclaw-launch-host."),
       ),
       orphanedTuiProcessIds: tuiProcessIds.filter((pid) => existsSync(`/proc/${pid}`)),
+      openshellCalls: existsSync(openshellCallsPath)
+        ? readFileSync(openshellCallsPath, "utf8")
+            .trim()
+            .split("\n")
+            .filter(Boolean)
+            .map(
+              (line) =>
+                JSON.parse(line) as {
+                  argv: string[];
+                  authorityNames: string[];
+                  route: "evidence" | "shim";
+                },
+            )
+        : [],
       pendingQualificationObserved: existsSync(pendingQualificationMarker),
       ptyRecordRemoved: !existsSync(ptyRecordRoot),
       ptyRecordReceipt: existsSync(ptyRecordReceiptPath)
@@ -540,12 +595,8 @@ function runOpenShellShimFixture(gatewayArgs: string[]) {
     realOpenShell,
     String.raw`#!/usr/bin/env node
 const authorityNames = new Set([
+  "NEMOCLAW_OPENSHELL_BIN",
   "NEMOCLAW_OPENSHELL_COMMAND",
-  "NEMOCLAW_LAUNCH_SANDBOX",
-  "NEMOCLAW_LAUNCH_RUN_ID",
-  "NEMOCLAW_LAUNCH_INTERCEPT_PATH",
-  "NEMOCLAW_LAUNCH_PTY_RECORD_WRITER_SCRIPT",
-  "NEMOCLAW_LAUNCH_RUNTIME_ENV_SCRIPT",
 ]);
 require("node:fs").appendFileSync(
   ${JSON.stringify(callsPath)},
@@ -554,7 +605,9 @@ require("node:fs").appendFileSync(
     authorityNames: Object.keys(process.env)
       .filter(
         (name) =>
-          authorityNames.has(name) || name.startsWith("OPENSHELL_NEMOCLAW_LAUNCH_"),
+          authorityNames.has(name) ||
+          name.startsWith("NEMOCLAW_LAUNCH_") ||
+          name.startsWith("OPENSHELL_NEMOCLAW_LAUNCH_"),
       )
       .sort(),
   }) + "\n",
@@ -566,6 +619,8 @@ require("node:fs").appendFileSync(
   chmodSync(shim, 0o755);
   const hostEnv = {
     ...process.env,
+    NEMOCLAW_OPENSHELL_BIN: shim,
+    NEMOCLAW_LAUNCH_FIRST_INPUT: "private input",
     NEMOCLAW_LAUNCH_INTERCEPT_PATH: interceptPath,
     NEMOCLAW_LAUNCH_PTY_RECORD_WRITER_SCRIPT: OPENCLAW_PTY_RECORD_WRITER_SCRIPT,
     NEMOCLAW_LAUNCH_RUN_ID: runId,
@@ -759,6 +814,28 @@ it("intercepts one OpenClaw launch, preserves pass-through argv, and strips laun
     ]);
   }
 });
+
+it("strips launch authority before a direct evidence OpenShell command fails (#9160)", () => {
+  const { openshellCalls, result } = runLaunchSessionFixture("evidence-command-failure", "absent");
+
+  expect(openshellCalls.length, result.stderr).toBeGreaterThan(0);
+  expect(openshellCalls.every((call) => call.route === "evidence")).toBe(true);
+  expect(openshellCalls.every((call) => call.authorityNames.length === 0)).toBe(true);
+  expect(result.status).toBe(1);
+});
+
+it.runIf(process.platform === "linux")(
+  "strips launch authority from shim and evidence OpenShell calls (#9160)",
+  () => {
+    const { openshellCalls, result } = runLaunchSessionFixture("valid", "absent");
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(new Set(openshellCalls.map((call) => call.route))).toEqual(
+      new Set(["evidence", "shim"]),
+    );
+    expect(openshellCalls.every((call) => call.authorityNames.length === 0)).toBe(true);
+  },
+);
 
 it.runIf(process.platform === "linux")(
   "rejects a record writer whose standard input is not a PTY (#9160)",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

OpenClaw E2E launch helpers could forward launch authority to the real OpenShell process through the shim or direct session-evidence route. This change captures required command values first, then removes the exact OpenShell command names and both launch-authority prefixes before every real OpenShell execution. It follows the security finding on #9258.

## Changes

- Remove `NEMOCLAW_OPENSHELL_BIN`, `NEMOCLAW_OPENSHELL_COMMAND`, every `NEMOCLAW_LAUNCH_*` variable, and every `OPENSHELL_NEMOCLAW_LAUNCH_*` variable from shim pass-through and intercepted calls.
- Apply the same removal before direct session-evidence and cleanup calls.
- Record shim and evidence OpenShell calls in the support fixture and reject any retained authority name, including future names under either prefix.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: The change is confined to internal E2E launch infrastructure and does not change a public CLI, configuration, default, supported workflow, error, or product behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The nine-category security review for `59d8ecf51` found no residual authority forwarding. Focused negative evidence covers shim pass-through, shim interception, direct evidence, and evidence cleanup calls. The change addresses https://github.com/NVIDIA/NemoClaw/pull/9258#issuecomment-5310131324.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `test/e2e/live/launch-agent-turn.ts` and `test/e2e/support/launch-agent-turn.test.ts` change internal E2E launch sanitization and regression coverage only; no public CLI, configuration, default, supported workflow, error, or product behavior changes.
- Agent: `Codex Desktop`
<!-- docs-review-head-sha: 59d8ecf51 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/launch-agent-turn.test.ts` passed on the tree now at `59d8ecf51`: 9 passed, 0 failed, and 21 intentional Linux-only skips on macOS. The generated Bash script passed `bash -n`; `npm run checks:repository`, `npm run typecheck:cli`, Oxfmt, and the conditional-count scan also passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
