### PR TITLE
fix(onboard): report a dropped corporate CA import

### DIFF
--- a/src/lib/onboard/dockerfile-patch-corporate-ca.test.ts
+++ b/src/lib/onboard/dockerfile-patch-corporate-ca.test.ts
@@ -301,16 +301,25 @@ describe("dockerfile patch — corporate CA baking (#6210)", () => {
   });
 
   it("does not bake a fallback corporate CA without root startup selection (#8803)", () => {
-    process.env.REQUESTS_CA_BUNDLE = writeCa();
+    const caPath = writeCa();
+    process.env.REQUESTS_CA_BUNDLE = caPath;
     const dockerfilePath = dockerfileWith([
       ...BASE_ARGS.filter((line) => !line.startsWith("ARG NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=")),
       "ARG NEMOCLAW_CORPORATE_CA_B64=",
       ...OPENCLAW_STARTUP,
     ]);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     patch(dockerfilePath);
+    const messages = errorSpy.mock.calls.map((call) => String(call[0]));
+    errorSpy.mockRestore();
 
     expect(corporateCaArgLine(dockerfilePath)).toBe("ARG NEMOCLAW_CORPORATE_CA_B64=");
+    const warning = messages.find((message) => message.includes("WARNING"));
+    assert.ok(warning, "expected a dropped corporate CA warning (#8454)");
+    expect(warning).toContain("REQUESTS_CA_BUNDLE");
+    expect(warning).toContain(caPath);
+    expect(warning).toContain("NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER");
   });
 
   it("keeps Deep Agents Code sandbox startup when baking a corporate CA (#8803)", () => {
@@ -335,10 +344,20 @@ describe("dockerfile patch — corporate CA baking (#6210)", () => {
   });
 
   it("stays a no-op for a fallback CA when a custom Dockerfile lacks the ARG", () => {
-    process.env.CURL_CA_BUNDLE = writeCa();
+    const caPath = writeCa();
+    process.env.CURL_CA_BUNDLE = caPath;
     const dockerfilePath = openClawDockerfileWith([]);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     expect(() => patch(dockerfilePath)).not.toThrow();
+    const messages = errorSpy.mock.calls.map((call) => String(call[0]));
+    errorSpy.mockRestore();
+
     expect(corporateCaArgLine(dockerfilePath)).toBeUndefined();
+    const warning = messages.find((message) => message.includes("WARNING"));
+    assert.ok(warning, "expected a dropped corporate CA warning (#8454)");
+    expect(warning).toContain("CURL_CA_BUNDLE");
+    expect(warning).toContain(caPath);
+    expect(warning).toContain("NEMOCLAW_CORPORATE_CA_B64");
   });
 });

--- a/src/lib/onboard/dockerfile-patch.ts
+++ b/src/lib/onboard/dockerfile-patch.ts
@@ -32,6 +32,7 @@ import {
   encodeCorporateCaArg,
   resolveCorporateCa,
 } from "./corporate-ca";
+import { warnCorporateCa } from "./corporate-ca-policy";
 import {
   DCODE_AUTO_APPROVAL_BUILD_ARG,
   type DcodeAutoApprovalMode,
@@ -598,9 +599,21 @@ export function patchStagedDockerfile(
           'ENTRYPOINT ["/usr/local/bin/nemoclaw-start"]. ' +
           "NemoClaw cannot bake the corporate CA from NEMOCLAW_CORPORATE_CA_BUNDLE.",
       );
+    } else {
+      // A fallback source stays a no-op when a custom Dockerfile lacks either
+      // build argument required for root-owned runtime trust. Onboarding still
+      // exits 0 and the sandbox still reaches Ready, so report the dropped
+      // anchor here; otherwise the missing trust is invisible until external
+      // TLS through the corporate proxy fails at runtime (#8454).
+      const reason = corporateCaArgPattern.test(dockerfile)
+        ? "the Dockerfile does not declare a final-stage ARG NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER that controls the image user before the NemoClaw entrypoint"
+        : "the Dockerfile is missing ARG NEMOCLAW_CORPORATE_CA_B64";
+      warnCorporateCa(
+        `corporate proxy CA from ${corporateCa.sourceEnv} (${corporateCa.sourcePath}) was not baked ` +
+          `into the sandbox image because ${reason}; the sandbox will start without a corporate ` +
+          "trust anchor and external TLS through the corporate proxy may fail",
+      );
     }
