### PR TITLE
fix(onboard): bind Hermes GPU proof to replacement

### DIFF
--- a/src/lib/onboard/__test-helpers__/sandbox-gpu-create-flow.ts
+++ b/src/lib/onboard/__test-helpers__/sandbox-gpu-create-flow.ts
@@ -70,6 +70,7 @@ export function createGpuFlowDeps(): SandboxGpuCreateFlowDeps {
 export function createGpuPatchFixture() {
   return {
     maybeApplyDuringCreate: vi.fn(),
+    replacementRuntimeId: vi.fn(() => null),
     createFailureMessage: vi.fn(() => null),
     exitOnPatchError: vi.fn(),
     rollbackManagedStartupAfterCreateFailure: vi.fn(),

--- a/src/lib/onboard/docker-gpu-sandbox-create-lifecycle.test.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create-lifecycle.test.ts
@@ -71,7 +71,9 @@ describe("createDockerGpuSandboxCreatePatch composed flow", () => {
       },
     });
 
+    expect(patch.replacementRuntimeId()).toBeNull();
     patch.maybeApplyDuringCreate();
+    expect(patch.replacementRuntimeId()).toBe(result.newContainerId);
     expect(recreatePatch).toHaveBeenCalledWith(
       expect.objectContaining({ waitForSupervisor: false }),
       expect.objectContaining({

--- a/src/lib/onboard/docker-gpu-sandbox-create.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create.ts
@@ -115,7 +115,7 @@ export interface DockerManagedBootstrapDeferredCutover {
 
 export type DockerGpuSandboxCreatePatch = {
   maybeApplyDuringCreate: () => void;
-  /** Full Docker container ID owned by the replacement transaction, or null before recreation. */
+  /** Full Docker container ID owned by the transaction, or null until it records a replacement. */
   replacementRuntimeId: () => string | null;
   createFailureMessage: () => string | null;
   exitOnPatchError: () => Promise<void>;

--- a/src/lib/onboard/docker-gpu-sandbox-create.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create.ts
@@ -31,10 +31,7 @@ import {
 } from "./docker-startup-command-sandbox-create";
 import { findOpenShellDockerSandboxContainerIds } from "./openshell-docker-sandbox-containers";
 
-export type {
-  DockerGpuRoutePlan,
-  SelectedDockerGpuRoute,
-} from "./docker-gpu-route";
+export type { DockerGpuRoutePlan, SelectedDockerGpuRoute } from "./docker-gpu-route";
 export {
   isDockerDesktopWslRuntime,
   resetIsDockerDesktopWslRuntimeCache,
@@ -118,6 +115,8 @@ export interface DockerManagedBootstrapDeferredCutover {
 
 export type DockerGpuSandboxCreatePatch = {
   maybeApplyDuringCreate: () => void;
+  /** Full Docker container ID owned by the replacement transaction, or null before recreation. */
+  replacementRuntimeId: () => string | null;
   createFailureMessage: () => string | null;
   exitOnPatchError: () => Promise<void>;
   attachManagedBootstrapCutover: (cutover: DockerManagedBootstrapDeferredCutover) => void;
@@ -295,6 +294,10 @@ export function createDockerGpuSandboxCreatePatch(
       }
     },
 
+    replacementRuntimeId() {
+      return result?.newContainerId ?? null;
+    },
+
     createFailureMessage() {
       if (!patchError) return null;
       return routeAdapter.enabled
@@ -470,10 +473,7 @@ export function createDockerGpuSandboxCreatePatch(
           : null;
         cutoverFinalized = true;
         if (!finalizeOutcome) return;
-        if (
-          finalizeOutcome.backupRemoved &&
-          finalizeOutcome.replacementRestarted === undefined
-        ) {
+        if (finalizeOutcome.backupRemoved && finalizeOutcome.replacementRestarted === undefined) {
           return;
         }
         if (finalizeOutcome.backupRemoved && finalizeOutcome.replacementRestarted) {

--- a/src/lib/onboard/managed-bootstrap/runtime-create.ts
+++ b/src/lib/onboard/managed-bootstrap/runtime-create.ts
@@ -40,6 +40,8 @@ export interface ManagedBootstrapRuntimeLimit {
 /** Provider-neutral lifecycle surface consumed by sandbox-create coordinators. */
 export interface ManagedBootstrapRuntimePatch {
   maybeApplyDuringCreate(): void | Promise<void>;
+  /** Exact runtime ID owned by the replacement transaction, or null before replacement. */
+  replacementRuntimeId?(): string | null;
   createFailureMessage(): string | null;
   exitOnPatchError(): void | Promise<void>;
   rollbackManagedStartupAfterCreateFailure(): void | Promise<void>;

--- a/src/lib/onboard/managed-bootstrap/runtime-create.ts
+++ b/src/lib/onboard/managed-bootstrap/runtime-create.ts
@@ -40,7 +40,7 @@ export interface ManagedBootstrapRuntimeLimit {
 /** Provider-neutral lifecycle surface consumed by sandbox-create coordinators. */
 export interface ManagedBootstrapRuntimePatch {
   maybeApplyDuringCreate(): void | Promise<void>;
-  /** Exact runtime ID owned by the replacement transaction, or null before replacement. */
+  /** Exact runtime ID owned by the transaction, or null until it records a replacement. */
   replacementRuntimeId?(): string | null;
   createFailureMessage(): string | null;
   exitOnPatchError(): void | Promise<void>;

--- a/src/lib/onboard/openshell-docker-sandbox-containers.ts
+++ b/src/lib/onboard/openshell-docker-sandbox-containers.ts
@@ -372,9 +372,9 @@ function parseNvidiaVisibleDevices(result: {
 
 /**
  * Inspect a native container before deletion. Default callers must resolve one
- * labeled container. Managed-bootstrap callers may instead provide the full
- * transaction-owned container ID, which must be present among the labeled
- * replacement and retained rollback backup.
+ * labeled container. A caller that owns a recreation transaction may instead
+ * provide the full replacement container ID. That ID must be present among
+ * the labeled replacement and retained rollback backup.
  *
  * Docker owns the fields returned here: `.Image` is the immutable retry
  * identity, `.Config.Image` is bookkeeping-only, and HostConfig supplies the

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -514,7 +514,7 @@ describe("runSandboxGpuCreateFlow proof authorization", () => {
     );
   });
 
-  it("inspects the recreated native container before authorizing compatibility fallback", async () => {
+  it("inspects the exact recreated native container before authorizing compatibility fallback", async () => {
     const deps = createDeps();
     const replacementContainerId = "b".repeat(64);
     vi.mocked(deps.verifyDirectSandboxGpu)
@@ -522,7 +522,7 @@ describe("runSandboxGpuCreateFlow proof authorization", () => {
       .mockReturnValue(VERIFIED_PROOF);
     mocks.createDockerGpuSandboxCreatePatch.mockReturnValueOnce({
       ...createPatch(),
-      replacementContainerId: vi.fn(() => replacementContainerId),
+      replacementRuntimeId: vi.fn(() => replacementContainerId),
     });
     mocks.queryOpenShellDockerSandboxRuntimeSnapshot.mockImplementation(
       (_sandboxName, _deps, options) =>

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -211,12 +211,12 @@ describe("resolveAgentCreateInput", () => {
       persistStartupCommand: true,
       portableLifecycle: true,
     });
-    expect(
-      resolveAgentCreateInput({ name: "hermes" } as AgentDefinition, true, env),
-    ).toMatchObject({
-      persistStartupCommand: true,
-      portableLifecycle: false,
-    });
+    expect(resolveAgentCreateInput({ name: "hermes" } as AgentDefinition, true, env)).toMatchObject(
+      {
+        persistStartupCommand: true,
+        portableLifecycle: false,
+      },
+    );
     expect(resolvePortableLifecycleMode(null, env)).toBe(true);
     expect(resolvePortableLifecycleMode({ name: "hermes" } as AgentDefinition, env)).toBe(false);
   });
@@ -514,12 +514,22 @@ describe("runSandboxGpuCreateFlow proof authorization", () => {
     );
   });
 
-  it("retries structured nvidia-smi failure only when host config proves no GPU attachment (#6110)", async () => {
+  it("inspects the recreated native container before authorizing compatibility fallback", async () => {
     const deps = createDeps();
+    const replacementContainerId = "b".repeat(64);
     vi.mocked(deps.verifyDirectSandboxGpu)
       .mockReturnValueOnce(NVIDIA_SMI_FAILED_PROOF)
       .mockReturnValue(VERIFIED_PROOF);
-    mockRuntimeSnapshot();
+    mocks.createDockerGpuSandboxCreatePatch.mockReturnValueOnce({
+      ...createPatch(),
+      replacementContainerId: vi.fn(() => replacementContainerId),
+    });
+    mocks.queryOpenShellDockerSandboxRuntimeSnapshot.mockImplementation(
+      (_sandboxName, _deps, options) =>
+        options?.expectedContainerId === replacementContainerId
+          ? { ...DEFAULT_RUNTIME_SNAPSHOT, containerId: replacementContainerId }
+          : { ok: false, error: "expected one labeled sandbox container, found 2" },
+    );
 
     await expect(runSandboxGpuCreateFlow(createInput(), deps)).resolves.toMatchObject({
       route: "compatibility",
@@ -527,33 +537,38 @@ describe("runSandboxGpuCreateFlow proof authorization", () => {
     });
 
     expect(mocks.streamSandboxCreate).toHaveBeenCalledTimes(2);
+    expect(mocks.queryOpenShellDockerSandboxRuntimeSnapshot).toHaveBeenCalledWith(
+      "alpha",
+      {},
+      { expectedContainerId: replacementContainerId },
+    );
     expect(deps.runOpenshell).toHaveBeenCalledWith(
       ["sandbox", "delete", "alpha"],
       expect.objectContaining({ suppressOutput: true }),
     );
   });
 
-  it.each([
-    "present",
-    "unknown",
-  ] as const)("fails closed on sandbox nvidia-smi text when host GPU attachment is %s", async (nativeGpuAttachmentState) => {
-    const deps = createDeps();
-    vi.mocked(deps.verifyDirectSandboxGpu).mockReturnValue(NVIDIA_SMI_FAILED_PROOF);
-    mockRuntimeSnapshot({ nativeGpuAttachmentState });
-    mockExit();
+  it.each(["present", "unknown"] as const)(
+    "fails closed on sandbox nvidia-smi text when host GPU attachment is %s",
+    async (nativeGpuAttachmentState) => {
+      const deps = createDeps();
+      vi.mocked(deps.verifyDirectSandboxGpu).mockReturnValue(NVIDIA_SMI_FAILED_PROOF);
+      mockRuntimeSnapshot({ nativeGpuAttachmentState });
+      mockExit();
 
-    await expect(runSandboxGpuCreateFlow(createInput(), deps)).rejects.toThrow("process.exit:1");
+      await expect(runSandboxGpuCreateFlow(createInput(), deps)).rejects.toThrow("process.exit:1");
 
-    expect(mocks.streamSandboxCreate).toHaveBeenCalledOnce();
-    expect(mocks.queryOpenShellDockerSandboxRuntimeSnapshot).toHaveBeenCalledOnce();
-    expect(deps.runOpenshell).not.toHaveBeenCalledWith(
-      ["sandbox", "delete", "alpha"],
-      expect.anything(),
-    );
-    expect(vi.mocked(console.error).mock.calls.flat().join("\n")).toContain(
-      "without corroborating host evidence cannot authorize",
-    );
-  });
+      expect(mocks.streamSandboxCreate).toHaveBeenCalledOnce();
+      expect(mocks.queryOpenShellDockerSandboxRuntimeSnapshot).toHaveBeenCalledOnce();
+      expect(deps.runOpenshell).not.toHaveBeenCalledWith(
+        ["sandbox", "delete", "alpha"],
+        expect.anything(),
+      );
+      expect(vi.mocked(console.error).mock.calls.flat().join("\n")).toContain(
+        "without corroborating host evidence cannot authorize",
+      );
+    },
+  );
 
   it("stops after one compatibility retry when its GPU proof also fails", async () => {
     const deps = createDeps();

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -278,13 +278,6 @@ export function createSandboxGpuCreateAttemptRunner(
           },
         })
       : null;
-    const inspectNativeRuntime = (): NativeRuntimeSnapshot | null => {
-      const lifecycleSnapshot = managedLifecycle?.inspectNativeRuntime?.();
-      if (lifecycleSnapshot !== undefined) return lifecycleSnapshot;
-      if (managedRouting) return managedRouting.inspectNativeRuntime();
-      const snapshot = queryOpenShellDockerSandboxRuntimeSnapshot(input.sandboxName);
-      return snapshot.ok ? snapshot : null;
-    };
     const persistRestartSafeStartup =
       input.persistStartupCommand === true &&
       (route !== "native" || !input.terminalAgent || hasRequiredUlimits);
@@ -315,6 +308,16 @@ export function createSandboxGpuCreateAttemptRunner(
             backend: input.sandboxGpuConfig.hostGpuPlatform === "jetson" ? "jetson" : "generic",
             deps,
           }));
+    const inspectNativeRuntime = (): NativeRuntimeSnapshot | null => {
+      const lifecycleSnapshot = managedLifecycle?.inspectNativeRuntime?.();
+      if (lifecycleSnapshot !== undefined) return lifecycleSnapshot;
+      if (managedRouting) return managedRouting.inspectNativeRuntime();
+      const expectedContainerId = runtimePatch.replacementRuntimeId?.() ?? null;
+      const snapshot = expectedContainerId
+        ? queryOpenShellDockerSandboxRuntimeSnapshot(input.sandboxName, {}, { expectedContainerId })
+        : queryOpenShellDockerSandboxRuntimeSnapshot(input.sandboxName);
+      return snapshot.ok ? snapshot : null;
+    };
     const recovery = await managedLifecycle?.recoverUnfinished();
     if (recovery) {
       enforceManagedBootstrapRecoveryForSandbox(recovery, input.sandboxName, (message) =>


### PR DESCRIPTION
## Summary

Legacy Docker recreation retains a rollback backup with the same OpenShell sandbox labels as the replacement container, so sandbox-name inspection cannot select the replacement. NemoClaw now binds host inspection to the transaction-owned replacement container ID. It authorizes the bounded compatibility retry only when that exact container's host configuration proves no GPU attachment.

## Changes

- Expose the full replacement container ID from the legacy Docker recreation transaction.
- Inspect that exact labeled replacement after native GPU proof fails. Refuse the retry when NemoClaw cannot select the replacement or host evidence does not confirm GPU absence.
- Add regression and lifecycle tests for duplicate labels and the point at which the replacement container ID becomes available.

E2E root cause: `hermes-gpu-fallback::post-recreation-native-attachment-not-provably-absent`

- Source run: [workflow run 32109622944](https://github.com/NVIDIA/NemoClaw/actions/runs/32109622944) (attempt 1)
- Failed jobs: [`hermes-gpu-startup (fallback, e2e-hgpu-fallback)` job 95626383603](https://github.com/NVIDIA/NemoClaw/actions/runs/32109622944/job/95626383603)
- Signature:
  - The native proof reports `Failed to initialize NVML: Driver/library version mismatch`.
  - Reading `/proc/self/comm` reports permission denied.
  - `cuInit(0)` is inconclusive.
  - NemoClaw reports `Native sandbox GPU proof failed`.
  - NemoClaw refuses the retry with `Sandbox-reported GPU output without corroborating host evidence cannot authorize a less-confined compatibility retry.`
- Scope: one root cause
- Matching recurrence evidence:
  - [`95604176394`](https://github.com/NVIDIA/NemoClaw/actions/runs/32101603265/job/95604176394)
  - [`95582857284`](https://github.com/NVIDIA/NemoClaw/actions/runs/32094360622/job/95582857284)
  - [`95570031056`](https://github.com/NVIDIA/NemoClaw/actions/runs/32089878527/job/95570031056)

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — independent security review PASS at commit under review `b3cb095b4`; no actionable finding remains ([security-review comment](https://github.com/NVIDIA/NemoClaw/pull/9450#issuecomment-5326450740)).
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — commit under review `b3cb095b4`: `npm exec -- vitest run --project cli src/lib/onboard/sandbox-gpu-create-flow.test.ts src/lib/onboard/docker-gpu-sandbox-create-lifecycle.test.ts src/lib/onboard/openshell-docker-sandbox-containers.test.ts` passed 3 files / 94 tests. Fail-first commit `5d3fba1df` returned 1 failed / 50 passed because the flow exited before selecting the exact replacement container.
    - Trusted manual PR live E2E evidence: [run 32126149373, attempt 1](https://github.com/NVIDIA/NemoClaw/actions/runs/32126149373/attempts/1) used the `jobs=hermes-gpu-startup` selector and bound PR #9450 to commit under review `b3cb095b4`. The [native](https://github.com/NVIDIA/NemoClaw/actions/runs/32126149373/job/95677407313), [fallback](https://github.com/NVIDIA/NemoClaw/actions/runs/32126149373/job/95677407184), and [compatibility-only](https://github.com/NVIDIA/NemoClaw/actions/runs/32126149373/job/95677407148) jobs passed. No target cleanup step failed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU sandbox recreation handling by consistently tracking and validating replacement container IDs.
  * Ensured fallback authorization uses the exact recreated container and fails closed when host GPU attachment is present or unknown.
  * Refined runtime inspection to query the correct replacement container after recreation.

* **Documentation**
  * Clarified requirements for replacement container IDs during runtime snapshot operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
