### PR TITLE
fix(onboard): persist managed OpenClaw agent identity

### DIFF
--- a/src/lib/onboard/sandbox-registration.test.ts
+++ b/src/lib/onboard/sandbox-registration.test.ts
@@ -1,14 +1,24 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { managedStartupE2eProfile } from "../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
 import {
   serializedHostLocalInferenceReceipt,
   serializedLlamaCppHostLocalInferenceReceipt,
 } from "../../../test/helpers/host-local-inference-receipt";
+import type { SandboxWorkloadReceipt } from "../state/registry/types";
 import { createSandboxHostLocalInferenceProvenance } from "../state/registry/host-local-inference";
+import {
+  MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
+  MANAGED_IMAGE_REPOSITORIES,
+  MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
+  type ManagedImageAgent,
+} from "./managed-image/contract";
+import { encodeManagedStartupProfile } from "./managed-startup/profile";
 
 const requireDist = createRequire(import.meta.url);
 const onboardSession = requireDist("../state/onboard-session.js");
@@ -31,7 +41,103 @@ const runtimeFields = {
   openshellVersion: "0.1.2",
 };
 
+function managedWorkloadReceipt(
+  agent: ManagedImageAgent,
+): Extract<SandboxWorkloadReceipt, { readonly kind: "managed-image" }> {
+  const encodedProfile = encodeManagedStartupProfile(managedStartupE2eProfile(agent));
+  const digest = agent === "openclaw" ? "a" : "b";
+  return {
+    schemaVersion: 1,
+    kind: "managed-image",
+    reference: `${MANAGED_IMAGE_REPOSITORIES[agent]}@sha256:${digest.repeat(64)}`,
+    platform: "linux/amd64",
+    release: "v0.0.100",
+    sourceRevision: "d".repeat(40),
+    sourceCohort: "ghrun-9356-1",
+    capabilityContractVersion: MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
+    startupProfileContractVersion: MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
+    encodedProfile,
+    startupProfileSha256: createHash("sha256").update(encodedProfile, "utf8").digest("hex"),
+    credentialProxyReplayRequired: false,
+    shared: true,
+  };
+}
+
+function createdRegistryEntryInput(
+  overrides: Partial<Parameters<typeof buildCreatedSandboxRegistryEntry>[0]> = {},
+): Parameters<typeof buildCreatedSandboxRegistryEntry>[0] {
+  return {
+    sandboxName: "demo",
+    inferenceSelection: {
+      model: "llama",
+      provider: "openai-compatible",
+      endpointUrl: null,
+      credentialEnv: null,
+      preferredInferenceApi: null,
+      compatibleEndpointReasoning: null,
+      compatibleEndpointReasoningEffort: null,
+      nimContainer: null,
+    },
+    runtimeFields,
+    agent: null,
+    agentVersionKnown: true,
+    imageTag: null,
+    appliedPolicies: [],
+    plannedMessagingState: undefined,
+    hermesToolGateways: [],
+    hermesDashboardState: { enabled: false, config: null },
+    dashboardPort: 18789,
+    gatewayName: "nemoclaw",
+    gatewayPort: 8080,
+    ...overrides,
+  };
+}
+
 describe("buildCreatedSandboxRegistryEntry", () => {
+  it("records explicit OpenClaw identity for a managed workload receipt (#9356)", () => {
+    const workload = managedWorkloadReceipt("openclaw");
+    const entry = buildCreatedSandboxRegistryEntry(
+      createdRegistryEntryInput({ imageTag: workload.reference, workload }),
+    );
+    const authority = requireDist(
+      "./workload/authority.ts",
+    ) as typeof import("./workload/authority");
+
+    expect(entry.agent).toBe("openclaw");
+    expect(authority.readManagedWorkloadAuthority(entry)?.agent).toBe("openclaw");
+  });
+
+  it("keeps the legacy OpenClaw registry identity for a custom image (#9356)", () => {
+    const entry = buildCreatedSandboxRegistryEntry(
+      createdRegistryEntryInput({
+        agentVersionKnown: false,
+        fromDockerfile: "/tmp/Dockerfile.custom",
+        imageTag: "custom-openclaw:latest",
+        workload: {
+          schemaVersion: 1,
+          kind: "legacy-dockerfile",
+          reference: "custom-openclaw:latest",
+          shared: false,
+        },
+      }),
+    );
+
+    expect(entry.agent).toBeNull();
+  });
+
+  it("rejects a managed receipt for a different agent before registry mutation (#9356)", () => {
+    const workload = managedWorkloadReceipt("hermes");
+    const registerSandbox = vi.fn();
+
+    expect(() =>
+      registerCreatedSandbox({
+        ...createdRegistryEntryInput({ imageTag: workload.reference, workload }),
+        registerSandbox,
+      }),
+    ).toThrow(/agent identity does not match its managed workload receipt/u);
+    expect(registerSandbox).not.toHaveBeenCalled();
+  });
+
   it("copies matching session profile provenance into the durable registry (#8246)", () => {
     const provenance = {
       schemaVersion: 1,

--- a/src/lib/onboard/sandbox-registration.ts
+++ b/src/lib/onboard/sandbox-registration.ts
@@ -26,6 +26,7 @@ import { DEFAULT_TOOL_DISCLOSURE, type ToolDisclosure } from "../tool-disclosure
 import type { DcodeAutoApprovalMode } from "./dcode-auto-approval";
 import { cloneSandboxHostMounts } from "../state/registry/host-mount";
 import { resolveOnboardHermesApiPort } from "./hermes-api-port";
+import { isManagedImageAgent, MANAGED_IMAGE_REPOSITORIES } from "./managed-image/contract";
 import {
   getHermesDashboardRegistryFields,
   type HermesDashboardOnboardState,
@@ -37,7 +38,7 @@ import {
   requireRuntimeProviderBundleForSandbox,
   requireRuntimeProviderMutationAuthority,
 } from "./runtime-provider/access";
-import { getSandboxAgentRegistryFields } from "./sandbox-agent";
+import { getRequestedSandboxAgentName, getSandboxAgentRegistryFields } from "./sandbox-agent";
 
 export type CreatedSandboxRuntimeFields = Pick<
   SandboxEntry,
@@ -224,13 +225,26 @@ export function buildCreatedSandboxRegistryEntry(
       hostLocalInferenceReceipt,
     );
   }
+  const agentFields = getSandboxAgentRegistryFields(input.agent, input.agentVersionKnown);
+  if (workload?.kind === "managed-image") {
+    const requestedAgent = getRequestedSandboxAgentName(input.agent);
+    if (
+      !isManagedImageAgent(requestedAgent) ||
+      !workload.reference.startsWith(`${MANAGED_IMAGE_REPOSITORIES[requestedAgent]}@sha256:`)
+    ) {
+      throw new RuntimeProviderSelectionError(
+        "Sandbox agent identity does not match its managed workload receipt.",
+      );
+    }
+    agentFields.agent = requestedAgent;
+  }
 
   return {
     name: input.sandboxName,
     servingProfileProvenance,
     ...inferenceSelectionRegistryFields(input.inferenceSelection),
     ...input.runtimeFields,
-    ...getSandboxAgentRegistryFields(input.agent, input.agentVersionKnown),
+    ...agentFields,
     imageTag: input.imageTag,
     workload,
     ...(hostLocalInferenceReceipt !== undefined ? { hostLocalInferenceReceipt } : {}),

--- a/test/helpers/managed-image-buildless-e2e.ts
+++ b/test/helpers/managed-image-buildless-e2e.ts
@@ -729,7 +729,7 @@ function assertManagedLaunch(
       result.payload.registerCalls,
     )}`,
   ).toBeDefined();
-  expect(registration?.agent).toBe(agent === "openclaw" ? null : agent);
+  expect(registration?.agent).toBe(agent);
   if (agent === "langchain-deepagents-code") {
     expect(registration?.dashboardPort).toBe(0);
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->
Managed OpenClaw sandbox registration now stores `agent: "openclaw"` when a validated managed-image receipt owns the sandbox. Legacy and custom-image registrations keep `agent: null`. A mismatch between the receipt and selected agent fails before the registry write.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->
Fixes #9356

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->
- `buildCreatedSandboxRegistryEntry()` now checks the selected agent against the validated managed-image receipt and persists the explicit agent identity. `readManagedWorkloadAuthority()` consumes this field during rebuild and restore operations.
- `sandbox-registration.test.ts` covers managed OpenClaw authority, the legacy custom-image convention, and rejection before the registry writer runs.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer Aaron Erickson explicitly accepted the reviewed sensitive-path change for admin merge on 2026-08-17 after CodeRabbit and all other feedback were clear; CodeRabbit reported no actionable comments and the exact-head PR Review Advisor reported zero findings.
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: Maintainer Aaron Erickson accepted the `CI / Pull Request / checks` non-success on 2026-08-17 because shard 6 is the unchanged Launchable authorization-step contract on `main` (follow-up #9368/#9369), and accepted `Images / Managed Images / PR exact all-agent managed runtime activation` because its exact-head-only build hits the unchanged two-argument `sandbox-messaging.ts` call already fixed on current `main` by #9366. Neither failure overlaps this PR’s changed files or behavior.

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `vitest run --project cli src/lib/onboard/sandbox-registration.test.ts --testTimeout 30000` — 18 tests passed; `vitest run --project integration test/onboard-managed-image-buildless-e2e.test.ts --testTimeout 30000` — 1 test passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

The `pre-commit` and `commit-msg` hooks passed for both commits. At base SHA `cb018f0224`, the `pre-push` CLI type check was blocked by unchanged errors in `sandbox-messaging.ts`, `sandbox-messaging.test.ts`, and `portable-uninstall-retirement.test.ts`. PR #9366 fixed the shared `sandbox-messaging.ts` root cause on `main`; current-base CI at `54cb2a414f` passed `build-typecheck` and `installer-integration`. CLI shard 6 remains blocked by an unchanged E2E test that references the removed `Authorize Launchable image publication` workflow step; PRs #9368 and #9369 update that contract, so this branch does not absorb the unrelated E2E change.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>