### PR TITLE
fix(cli): report Linux CPU models when Node cannot

### DIFF
--- a/src/lib/resources-cmd-lscpu.test.ts
+++ b/src/lib/resources-cmd-lscpu.test.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { spawnSyncMock } = vi.hoisted(() => ({ spawnSyncMock: vi.fn() }));
+
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return { ...actual, spawnSync: spawnSyncMock };
+});
+
+import { resolveCpuModel } from "./resources-cmd.js";
+
+describe("resources-cmd lscpu adapter", () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+  });
+
+  it("reads Linux CPU models through the bounded lscpu adapter (#9403)", () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ cpus: [{ modelname: "Cortex-X925" }] }),
+    });
+
+    expect(resolveCpuModel([{ model: "unknown" }], { platform: "linux" })).toBe("Cortex-X925");
+    expect(spawnSyncMock).toHaveBeenCalledWith("lscpu", ["--json", "--extended=CPU,MODELNAME"], {
+      encoding: "utf-8",
+      timeout: 3000,
+      maxBuffer: 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  });
+});

--- a/src/lib/resources-cmd.test.ts
+++ b/src/lib/resources-cmd.test.ts
@@ -150,6 +150,15 @@ describe("resources-cmd", () => {
     ).toBe("Cortex-X925");
   });
 
