### PR TITLE
fix(snapshot): name migration snapshots for the retention commands

### DIFF
--- a/nemoclaw/src/blueprint/snapshot-directory.test.ts
+++ b/nemoclaw/src/blueprint/snapshot-directory.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -13,11 +14,12 @@ import {
 } from "./snapshot-directory.js";
 
 // macOS resolves the default TMPDIR through a /var symlink, which the snapshot delete helper
-// rejects, so root every case under /private/tmp.
+// rejects. Other platforms can use their native temporary directory.
+const temporaryRoot = process.platform === "darwin" ? "/private/tmp" : tmpdir();
 const roots: string[] = [];
 
 function makeSnapshotsDir(): string {
-  const root = mkdtempSync(join("/private/tmp", "nemoclaw-snapshot-dir-"));
+  const root = mkdtempSync(join(temporaryRoot, "nemoclaw-snapshot-dir-"));
   roots.push(root);
   return join(root, "snapshots");
 }

--- a/nemoclaw/src/blueprint/snapshot-directory.test.ts
+++ b/nemoclaw/src/blueprint/snapshot-directory.test.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  compactUtcTimestamp,
+  reserveSnapshotDir,
+  SNAPSHOT_DIR_NAME_RE,
+} from "./snapshot-directory.js";
+
+// macOS resolves the default TMPDIR through a /var symlink, which the snapshot delete helper
+// rejects, so root every case under /private/tmp.
+const roots: string[] = [];
+
+function makeSnapshotsDir(): string {
+  const root = mkdtempSync(join("/private/tmp", "nemoclaw-snapshot-dir-"));
+  roots.push(root);
+  return join(root, "snapshots");
+}
+
+afterEach(() => {
+  roots.splice(0).forEach((root) => rmSync(root, { force: true, recursive: true }));
+});
+
+describe("blueprint snapshot directory reservation", () => {
+  it("names a reserved directory in the grammar the retention reader accepts", () => {
+    const reserved = reserveSnapshotDir(makeSnapshotsDir(), Date.parse("2026-08-18T06:43:16.500Z"));
+
+    expect(basename(reserved)).toBe("20260818T064316Z");
+    expect(basename(reserved)).toMatch(SNAPSHOT_DIR_NAME_RE);
+    expect(compactUtcTimestamp(Date.parse("2026-08-18T06:43:16.500Z"))).toBe(basename(reserved));
+  });
+
+  it("gives a same-second reservation the next unused second (#9433)", () => {
+    const snapshotsDir = makeSnapshotsDir();
+    const startedAt = Date.parse("2026-08-18T06:43:16.500Z");
+
+    const first = reserveSnapshotDir(snapshotsDir, startedAt);
+    writeFileSync(join(first, "reservation-marker"), "first");
+    const second = reserveSnapshotDir(snapshotsDir, startedAt);
+
+    expect(basename(first)).toBe("20260818T064316Z");
+    expect(basename(second)).toBe("20260818T064317Z");
+    expect(basename(second)).toMatch(SNAPSHOT_DIR_NAME_RE);
+    // The second reservation owns an empty directory, so it can neither read nor clean up the first.
+    expect(second).not.toBe(first);
+  });
+
+  it("advances past a planted symlink instead of following it", () => {
+    const snapshotsDir = makeSnapshotsDir();
+    const startedAt = Date.parse("2026-08-18T06:43:16.500Z");
+    reserveSnapshotDir(snapshotsDir, startedAt);
+    rmSync(join(snapshotsDir, "20260818T064316Z"), { recursive: true });
+    symlinkSync("/etc", join(snapshotsDir, "20260818T064316Z"));
+
+    const reserved = reserveSnapshotDir(snapshotsDir, startedAt);
+
+    expect(basename(reserved)).toBe("20260818T064317Z");
+  });
+});

