### PR TITLE
test(e2e): accept completed OpenClaw TUI turns

### DIFF
--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -1577,11 +1577,13 @@ if [[ -n "$NEMOCLAW_LAUNCH_EXIT_COMMAND" ]]; then
   # The TUI may finish cleanly immediately after publishing the two required
   # structured turns. Preserve that successful child status even when its
   # input reader wins the race with the best-effort exit command.
+  trap '' PIPE
   if printf '%s\r' "$NEMOCLAW_LAUNCH_EXIT_COMMAND" >&3; then
     :
   else
     exit_command_write_status=$?
   fi
+  trap - PIPE
 else
   # Some TUIs have no exit command. They may close the FIFO after the first
   # interrupt, so ignore SIGPIPE while sending the second one.

--- a/test/e2e/live/launch-agent-turn.ts
+++ b/test/e2e/live/launch-agent-turn.ts
@@ -1376,7 +1376,7 @@ cleanup() {
   local original_status=$?
   local cleanup_status=0
   trap - EXIT
-  exec 3>&- 2>/dev/null || true
+  exec 3>&- || true
   if [[ -n "$session_pid" ]] && kill -0 "$session_pid" 2>/dev/null; then
     kill -TERM "$session_pid" 2>/dev/null || true
     sleep 1
@@ -1572,8 +1572,16 @@ if ! printf '%s\r' "$NEMOCLAW_LAUNCH_SECOND_INPUT" >&3; then
 fi
 wait_for_turn_count 2
 
+exit_command_write_status=0
 if [[ -n "$NEMOCLAW_LAUNCH_EXIT_COMMAND" ]]; then
-  printf '%s\r' "$NEMOCLAW_LAUNCH_EXIT_COMMAND" >&3
+  # The TUI may finish cleanly immediately after publishing the two required
+  # structured turns. Preserve that successful child status even when its
+  # input reader wins the race with the best-effort exit command.
+  if printf '%s\r' "$NEMOCLAW_LAUNCH_EXIT_COMMAND" >&3; then
+    :
+  else
+    exit_command_write_status=$?
+  fi
 else
   # Some TUIs have no exit command. They may close the FIFO after the first
   # interrupt, so ignore SIGPIPE while sending the second one.
@@ -1593,6 +1601,9 @@ fi
 session_pid=""
 
 if [[ "$launch_status" != 0 ]]; then
+  if [[ "$exit_command_write_status" != 0 ]]; then
+    echo "launch PTY closed before the exit command was submitted (status $exit_command_write_status)" >&2
+  fi
   echo "launch exited with status $launch_status" >&2
   terminal_diagnostic
   exit "$launch_status"

--- a/test/e2e/support/launch-agent-turn.test.ts
+++ b/test/e2e/support/launch-agent-turn.test.ts
@@ -503,6 +503,7 @@ if (process.argv[2] !== "tui") {
   const second = await ask();
   append("user", second);
   append("assistant", "second response");
+  if (mode === "delayed-input-attachment") process.exit(0);
   const exitCommand = await ask();
   if (mode === "late-extra") append("user", firstInput);
   rl.close();
@@ -1056,7 +1057,7 @@ it.runIf(process.platform === "linux").each(["absent", "ansi", "reordered"] as c
 );
 
 it.runIf(process.platform === "linux")(
-  "waits for the OpenClaw TUI input mode before submitting PTY input (#9160)",
+  "waits for OpenClaw input mode and accepts a clean exit after two turns (#9160, #9384)",
   () => {
     const { baselineRemoved, result, ttyObserved } = runLaunchSessionFixture(
       "delayed-input-attachment",


### PR DESCRIPTION
## Summary

Preserve a successful OpenClaw launch when the TUI closes its input reader immediately after publishing the two required structured turns. The harness still requires the real child to exit zero; nonzero exits remain failures and now retain their bounded diagnostics.

This follows the merged startup-message fix in #9422. Two focused current-main runs reproduced the newly exposed exit race after hosted inference, sandbox inference, recovery, and the launch-readiness producer had all passed: [run 32112329966](https://github.com/NVIDIA/NemoClaw/actions/runs/32112329966) and [run 32112353122](https://github.com/NVIDIA/NemoClaw/actions/runs/32112353122).

## Related Issue

Follow-up to #9384

## Changes

- Treat the post-turn `/exit` write as best-effort after two ordered structured turns are already qualified.
- Continue to wait for and require the actual TUI child exit status, reporting both a failed exit-command write and any nonzero child exit.
- Keep cleanup diagnostics on stderr instead of redirecting the parent shell's stderr for the remainder of the session.
- Extend the Linux delayed-input fixture to cover a clean TUI exit after the two required turns without increasing the test-file budget.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The change runs only after exact PTY identity, noncanonical input mode, and two ordered structured turns are proven. It does not retry input, relax PTY evidence, or accept a nonzero TUI exit.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `vitest run --project e2e-support test/e2e/support/launch-agent-turn.test.ts` (19 passed; 24 Linux-only tests skipped locally)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable to this focused live-E2E exit-path change; the targeted support suite, source-shape budget, growth guardrails, repository checks, secret scan, and CLI typecheck passed in `npm run validate:pr`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launch cleanup and exit handling when terminal sessions close unexpectedly.
  * Exit commands now handle terminal closure more gracefully and provide clearer diagnostics when launches end unsuccessfully.
* **Tests**
  * Updated delayed-input coverage to verify that sessions can complete cleanly after two turns.
  * Improved validation of successful completion when input becomes available later in the launch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->