### PR TITLE
fix(doctor): warn when only half the inference route resolves

### DIFF
--- a/src/lib/actions/sandbox/doctor-inference.test.ts
+++ b/src/lib/actions/sandbox/doctor-inference.test.ts
@@ -70,6 +70,17 @@ describe("doctor inference checks", () => {
     );
   });
 
+  it.each([
+    ["nvidia-prod", "unknown"],
+    ["unknown", "nvidia/nemotron"],
+  ] as const)("warns with recovery guidance when only %s / %s resolves", async (provider, model) => {
+    const checks = await collectInferenceChecks("alpha", { provider, model }, false, {
+      probeProviderHealthImpl: () => null,
+    });
+
+    expect(checks[0]).toMatchObject({ label: "Route", status: "warn", hint: expect.any(String) });
+  });
+
   it("makes a broken inference.local route authoritative over a healthy upstream (#6192)", async () => {
     const checks = await collectInferenceChecks(
       "alpha",

--- a/src/lib/actions/sandbox/doctor-inference.ts
+++ b/src/lib/actions/sandbox/doctor-inference.ts
@@ -95,7 +95,7 @@ function pushInferenceHealthCheck(
 }
 
 function inferenceRouteCheck(sandboxName: string, route: DoctorInferenceRoute): DoctorCheck {
-  const known = route.provider !== "unknown" || route.model !== "unknown";
+  const known = route.provider !== "unknown" && route.model !== "unknown";
   return {
     group: "Inference",
     label: "Route",


### PR DESCRIPTION
## Summary

`nemoclaw <name> doctor` treated its Inference `Route` check as satisfied when
**either** half of the `(provider, model)` pair was known, so a half-resolved route
printed `[ok] Route: unknown / nvidia/nemotron` — a status that contradicts the
detail on the same line — and, because the recovery hint hangs off the same flag,
the `ok` branch also withheld the one line telling the operator how to recover.
After this change a route reads `ok` only when both halves resolved, and every
other shape keeps its `warn` and its hint.

## Related Issue

Fixes #9435

## Changes

- `src/lib/actions/sandbox/doctor-inference.ts` — `inferenceRouteCheck` now requires
  both halves of the route pair (`||` → `&&`). One line changed, no lines added.
  This matches every other route-usability predicate in the repository
  (`registry-entry-view.ts:27`, `start.ts:136`, `status-snapshot.ts:513/525/533/588`,
  `gateway-route-compatibility.ts:95`) and removes a self-contradiction inside this
  same file, where `collectProviderHealthDiagnostics` (`:188-191`) already reports
  `provider route is unknown` on a single unknown half.
- `src/lib/actions/sandbox/doctor-inference.test.ts` — extends the file's existing
  `it.each` scaffolding with a two-row table covering both half-resolved shapes. No
  new helper, fixture, import, `if`, or loop.

No new configuration, fallback, compatibility path, or supported surface. No
abstraction added.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: requesting maintainer review; the change is a single boolean operator in a diagnostic classifier and adds no new code path
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — `npm run validate:pr` exit 0 with `origin/main` refreshed to the branch base; `Codebase growth guardrails`, `Repository checks`, `Source-shape test budget`, `Oxfmt`, `Oxlint fixes`, and `TypeScript (CLI)` all Passed
- [x] Targeted behavior tests pass for the current change set — `npx vitest run --project cli src/lib/actions/sandbox/doctor-inference.test.ts` → 20 passed. With the production line reverted the two new rows fail (`status: "ok"`, `hint: undefined` versus the expected `warn` + guidance) and the other 18 cases still pass, so the test pins the fixed behavior and no pre-existing case depended on the old predicate.
- [ ] Applicable broad gate passed — not applicable; this is neither a broad runtime/test-harness change nor a repo-wide validation/coverage change
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Diff size

```
 src/lib/actions/sandbox/doctor-inference.test.ts | 11 +++++++++++
 src/lib/actions/sandbox/doctor-inference.ts      |  2 +-
 2 files changed, 12 insertions(+), 1 deletion(-)
```

Zero net production lines.

---
Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>




