### PR TITLE
fix(test): prepare root runtime authority without sudo

### DIFF
--- a/test/helpers/vitest-temp-root.ts
+++ b/test/helpers/vitest-temp-root.ts
@@ -54,10 +54,9 @@ export function prepareGitHubHostedRuntimeAuthority(
       execFileSync(command, args, execOptions);
     });
   install(
-    "sudo",
+    uid === 0 ? "/usr/bin/install" : "sudo",
     [
-      "--non-interactive",
-      "install",
+      ...(uid === 0 ? [] : ["--non-interactive", "install"]),
       "-d",
       "-m",
       "0700",

--- a/test/vitest-temp-root.test.ts
+++ b/test/vitest-temp-root.test.ts
@@ -90,6 +90,36 @@ describe("Vitest temp root", () => {
     expect(install).not.toHaveBeenCalled();
   });
 
+  it("uses /usr/bin/install without sudo when a GitHub-hosted Linux process runs as root (#8942)", () => {
+    const install = vi.fn();
+
+    prepareGitHubHostedRuntimeAuthority({
+      platform: "linux",
+      githubActions: "true",
+      runnerEnvironment: "github-hosted",
+      uid: 0,
+      gid: 0,
+      install,
+    });
+
+    expect(install).toHaveBeenCalledWith(
+      "/usr/bin/install",
+      [
+        "-d",
+        "-m",
+        "0700",
+        "-o",
+        "0",
+        "-g",
+        "0",
+        "/run/user/0",
+        "/run/user/0/nemoclaw",
+        "/run/user/0/nemoclaw/launch-readiness",
+      ],
+      { stdio: "inherit" },
+    );
+  });
+
   it("recognizes the GitHub-hosted image marker exported to test processes (#8942)", () => {
     const install = vi.fn();
 
@@ -277,6 +307,4 @@ describe("Vitest temp root", () => {
       }
     }
   });
-
-
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Ubuntu 26.04 contract runs as root in a container that does not install `sudo`, so Vitest global setup failed with `spawnSync sudo ENOENT` before selecting any tests. This change calls the fixed `/usr/bin/install` executable directly when the GitHub-hosted Linux process already runs as root; non-root hosted setup retains `sudo --non-interactive install`.

Source workflow: [Platform Evidence run 31984816062](https://github.com/NVIDIA/NemoClaw/actions/runs/31984816062), job [`ubuntu-2604-contract` 95257852576](https://github.com/NVIDIA/NemoClaw/actions/runs/31984816062/job/95257852576), commit `8158c4b628c1d957722c85bfff9751b5874e0f6e`.

## Changes

- Use `/usr/bin/install` directly for root GitHub-hosted Linux setup.
- Keep the existing non-root `sudo --non-interactive install` path unchanged.
- Add an enforcing test for the absolute root command, ownership, mode, and all runtime-authority paths.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal GitHub-hosted Vitest setup only; no supported or user-visible product surface changes.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent code and nine-category security reviews passed exact commit `ed80e701d7579a775d2a3dec1502072306642eb1` with no findings or blockers.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change makes internal GitHub-hosted Linux test setup call `/usr/bin/install` directly when the process already runs as root. Non-root setup remains unchanged, and no user-visible or supported product surface changes.
- Agent: Codex Desktop
<!-- docs-review-head-sha: ed80e701d -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `vitest run --project integration test/vitest-temp-root.test.ts`: 10/10 passed on the final current-main tree.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this two-branch setup repair; CLI typecheck, repository checks, source-shape, test-size, test-conditionals, and test-loops gates passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime authority setup on GitHub-hosted Linux environments running with root privileges.
  * Root processes now install required files directly, avoiding unnecessary `sudo` usage.
  * Non-root environments continue using secure, non-interactive installation behavior.

* **Tests**
  * Added coverage to verify installation commands, ownership, and runtime-authority paths for root execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->