### PR TITLE
fix(status): keep the recorded API family when only the model drifts

### DIFF
--- a/docs/inference/verify-inference-route.mdx
+++ b/docs/inference/verify-inference-route.mdx
@@ -32,7 +32,9 @@ $$nemoclaw <name> status
 
 The `Inference` row first checks the sandbox's `inference.local` path.
 When that route responds, `status` sends one inference request through the same path.
-The row reports `healthy` only when the route returns a structurally valid result for the recorded API family.
+When the live provider matches the recorded provider, `status` validates the result against the recorded API family, even when only the model differs.
+When the live provider differs, `status` does not carry the recorded API family to the live provider.
+The row reports `healthy` only when the route returns a structurally valid result for the selected API family.
 An empty body, malformed JSON, provider-error envelope, or wrong response shape reports `unhealthy`, even with a 2xx status.
 Status diagnostics do not include the response body.
 An HTTP `401` or `403` response reports `unauthorized`.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1876,8 +1876,9 @@ An empty body, malformed JSON, provider-error envelope, or wrong response shape 
 The probe captures at most 64 KiB and does not include the response body in diagnostics.
 The route probe treats any final HTTP status from `200` through `499` as reachable, so a route with an invalidated provider credential answers HTTP `401` while the route is up.
 The request uses the live gateway route's provider and model, and falls back to the recorded values when the live route is unreadable.
-When the live provider and model match the recorded route, the request also uses the sandbox's recorded API family, including `openai-responses`.
-During route drift, NemoClaw does not carry the sandbox's recorded API family to the live provider and model.
+When the live provider matches the recorded provider, the request uses the sandbox's recorded API family, even when only the model differs.
+This includes `openai-responses`.
+When the live provider differs, NemoClaw does not carry the recorded API family to the live provider.
 An ordinary run sends one 16-token request through the stored provider credential, with a 30-second timeout, and consumes provider tokens on a hosted route.
 When the same `status` run recovers a managed gateway, it retries the route and inference request together up to three total attempts, with a two-second delay between failed attempts.
 Each attempt can consume another 16 tokens on a hosted route.

--- a/src/lib/actions/sandbox/status-snapshot-route-drift.test.ts
+++ b/src/lib/actions/sandbox/status-snapshot-route-drift.test.ts
@@ -190,13 +190,12 @@ describe("collectSandboxStatusSnapshot inference invocation route (#9302)", () =
   });
 
   /**
-   * Capture the route the in-sandbox invocation probe is asked to exercise.
-   * The probe reports the health that decides `status --json`'s exit code.
+   * The probe stub rejects a request that does not contain every expected route field.
    */
