### PR TITLE
fix(policy): grant managed startup CA bundle read access

### DIFF
--- a/agents/hermes/policy-additions.yaml
+++ b/agents/hermes/policy-additions.yaml
@@ -21,6 +21,7 @@ filesystem_policy:
     - /proc
     - /dev/urandom
     - /app
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /etc
     - /var/log
     - /var/lib/dpkg                  # Allow package-version inspection without package mutation.

--- a/agents/hermes/policy-permissive.yaml
+++ b/agents/hermes/policy-permissive.yaml
@@ -22,6 +22,7 @@ filesystem_policy:
     - /proc
     - /dev/urandom
     - /app
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /etc
     - /var/log
     - /var/lib/dpkg                  # Allow package-version inspection without package mutation.

--- a/agents/langchain-deepagents-code/policy-additions.yaml
+++ b/agents/langchain-deepagents-code/policy-additions.yaml
@@ -18,6 +18,7 @@ filesystem_policy:
     - /proc
     - /dev/urandom
     - /app
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /etc
     - /var/log
     - /var/lib/dpkg                  # Allow package-version inspection without package mutation.

--- a/agents/openclaw/policy-permissive.yaml
+++ b/agents/openclaw/policy-permissive.yaml
@@ -18,6 +18,7 @@ filesystem_policy:
     - /proc
     - /dev/urandom
     - /app
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /etc
     - /var/log
     - /var/lib/dpkg                  # Allow package-version inspection without package mutation.

--- a/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml
@@ -23,6 +23,7 @@ filesystem_policy:
     - /proc
     - /dev/urandom
     - /app
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /etc
     - /var/log
     - /var/lib/dpkg                  # Allow package-version inspection without package mutation.

--- a/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+++ b/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
@@ -26,6 +26,7 @@ filesystem_policy:
     - /proc
     - /dev/urandom
     - /app
+    - /run/nemoclaw/managed-startup-ca-bundle.pem
     - /etc
     - /var/log
     - /var/lib/dpkg                  # Allow package-version inspection without package mutation.

--- a/src/lib/onboard/initial-policy-real-policy.test.ts
+++ b/src/lib/onboard/initial-policy-real-policy.test.ts
@@ -7,6 +7,8 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import YAML from "yaml";
 
