### PR TITLE
fix(policy): reject invalid custom preset YAML (Fixes #9406)

### DIFF
--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -2078,13 +2078,13 @@ function applyPresetContent(
       return false;
     }
     const reservedKey = [OPENCLAW_NPM_PRESET_KEY, PERSONAL_OPEN_INTERNET_POLICY_KEY].find(
-      (key) => np && Object.prototype.hasOwnProperty.call(np, key),
+      (key) => Object.prototype.hasOwnProperty.call(np, key),
     );
     if (reservedKey) {
       console.error(`  Custom presets cannot own reserved network policy key '${reservedKey}'.`);
       return false;
     }
-    const hasGeneratedPins = np !== null && networkPoliciesHasAllowedIps(np);
+    const hasGeneratedPins = networkPoliciesHasAllowedIps(np);
     const trustedPrivatePinsValid = isTrustedPrivatePolicyPinCapability(
       presetContent,
       options.custom.trustedPrivatePinCapability,

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -2073,6 +2073,10 @@ function applyPresetContent(
 
   if (options.custom) {
     const np = parseNetworkPolicies(presetContent);
+    if (!np) {
+      console.error(`  Preset '${presetName}' has invalid or missing network_policies.`);
+      return false;
+    }
     const reservedKey = [OPENCLAW_NPM_PRESET_KEY, PERSONAL_OPEN_INTERNET_POLICY_KEY].find(
       (key) => np && Object.prototype.hasOwnProperty.call(np, key),
     );

--- a/src/lib/policy/preset-allowed-ips.test.ts
+++ b/src/lib/policy/preset-allowed-ips.test.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { applyPresetContent, loadPresetFromFile, networkPoliciesHasAllowedIps } from ".";
 
@@ -209,6 +209,28 @@ describe("networkPoliciesHasAllowedIps prototype-chain guard (#6072)", () => {
 });
 
 describe("applyPresetContent allowed_ips guard (#6073)", () => {
+  it("rejects a custom preset when the full YAML document is invalid (#9406)", () => {
+    const content = `preset: corp
+preset: corp
+network_policies:
+  wide_open:
+    endpoints:
+      - allowed_ips: ["169.254.169.254"]
+`;
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    expect(
+      applyPresetContent("test-sandbox", "invalid-full-document", content, {
+        custom: { sourcePath: "invalid.yaml" },
+      }),
+    ).toBe(false);
+    expect(error).toHaveBeenCalledWith(
+      "  Preset 'invalid-full-document' has invalid or missing network_policies.",
+    );
+
+    error.mockRestore();
+  });
+
   it("rejects custom preset content containing allowed_ips before any side effects", () => {
     const content = `\
 preset:

--- a/test/policies.test.ts
+++ b/test/policies.test.ts
@@ -741,7 +741,13 @@ exit 1
     const registryModule = requireForTest(
       path.join(REPO_ROOT, "src", "lib", "state", "registry.ts"),
     ) as Record<string, any>;
-    const CUSTOM_CONTENT = "network_policies:\n  slack-files-upload:\n    host: files.slack.com\n";
+    const CUSTOM_CONTENT = `preset:
+  name: slack-files-upload
+  description: Allow Slack file uploads
+network_policies:
+  slack-files-upload:
+    host: files.slack.com
+`;
     const BUILTIN_CONTENT = "network_policies:\n  github:\n    host: github.com\n";
     const SOURCE_PATH = "/tmp/slack-files-upload-case.yaml";
 
@@ -841,7 +847,7 @@ exit 1
       }
     });
 
-    it("records the custom preset and returns true when the sandbox is registered", () => {
+    it("applies a well-formed custom preset and records it verbatim (#9406)", () => {
       registryModule.getSandbox = (name: string) => ({ name });
       const addSpy = vi.fn(() => true);
       registryModule.addCustomPolicy = addSpy;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Custom preset application now fails closed when the full preset document cannot be parsed into a `network_policies` mapping. This prevents malformed metadata above a valid policy tail from bypassing the custom-preset guards.

## Related Issue

Fixes #9406

## Changes

- Reject invalid or missing custom `network_policies` before reserved-key, `allowed_ips`, semantic, disclosure, or mutation work.
- Add a regression for a duplicate-key preset whose extracted policy tail remains valid.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Review pending.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/policy/preset-allowed-ips.test.ts` passed 14 tests.
- [x] Applicable broad gate passed — `npm run test:changed` passed 139 files and 1,944 tests after the 25-test growth-guardrail lane passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation:

- `npm run build:cli` passed.
- `npm run typecheck:cli` passed.
- `git diff --check` passed.

---
Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Custom policy presets are now rejected when policy data is missing, malformed, or invalid.
  - Presets with duplicate metadata or invalid policy definitions no longer continue through the application process.
  - Clear error reporting helps identify rejected preset configurations and prevents unintended policy changes.
  - Valid custom presets continue to be applied and recorded as provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->