### PR TITLE
fix(onboard): select the provider a requested serving profile needs

### DIFF
--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -119,6 +119,8 @@ $$nemoclaw onboard --profile <profile-id>
 ```
 
 The same profile selector works with interactive and non-interactive onboarding.
+NemoClaw selects the inference provider required by the profile's backend, so onboarding does not show the provider menu.
+If the profile's backend has no corresponding inference provider, onboarding exits before it changes runtime resources.
 NemoClaw rejects unknown, ambiguous, disabled, incompatible, or conflicting selections before image or model downloads begin.
 Before confirmation, the review screen shows the resolved profile and recipe IDs, model, immutable runtime image, support state, and estimated image and model downloads.
 Do not combine `--profile` with `NEMOCLAW_PROVIDER`, `NEMOCLAW_MODEL`, `NEMOCLAW_VLLM_MODEL`, `NEMOCLAW_MANAGED_CLUSTER_PEERS`, or `NEMOCLAW_VLLM_EXTRA_ARGS_JSON` overrides.

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -687,49 +687,61 @@ describe("onboard command options", () => {
     }
   });
 
-  it("restores every scoped command value before exiting on a handled error (#9035)", async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-handled-error-environment-"));
-    const manifestPath = path.join(tmpDir, "agents.yaml");
-    fs.writeFileSync(manifestPath, "agents: []\n");
-    const env: NodeJS.ProcessEnv = {
-      NEMOCLAW_EXTRA_AGENTS_JSON: "previous-agents",
-      NEMOCLAW_OLLAMA_NO_AUTOSTART: "previous-autostart",
-      NEMOCLAW_SERVING_PRESET: "previous-serving",
-      NEMOCLAW_TOOL_DISCLOSURE: "previous-disclosure",
-    };
-    let environmentAtExit: NodeJS.ProcessEnv | null = null;
-
-    try {
-      await expect(
-        runOnboardCommand({
-          flags: {
-            agents: manifestPath,
-            "no-ollama-autostart": true,
-            profile: COMPATIBLE_NANO_PROFILE.id,
-            "tool-disclosure": "direct",
-          },
-          env,
-          listServingProfiles: () => [COMPATIBLE_NANO_PROFILE],
-          runOnboard: async () => {
-            throw invalidGatewayManagementDeclarationError("unsupported contract");
-          },
-          error: () => {},
-          exit: (code): never => {
-            environmentAtExit = { ...env };
-            throw new Error(`exit:${code}`);
-          },
-        }),
-      ).rejects.toThrow("exit:1");
-      expect(environmentAtExit).toEqual({
+  it.each([
+    { providerState: "unset", previousProvider: undefined },
+    { providerState: "blank", previousProvider: "" },
+  ])(
+    "restores every scoped command value before a handled-error exit when the provider is $providerState (#9035)",
+    async ({ previousProvider }) => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-handled-error-environment-"),
+      );
+      const manifestPath = path.join(tmpDir, "agents.yaml");
+      fs.writeFileSync(manifestPath, "agents: []\n");
+      const env: NodeJS.ProcessEnv = {
         NEMOCLAW_EXTRA_AGENTS_JSON: "previous-agents",
         NEMOCLAW_OLLAMA_NO_AUTOSTART: "previous-autostart",
-        NEMOCLAW_SERVING_PRESET: "previous-serving",
+        NEMOCLAW_SERVING_PRESET: COMPATIBLE_NANO_PROFILE.id,
         NEMOCLAW_TOOL_DISCLOSURE: "previous-disclosure",
+        ...(previousProvider === undefined ? {} : { NEMOCLAW_PROVIDER: previousProvider }),
+      };
+      let environmentAtExit: NodeJS.ProcessEnv | null = null;
+      const runOnboard = vi.fn(async () => {
+        throw invalidGatewayManagementDeclarationError("unsupported contract");
       });
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
+
+      try {
+        await expect(
+          runOnboardCommand({
+            flags: {
+              agents: manifestPath,
+              "no-ollama-autostart": true,
+              profile: COMPATIBLE_NANO_PROFILE.id,
+              "tool-disclosure": "direct",
+            },
+            env,
+            listServingProfiles: () => [COMPATIBLE_NANO_PROFILE],
+            runOnboard,
+            error: () => {},
+            exit: (code): never => {
+              environmentAtExit = { ...env };
+              throw new Error(`exit:${code}`);
+            },
+          }),
+        ).rejects.toThrow("exit:1");
+        expect(runOnboard).toHaveBeenCalledOnce();
+        expect(environmentAtExit).toEqual({
+          NEMOCLAW_EXTRA_AGENTS_JSON: "previous-agents",
+          NEMOCLAW_OLLAMA_NO_AUTOSTART: "previous-autostart",
+          NEMOCLAW_SERVING_PRESET: COMPATIBLE_NANO_PROFILE.id,
+          NEMOCLAW_TOOL_DISCLOSURE: "previous-disclosure",
+          ...(previousProvider === undefined ? {} : { NEMOCLAW_PROVIDER: previousProvider }),
+        });
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("scopes the selected catalog preset to one onboarding run (#8384)", async () => {
     const env: NodeJS.ProcessEnv = {};
@@ -748,7 +760,7 @@ describe("onboard command options", () => {
     expect(env.NEMOCLAW_SERVING_PRESET).toBeUndefined();
   });
 
-  it("selects the profile's backend provider so onboarding skips the menu (#9313)", async () => {
+  it("selects the profile's inference provider so onboarding skips the menu (#9313)", async () => {
     // The preset alone only picks the model once a provider is chosen. Without
     // a provider the run fell through to the interactive provider menu with the
     // requested profile never applied.
@@ -837,7 +849,7 @@ describe("onboard command options", () => {
     // reports instead of accepting the flag and then asking for a provider.
     const withBackend = (backend: string) => ({ recipe: { backend } }) as never;
 
-    // Pinned against the provider menu's own key so the two cannot drift.
+    // Uses the provider menu's exported key so the two cannot drift.
     expect(servingProfileProviderKey(withBackend("vllm"))).toBe(MANAGED_VLLM_PROVIDER_KEY);
     expect(servingProfileProviderKey(withBackend("install-llama-cpp"))).toBe("install-llama-cpp");
     expect(servingProfileProviderKey(withBackend("future-backend"))).toBeNull();
@@ -1061,7 +1073,7 @@ describe("onboard command options", () => {
       name: "serving profile",
       flags: { profile: COMPATIBLE_NANO_PROFILE.id } as OnboardFlags,
       listServingProfiles: () => [COMPATIBLE_NANO_PROFILE],
-      keys: ["NEMOCLAW_SERVING_PRESET"],
+      keys: ["NEMOCLAW_PROVIDER", "NEMOCLAW_SERVING_PRESET"],
     },
   ])("restores the $name environment when an agents manifest is invalid", async (testCase) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-invalid-agents-manifest-"));

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -10,7 +10,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { getCredential } from "../credentials/store";
 import { loadServingCatalog } from "../inference/serving/catalog-loader";
 import { servingProfileProvenance } from "../inference/serving/profile-provenance";
-import { resolveOnboardOptions, runOnboardCommand } from "./command";
+import { resolveOnboardOptions, runOnboardCommand, servingProfileProviderKey } from "./command";
 import type { OnboardFlags } from "./command-support";
 import { PortableInferenceDescriptorError } from "./experimental/portable-inference-descriptor";
 import { invalidGatewayManagementDeclarationError } from "./gateway-management";
@@ -20,6 +20,7 @@ import {
   LOCAL_MODEL_PROFILE_RUNTIME_ENV,
 } from "./local-model-profile/plan";
 import { OnboardResumeIntentError, OnboardResumeIntentRaceError } from "./session-bootstrap";
+import { MANAGED_VLLM_PROVIDER_KEY } from "./vllm-menu";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -745,6 +746,63 @@ describe("onboard command options", () => {
 
     expect(observed).toBe(COMPATIBLE_NANO_PROFILE.id);
     expect(env.NEMOCLAW_SERVING_PRESET).toBeUndefined();
+  });
+
+  it("selects the profile's backend provider so onboarding skips the menu (#9313)", async () => {
+    // The preset alone only picks the model once a provider is chosen. Without
+    // a provider the run fell through to the interactive provider menu with the
+    // requested profile never applied.
+    const vllmProfile = {
+      ...COMPATIBLE_NANO_PROFILE,
+      id: "vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4",
+      displayName: "Muse Glimmer 30B NVFP4 W4A4 on one DGX Spark",
+      backend: "vllm",
+    };
+    const env: NodeJS.ProcessEnv = {};
+    let observedProvider: string | undefined;
+    let observedPreset: string | undefined;
+    await runOnboardCommand({
+      flags: { profile: vllmProfile.id },
+      env,
+      listServingProfiles: () => [vllmProfile],
+      runOnboard: async () => {
+        observedProvider = env.NEMOCLAW_PROVIDER;
+        observedPreset = env.NEMOCLAW_SERVING_PRESET;
+      },
+    });
+
+    expect(observedProvider).toBe("install-vllm");
+    expect(observedPreset).toBe(vllmProfile.id);
+    // Scoped to the run, like the preset itself.
+    expect(env.NEMOCLAW_PROVIDER).toBeUndefined();
+    expect(env.NEMOCLAW_SERVING_PRESET).toBeUndefined();
+  });
+
+  it("selects the managed llama.cpp provider for a llama-cpp profile (#9313)", async () => {
+    const env: NodeJS.ProcessEnv = {};
+    let observedProvider: string | undefined;
+    await runOnboardCommand({
+      flags: { profile: COMPATIBLE_NANO_PROFILE.id },
+      env,
+      listServingProfiles: () => [COMPATIBLE_NANO_PROFILE],
+      runOnboard: async () => {
+        observedProvider = env.NEMOCLAW_PROVIDER;
+      },
+    });
+
+    expect(observedProvider).toBe("install-llama-cpp");
+    expect(env.NEMOCLAW_PROVIDER).toBeUndefined();
+  });
+
+  it("maps each serving backend to the provider that can run it (#9313)", () => {
+    // A backend with no provider returns null, which `resolveServingProfile`
+    // reports instead of accepting the flag and then asking for a provider.
+    const withBackend = (backend: string) => ({ recipe: { backend } }) as never;
+
+    // Pinned against the provider menu's own key so the two cannot drift.
+    expect(servingProfileProviderKey(withBackend("vllm"))).toBe(MANAGED_VLLM_PROVIDER_KEY);
+    expect(servingProfileProviderKey(withBackend("install-llama-cpp"))).toBe("install-llama-cpp");
+    expect(servingProfileProviderKey(withBackend("future-backend"))).toBeNull();
   });
 
   it("records an installer profile without activating the disabled generic preset", async () => {

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -794,6 +794,44 @@ describe("onboard command options", () => {
     expect(env.NEMOCLAW_PROVIDER).toBeUndefined();
   });
 
+  it("rejects an unmapped backend on the resume path too (#9313)", () => {
+    // Explicit --profile, the installer path, and resume all converge on the
+    // same environment application, so the check lives at the end of the
+    // lifecycle rather than on the explicit path alone. Resume replays a
+    // recorded profile: a backend with no provider must be reported instead of
+    // resuming into the provider menu.
+    const catalog = loadServingCatalog();
+    // Retarget preset and recipe together; provenance requires them to agree.
+    const patchedCatalog = {
+      ...catalog,
+      presets: catalog.presets.map((preset) => ({
+        ...preset,
+        spec: { ...preset.spec, plan: { ...preset.spec.plan, backend: "future-backend" } },
+      })),
+      recipes: catalog.recipes.map((recipe) => ({
+        ...recipe,
+        spec: { ...recipe.spec, backend: "future-backend" },
+      })),
+    };
+    const recorded = servingProfileProvenance(
+      patchedCatalog as never,
+      catalog.presets[0]!.metadata.id,
+    );
+    const errors: string[] = [];
+
+    expect(() =>
+      resolve(
+        { resume: true },
+        {
+          loadServingCatalog: () => patchedCatalog as never,
+          loadSession: () => ({ servingProfileProvenance: recorded }) as never,
+          error: (message = "") => errors.push(message),
+        },
+      ),
+    ).toThrow("exit:1");
+    expect(errors.join("\n")).toContain("which onboarding cannot configure");
+  });
+
   it("maps each serving backend to the provider that can run it (#9313)", () => {
     // A backend with no provider returns null, which `resolveServingProfile`
     // reports instead of accepting the flag and then asking for a provider.

--- a/src/lib/onboard/command.ts
+++ b/src/lib/onboard/command.ts
@@ -275,7 +275,16 @@ function resolveServingProfile(
     throw error;
   }
   validateServingProfileConflicts(selectedProfileId, deps);
-  return servingProfileProvenance(catalog, selectedProfileId);
+  const provenance = servingProfileProvenance(catalog, selectedProfileId);
+  if (!servingProfileProviderKey(provenance)) {
+    // Reporting this beats the old behaviour of accepting the flag and then
+    // asking which provider to use, which left the profile silently unapplied.
+    fail(
+      deps,
+      `  Serving profile '${selectedProfileId}' uses backend '${provenance.recipe.backend}', which onboarding cannot configure with --profile.`,
+    );
+  }
+  return provenance;
 }
 
 function resolveInstallerServingProfile(
@@ -321,6 +330,29 @@ function resolveServingProfileLifecycle(
 function activeServingProfileId(provenance: ServingProfileProvenance | null): string | null {
   if (!provenance || provenance.preset.supportState === "disabled") return null;
   return provenance.preset.id;
+}
+
+/**
+ * Provider the requested serving profile has to run through.
+ *
+ * The preset alone only tells provider selection *which* profile to serve once
+ * a local-inference provider has been chosen; it never chooses the provider.
+ * Because `--profile` also rejects an explicit `NEMOCLAW_PROVIDER`, leaving
+ * this unset dropped onboarding into the interactive provider menu with the
+ * requested profile unusable (#9313). Returns null for a backend that has no
+ * provider wired up, which the caller reports rather than silently ignoring.
+ */
+export function servingProfileProviderKey(provenance: ServingProfileProvenance): string | null {
+  switch (provenance.recipe.backend) {
+    // Kept as literals so this module does not take a dependency on the
+    // provider menu; `command.test.ts` asserts they match its exported keys.
+    case "vllm":
+      return "install-vllm";
+    case "install-llama-cpp":
+      return "install-llama-cpp";
+    default:
+      return null;
+  }
 }
 
 function resolveResumedServingProfile(
@@ -477,9 +509,23 @@ function applyServingProfileEnvironment(
   if (!options.servingProfile) return () => {};
   const previous = env[NEMOCLAW_SERVING_PRESET_ENV];
   env[NEMOCLAW_SERVING_PRESET_ENV] = options.servingProfile;
+  // The preset selects the model once a provider is chosen; the profile's
+  // backend is what selects the provider. Setting only the former left the
+  // provider unresolved and onboarding fell back to the menu (#9313).
+  // `validateServingProfileConflicts` already rejected an operator-supplied
+  // NEMOCLAW_PROVIDER, so nothing of the caller's is being overwritten here.
+  const providerKey = options.servingProfileProvenance
+    ? servingProfileProviderKey(options.servingProfileProvenance)
+    : null;
+  const previousProvider = env.NEMOCLAW_PROVIDER;
+  if (providerKey) env.NEMOCLAW_PROVIDER = providerKey;
   return () => {
     if (previous === undefined) delete env[NEMOCLAW_SERVING_PRESET_ENV];
     else env[NEMOCLAW_SERVING_PRESET_ENV] = previous;
+    if (providerKey) {
+      if (previousProvider === undefined) delete env.NEMOCLAW_PROVIDER;
+      else env.NEMOCLAW_PROVIDER = previousProvider;
+    }
   };
 }
 

--- a/src/lib/onboard/command.ts
+++ b/src/lib/onboard/command.ts
@@ -275,16 +275,7 @@ function resolveServingProfile(
     throw error;
   }
   validateServingProfileConflicts(selectedProfileId, deps);
-  const provenance = servingProfileProvenance(catalog, selectedProfileId);
-  if (!servingProfileProviderKey(provenance)) {
-    // Reporting this beats the old behaviour of accepting the flag and then
-    // asking which provider to use, which left the profile silently unapplied.
-    fail(
-      deps,
-      `  Serving profile '${selectedProfileId}' uses backend '${provenance.recipe.backend}', which onboarding cannot configure with --profile.`,
-    );
-  }
-  return provenance;
+  return servingProfileProvenance(catalog, selectedProfileId);
 }
 
 function resolveInstallerServingProfile(
@@ -323,8 +314,26 @@ function resolveServingProfileLifecycle(
     );
   }
   const requested = explicit ?? installerProfile;
-  if (!resume) return requested;
-  return resolveResumedServingProfile(requested, deps);
+  const settled = resume ? resolveResumedServingProfile(requested, deps) : requested;
+  // Check the profile the run will actually apply, not just an explicit
+  // --profile: the installer and resume paths reach the same environment
+  // application, and an unmapped backend there would set the preset while
+  // leaving the provider unresolved — the silent fall-through to the provider
+  // menu this fixes (#9313).
+  return assertServingProfileProviderSupported(settled, deps);
+}
+
+function assertServingProfileProviderSupported(
+  provenance: ServingProfileProvenance | null,
+  deps: ResolveOnboardOptionsDeps,
+): ServingProfileProvenance | null {
+  const unsupported = provenance !== null && servingProfileProviderKey(provenance) === null;
+  return unsupported
+    ? fail(
+        deps,
+        `  Serving profile '${provenance.preset.id}' uses backend '${provenance.recipe.backend}', which onboarding cannot configure.`,
+      )
+    : provenance;
 }
 
 function activeServingProfileId(provenance: ServingProfileProvenance | null): string | null {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`onboard --profile` validated the requested serving profile and recorded its provenance, but never selected a provider. Onboarding therefore fell through to the interactive provider menu with the profile unapplied. The provider is now derived from the profile's backend and exported for the run alongside the preset.

Closes #9313.

## Reproduction

**Environment**

- Test machine: our DGX Spark `aarch64` test host with a GB10 GPU, matching the reporter's platform
- Ubuntu 24.04, Node.js 22.22.2, OpenShell CLI 0.0.101
- NemoClaw `main` at `8cdc3c41e`

```bash
nemoclaw profiles list
env | grep '^NEMOCLAW_'

