### PR TITLE
fix(messaging): scope credential availability to the owning channel

### DIFF
--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -1207,7 +1207,6 @@ function buildCredentialAvailability(channelIds: readonly string[]): Record<stri
     for (const input of manifest.inputs) {
       if (input.kind !== "secret" || !input.envKey) continue;
       if (!getMessagingToken(input.envKey)) continue;
-      availability[input.id] = true;
       availability[`${manifest.id}.${input.id}`] = true;
       availability[input.envKey] = true;
     }

--- a/src/lib/messaging/compiler/manifest-compiler.ts
+++ b/src/lib/messaging/compiler/manifest-compiler.ts
@@ -399,7 +399,9 @@ function isCredentialAvailable(
   context: ManifestCompilerContext,
 ): boolean {
   const availability = context.credentialAvailability ?? {};
-  const keys = [input.inputId, `${manifest.id}.${input.inputId}`, input.sourceEnv].filter(
+  // Input ids repeat across channels (`botToken` belongs to telegram, discord, slack and
+  // wechat), so an unqualified input id must never be an availability key.
+  const keys = [`${manifest.id}.${input.inputId}`, input.sourceEnv].filter(
     (key): key is string => typeof key === "string" && key.length > 0,
   );
 

--- a/src/lib/messaging/compiler/workflow-planner.test.ts
+++ b/src/lib/messaging/compiler/workflow-planner.test.ts
@@ -556,7 +556,7 @@ describe("MessagingWorkflowPlanner", () => {
     ]);
   });
 
