### PR TITLE
fix(e2e): use distro Podman for rootless builds

### DIFF
--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -68,6 +68,13 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install --yes fuse-overlayfs passt podman slirp4netns uidmap
+          package_podman="/usr/bin/podman"
+          test -x "$package_podman"
+          runtime_bin="$(mktemp -d "${RUNNER_TEMP}/nemoclaw-rootless-runtime.XXXXXX")"
+          ln -s "$package_podman" "$runtime_bin/podman"
+          export PATH="$runtime_bin:$PATH"
+          printf '%s\n' "$runtime_bin" >> "$GITHUB_PATH"
+          test "$(readlink -f "$(command -v podman)")" = "$package_podman"
           runtime_dir="/run/user/$(id -u)"
           sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" "$runtime_dir"
           if ! grep -q "^${USER}:" /etc/subuid; then

--- a/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
+++ b/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
@@ -22,6 +22,7 @@ describe("portable profile rootless runtime workflow", () => {
     const versionIndex = provision.indexOf("podman --version");
 
     expect(packageInstallIndex).toBeGreaterThanOrEqual(0);
+    expect(provision).toMatch(/sudo apt-get install --yes .*\bpodman\b/);
     expect(packagePodmanIndex).toBeGreaterThan(packageInstallIndex);
     expect(provision).toContain('ln -s "$package_podman" "$runtime_bin/podman"');
     expect(pathExportIndex).toBeGreaterThan(packagePodmanIndex);

--- a/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
+++ b/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { readYaml, type Workflow, type WorkflowStep } from "../../helpers/e2e-workflow-contract";
+
+function rootlessLinuxStep(name: string): WorkflowStep {
+  const workflow = readYaml<Workflow>(".github/workflows/portable-profile-e2e.yaml");
+  const step = workflow.jobs["rootless-linux"]?.steps?.find((candidate) => candidate.name === name);
+  expect(step).toBeDefined();
+  return step!;
+}
+
+describe("portable profile rootless runtime workflow", () => {
+  it("uses Ubuntu's Podman package with its installed OCI runtime", () => {
+    const provision = rootlessLinuxStep("Provision restricted rootless Linux runtime").run ?? "";
+    const packageInstallIndex = provision.indexOf("sudo apt-get install");
+    const packagePodmanIndex = provision.indexOf('package_podman="/usr/bin/podman"');
+    const pathExportIndex = provision.indexOf('export PATH="$runtime_bin:$PATH"');
+    const jobPathIndex = provision.indexOf('printf \'%s\\n\' "$runtime_bin" >> "$GITHUB_PATH"');
+    const versionIndex = provision.indexOf("podman --version");
+
+    expect(packageInstallIndex).toBeGreaterThanOrEqual(0);
+    expect(packagePodmanIndex).toBeGreaterThan(packageInstallIndex);
+    expect(provision).toContain('ln -s "$package_podman" "$runtime_bin/podman"');
+    expect(pathExportIndex).toBeGreaterThan(packagePodmanIndex);
+    expect(jobPathIndex).toBeGreaterThan(pathExportIndex);
+    expect(versionIndex).toBeGreaterThan(jobPathIndex);
+    expect(provision).toContain('test "$(readlink -f "$(command -v podman)")" = "$package_podman"');
+  });
+});

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -148,8 +148,14 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     testsToRun: runTests("test/e2e/support/standard-profile-workflow-boundary.test.ts"),
   },
   {
-    pattern:
-      /(?:^|\/)(?:\.github\/workflows\/portable-profile-e2e\.yaml|test\/e2e\/fixtures\/portable-profile-systemctl-shim\.sh)$/,
+    pattern: /(?:^|\/)\.github\/workflows\/portable-profile-e2e\.yaml$/,
+    testsToRun: runTests(
+      "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",
+      "test/e2e/support/portable-profile-systemctl-shim.test.ts",
+    ),
+  },
+  {
+    pattern: /(?:^|\/)test\/e2e\/fixtures\/portable-profile-systemctl-shim\.sh$/,
     testsToRun: runTests("test/e2e/support/portable-profile-systemctl-shim.test.ts"),
   },
   {

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -158,14 +158,13 @@ describe("Vitest opaque-input watch triggers", () => {
     expect(triggeredBy(".github/workflows/e2e-standard-profile.yaml")).toEqual([
       "test/e2e/support/standard-profile-workflow-boundary.test.ts",
     ]);
-    for (const portableProfilePath of [
-      ".github/workflows/portable-profile-e2e.yaml",
-      "test/e2e/fixtures/portable-profile-systemctl-shim.sh",
-    ]) {
-      expect(triggeredBy(portableProfilePath)).toEqual([
-        "test/e2e/support/portable-profile-systemctl-shim.test.ts",
-      ]);
-    }
+    expect(triggeredBy(".github/workflows/portable-profile-e2e.yaml")).toEqual([
+      "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",
+      "test/e2e/support/portable-profile-systemctl-shim.test.ts",
+    ]);
+    expect(triggeredBy("test/e2e/fixtures/portable-profile-systemctl-shim.sh")).toEqual([
+      "test/e2e/support/portable-profile-systemctl-shim.test.ts",
+    ]);
     for (const authPath of [
       ".github/actions/docker-auth-setup/action.yaml",
       ".github/actions/docker-auth-cleanup/action.yaml",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Portable Profile rootless job installed Ubuntu's Podman package but continued to resolve the runner image's Podman 5.8.4. That paired the runner binary with Ubuntu's `/usr/bin/crun`, which rejected container startup. This change makes the job use Ubuntu's `/usr/bin/podman` with the OCI runtime installed by the same package set.

Failure evidence: [Portable Profile run 31986375848](https://github.com/NVIDIA/NemoClaw/actions/runs/31986375848), [rootless Linux job 95262042184](https://github.com/NVIDIA/NemoClaw/actions/runs/31986375848/job/95262042184).

The separate Portable Profile BuildKit cgroup failure is outside this PR.

## Changes

- Put a trusted temporary directory containing only a symlink to `/usr/bin/podman` first in PATH for the rootless job.
- Verify the resolved Podman path before the live Portable Profile test starts.
- Add a fast workflow contract test and route workflow changes to it through the affected-test mapping.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes internal GitHub E2E runner setup and does not change a supported product surface.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The PATH boundary uses a private directory created by `mktemp` under `RUNNER_TEMP`, contains only a symlink to the fixed `/usr/bin/podman` path, and does not consume untrusted input or secrets.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: `.github/workflows/portable-profile-e2e.yaml` changes only internal E2E runner binary selection; the remaining changed files provide contract and watch-trigger tests. Supported product behavior does not change.
- Agent: Codex Desktop
<!-- docs-review-head-sha: aad148b0e -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `e2e-support`: 1/1 passed; affected-test mapping: 4/4 passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this focused workflow setup and contract-test change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of portable rootless Linux setup by ensuring Podman is available through the expected command path.
  * Added verification that the packaged Podman binary is correctly installed, linked, and recognized during workflows.

* **Tests**
  * Added end-to-end coverage for Podman installation and command resolution.
  * Refined test monitoring so relevant checks run when workflow or fixture changes occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->