-  async function captureInvocationRoute(
+  async function collectInferenceHealth(
     entry: Partial<SandboxEntry>,
-  ): Promise<Record<string, unknown> | null> {
-    let seen: Record<string, unknown> | null = null;
+    expectedRoute: Record<string, unknown>,
+  ) {
     const sandbox = {
       name: "alpha",
       agent: "openclaw",
@@ -204,7 +203,7 @@ describe("collectSandboxStatusSnapshot inference invocation route (#9302)", () =
       gatewayName: "nemoclaw",
       ...entry,
     } as SandboxEntry;
-    await collectSandboxStatusSnapshot("alpha", {
+    const snapshot = await collectSandboxStatusSnapshot("alpha", {
       deps: {
         getSandbox: () => sandbox,
         listSandboxes: () => ({ sandboxes: [sandbox], defaultSandbox: "alpha" }),
@@ -217,12 +216,14 @@ describe("collectSandboxStatusSnapshot inference invocation route (#9302)", () =
           httpStatus: 200,
         }),
         probeSandboxInferenceInvocationImpl: (input: Record<string, unknown>) => {
-          seen = input;
-          return { ok: true };
+          const accepted = Object.entries(expectedRoute).every(
+            ([key, value]) => input[key] === value,
+          );
+          return accepted ? { ok: true } : { ok: false, reason: "unexpected invocation route" };
         },
       },
     } as never);
-    return seen;
+    return snapshot.inferenceHealth;
   }
 
   const recorded = {
@@ -234,36 +235,43 @@ describe("collectSandboxStatusSnapshot inference invocation route (#9302)", () =
   } satisfies Partial<SandboxEntry>;
 
   it("keeps the recorded API family when only the model drifted", async () => {
-    // The recorded family describes the provider, which has not changed, so
+    // The recorded API family describes the provider, which has not changed, so
     // dropping it would probe /v1/chat/completions against a responses-only
     // endpoint and report a healthy route as unhealthy.
     liveGatewayInference("compatible-endpoint", "live/model");
 
-    expect(await captureInvocationRoute(recorded)).toMatchObject({
-      provider: "compatible-endpoint",
-      model: "live/model",
-      preferredInferenceApi: "openai-responses",
-    });
+    expect(
+      await collectInferenceHealth(recorded, {
+        provider: "compatible-endpoint",
+        model: "live/model",
+        preferredInferenceApi: "openai-responses",
+      }),
+    ).toMatchObject({ ok: true, probed: true });
   });
 
   it("keeps the recorded API family when the route is aligned", async () => {
     liveGatewayInference("compatible-endpoint", "recorded/model");
 
-    expect(await captureInvocationRoute(recorded)).toMatchObject({
-      model: "recorded/model",
-      preferredInferenceApi: "openai-responses",
-    });
+    expect(
+      await collectInferenceHealth(recorded, {
+        provider: "compatible-endpoint",
+        model: "recorded/model",
+        preferredInferenceApi: "openai-responses",
+      }),
+    ).toMatchObject({ ok: true, probed: true });
   });
 
   it("drops the recorded API family when the provider itself drifted", async () => {
-    // Regression lock: one provider's family must never be carried onto
-    // another that may have no such endpoint.
+    // A provider change must remove the recorded API family because the live
+    // provider might not implement it.
     liveGatewayInference("nvidia-prod", "nvidia/nemotron");
 
-    expect(await captureInvocationRoute(recorded)).toMatchObject({
-      provider: "nvidia-prod",
-      model: "nvidia/nemotron",
-      preferredInferenceApi: null,
-    });
+    expect(
+      await collectInferenceHealth(recorded, {
+        provider: "nvidia-prod",
+        model: "nvidia/nemotron",
+        preferredInferenceApi: null,
+      }),
+    ).toMatchObject({ ok: true, probed: true });
   });
 });

--- a/src/lib/actions/sandbox/status-snapshot-route-drift.test.ts
+++ b/src/lib/actions/sandbox/status-snapshot-route-drift.test.ts
@@ -183,3 +183,87 @@ describe("collectSandboxStatusSnapshot route drift", () => {
     expect(snapshot.routeDrift).toMatchObject({ canConnect: false });
   });
 });
