### PR TITLE
fix(cli): detect proxied connect sessions in session reporting

### DIFF
--- a/src/lib/adapters/openshell/sandbox-identity.test.ts
+++ b/src/lib/adapters/openshell/sandbox-identity.test.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { parseOpenShellSandboxId } from "./sandbox-identity";
+import { createOpenshellSandboxIdReader, parseOpenShellSandboxId } from "./sandbox-identity";
 
 describe("OpenShell sandbox identity parsing", () => {
   it("accepts one exact durable ID with optional terminal color", () => {
@@ -17,5 +17,31 @@ describe("OpenShell sandbox identity parsing", () => {
     expect(parseOpenShellSandboxId("ID: first\nID: second\n")).toBeNull();
     expect(parseOpenShellSandboxId("ID: sandbox/alpha\n")).toBeNull();
     expect(parseOpenShellSandboxId("id: sandbox-alpha\n")).toBeNull();
+  });
+});
+
+describe("OpenShell sandbox identity reading", () => {
+  it("reads each sandbox ID once per process (#9316)", () => {
+    const runCommand = vi.fn(() => ({ status: 0, stdout: "Name: alpha\nID: sandbox-alpha\n" }));
+    const readSandboxId = createOpenshellSandboxIdReader("/usr/bin/openshell", runCommand);
+
+    expect(readSandboxId("alpha")).toBe("sandbox-alpha");
+    expect(readSandboxId("alpha")).toBe("sandbox-alpha");
+    expect(runCommand).toHaveBeenCalledExactlyOnceWith("/usr/bin/openshell", [
+      "sandbox",
+      "get",
+      "alpha",
+    ]);
+  });
+
+  it("caches a failed sandbox ID lookup as unavailable (#9316)", () => {
+    const runCommand = vi.fn((): { status: number; stdout: string } => {
+      throw new Error("OpenShell unavailable");
+    });
+    const readSandboxId = createOpenshellSandboxIdReader("/usr/bin/openshell", runCommand);
+
+    expect(readSandboxId("alpha")).toBeNull();
+    expect(readSandboxId("alpha")).toBeNull();
+    expect(runCommand).toHaveBeenCalledOnce();
   });
 });

--- a/src/lib/adapters/openshell/sandbox-identity.ts
+++ b/src/lib/adapters/openshell/sandbox-identity.ts
@@ -30,3 +30,33 @@ export function resolveOpenShellSandboxId(
   }
   return sandboxId;
 }
+
+/**
+ * Read sandbox IDs from the OpenShell CLI, memoized per process.
+ *
+ * Session detection needs the durable ID because newer OpenShell connects every
+ * sandbox through one fixed SSH alias and names the target only on its proxy
+ * command (#9316). Keeping the host-boundary call here leaves the state layer
+ * to parsing and classification. A sandbox whose ID cannot be read yields null,
+ * which leaves detection on SSH-host matching rather than failing the
+ * surrounding command.
+ */
+export function createOpenshellSandboxIdReader(
+  openshellBinary: string,
+  runCommand: (binary: string, args: string[]) => { status: number | null; stdout: string },
+): (sandboxName: string) => string | null {
+  const cache = new Map<string, string | null>();
+  return (sandboxName: string): string | null => {
+    const cached = cache.get(sandboxName);
+    if (cached !== undefined) return cached;
+    let resolved: string | null = null;
+    try {
+      const result = runCommand(openshellBinary, ["sandbox", "get", sandboxName]);
+      resolved = result.status === 0 ? parseOpenShellSandboxId(result.stdout || "") : null;
+    } catch {
+      resolved = null;
+    }
+    cache.set(sandboxName, resolved);
+    return resolved;
+  };
+}

--- a/src/lib/list-command-deps.ts
+++ b/src/lib/list-command-deps.ts
@@ -50,6 +50,12 @@ export function buildListCommandDeps(): ListSandboxesCommandDeps {
   // Cache the SSH process probe once for all sandboxes — avoids spawning ps
   // per sandbox row. The getSshProcesses() call is the expensive part (5s timeout).
   let cachedSshOutput: string | null | undefined;
+
+  // Resolving a sandbox ID costs one OpenShell call, so only pay it when the
+  // process list actually contains a proxied connection that needs one (#9316).
+  const resolveSandboxIdForSessions = (sshOutput: string, name: string): string | null =>
+    sshOutput.includes("--sandbox-id") ? (sessionDeps?.resolveSandboxId?.(name) ?? null) : null;
+
   const getCachedSshOutput = () => {
     if (cachedSshOutput === undefined && sessionDeps) {
       try {
@@ -86,7 +92,8 @@ export function buildListCommandDeps(): ListSandboxesCommandDeps {
           try {
             const sshOutput = getCachedSshOutput();
             if (sshOutput === null) return null;
-            return parseSshProcesses(sshOutput, name).length;
+            return parseSshProcesses(sshOutput, name, resolveSandboxIdForSessions(sshOutput, name))
+              .length;
           } catch {
             return null;
           }

--- a/src/lib/state/sandbox-session.test.ts
+++ b/src/lib/state/sandbox-session.test.ts
@@ -102,6 +102,48 @@ describe("parseSshProcesses", () => {
     });
   });
 
+  // Newer OpenShell routes every sandbox through one fixed `sandbox` alias and
+  // names the target only on its proxy command, so the SSH host carries no
+  // sandbox reference at all (#9316).
+  const PROXY = (id: string) =>
+    `ssh -o ProxyCommand=/usr/local/bin/openshell ssh-proxy --gateway 'https://127.0.0.1:8080' --sandbox-id ${id} --token t --gateway-name nemoclaw -o StrictHostKeyChecking=no`;
+  const SANDBOX_ID = "de7eab7a-002f-41e9-acad-5fd4749e07bb";
+  const interactiveLine = `12345 ${PROXY(SANDBOX_ID)} -tt -o RequestTTY=force -o SetEnv=TERM=xterm-256color sandbox`;
+  const forwardLine = `12300 ${PROXY(SANDBOX_ID)} -N -o ExitOnForwardFailure=yes -L 127.0.0.1:18789:127.0.0.1:18789 sandbox`;
+
+  it("detects a proxied interactive session by sandbox ID (#9316)", () => {
+    expect(parseSshProcesses(interactiveLine, "my-sandbox", SANDBOX_ID)).toEqual([
+      {
+        sandboxName: "my-sandbox",
+        pid: 12345,
+        sshHost: "openshell-my-sandbox.default",
+      },
+    ]);
+  });
+
+  it("does not count the dashboard forward as a session (#9316)", () => {
+    // The forward runs through the same proxy and sandbox ID; only the
+    // interactive session requests a TTY. Counting it would report a session
+    // on every Ready sandbox.
+    expect(parseSshProcesses(forwardLine, "my-sandbox", SANDBOX_ID)).toEqual([]);
+    expect(
+      parseSshProcesses(`${forwardLine}\n${interactiveLine}`, "my-sandbox", SANDBOX_ID),
+    ).toHaveLength(1);
+  });
+
+  it("does not attribute a proxied session without a known sandbox ID (#9316)", () => {
+    // The command line carries no sandbox name, so guessing would attribute one
+    // sandbox's session to another.
+    expect(parseSshProcesses(interactiveLine, "my-sandbox")).toEqual([]);
+    expect(parseSshProcesses(interactiveLine, "my-sandbox", "")).toEqual([]);
+  });
+
+  it("does not match another sandbox's ID (#9316)", () => {
+    expect(
+      parseSshProcesses(interactiveLine, "other-sandbox", "aaaaaaaa-0000-0000-0000-000000000000"),
+    ).toEqual([]);
+  });
+
   it("detects a legacy SSH process during the upgrade window", () => {
     const output = `12345 ssh -F /tmp/config openshell-my-sandbox
 67890 ssh -F /tmp/config openshell-other-sandbox`;

--- a/src/lib/state/sandbox-session.test.ts
+++ b/src/lib/state/sandbox-session.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   classifySessionState,
   type ForwardEntry,
@@ -327,6 +327,45 @@ describe("getActiveSandboxSessions", () => {
     expect(result.detected).toBe(true);
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0].pid).toBe(12345);
+  });
+
+  it("resolves a durable ID for a proxied interactive session (#9316)", () => {
+    const sandboxId = "de7eab7a-002f-41e9-acad-5fd4749e07bb";
+    const resolveSandboxId = vi.fn(() => sandboxId);
+    const deps: SessionDetectionDeps = {
+      getForwardList: () => "",
+      getSshProcesses: () =>
+        `12345 ssh -o ProxyCommand=/usr/local/bin/openshell ssh-proxy --sandbox-id ${sandboxId} --token t -tt -o RequestTTY=force sandbox`,
+      resolveSandboxId,
+    };
+
+    const result = getActiveSandboxSessions("my-sandbox", deps);
+
+    expect(resolveSandboxId).toHaveBeenCalledExactlyOnceWith("my-sandbox");
+    expect(result).toEqual({
+      detected: true,
+      sessions: [
+        {
+          sandboxName: "my-sandbox",
+          pid: 12345,
+          sshHost: "openshell-my-sandbox.default",
+        },
+      ],
+    });
+  });
+
+  it("does not resolve a durable ID for a host-alias session (#9316)", () => {
+    const resolveSandboxId = vi.fn(() => "unused-id");
+    const deps: SessionDetectionDeps = {
+      getForwardList: () => "",
+      getSshProcesses: () => "12345 ssh -F /tmp/cfg openshell-my-sandbox.default\n",
+      resolveSandboxId,
+    };
+
+    const result = getActiveSandboxSessions("my-sandbox", deps);
+
+    expect(resolveSandboxId).not.toHaveBeenCalled();
+    expect(result.sessions).toHaveLength(1);
   });
 
   it("returns detected=false when pgrep unavailable (forward list alone insufficient)", () => {

--- a/src/lib/state/sandbox-session.ts
+++ b/src/lib/state/sandbox-session.ts
@@ -14,7 +14,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { parseOpenShellSandboxId } from "../adapters/openshell/sandbox-identity";
+import { createOpenshellSandboxIdReader } from "../adapters/openshell/sandbox-identity";
 import { openshellSandboxSshHost } from "../adapters/openshell/sandbox-ssh-host";
 
 // ---------------------------------------------------------------------------
@@ -339,34 +339,13 @@ export function createSystemDeps(openshellBinary: string): SessionDetectionDeps 
       }
     },
     getSshProcesses: querySshProcesses,
-    resolveSandboxId: createOpenshellSandboxIdResolver(openshellBinary),
-  };
-}
-
-/**
- * Read a sandbox's durable ID via `openshell sandbox get`, memoized per process
- * and failing soft. Detection stays on SSH-host matching when the lookup fails,
- * so an unavailable OpenShell client never breaks the surrounding command.
- */
-function createOpenshellSandboxIdResolver(
-  openshellBinary: string,
-): (sandboxName: string) => string | null {
-  const cache = new Map<string, string | null>();
-  return (sandboxName: string): string | null => {
-    const cached = cache.get(sandboxName);
-    if (cached !== undefined) return cached;
-    let resolved: string | null = null;
-    try {
-      const result = spawnSync(openshellBinary, ["sandbox", "get", sandboxName], {
+    resolveSandboxId: createOpenshellSandboxIdReader(openshellBinary, (binary, args) => {
+      const result = spawnSync(binary, args, {
         encoding: "utf-8",
         stdio: ["ignore", "pipe", "pipe"],
         timeout: 5000,
       });
-      resolved = result.status === 0 ? parseOpenShellSandboxId(result.stdout || "") : null;
-    } catch {
-      resolved = null;
-    }
-    cache.set(sandboxName, resolved);
-    return resolved;
+      return { status: result.status, stdout: result.stdout || "" };
+    }),
   };
 }

--- a/src/lib/state/sandbox-session.ts
+++ b/src/lib/state/sandbox-session.ts
@@ -14,6 +14,7 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { parseOpenShellSandboxId } from "../adapters/openshell/sandbox-identity";
 import { openshellSandboxSshHost } from "../adapters/openshell/sandbox-ssh-host";
 
 // ---------------------------------------------------------------------------
@@ -96,13 +97,30 @@ export function parseForwardList(output: string | null | undefined): ForwardEntr
 }
 
 /**
+ * Does this command line belong to an interactive shell rather than a forward?
+ *
+ * OpenShell starts the dashboard port-forward through the same proxy and the
+ * same `sandbox` host alias as `connect`, so the sandbox reference alone cannot
+ * tell them apart. The interactive session is the one that asks for a TTY; the
+ * forward runs `-N` with no remote command. Counting the forward would report a
+ * session on every Ready sandbox.
+ */
+function isInteractiveSshCommand(command: string): boolean {
+  return /(?:^|\s)-tt(?:\s|$)/.test(command) || /RequestTTY=force/.test(command);
+}
+
+/**
  * Parse process list output to find SSH processes targeting a specific sandbox.
  *
- * Current SSH connections use `openshell-<sandboxName>.default`. During the
- * supported v0.0.85 to v0.0.99 upgrade window, an already-running connection
- * may still target the legacy `openshell-<sandboxName>` alias. We recognize
- * both as complete tokens to avoid false positives when one sandbox name is a
- * prefix of another (e.g., `dev` vs `dev-staging`).
+ * Two shapes are recognized. OpenShell used to place the sandbox in the SSH
+ * host itself (`openshell-<sandboxName>.default`, and the legacy
+ * `openshell-<sandboxName>` from the v0.0.85 to v0.0.99 upgrade window); those
+ * are matched as complete tokens so one sandbox name cannot match another it is
+ * a prefix of (`dev` vs `dev-staging`). Newer OpenShell connects every sandbox
+ * through the fixed `sandbox` alias and identifies the target with
+ * `--sandbox-id <id>` on its proxy command instead, which left interactive
+ * sessions invisible to every session-reporting surface (#9316). When the
+ * caller knows the durable sandbox ID, that form is matched too.
  *
  * Input format: one line per process — `<PID> <full command line>`
  * (compatible with both `pgrep -a` on Linux and `ps -axo pid,command`)
@@ -110,6 +128,7 @@ export function parseForwardList(output: string | null | undefined): ForwardEntr
 export function parseSshProcesses(
   pgrepOutput: string | null | undefined,
   sandboxName: string,
+  sandboxId?: string | null,
 ): SandboxSession[] {
   if (!pgrepOutput || typeof pgrepOutput !== "string") return [];
   if (!sandboxName) return [];
@@ -118,6 +137,10 @@ export function parseSshProcesses(
   const hostPatterns = sshHosts.map(
     (sshHost) => [sshHost, new RegExp(`(?:^|\\s)${escapeRegExp(sshHost)}(?:\\s|$)`)] as const,
   );
+  const idPattern =
+    sandboxId && sandboxId.trim()
+      ? new RegExp(`--sandbox-id[=\\s]+${escapeRegExp(sandboxId.trim())}(?:\\s|$)`)
+      : null;
   const sessions: SandboxSession[] = [];
   const lines = pgrepOutput.split("\n").filter(Boolean);
 
@@ -126,10 +149,17 @@ export function parseSshProcesses(
     if (!pidMatch) continue;
 
     const pid = Number.parseInt(pidMatch[1], 10);
+    const command = pidMatch[2];
 
-    const sshHost = hostPatterns.find(([, pattern]) => pattern.test(pidMatch[2]))?.[0];
+    const sshHost = hostPatterns.find(([, pattern]) => pattern.test(command))?.[0];
     if (sshHost) {
       sessions.push({ sandboxName, pid, sshHost });
+      continue;
+    }
+    // The proxied form carries no sandbox name, so it is only attributable
+    // when the caller resolved the sandbox's durable ID.
+    if (idPattern?.test(command) && isInteractiveSshCommand(command)) {
+      sessions.push({ sandboxName, pid, sshHost: openshellSandboxSshHost(sandboxName) });
     }
   }
 
@@ -216,6 +246,12 @@ export interface SessionDetectionDeps {
   getForwardList: () => string | null;
   /** Run `pgrep -a ssh` and return stdout. Null if unavailable. */
   getSshProcesses: () => string | null;
+  /**
+   * Resolve the sandbox's durable OpenShell ID, or null when it cannot be
+   * determined. Only consulted when the process list contains a proxied
+   * connection, which is the only shape that needs it (#9316).
+   */
+  resolveSandboxId?: (sandboxName: string) => string | null;
 }
 
 /**
@@ -244,7 +280,12 @@ export function getActiveSandboxSessions(
     return { detected: false, sessions: [] };
   }
 
-  const sshSessions = parseSshProcesses(pgrepOutput, sandboxName);
+  // Resolving the ID costs an OpenShell call, so only pay it for the proxied
+  // shape that cannot be attributed from the SSH host alone (#9316).
+  const sandboxId = pgrepOutput.includes("--sandbox-id")
+    ? (deps.resolveSandboxId?.(sandboxName) ?? null)
+    : null;
+  const sshSessions = parseSshProcesses(pgrepOutput, sandboxName, sandboxId);
 
   return {
     detected: true,
@@ -298,5 +339,34 @@ export function createSystemDeps(openshellBinary: string): SessionDetectionDeps 
       }
     },
     getSshProcesses: querySshProcesses,
+    resolveSandboxId: createOpenshellSandboxIdResolver(openshellBinary),
+  };
+}
+
+/**
+ * Read a sandbox's durable ID via `openshell sandbox get`, memoized per process
+ * and failing soft. Detection stays on SSH-host matching when the lookup fails,
+ * so an unavailable OpenShell client never breaks the surrounding command.
+ */
+function createOpenshellSandboxIdResolver(
+  openshellBinary: string,
+): (sandboxName: string) => string | null {
+  const cache = new Map<string, string | null>();
+  return (sandboxName: string): string | null => {
+    const cached = cache.get(sandboxName);
+    if (cached !== undefined) return cached;
+    let resolved: string | null = null;
+    try {
+      const result = spawnSync(openshellBinary, ["sandbox", "get", sandboxName], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 5000,
+      });
+      resolved = result.status === 0 ? parseOpenShellSandboxId(result.stdout || "") : null;
+    } catch {
+      resolved = null;
+    }
+    cache.set(sandboxName, resolved);
+    return resolved;
   };
 }

--- a/src/lib/status-command-deps.ts
+++ b/src/lib/status-command-deps.ts
@@ -248,6 +248,12 @@ export function buildStatusCommandDeps(rootDir: string): ShowStatusCommandDeps {
   // Cache the SSH process probe once per command invocation — avoids
   // spawning ps per sandbox row. #2604; mirrors buildListCommandDeps.
   let cachedSshOutput: string | null | undefined;
+
+  // Resolving a sandbox ID costs one OpenShell call, so only pay it when the
+  // process list actually contains a proxied connection that needs one (#9316).
+  const resolveSandboxIdForSessions = (sshOutput: string, name: string): string | null =>
+    sshOutput.includes("--sandbox-id") ? (sessionDeps?.resolveSandboxId?.(name) ?? null) : null;
+
   const getCachedSshOutput = (): string | null => {
     if (cachedSshOutput === undefined && sessionDeps) {
       try {
@@ -278,7 +284,8 @@ export function buildStatusCommandDeps(rootDir: string): ShowStatusCommandDeps {
           try {
             const sshOutput = getCachedSshOutput();
             if (sshOutput === null) return null;
-            return parseSshProcesses(sshOutput, name).length;
+            return parseSshProcesses(sshOutput, name, resolveSandboxIdForSessions(sshOutput, name))
+              .length;
           } catch {
             return null;
           }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Session detection identified a sandbox by its SSH host alias, but newer OpenShell connects every sandbox through one fixed `sandbox` alias and names the target only on its proxy command. An attached `connect` session therefore matched nothing, and all three session-reporting surfaces showed no session. Detection now also matches the proxied shape by the sandbox's durable OpenShell ID.

Closes #9316.

## Reproduction

**Environment**

- Test machine: our Ubuntu 24.04 `x86_64` test host without a GPU
- Node.js 22.22.2, OpenShell CLI 0.0.101, NemoClaw `main` at `8cdc3c41e`
- Sandbox: OpenClaw with NVIDIA Endpoints

An interactive session was held open with a PTY driver, and the reporting surfaces were read from a separate shell while it was attached.

**Before this change**

The process is live and requests a TTY:

```text
PID 2647689  ssh -o ProxyCommand=/home/.../openshell ssh-proxy --gateway 'https://127.0.0.1:8080'
             --sandbox-id de7eab7a-002f-41e9-acad-5fd4749e07bb --token ... --gateway-name nemoclaw
             ... -tt -o RequestTTY=force -o SetEnv=TERM=xterm-256color sandbox
```

Every reporting surface nevertheless showed no session:

```text
parseSshProcesses:            0
nemoclaw <name> status:       SSH sessions: none
nemoclaw list --json:         "activeSessionCount": 0
nemoclaw list:                repro-9302 *          (no active-session dot)
```

**After this change**

```text
parseSshProcesses:            1
nemoclaw <name> status:       SSH sessions: 1
nemoclaw list --json:         "activeSessionCount": 1
nemoclaw list:                repro-9302 * ●
```

After that session detaches, the dashboard forward remains running while all three surfaces return to their empty state:

| State | Connect processes | Forward processes | `status` | `list --json` | `list` |
|---|---:|---:|---|---:|---|
| Attached, before this change | 1 | 1 | none | 0 | no dot |
| Attached, after this change | 1 | 1 | **1** | **1** | **●** |
| Detached, after this change | 0 | 1 | none | 0 | no dot |

## Analysis

`parseSshProcesses` in `src/lib/state/sandbox-session.ts` located a sandbox's sessions by scanning process command lines for its SSH host:

```ts
const sshHosts = [openshellSandboxSshHost(sandboxName), `openshell-${sandboxName}`] as const;
```

OpenShell 0.0.101 connects through a proxy instead. The host is the literal `sandbox` for every sandbox, and `--sandbox-id <uuid>` inside the `ProxyCommand` identifies the target. The command line contains no sandbox name, so the host patterns cannot match it.

All three surfaces share this detector: `list` and `list --json` use `getActiveSessionCount`, and `<name> status` uses `printActiveSessions` and `getActiveSandboxSessions`.

The dashboard forward uses the same proxy and sandbox ID. Matching the ID alone would count a session on every Ready sandbox. The interactive session requests a TTY with `-tt` or `RequestTTY=force`; the forward runs with `-N` and no remote command.

## Fix

`parseSshProcesses` accepts an optional durable sandbox ID. When that ID is available, it matches a proxy command carrying the exact ID and requesting a TTY. Existing SSH-host matching is unchanged, including the supported legacy alias.

The OpenShell identity adapter reads and validates the sandbox ID. Session dependencies inject that reader into the parser and contain its cost:

- The lookup runs only when the process list contains `--sandbox-id`.
- Successful and failed results are cached per sandbox for the life of the command.
- A failed lookup returns `null`, so `list` and `status` retain SSH-host matching instead of failing.

Tests cover parser classification, dashboard-forward exclusion, cross-sandbox isolation, high-level resolver wiring, the host-alias path that must not invoke the resolver, successful memoization, and fail-soft caching.

## Changes

- `src/lib/adapters/openshell/sandbox-identity.ts`: read, validate, and cache durable sandbox IDs behind the OpenShell adapter boundary.
- `src/lib/list-command-deps.ts`, `src/lib/status-command-deps.ts`: pass a conditionally resolved sandbox ID through the cached-process-list path.
- `src/lib/state/sandbox-session.ts`: match proxied interactive sessions by exact sandbox ID and TTY intent while excluding forwards.
- `src/lib/adapters/openshell/sandbox-identity.test.ts`, `src/lib/state/sandbox-session.test.ts`: cover parsing, classification, dependency wiring, memoization, and failure handling.

## Platform Scope

The issue was reproduced and the change was verified on our Ubuntu 24.04 `x86_64` test host. The reporter identified Ubuntu 26.04, Ubuntu 24.04, and DGX Spark. The cause is the OpenShell connection shape rather than host-specific behavior, so the fix applies uniformly; it was not separately run on `aarch64`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Verification

- [x] Normal commit and push hooks passed
- [x] Contributor verification passed 779 tests across state, inventory, and status-flow suites
- [x] Maintainer affected-test run passed 42/42
- [x] Tests added or updated for changed behavior and resolver wiring
- [x] Current required CI passed before the maintainer test follow-up; fresh CI is running
- [x] Cross-issue sweep found no adjacent fixes or contradictions
- [x] Independent documentation writer review concluded `docs-not-needed`
- [x] No secrets, API keys, or credentials committed

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-not-needed`
- Evidence: existing SSH-session output contracts remain accurate in `docs/manage-sandboxes/lifecycle.mdx` and `docs/reference/commands.mdx`; affected tests passed 42/42
- Agent: Codex Desktop
<!-- docs-review-head-sha: b6e52059b -->
<!-- docs-review-agents-blob-sha: b9fb6a9ba -->

## AI Disclosure

- [x] AI-assisted — contributor tool: Claude Code; maintainer review and follow-up: Codex Desktop

Signed-off-by: Yanyun Liao <yanyunl@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of interactive SSH sessions routed through sandbox host aliases.
  * Correctly distinguishes interactive sessions from dashboard port-forwarding sessions.
  * Added reliable matching for sessions that identify sandboxes with `--sandbox-id`.
  * Preserved support for legacy host matching and active-session error handling.
  * Improved session status reliability when sandbox identity lookups succeed, fail, or are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
