### PR TITLE
test: count loops hidden by test helpers

### DIFF
--- a/test/growth-guardrails.test.ts
+++ b/test/growth-guardrails.test.ts
@@ -243,6 +243,11 @@ describe("codebase growth guardrail test support", () => {
       "function collect(rows) { for (const row of rows) consume(row); } it('works', () => collect(rows)); it('also works', () => collect(moreRows));",
       0,
     ],
+    [
+      "same-named helpers in different lexical scopes",
+      "function collect(rows) { for (const row of rows) consume(row); } it('outer', () => collect(rows)); it('nested', () => { function collect(value) { consume(value); } collect(value); });",
+      1,
+    ],
     ["support helper loop", "function collect(rows) { for (const row of rows) consume(row); }", 0],
   ])("counts test loops in %s", (_name, source, expected) => {
     expect(checkTestOnly.countTestLoops("test/example.test.ts", source)).toBe(expected);

--- a/test/growth-guardrails.test.ts
+++ b/test/growth-guardrails.test.ts
@@ -61,7 +61,7 @@ describe("codebase growth guardrails", () => {
     expect(violations, diagnostics.conditionals(violations)).toEqual([]);
   });
 
-  it("does not add loops to changed test callbacks or test definitions", async () => {
+  it("does not add test loops directly, through one-use helpers, or through callback-forwarding helpers", async () => {
     const violations = await loopGrowthViolations(diff);
     expect(violations, diagnostics.loops(violations)).toEqual([]);
   });
@@ -217,6 +217,31 @@ describe("codebase growth guardrail test support", () => {
       "table definition loop",
       "for (const row of rows) it(row.name, () => expect(row).toBe(1));",
       1,
+    ],
+    [
+      "named test callback loop",
+      "function verifyRows() { for (const row of rows) expect(row).toBe(1); } it('works', verifyRows);",
+      1,
+    ],
+    [
+      "one-use loop helper",
+      "function collect(rows) { for (const row of rows) consume(row); } it('works', () => collect(rows));",
+      1,
+    ],
+    [
+      "thin callback-forwarding helper",
+      "function repeat(rows, action) { for (const row of rows) action(row); } it('works', () => repeat(rows, (row) => expect(row).toBe(1)));",
+      1,
+    ],
+    [
+      "callback-forwarding helper declared inside a test",
+      "it('works', () => { function repeat(rows, action) { for (const row of rows) action(row); } repeat(rows, (row) => expect(row).toBe(1)); });",
+      1,
+    ],
+    [
+      "reused setup helper",
+      "function collect(rows) { for (const row of rows) consume(row); } it('works', () => collect(rows)); it('also works', () => collect(moreRows));",
+      0,
     ],
     ["support helper loop", "function collect(rows) { for (const row of rows) consume(row); }", 0],
   ])("counts test loops in %s", (_name, source, expected) => {

--- a/test/helpers/growth-guardrail-checks.ts
+++ b/test/helpers/growth-guardrail-checks.ts
@@ -126,7 +126,7 @@ function containsTestDefinition(node: ts.Node): boolean {
   return found;
 }
 
-function isFunctionLike(node: ts.Node): boolean {
+function isFunctionLike(node: ts.Node): node is ts.FunctionLikeDeclaration {
   return (
     ts.isFunctionDeclaration(node) ||
     ts.isFunctionExpression(node) ||
@@ -138,8 +138,40 @@ function isFunctionLike(node: ts.Node): boolean {
   );
 }
 
-function isLoop(node: ts.Node): boolean {
+function functionName(node: ts.FunctionLikeDeclaration): string | null {
+  if (ts.isFunctionDeclaration(node) && node.name) return node.name.text;
+  return ts.isVariableDeclaration(node.parent) && ts.isIdentifier(node.parent.name)
+    ? node.parent.name.text
+    : null;
+}
+
+type LoopStatement = ts.ForStatement | ts.ForInStatement | ts.ForOfStatement;
+
+function isLoop(node: ts.Node): node is LoopStatement {
   return ts.isForStatement(node) || ts.isForInStatement(node) || ts.isForOfStatement(node);
+}
+
+function thinCallbackForwardingLoop(node: ts.FunctionLikeDeclaration): LoopStatement | null {
+  if (!node.body || !ts.isBlock(node.body) || node.body.statements.length !== 1) return null;
+  const statement = node.body.statements[0];
+  if (!statement || !isLoop(statement)) return null;
+  const parameters = new Set(
+    node.parameters.flatMap(({ name }) => (ts.isIdentifier(name) ? [name.text] : [])),
+  );
+  let invokesParameter = false;
+  function visit(child: ts.Node): void {
+    if (
+      ts.isCallExpression(child) &&
+      ts.isIdentifier(child.expression) &&
+      parameters.has(child.expression.text)
+    ) {
+      invokesParameter = true;
+      return;
+    }
+    ts.forEachChild(child, visit);
+  }
+  visit(statement);
+  return invokesParameter ? statement : null;
 }
 
 function countTestLoops(file: string, source: string | null): number {
@@ -151,24 +183,53 @@ function countTestLoops(file: string, source: string | null): number {
     true,
     scriptKind(file),
   );
-  const testContexts: boolean[] = [];
-  let count = 0;
+  const localFunctions = new Map<string, ts.FunctionLikeDeclaration>();
+  const callCounts = new Map<string, number>();
+  function collectFunctionsAndCalls(node: ts.Node): void {
+    if (isFunctionLike(node)) {
+      const name = functionName(node);
+      if (name) localFunctions.set(name, node);
+    }
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      callCounts.set(node.expression.text, (callCounts.get(node.expression.text) ?? 0) + 1);
+    }
+    ts.forEachChild(node, collectFunctionsAndCalls);
+  }
+  collectFunctionsAndCalls(sourceFile);
+
+  const countedLoops = new Set<LoopStatement>();
+  function visitTestContext(node: ts.Node, activeFunctions = new Set<string>()): void {
+    if (isLoop(node)) countedLoops.add(node);
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      const name = node.expression.text;
+      const helper = localFunctions.get(name);
+      if (
+        helper &&
+        !activeFunctions.has(name) &&
+        ((callCounts.get(name) ?? 0) === 1 || thinCallbackForwardingLoop(helper) !== null)
+      ) {
+        visitTestContext(helper, new Set([...activeFunctions, name]));
+      }
+    }
+    ts.forEachChild(node, (child) => visitTestContext(child, activeFunctions));
+  }
 
   function visit(node: ts.Node): void {
-    let enteredFunction = false;
-    if (isFunctionLike(node)) {
-      const call = ts.isCallExpression(node.parent) ? node.parent : null;
-      const name = call === null ? null : rootCallName(call.expression);
-      testContexts.push(name === "it" || name === "test" || testContexts.at(-1) === true);
-      enteredFunction = true;
+    if (isLoop(node) && containsTestDefinition(node)) countedLoops.add(node);
+    if (ts.isCallExpression(node) && ["it", "test"].includes(rootCallName(node.expression) ?? "")) {
+      for (const argument of node.arguments) {
+        if (isFunctionLike(argument)) visitTestContext(argument);
+        if (ts.isIdentifier(argument)) {
+          const callback = localFunctions.get(argument.text);
+          if (callback) visitTestContext(callback, new Set([argument.text]));
+        }
+      }
     }
-    if (isLoop(node) && (testContexts.at(-1) === true || containsTestDefinition(node))) count += 1;
     ts.forEachChild(node, visit);
-    if (enteredFunction) testContexts.pop();
   }
 
   visit(sourceFile);
-  return count;
+  return countedLoops.size;
 }
 
 function formatList(heading: string, details: readonly string[], remediation: string): string {
@@ -340,9 +401,9 @@ export const diagnostics = {
     ),
   loops: (details: readonly string[]) =>
     formatList(
-      "Changed test files add loops inside test callbacks or around test definitions.",
+      "Changed test files add loops inside test callbacks, around test definitions, through one-use helpers, or through callback-forwarding helpers.",
       details,
-      "Move iteration for one behavior into a named helper, or use test.each for independent cases.",
+      "Keep one-scenario setup, sequence, retry, polling, and aggregate loops direct. Use test.each for independent cases. Do not move one test's loop into a named callback or one-use helper.",
     ),
 };
 

--- a/test/helpers/growth-guardrail-checks.ts
+++ b/test/helpers/growth-guardrail-checks.ts
@@ -183,32 +183,65 @@ function countTestLoops(file: string, source: string | null): number {
     true,
     scriptKind(file),
   );
-  const localFunctions = new Map<string, ts.FunctionLikeDeclaration>();
-  const callCounts = new Map<string, number>();
-  function collectFunctionsAndCalls(node: ts.Node): void {
+  type LexicalScope = ts.SourceFile | ts.Block;
+  const localFunctions = new Map<LexicalScope, Map<string, ts.FunctionLikeDeclaration>>();
+  function enclosingScope(node: ts.Node): LexicalScope | null {
+    let current: ts.Node | undefined = node.parent;
+    while (current && !ts.isSourceFile(current) && !ts.isBlock(current)) {
+      current = current.parent;
+    }
+    return current ?? null;
+  }
+  function collectFunctions(node: ts.Node): void {
     if (isFunctionLike(node)) {
       const name = functionName(node);
-      if (name) localFunctions.set(name, node);
+      const scope = enclosingScope(node);
+      if (name && scope) {
+        const functions = localFunctions.get(scope) ?? new Map();
+        functions.set(name, node);
+        localFunctions.set(scope, functions);
+      }
     }
-    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
-      callCounts.set(node.expression.text, (callCounts.get(node.expression.text) ?? 0) + 1);
-    }
-    ts.forEachChild(node, collectFunctionsAndCalls);
+    ts.forEachChild(node, collectFunctions);
   }
-  collectFunctionsAndCalls(sourceFile);
+  collectFunctions(sourceFile);
+
+  function resolveLocalFunction(name: string, node: ts.Node): ts.FunctionLikeDeclaration | null {
+    let current: ts.Node | undefined = node;
+    while (current) {
+      if (ts.isSourceFile(current) || ts.isBlock(current)) {
+        const helper = localFunctions.get(current)?.get(name);
+        if (helper) return helper;
+      }
+      current = current.parent;
+    }
+    return null;
+  }
+
+  const callCounts = new Map<ts.FunctionLikeDeclaration, number>();
+  function collectCalls(node: ts.Node): void {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      const helper = resolveLocalFunction(node.expression.text, node);
+      if (helper) callCounts.set(helper, (callCounts.get(helper) ?? 0) + 1);
+    }
+    ts.forEachChild(node, collectCalls);
+  }
+  collectCalls(sourceFile);
 
   const countedLoops = new Set<LoopStatement>();
-  function visitTestContext(node: ts.Node, activeFunctions = new Set<string>()): void {
+  function visitTestContext(
+    node: ts.Node,
+    activeFunctions = new Set<ts.FunctionLikeDeclaration>(),
+  ): void {
     if (isLoop(node)) countedLoops.add(node);
     if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
-      const name = node.expression.text;
-      const helper = localFunctions.get(name);
+      const helper = resolveLocalFunction(node.expression.text, node);
       if (
         helper &&
-        !activeFunctions.has(name) &&
-        ((callCounts.get(name) ?? 0) === 1 || thinCallbackForwardingLoop(helper) !== null)
+        !activeFunctions.has(helper) &&
+        ((callCounts.get(helper) ?? 0) === 1 || thinCallbackForwardingLoop(helper) !== null)
       ) {
-        visitTestContext(helper, new Set([...activeFunctions, name]));
+        visitTestContext(helper, new Set([...activeFunctions, helper]));
       }
     }
     ts.forEachChild(node, (child) => visitTestContext(child, activeFunctions));
@@ -220,8 +253,8 @@ function countTestLoops(file: string, source: string | null): number {
       for (const argument of node.arguments) {
         if (isFunctionLike(argument)) visitTestContext(argument);
         if (ts.isIdentifier(argument)) {
-          const callback = localFunctions.get(argument.text);
-          if (callback) visitTestContext(callback, new Set([argument.text]));
+          const callback = resolveLocalFunction(argument.text, argument);
+          if (callback) visitTestContext(callback, new Set([callback]));
         }
       }
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The test-loop growth guardrail now counts loops hidden behind named test callbacks and one-use local helpers. Reused setup helpers remain valid, while callback-forwarding helpers cannot hide repeated assertions.

## Changes

- Resolve named `it` and `test` callbacks when counting loops.
- Resolve same-named helpers within their lexical scopes.
- Count loops reached through one-use local helpers.
- Count thin callback-forwarding helpers even when they are reused.
- Avoid duplicate counts when the same loop is reached by more than one path.
- Add regression cases for each rejected pattern and for reused setup helpers.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/growth-guardrails.test.ts` passed 31 tests; `npm run checks:repository` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: CI will run the repository-wide validation for this test-infrastructure change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded loop-detection coverage for named test callbacks, one-use helpers, nested helpers, and callback-forwarding patterns.
  * Improved detection across different lexical scopes while avoiding duplicate loop reports.
  * Continued excluding intentionally reused setup helpers from violations.
  * Updated diagnostics with clearer guidance for resolving loops detected through helper functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->