### PR TITLE
fix(policy): remove a preset the gateway enforces without a local record

### DIFF
--- a/docs/network-policy/apply-policy-presets.mdx
+++ b/docs/network-policy/apply-policy-presets.mdx
@@ -4,8 +4,8 @@
 title: "Apply Policy Presets"
 sidebar-title: "Apply Policy Presets"
 description: "Add, reapply, list, or remove policy presets for a running NemoClaw sandbox."
-description-agent: "Applies and manages policy presets for a running sandbox. Use when adding maintained integration access, previewing preset scope, reapplying an edited preset, or removing access."
-keywords: ["nemoclaw policy presets", "policy add", "policy remove"]
+description-agent: "Applies and manages policy presets for a running sandbox. Use when adding maintained integration access, previewing preset scope, reapplying an edited preset, removing access, or removing a preset the gateway enforces without a local record."
+keywords: ["nemoclaw policy presets", "policy add", "policy remove", "active on gateway missing from local state"]
 content:
   type: "how_to"
 skill:
@@ -111,12 +111,43 @@ $$nemoclaw my-assistant policy remove weather --yes
 
 `policy remove` accepts maintained and custom preset names.
 
+## Remove a Preset the Gateway Enforces Without a Local Record
+
+`policy list` marks a preset that the OpenShell gateway enforces while no local record explains it:
+
+```bash
+$$nemoclaw my-assistant policy list
+```
+
+Expected output:
+
+```text
+    ● github [source unverified] — GitHub.com and GitHub API access (git) (active on gateway, missing from local state)
+```
+
+`policy remove` accepts that preset:
+
+```bash
+$$nemoclaw my-assistant policy remove github --yes
+```
+
+It narrows the live policy and clears whatever local record remains.
+
+When NemoClaw cannot reach the gateway, `policy remove <preset>` has only the local record to check.
+It refuses an unrecorded preset and reports that it could not query the gateway, rather than treating an unanswered query as absence.
+The interactive picker lists the recorded presets only in that case.
+
 ## Understand Persistence
 
 Dynamic changes apply to the current live policy.
 NemoClaw also records maintained presets and custom presets applied through `--from-file` or `--from-dir`.
 The custom preset record includes the full YAML content.
 Snapshot restore and rebuild replay the recorded presets, even when the original custom file no longer exists.
+
+A sandbox that is absent from the local registry has nothing to record a preset against.
+For a maintained preset, `policy add` still applies it to the gateway and warns that `policy list` reports it as active on gateway, missing from local state.
+For a custom preset applied with `--from-file` or `--from-dir`, `policy add` reaches the gateway but exits non-zero, because a custom preset is discoverable only through the registry and would appear in neither `policy list` nor `status`.
+Recover or re-onboard the sandbox to restore the record, then re-apply any custom preset that failed this way.
 
 `$$nemoclaw <name> rebuild` reapplies every recorded policy preset to the recreated sandbox.
 For baseline changes that apply to every future sandbox, follow [Change the Baseline Network Policy](change-baseline-network-policy).

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -2510,6 +2510,8 @@ If the base policy read returns non-empty output that NemoClaw cannot parse, the
 Fix the gateway or policy read problem, then rerun the command.
 For custom presets, the command also reports when the preset reached the gateway but NemoClaw could not record it in the local sandbox registry, because unrecorded custom presets will not appear in `policy list` or `status`.
 Recover or re-onboard the sandbox, then re-apply the custom preset.
+For built-in presets in that same case, the command applies the preset and returns success, because a built-in preset stays discoverable from the gateway.
+It warns that `policy list` will report the preset as active on gateway, missing from local state.
 
 With `--from-file` or `--from-dir`, pass a repeatable `--trusted-private-host <exact-host-or-ip>` option to admit matching RFC1918, carrier-grade network address translation (CGNAT), or IPv6 unique local endpoints.
 The option is invalid for built-in presets.
@@ -2590,7 +2592,7 @@ $$nemoclaw my-assistant policy list
 ### `$$nemoclaw <name> policy remove`
 
 Remove a previously applied policy preset from a sandbox.
