### PR TITLE
test: convert more loop-generated cases to tables

### DIFF
--- a/test/dcode-wrapper-empty-prompt.test.ts
+++ b/test/dcode-wrapper-empty-prompt.test.ts
@@ -103,15 +103,13 @@ const REJECT_CASES: Array<{ label: string; args: string[] }> = [
 describe.skipIf(!canRun)(
   "agents/langchain-deepagents-code/dcode-wrapper.sh empty prompt (#5752)",
   () => {
-    for (const { label, args } of REJECT_CASES) {
-      it(`refuses ${label} with exit 2 and never launches dcode`, () => {
-        const run = runWrapper(args);
+    it.each(REJECT_CASES)("refuses $label with exit 2 and never launches dcode", ({ args }) => {
+      const run = runWrapper(args);
 
-        expect(run.status).toBe(2);
-        expect(run.stderr).toContain("empty non-interactive prompt");
-        expect(run.launched).toBe(false);
-      });
-    }
+      expect(run.status).toBe(2);
+      expect(run.stderr).toContain("empty non-interactive prompt");
+      expect(run.launched).toBe(false);
+    });
 
     it("passes a real -n prompt through to dcode with managed flags", () => {
       const run = runWrapper(["-n", "list the files"]);

--- a/test/dcode-wrapper-identity.test.ts
+++ b/test/dcode-wrapper-identity.test.ts
@@ -123,8 +123,9 @@ function withTempDir(run: (dir: string) => void): void {
 describe.skipIf(!canRun)(
   "agents/langchain-deepagents-code/dcode-wrapper.sh identity command",
   () => {
-    for (const sub of ["status", "whoami", "identity"]) {
-      it(`'${sub}' reports the sandbox identity and does not launch dcode`, () => {
+    it.each(["status", "whoami", "identity"])(
+      "'%s' reports the sandbox identity and does not launch dcode",
+      (sub) => {
         withTempDir((dir) => {
           const fixture = buildFixture(dir, SAMPLE_CONFIG);
           addAgentDir(fixture, "backend-dev");
@@ -143,8 +144,8 @@ describe.skipIf(!canRun)(
           expect(run.stdout).toContain("Endpoint: https://inference.local/v1");
           expect(run.stdout).toContain("Runtime:  Deep Agents Code (terminal)");
         });
-      });
-    }
+      },
+    );
 
     it("uses a valid recent dcode agent when the configured default is stale", () => {
       withTempDir((dir) => {

--- a/test/exit-code-user-error-surfaces.test.ts
+++ b/test/exit-code-user-error-surfaces.test.ts
@@ -186,8 +186,10 @@ describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
     ],
   ];
 
-  for (const [label, argv, expected] of cases) {
-    it(`${label} prints an error and exits non-zero`, testTimeoutOptions(30_000), () => {
+  it.each(cases)(
+    "%s prints an error and exits non-zero",
+    testTimeoutOptions(30_000),
+    (_label, argv, expected) => {
       const { status, signal, error, combined } = runCli(argv);
       // The process must have launched and exited on its own — not failed to
       // spawn and not been killed by a signal/timeout (which leaves
@@ -197,8 +199,8 @@ describe("user-error/startup surfaces return non-zero exit (#5974)", () => {
       expect(combined.trim().length).toBeGreaterThan(0);
       expect(combined).toContain(expected);
       expect(status).toBeGreaterThan(0);
-    });
-  }
+    },
+  );
 
   // PRA-1 (#5974): exercise the NATIVE oclif argv route end-to-end through the
   // real binary. `dispatchCli` sends a leading `sandbox`/`internal` token

--- a/test/package-contract/ssrf-parity.test.ts
+++ b/test/package-contract/ssrf-parity.test.ts
@@ -361,12 +361,13 @@ describe("CLI and plugin isPrivateHostname agree on every CIDR boundary", () => 
     ["ffc0::", true, "ff00::/8 three-quarter"],
   ];
 
-  for (const [addr, expected, label] of vectors) {
-    it(`classifies ${label} at ${addr} as ${String(expected)}`, () => {
+  it.each(vectors.map(([addr, expected, label]) => ({ addr, expected, label })))(
+    "classifies $label at $addr as $expected",
+    ({ addr, expected }) => {
       expect(pluginHelper.isPrivateHostname(addr)).toBe(expected);
       expect(cliHelper.isPrivateHostname(addr)).toBe(expected);
-    });
-  }
+    },
+  );
 });
 
 // ── Wrapper-level cases (bracket handling, cross-family, DNS) ───────
@@ -401,10 +402,15 @@ describe("CLI and plugin isPrivateHostname agree on wrapper-level cases", () => 
     ["", false, "empty"],
   ];
 
-  for (const [addr, expected, label] of extras) {
-    it(`classifies ${label} at ${JSON.stringify(addr)} as ${String(expected)}`, () => {
-      expect(pluginHelper.isPrivateHostname(addr)).toBe(expected);
-      expect(cliHelper.isPrivateHostname(addr)).toBe(expected);
-    });
-  }
+  it.each(
+    extras.map(([addr, expected, label]) => ({
+      addr,
+      expected,
+      label,
+      displayedAddr: JSON.stringify(addr),
+    })),
+  )("classifies $label at $displayedAddr as $expected", ({ addr, expected }) => {
+    expect(pluginHelper.isPrivateHostname(addr)).toBe(expected);
+    expect(cliHelper.isPrivateHostname(addr)).toBe(expected);
+  });
 });

--- a/test/rebuild-credential-hydration.test.ts
+++ b/test/rebuild-credential-hydration.test.ts
@@ -134,10 +134,10 @@ describe("credential hydration from legacy storage, layer 1 (#2273)", () => {
     },
   ];
 
-  for (const { name, credentialEnv, value } of providers) {
-    it(`hydrates ${credentialEnv} (${name}) from legacy credentials.json when not in process.env`, {
-      timeout: TEST_TIMEOUT_MS,
-    }, () => {
+  it.each(providers)(
+    "hydrates $credentialEnv ($name) from legacy credentials.json when not in process.env",
+    { timeout: TEST_TIMEOUT_MS },
+    ({ credentialEnv, value }) => {
       const { result } = verifyCredentialHydration(credentialEnv, value);
 
       if (result.status !== 0) {
@@ -149,6 +149,6 @@ describe("credential hydration from legacy storage, layer 1 (#2273)", () => {
       const payload = JSON.parse(result.stdout);
       expect(payload.hydrated).toBe(value);
       expect(payload.envValue).toBe(value);
-    });
-  }
+    },
+  );
 });

--- a/test/repro-2376.test.ts
+++ b/test/repro-2376.test.ts
@@ -60,17 +60,17 @@ function runRcFile(
 }
 
 describe("Hermes rc files source HERMES_HOME from proxy-env (#2376)", () => {
-  for (const rcFileName of [".bashrc", ".profile"] as const) {
-    it(`${rcFileName} exports HERMES_HOME when proxy-env exists`, () => {
-      const out = runRcFile(rcFileName, "export HERMES_HOME=/sandbox/.hermes\n");
-      expect(out).toBe("/sandbox/.hermes");
-    });
+  const rcFileNames = [".bashrc", ".profile"] as const;
 
-    it(`${rcFileName} prepends Hermes command directories to PATH`, () => {
-      const out = runRcFile(rcFileName, undefined, `printf '%s' "$PATH"`);
-      expect(out.split(":").slice(0, 2)).toEqual(["/usr/local/bin", "/opt/hermes/.venv/bin"]);
-    });
-  }
+  it.each(rcFileNames)("%s exports HERMES_HOME when proxy-env exists", (rcFileName) => {
+    const out = runRcFile(rcFileName, "export HERMES_HOME=/sandbox/.hermes\n");
+    expect(out).toBe("/sandbox/.hermes");
+  });
+
+  it.each(rcFileNames)("%s prepends Hermes command directories to PATH", (rcFileName) => {
+    const out = runRcFile(rcFileName, undefined, `printf '%s' "$PATH"`);
+    expect(out.split(":").slice(0, 2)).toEqual(["/usr/local/bin", "/opt/hermes/.venv/bin"]);
+  });
 
   it("rc sourcing is a no-op when proxy-env is absent", () => {
     const out = runRcFile(".bashrc");

--- a/test/secret-redaction.test.ts
+++ b/test/secret-redaction.test.ts
@@ -50,21 +50,17 @@ describe("secret redaction consistency (#1736)", () => {
   const TEST_TOKENS = [...LITERAL_PREFIX_TOKENS, ...MESSAGING_TOKENS];
 
   describe("runner.ts redacts all token types", () => {
-    for (const { name, token } of TEST_TOKENS) {
-      it(`redacts ${name}`, () => {
-        const text = runnerRedact(`error: authentication failed with ${token}`);
-        expect(text).not.toContain(token);
-      });
-    }
+    it.each(TEST_TOKENS)("redacts $name", ({ token }) => {
+      const text = runnerRedact(`error: authentication failed with ${token}`);
+      expect(text).not.toContain(token);
+    });
   });
 
   describe("debug.ts redacts all token types", () => {
-    for (const { name, token } of TEST_TOKENS) {
-      it(`redacts ${name}`, () => {
-        const text = debugRedact(`error: authentication failed with ${token}`);
-        expect(text).not.toContain(token);
-      });
-    }
+    it.each(TEST_TOKENS)("redacts $name", ({ token }) => {
+      const text = debugRedact(`error: authentication failed with ${token}`);
+      expect(text).not.toContain(token);
+    });
   });
 
   describe("redactor consistency (#2381)", () => {
@@ -176,12 +172,10 @@ describe("secret redaction consistency (#1736)", () => {
   });
 
   describe("onboard-session redactSensitiveText (#2336)", () => {
-    for (const { name, token } of TEST_TOKENS) {
-      it(`redacts ${name} from persisted failure messages`, () => {
-        const text = redactSensitiveText(`onboard step failed: provider returned ${token}`);
-        expect(text).not.toContain(token);
-      });
-    }
+    it.each(TEST_TOKENS)("redacts $name from persisted failure messages", ({ token }) => {
+      const text = redactSensitiveText(`onboard step failed: provider returned ${token}`);
+      expect(text).not.toContain(token);
+    });
 
     it("redacts Telegram token embedded in API URL path", () => {
       const token = "1234567890:" + "A".repeat(35);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Convert the next 10 loop-generated test groups to Vitest `it.each` tables. Each case now appears as an independent table row while preserving the existing assertions and behavior-oriented titles.

## Changes

- Convert dcode empty-prompt, identity alias, CLI user-error, credential hydration, and Hermes rc-file cases to table tests.
- Convert two SSRF parity groups and three secret-redaction groups to table tests.
- Reduce the test-loop scanner result from 1,367 to 1,357 loops.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This test-only registration refactor does not change user-visible behavior or a supported product contract.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The SSRF, credential, and redaction inputs and assertions remain unchanged. No production security control changed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed all seven changed test files and all 10 table-test conversions. The changes preserve test behavior and titles and do not change user-visible NemoClaw behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7f6610198 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run` passed all seven changed files and 318 tests; `npm run test:titles:check` passed; the scanner reports 1,357 loops.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored several test suites to use parameterized test cases.
  * Preserved existing assertions and coverage for prompt validation, identity commands, error handling, SSRF classification, credential hydration, shell configuration, and secret redaction.
  * Improved test organization and readability without changing product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->