### PR TITLE
fix(onboard): make the Ollama upgrade reach the required version

### DIFF
--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -31,7 +31,8 @@ The wizard checks `ollama --version` and `/api/version` on port `11434` independ
 If NemoClaw detects an installed CLI or local running daemon but cannot read its version, onboarding uses the upgrade path instead of reusing it.
 
 On macOS, the wizard uses `brew upgrade ollama` for the platform upgrade path.
-On Linux, the wizard uses the official `https://ollama.com/install.sh` path and asks it for `0.32.9` by name, because the version the installer calls latest is below the minimum on some hosts.
+On Linux, the wizard uses the official `https://ollama.com/install.sh` path and asks it for `0.32.9` by name when the installed binary is stale, because the version the installer calls latest is below the minimum on some hosts.
+If the installed binary is already at or above the minimum and only the daemon is stale, the wizard restarts the daemon without running the installer or replacing the newer binary.
 Linux upgrades use the sudo-driven system path because a user-local fallback would leave an existing system daemon serving the stale binary.
 If sudo is unavailable in a non-interactive run, rerun interactively or upgrade Ollama manually.
 An upgrade also needs sudo to restart the service onto the new binary, so it does not accept an already-loopback-only daemon as a reason to skip that step.

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -39,9 +39,11 @@ A fresh install takes the latest version.
 
 After an upgrade, NemoClaw probes the running daemon and the installed binary again.
 `ollama --version` reports the version of the daemon it can reach, so NemoClaw reads the binary's own version from the client-version line that the command prints when the two differ.
-If the daemon remains below the minimum or cannot be read, interactive onboarding returns to provider selection, and non-interactive onboarding exits.
-The failure names which side is stale.
+Both versions must be readable and at or above `0.32.9` before onboarding accepts the upgrade.
+If either version is below the minimum or cannot be read, interactive onboarding returns to provider selection, and non-interactive onboarding exits.
+The failure identifies each stale or unreadable version.
 A binary at or above the minimum means the service still serves the old one and needs a restart, while a binary below it means the installer did not deliver the required version on that host.
+When only the binary cannot be read, the failure asks you to verify the installed Ollama binary before you retry.
 When neither side can be read, the failure asks you to check that Ollama is installed and running before you retry.
 Fresh installs skip this second probe because the bundled installers provide a daemon at or above the minimum.
 

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -31,12 +31,18 @@ The wizard checks `ollama --version` and `/api/version` on port `11434` independ
 If NemoClaw detects an installed CLI or local running daemon but cannot read its version, onboarding uses the upgrade path instead of reusing it.
 
 On macOS, the wizard uses `brew upgrade ollama` for the platform upgrade path.
-On Linux, the wizard uses the official `https://ollama.com/install.sh` path.
+On Linux, the wizard uses the official `https://ollama.com/install.sh` path and asks it for `0.32.9` by name, because the version the installer calls latest is below the minimum on some hosts.
 Linux upgrades use the sudo-driven system path because a user-local fallback would leave an existing system daemon serving the stale binary.
 If sudo is unavailable in a non-interactive run, rerun interactively or upgrade Ollama manually.
+An upgrade also needs sudo to restart the service onto the new binary, so it does not accept an already-loopback-only daemon as a reason to skip that step.
+A fresh install takes the latest version.
 
-After an upgrade, NemoClaw probes the running daemon again.
-If the version remains below the minimum or cannot be read, interactive onboarding returns to provider selection, and non-interactive onboarding exits.
+After an upgrade, NemoClaw probes the running daemon and the installed binary again.
+`ollama --version` reports the version of the daemon it can reach, so NemoClaw reads the binary's own version from the client-version line that the command prints when the two differ.
+If the daemon remains below the minimum or cannot be read, interactive onboarding returns to provider selection, and non-interactive onboarding exits.
+The failure names which side is stale.
+A binary at or above the minimum means the service still serves the old one and needs a restart, while a binary below it means the installer did not deliver the required version on that host.
+When neither side can be read, the failure asks you to check that Ollama is installed and running before you retry.
 Fresh installs skip this second probe because the bundled installers provide a daemon at or above the minimum.
 
 The version gate does not apply to Windows-host Ollama reached from Docker Desktop through `host.docker.internal`.

--- a/src/lib/inference/ollama-version.test.ts
+++ b/src/lib/inference/ollama-version.test.ts
@@ -16,6 +16,11 @@ describe("Ollama version detection", () => {
     expect(getInstalledOllamaVersion(capture)).toBe("0.6.2");
   });
 
