### PR TITLE
fix(onboard): require a healthy endpoint before accepting the model router

### DIFF
--- a/src/lib/onboard/model-router-process.ts
+++ b/src/lib/onboard/model-router-process.ts
@@ -41,8 +41,8 @@ const ROUTER_HEALTH_BODY_MAX_BYTES = 64 * 1024;
 
 /**
  * Fetch /health and keep the response body for diagnosis (#8962). Unlike
- * `isRouterHealthy`, this waits for the body, so callers pass a longer
- * timeout; `startModelRouter` uses 30 seconds. LiteLLM's /health probes
+ * `isRouterHealthy`, this waits for the body, so a caller that must read it
+ * budgets for it; the final startup snapshot uses 30 seconds. LiteLLM's /health probes
  * every upstream endpoint per request and can answer well after the
  * 3-second liveness budget. The timeout is a wall-clock deadline, not a
  * socket idle timeout, so a responder that trickles bytes cannot hold the

--- a/src/lib/onboard/model-router.ts
+++ b/src/lib/onboard/model-router.ts
@@ -61,9 +61,9 @@ const ROUTER_HEALTH_INTERVAL_MS = 2000;
 const ROUTER_STARTUP_TIMEOUT_MS = 10 * 60_000;
 // LiteLLM's /health live-probes every upstream endpoint per request, so it
 // can need far longer than the 3-second liveness budget to answer (#8962).
-// The startup poll keeps the 3-second budget: the status-only liveness
-// probe must not accept a fast 200 that names zero healthy endpoints, so
-// recovery for a slow-but-healthy router runs through the body-checked
+// The startup poll keeps the 3-second budget and reads the body, so it
+// never accepts a fast 200 that names zero healthy endpoints; recovery for
+// a router whose /health outruns that budget runs through the body-checked
 // final snapshot after the poll exhausts its retries.
 const ROUTER_FINAL_HEALTH_SNAPSHOT_TIMEOUT_MS = 30_000;
 const ROUTER_LOG_TAIL_LINES = 20;
@@ -468,7 +468,8 @@ export async function startModelRouter(
       Math.min(ROUTER_HEALTH_REQUEST_TIMEOUT_MS, Math.ceil(remainingMs)),
     );
     healthAttempts += 1;
-    const healthy = await deps.isRouterHealthy(port, healthTimeoutMs);
+    const pollSnapshot = await deps.getRouterHealthSnapshot(port, healthTimeoutMs);
+    const healthy = pollSnapshot.healthy && hasHealthyEndpoint(pollSnapshot.body);
     const processAlive = deps.isProcessAlive(pid);
     if (healthy && processAlive) return pid;
     if (!processAlive) {

--- a/test/onboard-model-router.test.ts
+++ b/test/onboard-model-router.test.ts
@@ -43,6 +43,10 @@ const MODEL_ROUTER_FINGERPRINT_FILE = ".nemoclaw-source-fingerprint";
 const MODEL_ROUTER_TEST_SOURCE_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const MODEL_ROUTER_TEST_VERSION = "0.1.0";
 const NVIDIA_TEST_CREDENTIAL = "nvapi-TEST-NOT-A-REAL-ROUTER-KEY";
+const ROUTER_HEALTHY_BODY = JSON.stringify({
+  healthy_endpoints: [{ api_base: "https://integrate.api.nvidia.com/v1" }],
+  unhealthy_endpoints: [],
+});
 
 type PrepareCall = {
   venvDir: string;
@@ -295,7 +299,6 @@ describe("onboard Model Router setup", () => {
     const port = 45_678;
     const healthChecks: number[] = [];
     const sleepCalls: number[] = [];
-    let healthProbe = 0;
     let pid: number | null = null;
 
     const blueprintDir = path.join(rootDir, "nemoclaw-blueprint");
@@ -350,8 +353,11 @@ describe("onboard Model Router setup", () => {
                 name === "ROUTER_API_KEY" ? "router-secret" : null,
               isRouterHealthy: async (routerPort) => {
                 healthChecks.push(routerPort);
-                healthProbe += 1;
-                return healthProbe > 1;
+                return false;
+              },
+              getRouterHealthSnapshot: async (routerPort) => {
+                healthChecks.push(routerPort);
+                return { healthy: true, body: ROUTER_HEALTHY_BODY };
               },
               sleep: async (milliseconds) => {
                 sleepCalls.push(milliseconds);
@@ -406,7 +412,6 @@ describe("onboard Model Router setup", () => {
     const homeDir = path.join(tmpDir, "home");
     const routerCommand = path.join(tmpDir, "managed", "model-router");
     const port = 45_692;
-    let healthProbe = 0;
     let pid: number | null = null;
 
     fs.mkdirSync(path.join(rootDir, "nemoclaw-blueprint", "router"), { recursive: true });
@@ -433,10 +438,8 @@ describe("onboard Model Router setup", () => {
           homeDir,
           ensureModelRouterCommand: () => routerCommand,
           resolveProviderCredential: () => null,
-          isRouterHealthy: async () => {
-            healthProbe += 1;
-            return healthProbe > 1;
-          },
+          isRouterHealthy: async () => false,
+          getRouterHealthSnapshot: async () => ({ healthy: true, body: ROUTER_HEALTHY_BODY }),
           sleep: async () => undefined,
         },
       );
@@ -475,9 +478,10 @@ describe("onboard Model Router setup", () => {
         }),
         resolveProviderCredential: () => null,
         buildSubprocessEnv: () => ({}),
-        isRouterHealthy: async () => {
+        isRouterHealthy: async () => false,
+        getRouterHealthSnapshot: async () => {
           healthProbe += 1;
-          return healthProbe > 61;
+          return { healthy: healthProbe > 60, body: ROUTER_HEALTHY_BODY };
         },
         sleep,
         isProcessAlive: () => true,
@@ -487,7 +491,7 @@ describe("onboard Model Router setup", () => {
     );
 
     assert.equal(startedPid, pid);
-    assert.equal(healthProbe, 62);
+    assert.equal(healthProbe, 61);
     assert.equal(sleep.mock.calls.length, 61);
     assert.equal(terminateProcess.mock.calls.length, 0);
   });
@@ -496,7 +500,7 @@ describe("onboard Model Router setup", () => {
     const pid = 12_345;
     const sleep = vi.fn(async () => undefined);
     const terminateProcess = vi.fn();
-    const isRouterHealthy = vi.fn(async () => false);
+    const getRouterHealthSnapshot = vi.fn(async () => ({ healthy: false, body: null }));
 
     await assert.rejects(
       startModelRouter(
@@ -515,8 +519,8 @@ describe("onboard Model Router setup", () => {
           }),
           resolveProviderCredential: () => null,
           buildSubprocessEnv: () => ({}),
-          isRouterHealthy,
-          getRouterHealthSnapshot: async () => ({ healthy: false, body: null }),
+          isRouterHealthy: async () => false,
+          getRouterHealthSnapshot,
           sleep,
           isProcessAlive: () => true,
           terminateProcess,
@@ -526,7 +530,7 @@ describe("onboard Model Router setup", () => {
       /failed to become healthy on port 45680 within 600 seconds \(completed health checks: 300\)/,
     );
 
-    assert.equal(isRouterHealthy.mock.calls.length, 301);
+    assert.equal(getRouterHealthSnapshot.mock.calls.length, 301);
     assert.equal(sleep.mock.calls.length, 300);
     assert.deepEqual(terminateProcess.mock.calls, [[pid]]);
   });
@@ -534,7 +538,6 @@ describe("onboard Model Router setup", () => {
   it("sets OPENAI_API_KEY to the routed credential when an ambient OPENAI_API_KEY exists (#8962)", async () => {
     const pid = 12_345;
     let spawnedEnv: Record<string, string> | null = null;
-    let healthProbe = 0;
 
     await startModelRouter(
       { port: 45_690, pool_config_path: "router/test-pool.yaml", credential_env: "ROUTER_API_KEY" },
@@ -558,10 +561,8 @@ describe("onboard Model Router setup", () => {
         resolveProviderCredential: (name) =>
           ({ ROUTER_API_KEY: "router-secret", OPENAI_API_KEY: "stale-openai" })[name] ?? null,
         buildSubprocessEnv: (extra) => ({ ...extra }),
-        isRouterHealthy: async () => {
-          healthProbe += 1;
-          return healthProbe > 1;
-        },
+        isRouterHealthy: async () => false,
+        getRouterHealthSnapshot: async () => ({ healthy: true, body: ROUTER_HEALTHY_BODY }),
         sleep: async () => undefined,
         isProcessAlive: () => true,
         terminateProcess: () => undefined,
@@ -643,10 +644,6 @@ describe("onboard Model Router setup", () => {
   it("returns the router PID when the final health snapshot proves recovery (#8962)", async () => {
     const pid = 12_345;
     const terminateProcess = vi.fn();
-    const healthyBody = JSON.stringify({
-      healthy_endpoints: [{ api_base: "https://integrate.api.nvidia.com/v1" }],
-      unhealthy_endpoints: [],
-    });
 
     const startedPid = await startModelRouter(
       { port: 45_693, pool_config_path: "router/test-pool.yaml" },
@@ -665,7 +662,12 @@ describe("onboard Model Router setup", () => {
         resolveProviderCredential: () => null,
         buildSubprocessEnv: () => ({}),
         isRouterHealthy: async () => false,
-        getRouterHealthSnapshot: async () => ({ healthy: true, body: healthyBody }),
+        // /health outruns the poll's 3-second budget and answers only within
+        // the 30-second final-snapshot budget.
+        getRouterHealthSnapshot: async (_port: number, timeoutMs = 0) => ({
+          healthy: timeoutMs >= 30_000,
+          body: timeoutMs >= 30_000 ? ROUTER_HEALTHY_BODY : null,
+        }),
         sleep: async () => undefined,
         isProcessAlive: () => true,
         terminateProcess,
@@ -722,7 +724,7 @@ describe("onboard Model Router setup", () => {
     );
   });
 
-  it("still fails when the final snapshot is 2xx with zero healthy endpoints (#8962)", async () => {
+  it("still fails when the poll and final snapshot are 2xx with zero healthy endpoints (#8962)", async () => {
     const pid = 12_345;
     const terminateProcess = vi.fn();
     const allUnhealthyBody = JSON.stringify({
@@ -747,7 +749,9 @@ describe("onboard Model Router setup", () => {
           }),
           resolveProviderCredential: () => null,
           buildSubprocessEnv: () => ({}),
-          isRouterHealthy: async () => false,
+          // The pre-spawn port guard calls isRouterHealthy without a timeout;
+          // only the startup poll passes one. Answer 2xx for the poll alone.
+          isRouterHealthy: async (_port: number, timeoutMs) => timeoutMs !== undefined,
           getRouterHealthSnapshot: async () => ({ healthy: true, body: allUnhealthyBody }),
           sleep: async () => undefined,
           isProcessAlive: () => true,
@@ -827,7 +831,6 @@ describe("onboard Model Router setup", () => {
       const pid = 12_345;
       let spawnedEnv: Record<string, string> | null = null;
 
-      let healthProbe = 0;
       await startModelRouter(
         {
           port: 45_695,
@@ -853,10 +856,8 @@ describe("onboard Model Router setup", () => {
           resolveProviderCredential: (name) =>
             ({ ROUTER_API_KEY: "router-secret", OPENAI_API_KEY: "operator-openai" })[name] ?? null,
           buildSubprocessEnv: (extra) => ({ ...extra }),
-          isRouterHealthy: async () => {
-            healthProbe += 1;
-            return healthProbe > 1;
-          },
+          isRouterHealthy: async () => false,
+          getRouterHealthSnapshot: async () => ({ healthy: true, body: ROUTER_HEALTHY_BODY }),
           sleep: async () => undefined,
           isProcessAlive: () => true,
           terminateProcess: () => undefined,
@@ -874,7 +875,6 @@ describe("onboard Model Router setup", () => {
   it("preserves routed credential fallback for an unproven pool (#8962)", async () => {
     const pid = 12_345;
     let spawnedEnv: Record<string, string> | null = null;
-    let healthProbe = 0;
 
     await startModelRouter(
       {
@@ -900,10 +900,8 @@ describe("onboard Model Router setup", () => {
         readPoolConfig: () => 'models:\n  - litellm_model: "openai/gpt-test"\n',
         resolveProviderCredential: (name) => (name === "ROUTER_API_KEY" ? "router-secret" : null),
         buildSubprocessEnv: (extra) => ({ ...extra }),
-        isRouterHealthy: async () => {
-          healthProbe += 1;
-          return healthProbe > 1;
-        },
+        isRouterHealthy: async () => false,
+        getRouterHealthSnapshot: async () => ({ healthy: true, body: ROUTER_HEALTHY_BODY }),
         sleep: async () => undefined,
         isProcessAlive: () => true,
         terminateProcess: () => undefined,
@@ -924,9 +922,9 @@ describe("onboard Model Router setup", () => {
     const sleep = vi.fn(async (milliseconds: number) => {
       nowMs += milliseconds;
     });
-    const isRouterHealthy = vi.fn(async (_port: number, timeoutMs = 0) => {
+    const getRouterHealthSnapshot = vi.fn(async (_port: number, timeoutMs = 0) => {
       nowMs += timeoutMs;
-      return false;
+      return { healthy: false, body: null };
     });
 
     await assert.rejects(
@@ -946,11 +944,8 @@ describe("onboard Model Router setup", () => {
           }),
           resolveProviderCredential: () => null,
           buildSubprocessEnv: () => ({}),
-          isRouterHealthy,
-          getRouterHealthSnapshot: async (_port: number, timeoutMs = 0) => {
-            nowMs += timeoutMs;
-            return { healthy: false, body: null };
-          },
+          isRouterHealthy: async () => false,
+          getRouterHealthSnapshot,
           sleep,
           now: () => nowMs,
           isProcessAlive: () => true,
@@ -965,7 +960,7 @@ describe("onboard Model Router setup", () => {
     );
 
     assert.equal(nowMs, 600_000);
-    assert.equal(isRouterHealthy.mock.calls.length, 115);
+    assert.equal(getRouterHealthSnapshot.mock.calls.length, 115);
     assert.equal(sleep.mock.calls.length, 114);
     assert.deepEqual(terminateProcess.mock.calls, [[pid]]);
   });
@@ -980,7 +975,6 @@ describe("onboard Model Router setup", () => {
     const mkdirSync = vi.fn();
     const proxyConfigArgs: string[][] = [];
     const proxyArgs: string[][] = [];
-    let healthProbe = 0;
     vi.stubEnv("HOME", homeDir);
     vi.stubEnv("NEMOCLAW_GATEWAY_PORT", "9123");
     vi.resetModules();
@@ -1008,10 +1002,8 @@ describe("onboard Model Router setup", () => {
         },
         resolveProviderCredential: () => null,
         buildSubprocessEnv: () => ({}),
-        isRouterHealthy: async () => {
-          healthProbe += 1;
-          return healthProbe > 1;
-        },
+        isRouterHealthy: async () => false,
+        getRouterHealthSnapshot: async () => ({ healthy: true, body: ROUTER_HEALTHY_BODY }),
         sleep: async () => undefined,
         isProcessAlive: () => true,
         terminateProcess: () => undefined,


### PR DESCRIPTION

## Summary

The Model Router startup poll accepted any 2xx `/health`, while the final snapshot taken after the
poll required the response body to name at least one healthy endpoint. When the routed credential is
rejected, every upstream fails fast, `/health` answers `200` with an empty `healthy_endpoints` list
inside the 3-second liveness budget, and onboarding reported the router started before every sandbox
request failed against it. The poll now reads the body too, so both acceptance paths apply the same
rule.

## Related Issue

Fixes #9437

## Changes

- `src/lib/onboard/model-router.ts`: the startup poll takes the body-checked snapshot instead of the
  status-only probe, and accepts only when `/health` names at least one healthy endpoint. Both
  helpers were already in scope, so no import was added.
- `src/lib/onboard/model-router.ts`: corrected the comment that states this contract. It previously
  described a guard the poll did not apply.
- `src/lib/onboard/model-router-process.ts`: corrected the `getRouterHealthSnapshot` doc comment,
  which said callers pass a longer timeout. The poll is now a caller that passes the 3-second one.
- `test/onboard-model-router.test.ts`: extended the existing case "still fails when the final
  snapshot is 2xx with zero healthy endpoints (#8962)" to also own the poll path, and rewired the
  cases whose stubs drove the poll through `isRouterHealthy` so they drive it through
  `getRouterHealthSnapshot`. No new test case was added. Net **-7 lines** across the change.

`isRouterHealthy` is unchanged and still owns the pre-spawn "port already occupied" guard,
`reconcileModelRouter`, and destroy preflight, where a status-only answer is the right question.

### Timing

The poll keeps its 3-second per-request budget, its 300 retries, and its 570-second window, and
issues the same single `GET /health` it issued before — the snapshot reads the response body rather
than discarding it. A router that answers within the budget and names a healthy endpoint is still
accepted on the first probe. A router still bringing endpoints up is now accepted at the moment
`/health` names one, rather than at the moment it first answers 2xx. A router whose `/health`
outruns the 3-second budget still recovers through the 30-second final snapshot, unchanged.

The behavior that does change: a router that never names a healthy endpoint now costs the full
600-second budget before onboarding fails, instead of reporting success in about two seconds. The
failure carries the redacted endpoint error and the router log tail added in #8972.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — `npm run validate:pr`: all stages passed
- [x] Targeted behavior tests pass for the current change set — `npx vitest run --project integration test/onboard-model-router.test.ts`: 35 passed. Reverting only the production change and keeping the tests: 5 failed / 30 passed, with the owning case failing as `AssertionError: Missing expected rejection.` Also `npx vitest run --project cli src/lib/onboard/model-router-process.test.ts`: 20 passed; `npx vitest run --project package-contract test/package-contract/destroy-model-router-flow.test.ts`: 1 passed; `npm run typecheck:cli`: clean.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed

---
Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>
