### PR TITLE
fix(onboard): explain a gateway database with a modified migration

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -602,16 +602,23 @@ curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 
 The next installer run must continue past the OpenShell installation step without reporting a version mismatch.
 
-### Docker Driver Gateway Reports a Missing Migration
+### Docker Driver Gateway Reports an Incompatible Migration
 
-Onboarding can stop when the Docker driver gateway log contains both parts of this error:
+Onboarding can stop when the Docker driver gateway log contains both parts of either error:
 
 ```text
 migration N was previously applied
 is missing in the resolved migrations
 ```
 
-NemoClaw identifies `<selected-state-dir>/openshell.db` as incompatible with the installed OpenShell migration set.
+```text
+migration N was previously applied
+has been modified
+```
+
+The first error means the installed OpenShell migration set does not contain migration N.
+The second error means that migration set defines migration N with different contents.
+NemoClaw identifies `<selected-state-dir>/openshell.db` as incompatible with the installed OpenShell migration set for both errors.
 This failure can happen after an OpenShell downgrade.
 Installing a NemoClaw release that is older than the installed one performs that downgrade, because each release pins one OpenShell version and the installer reinstalls OpenShell at the pin.
 You reach that state in one of three ways:

--- a/src/lib/onboard/docker-driver-gateway-failure.test.ts
+++ b/src/lib/onboard/docker-driver-gateway-failure.test.ts
@@ -144,7 +144,7 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
     }
   });
 
