### PR TITLE
fix(portable): wait for settled Podman stop

### DIFF
--- a/src/lib/onboard/experimental/portable-demo-lifecycle-stop.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle-stop.test.ts
@@ -64,6 +64,7 @@ function socketAuthorityDeps(): PodmanSocketAuthorityDeps {
 
 function createPodman() {
   let running = true;
+  let status: string | null = "running";
   let containerId = CONTAINER_ID;
   const podman = vi.fn(
     (args: readonly string[], _env?: NodeJS.ProcessEnv): PortablePodmanLifecycleCommandResult => {
@@ -89,12 +90,13 @@ function createPodman() {
                     "openshell.ai/sandbox-workspace": "default",
                   },
                 },
-                State: { Running: running },
+                State: { Running: running, Status: status },
               },
             ]),
           };
         case "stop":
           running = false;
+          status = "exited";
           return { status: 0 };
         case "update":
           return { status: 0 };
@@ -108,8 +110,9 @@ function createPodman() {
     setContainerId(value: string) {
       containerId = value;
     },
-    setRunning(value: boolean) {
+    setState(value: boolean, nextStatus: string | null) {
       running = value;
+      status = nextStatus;
     },
   };
 }
@@ -200,7 +203,7 @@ function timedOutStop(
   });
 }
 
