### PR TITLE
docs(e2e): define selection and retry guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,51 @@ All hooks managed by [prek](https://prek.j178.dev/) (installed via `npm install`
 6. Use `./scripts/dev-setup.sh --expose-cli` only with explicit approval for host-visible CLI exposure
 7. Run the tests targeted to the behavior you change once per relevant change set; rerun them after later edits or hook autofixes that can affect that behavior
 
+### E2E Selection and Authoring
+
+Use live E2E only for behavior that needs a real shell, installer, process,
+Docker, OpenShell, `/proc`, sandbox, external service, or GitHub Actions
+boundary. Put deterministic code, parser, registry, workflow-planner, and
+fixture logic in unit, integration, package-contract, or `e2e-support` tests
+instead. Do not add a live E2E target for a check that can be observed through a
+stable local boundary.
+
+Before adding or extending E2E coverage, name the semantic coverage dimension
+that is missing. Existing migrated examples show the intended granularity:
+catalogue targets pair environment, onboarding profile, expected state, optional
+lifecycle, and `suiteIds`; `dashboard-remote-bind` owns install, onboard,
+artifacts, and terminal cleanup; `credential-sanitization`,
+`telegram-injection`, `messaging-providers`, `messaging-compatible-endpoint`,
+and `gpu-e2e` are separate behavior contracts rather than one broad "full" run.
+Extend matrix metadata only when it selects an already-defined behavior
+dimension. Do not duplicate behavior logic in a second registry, workflow list,
+or hand-maintained catalogue; use the typed registry and shared E2E workflow
+planner documented in [`test/e2e/README.md`](test/e2e/README.md) and
+[`test/e2e/docs/README.md`](test/e2e/docs/README.md).
+
+If a gap is real but not ready for a test, record it as a combinatorial gap
+instead of adding speculative coverage. State the missing dimension, the
+existing nearest coverage, why a new test would duplicate or overreach current
+behavior, and the issue or PR that will make it testable. A gap note must not
+change release judgment by itself.
+
+Assert outcomes, state, artifacts, and redacted diagnostics. Do not assert
+incidental terminal output, progress wording, spinner frames, ANSI escape
+sequences, timing text, or prompt layout unless that text is the product
+contract under review. Terminal traces are evidence; they are not stable
+behavior unless the issue explicitly makes them the behavior.
+
+Retries require a checked-in bounded policy with a narrow transient signature,
+owner, idempotence or reconciliation basis, attempt evidence, and an entry in
+[`test/e2e/RETRY_INVENTORY.md`](test/e2e/RETRY_INVENTORY.md). Do not add
+unproven retries, ambiguous mutation retries, or broad failed-job reruns. A
+mutation retry is allowed only after the test reconciles the external state and
+proves repeating the same desired operation is safe. Keep bounded operation
+retries separate from complete workflow reruns: `E2E / Main Retry` records
+attempts and does not request a broad rerun, while Hosted Runner Recovery owns
+at most one full rerun only for authenticated GitHub-hosted runner-loss
+evidence.
+
 ### Plain Language and Direct Design
 
 - Use existing repository vocabulary and name what a thing does.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,8 +274,9 @@ keeps environment, onboarding profile, expected state, lifecycle, and `suiteIds`
 as matrix metadata. Extend that metadata only to select existing behavior; do
 not duplicate behavior logic in workflows, lists, or catalogues. When a
 combination is missing but not ready for a test, record a combinatorial gap with
-the missing dimension, nearest existing coverage, and follow-up owner instead of
-adding speculative coverage or changing release judgment.
+the missing dimension, nearest existing coverage, why a new test would duplicate
+or overreach current behavior, the follow-up owner, and the issue or PR that will
+make the gap testable. Do not add speculative coverage or change release judgment.
 
 E2E assertions should check outcomes, state, artifacts, and redacted diagnostics.
 Do not assert incidental terminal output, progress wording, ANSI escape

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,6 +262,33 @@ artifact sink. Pass the auto fixture's frozen, canonical `progress` capability
 through unchanged; custom, copied, or no-op progress adapters are rejected at
 audited subprocess boundaries.
 
+Use live E2E only when the behavior needs a real shell, installer, process,
+Docker, OpenShell, `/proc`, sandbox, external service, or GitHub Actions
+boundary. Prefer unit, integration, package-contract, or `e2e-support` tests for
+deterministic code and workflow-planner logic. Select or extend coverage by
+semantic dimension, not by incidental output. Migrated targets such as
+`dashboard-remote-bind`, `credential-sanitization`, `telegram-injection`,
+`messaging-providers`, `messaging-compatible-endpoint`, and `gpu-e2e` show the
+expected shape: each target owns a behavior contract, while the typed registry
+keeps environment, onboarding profile, expected state, lifecycle, and `suiteIds`
+as matrix metadata. Extend that metadata only to select existing behavior; do
+not duplicate behavior logic in workflows, lists, or catalogues. When a
+combination is missing but not ready for a test, record a combinatorial gap with
+the missing dimension, nearest existing coverage, and follow-up owner instead of
+adding speculative coverage or changing release judgment.
+
+E2E assertions should check outcomes, state, artifacts, and redacted diagnostics.
+Do not assert incidental terminal output, progress wording, ANSI escape
+sequences, spinner frames, or timing text unless that text is the product
+contract. A retry must have a checked-in bounded policy, a narrow transient
+signature, idempotence or reconciliation evidence, per-attempt artifacts, and a
+matching [`test/e2e/RETRY_INVENTORY.md`](test/e2e/RETRY_INVENTORY.md) entry. Do
+not add unproven retries, ambiguous mutation retries, or broad failed-job
+reruns. Keep operation-level retries separate from complete workflow reruns:
+`E2E / Main Retry` records attempt evidence without requesting a broad rerun,
+and Hosted Runner Recovery owns at most one full rerun only for authenticated
+GitHub-hosted runner-loss evidence.
+
 ### macOS Test Dependencies
 
 Some tests run command-line tools that macOS does not ship.


### PR DESCRIPTION
## Summary

Adds canonical E2E selection and authoring guidance for agents and contributors.

## Changes

- Document when to choose live E2E versus deterministic unit, integration, package-contract, or `e2e-support` coverage.
- Define semantic coverage dimensions and point contributors to the typed registry and shared workflow planner instead of duplicating matrix logic.
- Explain how to record combinatorial gaps without adding speculative tests or changing release judgment.
- Clarify outcome-focused E2E assertions, terminal-output boundaries, bounded operation retries, ambiguous mutation retries, and complete workflow reruns.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: Documentation-only guidance change.
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: Contributor and agent guidance only; no user-facing command, configuration, default, or supported product behavior changed.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Documentation-only E2E guidance; no executable E2E workflow, retry policy, credential, runner, sandbox, or release gate behavior changed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [ ] Documentation writer subagent reviewed the completed changes
- Result:
- Evidence:
- Agent:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Documentation-only guidance change; no runtime behavior changed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Verification Run

- `git diff --check`

Fixes #9164

---

Signed-off-by: Glenn-Agent <glenn_agent@163.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for selecting and authoring live end-to-end tests.
  * Documented how to identify meaningful coverage dimensions and avoid redundant or speculative tests.
  * Clarified expectations for stable assertions, deterministic test layers, bounded retries, and retry documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->