### PR TITLE
test(inference): cover provider model validation failure and availability messages

### DIFF
--- a/src/lib/inference/provider-models.test.ts
+++ b/src/lib/inference/provider-models.test.ts
@@ -16,6 +16,7 @@ import {
   fetchNvidiaEndpointModels,
   fetchOpenAiLikeModels,
   validateAnthropicModel,
+  validateGeminiModel,
   validateNvidiaEndpointModel,
   validateOpenAiLikeModel,
 } from "./provider-models";
@@ -703,6 +704,114 @@ describe("provider model helpers", () => {
     } finally {
       restoreMkdtemp();
     }
+  });
+
+  it("fails NVIDIA endpoint validation with the checked endpoint when the catalog fetch fails", () => {
+    const result = validateNvidiaEndpointModel("nemotron", "nvapi-x", {
+      runCurlProbeImpl: () => ({
+        ok: false,
+        httpStatus: 503,
+        curlStatus: 7,
+        body: "",
+        stderr: "connection refused",
+        message: "connection refused",
+      }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      httpStatus: 503,
+      curlStatus: 7,
+      message: `Could not validate model against ${BUILD_ENDPOINT_URL}/models: connection refused`,
+    });
+  });
+
+  it("reports Gemini models missing from the native catalog", () => {
+    const result = validateGeminiModel("gemini-9.9-missing", "AIzaFakeKey123", {
+      runCurlProbeImpl: () => ({
+        ok: true,
+        httpStatus: 200,
+        curlStatus: 0,
+        body: JSON.stringify({
+          models: [
+            {
+              name: "models/gemini-2.5-pro",
+              supportedGenerationMethods: ["generateContent"],
+            },
+          ],
+        }),
+        stderr: "",
+        message: "",
+      }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      httpStatus: 200,
+      curlStatus: 0,
+      message: `Model 'gemini-9.9-missing' is not available from Google Gemini. Checked ${GEMINI_NATIVE_MODELS_ENDPOINT_URL}.`,
+    });
+  });
+
+  it("reports Anthropic models missing from the catalog", () => {
+    const result = validateAnthropicModel(
+      "https://api.anthropic.com",
+      "claude-missing",
+      "sk-ant-x",
+      {
+        runCurlProbeImpl: () => ({
+          ok: true,
+          httpStatus: 200,
+          curlStatus: 0,
+          body: JSON.stringify({ data: [{ id: "claude-opus" }] }),
+          stderr: "",
+          message: "",
+        }),
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      httpStatus: 200,
+      curlStatus: 0,
+      message:
+        "Model 'claude-missing' is not available from Anthropic. Checked https://api.anthropic.com/v1/models.",
+    });
+  });
+
+  it("fails Anthropic validation with the checked endpoint when the catalog fetch fails", () => {
+    const result = validateAnthropicModel("https://api.anthropic.com", "claude-opus", "sk-ant-x", {
+      runCurlProbeImpl: () => ({
+        ok: false,
+        httpStatus: 500,
+        curlStatus: 0,
+        body: "",
+        stderr: "HTTP 500",
+        message: "HTTP 500",
+      }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      httpStatus: 500,
+      curlStatus: 0,
+      message: "Could not validate model against https://api.anthropic.com/v1/models: HTTP 500",
+    });
+  });
+
+  it("treats Anthropic 404 catalog responses as non-blocking validation gaps", () => {
+    const result = validateAnthropicModel("https://api.anthropic.com", "claude-opus", "sk-ant-x", {
+      runCurlProbeImpl: () => ({
+        ok: false,
+        httpStatus: 404,
+        curlStatus: 0,
+        body: "",
+        stderr: "HTTP 404",
+        message: "HTTP 404",
+      }),
+    });
+
+    expect(result).toEqual({ ok: true, validated: false });
   });
 });
 


### PR DESCRIPTION
## What

The Gemini model-validation paths gained a dedicated test suite in #6975, but the **Anthropic** and **NVIDIA Endpoints** paths emit the same message contracts without direct tests — the exact gap the repository's risky-path heuristic keeps noting for `inference` files.

## Changes

Five tests in `src/lib/inference/provider-models.test.ts`, each asserting the **exact emitted strings** from `src/lib/inference/provider-models.ts`:

| Behavior | Message contract |
|---|---|
| NVIDIA catalog-fetch failure | `Could not validate model against {buildEndpointUrl}/models: {reason}` |
| Gemini availability miss | `Model '{model}' is not available from Google Gemini. Checked {endpointUrl}.` |
| Anthropic availability miss | `Model '{model}' is not available from Anthropic. Checked {endpointUrl}/v1/models.` |
| Anthropic catalog-fetch failure | `Could not validate model against {endpointUrl}/v1/models: {reason}` |
| Anthropic 404/405 graceful gap | returns `{ ok: true, validated: false }` |

The tests mirror the existing suite's style (injected `runCurlProbeImpl`, `toEqual` assertions on the full result object).

## Verification

- `npx vitest run src/lib/inference/provider-models.test.ts` — **29/29 pass** (24 existing + 5 new)
- `npx oxlint` — 0 warnings, 0 errors
- `npx oxfmt` — applied and clean

Signed-off-by: Ashish Shrees <flowoker1@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for provider model validation across NVIDIA, Gemini, and Anthropic.
  * Verified handling of catalog-fetch failures and missing models.
  * Confirmed Anthropic 404 responses remain non-blocking.
  * Ensured structured HTTP status details and endpoint-specific error messages are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->