### PR TITLE
test: parameterize another 10 loop-generated cases

### DIFF
--- a/test/channels-remove-full-teardown.test.ts
+++ b/test/channels-remove-full-teardown.test.ts
@@ -201,8 +201,9 @@ module.exports = {
 }
 
 describe("channels remove full teardown (#3998)", () => {
-  for (const sandboxAgent of ["openclaw", "hermes"] as const) {
-    it(`strips '${sandboxAgent}' session.policyPresets and clears the in-sandbox whatsapp state dir`, () => {
+  it.each(["openclaw", "hermes"] as const)(
+    "strips '%s' session.policyPresets and clears the in-sandbox whatsapp state dir",
+    (sandboxAgent) => {
       const script = `${buildPreamble({ sandboxAgent })}
 const ctx = module.exports;
 (async () => {
@@ -285,8 +286,8 @@ const ctx = module.exports;
         clearIdx < rebuildIdx,
         `sandbox state must be cleared before rebuild so the backup excludes the auth files: ${JSON.stringify(payload.callOrder)}`,
       );
-    });
-  }
+    },
+  );
 
   it("falls back to SSH when sandbox-exec wrapper does not return the sentinel", () => {
     const script = `${buildPreamble({

--- a/test/cli/logs-documented-invocations.test.ts
+++ b/test/cli/logs-documented-invocations.test.ts
@@ -68,13 +68,14 @@ describe("documented sandbox logs invocations", () => {
     expect(invocations.length).toBeGreaterThanOrEqual(5);
   });
 
-  for (const { args, reference } of invocations) {
-    it(`runs the invocation documented at ${reference}`, ({ resources }) => {
+  it.for(invocations.map(({ args, reference }) => [reference, args] as const))(
+    "runs the invocation documented at %s",
+    ([, args], { resources }) => {
       const setup = createLogsTestSetup(resources, "nemoclaw-cli-logs-documented-");
       const result = setup.runLogs(`${args} 2>&1`);
 
       expect(result.out).not.toContain("Nonexistent flag");
       expect(result.code).toBe(0);
-    });
-  }
+    },
+  );
 });

--- a/test/hermes-restart-config-seal-hostile-input.test.ts
+++ b/test/hermes-restart-config-seal-hostile-input.test.ts
@@ -15,8 +15,9 @@ import {
 } from "./helpers/hermes-restart-config-seal-fixture";
 
 describe.skipIf(process.platform === "win32")("Hermes mutable restart input seal", () => {
-  for (const oversizedName of ["config.yaml", ".env"] as const) {
-    it(`contains an oversized sparse ${oversizedName} without reading its logical payload`, () => {
+  it.each(["config.yaml", ".env"] as const)(
+    "contains an oversized sparse %s without reading its logical payload",
+    (oversizedName) => {
       const fixture = createRestartFixture();
       const oversizedPath = oversizedName === "config.yaml" ? fixture.configPath : fixture.envPath;
       fs.truncateSync(
@@ -41,8 +42,8 @@ describe.skipIf(process.platform === "win32")("Hermes mutable restart input seal
         fs.chmodSync(fixture.hermesDir, 0o700);
         fs.rmSync(fixture.root, { recursive: true, force: true });
       }
-    });
-  }
+    },
+  );
 
   it("fresh-seals a hardlinked input and revokes the external writable inode", () => {
     const fixture = createRestartFixture();
@@ -82,8 +83,9 @@ describe.skipIf(process.platform === "win32")("Hermes mutable restart input seal
     }
   });
 
-  for (const hostileKind of ["symlink", "fifo"] as const) {
-    it(`seals a hostile ${hostileKind} config entry into a root-only unavailable posture`, () => {
+  it.each(["symlink", "fifo"] as const)(
+    "seals a hostile %s config entry into a root-only unavailable posture",
+    (hostileKind) => {
       const fixture = createRestartFixture();
       fs.unlinkSync(fixture.configPath);
       const arrangeHostileConfig = {
@@ -119,11 +121,12 @@ describe.skipIf(process.platform === "win32")("Hermes mutable restart input seal
         fs.chmodSync(fixture.hermesDir, 0o700);
         fs.rmSync(fixture.root, { recursive: true, force: true });
       }
-    });
-  }
+    },
+  );
 
-  for (const hostileKind of ["symlink", "fifo"] as const) {
-    it(`quarantines an outer .hermes ${hostileKind} only after freezing /sandbox`, () => {
+  it.each(["symlink", "fifo"] as const)(
+    "quarantines an outer .hermes %s only after freezing /sandbox",
+    (hostileKind) => {
       const fixture = createRestartFixture();
       fs.rmSync(fixture.hermesDir, { recursive: true, force: true });
       const victim = path.join(fixture.root, "outer-victim");
@@ -154,8 +157,8 @@ describe.skipIf(process.platform === "win32")("Hermes mutable restart input seal
         fs.chmodSync(fixture.hermesDir, 0o700);
         fs.rmSync(fixture.root, { recursive: true, force: true });
       }
-    });
-  }
+    },
+  );
 
   it("re-seals an applied mutable transition before recursive rollback", () => {
     const fixture = createRestartFixture();

--- a/test/mcp-provider-ownership.test.ts
+++ b/test/mcp-provider-ownership.test.ts
@@ -214,8 +214,9 @@ bridge.removeMcpBridge("alpha", "fake").then(
 }
 
 describe("MCP provider ownership", () => {
-  for (const boundary of ["detach", "delete"] as const) {
-    it(`rechecks stable identity immediately before provider ${boundary}`, () => {
+  it.each(["detach", "delete"] as const)(
+    "rechecks stable identity immediately before provider %s",
+    (boundary) => {
       const result = runRemoveIdentityRace(boundary);
 
       expect(result.status, `${result.stdout}\\n${result.stderr}`).toBe(0);
@@ -234,8 +235,8 @@ describe("MCP provider ownership", () => {
         ),
       ).toBe(boundary === "delete");
       expect(payload.bridgePresent).toBe(true);
-    });
-  }
+    },
+  );
 
   it("removes an exact legacy provider whose credential name is now reserved", () => {
     const result = runLegacyReservedCredentialCleanup();

--- a/test/onboard-preset-diff.test.ts
+++ b/test/onboard-preset-diff.test.ts
@@ -365,8 +365,11 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
   // channel→preset registry iteration as Discord/Telegram, so each apply/remove
   // case guards the egress-policy application for every shipped channel — not
   // only the two already covered above (#5967).
-  for (const channel of ["teams", "whatsapp", "wechat"]) {
-    it(`resume selection applies the ${channel} policy required by a configured ${channel} channel (#5967)`, async () => {
+  const optionalChannelPresets = ["teams", "whatsapp", "wechat"].map((channel) => ({ channel }));
+
+  it.each(optionalChannelPresets)(
+    "resume selection applies the $channel policy required by a configured $channel channel (#5967)",
+    async ({ channel }) => {
       const payload = await runPolicyScenario({
         policyMode: "suggested",
         policyPresets: "",
@@ -380,9 +383,12 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
         `${channel} must be applied to the gateway when the channel is enabled; got applied ${JSON.stringify(payload.appliedCalls)}`,
       );
       assert.deepEqual(payload.finalApplied.slice().sort(), ["npm", "pypi", channel].sort());
-    });
+    },
+  );
 
-    it(`custom non-interactive selection removes disabled ${channel} while honoring the explicit preset list (#5967)`, async () => {
+  it.each(optionalChannelPresets)(
+    "custom non-interactive selection removes disabled $channel while honoring the explicit preset list (#5967)",
+    async ({ channel }) => {
       const payload = await runPolicyScenario({
         policyMode: "custom",
         policyPresets: "npm",
@@ -393,8 +399,8 @@ describe("setupPoliciesWithSelection preset diff (#2177)", () => {
       assert.deepEqual(payload.chosen, ["npm"]);
       assert.deepEqual(payload.removedCalls.slice().sort(), ["pypi", channel].sort());
       assert.deepEqual(payload.finalApplied, ["npm"]);
-    });
-  }
+    },
+  );
 
   it("custom non-interactive selection removes disabled Slack while honoring the explicit preset list", async () => {
     const payload = await runPolicyScenario({

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -2851,12 +2851,12 @@ reportChildScenario(async () => {
 
   const secretCredentialBackScenarios = PROCESS_CREDENTIAL_BACK_SCENARIOS.slice(1, -1);
 
-  for (const scenario of secretCredentialBackScenarios) {
-    const action = scenario.expectedOutcome === "exit" ? "exit" : "back";
-    it(`lets users type ${action} at the ${scenario.name} secret credential prompt`, () => {
-      runCredentialBackScenarioProcess(scenario);
-    });
-  }
+  it.each(secretCredentialBackScenarios.map((scenario) => ({
+    ...scenario,
+    action: scenario.expectedOutcome === "exit" ? "exit" : "back",
+  })))("lets users type $action at the $name secret credential prompt", (scenario) => {
+    runCredentialBackScenarioProcess(scenario);
+  });
 
   it("lets users type back at the Local NIM NGC API key secret credential prompt", () => {
     runCredentialBackScenarioProcess(PROCESS_CREDENTIAL_BACK_SCENARIOS.at(-1)!);

--- a/test/sandbox-init.test.ts
+++ b/test/sandbox-init.test.ts
@@ -760,16 +760,19 @@ EOF
   });
 
   describe("entrypoints call harden_resource_limits", () => {
+    const entrypoints = ["../scripts/nemoclaw-start.sh", "../agents/hermes/start.sh"];
+
     // Both entrypoints must delegate RLIMIT hardening to the shared helper and
     // must no longer carry the pre-#4527 raw inline `ulimit -Su 512` block.
-    for (const rel of ["../scripts/nemoclaw-start.sh", "../agents/hermes/start.sh"]) {
-      it(`${rel} calls harden_resource_limits and has no raw inline nproc block`, () => {
+    it.each(entrypoints)(
+      "%s calls harden_resource_limits and has no raw inline nproc block",
+      (rel) => {
         const src = readFileSync(join(import.meta.dirname, rel), "utf-8");
         expect(src).toContain("harden_resource_limits");
         expect(src).not.toContain("ulimit -Su 512");
         expect(src).not.toContain("ulimit -Hu 512");
-      });
-    }
+      },
+    );
 
     // SECURITY (#4527): the RLIMIT caps are only unraisable if they are set
     // while still root PID 1, BEFORE drop_capabilities (capsh) and the
@@ -777,18 +780,16 @@ EOF
     // privilege drop would turn it into dead code (cap set as the unprivileged
     // agent, hard limit no longer lowered) while every other test stayed green.
     // Pin the ordering so that regression is caught.
-    for (const rel of ["../scripts/nemoclaw-start.sh", "../agents/hermes/start.sh"]) {
-      it(`${rel} calls harden_resource_limits before drop_capabilities`, () => {
-        const src = readFileSync(join(import.meta.dirname, rel), "utf-8");
-        // Anchor to executable command lines, not free-text, so a comment
-        // mentioning either name cannot satisfy (or break) the ordering check.
-        const hardenIdx = src.match(/^\s*harden_resource_limits\s*$/m)?.index ?? -1;
-        const dropIdx = src.match(/^\s*drop_capabilities\b.*$/m)?.index ?? -1;
-        expect(hardenIdx).toBeGreaterThanOrEqual(0);
-        expect(dropIdx).toBeGreaterThanOrEqual(0);
-        expect(hardenIdx).toBeLessThan(dropIdx);
-      });
-    }
+    it.each(entrypoints)("%s calls harden_resource_limits before drop_capabilities", (rel) => {
+      const src = readFileSync(join(import.meta.dirname, rel), "utf-8");
+      // Anchor to executable command lines, not free-text, so a comment
+      // mentioning either name cannot satisfy (or break) the ordering check.
+      const hardenIdx = src.match(/^\s*harden_resource_limits\s*$/m)?.index ?? -1;
+      const dropIdx = src.match(/^\s*drop_capabilities\b.*$/m)?.index ?? -1;
+      expect(hardenIdx).toBeGreaterThanOrEqual(0);
+      expect(dropIdx).toBeGreaterThanOrEqual(0);
+      expect(hardenIdx).toBeLessThan(dropIdx);
+    });
   });
 
   describe("init_step_down_prefixes", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Convert the next 10 suite-level test generator loops to Vitest parameterized tables. This keeps the same cases and assertions while reducing the test-loop growth baseline from 1,357 to 1,347.

## Changes

- Parameterize channel teardown, documented logs invocation, Hermes hostile-input, MCP ownership, onboarding policy, credential-navigation, and sandbox entrypoint cases.
- Use `it.for` for the documented logs table because that test requires the extended resource fixture context.
- Preserve behavior-oriented row titles, cleanup, error cases, and security-sensitive assertions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Test registration changes only; user-visible behavior is unchanged.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Test-only changes preserve the original assertions, error cases, cleanup, identity checks, hostile-input containment, and resource-limit ordering checks.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed all seven changed test files and 10 table-test conversions. The changes preserve exact behavior-oriented test titles and do not change user-visible NemoClaw behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5b1d2f29d -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Seven changed test files passed together (169 tests); `test/onboard-selection.test.ts` passed again after the final title adjustment (64 tests). Test title and file-size checks passed. The loop scanner reports 1,347 loops, down from 1,357.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; these are suite-local test registration changes.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored multiple test suites to use parameterized test cases.
  * Preserved existing coverage and assertions for channel teardown, logging, configuration handling, provider ownership, onboarding, and sandbox initialization.
  * Improved consistency and maintainability of test declarations without changing end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->