-    // An OpenClaw fallback source stays a no-op when a custom Dockerfile lacks
-    // either build argument required for root-owned runtime trust.
   }
 
   replaceDockerfilePatchSnapshot(dockerfilePath, patchSnapshot, dockerfile);


### PR DESCRIPTION
## Summary

Onboarding resolved and validated a corporate CA from a conventional CA variable or a host
trust-store anchor, then dropped it with no diagnostic when the staged Dockerfile declared neither
build argument that root-owned runtime trust needs. Onboarding now reports the source variable,
the source path, and the reason.

## Related Issue

Contributes to #8454. This PR does not close #8454.

The reported run does not reach the branch this PR changes. On the shipped `Dockerfile` that run
bakes the anchor and onboarding prints a positive bake message. This PR corrects one adjacent
silent drop found while tracing the report. See "Root cause" for what the trace established and
what it did not.

## Changes

- Replace the silent no-op branch in `patchStagedDockerfile` with an operator warning when a
  resolved corporate CA cannot be baked into the staged Dockerfile. The explicit
  `NEMOCLAW_CORPORATE_CA_BUNDLE` source keeps its existing fail-closed behavior.
- Report the source variable, the source path, and the missing build argument through the existing
  `warnCorporateCa()` helper. No new helper, configuration, or fallback path is added.
- Extend the two existing tests that already own these branches to assert the diagnostic.

## Root cause

Established, and it explains `MERGED_CA_EXIT:1` in the report:

The documented runtime trust contract in `docs/security/configure-corporate-ca-trust.mdx` —
root-owned `/usr/local/share/nemoclaw/corporate-ca.pem` plus a merged
`/run/nemoclaw/managed-startup-ca-bundle.pem` — is implemented only by `mergeCorporateCa()` at
`src/lib/onboard/managed-startup/image-runtime.ts:1031-1059`. An onboard that is not
`tempManagedRuntime` and is not a rebuild gets `managedImages: null` at
`src/lib/onboard/managed-workload/onboard-orchestration.ts:141-148`, which makes
`managedImageRuntimeSupportError()` return a reason at `src/lib/onboard/workload/source.ts:131-133`,
which makes `src/lib/onboard/workload/preparation.ts:234-253` return a legacy-dockerfile workload
with `fallbackDiagnostic: null`. No managed startup profile is built, so `mergeCorporateCa()` never
runs. The legacy path writes its merged bundle to `/tmp/nemoclaw-ca-bundle.pem`
(`scripts/lib/corporate-ca-runtime.sh:23`).

`scripts/nemoclaw-start.sh` has never written `/run/nemoclaw/managed-startup-ca-bundle.pem`, so the
shared-helper extraction in #9244 preserved behavior and is not the reported regression.

Not established, and this is why the PR does not close the issue:

`CORPORATE_CA_EXIT:1` does not follow from the checked-in source. Patching the shipped `Dockerfile`
with the reporter's variable and agent bakes the anchor, sets
`ARG NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root`, and prints the bake message. `Dockerfile:659-665`
writes the anchor as `root:root 0444` in the single final stage. Distinguishing a skipped or cached
image rebuild needs the reporter's build log, which I requested on the issue.

## QA escape

Two detection gaps, at different sizes.