--- a/nemoclaw/src/blueprint/snapshot-directory.ts
+++ b/nemoclaw/src/blueprint/snapshot-directory.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+/** The snapshot directory grammar that the retention commands accept. */
+export const SNAPSHOT_DIR_NAME_RE = /^\d{8}T\d{6}Z$/;
+
+/** A UTC instant in the snapshot directory grammar: 20260818T064316Z. */
+export function compactUtcTimestamp(at: number = Date.now()): string {
+  return new Date(at).toISOString().replace(/[-:]|\.\d+(?=Z)/g, "");
+}
+
+/**
+ * Reserve one snapshot directory for the calling operation alone.
+ *
+ * The leaf mkdir is non-recursive, so the reservation is a single atomic syscall: EEXIST means
+ * some other snapshot already owns that second, and the caller never writes into, or cleans up, a
+ * directory it did not create. The grammar above is second-resolution, so a taken second advances
+ * to the next second rather than taking a suffix the retention reader would reject. Each attempt
+ * names a later second than the last, so the loop ends at the first unused one.
+ *
+ * A non-directory entry planted at a candidate name, including a symlink, also fails with EEXIST,
+ * so reservation advances past it instead of following it.
+ */
+export function reserveSnapshotDir(snapshotsDir: string, startedAt: number = Date.now()): string {
+  mkdirSync(snapshotsDir, { recursive: true });
+  for (let at = startedAt; ; at += 1000) {
+    const candidate = join(snapshotsDir, compactUtcTimestamp(at));
+    try {
+      mkdirSync(candidate);
+      return candidate;
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+  }
+}

--- a/nemoclaw/src/blueprint/snapshot-management.ts
+++ b/nemoclaw/src/blueprint/snapshot-management.ts
@@ -7,8 +7,7 @@ import { homedir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 import { deleteSnapshotDirectory, snapshotDeletionSupported } from "./snapshot-delete-helper.js";
-
-const SNAPSHOT_DIR_NAME_RE = /^\d{8}T\d{6}Z$/;
+import { SNAPSHOT_DIR_NAME_RE } from "./snapshot-directory.js";
 
 export { snapshotDeletionSupported };
 

--- a/nemoclaw/src/blueprint/snapshot.ts
+++ b/nemoclaw/src/blueprint/snapshot.ts
@@ -15,7 +15,6 @@ import {
   cpSync,
   existsSync,
   lstatSync,
-  mkdirSync,
   readdirSync,
   readlinkSync,
   renameSync,
@@ -23,11 +22,12 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import { execa } from "execa";
 
 import * as importedSandboxName from "../shared/sandbox-name.cjs";
+import { compactUtcTimestamp, reserveSnapshotDir } from "./snapshot-directory.js";
 
 const HOME = homedir();
 const OPENCLAW_DIR = join(HOME, ".openclaw");
@@ -39,13 +39,6 @@ const sourceOrGeneratedSandboxName = importedSandboxName as typeof importedSandb
   default?: typeof importedSandboxName;
 };
 const { assertValidName } = sourceOrGeneratedSandboxName.default ?? sourceOrGeneratedSandboxName;
-
-function compactTimestamp(): string {
-  return new Date()
-    .toISOString()
-    .replace(/[-:]/g, "")
-    .replace(/\.\d+Z$/, "Z");
-}
 
 /**
  * Reject a path if it — or any ancestor up to $HOME — is a symlink.
@@ -111,13 +104,11 @@ export function createSnapshot(): string | null {
   // sensitive files into the snapshot.
   rejectSymlinksOnPath(OPENCLAW_DIR);
 
-  const timestamp = compactTimestamp();
-  const snapshotDir = join(SNAPSHOTS_DIR, timestamp);
+  // SECURITY: Verify snapshot destination ancestors are not symlinks, before reserving.
+  rejectSymlinksOnPath(SNAPSHOTS_DIR);
 
-  // SECURITY: Verify snapshot destination ancestors are not symlinks.
-  rejectSymlinksOnPath(snapshotDir);
-
-  mkdirSync(snapshotDir, { recursive: true });
+  const snapshotDir = reserveSnapshotDir(SNAPSHOTS_DIR);
+  const timestamp = basename(snapshotDir);
 
   const dest = join(snapshotDir, "openclaw");
   cpSync(OPENCLAW_DIR, dest, { recursive: true });
@@ -245,7 +236,7 @@ export function cutoverHost(): boolean {
     return true;
   }
 
-  const archivePath = join(HOME, `.openclaw.pre-nemoclaw.${compactTimestamp()}`);
+  const archivePath = join(HOME, `.openclaw.pre-nemoclaw.${compactUtcTimestamp()}`);
   try {
     moveSync(OPENCLAW_DIR, archivePath);
     return true;
@@ -261,7 +252,7 @@ export function rollbackFromSnapshot(snapshotDir: string): boolean {
   }
 
   const archivePath = existsSync(OPENCLAW_DIR)
-    ? join(HOME, `.openclaw.nemoclaw-archived.${compactTimestamp()}`)
+    ? join(HOME, `.openclaw.nemoclaw-archived.${compactUtcTimestamp()}`)
     : null;
 
   try {

--- a/nemoclaw/src/commands/migration-state-security.test.ts
+++ b/nemoclaw/src/commands/migration-state-security.test.ts
@@ -96,10 +96,38 @@ function expectSnapshotFailure(
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   for (const root of roots.splice(0)) {
     rmSync(root, { force: true, recursive: true });
   }
+});
+
+describe("migration-state snapshot directory reservation", () => {
+  it("gives a same-second snapshot its own retention-visible directory", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-08-18T06:43:16.500Z"));
+    const { home, configPath, logger } = makeMinimalHostSnapshot();
+    const hostState = makeHostState(home, configPath);
+
+    const first = createSnapshotBundle(hostState, logger, { persist: true });
+    expectSnapshotBundle(first);
+    writeFileSync(path.join(first.snapshotDir, "reservation-marker"), "first");
+
+    const second = createSnapshotBundle(hostState, logger, { persist: true });
+    expectSnapshotBundle(second);
+
+    // The clock has not moved, so an unreserved leaf would be the first snapshot's directory.
+    expect(second.snapshotDir).not.toBe(first.snapshotDir);
+    // Both names stay inside the grammar the retention reader accepts, and each manifest names
+    // the directory it describes.
+    expect(path.basename(first.snapshotDir)).toBe(first.manifest.timestamp);
+    expect(path.basename(second.snapshotDir)).toBe(second.manifest.timestamp);
+    expect(path.basename(second.snapshotDir)).toMatch(/^\d{8}T\d{6}Z$/);
+    // The second operation left the first snapshot's contents untouched.
+    expect(existsSync(path.join(first.snapshotDir, "reservation-marker"))).toBe(true);
+    expect(readdirSync(path.join(home, ".nemoclaw", "snapshots")).length).toBe(2);
+  });
 });
 
 describe("migration-state prepared config security", () => {

--- a/nemoclaw/src/commands/migration-state-security.test.ts
+++ b/nemoclaw/src/commands/migration-state-security.test.ts
@@ -18,6 +18,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { listSnapshots, pruneSnapshots } from "../blueprint/snapshot-management.js";
 import type { PluginLogger } from "../index.js";
 import * as credentialFilter from "../security/credential-filter.js";
 import * as snapshotSanitizer from "../security/snapshot-sanitizer.js";
@@ -120,6 +121,36 @@ describe("migration-state snapshot directory reservation", () => {
     expect(second.snapshotDir).not.toBe(first.snapshotDir);
     expect(path.basename(first.snapshotDir)).toBe(first.manifest.timestamp);
     expect(path.basename(second.snapshotDir)).toBe(second.manifest.timestamp);
+  });
+
+  it("publishes persisted migration snapshots to the retention reader (#9433)", () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-08-18T06:43:16.500Z"));
+    const { home, configPath, logger } = makeMinimalHostSnapshot();
+    const bundle = createSnapshotBundle(makeHostState(home, configPath), logger, {
+      persist: true,
+    });
+    expectSnapshotBundle(bundle);
+    const snapshotsDir = path.join(home, ".nemoclaw", "snapshots");
+
+    expect(listSnapshots({ snapshotsDir })).toEqual([
+      expect.objectContaining({
+        path: bundle.snapshotDir,
+        timestamp: bundle.manifest.timestamp,
+      }),
+    ]);
+
+    const result = pruneSnapshots(0, {
+      snapshotsDir,
+      deleteDirectory: (root, name) => {
+        expect(root).toBe(snapshotsDir);
+        expect(name).toBe(bundle.manifest.timestamp);
+        rmSync(path.join(root, name), { force: true, recursive: true });
+        return true;
+      },
+    });
+    expect(result).toEqual({ deleted: [bundle.snapshotDir], failed: [], kept: [] });
+    expect(listSnapshots({ snapshotsDir })).toEqual([]);
   });
 });
 

--- a/nemoclaw/src/commands/migration-state-security.test.ts
+++ b/nemoclaw/src/commands/migration-state-security.test.ts
@@ -104,7 +104,7 @@ afterEach(() => {
 });
 
 describe("migration-state snapshot directory reservation", () => {
-  it("gives a same-second snapshot its own retention-visible directory", () => {
+  it("takes its snapshot directory from the shared reservation (#9433)", () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(new Date("2026-08-18T06:43:16.500Z"));
     const { home, configPath, logger } = makeMinimalHostSnapshot();
@@ -112,21 +112,14 @@ describe("migration-state snapshot directory reservation", () => {
 
     const first = createSnapshotBundle(hostState, logger, { persist: true });
     expectSnapshotBundle(first);
-    writeFileSync(path.join(first.snapshotDir, "reservation-marker"), "first");
-
     const second = createSnapshotBundle(hostState, logger, { persist: true });
     expectSnapshotBundle(second);
 
     // The clock has not moved, so an unreserved leaf would be the first snapshot's directory.
+    // Reservation grammar and same-second advance are owned by snapshot-directory.test.ts.
     expect(second.snapshotDir).not.toBe(first.snapshotDir);
-    // Both names stay inside the grammar the retention reader accepts, and each manifest names
-    // the directory it describes.
     expect(path.basename(first.snapshotDir)).toBe(first.manifest.timestamp);
     expect(path.basename(second.snapshotDir)).toBe(second.manifest.timestamp);
-    expect(path.basename(second.snapshotDir)).toMatch(/^\d{8}T\d{6}Z$/);
-    // The second operation left the first snapshot's contents untouched.
-    expect(existsSync(path.join(first.snapshotDir, "reservation-marker"))).toBe(true);
-    expect(readdirSync(path.join(home, ".nemoclaw", "snapshots")).length).toBe(2);
   });
 });
 

--- a/nemoclaw/src/commands/migration-state.test.ts
+++ b/nemoclaw/src/commands/migration-state.test.ts
@@ -519,13 +519,13 @@ describe("commands/migration-state", () => {
       const hostState = makeHostOpenClawState();
 
       const bundle = createSnapshotBundle(hostState, logger, { persist: true });
-      if (bundle === null) {
-        expect.unreachable("bundle should not be null");
-        return;
-      }
-      expect(bundle.manifest.version).toBe(3);
-      expect(bundle.manifest.homeDir).toBe("/home/user");
+      if (bundle === null) expect.unreachable("bundle should not be null");
+      expect(bundle.manifest).toMatchObject({ version: 3, homeDir: "/home/user" });
       expect(bundle.temporary).toBe(false);
+      // The retention reader accepts only this directory grammar and requires the
+      // manifest to name the same identity (blueprint/snapshot-management.ts).
+      expect(bundle.snapshotDir).toMatch(/^\/home\/user\/\.nemoclaw\/snapshots\/\d{8}T\d{6}Z$/);
+      expect(bundle.snapshotDir.endsWith(`/${String(bundle.manifest.timestamp)}`)).toBe(true);
     });
 
     it("snapshots external config when hasExternalConfig", () => {

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -754,6 +754,28 @@ function prepareSandboxState(snapshotDir: string, manifest: SnapshotManifest): s
   return preparedStateDir;
 }
 
+// Reserves one snapshot directory for this operation alone. The leaf mkdir is non-recursive, so
+// the reservation is one atomic syscall: EEXIST means another snapshot already owns that second,
+// and this operation never writes into, or cleans up, a directory it did not create. The retention
+// reader accepts only ^\d{8}T\d{6}Z$ (snapshot-management.ts), so a taken second advances to the
+// next second instead of taking a suffix the reader would reject. Each attempt names a later
+// second than the last, so the loop ends at the first unused one.
+function reserveSnapshotDir(snapshotsDir: string, startedAt: number): string {
+  mkdirSync(snapshotsDir, { recursive: true });
+  for (let at = startedAt; ; at += 1000) {
+    const candidate = path.join(
+      snapshotsDir,
+      new Date(at).toISOString().replace(/[-:]|\.\d+(?=Z)/g, ""),
+    );
+    try {
+      mkdirSync(candidate);
+      return candidate;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    }
+  }
+}
+
 export function createSnapshotBundle(
   hostState: HostOpenClawState,
   logger: PluginLogger,
@@ -764,17 +786,17 @@ export function createSnapshotBundle(
     return null;
   }
 
-  // Same directory grammar the retention reader accepts (snapshot-management.ts).
-  const timestamp = new Date().toISOString().replace(/[-:]|\.\d+(?=Z)/g, "");
-  const parentDir = path.join(
+  const snapshotsDir = path.join(
     hostState.homeDir,
     ".nemoclaw",
     options.persist ? "snapshots" : "staging",
-    timestamp,
   );
+  // Empty until this operation owns a directory, so failure cleanup can never remove another one.
+  let parentDir = "";
 
   try {
-    mkdirSync(parentDir, { recursive: true });
+    parentDir = reserveSnapshotDir(snapshotsDir, Date.now());
+    const timestamp = path.basename(parentDir);
     const snapshotStateDir = path.join(parentDir, "openclaw");
     copyDirectory(hostState.stateDir, snapshotStateDir, { stripCredentials: true });
     sanitizeMigrationDirectory(snapshotStateDir);

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -20,6 +20,7 @@ import path from "node:path";
 import JSON5 from "json5";
 import { create as createTar } from "tar";
 import type { PluginLogger } from "../index.js";
+import { reserveSnapshotDir } from "../blueprint/snapshot-directory.js";
 import {
   CREDENTIAL_SENSITIVE_BASENAMES,
   isSensitiveFile,
@@ -752,28 +753,6 @@ function prepareSandboxState(snapshotDir: string, manifest: SnapshotManifest): s
   }
 
   return preparedStateDir;
-}
-
-// Reserves one snapshot directory for this operation alone. The leaf mkdir is non-recursive, so
-// the reservation is one atomic syscall: EEXIST means another snapshot already owns that second,
-// and this operation never writes into, or cleans up, a directory it did not create. The retention
-// reader accepts only ^\d{8}T\d{6}Z$ (snapshot-management.ts), so a taken second advances to the
-// next second instead of taking a suffix the reader would reject. Each attempt names a later
-// second than the last, so the loop ends at the first unused one.
-function reserveSnapshotDir(snapshotsDir: string, startedAt: number): string {
-  mkdirSync(snapshotsDir, { recursive: true });
-  for (let at = startedAt; ; at += 1000) {
-    const candidate = path.join(
-      snapshotsDir,
-      new Date(at).toISOString().replace(/[-:]|\.\d+(?=Z)/g, ""),
-    );
-    try {
-      mkdirSync(candidate);
-      return candidate;
-    } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-    }
-  }
 }
 
 export function createSnapshotBundle(

--- a/nemoclaw/src/commands/migration-state.ts
+++ b/nemoclaw/src/commands/migration-state.ts
@@ -75,6 +75,7 @@ export interface HostOpenClawState {
 
 export interface SnapshotManifest {
   version: number;
+  timestamp?: string;
   createdAt: string;
   homeDir: string;
   stateDir: string;
@@ -577,6 +578,7 @@ function isSnapshotManifest(value: unknown): value is SnapshotManifest {
   return (
     isObjectRecord(value) &&
     typeof value.version === "number" &&
+    (value.timestamp === undefined || typeof value.timestamp === "string") &&
     typeof value.createdAt === "string" &&
     typeof value.homeDir === "string" &&
     typeof value.stateDir === "string" &&
@@ -762,7 +764,8 @@ export function createSnapshotBundle(
     return null;
   }
 
-  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  // Same directory grammar the retention reader accepts (snapshot-management.ts).
+  const timestamp = new Date().toISOString().replace(/[-:]|\.\d+(?=Z)/g, "");
   const parentDir = path.join(
     hostState.homeDir,
     ".nemoclaw",
@@ -808,6 +811,7 @@ export function createSnapshotBundle(
 
     const manifest: SnapshotManifest = {
       version: SNAPSHOT_VERSION,
+      timestamp,
       createdAt: new Date().toISOString(),
       homeDir: hostState.homeDir,
       stateDir: hostState.stateDir,


### PR DESCRIPTION

Fixes #9433

### Summary

`~/.nemoclaw/snapshots/` has two writers. `blueprint/snapshot.ts` writes `20260818T064937Z`.
`commands/migration-state.ts` (`createSnapshotBundle` with `persist: true`) wrote
`2026-08-18T06-43-16-599Z` and a manifest with no `timestamp` field.

`blueprint/snapshot-management.ts` accepts only `^\d{8}T\d{6}Z$` (`:11`) and additionally requires
`raw.timestamp === snapshotName` (`:90`). Migration snapshots satisfied neither, so all three
retention commands were blind to them:

- `snapshots prune --keep 0` reported nothing to prune and left the snapshot on disk. A sanitized
  copy of `~/.openclaw` plus every configured external root survived every prune at every retention
  level.
- `snapshots delete --path ~/.nemoclaw/snapshots/<dir>` failed with
  `Snapshot path must be inside the snapshots directory` for a path that is a direct child of that
  directory — the message states the opposite of the filesystem layout.

`docs/reference/host-files-and-state.mdx` documents these commands as managing exactly these
snapshots. Its directory table describes the sanitized, external-root-collecting copy that only
`createSnapshotBundle` produces, and its "Migration Snapshot Retention" section describes
`sanitizeMigrationDirectory` — called only from `commands/migration-state.ts` — immediately before
listing `snapshots list` / `prune` / `delete` "for migration snapshots".

### The change

`createSnapshotBundle` now emits the canonical directory grammar and records that identity in its
manifest as an optional `timestamp`. Four production lines, one of them a comment. No documentation
change: the docs already describe the intended behavior.

### Why the writer and not the reader

The reader's strictness is a safety property, not an oversight. `snapshotNameFromPath` is the gate
on `deleteSnapshot` and on `isSnapshotPathInsideSnapshotsDir`, and `snapshots delete` is
irreversible by design (the docs say so). `snapshot-management.test.ts` names its cases "lists
strict snapshot identities" and "skips malformed directories, manifests, and non-directory entries"
— fail-closed is the intent. Widening that pattern to accept a second grammar would relax an
irreversible-deletion gate to accommodate a writer that can simply emit the canonical name.

### Why not a compatibility read for snapshots already on disk

Snapshots written by an earlier version keep their old directory names and remain invisible to the
retention commands. That is deliberate.

- It is not a regression. Those snapshots are invisible today; this change does not move them.
- Making them visible is not a one-line widening. `listSnapshots` would still skip them because
  their manifests have no `timestamp` at all, so it would also require relaxing the
  manifest-identity check — the check that binds a manifest to the directory it describes. That is
  two loosened invariants in the reader, to serve a case with no current consumer.
- It would newly expose pre-existing host state to an irreversible command. After an upgrade,
  `prune --keep 3` would start deleting rollback points that no previous version could delete. An
  upgrade silently widening what an irreversible command destroys is worse than leaving the old
  directories alone.
- Those directories are plain directories under a documented path, and
  `docs/reference/host-files-and-state.mdx` already tells operators they may remove them once the
  corresponding rollback point is no longer needed.
- `CLAUDE.md`: "Do not add configuration, fallback, migration, compatibility, or extension layers
  without a current requirement."

If maintainers would rather have a one-time compatibility read, say so and I will add it as a
separate change with its own test.

### Compatibility

- `SnapshotManifest.timestamp` is **optional**. `isSnapshotManifest` is a conjunction of field
  checks with no whole-key check, so manifests written before this change still validate and
  `loadSnapshotManifest` still reads them. Existing rollback and restore paths are unaffected, and
  `migration-state-test-fixtures.ts::makeSnapshotManifest` needs no change.
- The `persist: false` staging path uses the same variable, so its directory name changes shape too.
  Nothing parses that name; the only consumers of `bundle.snapshotDir` join further path segments
  onto it.
- `test/e2e-test.sh` is unaffected. Step 6 asserts `listSnapshots().length === 1` after calling
  `createSnapshot()`, and the only `createSnapshotBundle` call in that script (step 8) runs later
  and uses `persist: false`, so no persisted migration snapshot exists while that assertion runs.

### Known duplication

The compact grammar is now expressed in two places: `blueprint/snapshot.ts`'s private
`compactTimestamp` and this call site. Sharing it would mean either a new module or importing
`blueprint/snapshot.ts` — which pulls in `execa` and evaluates `homedir()` at module scope — into
`commands/` for a date format. The contract that actually needs one owner is the pattern the reader
accepts, and `snapshot-management.ts:11` already owns that. Happy to extract a shared helper if you
prefer it.

### Tests

Extended the existing `createSnapshotBundle` case in
`nemoclaw/src/commands/migration-state.test.ts` — the file's only `persist: true` scenario. No new
file, no new import, no parallel case. The assertions cover the persisted directory grammar and the
manifest identity that binds to it; both are required for `list` and `prune` to see the snapshot.

The added assertions fail against the unpatched writer:

```
AssertionError: expected '/home/user/.nemoclaw/snapshots/2026-0…' to match /^\/home\/user\/\.nemoclaw\/snaps…
- Expected: /^\/home\/user\/\.nemoclaw\/snapshots\/\d{8}T\d{6}Z$/
+ Received: "/home/user/.nemoclaw/snapshots/2026-08-18T06-56-14-250Z"
```

`ci/test-file-size-budget.json` pins this file to exactly 1300 lines, so the case's null guard was
collapsed to one line and its two manifest assertions merged into one `toMatchObject` to pay for the
new ones. The file is still exactly 1300 lines and the budget file is untouched.

### Verification

- `npx vitest run --project plugin` — 32 files, 895 tests, all passed
- `npm --prefix nemoclaw run typecheck` — clean
- `npm --prefix nemoclaw run lint` — clean
- `npm run validate:pr` — exit 0 (pre-commit hooks, commitlint, pre-push TypeScript)
- `NEMOCLAW_GROWTH_BASE_REF=upstream/main npx prek --from-ref upstream/main --to-ref HEAD` — exit 0,
  including `Codebase growth guardrails` and `Source-shape test budget`

Net **+4 lines**, all in production; **0** net test lines.

### Scope

No new supported surface. Existing documented behavior begins working as documented.

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot metadata now records timestamps consistently with snapshot directory names.
  * Snapshot creation safely handles multiple snapshots created within the same second without overwriting data.
  * Snapshot directories avoid collisions and planted symlinks during creation.
  * Snapshot cleanup removes only directories created by the active operation.
  * Manifest validation supports optional timestamp metadata while preserving compatibility with existing snapshots.
  * Cutover and rollback archive names now use a consistent UTC timestamp format.

* **Tests**
  * Expanded coverage for timestamp naming, collision handling, symlink safety, cleanup, and snapshot preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->