### PR TITLE
fix(onboard): preserve portable model intent

### DIFF
--- a/docs/inference/set-up-openai-compatible-endpoint.mdx
+++ b/docs/inference/set-up-openai-compatible-endpoint.mdx
@@ -136,7 +136,7 @@ The portable profile handles the descriptor as follows:
 
 | Descriptor state | Onboarding result |
 |---|---|
-| Absent | NemoClaw keeps the existing portable behavior. The local Podman `qwen3-vl:4b` model remains the active inference route. |
+| Absent | Fresh Portable onboarding uses a nonempty `NEMOCLAW_MODEL`. An empty or absent value uses the local Podman `qwen3-vl:4b` model. A valid Portable inference descriptor remains authoritative when present. Portable resume ignores ambient model selectors and reuses the recorded provider and model authority. |
 | Directory and file metadata meet the requirements above, the descriptor is valid, and the authenticated onboarding checks pass | NemoClaw makes the compatible endpoint model the active inference route. If the local Podman `qwen3-vl:4b` runner already exists, NemoClaw leaves it installed as standby. |
 | File passes the metadata checks but contains malformed JSON, an invalid schema, an expired credential, or a rejected endpoint | NemoClaw deletes the descriptor and exits before it changes gateway, provider, sandbox, or onboarding state. |
 | Descriptor is valid, but the endpoint, selected model, or configured route fails an authenticated onboarding check | NemoClaw deletes the descriptor and exits without reporting onboarding success. The compatible route may already be configured. NemoClaw does not activate an existing local runner automatically. |

--- a/src/lib/onboard/portable-environment-scope.test.ts
+++ b/src/lib/onboard/portable-environment-scope.test.ts
@@ -40,6 +40,17 @@ describe("portable onboarding environment scope", () => {
     expect(env).toEqual({});
   });
 
