### PR TITLE
fix(connect): run probe-only recovery when absent authority cannot be created

### DIFF
--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -609,7 +609,7 @@ describe("connectSandbox flow", () => {
     );
   });
 
-  it("probe-only reports failure to create new authority after secure absence is proven (#8942)", async () => {
+  it("probe-only completes recovery after secure absence is proven and reports unpublished evidence (#9280)", async () => {
     const harness = createConnectHarness({
       readinessDecision: {
         kind: "fallback",
@@ -620,18 +620,21 @@ describe("connectSandbox flow", () => {
         fenceFailed: true,
         recoveryBlocked: false,
       },
+      readinessPublicationResult: { kind: "evidence-failed" },
     });
 
     await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
       "process.exit(1)",
     );
 
-    expect(harness.checkAndRecoverSpy).not.toHaveBeenCalled();
-    expect(harness.errorSpy.mock.calls.flat().join("\n")).toContain(
-      "no prior launch-readiness evidence can be accepted, but new launch-readiness authority could not be created",
+    expect(harness.checkAndRecoverSpy).toHaveBeenCalledOnce();
+    expect(harness.ensureLiveSandboxSpy).toHaveBeenCalled();
+    expect(harness.publishLaunchReadinessSpy).toHaveBeenCalledOnce();
+    expect(harness.errorSpy).toHaveBeenCalledWith(
+      "  Probe failed: complete probe and recovery succeeded, but final launch-readiness evidence could not be verified or published.",
     );
     expect(harness.errorSpy.mock.calls.flat().join("\n")).not.toContain(
-      "prior launch-readiness evidence could not be fenced",
+      "new launch-readiness authority could not be created",
     );
   });
 

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -1285,11 +1285,19 @@ export async function connectSandbox(
         console.log(`  Probe complete: launch readiness is healthy for '${sandboxName}'.`);
         return;
       }
-      if (readiness.fenceFailed && readiness.authorityUnsupported !== true) {
+      // Refuse recovery only when a prior epoch might exist and could not be
+      // durably rotated. When the authority and receipt are both securely
+      // absent but new authority creation fails (fenceFailed without
+      // recoveryBlocked), the documented contract runs the complete preflight
+      // and recovery and reports the publication failure afterwards, exactly
+      // as `launch` does for the same decision (#9280).
+      if (
+        readiness.fenceFailed &&
+        readiness.authorityUnsupported !== true &&
+        readiness.recoveryBlocked
+      ) {
         console.error(
-          readiness.recoveryBlocked
-            ? "  Probe failed: complete probe and recovery did not run because prior launch-readiness evidence could not be fenced. Repair the current user's secure OS runtime authority and NemoClaw state permissions, then retry."
-            : "  Probe failed: no prior launch-readiness evidence can be accepted, but new launch-readiness authority could not be created. Repair the current user's secure OS runtime authority and NemoClaw state permissions, then retry.",
+          "  Probe failed: complete probe and recovery did not run because prior launch-readiness evidence could not be fenced. Repair the current user's secure OS runtime authority and NemoClaw state permissions, then retry.",
         );
         process.exit(1);
       }


### PR DESCRIPTION
## Summary

On Ubuntu 24.04, `nemoclaw <name> connect --probe-only` exits 1 with *"no prior launch-readiness evidence can be accepted, but new launch-readiness authority could not be created"* **before running any preflight or recovery**, whenever the launch-readiness authority and receipt are both securely absent and new authority creation fails (e.g. no per-user OS runtime authority in the current session).

That early exit contradicts the shipped contract in two places:

- **Docs** (`docs/reference/commands.mdx`): "A securely absent runtime authority and receipt let ordinary `launch` run the complete preflight without optimization if new authority creation fails, but `connect --probe-only` still exits nonzero **because it could not publish launch-readiness evidence**" — i.e. the preflight runs and only the publication fails.
- **`launchSandbox`** (`src/lib/actions/sandbox/launch.ts`): refuses only on `decision.recoveryBlocked` and runs the complete preflight for this same decision.

## Change

- `connectSandbox` probe-only guard now exits early only when `recoveryBlocked` is set (a prior epoch might exist and could not be durably rotated). The securely-absent case (`fenceFailed` with `recoveryBlocked === false`) proceeds into the launch-readiness mutation gate.
- Safety is preserved: the gate independently re-verifies via `checkLaunchReadinessMutationAuthority(null)` that **both stores are still missing** before admitting the null-epoch recovery; any other state returns `changed`/`unsafe` and recovery does not run.
- After recovery, publication reports honestly: "Probe failed: complete probe and recovery succeeded, but final launch-readiness evidence could not be verified or published." (exit 1, per the documented Linux contract). Lifecycle callers with `requireLaunchReadinessPublication: false` now continue after recovery instead of failing before it.
- Rewrote the test that pinned the early exit (`connect-flow.test.ts`) to assert recovery runs, publication is attempted, and the misleading message is gone.

## Why Refs, not Closes

The issue's Expected Result asks for exit 0. The documented contract deliberately keeps `connect --probe-only` nonzero on Linux when evidence cannot be published, because a missing per-user runtime authority is a deployment signal infrastructure must repair. This PR fixes the defective part — recovery not running and the misleading refusal — and keeps the documented exit code. If maintainers want exit 0 for the securely-absent case (mirroring #9282's treatment of platform-unsupported evidence), that is a small follow-up on top of this change.

With this fix, the reproduction now prints "Probe complete: … restored dashboard port forward." followed by the honest publication failure, instead of refusing to recover at all.

Refs #9280

## Testing

- `npx vitest run src/lib/actions/sandbox/connect-flow.test.ts` (35 passed)
- `npx vitest run test/cli/connect-recovery.test.ts` (5 passed)
- sibling probe/readiness suites (93 passed), `npm run typecheck:cli`, `oxlint`, `npm run format:check` all clean

Signed-off-by: Dongni Yang <dongniy@nvidia.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved probe-only sandbox connection recovery when launch-readiness checks encounter fencing issues.
  * Recovery and sandbox setup now proceed in eligible cases, with failures reported as unavailable or unverifiable evidence.
  * Removed misleading authority-creation failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->