### PR TITLE
fix(docs): mount reviewer inputs before startup

### DIFF
--- a/test/post-merge-docs.test.ts
+++ b/test/post-merge-docs.test.ts
@@ -11,7 +11,7 @@ import YAML from "yaml";
 
 import { validatePostMergeDocsWorkflowBoundary } from "../tools/post-merge-docs/contract.mts";
 import { publishDocumentation, type Request } from "../tools/post-merge-docs/publish.mts";
-import { executePostMergeDocs } from "../tools/post-merge-docs/run.mts";
+import { configurePostMergeDocs, executePostMergeDocs } from "../tools/post-merge-docs/run.mts";
 import type { OpenShellTools } from "../tools/openshell-agent/runtime.mts";
 
 const directories: string[] = [];
@@ -182,6 +182,7 @@ function runnerFixture(phase: "author" | "review") {
       GITHUB_REPOSITORY: repository,
       GITHUB_SHA: mainSha,
       HOME: root,
+      OPENSHELL_GATEWAY_ENDPOINT: "http://127.0.0.1:8080",
       PI_IMAGE: "image",
       POST_MERGE_DOCS_ARTIFACT_DIR: path.join(root, "artifact"),
       POST_MERGE_DOCS_CANDIDATE_DIR: candidate,
@@ -190,6 +191,7 @@ function runnerFixture(phase: "author" | "review") {
       POST_MERGE_DOCS_WORKDIR: path.join(root, "work"),
       RANGE_START_SHA: mainSha,
       RANGE_START_TAG: "v1.0.0",
+      RUNNER_TEMP: path.join(root, "runner-temp"),
       SANDBOX_NAME: `docs-${phase}`,
       TRUSTED_CHECKOUT: source,
     },
@@ -203,13 +205,19 @@ function runnerTools(
   const { env, root } = input;
   const sandbox = path.join(root, "sandbox");
   const output = path.join(root, "work/output");
-  const state = { deleted: false };
+  const state = {
+    agentArgs: [] as readonly string[],
+    createArgs: [] as readonly string[],
+    deleted: false,
+  };
   const handlers: Record<string, (args: readonly string[]) => unknown> = {
-    create: () => {
+    create: (args) => {
+      state.createArgs = args;
       fs.cpSync(path.join(root, "work/repo"), sandbox, { recursive: true });
       expect(git(sandbox, ["rev-parse", "HEAD"])).toBe(env.GITHUB_SHA);
     },
-    agent: () => {
+    agent: (args) => {
+      state.agentArgs = args;
       const agents = {
         author: () => fs.writeFileSync(path.join(sandbox, "docs/guide.mdx"), "authored\n"),
         review: () =>
@@ -329,6 +337,22 @@ describe("post-merge documentation publisher", () => {
 });
 
 describe("post-merge documentation runner", () => {
+  it("enables bind mounts before creating a reviewer sandbox", async () => {
+    const input = runnerFixture("review");
+    const responses = new Map([["which", "/trusted/bin/openshell-sandbox"]]);
+    const tools: OpenShellTools = {
+      run: vi.fn((command) => responses.get(command) ?? ""),
+      start: vi.fn(),
+      wait: async () => undefined,
+    };
+    await configurePostMergeDocs(input.env, tools);
+    const config = fs.readFileSync(
+      path.join(input.root, "runner-temp/openshell-gateway/gateway.toml"),
+      "utf8",
+    );
+    expect(config).toContain("enable_bind_mounts = true");
+  });
+
   it("authors from the triggering SHA without exposing host credentials", () => {
     const input = runnerFixture("author");
     const { state, tools } = runnerTools(input);
@@ -336,11 +360,48 @@ describe("post-merge documentation runner", () => {
     expect(fs.readFileSync(path.join(input.root, "artifact/docs.patch"), "utf8")).toContain(
       "+authored",
     );
+    expect(state.createArgs.filter((argument) => argument === "--upload")).toHaveLength(3);
+    expect(state.createArgs).not.toContain("--driver-config-json");
+    expect(state.agentArgs.join("\n")).not.toContain("GIT_DIR=");
     expect(state.deleted).toBe(true);
   });
   it("records the exact independent approval", () => {
     const input = runnerFixture("review");
-    executePostMergeDocs(input.env, runnerTools(input).tools);
+    const { state, tools } = runnerTools(input);
+    executePostMergeDocs(input.env, tools);
+    const driverConfigIndex = state.createArgs.indexOf("--driver-config-json");
+    expect(JSON.parse(state.createArgs[driverConfigIndex + 1] as string)).toEqual({
+      docker: {
+        mounts: [
+          {
+            read_only: true,
+            source: path.join(input.root, "work/repo"),
+            target: "/sandbox/repo",
+            type: "bind",
+          },
+          {
+            read_only: true,
+            source: path.join(input.root, "config"),
+            target: "/sandbox/config",
+            type: "bind",
+          },
+        ],
+      },
+    });
+    expect(state.createArgs).not.toContain("--upload");
+    expect(state.createArgs.slice(-6)).toEqual([
+      "--",
+      "/usr/bin/git",
+      "--git-dir=/sandbox/repo/.git",
+      "--work-tree=/sandbox/repo",
+      "status",
+      "--short",
+    ]);
+    expect(state.agentArgs).toEqual(
+      expect.arrayContaining(["GIT_DIR=/sandbox/repo/.git", "GIT_WORK_TREE=/sandbox/repo"]),
+    );
+    expect(fs.statSync(path.join(input.root, "config")).mode & 0o777).toBe(0o755);
+    expect(fs.statSync(path.join(input.root, "config/task.txt")).mode & 0o777).toBe(0o444);
     expect(
       JSON.parse(fs.readFileSync(path.join(input.root, "artifact/review.json"), "utf8")),
     ).toEqual({

--- a/tools/post-merge-docs/run.mts
+++ b/tools/post-merge-docs/run.mts
@@ -164,8 +164,15 @@ function prepare(env: NodeJS.ProcessEnv): void {
   const config = required(env.POST_MERGE_DOCS_CONFIG_DIR, "POST_MERGE_DOCS_CONFIG_DIR");
   fs.mkdirSync(output, { mode: 0o700 });
   reset(config);
-  write(path.join(config, "models.json"), resolverModelConfiguration());
-  write(path.join(config, "task.txt"), `${prompt(env, current)}\n`);
+  const models = path.join(config, "models.json");
+  const task = path.join(config, "task.txt");
+  write(models, resolverModelConfiguration());
+  write(task, `${prompt(env, current)}\n`);
+  if (current === "review") {
+    fs.chmodSync(config, 0o755);
+    fs.chmodSync(models, 0o444);
+    fs.chmodSync(task, 0o444);
+  }
 }
 
 function agentCommand(current: Phase): string[] {
@@ -188,6 +195,8 @@ function agentCommand(current: Phase): string[] {
 function create(env: NodeJS.ProcessEnv, tools: OpenShellTools): void {
   const current = phase(env);
   const work = required(env.POST_MERGE_DOCS_WORKDIR, "POST_MERGE_DOCS_WORKDIR");
+  const config = required(env.POST_MERGE_DOCS_CONFIG_DIR, "POST_MERGE_DOCS_CONFIG_DIR");
+  const review = current === "review";
   const policy =
     current === "author"
       ? "pr-merge-conflict-fixer/policy.yaml"
@@ -195,29 +204,60 @@ function create(env: NodeJS.ProcessEnv, tools: OpenShellTools): void {
   createOpenShellSandbox(
     env,
     {
-      command: ["/usr/bin/git", "-C", "/sandbox/repo", "status", "--short"],
+      command: review
+        ? [
+            "/usr/bin/git",
+            "--git-dir=/sandbox/repo/.git",
+            "--work-tree=/sandbox/repo",
+            "status",
+            "--short",
+          ]
+        : ["/usr/bin/git", "-C", "/sandbox/repo", "status", "--short"],
       image: required(env.PI_IMAGE, "PI_IMAGE"),
       name: required(env.SANDBOX_NAME, "SANDBOX_NAME"),
       policyPath: path.join(required(env.TRUSTED_CHECKOUT, "TRUSTED_CHECKOUT"), "tools", policy),
-      uploads: [
-        { destination: "/sandbox", source: path.join(work, "repo") },
-        {
-          destination: "/sandbox",
-          source: required(env.POST_MERGE_DOCS_CONFIG_DIR, "POST_MERGE_DOCS_CONFIG_DIR"),
-        },
-        { destination: "/sandbox", source: path.join(work, "output") },
-      ],
+      driverConfig: review
+        ? {
+            docker: {
+              mounts: [
+                {
+                  read_only: true,
+                  source: path.join(work, "repo"),
+                  target: "/sandbox/repo",
+                  type: "bind",
+                },
+                {
+                  read_only: true,
+                  source: config,
+                  target: "/sandbox/config",
+                  type: "bind",
+                },
+              ],
+            },
+          }
+        : undefined,
+      uploads: review
+        ? []
+        : [
+            { destination: "/sandbox", source: path.join(work, "repo") },
+            { destination: "/sandbox", source: config },
+            { destination: "/sandbox", source: path.join(work, "output") },
+          ],
     },
     tools,
   );
 }
 
 function run(env: NodeJS.ProcessEnv, tools: OpenShellTools): void {
+  const current = phase(env);
   execOpenShellSandbox(
     env,
     {
-      command: agentCommand(phase(env)),
+      command: agentCommand(current),
       environment: {
+        ...(current === "review"
+          ? { GIT_DIR: "/sandbox/repo/.git", GIT_WORK_TREE: "/sandbox/repo" }
+          : {}),
         HOME: "/sandbox/output",
         PI_CODING_AGENT_DIR: "/sandbox/config",
         PI_OFFLINE: "1",
@@ -311,14 +351,26 @@ export function executePostMergeDocs(
   }
 }
 
+export function configurePostMergeDocs(
+  env: NodeJS.ProcessEnv,
+  tools: OpenShellTools = defaultOpenShellTools,
+): Promise<void> {
+  return configureOpenShellInference(
+    env,
+    {
+      enableBindMounts: true,
+      gatewayId: "post-merge-docs",
+      modelId: RESOLVER_MODEL_ID,
+      providerName: "docs",
+    },
+    tools,
+  );
+}
+
 async function main(): Promise<void> {
   switch (required(process.argv[2], "command")) {
     case "configure":
-      await configureOpenShellInference(process.env, {
-        gatewayId: "post-merge-docs",
-        modelId: RESOLVER_MODEL_ID,
-        providerName: "docs",
-      });
+      await configurePostMergeDocs(process.env);
       return;
     case "execute":
       executePostMergeDocs(process.env);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The post-merge documentation reviewer now mounts its prepared checkout and model configuration read-only when OpenShell creates the sandbox. The hard Landlock policy now finds both required paths before it starts the first container process.

## Changes

- Enable bind mounts on the workflow's loopback-only OpenShell gateway.
- Mount the reviewer checkout and configuration read-only at container creation, with no reviewer uploads.
- Use explicit Git metadata and worktree paths so the sandbox user can read the runner-owned checkout.
- Keep the author sandbox on its existing three-upload path with no driver configuration.
- Test the gateway capability, exact reviewer mounts, author path, cross-UID Git arguments, and config file modes.

The escaped defect came from the runner fake copying inputs without checking the real OpenShell startup transport. Public documentation is unchanged because this repairs the documented workflow instead of changing its contract.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Codex security review of `1545062c0` found no blocker. The production rerun remains the Docker and Landlock enforcement proof.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run --project integration test/post-merge-docs.test.ts` passed 27 tests; targeted strict TypeScript, Oxlint, Oxfmt, source-shape, and diff checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

The pre-commit and commit-message hooks passed. The pre-push `tsc-cli` hook was skipped after current `main` at `183a9c876` reproduced unrelated errors in `src/lib/onboard/machine/handlers/sandbox-messaging.ts`, its test, and `src/lib/state/portable-uninstall-retirement.test.ts`. All other applicable pre-push hooks passed.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Documentation review workflows now access repository and configuration files through read-only mounts.
  - Review runs use explicit repository settings for more reliable Git operations.
  - Configuration files receive appropriate permissions during reviews.
  - Authoring workflows continue to use uploaded content without unnecessary Git configuration.

- **Bug Fixes**
  - Improved isolation by preventing Git environment settings from leaking into authoring runs.
  - Added support for bind mounts in OpenShell-based documentation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->