### PR TITLE
fix(install): reject reserved gateway port 11438 in the installer guard

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -230,7 +230,7 @@ resolve_nemoclaw_gateway_port() {
     error "NEMOCLAW_GATEWAY_PORT must not overlap the 18789-18799 dashboard port range."
   fi
   case "$port" in
-    8000 | 8081 | 11434 | 11435 | 11436 | 11437)
+    8000 | 8081 | 11434 | 11435 | 11436 | 11437 | 11438)
       error "NEMOCLAW_GATEWAY_PORT must not overlap a reserved inference or runtime-adapter port ($port)."
       ;;
   esac

--- a/test/install-gateway-state-root.test.ts
+++ b/test/install-gateway-state-root.test.ts
@@ -194,13 +194,15 @@ nemoclaw_state_dir`,
     "08000",
     "08081",
     "11434",
+    "11438",
     "18790",
   ])("rejects conflicting gateway port %s before writing selected state", (gatewayPort) => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-installer-port-conflict-"));
     try {
       const result = runInstallerFunctions(
         home,
-        `NEMOCLAW_GATEWAY_PORT=${gatewayPort}
+        `NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_PORT=11500
+NEMOCLAW_GATEWAY_PORT=${gatewayPort}
 save_usage_notice_acceptance_shell "test-version"`,
       );
 


### PR DESCRIPTION
## Summary

The installer reserved-port guard in `resolve_nemoclaw_gateway_port` listed every reserved inference and runtime-adapter default except the HTTPS Pin Runtime adapter default `11438`. When `NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_PORT` held another port, the installer accepted `NEMOCLAW_GATEWAY_PORT=11438`, wrote host state under `~/.nemoclaw/gateways/11438`, and continued through onboarding, after which every `nemoclaw` command failed at module load. The installer now rejects `11438` before it writes host state, matching `src/lib/core/ports.ts` and `docs/reference/commands.mdx`.

## Related Issue

Fixes #9414

## Changes

- `scripts/install.sh`: add `11438` to the reserved inference and runtime-adapter port case in `resolve_nemoclaw_gateway_port`.
- `test/install-gateway-state-root.test.ts`: extend the existing `rejects conflicting gateway port %s before writing selected state` cases with `11438`, and set `NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_PORT=11500` in the shared shell body.

The environment assignment is required for the new case. With the adapter left at its default, the configured-port loop already rejects `11438`, so the case would pass without the fix. Setting the adapter to `11500` isolates the reserved-default guard. The same assignment applies to `08000`, `08081`, `11434`, and `18790`, which proves that the reserved-default guard does not depend on the configured adapter port.

This adds no abstraction, configuration, fallback, migration, or compatibility path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: requesting maintainer review; the change adds one value to an existing reject list in the installer preflight guard and writes no new code path.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

Not applicable. This PR does not change `scripts/prepare-dgx-station-host.sh`.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project integration test/install-gateway-state-root.test.ts` → 21 passed. Before the `install.sh` change the added `11438` case failed (`1 failed | 20 passed`). `npx vitest run --project cli src/lib/core/ports.test.ts` → 52 passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable; this change touches one installer guard and its owning test.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reserved port 11438 is now protected from gateway assignment to prevent conflicts with the HTTPS pin runtime adapter.
  - Improved validation detects gateway-port conflicts when the adapter port is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->