+  it("uses qwen3-vl:4b and restores empty fresh portable model intent (#9200)", () => {
+    const env: NodeJS.ProcessEnv = { NEMOCLAW_MODEL: "" };
+    const scope = createPortableOnboardEnvironmentScope(env, null);
+
+    expect(env.NEMOCLAW_PROVIDER).toBe("ollama");
+    expect(env.NEMOCLAW_MODEL).toBe("qwen3-vl:4b");
+
+    scope.restore();
+    expect(env).toEqual({ NEMOCLAW_MODEL: "" });
+  });
+
   it("uses the activation model instead of ambient fresh model intent (#9200)", () => {
     const env: NodeJS.ProcessEnv = { NEMOCLAW_MODEL: "ambient/model" };
     const scope = createPortableOnboardEnvironmentScope(env, {

--- a/src/lib/onboard/portable-environment-scope.test.ts
+++ b/src/lib/onboard/portable-environment-scope.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   createDefaultResumeProfileEnvironmentScope,
@@ -9,11 +9,75 @@ import {
   PORTABLE_RUNTIME_ENV_KEYS,
 } from "./session-bootstrap";
 
+const { getNonInteractiveModel } = require("./providers") as {
+  getNonInteractiveModel: (providerKey: string) => string | null;
+};
+
 const CLEARED_PORTABLE_RUNTIME_ENV_KEYS = PORTABLE_RUNTIME_ENV_KEYS.filter(
   (key) => key !== "NEMOCLAW_EXPERIMENTAL_PROFILE",
 );
 
 describe("portable onboarding environment scope", () => {
+  it("preserves an explicit model during fresh portable onboarding (#9200)", () => {
+    const env: NodeJS.ProcessEnv = { NEMOCLAW_MODEL: "qwen3.6:35b" };
+    const scope = createPortableOnboardEnvironmentScope(env, null);
+
+    expect(env.NEMOCLAW_PROVIDER).toBe("ollama");
+    expect(env.NEMOCLAW_MODEL).toBe("qwen3.6:35b");
+
+    scope.restore();
+    expect(env).toEqual({ NEMOCLAW_MODEL: "qwen3.6:35b" });
+  });
+
+  it("uses qwen3-vl:4b when fresh portable model intent is absent (#9200)", () => {
+    const env: NodeJS.ProcessEnv = {};
+    const scope = createPortableOnboardEnvironmentScope(env, null);
+
+    expect(env.NEMOCLAW_PROVIDER).toBe("ollama");
+    expect(env.NEMOCLAW_MODEL).toBe("qwen3-vl:4b");
+
+    scope.restore();
+    expect(env).toEqual({});
+  });
+
+  it("uses the activation model instead of ambient fresh model intent (#9200)", () => {
+    const env: NodeJS.ProcessEnv = { NEMOCLAW_MODEL: "ambient/model" };
+    const scope = createPortableOnboardEnvironmentScope(env, {
+      schemaVersion: 1,
+      baseUrl: "https://inference.example.test/v1",
+      model: "activation/model",
+      expiresAt: "2026-08-13T20:00:00.000Z",
+    });
+
+    expect(env.NEMOCLAW_PROVIDER).toBe("custom");
+    expect(env.NEMOCLAW_MODEL).toBe("activation/model");
+
+    scope.restore();
+    expect(env).toEqual({ NEMOCLAW_MODEL: "ambient/model" });
+  });
+
+  it("rejects malformed fresh model intent with the provider validator (#9200)", () => {
+    vi.stubEnv("NEMOCLAW_MODEL", "model;unsupported");
+    const scope = createPortableOnboardEnvironmentScope(process.env, null);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+
+    try {
+      expect(() => getNonInteractiveModel("ollama")).toThrow("process.exit(1)");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid NEMOCLAW_MODEL for provider 'ollama'"),
+      );
+    } finally {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+      scope.restore();
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("restores default checkpoint classification over hostile ambient portable intent", () => {
     const env: NodeJS.ProcessEnv = { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" };
     const scope = createDefaultResumeProfileEnvironmentScope(env);
@@ -102,6 +166,7 @@ describe("portable onboarding environment scope", () => {
     const env: NodeJS.ProcessEnv = {
       NEMOCLAW_PROVIDER: "ollama",
       NEMOCLAW_MODEL: "hostile-model",
+      NEMOCLAW_PROVIDER_MODEL: "hostile-fallback-model",
       NEMOCLAW_ENDPOINT_URL: "https://attacker.test/v1",
       NEMOCLAW_PREFERRED_API: "openai-completions",
       NEMOCLAW_POLICY_MODE: "custom",
@@ -121,6 +186,7 @@ describe("portable onboarding environment scope", () => {
     for (const key of [
       "NEMOCLAW_PROVIDER",
       "NEMOCLAW_MODEL",
+      "NEMOCLAW_PROVIDER_MODEL",
       "NEMOCLAW_ENDPOINT_URL",
       "NEMOCLAW_PREFERRED_API",
       "NEMOCLAW_POLICY_TIER",

--- a/src/lib/onboard/session-bootstrap.ts
+++ b/src/lib/onboard/session-bootstrap.ts
@@ -93,6 +93,7 @@ const PORTABLE_DEFAULT_ENV_KEYS = [
   TOOL_DISCLOSURE_ENV,
   "NEMOCLAW_PROVIDER",
   "NEMOCLAW_MODEL",
+  "NEMOCLAW_PROVIDER_MODEL",
   "NEMOCLAW_ENDPOINT_URL",
   "NEMOCLAW_PREFERRED_API",
   "NEMOCLAW_OLLAMA_NO_AUTOSTART",
@@ -218,9 +219,10 @@ export function createPortableOnboardEnvironmentScope(
     env.NEMOCLAW_PREFERRED_API = "openai-completions";
   }
   if (!options.resume) {
+    const requestedModel = previous.get("NEMOCLAW_MODEL")?.value?.trim();
     env[TOOL_DISCLOSURE_ENV] = "direct";
     env.NEMOCLAW_PROVIDER = activation ? "custom" : "ollama";
-    env.NEMOCLAW_MODEL = activation?.model ?? "qwen3-vl:4b";
+    env.NEMOCLAW_MODEL = activation?.model ?? (requestedModel || "qwen3-vl:4b");
     env.NEMOCLAW_POLICY_MODE = "custom";
     env.NEMOCLAW_POLICY_PRESETS =
       previous.get("NEMOCLAW_POLICY_PRESETS")?.value ?? "personal-open-internet";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fresh Portable onboarding removed an explicit `NEMOCLAW_MODEL` before provider selection and replaced it with `qwen3-vl:4b`.
This change preserves a nonempty explicit model until the existing provider validator evaluates it, while retaining descriptor and resume authority.

## Related Issue

Part of #9200.
Related to #9208.

## Changes

- Preserve a nonempty `NEMOCLAW_MODEL` during fresh Portable onboarding.
- Keep `qwen3-vl:4b` as the default when the value is absent or empty.
- Keep a valid Portable inference descriptor authoritative over ambient model input.
- Clear `NEMOCLAW_MODEL` and `NEMOCLAW_PROVIDER_MODEL` during resume so recorded provider and model state remains authoritative.
- Add regression coverage for explicit, empty, absent, malformed, descriptor, restore, and resume behavior.
- Update the compatible-endpoint documentation for the fresh and resume model-selection contract.

The escaped defect was not detected because the existing environment-scope tests covered hostile selector removal but did not assert that legitimate fresh model intent reached provider validation.
The new tests exercise that production boundary and the sibling fallback selector.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security review passed on commit `490d05919` with no findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/inference/set-up-openai-compatible-endpoint.mdx`; the review covered the fresh explicit/default/descriptor contract, resume authority, generated OpenClaw, Hermes, and Deep Agents variants, and the writing rules.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 490d05919 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/portable-environment-scope.test.ts src/lib/onboard/providers.test.ts` passed 64 tests. `./node_modules/.bin/vitest run --changed upstream/main --project cli --project plugin --project e2e-support` passed 1,520 tests across 120 files.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm run test:fast` was not used as candidate evidence because exact-main tests hit the private `/tmp` authority guard and the macOS host lacks GNU `timeout`; neither test is selected by the changed dependency graph.
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — `npm run docs` passed with 0 errors and 2 pre-existing suppressed warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portable onboarding supports explicit model selection through `NEMOCLAW_MODEL`.
  * When no model is provided, onboarding defaults to `qwen3-vl:4b`.
  * Portable resume reuses the provider and model recorded during onboarding.

* **Bug Fixes**
  * Improved validation of malformed model configuration.
  * Activation profile settings now take precedence during setup.

* **Documentation**
  * Updated setup guidance for model selection and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
