### PR TITLE
fix(e2e): detect credential values in sandbox scans

### DIFF
--- a/nemoclaw/src/security/secret-scanner.ts
+++ b/nemoclaw/src/security/secret-scanner.ts
@@ -21,15 +21,48 @@ interface SecretPattern {
   regex: RegExp;
 }
 
+/** Provider token formats shared by the in-process and sandbox scanners. */
+export const HIGH_CONFIDENCE_PREFIXED_TOKEN_SPECS = [
+  {
+    name: "NVIDIA API key",
+    prefixes: ["nvapi-"],
+    payloadCharacterClass: "A-Za-z0-9_-",
+    minimumPayloadLength: 20,
+  },
+  {
+    name: "GitHub token",
+    prefixes: ["ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_"],
+    payloadCharacterClass: "A-Za-z0-9",
+    minimumPayloadLength: 36,
+  },
+  {
+    name: "npm token",
+    prefixes: ["npm_"],
+    payloadCharacterClass: "A-Za-z0-9",
+    minimumPayloadLength: 36,
+  },
+] as const;
+
+/** POSIX ERE for high-confidence provider tokens in sandbox shell scans. */
+export const HIGH_CONFIDENCE_PREFIXED_TOKEN_ERE = `(${HIGH_CONFIDENCE_PREFIXED_TOKEN_SPECS.flatMap(
+  ({ prefixes, payloadCharacterClass, minimumPayloadLength }) =>
+    prefixes.map(
+      (prefix) => `${prefix}[${payloadCharacterClass}]{${minimumPayloadLength},}`,
+    ),
+).join("|")})`;
+
 const SECRET_PATTERNS: SecretPattern[] = [
-  // NVIDIA
-  { name: "NVIDIA API key", regex: /\bnvapi-[A-Za-z0-9_-]{20,}\b/ },
+  ...HIGH_CONFIDENCE_PREFIXED_TOKEN_SPECS.map(
+    ({ name, prefixes, payloadCharacterClass, minimumPayloadLength }) => ({
+      name,
+      regex: new RegExp(
+        `\\b(?:${prefixes.join("|")})[${payloadCharacterClass}]{${minimumPayloadLength},}\\b`,
+      ),
+    }),
+  ),
 
   // OpenAI — exclude sk-ant- (Anthropic) to avoid double-matching
   { name: "OpenAI API key", regex: /\bsk-(?!ant-)[A-Za-z0-9_-]{20,}\b/ },
-
-  // GitHub
-  { name: "GitHub token", regex: /\b(ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9]{36,}\b/ },
 
   // AWS
   { name: "AWS access key", regex: /\bAKIA[0-9A-Z]{16}\b/ },
@@ -47,9 +80,6 @@ const SECRET_PATTERNS: SecretPattern[] = [
     regex:
       /(?<=(?:discord|bot|DISCORD_TOKEN|BOT_TOKEN|token)\s*[=:]\s*["']?)[A-Za-z0-9]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}/,
   },
-
-  // npm
-  { name: "npm token", regex: /\bnpm_[A-Za-z0-9]{36,}\b/ },
 
   // Private keys (PEM)
   {

--- a/test/e2e/live/cloud-inference-secret-pattern.ts
+++ b/test/e2e/live/cloud-inference-secret-pattern.ts
@@ -1,5 +1,0 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-export const SANDBOX_SECRET_TOKEN_PATTERN =
-  "(nvapi-[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9_-]{10,}|npm_[A-Za-z0-9]{10,})";

--- a/test/e2e/live/cloud-inference-secret-pattern.ts
+++ b/test/e2e/live/cloud-inference-secret-pattern.ts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const SANDBOX_SECRET_TOKEN_PATTERN =
+  "(nvapi-[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9_-]{10,}|npm_[A-Za-z0-9]{10,})";

--- a/test/e2e/live/cloud-inference.test.ts
+++ b/test/e2e/live/cloud-inference.test.ts
@@ -32,7 +32,7 @@ import {
   parseCloudChatResponse,
   type PreContractExternalProviderFailure,
 } from "./cloud-inference-provider-skip.ts";
-import { SANDBOX_SECRET_TOKEN_PATTERN } from "./cloud-inference-secret-pattern.ts";
+import { HIGH_CONFIDENCE_PREFIXED_TOKEN_ERE } from "../../../nemoclaw/src/security/secret-scanner.ts";
 
 const REPO_SKILL_VALIDATOR = path.join(
   REPO_ROOT,
@@ -306,7 +306,7 @@ async function expectSandboxCredentialBoundary(
   const secretScanCommand = [
     "for dir in /sandbox/.openclaw /sandbox/.nemoclaw; do",
     '  [ -d "$dir" ] || continue',
-    `  matches=$(grep -rIlE '${SANDBOX_SECRET_TOKEN_PATTERN}' "$dir")`,
+    `  matches=$(grep -rIlE '${HIGH_CONFIDENCE_PREFIXED_TOKEN_ERE}' "$dir")`,
     "  scan_status=$?",
     '  case "$scan_status" in',
     `    0) filtered=$(printf '%s\\n' "$matches" | grep -Ev '/policies/|/plugin-runtime-deps/|/extensions/[^/]+/(dist|node_modules)/')`,
@@ -320,7 +320,7 @@ async function expectSandboxCredentialBoundary(
     "            write_status=$?",
     '            case "$write_status" in 0) ;; *) exit "$write_status" ;; esac',
     "            while IFS= read -r file; do",
-    `              matching_lines=$(grep -IE '${SANDBOX_SECRET_TOKEN_PATTERN}' "$file")`,
+    `              matching_lines=$(grep -IE '${HIGH_CONFIDENCE_PREFIXED_TOKEN_ERE}' "$file")`,
     "              match_status=$?",
     '              case "$match_status" in',
     `                0) printf '%s' "$matching_lines" | grep -qv 'STRIPPED'`,

--- a/test/e2e/live/cloud-inference.test.ts
+++ b/test/e2e/live/cloud-inference.test.ts
@@ -32,6 +32,7 @@ import {
   parseCloudChatResponse,
   type PreContractExternalProviderFailure,
 } from "./cloud-inference-provider-skip.ts";
+import { SANDBOX_SECRET_TOKEN_PATTERN } from "./cloud-inference-secret-pattern.ts";
 
 const REPO_SKILL_VALIDATOR = path.join(
   REPO_ROOT,
@@ -305,7 +306,7 @@ async function expectSandboxCredentialBoundary(
   const secretScanCommand = [
     "for dir in /sandbox/.openclaw /sandbox/.nemoclaw; do",
     '  [ -d "$dir" ] || continue',
-    `  matches=$(grep -rIlE 'nvapi-|ghp_|npm_' "$dir")`,
+    `  matches=$(grep -rIlE '${SANDBOX_SECRET_TOKEN_PATTERN}' "$dir")`,
     "  scan_status=$?",
     '  case "$scan_status" in',
     `    0) filtered=$(printf '%s\\n' "$matches" | grep -Ev '/policies/|/plugin-runtime-deps/|/extensions/[^/]+/(dist|node_modules)/')`,
@@ -319,7 +320,7 @@ async function expectSandboxCredentialBoundary(
     "            write_status=$?",
     '            case "$write_status" in 0) ;; *) exit "$write_status" ;; esac',
     "            while IFS= read -r file; do",
-    `              matching_lines=$(grep -IE 'nvapi-|ghp_|npm_' "$file")`,
+    `              matching_lines=$(grep -IE '${SANDBOX_SECRET_TOKEN_PATTERN}' "$file")`,
     "              match_status=$?",
     '              case "$match_status" in',
     `                0) printf '%s' "$matching_lines" | grep -qv 'STRIPPED'`,

--- a/test/e2e/support/cloud-inference-credential-pattern.test.ts
+++ b/test/e2e/support/cloud-inference-credential-pattern.test.ts
@@ -3,9 +3,9 @@
 
 import { describe, expect, it } from "vitest";
 
-import { SANDBOX_SECRET_TOKEN_PATTERN } from "../live/cloud-inference-secret-pattern.ts";
+import { HIGH_CONFIDENCE_PREFIXED_TOKEN_ERE } from "../../../nemoclaw/src/security/secret-scanner.ts";
 
-const credentialPattern = new RegExp(SANDBOX_SECRET_TOKEN_PATTERN, "u");
+const credentialPattern = new RegExp(HIGH_CONFIDENCE_PREFIXED_TOKEN_ERE, "u");
 
 describe("cloud inference credential scan", () => {
   it.each([
@@ -24,17 +24,19 @@ describe("cloud inference credential scan", () => {
     expect(value).toMatch(credentialPattern);
   });
 
-  it.each(["nvapi-", "ghp_", "npm_"])(
-    "rejects a nine-character payload for %s",
-    (prefix) => {
-      expect(`${prefix}${"a".repeat(9)}`).not.toMatch(credentialPattern);
-    },
-  );
+  it.each([
+    ["nvapi-", 20],
+    ["ghp_", 36],
+    ["npm_", 36],
+  ])("enforces the minimum payload for %s", (prefix, minimumPayloadLength) => {
+    expect(`${prefix}${"a".repeat(minimumPayloadLength - 1)}`).not.toMatch(credentialPattern);
+    expect(`${prefix}${"a".repeat(minimumPayloadLength)}`).toMatch(credentialPattern);
+  });
 
-  it.each(["nvapi-", "ghp_", "npm_"])(
-    "detects a ten-character payload for %s",
+  it.each(["gho_", "ghu_", "ghs_", "ghr_", "github_pat_"])(
+    "detects a supported GitHub token prefix: %s",
     (prefix) => {
-      expect(`${prefix}${"a".repeat(10)}`).toMatch(credentialPattern);
+      expect(`${prefix}${"a".repeat(36)}`).toMatch(credentialPattern);
     },
   );
 });

--- a/test/e2e/support/cloud-inference-credential-pattern.test.ts
+++ b/test/e2e/support/cloud-inference-credential-pattern.test.ts
@@ -23,4 +23,18 @@ describe("cloud inference credential scan", () => {
   ])("detects a credential-shaped value", (value) => {
     expect(value).toMatch(credentialPattern);
   });
+
+  it.each(["nvapi-", "ghp_", "npm_"])(
+    "rejects a nine-character payload for %s",
+    (prefix) => {
+      expect(`${prefix}${"a".repeat(9)}`).not.toMatch(credentialPattern);
+    },
+  );
+
+  it.each(["nvapi-", "ghp_", "npm_"])(
+    "detects a ten-character payload for %s",
+    (prefix) => {
+      expect(`${prefix}${"a".repeat(10)}`).toMatch(credentialPattern);
+    },
+  );
 });

--- a/test/e2e/support/cloud-inference-credential-pattern.test.ts
+++ b/test/e2e/support/cloud-inference-credential-pattern.test.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { SANDBOX_SECRET_TOKEN_PATTERN } from "../live/cloud-inference-secret-pattern.ts";
+
+const credentialPattern = new RegExp(SANDBOX_SECRET_TOKEN_PATTERN, "u");
+
+describe("cloud inference credential scan", () => {
+  it.each([
+    "/sandbox/.openclaw/extensions/example/node_modules/thread-stream/test/ts/transpile.sh",
+    "/sandbox/.openclaw/extensions/example/node_modules/jwks-rsa/package.json",
+    "package-lock entry for npm_config_cache metadata",
+  ])("accepts dependency text without a credential value: %s", (value) => {
+    expect(value).not.toMatch(credentialPattern);
+  });
+
+  it.each([
+    `NVIDIA_INFERENCE_API_KEY=nvapi-${"a".repeat(30)}`,
+    `GITHUB_TOKEN=ghp_${"b".repeat(36)}`,
+    `NPM_TOKEN=npm_${"c".repeat(36)}`,
+  ])("detects a credential-shaped value", (value) => {
+    expect(value).toMatch(credentialPattern);
+  });
+});


### PR DESCRIPTION
## Summary

The cloud-inference credential scan now distinguishes complete credential-shaped values from harmless dependency text. Dependency paths and package metadata no longer fail the scan, while NVIDIA, GitHub, and npm token-shaped values still do.

## Related Issue

Fixes #9363

## Changes

- Require a minimum credential payload after each scanned token prefix.
- Use the same pattern for file discovery and matching-line confirmation.
- Cover the reported dependency examples and representative credential canaries.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/e2e/support/cloud-inference-credential-pattern.test.ts` (6 passed)
- [x] Applicable broad gate passed — `npm run build:cli`, `npm run typecheck:cli`, repository checks, and codebase growth guardrails passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of high-confidence NVIDIA, GitHub, and npm credentials during sandbox scans.
  * Reduced false positives by enforcing provider-specific token formats and minimum lengths.

* **Tests**
  * Added coverage for valid credentials, unsupported or incomplete values, dependency text without credentials, and additional GitHub token prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->