+  it("combines known Node models with additional Linux models (#9403)", () => {
+    expect(
+      resolveCpuModel([{ model: "Cortex-X925" }, { model: "unknown" }], {
+        platform: "linux",
+        readLscpu: () => JSON.stringify({ cpus: [{ modelname: "Cortex-A725" }] }),
+      }),
+    ).toBe("Cortex-X925 / Cortex-A725");
+  });
+
   it("prints JSON and returns the hardware object in JSON mode", () => {
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     try {

--- a/src/lib/resources-cmd.test.ts
+++ b/src/lib/resources-cmd.test.ts
@@ -12,6 +12,7 @@ import {
   getHardwareResources,
   loadResourceProfiles,
   printHardwareResources,
+  resolveCpuModel,
   resolveProfile,
   resolveResourceValue,
 } from "./resources-cmd.js";
@@ -86,6 +87,67 @@ describe("resources-cmd", () => {
     expect(hw.cpu.model).toEqual(expect.any(String));
     expect(hw.memory.totalMB).toBeGreaterThan(0);
     expect(hw.profiles?.creator.cpu).toBe("50%");
+  });
+
+  it("keeps complete Node CPU models without running lscpu (#9403)", () => {
+    const readLscpu = vi.fn(() => null);
+
+    expect(
+      resolveCpuModel(
+        [{ model: "Cortex-X925" }, { model: "Cortex-X925" }, { model: "Cortex-A725" }],
+        { platform: "linux", readLscpu },
+      ),
+    ).toBe("Cortex-X925 / Cortex-A725");
+    expect(readLscpu).not.toHaveBeenCalled();
+  });
+
+  it("reports distinct lscpu models when Node reports unknown on Linux (#9403)", () => {
+    const readLscpu = vi.fn(() =>
+      JSON.stringify({
+        cpus: [
+          { cpu: 0, modelname: "Cortex-X925" },
+          { cpu: 1, modelname: "Cortex-X925" },
+          { cpu: 2, modelname: "Cortex-A725" },
+          { cpu: 3, modelname: "Cortex-A725" },
+        ],
+      }),
+    );
+
+    expect(
+      resolveCpuModel([{ model: "unknown" }, { model: "unknown" }], {
+        platform: "linux",
+        readLscpu,
+      }),
+    ).toBe("Cortex-X925 / Cortex-A725");
+    expect(readLscpu).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["unavailable", null],
+    ["malformed", "not JSON"],
+    ["missing rows", JSON.stringify({ cpus: "unknown" })],
+    [
+      "unsafe values",
+      JSON.stringify({
+        cpus: [{ modelname: "unknown" }, { modelname: "-" }, { modelname: "bad\nmodel" }],
+      }),
+    ],
+  ])("falls back safely when lscpu output is %s (#9403)", (_case, output) => {
+    expect(
+      resolveCpuModel([{ model: "unknown" }], {
+        platform: "linux",
+        readLscpu: () => output,
+      }),
+    ).toBe("unknown");
+  });
+
+  it("keeps known Node models when the Linux fallback cannot help (#9403)", () => {
+    expect(
+      resolveCpuModel([{ model: "Cortex-X925" }, { model: "unknown" }], {
+        platform: "linux",
+        readLscpu: () => null,
+      }),
+    ).toBe("Cortex-X925");
   });
 
   it("prints JSON and returns the hardware object in JSON mode", () => {

--- a/src/lib/resources-cmd.ts
+++ b/src/lib/resources-cmd.ts
@@ -132,7 +132,8 @@ export function resolveCpuModel(
 
   const lscpuOutput = (options.readLscpu ?? readLscpuJson)();
   const lscpuModels = lscpuOutput === null ? [] : parseLscpuCpuModels(lscpuOutput);
-  return (lscpuModels.length > 0 ? lscpuModels : nodeModels).join(" / ") || UNKNOWN_CPU_MODEL;
+  const models = distinctCpuModels([...nodeModels, ...lscpuModels]);
+  return models.join(" / ") || UNKNOWN_CPU_MODEL;
 }
 
 // ── Implementation ───────────────────────────────────────────────

--- a/src/lib/resources-cmd.ts
+++ b/src/lib/resources-cmd.ts
@@ -18,6 +18,10 @@ import * as YAML from "yaml";
 import { dockerSpawnSync } from "./adapters/docker";
 
 const GATEWAY_NAME = "nemoclaw";
+const UNKNOWN_CPU_MODEL = "unknown";
+const MAX_CPU_MODEL_LENGTH = 256;
+const LSCPU_MAX_OUTPUT_BYTES = 1024 * 1024;
+const CPU_MODEL_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/u;
 
 function getGatewayContainer(): string {
   return `openshell-cluster-${GATEWAY_NAME}`;
@@ -58,6 +62,79 @@ export interface HardwareResources {
   profiles: Record<string, ResourceProfile> | null;
 }
 
+interface CpuModelResolutionOptions {
+  platform?: NodeJS.Platform;
+  readLscpu?: () => string | null;
+}
+
+function normalizeCpuModel(value: unknown): string | null {
+  if (typeof value !== "string" || CPU_MODEL_CONTROL_CHARACTERS.test(value)) return null;
+
+  const model = value.trim();
+  if (
+    model.length === 0 ||
+    model.length > MAX_CPU_MODEL_LENGTH ||
+    model === "-" ||
+    model.toLowerCase() === UNKNOWN_CPU_MODEL
+  ) {
+    return null;
+  }
+  return model;
+}
+
+function distinctCpuModels(values: readonly unknown[]): string[] {
+  return [...new Set(values.map(normalizeCpuModel).filter((model) => model !== null))];
+}
+
+function parseLscpuCpuModels(output: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(output);
+    if (!parsed || typeof parsed !== "object") return [];
+
+    const cpus = (parsed as { cpus?: unknown }).cpus;
+    if (!Array.isArray(cpus)) return [];
+
+    return distinctCpuModels(
+      cpus.map((cpu) =>
+        cpu && typeof cpu === "object" ? (cpu as { modelname?: unknown }).modelname : undefined,
+      ),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function readLscpuJson(): string | null {
+  try {
+    const result = spawnSync("lscpu", ["--json", "--extended=CPU,MODELNAME"], {
+      encoding: "utf-8",
+      timeout: 3000,
+      maxBuffer: LSCPU_MAX_OUTPUT_BYTES,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return result.status === 0 && typeof result.stdout === "string" ? result.stdout : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveCpuModel(
+  cpus: readonly { model: string }[],
+  options: CpuModelResolutionOptions = {},
+): string {
+  const nodeModels = distinctCpuModels(cpus.map((cpu) => cpu.model));
+  const hasIncompleteNodeModel =
+    cpus.length === 0 || cpus.some((cpu) => normalizeCpuModel(cpu.model) === null);
+
+  if (!hasIncompleteNodeModel || (options.platform ?? process.platform) !== "linux") {
+    return nodeModels.join(" / ") || UNKNOWN_CPU_MODEL;
+  }
+
+  const lscpuOutput = (options.readLscpu ?? readLscpuJson)();
+  const lscpuModels = lscpuOutput === null ? [] : parseLscpuCpuModels(lscpuOutput);
+  return (lscpuModels.length > 0 ? lscpuModels : nodeModels).join(" / ") || UNKNOWN_CPU_MODEL;
+}
+
 // ── Implementation ───────────────────────────────────────────────
 
 /**
@@ -67,7 +144,7 @@ export interface HardwareResources {
  */
 export function getHardwareResources(): HardwareResources {
   const cpus = os.cpus();
-  const cpuModel = cpus[0]?.model?.trim() || "unknown";
+  const cpuModel = resolveCpuModel(cpus);
 
   let totalMB = 0;
   let swapMB = 0;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`nemoclaw resources` now uses Linux CPU data when Node reports an incomplete model. This fixes the `unknown` model on WSL2 ARM64 and reports mixed core families such as `Cortex-X925 / Cortex-A725`.

## Related Issue

Fixes #9403

## Changes

- Treat blank, `unknown`, and unsafe CPU model values as incomplete.
- When Node's data is incomplete on Linux, read per-CPU model names from `lscpu`, keep the first-seen order, and remove duplicates.
- Keep `unknown` as the safe result when `lscpu` is missing or returns unusable data.
- Add regression coverage for mixed ARM core families, unavailable and malformed output, and partial Node data.
- Leave the docs unchanged because the `resources` command contract is unchanged; this fixes the reported value.

This fallback is for the host-side `nemoclaw resources` consumer in #9403. A direct Node-only change is not enough because Node 22's bundled libuv returns the nonempty string `unknown` for the reported ARM CPU parts. The `resolveCpuModel` tests protect the fallback and failure behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/resources-cmd.test.ts src/lib/resources-cmd-lscpu.test.ts` (2 files and 19 tests passed); `npm run test:changed` passed after each change set
- [ ] Applicable broad gate passed — not applicable; this is a focused CLI bug fix
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Remaining hardware check

- [ ] Run `nemoclaw resources --json` on the reported WSL2 ARM64 device after CI is green.

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU model detection in hardware resource information.
  * Added fallback handling when system-reported CPU details are missing, invalid, or incomplete.
  * Prevented malformed, unsafe, or oversized system data from affecting displayed hardware information.
  * Preserved known CPU models when fallback data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->