### PR TITLE
fix(onboard): narrow portable policy defaults

### DIFF
--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -155,9 +155,10 @@ The sandbox's filesystem, process, gateway authentication, and managed credentia
 Use this tier only for trusted personal workloads with trusted prompts and data.
 </Warning>
 
-By default, the experimental portable profile selects only `personal-open-internet` from the Personal tier.
-Portable onboarding does not add narrower Personal presets when it uses this default.
+For a fresh onboarding run, the experimental portable profile selects `weather`, `public-reference`, and `github` when `NEMOCLAW_POLICY_PRESETS` is unset, blank, or contains only whitespace.
+This default does not select `personal-open-internet`.
 If `NEMOCLAW_POLICY_PRESETS` contains a non-blank list, portable onboarding treats that explicit list as authoritative instead.
+`$$nemoclaw onboard --resume` does not inject the fresh-onboarding default.
 
 After selecting a tier, a combined preset and access-mode screen lets you include or exclude individual presets and toggle each between read (GET only) and read-write (GET + POST/PUT/PATCH) access.
 Tier-default presets are pre-selected; additional presets can be added from the built-in preset list available to the sandbox's active agent.

--- a/src/lib/onboard/portable-environment-scope.test.ts
+++ b/src/lib/onboard/portable-environment-scope.test.ts
@@ -51,6 +51,42 @@ describe("portable onboarding environment scope", () => {
     expect(env).toEqual({ NEMOCLAW_MODEL: "" });
   });
 
