### PR TITLE
feat(inference): map Pi model tuning through the managed startup profile

### DIFF
--- a/agents/pi/Dockerfile
+++ b/agents/pi/Dockerfile
@@ -176,6 +176,10 @@ ARG NEMOCLAW_INFERENCE_PROVIDER_ID=inference
 ARG NEMOCLAW_UPSTREAM_PROVIDER=nvidia
 ARG NEMOCLAW_INFERENCE_BASE_URL=https://inference.local/v1
 ARG NEMOCLAW_INFERENCE_API=openai-completions
+ARG NEMOCLAW_CONTEXT_WINDOW=
+# hadolint ignore=DL3064
+ARG NEMOCLAW_MAX_TOKENS=
+ARG NEMOCLAW_REASONING=
 # Pi installs no optional package. The Pi image still declares the managed-image
 # capability contract used by OpenClaw, Hermes, and Deep Agents Code.
 ARG NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=0
@@ -197,6 +201,7 @@ RUN install -d -m 0755 /usr/local/share/nemoclaw \
     && chown root:root /usr/local/share/nemoclaw/pi-proxy-host /usr/local/share/nemoclaw/pi-proxy-port \
     && chmod 0444 /usr/local/share/nemoclaw/pi-proxy-host /usr/local/share/nemoclaw/pi-proxy-port
 
+# hadolint ignore=DL3064
 ENV HOME=/sandbox \
     PATH="/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin" \
     NEMOCLAW_MODEL=${NEMOCLAW_MODEL} \
@@ -204,6 +209,9 @@ ENV HOME=/sandbox \
     NEMOCLAW_UPSTREAM_PROVIDER=${NEMOCLAW_UPSTREAM_PROVIDER} \
     NEMOCLAW_INFERENCE_BASE_URL=${NEMOCLAW_INFERENCE_BASE_URL} \
     NEMOCLAW_INFERENCE_API=${NEMOCLAW_INFERENCE_API} \
+    NEMOCLAW_CONTEXT_WINDOW=${NEMOCLAW_CONTEXT_WINDOW} \
+    NEMOCLAW_MAX_TOKENS=${NEMOCLAW_MAX_TOKENS} \
+    NEMOCLAW_REASONING=${NEMOCLAW_REASONING} \
     NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=${NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION} \
     NEMOCLAW_BUILD_ID=${NEMOCLAW_BUILD_ID} \
     PI_OFFLINE=1 \