-function stopAfterSecondInspection(harness: ReturnType<typeof createStopHarness>) {
+function settleAfterSecondInspection(harness: ReturnType<typeof createStopHarness>) {
   let inspectionsAfterStop = 0;
   return (command: readonly string[]): undefined => {
     switch (command[0]) {
@@ -208,10 +211,30 @@ function stopAfterSecondInspection(harness: ReturnType<typeof createStopHarness>
         inspectionsAfterStop += 1;
         switch (inspectionsAfterStop) {
           case 2:
-            harness.runtime.setRunning(false);
+            harness.runtime.setState(false, "exited");
         }
     }
   };
+}
+
+function successfulStop(
+  harness: ReturnType<typeof createStopHarness>,
+  afterStop?: (command: readonly string[]) => PortablePodmanLifecycleCommandResult | undefined,
+) {
+  let stopAttempted = false;
+  harness.runtime.podman.mockImplementation((args, env) => {
+    const command = args[0] === "--url" ? args.slice(2) : args;
+    switch (command[0]) {
+      case "stop":
+        stopAttempted = true;
+        harness.runtime.setState(false, "stopping");
+        return { status: 0 };
+      default: {
+        const result = stopAttempted ? afterStop?.(command) : undefined;
+        return result ?? harness.originalPodman(args, env);
+      }
+    }
+  });
 }
 
 function replaceContainerOnInspection(harness: ReturnType<typeof createStopHarness>) {
@@ -242,10 +265,97 @@ afterEach(() => {
 });
 
 describe("portable demo sandbox stop reconciliation", () => {
+  it("waits for an already-stopping container to settle without another mutation (#9200)", () => {
+    const harness = createStopHarness();
+    let now = 0;
+    let inspections = 0;
+    harness.runtime.setState(false, "stopping");
+    harness.runtime.podman.mockImplementation((args, env) => {
+      const command = args[0] === "--url" ? args.slice(2) : args;
+      switch (command[0]) {
+        case "inspect":
+          inspections += 1;
+          switch (inspections) {
+            case 3:
+              harness.runtime.setState(false, "exited");
+          }
+      }
+      return harness.originalPodman(args, env);
+    });
+    const beforeStop = vi.fn();
+
+    expect(
+      stopSandbox(
+        harness,
+        {
+          now: () => now,
+          sleep: (milliseconds) => {
+            now += milliseconds;
+          },
+        },
+        beforeStop,
+      ),
+    ).toEqual({ kind: "already-stopped" });
+
+    expect(beforeStop).not.toHaveBeenCalled();
+    expect(now).toBe(1_000);
+    expectReceiptUnchanged(harness);
+    expect(
+      harness.runtime.podman.mock.calls.some(([args]) => {
+        const command = args[0] === "--url" ? args.slice(2) : args;
+        return command[0] === "stop";
+      }),
+    ).toBe(false);
+  });
+
+  it("waits for a successful stop to settle before returning (#9200)", () => {
+    const harness = createStopHarness();
+    let now = 0;
+    successfulStop(harness, settleAfterSecondInspection(harness));
+    const beforeStop = vi.fn();
+
+    expect(
+      stopSandbox(
+        harness,
+        {
+          now: () => now,
+          sleep: (milliseconds) => {
+            now += milliseconds;
+          },
+        },
+        beforeStop,
+      ),
+    ).toEqual({ kind: "stopped" });
+
+    expect(beforeStop).toHaveBeenCalledExactlyOnceWith();
+    expect(now).toBe(1_000);
+    expectReceiptUnchanged(harness);
+    expectOnlyExactStopAndInspects(harness);
+  });
+
+  it("fails after bounded settlement when a successful stop remains transitional (#9200)", () => {
+    const harness = createStopHarness();
+    let now = 0;
+    successfulStop(harness);
+
+    expect(() =>
+      stopSandbox(harness, {
+        now: () => now,
+        sleep: (milliseconds) => {
+          now += milliseconds;
+        },
+      }),
+    ).toThrow("did not settle into the exited state");
+
+    expect(now).toBe(30_000);
+    expectReceiptUnchanged(harness);
+    expectOnlyExactStopAndInspects(harness);
+  });
+
   it("reconciles an ETIMEDOUT stop to the exact receipt-owned container state (#9200)", () => {
     const harness = createStopHarness();
     let now = 0;
-    timedOutStop(harness, stopAfterSecondInspection(harness));
+    timedOutStop(harness, settleAfterSecondInspection(harness));
     const beforeStop = vi.fn();
 
     expect(

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
@@ -113,7 +113,7 @@ function createPodman(
                   "openshell.ai/sandbox-workspace": sandboxWorkspaceLabel,
                 },
               },
-              State: { Running: running },
+              State: { Running: running, Status: running ? "running" : "exited" },
             },
           ]),
         };

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.ts
@@ -53,7 +53,7 @@ const MAX_RECEIPT_DIRECTORY_ENTRIES = 1024;
 const COMMAND_TIMEOUT_MS = 30_000;
 const PROBE_TIMEOUT_MS = 5_000;
 const EXEC_READY_TIMEOUT_MS = 90_000;
-const STOP_RECONCILIATION_TIMEOUT_MS = 30_000;
+const STOP_SETTLEMENT_TIMEOUT_MS = 30_000;
 const STARTUP_STOP_TIMEOUT_MS = 30_000;
 const STARTUP_TIMEOUT_MS = 90_000;
 const OLLAMA_STARTUP_TIMEOUT_MS = 30_000;
@@ -114,6 +114,7 @@ interface PodmanContainerInspection {
   containerId: string;
   sandboxId: string;
   running: boolean;
+  status: string | null;
 }
 
 export interface PortableDemoPrivilegedExecTarget {
@@ -535,7 +536,11 @@ function inspectPodmanContainer(
       `Portable demo lifecycle refused container '${containerId}' because its OpenShell identity does not match sandbox '${sandboxName}'`,
     );
   }
-  return { containerId, sandboxId, running: state.Running };
+  const status =
+    typeof state.Status === "string" && state.Status.trim().length > 0
+      ? state.Status.trim().toLowerCase()
+      : null;
+  return { containerId, sandboxId, running: state.Running, status };
 }
 
 function isMissingPodmanContainer(result: CommandResult): boolean {
@@ -1314,11 +1319,8 @@ export function stopPortableDemoSandboxLifecycle(
     initialInspection,
   );
   requireReceiptOwnedInspection(receipt, inspection);
-  if (!inspection.running) return { kind: "already-stopped" };
-
-  beforeStop();
-  const stop = authority.podman(["stop", receipt.containerId]);
-  const inspectStoppedState = (): boolean => {
+  const timing = { now: deps.now ?? Date.now, sleep: deps.sleep ?? defaultSleep };
+  const inspectExitedState = (): boolean => {
     const result = authority.podman(["inspect", receipt.containerId]);
     if (isMissingPodmanContainer(result)) {
       throw new Error(
@@ -1332,20 +1334,31 @@ export function stopPortableDemoSandboxLifecycle(
       result,
     );
     requireReceiptOwnedInspection(receipt, stopped);
-    return !stopped.running;
+    return !stopped.running && stopped.status === "exited";
   };
+
+  if (!inspection.running) {
+    if (inspection.status !== "stopping") return { kind: "already-stopped" };
+    if (waitFor(STOP_SETTLEMENT_TIMEOUT_MS, timing, inspectExitedState)) {
+      return { kind: "already-stopped" };
+    }
+    throw new Error(`Portable sandbox '${sandboxName}' did not settle into the exited state`);
+  }
+
+  beforeStop();
+  const stop = authority.podman(["stop", receipt.containerId]);
   if (isCommandTimeout(stop)) {
     // The rootless Podman service can continue an accepted stop after its CLI
     // client times out. Reconcile only the exact receipt-owned container; do
     // not retry the mutation or weaken socket and container identity checks.
-    const timing = { now: deps.now ?? Date.now, sleep: deps.sleep ?? defaultSleep };
-    if (waitFor(STOP_RECONCILIATION_TIMEOUT_MS, timing, inspectStoppedState)) {
+    if (waitFor(STOP_SETTLEMENT_TIMEOUT_MS, timing, inspectExitedState)) {
       return { kind: "stopped" };
     }
+    requireCommand(stop, `Stopping portable sandbox '${sandboxName}'`);
   }
   requireCommand(stop, `Stopping portable sandbox '${sandboxName}'`);
-  if (!inspectStoppedState()) {
-    throw new Error(`Portable sandbox '${sandboxName}' did not enter the stopped state`);
+  if (!waitFor(STOP_SETTLEMENT_TIMEOUT_MS, timing, inspectExitedState)) {
+    throw new Error(`Portable sandbox '${sandboxName}' did not settle into the exited state`);
   }
   return { kind: "stopped" };
 }


### PR DESCRIPTION
## Summary

A rootless Podman stop can return status 0 while the receipt-owned container still reports `Running=false` and `Status=stopping`. NemoClaw previously treated that transitional observation as complete, so an immediate `start` could fail with Podman exit 125 because the container had not reached a restartable state.

This change:
- waits for the same full receipt-owned container ID to reach `Running=false` and `Status=exited` after either a successful stop or the existing bounded client-timeout reconciliation;
- waits without issuing another mutation when a later stop invocation observes the container already stopping;
- preserves the 30-second bound, qualified rootless socket, OpenShell label identity, single stop mutation, unchanged receipt, and immediate failure for non-timeout Podman errors;
- adds regressions for successful transitional settlement, bounded failure, already-stopping reentry, timeout settlement, identity drift, missing containers, and inspection errors.

No name lookup, Docker fallback, force-stop, mutation retry, receipt change, or authority relaxation is introduced.

Related to #9200 and #9208.

## Validation

- Focused portable lifecycle: 2 files, 55 tests passed.
- `npm run typecheck:cli`: passed.
- `npm run checks:repository`: passed; 1,749 files, 5,402 edges, 0 cycles.
- `npm run source-shape:check`: passed; 0 new cases, 0 invalid exceptions.
- Focused Oxlint and Oxfmt: passed.
- Normal pre-commit, commit-message, and pre-push hooks: passed.
- Base-aware changed suite: growth guardrails passed; 297 of 298 files passed with 4,357 of 4,367 tests passing. The remaining 10 failures are unchanged DGX-Spark host-readiness tests that reproduce on this ARM64 controller with source and test blobs identical to current main.
- GitHub CI: all required checks passed, including all 12 CLI shards, aggregate checks, CodeQL, DCO, CLI parity, growth guardrails, managed-image jobs, and rootless-Podman CPU proof.
- Brev L40S / rootless Podman 5.7 validation on commit `b1127e80aac2c03d9023fc4f21e03f354a01b746`:
  - stop returned 0 only after the same receipt-owned container reached `Running=false`, `Status=exited` (47.006s);
  - immediate start returned 0 in 21.626s with `Running=true`, `Status=running`, and no status 125;
  - `connect --probe-only` returned 0;
  - registry, schema-4 receipt, socket authority, full container identity, restart policy/labels projection, and two-role inventory remained unchanged;
  - a supported gateway-owned reset archived a pre-existing context-overflowed conversation; a fresh OpenClaw conversation then passed probe, TUI ready, exact reply, post-prompt idle, `/exit`, and launch status 0.

## Security and documentation

The change keeps every mutation bound to the recorded full container ID and qualified current-user Podman socket. Every poll revalidates the OpenShell identity; disappearance, replacement, malformed status, inspection failure, or failure to reach `exited` remains fail-closed. No secrets, dependencies, policy, network, cryptography, or receipt schema change.

No documentation update is needed because the supported command syntax and intended stop/start contract are unchanged; this corrects premature completion reporting.

## Quality Gates

- [x] Code change
- [x] Tests added for changed behavior
- [x] Sensitive lifecycle path reviewed
- [x] Signed DCO commit
- [x] Brev verification completed
- [x] All actionable review feedback addressed
- [x] Ready for maintainer review

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stopping behavior for portable demo containers.
  * Correctly handles containers that have already stopped.
  * Waits for confirmed shutdown before completing the stop operation.
  * Provides a bounded failure outcome when a container remains in a transitional state.
  * Improved timeout recovery while avoiding repeated stop attempts on the same container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->