### PR TITLE
fix(backup): stop rejecting hard-linked package files before backup

### DIFF
--- a/docs/manage-sandboxes/backup-restore.mdx
+++ b/docs/manage-sandboxes/backup-restore.mdx
@@ -231,7 +231,8 @@ It clears the remaining local shields state only after deletion succeeds, before
 ## Restore Agent Configuration Safely
 
 The `$$nemoclaw <name> rebuild` command uses the same snapshot mechanism automatically.
-NemoClaw rejects unsafe symlinks and hard links inside sandbox state during backup creation before they can enter a snapshot.
+NemoClaw rejects unsafe symlinks and special files inside sandbox state during backup creation.
+It records multiply-linked regular files and archives each path as a separate regular file.
 
 <AgentOnly variant="openclaw">
 Snapshot restore performs a targeted repair for legacy `.openclaw-data` symlinks that older images created.

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -1483,9 +1483,21 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
       if (existingDirs.length === 0) {
         _log("No state dirs found in sandbox (all empty)");
       } else {
-        // NC-2227-04: Pre-backup audit — reject symlinks, hardlinks, and special
-        // files inside state dirs. A compromised agent could plant a symlink like
+        // NC-2227-04: Pre-backup audit — reject symlinks and special files
+        // inside state dirs. A compromised agent could plant a symlink like
         // workspace/copy -> ../openclaw.json to exfiltrate config via backup.
+        //
+        // Multiply-linked regular files are collected for observability but do
+        // not reject the backup (#9314). `tar` runs without `-h`, so a hard
+        // link is archived as that path's own content and restores as a plain
+        // regular file: it cannot escape the archived tree the way a followed
+        // symlink can. It also offers no exfiltration path the audit could
+        // close, because an agent that can create a hard link inside a state
+        // dir can equally `cp` the same bytes there, and a copy is an ordinary
+        // regular file this audit never sees. Rejecting them only broke
+        // legitimate installs: package managers hard-link from their cache, so
+        // every Hermes sandbox that lazily installed a dependency failed its
+        // pre-upgrade backup.
         //
         // The printf format emits "<type>\t<absPath>\t<linkTarget>" — %l is
         // empty for non-symlinks but always present, so the field count is
@@ -1531,6 +1543,7 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
         if (auditOutput.length > 0) {
           const allEntries = auditOutput.split("\n").filter((l) => l.length > 0);
           const whitelisted: string[] = [];
+          const hardLinked: string[] = [];
           const violations: string[] = [];
           const dirPrefix = `${dir}/`;
           for (const entry of allEntries) {
@@ -1545,6 +1558,11 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
               : absPath;
             if (type === "l" && isAllowedStateSymlink(relPath, linkTarget)) {
               whitelisted.push(entry);
+            } else if (type === "f") {
+              // The audit's `find` only emits regular files through its
+              // `-links +1` branch, so a reported `f` row is a hard link.
+              // Recorded, not rejected — see the rationale above (#9314).
+              hardLinked.push(entry);
             } else {
               violations.push(entry);
             }
@@ -1554,8 +1572,13 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
               `Pre-backup audit whitelisted ${whitelisted.length} entries (image npm symlinks): ${whitelisted.slice(0, 5).join("; ")}`,
             );
           }
+          if (hardLinked.length > 0) {
+            _log(
+              `Pre-backup audit accepted ${hardLinked.length} multiply-linked regular files (archived as plain files): ${hardLinked.slice(0, 5).join("; ")}`,
+            );
+          }
           if (violations.length > 0) {
-            // Non-whitelisted symlinks / hard links / special files — reject
+            // Non-whitelisted symlinks / special files — reject
             _log(
               `SECURITY: Pre-backup audit found ${violations.length} unsafe entries: ${violations.slice(0, 5).join("; ")}`,
             );
@@ -1566,11 +1589,11 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
               failedDirs: [...existingDirs],
               backedUpFiles,
               failedFiles: stateFiles.map((f) => f.path),
-              error: `Pre-backup audit rejected: symlinks, hard links, or special files found in state dirs: ${violations.slice(0, 3).join("; ")}`,
+              error: `Pre-backup audit rejected: symlinks or special files found in state dirs: ${violations.slice(0, 3).join("; ")}`,
             };
           }
         }
