### PR TITLE
fix(sandbox): clean up the temp SSH config when skill install fails

### DIFF
--- a/src/lib/actions/sandbox/skill-install.test.ts
+++ b/src/lib/actions/sandbox/skill-install.test.ts
@@ -439,32 +439,47 @@ describe("sandbox skill action orchestration", () => {
     expect(skillInstall.postInstall).not.toHaveBeenCalled();
   });
 
-  it("adds shields recovery guidance when skill upload fails (#6859)", async () => {
+  it("adds shields recovery guidance when skill upload fails and deletes the temp SSH config (#6859)", async () => {
     const skillDir = makeSkillDir();
-    skillInstall.uploadDirectory.mockReturnValue({
-      uploaded: 0,
-      failed: ["SKILL.md"],
-      skippedDotfiles: [],
-      unsafePaths: [],
+    let tempConfig = "";
+    skillInstall.uploadDirectory.mockImplementation((ctx) => {
+      tempConfig = ctx.configFile;
+      return { uploaded: 0, failed: ["SKILL.md"], skippedDotfiles: [], unsafePaths: [] };
     });
     const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
-      throw new Error(`process.exit ${code}`);
-    }) as typeof process.exit);
 
     try {
-      await expect(
-        installSandboxSkill("alpha", { command: "install", path: skillDir }),
-      ).rejects.toThrow("process.exit 1");
+      await installSandboxSkill("alpha", { command: "install", path: skillDir });
     } finally {
       fs.rmSync(skillDir, { recursive: true, force: true });
     }
 
     const output = error.mock.calls.map((args) => args.join(" ")).join("\n");
+    expect(process.exitCode).toBe(1);
     expect(output).toContain("Failed to upload 1 file(s): SKILL.md");
     expect(output).toContain("locked while shields are up");
     expect(output).toContain("nemoclaw alpha shields down");
     expect(skillInstall.postInstall).not.toHaveBeenCalled();
-    expect(exit).toHaveBeenCalledWith(1);
+    expectTempSshConfigCleanedUp(tempConfig);
+  });
+
+  it("fails skill install when the upload cannot be verified and deletes the temp SSH config", async () => {
+    const skillDir = makeSkillDir();
+    let tempConfig = "";
+    skillInstall.verifyInstall.mockImplementation((ctx) => {
+      tempConfig = ctx.configFile;
+      return false;
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      await installSandboxSkill("alpha", { command: "install", path: skillDir });
+    } finally {
+      fs.rmSync(skillDir, { recursive: true, force: true });
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("verification failed"));
+    expectTempSshConfigCleanedUp(tempConfig);
   });
 });

--- a/src/lib/actions/sandbox/skill-install.ts
+++ b/src/lib/actions/sandbox/skill-install.ts
@@ -419,7 +419,8 @@ export async function installSandboxSkill(
     if (failed.length > 0) {
       console.error(`  Failed to upload ${failed.length} file(s): ${failed.join(", ")}`);
       printSkillUploadFailureHint(sandboxName);
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     console.log(`  ${G}✓${R} Uploaded ${uploaded} file(s) to sandbox`);
 
@@ -445,7 +446,8 @@ export async function installSandboxSkill(
         `  Skill uploaded but verification failed: SKILL.md missing at ${paths.uploadDir}` +
           (paths.mirrorDir ? ` or its agent mirror ${paths.mirrorDir}` : ""),
       );
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
   } finally {
     tmpSshConfig.cleanup();


### PR DESCRIPTION
## Summary

`nemoclaw <sandbox> skill install <path>` left its temporary SSH config directory in the system temp directory when the install failed after the SSH config was captured. Both post-connect failure branches called `process.exit(1)` inside the `try` whose `finally` removes that directory, and `process.exit` does not unwind the stack, so the cleanup never ran. Both branches now set `process.exitCode = 1` and return, which is the pattern `removeSandboxSkill` already uses in the same file. The exit status stays 1 and the printed diagnostics do not change.

## Related Issue

Fixes #9431

## Changes

- `src/lib/actions/sandbox/skill-install.ts`: the upload-failure branch (line 419) and the verification-failure branch (line 443) set `process.exitCode = 1` and return instead of calling `process.exit(1)`, so the `finally` that calls `tmpSshConfig.cleanup()` runs.
- `src/lib/actions/sandbox/skill-install.test.ts`: the existing case `adds shields recovery guidance when skill upload fails (#6859)` now awaits the call, asserts `process.exitCode` and the file-scoped `expectTempSshConfigCleanedUp` helper, and no longer needs the `process.exit` spy. One case covers the verification-failure branch with the same helper.

This change adds no abstraction, configuration, fallback, migration, or compatibility path. It uses the existing `process.exitCode` convention of `NemoClawCommand.setExitCode` and the existing test helper.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: requested from maintainers; the change is confined to the failure exits of `installSandboxSkill` and removes a leftover temp directory. It does not change what the command uploads, prints, or returns as an exit status.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

Not applicable. `scripts/prepare-dgx-station-host.sh` is unchanged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of skill installation upload and verification failures.
  * Ensured temporary SSH configuration is cleaned up before the process exits.
  * Failure status and error reporting are now preserved while allowing cleanup to complete.

* **Tests**
  * Added coverage for upload verification failures and SSH configuration cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>