-  it("prints a shell-quoted state-directory move after confirming no gateway process remains (#8797)", () => {
+  it("prints a shell-quoted state-directory move after confirming no gateway process remains (#8797, #9293)", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gw-fail-"));
     const stateDir = path.join(dir, "gateway state;echo it's ignored");
     const log = path.join(stateDir, "openshell-gateway.log");
@@ -152,8 +152,8 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
     fs.writeFileSync(
       log,
       [
-        "Error: execution error: migration error: migration 6 was previously applied",
-        "  is missing in the resolved migrations",
+        "Error: execution error: migration error: migration 4 was previously applied but",
+        "  has been modified",
       ].join("\n"),
     );
     try {
@@ -166,6 +166,7 @@ describe("reportDockerDriverGatewayStartFailure (#3111)", () => {
       const joined = errSpy.mock.calls.map((c: string[]) => c.join(" ")).join("\n");
       expect(joined).toContain("cannot use the existing gateway database");
       expect(joined).toContain(`Database: ${path.join(stateDir, "openshell.db")}`);
+      expect(joined).toContain("does not include, or defines with different contents");
       expect(joined).toContain("it'\\''s ignored'");
       expect(joined).toContain("it'\\''s ignored.incompatible'");
       expect(joined).toContain("contains credentials and all registrations");

--- a/src/lib/onboard/docker-driver-gateway-failure.ts
+++ b/src/lib/onboard/docker-driver-gateway-failure.ts
@@ -66,7 +66,9 @@ function printIncompatibleGatewayDatabaseRecovery(
     : onboardResumeRecoveryCommand();
   printError("  The installed OpenShell version cannot use the existing gateway database.");
   printError(`  Database: ${path.join(stateDir, "openshell.db")}`);
-  printError("  The database records a migration that this OpenShell version does not include.");
+  printError(
+    "  The database records a migration that this OpenShell version does not include, or defines with different contents.",
+  );
   printError("  This can happen after an OpenShell downgrade.");
   const stopCommand = resolveGatewayStopCommand();
   if (!stopCommand && isGatewayStateInUse?.() !== false) {

--- a/src/lib/onboard/gateway-start-failure.test.ts
+++ b/src/lib/onboard/gateway-start-failure.test.ts
@@ -73,6 +73,23 @@ describe("classifyGatewayStartFailure", () => {
     });
   });
 
+  it("classifies a modified applied migration as an incompatible database (#9293)", () => {
+    const output = [
+      "Error:   × execution error: migration error: migration 4 was previously applied but",
+      "  │ has been modified",
+    ].join("\n");
+
+    expect(classifyGatewayStartFailure(output)).toEqual({
+      kind: "database_migration_incompatible",
+    });
+  });
+
+  it("does not classify an on-disk migration-file edit as incompatible database state (#9293)", () => {
+    const output = "the file containing migration 6 has been modified on disk";
+
+    expect(classifyGatewayStartFailure(output)).toEqual({ kind: "unknown" });
+  });
+
   it("does not classify an unrelated SQLite migration failure as incompatible database state (#8797)", () => {
     const output = "database is locked while applying migration 6";
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -42,7 +42,10 @@ export interface GatewayStartFailure {
    *   dockerd on Linux) is not responding. Retrying the openshell health
    *   poll cannot recover from this — the user must start Docker first.
    * - `database_migration_incompatible`: the gateway database records a
-   *   migration that the installed OpenShell version does not include.
+   *   migration that the installed OpenShell version does not include, or
+   *   defines with different contents. Both sqlx signatures mean the database
+   *   was written by a newer OpenShell than the one now starting (#8797,
+   *   #9293).
    * - `unknown`: any other failure; callers should fall through to the
    *   normal retry/health-wait behavior.
    */
@@ -224,8 +227,12 @@ export function planSandboxCreateRecovery(
  */
 export function classifyGatewayStartFailure(output = ""): GatewayStartFailure {
   const text = String(output || "");
+  // Both sqlx migrate signatures for a database written by a newer OpenShell:
+  // the newer build appended a migration this build does not resolve
+  // ("is missing in the resolved migrations"), or it rewrote an applied
+  // migration so the checksum no longer matches ("has been modified").
   if (
-    /migration\s+\d+\s+was previously applied[\s\S]{0,512}\bis missing in the resolved migrations\b/i.test(
+    /migration\s+\d+\s+was previously applied[\s\S]{0,512}\b(?:is missing in the resolved migrations|has been modified)\b/i.test(
       text,
     )
   ) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

A gateway database written by a newer OpenShell fails gateway start with one of two sqlx texts. Gateway start explains the `is missing in the resolved migrations` text and prints a named-database recovery, but passes the sibling `has been modified` text through verbatim, so that failure still names no database, no cause, and no remedy. Gateway start now classifies both texts as an incompatible gateway database and prints the same recovery, and the troubleshooting page names both texts.

## Related Issue

Refs #9293

This change does not close #9293 on its own, and it intentionally uses no closing keyword. The literal text in that report, `migration 6 was previously applied but is missing in the resolved migrations`, is already classified on `main`: #8995 added `classifyGatewayStartFailure` and #8992 refined it. Neither is contained in `v0.0.103`, the release the reporter read the database with; both first ship in `v0.0.109`. The reported repro therefore no longer produces a raw migration error on a current release, and #9293 can be closed as fixed-in-release independently of this PR.

What remains is the sibling signature of the same defect. sqlx `0.8.6` — the version pinned by OpenShell's workspace `Cargo.toml` — reports a database written by a newer OpenShell through two `MigrateError` variants:

| Variant | Message |
|---|---|
| `VersionMissing` | `migration {0} was previously applied but is missing in the resolved migrations` |
| `VersionMismatch` | `migration {0} was previously applied but has been modified` |

`main` classifies only the first. The second occurs on the same downgrade when the newer OpenShell rewrote an applied migration instead of appending one, and it still reaches the user verbatim. This PR closes that path.

## Changes

- `src/lib/validation.ts`: `classifyGatewayStartFailure` matches both sqlx signatures and returns `database_migration_incompatible` for each. The alternation is anchored to the shared `migration N was previously applied` prefix, so `has been modified` alone does not classify. The `GatewayStartFailure` doc names both signatures.
- `src/lib/onboard/docker-driver-gateway-failure.ts`: the incompatible-database explanation now reads `The database records a migration that this OpenShell version does not include, or defines with different contents.` so it is accurate for both signatures. No other line of the recovery changes.
- `docs/reference/troubleshooting.mdx`: the section covering this failure names both error texts, states what each one means, and is retitled from `Reports a Missing Migration` to `Reports an Incompatible Migration`. No page links to the previous heading.
- `src/lib/onboard/gateway-start-failure.test.ts`: a classifier test for the modified-migration text, and a negative guard asserting that `the file containing migration 6 has been modified on disk` stays `unknown`.
- `src/lib/onboard/docker-driver-gateway-failure.test.ts`: a reporter test asserting the modified-migration failure names the database file, the cause, and the archive-and-reonboard recovery.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: requesting maintainer sensitive-path review. As an outside contributor I cannot record a review of my own change. The change adds one alternation to an existing classifier and rewords one printed line; it adds no new command, path, credential handling, or process control, and the recovery command construction and its shell quoting are unchanged from #8995.
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — hooks are not installed in this worktree; `git fetch origin main && npm run validate:pr` passed with zero problems.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/onboard/gateway-start-failure.test.ts src/lib/onboard/docker-driver-gateway-failure.test.ts` → 39 passed, 3 new. Reverting only the two source files to `origin/main` and keeping the tests fails both new positive tests, so they pin the new behavior. `npm run typecheck:cli` → clean. `npx oxlint` on the four changed source files → no findings. `npm run test:changed` was not run to completion on this macOS host; its affected-test selection includes subprocess-spawning lanes that need the GNU utilities described under `macOS Test Dependencies` in `CONTRIBUTING.md`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run. This change is a focused onboarding diagnostic and adds no runtime or test-harness surface; the targeted CLI tests, `typecheck:cli`, oxlint, `npm run docs`, and `npm run validate:pr` cover the changed contracts.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — `npm run docs` → `Found 0 errors and 2 warnings`. Both warnings reproduce on the unmodified page set and are unrelated to this change.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Follow-Up Observation

Not changed here, and offered only as a question for maintainers: `classifyGatewayStartFailure` has one non-test caller, `reportDockerDriverGatewayStartFailure`. A gateway start that terminates outside that reporter therefore never produces this diagnosis, even when the log carries either migration signature. If that is a gap worth closing rather than intended scoping, I am happy to open a separate issue.

---
Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of incompatible gateway databases when applied migrations are missing or have changed.
  - Enhanced error messages to explain the issue, identify the database path, and recommend creating an `.incompatible` state directory.
  - Added clearer handling for migration-related gateway startup failures.

- **Documentation**
  - Expanded troubleshooting guidance to cover both missing and modified migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->