### PR TITLE
test(sandbox): verify optimized build context sources

### DIFF
--- a/scripts/checks/optimized-build-context-copy-sources.mts
+++ b/scripts/checks/optimized-build-context-copy-sources.mts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/** Verifies direct COPY sources from the root Dockerfile in the optimized build context. */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  formatMissingDockerfileCopySources,
+  missingDockerfileCopySources,
+} from "../lib/dockerfile-copy-sources.mts";
+
+type BuildContextModule = typeof import("../../src/lib/sandbox/build-context.ts");
+
+const importedBuildContext = (await import("../../src/lib/sandbox/build-context.ts")) as
+  | BuildContextModule
+  | { default: BuildContextModule };
+const buildContextModule =
+  "default" in importedBuildContext ? importedBuildContext.default : importedBuildContext;
+const { stageOptimizedSandboxBuildContext } = buildContextModule;
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+export function checkOptimizedBuildContextCopySources(
+  rootDir: string = REPO_ROOT,
+  temporaryRoot: string = os.tmpdir(),
+): void {
+  const stagingRoot = fs.mkdtempSync(
+    path.join(temporaryRoot, "nemoclaw-build-context-copy-check-"),
+  );
+  try {
+    const staged = stageOptimizedSandboxBuildContext(rootDir, stagingRoot);
+    const missingSources = missingDockerfileCopySources(
+      staged.stagedDockerfile,
+      staged.buildCtx,
+      "Dockerfile",
+    );
+    if (missingSources.length > 0) {
+      throw new Error(formatMissingDockerfileCopySources(missingSources));
+    }
+  } finally {
+    fs.rmSync(stagingRoot, { recursive: true, force: true });
+  }
+}
+
+const currentModule = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === currentModule) {
+  checkOptimizedBuildContextCopySources();
+}