+  it("uses the narrow portable policy defaults when fresh intent is absent (#9200)", () => {
+    const env: NodeJS.ProcessEnv = {};
+    const scope = createPortableOnboardEnvironmentScope(env, null);
+
+    expect(env.NEMOCLAW_POLICY_PRESETS).toBe("weather,public-reference,github");
+    expect(env.NEMOCLAW_POLICY_PRESETS).not.toContain("personal-open-internet");
+
+    scope.restore();
+    expect(env).toEqual({});
+  });
+
+  it.each(["", "  \t "])(
+    "uses the narrow portable policy defaults and restores blank fresh intent %# (#9200)",
+    (policyPresets) => {
+      const env: NodeJS.ProcessEnv = { NEMOCLAW_POLICY_PRESETS: policyPresets };
+      const scope = createPortableOnboardEnvironmentScope(env, null);
+
+      expect(env.NEMOCLAW_POLICY_PRESETS).toBe("weather,public-reference,github");
+
+      scope.restore();
+      expect(env).toEqual({ NEMOCLAW_POLICY_PRESETS: policyPresets });
+    },
+  );
+
+  it("preserves a nonblank fresh portable policy list (#9200)", () => {
+    const env: NodeJS.ProcessEnv = {
+      NEMOCLAW_POLICY_PRESETS: "github,weather",
+    };
+    const scope = createPortableOnboardEnvironmentScope(env, null);
+
+    expect(env.NEMOCLAW_POLICY_PRESETS).toBe("github,weather");
+
+    scope.restore();
+    expect(env).toEqual({ NEMOCLAW_POLICY_PRESETS: "github,weather" });
+  });
+
   it("uses the activation model instead of ambient fresh model intent (#9200)", () => {
     const env: NodeJS.ProcessEnv = { NEMOCLAW_MODEL: "ambient/model" };
     const scope = createPortableOnboardEnvironmentScope(env, {

--- a/src/lib/onboard/session-bootstrap.ts
+++ b/src/lib/onboard/session-bootstrap.ts
@@ -107,6 +107,8 @@ const PORTABLE_OWNED_ENV_KEYS = [
   ...PORTABLE_DEFAULT_ENV_KEYS,
 ] as const;
 
+const PORTABLE_DEFAULT_POLICY_PRESETS = "weather,public-reference,github";
+
 interface PreviousEnvironmentValue {
   readonly present: boolean;
   readonly value: string | undefined;
@@ -220,12 +222,14 @@ export function createPortableOnboardEnvironmentScope(
   }
   if (!options.resume) {
     const requestedModel = previous.get("NEMOCLAW_MODEL")?.value?.trim();
+    const requestedPolicyPresets = previous.get("NEMOCLAW_POLICY_PRESETS")?.value;
     env[TOOL_DISCLOSURE_ENV] = "direct";
     env.NEMOCLAW_PROVIDER = activation ? "custom" : "ollama";
     env.NEMOCLAW_MODEL = activation?.model ?? (requestedModel || "qwen3-vl:4b");
     env.NEMOCLAW_POLICY_MODE = "custom";
-    env.NEMOCLAW_POLICY_PRESETS =
-      previous.get("NEMOCLAW_POLICY_PRESETS")?.value ?? "personal-open-internet";
+    env.NEMOCLAW_POLICY_PRESETS = requestedPolicyPresets?.trim()
+      ? requestedPolicyPresets
+      : PORTABLE_DEFAULT_POLICY_PRESETS;
     env.NEMOCLAW_POLICY_TIER = "personal";
   } else {
     const requestedPolicyPresets = previous.get("NEMOCLAW_POLICY_PRESETS")?.value?.trim();


### PR DESCRIPTION
## Summary

Fresh Portable onboarding previously selected the hostless `personal-open-internet` preset when no explicit policy list was supplied. It now defaults to the narrower `weather`, `public-reference`, and `github` presets, while nonblank operator overrides and resume authority remain unchanged.

## Related Issue

Part of #9200 and #9206.

## Changes

- default fresh Portable policy selection to `weather,public-reference,github` for absent, empty, or whitespace-only intent
- keep nonblank `NEMOCLAW_POLICY_PRESETS` authoritative and leave resume behavior unchanged
- document the fresh default and add positive and negative regression coverage

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent nine-category review passed all categories on `6df172770` and binary diff `0ddc8bce...`.
- [x] Non-success, skipped, or missing CI check accepted by maintainer — the Nemotron second-opinion lane failed because its SDK emitted text before a required terminology tool result completed. The primary Terra lane completed with zero findings and the published advisor recommendation is `merge_as_is`; no candidate follow-up is required.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/network-policies.mdx`; variants, routes, and Fern build passed with 0 errors and 2 existing warnings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 6df172770 -->
<!-- docs-review-agents-blob-sha: b9fb6a9ba -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `66/66` focused owner and policy-selection tests; `1,525/1,525` current-main changed-impact tests.
- [x] Applicable broad gate passed — this three-file scoped default change does not require the broad runtime or repository-wide coverage gate; current-main changed-impact, repository architecture/composition, typecheck, lint, and hooks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors and 2 existing repository warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Fresh Portable L40S validation

- Environment: dedicated Ubuntu 22.04.5 Brev host with NVIDIA L40S 48 GB
- Host admission: reviewed v2.1 preparation, real reboot, and strict read-only post-reboot check passed; rootless Podman client/server 5.7.0, cgroups v2, Netavark, exact mode-0600 current-user socket, and all four CPU-controller boundaries passed
- Installed source: exact commit `6df172770c11115b931f06390fdf417feedffa79`, confirmed from the installed source checkout
- Installer: fresh non-interactive Portable onboarding completed 8/8 in 585 seconds with `ollama` and `qwen3.6:35b`; the requested model was not substituted
- Sandbox: `my-assistant` reached `Ready`; gateway, dashboard, inference route, Ollama backend, and auth proxy were healthy
- GPU: direct sandbox `nvidia-smi`, `/proc` task-name write, and CUDA `cuInit(0)` proofs passed
- Policy: onboarding applied and loaded exactly `weather`, `public-reference`, and `github` as policy version 3; `personal-open-internet` was absent
- Network probes: `https://wttr.in/` succeeded through the `weather` policy; `https://example.com/` was denied
- Real chat: OpenClaw returned exactly `NEMOCLAW_PORTABLE_L40S_OK` in 1.605 seconds using `qwen3.6:35b`; execution reported no fallback
- Capacity: 36,965,822,464 bytes remained free on `/` after model, image, sandbox, and chat completion

The first installer invocation included the unsupported `--yes` option and stopped at argument parsing before product mutation. The same exact commit was then run with only that invalid option removed.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