+  it("prefers the client version line over the daemon version the CLI reports (#9276)", () => {
+    const capture = () => "ollama version is 0.23.4\nWarning: client version is 0.32.9";
+    expect(getInstalledOllamaVersion(capture)).toBe("0.32.9");
+  });
+
   it("returns null when ollama --version produces no output", () => {
     const capture = () => "";
     expect(getInstalledOllamaVersion(capture)).toBeNull();

--- a/src/lib/inference/ollama-version.ts
+++ b/src/lib/inference/ollama-version.ts
@@ -24,10 +24,14 @@ export type OllamaVersionRunCapture = (
  */
 export const MIN_OLLAMA_VERSION = "0.32.9";
 
+const OLLAMA_CLIENT_VERSION_LINE = /client version is\s+(\d+\.\d+\.\d+)/i;
+
 export function getInstalledOllamaVersion(runCaptureImpl?: OllamaVersionRunCapture): string | null {
   const capture = runCaptureImpl ?? runCapture;
   const out = capture(["ollama", "--version"], { ignoreError: true });
   if (!out) return null;
+  const clientVersion = out.match(OLLAMA_CLIENT_VERSION_LINE);
+  if (clientVersion) return clientVersion[1];
   const match = out.match(/(\d+)\.(\d+)\.(\d+)/);
   return match ? match[0] : null;
 }

--- a/src/lib/onboard/__test-helpers__/setup-nim-flow.ts
+++ b/src/lib/onboard/__test-helpers__/setup-nim-flow.ts
@@ -71,7 +71,7 @@ export function makeHostState(
     vllmProfile: null,
     hasVllmImage: false,
     vllmEntries: [],
-    ollamaInstallMenu: { entry: null, hasUpgradableOllama: false },
+    ollamaInstallMenu: { entry: null, hasUpgradableOllama: false, binaryNeedsUpgrade: false },
     gpuNimCapable: false,
     ...overrides,
   };

--- a/src/lib/onboard/install-ollama-linux-upgrade.test.ts
+++ b/src/lib/onboard/install-ollama-linux-upgrade.test.ts
@@ -3,6 +3,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { MIN_OLLAMA_VERSION } from "../inference/ollama-version";
 import {
   decideInstallOllamaLinuxMode,
   type InstallOllamaLinuxOptions,
@@ -211,6 +212,48 @@ describe("installOllamaOnLinux (upgrade recovery)", () => {
     expect(killIndex).toBeGreaterThanOrEqual(0);
     expect(launchIndex).toBeGreaterThan(killIndex);
     expect(sleepSecondsImpl).toHaveBeenCalled();
+  });
+
+  it("asks the official installer for the required version on an upgrade (#9276)", () => {
+    const runShellImpl = vi
+      .fn()
+      .mockReturnValue({ status: 0, stdout: "", stderr: "", error: null });
+    const opts = makeOpts({
+      modeOverride: "system",
+      runCaptureImpl: vi.fn().mockReturnValue("/usr/bin/zstd"),
+      runShellImpl,
+      isUpgrade: true,
+    });
+    expect(installOllamaOnLinux(opts).ok).toBe(true);
+    const installer = findRunShellCall(runShellImpl, "ollama.com/install.sh");
+    expect(installer).toContain(`OLLAMA_VERSION=${MIN_OLLAMA_VERSION} sh`);
+  });
+
+  it("leaves a fresh install unpinned so it takes the latest Ollama", () => {
+    const runShellImpl = vi
+      .fn()
+      .mockReturnValue({ status: 0, stdout: "", stderr: "", error: null });
+    const opts = makeOpts({
+      modeOverride: "system",
+      runCaptureImpl: vi.fn().mockReturnValue("/usr/bin/zstd"),
+      runShellImpl,
+    });
+    expect(installOllamaOnLinux(opts).ok).toBe(true);
+    const installer = findRunShellCall(runShellImpl, "ollama.com/install.sh");
+    expect(installer).toContain("| sh");
+    expect(installer).not.toContain("OLLAMA_VERSION=");
+  });
+
+  it("tells the systemd override that this run replaced the binary (#9276)", () => {
+    const ensureOverride = vi.fn().mockReturnValue("ready");
+    const opts = makeOpts({
+      modeOverride: "system",
+      runCaptureImpl: vi.fn().mockReturnValue("/usr/bin/zstd"),
+      ensureManagedOllamaLoopbackSystemdOverrideImpl: ensureOverride,
+      isUpgrade: true,
+    });
+    expect(installOllamaOnLinux(opts).ok).toBe(true);
+    expect(ensureOverride).toHaveBeenCalledWith(expect.objectContaining({ isUpgrade: true }));
   });
 
   it("re-probes loopback fresh instead of trusting the cached findReachableOllamaHost result", () => {

--- a/src/lib/onboard/install-ollama-linux-upgrade.test.ts
+++ b/src/lib/onboard/install-ollama-linux-upgrade.test.ts
@@ -229,6 +229,26 @@ describe("installOllamaOnLinux (upgrade recovery)", () => {
     expect(installer).toContain(`OLLAMA_VERSION=${MIN_OLLAMA_VERSION} sh`);
   });
 
+  it("restarts the daemon for an already-current binary without running the pinned installer", () => {
+    const runShellImpl = vi
+      .fn()
+      .mockReturnValue({ status: 0, stdout: "", stderr: "", error: null });
+    const ensureOverride = vi.fn().mockReturnValue("ready");
+    const log = vi.fn();
+    const opts = makeOpts({
+      modeOverride: "system",
+      runShellImpl,
+      ensureManagedOllamaLoopbackSystemdOverrideImpl: ensureOverride,
+      isUpgrade: true,
+      restartOnly: true,
+      log,
+    });
+    expect(installOllamaOnLinux(opts).ok).toBe(true);
+    expect(findRunShellCall(runShellImpl, "ollama.com/install.sh")).toBeUndefined();
+    expect(ensureOverride).toHaveBeenCalledWith(expect.objectContaining({ isUpgrade: true }));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("without replacing the binary"));
+  });
+
   it("leaves a fresh install unpinned so it takes the latest Ollama", () => {
     const runShellImpl = vi
       .fn()

--- a/src/lib/onboard/install-ollama-linux.ts
+++ b/src/lib/onboard/install-ollama-linux.ts
@@ -56,6 +56,8 @@ export type InstallOllamaLinuxResult = {
 };
 
 export type InstallOllamaLinuxOptions = InstallOllamaLinuxModeOptions & {
+  /** Restart the daemon for an already-current binary without running the pinned installer. */
+  restartOnly?: boolean;
   /** Test seam: override `os.homedir()`. */
   homedir?: () => string;
   /** Test seam: override `process.arch`. */
@@ -116,9 +118,9 @@ function detectJetpackVariant(opts: InstallOllamaLinuxOptions): "jetpack5" | "je
 /**
  * Run the official `https://ollama.com/install.sh`. Sudo-bound. Configures
  * the systemd `ollama.service`, creates the `ollama` system user, and
- * installs CUDA drivers when applicable. An upgrade asks the installer for
- * `MIN_OLLAMA_VERSION` by name; a fresh install has no floor to satisfy and
- * takes latest.
+ * installs CUDA drivers when applicable. An upgrade that replaces a stale
+ * binary asks the installer for `MIN_OLLAMA_VERSION` by name; a fresh install
+ * has no floor to satisfy and takes latest.
  */
 function runOfficialInstallScript(opts: InstallOllamaLinuxOptions): void {
   const log = opts.log ?? ((m: string) => console.log(m));
@@ -323,8 +325,14 @@ function installOllamaSystem(opts: InstallOllamaLinuxOptions): InstallOllamaLinu
     opts.ensureManagedOllamaLoopbackSystemdOverrideImpl ??
     ensureManagedOllamaLoopbackSystemdOverride;
 
-  runOfficialInstallScript(opts);
-  sleepSecondsImpl(2);
+  if (opts.restartOnly) {
+    log(
+      `  Installed Ollama already meets ${MIN_OLLAMA_VERSION}; restarting its daemon without replacing the binary.`,
+    );
+  } else {
+    runOfficialInstallScript(opts);
+    sleepSecondsImpl(2);
+  }
 
   const overrideState: OllamaLoopbackSystemdOverrideState = ensureOverrideImpl({
     isNonInteractive: opts.isNonInteractive,

--- a/src/lib/onboard/install-ollama-linux.ts
+++ b/src/lib/onboard/install-ollama-linux.ts
@@ -10,6 +10,7 @@ import {
   MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW,
   resolveOllamaContextWindowFloor,
 } from "../inference/ollama-runtime-context";
+import { MIN_OLLAMA_VERSION } from "../inference/ollama-version";
 import { cliName } from "./branding";
 import {
   OLLAMA_PORT,
@@ -115,7 +116,9 @@ function detectJetpackVariant(opts: InstallOllamaLinuxOptions): "jetpack5" | "je
 /**
  * Run the official `https://ollama.com/install.sh`. Sudo-bound. Configures
  * the systemd `ollama.service`, creates the `ollama` system user, and
- * installs CUDA drivers when applicable.
+ * installs CUDA drivers when applicable. An upgrade asks the installer for
+ * `MIN_OLLAMA_VERSION` by name; a fresh install has no floor to satisfy and
+ * takes latest.
  */
 function runOfficialInstallScript(opts: InstallOllamaLinuxOptions): void {
   const log = opts.log ?? ((m: string) => console.log(m));
@@ -125,7 +128,11 @@ function runOfficialInstallScript(opts: InstallOllamaLinuxOptions): void {
     "  The Ollama installer creates a system user, a systemd service, and writes to /usr/local. " +
       "It uses sudo, may ask for your password, and can take a few minutes; installer output will stream below.",
   );
-  runShellImpl("set -o pipefail; curl -fsSL https://ollama.com/install.sh | sh", {
+  const versionPin = opts.isUpgrade ? `OLLAMA_VERSION=${MIN_OLLAMA_VERSION} ` : "";
+  if (versionPin) {
+    log(`  Requesting Ollama ${MIN_OLLAMA_VERSION} from the installer.`);
+  }
+  runShellImpl(`set -o pipefail; curl -fsSL https://ollama.com/install.sh | ${versionPin}sh`, {
     stdio: "inherit",
   });
 }
@@ -322,6 +329,7 @@ function installOllamaSystem(opts: InstallOllamaLinuxOptions): InstallOllamaLinu
   const overrideState: OllamaLoopbackSystemdOverrideState = ensureOverrideImpl({
     isNonInteractive: opts.isNonInteractive,
     contextWindowFloor: opts.contextWindowFloor,
+    isUpgrade: opts.isUpgrade,
   });
   if (overrideState === "failed") {
     errorLog("  Ollama systemd restart did not recover after applying the loopback override.");

--- a/src/lib/onboard/ollama-install-menu.test.ts
+++ b/src/lib/onboard/ollama-install-menu.test.ts
@@ -11,6 +11,17 @@ import {
 
 const LINUX_NON_WSL = { platform: "linux" as const, isWsl: false };
 
+function captureOllamaVersions(
+  daemonVersion: string | null,
+  binaryVersion: string | null,
+): (command: readonly string[]) => string {
+  const responses = new Map([
+    ["curl", daemonVersion ? JSON.stringify({ version: daemonVersion }) : ""],
+    ["ollama", binaryVersion ? `ollama version is ${binaryVersion}` : ""],
+  ]);
+  return (command) => responses.get(command[0] ?? "") ?? "";
+}
+
 describe("resolveRunningOllamaMenuEntry", () => {
   it("labels unsupported Windows-host Ollama without suggesting it", () => {
     const entry = resolveRunningOllamaMenuEntry({
@@ -243,13 +254,8 @@ describe("resolveOllamaInstallMenuEntry", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("accepts the upgrade when the running daemon reports a fresh version", () => {
-    const capture = (cmd: readonly string[]) => {
-      const joined = cmd.join(" ");
-      if (joined.includes("/api/version")) return '{"version":"0.32.9"}';
-      if (joined.includes("ollama --version")) return "ollama version is 0.32.9";
-      return "";
-    };
+  it("accepts the upgrade when the daemon and installed binary meet the minimum", () => {
+    const capture = captureOllamaVersions("0.32.9", "0.32.9");
     const result = assertOllamaUpgradeApplied({ hasUpgradableOllama: true }, capture);
     expect(result.ok).toBe(true);
     expect(result.detectedDaemonVersion).toBe("0.32.9");
@@ -257,12 +263,7 @@ describe("resolveOllamaInstallMenuEntry", () => {
   });
 
   it("rejects the upgrade when the daemon still serves the stale version even though the binary is fresh", () => {
-    const capture = (cmd: readonly string[]) => {
-      const joined = cmd.join(" ");
-      if (joined.includes("/api/version")) return '{"version":"0.6.2"}';
-      if (joined.includes("ollama --version")) return "ollama version is 0.32.9";
-      return "";
-    };
+    const capture = captureOllamaVersions("0.6.2", "0.32.9");
     const result = assertOllamaUpgradeApplied({ hasUpgradableOllama: true }, capture);
     expect(result.ok).toBe(false);
     expect(result.detectedDaemonVersion).toBe("0.6.2");
@@ -272,19 +273,26 @@ describe("resolveOllamaInstallMenuEntry", () => {
     expect(result.message).toContain("systemctl restart ollama");
   });
 
-  it("points at the installer, not a restart, when the binary is still below the floor (#9276)", () => {
-    const capture = (cmd: readonly string[]) => {
-      const joined = cmd.join(" ");
-      if (joined.includes("/api/version")) return '{"version":"0.23.4"}';
-      if (joined.includes("ollama --version")) return "ollama version is 0.23.4";
-      return "";
-    };
+  it("rejects a stale binary when the running daemon meets the minimum (#9276)", () => {
+    const capture = captureOllamaVersions("0.32.9", "0.23.4");
     const result = assertOllamaUpgradeApplied({ hasUpgradableOllama: true }, capture);
     expect(result.ok).toBe(false);
+    expect(result.detectedDaemonVersion).toBe("0.32.9");
     expect(result.detectedBinaryVersion).toBe("0.23.4");
     expect(result.message).toContain(`did not deliver ${MIN_OLLAMA_VERSION} on this host`);
     expect(result.message).toContain(`OLLAMA_VERSION=${MIN_OLLAMA_VERSION} sh`);
     expect(result.message).not.toContain("systemctl restart ollama");
+  });
+
+  it("reports a known daemon when the installed binary version is unavailable (#9276)", () => {
+    const capture = captureOllamaVersions("0.23.4", null);
+    const result = assertOllamaUpgradeApplied({ hasUpgradableOllama: true }, capture);
+    expect(result.ok).toBe(false);
+    expect(result.detectedDaemonVersion).toBe("0.23.4");
+    expect(result.detectedBinaryVersion).toBeNull();
+    expect(result.message).toContain("running daemon reports 0.23.4 (binary: unknown)");
+    expect(result.message).toContain("installed binary version could not be read");
+    expect(result.message).not.toContain("Neither the daemon nor the binary could be read");
   });
 
   it("rejects the upgrade when the daemon is unreachable", () => {
@@ -293,6 +301,7 @@ describe("resolveOllamaInstallMenuEntry", () => {
     expect(result.ok).toBe(false);
     expect(result.detectedDaemonVersion).toBeNull();
     expect(result.message).toContain("unreachable");
+    expect(result.message).toContain("Neither the daemon nor the binary could be read");
   });
 
   it("does not return an entry on unsupported platforms", () => {

--- a/src/lib/onboard/ollama-install-menu.test.ts
+++ b/src/lib/onboard/ollama-install-menu.test.ts
@@ -15,11 +15,25 @@ function captureOllamaVersions(
   daemonVersion: string | null,
   binaryVersion: string | null,
 ): (command: readonly string[]) => string {
-  const responses = new Map([
-    ["curl", daemonVersion ? JSON.stringify({ version: daemonVersion }) : ""],
-    ["ollama", binaryVersion ? `ollama version is ${binaryVersion}` : ""],
+  const responses = new Map<string, string>([
+    [
+      JSON.stringify([
+        "curl",
+        "-sf",
+        "--connect-timeout",
+        "2",
+        "--max-time",
+        "5",
+        "http://127.0.0.1:11434/api/version",
+      ]),
+      daemonVersion ? JSON.stringify({ version: daemonVersion }) : "",
+    ],
+    [
+      JSON.stringify(["ollama", "--version"]),
+      binaryVersion ? `ollama version is ${binaryVersion}` : "",
+    ],
   ]);
-  return (command) => responses.get(command[0] ?? "") ?? "";
+  return (command) => responses.get(JSON.stringify(command)) ?? "";
 }
 
 describe("resolveRunningOllamaMenuEntry", () => {

--- a/src/lib/onboard/ollama-install-menu.test.ts
+++ b/src/lib/onboard/ollama-install-menu.test.ts
@@ -269,6 +269,22 @@ describe("resolveOllamaInstallMenuEntry", () => {
     expect(result.detectedBinaryVersion).toBe("0.32.9");
     expect(result.message).toContain("0.6.2");
     expect(result.message).toContain(MIN_OLLAMA_VERSION);
+    expect(result.message).toContain("systemctl restart ollama");
+  });
+
+  it("points at the installer, not a restart, when the binary is still below the floor (#9276)", () => {
+    const capture = (cmd: readonly string[]) => {
+      const joined = cmd.join(" ");
+      if (joined.includes("/api/version")) return '{"version":"0.23.4"}';
+      if (joined.includes("ollama --version")) return "ollama version is 0.23.4";
+      return "";
+    };
+    const result = assertOllamaUpgradeApplied({ hasUpgradableOllama: true }, capture);
+    expect(result.ok).toBe(false);
+    expect(result.detectedBinaryVersion).toBe("0.23.4");
+    expect(result.message).toContain(`did not deliver ${MIN_OLLAMA_VERSION} on this host`);
+    expect(result.message).toContain(`OLLAMA_VERSION=${MIN_OLLAMA_VERSION} sh`);
+    expect(result.message).not.toContain("systemctl restart ollama");
   });
 
   it("rejects the upgrade when the daemon is unreachable", () => {

--- a/src/lib/onboard/ollama-install-menu.test.ts
+++ b/src/lib/onboard/ollama-install-menu.test.ts
@@ -105,6 +105,7 @@ describe("resolveOllamaInstallMenuEntry", () => {
       ...LINUX_NON_WSL,
     });
     expect(result.hasUpgradableOllama).toBe(true);
+    expect(result.binaryNeedsUpgrade).toBe(true);
     expect(result.entry?.key).toBe("install-ollama");
     expect(result.entry?.label).toBe(
       `Upgrade Ollama (Linux) — upgrade installed binary 0.6.2 to ≥ ${MIN_OLLAMA_VERSION}`,
@@ -137,7 +138,26 @@ describe("resolveOllamaInstallMenuEntry", () => {
       ...LINUX_NON_WSL,
     });
     expect(result.hasUpgradableOllama).toBe(true);
+    expect(result.binaryNeedsUpgrade).toBe(false);
     // Stale source is the daemon; suffix names "running daemon" with that version.
+    expect(result.entry?.label).toBe(
+      `Upgrade Ollama (Linux) — upgrade running daemon 0.6.2 to ≥ ${MIN_OLLAMA_VERSION}`,
+    );
+  });
+
+  it("requires a binary install when a stale daemon is reachable without a local binary", () => {
+    const result = resolveOllamaInstallMenuEntry({
+      hasOllama: false,
+      ollamaRunning: true,
+      hasWindowsOllama: false,
+      windowsHostOllamaSupported: true,
+      ollamaHost: "127.0.0.1",
+      installedOllamaVersion: null,
+      runningOllamaVersion: "0.6.2",
+      ...LINUX_NON_WSL,
+    });
+    expect(result.hasUpgradableOllama).toBe(true);
+    expect(result.binaryNeedsUpgrade).toBe(true);
     expect(result.entry?.label).toBe(
       `Upgrade Ollama (Linux) — upgrade running daemon 0.6.2 to ≥ ${MIN_OLLAMA_VERSION}`,
     );
@@ -155,6 +175,7 @@ describe("resolveOllamaInstallMenuEntry", () => {
       ...LINUX_NON_WSL,
     });
     expect(result.hasUpgradableOllama).toBe(true);
+    expect(result.binaryNeedsUpgrade).toBe(true);
     // Stale source is the binary; suffix names "installed binary" with that version.
     expect(result.entry?.label).toBe(
       `Upgrade Ollama (Linux) — upgrade installed binary 0.6.2 to ≥ ${MIN_OLLAMA_VERSION}`,

--- a/src/lib/onboard/ollama-install-menu.ts
+++ b/src/lib/onboard/ollama-install-menu.ts
@@ -200,14 +200,11 @@ export interface OllamaUpgradeApplied {
 }
 
 /**
- * After the install/upgrade command, confirm the running Ollama daemon
- * actually advanced past `MIN_OLLAMA_VERSION`. The CLI binary on `PATH`
- * is not sufficient: a user-local install can put a newer binary on
- * `${HOME}/.local/bin` while the system daemon still owns `:11434`, and
- * `brew upgrade ollama` can fail silently with no daemon restart. Probe
- * `/api/version` on the daemon so the verdict matches what NemoClaw will
- * actually use for inference. The binary version is captured alongside
- * for diagnostics only.
+ * After an upgrade command, confirm that the running Ollama daemon and the
+ * installed binary both meet `MIN_OLLAMA_VERSION`. A user-local install
+ * can put a newer binary on `PATH` while the system daemon still owns `:11434`.
+ * The reverse mismatch can leave an older binary on `PATH` after the daemon
+ * restarts. Probe both versions so onboarding rejects either incomplete state.
  */
 export function assertOllamaUpgradeApplied(
   menu: { hasUpgradableOllama: boolean },
@@ -218,7 +215,10 @@ export function assertOllamaUpgradeApplied(
   }
   const detectedDaemonVersion = getRunningOllamaDaemonVersion(runCaptureImpl);
   const detectedBinaryVersion = getInstalledOllamaVersion(runCaptureImpl);
-  if (isOllamaVersionAtLeast(detectedDaemonVersion, MIN_OLLAMA_VERSION)) {
+  if (
+    isOllamaVersionAtLeast(detectedDaemonVersion, MIN_OLLAMA_VERSION) &&
+    isOllamaVersionAtLeast(detectedBinaryVersion, MIN_OLLAMA_VERSION)
+  ) {
     return { ok: true, detectedDaemonVersion, detectedBinaryVersion };
   }
   const daemonLabel = detectedDaemonVersion ?? "unreachable";
@@ -228,11 +228,14 @@ export function assertOllamaUpgradeApplied(
     ok: false,
     detectedDaemonVersion,
     detectedBinaryVersion,
-    message: `Ollama upgrade did not take effect — ${state}. ${resolveUpgradeRemedy(detectedBinaryVersion)}`,
+    message: `Ollama upgrade did not take effect — ${state}. ${resolveUpgradeRemedy(detectedDaemonVersion, detectedBinaryVersion)}`,
   };
 }
 
-function resolveUpgradeRemedy(detectedBinaryVersion: string | null): string {
+function resolveUpgradeRemedy(
+  detectedDaemonVersion: string | null,
+  detectedBinaryVersion: string | null,
+): string {
   if (isOllamaVersionAtLeast(detectedBinaryVersion, MIN_OLLAMA_VERSION)) {
     return (
       "The installed binary meets the minimum, so the service is still serving the old one. " +
@@ -240,9 +243,15 @@ function resolveUpgradeRemedy(detectedBinaryVersion: string | null): string {
     );
   }
   if (!detectedBinaryVersion) {
+    if (!detectedDaemonVersion) {
+      return (
+        "Neither the daemon nor the binary could be read. Check that Ollama is installed and " +
+        "running, then rerun, or install it manually (https://ollama.com/download)."
+      );
+    }
     return (
-      "Neither the daemon nor the binary could be read. Check that Ollama is installed and running, " +
-      "then rerun, or install it manually (https://ollama.com/download)."
+      "The installed binary version could not be read. Check that the Ollama binary is installed " +
+      "and available on PATH, then rerun, or install it manually (https://ollama.com/download)."
     );
   }
   return (

--- a/src/lib/onboard/ollama-install-menu.ts
+++ b/src/lib/onboard/ollama-install-menu.ts
@@ -223,12 +223,30 @@ export function assertOllamaUpgradeApplied(
   }
   const daemonLabel = detectedDaemonVersion ?? "unreachable";
   const binaryLabel = detectedBinaryVersion ?? "unknown";
+  const state = `running daemon reports ${daemonLabel} (binary: ${binaryLabel}), need ≥ ${MIN_OLLAMA_VERSION}`;
   return {
     ok: false,
     detectedDaemonVersion,
     detectedBinaryVersion,
-    message:
-      `Ollama upgrade did not take effect — running daemon reports ${daemonLabel} (binary: ${binaryLabel}), need ≥ ${MIN_OLLAMA_VERSION}. ` +
-      "Restart the system daemon and rerun, or upgrade Ollama manually (https://ollama.com/download).",
+    message: `Ollama upgrade did not take effect — ${state}. ${resolveUpgradeRemedy(detectedBinaryVersion)}`,
   };
+}
+
+function resolveUpgradeRemedy(detectedBinaryVersion: string | null): string {
+  if (isOllamaVersionAtLeast(detectedBinaryVersion, MIN_OLLAMA_VERSION)) {
+    return (
+      "The installed binary meets the minimum, so the service is still serving the old one. " +
+      "Restart it with 'sudo systemctl restart ollama' and rerun."
+    );
+  }
+  if (!detectedBinaryVersion) {
+    return (
+      "Neither the daemon nor the binary could be read. Check that Ollama is installed and running, " +
+      "then rerun, or install it manually (https://ollama.com/download)."
+    );
+  }
+  return (
+    `The installer did not deliver ${MIN_OLLAMA_VERSION} on this host. Install it directly with ` +
+    `'curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=${MIN_OLLAMA_VERSION} sh' and rerun.`
+  );
 }

--- a/src/lib/onboard/ollama-install-menu.ts
+++ b/src/lib/onboard/ollama-install-menu.ts
@@ -103,6 +103,8 @@ export interface OllamaInstallMenuEntry {
 export interface OllamaInstallMenuResult {
   entry: OllamaInstallMenuEntry | null;
   hasUpgradableOllama: boolean;
+  /** Whether recovery must install or replace the binary, rather than only restart its daemon. */
+  binaryNeedsUpgrade?: boolean;
 }
 
 function osTagFor(platform: NodeJS.Platform, isWsl: boolean): string | null {
@@ -147,10 +149,15 @@ export function resolveOllamaInstallMenuEntry(
   // put a fresh `ollama` on `PATH` while the system daemon keeps `:11434`
   // on the old version (and vice versa). Upgrade when either source is below
   // the minimum.
-  const binaryNeedsUpgrade =
-    input.hasOllama && !isOllamaVersionAtLeast(installedOllamaVersion, MIN_OLLAMA_VERSION);
+  const installedBinaryMeetsMinimum =
+    input.hasOllama && isOllamaVersionAtLeast(installedOllamaVersion, MIN_OLLAMA_VERSION);
   const daemonNeedsUpgrade =
     daemonProbeApplies && !isOllamaVersionAtLeast(runningOllamaVersion, MIN_OLLAMA_VERSION);
+  // Restart-only recovery is safe only with positive evidence that the
+  // installed binary meets the floor. A stale daemon without a local binary
+  // still needs the installer to provide one.
+  const binaryNeedsUpgrade =
+    !installedBinaryMeetsMinimum && (input.hasOllama || daemonNeedsUpgrade);
   const hasUpgradableOllama = binaryNeedsUpgrade || daemonNeedsUpgrade;
   // A Windows-host install only covers the local-inference need when the
   // sandbox can route to it. Under a container runtime without that routing,
@@ -160,11 +167,11 @@ export function resolveOllamaInstallMenuEntry(
   const showEntry =
     (!input.hasOllama && !input.ollamaRunning && !usableWindowsOllama) || hasUpgradableOllama;
   if (!showEntry) {
-    return { entry: null, hasUpgradableOllama };
+    return { entry: null, hasUpgradableOllama, binaryNeedsUpgrade };
   }
   const osTag = osTagFor(input.platform, input.isWsl);
   if (osTag === null) {
-    return { entry: null, hasUpgradableOllama };
+    return { entry: null, hasUpgradableOllama, binaryNeedsUpgrade };
   }
   const labelPrefix = hasUpgradableOllama ? "Upgrade Ollama" : "Install Ollama";
   // Name the stale source explicitly: "running daemon" when the daemon is
@@ -189,6 +196,7 @@ export function resolveOllamaInstallMenuEntry(
   return {
     entry: { key: "install-ollama", label: `${labelPrefix} (${osTag})${upgradeSuffix}` },
     hasUpgradableOllama,
+    binaryNeedsUpgrade,
   };
 }
 

--- a/src/lib/onboard/ollama-systemd.test.ts
+++ b/src/lib/onboard/ollama-systemd.test.ts
@@ -183,6 +183,36 @@ describe("ensureOllamaLoopbackSystemdOverride non-interactive sudo (#5716)", () 
     }
   });
 
+  it("refuses the loopback-only shortcut on an upgrade because the service must restart onto the new binary (#9276)", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    const loopbackOnly = vi.fn(() => true);
+    try {
+      expect(() =>
+        ensureOllamaLoopbackSystemdOverride({
+          platformImpl: () => "linux",
+          hasOllamaSystemdUnitImpl: () => true,
+          isNonInteractive: () => true,
+          hasPasswordlessSudoImpl: () => false,
+          isOllamaLoopbackOnlyImpl: loopbackOnly,
+          isUpgrade: true,
+        }),
+      ).toThrow("exit 1");
+      expect(loopbackOnly).not.toHaveBeenCalled();
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining("cannot be restarted onto the newly installed binary"),
+      );
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining("keep serving the old version"),
+      );
+    } finally {
+      exit.mockRestore();
+      error.mockRestore();
+    }
+  });
+
   it("fails before override commands when sudo is unavailable and loopback-only binding is unverified", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     const exit = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {

--- a/src/lib/onboard/ollama-systemd.ts
+++ b/src/lib/onboard/ollama-systemd.ts
@@ -26,6 +26,12 @@ type OllamaLoopbackSystemdOverrideOptions = {
   enableService?: boolean;
   /** Minimum daemon context length to preserve or apply in the systemd override. */
   contextWindowFloor?: number;
+  /**
+   * Set when the caller has just replaced the Ollama binary. The service must
+   * then be restarted onto it, so an already-loopback-only listener is not
+   * evidence that this step can be skipped.
+   */
+  isUpgrade?: boolean;
   detectNvidiaPlatformImpl?: () => string;
   hasOllamaCudaV13LibraryImpl?: () => boolean;
   /**
@@ -205,6 +211,17 @@ export function ensureOllamaLoopbackSystemdOverride(
   const sudoPrefix = getSudoPrefix((options.isNonInteractive ?? isEnvNonInteractive)());
   const hasPasswordlessSudo = options.hasPasswordlessSudoImpl ?? defaultHasPasswordlessSudo;
   if (shouldSkipOllamaLoopbackForMissingSudo(sudoPrefix, hasPasswordlessSudo)) {
+    if (options.isUpgrade) {
+      console.error(
+        "  Passwordless sudo is not available, so the Ollama service cannot be restarted onto the " +
+          "newly installed binary.",
+      );
+      console.error(
+        `  The running daemon would keep serving the old version. Set ${NON_INTERACTIVE_SUDO_MODE_ENV}=prompt ` +
+          "with a terminal, configure passwordless sudo, or run 'sudo systemctl restart ollama' and rerun onboarding.",
+      );
+      process.exit(1);
+    }
     const loopbackOnly =
       options.isOllamaLoopbackOnlyImpl?.() ?? isActiveOllamaListenerLoopbackOnly();
     if (loopbackOnly) {

--- a/src/lib/onboard/setup-nim-ollama.test.ts
+++ b/src/lib/onboard/setup-nim-ollama.test.ts
@@ -207,9 +207,29 @@ describe("createSetupNimOllamaHandlers", () => {
     await expect(
       handleInstallOllamaSelection(null, "conflict/model", null, state, {
         hasUpgradableOllama: false,
+        binaryNeedsUpgrade: false,
       }),
     ).rejects.toThrow("route conflict");
     expect(install).not.toHaveBeenCalled();
+  });
+
+  it("installs a missing binary while recovering a stale daemon", async () => {
+    const install = vi.fn(() => ({ ok: true }));
+    const { handleInstallOllamaSelection } = createSetupNimOllamaHandlers(
+      makeDeps({
+        process: { ...process, platform: "linux" } as NodeJS.Process,
+        installOllamaOnLinux: install,
+      }),
+    );
+
+    await handleInstallOllamaSelection(null, "qwen3:8b", null, makeState(), {
+      hasUpgradableOllama: true,
+      binaryNeedsUpgrade: true,
+    });
+
+    expect(install).toHaveBeenCalledWith(
+      expect.objectContaining({ isUpgrade: true, restartOnly: false }),
+    );
   });
 
   it("does not switch, install, or restart Windows Ollama when preflight rejects", async () => {
@@ -353,6 +373,7 @@ describe("createSetupNimOllamaHandlers", () => {
 
     const result = await handleInstallOllamaSelection(null, "requested", "recovered", state, {
       hasUpgradableOllama: false,
+      binaryNeedsUpgrade: false,
     });
 
     assert.equal(result, "selected");
@@ -381,6 +402,7 @@ describe("createSetupNimOllamaHandlers", () => {
 
     const result = await handleInstallOllamaSelection(null, null, null, state, {
       hasUpgradableOllama: false,
+      binaryNeedsUpgrade: false,
     });
 
     expect(result).toBe("selected");

--- a/src/lib/onboard/setup-nim-ollama.ts
+++ b/src/lib/onboard/setup-nim-ollama.ts
@@ -65,6 +65,7 @@ type SetupNimOllamaDeps = {
   installOllamaOnLinux: (args: {
     isNonInteractive: () => boolean;
     isUpgrade: boolean;
+    restartOnly?: boolean;
     contextWindowFloor?: number;
   }) => { ok: boolean };
   abortNonInteractive: (message: string) => never;
@@ -97,7 +98,7 @@ export function createSetupNimOllamaHandlers(deps: SetupNimOllamaDeps): {
     requestedModel: string | null,
     recoveredModel: string | null,
     state: SetupNimSelectionState,
-    ollamaInstallMenu: { hasUpgradableOllama: boolean },
+    ollamaInstallMenu: { hasUpgradableOllama: boolean; binaryNeedsUpgrade?: boolean },
   ) => Promise<SetupNimSelectionResult>;
 } {
   async function selectModel(
@@ -320,7 +321,7 @@ export function createSetupNimOllamaHandlers(deps: SetupNimOllamaDeps): {
     requestedModel: string | null,
     recoveredModel: string | null,
     state: SetupNimSelectionState,
-    ollamaInstallMenu: { hasUpgradableOllama: boolean },
+    ollamaInstallMenu: { hasUpgradableOllama: boolean; binaryNeedsUpgrade?: boolean },
   ): Promise<SetupNimSelectionResult> {
     if (!deps.checkOllamaPortsOrWarn({ isNonInteractive: deps.isNonInteractive })) {
       return "retry-selection";
@@ -337,6 +338,7 @@ export function createSetupNimOllamaHandlers(deps: SetupNimOllamaDeps): {
         : deps.installOllamaOnLinux({
             isNonInteractive: deps.isNonInteractive,
             isUpgrade,
+            restartOnly: isUpgrade && ollamaInstallMenu.binaryNeedsUpgrade === false,
             contextWindowFloor: state.ollamaContextWindowFloor,
           });
     if (!installResult.ok) {

--- a/test/onboard-ollama-upgrade-version-floor.test.ts
+++ b/test/onboard-ollama-upgrade-version-floor.test.ts
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { describe, it, vi } from "vitest";
+
+import { resetOllamaHostCache } from "../src/lib/inference/local.js";
+import { MIN_OLLAMA_VERSION } from "../src/lib/inference/ollama-version.js";
+import {
+  type InstallOllamaLinuxOptions,
+  installOllamaOnLinux,
+} from "../src/lib/onboard/install-ollama-linux.js";
+import {
+  assertOllamaUpgradeApplied,
+  resolveOllamaInstallMenuEntry,
+} from "../src/lib/onboard/ollama-install-menu.js";
+import { createSetupNimOllamaHandlers } from "../src/lib/onboard/setup-nim-ollama.js";
+import type { SetupNimSelectionState } from "../src/lib/onboard/setup-nim-selection.js";
+
+type SetupNimOllamaDeps = Parameters<typeof createSetupNimOllamaHandlers>[0];
+
+const STALE_VERSION = "0.23.4";
+
+function successfulRunShellResult(): ReturnType<
+  NonNullable<InstallOllamaLinuxOptions["runShellImpl"]>
+> {
+  return {
+    pid: 1,
+    output: [null, "", ""],
+    stdout: "",
+    stderr: "",
+    status: 0,
+    signal: null,
+  };
+}
+
+function makeInstallOptions(
+  overrides: Partial<InstallOllamaLinuxOptions> = {},
+): InstallOllamaLinuxOptions {
+  return {
+    isNonInteractive: () => true,
+    getEuid: () => 1000,
+    isTty: () => false,
+    homedir: () => "/home/test",
+    arch: () => "arm64",
+    canSudoNonInteractive: () => true,
+    runCaptureImpl: vi.fn().mockReturnValue(""),
+    runCaptureExImpl: vi
+      .fn()
+      .mockReturnValue({ stdout: "", stderr: "", exitCode: 0, timedOut: false }),
+    runShellImpl: vi.fn().mockReturnValue({ status: 0, stdout: "", stderr: "", error: null }),
+    waitForHttpImpl: vi.fn().mockReturnValue(true),
+    sleepSecondsImpl: vi.fn(),
+    ensureManagedOllamaLoopbackSystemdOverrideImpl: vi.fn().mockReturnValue("ready"),
+    fileExistsImpl: vi.fn().mockReturnValue(false),
+    readFileImpl: vi.fn().mockReturnValue(""),
+    recordUserLocalOllamaOwnershipImpl: vi.fn(),
+    removeUserLocalOllamaOwnershipImpl: vi.fn(),
+    log: vi.fn(),
+    errorLog: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeSelectionState(): SetupNimSelectionState {
+  return {
+    model: null,
+    provider: "nvidia-prod",
+    endpointUrl: null,
+    credentialEnv: "NVIDIA_INFERENCE_API_KEY",
+    hermesAuthMethod: null,
+    hermesToolGateways: [],
+    preferredInferenceApi: null,
+    nimContainer: null,
+    allowToolsIncompatible: false,
+    skipHostInferenceSmoke: false,
+  };
+}
+
+function makeOllamaDeps(overrides: Partial<SetupNimOllamaDeps> = {}): SetupNimOllamaDeps {
+  const processStub = {
+    platform: "linux",
+    exit(code?: number): never {
+      throw new Error(`Unexpected process.exit(${String(code)})`);
+    },
+  } as NodeJS.Process;
+  return {
+    OLLAMA_PORT: 11434,
+    OLLAMA_PROXY_PORT: 11435,
+    process: processStub,
+    isNonInteractive: () => true,
+    prompt: async () => "",
+    checkOllamaPortsOrWarn: () => true,
+    ensureOllamaLoopbackSystemdOverride: () => "not-applicable",
+    runOllamaStartupOrGate: () => ({ kind: "ready" }),
+    shouldFrontOllamaWithProxy: () => false,
+    getLocalProviderBaseUrl: () => "http://host.docker.internal:11434/v1",
+    selectAndValidateOllamaModel: async () => ({
+      outcome: "selected",
+      model: "qwen3:8b",
+      allowToolsIncompatible: false,
+    }),
+    printOllamaExposureWarning: () => {},
+    switchToWindowsOllamaHost: () => {},
+    installOllamaOnWindowsHost: async () => ({ ok: true }),
+    awaitWindowsOllamaReady: () => true,
+    setupWindowsOllamaWith0000Binding: () => true,
+    printWindowsOllamaTimeoutDiagnostics: () => {},
+    resetOllamaHostCache: () => {},
+    installOllamaOnMacOS: () => ({ ok: true }),
+    installOllamaOnLinux: () => ({ ok: true }),
+    abortNonInteractive(message: string): never {
+      throw new Error(message);
+    },
+    assertOllamaUpgradeApplied: () => ({ ok: true }),
+    ...overrides,
+  };
+}
+
+describe("onboard Ollama upgrade version floor", () => {
+  it("asks the installer for the required version and reports honestly when it is not delivered (#9276)", async () => {
+    const menu = resolveOllamaInstallMenuEntry({
+      hasOllama: true,
+      ollamaRunning: true,
+      ollamaHost: "127.0.0.1",
+      hasWindowsOllama: false,
+      installedOllamaVersion: STALE_VERSION,
+      runningOllamaVersion: STALE_VERSION,
+      platform: "linux",
+      isWsl: false,
+    });
+    assert.equal(menu.hasUpgradableOllama, true);
+    const commands: string[] = [];
+    const runCapture = (command: readonly string[]) => {
+      const rendered = command.join(" ");
+      switch (true) {
+        case rendered.includes("ollama --version"):
+          return `ollama version is ${STALE_VERSION}`;
+        case rendered.includes("/api/version"):
+          return `{"version":"${STALE_VERSION}"}`;
+        case command.at(-1) === "zstd":
+          return "/usr/bin/zstd";
+        default:
+          return "";
+      }
+    };
+    const errors: string[] = [];
+    const errorLog = vi.spyOn(console, "error").mockImplementation((...args) => {
+      errors.push(args.join(" "));
+    });
+    const { handleInstallOllamaSelection } = createSetupNimOllamaHandlers(
+      makeOllamaDeps({
+        installOllamaOnLinux: () =>
+          installOllamaOnLinux(
+            makeInstallOptions({
+              modeOverride: "system",
+              isUpgrade: true,
+              runCaptureImpl: runCapture,
+              runShellImpl: (command) => {
+                commands.push(command);
+                return successfulRunShellResult();
+              },
+            }),
+          ),
+        assertOllamaUpgradeApplied: (selection) => {
+          const outcome = assertOllamaUpgradeApplied(selection, runCapture);
+          return outcome.ok
+            ? { ok: true as const }
+            : { ok: false as const, message: outcome.message ?? "Ollama upgrade failed." };
+        },
+      }),
+    );
+
+    try {
+      await assert.rejects(
+        handleInstallOllamaSelection(null, "qwen3:8b", null, makeSelectionState(), menu),
+        /Unexpected process\.exit\(1\)/,
+      );
+      const installer = commands.find((command) => command.includes("ollama.com/install.sh"));
+      assert.ok(installer);
+      assert.ok(installer.includes(`OLLAMA_VERSION=${MIN_OLLAMA_VERSION}`));
+      const surfaced = errors.join("\n");
+      assert.ok(surfaced.includes(`did not deliver ${MIN_OLLAMA_VERSION} on this host`));
+      assert.ok(!surfaced.includes("systemctl restart ollama"));
+    } finally {
+      errorLog.mockRestore();
+      resetOllamaHostCache();
+    }
+  });
+});

--- a/test/onboard-ollama-upgrade-version-floor.test.ts
+++ b/test/onboard-ollama-upgrade-version-floor.test.ts
@@ -187,4 +187,76 @@ describe("onboard Ollama upgrade version floor", () => {
       resetOllamaHostCache();
     }
   });
+
+  it("restarts a stale daemon without downgrading a newer installed binary (#9276)", async () => {
+    const currentVersion = "0.40.0";
+    const menu = resolveOllamaInstallMenuEntry({
+      hasOllama: true,
+      ollamaRunning: true,
+      ollamaHost: "127.0.0.1",
+      hasWindowsOllama: false,
+      installedOllamaVersion: currentVersion,
+      runningOllamaVersion: STALE_VERSION,
+      platform: "linux",
+      isWsl: false,
+    });
+    assert.equal(menu.hasUpgradableOllama, true);
+    assert.equal(menu.binaryNeedsUpgrade, false);
+
+    const responses = new Map<string, string>([
+      [
+        JSON.stringify([
+          "curl",
+          "-sf",
+          "--connect-timeout",
+          "2",
+          "--max-time",
+          "5",
+          "http://127.0.0.1:11434/api/version",
+        ]),
+        JSON.stringify({ version: currentVersion }),
+      ],
+      [JSON.stringify(["ollama", "--version"]), `ollama version is ${currentVersion}`],
+    ]);
+    const runCapture = (command: readonly string[]) => responses.get(JSON.stringify(command)) ?? "";
+    const commands: string[] = [];
+    const ensureOverride = vi.fn().mockReturnValue("ready");
+    const install = vi.fn((options: Parameters<SetupNimOllamaDeps["installOllamaOnLinux"]>[0]) =>
+      installOllamaOnLinux(
+        makeInstallOptions({
+          ...options,
+          modeOverride: "system",
+          runCaptureImpl: runCapture,
+          runShellImpl: (command) => {
+            commands.push(command);
+            return successfulRunShellResult();
+          },
+          ensureManagedOllamaLoopbackSystemdOverrideImpl: ensureOverride,
+        }),
+      ),
+    );
+    const { handleInstallOllamaSelection } = createSetupNimOllamaHandlers(
+      makeOllamaDeps({
+        installOllamaOnLinux: install,
+        assertOllamaUpgradeApplied: (selection) => {
+          const outcome = assertOllamaUpgradeApplied(selection, runCapture);
+          return outcome.ok
+            ? { ok: true as const }
+            : { ok: false as const, message: outcome.message ?? "Ollama upgrade failed." };
+        },
+      }),
+    );
+
+    const result = await handleInstallOllamaSelection(
+      null,
+      "qwen3:8b",
+      null,
+      makeSelectionState(),
+      menu,
+    );
+    assert.equal(result, "selected");
+    assert.equal(install.mock.calls[0]?.[0].restartOnly, true);
+    assert.ok(!commands.some((command) => command.includes("ollama.com/install.sh")));
+    assert.equal(ensureOverride.mock.calls[0]?.[0].isUpgrade, true);
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->
A Linux Ollama upgrade ran the official installer without naming a version, so on a host whose latest release is below the required minimum the install reported success, the version never moved, and non-interactive onboarding exited 1 while advising a daemon restart that could not help. The upgrade now asks the installer for the minimum version by name, reads the binary's own version separately from the daemon's, restarts the service even when the current listener is already loopback-only, and names which side is stale in the failure. When the installed binary is already current and only the daemon is stale, recovery restarts the daemon without replacing or downgrading that binary.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Fixes #9276

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->
- `runOfficialInstallScript` in `src/lib/onboard/install-ollama-linux.ts` prefixes the installer with `OLLAMA_VERSION=<minimum>` when upgrade recovery must install or replace a stale binary. A fresh install stays unpinned and takes the latest version. When an installed binary already meets the floor and only the daemon is stale, Linux recovery skips the installer and restarts that daemon, preventing a downgrade.
- `getInstalledOllamaVersion` in `src/lib/inference/ollama-version.ts` prefers the `client version is X` line. `ollama --version` reports the version of the daemon it can reach and prints the client's own version only when the two differ, so the previous first-match read returned the daemon's version for both probes and collapsed the stale-binary and stale-daemon cases the install menu distinguishes.
- `ensureOllamaLoopbackSystemdOverride` in `src/lib/onboard/ollama-systemd.ts` takes an `isUpgrade` flag, passed by `installOllamaSystem`. The existing shortcut that skips the drop-in rewrite when the active listener is already loopback-only also skips the service restart, which an upgrade needs to move the daemon onto the new binary, so the flag refuses that shortcut and reports the missing sudo instead.
- `assertOllamaUpgradeApplied` in `src/lib/onboard/ollama-install-menu.ts` now requires both the daemon and installed binary to be readable and at or above the minimum. It selects remediation from both probes: restart when the binary is current but the daemon is stale, run the pinned installer when the binary is stale, check the binary and `PATH` when only its version is unreadable, and check installation and daemon state when neither version is readable.
- `docs/inference/set-up-ollama.mdx` records the pinned upgrade, the daemon-only restart that preserves a current binary, the `ollama --version` reporting behavior, the restart requirement, and the three failure outcomes.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: security review and requested corrections recorded in https://github.com/NVIDIA/NemoClaw/pull/9284#pullrequestreview-4949225063
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/inference/set-up-ollama.mdx`; reviewed terminology, structure, voice, Linux installer and restart behavior claims, user-visible remediation, behavior test titles, and the OpenClaw and Hermes generated variants against the implementation and tests.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 0834862e9 -->
<!-- docs-review-agents-blob-sha: b9fb6a9 -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run src/lib/inference/ollama-version.test.ts src/lib/onboard/ollama-install-menu.test.ts src/lib/onboard/install-ollama-linux-upgrade.test.ts src/lib/onboard/install-ollama-linux.test.ts src/lib/onboard/ollama-systemd.test.ts src/lib/onboard/setup-nim-ollama.test.ts test/onboard-ollama-upgrade-version-floor.test.ts test/onboard-selection.test.ts` — 8 files, 174 tests passed. Also `npm run typecheck`, `npm run typecheck:cli`, `npm run lint`, `npm run docs`, `npm run test-size:check`, and `npm run validate:pr` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ollama upgrades now install the required minimum version, while fresh installations continue to use the latest release.
  * Existing newer binaries can recover stale services without reinstalling.
  * Upgrade validation checks both the running service and installed binary, with clearer guidance when either is outdated or unavailable.
  * Upgrades fail safely when the service cannot restart onto the newly installed version.
  * Version detection correctly prioritizes the installed client version.

* **Documentation**
  * Updated Linux Ollama setup guidance to explain version-pinned upgrades, required permissions, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->