--- a/scripts/checks/run.mts
+++ b/scripts/checks/run.mts
@@ -114,6 +114,11 @@ export const CHECKS: readonly CheckCommand[] = [
     args: ["scripts/checks/no-unit-blocks-in-live-e2e.mts"],
   },
   {
+    name: "optimized-build-context-copy-sources",
+    command: TSX,
+    args: ["scripts/checks/optimized-build-context-copy-sources.mts"],
+  },
+  {
     name: "test-registration-boundary",
     command: TSX,
     args: ["scripts/checks/test-registration-boundary.mts"],

--- a/scripts/lib/dockerfile-copy-sources.mts
+++ b/scripts/lib/dockerfile-copy-sources.mts
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/** Parses direct Dockerfile COPY sources and rejects unhandled forms. */
+
+import fs from "node:fs";
+import path from "node:path";
+
+interface LogicalDockerfileInstruction {
+  lineNumber: number;
+  text: string;
+}
+
+export interface DirectDockerfileCopySource {
+  lineNumber: number;
+  source: string;
+}
+
+export interface MissingDockerfileCopySource extends DirectDockerfileCopySource {
+  dockerfileLabel: string;
+}
+
+function logicalDockerfileInstructions(
+  text: string,
+  dockerfileLabel: string,
+): LogicalDockerfileInstruction[] {
+  const instructions: LogicalDockerfileInstruction[] = [];
+  let currentParts: string[] = [];
+  let currentLineNumber = 0;
+  let sawInstruction = false;
+
+  for (const [lineIndex, rawLine] of text.split(/\r?\n/u).entries()) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      if (!sawInstruction) {
+        const escapeDirective = /^#\s*escape\s*=\s*(\S+)\s*$/iu.exec(line);
+        if (escapeDirective && escapeDirective[1] !== "\\") {
+          throw new Error(
+            `Unsupported ${dockerfileLabel} escape directive at line ${lineIndex + 1}: ${rawLine}`,
+          );
+        }
+      }
+      continue;
+    }
+
+    sawInstruction = true;
+    if (currentParts.length === 0) currentLineNumber = lineIndex + 1;
+
+    const continued = line.endsWith("\\");
+    const part = continued ? line.slice(0, -1).trimEnd() : line;
+    if (!part) {
+      throw new Error(
+        `Unsupported ${dockerfileLabel} continuation at line ${lineIndex + 1}: ${rawLine}`,
+      );
+    }
+    currentParts.push(part);
+
+    if (!continued) {
+      const instruction = currentParts.join(" ");
+      if (instruction.split(/\s+/u).some((token) => token.startsWith("<<"))) {
+        throw new Error(
+          `Unsupported ${dockerfileLabel} heredoc instruction at line ${currentLineNumber}: ${instruction}`,
+        );
+      }
+      instructions.push({ lineNumber: currentLineNumber, text: instruction });
+      currentParts = [];
+      currentLineNumber = 0;
+    }
+  }
+
+  if (currentParts.length > 0) {
+    throw new Error(`Dangling ${dockerfileLabel} continuation at line ${currentLineNumber}`);
+  }
+  return instructions;
+}
+
+function unsupportedDirectCopyForm(
+  instruction: LogicalDockerfileInstruction,
+  dockerfileLabel: string,
+): never {
+  throw new Error(
+    `Unsupported direct ${dockerfileLabel} COPY form at line ${instruction.lineNumber}: ${instruction.text}`,
+  );
+}
+
+function parseDirectCopyOperands(
+  tokens: string[],
+  instruction: LogicalDockerfileInstruction,
+  dockerfileLabel: string,
+): string[] | null {
+  let operandIndex = 0;
+  let copiesFromStage = false;
+  while (operandIndex < tokens.length && tokens[operandIndex]?.startsWith("--")) {
+    const flag = tokens[operandIndex]!;
+    if (/^--from=.+$/iu.test(flag)) {
+      copiesFromStage = true;
+      operandIndex += 1;
+      continue;
+    }
+    const handledDirectFlag =
+      /^--(?:chown|chmod)=.+$/iu.test(flag) ||
+      /^--(?:link|parents)(?:=(?:true|false))?$/iu.test(flag);
+    if (!handledDirectFlag) unsupportedDirectCopyForm(instruction, dockerfileLabel);
+    operandIndex += 1;
+  }
+
+  const operands = tokens.slice(operandIndex);
+  if (operands.length < 2 || operands.some((operand) => operand.startsWith("--"))) {
+    unsupportedDirectCopyForm(instruction, dockerfileLabel);
+  }
+  return copiesFromStage ? null : operands;
+}
+
+function validateDirectCopySource(
+  source: string,
+  instruction: LogicalDockerfileInstruction,
+  dockerfileLabel: string,
+): void {
+  const withoutTrailingSlash = source.replace(/\/+$/u, "");
+  const parts = withoutTrailingSlash.split("/");
+  const invalidSource =
+    !withoutTrailingSlash ||
+    path.posix.isAbsolute(source) ||
+    source.includes("\\") ||
+    /[$"'{}]/u.test(source) ||
+    source.includes("**") ||
+    source.startsWith("--") ||
+    parts.some((part) => !part || part === "." || part === "..");
+  if (invalidSource) {
+    throw new Error(
+      `Unsupported direct ${dockerfileLabel} COPY source at line ${instruction.lineNumber}: ${source}`,
+    );
+  }
+}
+
+export function directDockerfileCopySources(
+  dockerfilePath: string,
+  dockerfileLabel = path.basename(dockerfilePath),
+): DirectDockerfileCopySource[] {
+  const text = fs.readFileSync(dockerfilePath, "utf8");
+  const sources: DirectDockerfileCopySource[] = [];
+
+  for (const instruction of logicalDockerfileInstructions(text, dockerfileLabel)) {
+    const instructionMatch = /^(\S+)\b([\s\S]*)$/u.exec(instruction.text);
+    if (!instructionMatch || instructionMatch[1].toUpperCase() !== "COPY") continue;
+
+    const copyForm = instructionMatch[2].trim();
+    const tokens = copyForm.split(/\s+/u).filter(Boolean);
+    if (!copyForm || copyForm.startsWith("[")) {
+      unsupportedDirectCopyForm(instruction, dockerfileLabel);
+    }
+
+    const operands = parseDirectCopyOperands(tokens, instruction, dockerfileLabel);
+    if (operands === null) continue;
+
+    for (const source of operands.slice(0, -1)) {
+      validateDirectCopySource(source, instruction, dockerfileLabel);
+      sources.push({ lineNumber: instruction.lineNumber, source });
+    }
+  }
+
+  return sources;
+}
+
+function sourceExistsInContext(contextRoot: string, source: string): boolean {
+  if (/[*?[\]]/u.test(source)) {
+    return fs.globSync(source, { cwd: contextRoot }).length > 0;
+  }
+  return fs.existsSync(path.join(contextRoot, ...source.split("/")));
+}
+
+export function missingDockerfileCopySources(
+  dockerfilePath: string,
+  contextRoot: string,
+  dockerfileLabel = path.basename(dockerfilePath),
+): MissingDockerfileCopySource[] {
+  return directDockerfileCopySources(dockerfilePath, dockerfileLabel)
+    .filter(({ source }) => !sourceExistsInContext(contextRoot, source))
+    .map((source) => ({ ...source, dockerfileLabel }));
+}
+
+export function formatMissingDockerfileCopySources(
+  missingSources: readonly MissingDockerfileCopySource[],
+): string {
+  return [
+    "The optimized build context does not contain every direct Dockerfile COPY source.",
+    "Review each missing source before you add it to stageOptimizedSandboxBuildContext.",
+    "",
+    ...missingSources.map(
+      ({ dockerfileLabel, lineNumber, source }) =>
+        `${dockerfileLabel}:${lineNumber} missing ${source}`,
+    ),
+  ].join("\n");
+}

--- a/scripts/lib/dockerfile-copy-sources.mts
+++ b/scripts/lib/dockerfile-copy-sources.mts
@@ -105,6 +105,9 @@ function parseDirectCopyOperands(
   }
 
   const operands = tokens.slice(operandIndex);
+  if (operands[0]?.startsWith("[")) {
+    unsupportedDirectCopyForm(instruction, dockerfileLabel);
+  }
   if (operands.length < 2 || operands.some((operand) => operand.startsWith("--"))) {
     unsupportedDirectCopyForm(instruction, dockerfileLabel);
   }
@@ -146,7 +149,7 @@ export function directDockerfileCopySources(
 
     const copyForm = instructionMatch[2].trim();
     const tokens = copyForm.split(/\s+/u).filter(Boolean);
-    if (!copyForm || copyForm.startsWith("[")) {
+    if (!copyForm) {
       unsupportedDirectCopyForm(instruction, dockerfileLabel);
     }
 

--- a/src/lib/sandbox/optimized-build-context-copy-sources.test.ts
+++ b/src/lib/sandbox/optimized-build-context-copy-sources.test.ts
@@ -104,6 +104,7 @@ describe("optimized build-context Dockerfile sources", () => {
 
   it.each([
     ["JSON array", 'COPY ["scripts/lib/sandbox-init.sh", "/tmp/"]'],
+    ["build-stage JSON array", 'COPY --from=build ["out", "/target"]'],
     ["heredoc", "COPY <<EOF /tmp/generated"],
     ["unhandled direct flag", "COPY --exclude=*.md scripts/lib/sandbox-init.sh /tmp/"],
     ["unhandled build-stage flag", "COPY --from=build --exclude=*.md /out/runtime /tmp/runtime"],

--- a/src/lib/sandbox/optimized-build-context-copy-sources.test.ts
+++ b/src/lib/sandbox/optimized-build-context-copy-sources.test.ts
@@ -102,24 +102,20 @@ describe("optimized build-context Dockerfile sources", () => {
     expect(missingDockerfileCopySources(dockerfilePath, directory)).toEqual([]);
   });
 
-  it("rejects unsupported COPY forms instead of omitting their sources", () => {
-    const unsupportedForms = [
-      'COPY ["scripts/lib/sandbox-init.sh", "/tmp/"]',
-      "COPY <<EOF /tmp/generated",
-      "COPY --exclude=*.md scripts/lib/sandbox-init.sh /tmp/",
-      "COPY --from=build --exclude=*.md /out/runtime /tmp/runtime",
-      "COPY scripts/$SOURCE /tmp/source",
-      "COPY /etc/passwd /tmp/passwd",
-      "COPY ../outside /tmp/outside",
-    ];
+  it.each([
+    ["JSON array", 'COPY ["scripts/lib/sandbox-init.sh", "/tmp/"]'],
+    ["heredoc", "COPY <<EOF /tmp/generated"],
+    ["unhandled direct flag", "COPY --exclude=*.md scripts/lib/sandbox-init.sh /tmp/"],
+    ["unhandled build-stage flag", "COPY --from=build --exclude=*.md /out/runtime /tmp/runtime"],
+    ["variable source", "COPY scripts/$SOURCE /tmp/source"],
+    ["absolute source", "COPY /etc/passwd /tmp/passwd"],
+    ["parent traversal", "COPY ../outside /tmp/outside"],
+  ])("rejects the %s COPY form instead of omitting its sources", (_form, dockerfile) => {
+    const directory = makeTemporaryDirectory();
+    const dockerfilePath = writeDockerfile(directory, dockerfile);
 
-    for (const dockerfile of unsupportedForms) {
-      const directory = makeTemporaryDirectory();
-      const dockerfilePath = writeDockerfile(directory, dockerfile);
-
-      expect(() => directDockerfileCopySources(dockerfilePath), dockerfile).toThrow(
-        /Unsupported (?:direct )?Dockerfile (?:COPY (?:form|source)|heredoc instruction)/u,
-      );
-    }
+    expect(() => directDockerfileCopySources(dockerfilePath), dockerfile).toThrow(
+      /Unsupported (?:direct )?Dockerfile (?:COPY (?:form|source)|heredoc instruction)/u,
+    );
   });
 });

--- a/src/lib/sandbox/optimized-build-context-copy-sources.test.ts
+++ b/src/lib/sandbox/optimized-build-context-copy-sources.test.ts
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { testTimeout } from "../../../test/helpers/timeouts";
+import { checkOptimizedBuildContextCopySources } from "../../../scripts/checks/optimized-build-context-copy-sources.mts";
+import {
+  directDockerfileCopySources,
+  formatMissingDockerfileCopySources,
+  missingDockerfileCopySources,
+} from "../../../scripts/lib/dockerfile-copy-sources.mts";
+
+const temporaryDirectories: string[] = [];
+
+function makeTemporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-copy-sources-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function writeDockerfile(directory: string, source: string): string {
+  const dockerfilePath = path.join(directory, "Dockerfile");
+  fs.writeFileSync(dockerfilePath, source, "utf8");
+  return dockerfilePath;
+}
+
+describe("optimized build-context Dockerfile sources", () => {
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it(
+    "accepts every direct COPY source from the root Dockerfile in the optimized context",
+    () => {
+      checkOptimizedBuildContextCopySources(path.resolve(import.meta.dirname, "../../.."));
+    },
+    testTimeout(30_000),
+  );
+
+  it("parses flags, continuations, and multiple sources while ignoring build stages", () => {
+    const directory = makeTemporaryDirectory();
+    const dockerfilePath = writeDockerfile(
+      directory,
+      [
+        "FROM base AS build",
+        "COPY --chmod=0444 \\",
+        "  scripts/lib/corporate-ca-runtime.sh \\",
+        "  scripts/lib/sandbox-init.sh \\",
+        "  /usr/local/lib/nemoclaw/",
+        "COPY --from=build /out/runtime /usr/local/lib/runtime",
+      ].join("\n"),
+    );
+
+    expect(directDockerfileCopySources(dockerfilePath)).toEqual([
+      { lineNumber: 2, source: "scripts/lib/corporate-ca-runtime.sh" },
+      { lineNumber: 2, source: "scripts/lib/sandbox-init.sh" },
+    ]);
+  });
+
+  it("reports an absent flagged COPY source with its Dockerfile line", () => {
+    const directory = makeTemporaryDirectory();
+    const dockerfilePath = writeDockerfile(
+      directory,
+      [
+        "FROM base",
+        "COPY --chmod=0444 scripts/lib/corporate-ca-runtime.sh /usr/local/lib/nemoclaw/",
+      ].join("\n"),
+    );
+
+    const missing = missingDockerfileCopySources(dockerfilePath, directory);
+
+    expect(missing).toEqual([
+      {
+        dockerfileLabel: "Dockerfile",
+        lineNumber: 2,
+        source: "scripts/lib/corporate-ca-runtime.sh",
+      },
+    ]);
+    expect(formatMissingDockerfileCopySources(missing)).toContain(
+      "Dockerfile:2 missing scripts/lib/corporate-ca-runtime.sh",
+    );
+  });
+
+  it("requires a wildcard source to match at least one staged path", () => {
+    const directory = makeTemporaryDirectory();
+    const dockerfilePath = writeDockerfile(
+      directory,
+      "COPY nemoclaw-blueprint/scripts/*.js /usr/local/lib/nemoclaw/preloads/\n",
+    );
+    const scriptsDirectory = path.join(directory, "nemoclaw-blueprint", "scripts");
+    fs.mkdirSync(scriptsDirectory, { recursive: true });
+
+    expect(missingDockerfileCopySources(dockerfilePath, directory)).toHaveLength(1);
+
+    fs.writeFileSync(path.join(scriptsDirectory, "http-proxy-fix.js"), "fixture\n", "utf8");
+    expect(missingDockerfileCopySources(dockerfilePath, directory)).toEqual([]);
+  });
+
+  it("rejects unsupported COPY forms instead of omitting their sources", () => {
+    const unsupportedForms = [
+      'COPY ["scripts/lib/sandbox-init.sh", "/tmp/"]',
+      "COPY <<EOF /tmp/generated",
+      "COPY --exclude=*.md scripts/lib/sandbox-init.sh /tmp/",
+      "COPY --from=build --exclude=*.md /out/runtime /tmp/runtime",
+      "COPY scripts/$SOURCE /tmp/source",
+      "COPY /etc/passwd /tmp/passwd",
+      "COPY ../outside /tmp/outside",
+    ];
+
+    for (const dockerfile of unsupportedForms) {
+      const directory = makeTemporaryDirectory();
+      const dockerfilePath = writeDockerfile(directory, dockerfile);
+
+      expect(() => directDockerfileCopySources(dockerfilePath), dockerfile).toThrow(
+        /Unsupported (?:direct )?Dockerfile (?:COPY (?:form|source)|heredoc instruction)/u,
+      );
+    }
+  });
+});

--- a/test/checks-runner.test.ts
+++ b/test/checks-runner.test.ts
@@ -49,6 +49,14 @@ describe("checks runner", () => {
     });
   });
 
+  it("registers the optimized build-context source check", () => {
+    expect(CHECKS).toContainEqual({
+      name: "optimized-build-context-copy-sources",
+      command: process.platform === "win32" ? "tsx.cmd" : "tsx",
+      args: ["scripts/checks/optimized-build-context-copy-sources.mts"],
+    });
+  });
+
   it("runs Windows command shims through cmd.exe", () => {
     expect(
       buildCheckSpawnInvocation(sampleCheck, "win32", {

--- a/test/e2e/live/rebuild-openclaw-old-base-context.ts
+++ b/test/e2e/live/rebuild-openclaw-old-base-context.ts
@@ -4,6 +4,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { directDockerfileCopySources } from "../../../scripts/lib/dockerfile-copy-sources.mts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
 
 const DOCKERFILE_BASE = path.join(REPO_ROOT, "Dockerfile.base");
@@ -11,119 +12,15 @@ const DOCKERIGNORE = path.join(REPO_ROOT, ".dockerignore");
 const OLD_OPENCLAW_VERSION = "2026.3.11";
 const BLUEPRINT_RELPATH = "nemoclaw-blueprint/blueprint.yaml";
 
-interface LogicalDockerfileInstruction {
-  lineNumber: number;
-  text: string;
-}
-
 export function oldBaseContextSources(): string[] {
   return [BLUEPRINT_RELPATH, ...directDockerfileBaseCopySources()];
 }
 
-function logicalDockerfileInstructions(text: string): LogicalDockerfileInstruction[] {
-  const instructions: LogicalDockerfileInstruction[] = [];
-  let currentParts: string[] = [];
-  let currentLineNumber = 0;
-  let sawInstruction = false;
-
-  for (const [lineIndex, rawLine] of text.split(/\r?\n/).entries()) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith("#")) {
-      if (!sawInstruction) {
-        const escapeDirective = /^#\s*escape\s*=\s*(\S+)\s*$/i.exec(line);
-        if (escapeDirective && escapeDirective[1] !== "\\") {
-          throw new Error(
-            `Unsupported Dockerfile.base escape directive at line ${lineIndex + 1}: ${rawLine}`,
-          );
-        }
-      }
-      continue;
-    }
-
-    sawInstruction = true;
-    if (currentParts.length === 0) currentLineNumber = lineIndex + 1;
-
-    const continued = line.endsWith("\\");
-    const part = continued ? line.slice(0, -1).trimEnd() : line;
-    if (!part) {
-      throw new Error(
-        `Unsupported Dockerfile.base continuation at line ${lineIndex + 1}: ${rawLine}`,
-      );
-    }
-    currentParts.push(part);
-
-    if (!continued) {
-      const instruction = currentParts.join(" ");
-      if (instruction.split(/\s+/).some((token) => token.startsWith("<<"))) {
-        throw new Error(
-          `Unsupported Dockerfile.base heredoc instruction at line ${currentLineNumber}: ${instruction}`,
-        );
-      }
-      instructions.push({
-        lineNumber: currentLineNumber,
-        text: instruction,
-      });
-      currentParts = [];
-      currentLineNumber = 0;
-    }
-  }
-
-  if (currentParts.length > 0) {
-    throw new Error(`Dangling Dockerfile.base continuation at line ${currentLineNumber}`);
-  }
-  return instructions;
-}
-
-function unsupportedDirectCopyForm(instruction: LogicalDockerfileInstruction): never {
-  throw new Error(
-    `Unsupported direct Dockerfile.base COPY form at line ${instruction.lineNumber}: ${instruction.text}`,
-  );
-}
-
-function parseDirectCopyOperands(
-  tokens: string[],
-  instruction: LogicalDockerfileInstruction,
-): string[] | null {
-  let operandIndex = 0;
-  while (operandIndex < tokens.length && tokens[operandIndex]?.startsWith("--")) {
-    const flag = tokens[operandIndex]!;
-    if (/^--from=.+$/i.test(flag)) return null;
-    const reviewedDirectFlag =
-      /^--(?:chown|chmod)=.+$/i.test(flag) ||
-      /^--(?:link|parents)(?:=(?:true|false))?$/i.test(flag);
-    if (!reviewedDirectFlag) unsupportedDirectCopyForm(instruction);
-    operandIndex += 1;
-  }
-
-  const operands = tokens.slice(operandIndex);
-  if (operands.length < 2 || operands.some((operand) => operand.startsWith("--"))) {
-    unsupportedDirectCopyForm(instruction);
-  }
-  return operands;
-}
-
 export function directDockerfileBaseCopySources(dockerfilePath = DOCKERFILE_BASE): string[] {
-  const text = fs.readFileSync(dockerfilePath, "utf8");
-  const sources: string[] = [];
-
-  for (const instruction of logicalDockerfileInstructions(text)) {
-    const instructionMatch = /^(\S+)\b([\s\S]*)$/.exec(instruction.text);
-    if (!instructionMatch || instructionMatch[1].toUpperCase() !== "COPY") continue;
-
-    const copyForm = instructionMatch[2].trim();
-    const tokens = copyForm.split(/\s+/).filter(Boolean);
-    if (!copyForm || copyForm.startsWith("[")) unsupportedDirectCopyForm(instruction);
-
-    const operands = parseDirectCopyOperands(tokens, instruction);
-    if (operands === null) continue;
-
-    for (const source of operands.slice(0, -1)) {
-      validateOldBaseContextSource(source);
-      sources.push(source);
-    }
-  }
-
-  return sources;
+  return directDockerfileCopySources(dockerfilePath, "Dockerfile.base").map(({ source }) => {
+    validateOldBaseContextSource(source);
+    return source;
+  });
 }
 
 export function dockerignoreSecretPatterns(dockerignorePath = DOCKERIGNORE): string[] {

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -50,8 +50,14 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     ),
   },
   {
-    pattern: /(?:^|\/)(?:Dockerfile|agents\/(?:hermes|langchain-deepagents-code)\/Dockerfile)$/,
-    testsToRun: runTests("src/lib/onboard/managed-startup-profile.test.ts"),
+    pattern: /(?:^|\/)(agents\/(?:hermes|langchain-deepagents-code)\/)?Dockerfile$/,
+    testsToRun: (_file, match) =>
+      match[1]
+        ? ["src/lib/onboard/managed-startup-profile.test.ts"]
+        : [
+            "src/lib/onboard/managed-startup-profile.test.ts",
+            "src/lib/sandbox/optimized-build-context-copy-sources.test.ts",
+          ],
   },
   {
     pattern: /(?:^|\/)agents\/hermes\/policy-additions\.yaml$/,

--- a/test/sandbox-build-context.test.ts
+++ b/test/sandbox-build-context.test.ts
@@ -291,26 +291,6 @@ describe("sandbox build context staging", () => {
     fs.chmodSync(path.join(sourceRoot, "src", "lib", "tool-disclosure.ts"), 0o664);
   }
 
-  function expectDockerfileScriptCopiesExist(buildCtx: string, stagedDockerfile: string) {
-    const dockerfile = fs.readFileSync(stagedDockerfile, "utf8");
-    const copiedScripts = dockerfile
-      .split("\n")
-      .flatMap(
-        (line) =>
-          line
-            .trim()
-            .match(/^COPY(?:\s+--\S+)*\s+(.+)\s+\S+$/u)?.[1]
-            ?.split(/\s+/u) ?? [],
-      )
-      .filter((token) => token.startsWith("scripts/"))
-      .map((token) => token.slice("scripts/".length));
-    expect(copiedScripts).not.toHaveLength(0);
-
-    for (const relativePath of copiedScripts) {
-      expect(fs.existsSync(path.join(buildCtx, "scripts", relativePath)), relativePath).toBe(true);
-    }
-  }
-
   function expectStagedNemoclawModes(buildCtx: string) {
     const stagedNemoclaw = path.join(buildCtx, "nemoclaw");
     const stagedSrc = path.join(stagedNemoclaw, "src");
@@ -782,8 +762,7 @@ describe("sandbox build context staging", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-build-context-opt-"));
 
     try {
-      const { buildCtx, stagedDockerfile } = stageOptimizedSandboxBuildContext(repoRoot, tmpDir);
-      expectDockerfileScriptCopiesExist(buildCtx, stagedDockerfile);
+      const { buildCtx } = stageOptimizedSandboxBuildContext(repoRoot, tmpDir);
       for (const relativePath of [
         path.join("src", "lib", "core", "json-types.ts"),
         path.join("src", "lib", "core", "ports.ts"),

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -92,7 +92,10 @@ describe("Vitest opaque-input watch triggers", () => {
       "src/lib/inference/serving/resolver.test.ts",
       "test/managed-inference-catalog-compiler.test.ts",
     ]);
-    expect(triggeredBy("Dockerfile")).toEqual(["src/lib/onboard/managed-startup-profile.test.ts"]);
+    expect(triggeredBy("Dockerfile")).toEqual([
+      "src/lib/onboard/managed-startup-profile.test.ts",
+      "src/lib/sandbox/optimized-build-context-copy-sources.test.ts",
+    ]);
     expect(triggeredBy("agents/hermes/Dockerfile")).toEqual([
       "src/lib/onboard/managed-startup-profile.test.ts",
     ]);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add a fail-closed repository check that compares every direct local `COPY` source in the root `Dockerfile` with the actual optimized build context. Missing staged inputs now fail before Docker or E2E runs and identify the source and Dockerfile line.

## Related Issue

Fixes #9342

## Changes

- Parse handled direct `COPY` forms, reject ambiguous or unsafe forms, and verify exact and wildcard sources in the staged optimized context.
- Reuse the parser in the old-base E2E build-context helper and remove the redundant scripts-only integration assertion. The repository check and old-base helper need the same Dockerfile interpretation, and separate parsers previously diverged; focused parser and helper tests protect the shared contract.
- Register the check under `npm run checks:repository` and select its focused test when the root `Dockerfile` changes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Local review of commit `7c390054f` passed all nine repository security categories with no findings. The change affects repository validation and test helpers, not production sandbox behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change adds internal repository validation, parser reuse, and focused tests. It does not change a public API, CLI behavior, configuration, supported product behavior, or contributor documentation contract.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7c390054f -->
<!-- docs-review-agents-blob-sha: 993bdd850 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `cli`: 12 passed; `integration`: 30 passed and 2 skipped; `e2e-support`: 6 passed; test-loop scan passed; standalone optimized-context check passed; CLI type-check passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — `npm run check` passed Repository checks, then stopped on existing all-files Hadolint findings in Dockerfiles this branch does not change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect missing files referenced by Dockerfile `COPY` instructions in optimized build contexts.
  * Improved handling of Dockerfile syntax, flags, continuations, wildcards, and build-stage sources.
  * Updated file-change monitoring to run the appropriate validation checks for relevant Dockerfile changes.

* **Tests**
  * Expanded coverage for Dockerfile source validation, unsupported syntax, and watch-trigger behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->