### PR TITLE
fix(policy): allow managed startup CA reads

### DIFF
--- a/agents/hermes/policy-additions.yaml
+++ b/agents/hermes/policy-additions.yaml
@@ -22,6 +22,7 @@ filesystem_policy:
     - /dev/urandom
     - /app
     - /etc
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /var/log
     - /var/lib/dpkg                  # Allow package-version inspection without package mutation.
   read_write:

--- a/agents/hermes/policy-permissive.yaml
+++ b/agents/hermes/policy-permissive.yaml
@@ -23,6 +23,7 @@ filesystem_policy:
     - /dev/urandom
     - /app
     - /etc
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /var/log
     - /var/lib/dpkg                  # Allow package-version inspection without package mutation.
   read_write:

--- a/agents/langchain-deepagents-code/policy-additions.yaml
+++ b/agents/langchain-deepagents-code/policy-additions.yaml
@@ -19,6 +19,7 @@ filesystem_policy:
     - /dev/urandom
     - /app
     - /etc
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /var/log
     - /var/lib/dpkg                  # Allow package-version inspection without package mutation.
   read_write:

--- a/agents/openclaw/policy-permissive.yaml
+++ b/agents/openclaw/policy-permissive.yaml
@@ -19,6 +19,7 @@ filesystem_policy:
     - /dev/urandom
     - /app
     - /etc
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /var/log
     - /var/lib/dpkg                  # Allow package-version inspection without package mutation.
   read_write:

--- a/agents/pi/policy-additions.yaml
+++ b/agents/pi/policy-additions.yaml
@@ -13,6 +13,7 @@ filesystem_policy:
     - /proc
     - /dev/urandom
     - /etc
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /var/log
     - /var/lib/dpkg # Allow package-version inspection without package mutation.
   read_write:

--- a/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
@@ -24,6 +24,7 @@ filesystem_policy:
     - /dev/urandom
     - /app
     - /etc
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /var/log
     - /var/lib/dpkg                  # Allow package-version inspection without package mutation.
   read_write:

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -27,6 +27,7 @@ filesystem_policy:
     - /dev/urandom
     - /app
     - /etc
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /var/log
     - /var/lib/dpkg                  # Allow package-version inspection without package mutation.
   read_write:

--- a/test/managed-startup-ca-policy.test.ts
+++ b/test/managed-startup-ca-policy.test.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+const CA_BUNDLE = "/run/nemoclaw/managed-startup-ca-bundle.pem";
+const POLICY_PATHS = [
+  "nemoclaw-blueprint/policies/openclaw-sandbox.yaml",
+  "nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml",
+  "agents/openclaw/policy-permissive.yaml",
+  "agents/hermes/policy-additions.yaml",
+  "agents/hermes/policy-permissive.yaml",
+  "agents/langchain-deepagents-code/policy-additions.yaml",
+  "agents/pi/policy-additions.yaml",
+] as const;
+
+type Policy = {
+  filesystem_policy?: {
+    read_only?: string[];
+    read_write?: string[];
+  };
+};
+
+describe("managed startup CA policy", () => {
+  it.each(POLICY_PATHS)("grants only exact read access in %s", (policyPath) => {
+    const policy = YAML.parse(readFileSync(policyPath, "utf8")) as Policy;
+
+    expect(policy.filesystem_policy?.read_only).toContain(CA_BUNDLE);
+    expect(policy.filesystem_policy?.read_write ?? []).not.toContain(CA_BUNDLE);
+    expect(policy.filesystem_policy?.read_write ?? []).not.toContain("/run/nemoclaw");
+  });
+});

--- a/test/managed-startup-ca-policy.test.ts
+++ b/test/managed-startup-ca-policy.test.ts
@@ -27,9 +27,16 @@ type Policy = {
 describe("managed startup CA policy", () => {
   it.each(POLICY_PATHS)("grants only exact read access in %s", (policyPath) => {
     const policy = YAML.parse(readFileSync(policyPath, "utf8")) as Policy;
+    const runtimePrefix = "/run/nemoclaw";
+    const readOnlyRuntimeGrants = (policy.filesystem_policy?.read_only ?? []).filter(
+      (entry) => entry === runtimePrefix || entry.startsWith(`${runtimePrefix}/`),
+    );
+    const readWriteRuntimeGrants = (policy.filesystem_policy?.read_write ?? []).filter(
+      (entry) => entry === runtimePrefix || entry.startsWith(`${runtimePrefix}/`),
+    );
 
     expect(policy.filesystem_policy?.read_only).toContain(CA_BUNDLE);
-    expect(policy.filesystem_policy?.read_write ?? []).not.toContain(CA_BUNDLE);
-    expect(policy.filesystem_policy?.read_write ?? []).not.toContain("/run/nemoclaw");
+    expect(readOnlyRuntimeGrants).toEqual([CA_BUNDLE]);
+    expect(readWriteRuntimeGrants).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Shipping managed-agent policies now grant read-only access to the exact merged CA bundle produced during startup. The broader mutable `/run/nemoclaw` directory remains outside the policy grant.

## Related Issue

Fixes #9360

## Changes

- Add the exact managed CA file to OpenClaw, Hermes, Deep Agents Code, and Pi policy sources.
- Keep the file and its parent out of every writable path list.
- Add a policy-contract test covering baseline and permissive variants.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/managed-startup-ca-policy.test.ts` (7 passed)
- [x] Applicable broad gate passed — `npm run build:cli`, `npm run typecheck:cli`, repository checks, config schema validation, and codebase growth guardrails passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Sandboxed agents can now access the managed startup certificate bundle in read-only mode.
  - Updated sandbox policies consistently support secure certificate-based connections without exposing broader runtime directories.
  - Access remains narrowly scoped and does not permit modifications to the certificate bundle or surrounding files.

- **Tests**
  - Added coverage confirming the certificate bundle is read-only and that broader runtime-directory access remains blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->