-        _log("Pre-backup audit passed — no unsafe symlinks, hard links, or special files found");
+        _log("Pre-backup audit passed — no unsafe symlinks or special files found");
 
         // Download via SSH+tar
         // NC-2227-04: Removed -h flag (was following symlinks). State dirs are

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -1599,7 +1599,17 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
         // NC-2227-04: Removed -h flag (was following symlinks). State dirs are
         // now agent-writable and co-located with config — a compromised agent
         // could create symlinks to exfiltrate config contents via backup.
-        const tarCmd = `tar -cf - -C ${shellQuote(dir)} -- ${existingDirs.map(shellQuote).join(" ")}`;
+        //
+        // `--hard-dereference` archives each multiply-linked path as its own
+        // regular file. Without it `tar` emits a hard-link record for the second
+        // and later paths sharing an inode, and `safeTarExtract` rejects those
+        // records — so a state dir holding two links to one inode would pass the
+        // audit and then fail while unpacking (#9314). It also keeps the archive
+        // self-describing: every entry restores as a plain file, matching what
+        // the audit now accepts. Note this is about links *within* the archived
+        // tree; a link whose other end lives outside it (a package manager
+        // linking out of its cache) already archives as a plain file.
+        const tarCmd = `tar --hard-dereference -cf - -C ${shellQuote(dir)} -- ${existingDirs.map(shellQuote).join(" ")}`;
         _log(`Downloading via SSH+tar: ${tarCmd}`);
         let downloadedTarDir: string | undefined;
         let downloadedTarPath: string;

