### PR TITLE
fix(openclaw): isolate startup guard output

### DIFF
--- a/scripts/nemoclaw-start.sh
+++ b/scripts/nemoclaw-start.sh
@@ -5344,8 +5344,9 @@ run_openclaw_config_guard() {
     # child. A `timeout` wrapper or command substitution would become Python's
     # parent and invalidate that identity, so capture through a root-private
     # file while invoking Python directly.
-    install -d -o root -g root -m 700 /run/nemoclaw || return 1
-    output_file="/run/nemoclaw/.openclaw-config-guard.$$.output"
+    install -d -o root -g root -m 755 /run/nemoclaw || return 1
+    install -d -o root -g root -m 700 /run/nemoclaw/openclaw-config-guard || return 1
+    output_file="/run/nemoclaw/openclaw-config-guard/.$$.output"
     : >"$output_file"
     chmod 600 "$output_file"
     rc=0

--- a/test/nemoclaw-start-perms.test.ts
+++ b/test/nemoclaw-start-perms.test.ts
@@ -49,6 +49,27 @@ function replaceRequired(source: string, target: string, replacement: string): s
 const oneShotFunction = extractShellFunction("run_oneshot_command");
 const resolveNormalizerFunction = extractShellFunction("resolve_mutable_config_normalizer");
 const configGuardFunction = extractShellFunction("run_openclaw_config_guard");
+const canRunPrivilegedPermissionFixture =
+  process.platform === "linux" &&
+  spawnSync("sudo", ["-n", "test", "-x", "/usr/bin/setpriv"], { stdio: "ignore" }).status === 0;
+
+function useTestRuntimeDirectory(source: string): string {
+  let result = replaceRequired(
+    source,
+    " /run/nemoclaw || return 1",
+    ' "$NEMOCLAW_TEST_RUNTIME_DIR" || return 1',
+  );
+  result = replaceRequired(
+    result,
+    " /run/nemoclaw/openclaw-config-guard || return 1",
+    ' "$NEMOCLAW_TEST_RUNTIME_DIR/openclaw-config-guard" || return 1',
+  );
+  return replaceRequired(
+    result,
+    'output_file="/run/nemoclaw/openclaw-config-guard/.$$.output"',
+    'output_file="$NEMOCLAW_TEST_RUNTIME_DIR/openclaw-config-guard/.$$.output"',
+  );
+}
 
 describe("nemoclaw-start config guard output permissions", () => {
   it("keeps the shared runtime path traversable while startup-owner output stays private (#9357)", () => {
@@ -60,28 +81,12 @@ describe("nemoclaw-start config guard output permissions", () => {
     fs.mkdirSync(runtimeDir, { mode: 0o700 });
     fs.writeFileSync(caBundle, "corporate CA\n", { mode: 0o444 });
 
-    let testFunction = configGuardFunction.replaceAll(
-      "install -d -o root -g root -m",
-      "install -d -m",
-    );
-    testFunction = replaceRequired(
-      testFunction,
-      "install -d -m 755 /run/nemoclaw || return 1",
-      'install -d -m 755 "$NEMOCLAW_TEST_RUNTIME_DIR" || return 1',
-    );
-    testFunction = replaceRequired(
-      testFunction,
-      "install -d -m 700 /run/nemoclaw/openclaw-config-guard || return 1",
-      'install -d -m 700 "$NEMOCLAW_TEST_RUNTIME_DIR/openclaw-config-guard" || return 1',
-    );
-    testFunction = replaceRequired(
-      testFunction,
-      'output_file="/run/nemoclaw/openclaw-config-guard/.$$.output"',
-      'output_file="$NEMOCLAW_TEST_RUNTIME_DIR/openclaw-config-guard/.$$.output"',
+    const testFunction = useTestRuntimeDirectory(
+      configGuardFunction.replaceAll("install -d -o root -g root -m", "install -d -m"),
     );
     const script = [
       "set -euo pipefail",
-      'python3() { find "$NEMOCLAW_TEST_RUNTIME_DIR" -type f -name \'.*.output\' -print >"$NEMOCLAW_TEST_OBSERVED_OUTPUT"; printf \'private guard output\\n\'; }',
+      "python3() { find \"$NEMOCLAW_TEST_RUNTIME_DIR\" -type f -name '.*.output' -print >\"$NEMOCLAW_TEST_OBSERVED_OUTPUT\"; printf 'private guard output\\n'; }",
       "_OPENCLAW_CONFIG_GUARD=/tmp/openclaw-config-guard.py",
       testFunction,
       "run_openclaw_config_guard publish-startup-ready --startup-owner",
@@ -105,6 +110,74 @@ describe("nemoclaw-start config guard output permissions", () => {
       fs.rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it.runIf(canRunPrivilegedPermissionFixture)(
+    "keeps the CA readable while denying a distinct unprivileged user access to live guard output (#9357)",
+    () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-config-guard-root-output-"));
+      const runtimeDir = path.join(root, "nemoclaw");
+      const privateDir = path.join(runtimeDir, "openclaw-config-guard");
+      const caBundle = path.join(runtimeDir, "managed-startup-ca-bundle.pem");
+      const observedAccess = path.join(root, "observed-access");
+      const nobodyUid = spawnSync("id", ["-u", "nobody"], { encoding: "utf-8" }).stdout.trim();
+      const nobodyGid = spawnSync("id", ["-g", "nobody"], { encoding: "utf-8" }).stdout.trim();
+      fs.chmodSync(root, 0o755);
+      fs.mkdirSync(runtimeDir, { mode: 0o700 });
+      fs.writeFileSync(caBundle, "corporate CA\n", { mode: 0o444 });
+
+      const testFunction = useTestRuntimeDirectory(configGuardFunction);
+      const script = [
+        "set -euo pipefail",
+        "python3() {",
+        '  local output_path=""',
+        '  output_path="$(find "$NEMOCLAW_TEST_PRIVATE_DIR" -maxdepth 1 -type f -name \'.*.output\' -print -quit)"',
+        '  test -n "$output_path"',
+        '  /usr/bin/setpriv --reuid="$NEMOCLAW_TEST_NOBODY_UID" --regid="$NEMOCLAW_TEST_NOBODY_GID" --clear-groups -- sh -eu -c \'test ! -r "$1"; ! ls -A "$2" >/dev/null 2>&1; grep -Fqx "corporate CA" "$3"\' sh "$output_path" "$NEMOCLAW_TEST_PRIVATE_DIR" "$NEMOCLAW_TEST_CA_BUNDLE"',
+        "  printf 'denied\\n' >\"$NEMOCLAW_TEST_OBSERVED_ACCESS\"",
+        "  printf 'private guard output\\n'",
+        "}",
+        'chown root:root "$NEMOCLAW_TEST_CA_BUNDLE"',
+        "_OPENCLAW_CONFIG_GUARD=/tmp/openclaw-config-guard.py",
+        testFunction,
+        "run_openclaw_config_guard publish-startup-ready --startup-owner",
+      ].join("\n");
+
+      try {
+        const result = spawnSync(
+          "sudo",
+          [
+            "-n",
+            "env",
+            `PATH=${process.env.PATH ?? "/usr/bin:/bin"}`,
+            `NEMOCLAW_TEST_CA_BUNDLE=${caBundle}`,
+            `NEMOCLAW_TEST_NOBODY_GID=${nobodyGid}`,
+            `NEMOCLAW_TEST_NOBODY_UID=${nobodyUid}`,
+            `NEMOCLAW_TEST_OBSERVED_ACCESS=${observedAccess}`,
+            `NEMOCLAW_TEST_PRIVATE_DIR=${privateDir}`,
+            `NEMOCLAW_TEST_RUNTIME_DIR=${runtimeDir}`,
+            "bash",
+            "-c",
+            script,
+          ],
+          { encoding: "utf-8", timeout: 10_000 },
+        );
+        expect(result.status, result.stderr).toBe(0);
+        expect(fs.readFileSync(observedAccess, "utf-8")).toBe("denied\n");
+        expect(mode(runtimeDir)).toBe(0o755);
+        expect(fs.statSync(runtimeDir).uid).toBe(0);
+        expect(mode(caBundle)).toBe(0o444);
+        expect(fs.statSync(caBundle).uid).toBe(0);
+        expect(mode(privateDir)).toBe(0o700);
+        expect(fs.statSync(privateDir).uid).toBe(0);
+        expect(fs.readdirSync(privateDir)).toEqual([]);
+      } finally {
+        const cleanup = spawnSync("sudo", ["-n", "/usr/bin/rm", "-rf", "--", root], {
+          encoding: "utf-8",
+        });
+        expect(cleanup.status, cleanup.stderr).toBe(0);
+      }
+    },
+  );
 });
 
 describe("nemoclaw-start one-shot command lifecycle", () => {

--- a/test/nemoclaw-start-perms.test.ts
+++ b/test/nemoclaw-start-perms.test.ts
@@ -47,6 +47,44 @@ function replaceRequired(source: string, target: string, replacement: string): s
 
 const oneShotFunction = extractShellFunction("run_oneshot_command");
 const resolveNormalizerFunction = extractShellFunction("resolve_mutable_config_normalizer");
+const configGuardFunction = extractShellFunction("run_openclaw_config_guard");
+
+describe("nemoclaw-start config guard output permissions", () => {
+  it("keeps the shared runtime path traversable while startup-owner output stays private (#9357)", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-config-guard-output-"));
+    const runtimeDir = path.join(root, "nemoclaw");
+    const privateDir = path.join(runtimeDir, "openclaw-config-guard");
+    const caBundle = path.join(runtimeDir, "managed-startup-ca-bundle.pem");
+    const observedOutput = path.join(root, "observed-output");
+    fs.mkdirSync(runtimeDir, { mode: 0o700 });
+    fs.writeFileSync(caBundle, "corporate CA\n", { mode: 0o444 });
+
+    const testFunction = configGuardFunction
+      .replaceAll("/run/nemoclaw", runtimeDir)
+      .replaceAll("install -d -o root -g root -m", "install -d -m");
+    const script = [
+      "set -euo pipefail",
+      `python3() { find ${JSON.stringify(runtimeDir)} -type f -name '.*.output' -print >${JSON.stringify(observedOutput)}; printf 'private guard output\\n'; }`,
+      "_OPENCLAW_CONFIG_GUARD=/tmp/openclaw-config-guard.py",
+      testFunction,
+      "run_openclaw_config_guard publish-startup-ready --startup-owner",
+    ].join("\n");
+
+    try {
+      const result = runBash(script);
+      expect(result.status, result.stderr).toBe(0);
+      expect(mode(runtimeDir)).toBe(0o755);
+      expect(fs.readFileSync(caBundle, "utf-8")).toBe("corporate CA\n");
+      expect(mode(privateDir)).toBe(0o700);
+      const outputPath = fs.readFileSync(observedOutput, "utf-8").trim();
+      expect(path.dirname(outputPath)).toBe(privateDir);
+      expect(path.basename(outputPath)).toMatch(/^\.\d+\.output$/);
+      expect(fs.readdirSync(privateDir)).toEqual([]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("nemoclaw-start one-shot command lifecycle", () => {
   it("sources the trusted runtime env before preserving one-shot argv (#4504)", () => {

--- a/test/nemoclaw-start-perms.test.ts
+++ b/test/nemoclaw-start-perms.test.ts
@@ -28,9 +28,10 @@ function extractShellFunction(name: string): string {
   return `${name}() {${body}\n}`;
 }
 
-function runBash(script: string) {
+function runBash(script: string, env: NodeJS.ProcessEnv = process.env) {
   return spawnSync("bash", ["-c", script], {
     encoding: "utf-8",
+    env,
     timeout: 10_000,
   });
 }
@@ -59,19 +60,39 @@ describe("nemoclaw-start config guard output permissions", () => {
     fs.mkdirSync(runtimeDir, { mode: 0o700 });
     fs.writeFileSync(caBundle, "corporate CA\n", { mode: 0o444 });
 
-    const testFunction = configGuardFunction
-      .replaceAll("/run/nemoclaw", runtimeDir)
-      .replaceAll("install -d -o root -g root -m", "install -d -m");
+    let testFunction = configGuardFunction.replaceAll(
+      "install -d -o root -g root -m",
+      "install -d -m",
+    );
+    testFunction = replaceRequired(
+      testFunction,
+      "install -d -m 755 /run/nemoclaw || return 1",
+      'install -d -m 755 "$NEMOCLAW_TEST_RUNTIME_DIR" || return 1',
+    );
+    testFunction = replaceRequired(
+      testFunction,
+      "install -d -m 700 /run/nemoclaw/openclaw-config-guard || return 1",
+      'install -d -m 700 "$NEMOCLAW_TEST_RUNTIME_DIR/openclaw-config-guard" || return 1',
+    );
+    testFunction = replaceRequired(
+      testFunction,
+      'output_file="/run/nemoclaw/openclaw-config-guard/.$$.output"',
+      'output_file="$NEMOCLAW_TEST_RUNTIME_DIR/openclaw-config-guard/.$$.output"',
+    );
     const script = [
       "set -euo pipefail",
-      `python3() { find ${JSON.stringify(runtimeDir)} -type f -name '.*.output' -print >${JSON.stringify(observedOutput)}; printf 'private guard output\\n'; }`,
+      'python3() { find "$NEMOCLAW_TEST_RUNTIME_DIR" -type f -name \'.*.output\' -print >"$NEMOCLAW_TEST_OBSERVED_OUTPUT"; printf \'private guard output\\n\'; }',
       "_OPENCLAW_CONFIG_GUARD=/tmp/openclaw-config-guard.py",
       testFunction,
       "run_openclaw_config_guard publish-startup-ready --startup-owner",
     ].join("\n");
 
     try {
-      const result = runBash(script);
+      const result = runBash(script, {
+        ...process.env,
+        NEMOCLAW_TEST_OBSERVED_OUTPUT: observedOutput,
+        NEMOCLAW_TEST_RUNTIME_DIR: runtimeDir,
+      });
       expect(result.status, result.stderr).toBe(0);
       expect(mode(runtimeDir)).toBe(0o755);
       expect(fs.readFileSync(caBundle, "utf-8")).toBe("corporate CA\n");

--- a/test/nemoclaw-start-perms.test.ts
+++ b/test/nemoclaw-start-perms.test.ts
@@ -169,7 +169,13 @@ describe("nemoclaw-start config guard output permissions", () => {
         expect(fs.statSync(caBundle).uid).toBe(0);
         expect(mode(privateDir)).toBe(0o700);
         expect(fs.statSync(privateDir).uid).toBe(0);
-        expect(fs.readdirSync(privateDir)).toEqual([]);
+        const remainingOutput = spawnSync(
+          "sudo",
+          ["-n", "/usr/bin/find", privateDir, "-mindepth", "1", "-maxdepth", "1", "-print", "-quit"],
+          { encoding: "utf-8" },
+        );
+        expect(remainingOutput.status, remainingOutput.stderr).toBe(0);
+        expect(remainingOutput.stdout).toBe("");
       } finally {
         const cleanup = spawnSync("sudo", ["-n", "/usr/bin/rm", "-rf", "--", root], {
           encoding: "utf-8",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->

The OpenClaw startup guard no longer changes the shared `/run/nemoclaw` directory from mode `0755` to `0700`. The guard now captures command output in a root-owned mode `0700` child, so sandbox processes can read the root-owned mode `0444` managed CA bundle without reading guard output.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

Fixes #9357

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->

- Keep `/run/nemoclaw` root-owned at mode `0755` when the startup owner invokes the config guard.
- Capture config-guard output under `/run/nemoclaw/openclaw-config-guard`, which remains root-owned at mode `0700`.
- Add regression coverage that starts with the shared parent at mode `0700`, preserves a readable mode `0444` CA bundle, observes the temporary output in the private child, verifies cleanup, and proves a distinct unprivileged Linux user cannot read live guard output.
- Record the detection gap in that test: existing permission coverage did not execute `run_openclaw_config_guard --startup-owner` with another shared runtime file present.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — [exact-head maintainer gate record](https://github.com/NVIDIA/NemoClaw/pull/9371#issuecomment-5322172906)
- [x] Non-success, skipped, or missing CI check accepted by maintainer — `cli-test-shards (6)` and its aggregate `cli-tests`/`checks`; unrelated E2E infrastructure/base failures; [evidence and waiver](https://github.com/NVIDIA/NemoClaw/pull/9371#issuecomment-5322172906)

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — all normal hooks passed on exact head `a276e95dba50c4893da656ff0315197aa1b79bd8`.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run --project integration test/nemoclaw-start-perms.test.ts`: 1 file passed; 20 tests passed and 4 platform-specific tests skipped locally; the passwordless-sudo Linux fixture passed in CI shard 12.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
