### PR TITLE
fix(state): fail the restore when publishing the OpenClaw config fails

### DIFF
--- a/src/lib/state/state-file-restore-mode.test.ts
+++ b/src/lib/state/state-file-restore-mode.test.ts
@@ -13,20 +13,20 @@ import { buildStateFileRestoreCommand } from "./state-file-restore";
 const STATE_FILE = { path: "openclaw.json", strategy: "copy" } as const;
 const fixtures: string[] = [];
 
-function runRestore(refreshOpenClawConfigHash: boolean): {
-  configPath: string;
-  stateDir: string;
-} {
+function runRestore(
+  refreshOpenClawConfigHash: boolean,
+  occupy: (stateDir: string) => void = () => undefined,
+): { configPath: string; stateDir: string; status: number | null } {
   const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-state-file-mode-"));
   fixtures.push(fixture);
   const stateDir = path.join(fixture, ".openclaw");
   fs.mkdirSync(stateDir);
+  occupy(stateDir);
   const command = buildStateFileRestoreCommand(stateDir, STATE_FILE, refreshOpenClawConfigHash);
   const result = spawnSync("bash", ["-c", command], {
     input: Buffer.from('{"gateway":{"mode":"local"}}\n'),
   });
-  expect(result.status, result.stderr.toString()).toBe(0);
-  return { configPath: path.join(stateDir, STATE_FILE.path), stateDir };
+  return { configPath: path.join(stateDir, STATE_FILE.path), stateDir, status: result.status };
 }
 
 function mode(filePath: string): number {
@@ -41,16 +41,22 @@ afterEach(() => {
 
 describe("state-file restore modes", () => {
   it("restores an OpenClaw config with the mutable managed-guard mode", () => {
-    const { configPath, stateDir } = runRestore(true);
+    const { configPath, stateDir, status } = runRestore(true);
 
+    expect(status).toBe(0);
     expect(mode(configPath)).toBe(0o660);
     expect(mode(`${configPath}.last-good`)).toBe(0o660);
     expect(mode(path.join(stateDir, ".config-hash"))).toBe(0o660);
+
+    // A sandbox that cannot publish the config hash must not report a restore.
+    const blocked = runRestore(true, (dir) => fs.mkdirSync(path.join(dir, ".config-hash")));
+    expect(blocked.status).not.toBe(0);
   });
 
   it("keeps the restricted mode for ordinary copied state files", () => {
-    const { configPath } = runRestore(false);
+    const { configPath, status } = runRestore(false);
 
+    expect(status).toBe(0);
     expect(mode(configPath)).toBe(0o640);
   });
 });

--- a/src/lib/state/state-file-restore.ts
+++ b/src/lib/state/state-file-restore.ts
@@ -89,6 +89,10 @@ export function buildStateFileRestoreCommand(
   }
 
   const steps = [
+    // Steps join with ";", so only the last step sets the exit status and the
+    // OpenClaw path ends with `|| true`. "&&" is not a substitute: an earlier
+    // failure then falls into the next step's `|| { ...; exit N; }` guard.
+    "set -e",
     `dst=${quotedRemotePath}`,
     'parent="$(dirname "$dst")"',
     '[ ! -L "$parent" ] || { echo "refusing symlinked state parent: $parent" >&2; exit 10; }',


### PR DESCRIPTION
## Summary

`buildStateFileRestoreCommand` joins its copy-strategy steps with `;`, so the script NemoClaw runs over SSH reports the exit status of its last step only. On the OpenClaw config path that last step is `chmod 660 "$hash_file" 2>/dev/null || true`, which always succeeds, so a failed config swap or a failed `.config-hash` write reported a restored file. `restoreStateFile` returned true, `restoreSandboxState` reported `success: true`, and `nemoclaw rebuild` printed a restored-state count while `openclaw.json` kept its previous contents. The script now starts with `set -e`, so the first failed step ends it and the caller records the state file as failed.

## Related Issue

Fixes #9419

## Changes

- `src/lib/state/state-file-restore.ts`: prepend `set -e` to the copy-strategy step array, with a comment that records why `&&` is not a substitute.
- `src/lib/state/state-file-restore-mode.test.ts`: extend the existing `restores an OpenClaw config with the mutable managed-guard mode` case with a run whose `.config-hash` publish cannot be written, and assert the exit status in both existing cases. `runRestore` gains an optional fixture-preparation callback and returns the status instead of asserting it.

`&&` is not used here. `&&` and `||` have equal precedence and associate left to right, so an earlier failure would fall into the next step's `|| { …; exit N; }` guard and report an unrelated exit code. `set -e` reports the first failed step and leaves the existing guards' exit codes 10 to 14 unchanged.

This adds no abstraction, configuration, fallback, migration, or compatibility path, and no new supported surface. The `sqlite_backup` branch already joins with `&&` and is unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: requesting maintainer review; the change adds one shell option to an existing generated command and changes no step, guard, exit code, or file mode.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

Not applicable. This PR does not change `scripts/prepare-dgx-station-host.sh`.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/state/state-file-restore-mode.test.ts src/lib/state/state-file-sqlite-restore-behavior.test.ts src/lib/state/state-file-restore-custom-image.test.ts src/lib/state/sandbox-state-file-restore-contract.test.ts src/lib/agent/state-file-restore-reader.test.ts` → 26 passed. `npx vitest run --project integration test/state-file-restore-command.test.ts test/hermes-state-ledger-snapshot.test.ts` → 5 passed, 6 skipped. Before the `state-file-restore.ts` change the extended case failed at `expect(blocked.status).not.toBe(0)`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable; this change touches one generated command and its owning tests.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - State restoration now correctly reports failures when updating configuration metadata does not complete successfully.
  - Restore operations stop immediately when an earlier step fails, preventing misleading success results.

- **Tests**
  - Expanded restore coverage to verify both successful restores and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->