-The command lists only the presets currently applied, prompts you to select one, shows the endpoints that would be removed, and asks for confirmation before narrowing egress.
+The command lists the presets the local registry records together with the presets the live gateway enforces, prompts you to select one, shows the endpoints that would be removed, and asks for confirmation before narrowing egress.
 
 ```bash
 $$nemoclaw my-assistant policy remove
@@ -2604,7 +2606,9 @@ $$nemoclaw my-assistant policy remove pypi --yes
 
 Set `NEMOCLAW_NON_INTERACTIVE=1` as an alternative to `--yes`.
 Without a preset name, `policy remove` reports the same two picker errors as `policy add` and exits non-zero.
-If the preset is unknown or not currently applied, the command exits non-zero with a clear error.
+If the preset is unknown, or neither the local registry nor the live gateway holds it, the command exits non-zero with a clear error.
+A preset the gateway enforces without a local registry record is removable, which is the state `policy list` reports as active on gateway, missing from local state.
+When NemoClaw cannot query the gateway, the command checks the local registry alone; with a preset name it also reports that the gateway could not be queried.
 
 | Flag | Description |
 |------|-------------|

--- a/src/lib/actions/sandbox/policy-channel-lock.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-lock.test.ts
@@ -51,6 +51,7 @@ describe("policy and channel sandbox mutation locking", () => {
     ]);
     vi.spyOn(policies, "listCustomPresets").mockReturnValue([]);
     vi.spyOn(policies, "getAppliedPresets").mockReturnValue(["pypi"]);
+    vi.spyOn(policies, "getGatewayPresets").mockReturnValue(null);
     vi.spyOn(policies, "loadPresetForSandbox").mockImplementation(
       (_sandboxName, presetName) =>
         `network_policies:\n  ${presetName}:\n    name: ${presetName}\n    endpoints:\n      - host: example.com\n        port: 443\n`,

--- a/src/lib/actions/sandbox/policy-channel-policy.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-policy.test.ts
@@ -46,6 +46,7 @@ let exitSpy: MockInstance;
 let promptMock: MockInstance;
 let getSandboxMock: MockInstance;
 let getAppliedPresetsMock: MockInstance;
+let getGatewayPresetsMock: MockInstance;
 let selectFromListMock: MockInstance;
 let selectForRemovalMock: MockInstance;
 let loadPresetForSandboxMock: MockInstance;
@@ -108,6 +109,7 @@ beforeEach(() => {
   vi.spyOn(policies, "listPresets").mockReturnValue(POLICY_PRESETS);
   vi.spyOn(policies, "listCustomPresets").mockReturnValue([]);
   getAppliedPresetsMock = vi.spyOn(policies, "getAppliedPresets").mockReturnValue([]);
+  getGatewayPresetsMock = vi.spyOn(policies, "getGatewayPresets").mockReturnValue(null);
   selectFromListMock = vi.spyOn(policies, "selectFromList").mockResolvedValue("pypi");
   selectForRemovalMock = vi.spyOn(policies, "selectForRemoval").mockResolvedValue("pypi");
   vi.spyOn(policies, "loadPreset").mockImplementation((name: unknown) => {
@@ -419,5 +421,60 @@ describe("removeSandboxPolicy", () => {
 
     expect(printedText()).toContain("No input available on stdin");
     expect(removePresetMock).not.toHaveBeenCalled();
+  });
+
+  it("removes a preset the gateway enforces but the registry never recorded (#9295)", async () => {
+    getAppliedPresetsMock.mockReturnValue([]);
+    getGatewayPresetsMock.mockReturnValue(["npm"]);
+
+    await removeSandboxPolicy("test-sandbox", { preset: "npm", yes: true });
+
+    expect(removePresetMock).toHaveBeenCalledWith("test-sandbox", "npm");
+  });
+
+  it("refuses a preset neither the registry nor the gateway holds (#9295)", async () => {
+    getAppliedPresetsMock.mockReturnValue([]);
+    getGatewayPresetsMock.mockReturnValue(["pypi"]);
+
+    await expect(
+      captureExit(() => removeSandboxPolicy("test-sandbox", { preset: "npm", yes: true })),
+    ).resolves.toBe(1);
+
+    expect(printedText()).toContain("Preset 'npm' is not applied.");
+    expect(removePresetMock).not.toHaveBeenCalled();
+  });
+
+  it("names the unreachable gateway when it refuses on local state alone (#9295)", async () => {
+    getAppliedPresetsMock.mockReturnValue([]);
+    getGatewayPresetsMock.mockReturnValue(null);
+
+    await expect(
+      captureExit(() => removeSandboxPolicy("test-sandbox", { preset: "npm", yes: true })),
+    ).resolves.toBe(1);
+
+    expect(printedText()).toContain(
+      "Could not query the gateway, so only local state was checked.",
+    );
+    expect(removePresetMock).not.toHaveBeenCalled();
+  });
+
+  it("offers a gateway-only preset in the removal picker (#9295)", async () => {
+    getGatewayPresetsMock.mockReturnValue(["npm"]);
+
+    await removeSandboxPolicy("test-sandbox");
+
+    expect(selectForRemovalMock).toHaveBeenCalledWith(POLICY_PRESETS, {
+      applied: ["pypi", "npm"],
+    });
+  });
+
+  it("lists a preset both sources hold only once in the removal picker (#9295)", async () => {
+    getGatewayPresetsMock.mockReturnValue(["pypi", "npm"]);
+
+    await removeSandboxPolicy("test-sandbox");
+
+    expect(selectForRemovalMock).toHaveBeenCalledWith(POLICY_PRESETS, {
+      applied: ["pypi", "npm"],
+    });
   });
 });

--- a/src/lib/actions/sandbox/policy-channel-refresh.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-refresh.test.ts
@@ -92,6 +92,7 @@ beforeEach(() => {
   vi.spyOn(policies, "listPresets").mockReturnValue(POLICY_PRESETS);
   vi.spyOn(policies, "listCustomPresets").mockReturnValue([]);
   vi.spyOn(policies, "getAppliedPresets").mockReturnValue([]);
+  vi.spyOn(policies, "getGatewayPresets").mockReturnValue(null);
   vi.spyOn(policies, "selectFromList").mockResolvedValue("pypi");
   vi.spyOn(policies, "selectForRemoval").mockResolvedValue("pypi");
   vi.spyOn(policies, "loadPreset").mockImplementation((name: unknown) => {

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -1981,7 +1981,15 @@ async function removeSandboxPolicyUnlocked(
   const builtinPresets = policies.listPresets();
   const customPresets = policies.listCustomPresets(sandboxName);
   const allPresets = [...builtinPresets, ...customPresets];
+  // `policy list` reports a preset as active when either the registry or the
+  // gateway holds it, so removal has to accept the same set. A preset the
+  // gateway enforces but the registry never recorded is exactly the state
+  // `policy list` flags as "active on gateway, missing from local state", and
+  // removePreset() reconciles it without needing the registry entry. Null means
+  // the gateway could not be queried, which is not evidence of absence. (#9295)
   const applied = policies.getAppliedPresets(sandboxName);
+  const gatewayPresets = policies.getGatewayPresets(sandboxName);
+  const removable = gatewayPresets ? [...new Set([...applied, ...gatewayPresets])] : applied;
 
   const presetArg = options.preset;
   let answer = null;
@@ -1995,8 +2003,11 @@ async function removeSandboxPolicyUnlocked(
       );
       process.exit(1);
     }
-    if (!applied.includes(preset.name)) {
+    if (!removable.includes(preset.name)) {
       console.error(`  Preset '${preset.name}' is not applied.`);
+      if (gatewayPresets === null) {
+        console.error("  Could not query the gateway, so only local state was checked.");
+      }
       process.exit(1);
     }
     answer = preset.name;
@@ -2009,7 +2020,7 @@ async function removeSandboxPolicyUnlocked(
       exitPromptStdinClosed(usage);
     }
     answer = await pickPresetOrExit(
-      () => policies.selectForRemoval(allPresets, { applied }),
+      () => policies.selectForRemoval(allPresets, { applied: removable }),
       usage,
     );
   }

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -2131,6 +2131,16 @@ function applyPresetContent(
         `re-onboard the sandbox, then re-apply.`,
     );
     return false;
+  } else {
+    // A built-in preset stays discoverable from the gateway, so the mutation
+    // stands. Name the gap anyway: silence here is what leaves an operator
+    // holding egress that no local state explains. (#9295)
+    console.error(
+      `  Warning: '${presetName}' was applied to the gateway but could not be ` +
+        `recorded locally because sandbox '${sandboxName}' is not in the ` +
+        `registry, so policy list will report it as active on gateway, missing ` +
+        `from local state.`,
+    );
   }
 
   return true;

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -736,11 +736,12 @@ exit 1
     });
   });
 
-  describe("policy-add --from-file false success when the sandbox is absent from the registry (#4510)", () => {
+  describe("policy-add when the sandbox is absent from the registry (#4510, #9295)", () => {
     const registryModule = requireForTest(
       path.join(REPO_ROOT, "src", "lib", "state", "registry.ts"),
     ) as Record<string, any>;
     const CUSTOM_CONTENT = "network_policies:\n  slack-files-upload:\n    host: files.slack.com\n";
+    const BUILTIN_CONTENT = "network_policies:\n  github:\n    host: github.com\n";
     const SOURCE_PATH = "/tmp/slack-files-upload-case.yaml";
 
     let tmpHome: string;
@@ -749,6 +750,7 @@ exit 1
     let resolveSpy: ReturnType<typeof vi.spyOn>;
     let savedGetSandbox: any;
     let savedAddCustomPolicy: any;
+    let savedUpdateSandbox: any;
 
     beforeEach(() => {
       tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-issue4510-"));
@@ -767,6 +769,7 @@ exit 1
         .mockReturnValue(fakeOpenshell);
       savedGetSandbox = registryModule.getSandbox;
       savedAddCustomPolicy = registryModule.addCustomPolicy;
+      savedUpdateSandbox = registryModule.updateSandbox;
     });
 
     afterEach(() => {
@@ -775,6 +778,7 @@ exit 1
       resolveSpy.mockRestore();
       registryModule.getSandbox = savedGetSandbox;
       registryModule.addCustomPolicy = savedAddCustomPolicy;
+      registryModule.updateSandbox = savedUpdateSandbox;
       fs.rmSync(tmpHome, { recursive: true, force: true });
     });
 
@@ -804,6 +808,32 @@ exit 1
         expect(combined).toContain("my-assistant");
         expect(combined).toMatch(/could not be\s+recorded locally/);
         expect(combined).toMatch(/policy list or status/);
+      } finally {
+        errSpy.mockRestore();
+        logSpy.mockRestore();
+      }
+    });
+
+    it("warns but keeps the mutation when a built-in preset cannot be recorded locally (#9295)", () => {
+      registryModule.getSandbox = () => null;
+      const updateSpy = vi.fn(() => true);
+      registryModule.updateSandbox = updateSpy;
+      const errors: string[] = [];
+      const errSpy = vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+        errors.push(a.map((x) => String(x)).join(" "));
+      });
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      try {
+        // A built-in preset stays discoverable from the gateway, so the applied
+        // policy stands. The warning is what tells the operator why policy list
+        // will report it without local state behind it.
+        const result = policies.applyPresetContent("my-assistant", "github", BUILTIN_CONTENT, {});
+        expect(result).toBe(true);
+        expect(updateSpy).not.toHaveBeenCalled();
+        const combined = errors.join("\n");
+        expect(combined).toContain("my-assistant");
+        expect(combined).toMatch(/could not be\s+recorded locally/);
+        expect(combined).toMatch(/active on gateway, missing\s+from local state/);
       } finally {
         errSpy.mockRestore();
         logSpy.mockRestore();


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->
`policy list` reports a preset as active when either the local registry or the live gateway holds it, but `policy remove` consulted the registry alone and exited non-zero with `Preset 'X' is not applied.`, so the one state `policy list` exists to flag — active on gateway, missing from local state — was the only state with no removal path. `policy remove` now builds a single removable set from both sources and uses it for the named-preset guard and the interactive picker alike, and it distinguishes a gateway it could not query from a gateway that does not hold the preset. Applying a built-in preset to a sandbox that is missing from the registry no longer returns success in silence, which closes one way that divergence is created.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Fixes #9295

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->
- `removeSandboxPolicyUnlocked` in `src/lib/actions/sandbox/policy-channel.ts` derives one `removable` set from `getAppliedPresets` and `getGatewayPresets`, and both the named-preset guard and the `selectForRemoval` picker read it. Computing it once is what keeps the two entry points from disagreeing, which is the shape of the reported defect. `removePreset` already reconciles a gateway-held preset without a registry entry, so the CLI guard was the only obstacle. Covered by `removes a preset the gateway enforces but the registry never recorded`, `offers a gateway-only preset in the removal picker`, and `lists a preset both sources hold only once in the removal picker`.
- A `null` from `getGatewayPresets` means the gateway could not be queried, not that the preset is absent, so the command falls back to the registry and names the evidence it had instead of asserting the preset is not applied. Covered by `names the unreachable gateway when it refuses on local state alone`; the unchanged refusal path is covered by `refuses a preset neither the registry nor the gateway holds`.
- The built-in arm of `applyPresetContent` in `src/lib/policy/index.ts` warns when the sandbox has no registry entry instead of returning `true` in silence. It keeps the successful gateway mutation, because a built-in preset stays discoverable from the gateway and is now removable; the custom arm still returns `false`, because a custom preset is discoverable only through the registry. Covered by `warns but keeps the mutation when a built-in preset cannot be recorded locally`.
- `src/lib/actions/sandbox/policy-channel-refresh.test.ts` and `policy-channel-lock.test.ts` gain a `getGatewayPresets` stub. Without it the new gateway read in `policy remove` would make those unit tests spawn a real `openshell policy get`.
- `docs/network-policy/apply-policy-presets.mdx` documents removing a preset the gateway enforces without a local record, the unreachable-gateway behavior, and the unrecorded-sandbox case for maintained and custom presets. `docs/reference/commands.mdx` updates the `policy add` and `policy remove` reference sections to match.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line and one docs line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review
<!-- Required for code and documentation changes after the changes and applicable validation are complete. Keep one review checkbox and one instance of each visible or hidden field. For Evidence, list changed documentation paths. For documentation-only changes, also state that the writing rules and documentation style were reviewed. For other results, explain why no documentation change is needed or why the review is blocked. For Agent, use a consistent product and surface name, such as Codex Desktop, Codex CLI, Claude Code, or Cursor. After committing all review changes, put `git rev-parse --short HEAD` and `git rev-parse --short HEAD:AGENTS.md` in the hidden metadata below. Rerun the review and refresh that metadata after any new commit. This receipt is advisory during the data-collection pilot. -->
- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/network-policy/apply-policy-presets.mdx`, `docs/reference/commands.mdx`. The review returned request-changes. Its blocking finding was that the persistence paragraph stated the built-in outcome without scoping it, so a reader applying a custom preset with `--from-file` to an unregistered sandbox would expect a gateway-active preset when the command in fact exits non-zero and the preset appears nowhere. It also found the quoted `policy list` row indented two spaces where `formatPolicyListPresetRow` emits four, no command block before the `Expected output:` lead-in, the gateway named without its OpenShell qualifier on first use, an unreachable-gateway sentence that did not scope its message to the named form, and both reference sections in `docs/reference/commands.mdx` left describing the previous behavior. All findings were verified against source and applied.
- Agent: Claude Code
<!-- docs-review-head-sha: 7ebf1a6f0 -->
<!-- docs-review-agents-blob-sha: b9fb6a9ba -->

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run src/lib/actions/sandbox/policy-channel-policy.test.ts src/lib/actions/sandbox/policy-channel-refresh.test.ts src/lib/actions/sandbox/policy-channel-lock.test.ts src/lib/actions/sandbox/policy-channel-list.test.ts` — 4 files, 81 tests passed; `npx vitest run --project integration test/policies.test.ts` — 1 file, 76 tests passed. Reverting only the two changed source files fails 5 of the 6 new cases, so they guard the behavior rather than restate it; the sixth is the preserved refusal path and passes either way by design. `npm run typecheck:cli` and `npm run lint` are clean. The two `fern check` warnings are pre-existing — rebuilding with the doc changes stashed reports the same two.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Policy removal now detects presets enforced by the gateway, including presets missing from local state.
  - Interactive removal lists combine locally recorded and gateway-reported presets.
  - Built-in presets can be applied successfully even when local registry recording is unavailable, with a warning.

- **Bug Fixes**
  - Improved handling and diagnostics when gateway state cannot be queried or presets exist in neither source.

- **Documentation**
  - Updated policy command and preset guides to explain gateway-only presets, warnings, and offline removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->