The gap this PR closes: the two branches that dropped a resolved corporate CA already had tests in
`src/lib/onboard/dockerfile-patch-corporate-ca.test.ts` —
`does not bake a fallback corporate CA without root startup selection (#8803)` and
`stays a no-op for a fallback CA when a custom Dockerfile lacks the ARG`. Both assert the correct
outcome, that the build argument stays empty and that onboarding does not throw. Neither asserts
that NemoClaw tells the operator, so a validated CA could be dropped in silence. Both tests keep
their assertions unchanged and still pass. The two tests added here assert the diagnostic.

The larger gap, which this PR does not close, has two parts.

Onboarding prints `baking corporate proxy CA ... into the sandbox image trust` when it patches the
staged Dockerfile, before any image build, and nothing later verifies that the built image carries
the anchor. A skipped or cached rebuild therefore produces a positive bake message, exit code 0,
and a Ready phase with no anchor in the sandbox.

End-to-end coverage asserts the documented runtime contract only for a managed image.
`scripts/checks/run-managed-image-direct-e2e.ts:638-658` and
`scripts/checks/run-managed-image-openshell-e2e.ts:468-472` require
`/run/nemoclaw/managed-startup-ca-bundle.pem` at `0:0:444`. The legacy path that an ordinary
onboard takes has no equivalent assertion, so the difference the reporter measured was never
observed by a test.

Closing this gap needs maintainer direction on where trust state belongs in readiness output, so I
have not built it here.

## What this PR does not change

The legacy direct-start path still writes `/tmp/nemoclaw-ca-bundle.pem` rather than
`/run/nemoclaw/managed-startup-ca-bundle.pem`. Making the legacy image publish the managed runtime
bundle adds a root-owned trust anchor to an image that
`docs/security/configure-corporate-ca-trust.mdx` describes as read-only by mode and not a privilege
boundary. Under the Product Scope Gate in `CLAUDE.md`, that needs an accepted issue or design
decision defining ownership, lifecycle, compatibility, security, and validation. I requested
maintainer direction on the issue rather than establishing it in a bug fix.

The second comment on the issue reports an `inference.local` HTTP 503 on an OpenAI-compatible
route. The reporter states that gateway-side TLS diagnostics are still needed to confirm the cause,
so this PR does not claim to address it.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference,
      runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded —
      reviewer/approval link/justification: not obtained. This change touches onboarding and
      security paths and needs maintainer review before merge.

## Verification

- [x] PR description includes a `Signed-off-by:` line. The commit is signed with an SSH signing
      key; confirm the `Verified` badge on GitHub after the branch is pushed.
- [x] `npm run validate:pr` passed. Every `pre-commit`, `commit-msg`, and `pre-push` hook reported
      `Passed`, including `Codebase growth guardrails`, `TypeScript (CLI)`, and
      `TypeScript (plugin)`.
- [x] Targeted behavior tests pass for the current change set —
      `npx vitest run --project cli src/lib/onboard/dockerfile-patch-corporate-ca.test.ts`
      → 1 file passed, 16 tests passed.
- [x] No secrets, API keys, or credentials committed

Additional evidence:

- Both new tests fail without the source change. Reverting only
  `src/lib/onboard/dockerfile-patch.ts` to the parent commit gives 2 failed and 14 passed.
- `npm run typecheck:cli` → 0 errors, on this commit and on the parent commit. An unbuilt `dist/`
  reports 73 resolution errors on both commits with identical text; building `dist/` clears all
  73. No error references either changed file in either state.
- `npx oxlint src/lib/onboard/dockerfile-patch.ts src/lib/onboard/dockerfile-patch-corporate-ca.test.ts`
  → exit code 0, no findings.
- `npx commitlint --from HEAD~1 --to HEAD` → exit code 0.
- `npm test` and `npm run test:changed` were not run.

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added clear warnings when a corporate certificate fallback cannot be applied to a custom Dockerfile.
  - Onboarding and sandbox startup now continue successfully when required Dockerfile settings are unavailable.
  - Warnings identify the certificate source, certificate path, and missing Dockerfile requirement.
  - Certificate settings remain unchanged when they cannot be safely applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