--- a/agents/pi/generate-config.ts
+++ b/agents/pi/generate-config.ts
@@ -21,6 +21,9 @@ type Settings = {
   providerKey: string;
   upstreamProvider: string;
   inferenceApi: string;
+  contextWindow: number | null;
+  maxTokens: number | null;
+  reasoning: boolean | null;
 };
 
 type ManagedPiConfig = {
@@ -75,6 +78,27 @@ function normalizeInferenceBaseUrl(value: string): string {
   return text;
 }
 
+function normalizePositiveInteger(value: string | undefined, name: string): number | null {
+  const text = (value ?? "").trim();
+  if (!text) return null;
+  if (!/^\d+$/u.test(text)) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function normalizeReasoning(value: string | undefined): boolean | null {
+  const text = (value ?? "").trim();
+  if (!text) return null;
+  if (text === "true") return true;
+  if (text === "false") return false;
+  throw new Error('NEMOCLAW_REASONING must be "true" or "false".');
+}
+
 function readSettings(env: NodeJS.ProcessEnv): Settings {
   const providerKey = normalizeMetadata(
     env.NEMOCLAW_INFERENCE_PROVIDER_ID || env.NEMOCLAW_PROVIDER_KEY || "inference",
@@ -91,7 +115,18 @@ function readSettings(env: NodeJS.ProcessEnv): Settings {
       "NEMOCLAW_UPSTREAM_PROVIDER",
     ),
     inferenceApi: normalizeInferenceApi(env.NEMOCLAW_INFERENCE_API),
+    contextWindow: normalizePositiveInteger(env.NEMOCLAW_CONTEXT_WINDOW, "NEMOCLAW_CONTEXT_WINDOW"),
+    maxTokens: normalizePositiveInteger(env.NEMOCLAW_MAX_TOKENS, "NEMOCLAW_MAX_TOKENS"),
+    reasoning: normalizeReasoning(env.NEMOCLAW_REASONING),
   };
+}
+
+function buildModel(settings: Settings): Record<string, unknown> {
+  const model: Record<string, unknown> = { id: settings.model };
+  if (settings.contextWindow !== null) model.contextWindow = settings.contextWindow;
+  if (settings.maxTokens !== null) model.maxTokens = settings.maxTokens;
+  if (settings.reasoning !== null) model.reasoning = settings.reasoning;
+  return model;
 }
 
 function buildConfig(settings: Settings): ManagedPiConfig {
@@ -103,7 +138,7 @@ function buildConfig(settings: Settings): ManagedPiConfig {
         api: settings.inferenceApi,
         apiKey: MANAGED_PROVIDER_API_KEY,
         baseUrl: settings.baseUrl,
-        models: [{ id: settings.model }],
+        models: [buildModel(settings)],
       },
     },
   };

--- a/src/lib/onboard/managed-startup-agent-environment.test.ts
+++ b/src/lib/onboard/managed-startup-agent-environment.test.ts
@@ -707,22 +707,13 @@ describe("managed startup agent environment", () => {
       https_proxy: "",
       no_proxy: "",
     });
-    const expectedPiRuntime = { ...result.configurationEnvironment };
-    delete expectedPiRuntime.NEMOCLAW_INFERENCE_BASE_URL;
-    delete expectedPiRuntime.NEMOCLAW_CONTEXT_WINDOW;
-    delete expectedPiRuntime.NEMOCLAW_MAX_TOKENS;
-    delete expectedPiRuntime.NEMOCLAW_REASONING;
-    for (const name of [
-      "HTTP_PROXY",
-      "HTTPS_PROXY",
-      "NO_PROXY",
-      "http_proxy",
-      "https_proxy",
-      "no_proxy",
-    ]) {
-      delete expectedPiRuntime[name];
-    }
-    expect(result.runtimeEnvironment).toEqual(expectedPiRuntime);
+    expect(result.runtimeEnvironment).toEqual({
+      NEMOCLAW_INFERENCE_API: "openai-completions",
+      NEMOCLAW_INFERENCE_PROVIDER_ID: "inference",
+      NEMOCLAW_MODEL: "nvidia/nemotron-3-super-120b-a12b",
+      NEMOCLAW_TOOL_DISCLOSURE: "progressive",
+      NEMOCLAW_UPSTREAM_PROVIDER: "nvidia",
+    });
     expect(result.materials).toEqual([
       {
         kind: "corporate-ca-handoff",
@@ -770,17 +761,17 @@ describe("managed startup agent environment", () => {
     expect(result.configurationEnvironment).toMatchObject({
       NEMOCLAW_CONTEXT_WINDOW: "262144",
       NEMOCLAW_MAX_TOKENS: "32000",
-      NEMOCLAW_REASONING: "1",
+      NEMOCLAW_REASONING: "true",
     });
-    for (const name of ["NEMOCLAW_CONTEXT_WINDOW", "NEMOCLAW_MAX_TOKENS", "NEMOCLAW_REASONING"]) {
-      expect(result.runtimeEnvironment).not.toHaveProperty(name);
-    }
+    expect(result.runtimeEnvironment).not.toHaveProperty("NEMOCLAW_CONTEXT_WINDOW");
+    expect(result.runtimeEnvironment).not.toHaveProperty("NEMOCLAW_MAX_TOKENS");
+    expect(result.runtimeEnvironment).not.toHaveProperty("NEMOCLAW_REASONING");
     expect(
       mapManagedStartupProfileToAgentEnvironment({
         ...base,
         tuning: { ...base.tuning, reasoning: false },
       }).configurationEnvironment.NEMOCLAW_REASONING,
-    ).toBe("0");
+    ).toBe("false");
   });
 
   it("rebuilds the Pi generator inputs from the current route without retaining the previous one (#7930)", () => {
@@ -810,14 +801,10 @@ describe("managed startup agent environment", () => {
       { ...before.materials[2], contents: "3129\n" },
     ]);
     const serialized = JSON.stringify(after);
-    for (const stale of [
-      "https://inference.local/v1",
-      "nvidia/nemotron-3-super-120b-a12b",
-      "10.200.0.1",
-      "3128",
-    ]) {
-      expect(serialized).not.toContain(stale);
-    }
+    expect(serialized).not.toContain("https://inference.local/v1");
+    expect(serialized).not.toContain("nvidia/nemotron-3-super-120b-a12b");
+    expect(serialized).not.toContain("10.200.0.1");
+    expect(serialized).not.toContain("3128");
     expect(after.actions).toEqual(before.actions);
   });
 

--- a/src/lib/onboard/managed-startup-agent-environment.test.ts
+++ b/src/lib/onboard/managed-startup-agent-environment.test.ts
@@ -687,6 +687,140 @@ describe("managed startup agent environment", () => {
     ]);
   });
 
+  it("keeps the Pi managed route credential-free and confined to root-owned proxy files (#7930)", () => {
+    const result = mapManagedStartupProfileToAgentEnvironment(piProfile());
+
+    expect(result.configurationEnvironment).toEqual({
+      HTTP_PROXY: "",
+      HTTPS_PROXY: "",
+      NEMOCLAW_CONTEXT_WINDOW: "",
+      NEMOCLAW_INFERENCE_API: "openai-completions",
+      NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
+      NEMOCLAW_INFERENCE_PROVIDER_ID: "inference",
+      NEMOCLAW_MAX_TOKENS: "",
+      NEMOCLAW_MODEL: "nvidia/nemotron-3-super-120b-a12b",
+      NEMOCLAW_REASONING: "",
+      NEMOCLAW_TOOL_DISCLOSURE: "progressive",
+      NEMOCLAW_UPSTREAM_PROVIDER: "nvidia",
+      NO_PROXY: "",
+      http_proxy: "",
+      https_proxy: "",
+      no_proxy: "",
+    });
+    const expectedPiRuntime = { ...result.configurationEnvironment };
+    delete expectedPiRuntime.NEMOCLAW_INFERENCE_BASE_URL;
+    delete expectedPiRuntime.NEMOCLAW_CONTEXT_WINDOW;
+    delete expectedPiRuntime.NEMOCLAW_MAX_TOKENS;
+    delete expectedPiRuntime.NEMOCLAW_REASONING;
+    for (const name of [
+      "HTTP_PROXY",
+      "HTTPS_PROXY",
+      "NO_PROXY",
+      "http_proxy",
+      "https_proxy",
+      "no_proxy",
+    ]) {
+      delete expectedPiRuntime[name];
+    }
+    expect(result.runtimeEnvironment).toEqual(expectedPiRuntime);
+    expect(result.materials).toEqual([
+      {
+        kind: "corporate-ca-handoff",
+        legacyInput: "NEMOCLAW_CORPORATE_CA_B64",
+        expectedSha256: CA_SHA256,
+      },
+      {
+        kind: "root-owned-file",
+        legacyInput: "NEMOCLAW_PROXY_HOST",
+        path: "/usr/local/share/nemoclaw/pi-proxy-host",
+        contents: "10.200.0.1\n",
+        owner: "root",
+        group: "root",
+        mode: 0o444,
+      },
+      {
+        kind: "root-owned-file",
+        legacyInput: "NEMOCLAW_PROXY_PORT",
+        path: "/usr/local/share/nemoclaw/pi-proxy-port",
+        contents: "3128\n",
+        owner: "root",
+        group: "root",
+        mode: 0o444,
+      },
+    ]);
+    expect(result.actions).toEqual([
+      { kind: "generate-agent-config", agent: "pi", runAs: "sandbox" },
+      { kind: "configure-dashboard", dashboard: { agent: "pi", mode: "disabled" } },
+    ]);
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("nvapi-");
+    expect(serialized).not.toContain("NVIDIA_API_KEY");
+    expect(serialized).not.toContain("BEGIN CERTIFICATE");
+    expect(serialized).toContain(CA_SHA256);
+  });
+
+  it("hands Pi model tuning to its config generator and keeps it out of the long-running runtime (#7930)", () => {
+    const base = piProfile();
+    const result = mapManagedStartupProfileToAgentEnvironment({
+      ...base,
+      tuning: { contextWindow: 262_144, maxTokens: 32_000, reasoning: true, reasoningEffort: null },
+    });
+
+    expect(result.configurationEnvironment).toMatchObject({
+      NEMOCLAW_CONTEXT_WINDOW: "262144",
+      NEMOCLAW_MAX_TOKENS: "32000",
+      NEMOCLAW_REASONING: "1",
+    });
+    for (const name of ["NEMOCLAW_CONTEXT_WINDOW", "NEMOCLAW_MAX_TOKENS", "NEMOCLAW_REASONING"]) {
+      expect(result.runtimeEnvironment).not.toHaveProperty(name);
+    }
+    expect(
+      mapManagedStartupProfileToAgentEnvironment({
+        ...base,
+        tuning: { ...base.tuning, reasoning: false },
+      }).configurationEnvironment.NEMOCLAW_REASONING,
+    ).toBe("0");
+  });
+
+  it("rebuilds the Pi generator inputs from the current route without retaining the previous one (#7930)", () => {
+    const base = piProfile();
+    const before = mapManagedStartupProfileToAgentEnvironment(base);
+    const after = mapManagedStartupProfileToAgentEnvironment({
+      ...base,
+      inference: {
+        ...base.inference,
+        routeProvider: "rebuilt-inference",
+        upstreamProvider: "openrouter",
+        model: "openai/gpt-5.4",
+        routedBaseUrl: "https://rebuilt.inference.local/v1",
+      },
+      proxy: { ...base.proxy, managedHost: "10.200.0.9", managedPort: 3129 },
+    });
+
+    expect(after.configurationEnvironment).toMatchObject({
+      NEMOCLAW_INFERENCE_BASE_URL: "https://rebuilt.inference.local/v1",
+      NEMOCLAW_INFERENCE_PROVIDER_ID: "rebuilt-inference",
+      NEMOCLAW_MODEL: "openai/gpt-5.4",
+      NEMOCLAW_UPSTREAM_PROVIDER: "openrouter",
+    });
+    expect(after.materials).toEqual([
+      before.materials[0],
+      { ...before.materials[1], contents: "10.200.0.9\n" },
+      { ...before.materials[2], contents: "3129\n" },
+    ]);
+    const serialized = JSON.stringify(after);
+    for (const stale of [
+      "https://inference.local/v1",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "10.200.0.1",
+      "3128",
+    ]) {
+      expect(serialized).not.toContain(stale);
+    }
+    expect(after.actions).toEqual(before.actions);
+  });
+
   it("feeds the existing OpenClaw and Hermes config consumers without translation", () => {
     const openclaw = mapManagedStartupProfileToAgentEnvironment(openClawProfile());
     const openclawConfig = buildOpenClawConfig({

--- a/src/lib/onboard/managed-startup-onboard-profile.test.ts
+++ b/src/lib/onboard/managed-startup-onboard-profile.test.ts
@@ -136,7 +136,85 @@ function dcodeInput(
   };
 }
 
+function piInput(
+  overrides: Partial<ManagedStartupOnboardProfileInput> = {},
+): ManagedStartupOnboardProfileInput {
+  return {
+    agentName: "pi",
+    inference: {
+      routeProvider: "inference",
+      upstreamProvider: "nvidia",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      routedBaseUrl: "https://inference.local/v1",
+      upstreamEndpointUrl: null,
+      api: "openai-completions",
+      primaryModelRef: null,
+      compatibility: null,
+    },
+    chatUiUrl: "",
+    effectiveDashboardPort: 0,
+    manageDashboard: false,
+    dashboardBindAddress: undefined,
+    wslExposure: false,
+    hermesDashboardState: { config: null, enabled: false },
+    webSearch: null,
+    toolDisclosure: "progressive",
+    hermesToolGateways: [],
+    messagingPlan: null,
+    dcodeAutoApprovalMode: "disabled",
+    observabilityEnabled: false,
+    environment: EMPTY_ENVIRONMENT,
+    corporateCa: null,
+    ...overrides,
+  };
+}
+
 describe("buildManagedStartupOnboardProfile", () => {
+  it("builds Pi without requiring state another agent owns (#7930)", () => {
+    const built = buildManagedStartupOnboardProfile(
+      piInput({
+        environment: {
+          NEMOCLAW_CONTEXT_WINDOW: "262144",
+          NEMOCLAW_MAX_TOKENS: "32000",
+          NEMOCLAW_REASONING: "true",
+        },
+      }),
+    );
+
+    expect(built.profile).toMatchObject({
+      agent: "pi",
+      agentConfig: { agent: "pi" },
+      dashboard: { agent: "pi", mode: "disabled" },
+      messaging: { plan: null },
+      tuning: {
+        contextWindow: 262_144,
+        maxTokens: 32_000,
+        reasoning: true,
+        reasoningEffort: null,
+      },
+    });
+  });
+
+  it("rejects Pi web-search intent instead of carrying it into the profile (#7930)", () => {
+    expect(
+      buildManagedStartupOnboardProfile(
+        piInput({ webSearch: { fetchEnabled: true, provider: "tavily" } }),
+      ).profile.agentConfig,
+    ).toEqual({ agent: "pi" });
+  });
+
+  it("rejects Pi messaging intent instead of silently discarding it (#7930)", () => {
+    expect(() =>
+      buildManagedStartupOnboardProfile(piInput({ messagingPlan: messagingPlan("openclaw") })),
+    ).toThrow(/pi does not support messaging/);
+  });
+
+  it("rejects a Pi dashboard request (#7930)", () => {
+    expect(() =>
+      buildManagedStartupOnboardProfile(piInput({ manageDashboard: true })),
+    ).toThrow(/Pi must not enable a dashboard/);
+  });
+
   it("maps a remote OpenClaw dashboard and its complete agent-owned state", () => {
     const plan = messagingPlan("openclaw");
     const built = buildManagedStartupOnboardProfile(

--- a/src/lib/onboard/managed-startup-profile-builder.test.ts
+++ b/src/lib/onboard/managed-startup-profile-builder.test.ts
@@ -138,7 +138,78 @@ function dcodeInput(
   };
 }
 
+function piInput(
+  overrides: Partial<ManagedStartupProfileBuilderInput> = {},
+): ManagedStartupProfileBuilderInput {
+  return {
+    agent: "pi",
+    inference: {
+      routeProvider: "inference",
+      upstreamProvider: "nvidia",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      routedBaseUrl: "https://inference.local/v1",
+      upstreamEndpointUrl: null,
+      api: "openai-completions",
+      primaryModelRef: null,
+      compatibility: null,
+    },
+    dashboard: { agent: "pi", mode: "disabled" },
+    webSearch: null,
+    toolDisclosure: "progressive",
+    hermesToolGateways: [],
+    messagingPlan: null,
+    dcodeAutoApprovalMode: null,
+    observabilityEnabled: null,
+    environment: {},
+    corporateCa: null,
+    ...overrides,
+  };
+}
+
 describe("buildManagedStartupProfile", () => {
+  it("builds Pi model tuning from the environment and leaves the effort scale unset (#7930)", () => {
+    const built = buildManagedStartupProfile(
+      piInput({
+        environment: {
+          NEMOCLAW_MODEL: "nvidia/nemotron-3-super-120b-a12b",
+          NEMOCLAW_INFERENCE_PROVIDER_ID: "inference",
+          NEMOCLAW_UPSTREAM_PROVIDER: "nvidia",
+          NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
+          NEMOCLAW_INFERENCE_API: "openai-completions",
+          NEMOCLAW_TOOL_DISCLOSURE: "progressive",
+          NEMOCLAW_CONTEXT_WINDOW: "262144",
+          NEMOCLAW_MAX_TOKENS: "32000",
+          NEMOCLAW_REASONING: "true",
+          NEMOCLAW_PROXY_HOST: "10.200.0.1",
+          NEMOCLAW_PROXY_PORT: "3128",
+        },
+      }),
+    );
+
+    expect(built.profile.tuning).toEqual({
+      contextWindow: 262_144,
+      maxTokens: 32_000,
+      reasoning: true,
+      reasoningEffort: null,
+    });
+    expect(decodeManagedStartupProfile(built.encodedProfile)).toEqual(built.profile);
+  });
+
+  it("leaves every Pi model tuning field unset when the environment supplies none (#7930)", () => {
+    expect(buildManagedStartupProfile(piInput()).profile.tuning).toEqual({
+      contextWindow: null,
+      maxTokens: null,
+      reasoning: null,
+      reasoningEffort: null,
+    });
+  });
+
+  it("refuses a Pi reasoning flag that is neither true nor false (#7930)", () => {
+    expect(() =>
+      buildManagedStartupProfile(piInput({ environment: { NEMOCLAW_REASONING: "yes" } })),
+    ).toThrow(/NEMOCLAW_REASONING must be "true" or "false"/);
+  });
+
   it("parses and hydrates messaging before exposing the validated transport handoff", () => {
     const compactPlan = {
       schemaVersion: 1,

--- a/src/lib/onboard/managed-startup-profile.test.ts
+++ b/src/lib/onboard/managed-startup-profile.test.ts
@@ -229,7 +229,47 @@ const DCODE_PROFILE = {
   corporateCa: { bundleSha256: CA_SHA256 },
 } as const satisfies ManagedStartupProfile;
 
-const VALID_PROFILES = [OPENCLAW_PROFILE, HERMES_PROFILE, DCODE_PROFILE] as const;
+const PI_PROFILE = {
+  schemaVersion: MANAGED_STARTUP_PROFILE_SCHEMA_VERSION,
+  agent: "pi",
+  agentConfig: { agent: "pi" },
+  inference: {
+    routeProvider: "inference",
+    upstreamProvider: "nvidia",
+    model: "nvidia/nemotron-3-super-120b-a12b",
+    routedBaseUrl: "https://inference.local/v1",
+    upstreamEndpointUrl: null,
+    api: "openai-completions",
+    primaryModelRef: null,
+    compatibility: null,
+    inputModalities: null,
+  },
+  proxy: {
+    managedHost: "10.200.0.1",
+    managedPort: 3128,
+    hostHttpUrl: null,
+    hostHttpsUrl: null,
+    hostNoProxy: [],
+  },
+  dashboard: {
+    agent: "pi",
+    mode: "disabled",
+  },
+  tools: {
+    disclosure: "progressive",
+    enabledGateways: [],
+  },
+  messaging: { plan: null },
+  tuning: {
+    contextWindow: null,
+    maxTokens: null,
+    reasoning: null,
+    reasoningEffort: null,
+  },
+  corporateCa: { bundleSha256: CA_SHA256 },
+} as const satisfies ManagedStartupProfile;
+
+const VALID_PROFILES = [OPENCLAW_PROFILE, HERMES_PROFILE, DCODE_PROFILE, PI_PROFILE] as const;
 
 function encodeUnknown(value: unknown): string {
   return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
@@ -789,6 +829,64 @@ describe("managed startup profile", () => {
         dashboard: { agent: "langchain-deepagents-code", mode: "remote" },
       }),
     ).toThrow(/dashboard\.mode must be disabled/);
+  });
+
+  it("carries the Pi model tuning fields and rejects the effort scale Pi has no surface for (#7930)", () => {
+    expect(
+      validateManagedStartupProfile({
+        ...PI_PROFILE,
+        tuning: {
+          ...PI_PROFILE.tuning,
+          contextWindow: 65_536,
+          maxTokens: 8192,
+          reasoning: true,
+        },
+      }).tuning,
+    ).toEqual({
+      contextWindow: 65_536,
+      maxTokens: 8192,
+      reasoning: true,
+      reasoningEffort: null,
+    });
+    expect(() =>
+      validateManagedStartupProfile({
+        ...PI_PROFILE,
+        tuning: { ...PI_PROFILE.tuning, reasoningEffort: "high" },
+      }),
+    ).toThrow(/pi does not support startup tuning fields: reasoningEffort/);
+  });
+
+  it("keeps Pi messaging, dashboards, and inference APIs fail-closed while retaining host proxy intent", () => {
+    expect(() =>
+      validateManagedStartupProfile({
+        ...PI_PROFILE,
+        messaging: { plan: { schemaVersion: 1 } },
+      }),
+    ).toThrow(/messaging\.plan must be null/);
+    expect(
+      validateManagedStartupProfile({
+        ...PI_PROFILE,
+        proxy: { ...PI_PROFILE.proxy, hostHttpUrl: "http://proxy.example.test:8080" },
+      }).proxy.hostHttpUrl,
+    ).toBe("http://proxy.example.test:8080");
+    expect(() =>
+      validateManagedStartupProfile({
+        ...PI_PROFILE,
+        inference: { ...PI_PROFILE.inference, api: "openai-responses" },
+      }),
+    ).toThrow(/not supported/);
+    expect(() =>
+      validateManagedStartupProfile({
+        ...PI_PROFILE,
+        dashboard: { agent: "pi", mode: "loopback-forwarded" },
+      }),
+    ).toThrow(/dashboard\.mode must be disabled/);
+    expect(() =>
+      validateManagedStartupProfile({
+        ...PI_PROFILE,
+        inference: { ...PI_PROFILE.inference, upstreamEndpointUrl: "https://openrouter.ai/api/v1" },
+      }),
+    ).toThrow(/inference\.upstreamEndpointUrl must be null for pi/);
   });
 
   it("rejects unsupported langchain-deepagents-code inference APIs and OpenClaw-only inference fields", () => {

--- a/src/lib/onboard/managed-startup/agent-environment.ts
+++ b/src/lib/onboard/managed-startup/agent-environment.ts
@@ -568,10 +568,17 @@ function mapPiProfile(
 
   const configurationEnvironment: MutableEnvironment = {
     ...commonConfigurationEnvironment(profile),
+    NEMOCLAW_CONTEXT_WINDOW:
+      profile.tuning.contextWindow === null ? "" : String(profile.tuning.contextWindow),
+    NEMOCLAW_MAX_TOKENS: profile.tuning.maxTokens === null ? "" : String(profile.tuning.maxTokens),
+    NEMOCLAW_REASONING: profile.tuning.reasoning === null ? "" : booleanFlag(profile.tuning.reasoning),
   };
   appendHostProxyEnvironment(configurationEnvironment, profile);
   const runtimeEnvironment: MutableEnvironment = { ...configurationEnvironment };
   delete runtimeEnvironment.NEMOCLAW_INFERENCE_BASE_URL;
+  delete runtimeEnvironment.NEMOCLAW_CONTEXT_WINDOW;
+  delete runtimeEnvironment.NEMOCLAW_MAX_TOKENS;
+  delete runtimeEnvironment.NEMOCLAW_REASONING;
   for (const name of [
     "HTTP_PROXY",
     "HTTPS_PROXY",

--- a/src/lib/onboard/managed-startup/agent-environment.ts
+++ b/src/lib/onboard/managed-startup/agent-environment.ts
@@ -571,7 +571,8 @@ function mapPiProfile(
     NEMOCLAW_CONTEXT_WINDOW:
       profile.tuning.contextWindow === null ? "" : String(profile.tuning.contextWindow),
     NEMOCLAW_MAX_TOKENS: profile.tuning.maxTokens === null ? "" : String(profile.tuning.maxTokens),
-    NEMOCLAW_REASONING: profile.tuning.reasoning === null ? "" : booleanFlag(profile.tuning.reasoning),
+    NEMOCLAW_REASONING:
+      profile.tuning.reasoning === null ? "" : String(profile.tuning.reasoning),
   };
   appendHostProxyEnvironment(configurationEnvironment, profile);
   const runtimeEnvironment: MutableEnvironment = { ...configurationEnvironment };

--- a/src/lib/onboard/managed-startup/onboard-profile.ts
+++ b/src/lib/onboard/managed-startup/onboard-profile.ts
@@ -45,7 +45,13 @@ const PROFILE_ENVIRONMENT_INPUTS = {
     "NEMOCLAW_PROXY_PORT",
     "NEMOCLAW_REASONING_EFFORT",
   ],
-  pi: ["NEMOCLAW_PROXY_HOST", "NEMOCLAW_PROXY_PORT"],
+  pi: [
+    "NEMOCLAW_CONTEXT_WINDOW",
+    "NEMOCLAW_MAX_TOKENS",
+    "NEMOCLAW_PROXY_HOST",
+    "NEMOCLAW_PROXY_PORT",
+    "NEMOCLAW_REASONING",
+  ],
 } as const satisfies Record<ManagedStartupAgent, readonly string[]>;
 
 const HOST_NO_PROXY_INPUTS = ["NO_PROXY", "no_proxy"] as const;
@@ -240,7 +246,7 @@ export function buildManagedStartupOnboardProfile(
     agent,
     inference: input.inference,
     dashboard,
-    webSearch: agent === "langchain-deepagents-code" ? null : input.webSearch,
+    webSearch: capabilities.webSearchProviders.length > 0 ? input.webSearch : null,
     toolDisclosure: input.toolDisclosure,
     hermesToolGateways: agent === "hermes" ? input.hermesToolGateways : [],
     messagingPlan: capabilities.supportsMessaging ? input.messagingPlan : null,

--- a/src/lib/onboard/managed-startup/profile-builder.ts
+++ b/src/lib/onboard/managed-startup/profile-builder.ts
@@ -67,7 +67,7 @@ const EXPECTED_AFFORDANCE_INVENTORY_SHA256 = {
   openclaw: "9b722441e33f0b0d7580f74cd185c0174979de9c1a784556ff56ff931b2c9904",
   hermes: "26c2dc3750274e5c2a79bf382a4b18b3cf26c0ef64938e91b694427aa23756e8",
   "langchain-deepagents-code": "08c75cf22495ec93a090bc5b70544eac65970e658b10fba057dea5ffef502e4a",
-  pi: "195e7f361cf83f2fee7b896579c3ceb680498645368920b42e3b951244e5e08a",
+  pi: "6302d387182c596fd67ad18577ecf82107bad6271aeeb5e69714115f91557abb",
 } as const satisfies Record<ManagedStartupAgent, string>;
 
 const INVENTORY_INPUTS = new Set(
@@ -207,9 +207,9 @@ function parseOpenClawOtelEnabled(environment: NodeJS.ProcessEnv): boolean {
   return raw !== null && !FALSE_VALUES.has(raw.toLowerCase());
 }
 
-function parseReasoning(environment: NodeJS.ProcessEnv): boolean {
+function parseReasoning(environment: NodeJS.ProcessEnv): boolean | null {
   const raw = presentEnvironmentValue(environment, "NEMOCLAW_REASONING");
-  if (raw === null) return false;
+  if (raw === null) return null;
   if (raw === "true") return true;
   if (raw === "false") return false;
   fail('NEMOCLAW_REASONING must be "true" or "false"');
@@ -529,6 +529,20 @@ function assertAgentSpecificInput(input: ManagedStartupProfileBuilderInput): voi
       input.observabilityEnabled !== null
     ) {
       fail("Hermes input contains state owned by another agent");
+    }
+    return;
+  }
+  if (input.agent === "pi") {
+    if (
+      input.webSearch !== null ||
+      input.hermesToolGateways.length > 0 ||
+      input.messagingPlan !== null ||
+      input.inference.compatibility !== null ||
+      input.inference.upstreamEndpointUrl !== null ||
+      input.dcodeAutoApprovalMode !== null ||
+      input.observabilityEnabled !== null
+    ) {
+      fail("Pi input contains state owned by another agent");
     }
     return;
   }
@@ -897,7 +911,7 @@ function buildCandidate(input: ManagedStartupProfileBuilderInput): {
           "NEMOCLAW_MAX_TOKENS",
           DEFAULT_OPENCLAW_MAX_TOKENS,
         ) ?? DEFAULT_OPENCLAW_MAX_TOKENS,
-      reasoning: parseReasoning(input.environment),
+      reasoning: parseReasoning(input.environment) ?? false,
       reasoningEffort: parseReasoningEffort(input.environment),
     };
   } else if (input.agent === "hermes") {
@@ -915,9 +929,11 @@ function buildCandidate(input: ManagedStartupProfileBuilderInput): {
   } else if (input.agent === "pi") {
     agentConfig = { agent: "pi" };
     tuning = {
-      contextWindow: null,
-      maxTokens: null,
-      reasoning: null,
+      contextWindow: parsePositiveInteger(input.environment, "NEMOCLAW_CONTEXT_WINDOW", null, {
+        maximum: MAX_AUTODETECTED_OLLAMA_CONTEXT_WINDOW,
+      }),
+      maxTokens: parsePositiveInteger(input.environment, "NEMOCLAW_MAX_TOKENS", null),
+      reasoning: parseReasoning(input.environment),
       reasoningEffort: null,
     };
   } else {

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -426,7 +426,7 @@ const PROFILE_CAPABILITIES = {
     inputModalities: [],
     webSearchProviders: [],
     toolGateways: [],
-    tuningFields: [],
+    tuningFields: ["contextWindow", "maxTokens", "reasoning"],
     supportsMessaging: false,
     supportsInferenceCompatibility: false,
     supportsUpstreamEndpoint: false,
@@ -587,6 +587,9 @@ export const MANAGED_STARTUP_PROFILE_AFFORDANCE_INVENTORY = {
     affordance("NEMOCLAW_UPSTREAM_PROVIDER", "inference.upstreamProvider"),
     affordance("NEMOCLAW_INFERENCE_BASE_URL", "inference.routedBaseUrl"),
     affordance("NEMOCLAW_INFERENCE_API", "inference.api"),
+    affordance("NEMOCLAW_CONTEXT_WINDOW", "tuning.contextWindow"),
+    affordance("NEMOCLAW_MAX_TOKENS", "tuning.maxTokens"),
+    affordance("NEMOCLAW_REASONING", "tuning.reasoning"),
     affordance("NEMOCLAW_TOOL_DISCLOSURE", "tools.disclosure"),
     affordance("NEMOCLAW_PROXY_HOST", "proxy.managedHost"),
     affordance("NEMOCLAW_PROXY_PORT", "proxy.managedPort"),
@@ -916,7 +919,13 @@ const HERMES_DASHBOARD_KEYS = new Set([
 const DCODE_DASHBOARD_KEYS = new Set(["agent", "mode"]);
 const TOOLS_KEYS = new Set(["disclosure", "enabledGateways"]);
 const MESSAGING_KEYS = new Set(["plan"]);
-const TUNING_KEYS = new Set(["contextWindow", "maxTokens", "reasoning", "reasoningEffort"]);
+const TUNING_FIELD_ORDER = [
+  "contextWindow",
+  "maxTokens",
+  "reasoning",
+  "reasoningEffort",
+] as const satisfies readonly (keyof ManagedStartupTuning)[];
+const TUNING_KEYS = new Set<string>(TUNING_FIELD_ORDER);
 const CORPORATE_CA_KEYS = new Set(["bundleSha256"]);
 const OPENCLAW_CONFIG_KEYS = new Set([
   "agent",
@@ -1748,10 +1757,14 @@ function validateInference(value: unknown, agent: ManagedStartupAgent): ManagedS
           { allowEmpty: false },
         );
 
+  if (
+    upstreamEndpointUrl !== null &&
+    !MANAGED_STARTUP_PROFILE_CAPABILITIES[agent].supportsUpstreamEndpoint
+  ) {
+    invalid(`inference.upstreamEndpointUrl must be null for ${agent}`);
+  }
+
   if (agent === "openclaw") {
-    if (upstreamEndpointUrl !== null) {
-      invalid("inference.upstreamEndpointUrl must be null for openclaw");
-    }
     if (primaryModelRef === null || inputModalities === null) {
       invalid("openclaw requires primaryModelRef and inputModalities");
     }
@@ -1761,9 +1774,6 @@ function validateInference(value: unknown, agent: ManagedStartupAgent): ManagedS
   } else {
     if (primaryModelRef !== null || compatibility !== null || inputModalities !== null) {
       invalid(`${agent} does not support primaryModelRef, compatibility, or inputModalities`);
-    }
-    if (agent === "hermes" && upstreamEndpointUrl !== null) {
-      invalid("inference.upstreamEndpointUrl must be null for hermes");
     }
     if (
       agent === "langchain-deepagents-code" &&
@@ -1850,30 +1860,27 @@ function validateTuning(value: unknown, agent: ManagedStartupAgent): ManagedStar
             "tuning.reasoningEffort",
           ),
   };
+  const advertised = new Set<string>(MANAGED_STARTUP_PROFILE_CAPABILITIES[agent].tuningFields);
+  const unsupported = TUNING_FIELD_ORDER.filter(
+    (field) => result[field] !== null && !advertised.has(field),
+  );
+  if (unsupported.length > 0) {
+    invalid(`${agent} does not support startup tuning fields: ${unsupported.join(", ")}`);
+  }
   if (agent === "openclaw") {
-    if (
-      result.contextWindow === null ||
-      result.maxTokens === null ||
-      result.reasoning === null ||
-      result.reasoningEffort === null
-    ) {
-      invalid("openclaw requires contextWindow, maxTokens, reasoning, and reasoningEffort tuning");
-    }
-  } else if (agent === "hermes") {
-    if (result.contextWindow !== null && result.contextWindow < MIN_HERMES_CONTEXT_WINDOW) {
-      invalid(`hermes contextWindow must be at least ${String(MIN_HERMES_CONTEXT_WINDOW)} tokens`);
-    }
-    if (result.maxTokens !== null || result.reasoning !== null || result.reasoningEffort !== null) {
-      invalid("hermes supports only contextWindow tuning");
-    }
-  } else if (
-    result.contextWindow !== null ||
-    result.maxTokens !== null ||
-    result.reasoning !== null
-  ) {
-    invalid(
-      "langchain-deepagents-code does not support startup tuning fields beyond reasoningEffort",
+    const missing = TUNING_FIELD_ORDER.filter(
+      (field) => advertised.has(field) && result[field] === null,
     );
+    if (missing.length > 0) {
+      invalid(`openclaw requires ${missing.join(", ")} tuning`);
+    }
+  }
+  if (
+    agent === "hermes" &&
+    result.contextWindow !== null &&
+    result.contextWindow < MIN_HERMES_CONTEXT_WINDOW
+  ) {
+    invalid(`hermes contextWindow must be at least ${String(MIN_HERMES_CONTEXT_WINDOW)} tokens`);
   }
   return result;
 }
@@ -1901,8 +1908,8 @@ export function validateManagedStartupProfile(value: unknown): ManagedStartupPro
   const messaging = requireRecord(profile.messaging, "messaging");
   rejectUnknownKeys(messaging, MESSAGING_KEYS, "messaging");
   const messagingPlan = requireJsonObjectOrNull(messaging.plan, "messaging.plan");
-  if (agent === "langchain-deepagents-code" && messagingPlan !== null) {
-    invalid("messaging.plan must be null for langchain-deepagents-code");
+  if (messagingPlan !== null && !MANAGED_STARTUP_PROFILE_CAPABILITIES[agent].supportsMessaging) {
+    invalid(`messaging.plan must be null for ${agent}`);
   }
   if (
     messagingPlan !== null &&

--- a/test/pi-candidate-runtime-artifacts.test.ts
+++ b/test/pi-candidate-runtime-artifacts.test.ts
@@ -284,4 +284,64 @@ describe("Pi managed model catalog generation", () => {
     expect(status).not.toBe(0);
     expect(stderr).toContain("NEMOCLAW_INFERENCE_BASE_URL must not include credentials.");
   });
+
+  function readManagedModel(home: string): Record<string, unknown> {
+    const config = JSON.parse(
+      fs.readFileSync(path.join(home, ".pi", "agent", "models.json"), "utf8"),
+    ) as { providers: Record<string, { models: Record<string, unknown>[] }> };
+    return config.providers.openshell.models[0] as Record<string, unknown>;
+  }
+
+  it("writes the context window, output limit, and reasoning support Pi documents (#7930)", () => {
+    const { home, status, stderr } = generate({
+      NEMOCLAW_MODEL: "nvidia/nemotron-3-super-120b-a12b",
+      NEMOCLAW_CONTEXT_WINDOW: "262144",
+      NEMOCLAW_MAX_TOKENS: "32000",
+      NEMOCLAW_REASONING: "true",
+    });
+    expect(status, stderr).toBe(0);
+    expect(readManagedModel(home)).toEqual({
+      id: "nvidia/nemotron-3-super-120b-a12b",
+      contextWindow: 262_144,
+      maxTokens: 32_000,
+      reasoning: true,
+    });
+  });
+
+  it("omits unset model tuning so Pi keeps its own defaults (#7930)", () => {
+    const { home, status, stderr } = generate({
+      NEMOCLAW_MODEL: "nvidia/nemotron-3-super-120b-a12b",
+      NEMOCLAW_CONTEXT_WINDOW: "",
+      NEMOCLAW_MAX_TOKENS: "",
+      NEMOCLAW_REASONING: "",
+    });
+    expect(status, stderr).toBe(0);
+    expect(readManagedModel(home)).toEqual({ id: "nvidia/nemotron-3-super-120b-a12b" });
+  });
+
+  it("records a disabled reasoning decision instead of dropping it (#7930)", () => {
+    const { home, status, stderr } = generate({
+      NEMOCLAW_MODEL: "nvidia/nemotron-3-super-120b-a12b",
+      NEMOCLAW_REASONING: "false",
+    });
+    expect(status, stderr).toBe(0);
+    expect(readManagedModel(home)).toEqual({
+      id: "nvidia/nemotron-3-super-120b-a12b",
+      reasoning: false,
+    });
+  });
+
+  it.each([
+    ["NEMOCLAW_CONTEXT_WINDOW", "128k", "NEMOCLAW_CONTEXT_WINDOW must be a positive integer."],
+    ["NEMOCLAW_MAX_TOKENS", "0", "NEMOCLAW_MAX_TOKENS must be a positive integer."],
+    ["NEMOCLAW_REASONING", "yes", 'NEMOCLAW_REASONING must be "true" or "false".'],
+  ])("rejects %s=%s before writing a catalog (#7930)", (name, value, message) => {
+    const { home, status, stderr } = generate({
+      NEMOCLAW_MODEL: "nvidia/nemotron-3-super-120b-a12b",
+      [name]: value,
+    });
+    expect(status).not.toBe(0);
+    expect(stderr).toContain(message);
+    expect(fs.existsSync(path.join(home, ".pi", "agent", "models.json"))).toBe(false);
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The managed startup profile declares each agent's capabilities in one table whose stated contract is that a field an agent does not advertise is rejected rather than silently dropped, but four checks enforced that contract with hardcoded agent names. Pi matched none of them, so it accepted values it has no surface for and could not be built through the shared onboarding builder at all. Each check now reads the capability table, and Pi's context window, output limit, and reasoning support travel from the environment through the profile into the sandbox model catalog.

## Related Issue

Resolves #7930

## Changes

**Capability-table enforcement.** Four checks in the startup-profile boundary now read `MANAGED_STARTUP_PROFILE_CAPABILITIES` instead of naming agents directly. Each table row reproduces the previous hardcoded condition exactly, so every accept and reject outcome for OpenClaw, Hermes, and Deep Agents Code is unchanged.

- `validateTuning` reads `tuningFields`. Pi previously accepted a `reasoningEffort` value it has no surface for, and reported the rejection as belonging to `langchain-deepagents-code`.
- `validateInference` reads `supportsUpstreamEndpoint`. Pi declares `false` yet accepted an `upstreamEndpointUrl` that `mapPiProfile` then discarded.
- The `messaging.plan` null rule reads `supportsMessaging`. It was hardcoded to `langchain-deepagents-code`, so a Pi-shaped plan passed validation and failed later in the mapper.
- `assertAgentSpecificInput` gains a Pi branch. Pi fell into the Deep Agents Code tail, so `buildManagedStartupOnboardProfile` threw `DCode approval state must be explicit` and no Pi startup profile could be built. `onboard-profile.ts` also gates web-search intent on `webSearchProviders` rather than a single agent name.

Two error texts change as a result. OpenClaw now names only the missing tuning fields instead of always listing all four, and Hermes reports `hermes does not support startup tuning fields: maxTokens` where it previously reported `hermes supports only contextWindow tuning`. The generic unsupported-field check also runs before the Hermes minimum-context-window check, so an input that is both too small and carries `maxTokens` now reports the unsupported field first. No accept or reject outcome moves, and no documentation page carries these strings.

**Pi model tuning.** `NEMOCLAW_CONTEXT_WINDOW`, `NEMOCLAW_MAX_TOKENS`, and `NEMOCLAW_REASONING` now reach `/sandbox/.pi/agent/models.json`. The route runs through the `pi` capability row, the Pi affordance inventory and its builder digest, `PROFILE_ENVIRONMENT_INPUTS.pi`, the Pi branch of `profile-builder.ts`, `mapPiProfile`, and three `ARG`/`ENV` pairs in `agents/pi/Dockerfile`. `mapPiProfile` emits the three into the configuration environment that runs the generator and deletes them from the runtime environment, because the long-running Pi process reads the catalog rather than the environment.

`agents/pi/generate-config.ts` writes only `contextWindow`, `maxTokens`, and `reasoning`, the three fields the pinned `@earendil-works/pi-coding-agent@0.84.1` release documents for a catalog model entry, and omits each field the host leaves unset so the release default applies. That evidence came from installing the exact pinned graph with `npm ci --omit=dev --ignore-scripts` against `agents/pi/pi-runtime/` and reading the shipped `docs/models.md`, which satisfies the #7926 requirement that model-specific configuration carry compatibility evidence.

`NEMOCLAW_REASONING_EFFORT` stays rejected for Pi. Pi exposes no effort scalar: its model-level control is `thinkingLevelMap`, a per-level map, `compat.supportsReasoningEffort` is a provider wire-format flag, and `settings.json` `defaultThinkingLevel` is user restore state owned by the Pi manifest.

`parseReasoning` now returns `boolean | null` so an unset value can reach Pi as `null`. The OpenClaw call site applies `?? false`, preserving its default.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Pi is a gated release candidate with an empty qualification-receipt authority, so no public selection path reaches this code. Public activation is owned by #8818 and Pi documentation by #7929. Every existing page that names the three environment variables is scoped by `<AgentOnly>` or by `agent-variants` frontmatter, so none becomes inaccurate.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: the change adds no credential path. The generated catalog still carries only the `nemoclaw-managed-inference` placeholder, the upstream provider credential stays outside the sandbox, and the three new values are non-secret integers and a boolean that fail closed on malformed input before any file is written. Existing credential-absence coverage in `test/pi-candidate-runtime-artifacts.test.ts` and the image-build credential-pattern guard in `agents/pi/Dockerfile` are unchanged, and new coverage asserts that the mapper emits no credential bytes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: no documentation paths changed. An independent review of commit `73a480614` confirmed that no `docs/CONTRIBUTING.md` "When to Update Docs" trigger fires. Pi stays unreachable because `CANDIDATE_QUALIFICATION_RECEIPT_DIGESTS.pi` is empty, so `readCandidateQualificationReceipt` throws before opening a receipt and `listAgents` filters Pi out. `NEMOCLAW_CONTEXT_WINDOW`, `NEMOCLAW_MAX_TOKENS`, and `NEMOCLAW_REASONING` already appear in `docs/reference/commands.mdx` and `docs/inference/configure-model-limits.mdx`, but every occurrence sits inside an `<AgentOnly>` block or a page whose frontmatter declares `agent-variants`, so none of them claims to cover every agent. Pi has no presence under `docs/`, and `scripts/sync-agent-variant-docs.mts` declares the variant set as OpenClaw, Hermes, and Deep Agents Code, so a Pi row cannot be published before #8818 and #7929. The reviewer also confirmed that behaviour for shipped agents is unchanged by comparing each new capability-table read against the condition it replaced.
- Agent: Claude Code
<!-- docs-review-head-sha: 73a480614 -->
<!-- docs-review-agents-blob-sha: e30afb270 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run typecheck:cli` clean; `npm run checks:repository` exit 0; `npx vitest run --project cli` over the four core suites gives 201 passed, and over the 109 profile-consumer, Pi, snapshot, and runtime-provider suites gives 1898 passed; `npx vitest run --project integration` over the eight affected suites gives 152 passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Scope notes for reviewers

**Pre-existing environment failures.** A broad `src/lib/{actions/sandbox,onboard,agent,state}` sweep reports failures in this environment. Stashing the change, rerunning the same 36 files on clean `origin/main`, restoring, and rerunning gives an identical result both ways: 10 files and 46 tests failing, with identical failing-file sets. None belongs to a suite this change touches.

**Coverage.** New behaviour tests: `managed-startup-profile.test.ts` adds a Pi profile fixture to `VALID_PROFILES`, which previously had none, plus per-field tuning acceptance and fail-closed cases for messaging, inference API, dashboard mode, and upstream endpoint. `managed-startup-profile-builder.test.ts` and `managed-startup-onboard-profile.test.ts` add Pi inputs, which prove Pi can be built without state another agent owns. `managed-startup-agent-environment.test.ts` adds the first dedicated Pi mapping test, covering credential-free environments and materials, tuning handed to the generator but withheld from the runtime, and a route change that retains no stale value. `test/pi-candidate-runtime-artifacts.test.ts` drives the generator as a process and asserts the written catalog for supplied, unset, and malformed tuning.

**Out of scope.** #7926 also requires streaming and structured tool calls. The pinned Pi release enables both by default on `openai-completions`: `compat.supportsUsageInStreaming` and `compat.supportsFinishReason` both default to true, and the `compat` flags exist to switch capability off for degraded servers, so there is no capability field to validate a model against. Provider-catalog qualification evidence stays with #7928.

---
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Pi configuration options for context-window size, maximum output tokens, and reasoning mode.
  - Preserved explicitly disabled reasoning settings and omitted values that are not configured.
  - Enabled web search when supported by the selected agent and provider.
- **Bug Fixes**
  - Improved validation for unsupported settings, invalid values, messaging plans, dashboards, and upstream endpoints.
  - Prevented sensitive configuration values from being exposed during runtime.
- **Tests**
  - Added comprehensive coverage for Pi onboarding, configuration, validation, and generated model settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->