--- a/src/lib/state/sandbox.ts
+++ b/src/lib/state/sandbox.ts
@@ -1488,16 +1488,15 @@ export function backupSandboxState(sandboxName: string, options: BackupOptions =
         // workspace/copy -> ../openclaw.json to exfiltrate config via backup.
         //
         // Multiply-linked regular files are collected for observability but do
-        // not reject the backup (#9314). `tar` runs without `-h`, so a hard
-        // link is archived as that path's own content and restores as a plain
-        // regular file: it cannot escape the archived tree the way a followed
-        // symlink can. It also offers no exfiltration path the audit could
-        // close, because an agent that can create a hard link inside a state
-        // dir can equally `cp` the same bytes there, and a copy is an ordinary
-        // regular file this audit never sees. Rejecting them only broke
-        // legitimate installs: package managers hard-link from their cache, so
-        // every Hermes sandbox that lazily installed a dependency failed its
-        // pre-upgrade backup.
+        // not reject the backup (#9314). The archive command below uses
+        // `--hard-dereference`, so every included path is stored and restored
+        // as a plain regular file. It offers no exfiltration path the audit
+        // could close, because an agent that can create a hard link inside a
+        // state dir can equally `cp` the same bytes there, and a copy is an
+        // ordinary regular file this audit never sees. Rejecting hard links
+        // only broke legitimate installs: package managers hard-link from
+        // their cache, so every Hermes sandbox that lazily installed a
+        // dependency failed its pre-upgrade backup.
         //
         // The printf format emits "<type>\t<absPath>\t<linkTarget>" — %l is
         // empty for non-symlinks but always present, so the field count is

--- a/test/helpers/snapshot-state-discovery-fixture.ts
+++ b/test/helpers/snapshot-state-discovery-fixture.ts
@@ -36,7 +36,7 @@ if (cmd.includes("openclaw.json") && cmd.includes("cat --")) {
 if (cmd.includes("find ")) {
   process.exit(0);
 }
-if (cmd.includes("tar -cf -")) {
+if (cmd.includes("-cf -")) {
   const stagingDirs = fs.readdirSync(${JSON.stringify(stagingRoot)});
   const archivePaths = stagingDirs
     .map((entry) => require("node:path").join(${JSON.stringify(stagingRoot)}, entry, "archive.tar"))

--- a/test/snapshot-backup-audit-hardlinks.test.ts
+++ b/test/snapshot-backup-audit-hardlinks.test.ts
@@ -91,6 +91,13 @@ function backupWithAuditOutput(
     fs.mkdirSync(binDir, { recursive: true });
     for (const d of existingDirs) fs.mkdirSync(path.join(stateRoot, d), { recursive: true });
     fs.writeFileSync(path.join(stateRoot, "workspace", "note.txt"), "content\n");
+    // A real multiply-linked pair inside the archived tree, the shape a package
+    // manager leaves behind. `tar` would otherwise emit a hard-link record for
+    // the second path and `safeTarExtract` would reject the archive.
+    const linkedDir = path.join(stateRoot, "workspace", "lazy-packages");
+    fs.mkdirSync(linkedDir, { recursive: true });
+    fs.writeFileSync(path.join(linkedDir, "impl.py"), "package payload\n");
+    fs.linkSync(path.join(linkedDir, "impl.py"), path.join(linkedDir, "alias.py"));
 
     const openshell = writeFakeOpenshell(binDir);
     writeExecutable(
@@ -108,10 +115,11 @@ if (cmd.includes("find ")) {
   process.stdout.write(${JSON.stringify(auditLines)} + (${JSON.stringify(auditLines)} ? "\\n" : ""));
   process.exit(0);
 }
-if (cmd.includes("tar -cf -")) {
-  const r = spawnSync("tar", ["-cf", "-", "-C", ${JSON.stringify(stateRoot)}, ...existingDirs], {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+if (cmd.includes("tar ") && cmd.includes("-cf -")) {
+  // Run the archive command the product actually issued, with the sandbox
+  // state path mapped onto the fixture, so tar flags are exercised for real.
+  const real = cmd.split("/sandbox/.openclaw").join(${JSON.stringify(stateRoot)});
+  const r = spawnSync("sh", ["-c", real], { stdio: ["ignore", "pipe", "pipe"] });
   if (r.stdout) fs.writeSync(1, r.stdout);
   process.exit(r.status || 0);
 }
@@ -151,6 +159,13 @@ describe("pre-backup audit — multiply-linked regular files (#9314)", () => {
     expect(backup.success).toBe(true);
     expect(backup.error).toBeUndefined();
     expect(backup.backedUpDirs).toEqual(["workspace"]);
+
+    // Both linked paths must survive as independent regular files: the archive
+    // is unpacked through safeTarExtract, which rejects hard-link records.
+    const linked = path.join(String(backup.manifest?.backupPath), "workspace", "lazy-packages");
+    expect(fs.readFileSync(path.join(linked, "impl.py"), "utf8")).toBe("package payload\n");
+    expect(fs.readFileSync(path.join(linked, "alias.py"), "utf8")).toBe("package payload\n");
+    expect(fs.lstatSync(path.join(linked, "alias.py")).nlink).toBe(1);
   });
 
   it("still rejects an unsafe symlink alongside hard-linked files", () => {

--- a/test/snapshot-backup-audit-hardlinks.test.ts
+++ b/test/snapshot-backup-audit-hardlinks.test.ts
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pre-backup audit (NC-2227-04) treatment of multiply-linked regular files.
+ *
+ * Package managers hard-link installed files out of their cache, so a Hermes
+ * sandbox that lazily installed a dependency carries hundreds of them under
+ * `lazy-packages`. Rejecting those aborted the whole pre-upgrade backup
+ * (#9314). They are now recorded and archived; symlink and special-file
+ * rejection is unchanged.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+
+const ORIGINAL_HOME = process.env.HOME;
+const TMP_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-backup-audit-hardlinks-"));
+process.env.HOME = TMP_HOME;
+
+const REPO_ROOT = path.join(import.meta.dirname, "..");
+type SandboxStateModule = typeof import("../src/lib/state/sandbox.js");
+const sandboxState = (await import(
+  pathToFileURL(path.join(REPO_ROOT, "src", "lib", "state", "sandbox.ts")).href
+)) as SandboxStateModule;
+
+function writeExecutable(filePath: string, source: string): void {
+  fs.writeFileSync(filePath, source, { mode: 0o755 });
+}
+
+function writeRegistry(sandboxName: string): void {
+  fs.mkdirSync(path.join(TMP_HOME, ".nemoclaw"), { recursive: true });
+  fs.writeFileSync(
+    path.join(TMP_HOME, ".nemoclaw", "sandboxes.json"),
+    JSON.stringify({
+      defaultSandbox: sandboxName,
+      sandboxes: {
+        [sandboxName]: {
+          name: sandboxName,
+          model: "m",
+          provider: "p",
+          gpuEnabled: false,
+          policies: [],
+          agent: null,
+        },
+      },
+    }),
+  );
+}
+
+function writeFakeOpenshell(binDir: string): string {
+  const openshell = path.join(binDir, "openshell");
+  writeExecutable(
+    openshell,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "sandbox" && args[1] === "ssh-config") {
+  process.stdout.write("Host openshell-alpha\\n  HostName 127.0.0.1\\n  User sandbox\\n");
+  process.exit(0);
+}
+process.exit(0);
+`,
+  );
+  return openshell;
+}
+
+/**
+ * Run `backupSandboxState` against a fake sandbox whose pre-backup audit
+ * reports `auditLines` (raw `find -printf "%y\t%p\t%l\n"` rows).
+ */
+function backupWithAuditOutput(
+  auditLines: string,
+): ReturnType<SandboxStateModule["backupSandboxState"]> {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-audit-fixture-"));
+  const oldPath = process.env.PATH;
+  const oldOpenshell = process.env.NEMOCLAW_OPENSHELL_BIN;
+  try {
+    const binDir = path.join(fixture, "bin");
+    const stateRoot = path.join(fixture, "sandbox-root", ".openclaw");
+    const existingDirs = ["workspace"];
+    fs.mkdirSync(binDir, { recursive: true });
+    for (const d of existingDirs) fs.mkdirSync(path.join(stateRoot, d), { recursive: true });
+    fs.writeFileSync(path.join(stateRoot, "workspace", "note.txt"), "content\n");
+
+    const openshell = writeFakeOpenshell(binDir);
+    writeExecutable(
+      path.join(binDir, "ssh"),
+      `#!/usr/bin/env node
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const cmd = process.argv[process.argv.length - 1] || "";
+const existingDirs = ${JSON.stringify(existingDirs)};
+if (cmd.includes("[ -d ")) {
+  process.stdout.write(existingDirs.join("\\n") + "\\n");
+  process.exit(0);
+}
+if (cmd.includes("find ")) {
+  process.stdout.write(${JSON.stringify(auditLines)} + (${JSON.stringify(auditLines)} ? "\\n" : ""));
+  process.exit(0);
+}
+if (cmd.includes("tar -cf -")) {
+  const r = spawnSync("tar", ["-cf", "-", "-C", ${JSON.stringify(stateRoot)}, ...existingDirs], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (r.stdout) fs.writeSync(1, r.stdout);
+  process.exit(r.status || 0);
+}
+process.exit(0);
+`,
+    );
+
+    writeRegistry("alpha");
+    process.env.NEMOCLAW_OPENSHELL_BIN = openshell;
+    process.env.PATH = `${binDir}:${oldPath || ""}`;
+    return sandboxState.backupSandboxState("alpha");
+  } finally {
+    if (oldOpenshell === undefined) {
+      delete process.env.NEMOCLAW_OPENSHELL_BIN;
+    } else {
+      process.env.NEMOCLAW_OPENSHELL_BIN = oldOpenshell;
+    }
+    process.env.PATH = oldPath;
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
+}
+
+afterAll(() => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIGINAL_HOME;
+  fs.rmSync(TMP_HOME, { recursive: true, force: true });
+});
+
+describe("pre-backup audit — multiply-linked regular files (#9314)", () => {
+  it("backs up a sandbox whose state dirs contain hard-linked package files", () => {
+    // Shape emitted by `find -type f -a -links +1`: type `f`, empty link
+    // target. A lazily installed dependency hard-links out of the package
+    // manager cache, so every installed file looks like this.
+    const auditLines = [
+      "f\t/sandbox/.openclaw/workspace/lazy-packages/aiohappyeyeballs/impl.py\t",
+      "f\t/sandbox/.openclaw/workspace/lazy-packages/aiohappyeyeballs/utils.py\t",
+      "f\t/sandbox/.openclaw/workspace/lazy-packages/edge_tts/__init__.py\t",
+    ].join("\n");
+
+    const backup = backupWithAuditOutput(auditLines);
+
+    expect(backup.success).toBe(true);
+    expect(backup.error).toBeUndefined();
+    expect(backup.backedUpDirs).toEqual(["workspace"]);
+  });
+
+  it("still rejects an unsafe symlink alongside hard-linked files", () => {
+    // Regression lock: accepting hard links must not weaken symlink rejection.
+    const auditLines = [
+      "f\t/sandbox/.openclaw/workspace/lazy-packages/edge_tts/__init__.py\t",
+      "l\t/sandbox/.openclaw/workspace/escape\t../openclaw.json",
+    ].join("\n");
+
+    const backup = backupWithAuditOutput(auditLines);
+
+    expect(backup.success).toBe(false);
+    expect(backup.error).toMatch(/Pre-backup audit rejected/);
+    expect(backup.error).toContain("workspace/escape");
+  });
+
+  it("still rejects special files", () => {
+    // Regression lock: sockets/fifos/devices remain violations.
+    const backup = backupWithAuditOutput("s\t/sandbox/.openclaw/workspace/agent.sock\t");
+
+    expect(backup.success).toBe(false);
+    expect(backup.error).toMatch(/Pre-backup audit rejected/);
+    expect(backup.error).toContain("agent.sock");
+  });
+});

--- a/test/snapshot-backup-audit-hardlinks.test.ts
+++ b/test/snapshot-backup-audit-hardlinks.test.ts
@@ -12,6 +12,7 @@
  */
 
 import fs from "node:fs";
+import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -20,6 +21,11 @@ import { afterAll, describe, expect, it } from "vitest";
 const ORIGINAL_HOME = process.env.HOME;
 const TMP_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-backup-audit-hardlinks-"));
 process.env.HOME = TMP_HOME;
+const tarHelp = spawnSync("tar", ["--help"], { encoding: "utf8" });
+const supportsHardDereference = `${tarHelp.stdout}${tarHelp.stderr}`.includes("--hard-dereference");
+// Production executes GNU tar inside the Linux sandbox. Skip only this
+// archive-behavior case on hosts such as macOS whose BSD tar lacks that flag.
+const hardDereferenceTest = supportsHardDereference ? it : it.skip;
 
 const REPO_ROOT = path.join(import.meta.dirname, "..");
 type SandboxStateModule = typeof import("../src/lib/state/sandbox.js");
@@ -144,29 +150,32 @@ afterAll(() => {
 });
 
 describe("pre-backup audit — multiply-linked regular files (#9314)", () => {
-  it("backs up a sandbox whose state dirs contain hard-linked package files", () => {
-    // Shape emitted by `find -type f -a -links +1`: type `f`, empty link
-    // target. A lazily installed dependency hard-links out of the package
-    // manager cache, so every installed file looks like this.
-    const auditLines = [
-      "f\t/sandbox/.openclaw/workspace/lazy-packages/aiohappyeyeballs/impl.py\t",
-      "f\t/sandbox/.openclaw/workspace/lazy-packages/aiohappyeyeballs/utils.py\t",
-      "f\t/sandbox/.openclaw/workspace/lazy-packages/edge_tts/__init__.py\t",
-    ].join("\n");
+  hardDereferenceTest(
+    "backs up a sandbox whose state dirs contain hard-linked package files",
+    () => {
+      // Shape emitted by `find -type f -a -links +1`: type `f`, empty link
+      // target. A lazily installed dependency hard-links out of the package
+      // manager cache, so every installed file looks like this.
+      const auditLines = [
+        "f\t/sandbox/.openclaw/workspace/lazy-packages/aiohappyeyeballs/impl.py\t",
+        "f\t/sandbox/.openclaw/workspace/lazy-packages/aiohappyeyeballs/utils.py\t",
+        "f\t/sandbox/.openclaw/workspace/lazy-packages/edge_tts/__init__.py\t",
+      ].join("\n");
 
-    const backup = backupWithAuditOutput(auditLines);
+      const backup = backupWithAuditOutput(auditLines);
 
-    expect(backup.success).toBe(true);
-    expect(backup.error).toBeUndefined();
-    expect(backup.backedUpDirs).toEqual(["workspace"]);
+      expect(backup.success, backup.error).toBe(true);
+      expect(backup.error).toBeUndefined();
+      expect(backup.backedUpDirs).toEqual(["workspace"]);
 
-    // Both linked paths must survive as independent regular files: the archive
-    // is unpacked through safeTarExtract, which rejects hard-link records.
-    const linked = path.join(String(backup.manifest?.backupPath), "workspace", "lazy-packages");
-    expect(fs.readFileSync(path.join(linked, "impl.py"), "utf8")).toBe("package payload\n");
-    expect(fs.readFileSync(path.join(linked, "alias.py"), "utf8")).toBe("package payload\n");
-    expect(fs.lstatSync(path.join(linked, "alias.py")).nlink).toBe(1);
-  });
+      // Both linked paths must survive as independent regular files: the archive
+      // is unpacked through safeTarExtract, which rejects hard-link records.
+      const linked = path.join(String(backup.manifest?.backupPath), "workspace", "lazy-packages");
+      expect(fs.readFileSync(path.join(linked, "impl.py"), "utf8")).toBe("package payload\n");
+      expect(fs.readFileSync(path.join(linked, "alias.py"), "utf8")).toBe("package payload\n");
+      expect(fs.lstatSync(path.join(linked, "alias.py")).nlink).toBe(1);
+    },
+  );
 
   it("still rejects an unsafe symlink alongside hard-linked files", () => {
     // Regression lock: accepting hard links must not weaken symlink rejection.

--- a/test/snapshot-backup-audit-hardlinks.test.ts
+++ b/test/snapshot-backup-audit-hardlinks.test.ts
@@ -31,6 +31,13 @@ function writeExecutable(filePath: string, source: string): void {
   fs.writeFileSync(filePath, source, { mode: 0o755 });
 }
 
+/** Restore an env var without branching, mirroring the sibling snapshot tests. */
+function restoreEnv(name: string, value: string | undefined): void {
+  value === undefined
+    ? Reflect.deleteProperty(process.env, name)
+    : Reflect.set(process.env, name, value);
+}
+
 function writeRegistry(sandboxName: string): void {
   fs.mkdirSync(path.join(TMP_HOME, ".nemoclaw"), { recursive: true });
   fs.writeFileSync(
@@ -117,19 +124,14 @@ process.exit(0);
     process.env.PATH = `${binDir}:${oldPath || ""}`;
     return sandboxState.backupSandboxState("alpha");
   } finally {
-    if (oldOpenshell === undefined) {
-      delete process.env.NEMOCLAW_OPENSHELL_BIN;
-    } else {
-      process.env.NEMOCLAW_OPENSHELL_BIN = oldOpenshell;
-    }
-    process.env.PATH = oldPath;
+    restoreEnv("NEMOCLAW_OPENSHELL_BIN", oldOpenshell);
+    restoreEnv("PATH", oldPath);
     fs.rmSync(fixture, { recursive: true, force: true });
   }
 }
 
 afterAll(() => {
-  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
-  else process.env.HOME = ORIGINAL_HOME;
+  restoreEnv("HOME", ORIGINAL_HOME);
   fs.rmSync(TMP_HOME, { recursive: true, force: true });
 });
 

--- a/test/snapshot-runtime-auth-state.test.ts
+++ b/test/snapshot-runtime-auth-state.test.ts
@@ -91,7 +91,7 @@ if (cmd.startsWith("{ ") && cmd.includes("printf")) {
 // Backup: pre-backup symlink/hardlink audit — fixture has none.
 if (cmd.includes("-printf")) { process.exit(0); }
 // Backup: tar download of state dirs.
-if (cmd.startsWith("tar -cf - -C ")) {
+if (cmd.startsWith("tar ") && cmd.includes("-cf - -C ")) {
   const names = [...cmd.matchAll(/'([^']+)'/g)].map((m) => m[1]);
   const result = spawnSync("tar", ["-cf", "-", "-C", mapPath(names[0]), "--", ...names.slice(1)], {
     stdio: ["ignore", "pipe", "pipe"],

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -778,7 +778,7 @@ if (cmd.includes("openclaw.json") && cmd.includes("cat --")) {
 if (cmd.includes("find ")) {
   process.exit(0);
 }
-if (cmd.includes("tar -cf -")) {
+if (cmd.includes("-cf -")) {
   const r = spawnSync("tar", ["-cf", "-", "-C", ${JSON.stringify(openclawDir)}, ...existingDirs], {
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -875,7 +875,7 @@ if (cmd.includes("find ")) {
   process.stdout.write(${JSON.stringify(auditLines)} + "\\n");
   process.exit(0);
 }
-if (cmd.includes("tar -cf -")) {
+if (cmd.includes("-cf -")) {
   const r = spawnSync("tar", ["-cf", "-", "-C", ${JSON.stringify(openclawDir)}, ...existingDirs], {
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -939,7 +939,7 @@ if (cmd.includes("find ")) {
   process.stdout.write(${JSON.stringify(auditLines)} + "\\n");
   process.exit(0);
 }
-if (cmd.includes("tar -cf -")) {
+if (cmd.includes("-cf -")) {
   const r = spawnSync("tar", ["-cf", "-", "-C", openclawDir, ...existingDirs], {
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -1158,7 +1158,7 @@ if (cmd.includes("[ -d ")) {
 if (cmd.includes("find ")) {
   process.exit(0);
 }
-if (cmd.includes("tar -cf -")) {
+if (cmd.includes("-cf -")) {
   const r = spawnSync("tar", ["-cf", "-", "-C", ${JSON.stringify(openclawDir)}, "extensions"], {
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -1238,7 +1238,7 @@ if (cmd.includes("find ")) {
   }
   process.exit(0);
 }
-if (cmd.includes("tar -cf -")) {
+if (cmd.includes("-cf -")) {
   const r = spawnSync("tar", ["-cf", "-", "-C", ${JSON.stringify(openclawDir)}, ...existingDirs], {
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -1407,7 +1407,7 @@ if (cmd.includes("[ -d ")) {
 if (cmd.includes("find ")) {
   process.exit(0);
 }
-if (cmd.includes("tar -cf -")) {
+if (cmd.includes("-cf -")) {
   const r = spawnSync("tar", ["-cf", "-", "-C", deepAgentsDir, ".state", "skills", "agent/skills"], {
     stdio: ["ignore", "pipe", "pipe"],
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

A Hermes sandbox can contain multiply-linked regular files after installing lazy packages. The backup audit now records those files and archives each path as a separate regular file. Unsafe symlinks and special files still stop backup creation.

## Related Issue

Closes #9314.

## Changes

- Accept and report multiply-linked regular files during the pre-backup audit.
- Add `tar --hard-dereference` so every included path becomes a regular-file archive entry that the safe restore path accepts.
- Keep unsafe-symlink and special-file rejection unchanged.
- Add a genuine linked-pair fixture, restored-content assertions, and regression coverage for the retained rejection behavior.
- Correct the backup and restore documentation to describe the current security contract.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval: https://github.com/NVIDIA/NemoClaw/pull/9317#issuecomment-5318534947
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — not applicable; required CI and both Advisor lanes passed on the current revision: https://github.com/NVIDIA/NemoClaw/actions/runs/32054121014

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/manage-sandboxes/backup-restore.mdx`; `npm run docs` passed with 0 errors and 2 existing warnings; generated OpenClaw, Hermes, and Deep Agents variants contain the corrected wording
- Agent: Codex Desktop
<!-- docs-review-head-sha: 63e9dc031 -->
<!-- docs-review-agents-blob-sha: b9fb6a9ba -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass for the current change set — the contributor reports 788 snapshot, state, and backup tests passing; GitHub Actions run 32039470523 passed `cli-tests`, `checks`, build/typecheck, installer integration, and all 12 CLI test shards
- [ ] Applicable broad gate passed — not required for this focused backup change; required CI and targeted suites passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` passed with 0 errors; 2 existing warnings are unchanged
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Platform evidence

The contributor reproduced the failure and verified the fix on a DGX Spark aarch64 host with a Hermes sandbox containing 224 multiply-linked lazy-package files. Three consecutive `backup-all` runs showed success before lazy-package installation, the reported failure afterward, and success with the change. The restored linked paths were regular files with independent link counts.

---
Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backups now successfully include valid hard-linked files, archiving each path independently.
  * Hard-linked files are recorded and logged during backup audits.
  * Unsafe symlinks and special files continue to be rejected.
  * Audit messages now provide clearer reporting for unsupported file types.

* **Documentation**
  * Updated backup and restore guidance to describe hard-linked file handling and safety checks.

* **Tests**
  * Added coverage for hard-linked files, symlinks, special files, audit results, and backup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
