### PR TITLE
fix(e2e): match credential values in sandbox scan

### DIFF
--- a/nemoclaw/src/security/secret-scanner.test.ts
+++ b/nemoclaw/src/security/secret-scanner.test.ts
@@ -11,6 +11,7 @@ const FAKE = {
   openai: "sk-" + "abc123def456ghi789jkl012mno",
   openaiProject: "sk-proj-" + "abc123_def456-ghi789_jkl012-mno345",
   github: "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn",
+  githubFineGrained: "github_pat_" + "ABCDEFGHIJKLMNO_PQRSTUVWXYZabc",
   aws: "AKIA" + "IOSFODNN7EXAMPLE",
   slack: "xoxb-" + "123456789-abcdefghij",
   slackApp: "xapp-" + "1-A0000-12345-abcdef",
@@ -50,6 +51,12 @@ describe("scanForSecrets", () => {
 
     it("detects a GitHub personal access token", () => {
       const matches = scanForSecrets(`token: ${FAKE.github}`);
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe("GitHub token");
+    });
+
+    it("detects an underscore-bearing fine-grained GitHub personal access token", () => {
+      const matches = scanForSecrets(`token: ${FAKE.githubFineGrained}`);
       expect(matches).toHaveLength(1);
       expect(matches[0].pattern).toBe("GitHub token");
     });

--- a/nemoclaw/src/security/secret-scanner.ts
+++ b/nemoclaw/src/security/secret-scanner.ts
@@ -31,9 +31,15 @@ export const HIGH_CONFIDENCE_PREFIXED_TOKEN_SPECS = [
   },
   {
     name: "GitHub token",
-    prefixes: ["ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_"],
+    prefixes: ["ghp_", "gho_", "ghu_", "ghs_", "ghr_"],
     payloadCharacterClass: "A-Za-z0-9",
     minimumPayloadLength: 36,
+  },
+  {
+    name: "GitHub token",
+    prefixes: ["github_pat_"],
+    payloadCharacterClass: "A-Za-z0-9_",
+    minimumPayloadLength: 30,
   },
   {
     name: "npm token",

--- a/nemoclaw/src/security/secret-scanner.ts
+++ b/nemoclaw/src/security/secret-scanner.ts
@@ -21,15 +21,48 @@ interface SecretPattern {
   regex: RegExp;
 }
 
+/** Provider token formats shared by the in-process and sandbox scanners. */
+export const HIGH_CONFIDENCE_PREFIXED_TOKEN_SPECS = [
+  {
+    name: "NVIDIA API key",
+    prefixes: ["nvapi-"],
+    payloadCharacterClass: "A-Za-z0-9_-",
+    minimumPayloadLength: 20,
+  },
+  {
+    name: "GitHub token",
+    prefixes: ["ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_"],
+    payloadCharacterClass: "A-Za-z0-9",
+    minimumPayloadLength: 36,
+  },
+  {
+    name: "npm token",
+    prefixes: ["npm_"],
+    payloadCharacterClass: "A-Za-z0-9",
+    minimumPayloadLength: 36,
+  },
+] as const;
+
+const HIGH_CONFIDENCE_PREFIXED_TOKEN_ALTERNATIVES = HIGH_CONFIDENCE_PREFIXED_TOKEN_SPECS.flatMap(
+  ({ prefixes, payloadCharacterClass, minimumPayloadLength }) =>
+    prefixes.map((prefix) => `${prefix}[${payloadCharacterClass}]{${minimumPayloadLength},}`),
+).join("|");
+
+/** POSIX ERE for standalone high-confidence provider tokens in sandbox shell scans. */
+export const HIGH_CONFIDENCE_PREFIXED_TOKEN_ERE = `(^|[^[:alnum:]_])(${HIGH_CONFIDENCE_PREFIXED_TOKEN_ALTERNATIVES})([^[:alnum:]_]|$)`;
+
 const SECRET_PATTERNS: SecretPattern[] = [
-  // NVIDIA
-  { name: "NVIDIA API key", regex: /\bnvapi-[A-Za-z0-9_-]{20,}\b/ },
+  ...HIGH_CONFIDENCE_PREFIXED_TOKEN_SPECS.map(
+    ({ name, prefixes, payloadCharacterClass, minimumPayloadLength }) => ({
+      name,
+      regex: new RegExp(
+        `\\b(?:${prefixes.join("|")})[${payloadCharacterClass}]{${minimumPayloadLength},}\\b`,
+      ),
+    }),
+  ),
 
   // OpenAI — exclude sk-ant- (Anthropic) to avoid double-matching
   { name: "OpenAI API key", regex: /\bsk-(?!ant-)[A-Za-z0-9_-]{20,}\b/ },
-
-  // GitHub
-  { name: "GitHub token", regex: /\b(ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9]{36,}\b/ },
 
   // AWS
   { name: "AWS access key", regex: /\bAKIA[0-9A-Z]{16}\b/ },
@@ -47,9 +80,6 @@ const SECRET_PATTERNS: SecretPattern[] = [
     regex:
       /(?<=(?:discord|bot|DISCORD_TOKEN|BOT_TOKEN|token)\s*[=:]\s*["']?)[A-Za-z0-9]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}/,
   },
-
-  // npm
-  { name: "npm token", regex: /\bnpm_[A-Za-z0-9]{36,}\b/ },
 
   // Private keys (PEM)
   {

--- a/test/e2e/live/cloud-inference-credential-boundary.ts
+++ b/test/e2e/live/cloud-inference-credential-boundary.ts
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { shellQuote } from "../../../src/lib/core/shell-quote.ts";
-
-export const SANDBOX_CREDENTIAL_VALUE_PATTERN =
-  "nvapi-[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9_-]{10,}|npm_[A-Za-z0-9]{36}";
+import { HIGH_CONFIDENCE_PREFIXED_TOKEN_ERE } from "../../../nemoclaw/src/security/secret-scanner.ts";
 
 const DEFAULT_SANDBOX_STATE_DIRECTORIES = ["/sandbox/.openclaw", "/sandbox/.nemoclaw"];
 
@@ -16,7 +14,7 @@ export function buildSandboxCredentialScanCommand(
   return [
     `for dir in ${roots}; do`,
     '  [ -d "$dir" ] || continue',
-    `  matches=$(grep -rlE '${SANDBOX_CREDENTIAL_VALUE_PATTERN}' "$dir")`,
+    `  matches=$(grep -rlE '${HIGH_CONFIDENCE_PREFIXED_TOKEN_ERE}' "$dir")`,
     "  scan_status=$?",
     '  case "$scan_status" in',
     `    0) printf '%s\\n' "$matches" | grep -Ev '/policies/|/plugin-runtime-deps/|/extensions/[^/]+/(dist|node_modules)/'`,

--- a/test/e2e/live/cloud-inference-credential-boundary.ts
+++ b/test/e2e/live/cloud-inference-credential-boundary.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { shellQuote } from "../../../src/lib/core/shell-quote.ts";
+
+export const SANDBOX_CREDENTIAL_VALUE_PATTERN =
+  "nvapi-[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9_-]{10,}|npm_[A-Za-z0-9]{36}";
+
+const DEFAULT_SANDBOX_STATE_DIRECTORIES = ["/sandbox/.openclaw", "/sandbox/.nemoclaw"];
+
+/** Build a path-only scan for concrete credential values in sandbox state. */
+export function buildSandboxCredentialScanCommand(
+  directories: readonly string[] = DEFAULT_SANDBOX_STATE_DIRECTORIES,
+): string {
+  const roots = directories.map((directory) => shellQuote(directory)).join(" ");
+  return [
+    `for dir in ${roots}; do`,
+    '  [ -d "$dir" ] || continue',
+    `  matches=$(grep -rIlE '${SANDBOX_CREDENTIAL_VALUE_PATTERN}' "$dir")`,
+    "  scan_status=$?",
+    '  case "$scan_status" in',
+    `    0) printf '%s\\n' "$matches" | grep -Ev '/policies/|/plugin-runtime-deps/|/extensions/[^/]+/(dist|node_modules)/'`,
+    "       filter_status=$?",
+    '       case "$filter_status" in',
+    "         0|1) ;;",
+    '         *) exit "$filter_status" ;;',
+    "       esac",
+    "       ;;",
+    "    1) ;;",
+    '    *) exit "$scan_status" ;;',
+    "  esac",
+    "done",
+  ].join("\n");
+}

--- a/test/e2e/live/cloud-inference-credential-boundary.ts
+++ b/test/e2e/live/cloud-inference-credential-boundary.ts
@@ -16,7 +16,7 @@ export function buildSandboxCredentialScanCommand(
   return [
     `for dir in ${roots}; do`,
     '  [ -d "$dir" ] || continue',
-    `  matches=$(grep -rIlE '${SANDBOX_CREDENTIAL_VALUE_PATTERN}' "$dir")`,
+    `  matches=$(grep -rlE '${SANDBOX_CREDENTIAL_VALUE_PATTERN}' "$dir")`,
     "  scan_status=$?",
     '  case "$scan_status" in',
     `    0) printf '%s\\n' "$matches" | grep -Ev '/policies/|/plugin-runtime-deps/|/extensions/[^/]+/(dist|node_modules)/'`,

--- a/test/e2e/live/cloud-inference.test.ts
+++ b/test/e2e/live/cloud-inference.test.ts
@@ -32,6 +32,7 @@ import {
   parseCloudChatResponse,
   type PreContractExternalProviderFailure,
 } from "./cloud-inference-provider-skip.ts";
+import { buildSandboxCredentialScanCommand } from "./cloud-inference-credential-boundary.ts";
 
 const REPO_SKILL_VALIDATOR = path.join(
   REPO_ROOT,
@@ -302,50 +303,7 @@ async function expectSandboxCredentialBoundary(
     "",
   );
 
-  const secretScanCommand = [
-    "for dir in /sandbox/.openclaw /sandbox/.nemoclaw; do",
-    '  [ -d "$dir" ] || continue',
-    `  matches=$(grep -rIlE 'nvapi-|ghp_|npm_' "$dir")`,
-    "  scan_status=$?",
-    '  case "$scan_status" in',
-    `    0) filtered=$(printf '%s\\n' "$matches" | grep -Ev '/policies/|/plugin-runtime-deps/|/extensions/[^/]+/(dist|node_modules)/')`,
-    "       filter_status=$?",
-    '       case "$filter_status" in',
-    "         0) filtered_file=$(mktemp)",
-    "            temp_status=$?",
-    '            case "$temp_status" in 0) ;; *) exit "$temp_status" ;; esac',
-    `            trap 'rm -f "$filtered_file"' EXIT HUP INT TERM`,
-    `            printf '%s\\n' "$filtered" > "$filtered_file"`,
-    "            write_status=$?",
-    '            case "$write_status" in 0) ;; *) exit "$write_status" ;; esac',
-    "            while IFS= read -r file; do",
-    `              matching_lines=$(grep -IE 'nvapi-|ghp_|npm_' "$file")`,
-    "              match_status=$?",
-    '              case "$match_status" in',
-    `                0) printf '%s' "$matching_lines" | grep -qv 'STRIPPED'`,
-    "                   unstripped_status=$?",
-    '                   case "$unstripped_status" in',
-    `                     0) printf '%s\\n' "$file" ;;`,
-    "                     1) ;;",
-    '                     *) exit "$unstripped_status" ;;',
-    "                   esac",
-    "                   ;;",
-    "                1) ;;",
-    '                *) exit "$match_status" ;;',
-    "              esac",
-    '            done < "$filtered_file"',
-    '            rm -f "$filtered_file"',
-    "            trap - EXIT HUP INT TERM",
-    "            ;;",
-    "         1) ;;",
-    '         *) exit "$filter_status" ;;',
-    "       esac",
-    "       ;;",
-    "    1) ;;",
-    '    *) exit "$scan_status" ;;',
-    "  esac",
-    "done",
-  ].join("\n");
+  const secretScanCommand = buildSandboxCredentialScanCommand();
 
   const secretProbe = await sandbox.exec(SANDBOX_NAME, ["sh", "-lc", secretScanCommand], {
     artifactName: "phase-3-sandbox-secret-pattern-probe",

--- a/test/e2e/support/cloud-inference-credential-boundary.test.ts
+++ b/test/e2e/support/cloud-inference-credential-boundary.test.ts
@@ -17,12 +17,14 @@ afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 });
 
+/** Create and track an isolated sandbox-state fixture root. */
 function createScanRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cloud-credential-scan-"));
   roots.push(root);
   return root;
 }
 
+/** Write one text or binary sandbox-state fixture and return its path. */
 function writeFixture(root: string, relativePath: string, body: string | Uint8Array): string {
   const file = path.join(root, relativePath);
   fs.mkdirSync(path.dirname(file), { recursive: true });
@@ -30,6 +32,7 @@ function writeFixture(root: string, relativePath: string, body: string | Uint8Ar
   return file;
 }
 
+/** Run the exact live credential scan command against a fixture root. */
 function scan(root: string): string {
   return execFileSync("sh", ["-lc", buildSandboxCredentialScanCommand([root])], {
     encoding: "utf8",

--- a/test/e2e/support/cloud-inference-credential-boundary.test.ts
+++ b/test/e2e/support/cloud-inference-credential-boundary.test.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildSandboxCredentialScanCommand } from "../live/cloud-inference-credential-boundary.ts";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+function createScanRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cloud-credential-scan-"));
+  roots.push(root);
+  return root;
+}
+
+function writeFixture(root: string, relativePath: string, body: string): string {
+  const file = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, body);
+  return file;
+}
+
+function scan(root: string): string {
+  return execFileSync("sh", ["-lc", buildSandboxCredentialScanCommand([root])], {
+    encoding: "utf8",
+  });
+}
+
+describe("cloud inference sandbox credential scan", () => {
+  it("accepts npm dependency metadata that does not contain a credential value (#9363)", () => {
+    const root = createScanRoot();
+    writeFixture(
+      root,
+      "npm/projects/openclaw-whatsapp/node_modules/thread-stream/test/ts/transpile.sh",
+      'echo "${npm_config_user_agent}"\n',
+    );
+    writeFixture(
+      root,
+      "npm/projects/openclaw-msteams/node_modules/jwks-rsa/package.json",
+      '{"scripts":{"release":"git tag $npm_package_version"}}\n',
+    );
+    writeFixture(root, "configuration/token-key-path.txt", "ordinary dependency metadata\n");
+
+    expect(scan(root)).toBe("");
+  });
+
+  it.each([
+    ["NVIDIA", "nvapi-nemoclaw-credential-boundary-canary"],
+    ["GitHub", `ghp_${"a".repeat(36)}`],
+    ["npm", `npm_${"b".repeat(36)}`],
+  ])("reports only the path of a file that contains a %s credential canary", (_label, canary) => {
+    const root = createScanRoot();
+    const leakedFile = writeFixture(root, "openclaw.json", `{"apiKey":"${canary}"}\n`);
+
+    const output = scan(root);
+
+    expect(output.trim()).toBe(leakedFile);
+    expect(output).not.toContain(canary);
+  });
+});

--- a/test/e2e/support/cloud-inference-credential-boundary.test.ts
+++ b/test/e2e/support/cloud-inference-credential-boundary.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -26,7 +27,14 @@ function createScanRoot(): string {
 
 /** Write one text or binary sandbox-state fixture and return its path. */
 function writeFixture(root: string, relativePath: string, body: string | Uint8Array): string {
-  const file = path.join(root, relativePath);
+  const rootPath = path.resolve(root);
+  assert(!path.isAbsolute(relativePath), "Fixture path must be relative to the scan root");
+  const file = path.resolve(rootPath, relativePath);
+  const relativeFile = path.relative(rootPath, file);
+  assert(
+    relativeFile !== ".." && !relativeFile.startsWith(`..${path.sep}`),
+    "Fixture path must stay inside the scan root",
+  );
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, body);
   return file;
@@ -40,6 +48,17 @@ function scan(root: string): string {
 }
 
 describe("cloud inference sandbox credential scan", () => {
+  it("rejects fixture paths outside the temporary scan root", () => {
+    const root = createScanRoot();
+
+    expect(() => writeFixture(root, "../outside.txt", "outside\n")).toThrow(
+      "Fixture path must stay inside the scan root",
+    );
+    expect(() => writeFixture(root, path.join(root, "absolute.txt"), "outside\n")).toThrow(
+      "Fixture path must be relative to the scan root",
+    );
+  });
+
   it("accepts npm dependency metadata that does not contain a credential value (#9363)", () => {
     const root = createScanRoot();
     writeFixture(

--- a/test/e2e/support/cloud-inference-credential-boundary.test.ts
+++ b/test/e2e/support/cloud-inference-credential-boundary.test.ts
@@ -60,6 +60,7 @@ describe("cloud inference sandbox credential scan", () => {
   it.each([
     ["NVIDIA", "nvapi-nemoclaw-credential-boundary-canary"],
     ["GitHub", `ghp_${"a".repeat(36)}`],
+    ["GitHub fine-grained", `github_pat_${"a".repeat(15)}_${"b".repeat(14)}`],
     ["npm", `npm_${"b".repeat(36)}`],
   ])("reports only the path of a file that contains a %s credential canary", (_label, canary) => {
     const root = createScanRoot();

--- a/test/e2e/support/cloud-inference-credential-boundary.test.ts
+++ b/test/e2e/support/cloud-inference-credential-boundary.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { HIGH_CONFIDENCE_PREFIXED_TOKEN_SPECS } from "../../../nemoclaw/src/security/secret-scanner.ts";
 import { buildSandboxCredentialScanCommand } from "../live/cloud-inference-credential-boundary.ts";
 
 const roots: string[] = [];
@@ -65,6 +66,36 @@ describe("cloud inference sandbox credential scan", () => {
 
     expect(output.trim()).toBe(leakedFile);
     expect(output).not.toContain(canary);
+  });
+
+  it.each(
+    HIGH_CONFIDENCE_PREFIXED_TOKEN_SPECS.flatMap(({ prefixes, minimumPayloadLength }) =>
+      prefixes.map((prefix) => [prefix, minimumPayloadLength] as const),
+    ),
+  )("enforces the shared minimum payload for %s", (prefix, minimumPayloadLength) => {
+    const root = createScanRoot();
+    writeFixture(root, "short.txt", `${prefix}${"a".repeat(minimumPayloadLength - 1)}\n`);
+
+    expect(scan(root)).toBe("");
+
+    const detectedFile = writeFixture(
+      root,
+      "minimum.txt",
+      `${prefix}${"a".repeat(minimumPayloadLength)}\n`,
+    );
+    expect(scan(root).trim()).toBe(detectedFile);
+  });
+
+  it.each([
+    ["prefixed GitHub token", `prefixghp_${"a".repeat(36)}`],
+    ["suffixed GitHub token", `ghp_${"a".repeat(36)}_suffix`],
+    ["prefixed npm token", `prefixnpm_${"b".repeat(36)}`],
+    ["suffixed npm token", `npm_${"b".repeat(36)}_suffix`],
+  ])("does not report a token embedded in a larger identifier: %s", (_label, value) => {
+    const root = createScanRoot();
+    writeFixture(root, "embedded.txt", `${value}\n`);
+
+    expect(scan(root)).toBe("");
   });
 
   it("reports a credential canary in a NUL-containing file", () => {

--- a/test/e2e/support/cloud-inference-credential-boundary.test.ts
+++ b/test/e2e/support/cloud-inference-credential-boundary.test.ts
@@ -22,7 +22,7 @@ function createScanRoot(): string {
   return root;
 }
 
-function writeFixture(root: string, relativePath: string, body: string): string {
+function writeFixture(root: string, relativePath: string, body: string | Uint8Array): string {
   const file = path.join(root, relativePath);
   fs.mkdirSync(path.dirname(file), { recursive: true });
   fs.writeFileSync(file, body);
@@ -60,6 +60,17 @@ describe("cloud inference sandbox credential scan", () => {
   ])("reports only the path of a file that contains a %s credential canary", (_label, canary) => {
     const root = createScanRoot();
     const leakedFile = writeFixture(root, "openclaw.json", `{"apiKey":"${canary}"}\n`);
+
+    const output = scan(root);
+
+    expect(output.trim()).toBe(leakedFile);
+    expect(output).not.toContain(canary);
+  });
+
+  it("reports a credential canary in a NUL-containing file", () => {
+    const root = createScanRoot();
+    const canary = "nvapi-nemoclaw-binary-credential-canary";
+    const leakedFile = writeFixture(root, "state.bin", Buffer.from(`prefix\0${canary}\n`));
 
     const output = scan(root);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The cloud inference credential scan treated npm lifecycle variable names in installed dependencies as credential leaks. It now matches the high-confidence provider formats owned by the security scanner and reports only matching file paths, so dependency metadata passes while credential canaries still fail safely.

## Related Issue

Fixes #9363

## Changes

- Extract the live sandbox scan command into a focused helper so the exact production command is regression-tested.
- Derive the in-process and POSIX sandbox patterns from one high-confidence provider/threshold table in the owning security module, including the underscore-bearing fine-grained GitHub PAT format.
- Preserve the existing directory exclusions and grep error propagation while scanning text and NUL-containing files.
- Cover the observed `npm_config_user_agent` and `$npm_package_version` dependency records, token-shaped dependency paths, payload and identifier boundaries, and redacted canaries for each credential family.
- Consolidate the source-of-truth design from #9382 here with co-author credit to Deepak Jain.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer nine-category security review completed on the exact commit; no findings. The scan remains read-only, propagates errors, and emits paths rather than matched credential values.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — exact shell/support suites (27/27 passed), secret-scanner suite (56/56 passed), and growth guardrails (22/22 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — CI pending; the local macOS run was inconclusive because unrelated environment-sensitive suites timed out or consumed ambient host state.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved credential-boundary scanning for cloud inference sandbox data.
  - Detects high-confidence NVIDIA, GitHub—including fine-grained—and npm credentials while redacting secret values.
  - Excludes policy, dependency, and benign metadata paths from findings.
  - Safely handles missing directories, embedded or short tokens, NUL-containing files, and expected no-match results.
  - Scan results identify only affected file paths, protecting credential contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->