### PR TITLE
fix(checks): canonicalize source architecture root

### DIFF
--- a/scripts/checks/source-architecture.mts
+++ b/scripts/checks/source-architecture.mts
@@ -280,10 +280,13 @@ export function analyzeSourceArchitecture(
   repoRoot = REPO_ROOT,
   options: AnalyzeOptions = {},
 ): SourceArchitectureReport {
+  const canonicalRepoRoot = realpathSync(repoRoot);
   const scanRoots = options.scanRoots ?? DEFAULT_SCAN_ROOTS;
   const rootFileDirectories = options.rootFileDirectories ?? [];
   const absoluteFiles = [
-    ...new Set(scanRoots.flatMap((root) => [...walkSourceFiles(path.join(repoRoot, root))])),
+    ...new Set(
+      scanRoots.flatMap((root) => [...walkSourceFiles(path.join(canonicalRepoRoot, root))]),
+    ),
   ].sort();
   const sourceFiles = new Set(absoluteFiles);
   const edges = new Map<string, Set<string>>();
@@ -304,21 +307,27 @@ export function analyzeSourceArchitecture(
     }
   }
 
-  const files = absoluteFiles.map((file) => toRepoPath(repoRoot, file));
+  const files = absoluteFiles.map((file) => toRepoPath(canonicalRepoRoot, file));
   const fanIn = Object.fromEntries(
-    absoluteFiles.map((file) => [toRepoPath(repoRoot, file), fanInByAbsolutePath.get(file) ?? 0]),
+    absoluteFiles.map((file) => [
+      toRepoPath(canonicalRepoRoot, file),
+      fanInByAbsolutePath.get(file) ?? 0,
+    ]),
   );
   const fanOut = Object.fromEntries(
-    absoluteFiles.map((file) => [toRepoPath(repoRoot, file), edges.get(file)?.size ?? 0]),
+    absoluteFiles.map((file) => [toRepoPath(canonicalRepoRoot, file), edges.get(file)?.size ?? 0]),
   );
   const repoEdges = new Map(
     absoluteFiles.map((file) => [
-      toRepoPath(repoRoot, file),
-      new Set([...(edges.get(file) ?? [])].map((target) => toRepoPath(repoRoot, target))),
+      toRepoPath(canonicalRepoRoot, file),
+      new Set([...(edges.get(file) ?? [])].map((target) => toRepoPath(canonicalRepoRoot, target))),
     ]),
   );
   const rootFiles = Object.fromEntries(
-    rootFileDirectories.map((directory) => [directory, countRootFiles(repoRoot, directory)]),
+    rootFileDirectories.map((directory) => [
+      directory,
+      countRootFiles(canonicalRepoRoot, directory),
+    ]),
   );
 
   return {

--- a/test/source-architecture.test.ts
+++ b/test/source-architecture.test.ts
@@ -137,6 +137,31 @@ describe("source architecture budget (#7692)", () => {
     expect(report.fanIn).toMatchObject({ "bin/b.js": 1, "src/b.ts": 1 });
   });
 
+  test("reports repository-relative paths through an aliased repository root (#7692)", ({
+    resources,
+  }) => {
+    const root = resources.temporaryDirectory("nemoclaw-architecture-canonical-root-");
+    const aliasRoot = path.join(
+      resources.temporaryDirectory("nemoclaw-architecture-root-alias-"),
+      "repo",
+    );
+    writeModule(root, "src/a.ts", 'import "./b";\n');
+    writeModule(root, "src/b.ts", "export {};\n");
+    fs.symlinkSync(root, aliasRoot, process.platform === "win32" ? "junction" : "dir");
+
+    const report = analyzeSourceArchitecture(aliasRoot, {
+      scanRoots: ["src"],
+      rootFileDirectories: ["src"],
+    });
+
+    expect(report).toMatchObject({
+      files: ["src/a.ts", "src/b.ts"],
+      fanIn: { "src/a.ts": 0, "src/b.ts": 1 },
+      fanOut: { "src/a.ts": 1, "src/b.ts": 0 },
+      rootFiles: { src: 2 },
+    });
+  });
+
   test("ignores type-only dependency cycles", ({ resources }) => {
     const root = resources.temporaryDirectory("nemoclaw-architecture-types-");
     writeModule(root, "src/a.ts", 'import type { B } from "./b";\nexport type A = B;\n');


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Canonicalizes the repository root before the source-architecture check scans files or reports paths. This keeps macOS temporary repositories exposed through `/var` aliases aligned with their `/private/var` file identities instead of reporting paths outside the repository.

## Changes

- Resolve the supplied repository root once before scanning, repository-path conversion, edge reporting, and root-file counts.
- Add a real symlink/junction-root regression that verifies repository-relative files, fan-in, fan-out, and root-file counts.
- Preserve production behavior, architecture budgets, and descendant-symlink exclusion unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable — justification: This changes an internal repository architecture check and its regression coverage only; no production implementation or supported user surface changes.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change canonicalizes an aliased repository root inside an internal source-architecture check so reports remain repository-relative. It changes no production implementation, public behavior, configuration, workflow, or supported product surface.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 848e0f05a -->
<!-- docs-review-agents-blob-sha: b9fb6a9ba -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/source-architecture.test.ts`: 8/8 passed on macOS; CLI typecheck, repository checks, source-shape, test-size, conditionals, loops, formatting, and lint also passed.
- [ ] Applicable broad gate passed — Automatic current-commit Linux CI and Platform Evidence are pending on this draft PR.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-architecture analysis when repositories are accessed through symbolic links.
  * Reports now consistently show correct repository-relative file paths and dependency metrics, including fan-in, fan-out, and root-file counts.

* **Tests**
  * Added coverage to verify accurate analysis results for symlinked repository locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->