nemoclaw onboard --profile vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4 \
  --name muse-prof-9313 --fresh --yes --yes-i-accept-third-party-software < /dev/null
```

**Before this change**

```text
[3/8] Configuring inference provider
──────────────────────────────────────────────────
Detected local inference options: vLLM, Ollama

Select your inference provider:
  1) NVIDIA Endpoints
  ...
  14) Local llama.cpp

Choose [1]:   Installation cancelled
```

The requested profile was absent from the menu, and the provenance block did not print.

**After this change**

```text
[3/8] Configuring inference provider
──────────────────────────────────────────────────
[non-interactive] Provider: install-vllm

vLLM (DGX Spark):
  Image: vllm/vllm-openai@sha256:677afd5bf3b4bb9881f91e107af7098f8410726b4c05b25cb4a815900b398204
  Model: Inferact/Muse-Glimmer-30B-NVFP4-W4A4
```

The provider menu is skipped. The immutable runtime image and model are the values declared by the profile, and the provenance block prints in the summary.

## Analysis

`resolveOnboardOptions` resolves `--profile` into a `ServingProfileProvenance`, and `applyServingProfileEnvironment` exports it for the run:

```ts
env[NEMOCLAW_SERVING_PRESET_ENV] = options.servingProfile;
```

The preset tells provider selection which profile to serve after a local inference provider is chosen; it does not choose the provider. Nothing else in this flow consumed the provenance, so provider selection behaved as if no profile had been requested and presented the menu.

The two inputs were tested independently on the DGX Spark host. The preset alone reproduced the menu. Adding the provider required by the profile skipped it:

```text
NEMOCLAW_SERVING_PRESET=<profile>                                  -> menu shown
NEMOCLAW_SERVING_PRESET=<profile> NEMOCLAW_PROVIDER=install-vllm -> menu skipped
```

The flag was unusable rather than inconvenient: `PROFILE_CONFLICT_ENV` rejects an operator-supplied `NEMOCLAW_PROVIDER` together with `--profile`, so the missing provider could not be supplied separately. Without a TTY, the run blocked on the hidden prompt, matching the report.

## Fix

Derive the provider from the profile's backend and export it for the same run:

```ts
export function servingProfileProviderKey(provenance: ServingProfileProvenance): string | null {
  switch (provenance.recipe.backend) {
    case "vllm":
      return "install-vllm";
    case "install-llama-cpp":
      return "install-llama-cpp";
    default:
      return null;
  }
}
```

`applyServingProfileEnvironment` sets `NEMOCLAW_PROVIDER` next to the preset and restores both afterward. `validateServingProfileConflicts` has already rejected an operator-supplied `NEMOCLAW_PROVIDER`, so the run does not overwrite operator state.

The mapping is applied to explicit, installer, and resume paths. A backend with no configured provider now fails before onboarding changes runtime resources:

```text
Serving profile '<id>' uses backend '<backend>', which onboarding cannot configure.
```

Tests cover both supported provider mappings, all three profile paths, run-scoped cleanup after success and handled failure, cleanup after an invalid agent manifest, and the unsupported-backend result.

## Changes

- `src/lib/onboard/command.ts`: map a profile backend to its inference provider, export it with the preset for the run, and reject a backend with no provider.
- `src/lib/onboard/command.test.ts`: cover both mappings, every profile path, unsupported backends, and provider cleanup.
- `docs/inference/set-up-vllm.mdx`: document provider selection and the unsupported-backend boundary for `--profile`.

## Platform Scope

The issue was reproduced and the change was verified on our DGX Spark `aarch64` test host, matching the reporter's platform. The change is provider and flag resolution with no platform-specific branch, so it applies wherever a compatible profile is selected.

The test host initially had a mock vLLM process listening on `localhost:8000`, which caused the first run to reuse the running instance. Stopping it produced the managed-install run quoted above. Both runs skipped the provider menu.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] Normal commit and push hooks passed
- [x] Focused onboarding tests passed: 59/59
- [x] Tests added or updated for new or changed behavior
- [x] `npm run docs` passed all 68 guarded routes with 0 Fern errors
- [x] Documentation follows `docs/CONTRIBUTING.md`
- [x] Independent documentation writer review completed with no findings
- [x] No secrets, API keys, or credentials committed

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `docs/inference/set-up-vllm.mdx`; focused onboarding tests 59/59; `npm run docs` passed 68 guarded routes with 0 Fern errors
- Agent: Codex Desktop
<!-- docs-review-head-sha: 08a49f80b -->
<!-- docs-review-agents-blob-sha: b9fb6a9ba -->

## AI Disclosure

- [x] AI-assisted — contributor tool: Claude Code; maintainer review and follow-up: Codex Desktop

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Onboarding now selects the correct provider for supported serving profiles.
  - Unsupported serving-profile backends are rejected instead of proceeding without a provider.
  - Provider and preset settings are isolated to the current onboarding run and restored afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
