### PR TITLE
fix(onboard): accept managed runtime aliases

### DIFF
--- a/src/lib/onboard/managed-startup-runtime-alias.test.ts
+++ b/src/lib/onboard/managed-startup-runtime-alias.test.ts
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { managedStartupE2eProfile } from "../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import { slackManifest } from "../messaging/channels/slack/manifest.ts";
+import {
+  type ManagedStartupJsonObject,
+  type ManagedStartupProfile,
+  validateManagedStartupProfile,
+} from "./managed-startup/profile.ts";
+
+const [slackBotAlias] = slackManifest.runtime.hermes.envAliases;
+
+function profileWithAliases(aliases: readonly ManagedStartupJsonObject[]): ManagedStartupProfile {
+  const profile = managedStartupE2eProfile("hermes");
+  return {
+    ...profile,
+    messaging: {
+      plan: {
+        schemaVersion: 1,
+        agent: "hermes",
+        runtimeSetup: {
+          nodePreloads: [],
+          envAliases: aliases.map((alias) => ({ channelId: "slack", ...alias })),
+          secretScans: [],
+        },
+      },
+    },
+  };
+}
+
+describe("managed startup runtime aliases", () => {
+  it("accepts the stock Slack runtime aliases (#9397)", () => {
+    expect(() =>
+      validateManagedStartupProfile(profileWithAliases(slackManifest.runtime.hermes.envAliases)),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ["an invalid environment key", { ...slackBotAlias, envKey: "BAD KEY" }],
+    [
+      "an unanchored resolver expression",
+      { ...slackBotAlias, match: "openshell:resolve:env:SLACK_BOT_TOKEN" },
+    ],
+    [
+      "a resolver expression for another key",
+      {
+        ...slackBotAlias,
+        match: "^openshell:resolve:env:(v[0-9]+_)?SLACK_APP_TOKEN$",
+      },
+    ],
+    [
+      "a placeholder for another key",
+      { ...slackBotAlias, value: "xoxb-OPENSHELL-RESOLVE-ENV-SLACK_APP_TOKEN" },
+    ],
+    ["a raw credential", { ...slackBotAlias, value: `xoxb-${"a".repeat(32)}` }],
+  ])("rejects %s (#9397)", (_label, alias) => {
+    expect(() => validateManagedStartupProfile(profileWithAliases([alias]))).toThrow(
+      /credential-shaped string data/,
+    );
+  });
+
+  it.each([slackBotAlias.match, slackBotAlias.value])(
+    "rejects runtime alias data outside the schema-owned path (#9397)",
+    (runtimeAliasData) => {
+      const profile = profileWithAliases([]);
+      expect(() =>
+        validateManagedStartupProfile({
+          ...profile,
+          messaging: {
+            plan: {
+              ...profile.messaging.plan,
+              note: runtimeAliasData,
+            },
+          },
+        }),
+      ).toThrow(/credential-shaped string data/);
+    },
+  );
+});

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -1049,6 +1049,54 @@ function isMessagingCredentialPlaceholderAssignment(
   return CREDENTIAL_ENV_NAME_PATTERN.test(envKey) && envKey === placeholderEnvKey;
 }
 
+function isMessagingRuntimeEnvAliasPath(path: readonly string[]): boolean {
+  return (
+    path.length === 5 &&
+    path[0] === "messaging" &&
+    path[1] === "plan" &&
+    path[2] === "runtimeSetup" &&
+    path[3] === "envAliases" &&
+    JSON_ARRAY_INDEX_SEGMENT_RE.test(path[4] ?? "")
+  );
+}
+
+function ownDataPropertyValue(value: Record<string, unknown>, key: string): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  return descriptor && "value" in descriptor ? descriptor.value : undefined;
+}
+
+function isCanonicalMessagingRuntimeEnvAlias(
+  path: readonly string[],
+  value: Record<string, unknown>,
+): boolean {
+  if (!isMessagingRuntimeEnvAliasPath(path)) return false;
+  const envKey = ownDataPropertyValue(value, "envKey");
+  const match = ownDataPropertyValue(value, "match");
+  const placeholder = ownDataPropertyValue(value, "value");
+  return (
+    typeof envKey === "string" &&
+    CREDENTIAL_ENV_NAME_PATTERN.test(envKey) &&
+    match === `^openshell:resolve:env:(v[0-9]+_)?${envKey}$` &&
+    typeof placeholder === "string" &&
+    messagingCredentialPlaceholderEnvKey(placeholder) === envKey
+  );
+}
+
+function isAllowedMessagingRuntimeAliasStringPath(
+  path: readonly string[],
+  allowedAliasIndexes: ReadonlySet<string>,
+): boolean {
+  return (
+    path.length === 6 &&
+    path[0] === "messaging" &&
+    path[1] === "plan" &&
+    path[2] === "runtimeSetup" &&
+    path[3] === "envAliases" &&
+    allowedAliasIndexes.has(path[4] ?? "") &&
+    (path[5] === "match" || path[5] === "value")
+  );
+}
+
 function isMessagingPackagePin(path: readonly string[], value: unknown): boolean {
   return (
     path.length === 6 &&
@@ -1399,6 +1447,7 @@ function assertPayloadStructureAndCredentialShapes(root: unknown): void {
     depth: number;
     path: readonly string[];
   }> = [{ value: root, depth: 0, path: [] }];
+  const allowedRuntimeAliasIndexes = new Set<string>();
   let discoveredNodes = 1;
   let observedBytes = 0;
 
@@ -1426,6 +1475,7 @@ function assertPayloadStructureAndCredentialShapes(root: unknown): void {
     if (typeof current.value === "string") {
       observeText(current.value);
       if (
+        !isAllowedMessagingRuntimeAliasStringPath(current.path, allowedRuntimeAliasIndexes) &&
         !isMessagingCredentialPlaceholder(current.path, current.value) &&
         !isMessagingCredentialPlaceholderAssignment(current.path, current.value) &&
         (valueLooksLikeSecret(current.value) ||
@@ -1484,6 +1534,9 @@ function assertPayloadStructureAndCredentialShapes(root: unknown): void {
       if (!isPlainObject(current.value)) invalid("payload must contain only plain JSON objects");
       if ("toJSON" in current.value) {
         invalid("payload must not define a custom JSON serializer");
+      }
+      if (isCanonicalMessagingRuntimeEnvAlias(current.path, current.value)) {
+        allowedRuntimeAliasIndexes.add(current.path[4] as string);
       }
       const keys = Object.getOwnPropertyNames(current.value);
       if (


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Managed onboarding rejected the stock Slack runtime aliases before sandbox startup. The validator now accepts only canonical runtime alias triples whose environment key, anchored OpenShell resolver expression, and approved placeholder all identify the same credential environment variable.

## Related Issue

Fixes #9397

## Changes

- Recognize canonical entries only at `messaging.plan.runtimeSetup.envAliases[*]`.
- Keep raw credentials, invalid environment names, malformed expressions, mismatched aliases, and placeholders at other paths rejected.
- Add focused positive coverage for both stock Slack aliases and denial coverage for each neighboring failure mode.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `vitest run --project cli src/lib/onboard/managed-startup-runtime-alias.test.ts src/lib/onboard/managed-startup-profile.test.ts` (128 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for validating canonical messaging runtime environment aliases.
  * Valid aliases now support Slack bot and app credentials with matching placeholders.
  * Alias fields are accepted only in the expected runtime configuration paths.

* **Bug Fixes**
  * Invalid alias formats, mismatched placeholders, raw credentials, and misplaced credential-shaped data are now rejected.
  * Improved validation helps prevent incorrectly configured messaging runtime aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->