### PR TITLE
test: convert another 100 loops to table tests

### DIFF
--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -3,7 +3,7 @@
   "defaultMaxLines": 1500,
   "legacyMaxLines": {
     "nemoclaw/src/commands/migration-state.test.ts": 1300,
-    "src/lib/inference/nim.test.ts": 2067,
+    "src/lib/inference/nim.test.ts": 2064,
     "src/lib/onboard/preflight.test.ts": 1875,
     "test/generate-openclaw-config.test.ts": 1915,
     "test/install-preflight.test.ts": 3025,

--- a/nemoclaw/src/blueprint/ssrf.test.ts
+++ b/nemoclaw/src/blueprint/ssrf.test.ts
@@ -12,9 +12,8 @@ vi.mock("node:dns", () => ({
   promises: { lookup: (...args: unknown[]) => mockLookup(...(args as [string, { all: true }])) },
 }));
 
-const { isPrivateIp, safeEndpointUrlForDownstream, validateEndpointUrl } = await import(
-  "./ssrf.js"
-);
+const { isPrivateIp, safeEndpointUrlForDownstream, validateEndpointUrl } =
+  await import("./ssrf.js");
 
 // ── isPrivateIp ─────────────────────────────────────────────────
 
@@ -406,9 +405,8 @@ describe("validateEndpointUrl – URL parsing edge cases", () => {
     expect(() => safeEndpointUrlForDownstream(result)).toThrow(/DNS-backed HTTPS endpoint/);
   });
 
-  it("rejects URL with userinfo/basic auth credentials", async () => {
-    mockLookup.mockClear();
-    const cases = [
+  it.each(
+    [
       {
         url: "https://alice:s3cret-token@api.example.com/v1",
         secrets: ["alice", "s3cret-token", "alice:s3cret-token"],
@@ -417,36 +415,33 @@ describe("validateEndpointUrl – URL parsing edge cases", () => {
         url: "http://alice:s3cret-token@api.example.com/v1",
         secrets: ["alice", "s3cret-token", "alice:s3cret-token"],
       },
-      {
-        url: "https://only-alice@api.example.com/v1",
-        secrets: ["only-alice"],
-      },
-      {
-        url: "https://:only-s3cret@api.example.com/v1",
-        secrets: ["only-s3cret"],
-      },
-    ] as const;
-
-    for (const { url, secrets } of cases) {
-      let thrown: unknown;
-      try {
-        await validateEndpointUrl(url);
-      } catch (error) {
-        thrown = error;
-      }
-      expect(thrown).toBeInstanceOf(Error);
-      const message = thrown instanceof Error ? thrown.message : String(thrown);
-      expect(message).toMatch(/must not contain credentials/);
-      for (const secret of secrets) {
-        expect(message).not.toContain(secret);
-      }
+      { url: "https://only-alice@api.example.com/v1", secrets: ["only-alice"] },
+      { url: "https://:only-s3cret@api.example.com/v1", secrets: ["only-s3cret"] },
+    ].flatMap(({ url, secrets }, caseIndex) =>
+      secrets.map((secret, secretIndex) => ({
+        caseName: `credential URL ${caseIndex + 1}`,
+        secret,
+        secretName: `credential part ${secretIndex + 1}`,
+        url,
+      })),
+    ),
+  )("rejects $caseName without exposing $secretName", async ({ url, secret }) => {
+    mockLookup.mockClear();
+    let thrown: unknown;
+    try {
+      await validateEndpointUrl(url);
+    } catch (error) {
+      thrown = error;
     }
+    expect(thrown).toBeInstanceOf(Error);
+    const message = thrown instanceof Error ? thrown.message : String(thrown);
+    expect(message).toMatch(/must not contain credentials/);
+    expect(message).not.toContain(secret);
     expect(mockLookup).not.toHaveBeenCalled();
   });
 
-  it("does not expose credentials from malformed endpoint URLs", async () => {
-    mockLookup.mockClear();
-    const cases = [
+  it.each(
+    [
       {
         url: "https://alice:s3cret-token@",
         secrets: ["alice", "s3cret-token", "alice:s3cret-token"],
@@ -457,22 +452,26 @@ describe("validateEndpointUrl – URL parsing edge cases", () => {
       },
       { url: "https://:only-s3cret@", secrets: ["only-s3cret"] },
       { url: "https://only-alice@", secrets: ["only-alice"] },
-    ] as const;
-
-    for (const { url, secrets } of cases) {
-      let thrown: unknown;
-      try {
-        await validateEndpointUrl(url);
-      } catch (error) {
-        thrown = error;
-      }
-      expect(thrown).toBeInstanceOf(Error);
-      const message = thrown instanceof Error ? thrown.message : String(thrown);
-      expect(message).toMatch(/No hostname found in URL/);
-      for (const secret of secrets) {
-        expect(message).not.toContain(secret);
-      }
+    ].flatMap(({ url, secrets }, caseIndex) =>
+      secrets.map((secret, secretIndex) => ({
+        caseName: `malformed credential URL ${caseIndex + 1}`,
+        secret,
+        secretName: `credential part ${secretIndex + 1}`,
+        url,
+      })),
+    ),
+  )("does not expose $secretName from $caseName", async ({ url, secret }) => {
+    mockLookup.mockClear();
+    let thrown: unknown;
+    try {
+      await validateEndpointUrl(url);
+    } catch (error) {
+      thrown = error;
     }
+    expect(thrown).toBeInstanceOf(Error);
+    const message = thrown instanceof Error ? thrown.message : String(thrown);
+    expect(message).toMatch(/No hostname found in URL/);
+    expect(message).not.toContain(secret);
     expect(mockLookup).not.toHaveBeenCalled();
   });
 });

--- a/nemoclaw/src/shared/credential-filter-boundary.test.ts
+++ b/nemoclaw/src/shared/credential-filter-boundary.test.ts
@@ -50,64 +50,68 @@ describe("shared credential filter", () => {
     expect(isConfigValue(["model", new Date()])).toBe(false);
   });
 
-  it("classifies credential names without treating public keys as secrets (#8291)", () => {
-    for (const field of [
-      "botToken",
-      "bot_token",
-      "appToken",
-      "access_token",
-      "personal_access_token",
-      "refresh-token",
-      "client_secret",
-      "auth_token",
-      "oauth_token",
-      "apikey",
-      "Token",
-      "GITHUB_TOKEN",
-      "Authorization",
-      "X-API-Key",
-      "DB_PASS",
-    ]) {
-      expect(isCredentialField(field), field).toBe(true);
-    }
-    for (const field of ["publicKey", "public.key", "GITHUB_PUBLIC_KEY", "NODE_ENV", "model"]) {
-      expect(isCredentialField(field), field).toBe(false);
-    }
+  it.each([
+    "botToken",
+    "bot_token",
+    "appToken",
+    "access_token",
+    "personal_access_token",
+    "refresh-token",
+    "client_secret",
+    "auth_token",
+    "oauth_token",
+    "apikey",
+    "Token",
+    "GITHUB_TOKEN",
+    "Authorization",
+    "X-API-Key",
+    "DB_PASS",
+  ])("classifies credential field %s as sensitive (#8291)", (field) => {
+    expect(isCredentialField(field), field).toBe(true);
   });
 
-  it("recognizes raw secrets while preserving credential references (#8291)", () => {
-    for (const value of [
-      "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
-      "Bearer opaque-migration-secret",
-      "GITHUB_TOKEN=opaque-secret-value-123",
-      ["-----BEGIN", "PRIVATE KEY-----\nopaque\n-----END PRIVATE KEY-----"].join(" "),
-    ]) {
-      expect(valueLooksLikeSecret(value), value).toBe(true);
-    }
-    for (const value of [
-      "unused",
-      "Bearer unused",
-      "openshell:resolve:env:GITHUB_TOKEN",
-      "Bearer openshell:resolve:env:REMOTE_MCP_TOKEN",
-      "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_TOKEN",
-    ]) {
-      expect(isSafeCredentialPlaceholder(value), value).toBe(true);
-    }
+  it.each(["publicKey", "public.key", "GITHUB_PUBLIC_KEY", "NODE_ENV", "model"])(
+    "classifies non-credential field %s as non-sensitive (#8291)",
+    (field) => {
+      expect(isCredentialField(field), field).toBe(false);
+    },
+  );
+
+  it.each([
+    "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+    "Bearer opaque-migration-secret",
+    "GITHUB_TOKEN=opaque-secret-value-123",
+    ["-----BEGIN", "PRIVATE KEY-----\nopaque\n-----END PRIVATE KEY-----"].join(" "),
+  ])("recognizes raw secret vector %# (#8291)", (value) => {
+    expect(valueLooksLikeSecret(value), value).toBe(true);
+  });
+
+  it.each([
+    "unused",
+    "Bearer unused",
+    "openshell:resolve:env:GITHUB_TOKEN",
+    "Bearer openshell:resolve:env:REMOTE_MCP_TOKEN",
+    "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_TOKEN",
+  ])("preserves credential reference %s (#8291)", (value) => {
+    expect(isSafeCredentialPlaceholder(value), value).toBe(true);
+  });
+
+  it("preserves a value that has no secret shape (#8291)", () => {
     expect(valueLooksLikeSecret("keep-me")).toBe(false);
   });
 
-  it("freezes exported pattern collections and tolerates caller lastIndex state (#8291)", () => {
-    for (const patterns of [
-      TOKEN_PREFIX_PATTERNS,
-      STRUCTURED_TOKEN_PATTERNS,
-      CONTEXT_PATTERNS,
-      SECRET_BLOCK_PATTERNS,
-      SECRET_PATTERNS,
-    ]) {
-      expect(Object.isFrozen(patterns)).toBe(true);
-      expect(() => (patterns as RegExp[]).push(/caller-added-secret/g)).toThrow(TypeError);
-    }
+  it.each([
+    ["token prefix", TOKEN_PREFIX_PATTERNS],
+    ["structured token", STRUCTURED_TOKEN_PATTERNS],
+    ["context", CONTEXT_PATTERNS],
+    ["secret block", SECRET_BLOCK_PATTERNS],
+    ["secret", SECRET_PATTERNS],
+  ] as const)("freezes the %s pattern collection (#8291)", (_name, patterns) => {
+    expect(Object.isFrozen(patterns)).toBe(true);
+    expect(() => (patterns as RegExp[]).push(/caller-added-secret/g)).toThrow(TypeError);
+  });
 
+  it("tolerates caller lastIndex state (#8291)", () => {
     TOKEN_PREFIX_PATTERNS[0].lastIndex = Number.MAX_SAFE_INTEGER;
     expect(valueLooksLikeSecret("nvapi-abcdefghijklmnop")).toBe(true);
   });

--- a/nemoclaw/src/shared/openshell-policy-boundary.test.ts
+++ b/nemoclaw/src/shared/openshell-policy-boundary.test.ts
@@ -101,25 +101,34 @@ describe("canonical OpenShell policy boundary", () => {
     });
   });
 
-  it("rejects missing, diagnostic, malformed, scalar, and unmarked policy output", () => {
-    for (const raw of ["", "Version: 1\n---", "error: gateway unavailable"]) {
+  it.each(["", "Version: 1\n---", "error: gateway unavailable"])(
+    "rejects output without a policy: %j",
+    (raw) => {
       expect(() => parseOpenShellPolicy(raw)).toThrow(/does not contain a policy/);
-    }
+    },
+  );
+
+  it("rejects malformed and scalar policy output", () => {
     expect(() => parseOpenShellPolicy("version: [unterminated")).toThrow(/not valid YAML/);
     expect(() => parseOpenShellPolicy("---\nscalar")).toThrow(/must be a YAML mapping/);
-    for (const raw of [
-      "version: 1\nnetwork_policies: invalid",
-      "version: 1\nnetwork_policies: []",
-      "version: 1\nnetwork_policies: null",
-    ]) {
-      expect(() => parseOpenShellPolicy(raw)).toThrow(/network_policies must be a YAML mapping/);
-    }
-    for (const raw of [
-      'version: "1"\nnetwork_policies: {}',
-      "version: 1.5\nnetwork_policies: {}",
-    ]) {
+  });
+
+  it.each([
+    "version: 1\nnetwork_policies: invalid",
+    "version: 1\nnetwork_policies: []",
+    "version: 1\nnetwork_policies: null",
+  ])("rejects a non-mapping network_policies value: %j", (raw) => {
+    expect(() => parseOpenShellPolicy(raw)).toThrow(/network_policies must be a YAML mapping/);
+  });
+
+  it.each(['version: "1"\nnetwork_policies: {}', "version: 1.5\nnetwork_policies: {}"])(
+    "rejects a non-integer policy version: %j",
+    (raw) => {
       expect(() => parseOpenShellPolicy(raw)).toThrow(/version must be a positive integer/);
-    }
+    },
+  );
+
+  it("rejects unmarked future output", () => {
     expect(() => parseOpenShellPolicy("FutureKey: value")).toThrow(/does not contain a policy/);
   });
 
@@ -144,10 +153,14 @@ describe("canonical OpenShell policy boundary", () => {
     });
   });
 
-  it("leaves non-composed mappings unchanged and rejects malformed YAML", () => {
-    for (const policy of ["version: 1", "version: 1\nnetwork_policies:\n  safe: {}"]) {
+  it.each(["version: 1", "version: 1\nnetwork_policies:\n  safe: {}"])(
+    "leaves the non-composed mapping %j unchanged",
+    (policy) => {
       expect(stripProviderComposedPolicies(policy)).toBe(policy);
-    }
+    },
+  );
+
+  it("rejects malformed YAML while stripping composed policies", () => {
     expect(() => stripProviderComposedPolicies("version: [unterminated")).toThrow(/invalid YAML/);
   });
 });

--- a/src/lib/actions/inference-set-provider-alias.test.ts
+++ b/src/lib/actions/inference-set-provider-alias.test.ts
@@ -68,25 +68,27 @@ describe("normalizeInferenceSetProvider — facet 1 provider-name drift (#6321)"
     expect(normalizeInferenceSetProvider("BUILD")).toBe("nvidia-prod");
   });
 
-  it("passes OpenShell provider names through unchanged", () => {
-    for (const name of INFERENCE_SET_SUPPORTED_PROVIDER_NAMES) {
+  it.each(INFERENCE_SET_SUPPORTED_PROVIDER_NAMES)(
+    "passes the OpenShell provider name %s through unchanged",
+    (name) => {
       expect(normalizeInferenceSetProvider(name)).toBe(name);
-    }
-  });
+    },
+  );
 
   it("passes an unrecognized provider through unchanged (validation still rejects it later)", () => {
     expect(normalizeInferenceSetProvider("totally-made-up")).toBe("totally-made-up");
   });
 
-  it("every installer alias resolves to a supported OpenShell provider name (drift guard)", () => {
-    const supported = new Set<string>(INFERENCE_SET_SUPPORTED_PROVIDER_NAMES);
-    for (const [alias, resolved] of Object.entries(INFERENCE_SET_INSTALLER_PROVIDER_ALIASES)) {
+  it.each(Object.entries(INFERENCE_SET_INSTALLER_PROVIDER_ALIASES))(
+    "resolves the %s installer alias to the supported %s provider",
+    (alias, resolved) => {
+      const supported = new Set<string>(INFERENCE_SET_SUPPORTED_PROVIDER_NAMES);
       expect(
         supported.has(resolved),
         `${alias} -> ${resolved} not in SUPPORTED_PROVIDER_NAMES`,
       ).toBe(true);
-    }
-  });
+    },
+  );
 });
 
 describe("runInferenceSet accepts the installer provider name — facet 1 (#6321)", () => {
@@ -246,20 +248,21 @@ describe("runInferenceSet dcode refusal message — facet 3 (#6321)", () => {
     await expect(attempt).rejects.toThrow(`--name ${shellQuote(name)} --fresh`);
     // The bare, unquoted name must not sit directly after --name.
     await expect(attempt).rejects.not.toThrow(`--name ${name} --fresh`);
+  });
 
-    // PRA-2: validateName blocks metacharacter names before this hint, so the
-    // shellQuote layer is defense-in-depth. Assert it keeps spaces, quotes, ';',
-    // '$()' and backticks inside a single quoted argument that a shell cannot
-    // break out of.
-    for (const meta of ["a b", "a'b", "a;b", "a$(id)", "a`id`"]) {
+  // PRA-2: validateName blocks metacharacter names before the recovery hint, so
+  // shellQuote is defense-in-depth.
+  it.each(["a b", "a'b", "a;b", "a$(id)", "a`id`"])(
+    "keeps the metacharacter input %j inside one shell argument",
+    (meta) => {
       const quoted = shellQuote(meta);
       expect(quoted.startsWith("'")).toBe(true);
       expect(quoted.endsWith("'")).toBe(true);
       // After removing the only legal break-out escape ('\''), no bare single
       // quote remains — nothing can terminate the quoted argument early.
       expect(quoted.slice(1, -1).replaceAll("'\\''", "")).not.toContain("'");
-    }
-  });
+    },
+  );
 });
 
 // Hosts the stand-in guard treats as internal-resolving. Parsed exactly from
@@ -603,46 +606,38 @@ describe("runInferenceSet SSRF-block guidance — facet 2 (#6321)", () => {
 });
 
 describe("installer alias parity with onboard provider config — facet 1 drift guard (#6321)", () => {
-  it("matches onboard's getEffectiveProviderName for every shared provider key", () => {
-    // Bind the local alias map to onboard's source of truth: for every installer
-    // key onboard accepts that resolves to a provider inference set supports,
-    // normalizeInferenceSetProvider must produce the exact same OpenShell name.
-    // If onboard renames a provider or adds an alias, this fails until the local
-    // map is updated — closing the drift gap CodeRabbit / the PR advisor flagged.
-    const supported = new Set<string>(INFERENCE_SET_SUPPORTED_PROVIDER_NAMES);
-    const aliasKeys: string[] = Object.keys(
-      onboardProviders.NON_INTERACTIVE_PROVIDER_ALIASES ?? {},
+  const supported = new Set<string>(INFERENCE_SET_SUPPORTED_PROVIDER_NAMES);
+  const aliasKeys: string[] = Object.keys(onboardProviders.NON_INTERACTIVE_PROVIDER_ALIASES ?? {});
+  const directKeys: string[] = Array.from(
+    (onboardProviders.NON_INTERACTIVE_PROVIDER_KEYS ?? new Set()) as Iterable<string>,
+  );
+  const onboardKeys = [...new Set([...aliasKeys, ...directKeys])];
+  const relevant = onboardKeys
+    .map((key) => ({
+      key,
+      onboardResolved: onboardProviders.getEffectiveProviderName(
+        onboardProviders.NON_INTERACTIVE_PROVIDER_ALIASES?.[key] ?? key,
+      ) as string | null,
+    }))
+    .filter(
+      (entry): entry is { key: string; onboardResolved: string } =>
+        !!entry.onboardResolved && supported.has(entry.onboardResolved),
     );
-    const directKeys: string[] = Array.from(
-      (onboardProviders.NON_INTERACTIVE_PROVIDER_KEYS ?? new Set()) as Iterable<string>,
-    );
-    const onboardKeys = [...new Set([...aliasKeys, ...directKeys])];
+
+  it("loads a meaningful set of onboard provider keys", () => {
     // Sanity: onboard exposes a non-trivial key set (guards against an import
     // that silently resolved to an empty object).
     expect(onboardKeys.length).toBeGreaterThan(5);
+    expect(relevant.length).toBeGreaterThan(3);
+  });
 
-    // Resolve each onboard key to its OpenShell provider name, then keep only
-    // those that are inference-set targets. `.map().filter()` (not a loop with
-    // `if`/`continue`) to satisfy the test-shape gate.
-    const relevant = onboardKeys
-      .map((key) => ({
-        key,
-        onboardResolved: onboardProviders.getEffectiveProviderName(
-          onboardProviders.NON_INTERACTIVE_PROVIDER_ALIASES?.[key] ?? key,
-        ) as string | null,
-      }))
-      .filter(
-        (entry): entry is { key: string; onboardResolved: string } =>
-          !!entry.onboardResolved && supported.has(entry.onboardResolved),
-      );
-
-    for (const { key, onboardResolved } of relevant) {
+  it.each(relevant)(
+    "maps the onboard $key key to the $onboardResolved OpenShell provider",
+    ({ key, onboardResolved }) => {
       expect(
         normalizeInferenceSetProvider(key),
         `inference set must map onboard key '${key}' to '${onboardResolved}'`,
       ).toBe(onboardResolved);
-    }
-    // We actually exercised a meaningful set (anthropicCompatible, build, etc.).
-    expect(relevant.length).toBeGreaterThan(3);
-  });
+    },
+  );
 });

--- a/src/lib/actions/sandbox/mcp-bridge-input-targets.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-input-targets.test.ts
@@ -146,12 +146,15 @@ describe("MCP URL target validation", () => {
     }
   });
 
-  it("persists exact normalized pins after successful trusted-private admission (#8267)", {
-    timeout: 40_000,
-  }, () => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-private-mcp-add-success-"));
-    const sourceRequireHook = path.resolve("test/helpers/onboard-script-mocks.cjs");
-    const script = `
+  it(
+    "persists exact normalized pins after successful trusted-private admission (#8267)",
+    {
+      timeout: 40_000,
+    },
+    () => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-private-mcp-add-success-"));
+      const sourceRequireHook = path.resolve("test/helpers/onboard-script-mocks.cjs");
+      const script = `
 process.env.HOME = ${JSON.stringify(home)};
 process.env.LOCAL_MCP_TOKEN = "host-only-secret";
 require("node:dns/promises").lookup = async () => [
@@ -215,38 +218,39 @@ require("./src/lib/actions/sandbox/mcp-bridge.js").addMcpBridge("alpha", {
   process.stderr.write(error.stack || error.message, () => process.exit(1));
 });
 `;
-    try {
-      const result = spawnSync(process.execPath, ["-e", script], {
-        cwd: process.cwd(),
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          HOME: home,
-          NODE_OPTIONS: [process.env.NODE_OPTIONS, `--require=${sourceRequireHook}`]
-            .filter(Boolean)
-            .join(" "),
-        },
-        timeout: 30_000,
-      });
-      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-      const admission = JSON.parse(result.stdout) as {
-        entry: Record<string, unknown>;
-        target: Record<string, unknown>;
-      };
-      expect(admission.entry).toMatchObject({
-        allowedIps: ["10.20.30.40", "10.20.30.41"],
-        trustedPrivateHost: "mcp.corp.example",
-      });
-      expect(admission.target).toEqual({
-        addresses: ["10.20.30.40", "10.20.30.41"],
-        capability: true,
-        capabilityAddresses: ["10.20.30.40", "10.20.30.41"],
-        trustedPrivateHost: "mcp.corp.example",
-      });
-    } finally {
-      fs.rmSync(home, { recursive: true, force: true });
-    }
-  });
+      try {
+        const result = spawnSync(process.execPath, ["-e", script], {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            HOME: home,
+            NODE_OPTIONS: [process.env.NODE_OPTIONS, `--require=${sourceRequireHook}`]
+              .filter(Boolean)
+              .join(" "),
+          },
+          timeout: 30_000,
+        });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        const admission = JSON.parse(result.stdout) as {
+          entry: Record<string, unknown>;
+          target: Record<string, unknown>;
+        };
+        expect(admission.entry).toMatchObject({
+          allowedIps: ["10.20.30.40", "10.20.30.41"],
+          trustedPrivateHost: "mcp.corp.example",
+        });
+        expect(admission.target).toEqual({
+          addresses: ["10.20.30.40", "10.20.30.41"],
+          capability: true,
+          capabilityAddresses: ["10.20.30.40", "10.20.30.41"],
+          trustedPrivateHost: "mcp.corp.example",
+        });
+      } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("rejects mixed answers and an unused trusted-private option (#8267)", async () => {
     const lookup = vi.spyOn(dns, "lookup");
@@ -322,14 +326,11 @@ require("./src/lib/actions/sandbox/mcp-bridge.js").addMcpBridge("alpha", {
     ).toThrow(/Sandbox loopback is not the host MCP service.*stable routed private address/);
   });
 
-  it("rejects hostile OpenShell alias registrations before sandbox or network side effects", async () => {
-    const lookup = vi.spyOn(dns, "lookup");
-    try {
-      for (const host of [
-        "host.openshell.internal",
-        "host.docker.internal",
-        "host.containers.internal",
-      ]) {
+  it.each(["host.openshell.internal", "host.docker.internal", "host.containers.internal"])(
+    "rejects the hostile %s alias before sandbox or network side effects",
+    async (host) => {
+      const lookup = vi.spyOn(dns, "lookup");
+      try {
         await expect(
           addMcpBridge("missing-sandbox", {
             server: "local",
@@ -337,17 +338,18 @@ require("./src/lib/actions/sandbox/mcp-bridge.js").addMcpBridge("alpha", {
             env: [{ name: "SAFE_MCP_TOKEN", value: "host-only-secret" }],
           }),
         ).rejects.toThrow(/does not expose an attested driver gateway address/);
+        expect(lookup).not.toHaveBeenCalled();
+      } finally {
+        lookup.mockRestore();
       }
-      expect(lookup).not.toHaveBeenCalled();
-    } finally {
-      lookup.mockRestore();
-    }
-  });
+    },
+  );
 
-  it("rejects malformed percent paths before DNS or sandbox side effects", async () => {
-    const lookup = vi.spyOn(dns, "lookup");
-    try {
-      for (const path of ["%", "%GG", "%2"]) {
+  it.each(["%", "%GG", "%2"])(
+    "rejects the malformed %j path before DNS or sandbox side effects",
+    async (path) => {
+      const lookup = vi.spyOn(dns, "lookup");
+      try {
         await expect(
           addMcpBridge("missing-sandbox", {
             server: "malformed",
@@ -355,12 +357,12 @@ require("./src/lib/actions/sandbox/mcp-bridge.js").addMcpBridge("alpha", {
             env: [{ name: "SAFE_MCP_TOKEN", value: "host-only-secret" }],
           }),
         ).rejects.toThrow(/percent characters/);
+        expect(lookup).not.toHaveBeenCalled();
+      } finally {
+        lookup.mockRestore();
       }
-      expect(lookup).not.toHaveBeenCalled();
-    } finally {
-      lookup.mockRestore();
-    }
-  });
+    },
+  );
 
   it("rejects local, private, and OpenShell host-alias URL targets", () => {
     expect(() => normalizeMcpServerUrl("https://localhost:31337/mcp")).toThrow(
@@ -369,11 +371,6 @@ require("./src/lib/actions/sandbox/mcp-bridge.js").addMcpBridge("alpha", {
     expect(() => normalizeMcpServerUrl("https://127.0.0.1:31337/mcp")).toThrow(
       /private, local, or special-use IP/,
     );
-    for (const host of ["2130706433", "0177.0.0.1", "0x7f.0.0.1", "localhost."]) {
-      expect(() => normalizeMcpServerUrl(`https://${host}:31337/mcp`)).toThrow(
-        /private, local, or special-use IP/,
-      );
-    }
     expect(() => normalizeMcpServerUrl("https://169.254.169.254/latest")).toThrow(
       /private, local, or special-use IP/,
     );
@@ -397,16 +394,26 @@ require("./src/lib/actions/sandbox/mcp-bridge.js").addMcpBridge("alpha", {
     expect(() => normalizeMcpServerUrl("http://host.openshell.internal:31337/mcp")).toThrow(
       /must use https/,
     );
-    for (const host of [
-      "host.openshell.internal",
-      "host.openshell.internal.",
-      "host.docker.internal",
-      "host.containers.internal",
-    ]) {
+  });
+
+  it.each(["2130706433", "0177.0.0.1", "0x7f.0.0.1", "localhost."])(
+    "rejects the local host spelling %s",
+    (host) => {
       expect(() => normalizeMcpServerUrl(`https://${host}:31337/mcp`)).toThrow(
-        /does not expose an attested driver gateway address/,
+        /private, local, or special-use IP/,
       );
-    }
+    },
+  );
+
+  it.each([
+    "host.openshell.internal",
+    "host.openshell.internal.",
+    "host.docker.internal",
+    "host.containers.internal",
+  ])("rejects the unattested OpenShell host alias %s", (host) => {
+    expect(() => normalizeMcpServerUrl(`https://${host}:31337/mcp`)).toThrow(
+      /does not expose an attested driver gateway address/,
+    );
   });
 
   it("explains managed-vs-agent-native parity in the https rejection (#6971)", () => {

--- a/src/lib/actions/sandbox/mcp-bridge-input-validation.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-input-validation.test.ts
@@ -33,7 +33,6 @@ const CHILD_VISIBLE_CREDENTIAL_CASES = [
   ]),
 );
 
-
 describe("MCP CLI input validation", () => {
   it("parses server, URL, and env references", () => {
     const parsed = parseMcpAddArgs([
@@ -115,8 +114,9 @@ describe("MCP CLI input validation", () => {
     ).toThrow(/process arguments and shell history/);
   });
 
-  it("rejects OpenShell revisioned placeholder names as MCP credentials (#6379)", () => {
-    for (const name of ["v1_TOKEN", "v999999_very_unlikely", "v0_1"]) {
+  it.each(["v1_TOKEN", "v999999_very_unlikely", "v0_1"])(
+    "rejects OpenShell revisioned placeholder name %s as an MCP credential (#6379)",
+    (name) => {
       expect(() =>
         parseMcpAddArgs(["github", "--url", "https://mcp.example.test/mcp", "--env", name]),
       ).toThrow(/reserved for OpenShell credential revisions/);
@@ -128,14 +128,17 @@ describe("MCP CLI input validation", () => {
           [name]: "host-only-secret",
         }),
       ).toThrow(/reserved for OpenShell credential revisions/);
-    }
+    },
+  );
 
-    for (const name of ["v_TOKEN", "v10_", "versioned_token", "V10_TOKEN"]) {
+  it.each(["v_TOKEN", "v10_", "versioned_token", "V10_TOKEN"])(
+    "accepts non-revisioned MCP credential name %s (#6379)",
+    (name) => {
       expect(() =>
         parseMcpAddArgs(["github", "--url", "https://mcp.example.test/mcp", "--env", name]),
       ).not.toThrow();
-    }
-  });
+    },
+  );
 
   it.each(CHILD_VISIBLE_CREDENTIAL_CASES)(
     "rejects $name from $form at every MCP credential boundary",
@@ -152,47 +155,45 @@ describe("MCP CLI input validation", () => {
     },
   );
 
-  it("rejects sandbox runtime-control names as MCP credentials", () => {
-    for (const name of [
-      "BASH_ENV",
-      "ALL_PROXY",
-      "all_proxy",
-      "API_SERVER_KEY",
-      "DENO_CERT",
-      "grpc_proxy",
-      "NEMOCLAW_DASHBOARD_PORT",
-      "OPENCLAW_GATEWAY_URL",
-      "OPENAI_BASE_URL",
-      "HERMES_HOME",
-      "DEEPAGENTS_CONFIG_PATH",
-      "LANGCHAIN_TRACING_V2",
-      "ENV",
-      "LD_PRELOAD",
-      "DYLD_INSERT_LIBRARIES",
-      "GLIBC_TUNABLES",
-      "NODE_OPTIONS",
-      "PYTHONHOME",
-      "PYTHONPATH",
-      "RUBYOPT",
-      "PERL5OPT",
-      "JAVA_TOOL_OPTIONS",
-      "_JAVA_OPTIONS",
-      "CLASSPATH",
-      "VIRTUAL_ENV",
-      "UV_PROJECT_ENVIRONMENT",
-    ]) {
-      expect(() =>
-        parseMcpAddArgs(["github", "--url", "https://mcp.example.test/mcp", "--env", name]),
-      ).toThrow(/reserved for sandbox runtime control/);
-      expect(() => resolveCredentialEnv([{ name, value: "host-only-secret" }])).toThrow(
-        /could alter or prevent agent commands/,
-      );
-      expect(() =>
-        buildMcpBridgeProviderArgs("create", "provider", [{ name }], {
-          [name]: "host-only-secret",
-        }),
-      ).toThrow(/reserved for sandbox runtime control/);
-    }
+  it.each([
+    "BASH_ENV",
+    "ALL_PROXY",
+    "all_proxy",
+    "API_SERVER_KEY",
+    "DENO_CERT",
+    "grpc_proxy",
+    "NEMOCLAW_DASHBOARD_PORT",
+    "OPENCLAW_GATEWAY_URL",
+    "OPENAI_BASE_URL",
+    "HERMES_HOME",
+    "DEEPAGENTS_CONFIG_PATH",
+    "LANGCHAIN_TRACING_V2",
+    "ENV",
+    "LD_PRELOAD",
+    "DYLD_INSERT_LIBRARIES",
+    "GLIBC_TUNABLES",
+    "NODE_OPTIONS",
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "RUBYOPT",
+    "PERL5OPT",
+    "JAVA_TOOL_OPTIONS",
+    "_JAVA_OPTIONS",
+    "CLASSPATH",
+    "VIRTUAL_ENV",
+    "UV_PROJECT_ENVIRONMENT",
+  ])("rejects sandbox runtime-control name %s as an MCP credential", (name) => {
+    expect(() =>
+      parseMcpAddArgs(["github", "--url", "https://mcp.example.test/mcp", "--env", name]),
+    ).toThrow(/reserved for sandbox runtime control/);
+    expect(() => resolveCredentialEnv([{ name, value: "host-only-secret" }])).toThrow(
+      /could alter or prevent agent commands/,
+    );
+    expect(() =>
+      buildMcpBridgeProviderArgs("create", "provider", [{ name }], {
+        [name]: "host-only-secret",
+      }),
+    ).toThrow(/reserved for sandbox runtime control/);
   });
 
   it("rejects host stdio commands", () => {
@@ -292,7 +293,13 @@ describe("MCP CLI input validation", () => {
 
   it("normalizes URLs without persisting credentials", verifyCredentialFreeUrlNormalization);
 
-  it("rejects a malformed credential-bearing URL without echoing it (#8698)", () => {
+  it.each([
+    "https://qa-user:qa-pass-123@/mcp",
+    "//qa-user:qa-pass-123@/mcp",
+    "https:/qa-user:qa-pass-123@/mcp",
+    "https://qa-user:qa-pass-123 extra@/mcp",
+    "https://qa-user:qa-pass-123@/mcp/qa-pass-123",
+  ])("rejects malformed credential-bearing URL vector %# without echoing it (#8698)", (rawUrl) => {
     const user = "qa-user";
     const password = "qa-pass-123";
     const captureMessage = (rawUrl: string): string => {
@@ -303,19 +310,12 @@ describe("MCP CLI input validation", () => {
         return (error as Error).message;
       }
     };
-    for (const rawUrl of [
-      `https://${user}:${password}@/mcp`,
-      `//${user}:${password}@/mcp`,
-      `https:/${user}:${password}@/mcp`,
-      `https://${user}:${password} extra@/mcp`,
-      `https://${user}:${password}@/mcp/${password}`,
-    ]) {
-      const message = captureMessage(rawUrl);
-      expect(message).toMatch(/must be an absolute https:\/\/ URL/);
-      expect(message).not.toContain(user);
-      expect(message).not.toContain(password);
-      expect(message).not.toContain("/mcp");
-    }
+
+    const message = captureMessage(rawUrl);
+    expect(message).toMatch(/must be an absolute https:\/\/ URL/);
+    expect(message).not.toContain(user);
+    expect(message).not.toContain(password);
+    expect(message).not.toContain("/mcp");
   });
 
   it("bounds persisted MCP endpoint URLs consistently across adapters", () => {

--- a/src/lib/agent/candidate.test.ts
+++ b/src/lib/agent/candidate.test.ts
@@ -36,20 +36,25 @@ afterEach(() => {
 });
 
 describe("candidate agent gate", () => {
-  it("treats every declared candidate managed-image agent as a candidate (#7927)", () => {
-    for (const agent of CANDIDATE_MANAGED_IMAGE_AGENTS) {
+  it.each(CANDIDATE_MANAGED_IMAGE_AGENTS)(
+    "treats the declared %s managed-image agent as a candidate (#7927)",
+    (agent) => {
       expect(isCandidateAgent(agent)).toBe(true);
-    }
+    },
+  );
+
+  it("keeps shipped agents outside the candidate classification (#7927)", () => {
     expect(isCandidateAgent("openclaw")).toBe(false);
     expect(isCandidateAgent("hermes")).toBe(false);
     expect(isCandidateAgent("langchain-deepagents-code")).toBe(false);
   });
 
-  it("publishes no qualified candidate receipt in this release (#7927)", () => {
-    for (const agent of CANDIDATE_MANAGED_IMAGE_AGENTS) {
+  it.each(CANDIDATE_MANAGED_IMAGE_AGENTS)(
+    "publishes no qualified %s candidate receipt in this release (#7927)",
+    (agent) => {
       expect(CANDIDATE_QUALIFICATION_RECEIPT_DIGESTS[agent]).toEqual([]);
-    }
-  });
+    },
+  );
 
   it("never activates a candidate from the protected flag alone (#7927)", () => {
     expect(isCandidateAgentSelectable("pi", { [CANDIDATE_AGENT_FEATURE_ENV]: "1" })).toBe(false);
@@ -100,12 +105,13 @@ describe("candidate agent gate", () => {
     );
   });
 
-  it("never refuses a shipped agent through the candidate gate (#7927)", () => {
-    for (const agent of ["openclaw", "hermes", "langchain-deepagents-code"]) {
+  it.each(["openclaw", "hermes", "langchain-deepagents-code"])(
+    "never refuses the shipped %s agent through the candidate gate (#7927)",
+    (agent) => {
       expect(() => requireCandidateAgentSelectable(agent, {})).not.toThrow();
       expect(() => requireCandidateQualificationEnabled(agent, {})).not.toThrow();
-    }
-  });
+    },
+  );
 
   it("refuses to start a candidate without qualification authority (#7927)", () => {
     expect(() => requireCandidateQualificationEnabled("pi", {})).toThrow(

--- a/src/lib/cua/feature.test.ts
+++ b/src/lib/cua/feature.test.ts
@@ -11,11 +11,8 @@ import {
 } from "./feature";
 
 describe("CUA framework activation (#7750)", () => {
-  it("is disabled unless the dedicated CUA flag is exactly 1", () => {
+  it("uses the dedicated CUA framework flag", () => {
     expect(CUA_FRAMEWORK_FEATURE_ENV).toBe("NEMOCLAW_CUA_ENABLED");
-    for (const value of [undefined, "", "true", "0", "01", " 1", "1 "]) {
-      expect(isCuaFrameworkEnabled({ NEMOCLAW_CUA_ENABLED: value })).toBe(false);
-    }
     expect(isCuaFrameworkEnabled({ NEMOCLAW_CUA_ENABLED: "1" })).toBe(true);
     expect(() => requireCuaFrameworkEnabled({})).toThrow(
       "use the controlled Brev Launchable activation",
@@ -23,17 +20,16 @@ describe("CUA framework activation (#7750)", () => {
     expect(() => requireCuaFrameworkEnabled({ NEMOCLAW_CUA_ENABLED: "1" })).not.toThrow();
   });
 
-  it("requires a second explicit opt-in for candidate qualification", () => {
+  it.each([[undefined], [""], ["true"], ["0"], ["01"], [" 1"], ["1 "]])(
+    "keeps CUA disabled for the flag value %j",
+    (value) => {
+      expect(isCuaFrameworkEnabled({ NEMOCLAW_CUA_ENABLED: value })).toBe(false);
+    },
+  );
+
+  it("requires the framework flag before candidate qualification", () => {
     expect(CUA_QUALIFICATION_FEATURE_ENV).toBe("NEMOCLAW_CUA_QUALIFICATION");
     expect(isCuaQualificationEnabled({ NEMOCLAW_CUA_QUALIFICATION: "1" })).toBe(false);
-    for (const value of [undefined, "", "true", "0", "01", " 1", "1 "]) {
-      expect(
-        isCuaQualificationEnabled({
-          NEMOCLAW_CUA_ENABLED: "1",
-          NEMOCLAW_CUA_QUALIFICATION: value,
-        }),
-      ).toBe(false);
-    }
     expect(
       isCuaQualificationEnabled({
         NEMOCLAW_CUA_ENABLED: "1",
@@ -41,4 +37,16 @@ describe("CUA framework activation (#7750)", () => {
       }),
     ).toBe(true);
   });
+
+  it.each([[undefined], [""], ["true"], ["0"], ["01"], [" 1"], ["1 "]])(
+    "keeps candidate qualification disabled for the flag value %j",
+    (value) => {
+      expect(
+        isCuaQualificationEnabled({
+          NEMOCLAW_CUA_ENABLED: "1",
+          NEMOCLAW_CUA_QUALIFICATION: value,
+        }),
+      ).toBe(false);
+    },
+  );
 });

--- a/src/lib/inference/config.test.ts
+++ b/src/lib/inference/config.test.ts
@@ -32,18 +32,21 @@ import {
 } from "./config";
 
 describe("resolveAgentDefaultCloudModel", () => {
-  it("uses the Deep Agents manifest default without changing shared agent defaults", () => {
+  it("uses the Deep Agents manifest default", () => {
     expect(
       resolveAgentDefaultCloudModel({
         name: "langchain-deepagents-code",
         inference: { default_model: "nvidia/nemotron-3-ultra-550b-a55b" },
       }),
     ).toBe("nvidia/nemotron-3-ultra-550b-a55b");
-
-    for (const agent of [null, { name: "openclaw" }, { name: "hermes" }]) {
-      expect(resolveAgentDefaultCloudModel(agent)).toBe(DEFAULT_CLOUD_MODEL);
-    }
   });
+
+  it.each([[null], [{ name: "openclaw" }], [{ name: "hermes" }]])(
+    "keeps the shared default for %j",
+    (agent) => {
+      expect(resolveAgentDefaultCloudModel(agent)).toBe(DEFAULT_CLOUD_MODEL);
+    },
+  );
 });
 
 describe("resolveAgentInferenceApi", () => {
@@ -137,13 +140,13 @@ describe("inference selection config", () => {
     expect(HERMES_PROVIDER_MODEL_OPTIONS.length).toBeGreaterThan(10);
   });
 
-  it.each([
-    "z-ai/glm-5.1",
-    "moonshotai/kimi-k2.6",
-  ])("retires %s only from the NVIDIA Endpoints picker", (model) => {
-    expect(CLOUD_MODEL_OPTIONS.map((option) => option.id)).not.toContain(model);
-    expect(HERMES_PROVIDER_MODEL_OPTIONS).toContain(model);
-  });
+  it.each(["z-ai/glm-5.1", "moonshotai/kimi-k2.6"])(
+    "retires %s only from the NVIDIA Endpoints picker",
+    (model) => {
+      expect(CLOUD_MODEL_OPTIONS.map((option) => option.id)).not.toContain(model);
+      expect(HERMES_PROVIDER_MODEL_OPTIONS).toContain(model);
+    },
+  );
 
   it("maps ollama-local to the sandbox inference route and default model", () => {
     // Local Ollama uses a dedicated credential env so the sandbox-side
@@ -293,42 +296,39 @@ describe("inference selection config", () => {
     expect(getProviderSelectionConfig("bogus-provider")).toBe(null);
   });
 
-  it("does not grow beyond the approved provider set", () => {
-    const APPROVED_PROVIDERS = [
-      "nvidia-prod",
-      "nvidia-nim",
-      "openai-api",
-      "openrouter-api",
-      "anthropic-prod",
-      "compatible-anthropic-endpoint",
-      "gemini-api",
-      "compatible-endpoint",
-      "hermes-provider",
-      "vllm-local",
-      "ollama-local",
-    ];
-    for (const key of APPROVED_PROVIDERS) {
-      expect(getProviderSelectionConfig(key)).not.toBe(null);
-    }
-    const CANDIDATES = [
-      "bedrock",
-      "vertex",
-      "azure",
-      "azure-openai",
-      "deepseek",
-      "mistral",
-      "cohere",
-      "fireworks",
-      "together",
-      "groq",
-      "lambda",
-      "replicate",
-      "perplexity",
-      "sambanova",
-    ];
-    for (const key of CANDIDATES) {
-      expect(getProviderSelectionConfig(key)).toBe(null);
-    }
+  it.each([
+    "nvidia-prod",
+    "nvidia-nim",
+    "openai-api",
+    "openrouter-api",
+    "anthropic-prod",
+    "compatible-anthropic-endpoint",
+    "gemini-api",
+    "compatible-endpoint",
+    "hermes-provider",
+    "vllm-local",
+    "ollama-local",
+  ])("keeps the approved %s provider", (key) => {
+    expect(getProviderSelectionConfig(key)).not.toBe(null);
+  });
+
+  it.each([
+    "bedrock",
+    "vertex",
+    "azure",
+    "azure-openai",
+    "deepseek",
+    "mistral",
+    "cohere",
+    "fireworks",
+    "together",
+    "groq",
+    "lambda",
+    "replicate",
+    "perplexity",
+    "sambanova",
+  ])("keeps the unapproved %s candidate out", (key) => {
+    expect(getProviderSelectionConfig(key)).toBe(null);
   });
 
   it("falls back to provider defaults when model is omitted", () => {

--- a/src/lib/inference/max-tokens-field.test.ts
+++ b/src/lib/inference/max-tokens-field.test.ts
@@ -5,41 +5,42 @@ import { describe, expect, it } from "vitest";
 import { requiresMaxCompletionTokensField, resolveMaxTokensField } from "./max-tokens-field";
 
 describe("resolveMaxTokensField", () => {
-  it("selects max_completion_tokens for the GPT-5 family (#6642)", () => {
-    for (const model of ["gpt-5", "gpt-5.4", "gpt-5.4-turbo", "GPT-5.4"]) {
+  it.each(["gpt-5", "gpt-5.4", "gpt-5.4-turbo", "GPT-5.4"])(
+    "selects max_completion_tokens for GPT-5 family model %s (#6642)",
+    (model) => {
       expect(resolveMaxTokensField(model)).toBe("max_completion_tokens");
       expect(requiresMaxCompletionTokensField(model)).toBe(true);
-    }
-  });
+    },
+  );
 
-  it("selects max_completion_tokens for OpenAI reasoning models", () => {
-    for (const model of ["o1", "o1-mini", "o3", "o3-mini", "o4-mini"]) {
+  it.each(["o1", "o1-mini", "o3", "o3-mini", "o4-mini"])(
+    "selects max_completion_tokens for OpenAI reasoning model %s",
+    (model) => {
       expect(resolveMaxTokensField(model)).toBe("max_completion_tokens");
-    }
-  });
+    },
+  );
 
   it("strips a provider prefix before matching", () => {
     expect(resolveMaxTokensField("azure/gpt-5.4")).toBe("max_completion_tokens");
     expect(resolveMaxTokensField("openai/o3-mini")).toBe("max_completion_tokens");
   });
 
-  it("keeps max_tokens for legacy and non-OpenAI models", () => {
-    for (const model of [
-      "gpt-4o",
-      "gpt-4.1",
-      "nvidia/nemotron-3-super-120b-a12b",
-      "moonshotai/kimi-k2.6",
-      "deepseek-ai/deepseek-v4-pro",
-    ]) {
-      expect(resolveMaxTokensField(model)).toBe("max_tokens");
-    }
+  it.each([
+    "gpt-4o",
+    "gpt-4.1",
+    "nvidia/nemotron-3-super-120b-a12b",
+    "moonshotai/kimi-k2.6",
+    "deepseek-ai/deepseek-v4-pro",
+  ])("keeps max_tokens for legacy or non-OpenAI model %s", (model) => {
+    expect(resolveMaxTokensField(model)).toBe("max_tokens");
   });
 
-  it("does not misfire on models that merely start with the letter o", () => {
-    for (const model of ["openai-gpt", "orca-2", "olmo-7b"]) {
+  it.each(["openai-gpt", "orca-2", "olmo-7b"])(
+    "keeps max_tokens when model %s merely starts with the letter o",
+    (model) => {
       expect(resolveMaxTokensField(model)).toBe("max_tokens");
-    }
-  });
+    },
+  );
 
   it("defaults to max_tokens for empty or nullish model ids", () => {
     expect(resolveMaxTokensField("")).toBe("max_tokens");

--- a/src/lib/inference/nim.test.ts
+++ b/src/lib/inference/nim.test.ts
@@ -97,13 +97,11 @@ describe("nim", () => {
       expect(nim.listModels().length).toBe(5);
     });
 
-    it("each model has name, image, and minGpuMemoryMB", () => {
-      for (const m of nim.listModels()) {
-        expect(m.name).toBeTruthy();
-        expect(m.image).toBeTruthy();
-        expect(typeof m.minGpuMemoryMB === "number").toBeTruthy();
-        expect(m.minGpuMemoryMB > 0).toBeTruthy();
-      }
+    it.each(nim.listModels())("model $name has an image and positive GPU memory", (model) => {
+      expect(model.name).toBeTruthy();
+      expect(model.image).toBeTruthy();
+      expect(typeof model.minGpuMemoryMB === "number").toBeTruthy();
+      expect(model.minGpuMemoryMB > 0).toBeTruthy();
     });
   });
 
@@ -405,25 +403,23 @@ describe("nim", () => {
       }
     }
 
-    it("classifies explicit DGX Station identifiers as station", () => {
-      for (const model of ["NVIDIA DGX Station GB300", "DGX-Station", "P3830"]) {
+    it.each(["NVIDIA DGX Station GB300", "DGX-Station", "P3830"])(
+      "classifies explicit DGX Station identifier %s as station",
+      (model) => {
         withFirmwareModel(model, () => {
           expect(nim.detectNvidiaPlatform()).toBe("station");
         });
-      }
-    });
+      },
+    );
 
-    it("does not classify unrelated Galaxy or P3830 substrings as Station", () => {
-      for (const model of [
-        "Samsung Galaxy Book4 Ultra",
-        "Acme Galaxy Rack Server",
-        "Acme XP3830 Workstation",
-      ]) {
+    it.each(["Samsung Galaxy Book4 Ultra", "Acme Galaxy Rack Server", "Acme XP3830 Workstation"])(
+      "does not classify unrelated model %s as DGX Station",
+      (model) => {
         withFirmwareModel(model, () => {
           expect(nim.detectNvidiaPlatform()).toBe("linux");
         });
-      }
-    });
+      },
+    );
 
     it("falls back to devicetree when DMI is unreadable", () => {
       withDmiUnavailableAndDevicetreeModel("NVIDIA DGX Spark", () => {
@@ -1825,8 +1821,9 @@ describe("nim", () => {
       }
     });
 
-    it("uses published docker port when no port is provided", () => {
-      for (const mapping of ["0.0.0.0:9000", "127.0.0.1:9000", "[::]:9000", ":::9000"]) {
+    it.each(["0.0.0.0:9000", "127.0.0.1:9000", "[::]:9000", ":::9000"])(
+      "uses published Docker port mapping %s when no port is provided",
+      (mapping) => {
         const runCapture = vi.fn((cmd: string | string[]) => {
           if (!Array.isArray(cmd)) throw new Error("expected argv array");
           if (cmd[0] === "docker" && cmd.includes("inspect")) return "running";
@@ -1864,8 +1861,8 @@ describe("nim", () => {
         } finally {
           restore();
         }
-      }
-    });
+      },
+    );
 
     it("falls back to 8000 when docker port lookup fails", () => {
       const runCapture = vi.fn((cmd: string | string[]) => {

--- a/src/lib/inference/ollama-model-registry.test.ts
+++ b/src/lib/inference/ollama-model-registry.test.ts
@@ -16,12 +16,13 @@ import {
 } from "./ollama-model-registry";
 
 describe("OLLAMA_MODEL_REGISTRY", () => {
-  it("is ordered largest-first by requiredMemoryMB", () => {
-    for (let i = 0; i < OLLAMA_MODEL_REGISTRY.length - 1; i++) {
-      expect(OLLAMA_MODEL_REGISTRY[i].requiredMemoryMB).toBeGreaterThan(
-        OLLAMA_MODEL_REGISTRY[i + 1].requiredMemoryMB,
-      );
-    }
+  it.each(
+    OLLAMA_MODEL_REGISTRY.slice(0, -1).map((entry, index) => ({
+      entry,
+      next: OLLAMA_MODEL_REGISTRY[index + 1],
+    })),
+  )("orders $entry.tag before the smaller $next.tag model", ({ entry, next }) => {
+    expect(entry.requiredMemoryMB).toBeGreaterThan(next.requiredMemoryMB);
   });
 
   it("exposes the smallest tag as SMALLEST_OLLAMA_MODEL_TAG", () => {
@@ -117,6 +118,12 @@ describe("effectiveGpuMemoryMB", () => {
 });
 
 describe("fittableOllamaModelTags", () => {
+  const abundantMemoryTags = fittableOllamaModelTags({
+    type: "nvidia",
+    totalMemoryMB: 131_072,
+    availableMemoryMB: 131_072,
+  });
+
   it("returns the smallest tag for null gpus and ambiguous device types", () => {
     expect(fittableOllamaModelTags(null)).toEqual([SMALLEST_OLLAMA_MODEL_TAG]);
     expect(fittableOllamaModelTags({ type: "generic", totalMemoryMB: 131_072 })).toEqual([
@@ -124,21 +131,20 @@ describe("fittableOllamaModelTags", () => {
     ]);
   });
 
-  it("includes every entry that fits the available-memory figure (smallest-first)", () => {
-    const tags = fittableOllamaModelTags({
-      type: "nvidia",
-      totalMemoryMB: 131_072,
-      availableMemoryMB: 131_072,
-    });
-    expect(tags[0]).toBe(SMALLEST_OLLAMA_MODEL_TAG);
-    expect(tags.length).toBe(OLLAMA_MODEL_REGISTRY.length);
-    // Smallest-first: each subsequent entry should require at least as much
-    // memory as the previous one.
-    for (let i = 0; i < tags.length - 1; i++) {
-      const a = OLLAMA_MODEL_REGISTRY.find((e) => e.tag === tags[i]);
-      const b = OLLAMA_MODEL_REGISTRY.find((e) => e.tag === tags[i + 1]);
-      expect(a && b && a.requiredMemoryMB <= b.requiredMemoryMB).toBe(true);
-    }
+  it("includes every entry that fits the available-memory figure, smallest first", () => {
+    expect(abundantMemoryTags[0]).toBe(SMALLEST_OLLAMA_MODEL_TAG);
+    expect(abundantMemoryTags.length).toBe(OLLAMA_MODEL_REGISTRY.length);
+  });
+
+  it.each(
+    abundantMemoryTags.slice(0, -1).map((tag, index) => ({
+      nextTag: abundantMemoryTags[index + 1],
+      tag,
+    })),
+  )("orders $tag before the larger $nextTag model", ({ tag, nextTag }) => {
+    const entry = OLLAMA_MODEL_REGISTRY.find((candidate) => candidate.tag === tag);
+    const next = OLLAMA_MODEL_REGISTRY.find((candidate) => candidate.tag === nextTag);
+    expect(entry && next && entry.requiredMemoryMB <= next.requiredMemoryMB).toBe(true);
   });
 
   it("falls back to the smallest tag when nothing in the registry fits available memory", () => {
@@ -198,11 +204,12 @@ describe("modelFitsAvailableMemory", () => {
 });
 
 describe("OLLAMA_DOWNLOAD_SIZE_FALLBACK_BYTES", () => {
-  it("mirrors the registry's downloadSizeBytes for every entry", () => {
-    for (const entry of OLLAMA_MODEL_REGISTRY) {
+  it.each(OLLAMA_MODEL_REGISTRY)(
+    "mirrors the $tag registry download size in the fallback map",
+    (entry) => {
       expect(OLLAMA_DOWNLOAD_SIZE_FALLBACK_BYTES[entry.tag]).toBe(entry.downloadSizeBytes);
-    }
-  });
+    },
+  );
 
   it("exposes the largest fittable tag via largestFittableOllamaModelTag", () => {
     expect(

--- a/src/lib/inference/serving/catalog.test.ts
+++ b/src/lib/inference/serving/catalog.test.ts
@@ -2,15 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import catalogSchema from "../../../../managed-inference/schemas/catalog.schema.json" with {
-  type: "json",
-};
-import presetSchema from "../../../../managed-inference/schemas/preset.schema.json" with {
-  type: "json",
-};
-import recipeSchema from "../../../../managed-inference/schemas/recipe.schema.json" with {
-  type: "json",
-};
+import catalogSchema from "../../../../managed-inference/schemas/catalog.schema.json" with { type: "json" };
+import presetSchema from "../../../../managed-inference/schemas/preset.schema.json" with { type: "json" };
+import recipeSchema from "../../../../managed-inference/schemas/recipe.schema.json" with { type: "json" };
 import {
   compileTrustedServingCatalog,
   parseCompiledServingCatalogJson,
@@ -595,11 +589,14 @@ describe("managed inference serving catalog compiler", () => {
     ["materializer", { materializers: new Set<string>() }, "unknown materializer"],
     ["lifecycle adapter", { lifecycles: new Set<string>() }, "unknown lifecycle adapter"],
     ["readiness contract", { readinessContracts: new Set<string>() }, "unknown readiness contract"],
-  ])("rejects a llama.cpp recipe with an unknown %s reference (#8181)", (_name, registry, message) => {
-    expect(() => compile([llamaCppRecipeSource()], { ...REGISTRIES, ...registry })).toThrow(
-      message,
-    );
-  });
+  ])(
+    "rejects a llama.cpp recipe with an unknown %s reference (#8181)",
+    (_name, registry, message) => {
+      expect(() => compile([llamaCppRecipeSource()], { ...REGISTRIES, ...registry })).toThrow(
+        message,
+      );
+    },
+  );
 
   it("validates optional receipt and readiness contracts on generic recipes (#8181)", () => {
     const receiptRecipe = recipeSource("test.recipe.receipt", {
@@ -729,13 +726,16 @@ describe("managed inference serving catalog compiler", () => {
     ["container-runtime", "            value: docker", "            value: podman"],
     ["gpu-count", "            value: 1", "            value: 0"],
     ["driver-version", "            value: 570.0.0", "            value: 1.0.0"],
-  ])("rejects a llama.cpp preset whose %s contradicts its recipe (#8181)", (role, expected, replacement) => {
-    const preset = replaceSource(llamaCppPresetSource(), expected, replacement);
+  ])(
+    "rejects a llama.cpp preset whose %s contradicts its recipe (#8181)",
+    (role, expected, replacement) => {
+      const preset = replaceSource(llamaCppPresetSource(), expected, replacement);
 
-    expect(() => compile([llamaCppRecipeSource(), preset])).toThrow(
-      `must require ${role} matching llama.cpp recipe`,
-    );
-  });
+      expect(() => compile([llamaCppRecipeSource(), preset])).toThrow(
+        `must require ${role} matching llama.cpp recipe`,
+      );
+    },
+  );
 
   it.each([
     ["shell syntax", "$(id)"],
@@ -893,22 +893,27 @@ describe("managed inference serving catalog compiler", () => {
     ).toThrow("does not satisfy the ServingRecipe schema");
   });
 
-  it("accepts only exact immutable model revision forms (#8144)", () => {
-    for (const revision of ["e".repeat(40), "e".repeat(64), `sha256:${"e".repeat(64)}`]) {
+  it.each(["e".repeat(40), "e".repeat(64), `sha256:${"e".repeat(64)}`])(
+    "accepts the immutable model revision %s (#8144)",
+    (revision) => {
       expect(() =>
         compile([
           replaceSource(recipeSource(), `revision: ${MODEL_REVISION}`, `revision: ${revision}`),
         ]),
       ).not.toThrow();
-    }
-    for (const revision of ["e".repeat(41), "e".repeat(63)]) {
+    },
+  );
+
+  it.each(["e".repeat(41), "e".repeat(63)])(
+    "rejects the mutable model revision %s (#8144)",
+    (revision) => {
       expect(() =>
         compile([
           replaceSource(recipeSource(), `revision: ${MODEL_REVISION}`, `revision: ${revision}`),
         ]),
       ).toThrow("does not satisfy the ServingRecipe schema");
-    }
-  });
+    },
+  );
 
   it("rejects duplicate source paths and YAML aliases (#8144)", () => {
     const duplicatePath = { ...presetSource(), path: recipeSource().path };
@@ -940,19 +945,19 @@ describe("managed inference serving catalog compiler", () => {
       `      - path: model.gguf\n        digest: sha256:${"d".repeat(64)}\n      - path: model.gguf\n        digest: sha256:${"e".repeat(64)}`,
     );
     expect(() => compile([duplicateModelFile])).toThrow("repeats model file model.gguf");
+  });
 
-    for (const path of [
-      "./model.gguf",
-      "models//model.gguf",
-      "models/./model.gguf",
-      "models/",
-      "models\\model.gguf",
-      "C:\\model.gguf",
-    ]) {
-      expect(() =>
-        compile([replaceSource(recipeSource(), "path: model.gguf", `path: ${path}`)]),
-      ).toThrow("does not satisfy the ServingRecipe schema");
-    }
+  it.each([
+    "./model.gguf",
+    "models//model.gguf",
+    "models/./model.gguf",
+    "models/",
+    "models\\model.gguf",
+    "C:\\model.gguf",
+  ])("rejects the noncanonical model path %j (#8144)", (path) => {
+    expect(() =>
+      compile([replaceSource(recipeSource(), "path: model.gguf", `path: ${path}`)]),
+    ).toThrow("does not satisfy the ServingRecipe schema");
   });
 
   it("rejects adapter and readiness IDs outside the injected registries (#8144)", () => {

--- a/src/lib/messaging/compiler/manifest-compiler.test.ts
+++ b/src/lib/messaging/compiler/manifest-compiler.test.ts
@@ -473,63 +473,57 @@ describe("ManifestCompiler", () => {
     });
   });
 
-  it("rejects line feeds in Slack Hermes env render values", async () => {
-    for (const [envKey, value] of [
-      ["SLACK_ALLOWED_USERS", "U123\nEVIL=1"],
-      ["SLACK_ALLOWED_CHANNELS", "C123\nEVIL=1"],
-    ] as const) {
-      await expect(
-        withEnv(
-          {
-            SLACK_BOT_TOKEN: "xoxb-test-slack-token",
-            SLACK_APP_TOKEN: "xapp-test-slack-token",
-            [envKey]: value,
-          },
-          () =>
-            compiler().compile({
-              sandboxName: "demo",
-              agent: "hermes",
-              workflow: "rebuild",
-              isInteractive: false,
-              configuredChannels: ["slack"],
-              credentialAvailability: {
-                SLACK_BOT_TOKEN: true,
-                SLACK_APP_TOKEN: true,
-              },
-            }),
-        ),
-      ).rejects.toThrow(/line breaks/);
-    }
+  it.each([
+    ["SLACK_ALLOWED_USERS", "U123\nEVIL=1"],
+    ["SLACK_ALLOWED_CHANNELS", "C123\nEVIL=1"],
+  ] as const)("rejects a line feed in Slack Hermes env value %s", async (envKey, value) => {
+    await expect(
+      withEnv(
+        {
+          SLACK_BOT_TOKEN: "xoxb-test-slack-token",
+          SLACK_APP_TOKEN: "xapp-test-slack-token",
+          [envKey]: value,
+        },
+        () =>
+          compiler().compile({
+            sandboxName: "demo",
+            agent: "hermes",
+            workflow: "rebuild",
+            isInteractive: false,
+            configuredChannels: ["slack"],
+            credentialAvailability: {
+              SLACK_BOT_TOKEN: true,
+              SLACK_APP_TOKEN: true,
+            },
+          }),
+      ),
+    ).rejects.toThrow(/line breaks/);
   });
 
-  it("rejects unsafe Microsoft Teams Hermes env render values", async () => {
-    const cases: Array<readonly [string, string]> = [
-      ["MSTEAMS_APP_ID", "teams-app\nEVIL=1"],
-      ["MSTEAMS_TENANT_ID", "teams-tenant\nEVIL=1"],
-      ["TEAMS_ALLOWED_USERS", "user-one\nEVIL=1"],
-    ];
-
-    for (const [envKey, value] of cases) {
-      await expect(
-        withEnv(
-          {
-            ...TEST_TEAMS_ENV,
-            [envKey]: value,
-          },
-          () =>
-            compiler().compile({
-              sandboxName: "demo",
-              agent: "hermes",
-              workflow: "rebuild",
-              isInteractive: false,
-              configuredChannels: ["teams"],
-              credentialAvailability: {
-                MSTEAMS_APP_PASSWORD: true,
-              },
-            }),
-        ),
-      ).rejects.toThrow(/line breaks/);
-    }
+  it.each([
+    ["MSTEAMS_APP_ID", "teams-app\nEVIL=1"],
+    ["MSTEAMS_TENANT_ID", "teams-tenant\nEVIL=1"],
+    ["TEAMS_ALLOWED_USERS", "user-one\nEVIL=1"],
+  ] as const)("rejects unsafe Microsoft Teams Hermes env value %s", async (envKey, value) => {
+    await expect(
+      withEnv(
+        {
+          ...TEST_TEAMS_ENV,
+          [envKey]: value,
+        },
+        () =>
+          compiler().compile({
+            sandboxName: "demo",
+            agent: "hermes",
+            workflow: "rebuild",
+            isInteractive: false,
+            configuredChannels: ["teams"],
+            credentialAvailability: {
+              MSTEAMS_APP_PASSWORD: true,
+            },
+          }),
+      ),
+    ).rejects.toThrow(/line breaks/);
   });
 
   it("applies Microsoft Teams manifest defaults when optional env keys are unset", async () => {
@@ -664,40 +658,37 @@ describe("ManifestCompiler", () => {
     ).rejects.toThrow(/Microsoft Teams webhook port/);
   });
 
-  it("rejects unsafe WeChat Hermes env render values", async () => {
-    const cases: Array<readonly [string, string]> = [
-      ["WECHAT_ACCOUNT_ID", "wechat-account\nEVIL=1"],
-      ["WECHAT_BASE_URL", "https://ilinkai.wechat.com\nEVIL=1"],
-      ["WECHAT_ALLOWED_IDS", "friend-one\nEVIL=1"],
-    ];
-
-    for (const [envKey, value] of cases) {
-      await expect(
-        withEnv(
-          {
-            WECHAT_ACCOUNT_ID: "wechat-account",
-            WECHAT_BASE_URL: "https://ilinkai.wechat.com",
-            WECHAT_ALLOWED_IDS: "friend-one",
-            [envKey]: value,
-          },
-          () =>
-            compiler().compile({
-              sandboxName: "demo",
-              agent: "hermes",
-              workflow: "rebuild",
-              isInteractive: false,
-              configuredChannels: ["wechat"],
-              credentialAvailability: {
-                WECHAT_BOT_TOKEN: true,
-              },
-            }),
-        ),
-      ).rejects.toThrow(/line breaks/);
-    }
+  it.each([
+    ["WECHAT_ACCOUNT_ID", "wechat-account\nEVIL=1"],
+    ["WECHAT_BASE_URL", "https://ilinkai.wechat.com\nEVIL=1"],
+    ["WECHAT_ALLOWED_IDS", "friend-one\nEVIL=1"],
+  ] as const)("rejects unsafe WeChat Hermes env value %s", async (envKey, value) => {
+    await expect(
+      withEnv(
+        {
+          WECHAT_ACCOUNT_ID: "wechat-account",
+          WECHAT_BASE_URL: "https://ilinkai.wechat.com",
+          WECHAT_ALLOWED_IDS: "friend-one",
+          [envKey]: value,
+        },
+        () =>
+          compiler().compile({
+            sandboxName: "demo",
+            agent: "hermes",
+            workflow: "rebuild",
+            isInteractive: false,
+            configuredChannels: ["wechat"],
+            credentialAvailability: {
+              WECHAT_BOT_TOKEN: true,
+            },
+          }),
+      ),
+    ).rejects.toThrow(/line breaks/);
   });
 
-  it("rejects non-HTTPS or non-iLink WeChat baseUrl values", async () => {
-    for (const baseUrl of ["http://ilinkai.wechat.com", "https://example.com"] as const) {
+  it.each(["http://ilinkai.wechat.com", "https://example.com"] as const)(
+    "rejects unsafe WeChat baseUrl %s",
+    async (baseUrl) => {
       await expect(
         withEnv(
           {
@@ -717,8 +708,8 @@ describe("ManifestCompiler", () => {
             }),
         ),
       ).rejects.toThrow(/WeChat baseUrl/);
-    }
-  });
+    },
+  );
 
   it("does not activate a requested channel while any required manifest input is missing", async () => {
     const plan = await withEnv(

--- a/src/lib/onboard/reasoning-mode.test.ts
+++ b/src/lib/onboard/reasoning-mode.test.ts
@@ -14,13 +14,21 @@ describe("compatible endpoint reasoning mode", () => {
     delete process.env.NEMOCLAW_REASONING;
   });
 
-  it("normalizes supported boolean aliases (#3279)", () => {
-    for (const value of ["true", "1", "yes", "y", " YES "]) {
+  it.each(["true", "1", "yes", "y", " YES "])(
+    "normalizes truthy boolean alias %j (#3279)",
+    (value) => {
       expect(normalizeReasoningFlag(value)).toBe("true");
-    }
-    for (const value of ["false", "0", "no", "n", " NO "]) {
+    },
+  );
+
+  it.each(["false", "0", "no", "n", " NO "])(
+    "normalizes falsey boolean alias %j (#3279)",
+    (value) => {
       expect(normalizeReasoningFlag(value)).toBe("false");
-    }
+    },
+  );
+
+  it("rejects an unsupported boolean alias (#3279)", () => {
     expect(normalizeReasoningFlag("maybe")).toBeNull();
   });
 

--- a/src/lib/security/redact.test.ts
+++ b/src/lib/security/redact.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import { redactForLog, redactFull, redactLogSequence, redactSensitiveText } from "./redact.js";
 
 describe("redactForLog", () => {
-  it("redacts pass aliases in structured keys and canonical text assignments", () => {
+  it("redacts pass aliases in structured keys", () => {
     const payload = "opaqueCredentialPayloadZ1234567890";
 
     expect(
@@ -30,35 +30,36 @@ describe("redactForLog", () => {
       "db-pass": "<REDACTED>",
       replyToken: "<REDACTED>",
     });
-    for (const [assignment, expected] of [
-      [`CUSTOM_PASS=${payload}`, "CUSTOM_PASS=<REDACTED>"],
-      [`CUSTOM_PASSWD=${payload}`, "CUSTOM_PASSWD=<REDACTED>"],
-      [`CUSTOM_PASS ${payload}`, "CUSTOM_PASS <REDACTED>"],
-      ["CUSTOM_PASS=!OpaquePassword123", "CUSTOM_PASS=<REDACTED>"],
-      ["CUSTOM_PASS=abcdefghij!tail-secret", "CUSTOM_PASS=<REDACTED>"],
-      ["CUSTOM_PASS=,OpaquePassword123", "CUSTOM_PASS=<REDACTED>"],
-      ["CUSTOM_PASS=OpaquePassword123,", "CUSTOM_PASS=<REDACTED>"],
-      [`PASS: ${payload}`, "PASS: <REDACTED>"],
-      [`PASS = ${payload}`, "PASS = <REDACTED>"],
-      [`{"PASS":"${payload}"}`, '{"PASS":"<REDACTED>"}'],
-      [`api-key=${payload}`, "api-key=<REDACTED>"],
-      [`X-Api-Key=${payload}`, "X-Api-Key=<REDACTED>"],
-      [`clientSecret=${payload}`, "clientSecret=<REDACTED>"],
-      [`replyToken=${payload}`, "replyToken=<REDACTED>"],
-      [`{"replyToken":"${payload}"}`, '{"replyToken":"<REDACTED>"}'],
-      [`githubToken=${payload}`, "githubToken=<REDACTED>"],
-      [`webhookSecret=${payload}`, "webhookSecret=<REDACTED>"],
-      [`databaseCredential=${payload}`, "databaseCredential=<REDACTED>"],
-      [`customPass=${payload}`, "customPass=<REDACTED>"],
-      [`DBPass=${payload}`, "DBPass=<REDACTED>"],
-    ]) {
-      expect(redactSensitiveText(assignment)).toBe(expected);
-      expect(redactFull(assignment)).toBe(expected);
-      expect(redactForLog(assignment)).toBe(expected);
-    }
   });
 
-  it("preserves benign structured keys and assignments containing pass", () => {
+  it.each([
+    ["CUSTOM_PASS=opaqueCredentialPayloadZ1234567890", "CUSTOM_PASS=<REDACTED>"],
+    ["CUSTOM_PASSWD=opaqueCredentialPayloadZ1234567890", "CUSTOM_PASSWD=<REDACTED>"],
+    ["CUSTOM_PASS opaqueCredentialPayloadZ1234567890", "CUSTOM_PASS <REDACTED>"],
+    ["CUSTOM_PASS=!OpaquePassword123", "CUSTOM_PASS=<REDACTED>"],
+    ["CUSTOM_PASS=abcdefghij!tail-secret", "CUSTOM_PASS=<REDACTED>"],
+    ["CUSTOM_PASS=,OpaquePassword123", "CUSTOM_PASS=<REDACTED>"],
+    ["CUSTOM_PASS=OpaquePassword123,", "CUSTOM_PASS=<REDACTED>"],
+    ["PASS: opaqueCredentialPayloadZ1234567890", "PASS: <REDACTED>"],
+    ["PASS = opaqueCredentialPayloadZ1234567890", "PASS = <REDACTED>"],
+    ['{"PASS":"opaqueCredentialPayloadZ1234567890"}', '{"PASS":"<REDACTED>"}'],
+    ["api-key=opaqueCredentialPayloadZ1234567890", "api-key=<REDACTED>"],
+    ["X-Api-Key=opaqueCredentialPayloadZ1234567890", "X-Api-Key=<REDACTED>"],
+    ["clientSecret=opaqueCredentialPayloadZ1234567890", "clientSecret=<REDACTED>"],
+    ["replyToken=opaqueCredentialPayloadZ1234567890", "replyToken=<REDACTED>"],
+    ['{"replyToken":"opaqueCredentialPayloadZ1234567890"}', '{"replyToken":"<REDACTED>"}'],
+    ["githubToken=opaqueCredentialPayloadZ1234567890", "githubToken=<REDACTED>"],
+    ["webhookSecret=opaqueCredentialPayloadZ1234567890", "webhookSecret=<REDACTED>"],
+    ["databaseCredential=opaqueCredentialPayloadZ1234567890", "databaseCredential=<REDACTED>"],
+    ["customPass=opaqueCredentialPayloadZ1234567890", "customPass=<REDACTED>"],
+    ["DBPass=opaqueCredentialPayloadZ1234567890", "DBPass=<REDACTED>"],
+  ])("redacts canonical assignment vector %#", (assignment, expected) => {
+    expect(redactSensitiveText(assignment)).toBe(expected);
+    expect(redactFull(assignment)).toBe(expected);
+    expect(redactForLog(assignment)).toBe(expected);
+  });
+
+  it("preserves benign structured keys containing pass", () => {
     const benign = {
       compass: "north",
       bypass: false,
@@ -76,19 +77,20 @@ describe("redactForLog", () => {
     };
 
     expect(redactForLog(benign)).toEqual(benign);
-    for (const text of [
-      "COMPASS=opaqueNonSecretPayload123 BYPASS=allowedValue123",
-      "TOPSECRET=opaqueNonSecretPayload123 SUBTOKEN=opaqueNonSecretPayload123",
-      "publicKey=opaqueVerificationMaterial123 customKey=opaqueNonSecretPayload123",
-      "public-key=opaqueVerificationMaterial123 custom-key=opaqueNonSecretPayload123",
-      "passRate=opaqueNonSecretPayload123",
-      '{"key":"agent:main:main"}',
-      '{"correlationMarker":"reply-correlation-marker-123"}',
-    ]) {
-      expect(redactSensitiveText(text), text).toBe(text);
-      expect(redactFull(text), text).toBe(text);
-      expect(redactForLog(text), text).toBe(text);
-    }
+  });
+
+  it.each([
+    "COMPASS=opaqueNonSecretPayload123 BYPASS=allowedValue123",
+    "TOPSECRET=opaqueNonSecretPayload123 SUBTOKEN=opaqueNonSecretPayload123",
+    "publicKey=opaqueVerificationMaterial123 customKey=opaqueNonSecretPayload123",
+    "public-key=opaqueVerificationMaterial123 custom-key=opaqueNonSecretPayload123",
+    "passRate=opaqueNonSecretPayload123",
+    '{"key":"agent:main:main"}',
+    '{"correlationMarker":"reply-correlation-marker-123"}',
+  ])("preserves benign text vector %# containing credential substrings", (text) => {
+    expect(redactSensitiveText(text), text).toBe(text);
+    expect(redactFull(text), text).toBe(text);
+    expect(redactForLog(text), text).toBe(text);
   });
 
   it("redacts sensitive object keys recursively while preserving safe fields", () => {
@@ -261,7 +263,21 @@ describe("redactForLog", () => {
     ]);
   });
 
-  it("redacts Basic, Digest, proxy-auth, and cookie text without matching safe labels", () => {
+  it.each([
+    "opaque-basic-value",
+    "opaque-user",
+    "opaque-response",
+    "opaque-basic-plus",
+    "opaque-bearer-plus",
+    "opaque-digest-v2",
+    "opaque-equals-auth",
+    "opaque-equals-proxy",
+    "opaque-equals-cookie",
+    "opaque-equals-set-cookie",
+    "opaque-cookie-value",
+    "opaque-set-cookie-value",
+    "opaque-json-value",
+  ])("redacts HTTP credential vector %# without matching a safe label", (secret) => {
     const text = [
       "Authorization: Basic opaque-basic-value",
       "Proxy-Authorization: Digest username=opaque-user, response=opaque-response",
@@ -279,23 +295,7 @@ describe("redactForLog", () => {
     ].join("\n");
 
     const result = redactFull(text);
-    for (const secret of [
-      "opaque-basic-value",
-      "opaque-user",
-      "opaque-response",
-      "opaque-basic-plus",
-      "opaque-bearer-plus",
-      "opaque-digest-v2",
-      "opaque-equals-auth",
-      "opaque-equals-proxy",
-      "opaque-equals-cookie",
-      "opaque-equals-set-cookie",
-      "opaque-cookie-value",
-      "opaque-set-cookie-value",
-      "opaque-json-value",
-    ]) {
-      expect(result).not.toContain(secret);
-    }
+    expect(result).not.toContain(secret);
     expect(result).toContain("author: safe-author");
   });
 
@@ -305,24 +305,29 @@ describe("redactForLog", () => {
     );
   });
 
-  it("redacts folded credential headers without consuming the next diagnostic line", () => {
-    for (const header of ["Authorization", "Proxy-Authorization", "Cookie", "Set-Cookie"]) {
+  it.each(["Authorization", "Proxy-Authorization", "Cookie", "Set-Cookie"])(
+    "redacts folded %s headers without consuming the next diagnostic line",
+    (header) => {
       const result = redactFull(`${header}:\r\n\topaque-folded-value\r\nnext diagnostic`);
       expect(result).toBe(`${header}: <REDACTED>\r\nnext diagnostic`);
-    }
+    },
+  );
+
+  it("redacts a bare carriage return in a folded credential header", () => {
     expect(redactFull("Authorization:\ropaque-bare-cr\rnext diagnostic")).toBe(
       "Authorization: <REDACTED>\rnext diagnostic",
     );
   });
 
-  it("fails closed for malformed quoted credential fields", () => {
-    for (const input of [
-      '{"Authorization":"Basic opaque-unterminated',
-      '{"Cookie":"session=opaque-unterminated',
-      '{"Authorization": Basic opaque-unquoted}',
-    ]) {
-      expect(redactFull(input)).not.toContain("opaque-");
-    }
+  it.each([
+    '{"Authorization":"Basic opaque-unterminated',
+    '{"Cookie":"session=opaque-unterminated',
+    '{"Authorization": Basic opaque-unquoted}',
+  ])("fails closed for malformed quoted credential field vector %#", (input) => {
+    expect(redactFull(input)).not.toContain("opaque-");
+  });
+
+  it("redacts a complete quoted credential field", () => {
     expect(redactFull('{"Authorization":"Basic opaque-complete","status":"kept"}')).toBe(
       '{"Authorization":"Basic <REDACTED>","status":"kept"}',
     );

--- a/test/check-docs-published-routes.test.ts
+++ b/test/check-docs-published-routes.test.ts
@@ -106,14 +106,15 @@ ${body}
 }
 
 describe("published docs route checking", () => {
-  it("indexes the native changelog route for every agent variant", () => {
-    const index = buildPublishedRouteIndex(navYaml);
+  it.each(["openclaw", "hermes", "deepagents"])(
+    "indexes the native changelog route for %s",
+    (variant) => {
+      const index = buildPublishedRouteIndex(navYaml);
 
-    for (const variant of ["openclaw", "hermes", "deepagents"]) {
       expect(index.routes.has(`/user-guide/${variant}/release-notes`)).toBe(true);
       expect(index.routes.has(`/user-guide/${variant}/release-notes/2026/7/14`)).toBe(true);
-    }
-  });
+    },
+  );
 
   it("requires the shared changelog in every agent variant", () => {
     const incompleteNav = navYaml.replace(
@@ -435,8 +436,9 @@ describe("Manage Sandboxes extension routes", () => {
     expect(findMissingDirectLegacyManageSandboxRedirects()).toEqual([]);
   });
 
-  it("publishes MCP pages under the MCP Servers group for every agent variant", () => {
-    for (const variant of ["openclaw", "hermes", "deepagents"]) {
+  it.each(["openclaw", "hermes", "deepagents"])(
+    "publishes %s MCP pages under the MCP Servers group",
+    (variant) => {
       expect(
         index.routes.has(
           `/user-guide/${variant}/manage-sandboxes/mcp-servers/about-managed-mcp-servers`,
@@ -447,8 +449,8 @@ describe("Manage Sandboxes extension routes", () => {
           `/user-guide/${variant}/manage-sandboxes/extend-sandboxes/about-managed-mcp-servers`,
         ),
       ).toBe(false);
-    }
-  });
+    },
+  );
 
   it("publishes plugin installation directly under supported Manage Sandboxes variants", () => {
     expect(index.routes.has("/user-guide/openclaw/manage-sandboxes/install-openclaw-plugins")).toBe(
@@ -522,75 +524,81 @@ describe("public security review boundaries", () => {
   const destinations = new Map(redirects.map(({ source, destination }) => [source, destination]));
   const redirectIndexes = new Map(redirects.map(({ source }, index) => [source, index]));
 
-  it("keeps internal review records out of the public Security section", () => {
+  it("keeps internal review files out of the public Security section", () => {
     const publicReviewFiles = readdirSync(path.join(repoRoot, "docs", "security")).filter((name) =>
       /review/iu.test(name),
     );
 
     expect(publicReviewFiles).toEqual([]);
-    for (const variant of ["openclaw", "hermes", "deepagents"]) {
+  });
+
+  it.each(["openclaw", "hermes", "deepagents"])(
+    "keeps internal review routes out of the %s Security section",
+    (variant) => {
       expect(
         index.routes.has(`/user-guide/${variant}/security/openshell-0.0.72-compatibility-review`),
       ).toBe(false);
       expect(
         index.routes.has(`/user-guide/${variant}/security/openshell-0.0.71-gateway-auth-review`),
       ).toBe(false);
-    }
-  });
+    },
+  );
 
-  it("redirects retired review routes directly to current security guidance", () => {
-    for (const reviewSlug of [
-      "openshell-0.0.72-compatibility-review",
-      "openshell-0.0.71-gateway-auth-review",
-    ]) {
-      for (const [sourceBase, destinationBase] of [
+  it.each(
+    ["openshell-0.0.72-compatibility-review", "openshell-0.0.71-gateway-auth-review"].flatMap(
+      (reviewSlug) =>
         [
-          `/nemoclaw/latest/user-guide/:variant/security/${reviewSlug}`,
-          "/nemoclaw/latest/user-guide/:variant/security/security-controls/gateway-authentication-controls",
-        ],
-        [
-          `/nemoclaw/user-guide/:variant/security/${reviewSlug}`,
-          "/nemoclaw/user-guide/:variant/security/security-controls/gateway-authentication-controls",
-        ],
-        [
-          `/nemoclaw/latest/security/${reviewSlug}`,
-          "/nemoclaw/latest/user-guide/openclaw/security/security-controls/gateway-authentication-controls",
-        ],
-        [
-          `/nemoclaw/security/${reviewSlug}`,
-          "/nemoclaw/user-guide/openclaw/security/security-controls/gateway-authentication-controls",
-        ],
-      ]) {
-        expect(destinations.get(sourceBase)).toBe(destinationBase);
-        expect(destinations.get(`${sourceBase}.html`)).toBe(destinationBase);
-        expect(destinations.get(`${sourceBase}/index.html`)).toBe(destinationBase);
-        expect(destinations.get(`${sourceBase}.md`)).toBe(`${destinationBase}.md`);
-        expect(destinations.get(`${sourceBase}.mdx`)).toBe(`${destinationBase}.mdx`);
+          [
+            `/nemoclaw/latest/user-guide/:variant/security/${reviewSlug}`,
+            "/nemoclaw/latest/user-guide/:variant/security/security-controls/gateway-authentication-controls",
+          ],
+          [
+            `/nemoclaw/user-guide/:variant/security/${reviewSlug}`,
+            "/nemoclaw/user-guide/:variant/security/security-controls/gateway-authentication-controls",
+          ],
+          [
+            `/nemoclaw/latest/security/${reviewSlug}`,
+            "/nemoclaw/latest/user-guide/openclaw/security/security-controls/gateway-authentication-controls",
+          ],
+          [
+            `/nemoclaw/security/${reviewSlug}`,
+            "/nemoclaw/user-guide/openclaw/security/security-controls/gateway-authentication-controls",
+          ],
+        ].map(([sourceBase, destinationBase]) => ({ destinationBase, sourceBase })),
+    ),
+  )(
+    "redirects $sourceBase directly to current security guidance",
+    ({ sourceBase, destinationBase }) => {
+      expect(destinations.get(sourceBase)).toBe(destinationBase);
+      expect(destinations.get(`${sourceBase}.html`)).toBe(destinationBase);
+      expect(destinations.get(`${sourceBase}/index.html`)).toBe(destinationBase);
+      expect(destinations.get(`${sourceBase}.md`)).toBe(`${destinationBase}.md`);
+      expect(destinations.get(`${sourceBase}.mdx`)).toBe(`${destinationBase}.mdx`);
 
-        expect(redirectIndexes.get(`${sourceBase}.html`)).toBeLessThan(
-          redirectIndexes.get("/nemoclaw/:path*.html") ?? -1,
-        );
-        const genericIndexSource = sourceBase.startsWith("/nemoclaw/latest/")
-          ? "/nemoclaw/latest/:path*/index.html"
-          : "/nemoclaw/:path*/index.html";
-        expect(redirectIndexes.get(`${sourceBase}/index.html`)).toBeLessThan(
-          redirectIndexes.get(genericIndexSource) ?? -1,
-        );
-      }
-    }
-  });
+      expect(redirectIndexes.get(`${sourceBase}.html`)).toBeLessThan(
+        redirectIndexes.get("/nemoclaw/:path*.html") ?? -1,
+      );
+      const genericIndexSource = sourceBase.startsWith("/nemoclaw/latest/")
+        ? "/nemoclaw/latest/:path*/index.html"
+        : "/nemoclaw/:path*/index.html";
+      expect(redirectIndexes.get(`${sourceBase}/index.html`)).toBeLessThan(
+        redirectIndexes.get(genericIndexSource) ?? -1,
+      );
+    },
+  );
 });
 
 describe("headless server deployment routes", () => {
   const index = buildPublishedRouteIndex();
 
-  it("publishes the guide for every agent variant (#7180)", () => {
-    for (const variant of ["openclaw", "hermes", "deepagents"]) {
+  it.each(["openclaw", "hermes", "deepagents"])(
+    "publishes the guide for the %s agent variant (#7180)",
+    (variant) => {
       expect(index.routes.has(`/user-guide/${variant}/deployment/deploy-to-headless-server`)).toBe(
         true,
       );
-    }
-  });
+    },
+  );
 
   it("resolves every guide link against generated published routes (#7180)", () => {
     expect(findBrokenPublishedRoutes("deployment/deploy-to-headless-server.mdx", index)).toEqual(
@@ -603,60 +611,66 @@ describe("headless server deployment routes", () => {
     expect(index.routes.has("/user-guide/openclaw/deployment/brev-web-ui")).toBe(false);
   });
 
-  it("redirects every retired Brev deployment route directly to the shared guide (#7180)", () => {
-    const redirects = fernRedirects ?? [];
-    const destinations = new Map(redirects.map(({ source, destination }) => [source, destination]));
-    const redirectIndexes = new Map(redirects.map(({ source }, index) => [source, index]));
+  const retiredBrevRouteCases = ["deploy-to-remote-gpu", "brev-web-ui"].flatMap((retiredSlug) =>
+    [
+      [
+        `/nemoclaw/latest/user-guide/openclaw/deployment/${retiredSlug}`,
+        "/nemoclaw/latest/user-guide/openclaw/deployment/deploy-to-headless-server",
+      ],
+      [
+        `/nemoclaw/user-guide/openclaw/deployment/${retiredSlug}`,
+        "/nemoclaw/user-guide/openclaw/deployment/deploy-to-headless-server",
+      ],
+      [
+        `/nemoclaw/latest/deployment/${retiredSlug}`,
+        "/nemoclaw/latest/user-guide/openclaw/deployment/deploy-to-headless-server",
+      ],
+      [
+        `/nemoclaw/deployment/${retiredSlug}`,
+        "/nemoclaw/user-guide/openclaw/deployment/deploy-to-headless-server",
+      ],
+    ].map(([sourceBase, destinationBase]) => ({ destinationBase, sourceBase })),
+  );
 
-    for (const retiredSlug of ["deploy-to-remote-gpu", "brev-web-ui"]) {
-      for (const [sourceBase, destinationBase] of [
-        [
-          `/nemoclaw/latest/user-guide/openclaw/deployment/${retiredSlug}`,
-          "/nemoclaw/latest/user-guide/openclaw/deployment/deploy-to-headless-server",
-        ],
-        [
-          `/nemoclaw/user-guide/openclaw/deployment/${retiredSlug}`,
-          "/nemoclaw/user-guide/openclaw/deployment/deploy-to-headless-server",
-        ],
-        [
-          `/nemoclaw/latest/deployment/${retiredSlug}`,
-          "/nemoclaw/latest/user-guide/openclaw/deployment/deploy-to-headless-server",
-        ],
-        [
-          `/nemoclaw/deployment/${retiredSlug}`,
-          "/nemoclaw/user-guide/openclaw/deployment/deploy-to-headless-server",
-        ],
-      ]) {
-        expect(destinations.get(sourceBase)).toBe(destinationBase);
-        expect(destinations.get(`${sourceBase}.html`)).toBe(destinationBase);
-        expect(destinations.get(`${sourceBase}/index.html`)).toBe(destinationBase);
-        expect(destinations.get(`${sourceBase}.md`)).toBe(`${destinationBase}.md`);
-        expect(destinations.get(`${sourceBase}.mdx`)).toBe(`${destinationBase}.mdx`);
+  it.each(retiredBrevRouteCases)(
+    "redirects $sourceBase directly to the shared guide (#7180)",
+    ({ sourceBase, destinationBase }) => {
+      const redirects = fernRedirects ?? [];
+      const destinations = new Map(
+        redirects.map(({ source, destination }) => [source, destination]),
+      );
+      const redirectIndexes = new Map(redirects.map(({ source }, index) => [source, index]));
 
-        expect(redirectIndexes.get(`${sourceBase}.html`)).toBeLessThan(
-          redirectIndexes.get("/nemoclaw/:path*.html") ?? -1,
-        );
-        const genericIndexSource = sourceBase.startsWith("/nemoclaw/latest/")
-          ? "/nemoclaw/latest/:path*/index.html"
-          : "/nemoclaw/:path*/index.html";
-        expect(redirectIndexes.get(`${sourceBase}/index.html`)).toBeLessThan(
-          redirectIndexes.get(genericIndexSource) ?? -1,
-        );
-      }
-    }
-  });
+      expect(destinations.get(sourceBase)).toBe(destinationBase);
+      expect(destinations.get(`${sourceBase}.html`)).toBe(destinationBase);
+      expect(destinations.get(`${sourceBase}/index.html`)).toBe(destinationBase);
+      expect(destinations.get(`${sourceBase}.md`)).toBe(`${destinationBase}.md`);
+      expect(destinations.get(`${sourceBase}.mdx`)).toBe(`${destinationBase}.mdx`);
+
+      expect(redirectIndexes.get(`${sourceBase}.html`)).toBeLessThan(
+        redirectIndexes.get("/nemoclaw/:path*.html") ?? -1,
+      );
+      const genericIndexSource = sourceBase.startsWith("/nemoclaw/latest/")
+        ? "/nemoclaw/latest/:path*/index.html"
+        : "/nemoclaw/:path*/index.html";
+      expect(redirectIndexes.get(`${sourceBase}/index.html`)).toBeLessThan(
+        redirectIndexes.get(genericIndexSource) ?? -1,
+      );
+    },
+  );
 });
 
 describe("gateway lifecycle authority routes", () => {
   const index = buildPublishedRouteIndex();
 
-  it("publishes the OpenShell gateway guide for every guide variant (#6576)", () => {
-    for (const variant of ["openclaw", "hermes", "deepagents"]) {
+  it.each(["openclaw", "hermes", "deepagents"])(
+    "publishes the OpenShell gateway guide for the %s variant (#6576)",
+    (variant) => {
       expect(
         index.routes.has(`/user-guide/${variant}/deployment/gateway-lifecycle-authority`),
       ).toBe(true);
-    }
-  });
+    },
+  );
 
   it("resolves every OpenShell gateway guide link for each guide variant (#6576)", () => {
     expect(findBrokenPublishedRoutes("deployment/gateway-lifecycle-authority.mdx", index)).toEqual(

--- a/test/dcode-wrapper-identity.test.ts
+++ b/test/dcode-wrapper-identity.test.ts
@@ -197,9 +197,10 @@ describe.skipIf(!canRun)(
       });
     });
 
-    it("ignores agent preferences that dcode cannot activate", () => {
-      withTempDir((dir) => {
-        for (const invalidName of [".hidden", "   "]) {
+    it.each([".hidden", "   "])(
+      "ignores the %j agent preference that dcode cannot activate",
+      (invalidName) => {
+        withTempDir((dir) => {
           const config = SAMPLE_CONFIG.replace(
             'default = "backend-dev"',
             `default = "${invalidName}"`,
@@ -212,10 +213,9 @@ describe.skipIf(!canRun)(
           expect(run.status).toBe(0);
           expect(run.stdout).toContain("Agent:    frontend-dev");
           expect(run.stdout).not.toContain(`Agent:    ${invalidName}`);
-          fs.rmSync(path.join(fixture.configDir, "frontend-dev"), { recursive: true });
-        }
-      });
-    });
+        });
+      },
+    );
 
     it("does not write control characters from mutable identity metadata", () => {
       withTempDir((dir) => {
@@ -270,68 +270,67 @@ describe.skipIf(!canRun)(
       });
     });
 
-    it("does not write secret-shaped mutable identity metadata", () => {
+    it.each([
+      ["structured token", `tvly-${OPAQUE}`],
+      ["assignment", "API_KEY=opaquevalue12345"],
+      ["colon assignment", "TOKEN:opaquevalue12345"],
+      ["generic private key", fakePrivateKeyBlock()],
+      ["RSA private key", fakePrivateKeyBlock("RSA")],
+      ["credential-name context", "PASSWORD opaquevalue12345"],
+    ])("does not write %s mutable identity metadata", (_kind, secret) => {
       withTempDir((dir) => {
         const agentSecret = "PASSWORD opaquevalue12345";
         fs.mkdirSync(path.join(dir, agentSecret));
-        const secretValues = [
-          `tvly-${OPAQUE}`,
-          "API_KEY=opaquevalue12345",
-          "TOKEN:opaquevalue12345",
-          fakePrivateKeyBlock(),
-          fakePrivateKeyBlock("RSA"),
-          agentSecret,
-        ];
-        for (const secret of secretValues) {
-          const config = SAMPLE_CONFIG.replace("route: inference", `route: ${secret}`)
-            .replace("upstream provider: nvidia-prod", `upstream provider: ${secret}`)
-            .replace('default = "backend-dev"', `default = "${agentSecret}"`)
-            .replace('default = "openai:demo-model"', `default = "openai:${secret}"`);
-          const run = runBashWrapper(buildFixture(dir, config), ["status"], {});
+        const config = SAMPLE_CONFIG.replace("route: inference", `route: ${secret}`)
+          .replace("upstream provider: nvidia-prod", `upstream provider: ${secret}`)
+          .replace('default = "backend-dev"', `default = "${agentSecret}"`)
+          .replace('default = "openai:demo-model"', `default = "openai:${secret}"`);
+        const run = runBashWrapper(buildFixture(dir, config), ["status"], {});
 
-          expect(run.status).toBe(0);
-          expect(run.stdout).not.toContain(secret);
-          expect(run.stdout).not.toContain(agentSecret);
-          expect(run.stdout).toContain("Sandbox:  unknown");
-          expect(run.stdout).toContain("Agent:    agent (default)");
-          expect(run.stdout).not.toContain("Route:");
-          expect(run.stdout).not.toContain("Provider:");
-          expect(run.stdout).not.toContain("Model:");
-        }
+        expect(run.status).toBe(0);
+        expect(run.stdout).not.toContain(secret);
+        expect(run.stdout).not.toContain(agentSecret);
+        expect(run.stdout).toContain("Sandbox:  unknown");
+        expect(run.stdout).toContain("Agent:    agent (default)");
+        expect(run.stdout).not.toContain("Route:");
+        expect(run.stdout).not.toContain("Provider:");
+        expect(run.stdout).not.toContain("Model:");
       });
     });
 
-    it("keeps private-key block filtering aligned with the canonical secret contract", () => {
+    it("keeps the private-key block pattern aligned with the canonical secret contract", () => {
       expect(SECRET_BLOCK_PATTERNS.map((pattern) => `${pattern.source}::${pattern.flags}`)).toEqual(
         [
           "-----BEGIN (?:[A-Z0-9]+ )?PRIVATE KEY-----[\\s\\S]*?-----END (?:[A-Z0-9]+ )?PRIVATE KEY-----::g",
         ],
       );
+    });
 
-      const samples = [fakePrivateKeyBlock("", "\n"), fakePrivateKeyBlock("RSA")];
-      for (const [index, sample] of samples.entries()) {
-        withTempDir((dir) => {
-          const fixture = buildFixture(dir, SAMPLE_CONFIG);
-          const varName = `NEMOCLAW_PARITY_BLOB_${index}`;
-          const run = runBashWrapper(fixture, ["status"], { [varName]: sample });
+    it.each([
+      [0, fakePrivateKeyBlock("", "\n")],
+      [1, fakePrivateKeyBlock("RSA")],
+    ])("filters private-key block sample %i from runtime and env-file inputs", (index, sample) => {
+      withTempDir((dir) => {
+        const fixture = buildFixture(dir, SAMPLE_CONFIG);
+        const varName = `NEMOCLAW_PARITY_BLOB_${index}`;
+        const run = runBashWrapper(fixture, ["status"], { [varName]: sample });
 
-          expect(run.status).not.toBe(0);
-          expect(run.launched).toBe(false);
-          expect(run.stderr).toContain(varName);
-          expect(run.stderr).not.toContain(sample);
-          expect(run.stderr).not.toContain("opaque-test-body");
+        expect(run.status).not.toBe(0);
+        expect(run.launched).toBe(false);
+        expect(run.stderr).toContain(varName);
+        expect(run.stderr).not.toContain(sample);
+        expect(run.stderr).not.toContain("opaque-test-body");
 
-          fs.writeFileSync(fixture.envFile, `${varName}="${sample}"\n`, "utf8");
-          const envFileRun = runBashWrapper(fixture, ["--version"], {});
+        fs.writeFileSync(fixture.envFile, `${varName}="${sample}"\n`, "utf8");
+        const envFileRun = runBashWrapper(fixture, ["--version"], {});
 
-          expect(envFileRun.status).toBe(2);
-          expect(envFileRun.launched).toBe(false);
-          expect(envFileRun.stderr).toContain(path.join(dir, ".env"));
-          expect(envFileRun.stderr).not.toContain(sample);
-          expect(envFileRun.stderr).not.toContain("PRIVATE KEY-----");
-          expect(envFileRun.stderr).not.toContain("opaque-test-body");
-        });
-      }
+        expect(envFileRun.status).toBe(2);
+        expect(envFileRun.launched).toBe(false);
+        expect(envFileRun.stderr).toContain(path.join(dir, ".env"));
+        expect(envFileRun.stderr).not.toContain(sample);
+        expect(envFileRun.stderr).not.toContain("PRIVATE KEY-----");
+        expect(envFileRun.stderr).not.toContain("opaque-test-body");
+      });
     });
 
     it("falls back safely for malformed or unsupported generated config scalars", () => {
@@ -507,63 +506,63 @@ describe.skipIf(!canRun)(
       });
     });
 
-    it("refuses noncanonical OpenShell TLS key values without printing them", () => {
-      const pemValue = [
-        "-----BEGIN PRIVATE ",
-        "KEY-----\nraw-private-key\n-----END PRIVATE ",
-        "KEY-----",
-      ].join("");
-      for (const value of [
-        OPAQUE,
-        pemValue,
-        "relative/tls.key",
-        "/tmp/tls.key",
-        `${CANONICAL_TLS_KEY_PATH}.bak`,
-        `tvly-${OPAQUE}`,
-      ]) {
-        withTempDir((dir) => {
-          const run = runBashWrapper(buildFixture(dir, SAMPLE_CONFIG), ["--version"], {
-            OPENSHELL_TLS_KEY: value,
-          });
-
-          expect(run.status).toBe(2);
-          expect(run.launched).toBe(false);
-          expect(run.stderr).toContain("OPENSHELL_TLS_KEY");
-          expect(run.stderr).not.toContain(value);
+    it.each([
+      ["opaque value", OPAQUE],
+      [
+        "private-key block",
+        ["-----BEGIN PRIVATE ", "KEY-----\nraw-private-key\n-----END PRIVATE ", "KEY-----"].join(
+          "",
+        ),
+      ],
+      ["relative path", "relative/tls.key"],
+      ["temporary path", "/tmp/tls.key"],
+      ["canonical-path suffix", `${CANONICAL_TLS_KEY_PATH}.bak`],
+      ["structured token", `tvly-${OPAQUE}`],
+    ])("refuses the noncanonical OpenShell TLS key %s without printing it", (_kind, value) => {
+      withTempDir((dir) => {
+        const run = runBashWrapper(buildFixture(dir, SAMPLE_CONFIG), ["--version"], {
+          OPENSHELL_TLS_KEY: value,
         });
-      }
+
+        expect(run.status).toBe(2);
+        expect(run.launched).toBe(false);
+        expect(run.stderr).toContain("OPENSHELL_TLS_KEY");
+        expect(run.stderr).not.toContain(value);
+      });
     });
 
-    it("refuses OpenShell TLS key values in the mutable env file", () => {
-      for (const value of [CANONICAL_TLS_KEY_PATH, OPAQUE]) {
-        withTempDir((dir) => {
-          const fixture = buildFixture(dir, SAMPLE_CONFIG);
-          fs.writeFileSync(fixture.envFile, `OPENSHELL_TLS_KEY=${value}\n`, "utf8");
+    it.each([
+      ["canonical path", CANONICAL_TLS_KEY_PATH],
+      ["opaque value", OPAQUE],
+    ])("refuses the OpenShell TLS key %s in the mutable env file", (_kind, value) => {
+      withTempDir((dir) => {
+        const fixture = buildFixture(dir, SAMPLE_CONFIG);
+        fs.writeFileSync(fixture.envFile, `OPENSHELL_TLS_KEY=${value}\n`, "utf8");
 
-          const run = runBashWrapper(fixture, ["--version"], {});
+        const run = runBashWrapper(fixture, ["--version"], {});
 
-          expect(run.status).toBe(2);
-          expect(run.launched).toBe(false);
-          expect(run.stderr).toContain("OPENSHELL_TLS_KEY");
-          expect(run.stderr).toContain(path.join(dir, ".env"));
-          expect(run.stderr).not.toContain(value);
-        });
-      }
+        expect(run.status).toBe(2);
+        expect(run.launched).toBe(false);
+        expect(run.stderr).toContain("OPENSHELL_TLS_KEY");
+        expect(run.stderr).toContain(path.join(dir, ".env"));
+        expect(run.stderr).not.toContain(value);
+      });
     });
 
-    it("still refuses recognized provider tokens carried by OPENSHELL_TLS_KEY", () => {
-      for (const value of [`nvapi-${OPAQUE}`, `tvly-${OPAQUE}`]) {
-        withTempDir((dir) => {
-          const run = runBashWrapper(buildFixture(dir, SAMPLE_CONFIG), ["--version"], {
-            OPENSHELL_TLS_KEY: value,
-          });
-
-          expect(run.status).toBe(2);
-          expect(run.launched).toBe(false);
-          expect(run.stderr).toContain("OPENSHELL_TLS_KEY");
-          expect(run.stderr).not.toContain(value);
+    it.each([
+      ["NVIDIA API", `nvapi-${OPAQUE}`],
+      ["Tavily", `tvly-${OPAQUE}`],
+    ])("still refuses the %s provider token carried by OPENSHELL_TLS_KEY", (_provider, value) => {
+      withTempDir((dir) => {
+        const run = runBashWrapper(buildFixture(dir, SAMPLE_CONFIG), ["--version"], {
+          OPENSHELL_TLS_KEY: value,
         });
-      }
+
+        expect(run.status).toBe(2);
+        expect(run.launched).toBe(false);
+        expect(run.stderr).toContain("OPENSHELL_TLS_KEY");
+        expect(run.stderr).not.toContain(value);
+      });
     });
 
     it("still refuses an opaque credential-name-context variable outside the allowlist", () => {

--- a/test/gateway-http-reuse-wait.test.ts
+++ b/test/gateway-http-reuse-wait.test.ts
@@ -167,19 +167,20 @@ describe("isGatewayHttpReady status-code semantics (#3258)", () => {
     expect(await isGatewayHttpReady(2000, url)).toBe(false);
   });
 
-  it("falls back to the default timeout when given a non-positive value", async () => {
-    // A non-positive timeoutMs must not cause the request to be torn down
-    // immediately — the helper falls back to the safe default and lets the
-    // probe complete normally against a healthy server.
-    const server = await startStatusServer(200);
-    try {
-      for (const bad of [0, -1, Number.NaN]) {
-        expect(await isGatewayHttpReady(bad, server.url)).toBe(true);
+  it.each([0, -1, Number.NaN])(
+    "falls back to the default timeout when given %s",
+    async (timeoutMs) => {
+      // A non-positive timeoutMs must not cause the request to be torn down
+      // immediately — the helper falls back to the safe default and lets the
+      // probe complete normally against a healthy server.
+      const server = await startStatusServer(200);
+      try {
+        expect(await isGatewayHttpReady(timeoutMs, server.url)).toBe(true);
+      } finally {
+        await server.close();
       }
-    } finally {
-      await server.close();
-    }
-  });
+    },
+  );
 });
 
 describe("isDockerDriverGatewayHttpReady (#3111)", () => {
@@ -315,8 +316,9 @@ describe("waitForGatewayHttpReady (#3258)", () => {
     expect(sleeps).toEqual([]);
   });
 
-  it("always probes at least once even when maxAttempts is 0 or negative", async () => {
-    for (const bad of [0, -1, -100]) {
+  it.each([0, -1, -100])(
+    "always probes at least once when maxAttempts is %s",
+    async (maxAttempts) => {
       let calls = 0;
       const sleeps: number[] = [];
       const result = await waitForGatewayHttpReady({
@@ -325,17 +327,18 @@ describe("waitForGatewayHttpReady (#3258)", () => {
           return false;
         },
         sleeper: (s: number) => sleeps.push(s),
-        maxAttempts: bad,
+        maxAttempts,
         intervalSeconds: 5,
       });
       expect(result).toBe(false);
       expect(calls).toBe(1);
       expect(sleeps).toEqual([]);
-    }
-  });
+    },
+  );
 
-  it("does not loop forever when maxAttempts is Infinity or NaN", async () => {
-    for (const bad of [Number.POSITIVE_INFINITY, Number.NaN]) {
+  it.each([Number.POSITIVE_INFINITY, Number.NaN])(
+    "does not loop forever when maxAttempts is %s",
+    async (maxAttempts) => {
       let calls = 0;
       const sleeps: number[] = [];
       const result = await waitForGatewayHttpReady({
@@ -344,17 +347,18 @@ describe("waitForGatewayHttpReady (#3258)", () => {
           return false;
         },
         sleeper: (s: number) => sleeps.push(s),
-        maxAttempts: bad,
+        maxAttempts,
         intervalSeconds: 5,
       });
       expect(result).toBe(false);
       expect(calls).toBe(1);
       expect(sleeps).toEqual([]);
-    }
-  });
+    },
+  );
 
-  it("does not pass NaN/Infinity through to the sleeper", async () => {
-    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY]) {
+  it.each([Number.NaN, Number.POSITIVE_INFINITY])(
+    "does not pass intervalSeconds %s through to the sleeper",
+    async (intervalSeconds) => {
       let calls = 0;
       const sleeps: number[] = [];
       const result = await waitForGatewayHttpReady({
@@ -364,13 +368,13 @@ describe("waitForGatewayHttpReady (#3258)", () => {
         },
         sleeper: (s: number) => sleeps.push(s),
         maxAttempts: 3,
-        intervalSeconds: bad,
+        intervalSeconds,
       });
       expect(result).toBe(true);
       // One sleep before the second probe — must be 0, not NaN/Infinity.
       expect(sleeps).toEqual([0]);
-    }
-  });
+    },
+  );
 
   it("treats a probe rejection as 'not ready' and continues to the next attempt", async () => {
     let calls = 0;

--- a/test/package-contract/cli/command-registry.test.ts
+++ b/test/package-contract/cli/command-registry.test.ts
@@ -28,13 +28,11 @@ describe("command-registry", () => {
       expect(new Set(usages).size).toBe(usages.length);
     });
 
-    it("every command has required fields", () => {
-      for (const cmd of COMMANDS) {
-        expect(cmd.usage).toBeTruthy();
-        expect(cmd.description).toBeTruthy();
-        expect(cmd.group).toBeTruthy();
-        expect(["global", "sandbox"]).toContain(cmd.scope);
-      }
+    it.each(COMMANDS)("$usage has the required command metadata", (cmd) => {
+      expect(cmd.usage).toBeTruthy();
+      expect(cmd.description).toBeTruthy();
+      expect(cmd.group).toBeTruthy();
+      expect(["global", "sandbox"]).toContain(cmd.scope);
     });
   });
 
@@ -48,10 +46,8 @@ describe("command-registry", () => {
       expect(usages).toContain("nemoclaw status");
     });
 
-    it("every entry has scope global", () => {
-      for (const cmd of globalCommands()) {
-        expect(cmd.scope).toBe("global");
-      }
+    it.each(globalCommands())("$usage has global scope", (cmd) => {
+      expect(cmd.scope).toBe("global");
     });
   });
 
@@ -69,10 +65,8 @@ describe("command-registry", () => {
       expect(sandboxCommands()).toHaveLength(62);
     });
 
-    it("every entry has scope sandbox", () => {
-      for (const cmd of sandboxCommands()) {
-        expect(cmd.scope).toBe("sandbox");
-      }
+    it.each(sandboxCommands())("$usage has sandbox scope", (cmd) => {
+      expect(cmd.scope).toBe("sandbox");
     });
   });
 
@@ -81,10 +75,8 @@ describe("command-registry", () => {
       expect(visibleCommands()).toEqual(COMMANDS.filter((cmd) => !cmd.hidden));
     });
 
-    it("no visible command has hidden=true", () => {
-      for (const cmd of visibleCommands()) {
-        expect(cmd.hidden).not.toBe(true);
-      }
+    it.each(visibleCommands())("$usage remains visible", (cmd) => {
+      expect(cmd.hidden).not.toBe(true);
     });
   });
 
@@ -113,26 +105,21 @@ describe("command-registry", () => {
   });
 
   describe("oclif discovery coverage", () => {
-    it("requires public leaf commands to have display metadata", () => {
-      const metadataById = getRegisteredOclifCommandsMetadata();
-      const discoveredIds = Object.keys(metadataById).sort();
+    const discoveredIds = Object.keys(getRegisteredOclifCommandsMetadata()).sort();
+    const publicLeafCommandIds = discoveredIds.filter(
+      (commandId) =>
+        !commandId.startsWith("internal:") &&
+        !discoveredIds.some((id) => id.startsWith(`${commandId}:`)),
+    );
+
+    it.each(publicLeafCommandIds)("%s has display metadata", (commandId) => {
       const displayCommandIds = new Set(COMMANDS.map((command) => command.commandId));
-
-      for (const commandId of discoveredIds) {
-        if (commandId.startsWith("internal:")) continue;
-
-        const hasSubcommands = discoveredIds.some((id) => id.startsWith(`${commandId}:`));
-        if (hasSubcommands) continue;
-
-        expect(displayCommandIds.has(commandId), commandId).toBe(true);
-      }
+      expect(displayCommandIds.has(commandId), commandId).toBe(true);
     });
 
-    it("keeps every public display entry attached to a discovered oclif command", () => {
+    it.each(COMMANDS)("$usage remains attached to a discovered oclif command", (command) => {
       const discoveredIds = new Set(Object.keys(getRegisteredOclifCommandsMetadata()));
-      for (const command of COMMANDS) {
-        expect(discoveredIds.has(command.commandId), command.usage).toBe(true);
-      }
+      expect(discoveredIds.has(command.commandId), command.usage).toBe(true);
     });
   });
 
@@ -155,22 +142,16 @@ describe("command-registry", () => {
       expect(list).toEqual(sorted);
     });
 
-    it("every entry starts with nemoclaw", () => {
-      for (const entry of canonicalUsageList()) {
-        expect(entry).toMatch(/^nemoclaw /);
-      }
+    it.each(canonicalUsageList())("%s starts with nemoclaw", (entry) => {
+      expect(entry).toMatch(/^nemoclaw /);
     });
 
-    it("no entry contains description text (double spaces)", () => {
-      for (const entry of canonicalUsageList()) {
-        expect(entry).not.toMatch(/\s{2,}/);
-      }
+    it.each(canonicalUsageList())("%s excludes description text", (entry) => {
+      expect(entry).not.toMatch(/\s{2,}/);
     });
 
-    it("keeps optional flags out of canonical usage strings", () => {
-      for (const entry of canonicalUsageList()) {
-        expect(entry).not.toContain("[");
-      }
+    it.each(canonicalUsageList())("%s excludes optional flags", (entry) => {
+      expect(entry).not.toContain("[");
     });
 
     it("excludes hidden commands", () => {
@@ -275,27 +256,22 @@ describe("command-registry", () => {
   });
 
   describe("commandsByGroup()", () => {
-    it("groups visible commands by group name", () => {
-      const grouped = commandsByGroup();
-      // All group keys should appear in GROUP_ORDER
-      for (const key of grouped.keys()) {
-        expect(GROUP_ORDER).toContain(key);
-      }
-      // Total visible commands across all groups
-      let total = 0;
-      for (const cmds of grouped.values()) {
-        total += cmds.length;
-      }
+    it.each([...commandsByGroup().keys()])(
+      "includes the %s group in the display order",
+      (group) => {
+        expect(GROUP_ORDER).toContain(group);
+      },
+    );
+
+    it("groups every visible command", () => {
+      const total = [...commandsByGroup().values()].reduce((count, commands) => {
+        return count + commands.length;
+      }, 0);
       expect(total).toBe(visibleCommands().length);
     });
 
-    it("no hidden commands in any group", () => {
-      const grouped = commandsByGroup();
-      for (const cmds of grouped.values()) {
-        for (const cmd of cmds) {
-          expect(cmd.hidden).not.toBe(true);
-        }
-      }
+    it.each([...commandsByGroup().values()].flat())("keeps $usage visible in its group", (cmd) => {
+      expect(cmd.hidden).not.toBe(true);
     });
 
     it("exposes the default-sandbox command in root help", () => {

--- a/test/policy-tiers.test.ts
+++ b/test/policy-tiers.test.ts
@@ -76,13 +76,11 @@ describe("tiers", () => {
       expect(names).toEqual(["restricted", "balanced", "open", "personal"]);
     });
 
-    it("each tier has name, label, description, and presets array", () => {
-      for (const tier of listTiers()) {
-        expect(typeof tier.name).toBe("string");
-        expect(typeof tier.label).toBe("string");
-        expect(typeof tier.description).toBe("string");
-        expect(Array.isArray(tier.presets)).toBe(true);
-      }
+    it.each(listTiers())("$name has the required tier fields", (tier) => {
+      expect(typeof tier.name).toBe("string");
+      expect(typeof tier.label).toBe("string");
+      expect(typeof tier.description).toBe("string");
+      expect(Array.isArray(tier.presets)).toBe(true);
     });
 
     it("labels are human-readable capitalised strings", () => {
@@ -137,14 +135,15 @@ describe("tiers", () => {
       expect(names).not.toContain("weather");
     });
 
-    it("keeps dev presets read-write", () => {
-      const accessByName = new Map(
-        mustGetTier("balanced").presets.map((preset: TierPreset) => [preset.name, preset.access]),
-      );
-      for (const name of ["npm", "pypi", "huggingface", "brew", "brave"]) {
+    it.each(["npm", "pypi", "huggingface", "brew", "brave"])(
+      "keeps the %s preset read-write",
+      (name) => {
+        const accessByName = new Map(
+          mustGetTier("balanced").presets.map((preset: TierPreset) => [preset.name, preset.access]),
+        );
         expect(accessByName.get(name)).toBe("read-write");
-      }
-    });
+      },
+    );
 
     it("does not include messaging presets (slack, discord, telegram, wechat, whatsapp)", () => {
       const names = mustGetTier("balanced").presets.map((preset: TierPreset) => preset.name);
@@ -163,28 +162,26 @@ describe("tiers", () => {
       expect(openCount).toBeGreaterThan(balancedCount);
     });
 
-    it("keeps public data presets read-only and service presets read-write", () => {
+    it.each([
+      ["npm", "read-write"],
+      ["pypi", "read-write"],
+      ["huggingface", "read-write"],
+      ["brew", "read-write"],
+      ["brave", "read-write"],
+      ["slack", "read-write"],
+      ["discord", "read-write"],
+      ["telegram", "read-write"],
+      ["wechat", "read-write"],
+      ["whatsapp", "read-write"],
+      ["jira", "read-write"],
+      ["outlook", "read-write"],
+      ["weather", "read"],
+      ["public-reference", "read"],
+    ])("gives the %s preset %s access", (name, access) => {
       const accessByName = new Map(
         mustGetTier("open").presets.map((preset: TierPreset) => [preset.name, preset.access]),
       );
-      for (const name of [
-        "npm",
-        "pypi",
-        "huggingface",
-        "brew",
-        "brave",
-        "slack",
-        "discord",
-        "telegram",
-        "wechat",
-        "whatsapp",
-        "jira",
-        "outlook",
-      ]) {
-        expect(accessByName.get(name)).toBe("read-write");
-      }
-      expect(accessByName.get("weather")).toBe("read");
-      expect(accessByName.get("public-reference")).toBe("read");
+      expect(accessByName.get(name)).toBe(access);
     });
 
     it("includes messaging presets (slack, discord, telegram, wechat, whatsapp)", () => {
@@ -208,16 +205,11 @@ describe("tiers", () => {
       expect(names).toContain("public-reference");
     });
 
-    it("open tier contains all balanced presets by name", () => {
-      const balancedNames = new Set(
-        mustGetTier("balanced").presets.map((preset: TierPreset) => preset.name),
-      );
+    it.each(mustGetTier("balanced").presets)("includes the balanced $name preset", ({ name }) => {
       const openNames = new Set(
         mustGetTier("open").presets.map((preset: TierPreset) => preset.name),
       );
-      for (const name of balancedNames) {
-        expect(openNames.has(name)).toBe(true);
-      }
+      expect(openNames.has(name)).toBe(true);
     });
   });
 
@@ -230,21 +222,26 @@ describe("tiers", () => {
       expect(personal).toHaveLength(available.length);
     });
 
-    it("defaults every preset to read-write", () => {
-      for (const preset of mustGetTier("personal").presets) {
-        expect(preset.access).toBe("read-write");
-      }
+    it.each(mustGetTier("personal").presets)("defaults $name to read-write", (preset) => {
+      expect(preset.access).toBe("read-write");
     });
   });
 
   describe("resolveTierPresets", () => {
-    it("returns default presets for balanced with no overrides", () => {
-      const resolved: TierPreset[] = resolveTierPresets("balanced");
-      expect(resolved.length).toBe(5);
-      const accessByName = new Map(resolved.map((preset) => [preset.name, preset.access]));
-      for (const name of ["npm", "pypi", "huggingface", "brew", "brave"]) {
+    it.each(["npm", "pypi", "huggingface", "brew", "brave"])(
+      "returns the default %s preset for balanced",
+      (name) => {
+        const resolved: TierPreset[] = resolveTierPresets("balanced");
+        expect(resolved.length).toBe(5);
+        const accessByName = new Map(resolved.map((preset) => [preset.name, preset.access]));
         expect(accessByName.get(name)).toBe("read-write");
-      }
+      },
+    );
+
+    it("keeps weather out of balanced defaults", () => {
+      const accessByName = new Map(
+        resolveTierPresets("balanced").map((preset) => [preset.name, preset.access]),
+      );
       expect(accessByName.has("weather")).toBe(false);
     });
 
@@ -311,28 +308,27 @@ describe("tiers", () => {
       expect(resolved).toHaveLength(openTier.presets.length);
     });
 
-    it("each resolved preset has name and access fields", () => {
-      for (const tier of listTiers()) {
-        for (const preset of resolveTierPresets(tier.name)) {
-          expect(typeof preset.name).toBe("string");
-          expect(typeof preset.access).toBe("string");
-          expect(preset.access.length).toBeGreaterThan(0);
-        }
-      }
+    it.each(
+      listTiers().flatMap((tier) =>
+        resolveTierPresets(tier.name).map((preset) => ({ preset, tier: tier.name })),
+      ),
+    )("resolves $preset.name with name and access fields for $tier", ({ preset }) => {
+      expect(typeof preset.name).toBe("string");
+      expect(typeof preset.access).toBe("string");
+      expect(preset.access.length).toBeGreaterThan(0);
     });
   });
 
   describe("integration: all tier presets exist on disk", () => {
-    it("every preset referenced in tiers.yaml exists as a preset file", () => {
-      const available = new Set(policies.listPresets().map((preset: Preset) => preset.name));
-      for (const tier of listTiers()) {
-        for (const preset of tier.presets) {
-          expect(
-            available.has(preset.name),
-            `Preset '${preset.name}' in tier '${tier.name}' not found on disk`,
-          ).toBe(true);
-        }
-      }
-    });
+    it.each(listTiers().flatMap((tier) => tier.presets.map((preset) => ({ preset, tier }))))(
+      "finds the $preset.name preset referenced by $tier.name on disk",
+      ({ preset, tier }) => {
+        const available = new Set(policies.listPresets().map((preset: Preset) => preset.name));
+        expect(
+          available.has(preset.name),
+          `Preset '${preset.name}' in tier '${tier.name}' not found on disk`,
+        ).toBe(true);
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary

Convert another 100 scanner-detected test loops into table tests. The repository-wide test-loop count falls from 1,243 to 1,143 while preserving the existing test behavior and making each independent case visible in test output.

## Changes

- Replace independent input, output, error, route, policy, credential, and metadata loops across 21 test files with `it.each` cases.
- Keep aggregate assertions as aggregate tests where the sequence or combined result is the behavior under test.
- Use safe case labels for credential-shaped fixtures so test titles do not print their values.
- Lower the legacy `src/lib/inference/nim.test.ts` size ceiling from 2,067 to 2,064 lines.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Focused review confirmed that negative security assertions, cleanup, and error checks remain on every affected row; credential-shaped values use safe test labels.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 21 changed test files: 2,005 tests passed; security-focused rerun: 214 tests passed.
- [x] Applicable broad gate passed — `npm run checks:repository`; no runtime or test-harness behavior changed, so `npm test` is not applicable.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification:

- `npm run test-loops:scan -- --json`: 1,243 → 1,143 loops
- `npm run test:titles:check`
- `npm run test-size:check`
- `npm run typecheck:cli`
- `npm --prefix nemoclaw run typecheck`
- Oxfmt and diff whitespace checks

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit `949043987d1eab5f0ae0004420def4f421fea00b` changes test registration and one legacy test-size ceiling only. The independent review found no user-visible behavior or documentation impact, no named-function escape hatch, and no findings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 949043987d1eab5f0ae0004420def4f421fea00b -->
<!-- docs-review-agents-blob-sha: 993bdd85043ac24bc3b6605521d7acc4de665945 -->

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>
