### PR TITLE
fix(onboard): pass messaging dependencies during reuse

### DIFF
--- a/src/lib/onboard/machine/handlers/sandbox-messaging.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.test.ts
@@ -693,6 +693,9 @@ describe("reconcileSandboxMessaging plan authority", () => {
     // input; a channel the environment no longer configures must not re-enter
     // the selection, or its egress preset is re-applied.
     expect(deps.setupMessagingChannels).not.toHaveBeenCalled();
+    expect(deps.note).toHaveBeenCalledWith(expect.stringContaining("No host inputs configure discord"));
+    expect(deps.clearPlanEnv).toHaveBeenCalledOnce();
+    expect(deps.writePlanToEnv).not.toHaveBeenCalled();
     expect(result).toEqual({ plan: null, selectedChannels: [] });
   });
 

--- a/src/lib/onboard/machine/handlers/sandbox-messaging.test.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.test.ts
@@ -396,7 +396,7 @@ describe("reconcileReusedSandboxMessaging", () => {
     const result = reconcileReusedSandboxMessaging(
       structuredClone(plan),
       { name: "openclaw" },
-      { clearPlanEnv },
+      { clearPlanEnv, note: vi.fn(), writePlanToEnv: vi.fn() },
       plan,
     );
 
@@ -417,7 +417,7 @@ describe("reconcileReusedSandboxMessaging", () => {
     const result = reconcileReusedSandboxMessaging(
       structuredClone(plan),
       { name: "openclaw" },
-      { clearPlanEnv: vi.fn() },
+      { clearPlanEnv: vi.fn(), note: vi.fn(), writePlanToEnv: vi.fn() },
       plan,
     );
 
@@ -432,7 +432,7 @@ describe("reconcileReusedSandboxMessaging", () => {
     const result = reconcileReusedSandboxMessaging(
       structuredClone(plan),
       { name: "openclaw" },
-      { clearPlanEnv: vi.fn() },
+      { clearPlanEnv: vi.fn(), note: vi.fn(), writePlanToEnv: vi.fn() },
       plan,
     );
 

--- a/src/lib/onboard/machine/handlers/sandbox-messaging.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.ts
@@ -373,6 +373,7 @@ async function selectionFromMessagingSetup<Agent>(
   );
 }
 
+/** Reconcile checkpoint channels against current host inputs before reuse. */
 function selectionFromRecordedChannels<Agent>(
   recordedChannels: string[],
   envPlan: SandboxMessagingPlan | null,

--- a/src/lib/onboard/machine/handlers/sandbox-messaging.ts
+++ b/src/lib/onboard/machine/handlers/sandbox-messaging.ts
@@ -386,7 +386,7 @@ function selectionFromRecordedChannels<Agent>(
   if (envPlan) selection = selectionFromReusablePlan(envPlan, options.agent, false, options.deps);
   else if (registryPlan)
     selection = selectionFromReusablePlan(registryPlan, options.agent, true, options.deps);
-  selection = filterUnconfiguredHostChannelsFromSelection(selection, options.agent);
+  selection = filterUnconfiguredHostChannelsFromSelection(selection, options.agent, options.deps);
   if (selection.selectedChannels.length > 0) {
     options.deps.note(
       `  [non-interactive] Reusing messaging channel configuration: ${selection.selectedChannels.join(", ")}`,


### PR DESCRIPTION
## Summary

Restore the recorded messaging resume path after the lifecycle reconciliation update. Recorded channels now pass the required persistence and notification dependencies into host-channel filtering, and the affected reuse fixtures model that contract.

## Related Issue

Fixes #9359

## Changes

- Pass onboarding messaging dependencies through recorded-channel reconciliation.
- Update the existing reuse fixtures to provide the dependency contract required when channels are filtered and persisted.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/machine/handlers/sandbox-messaging.test.ts` (32 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation: `npm run build:cli`, `npm run typecheck:cli`, and `npm run lint`.

---
Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation when resuming recorded sandbox messaging sessions.
  * Missing host configuration is now clearly noted, while outdated saved plans are removed without being rewritten.
  * Improved filtering of unavailable messaging channels and handling of related plan updates and notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->