### PR TITLE
fix(onboard): reuse a Windows-host Ollama that WSL mirrored networking exposes on loopback

### DIFF
--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -29,6 +29,9 @@ When either the Ollama CLI or running daemon is below `0.32.9`, the wizard displ
 Older versions can return tool calls as message text instead of structured tool calls, which causes onboarding validation to stop.
 The wizard checks `ollama --version` and `/api/version` on port `11434` independently, so the entry appears when either side is stale.
 If NemoClaw detects an installed CLI or local running daemon but cannot read its version, onboarding uses the upgrade path instead of reusing it.
+On WSL with mirrored networking, Docker Desktop can expose a Windows-host Ollama daemon on the WSL loopback address.
+When NemoClaw confirms this topology, it reuses that daemon and does not offer the WSL Linux upgrade, which cannot replace a Windows install.
+Upgrade Ollama on Windows instead.
 
 On macOS, the wizard uses `brew upgrade ollama` for the platform upgrade path.
 On Linux, the wizard uses the official `https://ollama.com/install.sh` path and asks it for `0.32.9` by name when the installed binary is stale, because the version the installer calls latest is below the minimum on some hosts.

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -362,7 +362,7 @@ export function probeVllmModels(
 // `{ "models": [...] }`. An empty array is fine — that just means no models
 // pulled yet — but a body that doesn't parse as JSON-with-array-`models` did
 // not come from Ollama and the probe should not call it healthy. (#4275)
-function isValidOllamaTagsResponseBody(body: string): boolean {
+export function isValidOllamaTagsResponseBody(body: string): boolean {
   if (!body) return false;
   try {
     const parsed = JSON.parse(body);

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -216,6 +216,7 @@ const {
 } = require("./onboard/ollama-install-menu");
 const {
   detectInferenceProviderHostState,
+  detectWindowsDaemonOnWslLoopback,
 }: typeof import("./onboard/provider-host-state") = require("./onboard/provider-host-state");
 const {
   ensureOllamaAuthProxy,
@@ -3424,6 +3425,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
           ...reasoningMode.compatibleEndpointReasoningConfigureDeps,
           ...reasoningMode.compatibleEndpointReasoningClearDeps,
           repairLocalInferenceSystemdOverrideOrExit,
+          detectWindowsDaemonOnWslLoopback,
           isNonInteractive,
           getOpenshellBinary,
           needsBedrockRuntimeAdapter: (providerName, url) => providerName === "compatible-anthropic-endpoint" && bedrockRuntimeOnboard.needsBedrockRuntimeAdapter(url),

--- a/src/lib/onboard/local-inference-topology.test.ts
+++ b/src/lib/onboard/local-inference-topology.test.ts
@@ -124,6 +124,26 @@ describe("repairLocalInferenceSystemdOverrideOrExit (#6760)", () => {
     });
   }
 
+  it("skips Linux service repair for a mirrored Windows daemon on WSL loopback (#9300)", () => {
+    mockedFindReachableHost.mockReturnValue("127.0.0.1");
+    mockedValidateModel.mockReturnValue({ ok: true });
+    mockedApplyRuntimeContext.mockReturnValue({ ok: true });
+
+    repairLocalInferenceSystemdOverrideOrExit({
+      provider: "ollama-local",
+      model: recordedModel,
+      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
+      isNonInteractive,
+      detectWindowsDaemonOnWslLoopbackImpl: () => true,
+    });
+
+    // The recorded route points at the Windows daemon, which has no Linux
+    // service to repair. Model warm-up and validation still run.
+    expect(mockedEnsureSystemdOverride).not.toHaveBeenCalled();
+    expect(mockedValidateModel).toHaveBeenCalledWith(recordedModel);
+    expect(mockedApplyRuntimeContext).toHaveBeenCalled();
+  });
+
   function expectFailure(run: () => void, message: string): void {
     const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const exit = vi.spyOn(process, "exit").mockImplementation((code) => {

--- a/src/lib/onboard/local-inference-topology.ts
+++ b/src/lib/onboard/local-inference-topology.ts
@@ -16,6 +16,37 @@ import {
 import { type ContainerRuntime, containerCanReachHostLoopback } from "../platform";
 import { ensureOllamaLoopbackSystemdOverride } from "./ollama-systemd";
 
+type TopologyRunCapture = (args: string[], options?: { ignoreError?: boolean }) => string;
+
+/**
+ * True when the daemon answering WSL loopback is the Windows host's own
+ * Ollama.
+ *
+ * Mirrored WSL networking shares one loopback interface between Windows and
+ * the distro, so a single process owns `:11434` for both. `127.0.0.1` and
+ * `host.docker.internal` therefore cannot reach two different daemons, and a
+ * valid Ollama answer through the Windows-side probe identifies the process
+ * that loopback discovery already selected. Neither the Linux installer nor
+ * Linux service management applies to that daemon (#9300).
+ */
+export function isWindowsDaemonOnWslLoopback(input: {
+  isWsl: boolean;
+  ollamaHost: string | null;
+  windowsOllamaReachable: boolean;
+  runCapture: TopologyRunCapture;
+}): boolean {
+  if (!input.isWsl || input.ollamaHost !== "127.0.0.1" || !input.windowsOllamaReachable) {
+    return false;
+  }
+  return (
+    input
+      .runCapture(["wslinfo", "--networking-mode"], {
+        ignoreError: true,
+      })
+      .trim() === "mirrored"
+  );
+}
+
 export function getContainerRuntime(): ContainerRuntime {
   return detectContainerRuntimeFromDockerInfo();
 }
@@ -156,6 +187,9 @@ export interface RepairLocalInferenceSystemdOverrideOptions {
   model: string | null | undefined;
   contextWindowFloor: number;
   isNonInteractive: () => boolean;
+  /** Resolve the recorded route's daemon topology. Defaults to false, which
+   *  keeps Linux service repair; `onboard.ts` wires the real detector. */
+  detectWindowsDaemonOnWslLoopbackImpl?: () => boolean;
 }
 
 function failOllamaResumeRepair(message: string): never {
@@ -173,11 +207,18 @@ export function repairLocalInferenceSystemdOverrideOrExit(
   const { provider, model, isNonInteractive } = options;
   if (provider !== "ollama-local") return;
   const contextWindowFloor = resolveOllamaContextWindowFloor(options.contextWindowFloor);
-  const state = ensureOllamaLoopbackSystemdOverride({ isNonInteractive, contextWindowFloor });
-  if (state === "failed") {
-    failOllamaResumeRepair(
-      "Ollama systemd restart did not recover after applying the loopback override.",
-    );
+  // A recorded `ollama-local` route carries no topology, so re-detect it. The
+  // Windows daemon that mirrored WSL networking exposes on loopback has no
+  // Linux service to repair, and touching a residual `ollama.service` would
+  // ask for sudo and could take the port from the recorded route (#9300).
+  const detectTopology = options.detectWindowsDaemonOnWslLoopbackImpl ?? (() => false);
+  if (!detectTopology()) {
+    const state = ensureOllamaLoopbackSystemdOverride({ isNonInteractive, contextWindowFloor });
+    if (state === "failed") {
+      failOllamaResumeRepair(
+        "Ollama systemd restart did not recover after applying the loopback override.",
+      );
+    }
   }
   if (contextWindowFloor <= MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW) return;
   if (!model) {

--- a/src/lib/onboard/machine/core-flow-phases.test.ts
+++ b/src/lib/onboard/machine/core-flow-phases.test.ts
@@ -116,6 +116,7 @@ function createPhases(
     },
     deps: {
       checkGatewayRouteCompatibility: () => ({ ok: true }),
+      detectWindowsDaemonOnWslLoopback: () => false,
       preflightGatewayRouteDiscovery: () => ({
         ok: true,
         requiredModel: null,

--- a/src/lib/onboard/machine/handlers/provider-inference-ollama-context.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference-ollama-context.test.ts
@@ -31,6 +31,7 @@ describe("handleProviderInferenceState Ollama context resume (#6760)", () => {
       model: "qwen3.5:35b",
       contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
       isNonInteractive: deps.isNonInteractive,
+      detectWindowsDaemonOnWslLoopbackImpl: deps.detectWindowsDaemonOnWslLoopback,
     });
     expect(calls.setupNim).not.toHaveBeenCalled();
     expect(routeReady).toHaveBeenCalledWith("nemoclaw", "ollama-local", "qwen3.5:35b");

--- a/src/lib/onboard/machine/handlers/provider-inference-route-containment.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference-route-containment.test.ts
@@ -85,6 +85,7 @@ function createDeps() {
   };
   const deps: Options["deps"] = {
     checkGatewayRouteCompatibility: calls.checkGatewayRouteCompatibility,
+    detectWindowsDaemonOnWslLoopback: () => false,
     preflightGatewayRouteDiscovery: calls.preflightGatewayRouteDiscovery,
     getSandboxRecoveryAuthority: (): "missing" => "missing",
     withGatewayRouteMutationLock: async (_gatewayName, operation) => await operation(),

--- a/src/lib/onboard/machine/handlers/provider-inference.test-support.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test-support.ts
@@ -199,6 +199,7 @@ export function createDeps(
       },
       clearCompatibleEndpointReasoningEffort: () => null,
       repairLocalInferenceSystemdOverrideOrExit: calls.repair,
+      detectWindowsDaemonOnWslLoopback: () => false,
       isNonInteractive: () => true,
       getOpenshellBinary: () => "/usr/bin/openshell",
       needsBedrockRuntimeAdapter: () => false,

--- a/src/lib/onboard/machine/handlers/provider-inference.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test.ts
@@ -462,6 +462,7 @@ describe("handleProviderInferenceState", () => {
       model: "llama3.1",
       contextWindowFloor: 16_384,
       isNonInteractive: deps.isNonInteractive,
+      detectWindowsDaemonOnWslLoopbackImpl: deps.detectWindowsDaemonOnWslLoopback,
     });
     expect(calls.repairEvent).toHaveBeenCalledWith("state.repair.completed", {
       state: "provider_selection",

--- a/src/lib/onboard/machine/handlers/provider-inference.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.ts
@@ -245,6 +245,7 @@ export interface ProviderInferenceStateOptions<Gpu, Agent, Host> {
     repairLocalInferenceSystemdOverrideOrExit(
       options: RepairLocalInferenceSystemdOverrideOptions,
     ): void;
+    detectWindowsDaemonOnWslLoopback(): boolean;
     isNonInteractive(): boolean;
     getOpenshellBinary(): string;
     needsBedrockRuntimeAdapter(provider: string, endpointUrl: string | null): boolean;
@@ -846,7 +847,9 @@ async function configureResumeReasoning(
 
 type LocalInferenceRepairDeps = Pick<
   ProviderInferenceStateOptions<unknown, unknown, unknown>["deps"],
-  "recordRepairEvent" | "repairLocalInferenceSystemdOverrideOrExit"
+  | "recordRepairEvent"
+  | "repairLocalInferenceSystemdOverrideOrExit"
+  | "detectWindowsDaemonOnWslLoopback"
 >;
 
 async function repairResumedLocalInference(
@@ -860,6 +863,9 @@ async function repairResumedLocalInference(
     model,
     contextWindowFloor: getOllamaContextWindowFloorForAgent(agentName(agent)),
     isNonInteractive: () => false,
+    // A recorded route carries no daemon topology, so resume re-detects it and
+    // skips Linux service repair for a mirrored Windows-host daemon (#9300).
+    detectWindowsDaemonOnWslLoopbackImpl: deps.detectWindowsDaemonOnWslLoopback,
   };
   if (provider !== "ollama-local") {
     deps.repairLocalInferenceSystemdOverrideOrExit(options);

--- a/src/lib/onboard/ollama-install-menu.test.ts
+++ b/src/lib/onboard/ollama-install-menu.test.ts
@@ -200,6 +200,43 @@ describe("resolveOllamaInstallMenuEntry", () => {
     expect(result.entry).toBeNull();
   });
 
+  it("does not flag the daemon as upgradable when mirrored WSL networking answers the Windows host on loopback (#9300)", () => {
+    const result = resolveOllamaInstallMenuEntry({
+      hasOllama: true,
+      ollamaRunning: true,
+      hasWindowsOllama: true,
+      windowsHostOllamaSupported: true,
+      ollamaHost: "127.0.0.1",
+      windowsDaemonOnWslLoopback: true,
+      installedOllamaVersion: "0.32.5",
+      runningOllamaVersion: "0.32.5",
+      platform: "linux",
+      isWsl: true,
+    });
+    expect(result.hasUpgradableOllama).toBe(false);
+    expect(result.binaryNeedsUpgrade).toBe(false);
+    expect(result.entry).toBeNull();
+  });
+
+  it("still flags a stale WSL-local daemon on loopback as upgradable (#9300)", () => {
+    const result = resolveOllamaInstallMenuEntry({
+      hasOllama: true,
+      ollamaRunning: true,
+      hasWindowsOllama: true,
+      windowsHostOllamaSupported: true,
+      ollamaHost: "127.0.0.1",
+      windowsDaemonOnWslLoopback: false,
+      installedOllamaVersion: "0.32.5",
+      runningOllamaVersion: "0.32.5",
+      platform: "linux",
+      isWsl: true,
+    });
+    expect(result.hasUpgradableOllama).toBe(true);
+    expect(result.entry?.label).toBe(
+      `Upgrade Ollama (WSL Linux) — upgrade running daemon 0.32.5 to ≥ ${MIN_OLLAMA_VERSION}`,
+    );
+  });
+
   it("omits the entry when only Windows-host Ollama is present", () => {
     const result = resolveOllamaInstallMenuEntry({
       hasOllama: false,

--- a/src/lib/onboard/ollama-install-menu.ts
+++ b/src/lib/onboard/ollama-install-menu.ts
@@ -28,6 +28,11 @@ export interface OllamaInstallMenuInput {
    *  helper skips the daemon-version gate.
    *  Null when no daemon is running locally. */
   ollamaHost?: string | null;
+  /** Whether the daemon answering WSL loopback is the Windows host's own
+   *  Ollama. Mirrored WSL networking shares the loopback interface, so that
+   *  daemon resolves as `127.0.0.1` rather than `host.docker.internal`
+   *  (#9300). Defaults to false. */
+  windowsDaemonOnWslLoopback?: boolean;
   /** Override for tests. Defaults to a live `ollama --version` probe. */
   installedOllamaVersion?: string | null;
   /** Override for tests. Defaults to a live `/api/version` probe on the
@@ -138,7 +143,14 @@ export function resolveOllamaInstallMenuEntry(
   // 127.0.0.1/localhost. A Windows-host daemon reached via
   // `host.docker.internal` is handled by separate menu entries
   // (`install-windows-ollama` / `start-windows-ollama`).
-  const daemonProbeApplies = input.ollamaRunning && isLocalOllamaHost(input.ollamaHost);
+  // Mirrored WSL networking answers the Windows host's daemon on
+  // `127.0.0.1`, so the `host.docker.internal` check above does not recognize
+  // it. The Linux installer can replace neither that daemon nor the Windows
+  // `ollama` the WSL PATH exposes through interop, so both version gates stay
+  // off for this topology (#9300).
+  const windowsDaemonOnWslLoopback = input.windowsDaemonOnWslLoopback === true;
+  const daemonProbeApplies =
+    input.ollamaRunning && isLocalOllamaHost(input.ollamaHost) && !windowsDaemonOnWslLoopback;
   const runningOllamaVersion =
     input.runningOllamaVersion !== undefined
       ? input.runningOllamaVersion
@@ -157,7 +169,9 @@ export function resolveOllamaInstallMenuEntry(
   // installed binary meets the floor. A stale daemon without a local binary
   // still needs the installer to provide one.
   const binaryNeedsUpgrade =
-    !installedBinaryMeetsMinimum && (input.hasOllama || daemonNeedsUpgrade);
+    !windowsDaemonOnWslLoopback &&
+    !installedBinaryMeetsMinimum &&
+    (input.hasOllama || daemonNeedsUpgrade);
   const hasUpgradableOllama = binaryNeedsUpgrade || daemonNeedsUpgrade;
   // A Windows-host install only covers the local-inference need when the
   // sandbox can route to it. Under a container runtime without that routing,

--- a/src/lib/onboard/provider-host-state.test.ts
+++ b/src/lib/onboard/provider-host-state.test.ts
@@ -185,7 +185,7 @@ describe("detectInferenceProviderHostState", () => {
   it("detects Windows-host Ollama from Docker Desktop when WSL cannot reach it (#8127)", () => {
     const logs: string[] = [];
     const dockerCapture = vi.fn((command: string[]) =>
-      command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? "{}" : "",
+      command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? '{"models":[]}' : "",
     );
     const deps = buildDeps({
       isWsl: vi.fn(() => true),
@@ -304,12 +304,12 @@ describe("detectInferenceProviderHostState", () => {
         installedPath: "C:\\Ollama\\ollama.exe",
         loopbackOnly: false,
       })),
-      runCapture: vi.fn((command) => {
-        const joined = command.join(" ");
-        if (joined.includes("wslinfo --networking-mode")) return "mirrored\n";
-        return "";
-      }),
-      dockerCapture: vi.fn((command) => (command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? "{}" : "")),
+      runCapture: vi.fn((command) =>
+        command.join(" ").includes("wslinfo --networking-mode") ? "mirrored\n" : "",
+      ),
+      dockerCapture: vi.fn((command) =>
+        command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? '{"models":[]}' : "",
+      ),
     });
 
     const state = detectInferenceProviderHostState({
@@ -325,6 +325,159 @@ describe("detectInferenceProviderHostState", () => {
 
     expect(state.windowsOllamaReachable).toBe(true);
     expect(logs).toEqual([]);
+  });
+
+  it("keeps a stale Windows daemon on WSL mirrored loopback out of the Linux upgrade (#9300)", () => {
+    const deps = buildDeps({
+      isWsl: vi.fn(() => true),
+      findReachableOllamaHost: vi.fn(() => "127.0.0.1"),
+      hostCommandExists: vi.fn(() => true),
+      detectWindowsHostOllama: vi.fn(() => ({
+        installed: true,
+        installedPath: "C:\\Ollama\\ollama.exe",
+        loopbackOnly: false,
+      })),
+      runCapture: vi.fn((command) =>
+        command.join(" ").includes("wslinfo --networking-mode") ? "mirrored\n" : "",
+      ),
+      dockerCapture: vi.fn((command) =>
+        command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? '{"models":[]}' : "",
+      ),
+    });
+
+    const state = detectInferenceProviderHostState({
+      gpu: null,
+      experimental: false,
+      platform: "linux",
+      env: {},
+      log: () => {},
+      installedOllamaVersion: "0.32.5",
+      runningOllamaVersion: "0.32.5",
+      deps,
+    });
+
+    expect(state.ollamaInstallMenu.hasUpgradableOllama).toBe(false);
+    expect(state.ollamaInstallMenu.binaryNeedsUpgrade).toBe(false);
+    expect(state.ollamaInstallMenu.entry).toBeNull();
+    expect(state.windowsDaemonOnWslLoopback).toBe(true);
+  });
+
+  it("does not treat a loopback daemon as the Windows host without Docker Desktop routing (#9300)", () => {
+    const deps = buildDeps({
+      isWsl: vi.fn(() => true),
+      findReachableOllamaHost: vi.fn(() => "127.0.0.1"),
+      hostCommandExists: vi.fn(() => true),
+      getContainerRuntime: vi.fn<DetectInferenceProviderHostStateDeps["getContainerRuntime"]>(
+        () => "docker",
+      ),
+      getWindowsHostOllamaDockerRequirement: vi.fn(() =>
+        getWindowsHostOllamaDockerRequirement("docker"),
+      ),
+      detectWindowsHostOllama: vi.fn(() => ({
+        installed: true,
+        installedPath: "C:\\Ollama\\ollama.exe",
+        loopbackOnly: false,
+      })),
+      runCapture: vi.fn((command) =>
+        command.join(" ").includes("wslinfo --networking-mode") ? "mirrored\n" : "",
+      ),
+      dockerCapture: vi.fn((command) =>
+        command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? '{"models":[]}' : "",
+      ),
+    });
+
+    const state = detectInferenceProviderHostState({
+      gpu: null,
+      experimental: false,
+      platform: "linux",
+      env: {},
+      log: () => {},
+      installedOllamaVersion: "0.32.5",
+      runningOllamaVersion: "0.32.5",
+      deps,
+    });
+
+    // Native Docker Engine in WSL cannot route a sandbox to Windows-host
+    // Ollama, so NemoClaw keeps the WSL-local upgrade rather than handing the
+    // sandbox a daemon it cannot reach.
+    expect(state.windowsDaemonOnWslLoopback).toBe(false);
+    expect(state.ollamaInstallMenu.hasUpgradableOllama).toBe(true);
+  });
+
+  it("rejects a Windows-host reachability body that is not the Ollama wire format (#9300)", () => {
+    const deps = buildDeps({
+      isWsl: vi.fn(() => true),
+      findReachableOllamaHost: vi.fn(() => "127.0.0.1"),
+      hostCommandExists: vi.fn(() => true),
+      detectWindowsHostOllama: vi.fn(() => ({
+        installed: true,
+        installedPath: "C:\\Ollama\\ollama.exe",
+        loopbackOnly: false,
+      })),
+      runCapture: vi.fn((command) =>
+        command.join(" ").includes("wslinfo --networking-mode") ? "mirrored\n" : "",
+      ),
+      // A captive proxy or unrelated listener answering 2xx must not become
+      // evidence that the Windows daemon owns the port.
+      dockerCapture: vi.fn((command) =>
+        command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? "<html>hello</html>" : "",
+      ),
+    });
+
+    const state = detectInferenceProviderHostState({
+      gpu: null,
+      experimental: false,
+      platform: "linux",
+      env: {},
+      log: () => {},
+      installedOllamaVersion: "0.32.5",
+      runningOllamaVersion: "0.32.5",
+      deps,
+    });
+
+    expect(state.windowsOllamaReachable).toBe(false);
+    expect(state.windowsDaemonOnWslLoopback).toBe(false);
+    expect(state.ollamaInstallMenu.hasUpgradableOllama).toBe(true);
+  });
+
+  it("still warns about duplicate daemons under WSL NAT networking (#9300)", () => {
+    const logs: string[] = [];
+    const deps = buildDeps({
+      isWsl: vi.fn(() => true),
+      findReachableOllamaHost: vi.fn(() => "127.0.0.1"),
+      hostCommandExists: vi.fn(() => true),
+      detectWindowsHostOllama: vi.fn(() => ({
+        installed: true,
+        installedPath: "C:\\Ollama\\ollama.exe",
+        loopbackOnly: false,
+      })),
+      runCapture: vi.fn((command) =>
+        command.join(" ").includes("wslinfo --networking-mode") ? "nat\n" : "",
+      ),
+      dockerCapture: vi.fn((command) =>
+        command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? '{"models":[]}' : "",
+      ),
+    });
+
+    const state = detectInferenceProviderHostState({
+      gpu: null,
+      experimental: false,
+      platform: "linux",
+      env: {},
+      log: (message = "") => logs.push(message),
+      installedOllamaVersion: "0.32.5",
+      runningOllamaVersion: "0.32.5",
+      deps,
+    });
+
+    // Under NAT the two probes reach two separate daemons, so the WSL-local
+    // upgrade still applies and the duplicate-daemon warning must survive the
+    // refactor that moved the mirrored check out of the warning helper.
+    expect(state.windowsDaemonOnWslLoopback).toBe(false);
+    expect(state.ollamaInstallMenu.hasUpgradableOllama).toBe(true);
+    expect(logs.some((line) => line.includes("running on both WSL and the Windows host"))).toBe(
+      true,
+    );
   });
 
   it("does not probe the Windows-host switch path when running Ollama already resolves to the Windows host", () => {

--- a/src/lib/onboard/provider-host-state.ts
+++ b/src/lib/onboard/provider-host-state.ts
@@ -22,6 +22,7 @@ import { runCapture as defaultRunCapture } from "../runner";
 import {
   getContainerRuntime as defaultGetContainerRuntime,
   getWindowsHostOllamaDockerRequirement,
+  isWindowsDaemonOnWslLoopback,
   type WindowsHostOllamaDockerRequirement,
 } from "./local-inference-topology";
 import { warnAboutArm64NimImageCompatibility } from "./nim-image-compat-warning";
@@ -163,32 +164,32 @@ function probeWindowsOllamaReachable(input: {
 }
 
 /**
- * True when the daemon answering WSL loopback is the Windows host's own
- * Ollama.
- *
- * Mirrored WSL networking shares one loopback interface between Windows and
- * the distro, so a single process owns `:11434` for both. `127.0.0.1` and
- * `host.docker.internal` therefore cannot reach two different daemons, and a
- * valid Ollama answer through the Windows-side probe identifies the process
- * that loopback discovery already selected. `maybeWarnAboutDuplicateOllamaDaemons`
- * relies on the same reasoning to suppress its duplicate-daemon warning.
+ * Resolve the same topology from scratch, for callers holding no provider host
+ * snapshot. Resume repair is one: it reads a recorded `ollama-local` route,
+ * which records no topology (#9300). Each probe short-circuits, so a non-WSL
+ * host costs one `isWsl` check.
  */
-function isWindowsDaemonOnWslLoopback(input: {
-  isWsl: boolean;
-  ollamaHost: string | null;
-  windowsOllamaReachable: boolean;
-  runCapture: RunCapture;
-}): boolean {
-  if (!input.isWsl || input.ollamaHost !== "127.0.0.1" || !input.windowsOllamaReachable) {
-    return false;
-  }
-  return (
-    input
-      .runCapture(["wslinfo", "--networking-mode"], {
-        ignoreError: true,
-      })
-      .trim() === "mirrored"
-  );
+export function detectWindowsDaemonOnWslLoopback(
+  overrides: Partial<DetectInferenceProviderHostStateDeps> = {},
+): boolean {
+  const deps = buildDeps(overrides);
+  if (!deps.isWsl()) return false;
+  const ollamaHost = deps.findReachableOllamaHost();
+  if (ollamaHost !== "127.0.0.1") return false;
+  const windowsOllamaReachable = probeWindowsOllamaReachable({
+    isWsl: true,
+    isWindowsHostOllama: false,
+    dockerRequirementSupported: deps.getWindowsHostOllamaDockerRequirement(
+      deps.getContainerRuntime(),
+    ).supported,
+    dockerCapture: deps.dockerCapture,
+  });
+  return isWindowsDaemonOnWslLoopback({
+    isWsl: true,
+    ollamaHost,
+    windowsOllamaReachable,
+    runCapture: deps.runCapture,
+  });
 }
 
 function maybeWarnAboutDuplicateOllamaDaemons(input: {

--- a/src/lib/onboard/provider-host-state.ts
+++ b/src/lib/onboard/provider-host-state.ts
@@ -7,6 +7,7 @@ import {
   getLocalProviderAvailabilityEndpoint,
   getWindowsHostOllamaDockerReachabilityArgs,
   isLocalProviderProbeOutputHealthy,
+  isValidOllamaTagsResponseBody,
   OLLAMA_HOST_DOCKER_INTERNAL,
 } from "../inference/local";
 import type { NvidiaPlatform } from "../inference/nim";
@@ -46,6 +47,11 @@ export interface InferenceProviderHostState {
   ollamaHost: string | null;
   ollamaRunning: boolean;
   isWindowsHostOllama: boolean;
+  /** Whether the daemon on WSL loopback is the Windows host's own Ollama,
+   *  which mirrored networking exposes at `127.0.0.1` rather than
+   *  `host.docker.internal`. Neither the Linux installer nor Linux service
+   *  management applies to it. Absent means not that topology (#9300). */
+  windowsDaemonOnWslLoopback?: boolean;
   isWsl: boolean;
   hasWindowsOllama: boolean;
   winOllamaInstalledPath: string;
@@ -146,25 +152,54 @@ function probeWindowsOllamaReachable(input: {
   dockerCapture: DockerCapture;
 }): boolean {
   if (!input.isWsl || input.isWindowsHostOllama || !input.dockerRequirementSupported) return false;
-  return !!input.dockerCapture(getWindowsHostOllamaDockerReachabilityArgs(), {
-    ignoreError: true,
-  });
+  // A 2xx body alone does not prove Ollama answered: the same reasoning the
+  // loopback probe already applies (#4275) holds here, and this result now
+  // also decides whether a version gate runs (#9300).
+  return isValidOllamaTagsResponseBody(
+    input.dockerCapture(getWindowsHostOllamaDockerReachabilityArgs(), {
+      ignoreError: true,
+    }),
+  );
+}
+
+/**
+ * True when the daemon answering WSL loopback is the Windows host's own
+ * Ollama.
+ *
+ * Mirrored WSL networking shares one loopback interface between Windows and
+ * the distro, so a single process owns `:11434` for both. `127.0.0.1` and
+ * `host.docker.internal` therefore cannot reach two different daemons, and a
+ * valid Ollama answer through the Windows-side probe identifies the process
+ * that loopback discovery already selected. `maybeWarnAboutDuplicateOllamaDaemons`
+ * relies on the same reasoning to suppress its duplicate-daemon warning.
+ */
+function isWindowsDaemonOnWslLoopback(input: {
+  isWsl: boolean;
+  ollamaHost: string | null;
+  windowsOllamaReachable: boolean;
+  runCapture: RunCapture;
+}): boolean {
+  if (!input.isWsl || input.ollamaHost !== "127.0.0.1" || !input.windowsOllamaReachable) {
+    return false;
+  }
+  return (
+    input
+      .runCapture(["wslinfo", "--networking-mode"], {
+        ignoreError: true,
+      })
+      .trim() === "mirrored"
+  );
 }
 
 function maybeWarnAboutDuplicateOllamaDaemons(input: {
   isWsl: boolean;
   ollamaHost: string | null;
   windowsOllamaReachable: boolean;
-  runCapture: RunCapture;
+  windowsDaemonOnWslLoopback: boolean;
   log: (message?: string) => void;
 }): void {
   if (!input.isWsl || input.ollamaHost !== "127.0.0.1" || !input.windowsOllamaReachable) return;
-  const networkingMode = input
-    .runCapture(["wslinfo", "--networking-mode"], {
-      ignoreError: true,
-    })
-    .trim();
-  if (networkingMode === "mirrored") return;
+  if (input.windowsDaemonOnWslLoopback) return;
   input.log("");
   input.log("  ⚠ Ollama is running on both WSL and the Windows host.");
   input.log("    Stop one to avoid duplicated GPU memory and model caches.");
@@ -209,11 +244,18 @@ export function detectInferenceProviderHostState(
           dockerCapture: deps.dockerCapture,
         });
 
-  maybeWarnAboutDuplicateOllamaDaemons({
+  const windowsDaemonOnWslLoopback = isWindowsDaemonOnWslLoopback({
     isWsl,
     ollamaHost,
     windowsOllamaReachable,
     runCapture: deps.runCapture,
+  });
+
+  maybeWarnAboutDuplicateOllamaDaemons({
+    isWsl,
+    ollamaHost,
+    windowsOllamaReachable,
+    windowsDaemonOnWslLoopback,
     log,
   });
   const gpuNimCapable = Boolean(input.gpu?.nimCapable);
@@ -231,6 +273,7 @@ export function detectInferenceProviderHostState(
     windowsHostOllamaSupported:
       windowsHostOllamaDockerRequirement.supported && windowsOllamaReachable,
     ollamaHost,
+    windowsDaemonOnWslLoopback,
     platform,
     isWsl,
     installedOllamaVersion: input.installedOllamaVersion,
@@ -242,6 +285,7 @@ export function detectInferenceProviderHostState(
     ollamaHost,
     ollamaRunning,
     isWindowsHostOllama,
+    windowsDaemonOnWslLoopback,
     isWsl,
     hasWindowsOllama,
     winOllamaInstalledPath: winOllamaState.installedPath,

--- a/src/lib/onboard/setup-nim-flow-ollama-topology.test.ts
+++ b/src/lib/onboard/setup-nim-flow-ollama-topology.test.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { makeDeps, makeHostState, unexpected } from "./__test-helpers__/setup-nim-flow";
+import { getWindowsHostOllamaDockerRequirement } from "./local-inference-topology";
+import { createSetupNim, type SetupNimFlowDeps } from "./setup-nim-flow";
+
+describe("setupNim Ollama host topology", () => {
+  it("skips Linux service management for a mirrored Windows daemon on WSL loopback (#9300)", async () => {
+    const model = "qwen2.5:1.5b";
+    const handleRunningOllamaSelection = vi.fn<SetupNimFlowDeps["handleRunningOllamaSelection"]>(
+      async (_gpu, requestedModel, _recoveredModel, ollamaRunning, state, isWindowsHostOllama) => {
+        expect(requestedModel).toBe(model);
+        expect(ollamaRunning).toBe(true);
+        // The reuse handler reads this argument to decide whether to apply the
+        // Linux loopback systemd override, which needs sudo and targets a
+        // service the Windows daemon does not have.
+        expect(isWindowsHostOllama).toBe(true);
+        state.model = model;
+        state.provider = "ollama-local";
+        state.endpointUrl = "http://127.0.0.1:11434/v1";
+        state.credentialEnv = null;
+        state.preferredInferenceApi = "openai-completions";
+        return "selected";
+      },
+    );
+    const handleInstallOllamaSelection = vi.fn<SetupNimFlowDeps["handleInstallOllamaSelection"]>(
+      async () => unexpected("Ollama install selection"),
+    );
+    const setupNim = createSetupNim(
+      makeDeps({
+        isNonInteractive: () => true,
+        getNonInteractiveProvider: () => "ollama",
+        getNonInteractiveModel: () => model,
+        detectInferenceProviderHostState: () =>
+          makeHostState({
+            hasOllama: true,
+            ollamaHost: "127.0.0.1",
+            ollamaRunning: true,
+            isWindowsHostOllama: false,
+            windowsDaemonOnWslLoopback: true,
+            isWsl: true,
+            hasWindowsOllama: true,
+            windowsOllamaReachable: true,
+            windowsHostOllamaDockerRequirement:
+              getWindowsHostOllamaDockerRequirement("docker-desktop"),
+          }),
+        handleRunningOllamaSelection,
+        handleInstallOllamaSelection,
+      }),
+    );
+
+    await setupNim(null, null);
+
+    expect(handleRunningOllamaSelection).toHaveBeenCalledTimes(1);
+    expect(handleInstallOllamaSelection).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/onboard/setup-nim-flow.ts
+++ b/src/lib/onboard/setup-nim-flow.ts
@@ -230,16 +230,14 @@ function requireSelectedProvider(
 }
 
 function handleSelectedOllama(
-  deps: Pick<
-    SetupNimFlowDeps,
-    "handleInstallOllamaSelection" | "handleRunningOllamaSelection"
-  >,
+  deps: Pick<SetupNimFlowDeps, "handleInstallOllamaSelection" | "handleRunningOllamaSelection">,
   args: {
     gpu: SetupNimGpu;
     requestedModel: string | null;
     recoveredModel: string | null;
     ollamaRunning: boolean;
     isWindowsHostOllama: boolean;
+    windowsDaemonOnWslLoopback: boolean | undefined;
     state: SetupNimSelectionState;
     ollamaInstallMenu: InferenceProviderHostState["ollamaInstallMenu"];
   },
@@ -253,13 +251,17 @@ function handleSelectedOllama(
       args.ollamaInstallMenu,
     );
   }
+  // Mirrored WSL networking answers the Windows daemon on `127.0.0.1`, so
+  // `isWindowsHostOllama` stays false for it. The reuse handler reads this
+  // argument to decide whether Linux systemd management applies, and it does
+  // not apply to a Windows daemon reached either way (#9300).
   return deps.handleRunningOllamaSelection(
     args.gpu,
     args.requestedModel,
     args.recoveredModel,
     args.ollamaRunning,
     args.state,
-    args.isWindowsHostOllama,
+    Boolean(args.isWindowsHostOllama || args.windowsDaemonOnWslLoopback),
   );
 }
 
@@ -639,6 +641,7 @@ export function createSetupNim(
       ollamaHost,
       ollamaRunning,
       isWindowsHostOllama,
+      windowsDaemonOnWslLoopback,
       isWsl: isWslHost,
       hasWindowsOllama,
       winOllamaInstalledPath,
@@ -899,6 +902,7 @@ export function createSetupNim(
             recoveredModel: recoveredFromSandbox ? recoveredModel : null,
             ollamaRunning,
             isWindowsHostOllama,
+            windowsDaemonOnWslLoopback,
             state,
             ollamaInstallMenu,
           });


### PR DESCRIPTION
## Summary

Mirrored WSL networking shares the loopback interface with Windows, so the Windows host's Ollama daemon answers on `127.0.0.1` instead of `host.docker.internal`. Onboarding recognized a Windows-host daemon only by that hostname, so it read the Windows daemon's version as a local Linux one, found it below `0.32.9`, and drove two Linux paths that cannot apply to a Windows install: the install menu routed onboarding into the sudo-bound Linux installer, and the reuse handler applied the Linux loopback systemd override. A non-interactive run stopped before creating the sandbox. NemoClaw now reuses that daemon and takes neither Linux path.

## Related Issue

Refs: #9300

## Changes

`detectInferenceProviderHostState` already answers this exact question when it suppresses the duplicate-daemon warning: WSL, a daemon on `127.0.0.1`, a reachable Windows daemon, and `wslinfo --networking-mode` reporting `mirrored` mean one daemon, not two. That result was computed and thrown away. This makes it a state field so every consumer of the decision reads it.

- `src/lib/onboard/provider-host-state.ts`: extract `isWindowsDaemonOnWslLoopback` from `maybeWarnAboutDuplicateOllamaDaemons`, compute it once, and expose it as `windowsDaemonOnWslLoopback` on the provider host state.
- `src/lib/onboard/ollama-install-menu.ts`: add the optional `windowsDaemonOnWslLoopback` input. When set, hold off both the daemon version gate and the binary version gate.
- `src/lib/onboard/setup-nim-flow.ts`: pass the fact to the reuse handler's Windows-host argument, which is what decides whether Linux systemd management runs. `isWindowsHostOllama` itself is deliberately **not** widened — `provider-selection.ts:152` uses it to fail sandbox recovery with `wsl-recorded-ollama-windows-host`, and that behavior should not change here.
- `src/lib/onboard/provider-host-state.ts` + `src/lib/inference/local.ts`: the Windows reachability probe now requires the Ollama wire format (`{"models":[...]}`) instead of any non-empty body, reusing the exported `isValidOllamaTagsResponseBody`. The repository already applies this reasoning to the loopback probe (#4275); it matters more now that this result decides whether a version gate runs.
- `src/lib/onboard/local-inference-topology.ts` + `machine/handlers/provider-inference.ts`: resume re-detects the topology and skips Linux service repair for the same daemon (advisor finding PRA-1). `onboard.ts` stays pure wiring so the onboarding entry composition boundary keeps its recorded provider-decision count; the handler composes the option.
- `docs/inference/set-up-ollama.mdx`: name the exception to the "**Upgrade Ollama** entry appears when either side is below `0.32.9`" rule, scoped to the topology the code actually confirms.

No new configuration, fallback, or compatibility layer. The menu input is one optional boolean with a single production caller, derived from a predicate the repository already trusts, protected by the tests below.

### Judgment calls a reviewer should check

1. **The binary gate is held off with the daemon gate.** The `ollama` on the WSL PATH in this topology is the Windows client reached through interop, so the Linux installer cannot replace it either. Even where a genuine WSL-local binary coexists, the Windows daemon owns `:11434` under mirrored networking, so installing over it would start a service that cannot bind. The code does not separately prove CLI origin, only daemon origin.
2. **The predicate proves "one daemon across loopback", not literally "the Windows daemon".** Under mirrored networking the two probes cannot reach different listeners on `:11434`, which is why the existing duplicate-daemon warning already draws this conclusion. A `systemctl is-active ollama` probe would give positive origin evidence; that seemed like more mechanism than this defect earns, but it is the maintainers' call.
3. **Scope is bounded to Docker Desktop WSL integration** — see the limits section.
4. **The field is optional rather than required.** Production detection always sets a boolean, but making it required forces a line into `test/onboard-selection.test.ts`, which `Test file size budget` then rejects at 4179 lines against a 4178 legacy budget. `OllamaInstallMenuResult.binaryNeedsUpgrade?: boolean` uses the same shape.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: see below
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Advisor finding PRA-1

The PR review advisor's primary lane flagged that resume repair still applied the Linux systemd override to a recorded route pointing at the Windows daemon. Commit `c9eda3f3c` fixes it: `repairLocalInferenceSystemdOverrideOrExit` now takes a topology detector, `detectWindowsDaemonOnWslLoopback` resolves the same fact from the same predicate for callers with no host snapshot, and a resume test asserts `ensureOllamaLoopbackSystemdOverride` is not called while model warm-up and validation still run. Verified by mutation: forcing the guard open fails that test with `expected "vi.fn()" to not be called at all, but actually been called 1 times`.

Two existing handler tests asserted the exact repair options object and were updated to include the new field. They encoded the old call shape, not old behavior.

### Negative control

All six new tests, run against `git checkout origin/main --` of the four changed source files with the new tests kept:

```text
$ npx vitest run --project cli --no-file-parallelism \
    src/lib/onboard/provider-host-state.test.ts \
    src/lib/onboard/ollama-install-menu.test.ts \
    src/lib/onboard/setup-nim-flow-ollama-topology.test.ts

 × skips Linux service management for a mirrored Windows daemon on WSL loopback (#9300)
 × keeps a stale Windows daemon on WSL mirrored loopback out of the Linux upgrade (#9300)
 × does not treat a loopback daemon as the Windows host without Docker Desktop routing (#9300)
 × rejects a Windows-host reachability body that is not the Ollama wire format (#9300)
 × still warns about duplicate daemons under WSL NAT networking (#9300)
 × does not flag the daemon as upgradable when mirrored WSL networking answers the Windows host on loopback (#9300)

 Test Files  3 failed (3)
      Tests  6 failed | 34 passed (40)
```

With the change, the same command is `40 passed (40)`. The other 34 pass either way, so the change moves only the cases it claims to.

The routing test was also checked by mutation: reverting just `args.isWindowsHostOllama || args.windowsDaemonOnWslLoopback` to `args.isWindowsHostOllama` fails it with `expected false to be true`, so it is pinned to the systemd decision and not to incidental state.

### Blast radius

Every file in the repository matching `resolveOllamaInstallMenuEntry`, `OllamaInstallMenuInput`, `detectInferenceProviderHostState`, `InferenceProviderHostState`, `ollamaInstallMenu`, `windowsOllamaReachable`, `windowsDaemonOnWslLoopback`, `binaryNeedsUpgrade`, or `isValidOllamaTagsResponseBody`, run in both lanes — `integration` is not covered by `npm run test:changed`:

```text
$ npx vitest run --project cli --no-file-parallelism \
    src/lib/inference/local.test.ts \
    src/lib/onboard/{local-inference-topology,ollama-install-menu,provider-host-state,provider-menu,provider-selection,setup-nim-flow,setup-nim-flow-ollama-topology,setup-nim-ollama}.test.ts \
    src/lib/onboard/machine/core-flow-phases.test.ts
 Test Files  10 passed (10)
      Tests  231 passed (231)

$ npx vitest run --project integration --no-file-parallelism \
    test/onboard-ollama-upgrade-version-floor.test.ts \
    test/onboard-selection-windows-provider-rejection.test.ts test/onboard-selection.test.ts
 Test Files  3 passed (3)
      Tests  68 passed (68)
```

All 37 files under `src/lib/onboard/machine/handlers/` also pass (486 tests). `npm run typecheck:cli`, `npm run checks:repository`, `npx oxfmt --check`, `npx oxlint`, and `npm run docs` all pass on `origin/main` at `e746431d2`.

No existing test needed rewriting: the mirrored topology was untested, so nothing encoded the old behavior. The three Windows-host reachability mocks in `provider-host-state.test.ts` changed from `"{}"` to `'{"models":[]}'` — the real `/api/tags` shape, and the one the issue reports.

The new tests live in `src/lib/onboard/setup-nim-flow-ollama-topology.test.ts` rather than `setup-nim-flow.test.ts` because that file is at the 1500-line budget; `Test file size budget` rejected the commit until the test moved to a focused file.

### What this does not cover

- **Not proven on WSL2 hardware.** The tests drive the real `detectInferenceProviderHostState`, `resolveOllamaInstallMenuEntry`, and `createSetupNim` with only I/O seams injected, but the end-to-end claim in #9300 — that onboarding then pulls `qwen2.5:1.5b` and reaches a Ready Hermes sandbox — is not something this machine can run. Hence `Refs:` rather than `Closes:`. The pull itself already exists on the reuse path (`src/lib/onboard.ts` under `NEMOCLAW_YES=1`, and `src/lib/inference/ollama/proxy.ts` over HTTP when no Linux CLI exists, #7472).
- **Native Docker Engine, Podman, and Colima inside WSL are deliberately unchanged.** The predicate requires `windowsOllamaReachable`, which requires Docker Desktop WSL integration. Widening it there would be wrong, not merely incomplete: `local-inference-topology.ts` states that native Docker-in-WSL "cannot reliably route sandbox containers to Windows-host Ollama", so reusing the Windows daemon would hand the sandbox an endpoint it cannot reach. `does not treat a loopback daemon as the Windows host without Docker Desktop routing (#9300)` locks that boundary. Closing it properly needs a routing answer for those runtimes, which is a separate issue.
- **The reused daemon can still be below the `0.32.9` tool-call floor.** That matches existing Windows-host behavior — NemoClaw does not offer to upgrade a Windows Ollama from WSL today either — but model validation may still fail against a sufficiently old daemon. Upgrading Ollama on the Windows side in this topology is not addressed here.
- **The running-provider menu still labels this daemon `Local Ollama (WSL:11434)`.** `resolveRunningOllamaMenuEntry` (`src/lib/onboard/ollama-install-menu.ts`) branches on `ollamaHost === "host.docker.internal"`, which this change does not alter. It is the same misclassification in a display path; left out to keep the fix to the two paths that actually fail, and worth a follow-up.
- A requested `install-ollama` provider is unaffected: `resolveProviderKeyFallback` already collapses it to the reuse `ollama` entry (`src/lib/onboard/provider-key-fallback.ts`), and `scripts/install.sh:5093-5104` only emits `install-ollama` on WSL when Docker Desktop is absent — the case this predicate cannot fire in.

### Two review suggestions deliberately not taken

- **Widening the detection to non-Docker-Desktop WSL runtimes.** That would be wrong rather than merely incomplete — see the limits above.
- **Validating `/api/tags` bodies inside `findReachableOllamaHost`.** Applying `isValidOllamaTagsResponseBody` at host discovery would harden every platform, not just this topology, and it changes which host onboarding selects everywhere. `src/lib/inference/local.test.ts` currently asserts a non-JSON body is accepted there, so that is a standing contract worth its own issue rather than a rider on this fix. The Windows-side probe, which this change made load-bearing for a version-gate decision, is validated.

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Ollama setup on WSL with Docker Desktop mirrored networking.
  * Detects Windows-hosted Ollama daemons and avoids incompatible Linux installation or upgrade prompts.
  * Provides clearer handling for stale WSL-local Ollama daemons requiring an upgrade.
  * Prevents unnecessary Linux systemd repairs and duplicate-daemon warnings when using Windows-hosted Ollama.
  * Improves validation of Ollama responses during host detection.

* **Documentation**
  * Added guidance for upgrading Windows-hosted Ollama in mirrored WSL environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->