### PR TITLE
fix(sandbox): report an unregistered sandbox correctly in sandbox status

### DIFF
--- a/src/lib/actions/sandbox/status-flow.test.ts
+++ b/src/lib/actions/sandbox/status-flow.test.ts
@@ -441,6 +441,23 @@ describe("showSandboxStatus flow", () => {
     expect(harness.getSandboxDockerRuntimeSpy).not.toHaveBeenCalled();
   });
 
+  // The registry-membership claim is the contract under review: for an
+  // unregistered name every other observable (exit code 1, no registry
+  // removal) is identical to the registered case above, so only the claim
+  // itself distinguishes a true answer from a false one.
+  it("reports an unregistered sandbox as not registered when the live gateway also lacks it (#9425)", async () => {
+    const harness = createStatusFlowHarness({ lookupState: "missing", sandboxEntry: null });
+
+    await expect(harness.showSandboxStatus("alpha")).rejects.toThrow("process.exit(1)");
+
+    const output = harness.logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toContain("Sandbox 'alpha' is not registered.");
+    expect(output).not.toContain("is registered locally");
+    expect(output).not.toContain("No local registry entry was removed by this status check");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
+  });
+
   it("prints switch guidance without removing registry state for a wrong active gateway (#2276)", async () => {
     const harness = createStatusFlowHarness({
       inferenceHealth: null,

--- a/src/lib/actions/sandbox/status-lookup-rendering.test.ts
+++ b/src/lib/actions/sandbox/status-lookup-rendering.test.ts
@@ -27,6 +27,7 @@ async function printGuidance({
 }): Promise<void> {
   await printSandboxGatewayLookupStatus({
     sandboxName: "beta",
+    registered: true,
     lookup: { state: "present", output: `Sandbox:\n  Name: beta\n  Phase: ${phase}` },
     phase,
     dockerRuntime,

--- a/src/lib/actions/sandbox/status-lookup-rendering.ts
+++ b/src/lib/actions/sandbox/status-lookup-rendering.ts
@@ -17,6 +17,8 @@ import {
 
 type SandboxGatewayLookupStatusContext = {
   sandboxName: string;
+  /** Whether the local registry holds `sandboxName`, as the status snapshot read it. */
+  registered: boolean;
   lookup: SandboxGatewayState;
   phase: string | null;
   dockerRuntime: ReturnType<typeof getSandboxDockerRuntime> | null;
@@ -37,7 +39,7 @@ export async function printSandboxGatewayLookupStatus(
       console.log(context.lookup.output);
       process.exit(1);
     case "missing":
-      printMissingLiveSandboxStatusGuidance(context.sandboxName, context.lookup);
+      printMissingLiveSandboxStatusGuidance(context);
       process.exit(1);
     case "identity_drift":
       printIdentityDriftLookupStatus(context);
@@ -74,11 +76,21 @@ function printSandboxRecoveryFailedLookupStatus({
   process.exit(1);
 }
 
-function printMissingLiveSandboxStatusGuidance(
-  sandboxName: string,
-  lookup: SandboxGatewayState,
-): void {
+function printMissingLiveSandboxStatusGuidance({
+  sandboxName,
+  registered,
+  lookup,
+}: SandboxGatewayLookupStatusContext): void {
   console.log("");
+  // A gateway NotFound cannot distinguish a deleted sandbox from a name the
+  // local registry never held. Without `registered` the guidance below claims a
+  // local registration that `sandbox start` and `sandbox stop` deny (#9425).
+  if (!registered) {
+    console.log(
+      `  Sandbox '${sandboxName}' is not registered. Run '${CLI_NAME} list' to see registered sandboxes.`,
+    );
+    return;
+  }
   console.log(
     `  Sandbox '${sandboxName}' is registered locally, but is not present in the live OpenShell gateway.`,
   );

--- a/src/lib/actions/sandbox/status.ts
+++ b/src/lib/actions/sandbox/status.ts
@@ -125,6 +125,7 @@ export async function showSandboxStatus(sandboxName: string): Promise<void> {
 
   await printSandboxGatewayLookupStatus({
     sandboxName,
+    registered: sb !== null,
     lookup,
     phase,
     dockerRuntime,

--- a/test/support/status-flow-test-harness.ts
+++ b/test/support/status-flow-test-harness.ts
@@ -69,17 +69,20 @@ export type StatusFlowHarnessOptions = {
   gatewayRunning?: boolean;
   preflight?: SandboxStatusPreflightResult;
   postRecoveryPreflight?: SandboxStatusPreflightResult;
-  sandboxEntry?: Partial<Omit<typeof baseSandboxEntry, "agentVersion">> & {
-    agent?: string | null;
-    agentVersion?: string | null;
-    dcodeAutoApprovalMode?: "disabled" | "thread-opt-in";
-    baselineExclusions?: Array<{ version: 1; agent: string; key: string; digest: string }>;
-    baselineExclusionTransition?: BaselineExclusionTransition;
-    preferredInferenceApi?: string | null;
-    compatibleEndpointReasoningEffort?: "low" | "medium" | "high" | null;
-    hostMounts?: SandboxHostMount[];
-    dashboardRemoteBindPrepared?: boolean;
-  };
+  /** `null` models a sandbox name that the local registry does not hold. */
+  sandboxEntry?:
+    | (Partial<Omit<typeof baseSandboxEntry, "agentVersion">> & {
+        agent?: string | null;
+        agentVersion?: string | null;
+        dcodeAutoApprovalMode?: "disabled" | "thread-opt-in";
+        baselineExclusions?: Array<{ version: 1; agent: string; key: string; digest: string }>;
+        baselineExclusionTransition?: BaselineExclusionTransition;
+        preferredInferenceApi?: string | null;
+        compatibleEndpointReasoningEffort?: "low" | "medium" | "high" | null;
+        hostMounts?: SandboxHostMount[];
+        dashboardRemoteBindPrepared?: boolean;
+      })
+    | null;
   shieldsPosture?: {
     mode: "locked" | "mutable_default" | "mutable";
     detail: string;
@@ -137,7 +140,8 @@ export function createStatusFlowHarness(options: StatusFlowHarnessOptions = {}):
           recoverySandboxVia: "docker unpause",
         });
 
-  const sandboxEntry = { ...baseSandboxEntry, ...options.sandboxEntry };
+  const sandboxEntry =
+    options.sandboxEntry === null ? null : { ...baseSandboxEntry, ...options.sandboxEntry };
 
   vi.spyOn(registry, "getSandbox").mockReturnValue(sandboxEntry);
   const removeSandboxSpy = vi.spyOn(registry, "removeSandbox").mockImplementation(() => undefined);
@@ -155,15 +159,15 @@ export function createStatusFlowHarness(options: StatusFlowHarnessOptions = {}):
       sb: sandboxEntry,
       lookup,
       rpcIssue: null,
-      currentModel: options.currentModel ?? sandboxEntry.model,
+      currentModel: options.currentModel ?? sandboxEntry?.model,
       currentProvider: options.currentProvider ?? "ollama-local",
       recordedRoute: {
-        provider: sandboxEntry.provider,
-        model: sandboxEntry.model,
+        provider: sandboxEntry?.provider,
+        model: sandboxEntry?.model,
       },
       liveRoute: {
         provider: options.currentProvider ?? "ollama-local",
-        model: options.currentModel ?? sandboxEntry.model,
+        model: options.currentModel ?? sandboxEntry?.model,
       },
       routeDrift: options.routeDrift ?? null,
       inferenceHealth:
@@ -190,7 +194,7 @@ export function createStatusFlowHarness(options: StatusFlowHarnessOptions = {}):
       terminalRuntimeHealth: null,
       servingProcessHealth:
         options.servingProcessHealth === undefined
-          ? sandboxEntry.agent === "langchain-deepagents-code"
+          ? sandboxEntry?.agent === "langchain-deepagents-code"
             ? null
             : { checked: false }
           : options.servingProcessHealth,


### PR DESCRIPTION
## Summary

`nemoclaw sandbox status <name>` told an unregistered sandbox name that it "is
registered locally", then printed three lines of recovery guidance for a gateway
problem it did not have. `nemoclaw sandbox start` and `nemoclaw sandbox stop` already
answered that question correctly, so the CLI contradicted itself about one registry.
The status renderer now reports registry membership from the value the status snapshot
already read, and reuses the sentence those two commands already print.

## Related Issue

Fixes #9425

## Changes

- `src/lib/actions/sandbox/status-lookup-rendering.ts` — `SandboxGatewayLookupStatusContext`
  gains a `registered: boolean` field. `printMissingLiveSandboxStatusGuidance` takes the
  context and returns the not-registered sentence when the registry does not hold the
  name. The registered branch is unchanged.
- `src/lib/actions/sandbox/status.ts` — passes `registered: sb !== null`, from the `sb`
  the status snapshot already resolved.
- `src/lib/actions/sandbox/status-flow.test.ts` — one new case in the existing
  `showSandboxStatus flow` describe, next to the registered-and-missing case it mirrors.
- `test/support/status-flow-test-harness.ts` — `sandboxEntry` accepts `null` so the
  harness can model a name the registry does not hold.

No new abstraction, configuration, fallback, migration, or compatibility path. The one
new field is a boolean on an existing internal context type, and its only consumer is
`printMissingLiveSandboxStatusGuidance`.

### Why the message is corrected at the source rather than at the dispatcher

The alias form `nemoclaw <name> status` is guarded by `recoverRequestedSandboxIfNeeded`
(`src/lib/cli/public-dispatch.ts:268`); the `sandbox` namespace form bypasses it through
`NATIVE_OCLIF_NAMESPACES` (`:43`, applied at `:505`). Routing the namespace through that
guard would be the wrong fix, because the guard prints a text error and calls
`process.exit(1)` with no `--json` awareness. That would remove the behavior
`docs/reference/commands.mdx:1931` documents:

> the canonical form `nemoclaw sandbox status <name> --json` is the one to use from
> automation that may run against an unknown sandbox name, since it still emits a JSON
> document with `found: false` instead of a text error.

It would also apply registry recovery to every `nemoclaw sandbox <action>` and
`nemoclaw internal <action>` command, which is a scope decision rather than a bug fix.

Correcting the claim where it is made removes the divergence instead of hiding it: both
the status text and `sandbox start`/`sandbox stop` now derive their answer from the same
registry read, so they cannot disagree.

### Why `registered: boolean` rather than a registry read inside the renderer

Reading `registry.getSandbox` directly inside `status-lookup-rendering.ts` also works,
but it fails the repository's own `source-architecture` check:

```
Source architecture budget failed.
Reduce the dependency debt, or lower a stale limit to the measured value.
  - src/lib/state/registry.ts: fan-in 102 exceeds 101.
```

`showSandboxStatus` already holds the resolved entry, so passing the one bit the renderer
needs adds no dependency edge, and keeps a single registry read per invocation.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: requested from maintainers on this PR

### On asserting the message text

`AGENTS.md` says not to assert incidental terminal wording. The registry-membership claim
is not incidental here: it is the contract under review. For an unregistered name every
other observable is identical to the registered case — exit code `1`, no registry
removal, no Docker probe — so a structural-only assertion passes both before and after
the fix and cannot protect the behavior. The new case therefore asserts the claim itself
(`is not registered`, and the absence of `is registered locally`) and keeps the
structural assertions alongside it. The comment above the case records that reasoning.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass for the current change set

**Regression test, before the production change** (production files restored to
`upstream/main`, test and harness kept):

```
 FAIL  |cli| src/lib/actions/sandbox/status-flow.test.ts > showSandboxStatus flow >
       reports an unregistered sandbox as not registered when the live gateway also lacks it (#9425)
AssertionError: expected '\n  Sandbox \'alpha\' is registered l…' to contain 'Sandbox \'alpha\' is not registered.'

- Expected
+ Received

- Sandbox 'alpha' is not registered.
+
+   Sandbox 'alpha' is registered locally, but is not present in the live OpenShell gateway.
+   The NemoClaw gateway was just recovered via gateway reattach; it may still be reconciling post-restart sandbox state.
+   No local registry entry was removed by this status check.
+   Retry `nemoclaw alpha status` after the gateway finishes reconnecting.
+   If the sandbox was intentionally deleted, run `nemoclaw list` to inspect the remaining sandboxes or `nemoclaw onboard` to create a new one.

 Test Files  1 failed (1)
      Tests  1 failed | 41 passed (42)
```

**After the production change:**

```
$ npx vitest run --project cli \
    src/lib/actions/sandbox/status-flow.test.ts \
    src/lib/actions/sandbox/status-lookup-rendering.test.ts \
    src/lib/actions/sandbox/status.test.ts

 Test Files  3 passed (3)
      Tests  73 passed (73)
```

**Type check and lint:**

```
$ npm run typecheck:cli        # tsc -p tsconfig.cli.json — exit 0, no diagnostics
$ npx oxlint <touched files>   # exit 0, no diagnostics
```

**Hook stages** (run with `--from-ref upstream/main` because this fork is behind
`origin/main`; `npm run validate:pr` hardcodes `--from origin/main`):

```
$ NEMOCLAW_GROWTH_BASE_REF=upstream/main npx prek run --from-ref upstream/main --to-ref HEAD --stage pre-commit
...
Repository checks........................................................Passed
NEMOCLAW_* env-var documentation gate....................................Passed
gitleaks (secret scan)...................................................Passed
Source-shape test budget.................................................Passed
Codebase growth guardrails...............................................Passed
PRECOMMIT_EXIT=0

$ npx commitlint --from upstream/main --to HEAD          # exit 0

$ NEMOCLAW_GROWTH_BASE_REF=upstream/main npx prek run --from-ref upstream/main --to-ref HEAD --stage pre-push
TypeScript (CLI).........................................................Passed
PREPUSH_EXIT=0
```

**End-to-end CLI, after the change** (stub `openshell` reporting a healthy connected
`nemoclaw` gateway and `NotFound` for every `sandbox get`, empty registry):

```
########## nemoclaw sandbox status not-a-sandbox ##########

  Sandbox 'not-a-sandbox' is not registered. Run 'nemoclaw list' to see registered sandboxes.
EXIT=1

########## nemoclaw sandbox stop not-a-sandbox ##########
  Sandbox 'not-a-sandbox' is not registered. Run 'nemoclaw list' to see registered sandboxes.
EXIT=1
```

The registered-and-missing case is unchanged. With `alpha` present in the registry and
the same stub gateway, `nemoclaw sandbox status alpha` still prints the full sandbox
detail block followed by the original four guidance lines, and `sandbox status <name>
--json` still reports `"found": false` with exit 1.

- [x] No secrets, API keys, or credentials committed

## Line count

`git diff --shortstat upstream/main HEAD` → **5 files changed, 57 insertions(+), 22
deletions(-)**, net **+35**.

| File | +/− |
|---|---|
| `src/lib/actions/sandbox/status-lookup-rendering.ts` | +17 / −5 |
| `src/lib/actions/sandbox/status.ts` | +1 / −0 |
| `src/lib/actions/sandbox/status-lookup-rendering.test.ts` | +1 / −0 |
| `src/lib/actions/sandbox/status-flow.test.ts` | +17 / −0 |
| `test/support/status-flow-test-harness.ts` | +21 / −17 |

Production net: **+13**. The harness delta is mostly reindentation from wrapping an
existing type in a union with `null`. `Codebase growth guardrails` passes against
`upstream/main`.

---

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox status reporting when a sandbox is not registered locally.
  * Prevented registered-sandbox guidance from appearing for unregistered sandboxes.
  * Ensured missing sandbox status checks return the correct failure status and messaging.
* **Tests**
  * Added regression coverage for unregistered sandboxes and updated status lookup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
