### PR TITLE
test: convert 200 test loops to tables

### DIFF
--- a/ci/test-file-size-budget.json
+++ b/ci/test-file-size-budget.json
@@ -5,9 +5,9 @@
     "nemoclaw/src/commands/migration-state.test.ts": 1300,
     "src/lib/inference/nim.test.ts": 2064,
     "src/lib/onboard/preflight.test.ts": 1875,
-    "test/generate-openclaw-config.test.ts": 1915,
+    "test/generate-openclaw-config.test.ts": 1907,
     "test/install-preflight.test.ts": 3025,
-    "test/nemoclaw-start.test.ts": 4790,
+    "test/nemoclaw-start.test.ts": 4789,
     "test/onboard-messaging.test.ts": 2033,
     "test/onboard-selection.test.ts": 4178
   }

--- a/src/lib/actions/inference-set-patch-hermes.test.ts
+++ b/src/lib/actions/inference-set-patch-hermes.test.ts
@@ -87,8 +87,9 @@ describe("patchHermesInferenceConfig", () => {
     );
   });
 
-  it("replaces stale Hermes API keys with the OpenShell proxy rewrite sentinel", () => {
-    for (const api_key of ["no-key-required", "sk-real-looking-key-that-must-not-survive"]) {
+  it.each(["no-key-required", "sk-real-looking-key-that-must-not-survive"])(
+    "replaces stale Hermes API keys with the OpenShell proxy rewrite sentinel [case %#]",
+    (api_key) => {
       const config: ConfigObject = {
         model: {
           default: "old-model",
@@ -101,8 +102,8 @@ describe("patchHermesInferenceConfig", () => {
       patchHermesInferenceConfig(config, "hermes-provider", "openai/gpt-5.4-mini");
 
       expect((config.model as ConfigObject).api_key).toBe(HERMES_PROXY_REWRITE_SENTINEL);
-    }
-  });
+    },
+  );
 
   it("sets Hermes Anthropic Messages mode for Anthropic routes", () => {
     const config: ConfigObject = {

--- a/src/lib/actions/sandbox/agents/apply.test.ts
+++ b/src/lib/actions/sandbox/agents/apply.test.ts
@@ -131,28 +131,26 @@ describe("parseOpenClawAgentsList", () => {
 });
 
 describe("validateAgentsManifestForApply", () => {
-  it("rejects ids that do not match the AGENT_ID regex", () => {
-    for (const id of [
-      "--help",
-      "-h",
-      "Alpha",
-      "ALPHA",
-      "1leading",
-      "alpha space",
-      "../escape",
-      "alpha/sub",
-      "a".repeat(33),
-    ]) {
-      expect(() =>
-        validateAgentsManifestForApply([
-          {
-            id,
-            workspace: `/sandbox/.openclaw/workspace-${id}`,
-            agentDir: `/sandbox/.openclaw/agents/${id}`,
-          },
-        ]),
-      ).toThrow(/must match/);
-    }
+  it.each([
+    "--help",
+    "-h",
+    "Alpha",
+    "ALPHA",
+    "1leading",
+    "alpha space",
+    "../escape",
+    "alpha/sub",
+    "a".repeat(33),
+  ])("rejects ids that do not match the AGENT_ID regex [case %#]", (id) => {
+    expect(() =>
+      validateAgentsManifestForApply([
+        {
+          id,
+          workspace: `/sandbox/.openclaw/workspace-${id}`,
+          agentDir: `/sandbox/.openclaw/agents/${id}`,
+        },
+      ]),
+    ).toThrow(/must match/);
   });
 
   it("rejects the reserved `main` id", () => {

--- a/src/lib/actions/sandbox/connect-autopair-budget.test.ts
+++ b/src/lib/actions/sandbox/connect-autopair-budget.test.ts
@@ -34,18 +34,16 @@ describe("connect auto-pair budget", () => {
     expect(CONNECT_AUTO_PAIR_TIMEOUT_MS - innerWorstCaseMs).toBeGreaterThanOrEqual(10_000);
   });
 
-  it("uses positive whole numbers for attempt, command, and outer budgets", () => {
-    for (const value of [
-      CONNECT_AUTO_PAIR_MAX_APPROVALS,
-      CONNECT_AUTO_PAIR_LIST_TIMEOUT_S,
-      CONNECT_AUTO_PAIR_APPROVE_TIMEOUT_S,
-      CONNECT_AUTO_PAIR_PENDING_READ_ATTEMPTS,
-      CONNECT_AUTO_PAIR_POST_TIMEOUT_OBSERVE_S,
-      CONNECT_AUTO_PAIR_TIMEOUT_MS,
-    ]) {
-      expect(Number.isInteger(value)).toBe(true);
-      expect(value).toBeGreaterThan(0);
-    }
+  it.each([
+    CONNECT_AUTO_PAIR_MAX_APPROVALS,
+    CONNECT_AUTO_PAIR_LIST_TIMEOUT_S,
+    CONNECT_AUTO_PAIR_APPROVE_TIMEOUT_S,
+    CONNECT_AUTO_PAIR_PENDING_READ_ATTEMPTS,
+    CONNECT_AUTO_PAIR_POST_TIMEOUT_OBSERVE_S,
+    CONNECT_AUTO_PAIR_TIMEOUT_MS,
+  ])("uses positive whole numbers for attempt, command, and outer budgets [case %#]", (value) => {
+    expect(Number.isInteger(value)).toBe(true);
+    expect(value).toBeGreaterThan(0);
   });
 
   it("uses a positive pending-read poll interval", () => {

--- a/src/lib/actions/sandbox/doctor-tool-scope.test.ts
+++ b/src/lib/actions/sandbox/doctor-tool-scope.test.ts
@@ -111,14 +111,15 @@ describe("parseToolScopeProbe (#4616)", () => {
 describe("interpretToolScopeProbe (#4616)", () => {
   const base = { sandboxName: "sb", cliName: "nemoclaw", wantsFix: false };
 
-  it("reports info when the probe is unavailable", () => {
-    for (const p of [null, probe({ ok: false })]) {
+  it.each([null, probe({ ok: false })])(
+    "reports info when the probe is unavailable [case %#]",
+    (p) => {
       const checks = interpretToolScopeProbe(p, base);
       expect(checks).toHaveLength(1);
       expect(checks[0].status).toBe("info");
       expect(checks[0].detail).toContain("unavailable");
-    }
-  });
+    },
+  );
 
   it("fails with a fix hint when allowlisted upgrades are pending", () => {
     const checks = interpretToolScopeProbe(

--- a/src/lib/actions/sandbox/inference-route-health.test.ts
+++ b/src/lib/actions/sandbox/inference-route-health.test.ts
@@ -14,8 +14,9 @@ describe("sandbox inference route health", () => {
     async () =>
       ({ status, output }) as never;
 
-  it("reports a reachable route for final HTTP responses", async () => {
-    for (const httpStatus of [200, 401, 403]) {
+  it.each([200, 401, 403])(
+    "reports a reachable route for final HTTP responses [case %#]",
+    async (httpStatus) => {
       const result = await probeSandboxInferenceGatewayHealth("my-sandbox", {
         captureOpenshellImpl: makeCapture(`OK ${httpStatus}`),
       });
@@ -26,8 +27,8 @@ describe("sandbox inference route health", () => {
         endpoint: "https://inference.local/v1/models",
       });
       expect(result?.detail).toContain("full chain reachable");
-    }
-  });
+    },
+  );
 
   it("reports HTTP 5xx as an unhealthy authoritative route (#6192)", async () => {
     const result = await probeSandboxInferenceGatewayHealth("my-sandbox", {

--- a/src/lib/actions/sandbox/mcp-bridge-policy.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-policy.test.ts
@@ -145,30 +145,29 @@ describe("MCP OpenShell policy", () => {
     });
   });
 
-  it.each([
-    "mcporter",
-    "hermes-config",
-    "deepagents-config",
-  ] as const)("renders an exactly authorized private IPv4 target for %s (#8267)", (adapter) => {
-    const replay = replayTrustedPrivateEndpoint("10.20.30.40", ["10.20.30.40"]);
-    const policy = YAML.parse(
-      buildMcpBridgePolicyYaml("local", "https://10.20.30.40/mcp", adapter, {
-        addresses: [...replay.addresses],
-        trustedPrivateCapability: replay.trustedPrivateCapability,
-        trustedPrivateHost: replay.host,
-      }),
-    ) as {
-      network_policies: Record<
-        string,
-        { endpoints: Array<{ allowed_ips: string[]; host: string }> }
-      >;
-    };
+  it.each(["mcporter", "hermes-config", "deepagents-config"] as const)(
+    "renders an exactly authorized private IPv4 target for %s (#8267)",
+    (adapter) => {
+      const replay = replayTrustedPrivateEndpoint("10.20.30.40", ["10.20.30.40"]);
+      const policy = YAML.parse(
+        buildMcpBridgePolicyYaml("local", "https://10.20.30.40/mcp", adapter, {
+          addresses: [...replay.addresses],
+          trustedPrivateCapability: replay.trustedPrivateCapability,
+          trustedPrivateHost: replay.host,
+        }),
+      ) as {
+        network_policies: Record<
+          string,
+          { endpoints: Array<{ allowed_ips: string[]; host: string }> }
+        >;
+      };
 
-    expect(policy.network_policies.mcp_bridge_local.endpoints[0]).toMatchObject({
-      host: "10.20.30.40",
-      allowed_ips: ["10.20.30.40"],
-    });
-  });
+      expect(policy.network_policies.mcp_bridge_local.endpoints[0]).toMatchObject({
+        host: "10.20.30.40",
+        allowed_ips: ["10.20.30.40"],
+      });
+    },
+  );
 
   it("requires host-bound capability authority for a trusted private DNS policy (#8267)", () => {
     const replay = replayTrustedPrivateEndpoint("mcp.corp.internal", ["10.20.30.40"]);
@@ -264,35 +263,35 @@ describe("MCP OpenShell policy", () => {
     expect(gatewayState).toHaveBeenCalledWith("alpha", content);
   });
 
-  it.each([
-    "owned-first",
-    "unowned-first",
-  ])("rejects duplicate same-name ownership records regardless of order (%s)", (order) => {
-    const entry = githubBridgeEntry();
-    const pins = ["8.8.8.8"];
-    const content = buildMcpBridgePolicyYaml(entry.server, entry.url, "mcporter", {
-      addresses: pins,
-    });
-    const owned = {
-      name: entry.policyName,
-      content,
-      sourcePath: MCP_BRIDGE_POLICY_SOURCE,
-    };
-    const unowned = {
-      name: entry.policyName,
-      content: `${content}\n# conflicting duplicate`,
-      sourcePath: "/tmp/operator-policy.yaml",
-    };
-    vi.spyOn(registry, "getCustomPolicies").mockReturnValue(
-      order === "owned-first" ? [owned, unowned] : [unowned, owned],
-    );
-    const gatewayState = vi.spyOn(policies, "getPresetContentGatewayState");
+  it.each(["owned-first", "unowned-first"])(
+    "rejects duplicate same-name ownership records regardless of order (%s)",
+    (order) => {
+      const entry = githubBridgeEntry();
+      const pins = ["8.8.8.8"];
+      const content = buildMcpBridgePolicyYaml(entry.server, entry.url, "mcporter", {
+        addresses: pins,
+      });
+      const owned = {
+        name: entry.policyName,
+        content,
+        sourcePath: MCP_BRIDGE_POLICY_SOURCE,
+      };
+      const unowned = {
+        name: entry.policyName,
+        content: `${content}\n# conflicting duplicate`,
+        sourcePath: "/tmp/operator-policy.yaml",
+      };
+      vi.spyOn(registry, "getCustomPolicies").mockReturnValue(
+        order === "owned-first" ? [owned, unowned] : [unowned, owned],
+      );
+      const gatewayState = vi.spyOn(policies, "getPresetContentGatewayState");
 
-    expect(() =>
-      assertGeneratedPolicyExactReadOnly("alpha", entry, "mcporter", { addresses: pins }),
-    ).toThrow(/ownership is missing or ambiguous/);
-    expect(gatewayState).not.toHaveBeenCalled();
-  });
+      expect(() =>
+        assertGeneratedPolicyExactReadOnly("alpha", entry, "mcporter", { addresses: pins }),
+      ).toThrow(/ownership is missing or ambiguous/);
+      expect(gatewayState).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects individually valid policy records that disagree with their bridge definition", () => {
     const entry = githubBridgeEntry();
@@ -435,20 +434,21 @@ describe("MCP OpenShell policy", () => {
     expect(endpoint).not.toHaveProperty("tls");
   });
 
-  it("refuses to generate authenticated policies for unpinnable OpenShell host aliases", () => {
-    for (const host of [
-      "host.openshell.internal",
-      "host.openshell.internal.",
-      "host.docker.internal",
-      "host.containers.internal",
-    ]) {
+  it.each([
+    "host.openshell.internal",
+    "host.openshell.internal.",
+    "host.docker.internal",
+    "host.containers.internal",
+  ])(
+    "refuses to generate authenticated policies for unpinnable OpenShell host aliases [case %#]",
+    (host) => {
       expect(() =>
         buildMcpBridgePolicyYaml("local", `https://${host}:31337/mcp`, "mcporter", {
           addresses: ["8.8.8.8"],
         }),
       ).toThrow(/does not expose an attested driver gateway address/);
-    }
-  });
+    },
+  );
 
   it("scopes binaries to the selected agent adapter", () => {
     const hermes = YAML.parse(

--- a/src/lib/actions/sandbox/mcp-bridge-resolution-probe.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-resolution-probe.test.ts
@@ -89,8 +89,9 @@ describe("MCP credential-resolution probe classification", () => {
     expect(probe).toEqual({ ok: true, httpStatus: 200, controlHttpStatus: 401 });
   });
 
-  it("classifies identical placeholder and control rejections as inconclusive with both hypotheses (#6379)", () => {
-    for (const httpStatus of [400, 401, 403]) {
+  it.each([400, 401, 403])(
+    "classifies identical placeholder and control rejections as inconclusive with both hypotheses [case %#] (#6379)",
+    (httpStatus) => {
       const probe = classifyCredentialResolutionProbe(
         {
           status: 0,
@@ -109,8 +110,8 @@ describe("MCP credential-resolution probe classification", () => {
       expect(probe.controlHttpStatus).toBe(httpStatus);
       expect(probe.detail).toContain("rejected identically");
       expect(probe.detail).toContain("expired or revoked credential");
-    }
-  });
+    },
+  );
 
   it("classifies identical 5xx responses as indeterminate endpoint failure (#6379)", () => {
     const probe = classifyCredentialResolutionProbe(

--- a/src/lib/actions/sandbox/mcp-bridge-tool-discovery.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-tool-discovery.test.ts
@@ -168,59 +168,57 @@ describe("MCP tool discovery host boundary (#6901)", () => {
     });
   });
 
-  it("fails closed on malformed, duplicate, unsorted, or unframed results", () => {
-    for (const result of [
-      framedResult({ protocol: 1, ok: true, count: 1, tools: ["bad\nname"], truncated: false }),
-      framedResult({
-        protocol: 1,
-        ok: true,
-        count: 1,
-        tools: ["bad\ud800name"],
-        truncated: false,
-      }),
-      framedResult({
-        protocol: 1,
-        ok: true,
-        count: 1,
-        tools: ["safe\u202eevil"],
-        truncated: false,
-      }),
-      framedResult({
-        protocol: 1,
-        ok: true,
-        count: 1,
-        tools: ["safe\u2066evil"],
-        truncated: false,
-      }),
-      framedResult({
-        protocol: 1,
-        ok: true,
-        count: 1,
-        tools: ["safe\u2028evil"],
-        truncated: false,
-      }),
-      framedResult({
-        protocol: 1,
-        ok: true,
-        count: 2,
-        tools: ["same", "same"],
-        truncated: false,
-      }),
-      framedResult({
-        protocol: 1,
-        ok: true,
-        count: 2,
-        tools: ["zeta", "alpha"],
-        truncated: false,
-      }),
-      { status: 0, stdout: JSON.stringify({ protocol: 1 }), stderr: "" },
-    ]) {
-      expect(classifyMcpToolDiscoveryResult(result, entry, marker)).toMatchObject({
-        ok: false,
-        count: 0,
-        tools: [],
-      });
-    }
+  it.each([
+    framedResult({ protocol: 1, ok: true, count: 1, tools: ["bad\nname"], truncated: false }),
+    framedResult({
+      protocol: 1,
+      ok: true,
+      count: 1,
+      tools: ["bad\ud800name"],
+      truncated: false,
+    }),
+    framedResult({
+      protocol: 1,
+      ok: true,
+      count: 1,
+      tools: ["safe\u202eevil"],
+      truncated: false,
+    }),
+    framedResult({
+      protocol: 1,
+      ok: true,
+      count: 1,
+      tools: ["safe\u2066evil"],
+      truncated: false,
+    }),
+    framedResult({
+      protocol: 1,
+      ok: true,
+      count: 1,
+      tools: ["safe\u2028evil"],
+      truncated: false,
+    }),
+    framedResult({
+      protocol: 1,
+      ok: true,
+      count: 2,
+      tools: ["same", "same"],
+      truncated: false,
+    }),
+    framedResult({
+      protocol: 1,
+      ok: true,
+      count: 2,
+      tools: ["zeta", "alpha"],
+      truncated: false,
+    }),
+    { status: 0, stdout: JSON.stringify({ protocol: 1 }), stderr: "" },
+  ])("fails closed on malformed, duplicate, unsorted, or unframed results [case %#]", (result) => {
+    expect(classifyMcpToolDiscoveryResult(result, entry, marker)).toMatchObject({
+      ok: false,
+      count: 0,
+      tools: [],
+    });
   });
 
   it("does not surface process output when the image runtime cannot start", () => {

--- a/src/lib/actions/sandbox/mcp-tool-discovery-runtime.test.ts
+++ b/src/lib/actions/sandbox/mcp-tool-discovery-runtime.test.ts
@@ -111,18 +111,19 @@ describe("shared MCP tool discovery runtime", () => {
     ).rejects.toMatchObject({ code: "invalid-response" });
   });
 
-  it("rejects empty, malformed, control-bearing, and overlong tool names", async () => {
-    for (const name of [
-      "",
-      "bad\nname",
-      "bad\ud800name",
-      "x".repeat(MCP_TOOL_DISCOVERY_LIMITS.maxToolNameBytes + 1),
-    ]) {
+  it.each([
+    "",
+    "bad\nname",
+    "bad\ud800name",
+    "x".repeat(MCP_TOOL_DISCOVERY_LIMITS.maxToolNameBytes + 1),
+  ])(
+    "rejects empty, malformed, control-bearing, and overlong tool names [case %#]",
+    async (name) => {
       await expect(
         enumerateMcpToolNames(async () => ({ tools: [{ name }] })),
       ).rejects.toMatchObject({ code: "invalid-response" });
-    }
-  });
+    },
+  );
 
   it("returns an explicit partial failure at tool and page safety limits", async () => {
     const tools = Array.from({ length: MCP_TOOL_DISCOVERY_LIMITS.maxTools + 1 }, (_, index) => ({
@@ -276,8 +277,9 @@ describe("shared MCP tool discovery runtime", () => {
     expect(sourceCancel).toHaveBeenCalledOnce();
   });
 
-  it("bounds both total-deadline and per-request aborts with a credential-safe timeout", async () => {
-    for (const abortSource of ["deadline", "request"] as const) {
+  it.each(["deadline", "request"] as const)(
+    "bounds both total-deadline and per-request aborts with a credential-safe timeout [case %#]",
+    async (abortSource) => {
       const deadline = new AbortController();
       const request = new AbortController();
       const blockingFetch = vi.fn(
@@ -297,8 +299,8 @@ describe("shared MCP tool discovery runtime", () => {
       expect(error).toMatchObject({ code: "timeout" });
       expect(safeToolDiscoveryErrorDetail(error)).toBe("tool discovery timed out after 10s");
       expect(safeToolDiscoveryErrorDetail(error)).not.toContain("untrusted-timeout-detail");
-    }
-  });
+    },
+  );
 
   it("maps failures to bounded details without echoing untrusted messages", () => {
     expect(safeToolDiscoveryErrorDetail(new ToolDiscoveryRuntimeError("redirect"))).toBe(

--- a/src/lib/actions/sandbox/rebuild-recreate-journal.test.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-journal.test.ts
@@ -110,19 +110,17 @@ describe("rebuild replacement target fingerprint", () => {
     );
   });
 
-  it("changes when a recorded replacement input changes", () => {
-    for (const drift of [
-      { dcodeAutoApprovalMode: "thread-opt-in" },
-      { endpointSource: "onboard" },
-      { policyTier: "balanced" },
-      { recreateProvider: "compatible-endpoint" },
-      { recreateModel: "model-b" },
-      { recreatePreferredInferenceApi: "anthropic" },
-    ] as const) {
-      expect(fingerprintRebuildRecreateTargetIntent({ ...recreateOptions, ...drift })).not.toBe(
-        fingerprintRebuildRecreateTargetIntent(recreateOptions),
-      );
-    }
+  it.each([
+    { dcodeAutoApprovalMode: "thread-opt-in" },
+    { endpointSource: "onboard" },
+    { policyTier: "balanced" },
+    { recreateProvider: "compatible-endpoint" },
+    { recreateModel: "model-b" },
+    { recreatePreferredInferenceApi: "anthropic" },
+  ] as const)("changes when a recorded replacement input changes [case %#]", (drift) => {
+    expect(fingerprintRebuildRecreateTargetIntent({ ...recreateOptions, ...drift })).not.toBe(
+      fingerprintRebuildRecreateTargetIntent(recreateOptions),
+    );
   });
 
   it("changes when the replacement targets another gateway", () => {

--- a/src/lib/agent/defs.test.ts
+++ b/src/lib/agent/defs.test.ts
@@ -136,15 +136,12 @@ describe("agent definitions", () => {
     expect(manifest.expected_version).toBe("0.84.1");
     expect(manifest.runtime.kind).toBe("terminal");
     expect(manifest.config.dir).toBe("/sandbox/.pi/agent");
-    expect(manifest.state_dirs.filter(({ backup }) => backup !== false).map(({ path }) => path)).toEqual([
-      "sessions",
-      "prompts",
-      "themes",
-    ]);
-    expect(manifest.state_dirs.filter(({ backup }) => backup === false).map(({ path }) => path)).toEqual([
-      "tools",
-      "bin",
-    ]);
+    expect(
+      manifest.state_dirs.filter(({ backup }) => backup !== false).map(({ path }) => path),
+    ).toEqual(["sessions", "prompts", "themes"]);
+    expect(
+      manifest.state_dirs.filter(({ backup }) => backup === false).map(({ path }) => path),
+    ).toEqual(["tools", "bin"]);
     expect(manifest.state_files.map((file) => file.path)).toEqual(["settings.json"]);
     const restore = manifest.state_files[0]?.restore as {
       merge?: string;
@@ -294,18 +291,16 @@ describe("agent definitions", () => {
     expect(() => loadAgent(agentName)).toThrow(/config\.shields_files/);
   });
 
-  it("rejects invalid forward_ports values in manifests", () => {
-    for (const port of [1023, 70000]) {
-      const agentName = `invalid-forward-port-${String(port)}-${String(Date.now())}`;
-      writeTempAgentManifest(
-        agentName,
-        [`name: ${agentName}`, "display_name: Broken Ports", "forward_ports:", `  - ${port}`].join(
-          "\n",
-        ),
-      );
+  it.each([1023, 70000])("rejects invalid forward_ports value %s in manifests", (port) => {
+    const agentName = `invalid-forward-port-${String(port)}-${String(Date.now())}`;
+    writeTempAgentManifest(
+      agentName,
+      [`name: ${agentName}`, "display_name: Broken Ports", "forward_ports:", `  - ${port}`].join(
+        "\n",
+      ),
+    );
 
-      expect(() => loadAgent(agentName)).toThrow(/forward_ports\[0\]/);
-    }
+    expect(() => loadAgent(agentName)).toThrow(/forward_ports\[0\]/);
   });
 
   it("rejects invalid health_probe.port values in manifests", () => {
@@ -407,23 +402,23 @@ describe("agent definitions", () => {
     expect(() => loadAgent(agentName)).toThrow(/inference\.provider_type/);
   });
 
-  it.each([
-    "42",
-    '"bad model"',
-  ])("rejects invalid inference default models in manifests (%s)", (defaultModel) => {
-    const agentName = `invalid-inference-default-model-${String(Date.now())}-${defaultModel.length}`;
-    writeTempAgentManifest(
-      agentName,
-      [
-        `name: ${agentName}`,
-        "display_name: Broken Inference Default",
-        "inference:",
-        `  default_model: ${defaultModel}`,
-      ].join("\n"),
-    );
+  it.each(["42", '"bad model"'])(
+    "rejects invalid inference default models in manifests (%s)",
+    (defaultModel) => {
+      const agentName = `invalid-inference-default-model-${String(Date.now())}-${defaultModel.length}`;
+      writeTempAgentManifest(
+        agentName,
+        [
+          `name: ${agentName}`,
+          "display_name: Broken Inference Default",
+          "inference:",
+          `  default_model: ${defaultModel}`,
+        ].join("\n"),
+      );
 
-    expect(() => loadAgent(agentName)).toThrow(/inference\.default_model/);
-  });
+      expect(() => loadAgent(agentName)).toThrow(/inference\.default_model/);
+    },
+  );
 
   it("rejects invalid MCP bridge adapter declarations in manifests", () => {
     const agentName = `invalid-mcp-adapter-${String(Date.now())}`;

--- a/src/lib/agent/runtime-terminal.test.ts
+++ b/src/lib/agent/runtime-terminal.test.ts
@@ -90,12 +90,13 @@ describe("interactive agent command resolution", () => {
 
   // Regression guard: declaring runtime.interactive_command must not promote a
   // gateway agent to terminal behaviour for getTerminalCommand's four callers.
-  it("leaves getTerminalCommand returning null for gateway agents", () => {
-    for (const name of ["openclaw", "hermes"]) {
+  it.each(["openclaw", "hermes"])(
+    "leaves getTerminalCommand returning null for %s gateway",
+    (name) => {
       const agent = loadAgent(name);
       expect(agent.runtime?.kind).toBe("gateway");
       expect(getTerminalCommand(agent, "interactive")).toBeNull();
       expect(getTerminalCommand(agent, "headless")).toBeNull();
-    }
-  });
+    },
+  );
 });

--- a/src/lib/cli/terminal-style.test.ts
+++ b/src/lib/cli/terminal-style.test.ts
@@ -6,10 +6,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { B, D, failLine, G, R, RD, warnLine, YW } from "./terminal-style";
 
 describe("terminal-style", () => {
-  it("exports terminal style strings", () => {
-    for (const value of [B, D, G, R, RD, YW]) {
-      expect(typeof value).toBe("string");
-    }
+  it.each([B, D, G, R, RD, YW])("exports terminal style strings [case %#]", (value) => {
+    expect(typeof value).toBe("string");
   });
 });
 

--- a/src/lib/cua/qualification-evidence.test.ts
+++ b/src/lib/cua/qualification-evidence.test.ts
@@ -18,17 +18,15 @@ describe("CUA candidate environment", () => {
     expect(parseCuaQualificationEnvironment(candidate)).toEqual(candidate);
   });
 
-  it("rejects later-slice qualification and lifecycle evidence", () => {
-    for (const extra of [
-      { gpu: { count: 1 } },
-      { scenarios: ["browser"] },
-      { receipt: { status: "passed" } },
-      { targetChannel: { endpoint: "private.invalid" } },
-    ]) {
-      expect(() => parseCuaQualificationEnvironment({ ...candidate, ...extra })).toThrow(
-        /contain exactly/,
-      );
-    }
+  it.each([
+    { gpu: { count: 1 } },
+    { scenarios: ["browser"] },
+    { receipt: { status: "passed" } },
+    { targetChannel: { endpoint: "private.invalid" } },
+  ])("rejects later-slice qualification and lifecycle evidence [case %#]", (extra) => {
+    expect(() => parseCuaQualificationEnvironment({ ...candidate, ...extra })).toThrow(
+      /contain exactly/,
+    );
   });
 
   it("rejects malformed build and receipt identities", () => {

--- a/src/lib/domain/lifecycle/options.test.ts
+++ b/src/lib/domain/lifecycle/options.test.ts
@@ -116,22 +116,27 @@ describe("lifecycle option normalization", () => {
       });
     });
 
-    function verifyCleanupGatewayBooleanSpellings() {
-      for (const truthy of ["1", "true", "TRUE", "Yes"]) {
-        process.env[ENV_KEY] = truthy;
+    it.each(["1", "true", "TRUE", "Yes"])(
+      "recognises truthy NEMOCLAW_CLEANUP_GATEWAY spelling %#",
+      (value) => {
+        process.env[ENV_KEY] = value;
         expect(normalizeDestroySandboxOptions({}).cleanupGateway).toBe(true);
-      }
-      for (const falsy of ["0", "false", "No"]) {
-        process.env[ENV_KEY] = falsy;
+      },
+    );
+    it.each(["0", "false", "No"])(
+      "recognises falsy NEMOCLAW_CLEANUP_GATEWAY spelling %#",
+      (value) => {
+        process.env[ENV_KEY] = value;
         expect(normalizeDestroySandboxOptions({}).cleanupGateway).toBe(false);
-      }
-      for (const noise of ["", "  ", "maybe", "later"]) {
-        process.env[ENV_KEY] = noise;
+      },
+    );
+    it.each(["", "  ", "maybe", "later"])(
+      "ignores unrecognized NEMOCLAW_CLEANUP_GATEWAY spelling %#",
+      (value) => {
+        process.env[ENV_KEY] = value;
         expect(normalizeDestroySandboxOptions({}).cleanupGateway).toBeUndefined();
-      }
-    }
-
-    it("recognises common truthy/falsy spellings of NEMOCLAW_CLEANUP_GATEWAY", verifyCleanupGatewayBooleanSpellings);
+      },
+    );
   });
 
   it("preserves typed rebuild options and still accepts compatibility argv", () => {

--- a/src/lib/domain/sandbox/connect-env.test.ts
+++ b/src/lib/domain/sandbox/connect-env.test.ts
@@ -25,6 +25,15 @@ describe("sandbox connect environment helpers", () => {
     ]);
   });
 
+  it.each([{ HERMES_TUI_LIGHT: "0" }, { HERMES_TUI_THEME: "dark" }])(
+    "does not inspect Hermes config with explicit theme env %# (#6380)",
+    (env) => {
+      expect(
+        shouldInspectHermesLightSkinConfig({ name: "hermes" }, { COLORFGBG: "0;15", ...env }),
+      ).toBe(false);
+    },
+  );
+
   it("inspects Hermes config only when NemoClaw owns the theme decision (#6380)", () => {
     expect(
       shouldInspectHermesLightSkinConfig(
@@ -38,11 +47,6 @@ describe("sandbox connect environment helpers", () => {
         { COLORFGBG: "0;0", TERM_PROGRAM: "Apple_Terminal" },
       ),
     ).toBe(true);
-    for (const env of [{ HERMES_TUI_LIGHT: "0" }, { HERMES_TUI_THEME: "dark" }]) {
-      expect(
-        shouldInspectHermesLightSkinConfig({ name: "hermes" }, { COLORFGBG: "0;15", ...env }),
-      ).toBe(false);
-    }
     expect(shouldInspectHermesLightSkinConfig({ name: "openclaw" }, { COLORFGBG: "0;15" })).toBe(
       false,
     );

--- a/src/lib/gateway-start-guidance.test.ts
+++ b/src/lib/gateway-start-guidance.test.ts
@@ -40,11 +40,12 @@ describe("gatewayStartGuidance", () => {
     );
   });
 
-  it("never names a gateway lifecycle command the OpenShell CLI does not have", () => {
-    for (const launcher of ["nemoclaw", "openshell"] as const) {
+  it.each(["nemoclaw", "openshell"] as const)(
+    "never names a gateway lifecycle command the OpenShell CLI does not have [case %#]",
+    (launcher) => {
       expect(gatewayStartGuidance("nemoclaw", launcher)).not.toContain("openshell gateway start");
-    }
-  });
+    },
+  );
 
   it("reads the launcher the current runtime provider records", () => {
     expect(

--- a/src/lib/inference/endpoint-ssrf-preflight.test.ts
+++ b/src/lib/inference/endpoint-ssrf-preflight.test.ts
@@ -31,22 +31,19 @@ describe("assertEndpointResolvesPublic (#6293)", () => {
     expect(lookup).toHaveBeenCalledWith("vllm.example", { all: true });
   });
 
-  it.each([
-    "10.0.0.8",
-    "169.254.169.254",
-    "192.168.1.10",
-    "172.16.0.5",
-    "127.0.0.1",
-  ])("refuses a public hostname that resolves to the private/reserved address %s (#6293)", async (privateAddress) => {
-    const lookup = resolverTo(privateAddress);
-    const result = await assertEndpointResolvesPublic("https://public-name.example/v1", lookup);
-    expect(result).toMatchObject({
-      ok: false,
-      reasonCode: "private-answer",
-      offendingAddress: privateAddress,
-    });
-    expect(result.reason).toContain(privateAddress);
-  });
+  it.each(["10.0.0.8", "169.254.169.254", "192.168.1.10", "172.16.0.5", "127.0.0.1"])(
+    "refuses a public hostname that resolves to the private/reserved address %s (#6293)",
+    async (privateAddress) => {
+      const lookup = resolverTo(privateAddress);
+      const result = await assertEndpointResolvesPublic("https://public-name.example/v1", lookup);
+      expect(result).toMatchObject({
+        ok: false,
+        reasonCode: "private-answer",
+        offendingAddress: privateAddress,
+      });
+      expect(result.reason).toContain(privateAddress);
+    },
+  );
 
   it("refuses a literal private endpoint before resolving anything (#6293)", async () => {
     const lookup = vi.fn<EndpointDnsLookupFn>();
@@ -100,16 +97,17 @@ describe("assertEndpointResolvesPublic (#6293)", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("keeps private and metadata addresses blocked when the trust list is empty (#6861)", async () => {
-    for (const address of ["10.0.0.8", "169.254.169.254"]) {
+  it.each(["10.0.0.8", "169.254.169.254"])(
+    "keeps private and metadata addresses blocked when the trust list is empty [case %#] (#6861)",
+    async (address) => {
       const result = await assertEndpointResolvesPublic(
         "https://llm.corp.example/v1",
         resolverTo(address),
         { trustedPrivateHosts: [] },
       );
       expect(result.ok).toBe(false);
-    }
-  });
+    },
+  );
 
   it("keeps link-local metadata blocked even when its hostname is allowlisted (#6861)", async () => {
     const result = await assertEndpointResolvesPublic(
@@ -135,24 +133,22 @@ describe("assertEndpointResolvesPublic (#6293)", () => {
     expect(lookup).not.toHaveBeenCalled();
   });
 
-  it.each([
-    "100.64.0.0",
-    "100.127.255.255",
-    "fc00::1",
-    "fdff:ffff::1",
-  ])("admits the operator-trustable private boundary address %s (#6861)", async (address) => {
-    const result = await assertEndpointResolvesPublic(
-      "https://llm.corp.example/v1",
-      resolverTo(address),
-      { trustedPrivateHosts: ["llm.corp.example"] },
-    );
-    expect(result).toMatchObject({
-      ok: true,
-      addresses: [address],
-      trustedPrivateEndpoint: true,
-    });
-    expect(result.trustedPrivateCapability?.addresses).toEqual([address]);
-  });
+  it.each(["100.64.0.0", "100.127.255.255", "fc00::1", "fdff:ffff::1"])(
+    "admits the operator-trustable private boundary address %s (#6861)",
+    async (address) => {
+      const result = await assertEndpointResolvesPublic(
+        "https://llm.corp.example/v1",
+        resolverTo(address),
+        { trustedPrivateHosts: ["llm.corp.example"] },
+      );
+      expect(result).toMatchObject({
+        ok: true,
+        addresses: [address],
+        trustedPrivateEndpoint: true,
+      });
+      expect(result.trustedPrivateCapability?.addresses).toEqual([address]);
+    },
+  );
 
   it("carries an allowlisted private DNS result through curl argument validation (#6861)", async () => {
     const endpointUrl = "https://llm.corp.example/v1/models";
@@ -172,20 +168,18 @@ describe("assertEndpointResolvesPublic (#6293)", () => {
     );
   });
 
-  it.each([
-    "169.254.0.1",
-    "198.18.0.1",
-    "fe80::1",
-    "ff00::1",
-  ])("keeps the reserved address %s blocked for an allowlisted host (#6861)", async (address) => {
-    const result = await assertEndpointResolvesPublic(
-      "https://llm.corp.example/v1",
-      resolverTo(address),
-      { trustedPrivateHosts: ["llm.corp.example"] },
-    );
-    expect(result.ok).toBe(false);
-    expect(result.reason).toContain(address);
-  });
+  it.each(["169.254.0.1", "198.18.0.1", "fe80::1", "ff00::1"])(
+    "keeps the reserved address %s blocked for an allowlisted host (#6861)",
+    async (address) => {
+      const result = await assertEndpointResolvesPublic(
+        "https://llm.corp.example/v1",
+        resolverTo(address),
+        { trustedPrivateHosts: ["llm.corp.example"] },
+      );
+      expect(result.ok).toBe(false);
+      expect(result.reason).toContain(address);
+    },
+  );
 
   it("parses and canonicalizes the private inference host allowlist (#6861)", () => {
     expect(
@@ -202,17 +196,16 @@ describe("assertEndpointResolvesPublic (#6293)", () => {
     ).toEqual(["mcp.corp.example", "llm.corp.example", "10.0.0.8"]);
   });
 
-  it.each([
-    "http://127.0.0.1:8000/v1",
-    "http://localhost:8000/v1",
-    "http://[::1]:8000/v1",
-  ])("allows the explicit loopback endpoint %s without resolving (#6293)", async (endpointUrl) => {
-    const lookup = vi.fn<EndpointDnsLookupFn>();
-    const result = await assertEndpointResolvesPublic(endpointUrl, lookup);
-    expect(result.ok).toBe(true);
-    expect(result.addresses).toEqual([]);
-    expect(lookup).not.toHaveBeenCalled();
-  });
+  it.each(["http://127.0.0.1:8000/v1", "http://localhost:8000/v1", "http://[::1]:8000/v1"])(
+    "allows the explicit loopback endpoint %s without resolving (#6293)",
+    async (endpointUrl) => {
+      const lookup = vi.fn<EndpointDnsLookupFn>();
+      const result = await assertEndpointResolvesPublic(endpointUrl, lookup);
+      expect(result.ok).toBe(true);
+      expect(result.addresses).toEqual([]);
+      expect(lookup).not.toHaveBeenCalled();
+    },
+  );
 
   it("allows a public IP literal without resolving (#6293)", async () => {
     const lookup = vi.fn<EndpointDnsLookupFn>();
@@ -284,15 +277,18 @@ describe("assertEndpointResolvesPublic (#6293)", () => {
     "http://host.openshell.internal:8000/v1",
     "http://host.docker.internal:11434/v1",
     "http://host.containers.internal:11434/v1",
-  ])("exempts the OpenShell-managed alias %s without resolving or pinning (#6293)", async (endpointUrl) => {
-    const lookup = vi.fn<EndpointDnsLookupFn>();
-    const result = await assertEndpointResolvesPublic(endpointUrl, lookup);
-    expect(result.ok).toBe(true);
-    // Managed aliases need no --resolve pin, but the defined empty capability
-    // still forces credentialed host probes to bypass ambient proxies.
-    expect(result.addresses).toEqual([]);
-    expect(lookup).not.toHaveBeenCalled();
-  });
+  ])(
+    "exempts the OpenShell-managed alias %s without resolving or pinning (#6293)",
+    async (endpointUrl) => {
+      const lookup = vi.fn<EndpointDnsLookupFn>();
+      const result = await assertEndpointResolvesPublic(endpointUrl, lookup);
+      expect(result.ok).toBe(true);
+      // Managed aliases need no --resolve pin, but the defined empty capability
+      // still forces credentialed host probes to bypass ambient proxies.
+      expect(result.addresses).toEqual([]);
+      expect(lookup).not.toHaveBeenCalled();
+    },
+  );
 
   it("omits curl pinning without validated addresses or a valid target URL (#6293)", () => {
     expect(buildResolvePinArgs("https://vllm.example/v1", undefined)).toEqual([]);

--- a/src/lib/inference/ollama-runtime-context.test.ts
+++ b/src/lib/inference/ollama-runtime-context.test.ts
@@ -58,13 +58,16 @@ describe("Ollama runtime context helpers", () => {
     ).toBeNull();
   });
 
-  it("warns and ignores malformed or non-positive Ollama /api/ps context lengths", () => {
-    for (const value of ["bogus", "1.5", 0, -1]) {
+  it.each(["bogus", "1.5", 0, -1])(
+    "warns and ignores malformed Ollama /api/ps context length %#",
+    (value) => {
       const parsed = parseOllamaRuntimeContextLength(value);
       expect(parsed.contextLength).toBeUndefined();
       expect(parsed.warning).toContain("non-positive or malformed context_length");
-    }
+    },
+  );
 
+  it("reports malformed Ollama runtime model context lengths", () => {
     const status = probeOllamaRuntimeModelStatus("qwen3.6:35b", getOllamaHost, () =>
       JSON.stringify({ models: [{ name: "qwen3.6:35b", context_length: "bogus" }] }),
     );

--- a/src/lib/inference/onboard-probes.test.ts
+++ b/src/lib/inference/onboard-probes.test.ts
@@ -324,15 +324,16 @@ describe("OpenAI-compatible inference probes", () => {
     });
   });
 
-  it("uses max_completion_tokens for GPT-5 family and reasoning models (#6642)", () => {
-    for (const model of ["gpt-5.4", "azure/gpt-5.4", "o3-mini", "o1"]) {
+  it.each(["gpt-5.4", "azure/gpt-5.4", "o3-mini", "o1"])(
+    "uses max_completion_tokens for GPT-5 family and reasoning models [case %#] (#6642)",
+    (model) => {
       expect(getChatCompletionsProbePayload(model)).toEqual({
         model,
         messages: [{ role: "user", content: "Reply with exactly: OK" }],
         max_completion_tokens: 16,
       });
-    }
-  });
+    },
+  );
 
   // Some hosted endpoints reject a reply budget below 16 with HTTP 400 even
   // though discovery succeeds and normal inference works, so a bounded probe

--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -33,12 +33,13 @@ describe("vllm model registry", () => {
     expect(command).toMatch(/^pip install vllm\[fastsafetensors\] && vllm serve/u);
   });
 
-  it("records a finite positive Hugging Face file size for every model", () => {
-    for (const model of VLLM_MODELS) {
+  it.each(VLLM_MODELS)(
+    "records a finite positive Hugging Face file size for every model [case %#]",
+    (model) => {
       expect(Number.isFinite(model.downloadSizeBytes)).toBe(true);
       expect(model.downloadSizeBytes).toBeGreaterThan(0);
-    }
-  });
+    },
+  );
 
   it("pins the Hugging Face repository file totals used by storage preflight (#6858)", () => {
     expect(

--- a/src/lib/inference/vllm-runtime-context.test.ts
+++ b/src/lib/inference/vllm-runtime-context.test.ts
@@ -36,25 +36,27 @@ describe("vLLM runtime context helpers", () => {
     ).toBe("262144");
   });
 
-  it("treats omitted max_model_len values as compatibility no-ops", () => {
-    for (const value of [undefined, null, "   "]) {
+  it.each([undefined, null, "   "])(
+    "treats omitted max_model_len value %# as a compatibility no-op",
+    (value) => {
       const { env, messages } = applyContextWindow({
         data: [{ id: "model-a", max_model_len: value }],
       });
       expect(env.NEMOCLAW_CONTEXT_WINDOW).toBeUndefined();
       expect(messages).toEqual([]);
-    }
-  });
+    },
+  );
 
-  it("warns and ignores malformed or non-positive max_model_len values", () => {
-    for (const value of ["bogus", "1.5", 1.5, 0, -1]) {
+  it.each(["bogus", "1.5", 1.5, 0, -1])(
+    "warns and ignores malformed max_model_len value %#",
+    (value) => {
       const { env, messages } = applyContextWindow({
         data: [{ id: "model-a", max_model_len: value }],
       });
       expect(env.NEMOCLAW_CONTEXT_WINDOW).toBeUndefined();
       expect(messages.at(-1)).toContain("non-positive or malformed max_model_len");
-    }
-  });
+    },
+  );
 
   it("warns and ignores implausibly large max_model_len values", () => {
     const { env, messages } = applyContextWindow({

--- a/src/lib/messaging/channels/telegram/hooks/status-health-eval.test.ts
+++ b/src/lib/messaging/channels/telegram/hooks/status-health-eval.test.ts
@@ -71,14 +71,15 @@ describe("evaluateTelegramDiagnostics verdict", () => {
     ).toBe(true);
   });
 
-  it("reports unreachable for a definitive Bot API startup HTTP error", () => {
-    for (const status of [403, 429, 500, 502, 503]) {
+  it.each([403, 429, 500, 502, 503])(
+    "reports unreachable for a definitive Bot API startup HTTP error [case %#]",
+    (status) => {
       const report = evaluateTelegramDiagnostics(
         baseInput({ breadcrumbs: breadcrumbs({ startupHttpError: status }) }),
       );
       expect(report.verdict).toBe("unreachable");
-    }
-  });
+    },
+  );
 
   it("keeps provider-ready ahead of a stale Bot API startup error", () => {
     const idle = evaluateTelegramDiagnostics(

--- a/src/lib/messaging/channels/wechat/hooks/implementations.test.ts
+++ b/src/lib/messaging/channels/wechat/hooks/implementations.test.ts
@@ -92,13 +92,14 @@ describe("WeChat hook implementations", () => {
     });
   });
 
-  it("rejects invalid iLink baseUrl values before writing QR credentials", async () => {
-    for (const baseUrl of [
-      "http://ilinkai.wechat.com",
-      "https://example.com",
-      "https://ilinkai.wechat.com/path",
-      "https://ilinkai.wechat.com\nEVIL=1",
-    ] as const) {
+  it.each([
+    "http://ilinkai.wechat.com",
+    "https://example.com",
+    "https://ilinkai.wechat.com/path",
+    "https://ilinkai.wechat.com\nEVIL=1",
+  ] as const)(
+    "rejects invalid iLink baseUrl values before writing QR credentials [case %#]",
+    async (baseUrl) => {
       const env: NodeJS.ProcessEnv = {};
       const saved: Array<{ readonly key: string; readonly value: string }> = [];
       const registry = new MessagingHookRegistry([
@@ -134,8 +135,8 @@ describe("WeChat hook implementations", () => {
       ).rejects.toThrow(/WeChat baseUrl/);
       expect(saved).toEqual([]);
       expect(env).toEqual({});
-    }
-  });
+    },
+  );
 
   it("turns QR failures into hook failures without writing credentials", async () => {
     const env: NodeJS.ProcessEnv = {};
@@ -164,23 +165,25 @@ describe("WeChat hook implementations", () => {
     expect(env.WECHAT_BOT_TOKEN).toBeUndefined();
   });
 
-  it("rejects unsafe WeChat account ids before using them as build-file names", () => {
-    for (const accountId of ["../../openclaw", "nested/account", "control\u0001id"]) {
+  it.each(["../../openclaw", "nested/account", "control\u0001id"])(
+    "rejects unsafe WeChat account ids before using them as build-file names [case %#]",
+    (accountId) => {
       expect(() =>
         buildWechatSeedOpenClawAccountOutputs({
           "wechatConfig.accountId": accountId,
         }),
       ).toThrow("unsafe filename characters");
-    }
-  });
+    },
+  );
 
-  it("rejects invalid iLink baseUrl values before writing OpenClaw seed files", () => {
-    for (const baseUrl of [
-      "http://ilinkai.wechat.com",
-      "https://example.com",
-      "https://ilinkai.wechat.com/path",
-      "https://ilinkai.wechat.com\nEVIL=1",
-    ] as const) {
+  it.each([
+    "http://ilinkai.wechat.com",
+    "https://example.com",
+    "https://ilinkai.wechat.com/path",
+    "https://ilinkai.wechat.com\nEVIL=1",
+  ] as const)(
+    "rejects invalid iLink baseUrl values before writing OpenClaw seed files [case %#]",
+    (baseUrl) => {
       expect(() =>
         buildWechatSeedOpenClawAccountOutputs({
           "wechatConfig.accountId": "wechat-account",
@@ -188,8 +191,8 @@ describe("WeChat hook implementations", () => {
           "credential.wechatBotToken.placeholder": "openshell:resolve:env:WECHAT_BOT_TOKEN",
         }),
       ).toThrow(/WeChat baseUrl/);
-    }
-  });
+    },
+  );
 
   it("declares a health-check hook that requires captured account metadata", async () => {
     const hook = wechatManifest.hooks.find((entry) => entry.id === "wechat-health-check");

--- a/src/lib/messaging/channels/whatsapp/hooks/status-health-eval.test.ts
+++ b/src/lib/messaging/channels/whatsapp/hooks/status-health-eval.test.ts
@@ -468,24 +468,21 @@ describe("parseWhatsappHeartbeat", () => {
     ).toBe(true);
   });
 
-  it("rejects loose Date.parse-compatible timestamps that are not strict ISO 8601", () => {
-    // Regression guard: `Date.parse` accepts values like a bare integer or
-    // `Date.toString()` output with parenthesized text. Treating those as
-    // valid timestamps would (a) leak the raw string into the JSON report
-    // and (b) mark malformed heartbeat text as healthy inbound evidence.
-    for (const bad of [
-      "42",
-      "Wed May 28 2026 04:00:00 GMT+0000 (Coordinated Universal Time)",
-      "2026/05/28 04:00:00",
-      "not a date",
-    ]) {
+  it.each([
+    "42",
+    "Wed May 28 2026 04:00:00 GMT+0000 (Coordinated Universal Time)",
+    "2026/05/28 04:00:00",
+    "not a date",
+  ])(
+    "rejects loose Date.parse-compatible timestamps that are not strict ISO 8601 [case %#]",
+    (bad) => {
       const result = parseWhatsappHeartbeat(JSON.stringify({ lastInboundAt: bad }));
       expect(
         "heartbeat" in result && result.heartbeat.lastInboundAt,
         `expected ${JSON.stringify(bad)} to be rejected`,
       ).toBeNull();
-    }
-  });
+    },
+  );
 
   it("normalizes accepted timestamps to canonical ISO form", () => {
     const result = parseWhatsappHeartbeat(

--- a/src/lib/onboard/agents-manifest.test.ts
+++ b/src/lib/onboard/agents-manifest.test.ts
@@ -152,36 +152,37 @@ describe("loadAgentsManifest", () => {
     expect(() => loadAgentsManifest(dir)).toThrow(/must point to a file:/);
   });
 
-  it("rejects manifests with nested credential-named keys before they reach the build", () => {
-    for (const key of [
-      "apiKey",
-      "api_key",
-      "API_KEY",
-      "token",
-      "secret",
-      "password",
-      "passphrase",
-      "credential",
-      "bearer",
-      "auth",
-      "clientSecret",
-      "client_secret",
-      "accessToken",
-      "refreshToken",
-      "refresh-token",
-      "sessionToken",
-      "idToken",
-      "apiToken",
-      "privateKey",
-      "private_key",
-      "publicKey",
-      "signingKey",
-      "encryptionKey",
-      "AccessKey",
-      "bearerToken",
-      "webhookSecret",
-      "encryption_passphrase",
-    ]) {
+  it.each([
+    "apiKey",
+    "api_key",
+    "API_KEY",
+    "token",
+    "secret",
+    "password",
+    "passphrase",
+    "credential",
+    "bearer",
+    "auth",
+    "clientSecret",
+    "client_secret",
+    "accessToken",
+    "refreshToken",
+    "refresh-token",
+    "sessionToken",
+    "idToken",
+    "apiToken",
+    "privateKey",
+    "private_key",
+    "publicKey",
+    "signingKey",
+    "encryptionKey",
+    "AccessKey",
+    "bearerToken",
+    "webhookSecret",
+    "encryption_passphrase",
+  ])(
+    "rejects manifests with nested credential-named keys before they reach the build [case %#]",
+    (key) => {
       const file = manifestPath(
         `credential-${key}.yaml`,
         [
@@ -195,11 +196,12 @@ describe("loadAgentsManifest", () => {
         ].join("\n"),
       );
       expect(() => loadAgentsManifest(file)).toThrow(/looks like a credential and is not allowed/);
-    }
-  });
+    },
+  );
 
-  it("accepts benign field names that are not credential-shaped", () => {
-    for (const key of ["model", "workspace", "agentDir", "allowAgents", "maxSpawnDepth"]) {
+  it.each(["model", "workspace", "agentDir", "allowAgents", "maxSpawnDepth"])(
+    "accepts benign field names that are not credential-shaped [case %#]",
+    (key) => {
       const file = manifestPath(
         `benign-${key}.yaml`,
         [
@@ -211,8 +213,8 @@ describe("loadAgentsManifest", () => {
         ].join("\n"),
       );
       expect(() => loadAgentsManifest(file)).not.toThrow();
-    }
-  });
+    },
+  );
 });
 
 describe("applyAgentsManifestEnv", () => {

--- a/src/lib/onboard/dcode-selection-drift.test.ts
+++ b/src/lib/onboard/dcode-selection-drift.test.ts
@@ -95,12 +95,13 @@ describe("live DCode selection drift", () => {
     );
   });
 
-  it("reports provider drift for upstream, route, or endpoint changes (#6311)", () => {
-    for (const output of [
-      identity({ Provider: "openai-api" }),
-      identity({ Route: "openai" }),
-      identity({ Endpoint: "https://old.example/v1" }),
-    ]) {
+  it.each([
+    identity({ Provider: "openai-api" }),
+    identity({ Route: "openai" }),
+    identity({ Endpoint: "https://old.example/v1" }),
+  ])(
+    "reports provider drift for upstream, route, or endpoint changes [case %#] (#6311)",
+    (output) => {
       expect(
         getDcodeSelectionDrift("alpha", "nvidia-prod", "nvidia/nemotron-3-super-120b-a12b", null, {
           runCaptureOpenshell: () => output,
@@ -111,8 +112,8 @@ describe("live DCode selection drift", () => {
         modelChanged: false,
         unknown: false,
       });
-    }
-  });
+    },
+  );
 
   it("reports model drift from the live DCode config (#6311)", () => {
     expect(

--- a/src/lib/onboard/docker-gpu-supervisor-reconnect.test.ts
+++ b/src/lib/onboard/docker-gpu-supervisor-reconnect.test.ts
@@ -203,12 +203,9 @@ describe("docker-gpu-supervisor-reconnect Error-phase debounce", () => {
     expect(sleep).not.toHaveBeenCalled();
   });
 
-  it("falls back to the env-backed default when an injected override is non-finite", () => {
-    // NaN / +Infinity / -Infinity overrides must not silently neutralise the
-    // fast-fail loop. A NaN comparison would always be false and `Infinity`
-    // would never satisfy `>= debouncePolls`, leaving the wait to burn the
-    // full timeout window.
-    for (const bogus of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "falls back to the env-backed default when an injected override is non-finite [case %#]",
+    (bogus) => {
       const runOpenshell = vi.fn(() => ({ status: 1, stderr: "sandbox not ready" }));
       const runCaptureOpenshell = vi.fn(() => "alpha   Error   1s ago");
       const sleep = vi.fn();
@@ -224,6 +221,6 @@ describe("docker-gpu-supervisor-reconnect Error-phase debounce", () => {
       // Default K=60 from the env-backed helper: 60 polls + 59 sleeps before fast-fail.
       expect(runOpenshell).toHaveBeenCalledTimes(60);
       expect(sleep).toHaveBeenCalledTimes(59);
-    }
-  });
+    },
+  );
 });

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
@@ -573,16 +573,17 @@ describe("portable demo sandbox lifecycle", () => {
     expect(fs.existsSync(receiptPath)).toBe(false);
   });
 
-  it("refuses missing or duplicate portable containers before privileged exec (#8584)", () => {
-    for (const matches of [[], [CONTAINER_ID, "b".repeat(64)]]) {
+  it.each([[], [CONTAINER_ID, "b".repeat(64)]].map((matches) => [matches] as const))(
+    "refuses missing or duplicate portable containers before privileged exec [case %#] (#8584)",
+    (matches) => {
       const stateDir = temporaryStateDir();
       const runtime = createPodman();
       installReceipt(stateDir, runtime.podman);
       runtime.setMatches(matches);
 
       expect(() => resolveTarget(stateDir, runtime)).toThrow(`found ${matches.length}`);
-    }
-  });
+    },
+  );
 
   it("refuses renamed or relabeled portable containers before privileged exec (#8584)", () => {
     const stateDir = temporaryStateDir();

--- a/src/lib/onboard/gateway-management.test.ts
+++ b/src/lib/onboard/gateway-management.test.ts
@@ -160,19 +160,23 @@ describe("gateway management declaration", () => {
     ["a cloud metadata address", "http://169.254.169.254:8080"],
     ["a link-local address", "http://169.254.1.1:8080"],
     ["a non-loopback private address", "http://10.0.0.5:8080"],
-  ])("rejects an endpoint pointing at %s, which onboarding would otherwise request (#6576)", (_label, endpoint) => {
-    const result = parseGatewayManagementDeclaration(externalDeclaration({ endpoint }));
+  ])(
+    "rejects an endpoint pointing at %s, which onboarding would otherwise request (#6576)",
+    (_label, endpoint) => {
+      const result = parseGatewayManagementDeclaration(externalDeclaration({ endpoint }));
 
-    expect(result.ok === false && result.reason).toMatch(/not a supported local gateway origin/);
-  });
+      expect(result.ok === false && result.reason).toMatch(/not a supported local gateway origin/);
+    },
+  );
 
-  it("accepts only numeric loopback endpoint hosts (#6576)", () => {
-    for (const endpoint of ["http://127.0.0.1:8080", "http://[::1]:8080"]) {
+  it.each(["http://127.0.0.1:8080", "http://[::1]:8080"])(
+    "accepts only numeric loopback endpoint hosts [case %#] (#6576)",
+    (endpoint) => {
       expect(parseGatewayManagementDeclaration(externalDeclaration({ endpoint }))).toMatchObject({
         ok: true,
       });
-    }
-  });
+    },
+  );
 
   it("rejects a capability this build does not provide (#6576)", () => {
     const result = parseGatewayManagementDeclaration(
@@ -260,8 +264,9 @@ describe("gateway management declaration loading", () => {
 });
 
 describe("supported supervisor kinds (#6576)", () => {
-  it("accepts the systemd kinds it can bind a listener to", () => {
-    for (const kind of ["systemd-system", "systemd-user"]) {
+  it.each(["systemd-system", "systemd-user"])(
+    "accepts the systemd kinds it can bind a listener to [case %#]",
+    (kind) => {
       expect(
         parseGatewayManagementDeclaration(
           externalDeclaration({
@@ -273,8 +278,8 @@ describe("supported supervisor kinds (#6576)", () => {
           }),
         ),
       ).toMatchObject({ ok: true });
-    }
-  });
+    },
+  );
 
   it("rejects the opaque 'external' kind, which could never attach", () => {
     const result = parseGatewayManagementDeclaration(

--- a/src/lib/onboard/gpu-recovery.test.ts
+++ b/src/lib/onboard/gpu-recovery.test.ts
@@ -14,21 +14,28 @@ import { describe, expect, it, vi } from "vitest";
 import { gpuPassthroughRecoveryLines, reportGpuPassthroughRecovery } from "./gpu-recovery";
 
 describe("gpuPassthroughRecoveryLines", () => {
-  it("never emits a literal `<name>` placeholder for any input", () => {
-    for (const names of [null, [], ["alpha"], ["alpha", "beta"], ["alpha", "beta", "gamma"]]) {
-      const lines = gpuPassthroughRecoveryLines(names);
-      expect(lines.join("\n")).not.toMatch(/<name>/);
-    }
+  it.each(
+    [null, [], ["alpha"], ["alpha", "beta"], ["alpha", "beta", "gamma"]].map(
+      (names) => [names] as const,
+    ),
+  )("never emits a literal `<name>` placeholder for any input [case %#]", (names) => {
+    const lines = gpuPassthroughRecoveryLines(names);
+    expect(lines.join("\n")).not.toMatch(/<name>/);
   });
 
   // OpenShell dropped `gateway destroy` before 0.0.44 and now rejects it as an
   // unrecognized subcommand, so the command fails on every OpenShell version
   // NemoClaw installs (#8139).
-  it("omits openshell gateway destroy for every registered-sandbox count (#8139)", () => {
-    for (const names of [null, [], ["alpha"], ["alpha", "beta"], ["alpha", "beta", "gamma"]]) {
+  it.each(
+    [null, [], ["alpha"], ["alpha", "beta"], ["alpha", "beta", "gamma"]].map(
+      (names) => [names] as const,
+    ),
+  )(
+    "omits openshell gateway destroy for every registered-sandbox count [case %#] (#8139)",
+    (names) => {
       expect(gpuPassthroughRecoveryLines(names).join("\n")).not.toContain("gateway destroy");
-    }
-  });
+    },
+  );
 
   it("suggests targeted gateway cleanup when no sandboxes are registered (null input)", () => {
     const lines = gpuPassthroughRecoveryLines(null);

--- a/src/lib/onboard/inference-providers/compatible-endpoint-gateway-route.test.ts
+++ b/src/lib/onboard/inference-providers/compatible-endpoint-gateway-route.test.ts
@@ -13,8 +13,9 @@ import {
 } from "./compatible-endpoint-gateway-route";
 
 describe("compatible endpoint gateway routing", () => {
-  it("rewrites exact HTTP loopback hosts on bundled local-inference ports (#5744)", () => {
-    for (const host of ["localhost", "127.0.0.1", "[::1]"]) {
+  it.each(["localhost", "127.0.0.1", "[::1]"])(
+    "rewrites exact HTTP loopback hosts on bundled local-inference ports [case %#] (#5744)",
+    (host) => {
       for (const port of COMPATIBLE_ENDPOINT_GATEWAY_PORTS) {
         expect(
           gatewayReachableCompatibleEndpointUrl(
@@ -23,8 +24,8 @@ describe("compatible endpoint gateway routing", () => {
           ),
         ).toBe(`http://host.openshell.internal:${port}/v1`);
       }
-    }
-  });
+    },
+  );
 
   it("leaves a generic compatible-endpoint loopback URL unchanged on port 8081 (#8161)", () => {
     expect(

--- a/src/lib/onboard/initial-policy-real-policy.test.ts
+++ b/src/lib/onboard/initial-policy-real-policy.test.ts
@@ -59,6 +59,17 @@ function readPreparedPolicy(prepared: {
 }
 
 describe("initial sandbox policy real preset merge", () => {
+  const shippingPolicyCases = [
+    { path: ["nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"], agent: "openclaw" },
+    {
+      path: ["nemoclaw-blueprint", "policies", "openclaw-sandbox-permissive.yaml"],
+      agent: "openclaw",
+    },
+    { path: ["agents", "openclaw", "policy-permissive.yaml"], agent: "openclaw" },
+    { path: ["agents", "hermes", "policy-additions.yaml"], agent: "hermes" },
+    { path: ["agents", "hermes", "policy-permissive.yaml"], agent: "hermes" },
+  ] as const;
+
   it.each([
     {
       path: ["nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"],
@@ -69,28 +80,28 @@ describe("initial sandbox policy real preset merge", () => {
       path: ["agents", "langchain-deepagents-code", "policy-additions.yaml"],
       agent: "langchain-deepagents-code",
     },
-  ])("keeps $agent on the provider-neutral inference.local route without host-native inference egress", ({
-    path: policyPath,
-    agent,
-  }) => {
-    const effective = readPreparedPolicy(
-      prepareInitialSandboxCreatePolicy(repoPath(...policyPath), [], { agentName: agent }),
-    );
-    const endpoints = Object.values(effective.network_policies ?? {}).flatMap(
-      (policy) => policy.endpoints ?? [],
-    );
+  ])(
+    "keeps $agent on the provider-neutral inference.local route without host-native inference egress",
+    ({ path: policyPath, agent }) => {
+      const effective = readPreparedPolicy(
+        prepareInitialSandboxCreatePolicy(repoPath(...policyPath), [], { agentName: agent }),
+      );
+      const endpoints = Object.values(effective.network_policies ?? {}).flatMap(
+        (policy) => policy.endpoints ?? [],
+      );
 
-    expect(endpoints).toContainEqual(
-      expect.objectContaining({ host: "inference.local", port: 443 }),
-    );
-    expect(
-      endpoints.filter(
-        (endpoint) =>
-          endpoint.host === "host.openshell.internal" &&
-          [8000, 8001, 8081, 11434, 11435].includes(endpoint.port ?? 0),
-      ),
-    ).toEqual([]);
-  });
+      expect(endpoints).toContainEqual(
+        expect.objectContaining({ host: "inference.local", port: 443 }),
+      );
+      expect(
+        endpoints.filter(
+          (endpoint) =>
+            endpoint.host === "host.openshell.internal" &&
+            [8000, 8001, 8081, 11434, 11435].includes(endpoint.port ?? 0),
+        ),
+      ).toEqual([]);
+    },
+  );
 
   it("uses Hermes channel YAML when the Hermes base policy path implies the agent", () => {
     const prepared = prepareInitialSandboxCreatePolicy(
@@ -153,19 +164,9 @@ describe("initial sandbox policy real preset merge", () => {
     });
   });
 
-  it("prepares every shipping sandbox policy with writable PTY devices but not their symlink", () => {
-    const policyCases = [
-      { path: ["nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"], agent: "openclaw" },
-      {
-        path: ["nemoclaw-blueprint", "policies", "openclaw-sandbox-permissive.yaml"],
-        agent: "openclaw",
-      },
-      { path: ["agents", "openclaw", "policy-permissive.yaml"], agent: "openclaw" },
-      { path: ["agents", "hermes", "policy-additions.yaml"], agent: "hermes" },
-      { path: ["agents", "hermes", "policy-permissive.yaml"], agent: "hermes" },
-    ];
-
-    for (const policyCase of policyCases) {
+  it.each(shippingPolicyCases)(
+    "prepares $agent policy $path with writable PTY devices but not their symlink",
+    (policyCase) => {
       const prepared = prepareInitialSandboxCreatePolicy(repoPath(...policyCase.path), [], {
         agentName: policyCase.agent,
       });
@@ -174,26 +175,27 @@ describe("initial sandbox policy real preset merge", () => {
 
       expect(readWrite, policyCase.path.join("/")).toContain("/dev/pts");
       expect(readWrite, policyCase.path.join("/")).not.toContain("/dev/ptmx");
-    }
-  });
+    },
+  );
 
-  it("grants read-only package database access in every shipping sandbox policy (#8467)", () => {
-    const policyCases = [
-      { path: ["nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"], agent: "openclaw" },
-      {
-        path: ["nemoclaw-blueprint", "policies", "openclaw-sandbox-permissive.yaml"],
-        agent: "openclaw",
-      },
-      { path: ["agents", "openclaw", "policy-permissive.yaml"], agent: "openclaw" },
-      { path: ["agents", "hermes", "policy-additions.yaml"], agent: "hermes" },
-      { path: ["agents", "hermes", "policy-permissive.yaml"], agent: "hermes" },
-      {
-        path: ["agents", "langchain-deepagents-code", "policy-additions.yaml"],
-        agent: "langchain-deepagents-code",
-      },
-    ];
+  const packageDatabasePolicyCases = [
+    ...shippingPolicyCases,
+    {
+      path: ["agents", "langchain-deepagents-code", "policy-additions.yaml"],
+      agent: "langchain-deepagents-code",
+    },
+  ] as const;
 
-    for (const policyCase of policyCases) {
+  it.each(
+    packageDatabasePolicyCases.flatMap((policyCase) =>
+      ["/", "/var", "/var/lib", "/var/lib/dpkg"].map((writableAncestor) => ({
+        policyCase,
+        writableAncestor,
+      })),
+    ),
+  )(
+    "grants $policyCase.agent policy $policyCase.path read-only package access without writable $writableAncestor (#8467)",
+    ({ policyCase, writableAncestor }) => {
       const prepared = prepareInitialSandboxCreatePolicy(repoPath(...policyCase.path), [], {
         agentName: policyCase.agent,
       });
@@ -202,13 +204,14 @@ describe("initial sandbox policy real preset merge", () => {
       const readWrite = policy.filesystem_policy?.read_write ?? [];
 
       expect(readOnly, policyCase.path.join("/")).toContain("/var/lib/dpkg");
-      for (const writableAncestor of ["/", "/var", "/var/lib", "/var/lib/dpkg"]) {
-        expect(readWrite, policyCase.path.join("/")).not.toContain(writableAncestor);
-      }
-    }
-  });
+      expect(readWrite, policyCase.path.join("/")).not.toContain(writableAncestor);
+    },
+  );
 
-  it("preserves baseline writable paths in effective OpenClaw permissive create policies", () => {
+  it.each([
+    "nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml",
+    "agents/openclaw/policy-permissive.yaml",
+  ])("preserves baseline writable paths in effective OpenClaw permissive policy %s", (policy) => {
     const baseline = readPreparedPolicy(
       prepareInitialSandboxCreatePolicy(
         repoPath("nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"),
@@ -219,58 +222,43 @@ describe("initial sandbox policy real preset merge", () => {
     const baselineReadWrite = baseline.filesystem_policy?.read_write ?? [];
     expect(baselineReadWrite).toContain("/home/linuxbrew");
 
-    for (const policyPath of [
-      repoPath("nemoclaw-blueprint", "policies", "openclaw-sandbox-permissive.yaml"),
-      repoPath("agents", "openclaw", "policy-permissive.yaml"),
-    ]) {
-      const effective = readPreparedPolicy(
-        prepareInitialSandboxCreatePolicy(policyPath, [], { agentName: "openclaw" }),
-      );
-      expect(effective.filesystem_policy?.read_write, policyPath).toEqual(
-        expect.arrayContaining(baselineReadWrite),
-      );
-    }
+    const policyPath = repoPath(...policy.split("/"));
+    const effective = readPreparedPolicy(
+      prepareInitialSandboxCreatePolicy(policyPath, [], { agentName: "openclaw" }),
+    );
+    expect(effective.filesystem_policy?.read_write, policyPath).toEqual(
+      expect.arrayContaining(baselineReadWrite),
+    );
   });
 
-  it("keeps Slack request-body credential rewrite in permissive create policies", () => {
-    const policyCases = [
+  it.each(
+    [
       {
         path: repoPath("nemoclaw-blueprint", "policies", "openclaw-sandbox-permissive.yaml"),
         agent: "openclaw",
       },
       { path: repoPath("agents", "hermes", "policy-permissive.yaml"), agent: "hermes" },
-    ];
-
-    for (const policyCase of policyCases) {
-      const effective = readPreparedPolicy(
-        prepareInitialSandboxCreatePolicy(policyCase.path, ["slack"], {
-          agentName: policyCase.agent,
-        }),
-      );
-      const slackEndpoints = effective.network_policies?.slack?.endpoints ?? [];
-      for (const host of ["slack.com", "api.slack.com", "hooks.slack.com"]) {
-        const endpoint = slackEndpoints.find((candidate) => candidate.host === host);
-        expect(endpoint, `${policyCase.agent}:${host}`).toMatchObject({
-          protocol: "rest",
-          request_body_credential_rewrite: true,
-        });
-      }
-    }
+    ].flatMap((policyCase) =>
+      ["slack.com", "api.slack.com", "hooks.slack.com"].map((host) => ({ policyCase, host })),
+    ),
+  )("keeps Slack credential rewrite for $policyCase.agent on $host", ({ policyCase, host }) => {
+    const effective = readPreparedPolicy(
+      prepareInitialSandboxCreatePolicy(policyCase.path, ["slack"], {
+        agentName: policyCase.agent,
+      }),
+    );
+    const slackEndpoints = effective.network_policies?.slack?.endpoints ?? [];
+    const endpoint = slackEndpoints.find((candidate) => candidate.host === host);
+    expect(endpoint, `${policyCase.agent}:${host}`).toMatchObject({
+      protocol: "rest",
+      request_body_credential_rewrite: true,
+    });
   });
 
-  it("keeps optional Claude hosts out of every default and permissive create policy", () => {
-    const claudeHosts = new Set(["api.anthropic.com", "statsig.anthropic.com", "sentry.io"]);
-    const policyCases = [
-      { path: ["nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"], agent: "openclaw" },
-      {
-        path: ["nemoclaw-blueprint", "policies", "openclaw-sandbox-permissive.yaml"],
-        agent: "openclaw",
-      },
-      { path: ["agents", "openclaw", "policy-permissive.yaml"], agent: "openclaw" },
-      { path: ["agents", "hermes", "policy-permissive.yaml"], agent: "hermes" },
-    ];
-
-    for (const policyCase of policyCases) {
+  it.each(shippingPolicyCases.slice(0, 3).concat(shippingPolicyCases.slice(4)))(
+    "keeps optional Claude hosts out of $agent create policy $path",
+    (policyCase) => {
+      const claudeHosts = new Set(["api.anthropic.com", "statsig.anthropic.com", "sentry.io"]);
       const effective = readPreparedPolicy(
         prepareInitialSandboxCreatePolicy(repoPath(...policyCase.path), [], {
           agentName: policyCase.agent,
@@ -285,36 +273,42 @@ describe("initial sandbox policy real preset merge", () => {
         hosts.filter((host) => claudeHosts.has(host)),
         policyCase.path.join("/"),
       ).toEqual([]);
-    }
-  });
+    },
+  );
 
-  it("prepares Hermes package access with read-only runtime and verification identities", () => {
-    const effective = readPreparedPolicy(
-      prepareInitialSandboxCreatePolicy(repoPath("agents", "hermes", "policy-additions.yaml"), [], {
-        agentName: "hermes",
-      }),
-    );
-    const pypi = effective.network_policies?.pypi;
-    const binaryPaths = pypi?.binaries?.map((binary) => binary.path) ?? [];
+  it.each(["files.pythonhosted.org", "pypi.org"])(
+    "prepares Hermes package access for %s with read-only runtime and verification identities",
+    (host) => {
+      const effective = readPreparedPolicy(
+        prepareInitialSandboxCreatePolicy(
+          repoPath("agents", "hermes", "policy-additions.yaml"),
+          [],
+          {
+            agentName: "hermes",
+          },
+        ),
+      );
+      const pypi = effective.network_policies?.pypi;
+      const binaryPaths = pypi?.binaries?.map((binary) => binary.path) ?? [];
 
-    expect(binaryPaths).toEqual(
-      expect.arrayContaining([
-        "/usr/bin/curl",
-        "/usr/local/bin/curl",
-        "/usr/local/bin/pip3",
-        "/usr/bin/python3*",
-        "/opt/hermes/.venv/bin/python",
-      ]),
-    );
-    expect((pypi?.endpoints ?? []).map((endpoint) => endpoint.host).sort()).toEqual([
-      "files.pythonhosted.org",
-      "pypi.org",
-    ]);
-    for (const endpoint of pypi?.endpoints ?? []) {
+      expect(binaryPaths).toEqual(
+        expect.arrayContaining([
+          "/usr/bin/curl",
+          "/usr/local/bin/curl",
+          "/usr/local/bin/pip3",
+          "/usr/bin/python3*",
+          "/opt/hermes/.venv/bin/python",
+        ]),
+      );
+      expect((pypi?.endpoints ?? []).map((endpoint) => endpoint.host).sort()).toEqual([
+        "files.pythonhosted.org",
+        "pypi.org",
+      ]);
+      const endpoint = pypi?.endpoints?.find((candidate) => candidate.host === host);
       expect(endpoint).toMatchObject({ protocol: "rest" });
-      expect((endpoint.rules ?? []).map((rule) => rule.allow?.method)).toEqual(["GET"]);
-    }
-  });
+      expect((endpoint?.rules ?? []).map((rule) => rule.allow?.method)).toEqual(["GET"]);
+    },
+  );
 
   it("adds backend-neutral trace egress only to the requested DCode create policy", () => {
     const prepared = prepareInitialSandboxCreatePolicy(

--- a/src/lib/onboard/machine/gateway-stale-port-reuse.test.ts
+++ b/src/lib/onboard/machine/gateway-stale-port-reuse.test.ts
@@ -45,8 +45,9 @@ describe("classifyGatewayPortReuse", () => {
     ).toBe("reuse");
   });
 
-  it("returns reuse when the CLI lacks lifecycle commands, regardless of container state", () => {
-    for (const containerState of ["missing", "running", "unknown"] as GatewayContainerState[]) {
+  it.each(["missing", "running", "unknown"] as GatewayContainerState[])(
+    "returns reuse when the CLI lacks lifecycle commands, regardless of container state [case %#]",
+    (containerState) => {
       expect(
         classifyGatewayPortReuse({
           gatewayReuseState: "healthy",
@@ -54,11 +55,12 @@ describe("classifyGatewayPortReuse", () => {
           containerState,
         }),
       ).toBe("reuse");
-    }
-  });
+    },
+  );
 
-  it("returns skip for any non-healthy recorded state", () => {
-    for (const gatewayReuseState of NON_HEALTHY_STATES) {
+  it.each(NON_HEALTHY_STATES)(
+    "returns skip for any non-healthy recorded state [case %#]",
+    (gatewayReuseState) => {
       expect(
         classifyGatewayPortReuse({
           gatewayReuseState,
@@ -66,8 +68,8 @@ describe("classifyGatewayPortReuse", () => {
           containerState: "missing",
         }),
       ).toBe("skip");
-    }
-  });
+    },
+  );
 });
 
 const BASE_INPUT = {
@@ -113,64 +115,64 @@ describe("applyHealthyPortReuse", () => {
     expect(result).toBeNull();
   });
 
-  it.each([
-    "healthy",
-    "missing",
-  ] as GatewayReuseState[])("preserves an externally supervised gateway port for downstream attachment from %s state (#6576)", async (gatewayReuseState) => {
-    const destroyGateway = vi.fn(() => true);
-    const runOpenshell = vi.fn();
-    const checkPortAvailable = vi.fn();
-    const verifyGatewayContainerRunning = vi.fn(() => "missing" as GatewayContainerState);
+  it.each(["healthy", "missing"] as GatewayReuseState[])(
+    "preserves an externally supervised gateway port for downstream attachment from %s state (#6576)",
+    async (gatewayReuseState) => {
+      const destroyGateway = vi.fn(() => true);
+      const runOpenshell = vi.fn();
+      const checkPortAvailable = vi.fn();
+      const verifyGatewayContainerRunning = vi.fn(() => "missing" as GatewayContainerState);
 
-    const result = await applyHealthyPortReuse({
-      ...BASE_INPUT,
-      gatewayReuseState,
-      externallySupervised: true,
-      destroyGateway,
-      runOpenshell,
-      checkPortAvailable,
-      verifyGatewayContainerRunning,
-    });
+      const result = await applyHealthyPortReuse({
+        ...BASE_INPUT,
+        gatewayReuseState,
+        externallySupervised: true,
+        destroyGateway,
+        runOpenshell,
+        checkPortAvailable,
+        verifyGatewayContainerRunning,
+      });
 
-    expect(result).toBe("continue");
-    expect(verifyGatewayContainerRunning).not.toHaveBeenCalled();
-    expect(destroyGateway).not.toHaveBeenCalled();
-    expect(runOpenshell).not.toHaveBeenCalled();
-    expect(checkPortAvailable).not.toHaveBeenCalled();
-  });
+      expect(result).toBe("continue");
+      expect(verifyGatewayContainerRunning).not.toHaveBeenCalled();
+      expect(destroyGateway).not.toHaveBeenCalled();
+      expect(runOpenshell).not.toHaveBeenCalled();
+      expect(checkPortAvailable).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     { gatewayReuseState: "missing", port: 18789, relationship: "distinct" },
     { gatewayReuseState: "healthy", port: 18789, relationship: "distinct" },
     { gatewayReuseState: "missing", port: 8080, relationship: "equal-number" },
     { gatewayReuseState: "healthy", port: 8080, relationship: "equal-number" },
-  ] as const)("retains conflict handling for a $relationship external dashboard from $gatewayReuseState state (#6576)", async ({
-    gatewayReuseState,
-    port,
-  }) => {
-    const destroyGateway = vi.fn(() => true);
-    const runOpenshell = vi.fn();
-    const checkPortAvailable = vi.fn();
-    const verifyGatewayContainerRunning = vi.fn();
+  ] as const)(
+    "retains conflict handling for a $relationship external dashboard from $gatewayReuseState state (#6576)",
+    async ({ gatewayReuseState, port }) => {
+      const destroyGateway = vi.fn(() => true);
+      const runOpenshell = vi.fn();
+      const checkPortAvailable = vi.fn();
+      const verifyGatewayContainerRunning = vi.fn();
 
-    const result = await applyHealthyPortReuse({
-      ...BASE_INPUT,
-      kind: "dashboard",
-      port,
-      gatewayReuseState,
-      externallySupervised: true,
-      destroyGateway,
-      runOpenshell,
-      checkPortAvailable,
-      verifyGatewayContainerRunning,
-    });
+      const result = await applyHealthyPortReuse({
+        ...BASE_INPUT,
+        kind: "dashboard",
+        port,
+        gatewayReuseState,
+        externallySupervised: true,
+        destroyGateway,
+        runOpenshell,
+        checkPortAvailable,
+        verifyGatewayContainerRunning,
+      });
 
-    expect(result).toBeNull();
-    expect(verifyGatewayContainerRunning).not.toHaveBeenCalled();
-    expect(destroyGateway).not.toHaveBeenCalled();
-    expect(runOpenshell).not.toHaveBeenCalled();
-    expect(checkPortAvailable).not.toHaveBeenCalled();
-  });
+      expect(result).toBeNull();
+      expect(verifyGatewayContainerRunning).not.toHaveBeenCalled();
+      expect(destroyGateway).not.toHaveBeenCalled();
+      expect(runOpenshell).not.toHaveBeenCalled();
+      expect(checkPortAvailable).not.toHaveBeenCalled();
+    },
+  );
 
   it("cleans up stale metadata and returns downgraded state when the port frees up", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);

--- a/src/lib/onboard/machine/runner.test.ts
+++ b/src/lib/onboard/machine/runner.test.ts
@@ -244,8 +244,9 @@ describe("runOnboardMachine", () => {
     ).rejects.toThrow(OnboardMachineTransitionLimitError);
   });
 
-  it("uses the default transition limit for non-finite maxTransitions values", async () => {
-    for (const maxTransitions of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "uses the default transition limit for non-finite maxTransitions values [case %#]",
+    async (maxTransitions) => {
       const runtime = createRuntime();
 
       await expect(
@@ -262,6 +263,6 @@ describe("runOnboardMachine", () => {
           maxTransitions,
         }),
       ).rejects.toMatchObject({ maxTransitions: 100 });
-    }
-  });
+    },
+  );
 });

--- a/src/lib/onboard/machine/transitions.test.ts
+++ b/src/lib/onboard/machine/transitions.test.ts
@@ -93,11 +93,9 @@ describe("onboard machine transitions", () => {
     );
   });
 
-  it("allows every non-terminal state to fail", () => {
-    for (const state of ONBOARD_NON_TERMINAL_MACHINE_STATES) {
-      expect(canTransitionOnboardMachineState(state, "failed")).toBe(true);
-      expect(getOnboardMachineTransition(state, "failed")?.kind).toBe("failure");
-    }
+  it.each(ONBOARD_NON_TERMINAL_MACHINE_STATES)("allows the %s state to fail", (state) => {
+    expect(canTransitionOnboardMachineState(state, "failed")).toBe(true);
+    expect(getOnboardMachineTransition(state, "failed")?.kind).toBe("failure");
   });
 
   it("keeps terminal states terminal", () => {
@@ -148,27 +146,29 @@ describe("onboard machine transitions", () => {
     );
   });
 
-  it("never allows a terminal failed state to re-enter an agent or flow state (#6179)", () => {
-    for (const to of ["agent_setup", "openclaw", "sandbox", "policies", "init"] as const) {
+  it.each(["agent_setup", "openclaw", "sandbox", "policies", "init"] as const)(
+    "does not allow failed to re-enter %s (#6179)",
+    (to) => {
       expect(canTransitionOnboardMachineState("failed", to)).toBe(false);
       expect(getOnboardMachineTransition("failed", to)).toBeNull();
       expect(() => assertValidOnboardMachineTransition("failed", to)).toThrow(`failed -> ${to}`);
-    }
-    // Failure edges only ever point *into* the terminal failed state.
-    for (const transition of ONBOARD_MACHINE_TRANSITIONS) {
+    },
+  );
+
+  it.each(ONBOARD_MACHINE_TRANSITIONS)(
+    "keeps the $from to $to edge outside terminal source states (#6179)",
+    (transition) => {
       expect(transition.from).not.toBe("failed");
       expect(transition.from).not.toBe("complete");
-    }
-  });
+    },
+  );
 
-  it("keeps the next-state map aligned with the transition list", () => {
-    for (const state of ONBOARD_MACHINE_STATES) {
-      expect(
-        ONBOARD_MACHINE_TRANSITIONS.filter((transition) => transition.from === state).map(
-          (transition) => transition.to,
-        ),
-      ).toEqual(getNextOnboardMachineStates(state));
-    }
+  it.each(ONBOARD_MACHINE_STATES)("keeps the %s next-state map aligned", (state) => {
+    expect(
+      ONBOARD_MACHINE_TRANSITIONS.filter((transition) => transition.from === state).map(
+        (transition) => transition.to,
+      ),
+    ).toEqual(getNextOnboardMachineStates(state));
   });
 
   it("does not contain duplicate transition edges", () => {

--- a/src/lib/onboard/messaging-policy-presets.test.ts
+++ b/src/lib/onboard/messaging-policy-presets.test.ts
@@ -164,9 +164,10 @@ describe("messaging policy presets", () => {
   // and several call sites assume a channel's egress preset shares its name.
   // Pin that 1:1 mapping for every shipped channel so a future preset rename
   // (which would silently desync suggestions from finalization) fails here.
-  it("maps each messaging channel to a same-named egress preset (#5967)", () => {
-    for (const channel of ["slack", "discord", "telegram", "teams", "whatsapp", "wechat"]) {
+  it.each(["slack", "discord", "telegram", "teams", "whatsapp", "wechat"])(
+    "maps each messaging channel to a same-named egress preset [case %#] (#5967)",
+    (channel) => {
       expect(allMessagingChannelPolicyPresets([channel])).toEqual([channel]);
-    }
-  });
+    },
+  );
 });

--- a/src/lib/onboard/not-ready-recreate.test.ts
+++ b/src/lib/onboard/not-ready-recreate.test.ts
@@ -194,18 +194,18 @@ describe("selectPreUpgradeBackupForCreate", () => {
     expect(note).not.toHaveBeenCalled();
   });
 
-  it.each([
-    "ready",
-    "not_ready",
-  ] as const)("throws before backup access when a %s same-name sandbox reports no OpenShell Id (#7736)", (state) => {
-    process.env.NEMOCLAW_RESTORE_LATEST_BACKUP_ON_RECREATE = "1";
+  it.each(["ready", "not_ready"] as const)(
+    "throws before backup access when a %s same-name sandbox reports no OpenShell Id (#7736)",
+    (state) => {
+      process.env.NEMOCLAW_RESTORE_LATEST_BACKUP_ON_RECREATE = "1";
 
-    expect(() => select({ observation: { state, liveIdentityFingerprint: null } })).toThrow(
-      /reports no OpenShell Id/,
-    );
-    expect(getLatestBackupSpy).not.toHaveBeenCalled();
-    expect(note).not.toHaveBeenCalled();
-  });
+      expect(() => select({ observation: { state, liveIdentityFingerprint: null } })).toThrow(
+        /reports no OpenShell Id/,
+      );
+      expect(getLatestBackupSpy).not.toHaveBeenCalled();
+      expect(note).not.toHaveBeenCalled();
+    },
+  );
 
   it("throws before backup access when the source registry row changed (#7736)", () => {
     process.env.NEMOCLAW_RESTORE_LATEST_BACKUP_ON_RECREATE = "1";
@@ -249,23 +249,23 @@ describe("selectPreUpgradeBackupForCreate", () => {
       currentEntry: null,
       error: /source registry row is absent/,
     },
-  ] as const)("rejects a source registry row that $change after journal proof capture (#7736)", ({
-    currentEntry,
-    error,
-  }) => {
-    process.env.NEMOCLAW_RESTORE_LATEST_BACKUP_ON_RECREATE = "1";
-    const onProofRequested = vi.fn();
-    const readRegistryEntry = vi.fn(() => currentEntry);
+  ] as const)(
+    "rejects a source registry row that $change after journal proof capture (#7736)",
+    ({ currentEntry, error }) => {
+      process.env.NEMOCLAW_RESTORE_LATEST_BACKUP_ON_RECREATE = "1";
+      const onProofRequested = vi.fn();
+      const readRegistryEntry = vi.fn(() => currentEntry);
 
-    expect(() => select({ onProofRequested, readRegistryEntry })).toThrow(error);
-    expect(onProofRequested).toHaveBeenCalledTimes(1);
-    expect(readRegistryEntry).toHaveBeenCalledTimes(1);
-    expect(onProofRequested.mock.invocationCallOrder[0]).toBeLessThan(
-      readRegistryEntry.mock.invocationCallOrder[0],
-    );
-    expect(getLatestBackupSpy).not.toHaveBeenCalled();
-    expect(note).not.toHaveBeenCalled();
-  });
+      expect(() => select({ onProofRequested, readRegistryEntry })).toThrow(error);
+      expect(onProofRequested).toHaveBeenCalledTimes(1);
+      expect(readRegistryEntry).toHaveBeenCalledTimes(1);
+      expect(onProofRequested.mock.invocationCallOrder[0]).toBeLessThan(
+        readRegistryEntry.mock.invocationCallOrder[0],
+      );
+      expect(getLatestBackupSpy).not.toHaveBeenCalled();
+      expect(note).not.toHaveBeenCalled();
+    },
+  );
 
   it("throws before backup access when the transaction records another sandbox (#7736)", () => {
     process.env.NEMOCLAW_RESTORE_LATEST_BACKUP_ON_RECREATE = "1";
@@ -504,13 +504,14 @@ describe("installerRestoreOnRecreateFromEnv", () => {
     expect(installerRestoreOnRecreateFromEnv({})).toBe(false);
   });
 
-  it("returns false when the sentinel is set to any value other than '1'", () => {
-    for (const value of ["", "0", "true", "yes"]) {
+  it.each(["", "0", "true", "yes"])(
+    "returns false when the sentinel is set to any value other than '1' [case %#]",
+    (value) => {
       expect(
         installerRestoreOnRecreateFromEnv({
           NEMOCLAW_RESTORE_LATEST_BACKUP_ON_RECREATE: value,
         }),
       ).toBe(false);
-    }
-  });
+    },
+  );
 });

--- a/src/lib/onboard/ollama-proxy-reachability.test.ts
+++ b/src/lib/onboard/ollama-proxy-reachability.test.ts
@@ -150,8 +150,9 @@ describe("probeOllamaProxySandboxReachability (#3340)", () => {
     expect(result.reason).toBe("probe_unavailable");
   });
 
-  it("returns probe_unavailable for unexpected non-0/non-1 exit codes", async () => {
-    for (const code of [2, 127, 255]) {
+  it.each([2, 127, 255])(
+    "returns probe_unavailable for unexpected non-0/non-1 exit codes [case %#]",
+    async (code) => {
       const result = await probeOllamaProxySandboxReachability({
         inspectNetworkImpl: () => makeNetwork(),
         usesHostGatewayRouteImpl: () => false,
@@ -159,8 +160,8 @@ describe("probeOllamaProxySandboxReachability (#3340)", () => {
       });
       expect(result.ok).toBe(false);
       expect(result.reason).toBe("probe_unavailable");
-    }
-  });
+    },
+  );
 
   it("returns probe_unavailable when the container runner reports an error", async () => {
     const result = await probeOllamaProxySandboxReachability({

--- a/src/lib/onboard/onboard-recreate-journal.test.ts
+++ b/src/lib/onboard/onboard-recreate-journal.test.ts
@@ -49,18 +49,16 @@ describe("non-resumed replacement target fingerprint (#7735)", () => {
     );
   });
 
-  it("changes when a recorded replacement input changes", () => {
-    for (const drift of [
-      { observabilityEnabled: true },
-      { toolDisclosure: "direct" },
-      { sandboxGpuConfig: { sandboxGpuEnabled: true, mode: "all" } },
-      { dcodeAutoApprovalMode: "thread-opt-in" },
-      { policyTier: "balanced" },
-    ]) {
-      expect(fingerprintOnboardRecreateTargetIntent({ ...BASE_INTENT, ...drift })).not.toBe(
-        fingerprintOnboardRecreateTargetIntent(BASE_INTENT),
-      );
-    }
+  it.each([
+    { observabilityEnabled: true },
+    { toolDisclosure: "direct" },
+    { sandboxGpuConfig: { sandboxGpuEnabled: true, mode: "all" } },
+    { dcodeAutoApprovalMode: "thread-opt-in" },
+    { policyTier: "balanced" },
+  ])("changes when a recorded replacement input changes [case %#]", (drift) => {
+    expect(fingerprintOnboardRecreateTargetIntent({ ...BASE_INTENT, ...drift })).not.toBe(
+      fingerprintOnboardRecreateTargetIntent(BASE_INTENT),
+    );
   });
 
   it("changes when the replacement targets another gateway", () => {

--- a/src/lib/onboard/portable-resume-intent.test.ts
+++ b/src/lib/onboard/portable-resume-intent.test.ts
@@ -91,8 +91,9 @@ describe("portable resume intent", () => {
     expect(fs.readFileSync(file, "utf8")).toBe(before);
   });
 
-  it("refuses active schema v1-v3 checkpoints byte-for-byte with --fresh guidance (#9035)", () => {
-    for (const schemaVersion of [1, 2, 3]) {
+  it.each([1, 2, 3])(
+    "refuses active schema v1-v3 checkpoints byte-for-byte with --fresh guidance [case %#] (#9035)",
+    (schemaVersion) => {
       const legacy = JSON.parse(rawSession()) as Record<string, unknown>;
       legacy.checkpoint = { schemaVersion };
       const file = sessionFile(JSON.stringify(legacy, null, 2));
@@ -107,8 +108,8 @@ describe("portable resume intent", () => {
         }),
       ).toThrow(/predates recorded runtime authority.*--fresh/su);
       expect(fs.readFileSync(file, "utf8")).toBe(before);
-    }
-  });
+    },
+  );
 
   it("rejects terminal sessions before portable preparation can run (#9035)", () => {
     const parsed = JSON.parse(rawSession()) as Record<string, unknown>;

--- a/src/lib/onboard/preflight-gateway-cleanup-decision.test.ts
+++ b/src/lib/onboard/preflight-gateway-cleanup-decision.test.ts
@@ -59,8 +59,9 @@ describe("preflightGatewayCleanupDecision", () => {
     ).toBe("destroy-legacy");
   });
 
-  it("returns noop for an externally supervised gateway even when stale (#6576)", () => {
-    for (const state of ["stale", "active-unnamed"] as const) {
+  it.each(["stale", "active-unnamed"] as const)(
+    "returns noop for an externally supervised gateway even when stale [case %#] (#6576)",
+    (state) => {
       expect(
         preflightGatewayCleanupDecision({
           gatewayReuseState: state,
@@ -68,11 +69,12 @@ describe("preflightGatewayCleanupDecision", () => {
           externallySupervised: true,
         }),
       ).toBe("noop");
-    }
-  });
+    },
+  );
 
-  it("returns noop for non-stale states regardless of driver", () => {
-    for (const state of ["healthy", "missing", "foreign-active"] as const) {
+  it.each(["healthy", "missing", "foreign-active"] as const)(
+    "returns noop for non-stale states regardless of driver [case %#]",
+    (state) => {
       expect(
         preflightGatewayCleanupDecision({
           gatewayReuseState: state,
@@ -85,8 +87,8 @@ describe("preflightGatewayCleanupDecision", () => {
           isDockerDriverGatewayEnabled: false,
         }),
       ).toBe("noop");
-    }
-  });
+    },
+  );
 });
 
 describe("applyPreflightGatewayCleanup", () => {
@@ -178,8 +180,9 @@ describe("applyPreflightGatewayCleanup", () => {
     expect(ctx.destroyGateway).toHaveBeenCalledTimes(1);
   });
 
-  it("is a no-op for healthy / missing / foreign-active states", () => {
-    for (const state of ["healthy", "missing", "foreign-active"] as const) {
+  it.each(["healthy", "missing", "foreign-active"] as const)(
+    "is a no-op for healthy / missing / foreign-active states [case %#]",
+    (state) => {
       const ctx = makeDeps({ gatewayReuseState: state, isDockerDriverGatewayEnabled: true });
       const next = applyPreflightGatewayCleanup(ctx.deps);
       expect(next).toBe(state);
@@ -188,6 +191,6 @@ describe("applyPreflightGatewayCleanup", () => {
       expect(ctx.destroyGateway).not.toHaveBeenCalled();
       expect(ctx.destroyGatewayForReuse).not.toHaveBeenCalled();
       expect(ctx.runOpenshell).not.toHaveBeenCalled();
-    }
-  });
+    },
+  );
 });

--- a/src/lib/onboard/preflight-gateway-cleanup-decision.test.ts
+++ b/src/lib/onboard/preflight-gateway-cleanup-decision.test.ts
@@ -60,7 +60,7 @@ describe("preflightGatewayCleanupDecision", () => {
   });
 
   it.each(["stale", "active-unnamed"] as const)(
-    "returns noop for an externally supervised gateway even when stale [case %#] (#6576)",
+    "returns noop for an externally supervised %s gateway (#6576)",
     (state) => {
       expect(
         preflightGatewayCleanupDecision({

--- a/src/lib/onboard/preflight-orphan-gateway-cleanup.test.ts
+++ b/src/lib/onboard/preflight-orphan-gateway-cleanup.test.ts
@@ -72,18 +72,16 @@ describe("cleanupOrphanedGatewayContainer (#6576)", () => {
     );
   });
 
-  it("does nothing when the gateway is reusable or on the Docker-driver path", () => {
-    for (const overrides of [
-      { gatewayReuseState: "healthy" },
-      { isDockerDriverGatewayEnabled: true },
-    ]) {
+  it.each([{ gatewayReuseState: "healthy" }, { isDockerDriverGatewayEnabled: true }])(
+    "does nothing when the gateway is reusable or on the Docker-driver path [case %#]",
+    (overrides) => {
       const deps = makeDeps(overrides);
 
       cleanupOrphanedGatewayContainer(deps);
 
       expect(deps.dockerInspect).not.toHaveBeenCalled();
-    }
-  });
+    },
+  );
 
   it("does nothing when no orphaned container is present", () => {
     const deps = makeDeps({ dockerInspect: vi.fn(() => ({ status: 1 })) });

--- a/src/lib/onboard/recovered-provider-reuse.test.ts
+++ b/src/lib/onboard/recovered-provider-reuse.test.ts
@@ -245,16 +245,14 @@ describe("assessRecoveredProviderCredentialReuse", () => {
     ).toMatchObject({ kind: "reject", reason: expect.stringContaining("endpoint identity") });
   });
 
-  it("rejects mismatched recovered provider and model combinations", () => {
-    for (const override of [
-      { recoveredProvider: "another-provider" },
-      { recoveredModel: "another-model" },
-    ]) {
+  it.each([{ recoveredProvider: "another-provider" }, { recoveredModel: "another-model" }])(
+    "rejects mismatched recovered provider and model combinations [case %#]",
+    (override) => {
       expect(
         assessRecoveredProviderCredentialReuse({ ...completeRecovery, ...override }),
       ).toMatchObject({ kind: "reject" });
-    }
-  });
+    },
+  );
 
   it("rejects an unsupported API for the recovered provider type", () => {
     expect(

--- a/src/lib/onboard/runtime-provider/docker-llama-cpp-managed-lifecycle.test.ts
+++ b/src/lib/onboard/runtime-provider/docker-llama-cpp-managed-lifecycle.test.ts
@@ -440,38 +440,38 @@ describe("dormant Docker llama.cpp managed lifecycle", () => {
   it.each([
     { failure: "connection refusal", status: 7, stderr: "curl: (7) failed to connect" },
     { failure: "timeout", status: 28, stderr: "curl: (28) timed out" },
-  ])("reports a narrow UFW remediation and rolls back after bridge $failure (#8712)", ({
-    status,
-    stderr,
-  }) => {
-    const fixture = dockerFixture();
-    const store = journalStore();
-    const privateBridge = privateBridgeFixture();
-    fixture.failSandboxBridgeProbe({ status, stderr });
+  ])(
+    "reports a narrow UFW remediation and rolls back after bridge $failure (#8712)",
+    ({ status, stderr }) => {
+      const fixture = dockerFixture();
+      const store = journalStore();
+      const privateBridge = privateBridgeFixture();
+      fixture.failSandboxBridgeProbe({ status, stderr });
 
-    let failure: Error | undefined;
-    try {
-      createLifecycle(options(fixture, store), {}, privateBridge).start(receiptWriter());
-    } catch (error) {
-      failure = error instanceof Error ? error : new Error(String(error));
-    }
+      let failure: Error | undefined;
+      try {
+        createLifecycle(options(fixture, store), {}, privateBridge).start(receiptWriter());
+      } catch (error) {
+        failure = error instanceof Error ? error : new Error(String(error));
+      }
 
-    expect(failure?.message).toContain(
-      "Managed llama.cpp host-loopback health check passed, but the OpenShell Docker bridge health check failed.",
-    );
-    expect(failure?.message).toContain("OpenShell Docker network: openshell-docker");
-    expect(failure?.message).toContain("Source subnet: 172.29.0.0/16");
-    expect(failure?.message).toContain("Gateway IP address: 172.29.0.1");
-    expect(failure?.message).toContain("TCP port: 8081");
-    expect(failure?.message).toContain(
-      "sudo ufw allow from 172.29.0.0/16 to 172.29.0.1 port 8081 proto tcp",
-    );
-    expect(failure?.message).not.toContain("test-only-secret");
-    expect(privateBridge.stopTransaction).toHaveBeenCalledWith(TRANSACTION_ID);
-    expect(store.list()).toEqual([]);
-    expect(dockerCommandPrefixes(fixture)).toContainEqual(["rm", "--force"]);
-    expect(dockerCommandPrefixes(fixture)).toContainEqual(["network", "rm"]);
-  });
+      expect(failure?.message).toContain(
+        "Managed llama.cpp host-loopback health check passed, but the OpenShell Docker bridge health check failed.",
+      );
+      expect(failure?.message).toContain("OpenShell Docker network: openshell-docker");
+      expect(failure?.message).toContain("Source subnet: 172.29.0.0/16");
+      expect(failure?.message).toContain("Gateway IP address: 172.29.0.1");
+      expect(failure?.message).toContain("TCP port: 8081");
+      expect(failure?.message).toContain(
+        "sudo ufw allow from 172.29.0.0/16 to 172.29.0.1 port 8081 proto tcp",
+      );
+      expect(failure?.message).not.toContain("test-only-secret");
+      expect(privateBridge.stopTransaction).toHaveBeenCalledWith(TRANSACTION_ID);
+      expect(store.list()).toEqual([]);
+      expect(dockerCommandPrefixes(fixture)).toContainEqual(["rm", "--force"]);
+      expect(dockerCommandPrefixes(fixture)).toContainEqual(["network", "rm"]);
+    },
+  );
 
   it("does not report UFW remediation for a Docker probe command failure (#8712)", () => {
     const fixture = dockerFixture();
@@ -606,36 +606,45 @@ describe("dormant Docker llama.cpp managed lifecycle", () => {
       (fixture: DockerFixture) => fixture.onProbe(() => fixture.setNetworkId("6".repeat(64))),
       /network identity/u,
     ],
-  ] as const)("fails closed on post-readiness %s drift without replacement (#8144)", (_kind, drift, expected) => {
-    const fixture = dockerFixture();
-    const store = journalStore();
-    const lifecycle = controller(fixture, store);
-    const receipt = lifecycle.start(receiptWriter());
-    lifecycle.runtime.stopManaged(receipt);
-    drift(fixture);
-    fixture.capture.mockClear();
+  ] as const)(
+    "fails closed on post-readiness %s drift without replacement (#8144)",
+    (_kind, drift, expected) => {
+      const fixture = dockerFixture();
+      const store = journalStore();
+      const lifecycle = controller(fixture, store);
+      const receipt = lifecycle.start(receiptWriter());
+      lifecycle.runtime.stopManaged(receipt);
+      drift(fixture);
+      fixture.capture.mockClear();
 
-    expect(() => lifecycle.resume(receipt)).toThrow(expected);
-    const calls = fixture.capture.mock.calls.map((call) => call[0]);
-    expect(calls.filter((args) => args[0] === "start")).toEqual([["start", RUNTIME_ID]]);
-    expect(calls).toContainEqual(expect.arrayContaining(["run", "--rm"]));
-    expect(calls).not.toContainEqual(expect.arrayContaining(["create"]));
-    expect(calls).not.toContainEqual(expect.arrayContaining(["network", "create"]));
-    expect(store.load(TRANSACTION_ID)).toMatchObject({ phase: "finalized", runtimeId: RUNTIME_ID });
-  });
+      expect(() => lifecycle.resume(receipt)).toThrow(expected);
+      const calls = fixture.capture.mock.calls.map((call) => call[0]);
+      expect(calls.filter((args) => args[0] === "start")).toEqual([["start", RUNTIME_ID]]);
+      expect(calls).toContainEqual(expect.arrayContaining(["run", "--rm"]));
+      expect(calls).not.toContainEqual(expect.arrayContaining(["create"]));
+      expect(calls).not.toContainEqual(expect.arrayContaining(["network", "create"]));
+      expect(store.load(TRANSACTION_ID)).toMatchObject({
+        phase: "finalized",
+        runtimeId: RUNTIME_ID,
+      });
+    },
+  );
   it.each([
     ["configured", "8081", undefined, "127.0.0.1", 0, /must not configure/u],
     ["runtime", "", "8081", "127.0.0.1", 1, /must not publish/u],
     ["runtime-wide", "", "8081", "0.0.0.0", 1, /must not publish/u],
-  ] as const)("rolls back exact ownership for unexpected %s Docker publication (#8544)", (_kind, configured, published, ip, count, expectedError) => {
-    const [fixture, store] = [dockerFixture(configured, published, ip, count), journalStore()];
-    const lifecycle = createLifecycle(options(fixture, store));
-    expect(() => lifecycle.start(receiptWriter())).toThrow(expectedError);
-    const calls = fixture.capture.mock.calls.map((call) => call[0]);
-    expect(calls).toContainEqual(["rm", "--force", RUNTIME_ID]);
-    expect(calls).toContainEqual(["network", "rm", NETWORK_ID]);
-    expect(store.list()).toEqual([]);
-  });
+  ] as const)(
+    "rolls back exact ownership for unexpected %s Docker publication (#8544)",
+    (_kind, configured, published, ip, count, expectedError) => {
+      const [fixture, store] = [dockerFixture(configured, published, ip, count), journalStore()];
+      const lifecycle = createLifecycle(options(fixture, store));
+      expect(() => lifecycle.start(receiptWriter())).toThrow(expectedError);
+      const calls = fixture.capture.mock.calls.map((call) => call[0]);
+      expect(calls).toContainEqual(["rm", "--force", RUNTIME_ID]);
+      expect(calls).toContainEqual(["network", "rm", NETWORK_ID]);
+      expect(store.list()).toEqual([]);
+    },
+  );
   it("uses the declarative readiness timeout as both curl retry budget and capture budget", () => {
     const fixture = dockerFixture();
     const lifecycle = createLifecycle({
@@ -907,8 +916,9 @@ describe("dormant Docker llama.cpp managed lifecycle", () => {
     expect(writer.writeExact).toHaveBeenCalledTimes(2);
   });
 
-  it("fails closed on receipt writer target or existing-value drift (#8414)", () => {
-    for (const drift of ["transaction", "target", "value"] as const) {
+  it.each(["transaction", "target", "value"] as const)(
+    "fails closed on receipt writer target or existing-value drift [case %#] (#8414)",
+    (drift) => {
       const fixture = dockerFixture();
       const store = journalStore();
       const initialWriter = receiptWriter(() => {
@@ -937,8 +947,8 @@ describe("dormant Docker llama.cpp managed lifecycle", () => {
         case "target":
           expect(fixture.capture.mock.calls).toHaveLength(writesBeforeRecovery);
       }
-    }
-  });
+    },
+  );
 
   it("rejects a malformed receipt writer before engine or journal mutation (#8414)", () => {
     const fixture = dockerFixture();
@@ -1118,8 +1128,9 @@ describe("dormant Docker llama.cpp managed lifecycle", () => {
     expect(dockerCommandPrefixes(fixture)).not.toContainEqual(["network", "rm"]);
   });
 
-  it("recovers prepared and exact creating/created/started journals without touching finalized ownership (#8395)", () => {
-    for (const phase of ["prepared", "creating", "created", "started"] as const) {
+  it.each(["prepared", "creating", "created", "started"] as const)(
+    "recovers prepared and exact creating/created/started journals without touching finalized ownership [case %#] (#8395)",
+    (phase) => {
       const fixture = dockerFixture();
       const store = journalStore();
       const base = preparedJournal();
@@ -1146,11 +1157,12 @@ describe("dormant Docker llama.cpp managed lifecycle", () => {
       }).recoverUnfinished(receiptWriter());
       expect(recovery).toEqual({ recovered: [TRANSACTION_ID], failures: [] });
       expect(store.list()).toEqual([]);
-    }
-  });
+    },
+  );
 
-  it("refuses unfinished recovery when protected engine authority is missing or drifted (#8395)", () => {
-    for (const state of ["missing", "drifted"] as const) {
+  it.each(["missing", "drifted"] as const)(
+    "refuses unfinished recovery when protected engine authority is missing or drifted [case %#] (#8395)",
+    (state) => {
       const fixture = dockerFixture();
       const store = journalStore();
       const base = preparedJournal();
@@ -1175,8 +1187,8 @@ describe("dormant Docker llama.cpp managed lifecycle", () => {
       expect(recovery.failures).toHaveLength(1);
       expect(store.load(TRANSACTION_ID)).not.toBeNull();
       expect(dockerCommandPrefixes(fixture)).not.toContainEqual(["rm", "--force"]);
-    }
-  });
+    },
+  );
 
   it("fails re-prove on Docker network identity drift (#8395)", () => {
     const fixture = dockerFixture();

--- a/src/lib/onboard/runtime-provider/host-local-create-journal.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-create-journal.test.ts
@@ -312,8 +312,9 @@ describe("host-local create journal", () => {
     recoveryStore.releaseExecution(recovered);
   });
 
-  it("reclaims a dead recovery marker with and without an abandoned lease (#8395)", () => {
-    for (const withLease of [false, true]) {
+  it.each([false, true])(
+    "reclaims a dead recovery marker with and without an abandoned lease [case %#] (#8395)",
+    (withLease) => {
       fs.rmSync(stateDirectory, { force: true, recursive: true });
       fs.mkdirSync(stateDirectory, { mode: 0o700 });
       const setup = createHostLocalCreateJournalStore(stateDirectory, {
@@ -338,8 +339,8 @@ describe("host-local create journal", () => {
       expect(lease).toMatchObject({ ownerId: OWNER_THREE, ownerPid: 303 });
       expect(fs.existsSync(executionPath(".execution-recovery.json"))).toBe(false);
       recovered.releaseExecution(lease);
-    }
-  });
+    },
+  );
 
   it("preserves live recovery-marker exclusion (#8395)", () => {
     const setup = createHostLocalCreateJournalStore(stateDirectory);

--- a/src/lib/onboard/sandbox-gpu-create-failure-classification.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-failure-classification.test.ts
@@ -31,38 +31,40 @@ describe("native GPU create failure classification", () => {
     }
   });
 
-  it("requires exact-target terminal phase plus host runtime evidence for readiness fallback", () => {
-    for (const [failurePhase, runtimeError, expected] of [
-      ["Failed", "policy denied startup exec for gpu-device-initialization-failed", false],
-      [null, "CDI device injection failed: unresolvable nvidia.com/gpu=all", false],
-      ["Error", "CDI device injection failed: unresolvable CDI devices nvidia.com/gpu=all", true],
-    ] as const) {
+  it.each([
+    ["Failed", "policy denied startup exec for gpu-device-initialization-failed", false],
+    [null, "CDI device injection failed: unresolvable nvidia.com/gpu=all", false],
+    ["Error", "CDI device injection failed: unresolvable CDI devices nvidia.com/gpu=all", true],
+  ] as const)(
+    "requires exact-target terminal phase plus host runtime evidence for readiness fallback [case %#]",
+    (failurePhase, runtimeError, expected) => {
       expect(isNativeGpuReadinessRoutingFailure({ failurePhase, runtimeError })).toBe(expected);
-    }
-  });
+    },
+  );
 
-  it("recognizes only narrow host-owned OCI/CDI GPU runtime errors", () => {
-    for (const [message, expected] of [
-      ["unresolvable CDI devices nvidia.com/gpu=all", true],
-      [
-        "failed to create task for container: failed to create shim task: OCI runtime create failed: error injecting CDI devices: unresolvable CDI devices nvidia.com/gpu=all: unknown",
-        true,
-      ],
-      ['could not select device driver "" with capabilities: [[gpu]]', true],
-      ["Docker build failed while compiling CUDA support", false],
-      ["CDI device injection failed: unresolvable CDI devices example.com/widget=all", false],
-      [
-        'failed to create task: exec: "CDI injection failed nvidia.com/gpu=all": executable file not found',
-        false,
-      ],
-      [
-        'chdir to cwd ("/CDI device injection failed/nvidia.com/gpu=all") set in config.json failed: no such file or directory',
-        false,
-      ],
-      ["nvidia-container-cli: requirement error: unsatisfied condition: cuda>=999", false],
-      ["nvidia-container-cli: mount error: failed to mount /image-controlled/path", false],
-    ] as const) {
+  it.each([
+    ["unresolvable CDI devices nvidia.com/gpu=all", true],
+    [
+      "failed to create task for container: failed to create shim task: OCI runtime create failed: error injecting CDI devices: unresolvable CDI devices nvidia.com/gpu=all: unknown",
+      true,
+    ],
+    ['could not select device driver "" with capabilities: [[gpu]]', true],
+    ["Docker build failed while compiling CUDA support", false],
+    ["CDI device injection failed: unresolvable CDI devices example.com/widget=all", false],
+    [
+      'failed to create task: exec: "CDI injection failed nvidia.com/gpu=all": executable file not found',
+      false,
+    ],
+    [
+      'chdir to cwd ("/CDI device injection failed/nvidia.com/gpu=all") set in config.json failed: no such file or directory',
+      false,
+    ],
+    ["nvidia-container-cli: requirement error: unsatisfied condition: cuda>=999", false],
+    ["nvidia-container-cli: mount error: failed to mount /image-controlled/path", false],
+  ] as const)(
+    "recognizes only narrow host-owned OCI/CDI GPU runtime errors [case %#]",
+    (message, expected) => {
       expect(isTrustedNativeGpuRuntimeError(message)).toBe(expected);
-    }
-  });
+    },
+  );
 });

--- a/src/lib/onboard/ssh-forward-hint.test.ts
+++ b/src/lib/onboard/ssh-forward-hint.test.ts
@@ -34,13 +34,12 @@ describe("ssh-forward-hint", () => {
       ]);
     });
 
-    it("never leaks the SSH_CONNECTION socket IP across an alias, NAT, or ProxyJump (#5925)", () => {
-      // An `~/.ssh/config` alias or ProxyJump makes the SSH_CONNECTION server-IP
-      // (field 3) unrelated to what the operator typed, so it must never appear.
-      for (const sshConnection of [
-        "10.0.0.9 51000 10.6.76.40 22", // NAT'd / aliased direct host
-        "203.0.113.8 40222 10.10.0.5 2222", // private bastion-side (ProxyJump) target on a custom port
-      ]) {
+    it.each([
+      "10.0.0.9 51000 10.6.76.40 22", // NAT'd / aliased direct host
+      "203.0.113.8 40222 10.10.0.5 2222", // private bastion-side (ProxyJump) target on a custom port
+    ])(
+      "never leaks the SSH_CONNECTION socket IP across an alias, NAT, or ProxyJump [case %#] (#5925)",
+      (sshConnection) => {
         const lines = buildSshForwardHintLines({
           port: 18790,
           accessUrl: "http://127.0.0.1:18790",
@@ -52,8 +51,8 @@ describe("ssh-forward-hint", () => {
         expect(lines?.join("\n")).not.toContain("10.6.76.40");
         expect(lines?.join("\n")).not.toContain("10.10.0.5");
         expect(lines?.join("\n")).not.toContain("-p ");
-      }
-    });
+      },
+    );
 
     it("renders an explicitly supplied destination verbatim (#5925)", () => {
       const lines = buildSshForwardHintLines({

--- a/src/lib/onboard/station-express-resume.test.ts
+++ b/src/lib/onboard/station-express-resume.test.ts
@@ -121,16 +121,17 @@ describe("DGX Station Express resume (#7048)", () => {
     });
   });
 
-  it("rejects the dual-Station served alias without both qualified pair signals", () => {
-    for (const missing of ["NEMOCLAW_DGX_STATION_PEER", "NEMOCLAW_DGX_STATION_SSH_BINDING"]) {
+  it.each(["NEMOCLAW_DGX_STATION_PEER", "NEMOCLAW_DGX_STATION_SSH_BINDING"])(
+    "rejects the dual-Station served alias without both qualified pair signals [case %#]",
+    (missing) => {
       const env = dualExpressEnv();
       delete env[missing];
       expect(getStationExpressResumeIntent(env, "my-assistant")).toEqual({
         ok: false,
         message: "DGX Station Express has a conflicting NEMOCLAW_MODEL value.",
       });
-    }
-  });
+    },
+  );
 
   it("carries the installer receipt generation in the persisted intent", () => {
     const env = expressEnv();
@@ -282,38 +283,37 @@ describe("DGX Station Express resume (#7048)", () => {
       model: "nvidia/nemotron-3-ultra-550b-a55b",
       sandboxName: "other-assistant",
     },
-  ])("fails closed when recorded state conflicts with Station Express intent", async ({
-    provider,
-    model,
-    sandboxName = "my-assistant",
-  }) => {
-    const session = createSession({
-      mode: "non-interactive",
-      stationExpressIntent: boundUltraIntent,
-      sandboxName,
-      provider,
-      model,
-      steps: {
-        provider_selection: {
-          status: "complete",
-          startedAt: "2026-07-16T00:00:00.000Z",
-          completedAt: "2026-07-16T00:01:00.000Z",
-          error: null,
+  ])(
+    "fails closed when recorded state conflicts with Station Express intent",
+    async ({ provider, model, sandboxName = "my-assistant" }) => {
+      const session = createSession({
+        mode: "non-interactive",
+        stationExpressIntent: boundUltraIntent,
+        sandboxName,
+        provider,
+        model,
+        steps: {
+          provider_selection: {
+            status: "complete",
+            startedAt: "2026-07-16T00:00:00.000Z",
+            completedAt: "2026-07-16T00:01:00.000Z",
+            error: null,
+          },
         },
-      },
-    });
-    session.status = "failed";
-    const env: NodeJS.ProcessEnv = {};
-    const deps = resumeDeps(session);
-    const run = vi.fn(async () => undefined);
+      });
+      session.status = "failed";
+      const env: NodeJS.ProcessEnv = {};
+      const deps = resumeDeps(session);
+      const run = vi.fn(async () => undefined);
 
-    await expect(
-      withStationExpressResumeEnvironment(run, deps, env)({ resume: true }),
-    ).rejects.toThrow("exit 1");
+      await expect(
+        withStationExpressResumeEnvironment(run, deps, env)({ resume: true }),
+      ).rejects.toThrow("exit 1");
 
-    expect(run).not.toHaveBeenCalled();
-    expect(deps.error).toHaveBeenCalledWith(expect.stringContaining("state is invalid"));
-  });
+      expect(run).not.toHaveBeenCalled();
+      expect(deps.error).toHaveBeenCalledWith(expect.stringContaining("state is invalid"));
+    },
+  );
 
   it.each([
     {

--- a/src/lib/onboard/workload/native-artifact.test.ts
+++ b/src/lib/onboard/workload/native-artifact.test.ts
@@ -101,29 +101,23 @@ describe("native OpenClaw artifact workload contract", () => {
     expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(/canonical relative path/u);
   });
 
-  it.each([
-    "../agent",
-    "agent/../work",
-    "agent//work",
-    "agent/work.",
-    "agent/work ",
-  ])("rejects non-canonical working directory %j (#8178)", (workingDirectory) => {
-    const value = receipt();
-    launch(value).workingDirectory = workingDirectory;
-    expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(/canonical relative path/u);
-  });
+  it.each(["../agent", "agent/../work", "agent//work", "agent/work.", "agent/work "])(
+    "rejects non-canonical working directory %j (#8178)",
+    (workingDirectory) => {
+      const value = receipt();
+      launch(value).workingDirectory = workingDirectory;
+      expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(/canonical relative path/u);
+    },
+  );
 
-  it.each([
-    "bin/claw.exe.",
-    "bin/claw.exe ",
-    "bin/CON",
-    "bin/nul.txt",
-    "COM1/runtime",
-  ])("rejects Windows-normalizing executable path %j (#8178)", (relativePath) => {
-    const value = receipt();
-    executable(value).relativePath = relativePath;
-    expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(/canonical relative path/u);
-  });
+  it.each(["bin/claw.exe.", "bin/claw.exe ", "bin/CON", "bin/nul.txt", "COM1/runtime"])(
+    "rejects Windows-normalizing executable path %j (#8178)",
+    (relativePath) => {
+      const value = receipt();
+      executable(value).relativePath = relativePath;
+      expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(/canonical relative path/u);
+    },
+  );
 
   it("records environment-variable names without accepting literal assignments (#8178)", () => {
     const value = receipt();
@@ -175,23 +169,25 @@ describe("native OpenClaw artifact workload contract", () => {
     );
   });
 
-  it("rejects OCI image and mutable download fields (#8178)", () => {
-    for (const extra of ["image", "imageDigest", "downloadUrl"]) {
+  it.each(["image", "imageDigest", "downloadUrl"])(
+    "rejects OCI image and mutable download fields [case %#] (#8178)",
+    (extra) => {
       const value = receipt();
       value[extra] = "unexpected";
       expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(
         /contract must contain exactly/u,
       );
-    }
-  });
+    },
+  );
 
-  it("requires credential proxy replay and the shared artifact flag (#8178)", () => {
-    for (const field of ["credentialProxyReplayRequired", "shared"] as const) {
+  it.each(["credentialProxyReplayRequired", "shared"] as const)(
+    "requires credential proxy replay and the shared artifact flag [case %#] (#8178)",
+    (field) => {
       const value = receipt();
       value[field] = false;
       expect(() => parseNativeArtifactWorkloadReceiptV1(value)).toThrow(
         new RegExp(`contract\\.${field} must be true`, "u"),
       );
-    }
-  });
+    },
+  );
 });

--- a/src/lib/onboard/wsl-docker-desktop-gpu.test.ts
+++ b/src/lib/onboard/wsl-docker-desktop-gpu.test.ts
@@ -122,9 +122,9 @@ describe("createArm64WslDockerDesktopGpuProver (#4565)", () => {
     expect(runProof).toHaveBeenCalledTimes(1);
   });
 
-  it("leaves WSL hosts without Docker Desktop unproven (#8096)", () => {
-    // Windows-on-ARM passthrough scope is unchanged: only native Linux is added.
-    for (const status of ["not-docker-desktop", "unknown"] as const) {
+  it.each(["not-docker-desktop", "unknown"] as const)(
+    "leaves WSL hosts without Docker Desktop unproven [case %#] (#8096)",
+    (status) => {
       const runProof = vi.fn(() => passingProof);
       const prover = createArm64WslDockerDesktopGpuProver({
         platform: "linux",
@@ -136,8 +136,8 @@ describe("createArm64WslDockerDesktopGpuProver (#4565)", () => {
       });
       expect(prover(["JMJWOA-Generic-GPU"])).toBeNull();
       expect(runProof).not.toHaveBeenCalled();
-    }
-  });
+    },
+  );
 
   it("runs the bounded proof and reports the result on ARM64 Docker Desktop WSL", () => {
     const runProof = vi.fn((_argv: string[], _timeoutMs: number) => passingProof);

--- a/src/lib/openclaw/agent-json-provenance.test.ts
+++ b/src/lib/openclaw/agent-json-provenance.test.ts
@@ -358,12 +358,16 @@ describe("openClawAgentIncompleteTurnSignal", () => {
     expect(openClawAgentIncompleteTurnSignal(raw)).toBeNull();
   });
 
-  it("ignores a timeout phase that carries no value (#8723)", () => {
-    for (const timeoutPhase of ["", "   ", null, 3, true]) {
-      const raw = JSON.stringify({ status: "ok", result: { payloads: [], meta: { timeoutPhase } } });
+  it.each(["", "   ", null, 3, true])(
+    "ignores a timeout phase that carries no value [case %#] (#8723)",
+    (timeoutPhase) => {
+      const raw = JSON.stringify({
+        status: "ok",
+        result: { payloads: [], meta: { timeoutPhase } },
+      });
       expect(openClawAgentIncompleteTurnSignal(raw)).toBeNull();
-    }
-  });
+    },
+  );
 
   it("leaves the timeout phase absent for an abandoned turn that did not time out (#8723)", () => {
     const raw = JSON.stringify({

--- a/src/lib/security/credential-env.test.ts
+++ b/src/lib/security/credential-env.test.ts
@@ -14,73 +14,74 @@ import {
 } from "./credential-env";
 
 describe("isCredentialShapedName", () => {
-  it("matches credential stem words as the exact name", () => {
-    for (const name of ["KEY", "secret", "TOKEN", "password", "passwd", "auth", "credential"]) {
+  it.each(["KEY", "secret", "TOKEN", "password", "passwd", "auth", "credential"])(
+    "matches the exact credential stem %s",
+    (name) => {
       expect(isCredentialShapedName(name)).toBe(true);
-    }
+    },
+  );
+
+  it.each(["MY_API_KEY", "provider-secret", "SESSION_TOKEN", "x_auth_y"])(
+    "matches the separated credential name %s",
+    (name) => {
+      expect(isCredentialShapedName(name)).toBe(true);
+    },
+  );
+
+  it.each([
+    "APIKEY",
+    "apikey",
+    "accesskey",
+    "accessKey",
+    "secretkey",
+    "authtoken",
+    "refreshToken",
+    "accesstoken",
+    "clientsecret",
+  ])("matches the compound credential name %s", (name) => {
+    expect(isCredentialShapedName(name)).toBe(true);
   });
 
-  it("matches stems joined to other words with separators", () => {
-    for (const name of ["MY_API_KEY", "provider-secret", "SESSION_TOKEN", "x_auth_y"]) {
-      expect(isCredentialShapedName(name)).toBe(true);
-    }
+  it.each([
+    "PRIVATE_KEY",
+    "privateKey",
+    "passcode",
+    "personalAccessToken",
+    "connection_string",
+    "webhookURL",
+    "authorization",
+    "bearerToken",
+    "cookies",
+    "PAT",
+    "PIN",
+    "DSN",
+    "connectionstring",
+  ])("matches the local credential-capture name %s (#5048)", (name) => {
+    expect(isCredentialShapedName(name)).toBe(true);
   });
 
-  it("matches api/apikey and other run-together compound forms", () => {
-    for (const name of [
-      "APIKEY",
-      "apikey",
-      "accesskey",
-      "accessKey",
-      "secretkey",
-      "authtoken",
-      "refreshToken",
-      "accesstoken",
-      "clientsecret",
-    ]) {
-      expect(isCredentialShapedName(name)).toBe(true);
-    }
-  });
-
-  it("matches sensitive compound names shared with local credential capture (#5048)", () => {
-    for (const name of [
-      "PRIVATE_KEY",
-      "privateKey",
-      "passcode",
-      "personalAccessToken",
-      "connection_string",
-      "webhookURL",
-      "authorization",
-      "bearerToken",
-      "cookies",
-      "PAT",
-      "PIN",
-      "DSN",
-      "connectionstring",
-    ]) {
-      expect(isCredentialShapedName(name)).toBe(true);
-    }
-  });
-
-  it("does not overmatch sensitive-looking substrings inside benign names (#5048)", () => {
-    for (const name of ["SPIN", "DISPATCH", "COOKIEJAR", "PRIVATEERING"]) {
+  it.each(["SPIN", "DISPATCH", "COOKIEJAR", "PRIVATEERING"])(
+    "does not overmatch the benign name %s (#5048)",
+    (name) => {
       expect(isCredentialShapedName(name)).toBe(false);
-    }
-  });
+    },
+  );
 
-  it("does not match benign names", () => {
-    for (const name of ["PATH", "HOME", "NO_PROXY", "HTTP_PROXY", "LANG", "monkey", "keyboard"]) {
+  it.each(["PATH", "HOME", "NO_PROXY", "HTTP_PROXY", "LANG", "monkey", "keyboard"])(
+    "does not match the benign name %s",
+    (name) => {
       expect(isCredentialShapedName(name)).toBe(false);
-    }
-  });
+    },
+  );
 });
 
 describe("shouldStripCredentialEnv", () => {
-  it("strips every supported credential env name", () => {
-    for (const name of SUPPORTED_CREDENTIAL_ENV_NAMES) {
+  it.each([...SUPPORTED_CREDENTIAL_ENV_NAMES])(
+    "strips the supported credential env name %s",
+    (name) => {
       expect(shouldStripCredentialEnv(name)).toBe(true);
-    }
-  });
+    },
+  );
 
   it("keeps the legacy explicit-deny export on the shared inventory", () => {
     expect(CREDENTIAL_ENV_EXPLICIT_DENY).toBe(SUPPORTED_CREDENTIAL_ENV_NAMES);

--- a/src/lib/security/credential-filter.test.ts
+++ b/src/lib/security/credential-filter.test.ts
@@ -483,16 +483,14 @@ describe("sanitizeConfigFile", () => {
     expect(readFileSync(configPath, "utf-8")).toBe(source);
   });
 
-  it("preserves empty and comment-only YAML documents", () => {
-    for (const [name, source] of [
-      ["empty.yaml", ""],
-      ["comments.yaml", "# nothing to sanitize\n"],
-    ]) {
-      const configPath = join(tmpDir, name);
-      writeFileSync(configPath, source);
-      expect(sanitizeYamlConfigFile(configPath)).toBe(true);
-      expect(readFileSync(configPath, "utf-8")).toBe(source);
-    }
+  it.each([
+    ["empty.yaml", ""],
+    ["comments.yaml", "# nothing to sanitize\n"],
+  ])("preserves empty and comment-only YAML documents [case %#]", (name, source) => {
+    const configPath = join(tmpDir, name);
+    writeFileSync(configPath, source);
+    expect(sanitizeYamlConfigFile(configPath)).toBe(true);
+    expect(readFileSync(configPath, "utf-8")).toBe(source);
   });
 
   it("sanitizes valid JSON arrays instead of treating them as failures", () => {

--- a/src/lib/shields/audit-reader.test.ts
+++ b/src/lib/shields/audit-reader.test.ts
@@ -96,10 +96,10 @@ describe("readRecentShieldsAutoRestore", () => {
     expect(result).toEqual({ kind: "none" });
   });
 
-  it("returns null timeoutSeconds for out-of-bounds timeout values in shields_down entry (#5922)", () => {
-    const now = new Date().toISOString();
-    // JSON.stringify serializes these correctly (finite numbers)
-    for (const bad of [0, -1, 1801, 9999, 1.5]) {
+  it.each([0, -1, 1801, 9999, 1.5])(
+    "returns null timeoutSeconds for out-of-bounds value %s in shields_down entry (#5922)",
+    (bad) => {
+      const now = new Date().toISOString();
       fs.writeFileSync(
         auditPath,
         JSON.stringify({
@@ -115,8 +115,8 @@ describe("readRecentShieldsAutoRestore", () => {
       const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
       expect(event.timestamp, `bad value ${String(bad)}`).toBe(now);
       expect(event.timeoutSeconds, `bad value ${String(bad)}`).toBeNull();
-    }
-  });
+    },
+  );
 
   it("returns correct timeoutSeconds when a malformed JSONL line sits between shields_down and shields_auto_restore (#5922)", () => {
     const now = new Date().toISOString();
@@ -222,11 +222,12 @@ describe("readRecentShieldsAutoRestore", () => {
     });
   });
 
-  it("returns null timeoutSeconds when shields_down has NaN or Infinity as a raw string payload (#5922)", () => {
-    // JSON.stringify(NaN) and JSON.stringify(Infinity) both produce "null",
-    // so write the JSONL line manually to exercise the non-finite path.
-    const now = new Date().toISOString();
-    for (const rawValue of ["NaN", "Infinity", "-Infinity"]) {
+  it.each(["NaN", "Infinity", "-Infinity"])(
+    "returns null timeoutSeconds when shields_down has raw %s payload (#5922)",
+    (rawValue) => {
+      // JSON.stringify(NaN) and JSON.stringify(Infinity) both produce "null",
+      // so write the JSONL line manually to exercise the non-finite path.
+      const now = new Date().toISOString();
       const downLine = `{"action":"shields_down","sandbox":"alpha","timestamp":"${new Date(Date.now() - 25 * 1000).toISOString()}","timeout_seconds":${rawValue}}`;
       const restoreLine = JSON.stringify({
         action: "shields_auto_restore",
@@ -238,8 +239,8 @@ describe("readRecentShieldsAutoRestore", () => {
       const event = requireEvent(readRecentShieldsAutoRestore("alpha", 10 * 60 * 1000, auditPath));
       expect(event.timestamp, `raw value ${rawValue}`).toBe(now);
       expect(event.timeoutSeconds, `raw value ${rawValue}`).toBeNull();
-    }
-  });
+    },
+  );
 
   it("distinguishes unreadable audit history from an absent audit file (#5922)", () => {
     fs.mkdirSync(auditPath);

--- a/src/lib/shields/openclaw-config-lock.test.ts
+++ b/src/lib/shields/openclaw-config-lock.test.ts
@@ -432,8 +432,9 @@ describe("OpenClaw config guard failed-startup recovery wiring (#8304)", () => {
     expect(recovery?.[planIndex + 1]).toBe('{"version":1}');
   });
 
-  it("rejects a missing recovery plan before privileged execution", () => {
-    for (const planJson of [undefined, ""]) {
+  it.each([undefined, ""])(
+    "rejects a missing recovery plan before privileged execution [case %#]",
+    (planJson) => {
       const { calls, privileged } = createExec(true);
       const result = runOpenClawConfigGuard(privileged, "unlock-failed-startup", {
         planJson,
@@ -444,8 +445,8 @@ describe("OpenClaw config guard failed-startup recovery wiring (#8304)", () => {
         chattrApplied: false,
       });
       expect(calls).toEqual([]);
-    }
-  });
+    },
+  );
 
   it("refuses the recovery action when the sandbox has no installed guard", () => {
     const { privileged } = createExec(false);

--- a/src/lib/state/registry-lock.test.ts
+++ b/src/lib/state/registry-lock.test.ts
@@ -116,8 +116,9 @@ describe("registry lock ownership decisions", () => {
     ).toBe("break");
   });
 
-  it("never age-breaks an exact original or unverifiable process-bound owner", () => {
-    for (const ownerStatus of ["original", "unverifiable"] as const) {
+  it.each(["original", "unverifiable"] as const)(
+    "never age-breaks an exact original or unverifiable process-bound owner [case %#]",
+    (ownerStatus) => {
       expect(
         classifyExistingLock({
           ownerAlive: true,
@@ -128,16 +129,17 @@ describe("registry lock ownership decisions", () => {
           staleMs: STALE,
         }),
       ).toBe("wait");
-    }
-  });
+    },
+  );
 
-  it("retains the bounded age rule for ordinary or unreadable owners", () => {
-    for (const [ownerPid, nowMs, expected] of [
-      [4242, LOCK_MTIME + 1, "wait"],
-      [4242, LOCK_MTIME + STALE + 1, "break"],
-      [null, LOCK_MTIME + 1, "wait"],
-      [null, LOCK_MTIME + STALE + 1, "break"],
-    ] as const) {
+  it.each([
+    [4242, LOCK_MTIME + 1, "wait"],
+    [4242, LOCK_MTIME + STALE + 1, "break"],
+    [null, LOCK_MTIME + 1, "wait"],
+    [null, LOCK_MTIME + STALE + 1, "break"],
+  ] as const)(
+    "retains the bounded age rule for ordinary or unreadable owners [case %#]",
+    (ownerPid, nowMs, expected) => {
       expect(
         classifyExistingLock({
           ownerAlive: ownerPid !== null,
@@ -148,8 +150,8 @@ describe("registry lock ownership decisions", () => {
           staleMs: STALE,
         }),
       ).toBe(expected);
-    }
-  });
+    },
+  );
 });
 
 describe("process-bound registry locking", () => {

--- a/test/bump-version.test.ts
+++ b/test/bump-version.test.ts
@@ -13,11 +13,12 @@ import {
 } from "../scripts/bump-version.mts";
 
 describe("bump-version release contract", () => {
-  it("rejects removed release PR flags", () => {
-    for (const flag of ["--create-pr", "--no-create-pr", "--branch=release/1.2.3"]) {
+  it.each(["--create-pr", "--no-create-pr", "--branch=release/1.2.3"])(
+    "rejects removed release PR flags [case %#]",
+    (flag) => {
       expect(() => parseArgs(["1.2.3", flag])).toThrow(`Unknown flag: ${flag}`);
-    }
-  });
+    },
+  );
 
   it("has no reachable scripts/bump-version.ts entrypoint left behind by the .mts migration", () => {
     const repoRoot = path.join(import.meta.dirname, "..");

--- a/test/config-set.test.ts
+++ b/test/config-set.test.ts
@@ -115,14 +115,15 @@ describe("selectDirectSandboxContainer", () => {
 
 describe("config set helpers", () => {
   describe("buildConfigSetRestartGuidance", () => {
-    it("keeps managed restart guidance for OpenClaw and Hermes", () => {
-      for (const agentName of ["openclaw", "hermes"]) {
+    it.each(["openclaw", "hermes"])(
+      "keeps managed restart guidance for OpenClaw and Hermes [case %#]",
+      (agentName) => {
         const output = buildConfigSetRestartGuidance("alpha", agentName).join("\n");
 
         expect(output).toContain("--restart");
         expect(output).toContain("nemoclaw 'alpha' gateway restart");
-      }
-    });
+      },
+    );
 
     it("does not name Hermes in the OpenClaw restart note (#8614)", () => {
       const output = buildConfigSetRestartGuidance("alpha", "openclaw").join("\n");

--- a/test/corporate-ca-dockerfile-decode.test.ts
+++ b/test/corporate-ca-dockerfile-decode.test.ts
@@ -72,15 +72,16 @@ afterEach(() => {
 });
 
 describe("Deep Agents Code Dockerfile corporate CA validation", () => {
-  it("requires CA:TRUE at every X.509 certificate parser (#8119)", () => {
-    for (const dockerfile of DEEP_AGENTS_DOCKERFILES) {
+  it.each([...DEEP_AGENTS_DOCKERFILES])(
+    "requires CA:TRUE at every X.509 certificate parser [case %#] (#8119)",
+    (dockerfile) => {
       const source = readFileSync(dockerfile, "utf8");
       const parsedCertificates = source.match(/new X509Certificate\(/g) ?? [];
       const caChecks = source.match(/new X509Certificate\([^)]*\)\.ca/g) ?? [];
       expect(parsedCertificates.length).toBeGreaterThan(0);
       expect(caChecks).toHaveLength(parsedCertificates.length);
-    }
-  });
+    },
+  );
 });
 
 describe.skipIf(!canRunDecodeBlock)("Deep Agents Code corporate CA constraint", () => {

--- a/test/credential-exposure.test.ts
+++ b/test/credential-exposure.test.ts
@@ -104,8 +104,9 @@ describe("credential exposure in process arguments", () => {
     }
   });
 
-  it("subprocess-env NO_PROXY local hosts are in sync for CLI and plugin", () => {
-    for (const withLocalNoProxy of [withCliLocalNoProxy, withPluginLocalNoProxy]) {
+  it.each([withCliLocalNoProxy, withPluginLocalNoProxy])(
+    "subprocess-env NO_PROXY local hosts are in sync for CLI and plugin [case %#]",
+    (withLocalNoProxy) => {
       const env: Record<string, string> = {
         HTTP_PROXY: "http://proxy.example.com:8888",
         NO_PROXY: "corp.internal,localhost",
@@ -120,8 +121,8 @@ describe("credential exposure in process arguments", () => {
       expect(env.no_proxy).toBe(
         "corp.internal,localhost,127.0.0.1,host.docker.internal,host.containers.internal,::1,0.0.0.0,inference.local",
       );
-    }
-  });
+    },
+  );
 
   it("subprocess env builder does not spread full process.env into subprocesses", () => {
     const previous = {

--- a/test/credential-rotation-docs.test.ts
+++ b/test/credential-rotation-docs.test.ts
@@ -18,47 +18,47 @@ function fencedBlocks(text: string, language: string): string[] {
 }
 
 describe("credential rotation documentation", () => {
-  it("keeps every non-interactive onboard example executable", () => {
-    const examples = [
-      ...fencedBlocks(readGuide(), "bash"),
-      ...fencedBlocks(readGuide(), "yaml"),
-    ].filter((block) => block.includes("onboard") && block.includes("--non-interactive"));
+  const nonInteractiveOnboardExamples = [
+    ...fencedBlocks(readGuide(), "bash"),
+    ...fencedBlocks(readGuide(), "yaml"),
+  ].filter((block) => block.includes("onboard") && block.includes("--non-interactive"));
 
-    expect(examples.length).toBeGreaterThan(0);
-    for (const example of examples) {
+  it("includes a non-interactive onboard example", () => {
+    expect(nonInteractiveOnboardExamples.length).toBeGreaterThan(0);
+  });
+
+  it.each(nonInteractiveOnboardExamples)(
+    "keeps non-interactive onboard example %# executable",
+    (example) => {
       expect(example).toContain("--name <sandbox>");
       expect(example).toContain("--yes-i-accept-third-party-software");
-    }
-  });
+    },
+  );
 
   it("uses normal onboarding instead of interrupted-session resume", () => {
     expect(readGuide()).not.toContain("--resume");
   });
 
-  it("keeps replacement credentials out of command text (#6266)", () => {
+  it.each([
+    "NVIDIA_INFERENCE_API_KEY",
+    "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
+    "TELEGRAM_BOT_TOKEN",
+    "DISCORD_BOT_TOKEN",
+    "BRAVE_API_KEY",
+    "TAVILY_API_KEY",
+  ])("keeps replacement credential %s out of command text (#6266)", (variable) => {
     const guide = readGuide();
-    const credentialVariables = [
-      "NVIDIA_INFERENCE_API_KEY",
-      "SLACK_BOT_TOKEN",
-      "SLACK_APP_TOKEN",
-      "TELEGRAM_BOT_TOKEN",
-      "DISCORD_BOT_TOKEN",
-      "BRAVE_API_KEY",
-      "TAVILY_API_KEY",
-    ];
-
-    for (const variable of credentialVariables) {
-      expect(guide).toMatch(new RegExp(`IFS= read -r -s ${variable}`));
-      expect(guide).toMatch(new RegExp(`unset [^\\n]*\\b${variable}\\b`));
-      expect(guide).not.toMatch(new RegExp(`${variable}=[^\\s$]`));
-    }
+    expect(guide).toMatch(new RegExp(`IFS= read -r -s ${variable}`));
+    expect(guide).toMatch(new RegExp(`unset [^\\n]*\\b${variable}\\b`));
+    expect(guide).not.toMatch(new RegExp(`${variable}=[^\\s$]`));
   });
 
-  it("documents onboarding-managed messaging and web search recreation", () => {
-    const guide = readGuide();
-    const bash = fencedBlocks(guide, "bash");
-
-    for (const credential of ["SLACK_BOT_TOKEN", "TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN"]) {
+  it.each(["SLACK_BOT_TOKEN", "TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN"])(
+    "documents onboarding-managed recreation for %s",
+    (credential) => {
+      const guide = readGuide();
+      const bash = fencedBlocks(guide, "bash");
       const example = bash.find(
         (block) => block.includes(credential) && block.includes("onboard --name <sandbox>"),
       );
@@ -66,8 +66,12 @@ describe("credential rotation documentation", () => {
       expect(example, credential).toContain("--yes-i-accept-third-party-software");
       expect(example, credential).not.toContain("channels add");
       expect(example, credential).not.toContain("rebuild --yes");
-    }
+    },
+  );
 
+  it("documents messaging and web search recreation boundaries", () => {
+    const guide = readGuide();
+    const bash = fencedBlocks(guide, "bash");
     expect(guide).toContain("WECHAT_BOT_TOKEN");
     expect(guide).toContain("MSTEAMS_APP_PASSWORD");
     expect(guide).toContain("Telegram, Discord, Slack, WeChat, or Microsoft Teams");
@@ -88,12 +92,16 @@ describe("credential rotation documentation", () => {
     );
     expect(guide).not.toContain("rebuild downtime");
 
-    const searchExamples = bash.filter((block) => block.includes("NEMOCLAW_WEB_SEARCH_PROVIDER"));
-    expect(searchExamples.length).toBeGreaterThan(0);
-    for (const example of searchExamples) {
-      expect(example).toContain("--fresh");
-      expect(example).toContain("--recreate-sandbox");
-    }
+    expect(bash.some((block) => block.includes("NEMOCLAW_WEB_SEARCH_PROVIDER"))).toBe(true);
+  });
+
+  it.each(
+    fencedBlocks(readGuide(), "bash").filter((block) =>
+      block.includes("NEMOCLAW_WEB_SEARCH_PROVIDER"),
+    ),
+  )("uses recreation flags in web search example %#", (example) => {
+    expect(example).toContain("--fresh");
+    expect(example).toContain("--recreate-sandbox");
   });
 
   it("uses real provider names and separates configuration checks from live proof", () => {

--- a/test/deepagents-mcp-runtime-capability.test.ts
+++ b/test/deepagents-mcp-runtime-capability.test.ts
@@ -55,18 +55,19 @@ describe("Deep Agents managed MCP runtime capability", () => {
     });
   });
 
-  it("requires a rebuild before MCP side effects on stale or unreachable images", () => {
-    for (const result of [
-      null,
-      { status: 2, stdout: "", stderr: "unknown option" },
-      { status: 0, stdout: "NEMOCLAW_DEEPAGENTS_MCP_CAPABILITY=1\n", stderr: "" },
-      { status: 0, stdout: "deepagents-code 0.1.12\n", stderr: "" },
-    ]) {
+  it.each([
+    null,
+    { status: 2, stdout: "", stderr: "unknown option" },
+    { status: 0, stdout: "NEMOCLAW_DEEPAGENTS_MCP_CAPABILITY=1\n", stderr: "" },
+    { status: 0, stdout: "deepagents-code 0.1.12\n", stderr: "" },
+  ])(
+    "requires a rebuild before MCP side effects on stale or unreachable images [case %#]",
+    (result) => {
       const probe = runDeepAgentsProbe(result);
       expect(probe.calls).toHaveLength(1);
       expect(probe.message).toMatch(/does not contain managed MCP capability v2/i);
       expect(probe.message).toMatch(/rebuild the sandbox before changing authenticated MCP state/i);
       expect(probe.message).not.toContain("unknown option");
-    }
-  });
+    },
+  );
 });

--- a/test/e2e-fixture-dependency-review.test.ts
+++ b/test/e2e-fixture-dependency-review.test.ts
@@ -36,19 +36,16 @@ describe("E2E fixture dependency review", () => {
     }
   });
 
-  it("records the fixture threat controls and revalidation contract", () => {
-    for (const marker of [
-      "npm ci --ignore-scripts",
-      "read-only `contents` permission",
-      "full-SHA-pinned actions",
-      "disables checkout credential persistence",
-      "receives no repository secrets",
-      "npm audit --package-lock-only --ignore-scripts --json",
-      "accepted residual risk is limited to this secret-free E2E lane with read-only contents permission",
-      "Rerun it whenever `package.json` or `package-lock.json` changes",
-    ]) {
-      expect(review).toContain(marker);
-    }
+  it.each([
+    "npm ci --ignore-scripts",
+    "read-only `contents` permission",
+    "full-SHA-pinned actions",
+    "disables checkout credential persistence",
+    "receives no repository secrets",
+    "npm audit --package-lock-only --ignore-scripts --json",
+    "accepted residual risk is limited to this secret-free E2E lane with read-only contents permission",
+    "Rerun it whenever `package.json` or `package-lock.json` changes",
+  ])("records the fixture threat controls and revalidation contract [case %#]", (marker) => {
+    expect(review).toContain(marker);
   });
-
 });

--- a/test/e2e/support/e2e-cleanup-resources.test.ts
+++ b/test/e2e/support/e2e-cleanup-resources.test.ts
@@ -109,8 +109,9 @@ describe("cleanup resources", () => {
     expect(calls).toBe(1);
   });
 
-  it("registers sandbox cleanup before installer side effects (#7146)", () => {
-    for (const fileName of ["full-e2e.test.ts", "hermes-e2e.test.ts"]) {
+  it.each(["full-e2e.test.ts", "hermes-e2e.test.ts"])(
+    "registers sandbox cleanup before installer side effects [case %#] (#7146)",
+    (fileName) => {
       const source = fs.readFileSync(
         path.resolve(import.meta.dirname, "..", "live", fileName),
         "utf8",
@@ -125,8 +126,8 @@ describe("cleanup resources", () => {
       expect(installerStart, `${fileName} must invoke install.sh`).toBeGreaterThan(
         cleanupRegistration,
       );
-    }
-  });
+    },
+  );
 
   it("continues typed cleanup after a resource failure", async () => {
     const calls: string[] = [];

--- a/test/e2e/support/e2e-live-target-gating.test.ts
+++ b/test/e2e/support/e2e-live-target-gating.test.ts
@@ -131,38 +131,32 @@ describe("live E2E target gating", () => {
     expect(collected).toEqual(discovered);
   });
 
-  it(
-    "applies each special target's explicit opt-in at real Vitest collection",
+  it.each([["issue-4434-tui-unreachable-inference.test.ts", "NEMOCLAW_ISSUE_4434_LIVE"]] as const)(
+    "applies the %s special target's %s opt-in at real Vitest collection",
     testTimeoutOptions(15_000),
-    () => {
-      const gatedFiles = [
-        ["issue-4434-tui-unreachable-inference.test.ts", "NEMOCLAW_ISSUE_4434_LIVE"],
-      ] as const;
-      const files = gatedFiles.map(([file]) => file);
-      const disabled = listLiveTests({ enabled: true, files });
+    (file, gate) => {
+      const disabled = listLiveTests({ enabled: true, files: [file] });
 
       expect(disabled.status, disabled.stderr || disabled.stdout).toBe(0);
-      for (const [file, gate] of gatedFiles) {
-        const enabled = listLiveTests({ enabled: true, env: { [gate]: "1" }, files: [file] });
+      const enabled = listLiveTests({ enabled: true, env: { [gate]: "1" }, files: [file] });
 
-        expect(enabled.status, enabled.stderr || enabled.stdout).toBe(0);
-        expect(
-          linesForFile(enabled.lines, file).length,
-          `${file} should collect more tests when ${gate}=1`,
-        ).toBeGreaterThan(linesForFile(disabled.lines, file).length);
-      }
+      expect(enabled.status, enabled.stderr || enabled.stdout).toBe(0);
+      expect(
+        linesForFile(enabled.lines, file).length,
+        `${file} should collect more tests when ${gate}=1`,
+      ).toBeGreaterThan(linesForFile(disabled.lines, file).length);
     },
   );
 
-  it("collects exactly one reviewed MCP bridge agent shard", testTimeoutOptions(30_000), () => {
-    const file = "mcp-bridge.test.ts";
-    const expectedTestByShard = {
-      deepagents: "mcp-bridge-deepagents",
-      hermes: "mcp-bridge-hermes",
-      openclaw: "mcp-bridge",
-    } as const;
-
-    for (const [shard, expectedTest] of Object.entries(expectedTestByShard)) {
+  it.each([
+    ["deepagents", "mcp-bridge-deepagents"],
+    ["hermes", "mcp-bridge-hermes"],
+    ["openclaw", "mcp-bridge"],
+  ] as const)(
+    "collects exactly the reviewed %s MCP bridge agent shard",
+    testTimeoutOptions(30_000),
+    (shard, expectedTest) => {
+      const file = "mcp-bridge.test.ts";
       const result = listLiveTests({
         enabled: true,
         env: { NEMOCLAW_MCP_BRIDGE_AGENT: shard },
@@ -173,8 +167,11 @@ describe("live E2E target gating", () => {
       expect(linesForFile(result.lines, file)).toEqual([
         `[e2e-live] test/e2e/live/${file} > ${expectedTest}`,
       ]);
-    }
+    },
+  );
 
+  it("rejects an unreviewed MCP bridge agent shard", testTimeoutOptions(30_000), () => {
+    const file = "mcp-bridge.test.ts";
     const invalid = listLiveTests({
       enabled: true,
       env: { NEMOCLAW_MCP_BRIDGE_AGENT: "all" },
@@ -184,84 +181,75 @@ describe("live E2E target gating", () => {
     expect(invalid.stderr).toContain("Unsupported NEMOCLAW_MCP_BRIDGE_AGENT: all");
   });
 
-  it(
-    "rejects a TARGET_ID no registry target declares (#8286)",
+  it("rejects a TARGET_ID no registry target declares (#8286)", testTimeoutOptions(30_000), () => {
+    const file = "registry-targets.test.ts";
+
+    // The workflow selects one target with `-t "^${TARGET_ID}$"`. An id no
+    // target declares matches nothing, and an empty id builds `-t "^$"`,
+    // which also matches nothing, so the run would collect no test and
+    // exit 0 having executed no target.
+    const unknown = listLiveTests({
+      enabled: true,
+      env: { TARGET_ID: "does-not-exist" },
+      files: [file],
+    });
+
+    expect(unknown.status, unknown.stdout).not.toBe(0);
+    expect(`${unknown.stdout}${unknown.stderr}`).toContain("Unknown target 'does-not-exist'");
+
+    const empty = listLiveTests({ enabled: true, env: { TARGET_ID: "" }, files: [file] });
+
+    expect(empty.status, empty.stdout).not.toBe(0);
+    expect(`${empty.stdout}${empty.stderr}`).toContain("Selected target ID ''");
+
+    const unsafe = listLiveTests({
+      enabled: true,
+      env: { TARGET_ID: "unsafe/id" },
+      files: [file],
+    });
+
+    expect(unsafe.status, unsafe.stdout).not.toBe(0);
+    expect(`${unsafe.stdout}${unsafe.stderr}`).toContain("Selected target ID 'unsafe/id'");
+  });
+
+  it.each([true, false])(
+    "collects registry targets when wired is %s for a declared TARGET_ID (#8286)",
     testTimeoutOptions(30_000),
-    () => {
-      const file = "registry-targets.test.ts";
-
-      // The workflow selects one target with `-t "^${TARGET_ID}$"`. An id no
-      // target declares matches nothing, and an empty id builds `-t "^$"`,
-      // which also matches nothing, so the run would collect no test and
-      // exit 0 having executed no target.
-      const unknown = listLiveTests({
-        enabled: true,
-        env: { TARGET_ID: "does-not-exist" },
-        files: [file],
-      });
-
-      expect(unknown.status, unknown.stdout).not.toBe(0);
-      expect(`${unknown.stdout}${unknown.stderr}`).toContain("Unknown target 'does-not-exist'");
-
-      const empty = listLiveTests({ enabled: true, env: { TARGET_ID: "" }, files: [file] });
-
-      expect(empty.status, empty.stdout).not.toBe(0);
-      expect(`${empty.stdout}${empty.stderr}`).toContain("Selected target ID ''");
-
-      const unsafe = listLiveTests({
-        enabled: true,
-        env: { TARGET_ID: "unsafe/id" },
-        files: [file],
-      });
-
-      expect(unsafe.status, unsafe.stdout).not.toBe(0);
-      expect(`${unsafe.stdout}${unsafe.stderr}`).toContain("Selected target ID 'unsafe/id'");
-    },
-  );
-
-  it(
-    "collects registry targets for any declared TARGET_ID (#8286)",
-    testTimeoutOptions(30_000),
-    () => {
+    (wired) => {
       const file = "registry-targets.test.ts";
 
       // The check rejects only ids the registry does not declare, so a wired id
       // and a declared placeholder both still collect. Collecting at least one
       // test proves the file was evaluated rather than skipped outright.
-      for (const wired of [true, false]) {
-        const result = listLiveTests({
-          enabled: true,
-          env: { TARGET_ID: declaredTargetId({ wired }) },
-          files: [file],
-        });
+      const result = listLiveTests({
+        enabled: true,
+        env: { TARGET_ID: declaredTargetId({ wired }) },
+        files: [file],
+      });
 
-        expect(result.status, result.stderr || result.stdout).toBe(0);
-        expect(linesForFile(result.lines, file).length).toBeGreaterThan(0);
-      }
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(linesForFile(result.lines, file).length).toBeGreaterThan(0);
     },
   );
 
-  it("applies Linux gates at real Vitest collection", () => {
-    const linuxTests = [
-      [
-        "spark-install.test.ts",
-        "spark install path: standard non-interactive install leaves NemoClaw and OpenShell usable",
-      ],
-      [
-        "openshell-gateway-upgrade.test.ts",
-        "openshell-gateway-upgrade: upgrades old working OpenClaw claw and restores survivor state",
-      ],
-    ] as const;
+  it.each([
+    [
+      "spark-install.test.ts",
+      "spark install path: standard non-interactive install leaves NemoClaw and OpenShell usable",
+    ],
+    [
+      "openshell-gateway-upgrade.test.ts",
+      "openshell-gateway-upgrade: upgrades old working OpenClaw claw and restores survivor state",
+    ],
+  ] as const)("applies the Linux gate to %s at real Vitest collection", (file, testName) => {
     const result = listLiveTests({
       enabled: true,
-      files: linuxTests.map(([file]) => file),
+      files: [file],
     });
 
     expect(result.status, result.stderr || result.stdout).toBe(0);
-    for (const [file, testName] of linuxTests) {
-      expect(linesForFile(result.lines, file).some((line) => line.endsWith(testName))).toBe(
-        process.platform === "linux",
-      );
-    }
+    expect(linesForFile(result.lines, file).some((line) => line.endsWith(testName))).toBe(
+      process.platform === "linux",
+    );
   });
 });

--- a/test/e2e/support/e2e-phase-runtime.test.ts
+++ b/test/e2e/support/e2e-phase-runtime.test.ts
@@ -353,8 +353,9 @@ describe("runtime phase fixture", () => {
     });
   });
 
-  it("rejects invalid curl max time values before runtime probe execution", async () => {
-    for (const curlMaxTimeSeconds of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects invalid curl max time values before runtime probe execution [case %#]",
+    async (curlMaxTimeSeconds) => {
       const runner = new FakeRunner();
 
       await expect(
@@ -363,8 +364,8 @@ describe("runtime phase fixture", () => {
         }),
       ).rejects.toThrow("inference request curlMaxTimeSeconds must be a finite positive number");
       expect(runner.calls).toEqual([]);
-    }
-  });
+    },
+  );
 
   it("rejects provider model probes without compatible model data", async () => {
     const runner = new FakeRunner();

--- a/test/e2e/support/e2e-retired-shell-entrypoints.test.ts
+++ b/test/e2e/support/e2e-retired-shell-entrypoints.test.ts
@@ -31,11 +31,12 @@ function workflowFiles(): string[] {
 }
 
 describe("retired shell E2E entrypoints", () => {
-  it("keeps retired standalone Ollama lanes deleted", () => {
-    for (const relativePath of FORBIDDEN_REPO_PATHS) {
+  it.each([...FORBIDDEN_REPO_PATHS])(
+    "keeps retired standalone Ollama lanes deleted [case %#]",
+    (relativePath) => {
       expect(fs.existsSync(path.join(REPO_ROOT, relativePath)), relativePath).toBe(false);
-    }
-  });
+    },
+  );
 
   it("keeps shell E2E entrypoints out of test/e2e recursively", () => {
     const shellEntrypoints = fs

--- a/test/e2e/support/kimi-inference-compat-helpers.test.ts
+++ b/test/e2e/support/kimi-inference-compat-helpers.test.ts
@@ -157,8 +157,8 @@ describe("Kimi inference compatibility mode selection", () => {
     });
   });
 
-  it("rejects unsafe or malformed source commands in both mock and public trajectory summaries", () => {
-    for (const sourceCommands of [
+  it.each(
+    [
       ["hostname; date; uptime"],
       ["hostname | date"],
       ["hostname $(date)"],
@@ -167,7 +167,10 @@ describe("Kimi inference compatibility mode selection", () => {
       ["cat < /etc/passwd"],
       ["whoami"],
       [null],
-    ]) {
+    ].map((sourceCommands) => [sourceCommands] as const),
+  )(
+    "rejects unsafe or malformed source commands in both mock and public trajectory summaries [case %#]",
+    (sourceCommands) => {
       expect(() =>
         assertKimiTrajectorySummary({
           errors: [],
@@ -181,6 +184,6 @@ describe("Kimi inference compatibility mode selection", () => {
           toolMetasCount: 1,
         }),
       ).toThrow();
-    }
-  });
+    },
+  );
 });

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -758,16 +758,18 @@ it("rejects an unterminated appended session record (#9160)", () => {
   expect(qualification.status).toBe(2);
 });
 
-it("rejects an invalid baseline or a removed, rewritten, or truncated session (#9160)", () => {
-  for (const mutation of ["invalid", "removed", "rewritten", "truncated"] as const) {
+it.each(["invalid", "removed", "rewritten", "truncated"] as const)(
+  "rejects an invalid baseline or a removed, rewritten, or truncated session [case %#] (#9160)",
+  (mutation) => {
     const { baseline, qualification } = runBaselineMutationFixture(mutation);
     expect(baseline.status).toBe(0);
     expect(qualification.status).toBe(2);
-  }
-});
+  },
+);
 
-it("intercepts one OpenClaw launch, preserves pass-through argv, and strips launch authority from filtered and inherited environments (#9160)", () => {
-  for (const gatewayArgs of [[], ["-g", "fixture-gateway"]]) {
+it.each([[], ["-g", "fixture-gateway"]].map((gatewayArgs) => [gatewayArgs] as const))(
+  "intercepts one OpenClaw launch, preserves pass-through argv, and strips launch authority from filtered and inherited environments [case %#] (#9160)",
+  (gatewayArgs) => {
     const fixture = runOpenShellShimFixture(gatewayArgs);
     const separator = fixture.exactArgv.indexOf("--");
     const expectedRemote = fixture.exactArgv.slice(separator + 1);
@@ -795,8 +797,8 @@ it("intercepts one OpenClaw launch, preserves pass-through argv, and strips laun
       fixture.recordRoot,
       ...expectedRemote,
     ]);
-  }
-});
+  },
+);
 
 it.runIf(process.platform === "linux")(
   "rejects a record writer whose standard input is not a PTY (#9160)",

--- a/test/e2e/support/live-vitest-invocation.test.ts
+++ b/test/e2e/support/live-vitest-invocation.test.ts
@@ -28,11 +28,12 @@ describe("validateLiveProject (#6961)", () => {
     expect(validateLiveProject(undefined)).toBe(LIVE_VITEST_PROJECT);
   });
 
-  it("rejects any other project", () => {
-    for (const project of ["cli", "e2e-support", "e2e-live-extra", "integration"]) {
+  it.each(["cli", "e2e-support", "e2e-live-extra", "integration"])(
+    "rejects any other project [case %#]",
+    (project) => {
       expect(() => validateLiveProject(project)).toThrow(/unsupported vitest project/);
-    }
-  });
+    },
+  );
 });
 
 describe("validateLiveTestPath (#6961)", () => {
@@ -57,16 +58,14 @@ describe("validateLiveTestPath (#6961)", () => {
     expect(() => validateLiveTestPath("/etc/passwd")).toThrow(/unsupported character|absolute/);
   });
 
-  it("rejects shell metacharacters", () => {
-    for (const bad of [
-      "test/e2e/live/x.test.ts; rm -rf /",
-      "test/e2e/live/$(whoami).test.ts",
-      "test/e2e/live/x.test.ts && curl evil",
-      "test/e2e/live/`id`.test.ts",
-      "test/e2e/live/x.test.ts|cat",
-    ]) {
-      expect(() => validateLiveTestPath(bad)).toThrow(/unsupported character/);
-    }
+  it.each([
+    "test/e2e/live/x.test.ts; rm -rf /",
+    "test/e2e/live/$(whoami).test.ts",
+    "test/e2e/live/x.test.ts && curl evil",
+    "test/e2e/live/`id`.test.ts",
+    "test/e2e/live/x.test.ts|cat",
+  ])("rejects shell metacharacters [case %#]", (bad) => {
+    expect(() => validateLiveTestPath(bad)).toThrow(/unsupported character/);
   });
 
   it("requires a .test.ts file", () => {
@@ -93,18 +92,12 @@ describe("validateLiveSelector (#6961)", () => {
     expect(validateLiveSelector("   ")).toBeUndefined();
   });
 
-  it("rejects shell metacharacters in the expanded selector", () => {
-    for (const bad of [
-      "^$(touch pwned)$",
-      "^x$; rm -rf /",
-      "^x$ && evil",
-      "^`id`$",
-      "^x|y$",
-      "^x>out$",
-    ]) {
+  it.each(["^$(touch pwned)$", "^x$; rm -rf /", "^x$ && evil", "^`id`$", "^x|y$", "^x>out$"])(
+    "rejects shell metacharacters in the expanded selector [case %#]",
+    (bad) => {
       expect(() => validateLiveSelector(bad)).toThrow(/unsupported character/);
-    }
-  });
+    },
+  );
 });
 
 describe("resolveLiveSelector (#6901)", () => {
@@ -112,18 +105,21 @@ describe("resolveLiveSelector (#6901)", () => {
     ["openclaw", "^mcp-bridge$"],
     ["hermes", "^mcp-bridge-hermes$"],
     ["deepagents", "^mcp-bridge-deepagents$"],
-  ])("infers the reviewed %s selector for trusted base-workflow compatibility", (agent, expected) => {
-    expect(
-      resolveLiveSelector(MCP_BRIDGE_TEST_PATH, undefined, {
-        NEMOCLAW_MCP_BRIDGE_AGENT: agent,
-      }),
-    ).toBe(expected);
-    expect(
-      resolveLiveSelector(MCP_BRIDGE_TEST_PATH, expected, {
-        NEMOCLAW_MCP_BRIDGE_AGENT: agent,
-      }),
-    ).toBe(expected);
-  });
+  ])(
+    "infers the reviewed %s selector for trusted base-workflow compatibility",
+    (agent, expected) => {
+      expect(
+        resolveLiveSelector(MCP_BRIDGE_TEST_PATH, undefined, {
+          NEMOCLAW_MCP_BRIDGE_AGENT: agent,
+        }),
+      ).toBe(expected);
+      expect(
+        resolveLiveSelector(MCP_BRIDGE_TEST_PATH, expected, {
+          NEMOCLAW_MCP_BRIDGE_AGENT: agent,
+        }),
+      ).toBe(expected);
+    },
+  );
 
   it("keeps the existing OpenClaw default for local MCP runs", () => {
     expect(resolveLiveSelector(MCP_BRIDGE_TEST_PATH, undefined, {})).toBe("^mcp-bridge$");

--- a/test/e2e/support/runner-pressure.test.ts
+++ b/test/e2e/support/runner-pressure.test.ts
@@ -673,25 +673,30 @@ describe("bounded secret-safe snapshot line (#7146)", () => {
     expect(payload.containers).toHaveLength(5);
   });
 
-  it("rejects phase labels that could inject argv options", () => {
-    expect(assertPhaseLabel("rebuild-hermes.image-build")).toBe("rebuild-hermes.image-build");
-    for (const bad of [undefined, "", "-oProxyCommand=x", "a b", "a$(x)", "a".repeat(80)]) {
+  it.each([undefined, "", "-oProxyCommand=x", "a b", "a$(x)", "a".repeat(80)])(
+    "rejects phase label %# that could inject argv options",
+    (bad) => {
       expect(() => assertPhaseLabel(bad)).toThrow(/phase label/);
-    }
+    },
+  );
+
+  it("accepts a bounded phase label", () => {
+    expect(assertPhaseLabel("rebuild-hermes.image-build")).toBe("rebuild-hermes.image-build");
   });
 
-  it("accepts only a bounded canonical UTC timestamp", () => {
+  it.each([
+    undefined,
+    "",
+    "2026-07-18",
+    "2026-07-18T00:00:00Z",
+    "2026-02-31T00:00:00.000Z",
+    `2026-07-18T00:00:00.000Z${"invalid".repeat(500)}`,
+  ])("rejects non-canonical UTC timestamp %#", (bad) => {
+    expect(() => assertCanonicalTimestamp(bad)).toThrow(/timestamp/);
+  });
+
+  it("accepts a bounded canonical UTC timestamp", () => {
     expect(assertCanonicalTimestamp("2026-07-18T00:00:00.000Z")).toBe("2026-07-18T00:00:00.000Z");
-    for (const bad of [
-      undefined,
-      "",
-      "2026-07-18",
-      "2026-07-18T00:00:00Z",
-      "2026-02-31T00:00:00.000Z",
-      `2026-07-18T00:00:00.000Z${"ghp_secret".repeat(500)}`,
-    ]) {
-      expect(() => assertCanonicalTimestamp(bad)).toThrow(/timestamp/);
-    }
   });
 });
 
@@ -929,32 +934,28 @@ describe("runner-loss signature and retry policy (#7146)", () => {
     expect(decision.reason).toContain("assertion");
   });
 
-  it("never retries classified OOM, disk-pressure, timeout, or unknown failures", () => {
-    for (const classification of [
-      "process-oom",
-      "container-oom",
-      "disk-pressure",
-      "timeout",
-      "unknown",
-    ] as const) {
+  it.each(["process-oom", "container-oom", "disk-pressure", "timeout", "unknown"] as const)(
+    "never retries a classified %s failure",
+    (classification) => {
       expect(decideRetry({ runnerLoss: false, classification, attempt: 1 }).retry).toBe(false);
-    }
-  });
+    },
+  );
 
-  it("fails closed when runner-loss evidence contradicts a terminal classification", () => {
-    for (const classification of [
-      "assertion",
-      "timeout",
-      "process-oom",
-      "container-oom",
-      "disk-pressure",
-      "unknown",
-    ] as const) {
+  it.each([
+    "assertion",
+    "timeout",
+    "process-oom",
+    "container-oom",
+    "disk-pressure",
+    "unknown",
+  ] as const)(
+    "fails closed when runner-loss evidence contradicts a terminal %s classification",
+    (classification) => {
       const decision = decideRetry({ runnerLoss: true, classification, attempt: 1 });
       expect(decision.retry).toBe(false);
       expect(decision.reason).toContain("terminal");
-    }
-  });
+    },
+  );
 
   it("permits exactly one retry for a confirmed runner loss and links the attempts", () => {
     const first = decideRetry({ runnerLoss: true, classification: null, attempt: 1 });
@@ -1023,90 +1024,94 @@ describe("runner-pressure CLI fail-closed entrypoint (#7146)", () => {
     }
   }, 90_000);
 
-  it.each([
-    "assertion",
-    "timeout",
-  ] as const)("classifies a trusted harness %s artifact through the real CLI", (outcome) => {
-    withEvidenceFiles(outcome, (baselinePath, outcomePath) => {
-      const classificationPath = path.join(path.dirname(baselinePath), "classification.jsonl");
-      fs.writeFileSync(classificationPath, "", { mode: 0o600 });
-      const result = runHelper(["classify"], {
+  it.each(["assertion", "timeout"] as const)(
+    "classifies a trusted harness %s artifact through the real CLI",
+    (outcome) => {
+      withEvidenceFiles(outcome, (baselinePath, outcomePath) => {
+        const classificationPath = path.join(path.dirname(baselinePath), "classification.jsonl");
+        fs.writeFileSync(classificationPath, "", { mode: 0o600 });
+        const result = runHelper(["classify"], {
+          E2E_RESOURCE_BASELINE_FILE: baselinePath,
+          E2E_TERMINAL_CLASSIFICATION_FILE: classificationPath,
+          E2E_TEST_OUTCOME_FILE: outcomePath,
+        });
+        expect(result.status).toBe(0);
+        const line = result.stdout
+          .split("\n")
+          .find((l) => l.startsWith(CLASSIFICATION_LINE_PREFIX));
+        expect(line).toBeDefined();
+        expect(
+          JSON.parse((line as string).slice(CLASSIFICATION_LINE_PREFIX.length)).classification,
+        ).toBe(outcome);
+        expect(fs.readFileSync(classificationPath, "utf8").trim()).toBe(line);
+      });
+    },
+    90_000,
+  );
+
+  it.each(["symlink", "hardlink"] as const)(
+    "rejects %s-substituted baseline, phase, and classification evidence",
+    (linkKind) => {
+      const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-linked-evidence-"));
+      const baselinePath = path.join(directory, "baseline.jsonl");
+      const phaseBaselinesPath = path.join(directory, "phase-baselines.jsonl");
+      const classificationPath = path.join(directory, "classification.jsonl");
+      const outcomePath = path.join(directory, LIVE_TEST_OUTCOME_FILE);
+      const canonicalBaseline = `${renderBaselineLine({
+        phase: "unit-test",
+        at: "2026-07-18T00:00:00.000Z",
+        cgroupOomKills: 0,
+        kernelOomKillCount: 0,
+        containerOomKilled: false,
+      })}\n`;
+      const canonicalClassification = `${renderClassificationLine({
+        classification: "assertion",
+        reason: "protected target",
+      })}\n`;
+      const link = LINK_CREATORS[linkKind];
+      const environment = {
+        DOCKER_OOM_CONTAINER: "",
+        E2E_PHASE: "unit-test",
         E2E_RESOURCE_BASELINE_FILE: baselinePath,
+        E2E_RESOURCE_PHASE_BASELINES_FILE: phaseBaselinesPath,
         E2E_TERMINAL_CLASSIFICATION_FILE: classificationPath,
         E2E_TEST_OUTCOME_FILE: outcomePath,
-      });
-      expect(result.status).toBe(0);
-      const line = result.stdout.split("\n").find((l) => l.startsWith(CLASSIFICATION_LINE_PREFIX));
-      expect(line).toBeDefined();
-      expect(
-        JSON.parse((line as string).slice(CLASSIFICATION_LINE_PREFIX.length)).classification,
-      ).toBe(outcome);
-      expect(fs.readFileSync(classificationPath, "utf8").trim()).toBe(line);
-    });
-  }, 90_000);
+      };
+      try {
+        fs.writeFileSync(outcomePath, renderLiveTestOutcome("assertion"), { mode: 0o600 });
 
-  it.each([
-    "symlink",
-    "hardlink",
-  ] as const)("rejects %s-substituted baseline, phase, and classification evidence", (linkKind) => {
-    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-linked-evidence-"));
-    const baselinePath = path.join(directory, "baseline.jsonl");
-    const phaseBaselinesPath = path.join(directory, "phase-baselines.jsonl");
-    const classificationPath = path.join(directory, "classification.jsonl");
-    const outcomePath = path.join(directory, LIVE_TEST_OUTCOME_FILE);
-    const canonicalBaseline = `${renderBaselineLine({
-      phase: "unit-test",
-      at: "2026-07-18T00:00:00.000Z",
-      cgroupOomKills: 0,
-      kernelOomKillCount: 0,
-      containerOomKilled: false,
-    })}\n`;
-    const canonicalClassification = `${renderClassificationLine({
-      classification: "assertion",
-      reason: "protected target",
-    })}\n`;
-    const link = LINK_CREATORS[linkKind];
-    const environment = {
-      DOCKER_OOM_CONTAINER: "",
-      E2E_PHASE: "unit-test",
-      E2E_RESOURCE_BASELINE_FILE: baselinePath,
-      E2E_RESOURCE_PHASE_BASELINES_FILE: phaseBaselinesPath,
-      E2E_TERMINAL_CLASSIFICATION_FILE: classificationPath,
-      E2E_TEST_OUTCOME_FILE: outcomePath,
-    };
-    try {
-      fs.writeFileSync(outcomePath, renderLiveTestOutcome("assertion"), { mode: 0o600 });
+        const baselineTarget = path.join(directory, "baseline-target.jsonl");
+        fs.writeFileSync(baselineTarget, canonicalBaseline, { mode: 0o600 });
+        link(baselineTarget, baselinePath);
+        fs.writeFileSync(phaseBaselinesPath, "", { mode: 0o600 });
+        fs.writeFileSync(classificationPath, "", { mode: 0o600 });
+        expect(runHelper(["classify"], environment).status).not.toBe(0);
+        expect(fs.readFileSync(baselineTarget, "utf8")).toBe(canonicalBaseline);
 
-      const baselineTarget = path.join(directory, "baseline-target.jsonl");
-      fs.writeFileSync(baselineTarget, canonicalBaseline, { mode: 0o600 });
-      link(baselineTarget, baselinePath);
-      fs.writeFileSync(phaseBaselinesPath, "", { mode: 0o600 });
-      fs.writeFileSync(classificationPath, "", { mode: 0o600 });
-      expect(runHelper(["classify"], environment).status).not.toBe(0);
-      expect(fs.readFileSync(baselineTarget, "utf8")).toBe(canonicalBaseline);
+        fs.unlinkSync(baselinePath);
+        fs.writeFileSync(baselinePath, canonicalBaseline, { mode: 0o600 });
+        fs.unlinkSync(phaseBaselinesPath);
+        const phaseTarget = path.join(directory, "phase-target.jsonl");
+        fs.writeFileSync(phaseTarget, "", { mode: 0o600 });
+        link(phaseTarget, phaseBaselinesPath);
+        expect(runHelper(["classify"], environment).status).not.toBe(0);
+        expect(fs.readFileSync(phaseTarget, "utf8")).toBe("");
 
-      fs.unlinkSync(baselinePath);
-      fs.writeFileSync(baselinePath, canonicalBaseline, { mode: 0o600 });
-      fs.unlinkSync(phaseBaselinesPath);
-      const phaseTarget = path.join(directory, "phase-target.jsonl");
-      fs.writeFileSync(phaseTarget, "", { mode: 0o600 });
-      link(phaseTarget, phaseBaselinesPath);
-      expect(runHelper(["classify"], environment).status).not.toBe(0);
-      expect(fs.readFileSync(phaseTarget, "utf8")).toBe("");
-
-      fs.unlinkSync(phaseBaselinesPath);
-      fs.writeFileSync(phaseBaselinesPath, "", { mode: 0o600 });
-      fs.unlinkSync(classificationPath);
-      const classificationTarget = path.join(directory, "classification-target.jsonl");
-      fs.writeFileSync(classificationTarget, canonicalClassification, { mode: 0o600 });
-      link(classificationTarget, classificationPath);
-      expect(runHelper(["initialize-evidence"], environment).status).not.toBe(0);
-      expect(runHelper(["validate-classification"], environment).status).not.toBe(0);
-      expect(fs.readFileSync(classificationTarget, "utf8")).toBe(canonicalClassification);
-    } finally {
-      fs.rmSync(directory, { recursive: true, force: true });
-    }
-  }, 90_000);
+        fs.unlinkSync(phaseBaselinesPath);
+        fs.writeFileSync(phaseBaselinesPath, "", { mode: 0o600 });
+        fs.unlinkSync(classificationPath);
+        const classificationTarget = path.join(directory, "classification-target.jsonl");
+        fs.writeFileSync(classificationTarget, canonicalClassification, { mode: 0o600 });
+        link(classificationTarget, classificationPath);
+        expect(runHelper(["initialize-evidence"], environment).status).not.toBe(0);
+        expect(runHelper(["validate-classification"], environment).status).not.toBe(0);
+        expect(fs.readFileSync(classificationTarget, "utf8")).toBe(canonicalClassification);
+      } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    },
+    90_000,
+  );
 
   it("rejects missing or malformed pre-phase evidence before classification", () => {
     const missing = runHelper(["classify"], {});
@@ -1188,11 +1193,13 @@ describe("runner-pressure CLI fail-closed entrypoint (#7146)", () => {
     expect(JSON.parse(loss.stdout.trim()).retry).toBe(true);
   }, 90_000);
 
-  it("fails closed on a missing or unsupported subcommand", () => {
-    for (const args of [[], ["snapshotx"], ["run"]]) {
-      const result = runHelper(args, {});
+  it.each([[[]], [["snapshotx"]], [["run"]]] as const)(
+    "fails closed on missing or unsupported subcommand %#",
+    (args) => {
+      const result = runHelper([...args], {});
       expect(result.status).toBe(2);
       expect(result.stderr).toContain("usage:");
-    }
-  }, 90_000);
+    },
+    90_000,
+  );
 });

--- a/test/e2e/support/sandbox-images-workflow-boundary.test.ts
+++ b/test/e2e/support/sandbox-images-workflow-boundary.test.ts
@@ -174,8 +174,9 @@ describe("sandbox image workflow boundary", () => {
     );
   });
 
-  it("rejects non-canonical Hermes Buildx action pins", () => {
-    for (const stepName of ["Set up Docker Buildx", "Build Hermes production image"]) {
+  it.each(["Set up Docker Buildx", "Build Hermes production image"])(
+    "rejects non-canonical Hermes Buildx action pins [case %#]",
+    (stepName) => {
       const { imageWorkflow, mainWorkflow } = readWorkflows();
       const step = imageWorkflow.jobs["build-hermes-sandbox-image"].steps!.find(
         (candidate) => candidate.name === stepName,
@@ -187,8 +188,8 @@ describe("sandbox image workflow boundary", () => {
           ? "Hermes producer must use the canonical Docker Buildx setup action exactly once"
           : "Hermes producer must build the production image exactly once with the canonical local-load Buildx action and OS/architecture-scoped GHA cache",
       );
-    }
-  });
+    },
+  );
 
   it("rejects a non-canonical Hermes artifact download pin", () => {
     const { imageWorkflow, mainWorkflow } = readWorkflows();
@@ -567,24 +568,22 @@ describe("sandbox image workflow boundary", () => {
     );
   });
 
-  it("rejects direct base64 encoding of the broad system CA bundle", () => {
-    for (const forbidden of [
-      'forbidden_ca_b64="$(base64 -w 0 "$system_ca_bundle")"',
-      [
-        "corporate_ca_bundle=/etc/ssl/certs/ca-certificates.crt",
-        'forbidden_ca_b64="$(base64 -w 0 "$corporate_ca_bundle")"',
-      ].join("\n"),
-    ]) {
-      const { imageWorkflow, mainWorkflow } = readWorkflows();
-      const hermes = imageWorkflow.jobs["messaging-plan-image-boundary"].steps!.find(
-        (step) => step.name === "Build and verify Hermes messaging plan boundary",
-      )!;
-      hermes.run = `${hermes.run}\n${forbidden}`;
+  it.each([
+    'forbidden_ca_b64="$(base64 -w 0 "$system_ca_bundle")"',
+    [
+      "corporate_ca_bundle=/etc/ssl/certs/ca-certificates.crt",
+      'forbidden_ca_b64="$(base64 -w 0 "$corporate_ca_bundle")"',
+    ].join("\n"),
+  ])("rejects direct base64 encoding of the broad system CA bundle [case %#]", (forbidden) => {
+    const { imageWorkflow, mainWorkflow } = readWorkflows();
+    const hermes = imageWorkflow.jobs["messaging-plan-image-boundary"].steps!.find(
+      (step) => step.name === "Build and verify Hermes messaging plan boundary",
+    )!;
+    hermes.run = `${hermes.run}\n${forbidden}`;
 
-      expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).toContain(
-        "hermes messaging plan image boundary must not encode the system CA bundle directly",
-      );
-    }
+    expect(validateSandboxImagesWorkflow(imageWorkflow, mainWorkflow)).toContain(
+      "hermes messaging plan image boundary must not encode the system CA bundle directly",
+    );
   });
 
   it("requires offline equality and parse proofs for the installed Hermes CA bundle", () => {

--- a/test/e2e/support/snapshot-credential-scanner.test.ts
+++ b/test/e2e/support/snapshot-credential-scanner.test.ts
@@ -16,18 +16,16 @@ import {
 } from "../live/snapshot-credential-scanner.ts";
 
 describe("snapshot credential scanner", () => {
-  it("keeps required provider aliases in the shared credential inventory", () => {
-    for (const name of [
-      "NVIDIA_API_KEY",
-      "OPENROUTER_API_KEY",
-      "GEMINI_API_KEY",
-      "GOOGLE_API_KEY",
-      "AWS_BEARER_TOKEN_BEDROCK",
-      "COMPATIBLE_ANTHROPIC_API_KEY",
-      "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
-    ]) {
-      expect(SUPPORTED_CREDENTIAL_ENV_NAMES.has(name), name).toBe(true);
-    }
+  it.each([
+    "NVIDIA_API_KEY",
+    "OPENROUTER_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "COMPATIBLE_ANTHROPIC_API_KEY",
+    "NEMOCLAW_LLAMACPP_LOCAL_TOKEN",
+  ])("keeps required provider aliases in the shared credential inventory [case %#]", (name) => {
+    expect(SUPPORTED_CREDENTIAL_ENV_NAMES.has(name), name).toBe(true);
   });
 
   it("accepts only non-secret environment and secret-reference markers in models.json", () => {
@@ -46,18 +44,19 @@ describe("snapshot credential scanner", () => {
     expect(modelsJsonContainsCredentialLeak(body)).toBe(false);
   });
 
-  it.each([
-    ...MODELS_JSON_CREDENTIAL_ENV_REFERENCES,
-  ])("preserves the allowed bare and braced models.json reference marker %s", (name) => {
-    expect(
-      modelsJsonContainsCredentialLeak(JSON.stringify({ providers: { bare: { apiKey: name } } })),
-    ).toBe(false);
-    expect(
-      modelsJsonContainsCredentialLeak(
-        JSON.stringify({ providers: { braced: { apiKey: `\${${name}}` } } }),
-      ),
-    ).toBe(false);
-  });
+  it.each([...MODELS_JSON_CREDENTIAL_ENV_REFERENCES])(
+    "preserves the allowed bare and braced models.json reference marker %s",
+    (name) => {
+      expect(
+        modelsJsonContainsCredentialLeak(JSON.stringify({ providers: { bare: { apiKey: name } } })),
+      ).toBe(false);
+      expect(
+        modelsJsonContainsCredentialLeak(
+          JSON.stringify({ providers: { braced: { apiKey: `\${${name}}` } } }),
+        ),
+      ).toBe(false);
+    },
+  );
 
   it.each([
     ["NVIDIA key", { apiKey: "nvapi-concrete-secret" }],
@@ -72,19 +71,16 @@ describe("snapshot credential scanner", () => {
     ).toBe(true);
   });
 
-  it.each([
-    "access_token",
-    "secret_key",
-    "bearer_token",
-    "secretKey",
-    "apikey",
-  ])("rejects opaque values under the credential field %s", (field) => {
-    expect(
-      modelsJsonContainsCredentialLeak(
-        JSON.stringify({ providers: { test: { [field]: "opaque-concrete-value" } } }),
-      ),
-    ).toBe(true);
-  });
+  it.each(["access_token", "secret_key", "bearer_token", "secretKey", "apikey"])(
+    "rejects opaque values under the credential field %s",
+    (field) => {
+      expect(
+        modelsJsonContainsCredentialLeak(
+          JSON.stringify({ providers: { test: { [field]: "opaque-concrete-value" } } }),
+        ),
+      ).toBe(true);
+    },
+  );
 
   it("rejects credential assignments and malformed models.json", () => {
     expect(
@@ -100,14 +96,15 @@ describe("snapshot credential scanner", () => {
     expect(modelsJsonContainsCredentialLeak('{"providers":')).toBe(true);
   });
 
-  it.each([
-    ...SUPPORTED_CREDENTIAL_ENV_NAMES,
-  ])("rejects an opaque assignment for the supported credential name %s", (name) => {
-    expect(snapshotFileContainsCredentialLeak("runtime.env", `${name}=opaque-value`)).toBe(true);
-    expect(snapshotFileContainsCredentialLeak("runtime.env", `export ${name}=opaque-value`)).toBe(
-      true,
-    );
-  });
+  it.each([...SUPPORTED_CREDENTIAL_ENV_NAMES])(
+    "rejects an opaque assignment for the supported credential name %s",
+    (name) => {
+      expect(snapshotFileContainsCredentialLeak("runtime.env", `${name}=opaque-value`)).toBe(true);
+      expect(snapshotFileContainsCredentialLeak("runtime.env", `export ${name}=opaque-value`)).toBe(
+        true,
+      );
+    },
+  );
 
   it("preserves the existing non-model file boundaries", () => {
     expect(snapshotFileContainsCredentialLeak("openclaw.json", '{"apiKey":"unused"}')).toBe(false);

--- a/test/gateway-failure-classifier.test.ts
+++ b/test/gateway-failure-classifier.test.ts
@@ -322,11 +322,9 @@ describe("isDockerRuntimeDown", () => {
     ).toBe(true);
   });
 
-  it("treats legacy/recovered entries without driver metadata as Docker-backed", () => {
-    // Sandboxes registered before `openshellDriver` existed (or recovered from
-    // gateway state) omit the field; they must still get the outage guard
-    // rather than falling back to the broken Provisioning/rebuild path (#4428).
-    for (const entry of [{}, { openshellDriver: null }, () => null] as const) {
+  it.each([{}, { openshellDriver: null }, () => null] as const)(
+    "treats legacy/recovered entries without driver metadata as Docker-backed [case %#]",
+    (entry) => {
       const getSandbox = typeof entry === "function" ? entry : () => entry;
       expect(
         isDockerRuntimeDown("alpha", {
@@ -334,8 +332,8 @@ describe("isDockerRuntimeDown", () => {
           getSandbox,
         }),
       ).toBe(true);
-    }
-  });
+    },
+  );
 });
 
 describe("printDockerRuntimeDownGuidance", () => {

--- a/test/generate-openclaw-config-agents-manifest.test.ts
+++ b/test/generate-openclaw-config-agents-manifest.test.ts
@@ -284,8 +284,9 @@ describe("generate-openclaw-config :: agents manifest", () => {
     expect(config.agents.defaults.subagents).toEqual({ maxSpawnDepth: 3 });
   });
 
-  it("rejects defaults.subagents.maxSpawnDepth outside OpenClaw's 1..5 range", () => {
-    for (const depth of [0, 6, -1, 1.5]) {
+  it.each([0, 6, -1, 1.5])(
+    "rejects defaults.subagents.maxSpawnDepth outside OpenClaw's 1..5 range [case %#]",
+    (depth) => {
       expectBuildConfigError(
         {
           NEMOCLAW_EXTRA_AGENTS_JSON_B64: extraAgentsB64({
@@ -295,8 +296,8 @@ describe("generate-openclaw-config :: agents manifest", () => {
         },
         /maxSpawnDepth must be an integer between 1 and 5/,
       );
-    }
-  });
+    },
+  );
 
   it("merges main.subagents and main.tools onto the canonical main entry", () => {
     const mainTools = { profile: "minimal", allow: ["read", "write"] };

--- a/test/generate-openclaw-config.test.ts
+++ b/test/generate-openclaw-config.test.ts
@@ -536,17 +536,18 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(config.plugins?.entries?.["openclaw-weixin"]).toBeUndefined();
   });
 
-  it("ignores malformed existing plugin install registries while regenerating config", () => {
-    const configPath = path.join(tmpDir, ".openclaw", "openclaw.json");
-    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  it.each([null, { plugins: null }, { plugins: { installs: {} } }])(
+    "ignores malformed existing plugin install registry %# while regenerating config",
+    (existing) => {
+      const configPath = path.join(tmpDir, ".openclaw", "openclaw.json");
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
 
-    for (const existing of [null, { plugins: null }, { plugins: { installs: {} } }]) {
       fs.writeFileSync(configPath, JSON.stringify(existing));
       const config = runConfigScript();
       expect(config.plugins?.entries?.["openclaw-weixin"]).toBeUndefined();
       expect(config.plugins?.installs).toBeUndefined();
-    }
-  });
+    },
+  );
 
   it("emits canonical placeholders and proxy routing for non-Slack channels", async () => {
     const channels = Buffer.from(JSON.stringify(["telegram", "discord"])).toString("base64");
@@ -948,36 +949,32 @@ describe("generate-openclaw-config.mts: config generation", () => {
     );
   });
 
-  it("rejects extras whose workspace points anywhere but the canonical workspace-<id> slot", () => {
+  it.each([
+    "/sandbox/.openclaw",
+    "/sandbox/.openclaw/openclaw.json",
+    "/sandbox/.openclaw/credentials",
+    "/sandbox/.openclaw/workspace",
+    "/sandbox/.openclaw/workspace-other",
+  ])("rejects extra workspace %s outside the canonical workspace-<id> slot", (workspace) => {
     // The runtime startup script provisions /sandbox/.openclaw/workspace-<id>
     // as the per-agent workspace. Pointing at sibling paths (gateway state,
     // openclaw.json, credentials/) blurs that isolation boundary.
-    for (const workspace of [
-      "/sandbox/.openclaw",
-      "/sandbox/.openclaw/openclaw.json",
-      "/sandbox/.openclaw/credentials",
-      "/sandbox/.openclaw/workspace",
-      "/sandbox/.openclaw/workspace-other",
-    ]) {
-      expectBuildConfigError(
-        { NEMOCLAW_EXTRA_AGENTS_JSON_B64: extraAgentsB64([makeExtra({ workspace })]) },
-        /workspace must equal "\/sandbox\/\.openclaw\/workspace-research"/,
-      );
-    }
+    expectBuildConfigError(
+      { NEMOCLAW_EXTRA_AGENTS_JSON_B64: extraAgentsB64([makeExtra({ workspace })]) },
+      /workspace must equal "\/sandbox\/\.openclaw\/workspace-research"/,
+    );
   });
 
-  it("rejects extras whose agentDir points anywhere but the canonical agents/<id> slot", () => {
-    for (const agentDir of [
-      "/sandbox/.openclaw",
-      "/sandbox/.openclaw/agents",
-      "/sandbox/.openclaw/agents/other",
-      "/sandbox/.openclaw/openclaw.json",
-    ]) {
-      expectBuildConfigError(
-        { NEMOCLAW_EXTRA_AGENTS_JSON_B64: extraAgentsB64([makeExtra({ agentDir })]) },
-        /agentDir must equal "\/sandbox\/\.openclaw\/agents\/research"/,
-      );
-    }
+  it.each([
+    "/sandbox/.openclaw",
+    "/sandbox/.openclaw/agents",
+    "/sandbox/.openclaw/agents/other",
+    "/sandbox/.openclaw/openclaw.json",
+  ])("rejects extra agentDir %s outside the canonical agents/<id> slot", (agentDir) => {
+    expectBuildConfigError(
+      { NEMOCLAW_EXTRA_AGENTS_JSON_B64: extraAgentsB64([makeExtra({ agentDir })]) },
+      /agentDir must equal "\/sandbox\/\.openclaw\/agents\/research"/,
+    );
   });
 
   it("rejects extras that lack a tools policy", () => {
@@ -1235,8 +1232,9 @@ describe("generate-openclaw-config.mts: config generation", () => {
   // OpenClaw's own Ollama detector does not recognise — so we force the
   // flag here. Cloud providers and other local backends must not be
   // affected.
-  it("enables supportsUsageInStreaming for Ollama provider keys (#2747)", () => {
-    for (const providerKey of ["ollama", "ollama-local"]) {
+  it.each(["ollama", "ollama-local"])(
+    "enables supportsUsageInStreaming for Ollama provider key %s (#2747)",
+    (providerKey) => {
       const config = runConfigScript({
         NEMOCLAW_MODEL: "qwen3.5:9b",
         NEMOCLAW_PROVIDER_KEY: providerKey,
@@ -1246,33 +1244,29 @@ describe("generate-openclaw-config.mts: config generation", () => {
       });
       const model = config.models.providers[providerKey].models[0];
       expect(model.compat?.supportsUsageInStreaming).toBe(true);
-    }
-  });
+    },
+  );
 
-  it("does not enable supportsUsageInStreaming for non-Ollama providers (#2747)", () => {
-    const cases = [
-      { NEMOCLAW_PROVIDER_KEY: "openai", NEMOCLAW_INFERENCE_BASE_URL: "https://api.openai.com/v1" },
-      {
-        NEMOCLAW_PROVIDER_KEY: "anthropic",
-        NEMOCLAW_INFERENCE_BASE_URL: "https://api.anthropic.com",
-      },
-      { NEMOCLAW_PROVIDER_KEY: "vllm", NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1" },
-      {
-        NEMOCLAW_PROVIDER_KEY: "nim-local",
-        NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
-      },
-    ];
-
-    for (const envCase of cases) {
-      const config = runConfigScript({
-        NEMOCLAW_MODEL: "test-model",
-        NEMOCLAW_PRIMARY_MODEL_REF: "test-ref",
-        NEMOCLAW_INFERENCE_API: "openai-completions",
-        ...envCase,
-      });
-      const model = config.models.providers[envCase.NEMOCLAW_PROVIDER_KEY].models[0];
-      expect(model.compat?.supportsUsageInStreaming).toBeUndefined();
-    }
+  it.each([
+    { NEMOCLAW_PROVIDER_KEY: "openai", NEMOCLAW_INFERENCE_BASE_URL: "https://api.openai.com/v1" },
+    {
+      NEMOCLAW_PROVIDER_KEY: "anthropic",
+      NEMOCLAW_INFERENCE_BASE_URL: "https://api.anthropic.com",
+    },
+    { NEMOCLAW_PROVIDER_KEY: "vllm", NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1" },
+    {
+      NEMOCLAW_PROVIDER_KEY: "nim-local",
+      NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
+    },
+  ])("does not enable supportsUsageInStreaming for $NEMOCLAW_PROVIDER_KEY (#2747)", (envCase) => {
+    const config = runConfigScript({
+      NEMOCLAW_MODEL: "test-model",
+      NEMOCLAW_PRIMARY_MODEL_REF: "test-ref",
+      NEMOCLAW_INFERENCE_API: "openai-completions",
+      ...envCase,
+    });
+    const model = config.models.providers[envCase.NEMOCLAW_PROVIDER_KEY].models[0];
+    expect(model.compat?.supportsUsageInStreaming).toBeUndefined();
   });
 
   // If a future model-specific-setup manifest declares
@@ -1292,15 +1286,15 @@ describe("generate-openclaw-config.mts: config generation", () => {
     expect(config.models.providers.ollama.models[0].compat.supportsUsageInStreaming).toBe(false);
   });
 
-  it("does not activate the OpenClaw Kimi setup for non-matching routes", () => {
-    const cases = [
-      { NEMOCLAW_MODEL: "deepseek-ai/DeepSeek-V4-Flash" },
-      { NEMOCLAW_PROVIDER_KEY: "openai" },
-      { NEMOCLAW_INFERENCE_API: "responses" },
-      { NEMOCLAW_INFERENCE_BASE_URL: "https://integrate.api.nvidia.com/v1" },
-    ];
-
-    for (const envCase of cases) {
+  it.each([
+    { NEMOCLAW_MODEL: "deepseek-ai/DeepSeek-V4-Flash" },
+    { NEMOCLAW_PROVIDER_KEY: "openai" },
+    { NEMOCLAW_INFERENCE_API: "responses" },
+    { NEMOCLAW_INFERENCE_BASE_URL: "https://integrate.api.nvidia.com/v1" },
+  ])(
+    "does not activate the OpenClaw Kimi setup for non-matching route %#",
+    { timeout: 20_000 },
+    (envCase) => {
       const config = runConfigScript({
         NEMOCLAW_MODEL: "moonshotai/kimi-k2.6",
         NEMOCLAW_PROVIDER_KEY: "inference",
@@ -1318,34 +1312,32 @@ describe("generate-openclaw-config.mts: config generation", () => {
       expect(config.plugins.entries["nemoclaw-kimi-inference-compat"]).toBeUndefined();
       expect(config.plugins.load).toBeUndefined();
       expect(config.tools?.toolSearch).toEqual(STRUCTURED_TOOL_SEARCH);
-    }
-  }, 20_000);
+    },
+  );
   // #4780: keep false safeguards until live search can replace the direct-tool fallback.
-  it("keeps Tool Search disabled for Nemotron managed inference (#4780)", () => {
-    for (const model of [
-      "nvidia/nemotron-3-super-120b-a12b",
-      "nvidia/nemotron-3-ultra-550b-a55b",
-      "nvidia/nvidia/nemotron-3-ultra",
-    ]) {
-      const config = runConfigScript({
-        NEMOCLAW_MODEL: model,
-        NEMOCLAW_PROVIDER_KEY: "inference",
-        NEMOCLAW_PRIMARY_MODEL_REF: `inference/${model}`,
-        NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
-        NEMOCLAW_INFERENCE_API: "openai-completions",
-      });
-      expect(config.tools?.toolSearch, model).toBe(false);
-    }
+  it.each([
+    "nvidia/nemotron-3-super-120b-a12b",
+    "nvidia/nemotron-3-ultra-550b-a55b",
+    "nvidia/nvidia/nemotron-3-ultra",
+  ])("keeps Tool Search disabled for Nemotron model %s (#4780)", (model) => {
+    const config = runConfigScript({
+      NEMOCLAW_MODEL: model,
+      NEMOCLAW_PROVIDER_KEY: "inference",
+      NEMOCLAW_PRIMARY_MODEL_REF: `inference/${model}`,
+      NEMOCLAW_INFERENCE_BASE_URL: "https://inference.local/v1",
+      NEMOCLAW_INFERENCE_API: "openai-completions",
+    });
+    expect(config.tools?.toolSearch, model).toBe(false);
   });
-  it("keeps structured Tool Search for non-matching Nemotron routes (#4780)", () => {
-    const cases = [
-      { NEMOCLAW_MODEL: "nvidia/nemotron-3-nano:30b" },
-      { NEMOCLAW_PROVIDER_KEY: "nvidia" },
-      { NEMOCLAW_INFERENCE_API: "responses" },
-      { NEMOCLAW_INFERENCE_BASE_URL: "https://integrate.api.nvidia.com/v1" },
-    ];
-
-    for (const envCase of cases) {
+  it.each([
+    { NEMOCLAW_MODEL: "nvidia/nemotron-3-nano:30b" },
+    { NEMOCLAW_PROVIDER_KEY: "nvidia" },
+    { NEMOCLAW_INFERENCE_API: "responses" },
+    { NEMOCLAW_INFERENCE_BASE_URL: "https://integrate.api.nvidia.com/v1" },
+  ])(
+    "keeps structured Tool Search for non-matching Nemotron route %# (#4780)",
+    { timeout: 20_000 },
+    (envCase) => {
       const config = runConfigScript({
         NEMOCLAW_MODEL: "nvidia/nemotron-3-super-120b-a12b",
         NEMOCLAW_PROVIDER_KEY: "inference",
@@ -1356,8 +1348,8 @@ describe("generate-openclaw-config.mts: config generation", () => {
       });
 
       expect(config.tools?.toolSearch).toEqual(STRUCTURED_TOOL_SEARCH);
-    }
-  }, 20_000);
+    },
+  );
 
   it("rejects model-specific setup manifests without a known agent", () => {
     const blueprintDir = path.join(tmpDir, "fixture-blueprint");

--- a/test/hermes-discord-recovery-permissions.test.ts
+++ b/test/hermes-discord-recovery-permissions.test.ts
@@ -150,8 +150,9 @@ describe("Hermes cross-UID ledger permissions", () => {
     expect(imageBuildProbes).toContain('source.count("os.chmod(path, 0o660)") == 1');
   });
 
-  it("prepares both setgid cross-UID parents in both image layouts", () => {
-    for (const source of [baseDockerfile, dockerfile]) {
+  it.each([baseDockerfile, dockerfile])(
+    "prepares both setgid cross-UID parents in both image layouts [case %#]",
+    (source) => {
       expect(source).toContain("/sandbox/.hermes/cron");
       expect(source).toContain("/sandbox/.hermes/gateway");
       expect(source).toMatch(
@@ -160,8 +161,8 @@ describe("Hermes cross-UID ledger permissions", () => {
       expect(source).toMatch(
         /chmod 2770 \\\n(?:[\s\S]*?)\/sandbox\/[.]hermes\/cron \\\n\s+\/sandbox\/[.]hermes\/gateway \\\n\s+\/sandbox\/[.]hermes\/runtime/,
       );
-    }
-  });
+    },
+  );
 
   it("requires a Dockerfile cross-identity probe for the cron ledger lifecycle", () => {
     expect(dockerfile).toContain(

--- a/test/hermes-restart-config-seal-transition.test.ts
+++ b/test/hermes-restart-config-seal-transition.test.ts
@@ -198,8 +198,9 @@ describe.skipIf(process.platform === "win32")("Hermes mutable restart input seal
     }
   });
 
-  it("keeps weakening fan-out inaccessible and keeps monotonic lock fan-out readable", () => {
-    for (const targetMode of ["mutable", "locked"] as const) {
+  it.each(["mutable", "locked"] as const)(
+    "keeps weakening fan-out inaccessible and keeps monotonic lock fan-out readable [case %#]",
+    (targetMode) => {
       const fixture = createRestartFixture();
       try {
         const begun = runShieldsTransactionAction(fixture, "begin-shields-transition", {
@@ -230,8 +231,8 @@ describe.skipIf(process.platform === "win32")("Hermes mutable restart input seal
       } finally {
         fs.rmSync(fixture.root, { recursive: true, force: true });
       }
-    }
-  });
+    },
+  );
 
   it("retains the 0500 recursive clamp and resumes the same lock transaction", () => {
     const fixture = createRestartFixture();

--- a/test/hermes-runtime-api-key.test.ts
+++ b/test/hermes-runtime-api-key.test.ts
@@ -513,12 +513,13 @@ describe("agents/hermes/start.sh runtime API server key", () => {
     expect(run.result.stderr).not.toContain("Minted Hermes API_SERVER_KEY");
   });
 
-  it("ensure_hermes_runtime_api_server_key rotates malformed existing API_SERVER_KEY values and refreshes hashes", () => {
-    for (const { envLine, weakValue } of [
-      { envLine: "API_SERVER_KEY=x", weakValue: "x" },
-      { envLine: "API_SERVER_KEY=server-key", weakValue: "server-key" },
-      { envLine: "export API_SERVER_KEY='server-key'", weakValue: "server-key" },
-    ]) {
+  it.each([
+    { envLine: "API_SERVER_KEY=x", weakValue: "x" },
+    { envLine: "API_SERVER_KEY=server-key", weakValue: "server-key" },
+    { envLine: "export API_SERVER_KEY='server-key'", weakValue: "server-key" },
+  ])(
+    "ensure_hermes_runtime_api_server_key rotates malformed existing API_SERVER_KEY values and refreshes hashes [case %#]",
+    ({ envLine, weakValue }) => {
       const run = runHermesRuntimeApiServerKeyMint({
         envFile: ["API_SERVER_PORT=18642", "API_SERVER_HOST=127.0.0.1", envLine, ""].join("\n"),
         fakeRoot: true,
@@ -532,8 +533,8 @@ describe("agents/hermes/start.sh runtime API server key", () => {
       expect(run.strictHashValid, envLine).toBe(true);
       expect(run.compatHashValid, envLine).toBe(true);
       expect(run.result.stderr, envLine).toContain("Minted Hermes API_SERVER_KEY");
-    }
-  });
+    },
+  );
 
   it("does not append missing provider placeholders without a runtime plan", () => {
     const originalEnv = "API_SERVER_PORT=18642\n";
@@ -582,11 +583,12 @@ describe("agents/hermes/start.sh runtime API server key", () => {
     expect(run.strictHashValid).toBe(true);
   });
 
-  it("preserves the exact OpenShell provider placeholder generation in Hermes .env (#8893)", () => {
-    for (const envFile of [
-      "DISCORD_BOT_TOKEN=openshell:resolve:env:DISCORD_BOT_TOKEN\n",
-      "DISCORD_BOT_TOKEN=openshell:resolve:env:v111_DISCORD_BOT_TOKEN\n",
-    ]) {
+  it.each([
+    "DISCORD_BOT_TOKEN=openshell:resolve:env:DISCORD_BOT_TOKEN\n",
+    "DISCORD_BOT_TOKEN=openshell:resolve:env:v111_DISCORD_BOT_TOKEN\n",
+  ])(
+    "preserves the exact OpenShell provider placeholder generation in Hermes .env [case %#] (#8893)",
+    (envFile) => {
       const run = runHermesRuntimeProviderPlaceholderRefresh({
         envFile,
         envOverrides: {
@@ -600,8 +602,8 @@ describe("agents/hermes/start.sh runtime API server key", () => {
       );
       expect(run.envFileContent).not.toContain("v111_DISCORD_BOT_TOKEN");
       expect(run.strictHashValid).toBe(true);
-    }
-  });
+    },
+  );
 
   it("does not rewrite API_SERVER_KEY or unrelated .env keys from ambient runtime env", () => {
     const apiServerKey = "e".repeat(64);
@@ -712,31 +714,32 @@ describe("agents/hermes/start.sh runtime API server key", () => {
       name: "revisioned",
       value: "openshell:resolve:env:v101_DISCORD_BOT_TOKEN",
     },
-  ])("does not rewrite an exact $name runtime placeholder already persisted in .env (#8893)", ({
-    value,
-  }) => {
-    const hashFileContent = "sentinel\n";
-    const run = runHermesRuntimeProviderPlaceholderRefresh({
-      envFile: `DISCORD_BOT_TOKEN=${value}\n`,
-      envOverrides: {
-        DISCORD_BOT_TOKEN: value,
-      },
-      runtimePlan: {
-        schemaVersion: 1,
-        sandboxName: "test-sandbox",
-        agent: "hermes",
-        channels: [{ channelId: "discord", active: true, disabled: false }],
-        disabledChannels: [],
-        credentialBindings: [{ channelId: "discord", providerEnvKey: "DISCORD_BOT_TOKEN" }],
-        runtimeSetup: { nodePreloads: [], envAliases: [], secretScans: [] },
-      },
-      hashFileContent,
-    });
+  ])(
+    "does not rewrite an exact $name runtime placeholder already persisted in .env (#8893)",
+    ({ value }) => {
+      const hashFileContent = "sentinel\n";
+      const run = runHermesRuntimeProviderPlaceholderRefresh({
+        envFile: `DISCORD_BOT_TOKEN=${value}\n`,
+        envOverrides: {
+          DISCORD_BOT_TOKEN: value,
+        },
+        runtimePlan: {
+          schemaVersion: 1,
+          sandboxName: "test-sandbox",
+          agent: "hermes",
+          channels: [{ channelId: "discord", active: true, disabled: false }],
+          disabledChannels: [],
+          credentialBindings: [{ channelId: "discord", providerEnvKey: "DISCORD_BOT_TOKEN" }],
+          runtimeSetup: { nodePreloads: [], envAliases: [], secretScans: [] },
+        },
+        hashFileContent,
+      });
 
-    expect(run.result.status, run.result.stderr).toBe(0);
-    expect(run.envFileContent).toBe(`DISCORD_BOT_TOKEN=${value}\n`);
-    expect(run.strictHashContent).toBe(hashFileContent);
-  });
+      expect(run.result.status, run.result.stderr).toBe(0);
+      expect(run.envFileContent).toBe(`DISCORD_BOT_TOKEN=${value}\n`);
+      expect(run.strictHashContent).toBe(hashFileContent);
+    },
+  );
 
   it.each([
     {
@@ -922,25 +925,25 @@ describe("agents/hermes/start.sh runtime API server key", () => {
       runtimePlanPathKind: "worldWritable",
       error: "refusing group/world-writable runtime config path",
     },
-  ] as const)("refuses $name runtime plans before refreshing Hermes provider placeholders", ({
-    runtimePlanPathKind,
-    error,
-  }) => {
-    const originalEnv = "SLACK_BOT_TOKEN=openshell:resolve:env:SLACK_BOT_TOKEN\n";
-    const run = runHermesRuntimeProviderPlaceholderRefresh({
-      envFile: originalEnv,
-      envOverrides: {
-        SLACK_BOT_TOKEN: "openshell:resolve:env:SLACK_BOT_TOKEN",
-      },
-      runtimePlanPathKind,
-      runtimePlan: baseMessagingRuntimePlan(),
-    });
+  ] as const)(
+    "refuses $name runtime plans before refreshing Hermes provider placeholders",
+    ({ runtimePlanPathKind, error }) => {
+      const originalEnv = "SLACK_BOT_TOKEN=openshell:resolve:env:SLACK_BOT_TOKEN\n";
+      const run = runHermesRuntimeProviderPlaceholderRefresh({
+        envFile: originalEnv,
+        envOverrides: {
+          SLACK_BOT_TOKEN: "openshell:resolve:env:SLACK_BOT_TOKEN",
+        },
+        runtimePlanPathKind,
+        runtimePlan: baseMessagingRuntimePlan(),
+      });
 
-    expect(run.result.status).toBe(1);
-    expect(run.result.stderr).toContain(error);
-    expect(run.envFileContent).toBe(originalEnv);
-    expect(run.strictHashValid).toBe(true);
-  });
+      expect(run.result.status).toBe(1);
+      expect(run.result.stderr).toContain(error);
+      expect(run.envFileContent).toBe(originalEnv);
+      expect(run.strictHashValid).toBe(true);
+    },
+  );
 
   it("Hermes Dockerfile runtime-plan guard accepts reduced artifacts", () => {
     const accepted = runHermesDockerfileRuntimePlanGuard(baseMessagingRuntimePlan());
@@ -948,17 +951,15 @@ describe("agents/hermes/start.sh runtime API server key", () => {
     expect(accepted.status, accepted.stderr).toBe(0);
   });
 
-  it.each([
-    "agentRender",
-    "buildSteps",
-    "stateUpdates",
-    "healthChecks",
-  ])("Hermes Dockerfile runtime-plan guard rejects unreduced %s artifacts", (key) => {
-    const rejected = runHermesDockerfileRuntimePlanGuard(baseMessagingRuntimePlan({ [key]: [] }));
+  it.each(["agentRender", "buildSteps", "stateUpdates", "healthChecks"])(
+    "Hermes Dockerfile runtime-plan guard rejects unreduced %s artifacts",
+    (key) => {
+      const rejected = runHermesDockerfileRuntimePlanGuard(baseMessagingRuntimePlan({ [key]: [] }));
 
-    expect(rejected.status).toBe(1);
-    expect(rejected.stderr).toContain(`runtime plan contains unreduced key ${key}`);
-  });
+      expect(rejected.status).toBe(1);
+      expect(rejected.stderr).toContain(`runtime plan contains unreduced key ${key}`);
+    },
+  );
 
   it.each([
     {

--- a/test/hermes-secret-boundary-api-key.test.ts
+++ b/test/hermes-secret-boundary-api-key.test.ts
@@ -89,15 +89,16 @@ describe("agents/hermes/validate-hermes-env-secret-boundary API_SERVER_KEY contr
     expect(runtimeEnvResult.stderr).not.toContain(INHERITED_HEX_TOKEN.slice(0, 16));
   });
 
-  it("rejects weak API_SERVER_KEY values in Hermes .env without printing the value", () => {
-    for (const { envLine, redactedValue } of [
-      { envLine: "API_SERVER_KEY=x", redactedValue: "API_SERVER_KEY=x" },
-      { envLine: "API_SERVER_KEY=server-key", redactedValue: "server-key" },
-      {
-        envLine: "export API_SERVER_KEY='server-key'",
-        redactedValue: "server-key",
-      },
-    ]) {
+  it.each([
+    { envLine: "API_SERVER_KEY=x", redactedValue: "API_SERVER_KEY=x" },
+    { envLine: "API_SERVER_KEY=server-key", redactedValue: "server-key" },
+    {
+      envLine: "export API_SERVER_KEY='server-key'",
+      redactedValue: "server-key",
+    },
+  ])(
+    "rejects weak API_SERVER_KEY values in Hermes .env without printing the value [case %#]",
+    ({ envLine, redactedValue }) => {
       const result = runEnvFileValidator(
         ["API_SERVER_PORT=18642", "API_SERVER_HOST=127.0.0.1", envLine, ""].join("\n"),
       );
@@ -105,8 +106,8 @@ describe("agents/hermes/validate-hermes-env-secret-boundary API_SERVER_KEY contr
       expect(result.status, `${envLine}: ${result.stderr}`).toBe(1);
       expect(result.stderr, envLine).toContain("API_SERVER_KEY (line 3)");
       expect(result.stderr, envLine).not.toContain(redactedValue);
-    }
-  });
+    },
+  );
 
   it("rejects weak API_SERVER_KEY values in process env without printing the value", () => {
     const weakKey = "server-key";

--- a/test/hermes-start.test.ts
+++ b/test/hermes-start.test.ts
@@ -1429,18 +1429,19 @@ describe("agents/hermes/start.sh shields-up kanban dispatcher override", () => {
 });
 
 describe("agents/hermes/start.sh Tirith marker bootstrap", () => {
-  it.each([
-    true,
-    false,
-  ])("resolves the installed Tirith finalizer before fallback (%s)", (installed) => {
-    const run = runTirithFinalizerPathResolution(installed);
+  it.each([true, false])(
+    "resolves the installed Tirith finalizer before fallback (%s)",
+    (installed) => {
+      const run = runTirithFinalizerPathResolution(installed);
 
-    expect(run.result.status, run.result.stderr).toBe(0);
-    expect(run.result.stdout.trim()).toBe(run.expected);
-  });
+      expect(run.result.status, run.result.stderr).toBe(0);
+      expect(run.result.stdout.trim()).toBe(run.expected);
+    },
+  );
 
-  it("removes retryable Tirith markers before explicit command dispatch", () => {
-    for (const mode of ["non-root", "root"] as const) {
+  it.each(["non-root", "root"] as const)(
+    "removes retryable Tirith markers before explicit command dispatch [case %#]",
+    (mode) => {
       const run = runTirithExplicitCommandDispatch(mode);
 
       expect(run.result.status, `${mode}: ${run.result.stderr}`).toBe(0);
@@ -1448,8 +1449,8 @@ describe("agents/hermes/start.sh Tirith marker bootstrap", () => {
       expect(run.result.stderr).toContain(
         "download_failed marker present; letting Hermes runtime fallback retry Tirith",
       );
-    }
-  });
+    },
+  );
 
   it("repairs the Hermes config root before strict runtime config updates", () => {
     const run = runHermesRootStartupMutableRootPreflight();

--- a/test/hermes-wrapper-provider-merge.test.ts
+++ b/test/hermes-wrapper-provider-merge.test.ts
@@ -80,8 +80,9 @@ describe.skipIf(!canRun)("agents/hermes/hermes-wrapper.py provider/model merge",
     expect(run.realArgv).toEqual(["-m", "opencode-zen/already-prefixed"]);
   });
 
-  it("merges after value-less short and long continue flags (#7361)", () => {
-    for (const continueFlag of ["-c", "--continue"]) {
+  it.each(["-c", "--continue"])(
+    "merges after value-less short and long continue flags [case %#] (#7361)",
+    (continueFlag) => {
       const run = runWrapper(
         [continueFlag, "--provider", "nvidia-prod", "--model", "nvidia/nemotron-3-super-120b-a12b"],
         {},
@@ -93,8 +94,8 @@ describe.skipIf(!canRun)("agents/hermes/hermes-wrapper.py provider/model merge",
         "--model",
         "nvidia-prod/nvidia/nemotron-3-super-120b-a12b",
       ]);
-    }
-  });
+    },
+  );
 
   it("rejects an ambiguous unquoted multi-word continue form (#8011)", () => {
     const argv = [

--- a/test/install-clone-ref.test.ts
+++ b/test/install-clone-ref.test.ts
@@ -107,8 +107,9 @@ describe("installer git checkout", () => {
 describe("installer version stamping", () => {
   const extract = (stdout: string) => stdout.match(/START([\s\S]*?)STOP/)?.[1] ?? null;
 
-  it("stamps a requested version tag and defers mutable refs to describe (#7474)", () => {
-    for (const installer of [INSTALLER_PAYLOAD, CURL_PIPE_INSTALLER]) {
+  it.each([INSTALLER_PAYLOAD, CURL_PIPE_INSTALLER])(
+    "stamps a requested version tag and defers mutable refs to describe [case %#] (#7474)",
+    (installer) => {
       const stamp = (ref: string) => {
         const result = spawnSync(
           "bash",
@@ -126,8 +127,8 @@ describe("installer version stamping", () => {
       expect(stamp("lkg")).toBe("");
       expect(stamp("latest")).toBe("");
       expect(stamp("main")).toBe("");
-    }
-  });
+    },
+  );
 
   it("reports the stamped .version over a mismatched git describe (#7474)", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-version-"));

--- a/test/install-express-prompt.test.ts
+++ b/test/install-express-prompt.test.ts
@@ -848,21 +848,18 @@ maybe_offer_express_install`,
       env: { NEMOCLAW_VLLM_MODEL: "nemotron-3-ultra-550b-a55b" },
       message: /--station-deepseek conflicts with NEMOCLAW_VLLM_MODEL='nemotron-3-ultra-550b-a55b'/,
     },
-  ])("rejects $name before Docker or build-dependency mutation", ({
-    args,
-    platform,
-    env,
-    message,
-  }) => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-station-flag-preflight-"));
-    const mutationLog = path.join(tmp, "host-mutations.log");
-    const result = spawnSync(
-      "bash",
-      [
-        "--noprofile",
-        "--norc",
-        "-c",
-        `
+  ])(
+    "rejects $name before Docker or build-dependency mutation",
+    ({ args, platform, env, message }) => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-station-flag-preflight-"));
+      const mutationLog = path.join(tmp, "host-mutations.log");
+      const result = spawnSync(
+        "bash",
+        [
+          "--noprofile",
+          "--norc",
+          "-c",
+          `
 source "$INSTALLER_UNDER_TEST" >/dev/null
 detect_express_platform() { printf "%s" "$EXPRESS_PLATFORM"; }
 classify_dgx_station_release() { printf "%s" "\${EXPRESS_RELEASE_STATE:-generic-ubuntu}"; }
@@ -870,30 +867,31 @@ ensure_docker() { printf "ensure_docker\\n" >>"$MUTATION_LOG"; }
 ensure_openshell_build_deps() { printf "ensure_openshell_build_deps\\n" >>"$MUTATION_LOG"; }
 main "$@"
 `,
-        "_",
-        ...args,
-      ],
-      {
-        cwd: tmp,
-        encoding: "utf-8",
-        env: {
-          HOME: tmp,
-          PATH: TEST_SYSTEM_PATH,
-          INSTALLER_UNDER_TEST: INSTALLER_PAYLOAD,
-          MUTATION_LOG: mutationLog,
-          EXPRESS_PLATFORM: platform,
-          ...env,
+          "_",
+          ...args,
+        ],
+        {
+          cwd: tmp,
+          encoding: "utf-8",
+          env: {
+            HOME: tmp,
+            PATH: TEST_SYSTEM_PATH,
+            INSTALLER_UNDER_TEST: INSTALLER_PAYLOAD,
+            MUTATION_LOG: mutationLog,
+            EXPRESS_PLATFORM: platform,
+            ...env,
+          },
         },
-      },
-    );
-    const output = `${result.stdout}${result.stderr}`;
-    const mutations = fs.existsSync(mutationLog) ? fs.readFileSync(mutationLog, "utf-8") : "";
+      );
+      const output = `${result.stdout}${result.stderr}`;
+      const mutations = fs.existsSync(mutationLog) ? fs.readFileSync(mutationLog, "utf-8") : "";
 
-    expect(result.status, output).not.toBe(0);
-    expect(output).toMatch(message);
-    expect(mutations).toBe("");
-    fs.rmSync(tmp, { recursive: true, force: true });
-  });
+      expect(result.status, output).not.toBe(0);
+      expect(output).toMatch(message);
+      expect(mutations).toBe("");
+      fs.rmSync(tmp, { recursive: true, force: true });
+    },
+  );
 
   it.each<{
     name: string;
@@ -910,30 +908,30 @@ main "$@"
       extraEnv: {},
       entrypointArgs: ["--station-deepseek", "--yes-i-accept-third-party-software"],
     },
-  ])("reaches and accepts the DeepSeek express prompt through main with $name (#7008)", ({
-    extraEnv,
-    entrypointArgs,
-  }) => {
-    const result = runExpressPromptWithTty(
-      "\n",
-      "pipe",
-      "DGX Station",
-      extraEnv,
-      "accepted-station-main",
-      entrypointArgs,
-    );
-    const output = `${result.stdout}${result.stderr}`;
-    expect(result.status, output).toBe(0);
-    expect(output).toMatch(
-      /Express install will configure managed local vLLM with DeepSeek V4 Flash/,
-    );
-    expect(output.match(/Run express install with these settings\?/g)).toHaveLength(1);
-    expect(output).toMatch(/Using express install for DGX Station/);
-    expect(output).toMatch(
-      /RESULT NON_INTERACTIVE=1 SUDO_MODE=prompt PROVIDER=install-vllm MODEL=deepseek-ai\/DeepSeek-V4-Flash VLLM_MODEL=deepseek-v4-flash POLICY=suggested YES=1 SANDBOX=my-assistant/,
-    );
-    expect(output).not.toMatch(/cannot be combined with non-interactive mode/);
-  });
+  ])(
+    "reaches and accepts the DeepSeek express prompt through main with $name (#7008)",
+    ({ extraEnv, entrypointArgs }) => {
+      const result = runExpressPromptWithTty(
+        "\n",
+        "pipe",
+        "DGX Station",
+        extraEnv,
+        "accepted-station-main",
+        entrypointArgs,
+      );
+      const output = `${result.stdout}${result.stderr}`;
+      expect(result.status, output).toBe(0);
+      expect(output).toMatch(
+        /Express install will configure managed local vLLM with DeepSeek V4 Flash/,
+      );
+      expect(output.match(/Run express install with these settings\?/g)).toHaveLength(1);
+      expect(output).toMatch(/Using express install for DGX Station/);
+      expect(output).toMatch(
+        /RESULT NON_INTERACTIVE=1 SUDO_MODE=prompt PROVIDER=install-vllm MODEL=deepseek-ai\/DeepSeek-V4-Flash VLLM_MODEL=deepseek-v4-flash POLICY=suggested YES=1 SANDBOX=my-assistant/,
+      );
+      expect(output).not.toMatch(/cannot be combined with non-interactive mode/);
+    },
+  );
 
   it.each<{
     name: string;
@@ -953,32 +951,32 @@ main "$@"
       extraEnv: { EXPRESS_RELEASE_STATE: "unsupported-dgx-os" },
       entrypointArgs: ["--force-station-install", "--yes-i-accept-third-party-software"],
     },
-  ])("reaches and accepts the forced Station express prompt through main with $name", ({
-    extraEnv,
-    entrypointArgs,
-  }) => {
-    const result = runExpressPromptWithTty(
-      "\n",
-      "pipe",
-      "DGX Station",
-      extraEnv,
-      "accepted-station-main",
-      entrypointArgs,
-    );
-    const output = `${result.stdout}${result.stderr}`;
+  ])(
+    "reaches and accepts the forced Station express prompt through main with $name",
+    ({ extraEnv, entrypointArgs }) => {
+      const result = runExpressPromptWithTty(
+        "\n",
+        "pipe",
+        "DGX Station",
+        extraEnv,
+        "accepted-station-main",
+        entrypointArgs,
+      );
+      const output = `${result.stdout}${result.stderr}`;
 
-    expect(result.status, output).toBe(0);
-    expect(output).toMatch(
-      /Explicit --force-station-install intent bypasses only DGX release-metadata qualification/,
-    );
-    expect(output).toMatch(
-      /Active agent and unrelated Docker workloads still block Station preparation; an existing vLLM workload receives explicit handling choices/,
-    );
-    expect(output.match(/Run express install with these settings\?/g)).toHaveLength(1);
-    expect(output).toMatch(/Using express install for DGX Station/);
-    expect(output).toMatch(/PROVIDER=install-vllm/);
-    expect(output).not.toMatch(/cannot be combined with non-interactive mode/);
-  });
+      expect(result.status, output).toBe(0);
+      expect(output).toMatch(
+        /Explicit --force-station-install intent bypasses only DGX release-metadata qualification/,
+      );
+      expect(output).toMatch(
+        /Active agent and unrelated Docker workloads still block Station preparation; an existing vLLM workload receives explicit handling choices/,
+      );
+      expect(output.match(/Run express install with these settings\?/g)).toHaveLength(1);
+      expect(output).toMatch(/Using express install for DGX Station/);
+      expect(output).toMatch(/PROVIDER=install-vllm/);
+      expect(output).not.toMatch(/cannot be combined with non-interactive mode/);
+    },
+  );
 
   it("errors instead of silently skipping --station-deepseek when no interactive terminal is available (#7014)", () => {
     // Python's start_new_session runs main without a controlling terminal, and
@@ -1117,16 +1115,19 @@ printf 'NON_EXPRESS_ALLOWED\n'
     // the "(triggered by: …)" clause is omitted.
     ["NON_INTERACTIVE", "1", /cannot be combined with non-interactive mode\./],
     ["NEMOCLAW_PROVIDER", "install-vllm", /conflicts with NEMOCLAW_PROVIDER=install-vllm/],
-  ])("rejects %s when the Station demo override would otherwise be ignored", (name, value, message) => {
-    const result = runExpressPromptWithTty("\n", "pipe", "DGX Station", {
-      STATION_DEEPSEEK: "1",
-      [name]: value,
-    });
-    const output = `${result.stdout}${result.stderr}`;
-    expect(result.status, output).not.toBe(0);
-    expect(output).toMatch(message);
-    expect(output).not.toMatch(/Run express install/);
-  });
+  ])(
+    "rejects %s when the Station demo override would otherwise be ignored",
+    (name, value, message) => {
+      const result = runExpressPromptWithTty("\n", "pipe", "DGX Station", {
+        STATION_DEEPSEEK: "1",
+        [name]: value,
+      });
+      const output = `${result.stdout}${result.stderr}`;
+      expect(result.status, output).not.toBe(0);
+      expect(output).toMatch(message);
+      expect(output).not.toMatch(/Run express install/);
+    },
+  );
 
   it("describes and preserves an explicit DGX Station model override", () => {
     const result = runExpressPromptWithTty("\n", "pipe", "DGX Station", {
@@ -1181,28 +1182,25 @@ detect_express_platform
     expect(result.stdout).toBe("Windows WSL");
   });
 
-  it.each([
-    "Dell Pro Max with Station GB300",
-    "NVIDIA DGX Station GB300",
-    "DGX_Station_GB300",
-  ])("recognizes supported Station GB300 firmware as DGX Station: %s", (productName) => {
-    const result = detectExpressPlatformForProductName(productName);
-
-    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
-    expect(result.stdout).toBe("DGX Station");
-  });
-
-  it("rejects partial and unsupported Station product identifiers", () => {
-    for (const productName of [
-      "Acme XP3830 Workstation",
-      "Dell Pro Max with Station GB200",
-      "Dell Pro Max with GB300",
-    ]) {
+  it.each(["Dell Pro Max with Station GB300", "NVIDIA DGX Station GB300", "DGX_Station_GB300"])(
+    "recognizes supported Station GB300 firmware as DGX Station: %s",
+    (productName) => {
       const result = detectExpressPlatformForProductName(productName);
 
       expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
-      expect(result.stdout).not.toBe("DGX Station");
-    }
+      expect(result.stdout).toBe("DGX Station");
+    },
+  );
+
+  it.each([
+    "Acme XP3830 Workstation",
+    "Dell Pro Max with Station GB200",
+    "Dell Pro Max with GB300",
+  ])("rejects partial and unsupported Station product identifiers [case %#]", (productName) => {
+    const result = detectExpressPlatformForProductName(productName);
+
+    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+    expect(result.stdout).not.toBe("DGX Station");
   });
 
   it.each(["7.2.0", "7.4.0", "7.5.0"])("recognizes stock DGX OS %s on Station GB300", (version) => {
@@ -1225,18 +1223,18 @@ detect_express_platform
     expect(result.stdout).toBe("DGX Station");
   });
 
-  it.each([
-    "colossus-baseos",
-    "ai-developer-tools",
-  ] as const)("recognizes the exact no-OTA %s Station profile", (profile) => {
-    const result = detectExpressPlatformForStockDgxRelease(
-      "DGX Station GB300",
-      noOtaFactoryRelease(profile),
-    );
+  it.each(["colossus-baseos", "ai-developer-tools"] as const)(
+    "recognizes the exact no-OTA %s Station profile",
+    (profile) => {
+      const result = detectExpressPlatformForStockDgxRelease(
+        "DGX Station GB300",
+        noOtaFactoryRelease(profile),
+      );
 
-    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
-    expect(result.stdout).toBe("DGX Station");
-  });
+      expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+      expect(result.stdout).toBe("DGX Station");
+    },
+  );
 
   it("classifies the exact GB300WS 7.5.0 build 2026-05-13-18-42-38 as Station Express (#7979)", () => {
     const release = noOtaFactoryRelease("ai-developer-tools").replace(
@@ -1311,12 +1309,15 @@ detect_express_platform
     ["NVIDIA DGX Station GB300X", "Unsupported DGX Station generation"],
     ["Dell Pro Max with Station GB200", ""],
     ["Dell Pro Max with GB300", ""],
-  ])("rejects partial or unsupported Station product identifier: %s (#7103)", (productName, expected) => {
-    const result = detectExpressPlatformForProductName(productName);
+  ])(
+    "rejects partial or unsupported Station product identifier: %s (#7103)",
+    (productName, expected) => {
+      const result = detectExpressPlatformForProductName(productName);
 
-    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
-    expect(result.stdout).toBe(expected);
-  });
+      expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+      expect(result.stdout).toBe(expected);
+    },
+  );
 
   it("classifies older DGX Station generations as unsupported", () => {
     const result = detectExpressPlatformForProductName("NVIDIA DGX Station A100");
@@ -1325,40 +1326,40 @@ detect_express_platform
     expect(result.stdout).toBe("Unsupported DGX Station generation");
   });
 
-  it.each([
-    "Unsupported DGX Station OS",
-    "Unsupported DGX Station generation",
-  ])("rejects %s before the express prompt", (platform) => {
-    const result = spawnSync(
-      "bash",
-      [
-        "--noprofile",
-        "--norc",
-        "-c",
-        `
+  it.each(["Unsupported DGX Station OS", "Unsupported DGX Station generation"])(
+    "rejects %s before the express prompt",
+    (platform) => {
+      const result = spawnSync(
+        "bash",
+        [
+          "--noprofile",
+          "--norc",
+          "-c",
+          `
 source "$INSTALLER_UNDER_TEST" >/dev/null
 validate_express_platform_boundary "$EXPRESS_PLATFORM"
 printf 'PROMPT_REACHED\n'
 `,
-      ],
-      {
-        cwd: path.join(import.meta.dirname, ".."),
-        encoding: "utf-8",
-        env: {
-          HOME: fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-express-platform-reject-")),
-          PATH: TEST_SYSTEM_PATH,
-          INSTALLER_UNDER_TEST: INSTALLER_PAYLOAD,
-          EXPRESS_PLATFORM: platform,
+        ],
+        {
+          cwd: path.join(import.meta.dirname, ".."),
+          encoding: "utf-8",
+          env: {
+            HOME: fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-express-platform-reject-")),
+            PATH: TEST_SYSTEM_PATH,
+            INSTALLER_UNDER_TEST: INSTALLER_PAYLOAD,
+            EXPRESS_PLATFORM: platform,
+          },
         },
-      },
-    );
-    const output = `${result.stdout}${result.stderr}`;
-    expect(result.status, output).not.toBe(0);
-    expect(output).toMatch(
-      /outside the (recognized Station Express release-metadata|validated Station GB300 express) boundary/,
-    );
-    expect(output).not.toContain("PROMPT_REACHED");
-  });
+      );
+      const output = `${result.stdout}${result.stderr}`;
+      expect(result.status, output).not.toBe(0);
+      expect(output).toMatch(
+        /outside the (recognized Station Express release-metadata|validated Station GB300 express) boundary/,
+      );
+      expect(output).not.toContain("PROMPT_REACHED");
+    },
+  );
 
   it("explains the supported boundary for an unrecognized DGX OS before Station preparation", () => {
     const result = spawnSync(

--- a/test/issue-4462-admin-approval-helper.test.ts
+++ b/test/issue-4462-admin-approval-helper.test.ts
@@ -118,13 +118,14 @@ describe("prepared connect-shell administrative approval", () => {
     expect(() => extractPendingRequestId("requestId: not-a-canonical-uuid")).toThrow("found 0");
   });
 
-  it("selects only the cron requestId on its exact paired CLI device and bounded scopes (#5324)", () => {
-    for (const tokenShape of ["array", "object"] as const) {
+  it.each(["array", "object"] as const)(
+    "selects only the cron requestId on its exact paired CLI device and bounded scopes [case %#] (#5324)",
+    (tokenShape) => {
       const result = runSelector(adminState(tokenShape));
       expect(result.status, result.stderr).toBe(0);
       expect(result.stdout.trim()).toBe(EXPECTED_REQUEST_ID);
-    }
-  });
+    },
+  );
 
   it("accepts compact device grants when the active token includes implied read scope (#5324)", () => {
     const state = adminState("object");

--- a/test/langchain-deepagents-code-direct-module-patch.test.ts
+++ b/test/langchain-deepagents-code-direct-module-patch.test.ts
@@ -219,27 +219,27 @@ else:
     expect(`${result.stdout}\n${result.stderr}`).toContain("disabled in NemoClaw-managed");
   });
 
-  it.each([
-    ["-y"],
-    ["--auto-approve"],
-  ])("preserves explicit direct-module auto-approval in thread-opt-in mode: %s (#6478)", (...args) => {
-    const tempDir = createPackageFixture();
-    patchFixture(tempDir);
-    writeManagedAutoApproval(tempDir, "thread-opt-in\n");
-    const result = spawnSync("python3", ["-m", "deepagents_code", ...args], {
-      env: {
-        PATH: process.env.PATH,
-        PYTHONPATH: tempDir,
-        NEMOCLAW_DCODE_AUTO_APPROVAL: "disabled",
-      },
-      encoding: "utf8",
-    });
+  it.each([["-y"], ["--auto-approve"]])(
+    "preserves explicit direct-module auto-approval in thread-opt-in mode: %s (#6478)",
+    (...args) => {
+      const tempDir = createPackageFixture();
+      patchFixture(tempDir);
+      writeManagedAutoApproval(tempDir, "thread-opt-in\n");
+      const result = spawnSync("python3", ["-m", "deepagents_code", ...args], {
+        env: {
+          PATH: process.env.PATH,
+          PYTHONPATH: tempDir,
+          NEMOCLAW_DCODE_AUTO_APPROVAL: "disabled",
+        },
+        encoding: "utf8",
+      });
 
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain("managed-posture-ok auto_approve=True");
-    expect(result.stderr).toContain("Auto-approval is enabled for this thread");
-    expect(result.stderr).toContain("shell commands");
-  });
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("managed-posture-ok auto_approve=True");
+      expect(result.stderr).toContain("Auto-approval is enabled for this thread");
+      expect(result.stderr).toContain("shell commands");
+    },
+  );
 
   it("validates exact trusted auto-approval state and otherwise fails closed (#6478)", () => {
     const tempDir = createPackageFixture();
@@ -313,10 +313,11 @@ check("disabled", False)
     expect(result.stderr).toContain("capability contents are invalid");
   });
 
-  it("preserves ordinary direct-module and read-only tools execution", () => {
-    const tempDir = createPackageFixture();
-    patchFixture(tempDir);
-    for (const args of [[], ["tools", "list"], ["tools", "help"]]) {
+  it.each([[[]], [["tools", "list"]], [["tools", "help"]]] as const)(
+    "preserves ordinary direct-module and read-only tools execution for argv %#",
+    (args) => {
+      const tempDir = createPackageFixture();
+      patchFixture(tempDir);
       const result = spawnSync("python3", ["-m", "deepagents_code", ...args], {
         env: {
           PATH: process.env.PATH,
@@ -327,24 +328,23 @@ check("disabled", False)
       });
       expect(result.status, `${args.join(" ")} failed: ${result.stderr}`).toBe(0);
       expect(result.stdout).toContain("managed-posture-ok");
-    }
-  });
+    },
+  );
 
-  it("rejects direct-module runtime credentials before settings bootstrap", () => {
-    const tempDir = createPackageFixture();
-    patchFixture(tempDir);
-    for (const [name, value] of [
-      ["OPENAI_API_KEY", "sk-TEST-FAKE-DO-NOT-USE-000000000000"],
-      ["NOTES", "metadata API_KEY=ABCDEFGHIJKL"],
-      ["SLACK_BOT_TOKEN", "xoxb-sk-abcdefghijklmnopqrstuv"],
-      ["LANGSMITH_RUNS_ENDPOINTS", '{"https://trace.example":"opaque-key-value"}'],
-      ["LANGCHAIN_RUNS_ENDPOINTS", '{"https://trace.example":"opaque-key-value"}'],
-      // A plain OTLP endpoint URL is allowed (#6466); credential-bearing forms
-      // (embedded userinfo, structured key blob) are still refused.
-      ["OTEL_EXPORTER_OTLP_ENDPOINT", "http://token@collector.example:4318"],
-      ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", '{"https://trace.example":"opaque-key-value"}'],
-      ["OTEL_EXPORTER_OTLP_HEADERS", "authorization=opaque-value"],
-    ]) {
+  it.each([
+    ["OPENAI_API_KEY", "sk-TEST-FAKE-DO-NOT-USE-000000000000"],
+    ["NOTES", "metadata API_KEY=ABCDEFGHIJKL"],
+    ["SLACK_BOT_TOKEN", "xoxb-sk-abcdefghijklmnopqrstuv"],
+    ["LANGSMITH_RUNS_ENDPOINTS", '{"https://trace.example":"opaque-key-value"}'],
+    ["LANGCHAIN_RUNS_ENDPOINTS", '{"https://trace.example":"opaque-key-value"}'],
+    ["OTEL_EXPORTER_OTLP_ENDPOINT", "http://token@collector.example:4318"],
+    ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", '{"https://trace.example":"opaque-key-value"}'],
+    ["OTEL_EXPORTER_OTLP_HEADERS", "authorization=opaque-value"],
+  ] as const)(
+    "rejects direct-module runtime credential in %s before settings bootstrap",
+    (name, value) => {
+      const tempDir = createPackageFixture();
+      patchFixture(tempDir);
       const result = spawnSync("python3", ["-m", "deepagents_code"], {
         env: { PATH: process.env.PATH, PYTHONPATH: tempDir, [name]: value },
         encoding: "utf8",
@@ -352,8 +352,8 @@ check("disabled", False)
 
       expect(result.status, `${name} was allowed`).not.toBe(0);
       expect(result.stderr).toContain(`runtime environment variable ${name}`);
-    }
-  });
+    },
+  );
 
   it.each([
     ["OPENSHELL_TLS_CA", "/etc/openshell/tls/client/ca.crt"],
@@ -373,30 +373,28 @@ check("disabled", False)
     expect(result.stderr).not.toContain(value);
   });
 
-  it("allows the managed OTLP collector URL in the direct-module runtime (#6466)", () => {
-    const tempDir = createPackageFixture();
-    patchFixture(tempDir);
-    for (const name of ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]) {
-      for (const value of [
+  it.each(
+    ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"].flatMap((name) =>
+      [
         "http://host.openshell.internal:4318",
         "http://host.openshell.internal:4318/v1/traces",
         "http://host.openshell.internal",
-      ]) {
-        const result = spawnSync("python3", ["-m", "deepagents_code"], {
-          env: { PATH: process.env.PATH, PYTHONPATH: tempDir, [name]: value },
-          encoding: "utf8",
-        });
-        expect(result.status, `${name}=${value} was rejected: ${result.stderr}`).toBe(0);
-        expect(result.stdout).toContain("managed-posture-ok");
-      }
-    }
-  });
-
-  it("rejects fail-open OTLP endpoint values in the direct-module runtime (#6538)", () => {
+      ].map((value) => ({ name, value })),
+    ),
+  )("allows managed OTLP collector URL candidate %# for $name (#6466)", ({ name, value }) => {
     const tempDir = createPackageFixture();
     patchFixture(tempDir);
-    for (const name of ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]) {
-      for (const value of [
+    const result = spawnSync("python3", ["-m", "deepagents_code"], {
+      env: { PATH: process.env.PATH, PYTHONPATH: tempDir, [name]: value },
+      encoding: "utf8",
+    });
+    expect(result.status, `${name}=${value} was rejected: ${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("managed-posture-ok");
+  });
+
+  it.each(
+    ["OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"].flatMap((name) =>
+      [
         "https://collector.example.com:4318",
         "http://evil.host.openshell.internal:4318",
         "http://host.openshell.internal.evil.com",
@@ -410,15 +408,17 @@ check("disabled", False)
         "http://héllo:4318",
         "http://",
         `http://host.openshell.internal:4318/p${"a".repeat(3000)}`,
-      ]) {
-        const result = spawnSync("python3", ["-m", "deepagents_code"], {
-          env: { PATH: process.env.PATH, PYTHONPATH: tempDir, [name]: value },
-          encoding: "utf8",
-        });
-        expect(result.status, `${name}=${value} was allowed`).not.toBe(0);
-        expect(result.stderr).toContain(`runtime environment variable ${name}`);
-      }
-    }
+      ].map((value) => ({ name, value })),
+    ),
+  )("rejects fail-open OTLP endpoint candidate %# for $name (#6538)", ({ name, value }) => {
+    const tempDir = createPackageFixture();
+    patchFixture(tempDir);
+    const result = spawnSync("python3", ["-m", "deepagents_code"], {
+      env: { PATH: process.env.PATH, PYTHONPATH: tempDir, [name]: value },
+      encoding: "utf8",
+    });
+    expect(result.status, `${name}=${value} was allowed`).not.toBe(0);
+    expect(result.stderr).toContain(`runtime environment variable ${name}`);
   });
 
   it("allows only scoped managed credential-shaped runtime values", () => {
@@ -447,7 +447,11 @@ check("disabled", False)
     expect(result.stdout).toContain("managed-posture-ok");
   });
 
-  it("accepts only exact same-name OpenShell credential placeholders", () => {
+  it.each([
+    "openshell:resolve:env:GITHUB_MCP_TOKEN",
+    "openshell:resolve:env:v0_GITHUB_MCP_TOKEN",
+    `openshell:resolve:env:v${"1".repeat(20)}_GITHUB_MCP_TOKEN`,
+  ])("accepts exact same-name OpenShell credential placeholder candidate %#", (value) => {
     const tempDir = createPackageFixture();
     patchFixture(tempDir);
     const run = (name: string, value: string) =>
@@ -456,24 +460,25 @@ check("disabled", False)
         encoding: "utf8",
       });
 
-    for (const value of [
-      "openshell:resolve:env:GITHUB_MCP_TOKEN",
-      "openshell:resolve:env:v0_GITHUB_MCP_TOKEN",
-      `openshell:resolve:env:v${"1".repeat(20)}_GITHUB_MCP_TOKEN`,
-    ]) {
-      const result = run("GITHUB_MCP_TOKEN", value);
-      expect(result.status, result.stderr).toBe(0);
-    }
+    const result = run("GITHUB_MCP_TOKEN", value);
+    expect(result.status, result.stderr).toBe(0);
+  });
 
-    for (const [name, value] of [
-      ["GITHUB_MCP_TOKEN", "prefix-openshell:resolve:env:GITHUB_MCP_TOKEN"],
-      ["GITHUB_MCP_TOKEN", "openshell:resolve:env:OTHER_TOKEN"],
-      ["GITHUB_MCP_TOKEN", `openshell:resolve:env:v${"1".repeat(21)}_GITHUB_MCP_TOKEN`],
-    ]) {
-      const result = run(name, value);
-      expect(result.status, `${name}=${value} was allowed`).not.toBe(0);
-      expect(result.stderr).toContain("invalid OpenShell credential placeholder");
-    }
+  it.each([
+    ["GITHUB_MCP_TOKEN", "prefix-openshell:resolve:env:GITHUB_MCP_TOKEN"],
+    ["GITHUB_MCP_TOKEN", "openshell:resolve:env:OTHER_TOKEN"],
+    ["GITHUB_MCP_TOKEN", `openshell:resolve:env:v${"1".repeat(21)}_GITHUB_MCP_TOKEN`],
+  ] as const)("rejects mismatched OpenShell credential placeholder candidate %#", (name, value) => {
+    const tempDir = createPackageFixture();
+    patchFixture(tempDir);
+    const run = (candidateName: string, candidateValue: string) =>
+      spawnSync("python3", ["-m", "deepagents_code"], {
+        env: { PATH: process.env.PATH, PYTHONPATH: tempDir, [candidateName]: candidateValue },
+        encoding: "utf8",
+      });
+    const result = run(name, value);
+    expect(result.status, `${name}=${value} was allowed`).not.toBe(0);
+    expect(result.stderr).toContain("invalid OpenShell credential placeholder");
   });
 
   it("loads only strict HTTPS-only managed MCP configuration", () => {

--- a/test/langchain-deepagents-code-image-credentials.test.ts
+++ b/test/langchain-deepagents-code-image-credentials.test.ts
@@ -54,17 +54,16 @@ describe("LangChain Deep Agents Code image credential boundary", () => {
     expect(fs.existsSync(ranMarker)).toBe(false);
   });
 
-  it("allows only exact same-name OpenShell env placeholders in runtime and dotenv inputs", () => {
-    const name = "GITHUB_MCP_TOKEN";
-    const validPlaceholders = [
-      `openshell:resolve:env:${name}`,
-      `openshell:resolve:env:v0_${name}`,
-      `openshell:resolve:env:v1442987827285932589_${name}`,
-    ];
-
-    for (const [index, placeholder] of validPlaceholders.entries()) {
+  it.each([
+    "openshell:resolve:env:GITHUB_MCP_TOKEN",
+    "openshell:resolve:env:v0_GITHUB_MCP_TOKEN",
+    "openshell:resolve:env:v1442987827285932589_GITHUB_MCP_TOKEN",
+  ])(
+    "allows exact same-name OpenShell env placeholder candidate %# in runtime and dotenv",
+    (placeholder) => {
+      const name = "GITHUB_MCP_TOKEN";
       const runtimeDir = fs.mkdtempSync(
-        path.join(os.tmpdir(), `nemoclaw-dcode-placeholder-runtime-${index}-`),
+        path.join(os.tmpdir(), "nemoclaw-dcode-placeholder-runtime-"),
       );
       const runtimeFixture = makeWrapperFixture(runtimeDir);
       const runtimeResult = runWrapper(runtimeFixture.wrapperPath, ["-n", "hi"], {
@@ -75,7 +74,7 @@ describe("LangChain Deep Agents Code image credential boundary", () => {
       expect(fs.existsSync(runtimeFixture.ranMarker)).toBe(true);
 
       const dotenvDir = fs.mkdtempSync(
-        path.join(os.tmpdir(), `nemoclaw-dcode-placeholder-dotenv-${index}-`),
+        path.join(os.tmpdir(), "nemoclaw-dcode-placeholder-dotenv-"),
       );
       const dotenvFixture = makeWrapperFixture(dotenvDir);
       fs.writeFileSync(dotenvFixture.envFile, `${name}="${placeholder}"\n`, "utf8");
@@ -83,8 +82,8 @@ describe("LangChain Deep Agents Code image credential boundary", () => {
       expect(dotenvResult.status, placeholder).toBe(0);
       expect(dotenvResult.stdout).toContain("dcode-stub-ran");
       expect(fs.existsSync(dotenvFixture.ranMarker)).toBe(true);
-    }
-  });
+    },
+  );
 
   function verifyOtlpEndpointCredentialContract() {
     // The managed collector URL is not a credential and must pass; everything
@@ -178,47 +177,42 @@ describe("LangChain Deep Agents Code image credential boundary", () => {
     verifyOtlpEndpointCredentialContract,
   );
 
-  it("rejects mismatched, malformed, wrapped, and raw credential placeholders", () => {
-    const oversizedName = "A".repeat(129);
-    const invalidCases = [
-      { name: "MODEL_NAME", value: "openshell:resolve:env:OTHER_NAME" },
-      { name: "MODEL_NAME", value: "openshell:resolve:env:v12_OTHER_NAME" },
-      { name: "MODEL_NAME", value: "openshell:resolve:env:v_MODEL_NAME" },
-      { name: "MODEL_NAME", value: "openshell:resolve:env:v12x_MODEL_NAME" },
-      { name: "MODEL_NAME", value: "openshell:resolve:env:v12__MODEL_NAME" },
-      { name: "MODEL_NAME", value: "Bearer openshell:resolve:env:MODEL_NAME" },
-      { name: "MODEL_NAME", value: "openshell:resolve:env:MODEL_NAME:suffix" },
-      { name: "MODEL-NAME", value: "openshell:resolve:env:MODEL-NAME" },
-      { name: "OPENSHELL_TLS_KEY", value: "openshell:resolve:env:OPENSHELL_TLS_KEY" },
-      { name: "OPENSHELL_TLS_KEY", value: "openshell:resolve:env:v12_OPENSHELL_TLS_KEY" },
-      { name: oversizedName, value: `openshell:resolve:env:${oversizedName}` },
-      { name: "GITHUB_MCP_TOKEN", value: "opaqueRawCredentialValue12345" },
-    ];
+  it.each([
+    { name: "MODEL_NAME", value: "openshell:resolve:env:OTHER_NAME" },
+    { name: "MODEL_NAME", value: "openshell:resolve:env:v12_OTHER_NAME" },
+    { name: "MODEL_NAME", value: "openshell:resolve:env:v_MODEL_NAME" },
+    { name: "MODEL_NAME", value: "openshell:resolve:env:v12x_MODEL_NAME" },
+    { name: "MODEL_NAME", value: "openshell:resolve:env:v12__MODEL_NAME" },
+    { name: "MODEL_NAME", value: "Bearer openshell:resolve:env:MODEL_NAME" },
+    { name: "MODEL_NAME", value: "openshell:resolve:env:MODEL_NAME:suffix" },
+    { name: "MODEL-NAME", value: "openshell:resolve:env:MODEL-NAME" },
+    { name: "OPENSHELL_TLS_KEY", value: "openshell:resolve:env:OPENSHELL_TLS_KEY" },
+    { name: "OPENSHELL_TLS_KEY", value: "openshell:resolve:env:v12_OPENSHELL_TLS_KEY" },
+    { name: "A".repeat(129), value: `openshell:resolve:env:${"A".repeat(129)}` },
+    { name: "GITHUB_MCP_TOKEN", value: "opaqueRawCredentialValue12345" },
+  ])("rejects mismatched or malformed credential placeholder candidate %#", ({ name, value }) => {
+    const runtimeDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-dcode-placeholder-invalid-runtime-"),
+    );
+    const runtimeFixture = makeWrapperFixture(runtimeDir);
+    const runtimeResult = runWrapper(runtimeFixture.wrapperPath, ["-n", "hi"], {
+      [name]: value,
+    });
+    expect(runtimeResult.status, `runtime accepted ${value}`).not.toBe(0);
+    expect(runtimeResult.stderr).toContain(name);
+    expect(runtimeResult.stderr).not.toContain(value);
+    expect(fs.existsSync(runtimeFixture.ranMarker)).toBe(false);
 
-    for (const [index, { name, value }] of invalidCases.entries()) {
-      const runtimeDir = fs.mkdtempSync(
-        path.join(os.tmpdir(), `nemoclaw-dcode-placeholder-invalid-runtime-${index}-`),
-      );
-      const runtimeFixture = makeWrapperFixture(runtimeDir);
-      const runtimeResult = runWrapper(runtimeFixture.wrapperPath, ["-n", "hi"], {
-        [name]: value,
-      });
-      expect(runtimeResult.status, `runtime accepted ${value}`).not.toBe(0);
-      expect(runtimeResult.stderr).toContain(name);
-      expect(runtimeResult.stderr).not.toContain(value);
-      expect(fs.existsSync(runtimeFixture.ranMarker)).toBe(false);
-
-      const dotenvDir = fs.mkdtempSync(
-        path.join(os.tmpdir(), `nemoclaw-dcode-placeholder-invalid-dotenv-${index}-`),
-      );
-      const dotenvFixture = makeWrapperFixture(dotenvDir);
-      fs.writeFileSync(dotenvFixture.envFile, `${name}=${value}\n`, "utf8");
-      const dotenvResult = runWrapper(dotenvFixture.wrapperPath, ["-n", "hi"], {});
-      expect(dotenvResult.status, `dotenv accepted ${value}`).not.toBe(0);
-      expect(dotenvResult.stderr).toContain(name);
-      expect(dotenvResult.stderr).not.toContain(value);
-      expect(fs.existsSync(dotenvFixture.ranMarker)).toBe(false);
-    }
+    const dotenvDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-dcode-placeholder-invalid-dotenv-"),
+    );
+    const dotenvFixture = makeWrapperFixture(dotenvDir);
+    fs.writeFileSync(dotenvFixture.envFile, `${name}=${value}\n`, "utf8");
+    const dotenvResult = runWrapper(dotenvFixture.wrapperPath, ["-n", "hi"], {});
+    expect(dotenvResult.status, `dotenv accepted ${value}`).not.toBe(0);
+    expect(dotenvResult.stderr).toContain(name);
+    expect(dotenvResult.stderr).not.toContain(value);
+    expect(fs.existsSync(dotenvFixture.ranMarker)).toBe(false);
   });
 
   it.each([
@@ -259,17 +253,16 @@ describe("LangChain Deep Agents Code image credential boundary", () => {
     expect(fs.existsSync(ranMarker)).toBe(true);
   });
 
-  it("rejects managed Slack runtime env vars that wrap non-Slack secret values", () => {
-    const cases: Array<{ name: string; value: string }> = [
-      { name: "SLACK_BOT_TOKEN", value: "xoxb-sk-abcdefghijklmnopqrstuvwx" },
-      { name: "SLACK_APP_TOKEN", value: "xapp-ghp_abcdefghijklmnopqr" },
-      { name: "SLACK_BOT_TOKEN", value: "xoxb-API_KEY=opaquevalue12345" },
-      { name: "SLACK_APP_TOKEN", value: "xapp-TOKEN:opaquevalue12345" },
-      { name: "SLACK_BOT_TOKEN", value: `xoxb-lsv2_pt_${"a".repeat(36)}_${"b".repeat(10)}` },
-      { name: "SLACK_APP_TOKEN", value: `xapp-${fakePrivateKeyBlock()}` },
-    ];
-
-    for (const { name, value } of cases) {
+  it.each([
+    { name: "SLACK_BOT_TOKEN", value: "xoxb-sk-abcdefghijklmnopqrstuvwx" },
+    { name: "SLACK_APP_TOKEN", value: "xapp-ghp_abcdefghijklmnopqr" },
+    { name: "SLACK_BOT_TOKEN", value: "xoxb-API_KEY=opaquevalue12345" },
+    { name: "SLACK_APP_TOKEN", value: "xapp-TOKEN:opaquevalue12345" },
+    { name: "SLACK_BOT_TOKEN", value: `xoxb-lsv2_pt_${"a".repeat(36)}_${"b".repeat(10)}` },
+    { name: "SLACK_APP_TOKEN", value: `xapp-${fakePrivateKeyBlock()}` },
+  ])(
+    "rejects managed Slack runtime $name wrapping non-Slack secret candidate %#",
+    ({ name, value }) => {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-slack-wrap-"));
       const { wrapperPath, ranMarker } = makeWrapperFixture(tempDir);
       const result = runWrapper(wrapperPath, ["-n", "hi"], { [name]: value });
@@ -278,20 +271,19 @@ describe("LangChain Deep Agents Code image credential boundary", () => {
       expect(result.stderr).toContain(name);
       expect(result.stderr).not.toContain(value);
       expect(fs.existsSync(ranMarker)).toBe(false);
-    }
-  });
+    },
+  );
 
-  it("rejects managed Slack env-file values that wrap non-Slack secret values", () => {
-    const cases: Array<{ name: string; value: string }> = [
-      { name: "SLACK_BOT_TOKEN", value: "xoxb-nvapi-abcdefghijklmnop" },
-      { name: "SLACK_APP_TOKEN", value: "xapp-pypi-abcdefghijklmnop" },
-      { name: "SLACK_BOT_TOKEN", value: "xoxb-PASSWORD opaquevalue12345" },
-      { name: "SLACK_APP_TOKEN", value: "xapp-CREDENTIAL=opaquevalue12345" },
-      { name: "SLACK_APP_TOKEN", value: `xapp-lsv2_sk_${"a".repeat(36)}_${"b".repeat(10)}` },
-      { name: "SLACK_BOT_TOKEN", value: `xoxb-${fakePrivateKeyBlock("RSA")}` },
-    ];
-
-    for (const { name, value } of cases) {
+  it.each([
+    { name: "SLACK_BOT_TOKEN", value: "xoxb-nvapi-abcdefghijklmnop" },
+    { name: "SLACK_APP_TOKEN", value: "xapp-pypi-abcdefghijklmnop" },
+    { name: "SLACK_BOT_TOKEN", value: "xoxb-PASSWORD opaquevalue12345" },
+    { name: "SLACK_APP_TOKEN", value: "xapp-CREDENTIAL=opaquevalue12345" },
+    { name: "SLACK_APP_TOKEN", value: `xapp-lsv2_sk_${"a".repeat(36)}_${"b".repeat(10)}` },
+    { name: "SLACK_BOT_TOKEN", value: `xoxb-${fakePrivateKeyBlock("RSA")}` },
+  ])(
+    "rejects managed Slack env-file $name wrapping non-Slack secret candidate %#",
+    ({ name, value }) => {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-slack-wrap-file-"));
       const { wrapperPath, ranMarker, envFile } = makeWrapperFixture(tempDir);
       fs.writeFileSync(envFile, `${name}=${value}\n`, "utf8");
@@ -302,8 +294,8 @@ describe("LangChain Deep Agents Code image credential boundary", () => {
       expect(result.stderr).toContain(envFile);
       expect(result.stderr).not.toContain(value);
       expect(fs.existsSync(ranMarker)).toBe(false);
-    }
-  });
+    },
+  );
 
   it.each([
     {
@@ -553,29 +545,28 @@ describe("LangChain Deep Agents Code image credential boundary", () => {
     expect(fs.existsSync(ranMarker)).toBe(false);
   });
 
+  it.each([{ args: ["tools", "list"] }, { args: ["tools", "--help"] }, { args: ["tools"] }])(
+    "passes through read-only tools subcommand $args",
+    ({ args }) => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-tools-readonly-"));
+      const { wrapperPath, ranMarker } = makeWrapperFixture(tempDir);
+
+      const result = runWrapper(wrapperPath, args, {});
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("dcode-stub-ran");
+      expect(fs.existsSync(ranMarker)).toBe(true);
+    },
+  );
+
   it.each([
-    { args: ["tools", "list"] },
-    { args: ["tools", "--help"] },
-    { args: ["tools"] },
-  ])("passes through read-only tools subcommand $args", ({ args }) => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-tools-readonly-"));
-    const { wrapperPath, ranMarker } = makeWrapperFixture(tempDir);
-
-    const result = runWrapper(wrapperPath, args, {});
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("dcode-stub-ran");
-    expect(fs.existsSync(ranMarker)).toBe(true);
-  });
-
-  it("rejects non-messaging secret shapes carried by managed runtime env names", () => {
-    const cases: Array<{ name: string; sample: string }> = [
-      { name: "SLACK_BOT_TOKEN", sample: "sk-abcdefghijklmnopqrstuvwx" },
-      { name: "SLACK_APP_TOKEN", sample: "ghp_abcdefghijklmnopqr" },
-      { name: "TELEGRAM_BOT_TOKEN", sample: "ghp_abcdefghijklmnopqr" },
-      { name: "DISCORD_BOT_TOKEN", sample: ["AK", "IAABCDEFGHIJKLMNOP"].join("") },
-    ];
-    for (const { name, sample } of cases) {
+    { name: "SLACK_BOT_TOKEN", sample: "sk-abcdefghijklmnopqrstuvwx" },
+    { name: "SLACK_APP_TOKEN", sample: "ghp_abcdefghijklmnopqr" },
+    { name: "TELEGRAM_BOT_TOKEN", sample: "ghp_abcdefghijklmnopqr" },
+    { name: "DISCORD_BOT_TOKEN", sample: ["AK", "IAABCDEFGHIJKLMNOP"].join("") },
+  ])(
+    "rejects non-messaging secret candidate %# carried by managed runtime $name",
+    ({ name, sample }) => {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-mgmix-"));
       const { wrapperPath, ranMarker } = makeWrapperFixture(tempDir);
       const result = runWrapper(wrapperPath, ["-n", "hi"], { [name]: sample });
@@ -583,16 +574,16 @@ describe("LangChain Deep Agents Code image credential boundary", () => {
       expect(result.stderr).toContain(name);
       expect(result.stderr).not.toContain(sample);
       expect(fs.existsSync(ranMarker)).toBe(false);
-    }
-  });
+    },
+  );
 
-  it("rejects non-messaging secret shapes carried by managed env-file names", () => {
-    const cases: Array<{ name: string; sample: string }> = [
-      { name: "SLACK_BOT_TOKEN", sample: "sk-abcdefghijklmnopqrstuvwx" },
-      { name: "TELEGRAM_BOT_TOKEN", sample: "nvapi-abcdefghijklmnop" },
-      { name: "DISCORD_BOT_TOKEN", sample: "hf_abcdefghijklmnopq" },
-    ];
-    for (const { name, sample } of cases) {
+  it.each([
+    { name: "SLACK_BOT_TOKEN", sample: "sk-abcdefghijklmnopqrstuvwx" },
+    { name: "TELEGRAM_BOT_TOKEN", sample: "nvapi-abcdefghijklmnop" },
+    { name: "DISCORD_BOT_TOKEN", sample: "hf_abcdefghijklmnopq" },
+  ])(
+    "rejects non-messaging secret candidate %# carried by managed env-file $name",
+    ({ name, sample }) => {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-mgfile-"));
       const { wrapperPath, ranMarker, envFile } = makeWrapperFixture(tempDir);
       fs.writeFileSync(envFile, `${name}=${sample}\n`, "utf8");
@@ -602,8 +593,8 @@ describe("LangChain Deep Agents Code image credential boundary", () => {
       expect(result.stderr).toContain(envFile);
       expect(result.stderr).not.toContain(sample);
       expect(fs.existsSync(ranMarker)).toBe(false);
-    }
-  });
+    },
+  );
 
   it("emits no NET:OPEN, inference.local, or pypi.org log entries when a runtime secret triggers rejection", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-netlog-"));
@@ -735,43 +726,40 @@ describe("LangChain Deep Agents Code image credential boundary", () => {
     expect(fs.existsSync(ranMarker)).toBe(false);
   });
 
-  it("rejects the wrapper credential-name policy with opaque payloads", () => {
-    const cases = [
-      "KEY",
-      "TOKEN",
-      "SECRET",
-      "PASSWORD",
-      "PASSWD",
-      "PASS",
-      "CREDENTIAL",
-      "API_KEY",
-      "CUSTOM_PASSWD",
-      "CUSTOM_PASS",
-      "customPass",
-      "customPasswd",
-      "DBPass",
-      "db_pass",
-      "db_passwd",
-      "db-pass",
-      "db-passwd",
-      "apiKey",
-      "accessToken",
-      "replyToken",
-      "clientSecret",
-      "myCredential",
-      "customPassword",
-      "privateKey",
-    ];
+  it.each([
+    "KEY",
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "PASSWD",
+    "PASS",
+    "CREDENTIAL",
+    "API_KEY",
+    "CUSTOM_PASSWD",
+    "CUSTOM_PASS",
+    "customPass",
+    "customPasswd",
+    "DBPass",
+    "db_pass",
+    "db_passwd",
+    "db-pass",
+    "db-passwd",
+    "apiKey",
+    "accessToken",
+    "replyToken",
+    "clientSecret",
+    "myCredential",
+    "customPassword",
+    "privateKey",
+  ])("rejects wrapper credential-name policy entry %s with an opaque payload", (name) => {
     const opaque = "opaqueCredentialPayloadZ1234567890";
-    for (const name of cases) {
-      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `nemoclaw-dcode-exactctx-${name}-`));
-      const { wrapperPath, ranMarker } = makeWrapperFixture(tempDir);
-      const result = runWrapper(wrapperPath, ["-n", "hi"], { [name]: opaque });
-      expect(result.status, `${name} with opaque value not rejected`).not.toBe(0);
-      expect(result.stderr).toContain(name);
-      expect(result.stderr).not.toContain(opaque);
-      expect(fs.existsSync(ranMarker)).toBe(false);
-    }
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `nemoclaw-dcode-exactctx-${name}-`));
+    const { wrapperPath, ranMarker } = makeWrapperFixture(tempDir);
+    const result = runWrapper(wrapperPath, ["-n", "hi"], { [name]: opaque });
+    expect(result.status, `${name} with opaque value not rejected`).not.toBe(0);
+    expect(result.stderr).toContain(name);
+    expect(result.stderr).not.toContain(opaque);
+    expect(fs.existsSync(ranMarker)).toBe(false);
   });
 
   it("allows benign runtime names containing pass as a substring", () => {
@@ -848,20 +836,21 @@ describe("LangChain Deep Agents Code image credential boundary", () => {
     expect(fs.existsSync(ranMarker)).toBe(false);
   });
 
-  it.each(
-    CANONICAL_SECRET_POSITIVE_VECTORS,
-  )("rejects canonical $label secrets before dcode starts (#6195)", ({ label, value }) => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `nemoclaw-dcode-parity-${label}-`));
-    try {
-      const { wrapperPath, ranMarker } = makeWrapperFixture(tempDir);
-      const varName = `NEMOCLAW_PARITY_${label.toUpperCase()}`;
-      const result = runWrapper(wrapperPath, ["-n", "hi"], { [varName]: value });
-      expect(result.status, `${label} via runtime env not rejected`).not.toBe(0);
-      expect(result.stderr).toContain(varName);
-      expect(result.stderr).not.toContain(value);
-      expect(fs.existsSync(ranMarker)).toBe(false);
-    } finally {
-      fs.rmSync(tempDir, { force: true, recursive: true });
-    }
-  });
+  it.each(CANONICAL_SECRET_POSITIVE_VECTORS)(
+    "rejects canonical $label secrets before dcode starts (#6195)",
+    ({ label, value }) => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `nemoclaw-dcode-parity-${label}-`));
+      try {
+        const { wrapperPath, ranMarker } = makeWrapperFixture(tempDir);
+        const varName = `NEMOCLAW_PARITY_${label.toUpperCase()}`;
+        const result = runWrapper(wrapperPath, ["-n", "hi"], { [varName]: value });
+        expect(result.status, `${label} via runtime env not rejected`).not.toBe(0);
+        expect(result.stderr).toContain(varName);
+        expect(result.stderr).not.toContain(value);
+        expect(fs.existsSync(ranMarker)).toBe(false);
+      } finally {
+        fs.rmSync(tempDir, { force: true, recursive: true });
+      }
+    },
+  );
 });

--- a/test/langchain-deepagents-code-managed-entrypoints.test.ts
+++ b/test/langchain-deepagents-code-managed-entrypoints.test.ts
@@ -87,13 +87,14 @@ function makeWrapperFixture(
 }
 
 describe("LangChain Deep Agents Code managed entrypoints", () => {
-  it("uses trusted privileged-mode Bash for every image entry script", () => {
-    for (const name of ["dcode-launcher.sh", "dcode-wrapper.sh", "start.sh"]) {
+  it.each(["dcode-launcher.sh", "dcode-wrapper.sh", "start.sh"])(
+    "uses trusted privileged-mode Bash for every image entry script [case %#]",
+    (name) => {
       const source = readAgentFile(name);
       expect(source.startsWith("#!/bin/bash -p\n"), name).toBe(true);
       expect(source).toContain("unset BASH_ENV ENV");
-    }
-  });
+    },
+  );
 
   it("forces every LangChain and LangSmith tracing flag off across image boundaries", () => {
     const dockerfile = readAgentFile("Dockerfile");
@@ -210,20 +211,23 @@ describe("LangChain Deep Agents Code managed entrypoints", () => {
     "--auto-appro",
     "--auto-approv",
     "--auto-approve",
-  ])("allows explicit thread auto-approval through %s only in thread-opt-in mode (#6478)", (arg) => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-auto-opt-in-"));
-    const { wrapperPath, ranMarker } = makeWrapperFixture(tempDir, "thread-opt-in\n");
-    const result = spawnSync("bash", [wrapperPath, arg], {
-      env: {
-        PATH: process.env.PATH ?? "/usr/bin:/bin",
-        NEMOCLAW_DCODE_AUTO_APPROVAL: "disabled",
-      },
-      encoding: "utf8",
-    });
+  ])(
+    "allows explicit thread auto-approval through %s only in thread-opt-in mode (#6478)",
+    (arg) => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-auto-opt-in-"));
+      const { wrapperPath, ranMarker } = makeWrapperFixture(tempDir, "thread-opt-in\n");
+      const result = spawnSync("bash", [wrapperPath, arg], {
+        env: {
+          PATH: process.env.PATH ?? "/usr/bin:/bin",
+          NEMOCLAW_DCODE_AUTO_APPROVAL: "disabled",
+        },
+        encoding: "utf8",
+      });
 
-    expect(result.status, result.stderr).toBe(0);
-    expect(fs.existsSync(ranMarker)).toBe(true);
-  });
+      expect(result.status, result.stderr).toBe(0);
+      expect(fs.existsSync(ranMarker)).toBe(true);
+    },
+  );
 
   it("keeps non-interactive argument scanning fail-closed around auto-approval (#6478)", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-auto-headless-"));

--- a/test/langchain-deepagents-code-proxy-launcher.test.ts
+++ b/test/langchain-deepagents-code-proxy-launcher.test.ts
@@ -458,8 +458,9 @@ describe("Deep Agents Code direct-exec proxy launcher", () => {
     expect(combined).not.toContain("all-password");
   });
 
-  it("fails closed when the image-baked dcode proxy contract is missing (#6191)", () => {
-    for (const missingFile of ["trusted-proxy-host", "trusted-proxy-port"]) {
+  it.each(["trusted-proxy-host", "trusted-proxy-port"])(
+    "fails closed when the image-baked dcode proxy contract is missing [case %#] (#6191)",
+    (missingFile) => {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-missing-proxy-"));
       const launcherPath = makeLauncherProxyProbeFixture(tempDir);
       const { scriptPath } = makeStartProxyProbeFixture(tempDir);
@@ -482,8 +483,8 @@ describe("Deep Agents Code direct-exec proxy launcher", () => {
       const combined = `${launcherResult.stdout}\n${launcherResult.stderr}\n${startResult.stdout}\n${startResult.stderr}`;
       expect(combined).toContain("trusted managed proxy");
       expect(combined).not.toContain("attacker-proxy.internal");
-    }
-  });
+    },
+  );
 
   it("rejects writable image-baked dcode proxy files (#6191)", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-dcode-proxy-mode-"));
@@ -583,12 +584,12 @@ describe("Deep Agents Code direct-exec proxy launcher", () => {
         fs.symlinkSync(`${caFile}.missing`, caFile);
       },
     },
-  ])("rejects $condition managed fetch CA bundles in start, connect, and direct dcode paths (#6636)", ({
-    expected,
-    mutate,
-  }) => {
-    expectManagedCaBundleRejection({ expected, mutate });
-  });
+  ])(
+    "rejects $condition managed fetch CA bundles in start, connect, and direct dcode paths (#6636)",
+    ({ expected, mutate }) => {
+      expectManagedCaBundleRejection({ expected, mutate });
+    },
+  );
 
   it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
     "rejects an unreadable managed fetch CA bundle in start, connect, and direct dcode paths (#6636)",

--- a/test/managed-image-publication-evidence.test.ts
+++ b/test/managed-image-publication-evidence.test.ts
@@ -483,13 +483,14 @@ describe("managed image publication evidence verifier", () => {
     expect(fixture.evidence).toBeNull();
   });
 
-  it("rejects missing or duplicate predicate layers", () => {
-    for (const options of [{ omitSlsa: true }, { omitSpdx: true }, { duplicateSlsaLayer: true }]) {
+  it.each([{ omitSlsa: true }, { omitSpdx: true }, { duplicateSlsaLayer: true }])(
+    "rejects missing or duplicate predicate layers [case %#]",
+    (options) => {
       const fixture = runEvidence(options);
       expect(fixture.result.status).not.toBe(0);
       expect(fixture.evidence).toBeNull();
-    }
-  });
+    },
+  );
 
   it("rejects an attestation layer labeled with the wrong predicate type", () => {
     const fixture = runEvidence({
@@ -508,17 +509,15 @@ describe("managed image publication evidence verifier", () => {
     expect(fixture.evidence).toBeNull();
   });
 
-  it("rejects exact statement blobs mixed with a different workload subject", () => {
-    for (const options of [
-      { slsaSubjectDigest: "9".repeat(64) },
-      { spdxSubjectDigest: "9".repeat(64) },
-    ]) {
+  it.each([{ slsaSubjectDigest: "9".repeat(64) }, { spdxSubjectDigest: "9".repeat(64) }])(
+    "rejects exact statement blobs mixed with a different workload subject [case %#]",
+    (options) => {
       const fixture = runEvidence(options);
       expect(fixture.result.status).not.toBe(0);
       expect(fixture.result.stderr).toMatch(/statement does not bind/);
       expect(fixture.evidence).toBeNull();
-    }
-  });
+    },
+  );
 
   it.each([
     ["agent", { slsaAgent: "hermes" }],

--- a/test/nemoclaw-start-perms.test.ts
+++ b/test/nemoclaw-start-perms.test.ts
@@ -150,8 +150,9 @@ describe("nemoclaw-start one-shot command lifecycle", () => {
     }
   });
 
-  it("forwards TERM and INT to the direct child, reaps it, and still runs cleanup (#6047)", () => {
-    for (const signal of ["TERM", "INT"] as const) {
+  it.each(["TERM", "INT"] as const)(
+    "forwards TERM and INT to the direct child, reaps it, and still runs cleanup [case %#] (#6047)",
+    (signal) => {
       const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-oneshot-signal-"));
       const childScript = path.join(root, "child.sh");
       const childPidFile = path.join(root, "child.pid");
@@ -195,8 +196,8 @@ describe("nemoclaw-start one-shot command lifecycle", () => {
       } finally {
         fs.rmSync(root, { recursive: true, force: true });
       }
-    }
-  });
+    },
+  );
 
   it("returns cleanup failure and reports both statuses (#6047)", () => {
     const script = [

--- a/test/nemoclaw-start.test.ts
+++ b/test/nemoclaw-start.test.ts
@@ -2486,43 +2486,41 @@ describe("seed_default_workspace_templates (#3240)", () => {
     }
   });
 
-  it("resolves supported OpenClaw package template layouts", () => {
-    for (const relativeTemplatesDir of [
-      path.join("docs", "reference", "templates"),
-      path.join("dist", "docs", "reference", "templates"),
-    ]) {
-      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-seed-package-"));
-      const workspaceDir = path.join(tmpDir, "workspace");
-      const fakeBin = path.join(tmpDir, "bin");
-      const npmRoot = path.join(tmpDir, "npm-root");
-      const templatesDir = path.join(npmRoot, "openclaw", relativeTemplatesDir);
-      fs.mkdirSync(workspaceDir, { recursive: true });
-      fs.mkdirSync(fakeBin, { recursive: true });
-      writeTemplates(templatesDir);
-      fs.writeFileSync(
-        path.join(fakeBin, "npm"),
-        [
-          "#!/usr/bin/env bash",
-          'if [ "${1:-}" = "root" ] && [ "${2:-}" = "-g" ]; then',
-          `  printf '%s\\n' ${JSON.stringify(npmRoot)}`,
-          "  exit 0",
-          "fi",
-          'printf "unexpected npm args: %s\\n" "$*" >&2',
-          "exit 2",
-        ].join("\n"),
-        { mode: 0o700 },
-      );
+  it.each([
+    path.join("docs", "reference", "templates"),
+    path.join("dist", "docs", "reference", "templates"),
+  ])("resolves supported OpenClaw package template layouts [case %#]", (relativeTemplatesDir) => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-seed-package-"));
+    const workspaceDir = path.join(tmpDir, "workspace");
+    const fakeBin = path.join(tmpDir, "bin");
+    const npmRoot = path.join(tmpDir, "npm-root");
+    const templatesDir = path.join(npmRoot, "openclaw", relativeTemplatesDir);
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.mkdirSync(fakeBin, { recursive: true });
+    writeTemplates(templatesDir);
+    fs.writeFileSync(
+      path.join(fakeBin, "npm"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "${1:-}" = "root" ] && [ "${2:-}" = "-g" ]; then',
+        `  printf '%s\\n' ${JSON.stringify(npmRoot)}`,
+        "  exit 0",
+        "fi",
+        'printf "unexpected npm args: %s\\n" "$*" >&2',
+        "exit 2",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
 
-      try {
-        const result = runSeed(workspaceDir, "", path.join(tmpDir, "seed.sh"), {
-          env: { PATH: `${fakeBin}:${process.env.PATH || ""}` },
-        });
-        expect(result.status).toBe(0);
-        expect(fs.existsSync(path.join(workspaceDir, "SOUL.md"))).toBe(true);
-        expect(result.stderr).toContain("seeded 6 default workspace template");
-      } finally {
-        fs.rmSync(tmpDir, { recursive: true, force: true });
-      }
+    try {
+      const result = runSeed(workspaceDir, "", path.join(tmpDir, "seed.sh"), {
+        env: { PATH: `${fakeBin}:${process.env.PATH || ""}` },
+      });
+      expect(result.status).toBe(0);
+      expect(fs.existsSync(path.join(workspaceDir, "SOUL.md"))).toBe(true);
+      expect(result.stderr).toContain("seeded 6 default workspace template");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 
@@ -3712,8 +3710,9 @@ process.stderr.write('FailoverError: token=123456:LATER\\n');
     expect(diagnosticLines[0]).not.toContain("LATER");
   });
 
-  it("installs and validates the diagnostics preload in both entrypoint paths before gateway launch", () => {
-    for (const kind of ["non-root", "root"] as const) {
+  it.each(["non-root", "root"] as const)(
+    "installs and validates the diagnostics preload in both entrypoint paths before gateway launch [case %#]",
+    (kind) => {
       const setup = runPreGatewaySetup(kind);
       expect(setup.result.status).toBe(0);
       expect(setup.preloadExists).toBe(true);
@@ -3723,8 +3722,8 @@ process.stderr.write('FailoverError: token=123456:LATER\\n');
       expect(setup.result.stdout).toContain(setup.preloadPath);
       expect(setup.pluginRefreshLogExists).toBe(true);
       expect(setup.pluginRefreshLogMode).toBe("600");
-    }
-  });
+    },
+  );
 
   it("connect-shell rc sources the diagnostics preload when present", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-telegram-rc-"));

--- a/test/network-policies-published-routes.test.ts
+++ b/test/network-policies-published-routes.test.ts
@@ -141,21 +141,23 @@ describe("shared Network Policies published routes", () => {
     expect(findBrokenPublishedRoutes(CUSTOMIZE_POLICY_SOURCE, index)).toEqual([]);
   });
 
-  it("publishes the bounded policy task set for Deep Agents", () => {
+  it.each(DEEPAGENTS_POLICY_ROUTES)("publishes the Deep Agents policy route %s", (route) => {
     const index = buildPublishedRouteIndex();
-
-    for (const route of DEEPAGENTS_POLICY_ROUTES) {
-      expect(index.routes.has(route), route).toBe(true);
-    }
-    for (const route of DEEPAGENTS_EXCLUDED_POLICY_ROUTES) {
-      expect(index.routes.has(route), route).toBe(false);
-    }
+    expect(index.routes.has(route), route).toBe(true);
   });
 
-  it("publishes shared policy configuration pages for every supported agent", () => {
-    const index = buildPublishedRouteIndex();
+  it.each(DEEPAGENTS_EXCLUDED_POLICY_ROUTES)(
+    "excludes the Deep Agents policy route %s",
+    (route) => {
+      const index = buildPublishedRouteIndex();
+      expect(index.routes.has(route), route).toBe(false);
+    },
+  );
 
-    for (const source of SHARED_CONFIGURATION_SOURCES) {
+  it.each(SHARED_CONFIGURATION_SOURCES)(
+    "publishes the shared %s policy page for every supported agent",
+    (source) => {
+      const index = buildPublishedRouteIndex();
       const slug = source
         .split("/")
         .at(-1)
@@ -171,8 +173,8 @@ describe("shared Network Policies published routes", () => {
         `/user-guide/openclaw/network-policy/configure-policies/${slug}`,
       ]);
       expect(findBrokenPublishedRoutes(source, index)).toEqual([]);
-    }
-  });
+    },
+  );
 
   it("keeps raw TLS configuration scoped to OpenClaw and Hermes", () => {
     const index = buildPublishedRouteIndex();
@@ -253,13 +255,16 @@ describe("shared Network Policies published routes", () => {
     ]);
   });
 
-  it("preserves compatibility anchors on the retained policy routes (#7495)", () => {
-    const customizePolicy = readDoc(CUSTOMIZE_POLICY_SOURCE);
-
-    expect(customizePolicy).toContain("## Custom Preset Files");
-    for (const { anchors, target } of LEGACY_CUSTOMIZE_POLICY_POINTERS) {
+  it.each(LEGACY_CUSTOMIZE_POLICY_POINTERS)(
+    "preserves the compatibility anchors before $target (#7495)",
+    ({ anchors, target }) => {
+      const customizePolicy = readDoc(CUSTOMIZE_POLICY_SOURCE);
       expectUniqueAnchorsBeforePointer(customizePolicy, anchors, target);
-    }
+    },
+  );
+
+  it("preserves retained policy sections (#7495)", () => {
+    expect(readDoc(CUSTOMIZE_POLICY_SOURCE)).toContain("## Custom Preset Files");
     expect(readDoc(INTEGRATION_POLICY_SOURCE)).toContain("## Gmail With an App Password");
   });
 });

--- a/test/onboard-fsm-live-slices.test.ts
+++ b/test/onboard-fsm-live-slices.test.ts
@@ -601,14 +601,15 @@ describe("live onboard FSM slice boundaries", () => {
     ]);
   });
 
-  it("leaves ordinary policy tiers non-authoritative in the runOnboard machine", () => {
-    for (const policyTier of ["balanced", "restricted"] as const) {
+  it.each(["balanced", "restricted"] as const)(
+    "leaves ordinary policy tiers non-authoritative in the runOnboard machine [case %#]",
+    (policyTier) => {
       assert.deepEqual(runSliceProbe({ slice: "core", mode: "ordinary-policy-tier", policyTier }), [
         "initial:init",
         "authoritative-policy-tier:undefined",
       ]);
-    }
-  });
+    },
+  );
 
   it("preserves an explicit null policy tier for authoritative rebuilds", () => {
     const called = runSliceProbe({

--- a/test/onboard-messaging-slack-token-format.test.ts
+++ b/test/onboard-messaging-slack-token-format.test.ts
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, it } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+async function loadSlackChannel() {
+  const onboardPath = path.join(repoRoot, "src", "lib", "onboard.ts");
+  const onboardUrl = `${pathToFileURL(onboardPath).href}?update=${Date.now()}`;
+  const { MESSAGING_CHANNELS } = await import(onboardUrl);
+  const slack = MESSAGING_CHANNELS.find((channel: { name: string }) => channel.name === "slack");
+  assert.ok(slack, "slack messaging channel definition present");
+  return slack;
+}
+
+describe("onboard Slack token formats", () => {
+  it("defines Slack bot and app token format guidance (#1912)", async () => {
+    const slack = await loadSlackChannel();
+
+    assert.ok(slack.tokenFormat instanceof RegExp, "slack.tokenFormat is a regex");
+    assert.ok(
+      typeof slack.tokenFormatHint === "string" && slack.tokenFormatHint.length > 0,
+      "slack.tokenFormatHint set",
+    );
+    assert.ok(slack.appTokenFormat instanceof RegExp, "slack.appTokenFormat is a regex");
+    assert.ok(
+      typeof slack.appTokenFormatHint === "string" && slack.appTokenFormatHint.length > 0,
+      "slack.appTokenFormatHint set",
+    );
+  });
+
+  it.each([
+    "abcd",
+    "",
+    "xoxb",
+    "xoxb-",
+    "xoxp-" + "test-user-token", // gitleaks:allow
+    "xapp-" + "test-app-token", // gitleaks:allow
+    "Bearer xoxb-fake",
+    "xoxb-fake with space",
+  ])("rejects Slack bot token vector %# (#1912)", async (token) => {
+    const slack = await loadSlackChannel();
+    assert.ok(
+      !slack.tokenFormat.test(token),
+      `expected ${JSON.stringify(token)} to be rejected as Slack bot token`,
+    );
+  });
+
+  it.each([
+    "xoxb-test-slack-token-value",
+    "xoxb-fake-bot-token",
+    "xoxb-A",
+    "xoxb-test_with_underscores",
+    "xoxb-mix_of-hyphens_and_underscores",
+  ])("accepts Slack bot token vector %# (#1912)", async (token) => {
+    const slack = await loadSlackChannel();
+    assert.ok(
+      slack.tokenFormat.test(token),
+      `expected ${JSON.stringify(token)} to be accepted as Slack bot token`,
+    );
+  });
+
+  it.each([
+    "abcd",
+    "",
+    "xapp",
+    "xapp-",
+    "xoxb-" + "test-bot-token", // gitleaks:allow
+    "Bearer xapp-fake",
+    "xapp-fake with space",
+  ])("rejects Slack app token vector %# (#1912)", async (token) => {
+    const slack = await loadSlackChannel();
+    assert.ok(
+      !slack.appTokenFormat.test(token),
+      `expected ${JSON.stringify(token)} to be rejected as Slack app token`,
+    );
+  });
+
+  it.each([
+    "xapp-" + "1-A0000-12345-abcdef",
+    "xapp-" + "test-app-token-value",
+    "xapp-" + "A",
+    "xapp-" + "with_underscores_and-hyphens",
+  ])("accepts Slack app token vector %# (#1912)", async (token) => {
+    const slack = await loadSlackChannel();
+    assert.ok(
+      slack.appTokenFormat.test(token),
+      `expected ${JSON.stringify(token)} to be accepted as Slack app token`,
+    );
+  });
+});

--- a/test/onboard-messaging.test.ts
+++ b/test/onboard-messaging.test.ts
@@ -7,7 +7,6 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 
 import { beforeEach, describe, it, vi } from "vitest";
 import YAML from "yaml";
@@ -49,26 +48,33 @@ beforeEach(() => {
   vi.stubEnv("NEMOCLAW_SANDBOX_PREBUILD", "1");
 });
 describe("onboard messaging", () => {
-  it("creates providers for messaging tokens and attaches them to the sandbox", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-messaging-providers-"));
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "messaging-provider-check.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-    const registryPath = JSON.stringify(path.join(repoRoot, "src", "lib", "state", "registry.ts"));
-    const preflightPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
-    );
-    const credentialsPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
-    );
+  it(
+    "creates providers for messaging tokens and attaches them to the sandbox",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-messaging-providers-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "messaging-provider-check.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+      const registryPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "state", "registry.ts"),
+      );
+      const preflightPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
+      );
+      const credentialsPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+      );
 
-    fs.mkdirSync(fakeBin, { recursive: true });
-    writeOkOpenshell(fakeBin, { readySandboxGet: true });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      writeOkOpenshell(fakeBin, { readySandboxGet: true });
 
-    const script = String.raw`
+      const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 const registry = require(${registryPath});
@@ -150,174 +156,187 @@ const { createSandbox, setupMessagingChannels } = require(${onboardPath});
   process.exit(1);
 });
 `;
-    fs.writeFileSync(scriptPath, script);
+      fs.writeFileSync(scriptPath, script);
 
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-        NEMOCLAW_NON_INTERACTIVE: "1",
-      },
-    });
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+      });
 
-    assert.equal(result.status, 0, result.stderr);
-    const payload = parseStdoutJson(result.stdout);
+      assert.equal(result.status, 0, result.stderr);
+      const payload = parseStdoutJson(result.stdout);
 
-    // Verify providers were created with the right credential keys
-    const providerCommands = payload.commands.filter((e: CommandEntry) =>
-      e.command.includes("provider create"),
-    );
-    const discordProvider = providerCommands.find((e: CommandEntry) =>
-      e.command.includes("my-assistant-discord-bridge"),
-    );
-    assert.ok(discordProvider, "expected my-assistant-discord-bridge provider create command");
-    assert.match(discordProvider.command, /--credential DISCORD_BOT_TOKEN/);
-
-    const slackProvider = providerCommands.find((e: CommandEntry) =>
-      e.command.includes("my-assistant-slack-bridge"),
-    );
-    assert.ok(slackProvider, "expected my-assistant-slack-bridge provider create command");
-    assert.match(slackProvider.command, /--credential SLACK_BOT_TOKEN/);
-
-    const telegramProvider = providerCommands.find((e: CommandEntry) =>
-      e.command.includes("my-assistant-telegram-bridge"),
-    );
-    assert.ok(telegramProvider, "expected my-assistant-telegram-bridge provider create command");
-    assert.match(telegramProvider.command, /--credential TELEGRAM_BOT_TOKEN/);
-
-    // Verify sandbox create includes --provider flags for all three
-    const createCommand = payload.commands.find((e: CommandEntry) =>
-      e.command.includes("sandbox create"),
-    );
-    assert.ok(createCommand, "expected sandbox create command");
-    assert.match(createCommand.command, /--provider my-assistant-discord-bridge/);
-    assert.match(createCommand.command, /--provider my-assistant-slack-bridge/);
-    assert.match(createCommand.command, /--provider my-assistant-telegram-bridge/);
-    assert.match(createCommand.command, /--policy [^ ]*nemoclaw-initial-policy[^ ]*\.yaml/);
-    assert.equal(createCommand.policyReadError, undefined);
-    const policyDoc = YAML.parse(createCommand.policyContent || "") || {};
-    const slackEndpointHosts = (policyDoc.network_policies?.slack?.endpoints || []).map(
-      (entry: { host?: string }) => entry.host,
-    );
-    const slackWebsocketHosts = slackEndpointHosts
-      .filter(
-        (host: string | undefined) =>
-          host === "wss-primary.slack.com" || host === "wss-backup.slack.com",
-      )
-      .sort();
-    assert.deepEqual(slackWebsocketHosts, ["wss-backup.slack.com", "wss-primary.slack.com"].sort());
-
-    // Messaging tokens must NOT appear in the sandbox create command
-    // (they flow exclusively through the openshell provider credential system).
-    assert.doesNotMatch(createCommand.command, /test-discord-token-value/);
-    assert.doesNotMatch(createCommand.command, /123456:ABC-test-telegram-token/);
-    assert.doesNotMatch(createCommand.command, /DISCORD_BOT_TOKEN=/);
-    assert.doesNotMatch(createCommand.command, /TELEGRAM_BOT_TOKEN=/);
-    assert.doesNotMatch(createCommand.command, /xoxb-test-slack-token-value/);
-    assert.doesNotMatch(createCommand.command, /xapp-test-slack-app-token-value/);
-    assert.doesNotMatch(createCommand.command, /SLACK_BOT_TOKEN=/);
-    assert.doesNotMatch(createCommand.command, /SLACK_APP_TOKEN=/);
-    assert.doesNotMatch(createCommand.command, /NEMOCLAW_MESSAGING_PLAN_B64=/);
-
-    assert.ok(payload.messagingPlanEnv, "expected serialized messaging plan in host process env");
-    const messagingPlan = JSON.parse(
-      Buffer.from(payload.messagingPlanEnv, "base64").toString("utf8"),
-    );
-    assert.equal(messagingPlan.sandboxName, "my-assistant");
-    assert.deepEqual(
-      messagingPlan.channels.map((channel: { channelId: string }) => channel.channelId).sort(),
-      ["discord", "slack", "telegram"].sort(),
-    );
-    assert.doesNotMatch(JSON.stringify(messagingPlan), /test-discord-token-value/);
-    assert.doesNotMatch(JSON.stringify(messagingPlan), /123456:ABC-test-telegram-token/);
-
-    // Verify blocked credentials are NOT in the sandbox spawn environment
-    assert.ok(createCommand.env, "expected env to be captured from spawn call");
-    assert.equal(
-      createCommand.env.DISCORD_BOT_TOKEN,
-      undefined,
-      "DISCORD_BOT_TOKEN must not be in sandbox env",
-    );
-    assert.equal(
-      createCommand.env.SLACK_BOT_TOKEN,
-      undefined,
-      "SLACK_BOT_TOKEN must not be in sandbox env",
-    );
-    assert.equal(
-      createCommand.env.SLACK_APP_TOKEN,
-      undefined,
-      "SLACK_APP_TOKEN must not be in sandbox env",
-    );
-    assert.equal(
-      createCommand.env.TELEGRAM_BOT_TOKEN,
-      undefined,
-      "TELEGRAM_BOT_TOKEN must not be in sandbox env",
-    );
-    assert.equal(
-      createCommand.env.NVIDIA_INFERENCE_API_KEY,
-      undefined,
-      "NVIDIA_INFERENCE_API_KEY must not be in sandbox env",
-    );
-    assert.equal(createCommand.env.KUBECONFIG, undefined, "KUBECONFIG must not be in sandbox env");
-    assert.equal(
-      createCommand.env.SSH_AUTH_SOCK,
-      undefined,
-      "SSH_AUTH_SOCK must not be in sandbox env",
-    );
-
-    // Belt-and-suspenders: raw token values must not appear anywhere in env
-    const envString = JSON.stringify(createCommand.env);
-    assert.ok(
-      !envString.includes("test-discord-token-value"),
-      "Discord token value must not leak into sandbox env",
-    );
-    assert.ok(
-      !envString.includes("xoxb-test-slack-token-value"),
-      "Slack bot token value must not leak into sandbox spawn env",
-    );
-    assert.ok(
-      !envString.includes("xapp-test-slack-app-token-value"),
-      "Slack app token value must not leak into sandbox spawn env",
-    );
-    assert.ok(
-      !envString.includes("123456:ABC-test-telegram-token"),
-      "Telegram token value must not leak into sandbox env",
-    );
-  });
-
-  it("preserves Hermes Slack policy when Slack is active at sandbox create time", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-hermes-slack-"));
-    try {
-      const fakeBin = path.join(tmpDir, "bin");
-      const customBuildDir = path.join(tmpDir, "custom-build");
-      const customDockerfilePath = path.join(customBuildDir, "Dockerfile");
-      const scriptPath = path.join(tmpDir, "hermes-slack-policy.js");
-      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-      const agentDefsPath = JSON.stringify(path.join(repoRoot, "src", "lib", "agent", "defs.ts"));
-      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-      const registryPath = JSON.stringify(
-        path.join(repoRoot, "src", "lib", "state", "registry.ts"),
+      const providerCommands = payload.commands.filter((e: CommandEntry) =>
+        e.command.includes("provider create"),
       );
-      const preflightPath = JSON.stringify(
-        path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
+      const discordProvider = providerCommands.find((e: CommandEntry) =>
+        e.command.includes("my-assistant-discord-bridge"),
       );
-      const credentialsPath = JSON.stringify(
-        path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+      assert.ok(discordProvider, "expected my-assistant-discord-bridge provider create command");
+      assert.match(discordProvider.command, /--credential DISCORD_BOT_TOKEN/);
+
+      const slackProvider = providerCommands.find((e: CommandEntry) =>
+        e.command.includes("my-assistant-slack-bridge"),
       );
-      const yamlPath = JSON.stringify(yamlModulePath);
-      const customDockerfileArg = JSON.stringify(customDockerfilePath);
+      assert.ok(slackProvider, "expected my-assistant-slack-bridge provider create command");
+      assert.match(slackProvider.command, /--credential SLACK_BOT_TOKEN/);
 
-      fs.mkdirSync(fakeBin, { recursive: true });
-      fs.mkdirSync(customBuildDir, { recursive: true });
-      fs.writeFileSync(customDockerfilePath, "FROM scratch\nARG NEMOCLAW_MESSAGING_PLAN_B64=\nARG NEMOCLAW_TOOL_DISCLOSURE=progressive\nENV NEMOCLAW_TOOL_DISCLOSURE=${NEMOCLAW_TOOL_DISCLOSURE}\n");
-      writeOkOpenshell(fakeBin, { readySandboxGet: true });
+      const telegramProvider = providerCommands.find((e: CommandEntry) =>
+        e.command.includes("my-assistant-telegram-bridge"),
+      );
+      assert.ok(telegramProvider, "expected my-assistant-telegram-bridge provider create command");
+      assert.match(telegramProvider.command, /--credential TELEGRAM_BOT_TOKEN/);
 
-      const script = String.raw`
+      // Verify sandbox create includes --provider flags for all three
+      const createCommand = payload.commands.find((e: CommandEntry) =>
+        e.command.includes("sandbox create"),
+      );
+      assert.ok(createCommand, "expected sandbox create command");
+      assert.match(createCommand.command, /--provider my-assistant-discord-bridge/);
+      assert.match(createCommand.command, /--provider my-assistant-slack-bridge/);
+      assert.match(createCommand.command, /--provider my-assistant-telegram-bridge/);
+      assert.match(createCommand.command, /--policy [^ ]*nemoclaw-initial-policy[^ ]*\.yaml/);
+      assert.equal(createCommand.policyReadError, undefined);
+      const policyDoc = YAML.parse(createCommand.policyContent || "") || {};
+      const slackEndpointHosts = (policyDoc.network_policies?.slack?.endpoints || []).map(
+        (entry: { host?: string }) => entry.host,
+      );
+      const slackWebsocketHosts = slackEndpointHosts
+        .filter(
+          (host: string | undefined) =>
+            host === "wss-primary.slack.com" || host === "wss-backup.slack.com",
+        )
+        .sort();
+      assert.deepEqual(
+        slackWebsocketHosts,
+        ["wss-backup.slack.com", "wss-primary.slack.com"].sort(),
+      );
+
+      // Messaging tokens must NOT appear in the sandbox create command
+      // (they flow exclusively through the openshell provider credential system).
+      assert.doesNotMatch(createCommand.command, /test-discord-token-value/);
+      assert.doesNotMatch(createCommand.command, /123456:ABC-test-telegram-token/);
+      assert.doesNotMatch(createCommand.command, /DISCORD_BOT_TOKEN=/);
+      assert.doesNotMatch(createCommand.command, /TELEGRAM_BOT_TOKEN=/);
+      assert.doesNotMatch(createCommand.command, /xoxb-test-slack-token-value/);
+      assert.doesNotMatch(createCommand.command, /xapp-test-slack-app-token-value/);
+      assert.doesNotMatch(createCommand.command, /SLACK_BOT_TOKEN=/);
+      assert.doesNotMatch(createCommand.command, /SLACK_APP_TOKEN=/);
+      assert.doesNotMatch(createCommand.command, /NEMOCLAW_MESSAGING_PLAN_B64=/);
+
+      assert.ok(payload.messagingPlanEnv, "expected serialized messaging plan in host process env");
+      const messagingPlan = JSON.parse(
+        Buffer.from(payload.messagingPlanEnv, "base64").toString("utf8"),
+      );
+      assert.equal(messagingPlan.sandboxName, "my-assistant");
+      assert.deepEqual(
+        messagingPlan.channels.map((channel: { channelId: string }) => channel.channelId).sort(),
+        ["discord", "slack", "telegram"].sort(),
+      );
+      assert.doesNotMatch(JSON.stringify(messagingPlan), /test-discord-token-value/);
+      assert.doesNotMatch(JSON.stringify(messagingPlan), /123456:ABC-test-telegram-token/);
+
+      // Verify blocked credentials are NOT in the sandbox spawn environment
+      assert.ok(createCommand.env, "expected env to be captured from spawn call");
+      assert.equal(
+        createCommand.env.DISCORD_BOT_TOKEN,
+        undefined,
+        "DISCORD_BOT_TOKEN must not be in sandbox env",
+      );
+      assert.equal(
+        createCommand.env.SLACK_BOT_TOKEN,
+        undefined,
+        "SLACK_BOT_TOKEN must not be in sandbox env",
+      );
+      assert.equal(
+        createCommand.env.SLACK_APP_TOKEN,
+        undefined,
+        "SLACK_APP_TOKEN must not be in sandbox env",
+      );
+      assert.equal(
+        createCommand.env.TELEGRAM_BOT_TOKEN,
+        undefined,
+        "TELEGRAM_BOT_TOKEN must not be in sandbox env",
+      );
+      assert.equal(
+        createCommand.env.NVIDIA_INFERENCE_API_KEY,
+        undefined,
+        "NVIDIA_INFERENCE_API_KEY must not be in sandbox env",
+      );
+      assert.equal(
+        createCommand.env.KUBECONFIG,
+        undefined,
+        "KUBECONFIG must not be in sandbox env",
+      );
+      assert.equal(
+        createCommand.env.SSH_AUTH_SOCK,
+        undefined,
+        "SSH_AUTH_SOCK must not be in sandbox env",
+      );
+
+      // Belt-and-suspenders: raw token values must not appear anywhere in env
+      const envString = JSON.stringify(createCommand.env);
+      assert.ok(
+        !envString.includes("test-discord-token-value"),
+        "Discord token value must not leak into sandbox env",
+      );
+      assert.ok(
+        !envString.includes("xoxb-test-slack-token-value"),
+        "Slack bot token value must not leak into sandbox spawn env",
+      );
+      assert.ok(
+        !envString.includes("xapp-test-slack-app-token-value"),
+        "Slack app token value must not leak into sandbox spawn env",
+      );
+      assert.ok(
+        !envString.includes("123456:ABC-test-telegram-token"),
+        "Telegram token value must not leak into sandbox env",
+      );
+    },
+  );
+
+  it(
+    "preserves Hermes Slack policy when Slack is active at sandbox create time",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-hermes-slack-"));
+      try {
+        const fakeBin = path.join(tmpDir, "bin");
+        const customBuildDir = path.join(tmpDir, "custom-build");
+        const customDockerfilePath = path.join(customBuildDir, "Dockerfile");
+        const scriptPath = path.join(tmpDir, "hermes-slack-policy.js");
+        const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+        const agentDefsPath = JSON.stringify(path.join(repoRoot, "src", "lib", "agent", "defs.ts"));
+        const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+        const registryPath = JSON.stringify(
+          path.join(repoRoot, "src", "lib", "state", "registry.ts"),
+        );
+        const preflightPath = JSON.stringify(
+          path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
+        );
+        const credentialsPath = JSON.stringify(
+          path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+        );
+        const yamlPath = JSON.stringify(yamlModulePath);
+        const customDockerfileArg = JSON.stringify(customDockerfilePath);
+
+        fs.mkdirSync(fakeBin, { recursive: true });
+        fs.mkdirSync(customBuildDir, { recursive: true });
+        fs.writeFileSync(
+          customDockerfilePath,
+          "FROM scratch\nARG NEMOCLAW_MESSAGING_PLAN_B64=\nARG NEMOCLAW_TOOL_DISCLOSURE=progressive\nENV NEMOCLAW_TOOL_DISCLOSURE=${NEMOCLAW_TOOL_DISCLOSURE}\n",
+        );
+        writeOkOpenshell(fakeBin, { readySandboxGet: true });
+
+        const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 const registry = require(${registryPath});
@@ -434,74 +453,80 @@ const { createSandbox } = require(${onboardPath});
   process.exit(1);
 });
 `;
-      fs.writeFileSync(scriptPath, script);
+        fs.writeFileSync(scriptPath, script);
 
-      const result = spawnSync(process.execPath, [scriptPath], {
-        cwd: repoRoot,
-        encoding: "utf-8",
-        env: {
-          ...process.env,
-          HOME: tmpDir,
-          PATH: `${fakeBin}:${process.env.PATH || ""}`,
-          NEMOCLAW_NON_INTERACTIVE: "1",
-        },
-      });
+        const result = spawnSync(process.execPath, [scriptPath], {
+          cwd: repoRoot,
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            HOME: tmpDir,
+            PATH: `${fakeBin}:${process.env.PATH || ""}`,
+            NEMOCLAW_NON_INTERACTIVE: "1",
+          },
+        });
 
-      assert.equal(result.status, 0, result.stderr);
-      const payload = parseStdoutJson(result.stdout);
+        assert.equal(result.status, 0, result.stderr);
+        const payload = parseStdoutJson(result.stdout);
 
-      assert.ok(payload.createCommand.command.includes("sandbox create"));
-      assert.match(payload.createCommand.command, /--provider my-assistant-slack-bridge/);
-      assert.match(payload.createCommand.command, /--provider my-assistant-slack-app/);
-      assert.match(payload.createCommand.policyPath, /nemoclaw-initial-policy/);
-      assert.equal(payload.createCommand.policyReadError, null);
-      assert.deepEqual(payload.registeredPolicies, ["slack"]);
-      assert.deepEqual(payload.slackBinaryPaths, [
-        "/usr/local/bin/hermes",
-        "/usr/bin/python3*",
-        "/opt/hermes/.venv/bin/python",
-      ]);
-      assert.ok(
-        !payload.slackBinaryPaths.includes("/usr/local/bin/node"),
-        "Hermes Slack policy must not be replaced by the generic Node Slack preset",
+        assert.ok(payload.createCommand.command.includes("sandbox create"));
+        assert.match(payload.createCommand.command, /--provider my-assistant-slack-bridge/);
+        assert.match(payload.createCommand.command, /--provider my-assistant-slack-app/);
+        assert.match(payload.createCommand.policyPath, /nemoclaw-initial-policy/);
+        assert.equal(payload.createCommand.policyReadError, null);
+        assert.deepEqual(payload.registeredPolicies, ["slack"]);
+        assert.deepEqual(payload.slackBinaryPaths, [
+          "/usr/local/bin/hermes",
+          "/usr/bin/python3*",
+          "/opt/hermes/.venv/bin/python",
+        ]);
+        assert.ok(
+          !payload.slackBinaryPaths.includes("/usr/local/bin/node"),
+          "Hermes Slack policy must not be replaced by the generic Node Slack preset",
+        );
+        const slackWebsocketHosts = payload.slackEndpointHosts
+          .filter(
+            (host: string) => host === "wss-primary.slack.com" || host === "wss-backup.slack.com",
+          )
+          .sort();
+        assert.deepEqual(
+          slackWebsocketHosts,
+          ["wss-backup.slack.com", "wss-primary.slack.com"].sort(),
+        );
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it(
+    "reuses existing messaging providers during non-interactive recreate when tokens are not in the host env",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-messaging-reuse-provider-"),
       );
-      const slackWebsocketHosts = payload.slackEndpointHosts
-        .filter(
-          (host: string) => host === "wss-primary.slack.com" || host === "wss-backup.slack.com",
-        )
-        .sort();
-      assert.deepEqual(
-        slackWebsocketHosts,
-        ["wss-backup.slack.com", "wss-primary.slack.com"].sort(),
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "messaging-reuse-provider.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+      const registryPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "state", "registry.ts"),
       );
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
+      const preflightPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
+      );
+      const credentialsPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+      );
+      const messagingPlanB64 = encodeMessagingPlanForChannels(["discord", "slack"]);
 
-  it("reuses existing messaging providers during non-interactive recreate when tokens are not in the host env", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "nemoclaw-onboard-messaging-reuse-provider-"),
-    );
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "messaging-reuse-provider.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-    const registryPath = JSON.stringify(path.join(repoRoot, "src", "lib", "state", "registry.ts"));
-    const preflightPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
-    );
-    const credentialsPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
-    );
-    const messagingPlanB64 = encodeMessagingPlanForChannels(["discord", "slack"]);
+      fs.mkdirSync(fakeBin, { recursive: true });
+      writeOkOpenshell(fakeBin, { readySandboxGet: true });
 
-    fs.mkdirSync(fakeBin, { recursive: true });
-    writeOkOpenshell(fakeBin, { readySandboxGet: true });
-
-    const script = String.raw`
+      const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 const registry = require(${registryPath});
@@ -588,80 +613,86 @@ const { createSandbox } = require(${onboardPath});
   process.exit(1);
 });
 `;
-    fs.writeFileSync(scriptPath, script);
+      fs.writeFileSync(scriptPath, script);
 
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-        NEMOCLAW_NON_INTERACTIVE: "1",
-        NEMOCLAW_MESSAGING_PLAN_B64: messagingPlanB64,
-        DISCORD_BOT_TOKEN: "",
-        SLACK_BOT_TOKEN: "",
-        SLACK_APP_TOKEN: "",
-        TELEGRAM_BOT_TOKEN: "",
-      },
-    });
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+          NEMOCLAW_MESSAGING_PLAN_B64: messagingPlanB64,
+          DISCORD_BOT_TOKEN: "",
+          SLACK_BOT_TOKEN: "",
+          SLACK_APP_TOKEN: "",
+          TELEGRAM_BOT_TOKEN: "",
+        },
+      });
 
-    assert.equal(result.status, 0, result.stderr);
-    const payload = parseStdoutJson(result.stdout);
+      assert.equal(result.status, 0, result.stderr);
+      const payload = parseStdoutJson(result.stdout);
 
-    const providerMutationCommands = payload.commands.filter((entry: CommandEntry) =>
-      /\bprovider (create|update)\b/.test(entry.command),
-    );
-    assert.equal(
-      providerMutationCommands.length,
-      0,
-      "tokenless rebuild should not mutate providers",
-    );
+      const providerMutationCommands = payload.commands.filter((entry: CommandEntry) =>
+        /\bprovider (create|update)\b/.test(entry.command),
+      );
+      assert.equal(
+        providerMutationCommands.length,
+        0,
+        "tokenless rebuild should not mutate providers",
+      );
 
-    const createCommand = payload.commands.find((entry: CommandEntry) =>
-      entry.command.includes("sandbox create"),
-    );
-    assert.ok(createCommand, "expected sandbox create command");
-    assert.equal(createCommand.dockerfileReadError, undefined);
-    assert.match(createCommand.command, /--provider my-assistant-discord-bridge/);
-    assert.match(createCommand.command, /--provider my-assistant-slack-bridge/);
-    assert.match(createCommand.command, /--provider my-assistant-slack-app/);
-    assert.deepEqual(activeChannelsFromDockerfile(createCommand.dockerfileContent), [
-      "discord",
-      "slack",
-    ]);
-    assert.deepEqual(
-      payload.registerCalls[0]?.messaging?.plan?.channels.map(
-        (channel: { channelId: string }) => channel.channelId,
-      ),
-      ["discord", "slack"],
-    );
-    assert.equal(payload.registerCalls[0]?.messagingChannels, undefined);
-  });
+      const createCommand = payload.commands.find((entry: CommandEntry) =>
+        entry.command.includes("sandbox create"),
+      );
+      assert.ok(createCommand, "expected sandbox create command");
+      assert.equal(createCommand.dockerfileReadError, undefined);
+      assert.match(createCommand.command, /--provider my-assistant-discord-bridge/);
+      assert.match(createCommand.command, /--provider my-assistant-slack-bridge/);
+      assert.match(createCommand.command, /--provider my-assistant-slack-app/);
+      assert.deepEqual(activeChannelsFromDockerfile(createCommand.dockerfileContent), [
+        "discord",
+        "slack",
+      ]);
+      assert.deepEqual(
+        payload.registerCalls[0]?.messaging?.plan?.channels.map(
+          (channel: { channelId: string }) => channel.channelId,
+        ),
+        ["discord", "slack"],
+      );
+      assert.equal(payload.registerCalls[0]?.messagingChannels, undefined);
+    },
+  );
 
-  it("preserves disabled channels in the registry after a recreate so `channels start` can re-enable them (#3381)", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "nemoclaw-onboard-disabled-channels-preserve-"),
-    );
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "disabled-channels-preserve.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-    const registryPath = JSON.stringify(path.join(repoRoot, "src", "lib", "state", "registry.ts"));
-    const preflightPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
-    );
-    const credentialsPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
-    );
-    const messagingPlanB64 = encodeMessagingPlanForChannels(["telegram"], ["telegram"]);
+  it(
+    "preserves disabled channels in the registry after a recreate so `channels start` can re-enable them (#3381)",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-disabled-channels-preserve-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "disabled-channels-preserve.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+      const registryPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "state", "registry.ts"),
+      );
+      const preflightPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
+      );
+      const credentialsPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+      );
+      const messagingPlanB64 = encodeMessagingPlanForChannels(["telegram"], ["telegram"]);
 
-    fs.mkdirSync(fakeBin, { recursive: true });
-    writeOkOpenshell(fakeBin, { readySandboxGet: true });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      writeOkOpenshell(fakeBin, { readySandboxGet: true });
 
-    const script = String.raw`
+      const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 const registry = require(${registryPath});
@@ -743,78 +774,82 @@ const { createSandbox } = require(${onboardPath});
   process.exit(1);
 });
 `;
-    fs.writeFileSync(scriptPath, script);
+      fs.writeFileSync(scriptPath, script);
 
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-        NEMOCLAW_NON_INTERACTIVE: "1",
-        NEMOCLAW_MESSAGING_PLAN_B64: messagingPlanB64,
-        TELEGRAM_BOT_TOKEN: "",
-      },
-    });
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+          NEMOCLAW_MESSAGING_PLAN_B64: messagingPlanB64,
+          TELEGRAM_BOT_TOKEN: "",
+        },
+      });
 
-    assert.equal(result.status, 0, result.stderr);
-    const payload = parseStdoutJson(result.stdout);
+      assert.equal(result.status, 0, result.stderr);
+      const payload = parseStdoutJson(result.stdout);
 
-    const createCommand = payload.commands.find((entry: CommandEntry) =>
-      entry.command.includes("sandbox create"),
-    );
-    assert.ok(createCommand, "expected sandbox create command");
-    assert.equal(createCommand.dockerfileReadError, undefined);
-
-    assert.deepEqual(
-      activeChannelsFromDockerfile(createCommand.dockerfileContent),
-      [],
-      "disabled channel must not be active in the image plan",
-    );
-    assert.doesNotMatch(
-      createCommand.command,
-      /--provider my-assistant-telegram-bridge/,
-      "disabled channel's bridge must not be attached to the new sandbox",
-    );
-
-    const registeredPlan = payload.registerCalls[0]?.messaging?.plan;
-    assert.deepEqual(
-      registeredPlan?.channels.map((channel: { channelId: string }) => channel.channelId),
-      ["telegram"],
-      "registry.messaging.plan must keep the disabled-but-configured channel so `channels start` can recover it",
-    );
-    assert.deepEqual(
-      registeredPlan?.disabledChannels,
-      ["telegram"],
-      "registry.messaging.plan.disabledChannels must round-trip through the rebuild",
-    );
-  });
-
-  it("bakes WhatsApp into the sandbox image without bridge providers when no messaging tokens are set", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-tokenless-whatsapp-"));
-    try {
-      const fakeBin = path.join(tmpDir, "bin");
-      const scriptPath = path.join(tmpDir, "tokenless-whatsapp.js");
-      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-      const registryPath = JSON.stringify(
-        path.join(repoRoot, "src", "lib", "state", "registry.ts"),
+      const createCommand = payload.commands.find((entry: CommandEntry) =>
+        entry.command.includes("sandbox create"),
       );
-      const preflightPath = JSON.stringify(
-        path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
-      );
-      const credentialsPath = JSON.stringify(
-        path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
-      );
-      const messagingPlanB64 = encodeMessagingPlanForChannels(["whatsapp"]);
+      assert.ok(createCommand, "expected sandbox create command");
+      assert.equal(createCommand.dockerfileReadError, undefined);
 
-      fs.mkdirSync(fakeBin, { recursive: true });
-      writeOkOpenshell(fakeBin, { readySandboxGet: true });
+      assert.deepEqual(
+        activeChannelsFromDockerfile(createCommand.dockerfileContent),
+        [],
+        "disabled channel must not be active in the image plan",
+      );
+      assert.doesNotMatch(
+        createCommand.command,
+        /--provider my-assistant-telegram-bridge/,
+        "disabled channel's bridge must not be attached to the new sandbox",
+      );
 
-      const script = String.raw`
+      const registeredPlan = payload.registerCalls[0]?.messaging?.plan;
+      assert.deepEqual(
+        registeredPlan?.channels.map((channel: { channelId: string }) => channel.channelId),
+        ["telegram"],
+        "registry.messaging.plan must keep the disabled-but-configured channel so `channels start` can recover it",
+      );
+      assert.deepEqual(
+        registeredPlan?.disabledChannels,
+        ["telegram"],
+        "registry.messaging.plan.disabledChannels must round-trip through the rebuild",
+      );
+    },
+  );
+
+  it(
+    "bakes WhatsApp into the sandbox image without bridge providers when no messaging tokens are set",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-tokenless-whatsapp-"));
+      try {
+        const fakeBin = path.join(tmpDir, "bin");
+        const scriptPath = path.join(tmpDir, "tokenless-whatsapp.js");
+        const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+        const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+        const registryPath = JSON.stringify(
+          path.join(repoRoot, "src", "lib", "state", "registry.ts"),
+        );
+        const preflightPath = JSON.stringify(
+          path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
+        );
+        const credentialsPath = JSON.stringify(
+          path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+        );
+        const messagingPlanB64 = encodeMessagingPlanForChannels(["whatsapp"]);
+
+        fs.mkdirSync(fakeBin, { recursive: true });
+        writeOkOpenshell(fakeBin, { readySandboxGet: true });
+
+        const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 const registry = require(${registryPath});
@@ -895,76 +930,82 @@ const { createSandbox } = require(${onboardPath});
   process.exit(1);
 });
 `;
-      fs.writeFileSync(scriptPath, script);
+        fs.writeFileSync(scriptPath, script);
 
-      const result = spawnSync(process.execPath, [scriptPath], {
-        cwd: repoRoot,
-        encoding: "utf-8",
-        env: {
-          ...process.env,
-          HOME: tmpDir,
-          PATH: `${fakeBin}:${process.env.PATH || ""}`,
-          NEMOCLAW_NON_INTERACTIVE: "1",
-          NEMOCLAW_MESSAGING_PLAN_B64: messagingPlanB64,
-        },
-      });
+        const result = spawnSync(process.execPath, [scriptPath], {
+          cwd: repoRoot,
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            HOME: tmpDir,
+            PATH: `${fakeBin}:${process.env.PATH || ""}`,
+            NEMOCLAW_NON_INTERACTIVE: "1",
+            NEMOCLAW_MESSAGING_PLAN_B64: messagingPlanB64,
+          },
+        });
 
-      assert.equal(result.status, 0, result.stderr);
-      const payload = parseStdoutJson(result.stdout);
+        assert.equal(result.status, 0, result.stderr);
+        const payload = parseStdoutJson(result.stdout);
 
-      const providerMutationCommands = payload.commands.filter((entry: CommandEntry) =>
-        /\bprovider (create|update)\b/.test(entry.command),
-      );
-      assert.equal(
-        providerMutationCommands.length,
-        0,
-        "QR-only channel selection must not create bridge providers",
-      );
+        const providerMutationCommands = payload.commands.filter((entry: CommandEntry) =>
+          /\bprovider (create|update)\b/.test(entry.command),
+        );
+        assert.equal(
+          providerMutationCommands.length,
+          0,
+          "QR-only channel selection must not create bridge providers",
+        );
 
-      const createCommand = payload.commands.find((entry: CommandEntry) =>
-        entry.command.includes("sandbox create"),
-      );
-      assert.ok(createCommand, "expected sandbox create command");
-      assert.equal(createCommand.dockerfileReadError, undefined);
-      assert.doesNotMatch(createCommand.command, /--provider \S+-bridge\b/);
+        const createCommand = payload.commands.find((entry: CommandEntry) =>
+          entry.command.includes("sandbox create"),
+        );
+        assert.ok(createCommand, "expected sandbox create command");
+        assert.equal(createCommand.dockerfileReadError, undefined);
+        assert.doesNotMatch(createCommand.command, /--provider \S+-bridge\b/);
 
-      assert.deepEqual(activeChannelsFromDockerfile(createCommand.dockerfileContent), ["whatsapp"]);
-      assert.deepEqual(
-        payload.registerCalls[0]?.messaging?.plan?.channels.map(
-          (channel: { channelId: string }) => channel.channelId,
-        ),
-        ["whatsapp"],
-      );
-      assert.equal(payload.registerCalls[0]?.messagingChannels, undefined);
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
+        assert.deepEqual(activeChannelsFromDockerfile(createCommand.dockerfileContent), [
+          "whatsapp",
+        ]);
+        assert.deepEqual(
+          payload.registerCalls[0]?.messaging?.plan?.channels.map(
+            (channel: { channelId: string }) => channel.channelId,
+          ),
+          ["whatsapp"],
+        );
+        assert.equal(payload.registerCalls[0]?.messagingChannels, undefined);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    },
+  );
 
-  it("drops WhatsApp from the rebuilt image when the registry marks it disabled", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-disabled-whatsapp-"));
-    try {
-      const fakeBin = path.join(tmpDir, "bin");
-      const scriptPath = path.join(tmpDir, "disabled-whatsapp.js");
-      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-      const registryPath = JSON.stringify(
-        path.join(repoRoot, "src", "lib", "state", "registry.ts"),
-      );
-      const preflightPath = JSON.stringify(
-        path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
-      );
-      const credentialsPath = JSON.stringify(
-        path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
-      );
-      const messagingPlanB64 = encodeMessagingPlanForChannels(["whatsapp"], ["whatsapp"]);
+  it(
+    "drops WhatsApp from the rebuilt image when the registry marks it disabled",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-disabled-whatsapp-"));
+      try {
+        const fakeBin = path.join(tmpDir, "bin");
+        const scriptPath = path.join(tmpDir, "disabled-whatsapp.js");
+        const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+        const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+        const registryPath = JSON.stringify(
+          path.join(repoRoot, "src", "lib", "state", "registry.ts"),
+        );
+        const preflightPath = JSON.stringify(
+          path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
+        );
+        const credentialsPath = JSON.stringify(
+          path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+        );
+        const messagingPlanB64 = encodeMessagingPlanForChannels(["whatsapp"], ["whatsapp"]);
 
-      fs.mkdirSync(fakeBin, { recursive: true });
-      writeOkOpenshell(fakeBin, { readySandboxGet: true });
+        fs.mkdirSync(fakeBin, { recursive: true });
+        writeOkOpenshell(fakeBin, { readySandboxGet: true });
 
-      const script = String.raw`
+        const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 const registry = require(${registryPath});
@@ -1050,49 +1091,50 @@ const { createSandbox } = require(${onboardPath});
   process.exit(1);
 });
 `;
-      fs.writeFileSync(scriptPath, script);
+        fs.writeFileSync(scriptPath, script);
 
-      const result = spawnSync(process.execPath, [scriptPath], {
-        cwd: repoRoot,
-        encoding: "utf-8",
-        env: {
-          ...process.env,
-          HOME: tmpDir,
-          PATH: `${fakeBin}:${process.env.PATH || ""}`,
-          NEMOCLAW_NON_INTERACTIVE: "1",
-          NEMOCLAW_MESSAGING_PLAN_B64: messagingPlanB64,
-        },
-      });
+        const result = spawnSync(process.execPath, [scriptPath], {
+          cwd: repoRoot,
+          encoding: "utf-8",
+          env: {
+            ...process.env,
+            HOME: tmpDir,
+            PATH: `${fakeBin}:${process.env.PATH || ""}`,
+            NEMOCLAW_NON_INTERACTIVE: "1",
+            NEMOCLAW_MESSAGING_PLAN_B64: messagingPlanB64,
+          },
+        });
 
-      assert.equal(result.status, 0, result.stderr);
-      const payload = parseStdoutJson(result.stdout);
+        assert.equal(result.status, 0, result.stderr);
+        const payload = parseStdoutJson(result.stdout);
 
-      const createCommand = payload.commands.find((entry: CommandEntry) =>
-        entry.command.includes("sandbox create"),
-      );
-      assert.ok(createCommand, "expected sandbox create command");
-      assert.equal(createCommand.dockerfileReadError, undefined);
+        const createCommand = payload.commands.find((entry: CommandEntry) =>
+          entry.command.includes("sandbox create"),
+        );
+        assert.ok(createCommand, "expected sandbox create command");
+        assert.equal(createCommand.dockerfileReadError, undefined);
 
-      assert.deepEqual(
-        activeChannelsFromDockerfile(createCommand.dockerfileContent),
-        [],
-        "disabled QR channel must not be active in the image plan",
-      );
-      const registeredPlan = payload.registerCalls[0]?.messaging?.plan;
-      assert.deepEqual(
-        registeredPlan?.channels.map((channel: { channelId: string }) => channel.channelId),
-        ["whatsapp"],
-        "registry.messaging.plan must keep the disabled QR channel so `channels start` can recover it (mirrors #3381)",
-      );
-      assert.deepEqual(
-        registeredPlan?.disabledChannels,
-        ["whatsapp"],
-        "registry.messaging.plan.disabledChannels must round-trip through the rebuild",
-      );
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
+        assert.deepEqual(
+          activeChannelsFromDockerfile(createCommand.dockerfileContent),
+          [],
+          "disabled QR channel must not be active in the image plan",
+        );
+        const registeredPlan = payload.registerCalls[0]?.messaging?.plan;
+        assert.deepEqual(
+          registeredPlan?.channels.map((channel: { channelId: string }) => channel.channelId),
+          ["whatsapp"],
+          "registry.messaging.plan must keep the disabled QR channel so `channels start` can recover it (mirrors #3381)",
+        );
+        assert.deepEqual(
+          registeredPlan?.disabledChannels,
+          ["whatsapp"],
+          "registry.messaging.plan.disabledChannels must round-trip through the rebuild",
+        );
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("aborts onboard when a messaging provider upsert fails", { timeout: 60_000 }, async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-provider-fail-"));
@@ -1174,22 +1216,27 @@ const { createSandbox } = require(${onboardPath});
     );
   });
 
-  it("reuses sandbox when messaging providers already exist in gateway", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-reuse-providers-"));
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "reuse-with-providers.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-    const registryPath = JSON.stringify(path.join(repoRoot, "src", "lib", "state", "registry.ts"));
+  it(
+    "reuses sandbox when messaging providers already exist in gateway",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-reuse-providers-"));
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "reuse-with-providers.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+      const registryPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "state", "registry.ts"),
+      );
 
-    fs.mkdirSync(fakeBin, { recursive: true });
-    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
-      mode: 0o755,
-    });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
 
-    const script = String.raw`
+      const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 const registry = require(${registryPath});
@@ -1223,70 +1270,78 @@ const { createSandbox } = require(${onboardPath});
   process.exit(1);
 });
 `;
-    fs.writeFileSync(scriptPath, script);
+      fs.writeFileSync(scriptPath, script);
 
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-        NEMOCLAW_NON_INTERACTIVE: "1",
-      },
-    });
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+      });
 
-    assert.equal(result.status, 0, result.stderr);
-    const payload = parseStdoutJson(result.stdout);
+      assert.equal(result.status, 0, result.stderr);
+      const payload = parseStdoutJson(result.stdout);
 
-    assert.equal(payload.sandboxName, "my-assistant", "should reuse existing sandbox");
-    assert.ok(
-      payload.commands.every((entry: CommandEntry) => !entry.command.includes("sandbox create")),
-      "should NOT recreate sandbox when providers already exist in gateway",
-    );
-    assert.ok(
-      payload.commands.every((entry: CommandEntry) => !entry.command.includes("sandbox delete")),
-      "should NOT delete sandbox when providers already exist in gateway",
-    );
+      assert.equal(payload.sandboxName, "my-assistant", "should reuse existing sandbox");
+      assert.ok(
+        payload.commands.every((entry: CommandEntry) => !entry.command.includes("sandbox create")),
+        "should NOT recreate sandbox when providers already exist in gateway",
+      );
+      assert.ok(
+        payload.commands.every((entry: CommandEntry) => !entry.command.includes("sandbox delete")),
+        "should NOT delete sandbox when providers already exist in gateway",
+      );
 
-    // Providers should still be upserted on reuse (credential refresh).
-    // Since the mock reports providers as existing (run returns status 0),
-    // upsertProvider issues 'update' rather than 'create'.
-    const providerUpserts = payload.commands.filter((entry: CommandEntry) =>
-      entry.command.includes("provider update"),
-    );
-    assert.ok(
-      providerUpserts.some((e: CommandEntry) => e.command.includes("my-assistant-discord-bridge")),
-      "should upsert discord provider on reuse to refresh credentials",
-    );
-    assert.ok(
-      providerUpserts.some((e: CommandEntry) => e.command.includes("my-assistant-slack-bridge")),
-      "should upsert slack provider on reuse to refresh credentials",
-    );
-  });
+      // Providers should still be upserted on reuse (credential refresh).
+      // Since the mock reports providers as existing (run returns status 0),
+      // upsertProvider issues 'update' rather than 'create'.
+      const providerUpserts = payload.commands.filter((entry: CommandEntry) =>
+        entry.command.includes("provider update"),
+      );
+      assert.ok(
+        providerUpserts.some((e: CommandEntry) =>
+          e.command.includes("my-assistant-discord-bridge"),
+        ),
+        "should upsert discord provider on reuse to refresh credentials",
+      );
+      assert.ok(
+        providerUpserts.some((e: CommandEntry) => e.command.includes("my-assistant-slack-bridge")),
+        "should upsert slack provider on reuse to refresh credentials",
+      );
+    },
+  );
 
-  it("filters messaging providers to only enabledChannels when provided", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "nemoclaw-onboard-enabled-channels-filter-"),
-    );
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "enabled-channels-filter.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-    const registryPath = JSON.stringify(path.join(repoRoot, "src", "lib", "state", "registry.ts"));
-    const preflightPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
-    );
-    const credentialsPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
-    );
+  it(
+    "filters messaging providers to only enabledChannels when provided",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-enabled-channels-filter-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "enabled-channels-filter.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+      const registryPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "state", "registry.ts"),
+      );
+      const preflightPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
+      );
+      const credentialsPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+      );
 
-    fs.mkdirSync(fakeBin, { recursive: true });
-    writeOkOpenshell(fakeBin, { readySandboxGet: true });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      writeOkOpenshell(fakeBin, { readySandboxGet: true });
 
-    const script = String.raw`
+      const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 const registry = require(${registryPath});
@@ -1350,74 +1405,80 @@ const { createSandbox } = require(${onboardPath});
   process.exit(1);
 });
 `;
-    fs.writeFileSync(scriptPath, script);
+      fs.writeFileSync(scriptPath, script);
 
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-        NEMOCLAW_NON_INTERACTIVE: "1",
-      },
-    });
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+      });
 
-    assert.equal(result.status, 0, result.stderr);
-    const payload = parseStdoutJson(result.stdout);
+      assert.equal(result.status, 0, result.stderr);
+      const payload = parseStdoutJson(result.stdout);
 
-    // Only telegram provider should be created
-    const providerCommands = payload.commands.filter((e: CommandEntry) =>
-      e.command.includes("provider create"),
-    );
-    const telegramProvider = providerCommands.find((e: CommandEntry) =>
-      e.command.includes("my-assistant-telegram-bridge"),
-    );
-    assert.ok(telegramProvider, "expected telegram provider to be created");
+      // Only telegram provider should be created
+      const providerCommands = payload.commands.filter((e: CommandEntry) =>
+        e.command.includes("provider create"),
+      );
+      const telegramProvider = providerCommands.find((e: CommandEntry) =>
+        e.command.includes("my-assistant-telegram-bridge"),
+      );
+      assert.ok(telegramProvider, "expected telegram provider to be created");
 
-    // Discord and slack providers should NOT be created
-    const discordProvider = providerCommands.find((e: CommandEntry) =>
-      e.command.includes("my-assistant-discord-bridge"),
-    );
-    assert.ok(!discordProvider, "discord provider should be filtered out");
+      // Discord and slack providers should NOT be created
+      const discordProvider = providerCommands.find((e: CommandEntry) =>
+        e.command.includes("my-assistant-discord-bridge"),
+      );
+      assert.ok(!discordProvider, "discord provider should be filtered out");
 
-    const slackProvider = providerCommands.find((e: CommandEntry) =>
-      e.command.includes("my-assistant-slack-bridge"),
-    );
-    assert.ok(!slackProvider, "slack provider should be filtered out");
+      const slackProvider = providerCommands.find((e: CommandEntry) =>
+        e.command.includes("my-assistant-slack-bridge"),
+      );
+      assert.ok(!slackProvider, "slack provider should be filtered out");
 
-    // Sandbox create should only have the telegram --provider flag
-    const createCommand = payload.commands.find((e: CommandEntry) =>
-      e.command.includes("sandbox create"),
-    );
-    assert.ok(createCommand, "expected sandbox create command");
-    assert.match(createCommand.command, /--provider my-assistant-telegram-bridge/);
-    assert.doesNotMatch(createCommand.command, /my-assistant-discord-bridge/);
-    assert.doesNotMatch(createCommand.command, /my-assistant-slack-bridge/);
-  });
+      // Sandbox create should only have the telegram --provider flag
+      const createCommand = payload.commands.find((e: CommandEntry) =>
+        e.command.includes("sandbox create"),
+      );
+      assert.ok(createCommand, "expected sandbox create command");
+      assert.match(createCommand.command, /--provider my-assistant-telegram-bridge/);
+      assert.doesNotMatch(createCommand.command, /my-assistant-discord-bridge/);
+      assert.doesNotMatch(createCommand.command, /my-assistant-slack-bridge/);
+    },
+  );
 
-  it("creates no messaging providers when enabledChannels is empty", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "nemoclaw-onboard-enabled-channels-empty-"),
-    );
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "enabled-channels-empty.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-    const registryPath = JSON.stringify(path.join(repoRoot, "src", "lib", "state", "registry.ts"));
-    const preflightPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
-    );
-    const credentialsPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
-    );
+  it(
+    "creates no messaging providers when enabledChannels is empty",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-enabled-channels-empty-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "enabled-channels-empty.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+      const registryPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "state", "registry.ts"),
+      );
+      const preflightPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "onboard", "preflight.ts"),
+      );
+      const credentialsPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+      );
 
-    fs.mkdirSync(fakeBin, { recursive: true });
-    writeOkOpenshell(fakeBin, { readySandboxGet: true });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      writeOkOpenshell(fakeBin, { readySandboxGet: true });
 
-    const script = String.raw`
+      const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 const registry = require(${registryPath});
@@ -1479,59 +1540,63 @@ const { createSandbox } = require(${onboardPath});
   process.exit(1);
 });
 `;
-    fs.writeFileSync(scriptPath, script);
+      fs.writeFileSync(scriptPath, script);
 
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-        NEMOCLAW_NON_INTERACTIVE: "1",
-      },
-    });
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+      });
 
-    assert.equal(result.status, 0, result.stderr);
-    const payload = parseStdoutJson(result.stdout);
+      assert.equal(result.status, 0, result.stderr);
+      const payload = parseStdoutJson(result.stdout);
 
-    // No messaging providers should be created at all
-    const providerCommands = payload.commands.filter((e: CommandEntry) =>
-      e.command.includes("provider create"),
-    );
-    assert.equal(
-      providerCommands.length,
-      0,
-      "no providers should be created when enabledChannels is empty",
-    );
+      // No messaging providers should be created at all
+      const providerCommands = payload.commands.filter((e: CommandEntry) =>
+        e.command.includes("provider create"),
+      );
+      assert.equal(
+        providerCommands.length,
+        0,
+        "no providers should be created when enabledChannels is empty",
+      );
 
-    // Sandbox create should have no --provider flags for messaging bridges
-    const createCommand = payload.commands.find((e: CommandEntry) =>
-      e.command.includes("sandbox create"),
-    );
-    assert.ok(createCommand, "expected sandbox create command");
-    assert.doesNotMatch(createCommand.command, /discord-bridge/);
-    assert.doesNotMatch(createCommand.command, /slack-bridge/);
-    assert.doesNotMatch(createCommand.command, /telegram-bridge/);
-  });
+      // Sandbox create should have no --provider flags for messaging bridges
+      const createCommand = payload.commands.find((e: CommandEntry) =>
+        e.command.includes("sandbox create"),
+      );
+      assert.ok(createCommand, "expected sandbox create command");
+      assert.doesNotMatch(createCommand.command, /discord-bridge/);
+      assert.doesNotMatch(createCommand.command, /slack-bridge/);
+      assert.doesNotMatch(createCommand.command, /telegram-bridge/);
+    },
+  );
 
-  it("non-interactive setupMessagingChannels returns channels with tokens", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "nemoclaw-onboard-messaging-noninteractive-"),
-    );
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "messaging-noninteractive.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+  it(
+    "non-interactive setupMessagingChannels returns channels with tokens",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-messaging-noninteractive-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "messaging-noninteractive.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
 
-    fs.mkdirSync(fakeBin, { recursive: true });
-    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
-      mode: 0o755,
-    });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
 
-    const script = String.raw`
+      const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 runner.run = () => ({ status: 0 });
@@ -1561,49 +1626,53 @@ const { setupMessagingChannels } = require(${onboardPath});
   process.exit(1);
 });
 `;
-    fs.writeFileSync(scriptPath, script);
+      fs.writeFileSync(scriptPath, script);
 
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-        NEMOCLAW_NON_INTERACTIVE: "1",
-      },
-    });
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+      });
 
-    assert.equal(result.status, 0, result.stderr);
-    const channels = parseStdoutJson<string[]>(result.stdout);
+      assert.equal(result.status, 0, result.stderr);
+      const channels = parseStdoutJson<string[]>(result.stdout);
 
-    // Should return only the channels that have tokens set
-    assert.ok(Array.isArray(channels), "expected an array return value");
-    assert.ok(channels.includes("telegram"), "expected telegram in returned channels");
-    assert.ok(channels.includes("slack"), "expected slack in returned channels");
-    assert.ok(!channels.includes("discord"), "discord should not be in returned channels");
-  });
+      // Should return only the channels that have tokens set
+      assert.ok(Array.isArray(channels), "expected an array return value");
+      assert.ok(channels.includes("telegram"), "expected telegram in returned channels");
+      assert.ok(channels.includes("slack"), "expected slack in returned channels");
+      assert.ok(!channels.includes("discord"), "discord should not be in returned channels");
+    },
+  );
 
-  it("non-interactive setupMessagingChannels drops Slack when live Slack API validation rejects the token", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "nemoclaw-onboard-messaging-slack-live-reject-"),
-    );
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "messaging-slack-live-reject.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-    const httpProbePath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "adapters", "http", "probe.ts"),
-    );
+  it(
+    "non-interactive setupMessagingChannels drops Slack when live Slack API validation rejects the token",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-messaging-slack-live-reject-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "messaging-slack-live-reject.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+      const httpProbePath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "adapters", "http", "probe.ts"),
+      );
 
-    fs.mkdirSync(fakeBin, { recursive: true });
-    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
-      mode: 0o755,
-    });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
 
-    const script = String.raw`
+      const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 runner.run = () => ({ status: 0 });
@@ -1646,43 +1715,49 @@ const { setupMessagingChannels } = require(${onboardPath});
   process.exit(1);
 });
 `;
-    fs.writeFileSync(scriptPath, script);
+      fs.writeFileSync(scriptPath, script);
 
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-        NEMOCLAW_NON_INTERACTIVE: "1",
-      },
-    });
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+        },
+      });
 
-    assert.equal(result.status, 0, result.stderr);
-    const channels = parseStdoutJson<string[]>(result.stdout);
+      assert.equal(result.status, 0, result.stderr);
+      const channels = parseStdoutJson<string[]>(result.stdout);
 
-    assert.ok(Array.isArray(channels), "expected an array return value");
-    assert.ok(!channels.includes("slack"), "Slack should be dropped after API rejection");
-    assert.doesNotMatch(result.stdout, /xoxb-fake-bot-token/);
-    assert.doesNotMatch(result.stderr, /xoxb-fake-bot-token/);
-  });
+      assert.ok(Array.isArray(channels), "expected an array return value");
+      assert.ok(!channels.includes("slack"), "Slack should be dropped after API rejection");
+      assert.doesNotMatch(result.stdout, /xoxb-fake-bot-token/);
+      assert.doesNotMatch(result.stderr, /xoxb-fake-bot-token/);
+    },
+  );
 
-  it("non-interactive setupMessagingChannels returns empty array when no tokens set", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-messaging-no-tokens-"));
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "messaging-no-tokens.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+  it(
+    "non-interactive setupMessagingChannels returns empty array when no tokens set",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-messaging-no-tokens-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "messaging-no-tokens.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
 
-    fs.mkdirSync(fakeBin, { recursive: true });
-    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
-      mode: 0o755,
-    });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
 
-    const script = String.raw`
+      const script = String.raw`
 const runner = require(${runnerPath});
 const _n = (c) => (Array.isArray(c) ? c.join(" ") : String(c)).replace(/'/g, "");
 runner.run = () => ({ status: 0 });
@@ -1703,54 +1778,60 @@ const { setupMessagingChannels } = require(${onboardPath});
   process.exit(1);
 });
 `;
-    fs.writeFileSync(scriptPath, script);
+      fs.writeFileSync(scriptPath, script);
 
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-        NEMOCLAW_NON_INTERACTIVE: "1",
-        TELEGRAM_BOT_TOKEN: "",
-        DISCORD_BOT_TOKEN: "",
-        SLACK_BOT_TOKEN: "",
-        SLACK_APP_TOKEN: "",
-      },
-    });
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+          NEMOCLAW_NON_INTERACTIVE: "1",
+          TELEGRAM_BOT_TOKEN: "",
+          DISCORD_BOT_TOKEN: "",
+          SLACK_BOT_TOKEN: "",
+          SLACK_APP_TOKEN: "",
+        },
+      });
 
-    assert.equal(result.status, 0, result.stderr);
-    const channels = parseStdoutJson<string[]>(result.stdout);
+      assert.equal(result.status, 0, result.stderr);
+      const channels = parseStdoutJson<string[]>(result.stdout);
 
-    assert.ok(Array.isArray(channels), "expected an array return value");
-    assert.equal(channels.length, 0, "expected empty array when no tokens are set");
-  });
+      assert.ok(Array.isArray(channels), "expected an array return value");
+      assert.equal(channels.length, 0, "expected empty array when no tokens are set");
+    },
+  );
 
-  it("interactive setupMessagingChannels drops slack when prompted token fails tokenFormat check (#1912)", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-slack-format-reject-"));
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "slack-format-reject.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-    const credentialsPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
-    );
+  it(
+    "interactive setupMessagingChannels drops slack when prompted token fails tokenFormat check (#1912)",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-slack-format-reject-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "slack-format-reject.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+      const credentialsPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+      );
 
-    fs.mkdirSync(fakeBin, { recursive: true });
-    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
-      mode: 0o755,
-    });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
 
-    // Subscript: mocks credentials.prompt to return a bogus Slack token,
-    // exposes MESSAGING_CHANNELS so the parent can look up the Slack toggle
-    // digit, and asserts that setupMessagingChannels rejects the invalid
-    // token without persisting it. Slack is the 3rd channel in insertion
-    // order today (telegram, discord, slack) but we compute the index
-    // dynamically to avoid a brittle coupling to that ordering.
-    const script = String.raw`
+      // Subscript: mocks credentials.prompt to return a bogus Slack token,
+      // exposes MESSAGING_CHANNELS so the parent can look up the Slack toggle
+      // digit, and asserts that setupMessagingChannels rejects the invalid
+      // token without persisting it. Slack is the 3rd channel in insertion
+      // order today (telegram, discord, slack) but we compute the index
+      // dynamically to avoid a brittle coupling to that ordering.
+      const script = String.raw`
 const credentials = require(${credentialsPath});
 const runner = require(${runnerPath});
 
@@ -1784,81 +1865,85 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
   process.exit(1);
 });
 `;
-    fs.writeFileSync(scriptPath, script);
+      fs.writeFileSync(scriptPath, script);
 
-    // Dry run with just Enter — no toggles, empty result — used to read back
-    // Slack's 1-based index from the same subscript so the real run can
-    // press the right digit.
-    const introspect = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-      },
-      input: "\n",
-    });
-    assert.equal(introspect.status, 0, introspect.stderr);
-    const introspectOut = JSON.parse(introspect.stdout.trim().split("\n").pop()!);
-    const slackIdx = introspectOut.slackIndex1Based;
-    assert.ok(slackIdx >= 1, `unexpected slack index: ${slackIdx}`);
+      // Dry run with just Enter — no toggles, empty result — used to read back
+      // Slack's 1-based index from the same subscript so the real run can
+      // press the right digit.
+      const introspect = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        },
+        input: "\n",
+      });
+      assert.equal(introspect.status, 0, introspect.stderr);
+      const introspectOut = JSON.parse(introspect.stdout.trim().split("\n").pop()!);
+      const slackIdx = introspectOut.slackIndex1Based;
+      assert.ok(slackIdx >= 1, `unexpected slack index: ${slackIdx}`);
 
-    // Real run: press Slack's digit, Enter. Slack gets toggled on, prompt
-    // fires, mocked prompt returns "abcd", tokenFormat regex rejects it,
-    // channel is dropped, saveCredential never runs for SLACK_BOT_TOKEN.
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-      },
-      input: `${slackIdx}\n`,
-    });
+      // Real run: press Slack's digit, Enter. Slack gets toggled on, prompt
+      // fires, mocked prompt returns "abcd", tokenFormat regex rejects it,
+      // channel is dropped, saveCredential never runs for SLACK_BOT_TOKEN.
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        },
+        input: `${slackIdx}\n`,
+      });
 
-    assert.equal(result.status, 0, result.stderr);
-    const out = JSON.parse(result.stdout.trim().split("\n").pop()!);
+      assert.equal(result.status, 0, result.stderr);
+      const out = JSON.parse(result.stdout.trim().split("\n").pop()!);
 
-    assert.ok(
-      !out.result.includes("slack"),
-      `slack should have been dropped after invalid token; got ${JSON.stringify(out.result)}`,
-    );
-    assert.ok(
-      !out.saveCalls.some((c: { key: string }) => c.key === "SLACK_BOT_TOKEN"),
-      `SLACK_BOT_TOKEN should NOT have been persisted; saveCalls=${JSON.stringify(out.saveCalls)}`,
-    );
-    assert.ok(
-      result.stderr.includes("Invalid format") || result.stdout.includes("Invalid format"),
-      `expected 'Invalid format' warning; stderr=${result.stderr} stdout=${result.stdout}`,
-    );
-  });
+      assert.ok(
+        !out.result.includes("slack"),
+        `slack should have been dropped after invalid token; got ${JSON.stringify(out.result)}`,
+      );
+      assert.ok(
+        !out.saveCalls.some((c: { key: string }) => c.key === "SLACK_BOT_TOKEN"),
+        `SLACK_BOT_TOKEN should NOT have been persisted; saveCalls=${JSON.stringify(out.saveCalls)}`,
+      );
+      assert.ok(
+        result.stderr.includes("Invalid format") || result.stdout.includes("Invalid format"),
+        `expected 'Invalid format' warning; stderr=${result.stderr} stdout=${result.stdout}`,
+      );
+    },
+  );
 
-  it("interactive setupMessagingChannels drops slack when app token fails appTokenFormat check (#1912)", {
-    timeout: 60_000,
-  }, async () => {
-    const tmpDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "nemoclaw-onboard-slack-app-format-reject-"),
-    );
-    const fakeBin = path.join(tmpDir, "bin");
-    const scriptPath = path.join(tmpDir, "slack-app-format-reject.js");
-    const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
-    const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
-    const credentialsPath = JSON.stringify(
-      path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
-    );
+  it(
+    "interactive setupMessagingChannels drops slack when app token fails appTokenFormat check (#1912)",
+    {
+      timeout: 60_000,
+    },
+    async () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "nemoclaw-onboard-slack-app-format-reject-"),
+      );
+      const fakeBin = path.join(tmpDir, "bin");
+      const scriptPath = path.join(tmpDir, "slack-app-format-reject.js");
+      const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
+      const runnerPath = JSON.stringify(path.join(repoRoot, "src", "lib", "runner.ts"));
+      const credentialsPath = JSON.stringify(
+        path.join(repoRoot, "src", "lib", "credentials", "store.ts"),
+      );
 
-    fs.mkdirSync(fakeBin, { recursive: true });
-    fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
-      mode: 0o755,
-    });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, "openshell"), "#!/usr/bin/env bash\nexit 0\n", {
+        mode: 0o755,
+      });
 
-    // Subscript: mocks prompt to return a VALID bot token but a bogus app
-    // token. Expected behavior: bot token passes the regex and persists,
-    // app token fails the regex, channel is dropped from the enabled set,
-    // and SLACK_APP_TOKEN is never saved.
-    const script = String.raw`
+      // Subscript: mocks prompt to return a VALID bot token but a bogus app
+      // token. Expected behavior: bot token passes the regex and persists,
+      // app token fails the regex, channel is dropped from the enabled set,
+      // and SLACK_APP_TOKEN is never saved.
+      const script = String.raw`
 const credentials = require(${credentialsPath});
 const runner = require(${runnerPath});
 
@@ -1893,141 +1978,56 @@ const { setupMessagingChannels, MESSAGING_CHANNELS } = require(${onboardPath});
   process.exit(1);
 });
 `;
-    fs.writeFileSync(scriptPath, script);
+      fs.writeFileSync(scriptPath, script);
 
-    // Dry run with Enter only to introspect Slack's 1-based digit.
-    const introspect = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-      },
-      input: "\n",
-    });
-    assert.equal(introspect.status, 0, introspect.stderr);
-    const slackIdx = JSON.parse(introspect.stdout.trim().split("\n").pop()!).slackIndex1Based;
-    assert.ok(slackIdx >= 1, `unexpected slack index: ${slackIdx}`);
+      // Dry run with Enter only to introspect Slack's 1-based digit.
+      const introspect = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        },
+        input: "\n",
+      });
+      assert.equal(introspect.status, 0, introspect.stderr);
+      const slackIdx = JSON.parse(introspect.stdout.trim().split("\n").pop()!).slackIndex1Based;
+      assert.ok(slackIdx >= 1, `unexpected slack index: ${slackIdx}`);
 
-    // Real run: toggle Slack on, exit UI, bot prompt returns valid, app
-    // prompt returns "abcd", app-token check rejects, channel dropped.
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: `${fakeBin}:${process.env.PATH || ""}`,
-      },
-      input: `${slackIdx}\n`,
-    });
+      // Real run: toggle Slack on, exit UI, bot prompt returns valid, app
+      // prompt returns "abcd", app-token check rejects, channel dropped.
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf-8",
+        env: {
+          ...process.env,
+          HOME: tmpDir,
+          PATH: `${fakeBin}:${process.env.PATH || ""}`,
+        },
+        input: `${slackIdx}\n`,
+      });
 
-    assert.equal(result.status, 0, result.stderr);
-    const out = JSON.parse(result.stdout.trim().split("\n").pop()!);
+      assert.equal(result.status, 0, result.stderr);
+      const out = JSON.parse(result.stdout.trim().split("\n").pop()!);
 
-    assert.ok(
-      !out.result.includes("slack"),
-      `slack should have been dropped after invalid app token; got ${JSON.stringify(out.result)}`,
-    );
-    assert.ok(
-      !out.saveCalls.some((c: { key: string }) => c.key === "SLACK_BOT_TOKEN"),
-      `SLACK_BOT_TOKEN should NOT be persisted until the app token also passes; saveCalls=${JSON.stringify(out.saveCalls)}`,
-    );
-    assert.ok(
-      !out.saveCalls.some((c: { key: string }) => c.key === "SLACK_APP_TOKEN"),
-      `SLACK_APP_TOKEN should NOT have been persisted (invalid format); saveCalls=${JSON.stringify(out.saveCalls)}`,
-    );
-    assert.ok(
-      result.stderr.includes("Invalid format") || result.stdout.includes("Invalid format"),
-      `expected 'Invalid format' warning; stderr=${result.stderr} stdout=${result.stdout}`,
-    );
-  });
-
-  it("Slack bot token format regex rejects obvious bogus tokens and accepts valid ones (#1912)", async () => {
-    const onboardPath = path.join(repoRoot, "src", "lib", "onboard.ts");
-    // Cache-bust the dynamic import so repeated test runs pick up rebuilds.
-    const onboardUrl = `${pathToFileURL(onboardPath).href}?update=${Date.now()}`;
-    const { MESSAGING_CHANNELS } = await import(onboardUrl);
-    const slack = MESSAGING_CHANNELS.find((c: { name: string }) => c.name === "slack");
-
-    assert.ok(slack, "slack messaging channel definition present");
-    assert.ok(slack.tokenFormat instanceof RegExp, "slack.tokenFormat is a regex");
-    assert.ok(
-      typeof slack.tokenFormatHint === "string" && slack.tokenFormatHint.length > 0,
-      "slack.tokenFormatHint set",
-    );
-
-    // Bogus tokens from the bug report and other common misentries — must be rejected.
-    // gitleaks-allow below: intentionally pasted fake prefixes to prove they don't match.
-    const invalid = [
-      "abcd",
-      "",
-      "xoxb",
-      "xoxb-",
-      "xoxp-" + "test-user-token", // gitleaks:allow
-      "xapp-" + "test-app-token", // gitleaks:allow
-      "Bearer xoxb-fake",
-      "xoxb-fake with space",
-    ];
-    for (const token of invalid) {
       assert.ok(
-        !slack.tokenFormat.test(token),
-        `expected ${JSON.stringify(token)} to be rejected as Slack bot token`,
+        !out.result.includes("slack"),
+        `slack should have been dropped after invalid app token; got ${JSON.stringify(out.result)}`,
       );
-    }
+      assert.ok(
+        !out.saveCalls.some((c: { key: string }) => c.key === "SLACK_BOT_TOKEN"),
+        `SLACK_BOT_TOKEN should NOT be persisted until the app token also passes; saveCalls=${JSON.stringify(out.saveCalls)}`,
+      );
+      assert.ok(
+        !out.saveCalls.some((c: { key: string }) => c.key === "SLACK_APP_TOKEN"),
+        `SLACK_APP_TOKEN should NOT have been persisted (invalid format); saveCalls=${JSON.stringify(out.saveCalls)}`,
+      );
+      assert.ok(
+        result.stderr.includes("Invalid format") || result.stdout.includes("Invalid format"),
+        `expected 'Invalid format' warning; stderr=${result.stderr} stdout=${result.stdout}`,
+      );
+    },
+  );
 
-    // Syntactically valid bot tokens — must be accepted. Values are
-    // intentionally obvious test strings to avoid tripping gitleaks.
-    const valid = [
-      "xoxb-test-slack-token-value",
-      "xoxb-fake-bot-token",
-      "xoxb-A",
-      // Slack tokens can contain underscores — lock in the widened
-      // character class per @jyaunches review on #2130.
-      "xoxb-test_with_underscores",
-      "xoxb-mix_of-hyphens_and_underscores",
-    ];
-    for (const token of valid) {
-      assert.ok(
-        slack.tokenFormat.test(token),
-        `expected ${JSON.stringify(token)} to be accepted as Slack bot token`,
-      );
-    }
-
-    // App token (xapp-) has its own format — same permissive character
-    // class. Per @jyaunches suggestion #2 on #2130.
-    assert.ok(slack.appTokenFormat instanceof RegExp, "slack.appTokenFormat is a regex");
-    assert.ok(
-      typeof slack.appTokenFormatHint === "string" && slack.appTokenFormatHint.length > 0,
-      "slack.appTokenFormatHint set",
-    );
-    const invalidApp = [
-      "abcd",
-      "",
-      "xapp",
-      "xapp-",
-      "xoxb-" + "test-bot-token", // gitleaks:allow
-      "Bearer xapp-fake",
-      "xapp-fake with space",
-    ];
-    for (const token of invalidApp) {
-      assert.ok(
-        !slack.appTokenFormat.test(token),
-        `expected ${JSON.stringify(token)} to be rejected as Slack app token`,
-      );
-    }
-    const validApp = [
-      "xapp-" + "1-A0000-12345-abcdef",
-      "xapp-" + "test-app-token-value",
-      "xapp-" + "A",
-      "xapp-" + "with_underscores_and-hyphens",
-    ];
-    for (const token of validApp) {
-      assert.ok(
-        slack.appTokenFormat.test(token),
-        `expected ${JSON.stringify(token)} to be accepted as Slack app token`,
-      );
-    }
-  });
 });

--- a/test/onboard.test.ts
+++ b/test/onboard.test.ts
@@ -132,52 +132,49 @@ describe("onboard helpers", () => {
     expect(envArgs).toEqual(["CHAT_UI_URL=http://127.0.0.1:18789"]);
   });
 
-  it("trims surrounding whitespace from proxy env values before forwarding", () => {
+  it.each([
+    ["HTTP_PROXY", "  http://127.0.0.1:8888  "],
+    ["HTTPS_PROXY", "\thttp://127.0.0.1:8888\n"],
+  ])("trims surrounding whitespace from %s before forwarding", (name, value) => {
     // A `HTTP_PROXY="  http://x:8888  "` from a sloppy shell rc must not
     // flow through with surrounding whitespace — downstream consumers
     // that don't re-trim would treat the value as malformed.
     const envArgs: string[] = [];
 
-    appendHostProxyEnvArgs(envArgs, {
-      HTTP_PROXY: "  http://127.0.0.1:8888  ",
-      HTTPS_PROXY: "\thttp://127.0.0.1:8888\n",
-    });
+    appendHostProxyEnvArgs(envArgs, { [name]: value });
 
-    expect(envArgs).toContain("HTTP_PROXY=http://127.0.0.1:8888");
-    expect(envArgs).toContain("HTTPS_PROXY=http://127.0.0.1:8888");
-    for (const entry of envArgs) {
-      expect(entry, "no forwarded entry should contain leading/trailing whitespace").toBe(
-        entry.trim(),
-      );
-    }
+    const forwarded = envArgs.find((entry) => entry.startsWith(`${name}=`));
+    expect(forwarded).toBe(`${name}=http://127.0.0.1:8888`);
+    expect(forwarded, "the forwarded entry must not contain surrounding whitespace").toBe(
+      forwarded?.trim(),
+    );
   });
 
-  it("synthesizes both NO_PROXY and no_proxy in the sandbox so case-sensitive consumers stay covered", () => {
-    // `withLocalNoProxy` augments both NO_PROXY and no_proxy regardless of
-    // which one the user originally set. A user who only sets HTTP_PROXY
-    // (with no NO_PROXY at all) still gets both cases synthesized in the
-    // sandbox so case-sensitive consumers (e.g. some Python libs read
-    // `no_proxy` lowercase, Node fetch checks `NO_PROXY`) all honor the
-    // localhost/Docker-host carve-outs. Pinning the dual-key behavior so a
-    // future refactor of `withLocalNoProxy` doesn't silently drop one case.
-    const envArgs: string[] = [];
+  it.each(["NO_PROXY", "no_proxy"])(
+    "synthesizes %s in the sandbox for case-sensitive consumers",
+    (name) => {
+      // `withLocalNoProxy` augments both NO_PROXY and no_proxy regardless of
+      // which one the user originally set. A user who only sets HTTP_PROXY
+      // (with no NO_PROXY at all) still gets both cases synthesized in the
+      // sandbox so case-sensitive consumers (e.g. some Python libs read
+      // `no_proxy` lowercase, Node fetch checks `NO_PROXY`) all honor the
+      // localhost/Docker-host carve-outs. Pinning the dual-key behavior so a
+      // future refactor of `withLocalNoProxy` doesn't silently drop one case.
+      const envArgs: string[] = [];
 
-    appendHostProxyEnvArgs(envArgs, {
-      HTTP_PROXY: "http://127.0.0.1:8888",
-    });
+      appendHostProxyEnvArgs(envArgs, {
+        HTTP_PROXY: "http://127.0.0.1:8888",
+      });
 
-    const upper = envArgs.find((e) => e.startsWith("NO_PROXY="));
-    const lower = envArgs.find((e) => e.startsWith("no_proxy="));
-    expect(upper, "NO_PROXY should be synthesized").toBeDefined();
-    expect(lower, "no_proxy (lowercase) should also be synthesized").toBeDefined();
-    for (const v of [upper, lower]) {
-      expect(v).toContain("localhost");
-      expect(v).toContain("127.0.0.1");
-      expect(v).toContain("host.docker.internal");
-    }
-  });
+      const value = envArgs.find((entry) => entry.startsWith(`${name}=`));
+      expect(value, `${name} should be synthesized`).toBeDefined();
+      expect(value).toContain("localhost");
+      expect(value).toContain("127.0.0.1");
+      expect(value).toContain("host.docker.internal");
+    },
+  );
 
-  it("seeds inference.local and host.containers.internal into the sandbox-create NO_PROXY/no_proxy", () => {
+  it.each(["NO_PROXY", "no_proxy"])("seeds managed hosts into sandbox-create %s", (name) => {
     // Boundary pin: appendHostProxyEnvArgs() forwards env into `openshell
     // sandbox create -- env ...`, and OpenShell consults the seeded
     // NO_PROXY at sandbox-create time when deciding whether to chain its
@@ -194,15 +191,11 @@ describe("onboard helpers", () => {
       HTTP_PROXY: "http://127.0.0.1:8118",
     });
 
-    const upper = envArgs.find((e) => e.startsWith("NO_PROXY="));
-    const lower = envArgs.find((e) => e.startsWith("no_proxy="));
-    expect(upper, "NO_PROXY should be synthesized").toBeDefined();
-    expect(lower, "no_proxy should be synthesized").toBeDefined();
-    for (const v of [upper, lower]) {
-      const parts = (v ?? "").split("=")[1]?.split(",") ?? [];
-      expect(parts).toContain("inference.local");
-      expect(parts).toContain("host.containers.internal");
-    }
+    const value = envArgs.find((entry) => entry.startsWith(`${name}=`));
+    expect(value, `${name} should be synthesized`).toBeDefined();
+    const parts = (value ?? "").split("=")[1]?.split(",") ?? [];
+    expect(parts).toContain("inference.local");
+    expect(parts).toContain("host.containers.internal");
   });
 
   it("propagates NEMOCLAW_MINIMAL_BOOTSTRAP=1 from host into sandbox env (#2598)", () => {
@@ -211,15 +204,16 @@ describe("onboard helpers", () => {
     expect(envArgs).toContain("NEMOCLAW_MINIMAL_BOOTSTRAP=1");
   });
 
-  it("omits NEMOCLAW_MINIMAL_BOOTSTRAP when unset or not the literal '1' (#2598)", () => {
-    for (const value of [undefined, "", "0", "true", "yes"]) {
+  it.each([[undefined], [""], ["0"], ["true"], ["yes"]])(
+    "omits NEMOCLAW_MINIMAL_BOOTSTRAP for %j (#2598)",
+    (value) => {
       const envArgs: string[] = [];
       const env: NodeJS.ProcessEnv =
         value === undefined ? {} : { NEMOCLAW_MINIMAL_BOOTSTRAP: value };
       appendHostProxyEnvArgs(envArgs, env);
       expect(envArgs.some((e) => e.startsWith("NEMOCLAW_MINIMAL_BOOTSTRAP="))).toBe(false);
-    }
-  });
+    },
+  );
 
   it(
     "prints owning-deployment guidance when NemoClaw does not launch the gateway (#9120)",

--- a/test/openclaw-config-guard.test.ts
+++ b/test/openclaw-config-guard.test.ts
@@ -496,35 +496,33 @@ describe("openclaw-config-guard", () => {
       fs.closeSync(staleHashFd);
     }
   });
-  it("rejects external symlink, hardlink, and special-file substitutions", () => {
-    for (const attack of ["symlink", "hardlink", "fifo"] as const) {
-      const { root, configDir, configPath, hashPath } = fixture();
-      const external = path.join(root, "external.json");
-      fs.writeFileSync(external, "outside\n");
-      fs.rmSync(configPath);
-      const arrangeAttack = {
-        symlink: () => fs.symlinkSync(external, configPath),
-        hardlink: () => fs.linkSync(external, configPath),
-        fifo: () => expect(spawnSync("mkfifo", [configPath]).status).toBe(0),
-      } satisfies Record<typeof attack, () => void>;
-      arrangeAttack[attack]();
+  it.each(["symlink", "hardlink", "fifo"] as const)("rejects external %s config", (attack) => {
+    const { root, configDir, configPath, hashPath } = fixture();
+    const external = path.join(root, "external.json");
+    fs.writeFileSync(external, "outside\n");
+    fs.rmSync(configPath);
+    const arrangeAttack = {
+      symlink: () => fs.symlinkSync(external, configPath),
+      hardlink: () => fs.linkSync(external, configPath),
+      fifo: () => expect(spawnSync("mkfifo", [configPath]).status).toBe(0),
+    } satisfies Record<typeof attack, () => void>;
+    arrangeAttack[attack]();
 
-      const beforeHash = fs.readFileSync(hashPath);
-      const result = runGuard("preflight", configDir);
+    const beforeHash = fs.readFileSync(hashPath);
+    const result = runGuard("preflight", configDir);
 
-      expect(result.status).toBe(1);
-      expect(result.lines).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            type: "issue",
-            code: attack === "hardlink" ? "hardlinked-config-file" : "unsafe-config-file",
-            path: configPath,
-          }),
-        ]),
-      );
-      expect(fs.readFileSync(external, "utf-8")).toBe("outside\n");
-      expect(fs.readFileSync(hashPath)).toEqual(beforeHash);
-    }
+    expect(result.status).toBe(1);
+    expect(result.lines).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "issue",
+          code: attack === "hardlink" ? "hardlinked-config-file" : "unsafe-config-file",
+          path: configPath,
+        }),
+      ]),
+    );
+    expect(fs.readFileSync(external, "utf-8")).toBe("outside\n");
+    expect(fs.readFileSync(hashPath)).toEqual(beforeHash);
   });
   it("fail-closes a rename-swapped config namespace and leaves the external tree untouched", () => {
     const { root, configDir } = fixture();

--- a/test/openclaw-device-self-approval-patch.test.ts
+++ b/test/openclaw-device-self-approval-patch.test.ts
@@ -635,55 +635,55 @@ describe("OpenClaw bounded device self-approval patch (#4462)", () => {
     }
   });
 
-  it.each([
-    true,
-    false,
-  ])("uses the exact clone paired token for one matching bounded scope upgrade (repair=%s)", async (isRepair) => {
-    const { runtime, tmp } = openPatchedCliFixture();
-    try {
-      const token = "clone-paired-token";
-      const pending = validPending({ isRepair });
-      runtime.setPairingLists(
-        { pending: [pending], paired: [clonePairedTokenRecord(token)] },
-        { pending: [pending], paired: [validPaired({ approvedScopes: undefined })] },
-      );
-      runtime.setPairedTokenEnvironment();
+  it.each([true, false])(
+    "uses the exact clone paired token for one matching bounded scope upgrade (repair=%s)",
+    async (isRepair) => {
+      const { runtime, tmp } = openPatchedCliFixture();
+      try {
+        const token = "clone-paired-token";
+        const pending = validPending({ isRepair });
+        runtime.setPairingLists(
+          { pending: [pending], paired: [clonePairedTokenRecord(token)] },
+          { pending: [pending], paired: [validPaired({ approvedScopes: undefined })] },
+        );
+        runtime.setPairedTokenEnvironment();
 
-      await expect(
-        runtime.approvePairingWithFallback({ json: true }, "request-1"),
-      ).resolves.toEqual({ requestId: "request-1", approved: true });
-      expect(runtime.gatewayCalls.map((call) => call.method)).toEqual([
-        "device.pair.list",
-        "device.pair.approve",
-      ]);
-      for (const call of runtime.gatewayCalls) {
-        expect(call).toMatchObject({
-          scopes: ["operator.pairing"],
-          credentialSource: "option",
-          nemoclawDisableStoredDeviceAuth: true,
-          signedIdentityForced: true,
-          token,
-          url: "ws://127.0.0.1:18789",
+        await expect(
+          runtime.approvePairingWithFallback({ json: true }, "request-1"),
+        ).resolves.toEqual({ requestId: "request-1", approved: true });
+        expect(runtime.gatewayCalls.map((call) => call.method)).toEqual([
+          "device.pair.list",
+          "device.pair.approve",
+        ]);
+        for (const call of runtime.gatewayCalls) {
+          expect(call).toMatchObject({
+            scopes: ["operator.pairing"],
+            credentialSource: "option",
+            nemoclawDisableStoredDeviceAuth: true,
+            signedIdentityForced: true,
+            token,
+            url: "ws://127.0.0.1:18789",
+          });
+          expect(call.password).toBeUndefined();
+          expect(call.cliArgUrl).toBeUndefined();
+          expect(call.cliArgToken).toBeUndefined();
+          expect(call.cliArgPassword).toBeUndefined();
+          expect(call).not.toHaveProperty("useStoredDeviceAuth");
+          expect(call).not.toHaveProperty("requiredStoredDeviceAuthScopes");
+        }
+        expect(runtime.pairingStats()).toEqual({
+          localPairingReadCount: 0,
+          localApprovalCount: 0,
         });
-        expect(call.password).toBeUndefined();
-        expect(call.cliArgUrl).toBeUndefined();
-        expect(call.cliArgToken).toBeUndefined();
-        expect(call.cliArgPassword).toBeUndefined();
-        expect(call).not.toHaveProperty("useStoredDeviceAuth");
-        expect(call).not.toHaveProperty("requiredStoredDeviceAuthScopes");
+        expect(runtime.pairingDescriptorReads()).toEqual([
+          { fd: 41, position: 0 },
+          { fd: 42, position: 0 },
+        ]);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
       }
-      expect(runtime.pairingStats()).toEqual({
-        localPairingReadCount: 0,
-        localApprovalCount: 0,
-      });
-      expect(runtime.pairingDescriptorReads()).toEqual([
-        { fd: 41, position: 0 },
-        { fd: 42, position: 0 },
-      ]);
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
-  });
+    },
+  );
 
   it.each([
     ["a missing pending descriptor", { pendingFd: undefined }, {}, {}],
@@ -730,27 +730,30 @@ describe("OpenClaw bounded device self-approval patch (#4462)", () => {
       },
       {},
     ],
-  ] as const)("rejects a paired-token request with %s before reaching the gateway", async (_label, environment, pairedOverrides, approvalOverrides) => {
-    const { runtime, tmp } = openPatchedCliFixture();
-    try {
-      runtime.setPairingLists({
-        pending: [validPending({ isRepair: false })],
-        paired: [clonePairedTokenRecord("clone-paired-token", pairedOverrides)],
-      });
-      runtime.setPairedTokenEnvironment(environment);
+  ] as const)(
+    "rejects a paired-token request with %s before reaching the gateway",
+    async (_label, environment, pairedOverrides, approvalOverrides) => {
+      const { runtime, tmp } = openPatchedCliFixture();
+      try {
+        runtime.setPairingLists({
+          pending: [validPending({ isRepair: false })],
+          paired: [clonePairedTokenRecord("clone-paired-token", pairedOverrides)],
+        });
+        runtime.setPairedTokenEnvironment(environment);
 
-      await expect(
-        runtime.approvePairingWithFallback({ json: true, ...approvalOverrides }, "request-1"),
-      ).rejects.toThrow(/forced pairing pinned/u);
-      expect(runtime.gatewayCalls).toEqual([]);
-      expect(runtime.pairingStats()).toEqual({
-        localPairingReadCount: 0,
-        localApprovalCount: 0,
-      });
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
-  });
+        await expect(
+          runtime.approvePairingWithFallback({ json: true, ...approvalOverrides }, "request-1"),
+        ).rejects.toThrow(/forced pairing pinned/u);
+        expect(runtime.gatewayCalls).toEqual([]);
+        expect(runtime.pairingStats()).toEqual({
+          localPairingReadCount: 0,
+          localApprovalCount: 0,
+        });
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("rejects live pairing drift after one direct bounded list and before approval", async () => {
     const { runtime, tmp } = openPatchedCliFixture();
@@ -1158,38 +1161,43 @@ describe("OpenClaw bounded device self-approval patch (#4462)", () => {
     ["prepared", "paired published first", "before", "after"],
     ["committed", "pending published first", "after", "before"],
     ["committed", "paired published first", "before", "after"],
-  ] as const)("recovers a %s journal when %s", async (phase, _direction, pendingSide, pairedSide) => {
-    const { runtime, tmp } = openPatchedPairingFixture();
-    try {
-      const snapshots = transactionSnapshots();
-      const currentPending = snapshots[pendingSide].pendingById;
-      const currentPaired = snapshots[pairedSide].pairedByDeviceId;
-      const { journalPath } = runtime.getPairingPaths();
-      runtime.setPairingState(currentPending, currentPaired);
-      runtime.setFile(journalPath, transactionJournal(phase, snapshots));
+  ] as const)(
+    "recovers a %s journal when %s",
+    async (phase, _direction, pendingSide, pairedSide) => {
+      const { runtime, tmp } = openPatchedPairingFixture();
+      try {
+        const snapshots = transactionSnapshots();
+        const currentPending = snapshots[pendingSide].pendingById;
+        const currentPaired = snapshots[pairedSide].pairedByDeviceId;
+        const { journalPath } = runtime.getPairingPaths();
+        runtime.setPairingState(currentPending, currentPaired);
+        runtime.setFile(journalPath, transactionJournal(phase, snapshots));
 
-      const listed = await runtime.listDevicePairing();
-      const expected = phase === "prepared" ? snapshots.before : snapshots.after;
-      expect(runtime.getFile(runtime.getPairingPaths().pendingPath)).toEqual(expected.pendingById);
-      expect(runtime.getFile(runtime.getPairingPaths().pairedPath)).toEqual(
-        expected.pairedByDeviceId,
-      );
-      expect(runtime.getFile(journalPath)).toEqual({
-        version: 1,
-        kind: "nemoclaw-self-approval",
-        phase: "idle",
-      });
-      expect(listed.pending).toHaveLength(phase === "prepared" ? 1 : 0);
-      expect(listed.paired).toHaveLength(1);
+        const listed = await runtime.listDevicePairing();
+        const expected = phase === "prepared" ? snapshots.before : snapshots.after;
+        expect(runtime.getFile(runtime.getPairingPaths().pendingPath)).toEqual(
+          expected.pendingById,
+        );
+        expect(runtime.getFile(runtime.getPairingPaths().pairedPath)).toEqual(
+          expected.pairedByDeviceId,
+        );
+        expect(runtime.getFile(journalPath)).toEqual({
+          version: 1,
+          kind: "nemoclaw-self-approval",
+          phase: "idle",
+        });
+        expect(listed.pending).toHaveLength(phase === "prepared" ? 1 : 0);
+        expect(listed.paired).toHaveLength(1);
 
-      // Recovery is idempotent through another independently locked reader.
-      expect(await runtime.getPairedDevice("device-1")).toEqual(
-        expected.pairedByDeviceId["device-1"],
-      );
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
-  });
+        // Recovery is idempotent through another independently locked reader.
+        expect(await runtime.getPairedDevice("device-1")).toEqual(
+          expected.pairedByDeviceId["device-1"],
+        );
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("fails closed and preserves a malformed or state-mismatched journal", async () => {
     const { runtime, tmp } = openPatchedPairingFixture();
@@ -1390,36 +1398,34 @@ describe("OpenClaw bounded device self-approval patch (#4462)", () => {
     }
   });
 
-  it("fails closed on missing, duplicate, and drifted compiled targets", () => {
-    for (const mutate of [
-      (dist: string) => fs.rmSync(path.join(dist, "devices-fixture.js")),
-      (dist: string) =>
-        fs.copyFileSync(path.join(dist, "devices-fixture.js"), path.join(dist, "devices-copy.js")),
-      (dist: string) => {
-        const file = path.join(dist, "device-pairing-fixture.js");
-        fs.writeFileSync(
-          file,
-          fs
-            .readFileSync(file, "utf8")
-            .replace(
-              "allowedScopes: options.callerScopes",
-              "allowedScopes: [...options.callerScopes]",
-            ),
-        );
-      },
-    ]) {
-      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-device-patch-drift-"));
-      const dist = path.join(tmp, "dist");
-      fs.mkdirSync(dist);
-      writeFixtureDist(dist);
-      try {
-        mutate(dist);
-        const audit = runPatch(dist, true);
-        expect(audit.status).toBe(3);
-        expect(audit.stdout).toContain("[MISS]");
-      } finally {
-        fs.rmSync(tmp, { recursive: true, force: true });
-      }
+  it.each([
+    (dist: string) => fs.rmSync(path.join(dist, "devices-fixture.js")),
+    (dist: string) =>
+      fs.copyFileSync(path.join(dist, "devices-fixture.js"), path.join(dist, "devices-copy.js")),
+    (dist: string) => {
+      const file = path.join(dist, "device-pairing-fixture.js");
+      fs.writeFileSync(
+        file,
+        fs
+          .readFileSync(file, "utf8")
+          .replace(
+            "allowedScopes: options.callerScopes",
+            "allowedScopes: [...options.callerScopes]",
+          ),
+      );
+    },
+  ])("fails closed on missing, duplicate, and drifted compiled targets [case %#]", (mutate) => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-device-patch-drift-"));
+    const dist = path.join(tmp, "dist");
+    fs.mkdirSync(dist);
+    writeFixtureDist(dist);
+    try {
+      mutate(dist);
+      const audit = runPatch(dist, true);
+      expect(audit.status).toBe(3);
+      expect(audit.stdout).toContain("[MISS]");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
 

--- a/test/package-contract/openshell-policy-boundary.test.ts
+++ b/test/package-contract/openshell-policy-boundary.test.ts
@@ -25,8 +25,9 @@ function packageFiles(packageRoot: string): string[] {
 }
 
 describe("OpenShell policy boundary package contract", () => {
-  it("pins the YAML parser used by both production package boundaries", () => {
-    for (const packageRoot of [repoRoot, path.join(repoRoot, "nemoclaw")]) {
+  it.each([repoRoot, path.join(repoRoot, "nemoclaw")])(
+    "pins the YAML parser used by both production package boundaries [case %#]",
+    (packageRoot) => {
       const dependencyVersion = JSON.parse(
         execFileSync("npm", ["pkg", "get", "dependencies.yaml"], {
           cwd: packageRoot,
@@ -35,8 +36,8 @@ describe("OpenShell policy boundary package contract", () => {
       ) as string;
 
       expect(dependencyVersion).toBe("2.8.3");
-    }
-  });
+    },
+  );
 
   it("routes the CommonJS CLI and ESM plugin through one canonical CJS boundary", async () => {
     const cliPolicy = require("../../dist/lib/policy/merge.js") as {

--- a/test/perl-critical-cve-remediation.test.ts
+++ b/test/perl-critical-cve-remediation.test.ts
@@ -124,19 +124,16 @@ describe("managed base-image Perl CVE remediation", () => {
   });
 
   it("skips only raw-ICMP assertions after a matching permission denial (#9028)", () => {
-    execFileSync(
-      "bash",
-      [
-        "-c",
-        `set -euo pipefail
+    execFileSync("bash", [
+      "-c",
+      `set -euo pipefail
 ! grep -Eq '^\\+.*(?:Net::Ping::_isroot|&Net::Ping::_isroot)' "$1"
 grep -Fq '+    isa_ok($p, "Net::Ping");' "$1"
 grep -Fq '+    die $@;' "$1"
 ! grep -Fq '+    plan skip_all => "no icmpv6 on this machine $@";' "$1"`,
-        "bash",
-        path.join(repoRoot, netPingCapabilityPatchPath),
-      ],
-    );
+      "bash",
+      path.join(repoRoot, netPingCapabilityPatchPath),
+    ]);
     const patchSummary = execFileSync(
       "git",
       ["apply", "--numstat", path.join(repoRoot, netPingCapabilityPatchPath)],
@@ -265,9 +262,7 @@ sub new {
         const missingObjectWithPermissionErrno = runProbe("missing_eperm");
         expect(missingObjectWithPermissionErrno.status).not.toBe(0);
         expect(missingObjectWithPermissionErrno.status).not.toBe(77);
-        expect(missingObjectWithPermissionErrno.stderr).toContain(
-          "constructor returned no object",
-        );
+        expect(missingObjectWithPermissionErrno.stderr).toContain("constructor returned no object");
       } finally {
         fs.rmSync(fixtureRoot, { recursive: true });
       }
@@ -382,8 +377,9 @@ env "\${perl_test_env[@]}" bash -c 'test "$NEMOCLAW_PERL_SKIP_RAW_ICMPV4_TESTS" 
     }
   });
 
-  it("fails each image build unless the reviewed fixes execute (#7338)", () => {
-    for (const image of managedImages) {
+  it.each([...managedImages])(
+    "fails each image build unless the reviewed fixes execute [case %#] (#7338)",
+    (image) => {
       const runtime = completedStage(image.source);
 
       expect(runtime, image.name).toContain(
@@ -411,8 +407,8 @@ env "\${perl_test_env[@]}" bash -c 'test "$NEMOCLAW_PERL_SKIP_RAW_ICMPV4_TESTS" 
       expect(runtime, image.name).toContain('die "short source accepted"');
       expect(runtime, image.name).toContain('use re "Debug"');
       expect(runtime, image.name).toContain('"fnord" =~ m/(?:$x)|(?:$y)/');
-    }
-  });
+    },
+  );
 
   it("builds both architectures and every managed image from the PR head (#7338)", () => {
     expect(baseImageWorkflow).toContain("runner: ubuntu-24.04");

--- a/test/plugin-vitest-project.test.ts
+++ b/test/plugin-vitest-project.test.ts
@@ -7,7 +7,6 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-
 const repositoryRoot = path.resolve(import.meta.dirname, "..");
 const rootRequire = createRequire(path.join(repositoryRoot, "package.json"));
 const pluginRequire = createRequire(path.join(repositoryRoot, "nemoclaw", "package.json"));
@@ -29,13 +28,14 @@ function listedTypeScriptFiles(configPath: string): string[] {
 }
 
 describe("plugin Vitest project contract", () => {
-  it("keeps standalone plugin dependencies on the root Vitest toolchain", () => {
-    for (const packageName of ["vitest", "vite"] as const) {
+  it.each(["vitest", "vite"] as const)(
+    "keeps standalone plugin dependencies on the root Vitest toolchain [case %#]",
+    (packageName) => {
       expect(installedVersion(pluginRequire, packageName), packageName).toBe(
         installedVersion(rootRequire, packageName),
       );
-    }
-  });
+    },
+  );
 
   it("typechecks plugin production and test sources without emitting tests", () => {
     const productionFiles = listedTypeScriptFiles("nemoclaw/tsconfig.json");

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -998,13 +998,14 @@ exit 1
       ).toThrow(/Cannot merge policy preset: the current policy is not a valid YAML mapping/);
     });
 
-    it("fails closed when preset entries are malformed or not a mapping", () => {
-      for (const invalidEntries of ["  broken: [unterminated", "  - host: example.com"]) {
+    it.each(["  broken: [unterminated", "  - host: example.com"])(
+      "fails closed when preset entries are malformed or not a mapping [case %#]",
+      (invalidEntries) => {
         expect(() => policies.mergePresetIntoPolicy("version: 1", invalidEntries)).toThrow(
           /preset network_policies entries must be a valid YAML mapping/,
         );
-      }
-    });
+      },
+    );
 
     const realisticEntries =
       "  pypi_access:\n" +

--- a/test/policy-tiers-onboard.test.ts
+++ b/test/policy-tiers-onboard.test.ts
@@ -396,7 +396,7 @@ describe("policy tier selection", () => {
     assert.deepEqual(tiers.resolveTierPresets("restricted"), []);
   });
 
-  it("balanced tier resolves exactly the five dev presets read-write without weather", () => {
+  it("balanced tier resolves exactly the five dev presets without weather", () => {
     const presets = tiers.resolveTierPresets("balanced");
     const names = presets.map((preset) => preset.name);
     assert.deepEqual(
@@ -404,11 +404,17 @@ describe("policy tier selection", () => {
       ["brave", "brew", "huggingface", "npm", "pypi"],
       "balanced tier must resolve exactly brave, brew, huggingface, npm, pypi",
     );
-    const accessByName = new Map(presets.map((preset) => [preset.name, preset.access]));
-    for (const name of ["npm", "pypi", "huggingface", "brew", "brave"]) {
-      assert.equal(accessByName.get(name), "read-write", `${name} should be read-write`);
-    }
   });
+
+  it.each(["npm", "pypi", "huggingface", "brew", "brave"])(
+    "gives the balanced %s preset read-write access",
+    (name) => {
+      const accessByName = new Map(
+        tiers.resolveTierPresets("balanced").map((preset) => [preset.name, preset.access]),
+      );
+      assert.equal(accessByName.get(name), "read-write", `${name} should be read-write`);
+    },
+  );
 
   it("open tier resolves presets including at least one social or messaging preset", () => {
     const names = tiers.resolveTierPresets("open").map((preset) => preset.name);
@@ -457,22 +463,27 @@ describe("policy tier setup", () => {
     assert.deepEqual(result.applied, []);
   });
 
-  it("keeps OpenClaw web search and OpenClaw-only presets in Personal", async () => {
+  it.each([
+    "personal-open-internet",
+    "brave",
+    "tavily",
+    "openclaw-pricing",
+    "openclaw-diagnostics-otel-local",
+    "googlechat",
+  ])("keeps the %s OpenClaw preset in Personal", async (name) => {
     const result = await runPolicySetup(
       { tierName: "personal" },
       { agent: "openclaw", webSearchConfig: null, webSearchSupported: true },
     );
 
-    for (const name of [
-      "personal-open-internet",
-      "brave",
-      "tavily",
-      "openclaw-pricing",
-      "openclaw-diagnostics-otel-local",
-      "googlechat",
-    ]) {
-      assert.ok(result.applied.includes(name), `${name} should be applied`);
-    }
+    assert.ok(result.applied.includes(name), `${name} should be applied`);
+  });
+
+  it("keeps non-OpenClaw presets out of OpenClaw Personal", async () => {
+    const result = await runPolicySetup(
+      { tierName: "personal" },
+      { agent: "openclaw", webSearchConfig: null, webSearchSupported: true },
+    );
     assert.ok(!result.applied.includes("nous-web"), "Hermes-only presets must remain filtered");
     assert.ok(
       !result.applied.includes("observability-otlp-local"),
@@ -480,15 +491,23 @@ describe("policy tier setup", () => {
     );
   });
 
-  it("keeps supported Hermes web search and Hermes-only presets in Personal", async () => {
+  it.each(["personal-open-internet", "tavily", "nous-web", "nous-browser"])(
+    "keeps the %s Hermes preset in Personal",
+    async (name) => {
+      const result = await runPolicySetup(
+        { tierName: "personal" },
+        { agent: "hermes", webSearchConfig: null, webSearchSupported: true },
+      );
+
+      assert.ok(result.applied.includes(name), `${name} should be applied`);
+    },
+  );
+
+  it("keeps unsupported presets out of Hermes Personal", async () => {
     const result = await runPolicySetup(
       { tierName: "personal" },
       { agent: "hermes", webSearchConfig: null, webSearchSupported: true },
     );
-
-    for (const name of ["personal-open-internet", "tavily", "nous-web", "nous-browser"]) {
-      assert.ok(result.applied.includes(name), `${name} should be applied`);
-    }
     assert.ok(!result.applied.includes("brave"), "unsupported Brave must remain filtered");
     assert.ok(
       !result.applied.includes("openclaw-pricing"),
@@ -561,21 +580,24 @@ describe("policy tier setup", () => {
       { fetchEnabled: true, provider: "tavily" as const },
       ["tavily"],
     ],
-  ])("preselects only the matching web-search preset for fresh interactive %s onboarding with %s (#7125)", async (_agentLabel, agent, _searchLabel, webSearchConfig, expectedSearchPresets) => {
-    const result = await runPolicySetup(
-      { tierName: "balanced", nonInteractive: false },
-      {
-        agent,
-        webSearchConfig,
-        webSearchSupported: true,
-      },
-    );
+  ])(
+    "preselects only the matching web-search preset for fresh interactive %s onboarding with %s (#7125)",
+    async (_agentLabel, agent, _searchLabel, webSearchConfig, expectedSearchPresets) => {
+      const result = await runPolicySetup(
+        { tierName: "balanced", nonInteractive: false },
+        {
+          agent,
+          webSearchConfig,
+          webSearchSupported: true,
+        },
+      );
 
-    assert.deepEqual(
-      result.applied.filter((name) => name === "brave" || name === "tavily"),
-      expectedSearchPresets,
-    );
-  });
+      assert.deepEqual(
+        result.applied.filter((name) => name === "brave" || name === "tavily"),
+        expectedSearchPresets,
+      );
+    },
+  );
 
   it("keeps explicitly requested built-in Brave when web search is supported", async () => {
     const result = await runPolicySetup(
@@ -591,21 +613,18 @@ describe("policy tier setup", () => {
     assert.deepEqual(result.appliedCalls, ["brave", "npm"]);
   });
 
-  it(
-    "keeps an explicit Personal preset list authoritative before policy mutation (#8991)",
-    async () => {
-      const explicitPresets = ["weather", "public-reference", "github"];
-      const result = await runPolicySetup({
-        tierName: "personal",
-        policyMode: "custom",
-        policyPresets: explicitPresets.join(","),
-      });
+  it("keeps an explicit Personal preset list authoritative before policy mutation (#8991)", async () => {
+    const explicitPresets = ["weather", "public-reference", "github"];
+    const result = await runPolicySetup({
+      tierName: "personal",
+      policyMode: "custom",
+      policyPresets: explicitPresets.join(","),
+    });
 
-      assert.deepEqual(result.applied, explicitPresets);
-      assert.deepEqual(result.appliedCalls, explicitPresets);
-      assert.deepEqual(result.syncCalls[0]?.selected, explicitPresets);
-    },
-  );
+    assert.deepEqual(result.applied, explicitPresets);
+    assert.deepEqual(result.appliedCalls, explicitPresets);
+    assert.deepEqual(result.syncCalls[0]?.selected, explicitPresets);
+  });
 
   it("preserves a recorded Balanced tier default during resumed reapply (#6844)", async () => {
     const result = await runPolicySetup(
@@ -801,46 +820,51 @@ describe("policy tier setup", () => {
     ]);
   });
 
-  it("does not re-add OpenClaw OTEL presets for the restricted tier", async () => {
-    const result = await runPolicySetup(
-      {
-        tierName: "restricted",
-        env: {
-          NEMOCLAW_OPENCLAW_OTEL: "1",
-          NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
+  it.each(["openclaw-pricing", "openclaw-diagnostics-otel-local"])(
+    "does not re-add the %s OpenClaw preset for the restricted tier",
+    async (name) => {
+      const result = await runPolicySetup(
+        {
+          tierName: "restricted",
+          env: {
+            NEMOCLAW_OPENCLAW_OTEL: "1",
+            NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
+          },
         },
-      },
-      { agent: "openclaw" },
-    );
+        { agent: "openclaw" },
+      );
 
-    for (const name of ["openclaw-pricing", "openclaw-diagnostics-otel-local"]) {
       assert.ok(!result.applied.includes(name));
       assert.ok(!result.appliedCalls.includes(name));
-    }
-  });
+    },
+  );
 
-  it("reports the final restricted preset suppression in its note", async () => {
-    const result = await runPolicySetup(
-      {
-        tierName: "restricted",
-        env: {
-          NEMOCLAW_OPENCLAW_OTEL: "1",
-          NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
+  it.each(["openclaw-pricing", "openclaw-diagnostics-otel-local"])(
+    "reports suppression of %s in the final restricted note",
+    async (name) => {
+      const result = await runPolicySetup(
+        {
+          tierName: "restricted",
+          env: {
+            NEMOCLAW_OPENCLAW_OTEL: "1",
+            NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
+          },
         },
-      },
-      { agent: "openclaw" },
-    );
-    const noteLine = result.notes.find((line) =>
-      line.includes("Restricted tier suppresses agent-required preset"),
-    );
+        { agent: "openclaw" },
+      );
+      const noteLine = result.notes.find((line) =>
+        line.includes("Restricted tier suppresses agent-required preset"),
+      );
 
-    assert.ok(noteLine, `suppression note must be printed, lines: ${JSON.stringify(result.notes)}`);
-    for (const name of ["openclaw-pricing", "openclaw-diagnostics-otel-local"]) {
+      assert.ok(
+        noteLine,
+        `suppression note must be printed, lines: ${JSON.stringify(result.notes)}`,
+      );
       assert.ok(noteLine.includes(name), `note must mention ${name}, got: ${noteLine}`);
       assert.ok(!result.applied.includes(name));
       assert.ok(!result.appliedCalls.includes(name));
-    }
-  });
+    },
+  );
 
   it("removes previously-applied OpenClaw pricing for the restricted tier", async () => {
     const result = await runPolicySetup(
@@ -852,24 +876,25 @@ describe("policy tier setup", () => {
     assert.ok(result.removedCalls.includes("openclaw-pricing"));
   });
 
-  it("removes previously-applied OpenClaw OTEL diagnostics for the restricted tier", async () => {
-    const result = await runPolicySetup(
-      {
-        tierName: "restricted",
-        currentApplied: ["openclaw-diagnostics-otel-local", "openclaw-pricing"],
-        env: {
-          NEMOCLAW_OPENCLAW_OTEL: "1",
-          NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
+  it.each(["openclaw-pricing", "openclaw-diagnostics-otel-local"])(
+    "removes the previously applied %s preset for the restricted tier",
+    async (name) => {
+      const result = await runPolicySetup(
+        {
+          tierName: "restricted",
+          currentApplied: ["openclaw-diagnostics-otel-local", "openclaw-pricing"],
+          env: {
+            NEMOCLAW_OPENCLAW_OTEL: "1",
+            NEMOCLAW_OPENCLAW_OTEL_ENDPOINT: undefined,
+          },
         },
-      },
-      { agent: "openclaw" },
-    );
+        { agent: "openclaw" },
+      );
 
-    for (const name of ["openclaw-pricing", "openclaw-diagnostics-otel-local"]) {
       assert.ok(!result.applied.includes(name));
       assert.ok(result.removedCalls.includes(name));
-    }
-  });
+    },
+  );
 
   it("keeps an empty restricted resume target empty", async () => {
     const result = await runPolicySetup(
@@ -934,16 +959,21 @@ describe("selectTierPresetsAndAccess", () => {
     return helpers.selectTierPresetsAndAccess(tierName, policy.listPresets(), initialSelected);
   }
 
-  it("returns tier presets with their default access levels", async () => {
-    const resolved = await resolve("balanced");
-    const names = resolved.map((preset) => preset.name);
-    assert.ok(names.includes("npm"), "npm should be included");
-    assert.ok(names.includes("brave"), "brave should be included");
+  it.each(tiers.resolveTierPresets("balanced"))(
+    "returns the balanced $name preset with $access access",
+    async ({ name, access }) => {
+      const resolved = await resolve("balanced");
+      assert.deepEqual(
+        resolved.find((preset) => preset.name === name),
+        { name, access },
+      );
+    },
+  );
+
+  it("keeps weather and Slack out of balanced defaults", async () => {
+    const names = (await resolve("balanced")).map((preset) => preset.name);
     assert.ok(!names.includes("weather"), "weather should not be a balanced tier default");
     assert.ok(!names.includes("slack"), "slack should not be included in balanced");
-    for (const preset of resolved) {
-      assert.equal(preset.access, "read-write", `${preset.name} should default to read-write`);
-    }
   });
 
   it("returns an empty array for the restricted tier", async () => {
@@ -968,15 +998,18 @@ describe("selectTierPresetsAndAccess", () => {
     assert.ok(slackIdx > lastTierIdx, "non-tier preset (slack) should appear after tier presets");
   });
 
-  it("returns name and access fields for every resolved preset", async () => {
-    const resolved = await resolve("open");
-    assert.ok(resolved.length > 0, "open tier should have presets");
-    for (const preset of resolved) {
+  it.each(tiers.resolveTierPresets("open"))(
+    "returns name and access fields for the open $name preset",
+    async ({ name }) => {
+      const resolved = await resolve("open");
+      assert.ok(resolved.length > 0, "open tier should have presets");
+      const preset = resolved.find((candidate) => candidate.name === name);
+      assert.ok(preset, `${name} should resolve`);
       assert.equal(typeof preset.name, "string");
       assert.ok(
         preset.access === "read" || preset.access === "read-write",
         `unexpected access: ${preset.access}`,
       );
-    }
-  });
+    },
+  );
 });

--- a/test/pr-review-advisor-openshell.test.ts
+++ b/test/pr-review-advisor-openshell.test.ts
@@ -100,21 +100,22 @@ afterEach(() => {
 });
 
 describe("PR review advisor OpenShell wrapper", () => {
-  it("keeps credential-bearing host commands out of the Pi SDK import graph", () => {
-    for (const relativePath of [
-      "tools/pr-review-advisor/openshell.mts",
-      "tools/pr-review-advisor/github-context.mts",
-      "tools/advisors/provider-constants.mts",
-      "tools/advisors/github.mts",
-      "tools/advisors/json.mts",
-      "tools/openshell-agent/runtime.mts",
-    ]) {
+  it.each([
+    "tools/pr-review-advisor/openshell.mts",
+    "tools/pr-review-advisor/github-context.mts",
+    "tools/advisors/provider-constants.mts",
+    "tools/advisors/github.mts",
+    "tools/advisors/json.mts",
+    "tools/openshell-agent/runtime.mts",
+  ])(
+    "keeps credential-bearing host commands out of the Pi SDK import graph [case %#]",
+    (relativePath) => {
       const source = fs.readFileSync(path.resolve(import.meta.dirname, "..", relativePath), "utf8");
       expect(source, relativePath).not.toMatch(
         /(?:@earendil-works\/pi-coding-agent|\btypebox\b|\/session\.mts|\/analyze\.mts)/u,
       );
-    }
-  });
+    },
+  );
 
   it("allows only the hosted service and OpenShell inference gateway", () => {
     expect(advisorInferenceBaseUrl({})).toBe(ADVISOR_OPENAI_COMPATIBLE_BASE_URL);
@@ -408,7 +409,10 @@ describe("PR review advisor OpenShell wrapper", () => {
     }
   }
 
-  it("materializes bounded host context and pinned read tools for read-only mounts", verifyAdvisorReadOnlyMountContext);
+  it(
+    "materializes bounded host context and pinned read tools for read-only mounts",
+    verifyAdvisorReadOnlyMountContext,
+  );
 
   it("requires repository metadata before placing immutable-boundary proof files", async () => {
     const env = advisorEnvironment();

--- a/test/pr-workflow-contract.test.ts
+++ b/test/pr-workflow-contract.test.ts
@@ -451,106 +451,107 @@ describe("pull request and main workflow contracts", () => {
     }
   });
 
-  it("requires migrated .mts coverage entrypoints (#6918)", () => {
-    const cases = [
-      {
-        action: sharedActions.cliCoverageShard,
-        step: "Build CLI for coverage shard",
-        stem: "scripts/check-dist-sourcemaps",
-      },
-      {
-        action: sharedActions.cliCoverageMerge,
-        step: "Verify compiled CLI artifact",
-        stem: "scripts/check-dist-sourcemaps",
-      },
-      {
-        action: sharedActions.cliCoverageMerge,
-        step: "Merge CLI coverage",
-        stem: "scripts/check-coverage-ratchet",
-      },
-      {
-        action: sharedActions.pluginCoverage,
-        step: "Run plugin coverage",
-        stem: "scripts/check-coverage-ratchet",
-      },
-    ] as const;
-    const variants = [
-      {
-        fixtureExtension: "mts",
-        expectedEntrypointExtension: "mts",
-        expectedStatus: 0,
-      },
-      {
-        fixtureExtension: "missing",
-        expectedEntrypointExtension: "mts",
-        expectedStatus: 1,
-      },
-    ] as const;
+  const coverageEntrypointCases = [
+    {
+      action: sharedActions.cliCoverageShard,
+      step: "Build CLI for coverage shard",
+      stem: "scripts/check-dist-sourcemaps",
+    },
+    {
+      action: sharedActions.cliCoverageMerge,
+      step: "Verify compiled CLI artifact",
+      stem: "scripts/check-dist-sourcemaps",
+    },
+    {
+      action: sharedActions.cliCoverageMerge,
+      step: "Merge CLI coverage",
+      stem: "scripts/check-coverage-ratchet",
+    },
+    {
+      action: sharedActions.pluginCoverage,
+      step: "Run plugin coverage",
+      stem: "scripts/check-coverage-ratchet",
+    },
+  ] as const;
+  const coverageEntrypointVariants = [
+    {
+      fixtureExtension: "mts",
+      expectedEntrypointExtension: "mts",
+      expectedStatus: 0,
+    },
+    {
+      fixtureExtension: "missing",
+      expectedEntrypointExtension: "mts",
+      expectedStatus: 1,
+    },
+  ] as const;
 
-    for (const testCase of cases) {
-      for (const variant of variants) {
-        const temp = mkdtempSync(join(tmpdir(), "nemoclaw-coverage-entrypoint-"));
-        const fakeBin = join(temp, "bin");
-        mkdirSync(fakeBin);
-        mkdirSync(join(temp, "dist"));
-        mkdirSync(join(temp, "scripts"));
-        writeFileSync(join(temp, "dist", ["nemoclaw", "js"].join(".")), "built\n");
-        for (const command of ["node", "npm"]) {
-          writeFileSync(join(fakeBin, command), "#!/usr/bin/env bash\nexit 0\n", {
-            mode: 0o755,
-          });
-        }
-        writeFileSync(
-          join(fakeBin, "npx"),
-          [
-            "#!/usr/bin/env bash",
-            "set -euo pipefail",
-            'if [ "${1:-}" = "tsx" ] && [[ "${2:-}" == scripts/check-* ]]; then',
-            '  test "${2}" = "${EXPECTED_ENTRYPOINT}"',
-            '  test -f "${2}"',
-            "fi",
-          ].join("\n"),
-          { mode: 0o755 },
+  it.each(
+    coverageEntrypointCases.flatMap((testCase) =>
+      coverageEntrypointVariants.map((variant) => ({ testCase, variant })),
+    ),
+  )(
+    "requires the migrated $testCase.stem.$variant.expectedEntrypointExtension entrypoint",
+    ({ testCase, variant }) => {
+      const temp = mkdtempSync(join(tmpdir(), "nemoclaw-coverage-entrypoint-"));
+      const fakeBin = join(temp, "bin");
+      mkdirSync(fakeBin);
+      mkdirSync(join(temp, "dist"));
+      mkdirSync(join(temp, "scripts"));
+      writeFileSync(join(temp, "dist", ["nemoclaw", "js"].join(".")), "built\n");
+      writeFileSync(join(fakeBin, "node"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+      writeFileSync(join(fakeBin, "npm"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+      writeFileSync(
+        join(fakeBin, "npx"),
+        [
+          "#!/usr/bin/env bash",
+          "set -euo pipefail",
+          'if [ "${1:-}" = "tsx" ] && [[ "${2:-}" == scripts/check-* ]]; then',
+          '  test "${2}" = "${EXPECTED_ENTRYPOINT}"',
+          '  test -f "${2}"',
+          "fi",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+      writeFileSync(join(temp, `${testCase.stem}.${variant.fixtureExtension}`), "// fixture\n");
+
+      try {
+        const result = runWorkflowShellStep(
+          requiredStep(testCase.action, testCase.step),
+          {
+            EXPECTED_ENTRYPOINT: `${testCase.stem}.${variant.expectedEntrypointExtension}`,
+            PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          },
+          temp,
         );
-        writeFileSync(join(temp, `${testCase.stem}.${variant.fixtureExtension}`), "// fixture\n");
 
-        try {
-          const result = runWorkflowShellStep(
-            requiredStep(testCase.action, testCase.step),
-            {
-              EXPECTED_ENTRYPOINT: `${testCase.stem}.${variant.expectedEntrypointExtension}`,
-              PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
-            },
-            temp,
-          );
-
-          expect(result.status, result.stderr).toBe(variant.expectedStatus);
-        } finally {
-          rmSync(temp, { force: true, recursive: true });
-        }
+        expect(result.status, result.stderr).toBe(variant.expectedStatus);
+      } finally {
+        rmSync(temp, { force: true, recursive: true });
       }
-    }
-  });
+    },
+  );
 
-  it("links every failed CLI shard and falls back safely when job metadata is unavailable", () => {
-    const runUrl = "https://github.com/NVIDIA/NemoClaw/actions/runs/123";
-    const failedShards = workflowJobListing([
-      workflowJob(101, "cli-test-shards (1)", "success"),
-      workflowJob(102, "cli-test-shards (2)", "failure"),
-      workflowJob(112, "cli-test-shards (12)", "cancelled"),
-      workflowJob(109, "plugin-tests", "success"),
-    ]);
-    const malformedShards = workflowJobListing([
-      workflowJob("not-a-number", "cli-test-shards (2)", "failure"),
-    ]);
-    const oversizedShards = workflowJobListing([
-      workflowJob(9_007_199_254_740_992, "cli-test-shards (2)", "failure"),
-    ]);
+  it.each([
+    ["pull_request", prWorkflow],
+    ["main", mainWorkflow],
+  ] as const)(
+    "links every failed %s CLI shard and falls back when job metadata is unavailable",
+    (workflowName, workflow) => {
+      const runUrl = "https://github.com/NVIDIA/NemoClaw/actions/runs/123";
+      const failedShards = workflowJobListing([
+        workflowJob(101, "cli-test-shards (1)", "success"),
+        workflowJob(102, "cli-test-shards (2)", "failure"),
+        workflowJob(112, "cli-test-shards (12)", "cancelled"),
+        workflowJob(109, "plugin-tests", "success"),
+      ]);
+      const malformedShards = workflowJobListing([
+        workflowJob("not-a-number", "cli-test-shards (2)", "failure"),
+      ]);
+      const oversizedShards = workflowJobListing([
+        workflowJob(9_007_199_254_740_992, "cli-test-shards (2)", "failure"),
+      ]);
 
-    for (const [workflowName, workflow] of [
-      ["pull_request", prWorkflow],
-      ["main", mainWorkflow],
-    ] as const) {
       const cliGate = requiredWorkflowStep(
         workflow.jobs["cli-tests"],
         "Verify CLI shards completed",
@@ -588,8 +589,8 @@ describe("pull request and main workflow contracts", () => {
       expect(oversized.stdout).not.toContain(`${runUrl}/job/`);
       expect(unavailable.status).not.toBe(0);
       expect(unavailable.stdout).toContain(`Expected success, got cancelled. Details: ${runUrl}`);
-    }
-  });
+    },
+  );
 
   it("accepts successful aggregate checks and rejects failed required lanes", () => {
     const prChecks = prWorkflow.jobs.checks;

--- a/test/repro-5978-policy-denial-hint.test.ts
+++ b/test/repro-5978-policy-denial-hint.test.ts
@@ -175,13 +175,14 @@ describe("sandbox policy-denial logs breadcrumb (#5978)", () => {
     expect(stdout).toContain("nemoclaw qa-5978 logs --tail 50");
   });
 
-  it("falls back to <name> when OPENSHELL_SANDBOX is unusable (older OpenShell)", () => {
-    for (const value of ["", "1", "true"]) {
+  it.each(["", "1", "true"])(
+    "falls back to <name> when OPENSHELL_SANDBOX is unusable (older OpenShell) [case %#]",
+    (value) => {
       const { stdout, status } = gate({ OPENSHELL_SANDBOX: value });
       expect(status).toBe(0);
       expect(stdout).toContain("nemoclaw <name> logs --tail 50");
-    }
-  });
+    },
+  );
 
   it("allowlists the name: a crafted OPENSHELL_SANDBOX cannot inject TTY escapes", () => {
     // ESC + newline make the value fail the RFC-1123 allowlist, so it is

--- a/test/reviewed-npm-archive.test.ts
+++ b/test/reviewed-npm-archive.test.ts
@@ -125,11 +125,12 @@ describe("reviewed npm archive", () => {
     expect(fs.existsSync(archive.rootDirectory)).toBe(false);
   });
 
-  it("fails before packing when registry integrity or tarball metadata drifts", () => {
-    for (const [field, actual] of [
-      ["dist.integrity", "sha512-drift"],
-      ["dist.tarball", "https://unexpected.invalid/reviewed.tgz"],
-    ] as const) {
+  it.each([
+    ["dist.integrity", "sha512-drift"],
+    ["dist.tarball", "https://unexpected.invalid/reviewed.tgz"],
+  ] as const)(
+    "fails before packing when registry integrity or tarball metadata drifts [case %#]",
+    (field, actual) => {
       const calls: string[][] = [];
       expect(() =>
         verifyReviewedNpmMetadata(request(), (args) => {
@@ -143,8 +144,8 @@ describe("reviewed npm archive", () => {
         }),
       ).toThrow(field === "dist.integrity" ? "npm integrity mismatch" : "npm tarball URL mismatch");
       expect(calls.some((args) => args[0] === "pack")).toBe(false);
-    }
-  });
+    },
+  );
 
   it("removes the fresh directory when packed SRI drifts", () => {
     const reviewed = request();

--- a/test/validate-config-schemas.test.ts
+++ b/test/validate-config-schemas.test.ts
@@ -120,23 +120,24 @@ function registerOpenShellJsonRpcMcpMatcherTests(
     expect(validate(fixture)).toBe(false);
   });
 
-  it("rejects wildcard tool selectors when strict tool names are disabled", () => {
-    const exact = l7SchemaFixture(kind, {
-      protocol: "mcp",
-      mcp: { strict_tool_names: false },
-      rules: [{ allow: { method: "tools/call", tool: "search" } }],
-    });
-    expectValid(validate, exact, `${kind} exact MCP tool selector`);
+  it.each(["search*", { any: ["search", "admin?"] }])(
+    "rejects the wildcard MCP tool selector %# when strict names are disabled",
+    (tool) => {
+      const exact = l7SchemaFixture(kind, {
+        protocol: "mcp",
+        mcp: { strict_tool_names: false },
+        rules: [{ allow: { method: "tools/call", tool: "search" } }],
+      });
+      expectValid(validate, exact, `${kind} exact MCP tool selector`);
 
-    for (const tool of ["search*", { any: ["search", "admin?"] }]) {
       const wildcard = l7SchemaFixture(kind, {
         protocol: "mcp",
         mcp: { strict_tool_names: false },
         rules: [{ allow: { method: "tools/call", tool } }],
       });
       expect(validate(wildcard)).toBe(false);
-    }
-  });
+    },
+  );
 
   it("allows empty MCP matchers only under the allow-all method profile", () => {
     const profiled = l7SchemaFixture(kind, {
@@ -175,39 +176,45 @@ function registerOpenShellJsonRpcMcpMatcherTests(
     expect(validate(fixture)).toBe(false);
   });
 
-  it("keeps MCP-only options off non-MCP protocols while retaining the body-size alias", () => {
-    const bodySizeAlias = l7SchemaFixture(kind, {
-      protocol: "json-rpc",
-      mcp: { max_body_bytes: 131072 },
-      rules: [{ allow: { method: "ping" } }],
-    });
-    expectValid(validate, bodySizeAlias, `${kind} non-MCP body-size alias`);
-
-    for (const option of ["strict_tool_names", "allow_all_known_mcp_methods"]) {
+  it.each(["strict_tool_names", "allow_all_known_mcp_methods"])(
+    "keeps the %s MCP option off non-MCP protocols",
+    (option) => {
       const invalid = l7SchemaFixture(kind, {
         protocol: "json-rpc",
         mcp: { max_body_bytes: 131072, [option]: true },
         rules: [{ allow: { method: "ping" } }],
       });
       expect(validate(invalid)).toBe(false);
-    }
+    },
+  );
+
+  it("retains the body-size alias on non-MCP protocols", () => {
+    const bodySizeAlias = l7SchemaFixture(kind, {
+      protocol: "json-rpc",
+      mcp: { max_body_bytes: 131072 },
+      rules: [{ allow: { method: "ping" } }],
+    });
+    expectValid(validate, bodySizeAlias, `${kind} non-MCP body-size alias`);
   });
 
-  it("accepts only exact JSON-RPC methods or the sole wildcard sentinel", () => {
+  it("accepts the sole JSON-RPC wildcard sentinel", () => {
     const wildcard = l7SchemaFixture(kind, {
       protocol: "json-rpc",
       rules: [{ allow: { method: "*" } }],
     });
     expectValid(validate, wildcard, `${kind} JSON-RPC wildcard sentinel`);
+  });
 
-    for (const method of ["reports.*", "reports?", "reports[0]", "reports{admin}"]) {
+  it.each(["reports.*", "reports?", "reports[0]", "reports{admin}"])(
+    "rejects the JSON-RPC method glob %s",
+    (method) => {
       const glob = l7SchemaFixture(kind, {
         protocol: "json-rpc",
         rules: [{ allow: { method } }],
       });
       expect(validate(glob)).toBe(false);
-    }
-  });
+    },
+  );
 }
 
 // ── Validation target discovery ─────────────────────────────────────────────
@@ -1431,14 +1438,15 @@ describe("model-specific-setup/schema.json", () => {
     expect(validate(bad)).toBe(false);
   });
 
-  it("rejects OpenClaw plugin paths outside the staged plugin trees", () => {
-    for (const [pathValue, loadPathValue] of [
-      ["/etc/passwd", "/usr/local/share/nemoclaw/openclaw-plugins/fixture"],
-      ["../secrets", "/usr/local/share/nemoclaw/openclaw-plugins/fixture"],
-      ["openclaw-plugins/subdir/../escape", "/usr/local/share/nemoclaw/openclaw-plugins/fixture"],
-      ["openclaw-plugins/fixture", "/etc/passwd"],
-      ["openclaw-plugins/fixture", "/usr/local/share/nemoclaw/openclaw-plugins/subdir/../escape"],
-    ]) {
+  it.each([
+    ["/etc/passwd", "/usr/local/share/nemoclaw/openclaw-plugins/fixture"],
+    ["../secrets", "/usr/local/share/nemoclaw/openclaw-plugins/fixture"],
+    ["openclaw-plugins/subdir/../escape", "/usr/local/share/nemoclaw/openclaw-plugins/fixture"],
+    ["openclaw-plugins/fixture", "/etc/passwd"],
+    ["openclaw-plugins/fixture", "/usr/local/share/nemoclaw/openclaw-plugins/subdir/../escape"],
+  ])(
+    "rejects the OpenClaw plugin path pair %# outside the staged trees",
+    (pathValue, loadPathValue) => {
       const bad = {
         ...cloneObject(exactModelFixture),
         effects: {
@@ -1452,8 +1460,8 @@ describe("model-specific-setup/schema.json", () => {
         },
       };
       expect(validate(bad)).toBe(false);
-    }
-  });
+    },
+  );
 
   it("accepts OpenClaw plugin paths inside the staged plugin trees", () => {
     const valid = {

--- a/test/wsl2-probe-timeout.test.ts
+++ b/test/wsl2-probe-timeout.test.ts
@@ -120,13 +120,14 @@ describe("WSL2 inference verification timeouts (#987)", () => {
       );
     });
 
-    it("retries on curl exit codes 6 and 7 (connection failure)", () => {
-      for (const status of [6, 7]) {
+    it.each([6, 7])(
+      "retries on curl exit codes 6 and 7 (connection failure) [case %#]",
+      (status) => {
         const { result, calls } = runProbeWithCurlStatuses([status, status, 0]);
         expect(result.ok).toBe(true);
         expect(calls.length).toBe(3);
-      }
-    });
+      },
+    );
 
     it("does not retry on curl exit code 0 (success) or 22 (HTTP error)", () => {
       expect(runProbeWithCurlStatuses([0]).calls.length).toBe(1);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Convert 200 existing test loops into independently reported table tests. The test-loop scanner moves from 1,143 findings on the merged baseline to 943 without adding named-function callback exemptions.

## Changes

- Replace input, policy, environment, workflow, and security-case loops with inline `it.each` registrations across 111 test files.
- Move Slack token-format tables into a focused test file so the existing file-size ceiling does not grow.
- Lower the legacy size budgets for two test files that became shorter.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Test-only registration refactor; negative and redaction assertions remain intact, credential-shaped fixtures stay out of titles, and the independent documentation-writer review passed on commit `f4952aca22f3d323d3e05842a90601ca1b973108`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run <all 110 changed test files>`: 3,605 passed, 4 skipped; focused post-split replay: 87 passed; review-fix replay: 15 passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — `npm test` was attempted but did not pass on this host: 40 unrelated host-dependent tests reproduced failures from a group-writable workspace ancestor, an installed foreign gateway unit, DGX/N1X host detection, and ARM64/Python topology; two existing dependency-ledger fixtures then opened the configured editor during `git tag`, so the stalled run was terminated
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation:

- `npm run typecheck:cli`
- `npm run checks:repository`
- `npm run test:titles:check`
- `npm run test-size:check`
- `npm run test-loops:scan -- --top 3`: 2,428 files, 943 loops in 449 files
- Documentation writer review: PASS, no docs needed; reviewer `/root/documentation_writer_review_round_seven`, commit `f4952aca22f3d323d3e05842a90601ca1b973108`

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test clarity and reporting by converting numerous loop-based checks into independently labeled parameterized cases.
  * Expanded coverage for onboarding, messaging tokens, inference providers, security boundaries, policy validation, gateway recovery, and end-to-end workflows.
  * Added validation for supported Slack token formats, malformed inputs, unsafe filesystem conditions, and additional runtime edge cases.
* **Chores**
  * Updated legacy test file-size budgets to reflect reduced test sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->