+
+describe("collectSandboxStatusSnapshot inference invocation route (#9302)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Capture the route the in-sandbox invocation probe is asked to exercise.
+   * The probe reports the health that decides `status --json`'s exit code.
+   */
+  async function captureInvocationRoute(
+    entry: Partial<SandboxEntry>,
+  ): Promise<Record<string, unknown> | null> {
+    let seen: Record<string, unknown> | null = null;
+    const sandbox = {
+      name: "alpha",
+      agent: "openclaw",
+      policies: [],
+      gatewayName: "nemoclaw",
+      ...entry,
+    } as SandboxEntry;
+    await collectSandboxStatusSnapshot("alpha", {
+      deps: {
+        getSandbox: () => sandbox,
+        listSandboxes: () => ({ sandboxes: [sandbox], defaultSandbox: "alpha" }),
+        reconcile: async () => ({ state: "present", output: "Phase: Ready" }),
+        probeProviderHealthImpl: () => null,
+        probeSandboxInferenceGatewayHealthImpl: async () => ({
+          ok: true,
+          endpoint: "https://inference.local/v1/models",
+          detail: "reachable",
+          httpStatus: 200,
+        }),
+        probeSandboxInferenceInvocationImpl: (input: Record<string, unknown>) => {
+          seen = input;
+          return { ok: true };
+        },
+      },
+    } as never);
+    return seen;
+  }
+
+  const recorded = {
+    provider: "compatible-endpoint",
+    model: "recorded/model",
+    endpointUrl: "https://target.example/v1",
+    credentialEnv: "TARGET_KEY",
+    preferredInferenceApi: "openai-responses",
+  } satisfies Partial<SandboxEntry>;
+
+  it("keeps the recorded API family when only the model drifted", async () => {
+    // The recorded family describes the provider, which has not changed, so
+    // dropping it would probe /v1/chat/completions against a responses-only
+    // endpoint and report a healthy route as unhealthy.
+    liveGatewayInference("compatible-endpoint", "live/model");
+
+    expect(await captureInvocationRoute(recorded)).toMatchObject({
+      provider: "compatible-endpoint",
+      model: "live/model",
+      preferredInferenceApi: "openai-responses",
+    });
+  });
+
+  it("keeps the recorded API family when the route is aligned", async () => {
+    liveGatewayInference("compatible-endpoint", "recorded/model");
+
+    expect(await captureInvocationRoute(recorded)).toMatchObject({
+      model: "recorded/model",
+      preferredInferenceApi: "openai-responses",
+    });
+  });
+
+  it("drops the recorded API family when the provider itself drifted", async () => {
+    // Regression lock: one provider's family must never be carried onto
+    // another that may have no such endpoint.
+    liveGatewayInference("nvidia-prod", "nvidia/nemotron");
+
+    expect(await captureInvocationRoute(recorded)).toMatchObject({
+      provider: "nvidia-prod",
+      model: "nvidia/nemotron",
+      preferredInferenceApi: null,
+    });
+  });
+});

