### PR TITLE
fix(onboard): preserve lifecycle channel selections

### DIFF
--- a/src/lib/onboard/machine/handlers/sandbox-messaging.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.test.ts
@@ -424,6 +424,22 @@ describe("reconcileReusedSandboxMessaging", () => {
     expect(result.selectedChannels).toEqual(["whatsapp"]);
   });
 
+  it("keeps a lifecycle-selected channel in a reused sandbox selection (#9283)", () => {
+    const plan = {
+      ...discordPlan(hashCredential("previous-discord-token") ?? ""),
+      workflow: "add-channel" as const,
+    };
+    vi.stubEnv("DISCORD_BOT_TOKEN", "");
+
+    const result = reconcileReusedSandboxMessaging(
+      plan,
+      { name: "openclaw" },
+      { clearPlanEnv() {} },
+    );
+
+    expect(result).toEqual({ plan, selectedChannels: ["discord"], changed: false });
+  });
+
   it("removes every unsupported channel artifact from a reused plan", () => {
     // Keep the channel host-configured so this case stays about unsupported
     // artifact removal, not the #9283 unconfigured-channel selection filter.

--- a/src/lib/onboard/machine/handlers/sandbox-messaging.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.test.ts
@@ -613,6 +613,30 @@ describe("reconcileSandboxMessaging plan authority", () => {
     expect(result).toEqual({ plan: null, selectedChannels: ["whatsapp"] });
   });
 
+  it("keeps a lifecycle-selected channel in a completed registry resume (#9283)", async () => {
+    const registryPlan = {
+      ...discordPlan(hashCredential("previous-discord-token") ?? ""),
+      workflow: "add-channel" as const,
+    };
+    const deps = reconcileDeps([]);
+    deps.getRegistrySandboxMessagingAuthority.mockReturnValue({
+      authoritative: true,
+      plan: registryPlan,
+    });
+    vi.stubEnv("DISCORD_BOT_TOKEN", "");
+
+    const result = await reconcileSandboxMessaging({
+      resume: true,
+      session: completedCheckpointSession(registryPlan),
+      sandboxName: "alpha",
+      agent: { name: "openclaw" },
+      deps,
+    });
+
+    expect(deps.setupMessagingChannels).not.toHaveBeenCalled();
+    expect(result).toEqual({ plan: registryPlan, selectedChannels: ["discord"] });
+  });
+
   it("keeps an in-sandbox QR channel in a completed registry resume (#9109)", async () => {
     const registryPlan = whatsappPlan();
     const deps = reconcileDeps([]);

--- a/src/lib/onboard/machine/handlers/sandbox-messaging.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.ts
@@ -615,6 +615,7 @@ async function selectionFromRegistryAuthority<Agent>(
       authority.plan,
       false,
     );
+    if (authority.plan && registryPlanRecordsLifecycleSelection(authority.plan)) return selection;
     return filterUnconfiguredHostChannelsFromSelection(selection, options.agent);
   }
   if (authority.plan) return selectionFromRegistryPlan(authority.plan, options);

--- a/src/lib/onboard/machine/handlers/sandbox-messaging.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.ts
@@ -435,15 +435,16 @@ export function reconcileReusedSandboxMessaging<Agent>(
   const filtered = plan ? filterMessagingPlanForCurrentAgent(plan, agent) : null;
   const changed = !isDeepStrictEqual(filtered, recordedPlan);
   if (changed) deps.clearPlanEnv();
-  // The reused plan records the previous selection, not the current host
-  // input. Report only channels the environment still configures so the
-  // policies handler can classify a retired channel as unconfigured and drop
-  // its egress preset (#9283). The plan itself stays untouched.
+  const selection = {
+    plan: filtered,
+    selectedChannels: getActiveChannelsFromPlan(filtered),
+  };
+  const currentSelection =
+    filtered && registryPlanRecordsLifecycleSelection(filtered)
+      ? selection
+      : filterUnconfiguredHostChannelsFromSelection(selection, agent);
   return {
-    ...filterUnconfiguredHostChannelsFromSelection(
-      { plan: filtered, selectedChannels: getActiveChannelsFromPlan(filtered) },
-      agent,
-    ),
+    ...currentSelection,
     changed,
   };
 }


### PR DESCRIPTION
## Summary

Preserve explicit messaging lifecycle selections when a reused sandbox or completed registry resume has no matching host credential. This complements the retired-channel filtering merged in #9327 without reintroducing any of that PR's now-upstream implementation or tests.

## Related Issue

Fixes #9283

## Changes

- Keep a lifecycle-authored selection from `channels add`, `remove`, `start`, or `stop` authoritative in the reused-sandbox path.
- Apply the same lifecycle exception to completed registry resume reconciliation.
- Add focused regression tests for both lifecycle-owned paths; retired host-backed and QR-channel controls remain supplied by #9327.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/machine/handlers/sandbox-messaging.test.ts` (30 passed)
- [x] Applicable broad gate passed — `npm run typecheck:cli`; `npm run lint`
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved lifecycle-selected Discord channels when reusing a sandbox, even if the host credential is unavailable.
  * Preserved selected channels when resuming completed sandbox setups.
  * Prevented unnecessary messaging setup during completed resume flows when configuration is unavailable.
  * Improved consistency between sandbox reuse and registry-based resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->