-  it("does not trust credential availability from mismatched sandbox entry plans", async () => {
+  it("does not trust credential availability across sandbox or channel boundaries", async () => {
     const registry = createChannelManifestRegistry([CREDENTIAL_ONLY_MANIFEST]);
     const localPlanner = new MessagingWorkflowPlanner(
       registry,
@@ -599,6 +599,30 @@ describe("MessagingWorkflowPlanner", () => {
       channelId: "matrix",
       credentialAvailable: false,
     });
+
+    // `botToken` is the input id of telegram, discord, slack and wechat, so a Telegram token
+    // must not satisfy the WeChat host-QR secret.
+    const crossChannel = await withEnv(
+      { WECHAT_ACCOUNT_ID: "wechat-account-1", WECHAT_BOT_TOKEN: undefined },
+      () =>
+        planner().buildPlan({
+          sandboxName: "demo",
+          agent: "openclaw",
+          workflow: "onboard",
+          isInteractive: false,
+          configuredChannels: ["telegram", "wechat"],
+          credentialAvailability: { botToken: true, TELEGRAM_BOT_TOKEN: true },
+        }),
+    );
+
+    expect(crossChannel.channels.find((channel) => channel.channelId === "wechat")).toMatchObject({
+      active: false,
+      configured: false,
+    });
+    expect(
+      crossChannel.credentialBindings.find((binding) => binding.channelId === "wechat"),
+    ).toMatchObject({ credentialAvailable: false });
+    expect(crossChannel.agentRender.map((entry) => entry.channelId)).not.toContain("wechat");
   });
 
   it("mutates disabled channel state in an existing sandbox entry plan", async () => {

--- a/src/lib/messaging/compiler/workflow-planner.ts
+++ b/src/lib/messaging/compiler/workflow-planner.ts
@@ -206,7 +206,6 @@ export class MessagingWorkflowPlanner {
           (b) => b.channelId === channelId && b.providerEnvKey === credential.providerEnvKey,
         );
         if (!binding?.credentialAvailable) continue;
-        availability[credential.sourceInput] = true;
         availability[manifest.id + "." + credential.sourceInput] = true;
         availability[credential.id] = true;
         availability[manifest.id + "." + credential.id] = true;
@@ -510,7 +509,6 @@ function credentialAvailabilityFromPlan(
   for (const channel of plan.channels) {
     for (const input of channel.inputs) {
       if (input.kind !== "secret" || input.credentialAvailable !== true) continue;
-      availability[input.inputId] = true;
       availability[`${channel.channelId}.${input.inputId}`] = true;
       if (input.sourceEnv) availability[input.sourceEnv] = true;
     }
@@ -519,7 +517,6 @@ function credentialAvailabilityFromPlan(
     if (!credential.credentialAvailable) continue;
     availability[credential.credentialId] = true;
     availability[`${credential.channelId}.${credential.credentialId}`] = true;
-    availability[credential.sourceInput] = true;
     availability[`${credential.channelId}.${credential.sourceInput}`] = true;
     availability[credential.providerEnvKey] = true;
   }

--- a/src/lib/messaging/persistence.ts
+++ b/src/lib/messaging/persistence.ts
@@ -448,7 +448,6 @@ function credentialAvailabilityFromPlan(plan: SandboxMessagingPlan): Record<stri
   for (const channel of plan.channels) {
     for (const input of channel.inputs) {
       if (input.kind !== "secret" || input.credentialAvailable !== true) continue;
-      availability[input.inputId] = true;
       availability[`${channel.channelId}.${input.inputId}`] = true;
       if (input.sourceEnv) availability[input.sourceEnv] = true;
     }
@@ -457,7 +456,6 @@ function credentialAvailabilityFromPlan(plan: SandboxMessagingPlan): Record<stri
     if (!credential.credentialAvailable) continue;
     availability[credential.credentialId] = true;
     availability[`${credential.channelId}.${credential.credentialId}`] = true;
-    availability[credential.sourceInput] = true;
     availability[`${credential.channelId}.${credential.sourceInput}`] = true;
     availability[credential.providerEnvKey] = true;
   }

--- a/src/lib/onboard/messaging-channel-setup.ts
+++ b/src/lib/onboard/messaging-channel-setup.ts
@@ -436,7 +436,6 @@ function buildCredentialAvailability(
       if (input.kind !== "secret" || !input.envKey || !getMessagingToken(input.envKey)) {
         continue;
       }
-      availability[input.id] = true;
       availability[`${manifest.id}.${input.id}`] = true;
       availability[input.envKey] = true;
     }


### PR DESCRIPTION
## Summary

`isCredentialAvailable()` matched an unqualified messaging input id, and input ids repeat across channels: `botToken` is the secret input of telegram, discord, slack and wechat. One channel's token therefore marked another channel's secret available. Before this change, an onboard run with Telegram and WeChat selected and only `TELEGRAM_BOT_TOKEN` present planned wechat as `active: true, configured: true` and skipped the `wechat.ilinkLogin` host-QR pairing hook, with no WeChat token in existence. After this change, availability keys are channel-qualified input ids and environment keys only, so wechat stays inactive and its pairing hook runs.

## Related Issue

Fixes #9429

## Changes

- `src/lib/messaging/compiler/manifest-compiler.ts`: `isCredentialAvailable()` no longer accepts the unqualified `input.inputId` as an availability key. It now matches `` `${manifest.id}.${input.inputId}` `` and `input.sourceEnv`. A comment records why an unqualified input id cannot be a key.
- Removed the unqualified writes that this makes unreachable, in the same change:
  - `src/lib/onboard/messaging-channel-setup.ts:439`
  - `src/lib/actions/sandbox/policy-channel.ts:1210`
  - `src/lib/messaging/compiler/workflow-planner.ts:209,513,522`
  - `src/lib/messaging/persistence.ts:451,460`
- `src/lib/messaging/compiler/workflow-planner.test.ts`: extended the existing case that owns the "availability must not be trusted across a boundary" invariant with the channel boundary, and renamed its title to cover both boundaries.

This adds no abstraction, configuration, fallback, migration or compatibility path. Net source change is 8 deletions against 3 insertions.

Credential ids stay unqualified. `planCredentialBindings()` reads `availability[credential.id]` and `` availability[`${manifest.id}.${credential.id}`] `` (`compiler/engines/credential-binding-engine.ts:23-24`), and credential ids are channel-unique: `telegramBotToken`, `discordBotToken`, `slackBotToken`, `slackAppToken`, `teamsClientSecret`, `wechatBotToken`. That lookup is unchanged.

The removal is safe because `isCredentialAvailable()` and `planCredentialBindings()` are the only readers of `context.credentialAvailability` in the repository, and every producer that wrote the unqualified id also wrote the channel-qualified id and the environment key on the adjacent lines. Every existing caller and every existing test supplies environment-variable keys such as `TELEGRAM_BOT_TOKEN`, `SLACK_BOT_TOKEN`, `MSTEAMS_APP_PASSWORD` and `MATRIX_BOT_TOKEN`, never a bare input id. Persisted plans store `inputs[].credentialAvailable` rather than the availability map, which is derived at runtime, so no persisted state migrates.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

The change touches credentials, onboarding and messaging, so it needs sensitive-path review.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Evidence:

Regression test, before the source change:

```
$ npx vitest run --project cli src/lib/messaging/compiler/workflow-planner.test.ts \
    -t "does not trust credential availability"

 FAIL  |cli| src/lib/messaging/compiler/workflow-planner.test.ts > MessagingWorkflowPlanner
       > does not trust credential availability across sandbox or channel boundaries
AssertionError: expected { channelId: 'wechat', …(8) } to match object
                { active: false, configured: false }

- Expected
+ Received

  {
-   "active": false,
-   "configured": false,
+   "active": true,
+   "configured": true,
  }

 Test Files  1 failed (1)
      Tests  1 failed | 22 skipped (23)
```

Same test, after the source change:

```
$ npx vitest run --project cli src/lib/messaging/compiler/workflow-planner.test.ts \
    -t "does not trust credential availability"

 Test Files  1 passed (1)
      Tests  1 passed | 22 skipped (23)
```

Messaging and channel suites:

```
$ npx vitest run --project cli src/lib/messaging \
    src/lib/onboard/messaging-channel-setup.test.ts \
    src/lib/onboard/messaging-channel-setup-fallback.test.ts \
    src/lib/onboard/channel-state.test.ts \
    src/lib/actions/sandbox/policy-channel-add-drift.test.ts \
    src/lib/actions/sandbox/policy-channel-baseline.test.ts \
    src/lib/actions/sandbox/policy-channel-refresh.test.ts \
    src/lib/actions/sandbox/channel-status.test.ts

 Test Files  66 passed (66)
      Tests  777 passed (777)
```

Type check and lint:

```
$ npm run typecheck:cli
> tsc -p tsconfig.cli.json
(no output)

$ npx oxlint .
(no findings)

$ npm run format:check
> bash tools/lint/format-added-files.sh --check
(no findings)
```

Growth guardrails, compared against `upstream/main`:

```
$ NEMOCLAW_GROWTH_BASE_REF=upstream/main \
  npx vitest run --project integration test/growth-guardrails.test.ts --reporter=verbose

 ✓ codebase growth guardrails > requires TypeScript for new Node.js files
 ✓ codebase growth guardrails > keeps src/lib/onboard.ts net-neutral or smaller
 ✓ codebase growth guardrails > keeps changed test files within the size budget
 ✓ codebase growth guardrails > does not add if statements to changed test files
 ✓ codebase growth guardrails > does not add loops to changed test callbacks or test definitions

 Test Files  1 passed (1)
      Tests  25 passed (25)
```

Hooks, run against `upstream/main` because this fork's `origin/main` is behind:

```
$ NEMOCLAW_GROWTH_BASE_REF=upstream/main NEMOCLAW_FORMAT_BASE_REF=upstream/main \
  npx prek run --from-ref upstream/main --to-ref HEAD --stage pre-commit

Oxfmt....................................................................Passed
Oxlint fixes.............................................................Passed
detect private key.......................................................Passed
Repository checks........................................................Passed
NEMOCLAW_* env-var documentation gate....................................Passed
gitleaks (secret scan)...................................................Passed
Source-shape test budget.................................................Passed
Codebase growth guardrails...............................................Passed
(all other hooks Passed or Skipped for no matching files)

$ NEMOCLAW_GROWTH_BASE_REF=upstream/main NEMOCLAW_FORMAT_BASE_REF=upstream/main \
  npx prek run --from-ref upstream/main --to-ref HEAD --stage pre-push

TypeScript (CLI).........................................................Passed

$ npx commitlint --from upstream/main --to HEAD
(exit 0)
```

Diff size:

```
$ git diff --shortstat upstream/main...HEAD
 6 files changed, 28 insertions(+), 9 deletions(-)
```

Source files alone are 3 insertions against 8 deletions. The test file accounts for 25 insertions and 1 deletion.

---

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>

---

# Working Notes

<!-- Not part of the PR body. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved messaging credential isolation across channels and environments.
  * Prevented credentials with matching names from being incorrectly shared between channels.
  * Ensured channels remain inactive and unconfigured when the required channel-specific credentials are unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->