--- a/src/lib/actions/sandbox/status-snapshot.ts
+++ b/src/lib/actions/sandbox/status-snapshot.ts
@@ -589,11 +589,14 @@ export async function collectSandboxStatusSnapshot(
         ? {
             provider: live.provider,
             model: live.model,
-            // The live gateway RPC does not expose a stored API override. Do
-            // not carry an API family across route drift. When the live pair
-            // is unchanged, the recorded family still describes that route.
+            // The live gateway RPC does not expose a stored API override. The
+            // recorded family describes the recorded *provider*, so it keeps
+            // describing the live route while that provider is unchanged —
+            // including when only the model drifted. Drop it only when the
+            // provider itself changed, so one provider's family cannot be
+            // carried onto another that has no such endpoint (#9302).
             preferredInferenceApi:
-              routeDriftPlan?.kind === "aligned" ? (sb?.preferredInferenceApi ?? null) : null,
+              live.provider === sb?.provider ? (sb?.preferredInferenceApi ?? null) : null,
           }
         : {
             provider: currentProvider,

--- a/src/lib/actions/sandbox/status-snapshot.ts
+++ b/src/lib/actions/sandbox/status-snapshot.ts
@@ -589,11 +589,11 @@ export async function collectSandboxStatusSnapshot(
         ? {
             provider: live.provider,
             model: live.model,
-            // The live gateway RPC does not expose a stored API override. The
-            // recorded family describes the recorded *provider*, so it keeps
-            // describing the live route while that provider is unchanged —
+            // The live gateway RPC does not expose a stored API family. The
+            // recorded API family describes the recorded provider, so it keeps
+            // describing the live route while that provider is unchanged,
             // including when only the model drifted. Drop it only when the
-            // provider itself changed, so one provider's family cannot be
+            // provider itself changed, so one provider's API family cannot be
             // carried onto another that has no such endpoint (#9302).
             preferredInferenceApi:
               live.provider === sb?.provider ? (sb?.preferredInferenceApi ?? null) : null,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Sandbox status probes the live shared inference route with one real inference request, and that request's result decides `status --json`'s exit code. The probe dropped the sandbox's recorded API family whenever the live route was not exactly aligned — including when the shared route drifted by **model alone** and the provider was unchanged. For a compatible endpoint that family is the only signal that the route speaks `openai-responses` or `anthropic-messages`, so a healthy route was probed with the wrong API and reported unhealthy, making the command exit nonzero.

Refs #9302.

## Reproduction

**Environment**

- Test machine: our Ubuntu 24.04 x86_64 test host (no GPU)
- NemoClaw `main` at `588bb6db9b1132266840e4604fa16c2a4912cbfc` (`v0.0.109-96-g588bb6db9`), OpenShell CLI 0.0.101
- Sandbox: OpenClaw, provider NVIDIA Endpoints (`nvidia-prod`)
- The reporter's platform is Ubuntu 26.04 GPU; this path is CLI/JSON exit-code logic with no GPU or OS-version dependency, but see **Platform scope** below.

First, what already works on `main`. Recorded route `nvidia-prod/nvidia/nemotron-3-ultra-550b-a55b`; the shared route was changed externally with `openshell inference set` to another route that genuinely serves:

```text
### drift to a healthy route
  exit=0 | drift=yes | live=openai/gpt-oss-20b | inferenceHealth.ok=True | recordedRoute/liveRoute/routeDrift all present
```

Route drift on its own already exits `0` and already returns all three documented fields, so the drift itself is not the trigger.

The trigger is the API family. With the recorded route on a compatible endpoint that speaks `openai-responses`, and the shared route drifting by model only, the probe on `main` is handed no API family at all:

```json
{ "provider": "compatible-endpoint", "model": "live/model", "preferredInferenceApi": null }
```

`getSandboxInferenceConfig` resolves `null` to `openai-completions`, which for that provider is the wrong endpoint:

```text
compatible-endpoint  recorded=openai-responses     kept=openai-responses     dropped=openai-completions   <-- family changes
compatible-endpoint  recorded=anthropic-messages   kept=anthropic-messages   dropped=openai-completions   <-- family changes
compatible-endpoint  recorded=openai-completions   kept=openai-completions   dropped=openai-completions
nvidia-prod          recorded=openai-responses     kept=openai-completions   dropped=openai-completions
```

The request then fails against a route that is actually healthy, `inferenceHealth.ok` goes false, and `status --json` exits `1`.

**Observed on `main` (before fix)** — invocation probe input for a model-only drift on a compatible endpoint:

```json
{ "provider": "compatible-endpoint", "model": "live/model", "preferredInferenceApi": null }
```

**Observed on `fix/...` (after fix)**

```json
{ "provider": "compatible-endpoint", "model": "live/model", "preferredInferenceApi": "openai-responses" }
```

Live re-verification on the test host, with the same sandbox, after the fix:

```text
### drift to a healthy route      -> exit=0 | inferenceHealth.ok=True  | all three fields present
### route aligned                 -> exit=0 | inferenceHealth.ok=True  | all three fields present
### drift to an unusable route    -> exit=1 | inferenceHealth.ok=False | all three fields present
```

The third row is unchanged on purpose — see **Scope** below.

## Analysis

`src/lib/actions/sandbox/status-snapshot.ts` builds the route for the in-sandbox invocation probe. It takes provider and model as one pair from the live gateway route, which #8731 introduced deliberately, and then set:

```ts
preferredInferenceApi:
  routeDriftPlan?.kind === "aligned" ? (sb?.preferredInferenceApi ?? null) : null,
```

`aligned` means provider **and** model both match. The stated reason for dropping the family is sound but only covers the provider case: a family recorded for one provider must not be carried onto a different provider, because `getSandboxInferenceConfig` would otherwise route e.g. a persisted `openai-responses` onto a provider with no `/v1/responses` endpoint and 404 every request — the same hazard its own comment describes.

That reason does not hold when only the model drifted. The recorded family describes the recorded *provider*, and that provider is unchanged, so the family still describes the live route exactly. Dropping it there falls back to `openai-completions` and probes an endpoint the provider does not serve, so a healthy route is reported unhealthy and the command exits nonzero.

Built-in providers hide this: `getSandboxInferenceConfig` forces the family from the provider for `anthropic-prod` and for every provider matching `shouldSkipResponsesProbe`, so `nvidia-prod` resolves to `openai-completions` either way. Only providers whose family is carried in the sandbox record — the compatible endpoints — are affected.

## Fix

Gate on the provider rather than on full alignment:

```diff
-  routeDriftPlan?.kind === "aligned" ? (sb?.preferredInferenceApi ?? null) : null,
+  live.provider === sb?.provider ? (sb?.preferredInferenceApi ?? null) : null,
```

This is strictly wider than `aligned` (which already required the provider to match), so the aligned case is unchanged and the cross-provider guard is preserved verbatim: the family is still dropped whenever the provider itself drifted.

Three tests enforce the contract: the recorded API family survives a model-only drift and an aligned route, while a provider change removes it. The first test fails against the earlier logic and passes after the fix.

## Scope

This PR uses `Refs`, not `Fixes`, because it covers one of two ways the reported symptom can arise and I could not confirm which one the reporter hit.

Measured on `main`, `status --json` exits nonzero after a shared-route change in exactly two situations:

1. **The live route is healthy but probed with the wrong API family.** That is the defect this PR fixes.
2. **The live route is genuinely unusable** (for example the shared route was repointed at a placeholder model to manufacture the mismatch). There `inferenceHealth.ok` is legitimately false and the nonzero exit is the contract #8731 established for #8705 — status sends one real inference request and reports its result.

Worth noting for the second case: the exit code does not withhold the payload. In every failing run above, stdout still carried the complete JSON document with `recordedRoute`, `liveRoute` and `routeDrift` populated, so a caller can read the drift fields even when the command exits `1`. If the validation job treats a nonzero exit as "no JSON to parse", it will report the fields as unavailable when they are in fact present.

To confirm whether case 1 is what the pipeline hit, the reporter's provider and `--inference-api` for the sandbox under test, plus the captured stdout of the failing `status --json`, would settle it.

## Platform scope

Reproduced and verified on our Ubuntu 24.04 x86_64 test host; the reporter's runner is Ubuntu 26.04 GPU. The changed code is provider/API-family resolution in the status snapshot, with no GPU, kernel, or OS-version dependency, but this was not re-run on Ubuntu 26.04.

## Changes

- `src/lib/actions/sandbox/status-snapshot.ts`: keep the recorded API family while the live provider matches the recorded provider; drop it only on a provider change.
- `src/lib/actions/sandbox/status-snapshot-route-drift.test.ts`: cover model-only drift, aligned routes, and provider changes at the public health-result boundary.
- `docs/reference/commands.mdx` and `docs/inference/verify-inference-route.mdx`: describe API-family selection during route drift.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] `npx prek run` passes on the changed files
- [x] `npm test` passes (3105 tests across `src/lib/actions/sandbox/` and `test/cli/sandbox-status-json.test.ts`)
- [x] Tests added or updated for new or changed behavior
- [x] Focused route-drift tests pass (11 of 11)
- [x] No secrets, API keys, or credentials committed
- [x] Docs updated for the user-facing route-validation behavior
- [x] `npm run docs` passes with 0 errors and 2 existing warnings
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/reference/commands.mdx` and `docs/inference/verify-inference-route.mdx`
- Agent: Codex Desktop
<!-- docs-review-head-sha: 3f3f6cd3d -->
<!-- docs-review-agents-blob-sha: b9fb6a9ba -->

## AI Disclosure
- [x] AI-assisted — tool: Claude Code

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inference health checks when only the selected model changes.
  - Preserved the recorded API family for the same provider, including compatible response-based routes.
  - Prevented outdated API routing from being reused when the provider changes.
  - Health is now reported only for structurally valid responses.

- **Documentation**
  - Updated sandbox status and inference route documentation to reflect provider and model handling.

- **Tests**
  - Added regression coverage for provider and model routing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->