### PR TITLE
fix(onboard): accept schema-owned messaging plan fields

### DIFF
--- a/src/lib/onboard/managed-startup-profile.test.ts
+++ b/src/lib/onboard/managed-startup-profile.test.ts
@@ -729,6 +729,107 @@ describe("managed startup profile", () => {
     ).toThrow(/credential-shaped field name/);
   });
 
+  it("accepts schema-owned messaging package pins and credential placeholder lines (#9355)", () => {
+    expect(() =>
+      validateManagedStartupProfile({
+        ...OPENCLAW_PROFILE,
+        messaging: {
+          plan: {
+            ...OPENCLAW_PROFILE.messaging.plan,
+            buildSteps: [
+              {
+                channelId: "slack",
+                kind: "package-install",
+                outputId: "slack-openclaw-plugin",
+                required: true,
+                value: {
+                  manager: "npm",
+                  spec: "@slack/web-api@7.9.3",
+                  pin: true,
+                },
+              },
+            ],
+            agentRender: [
+              ...OPENCLAW_PROFILE.messaging.plan.agentRender,
+              {
+                channelId: "slack",
+                agent: "hermes",
+                target: "~/.hermes/.env",
+                kind: "env-lines",
+                lines: [
+                  "SLACK_BOT_TOKEN=xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
+                  "DISCORD_BOT_TOKEN=openshell:resolve:env:DISCORD_BOT_TOKEN",
+                ],
+                templateRefs: ["credential.slackBotToken.placeholder"],
+              },
+            ],
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ["a raw credential", `SLACK_BOT_TOKEN=xoxb-${"a".repeat(32)}`],
+    ["a malformed assignment", "SLACK_BOT_TOKEN =openshell:resolve:env:SLACK_BOT_TOKEN"],
+    [
+      "a placeholder for a different environment key",
+      "SLACK_BOT_TOKEN=openshell:resolve:env:DISCORD_BOT_TOKEN",
+    ],
+  ])("rejects %s in messaging environment lines (#9355)", (_label, line) => {
+    expect(() =>
+      validateManagedStartupProfile({
+        ...OPENCLAW_PROFILE,
+        messaging: {
+          plan: {
+            ...OPENCLAW_PROFILE.messaging.plan,
+            agentRender: [
+              {
+                channelId: "slack",
+                agent: "hermes",
+                target: "~/.hermes/.env",
+                kind: "env-lines",
+                lines: [line],
+                templateRefs: ["credential.slackBotToken.placeholder"],
+              },
+            ],
+          },
+        },
+      }),
+    ).toThrow(/credential-shaped string data/);
+  });
+
+  it.each([
+    [
+      "a package pin outside buildSteps[*].value",
+      {
+        ...OPENCLAW_PROFILE.messaging.plan,
+        buildSteps: [{ pin: true }],
+      },
+    ],
+    [
+      "a non-boolean package pin",
+      {
+        ...OPENCLAW_PROFILE.messaging.plan,
+        buildSteps: [{ value: { pin: "true" } }],
+      },
+    ],
+    [
+      "a credential placeholder assignment outside agentRender[*].lines[*]",
+      {
+        ...OPENCLAW_PROFILE.messaging.plan,
+        note: "SLACK_BOT_TOKEN=openshell:resolve:env:SLACK_BOT_TOKEN",
+      },
+    ],
+  ])("rejects %s (#9355)", (_label, plan) => {
+    expect(() =>
+      validateManagedStartupProfile({
+        ...OPENCLAW_PROFILE,
+        messaging: { plan },
+      }),
+    ).toThrow(/credential-shaped/);
+  });
+
   it.each([
     ["routed inference", "inference", "routedBaseUrl"],
     ["upstream inference", "inference", "upstreamEndpointUrl"],

--- a/src/lib/onboard/managed-startup-profile.test.ts
+++ b/src/lib/onboard/managed-startup-profile.test.ts
@@ -759,6 +759,7 @@ describe("managed startup profile", () => {
                 lines: [
                   "SLACK_BOT_TOKEN=xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
                   "DISCORD_BOT_TOKEN=openshell:resolve:env:DISCORD_BOT_TOKEN",
+                  "TELEGRAM_BOT_TOKEN=openshell:resolve:env:v1_TELEGRAM_BOT_TOKEN",
                 ],
                 templateRefs: ["credential.slackBotToken.placeholder"],
               },
@@ -775,6 +776,10 @@ describe("managed startup profile", () => {
     [
       "a placeholder for a different environment key",
       "SLACK_BOT_TOKEN=openshell:resolve:env:DISCORD_BOT_TOKEN",
+    ],
+    [
+      "a versioned placeholder for a different environment key",
+      "SLACK_BOT_TOKEN=openshell:resolve:env:v1_DISCORD_BOT_TOKEN",
     ],
   ])("rejects %s in messaging environment lines (#9355)", (_label, line) => {
     expect(() =>
@@ -819,6 +824,13 @@ describe("managed startup profile", () => {
       {
         ...OPENCLAW_PROFILE.messaging.plan,
         note: "SLACK_BOT_TOKEN=openshell:resolve:env:SLACK_BOT_TOKEN",
+      },
+    ],
+    [
+      "a direct credential placeholder outside schema-owned fields",
+      {
+        ...OPENCLAW_PROFILE.messaging.plan,
+        note: "openshell:resolve:env:SLACK_BOT_TOKEN",
       },
     ],
   ])("rejects %s (#9355)", (_label, plan) => {

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -994,13 +994,24 @@ function valueLooksLikeSecret(value: string): boolean {
 }
 
 function isMessagingCredentialPlaceholder(path: readonly string[], value: unknown): boolean {
-  return (
-    path.length >= 2 &&
+  if (typeof value !== "string" || !MESSAGING_CREDENTIAL_PLACEHOLDER_RE.test(value)) {
+    return false;
+  }
+  const isCredentialBindingPlaceholder =
+    path.length === 5 &&
     path[0] === "messaging" &&
     path[1] === "plan" &&
-    typeof value === "string" &&
-    MESSAGING_CREDENTIAL_PLACEHOLDER_RE.test(value)
-  );
+    path[2] === "credentialBindings" &&
+    JSON_ARRAY_INDEX_SEGMENT_RE.test(path[3] ?? "") &&
+    path[4] === "placeholder";
+  const isAgentRenderValuePlaceholder =
+    path.length >= 5 &&
+    path[0] === "messaging" &&
+    path[1] === "plan" &&
+    path[2] === "agentRender" &&
+    JSON_ARRAY_INDEX_SEGMENT_RE.test(path[3] ?? "") &&
+    path[4] === "value";
+  return isCredentialBindingPlaceholder || isAgentRenderValuePlaceholder;
 }
 
 function messagingCredentialPlaceholderEnvKey(value: string): string | null {
@@ -1503,7 +1514,7 @@ function assertPayloadStructureAndCredentialShapes(root: unknown): void {
         const child = descriptor.value;
         if (
           isCredentialShapedName(key) &&
-          !isMessagingCredentialPlaceholder(current.path, child) &&
+          !isMessagingCredentialPlaceholder([...current.path, key], child) &&
           !isMessagingPackagePin([...current.path, key], child)
         ) {
           invalid(

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -1841,7 +1841,10 @@ function validateInference(value: unknown, agent: ManagedStartupAgent): ManagedS
     if (primaryModelRef !== null || compatibility !== null || inputModalities !== null) {
       invalid(`${agent} does not support primaryModelRef, compatibility, or inputModalities`);
     }
-    if (agent === "langchain-deepagents-code" && !isValidDcodeUpstreamProvider(upstreamProvider)) {
+    if (
+      agent === "langchain-deepagents-code" &&
+      !isValidDcodeUpstreamProvider(upstreamProvider)
+    ) {
       invalid(
         "inference.upstreamProvider must start with an ASCII letter or digit and contain 1-64 ASCII letters, digits, dots, underscores, or hyphens for DCode",
       );

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -59,6 +59,7 @@ const NON_SECRET_KEY_METADATA_NAMES = new Set([
 ]);
 const MESSAGING_CREDENTIAL_PLACEHOLDER_RE =
   /^(?:openshell:resolve:env:|[A-Za-z0-9]+-OPENSHELL-RESOLVE-ENV-)(?:v[0-9]+_)?[A-Z][A-Z0-9_]*$/u;
+const JSON_ARRAY_INDEX_SEGMENT_RE = /^\[(?:0|[1-9][0-9]*)\]$/u;
 const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
   /nvapi-[A-Za-z0-9_-]{10,}/u,
   /nvcf-[A-Za-z0-9_-]{10,}/u,
@@ -1002,6 +1003,54 @@ function isMessagingCredentialPlaceholder(path: readonly string[], value: unknow
   );
 }
 
+function messagingCredentialPlaceholderEnvKey(value: string): string | null {
+  if (!MESSAGING_CREDENTIAL_PLACEHOLDER_RE.test(value)) return null;
+  const marker = value.startsWith("openshell:resolve:env:")
+    ? "openshell:resolve:env:"
+    : "-OPENSHELL-RESOLVE-ENV-";
+  const key = value.slice(value.indexOf(marker) + marker.length);
+  return key.replace(/^v[0-9]+_/u, "");
+}
+
+function containsMessagingCredentialPlaceholder(value: string): boolean {
+  return value.includes("openshell:resolve:env:") || value.includes("-OPENSHELL-RESOLVE-ENV-");
+}
+
+function isMessagingCredentialPlaceholderAssignment(
+  path: readonly string[],
+  value: string,
+): boolean {
+  if (
+    path.length !== 6 ||
+    path[0] !== "messaging" ||
+    path[1] !== "plan" ||
+    path[2] !== "agentRender" ||
+    !JSON_ARRAY_INDEX_SEGMENT_RE.test(path[3] ?? "") ||
+    path[4] !== "lines" ||
+    !JSON_ARRAY_INDEX_SEGMENT_RE.test(path[5] ?? "")
+  ) {
+    return false;
+  }
+  const separator = value.indexOf("=");
+  if (separator <= 0 || value.indexOf("=", separator + 1) !== -1) return false;
+  const envKey = value.slice(0, separator);
+  const placeholderEnvKey = messagingCredentialPlaceholderEnvKey(value.slice(separator + 1));
+  return CREDENTIAL_ENV_NAME_PATTERN.test(envKey) && envKey === placeholderEnvKey;
+}
+
+function isMessagingPackagePin(path: readonly string[], value: unknown): boolean {
+  return (
+    path.length === 6 &&
+    path[0] === "messaging" &&
+    path[1] === "plan" &&
+    path[2] === "buildSteps" &&
+    JSON_ARRAY_INDEX_SEGMENT_RE.test(path[3] ?? "") &&
+    path[4] === "value" &&
+    path[5] === "pin" &&
+    typeof value === "boolean"
+  );
+}
+
 function containsUrlWithCredentialMaterial(value: string): boolean {
   const candidates = value.match(URL_CANDIDATE_RE) ?? [];
   for (let index = 0; index < candidates.length; index += 1) {
@@ -1367,7 +1416,9 @@ function assertPayloadStructureAndCredentialShapes(root: unknown): void {
       observeText(current.value);
       if (
         !isMessagingCredentialPlaceholder(current.path, current.value) &&
-        valueLooksLikeSecret(current.value)
+        !isMessagingCredentialPlaceholderAssignment(current.path, current.value) &&
+        (valueLooksLikeSecret(current.value) ||
+          containsMessagingCredentialPlaceholder(current.value))
       ) {
         invalid(
           `payload field ${payloadPath(current.path)} contains credential-shaped string data`,
@@ -1450,7 +1501,11 @@ function assertPayloadStructureAndCredentialShapes(root: unknown): void {
           invalid("payload must contain only JSON data properties");
         }
         const child = descriptor.value;
-        if (isCredentialShapedName(key) && !isMessagingCredentialPlaceholder(current.path, child)) {
+        if (
+          isCredentialShapedName(key) &&
+          !isMessagingCredentialPlaceholder(current.path, child) &&
+          !isMessagingPackagePin([...current.path, key], child)
+        ) {
           invalid(
             `payload field ${payloadPath([...current.path, key])} has a credential-shaped field name`,
           );
@@ -1775,10 +1830,7 @@ function validateInference(value: unknown, agent: ManagedStartupAgent): ManagedS
     if (primaryModelRef !== null || compatibility !== null || inputModalities !== null) {
       invalid(`${agent} does not support primaryModelRef, compatibility, or inputModalities`);
     }
-    if (
-      agent === "langchain-deepagents-code" &&
-      !isValidDcodeUpstreamProvider(upstreamProvider)
-    ) {
+    if (agent === "langchain-deepagents-code" && !isValidDcodeUpstreamProvider(upstreamProvider)) {
       invalid(
         "inference.upstreamProvider must start with an ASCII letter or digit and contain 1-64 ASCII letters, digits, dots, underscores, or hyphens for DCode",
       );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The managed startup profile validator rejected hydrated messaging package pins and credential placeholder lines before sandbox startup. This change accepts only the two schema-owned forms while continuing to reject raw credentials, malformed assignments, mismatched keys, wrong paths, and wrong types.

## Related Issue
Fixes #9355

## Changes
- Accept a boolean `pin` only at `messaging.plan.buildSteps[*].value.pin`.
- Accept a single canonical environment assignment only at `messaging.plan.agentRender[*].lines[*]` when its approved credential placeholder key matches the left-hand environment key.
- Add focused positive and negative regression coverage for both accepted forms and the nearby rejection cases.
- Close the detection gap where the generic credential-shape scanner had tests for standalone placeholders and raw secrets, but not for the hydrated messaging plan shapes that own these values.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer Aaron Erickson authorized admin merge on 2026-08-17 after exact-head CI, CodeRabbit, all feedback, and regression evidence were reviewed. CodeRabbit reports minimal merge risk and no actionable comments; the exact-head advisor recommends `merge_as_is` with no canonical findings.
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: Maintainer Aaron Erickson accepted `CI / Pull Request / cli-test-shards (6)` and its `cli-tests`/`checks` aggregates. The unchanged current-main test references the renamed `Authorize Launchable image publication` step; PR #9369 corrects that one-line contract, and merged PR #9370 records the same accepted non-success. The failure does not overlap this PR's files or behavior.

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/managed-startup-profile.test.ts` (120 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Exact-head qualification: [unfiltered PR E2E run 32080556047](https://github.com/NVIDIA/NemoClaw/actions/runs/32080556047) tested `512a2fc0942516fb2533252fe2bedc931992444c`. The current-main `messaging-providers` issue gate passed with every phase green, and protected all-agent GPU/local-inference/rollback/cleanup qualification passed. Eight unrelated non-successes were classified: six old-head OpenClaw ownership-handoff/cascade failures fixed on current `main` by #9370, one GPU runner driver/library mismatch that failed closed, and one Deep Agents evidence-publication failure after its behavior phases passed. The four additional #9355 targets live only in the still-unmerged #9323 matrix and must rerun there after #9323 consumes this prerequisite.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for credential placeholders in messaging startup configurations.
  * Added support for boolean package-install pins.
  * Valid credential references and correctly placed package pins are now accepted.

* **Bug Fixes**
  * Improved validation of credential placeholders and package pins.
  * Continued rejecting raw credentials, malformed or mismatched assignments, misplaced pins, invalid pin types, and unsupported placeholder locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