+import { SHIPPED_MANAGED_IMAGE_AGENTS } from "./managed-image/contract";
+import { MANAGED_STARTUP_MERGED_CA_FILE } from "./managed-startup/image-runtime";
 import { prepareInitialSandboxCreatePolicy } from "./initial-policy";
 
 type PolicyRule = {
@@ -69,6 +71,39 @@ describe("initial sandbox policy real preset merge", () => {
     { path: ["agents", "hermes", "policy-additions.yaml"], agent: "hermes" },
     { path: ["agents", "hermes", "policy-permissive.yaml"], agent: "hermes" },
   ] as const;
+
+  const managedStartupCaPolicyCases = [
+    ...shippingPolicyCases,
+    {
+      path: ["agents", "langchain-deepagents-code", "policy-additions.yaml"],
+      agent: "langchain-deepagents-code",
+    },
+  ] as const;
+
+  it("covers every shipped managed-image agent in the managed startup CA policy cases", () => {
+    expect(new Set(managedStartupCaPolicyCases.map(({ agent }) => agent))).toEqual(
+      new Set(SHIPPED_MANAGED_IMAGE_AGENTS),
+    );
+  });
+
+  it.each(managedStartupCaPolicyCases)(
+    "grants $agent policy $path exact read-only access to the managed startup CA bundle (#9360)",
+    (policyCase) => {
+      const prepared = prepareInitialSandboxCreatePolicy(repoPath(...policyCase.path), [], {
+        agentName: policyCase.agent,
+      });
+      const policy = readPreparedPolicy(prepared);
+      const readOnly = policy.filesystem_policy?.read_only ?? [];
+      const readWrite = policy.filesystem_policy?.read_write ?? [];
+
+      expect(readOnly, policyCase.path.join("/")).toContain(MANAGED_STARTUP_MERGED_CA_FILE);
+      expect(readWrite, policyCase.path.join("/")).not.toContain(MANAGED_STARTUP_MERGED_CA_FILE);
+      expect(readOnly, policyCase.path.join("/")).not.toContain("/run");
+      expect(readWrite, policyCase.path.join("/")).not.toContain("/run");
+      expect(readOnly, policyCase.path.join("/")).not.toContain("/run/nemoclaw");
+      expect(readWrite, policyCase.path.join("/")).not.toContain("/run/nemoclaw");
+    },
+  );
 
   it.each([
     {

--- a/src/lib/onboard/initial-policy-real-policy.test.ts
+++ b/src/lib/onboard/initial-policy-real-policy.test.ts
@@ -52,6 +52,20 @@ function repoPath(...segments: string[]): string {
   return path.join(import.meta.dirname, "..", "..", "..", ...segments);
 }
 
+function normalizeFilesystemPolicyPath(policyPath: string): string {
+  return path.posix.normalize(policyPath).replace(/\/+$/, "") || "/";
+}
+
+function filesystemPolicyAncestors(policyPath: string): string[] {
+  const segments = normalizeFilesystemPolicyPath(policyPath).split("/").filter(Boolean);
+  return [
+    "/",
+    ...segments
+      .slice(0, -1)
+      .map((_, index) => `/${segments.slice(0, index + 1).join("/")}`),
+  ];
+}
+
 function readPreparedPolicy(prepared: {
   policyPath: string;
   cleanup?: () => boolean;
@@ -80,7 +94,29 @@ describe("initial sandbox policy real preset merge", () => {
     },
   ] as const;
 
-  it("covers every shipped managed-image agent in the managed startup CA policy cases", () => {
+  it("covers the complete shipped managed startup CA policy matrix", () => {
+    expect(
+      managedStartupCaPolicyCases.map(({ path: policyPath, agent }) => ({
+        policyPath: policyPath.join("/"),
+        agent,
+      })),
+    ).toEqual([
+      {
+        policyPath: "nemoclaw-blueprint/policies/openclaw-sandbox.yaml",
+        agent: "openclaw",
+      },
+      {
+        policyPath: "nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml",
+        agent: "openclaw",
+      },
+      { policyPath: "agents/openclaw/policy-permissive.yaml", agent: "openclaw" },
+      { policyPath: "agents/hermes/policy-additions.yaml", agent: "hermes" },
+      { policyPath: "agents/hermes/policy-permissive.yaml", agent: "hermes" },
+      {
+        policyPath: "agents/langchain-deepagents-code/policy-additions.yaml",
+        agent: "langchain-deepagents-code",
+      },
+    ]);
     expect(new Set(managedStartupCaPolicyCases.map(({ agent }) => agent))).toEqual(
       new Set(SHIPPED_MANAGED_IMAGE_AGENTS),
     );
@@ -95,13 +131,22 @@ describe("initial sandbox policy real preset merge", () => {
       const policy = readPreparedPolicy(prepared);
       const readOnly = policy.filesystem_policy?.read_only ?? [];
       const readWrite = policy.filesystem_policy?.read_write ?? [];
+      const normalizedReadOnly = readOnly.map(normalizeFilesystemPolicyPath);
+      const normalizedReadWrite = readWrite.map(normalizeFilesystemPolicyPath);
+      const managedCaAncestors = filesystemPolicyAncestors(MANAGED_STARTUP_MERGED_CA_FILE);
 
       expect(readOnly, policyCase.path.join("/")).toContain(MANAGED_STARTUP_MERGED_CA_FILE);
-      expect(readWrite, policyCase.path.join("/")).not.toContain(MANAGED_STARTUP_MERGED_CA_FILE);
-      expect(readOnly, policyCase.path.join("/")).not.toContain("/run");
-      expect(readWrite, policyCase.path.join("/")).not.toContain("/run");
-      expect(readOnly, policyCase.path.join("/")).not.toContain("/run/nemoclaw");
-      expect(readWrite, policyCase.path.join("/")).not.toContain("/run/nemoclaw");
+      expect(normalizedReadWrite, policyCase.path.join("/")).not.toContain(
+        MANAGED_STARTUP_MERGED_CA_FILE,
+      );
+      expect(
+        normalizedReadOnly.filter((candidate) => managedCaAncestors.includes(candidate)),
+        policyCase.path.join("/"),
+      ).toEqual([]);
+      expect(
+        normalizedReadWrite.filter((candidate) => managedCaAncestors.includes(candidate)),
+        policyCase.path.join("/"),
+      ).toEqual([]);
     },
   );
 

--- a/src/lib/onboard/initial-policy-real-policy.test.ts
+++ b/src/lib/onboard/initial-policy-real-policy.test.ts
@@ -75,54 +75,42 @@ function readPreparedPolicy(prepared: {
 }
 
 describe("initial sandbox policy real preset merge", () => {
-  const shippingPolicyCases = [
-    { path: ["nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"], agent: "openclaw" },
-    {
-      path: ["nemoclaw-blueprint", "policies", "openclaw-sandbox-permissive.yaml"],
-      agent: "openclaw",
-    },
-    { path: ["agents", "openclaw", "policy-permissive.yaml"], agent: "openclaw" },
-    { path: ["agents", "hermes", "policy-additions.yaml"], agent: "hermes" },
-    { path: ["agents", "hermes", "policy-permissive.yaml"], agent: "hermes" },
-  ] as const;
+  const managedImagePolicyPathsByAgent = {
+    openclaw: [
+      ["nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"],
+      ["nemoclaw-blueprint", "policies", "openclaw-sandbox-permissive.yaml"],
+      ["agents", "openclaw", "policy-permissive.yaml"],
+    ],
+    hermes: [
+      ["agents", "hermes", "policy-additions.yaml"],
+      ["agents", "hermes", "policy-permissive.yaml"],
+    ],
+    "langchain-deepagents-code": [
+      ["agents", "langchain-deepagents-code", "policy-additions.yaml"],
+    ],
+  } as const satisfies Record<
+    (typeof SHIPPED_MANAGED_IMAGE_AGENTS)[number],
+    readonly (readonly string[])[]
+  >;
 
-  const managedStartupCaPolicyCases = [
-    ...shippingPolicyCases,
-    {
-      path: ["agents", "langchain-deepagents-code", "policy-additions.yaml"],
-      agent: "langchain-deepagents-code",
-    },
-  ] as const;
+  const managedImagePolicyCases = SHIPPED_MANAGED_IMAGE_AGENTS.flatMap((agent) =>
+    managedImagePolicyPathsByAgent[agent].map((policyPath) => ({ path: policyPath, agent })),
+  );
+  const shippingPolicyCases = managedImagePolicyCases.filter(
+    ({ agent }) => agent !== "langchain-deepagents-code",
+  );
 
   it("covers the complete shipped managed startup CA policy matrix", () => {
-    expect(
-      managedStartupCaPolicyCases.map(({ path: policyPath, agent }) => ({
-        policyPath: policyPath.join("/"),
-        agent,
-      })),
-    ).toEqual([
-      {
-        policyPath: "nemoclaw-blueprint/policies/openclaw-sandbox.yaml",
-        agent: "openclaw",
-      },
-      {
-        policyPath: "nemoclaw-blueprint/policies/openclaw-sandbox-permissive.yaml",
-        agent: "openclaw",
-      },
-      { policyPath: "agents/openclaw/policy-permissive.yaml", agent: "openclaw" },
-      { policyPath: "agents/hermes/policy-additions.yaml", agent: "hermes" },
-      { policyPath: "agents/hermes/policy-permissive.yaml", agent: "hermes" },
-      {
-        policyPath: "agents/langchain-deepagents-code/policy-additions.yaml",
-        agent: "langchain-deepagents-code",
-      },
-    ]);
-    expect(new Set(managedStartupCaPolicyCases.map(({ agent }) => agent))).toEqual(
-      new Set(SHIPPED_MANAGED_IMAGE_AGENTS),
+    const policyIdentities = managedImagePolicyCases.map(
+      ({ path: policyPath, agent }) => `${agent}:${policyPath.join("/")}`,
     );
+
+    expect(Object.keys(managedImagePolicyPathsByAgent)).toEqual([...SHIPPED_MANAGED_IMAGE_AGENTS]);
+    expect(policyIdentities).toHaveLength(6);
+    expect(new Set(policyIdentities).size).toBe(policyIdentities.length);
   });
 
-  it.each(managedStartupCaPolicyCases)(
+  it.each(managedImagePolicyCases)(
     "grants $agent policy $path exact read-only access to the managed startup CA bundle (#9360)",
     (policyCase) => {
       const prepared = prepareInitialSandboxCreatePolicy(repoPath(...policyCase.path), [], {
@@ -258,16 +246,8 @@ describe("initial sandbox policy real preset merge", () => {
     },
   );
 
-  const packageDatabasePolicyCases = [
-    ...shippingPolicyCases,
-    {
-      path: ["agents", "langchain-deepagents-code", "policy-additions.yaml"],
-      agent: "langchain-deepagents-code",
-    },
-  ] as const;
-
   it.each(
-    packageDatabasePolicyCases.flatMap((policyCase) =>
+    managedImagePolicyCases.flatMap((policyCase) =>
       ["/", "/var", "/var/lib", "/var/lib/dpkg"].map((writableAncestor) => ({
         policyCase,
         writableAncestor,


### PR DESCRIPTION
## Summary

Managed startup writes the active CA bundle to `/run/nemoclaw/managed-startup-ca-bundle.pem`, but the shipping filesystem policies do not allow agents to read that file. This change grants exact-file read access without granting access to the mutable `/run/nemoclaw` directory.

## Related Issue

Fixes #9360

## Changes

- Grant the managed startup CA bundle exact read-only access in each shipping OpenClaw, Hermes, and LangChain Deep Agents Code baseline and permissive policy.
- Add a real-policy regression test that covers every shipping managed-image agent and rejects read or write grants to `/run` and `/run/nemoclaw`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [PR Review Advisor](https://github.com/NVIDIA/NemoClaw/actions/runs/32094112349) reported 0 blockers, 0 warnings, and 0 suggestions on exact head `53efaff8d6`; maintainer security review found no findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/initial-policy-real-policy.test.ts` passed 59/59; `npm run validate:configs` validated all 53 configuration files.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; this diff changes six policy entries and one focused regression test.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sandbox policies to provide read-only access to the managed startup certificate bundle.
  * Ensured startup certificate access does not broaden permissions for other runtime directories.
  * Improved certificate availability during startup while preserving existing filesystem protections across supported managed agents.

* **Tests**
  * Added coverage verifying the certificate bundle is readable, not writable, and restricted to the intended path across supported managed agents.
  * Expanded policy validation to cover all shipped agent and sandbox policy combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->