### PR TITLE
fix(agent): supply the corporate CA build argument to the Pi base image

### DIFF
--- a/src/lib/agent/base-image.test.ts
+++ b/src/lib/agent/base-image.test.ts
@@ -53,6 +53,23 @@ function makeDifferingImageInspection(
     : "";
 }
 
+const AGENTS_DIR = path.resolve(import.meta.dirname, "../../../agents");
+
+function declaresCorporateCaBuildArg(dockerfilePath: string): boolean {
+  return (
+    fs.existsSync(dockerfilePath) &&
+    fs.readFileSync(dockerfilePath, "utf8").includes("ARG NEMOCLAW_CORPORATE_CA_B64")
+  );
+}
+
+// Read the agent names from the checked-in Dockerfiles so a base image that
+// starts consuming the corporate CA cannot ship without the build argument.
+const CORPORATE_CA_BASE_IMAGE_AGENTS = fs
+  .readdirSync(AGENTS_DIR)
+  .filter((agentName) =>
+    declaresCorporateCaBuildArg(path.join(AGENTS_DIR, agentName, "Dockerfile.base")),
+  );
+
 describe("agent base image provisioning", () => {
   beforeEach(() => {
     vi.stubEnv("NEMOCLAW_CORPORATE_CA_ANCHOR_DIRS", "");
@@ -487,35 +504,40 @@ describe("agent base image provisioning", () => {
     });
   });
 
-  it("passes the resolved corporate CA into local agent base image builds (#8119)", () => {
-    vi.stubEnv("NEMOCLAW_CORPORATE_CA_BUNDLE", writeCa(tmpDir()));
-    withMockedDocker(({ ensureAgentBaseImage, dockerBuildMock, resolveSandboxBaseImageMock }) => {
-      resolveSandboxBaseImageMock.mockReturnValue({
-        ref: "nemoclaw-dcode-sandbox-base-local:compatible",
-        digest: null,
-        source: "local",
-        glibcVersion: "2.41",
+  it.each(CORPORATE_CA_BASE_IMAGE_AGENTS)(
+    "passes the resolved corporate CA into local %s base image builds (#8119)",
+    (agentName) => {
+      vi.stubEnv("NEMOCLAW_CORPORATE_CA_BUNDLE", writeCa(tmpDir()));
+      withMockedDocker(({ ensureAgentBaseImage, dockerBuildMock, resolveSandboxBaseImageMock }) => {
+        resolveSandboxBaseImageMock.mockReturnValue({
+          ref: `nemoclaw-${agentName}-sandbox-base-local:compatible`,
+          digest: null,
+          source: "local",
+          glibcVersion: "2.41",
+        });
+
+        ensureAgentBaseImage(
+          makeAgent({
+            name: agentName,
+            displayName: agentName,
+            expectedVersion: "0.1.34",
+            dockerfileBasePath: `/test/root/agents/${agentName}/Dockerfile.base`,
+            dockerfilePath: `/test/root/agents/${agentName}/Dockerfile`,
+          }),
+          { forceBaseImageRebuild: true },
+        );
+
+        const options = dockerBuildMock.mock.calls[0]?.[3] as {
+          buildArgs?: Record<string, string>;
+        };
+        const encoded = options.buildArgs?.NEMOCLAW_CORPORATE_CA_B64;
+        expect(encoded).toBeTypeOf("string");
+        expect(Buffer.from(encoded ?? "", "base64").toString("utf8")).toContain(
+          "BEGIN CERTIFICATE",
+        );
       });
-
-      ensureAgentBaseImage(
-        makeAgent({
-          name: "langchain-deepagents-code",
-          displayName: "LangChain Deep Agents Code",
-          expectedVersion: "0.1.34",
-          dockerfileBasePath: "/test/root/agents/langchain-deepagents-code/Dockerfile.base",
-          dockerfilePath: "/test/root/agents/langchain-deepagents-code/Dockerfile",
-        }),
-        { forceBaseImageRebuild: true },
-      );
-
-      const options = dockerBuildMock.mock.calls[0]?.[3] as {
-        buildArgs?: Record<string, string>;
-      };
-      const encoded = options.buildArgs?.NEMOCLAW_CORPORATE_CA_B64;
-      expect(encoded).toBeTypeOf("string");
-      expect(Buffer.from(encoded ?? "", "base64").toString("utf8")).toContain("BEGIN CERTIFICATE");
-    });
-  });
+    },
+  );
 
   it("omits corporate CA build inputs when corporate CA import is disabled (#8119)", () => {
     vi.stubEnv("NEMOCLAW_CORPORATE_CA_BUNDLE", writeCa(tmpDir()));

--- a/src/lib/agent/base-image.ts
+++ b/src/lib/agent/base-image.ts
@@ -63,7 +63,11 @@ function agentBaseImageBuildArgs(agent: AgentDefinition): Record<string, string>
   if (agent.name === "nemocua") {
     return { NEMOCUA_RUNTIME_IMAGE: getCuaSandboxImageRef() };
   }
-  return agent.name === "langchain-deepagents-code" ? corporateCaBuildArgs() : undefined;
+  // Only these base Dockerfiles declare ARG NEMOCLAW_CORPORATE_CA_B64 and anchor
+  // the decoded certificates before their HTTPS package fetches (#8119).
+  return agent.name === "langchain-deepagents-code" || agent.name === "pi"
+    ? corporateCaBuildArgs()
+    : undefined;
 }
 
 const HERMES_MCP_RUNTIME_PROBE_OK = "nemoclaw-hermes-mcp-runtime-ok";


### PR DESCRIPTION
## Summary

`agents/pi/Dockerfile.base` declares `ARG NEMOCLAW_CORPORATE_CA_B64` and anchors the decoded
certificates before its HTTPS package fetches, but NemoClaw supplied that build argument only for
Deep Agents Code. A local Pi base image build therefore received the empty default and produced a
base image without the configured corporate CA. NemoClaw now supplies the argument for Pi as well.

## Related Issue

Fixes #9416

## Changes

- Return the resolved corporate CA build argument for the Pi base image build in
  `agentBaseImageBuildArgs`. Pi and Deep Agents Code are the only agents whose `Dockerfile.base`
  declares `ARG NEMOCLAW_CORPORATE_CA_B64`.
- Extend the existing owning test in `src/lib/agent/base-image.test.ts` to a table test whose agent
  list is read from the checked-in `agents/*/Dockerfile.base` files. An agent base image that
  starts declaring the argument without a matching build argument now fails this test. No new test
  file and no new production abstraction were added.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: requested from maintainers; this change adds no new trust decision and reuses the existing `corporateCaBuildArgs` path introduced by #8150.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub — the single commit is SSH-signed; confirm GitHub reports it as `Verified` after pushing the branch, before opening this PR.
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — `prek` `pre-commit` and `pre-push` stages ran over `upstream/main..HEAD` and passed, including `Codebase growth guardrails` and `Source-shape test budget`; `npx commitlint --from HEAD~1 --to HEAD` exited 0.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/agent/base-image.test.ts` — `31 passed (31)`. The Pi case fails on the parent commit with `expected undefined to be type of 'string'`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run; this change touches one function and its owning test.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Pi is a release candidate. `CANDIDATE_MANAGED_IMAGE_AGENTS` lists `pi`, and selection requires
`NEMOCLAW_CANDIDATE_AGENTS=1` plus a published qualification receipt, so I could not run a Pi
onboard or rebuild to observe the built image. The evidence is the checked-in Dockerfile, the build
call sites, and the regression test.

---
Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Corporate certificate support is now enabled for additional agent base images, including Pi.
  * Agent base image validation now automatically covers all discovered agents that declare corporate certificate support.

* **Bug Fixes**
  * Improved verification that corporate certificates are correctly passed to and decoded by supported agent images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->