### PR TITLE
refactor(security): share private-network boundary

### DIFF
--- a/nemoclaw/src/blueprint/private-networks.test.ts
+++ b/nemoclaw/src/blueprint/private-networks.test.ts
@@ -275,6 +275,22 @@ describe("private-networks loader", () => {
       expect(() => getNetworkEntries()).toThrow(/missing or empty 'name'/);
     });
 
+    it.each([" localhost", "localhost ", "."])("rejects non-canonical name %j", (name) => {
+      seedYaml(
+        "/blueprint/private-networks.yaml",
+        `ipv4: []\nipv6: []\nnames:\n  - name: ${JSON.stringify(name)}\n    purpose: malformed\n`,
+      );
+      expect(() => getNetworkEntries()).toThrow(/'name' must be canonical/);
+    });
+
+    it("accepts a canonical name with a terminal dot", () => {
+      seedYaml(
+        "/blueprint/private-networks.yaml",
+        "ipv4: []\nipv6: []\nnames:\n  - name: localhost.\n    purpose: canonical FQDN\n",
+      );
+      expect(isPrivateHostname("localhost")).toBe(true);
+    });
+
     it("rejects a names entry with empty purpose", () => {
       seedYaml(
         "/blueprint/private-networks.yaml",

--- a/nemoclaw/src/blueprint/private-networks.ts
+++ b/nemoclaw/src/blueprint/private-networks.ts
@@ -4,9 +4,8 @@
 // Private-network block list for SSRF validation. Loads the canonical
 // CIDR set from nemoclaw-blueprint/private-networks.yaml and builds a
 // node:net BlockList on first use, then memoises until the YAML file
-// source or stats (mtime/size) change. The CLI has an equivalent module
-// at src/lib/private-networks.ts; the parity test at test/ssrf-parity.test.ts
-// verifies both produce identical results.
+// source or stats (mtime/size) change. Pure parsing and matching live in
+// the shared private-network boundary.
 //
 // Path resolution mirrors loadBlueprint() in runner.ts: honour
 // NEMOCLAW_BLUEPRINT_PATH when set, otherwise try the dev-checkout
@@ -16,28 +15,29 @@
 // cwd-located blueprint is required at runtime.
 
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { BlockList, isIP } from "node:net";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import YAML from "yaml";
+import * as importedPrivateNetworkBoundary from "../shared/private-networks-boundary.cjs";
+import type {
+  NetworkDocument,
+  PrivateNetworkMatcher,
+} from "../shared/private-networks-boundary.cjs";
 
-export interface NetworkEntry {
-  address: string;
-  prefix: number;
-  purpose: string;
-}
+export type {
+  NameEntry,
+  NetworkDocument,
+  NetworkEntry,
+} from "../shared/private-networks-boundary.cjs";
 
-export interface NameEntry {
-  name: string;
-  purpose: string;
-}
-
-export interface NetworkDocument {
-  ipv4: NetworkEntry[];
-  ipv6: NetworkEntry[];
-  names: NameEntry[];
-}
+// The generated module exposes named CommonJS exports. Source-mode tsx maps
+// the .cjs specifier to .cts and exposes the same module as its default.
+const sourceOrGeneratedPrivateNetworkBoundary =
+  importedPrivateNetworkBoundary as typeof importedPrivateNetworkBoundary & {
+    default?: typeof importedPrivateNetworkBoundary;
+  };
+const { createPrivateNetworkMatcher, parsePrivateNetworkDocument } =
+  sourceOrGeneratedPrivateNetworkBoundary.default ?? sourceOrGeneratedPrivateNetworkBoundary;
 
 interface LoadedNetworks {
   source: string;
@@ -45,8 +45,7 @@ interface LoadedNetworks {
   size: number;
   checkedAtMs: number;
   networks: NetworkDocument;
-  blockList: BlockList;
-  normalisedNames: string[];
+  matcher: PrivateNetworkMatcher;
 }
 
 // Keep hot SSRF checks in memory while still letting long-running plugin
@@ -72,79 +71,6 @@ function resolveBlueprintPath(): string {
   // the expected file falls through to cwd instead of a read failure.
   if (existsSync(join(devGuess, "private-networks.yaml"))) return devGuess;
   return ".";
-}
-
-function validateNetworkEntry(
-  entry: unknown,
-  family: "ipv4" | "ipv6",
-  index: number,
-  source: string,
-): NetworkEntry {
-  const where = `${source}: ${family}[${String(index)}]`;
-  if (typeof entry !== "object" || entry === null) {
-    throw new Error(`${where}: expected an object`);
-  }
-  const record = entry as Record<string, unknown>;
-  const address = record.address;
-  const prefix = record.prefix;
-  const purpose = record.purpose;
-  if (typeof address !== "string" || address.length === 0) {
-    throw new Error(`${where}: missing or empty 'address'`);
-  }
-  const expectedFamily = family === "ipv4" ? 4 : 6;
-  if (isIP(address) !== expectedFamily) {
-    throw new Error(
-      `${where}: 'address' must be a valid ${family} literal, got ${JSON.stringify(address)}`,
-    );
-  }
-  const maxPrefix = family === "ipv4" ? 32 : 128;
-  if (typeof prefix !== "number" || !Number.isInteger(prefix) || prefix < 0 || prefix > maxPrefix) {
-    throw new Error(
-      `${where}: 'prefix' must be an integer in [0, ${String(maxPrefix)}], got ${JSON.stringify(prefix)}`,
-    );
-  }
-  if (typeof purpose !== "string" || purpose.trim().length === 0) {
-    throw new Error(
-      `${where}: 'purpose' must be a non-empty string so reviewers can judge the block`,
-    );
-  }
-  return { address, prefix, purpose };
-}
-
-function validateNameEntry(entry: unknown, index: number, source: string): NameEntry {
-  const where = `${source}: names[${String(index)}]`;
-  if (typeof entry !== "object" || entry === null) {
-    throw new Error(`${where}: expected an object`);
-  }
-  const record = entry as Record<string, unknown>;
-  const name = record.name;
-  const purpose = record.purpose;
-  if (typeof name !== "string" || name.length === 0) {
-    throw new Error(`${where}: missing or empty 'name'`);
-  }
-  if (typeof purpose !== "string" || purpose.trim().length === 0) {
-    throw new Error(
-      `${where}: 'purpose' must be a non-empty string so reviewers can judge the block`,
-    );
-  }
-  return { name, purpose };
-}
-
-function parseDocument(raw: string, source: string): NetworkDocument {
-  const parsed = YAML.parse(raw) as Record<string, unknown> | null;
-  if (
-    !parsed ||
-    !Array.isArray(parsed.ipv4) ||
-    !Array.isArray(parsed.ipv6) ||
-    !Array.isArray(parsed.names)
-  ) {
-    throw new Error(`${source}: expected top-level 'ipv4', 'ipv6', and 'names' arrays`);
-  }
-  return {
-    ipv4: parsed.ipv4.map((entry, i) => validateNetworkEntry(entry, "ipv4", i, source)),
-    ipv6: parsed.ipv6.map((entry, i) => validateNetworkEntry(entry, "ipv6", i, source)),
-    names: parsed.names.map((entry, i) => validateNameEntry(entry, i, source)),
-  };
 }
 
 function isNodeEnoent(err: unknown): boolean {
@@ -179,23 +105,20 @@ function load(): LoadedNetworks {
     cached.checkedAtMs = now;
     return cached;
   }
-  const networks = parseDocument(readPrivateNetworksFile(source), source);
-  const blockList = new BlockList();
-  for (const { address, prefix } of networks.ipv4) blockList.addSubnet(address, prefix, "ipv4");
-  for (const { address, prefix } of networks.ipv6) blockList.addSubnet(address, prefix, "ipv6");
-  const normalisedNames = networks.names.map((e) => e.name.replace(/\.$/, "").toLowerCase());
-  cached = { source, mtimeMs, size, checkedAtMs: now, networks, blockList, normalisedNames };
+  const networks = parsePrivateNetworkDocument(readPrivateNetworksFile(source), source);
+  cached = {
+    source,
+    mtimeMs,
+    size,
+    checkedAtMs: now,
+    networks,
+    matcher: createPrivateNetworkMatcher(networks),
+  };
   return cached;
 }
 
-function isPrivateIpInBlockList(address: string, blockList: BlockList): boolean {
-  const family = isIP(address);
-  if (family === 0) return false;
-  return blockList.check(address, family === 6 ? "ipv6" : "ipv4");
-}
-
-export function getPrivateNetworks(): BlockList {
-  return load().blockList;
+export function getPrivateNetworks(): PrivateNetworkMatcher["blockList"] {
+  return load().matcher.blockList;
 }
 
 export function getNetworkEntries(): NetworkDocument {
@@ -223,7 +146,7 @@ export function resetCache(): void {
  * because BlockList does not extract embedded IPv4 from those forms.
  */
 export function isPrivateIp(address: string): boolean {
-  return isPrivateIpInBlockList(address, getPrivateNetworks());
+  return load().matcher.isPrivateIp(address);
 }
 
 /**
@@ -239,15 +162,5 @@ export function isPrivateIp(address: string): boolean {
  * the narrower isPrivateIp.
  */
 export function isPrivateHostname(hostname: string): boolean {
-  // Strip URL IPv6 brackets before any check. Brackets are only legal
-  // in URL syntax around IPv6 literals, so stripping them is safe for
-  // both the name-level and IP-literal checks below.
-  const stripped =
-    hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
-  const normalised = stripped.replace(/\.$/, "").toLowerCase();
-  const { blockList, normalisedNames } = load();
-  for (const reserved of normalisedNames) {
-    if (normalised === reserved || normalised.endsWith(`.${reserved}`)) return true;
-  }
-  return isPrivateIpInBlockList(normalised, blockList);
+  return load().matcher.isPrivateHostname(hostname);
 }

--- a/nemoclaw/src/shared/private-networks-boundary.cts
+++ b/nemoclaw/src/shared/private-networks-boundary.cts
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { BlockList, isIP } from "node:net";
+
+import YAML from "yaml";
+
+export interface NetworkEntry {
+  address: string;
+  prefix: number;
+  purpose: string;
+}
+
+export interface NameEntry {
+  name: string;
+  purpose: string;
+}
+
+export interface NetworkDocument {
+  ipv4: NetworkEntry[];
+  ipv6: NetworkEntry[];
+  names: NameEntry[];
+}
+
+export interface PrivateNetworkMatcher {
+  blockList: BlockList;
+  isPrivateIp(address: string): boolean;
+  isPrivateHostname(hostname: string): boolean;
+}
+
+function validateNetworkEntry(
+  entry: unknown,
+  family: "ipv4" | "ipv6",
+  index: number,
+  source: string,
+): NetworkEntry {
+  const where = `${source}: ${family}[${String(index)}]`;
+  if (typeof entry !== "object" || entry === null) {
+    throw new Error(`${where}: expected an object`);
+  }
+  const record = entry as Record<string, unknown>;
+  const { address, prefix, purpose } = record;
+  if (typeof address !== "string" || address.length === 0) {
+    throw new Error(`${where}: missing or empty 'address'`);
+  }
+  const expectedFamily = family === "ipv4" ? 4 : 6;
+  if (isIP(address) !== expectedFamily) {
+    throw new Error(
+      `${where}: 'address' must be a valid ${family} literal, got ${JSON.stringify(address)}`,
+    );
+  }
+  const maxPrefix = family === "ipv4" ? 32 : 128;
+  if (typeof prefix !== "number" || !Number.isInteger(prefix) || prefix < 0 || prefix > maxPrefix) {
+    throw new Error(
+      `${where}: 'prefix' must be an integer in [0, ${String(maxPrefix)}], got ${JSON.stringify(prefix)}`,
+    );
+  }
+  if (typeof purpose !== "string" || purpose.trim().length === 0) {
+    throw new Error(
+      `${where}: 'purpose' must be a non-empty string so reviewers can judge the block`,
+    );
+  }
+  return { address, prefix, purpose };
+}
+
+function validateNameEntry(entry: unknown, index: number, source: string): NameEntry {
+  const where = `${source}: names[${String(index)}]`;
+  if (typeof entry !== "object" || entry === null) {
+    throw new Error(`${where}: expected an object`);
+  }
+  const record = entry as Record<string, unknown>;
+  const { name, purpose } = record;
+  if (typeof name !== "string" || name.length === 0) {
+    throw new Error(`${where}: missing or empty 'name'`);
+  }
+  if (typeof purpose !== "string" || purpose.trim().length === 0) {
+    throw new Error(
+      `${where}: 'purpose' must be a non-empty string so reviewers can judge the block`,
+    );
+  }
+  return { name, purpose };
+}
+
+export function parsePrivateNetworkDocument(raw: string, source: string): NetworkDocument {
+  const parsed = YAML.parse(raw) as Record<string, unknown> | null;
+  if (
+    !parsed ||
+    !Array.isArray(parsed.ipv4) ||
+    !Array.isArray(parsed.ipv6) ||
+    !Array.isArray(parsed.names)
+  ) {
+    throw new Error(`${source}: expected top-level 'ipv4', 'ipv6', and 'names' arrays`);
+  }
+  return {
+    ipv4: parsed.ipv4.map((entry, index) => validateNetworkEntry(entry, "ipv4", index, source)),
+    ipv6: parsed.ipv6.map((entry, index) => validateNetworkEntry(entry, "ipv6", index, source)),
+    names: parsed.names.map((entry, index) => validateNameEntry(entry, index, source)),
+  };
+}
+
+export function createPrivateNetworkMatcher(networks: NetworkDocument): PrivateNetworkMatcher {
+  const blockList = new BlockList();
+  for (const { address, prefix } of networks.ipv4) blockList.addSubnet(address, prefix, "ipv4");
+  for (const { address, prefix } of networks.ipv6) blockList.addSubnet(address, prefix, "ipv6");
+  const normalisedNames = networks.names.map((entry) =>
+    entry.name.replace(/\.$/, "").toLowerCase(),
+  );
+
+  const isPrivateIp = (address: string): boolean => {
+    const family = isIP(address);
+    if (family === 0) return false;
+    return blockList.check(address, family === 6 ? "ipv6" : "ipv4");
+  };
+
+  return {
+    blockList,
+    isPrivateIp,
+    isPrivateHostname(hostname: string): boolean {
+      const stripped =
+        hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+      const normalised = stripped.replace(/\.$/, "").toLowerCase();
+      for (const reserved of normalisedNames) {
+        if (normalised === reserved || normalised.endsWith(`.${reserved}`)) return true;
+      }
+      return isPrivateIp(normalised);
+    },
+  };
+}

--- a/nemoclaw/src/shared/private-networks-boundary.cts
+++ b/nemoclaw/src/shared/private-networks-boundary.cts
@@ -73,6 +73,9 @@ function validateNameEntry(entry: unknown, index: number, source: string): NameE
   if (typeof name !== "string" || name.length === 0) {
     throw new Error(`${where}: missing or empty 'name'`);
   }
+  if (name !== name.trim() || name.replace(/\.$/, "").length === 0) {
+    throw new Error(`${where}: 'name' must be canonical and contain no surrounding whitespace`);
+  }
   if (typeof purpose !== "string" || purpose.trim().length === 0) {
     throw new Error(
       `${where}: 'purpose' must be a non-empty string so reviewers can judge the block`,

--- a/nemoclaw/tsconfig.shared.json
+++ b/nemoclaw/tsconfig.shared.json
@@ -8,6 +8,7 @@
     "src/shared/banner-boundary.cts",
     "src/shared/credential-filter-boundary.cts",
     "src/shared/openshell-policy-boundary.cts",
+    "src/shared/private-networks-boundary.cts",
     "src/shared/sandbox-name.cts",
     "src/shared/snapshot-sanitizer-boundary.cts"
   ],

--- a/nemoclaw/vitest.project.ts
+++ b/nemoclaw/vitest.project.ts
@@ -13,6 +13,10 @@ const canonicalOpenShellPolicyBoundary = path.resolve(
   import.meta.dirname,
   "src/shared/openshell-policy-boundary.cts",
 );
+const canonicalPrivateNetworksBoundary = path.resolve(
+  import.meta.dirname,
+  "src/shared/private-networks-boundary.cts",
+);
 const canonicalSandboxName = path.resolve(import.meta.dirname, "src/shared/sandbox-name.cts");
 const canonicalSnapshotSanitizerBoundary = path.resolve(
   import.meta.dirname,
@@ -59,6 +63,10 @@ const pluginVitestProjectOptions = {
       {
         find: /^.*openshell-policy-boundary\.cjs$/,
         replacement: canonicalOpenShellPolicyBoundary,
+      },
+      {
+        find: /^.*private-networks-boundary\.cjs$/,
+        replacement: canonicalPrivateNetworksBoundary,
       },
       {
         find: /^.*sandbox-name\.cjs$/,

--- a/src/lib/private-networks.ts
+++ b/src/lib/private-networks.ts
@@ -3,15 +3,21 @@
 //
 // Private-network block list for SSRF validation. Loads the canonical
 // CIDR set from nemoclaw-blueprint/private-networks.yaml and builds a
-// node:net BlockList on first use, then memoises. The plugin has an
-// equivalent module at nemoclaw/src/blueprint/private-networks.ts; the
-// parity test at test/ssrf-parity.test.ts verifies both produce
-// identical results.
+// node:net BlockList on first use, then memoises. Pure parsing and
+// matching live in the shared private-network boundary.
 
 import fs from "node:fs";
-import { BlockList, isIP } from "node:net";
+import { isIP } from "node:net";
 import path from "node:path";
-import YAML from "yaml";
+
+import {
+  createPrivateNetworkMatcher,
+  parsePrivateNetworkDocument,
+} from "../../nemoclaw/dist/shared/private-networks-boundary.cjs";
+import type {
+  NetworkDocument,
+  PrivateNetworkMatcher,
+} from "../../nemoclaw/dist/shared/private-networks-boundary.cjs";
 
 import { ROOT } from "./runner";
 
@@ -19,102 +25,18 @@ const NETWORKS_FILE = path.join(ROOT, "nemoclaw-blueprint", "private-networks.ya
 
 export const OPENSHELL_SANDBOX_HOST_BRIDGE = "host.openshell.internal";
 
-export interface NetworkEntry {
-  address: string;
-  prefix: number;
-  purpose: string;
-}
-
-export interface NameEntry {
-  name: string;
-  purpose: string;
-}
-
-export interface NetworkDocument {
-  ipv4: NetworkEntry[];
-  ipv6: NetworkEntry[];
-  names: NameEntry[];
-}
+export type {
+  NameEntry,
+  NetworkDocument,
+  NetworkEntry,
+} from "../../nemoclaw/dist/shared/private-networks-boundary.cjs";
 
 interface LoadedNetworks {
   networks: NetworkDocument;
-  blockList: BlockList;
-  normalisedNames: string[];
+  matcher: PrivateNetworkMatcher;
 }
 
 let cached: LoadedNetworks | null = null;
-
-function validateNetworkEntry(
-  entry: unknown,
-  family: "ipv4" | "ipv6",
-  index: number,
-): NetworkEntry {
-  const where = `${NETWORKS_FILE}: ${family}[${String(index)}]`;
-  if (typeof entry !== "object" || entry === null) {
-    throw new Error(`${where}: expected an object`);
-  }
-  const record = entry as Record<string, unknown>;
-  const address = record.address;
-  const prefix = record.prefix;
-  const purpose = record.purpose;
-  if (typeof address !== "string" || address.length === 0) {
-    throw new Error(`${where}: missing or empty 'address'`);
-  }
-  const expectedFamily = family === "ipv4" ? 4 : 6;
-  if (isIP(address) !== expectedFamily) {
-    throw new Error(
-      `${where}: 'address' must be a valid ${family} literal, got ${JSON.stringify(address)}`,
-    );
-  }
-  const maxPrefix = family === "ipv4" ? 32 : 128;
-  if (typeof prefix !== "number" || !Number.isInteger(prefix) || prefix < 0 || prefix > maxPrefix) {
-    throw new Error(
-      `${where}: 'prefix' must be an integer in [0, ${String(maxPrefix)}], got ${JSON.stringify(prefix)}`,
-    );
-  }
-  if (typeof purpose !== "string" || purpose.trim().length === 0) {
-    throw new Error(
-      `${where}: 'purpose' must be a non-empty string so reviewers can judge the block`,
-    );
-  }
-  return { address, prefix, purpose };
-}
-
-function validateNameEntry(entry: unknown, index: number): NameEntry {
-  const where = `${NETWORKS_FILE}: names[${String(index)}]`;
-  if (typeof entry !== "object" || entry === null) {
-    throw new Error(`${where}: expected an object`);
-  }
-  const record = entry as Record<string, unknown>;
-  const name = record.name;
-  const purpose = record.purpose;
-  if (typeof name !== "string" || name.length === 0) {
-    throw new Error(`${where}: missing or empty 'name'`);
-  }
-  if (typeof purpose !== "string" || purpose.trim().length === 0) {
-    throw new Error(
-      `${where}: 'purpose' must be a non-empty string so reviewers can judge the block`,
-    );
-  }
-  return { name, purpose };
-}
-
-function parseDocument(raw: string): NetworkDocument {
-  const parsed = YAML.parse(raw) as Record<string, unknown> | null;
-  if (
-    !parsed ||
-    !Array.isArray(parsed.ipv4) ||
-    !Array.isArray(parsed.ipv6) ||
-    !Array.isArray(parsed.names)
-  ) {
-    throw new Error(`${NETWORKS_FILE}: expected top-level 'ipv4', 'ipv6', and 'names' arrays`);
-  }
-  return {
-    ipv4: parsed.ipv4.map((entry, i) => validateNetworkEntry(entry, "ipv4", i)),
-    ipv6: parsed.ipv6.map((entry, i) => validateNetworkEntry(entry, "ipv6", i)),
-    names: parsed.names.map((entry, i) => validateNameEntry(entry, i)),
-  };
-}
 
 function load(): LoadedNetworks {
   if (cached) return cached;
@@ -126,17 +48,16 @@ function load(): LoadedNetworks {
         `(the plugin has a separate NEMOCLAW_BLUEPRINT_PATH override).`,
     );
   }
-  const networks = parseDocument(fs.readFileSync(NETWORKS_FILE, "utf-8"));
-  const blockList = new BlockList();
-  for (const { address, prefix } of networks.ipv4) blockList.addSubnet(address, prefix, "ipv4");
-  for (const { address, prefix } of networks.ipv6) blockList.addSubnet(address, prefix, "ipv6");
-  const normalisedNames = networks.names.map((e) => e.name.replace(/\.$/, "").toLowerCase());
-  cached = { networks, blockList, normalisedNames };
+  const networks = parsePrivateNetworkDocument(
+    fs.readFileSync(NETWORKS_FILE, "utf-8"),
+    NETWORKS_FILE,
+  );
+  cached = { networks, matcher: createPrivateNetworkMatcher(networks) };
   return cached;
 }
 
-export function getPrivateNetworks(): BlockList {
-  return load().blockList;
+export function getPrivateNetworks(): PrivateNetworkMatcher["blockList"] {
+  return load().matcher.blockList;
 }
 
 export function getNetworkEntries(): NetworkDocument {
@@ -162,9 +83,7 @@ export function resetCache(): void {
  * because BlockList does not extract embedded IPv4 from those forms.
  */
 export function isPrivateIp(address: string): boolean {
-  const family = isIP(address);
-  if (family === 0) return false;
-  return getPrivateNetworks().check(address, family === 6 ? "ipv6" : "ipv4");
+  return load().matcher.isPrivateIp(address);
 }
 
 /**
@@ -180,17 +99,7 @@ export function isPrivateIp(address: string): boolean {
  * the narrower isPrivateIp.
  */
 export function isPrivateHostname(hostname: string): boolean {
-  // Strip URL IPv6 brackets before any check. Brackets are only legal
-  // in URL syntax around IPv6 literals, so stripping them is safe for
-  // both the name-level and IP-literal checks below.
-  const stripped =
-    hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
-  const normalised = stripped.replace(/\.$/, "").toLowerCase();
-  const { normalisedNames } = load();
-  for (const reserved of normalisedNames) {
-    if (normalised === reserved || normalised.endsWith(`.${reserved}`)) return true;
-  }
-  return isPrivateIp(normalised);
+  return load().matcher.isPrivateHostname(hostname);
 }
 
 export function isAllowedOpenShellSandboxBridgeUrl(url: URL): boolean {

--- a/test/package-contract/ssrf-parity.test.ts
+++ b/test/package-contract/ssrf-parity.test.ts
@@ -1,16 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Parity guard for SSRF block lists. The CLI
-// (src/lib/private-networks.ts) and the plugin
-// (nemoclaw/src/blueprint/private-networks.ts) both load their rules
-// from the shared nemoclaw-blueprint/private-networks.yaml, so a single
-// data edit propagates to both. This test enforces:
+// Contract guard for the shared private-network boundary. The CLI and plugin
+// keep package-local loaders and caches, then delegate schema parsing and
+// address matching to the generated .cts boundary. This test enforces:
 //
 //   1. Every entry in the YAML ships with a non-empty `purpose` field
 //      so no block lands without a human-reviewable rationale.
-//   2. The CLI and plugin `isPrivateHostname` implementations agree on a
-//      vector per CIDR covering the start of the range, the end, two
+//   2. The shared matcher classifies a vector per CIDR covering the start, end, two
 //      middle points, one address below the start, and one above the
 //      end. Boundary-outside expectations account for adjacent ranges
 //      (e.g., 224.0.0.0/4 meeting 240.0.0.0/4, where the neighbour is
@@ -43,9 +40,19 @@ interface NetworkHelper {
   isPrivateHostname(hostname: string): boolean;
 }
 
-function loadHelper(modulePath: string, buildHint: string): NetworkHelper {
+interface PrivateNetworkMatcher {
+  isPrivateHostname(hostname: string): boolean;
+}
+
+interface PrivateNetworkBoundary {
+  createPrivateNetworkMatcher(
+    networks: ReturnType<NetworkHelper["getNetworkEntries"]>,
+  ): PrivateNetworkMatcher;
+}
+
+function loadHelper<T>(modulePath: string, buildHint: string): T {
   try {
-    return require(modulePath) as NetworkHelper;
+    return require(modulePath) as T;
   } catch (error) {
     const code = (error as { code?: unknown })?.code;
     if (code === "MODULE_NOT_FOUND") {
@@ -59,11 +66,20 @@ function loadHelper(modulePath: string, buildHint: string): NetworkHelper {
   }
 }
 
-const cliHelper = loadHelper("../../dist/lib/private-networks", "`npm run build:cli`");
-const pluginHelper = loadHelper(
+const cliHelper = loadHelper<NetworkHelper>(
+  "../../dist/lib/private-networks",
+  "`npm run build:cli`",
+);
+const pluginHelper = loadHelper<NetworkHelper>(
   "../../nemoclaw/dist/blueprint/private-networks.js",
   "`npm run build` inside nemoclaw/",
 );
+const boundary = loadHelper<PrivateNetworkBoundary>(
+  "../../nemoclaw/dist/shared/private-networks-boundary.cjs",
+  "`npm run build:cli`",
+);
+const sharedNetworks = cliHelper.getNetworkEntries();
+const matcher = boundary.createPrivateNetworkMatcher(sharedNetworks);
 
 function entryLabel(entry: NetworkEntry | NameEntry): string {
   return "address" in entry ? `${entry.address}/${String(entry.prefix)}` : entry.name;
@@ -75,6 +91,7 @@ describe("private-networks.yaml schema", () => {
   it("produces matching entry counts on the CLI and plugin sides", () => {
     const cli = cliHelper.getNetworkEntries();
     const plugin = pluginHelper.getNetworkEntries();
+    expect(cli.ipv4.length).toBe(sharedNetworks.ipv4.length);
     expect(cli.ipv4.length).toBe(plugin.ipv4.length);
     expect(cli.ipv6.length).toBe(plugin.ipv6.length);
     expect(cli.names.length).toBe(plugin.names.length);
@@ -124,7 +141,7 @@ describe("private-networks.yaml schema", () => {
 // end (where defined). Outside-boundary expectations set to `true`
 // where the neighbour happens to live in another blocked range.
 
-describe("CLI and plugin isPrivateHostname agree on every CIDR boundary", () => {
+describe("shared private-network matcher classifies every CIDR boundary", () => {
   const vectors: [string, boolean, string][] = [
     // 0.0.0.0/8 — This network
     ["0.0.0.0", true, "0.0.0.0/8 start"],
@@ -366,15 +383,14 @@ describe("CLI and plugin isPrivateHostname agree on every CIDR boundary", () => 
   it.each(vectors.map(([addr, expected, label]) => ({ addr, expected, label })))(
     "classifies $label at $addr as $expected",
     ({ addr, expected }) => {
-      expect(pluginHelper.isPrivateHostname(addr)).toBe(expected);
-      expect(cliHelper.isPrivateHostname(addr)).toBe(expected);
+      expect(matcher.isPrivateHostname(addr)).toBe(expected);
     },
   );
 });
 
 // ── Wrapper-level cases (bracket handling, cross-family, DNS) ───────
 
-describe("CLI and plugin isPrivateHostname agree on wrapper-level cases", () => {
+describe("shared private-network matcher classifies wrapper-level inputs", () => {
   const extras: [string, boolean, string][] = [
     ["[::1]", true, "bracketed IPv6 loopback"],
     ["[fe80::1]", true, "bracketed link-local"],
@@ -412,7 +428,13 @@ describe("CLI and plugin isPrivateHostname agree on wrapper-level cases", () => 
       displayedAddr: JSON.stringify(addr),
     })),
   )("classifies $label at $displayedAddr as $expected", ({ addr, expected }) => {
-    expect(pluginHelper.isPrivateHostname(addr)).toBe(expected);
-    expect(cliHelper.isPrivateHostname(addr)).toBe(expected);
+    expect(matcher.isPrivateHostname(addr)).toBe(expected);
+  });
+
+  it("keeps both package loaders connected to the shared matcher", () => {
+    expect(cliHelper.isPrivateHostname("LOCALHOST.")).toBe(matcher.isPrivateHostname("LOCALHOST."));
+    expect(pluginHelper.isPrivateHostname("[2606:4700::1]")).toBe(
+      matcher.isPrivateHostname("[2606:4700::1]"),
+    );
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,6 +27,9 @@ const canonicalCredentialFilterBoundary = path.resolve(
 const canonicalOpenShellPolicyBoundary = path.resolve(
   "nemoclaw/src/shared/openshell-policy-boundary.cts",
 );
+const canonicalPrivateNetworksBoundary = path.resolve(
+  "nemoclaw/src/shared/private-networks-boundary.cts",
+);
 const canonicalSandboxName = path.resolve("nemoclaw/src/shared/sandbox-name.cts");
 const canonicalSnapshotSanitizerBoundary = path.resolve(
   "nemoclaw/src/shared/snapshot-sanitizer-boundary.cts",
@@ -46,6 +49,10 @@ const canonicalSourceAliases = [
   {
     find: /^.*openshell-policy-boundary\.cjs$/,
     replacement: canonicalOpenShellPolicyBoundary,
+  },
+  {
+    find: /^.*private-networks-boundary\.cjs$/,
+    replacement: canonicalPrivateNetworksBoundary,
   },
   {
     find: /^.*sandbox-name\.cjs$/,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Share private-network policy parsing and address matching between the CLI and blueprint packages. Package-local loading, path resolution, and caching stay unchanged while the duplicated security logic moves behind one generated CommonJS boundary.

## Related Issue

Fixes #8291

## Changes

- Add `nemoclaw/src/shared/private-networks-boundary.cts` as the single parser and matcher implementation used by both packages.
- Keep each package's existing policy-file resolution, cache behavior, and package-specific helpers in its local wrapper.
- Build and resolve the shared boundary in both package and Vitest configurations.
- Update the package-contract test to exercise the generated boundary and both package loaders by behavior. A direct change to either package alone would leave the other copy free to drift; the 235-case package-contract suite protects the shared consumer boundary.
- Remove more duplicated code than the shared module adds: 246 insertions and 258 deletions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [Focused security review of commit `f84d33115a87bca9c1405f0feb454307473cac3a` passed with no actionable findings](https://github.com/NVIDIA/NemoClaw/pull/9445#pullrequestreview-4963671085).
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; no DGX Station preparation changes.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project package-contract test/package-contract/ssrf-parity.test.ts test/package-contract/openshell-policy-boundary.test.ts` (235 passed); plugin SSRF suites (146 passed); adjacent CLI/integration SSRF suites (77 passed)
- [x] Applicable broad gate passed — This is a bounded internal refactor rather than a repo-wide runtime or test-harness change. Both package builds, both package typechecks, `npm run lint`, and the normal commit/push hooks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved private-network validation with clearer source and entry-level errors.
  * Improved matching for private IP addresses, hostnames, subdomains, bracketed hostnames, and trailing-dot forms.
  * Enforced canonical hostname formats while accepting valid terminal-dot names.
  * Ensured reserved names and private-network checks behave consistently across application components.

* **Refactor**
  * Centralized private-network parsing and matching for more consistent results across supported interfaces.

* **Tests**
  * Expanded coverage for CIDR matching, hostname handling, validation, and cross-component behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
