### PR TITLE
fix(cli): retain published LangChain Deep Agents Code base-image reference on rebuild

### DIFF
--- a/src/lib/actions/sandbox/rebuild-dcode-base-image-lease.test.ts
+++ b/src/lib/actions/sandbox/rebuild-dcode-base-image-lease.test.ts
@@ -11,6 +11,10 @@ import {
   installRebuildFlowTestHooks,
   snapshotEnv,
 } from "../../../../test/helpers/rebuild-flow-dcode-harness";
+import {
+  SANDBOX_BASE_RESOLUTION_LABEL,
+  type SandboxBaseImageResolutionMetadata,
+} from "../../sandbox-base-image";
 
 const overrideEnvName = "NEMOCLAW_LANGCHAIN_DEEPAGENTS_CODE_SANDBOX_BASE_IMAGE_REF";
 const trustedLocalOverride = {
@@ -46,6 +50,17 @@ const trustedRemoteResolutionMetadata = {
   requireOpenshellSandboxAbi: true,
   minGlibcVersion: "2.39",
 };
+const publishedOverrideResolutionMetadata = {
+  ...trustedRemoteResolutionMetadata,
+  key: "published-dcode-base",
+  source: "override" as const,
+} satisfies SandboxBaseImageResolutionMetadata;
+
+function resolutionLabelsOutput(metadata: object): string {
+  return JSON.stringify({
+    [SANDBOX_BASE_RESOLUTION_LABEL]: Buffer.from(JSON.stringify(metadata)).toString("base64url"),
+  });
+}
 
 describe("rebuildSandbox DCode flow: base-image trust lease", () => {
   installRebuildFlowTestHooks({ acceptThirdPartySoftware: true });
@@ -133,6 +148,175 @@ describe("rebuildSandbox DCode flow: base-image trust lease", () => {
     expect(harness.restoreTrustedAgentRemoteBaseImageOverrideSpy).toHaveBeenCalledOnce();
     expect(harness.dockerRmiSpy).not.toHaveBeenCalledWith(trustedRemoteRef, expect.anything());
     expect(leaseActive).toBe(false);
+  });
+
+  it("retains the recorded published base reference when the named Deep Agents Code rebuild has no explicit override (#9386)", async () => {
+    const restoreEnv = snapshotEnv([overrideEnvName, "NEMOCLAW_SANDBOX_BASE_IMAGE_REFRESH"]);
+    delete process.env[overrideEnvName];
+    delete process.env.NEMOCLAW_SANDBOX_BASE_IMAGE_REFRESH;
+    const resolutionMetadata = publishedOverrideResolutionMetadata;
+    const harness = createRebuildFlowHarness({
+      agentName: "langchain-deepagents-code",
+      sandboxEntry: {
+        ...makeDcodeSandboxEntry(),
+        imageTag: "nemoclaw-langchain-deepagents-code:recorded",
+      },
+      sandboxBaseImageLabelsOutput: resolutionLabelsOutput(resolutionMetadata),
+    });
+    configureDcodeSession(harness);
+    let leasedMetadata: SandboxBaseImageResolutionMetadata | undefined;
+    harness.pinTrustedAgentRemoteBaseImageOverrideForOperationSpy.mockImplementation(
+      (_envName, override) => {
+        leasedMetadata = override.resolutionMetadata;
+        return harness.restoreTrustedAgentRemoteBaseImageOverrideSpy;
+      },
+    );
+    harness.ensureAgentBaseImageSpy.mockImplementation((_agent, options) => {
+      expect(process.env[overrideEnvName]).toBe(trustedRemoteRef);
+      expect(options).toEqual({ forceBaseImageRefresh: true });
+      return {
+        imageTag: trustedRemoteRef,
+        built: false,
+        resolutionMetadata: leasedMetadata,
+      };
+    });
+    harness.prepareManagedDcodeRebuildImageSpy.mockImplementation(async (input) => {
+      expect(input.preResolvedBaseImageMetadata).toBe(leasedMetadata);
+      return { ok: true, prepared: harness.preparedDcodeBuildContext };
+    });
+
+    try {
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).resolves.toBeUndefined();
+
+      expect(harness.ensureAgentBaseImageSpy).toHaveBeenCalledOnce();
+      expect(leasedMetadata).toEqual(resolutionMetadata);
+      expect(harness.pinTrustedAgentRemoteBaseImageOverrideForOperationSpy).toHaveBeenCalledWith(
+        overrideEnvName,
+        { ref: trustedRemoteRef, resolutionMetadata },
+      );
+      expect(process.env[overrideEnvName]).toBeUndefined();
+    } finally {
+      restoreEnv();
+    }
+  });
+
+  it("fails closed when recorded Deep Agents Code base-image metadata cannot be revalidated (#9386)", async () => {
+    const restoreEnv = snapshotEnv([overrideEnvName, "NEMOCLAW_SANDBOX_BASE_IMAGE_REFRESH"]);
+    delete process.env[overrideEnvName];
+    delete process.env.NEMOCLAW_SANDBOX_BASE_IMAGE_REFRESH;
+    const harness = createRebuildFlowHarness({
+      agentName: "langchain-deepagents-code",
+      sandboxEntry: {
+        ...makeDcodeSandboxEntry(),
+        imageTag: "nemoclaw-langchain-deepagents-code:recorded",
+      },
+      sandboxBaseImageLabelsOutput: resolutionLabelsOutput(publishedOverrideResolutionMetadata),
+    });
+    configureDcodeSession(harness);
+    let leaseActive = false;
+    harness.pinTrustedAgentRemoteBaseImageOverrideForOperationSpy.mockImplementation(() => {
+      leaseActive = true;
+      return harness.restoreTrustedAgentRemoteBaseImageOverrideSpy;
+    });
+    harness.restoreTrustedAgentRemoteBaseImageOverrideSpy.mockImplementation(() => {
+      leaseActive = false;
+    });
+    harness.ensureAgentBaseImageSpy.mockImplementation(() => {
+      expect(leaseActive).toBe(true);
+      expect(process.env[overrideEnvName]).toBe(trustedRemoteRef);
+      throw new Error("base-image trust lease no longer matches its resolution metadata");
+    });
+
+    try {
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow("base-image trust lease no longer matches its resolution metadata");
+
+      expect(harness.ensureAgentBaseImageSpy).toHaveBeenCalledOnce();
+      expect(harness.prepareManagedDcodeRebuildImageSpy).not.toHaveBeenCalled();
+      expect(harness.restoreTrustedAgentRemoteBaseImageOverrideSpy).toHaveBeenCalledOnce();
+      expect(leaseActive).toBe(false);
+      expect(process.env[overrideEnvName]).toBeUndefined();
+    } finally {
+      restoreEnv();
+    }
+  });
+
+  it("rejects a recorded Deep Agents Code base reference from a different repository (#9386)", async () => {
+    const restoreEnv = snapshotEnv([overrideEnvName, "NEMOCLAW_SANDBOX_BASE_IMAGE_REFRESH"]);
+    delete process.env[overrideEnvName];
+    delete process.env.NEMOCLAW_SANDBOX_BASE_IMAGE_REFRESH;
+    const harness = createRebuildFlowHarness({
+      agentName: "langchain-deepagents-code",
+      sandboxEntry: {
+        ...makeDcodeSandboxEntry(),
+        imageTag: "nemoclaw-langchain-deepagents-code:recorded",
+      },
+      sandboxBaseImageLabelsOutput: resolutionLabelsOutput({
+        ...publishedOverrideResolutionMetadata,
+        imageName: "ghcr.io/example/deep-agents-code-base",
+      }),
+    });
+    configureDcodeSession(harness);
+
+    try {
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).rejects.toThrow(
+        "the recorded Deep Agents Code base-image resolution metadata does not describe an exact published override",
+      );
+
+      expect(harness.ensureAgentBaseImageSpy).not.toHaveBeenCalled();
+      expect(harness.prepareManagedDcodeRebuildImageSpy).not.toHaveBeenCalled();
+    } finally {
+      restoreEnv();
+    }
+  });
+
+  it("honors an explicit base-image refresh instead of the recorded Deep Agents Code base reference (#9386)", async () => {
+    const restoreEnv = snapshotEnv([overrideEnvName, "NEMOCLAW_SANDBOX_BASE_IMAGE_REFRESH"]);
+    delete process.env[overrideEnvName];
+    process.env.NEMOCLAW_SANDBOX_BASE_IMAGE_REFRESH = "true";
+    const refreshedMetadata = trustedRemoteResolutionMetadata;
+    const harness = createRebuildFlowHarness({
+      agentName: "langchain-deepagents-code",
+      sandboxEntry: {
+        ...makeDcodeSandboxEntry(),
+        imageTag: "nemoclaw-langchain-deepagents-code:recorded",
+      },
+      sandboxBaseImageLabelsOutput: resolutionLabelsOutput(publishedOverrideResolutionMetadata),
+    });
+    configureDcodeSession(harness);
+    harness.ensureAgentBaseImageSpy.mockImplementation((_agent, options) => {
+      expect(process.env[overrideEnvName]).toBeUndefined();
+      expect(options).toEqual({ forceBaseImageRefresh: true });
+      return {
+        imageTag: trustedRemoteRef,
+        built: false,
+        resolutionMetadata: refreshedMetadata,
+      };
+    });
+    harness.prepareManagedDcodeRebuildImageSpy.mockImplementation(async (input) => {
+      expect(input.preResolvedBaseImageMetadata).toBe(refreshedMetadata);
+      return { ok: true, prepared: harness.preparedDcodeBuildContext };
+    });
+
+    try {
+      await expect(
+        harness.rebuildSandbox("alpha", ["--yes"], { throwOnError: true }),
+      ).resolves.toBeUndefined();
+
+      expect(harness.ensureAgentBaseImageSpy).toHaveBeenCalledOnce();
+      expect(harness.pinTrustedAgentRemoteBaseImageOverrideForOperationSpy).toHaveBeenCalledOnce();
+      expect(harness.pinTrustedAgentRemoteBaseImageOverrideForOperationSpy).toHaveBeenCalledWith(
+        overrideEnvName,
+        { ref: trustedRemoteRef, resolutionMetadata: refreshedMetadata },
+      );
+    } finally {
+      restoreEnv();
+    }
   });
 
   it("forces a trusted local build when refresh returns a mutable reference (#8120)", async () => {

--- a/src/lib/actions/sandbox/rebuild-dcode-orchestrator.test.ts
+++ b/src/lib/actions/sandbox/rebuild-dcode-orchestrator.test.ts
@@ -65,7 +65,7 @@ describe("DCode rebuild orchestrator", () => {
     expect(ensureAgentBaseImage).toHaveBeenCalledWith("hermes", bail, baseImageOptions);
   });
 
-  it("keeps warm-cache options out of the sealed DCode image path (#6195)", async () => {
+  it("forwards recorded base-image resolution metadata to Deep Agents Code preflight (#9386)", async () => {
     const ensureAgentBaseImage = vi.fn(() => true);
     const bail = vi.fn((message: string): never => {
       throw new Error(message);
@@ -110,6 +110,10 @@ describe("DCode rebuild orchestrator", () => {
         dcodeAutoApprovalMode: "thread-opt-in",
         skipLiveRoute: false,
         gatewayPort: 19_080,
+        baseImageOptions: {
+          resolutionHint,
+          forceBaseImageRefresh: true,
+        },
       }),
     );
     expect(ensureAgentBaseImage).not.toHaveBeenCalled();

--- a/src/lib/actions/sandbox/rebuild-dcode-orchestrator.ts
+++ b/src/lib/actions/sandbox/rebuild-dcode-orchestrator.ts
@@ -183,6 +183,7 @@ export function createDcodeRebuildOrchestrator(
           dcodeAutoApprovalMode,
           skipLiveRoute,
           gatewayPort,
+          baseImageOptions,
           log,
           bail: scope.bail,
           checkGatewaySchema: () => deps.checkGatewaySchema(sandboxName, scope.bail),

--- a/src/lib/actions/sandbox/rebuild-dcode-preflight.ts
+++ b/src/lib/actions/sandbox/rebuild-dcode-preflight.ts
@@ -8,6 +8,7 @@ import type { TrustedRemoteBaseImageOverride } from "../../agent/base-image";
 import { loadAgent } from "../../agent/defs";
 import {
   ensureAgentBaseImage,
+  getAgentSandboxBaseImageEnvVar,
   pinTrustedAgentBaseImageOverrideForOperation,
   pinTrustedAgentRemoteBaseImageOverrideForOperation,
 } from "../../agent/onboard";
@@ -16,6 +17,7 @@ import { recoverNamedGatewayRuntime } from "../../gateway-runtime-action";
 import * as nim from "../../inference/nim";
 import type { WebSearchConfig } from "../../inference/web-search";
 import type { DcodeAutoApprovalMode } from "../../onboard/dcode-auto-approval";
+import { isSandboxBaseImageRefreshRequested } from "../../onboard/base-image-resolution-flow";
 import { resolveSandboxGatewayName } from "../../onboard/gateway-binding";
 import {
   getResumeSandboxGpuOverrides,
@@ -36,7 +38,7 @@ import {
   type ResolvedDcodeRebuildTarget,
   resolveDcodeRebuildTarget,
 } from "./rebuild-dcode-target";
-import type { RebuildSandboxEntry } from "./rebuild-flow-helpers";
+import type { RebuildAgentBaseImageOptions, RebuildSandboxEntry } from "./rebuild-flow-helpers";
 import {
   disposePreparedDcodeRebuildImage,
   type PreparedDcodeRebuildImage,
@@ -81,6 +83,7 @@ export type DcodeReplacementPreflightInput = {
 
 export type DcodeReplacementPreparationInput = DcodeReplacementPreflightInput & {
   webSearchConfig: WebSearchConfig | null;
+  baseImageOptions?: RebuildAgentBaseImageOptions;
 };
 
 export type DcodeRebuildPreflightScope = {
@@ -281,22 +284,94 @@ function isImmutableRemoteImageRef(imageRef: string): boolean {
   return /^[^\s@]+@sha256:[0-9a-f]{64}$/i.test(imageRef);
 }
 
-function resolvePinnedDcodeBaseImage(bail: DcodeRebuildPreflightBail): PinnedDcodeBaseImage {
+function recordedDcodeOverrideReference(
+  metadata: SandboxBaseImageResolutionMetadata | null | undefined,
+  imageName: string,
+  bail: DcodeRebuildPreflightBail,
+): string | null {
+  if (!metadata || metadata.source !== "override") return null;
+  if (
+    typeof metadata.digest !== "string" ||
+    !/^sha256:[0-9a-f]{64}$/u.test(metadata.digest) ||
+    metadata.imageName !== imageName ||
+    metadata.ref !== `${imageName}@${metadata.digest}` ||
+    metadata.pinnedRemoteRef !== undefined
+  ) {
+    fail(
+      "the recorded Deep Agents Code base-image resolution metadata does not describe an exact published override",
+      bail,
+    );
+  }
+  return metadata.ref;
+}
+
+function reuseRecordedDcodeBaseImage(
+  agent: ReturnType<typeof loadAgent>,
+  options: RebuildAgentBaseImageOptions,
+  bail: DcodeRebuildPreflightBail,
+): ReturnType<typeof ensureAgentBaseImage> | null {
+  const metadata = options.resolutionHint;
+  const envName = getAgentSandboxBaseImageEnvVar(agent.name);
+  if (
+    process.env[envName]?.trim() ||
+    options.forceBaseImageRefresh === true ||
+    isSandboxBaseImageRefreshRequested(process.env) ||
+    !metadata
+  ) {
+    return null;
+  }
+  const imageName = `ghcr.io/nvidia/nemoclaw/${agent.name}-sandbox-base`;
+  const imageRef = recordedDcodeOverrideReference(metadata, imageName, bail);
+  if (!imageRef) return null;
+
+  const hadPrevious = Object.hasOwn(process.env, envName);
+  const previous = process.env[envName];
+  const restoreLease = pinTrustedAgentRemoteBaseImageOverrideForOperation(envName, {
+    ref: imageRef,
+    resolutionMetadata: metadata,
+  });
+  try {
+    process.env[envName] = imageRef;
+    const result = ensureAgentBaseImage(agent, { forceBaseImageRefresh: true });
+    if (
+      result.imageTag !== imageRef ||
+      result.resolutionMetadata !== metadata ||
+      result.resolutionMetadata.source !== "override"
+    ) {
+      fail(
+        "the recorded Deep Agents Code base-image resolution metadata could not be revalidated",
+        bail,
+      );
+    }
+    return result;
+  } finally {
+    restoreLease();
+    if (hadPrevious && previous !== undefined) process.env[envName] = previous;
+    else delete process.env[envName];
+  }
+}
+
+function resolvePinnedDcodeBaseImage(
+  bail: DcodeRebuildPreflightBail,
+  options: RebuildAgentBaseImageOptions = {},
+): PinnedDcodeBaseImage {
   const agent = loadAgent(DCODE_AGENT_NAME);
   if (!agent.dockerfileBasePath) {
     fail("DCode is missing its sandbox base Dockerfile", bail);
   }
-  let result: ReturnType<typeof ensureAgentBaseImage>;
-  try {
-    result = ensureAgentBaseImage(agent, { forceBaseImageRefresh: true });
-  } catch (error) {
+  let result = reuseRecordedDcodeBaseImage(agent, options, bail);
+  if (!result) {
     try {
-      result = ensureAgentBaseImage(agent, { forceBaseImageRebuild: true });
-    } catch (buildError) {
-      fail(
-        `DCode base image could not be resolved or built: ${buildError instanceof Error ? buildError.message : String(buildError)}`,
-        bail,
-      );
+      result = ensureAgentBaseImage(agent, { forceBaseImageRefresh: true });
+    } catch (error) {
+      try {
+        result = ensureAgentBaseImage(agent, { forceBaseImageRebuild: true });
+      } catch (buildError) {
+        fail(
+          `DCode base image could not be resolved or built: ${buildError instanceof Error ? buildError.message : String(buildError)}`,
+          bail,
+        );
+      }
     }
   }
   if (
@@ -450,7 +525,7 @@ export async function prepareDcodeReplacementBeforeMutation(
     const target = resolveTarget(entry, resumeConfig, bail, gatewayPort);
     if (!skipLiveRoute) requireInferenceRoute(sandboxName, target, bail);
 
-    pinnedBase = resolvePinnedDcodeBaseImage(bail);
+    pinnedBase = resolvePinnedDcodeBaseImage(bail, input.baseImageOptions);
     const sandboxGpuConfig = getRecordedGpuConfig(sandboxName, entry, session);
     if (sandboxGpuConfig.errors.length > 0) fail(sandboxGpuConfig.errors.join(" "), bail);
     const pinnedBaseForPreparation = pinnedBase;

--- a/src/lib/actions/sandbox/rebuild-preflight-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-preflight-phase.ts
@@ -285,6 +285,9 @@ export async function runRebuildPreflightPhase(
           preparedTarget.targetConfig.durableConfig.dcodeAutoApprovalMode,
           recoveryRecreate,
           preparedTarget.recreateOptions.targetGatewayPort,
+          {
+            resolutionHint: preparedTarget.recreateOptions.baseImageResolutionHint,
+          },
         );
         if (!imageReady) return null;
         if (!preparedTarget.recreateOptions.managedWorkloadRebuild) {

--- a/test/e2e/live/dcode-base-image-runtime-evidence.ts
+++ b/test/e2e/live/dcode-base-image-runtime-evidence.ts
@@ -128,28 +128,29 @@ export function verifyDcodeBaseImageRuntimeEvidence(
   }
   const expectedDigest = contract.platformDigests[DCODE_BASE_IMAGE_TARGET_PLATFORM];
   const expectedReference = dcodeBaseImageReferenceForContract(contract);
-  if (
-    metadata.schema !== 1 ||
-    metadata.imageName !== contract.image ||
-    metadata.source !== "override" ||
-    metadata.pinnedRemoteRef !== undefined ||
-    metadata.digest !== expectedDigest ||
-    metadata.ref !== expectedReference ||
-    metadata.ref !== `${metadata.imageName}@${metadata.digest}`
-  ) {
+  const mismatchedFields = [
+    metadata.schema !== 1 ? "schema" : null,
+    metadata.imageName !== contract.image ? "image" : null,
+    metadata.source !== "override" ? "source" : null,
+    metadata.pinnedRemoteRef !== undefined ? "pinned reference" : null,
+    metadata.digest !== expectedDigest ? "digest" : null,
+    metadata.ref !== expectedReference ? "reference" : null,
+    metadata.ref !== `${metadata.imageName}@${metadata.digest}` ? "reference binding" : null,
+  ].filter((field): field is string => field !== null);
+  if (mismatchedFields.length > 0) {
     throw new Error(
-      `Deep Agents Code sandbox image did not use the published ${DCODE_BASE_IMAGE_TARGET_PLATFORM} base digest`,
+      `Deep Agents Code sandbox image does not match the published ${DCODE_BASE_IMAGE_TARGET_PLATFORM} base-image contract (mismatched fields: ${mismatchedFields.join(", ")})`,
     );
   }
   return {
     contractReference: contract.reference,
-    digest: metadata.digest,
-    image: metadata.imageName,
+    digest: expectedDigest,
+    image: contract.image,
     imageId: metadata.imageId,
     platform: DCODE_BASE_IMAGE_TARGET_PLATFORM,
-    reference: metadata.ref,
+    reference: expectedReference,
     sandboxImage,
-    source: metadata.source,
+    source: "override",
     sourceRevision: contract.sourceRevision,
   };
 }

--- a/test/e2e/support/dcode-base-image-runtime-evidence.test.ts
+++ b/test/e2e/support/dcode-base-image-runtime-evidence.test.ts
@@ -21,7 +21,23 @@ const AMD64_REFERENCE = `${DCODE_BASE_IMAGE}@${AMD64_DIGEST}`;
 const ARM64_REFERENCE = `${DCODE_BASE_IMAGE}@${ARM64_DIGEST}`;
 const CANDIDATE_REVISION = "d".repeat(40);
 const PUBLICATION_REVISION = "e".repeat(40);
-const BASE_CONTRACT_MISMATCH = /does not match the published linux\/amd64 base-image contract/;
+const PLATFORM_MISMATCH =
+  "Deep Agents Code sandbox image did not use the published linux/amd64 base digest";
+
+function baseContractMismatch(...labels: string[]): string {
+  return `Deep Agents Code sandbox image does not match the published linux/amd64 base-image contract (mismatched fields: ${labels.join(", ")})`;
+}
+
+function thrownMessage(action: () => unknown): string {
+  let thrown: unknown;
+  try {
+    action();
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(Error);
+  return (thrown as Error).message;
+}
 
 function publicationEnvironment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
@@ -114,13 +130,12 @@ describe("Deep Agents Code published base runtime evidence", () => {
     });
   });
 
-  it("reports only mismatched base-image resolution field names (#9386)", () => {
+  it("reports base-image resolution mismatch labels without rejected values (#9386)", () => {
     const contract = parseDcodeBaseImagePublicationEvidence(
       publicationEvidence(),
       publicationEnvironment(),
     );
-
-    expect(() =>
+    const message = thrownMessage(() =>
       verifyDcodeBaseImageRuntimeEvidence(
         contract,
         "nemoclaw-langchain-deepagents-code:e2e",
@@ -130,7 +145,12 @@ describe("Deep Agents Code published base runtime evidence", () => {
           ref: INDEX_REFERENCE,
         }),
       ),
-    ).toThrow(/mismatched fields: source, digest, reference/);
+    );
+
+    expect(message).toBe(baseContractMismatch("source", "digest", "reference"));
+    expect(
+      ["source-sha", INDEX_DIGEST, INDEX_REFERENCE].filter((value) => message.includes(value)),
+    ).toEqual([]);
   });
 
   it("rejects the publication index instead of the validated platform reference (#9386)", () => {
@@ -245,58 +265,72 @@ describe("Deep Agents Code published base runtime evidence", () => {
   });
 
   it.each([
-    ["missing metadata", null, /missing base resolution metadata/],
-    [
-      "the publication index instead of the selected platform",
-      resolutionMetadata({ digest: INDEX_DIGEST, ref: INDEX_REFERENCE }),
-      BASE_CONTRACT_MISMATCH,
-    ],
-    [
-      "the opposite platform digest for amd64",
-      resolutionMetadata({ digest: ARM64_DIGEST, ref: ARM64_REFERENCE }),
-      BASE_CONTRACT_MISMATCH,
-    ],
-    [
-      "self-consistent opposite-platform metadata",
-      resolutionMetadata({
+    {
+      label: "missing metadata",
+      metadata: null,
+      expectedMessage: "Deep Agents Code sandbox image is missing base resolution metadata",
+      rejectedValues: [],
+    },
+    {
+      label: "the publication index instead of the selected platform",
+      metadata: resolutionMetadata({ digest: INDEX_DIGEST, ref: INDEX_REFERENCE }),
+      expectedMessage: baseContractMismatch("digest", "reference"),
+      rejectedValues: [INDEX_DIGEST, INDEX_REFERENCE],
+    },
+    {
+      label: "the opposite platform digest for amd64",
+      metadata: resolutionMetadata({ digest: ARM64_DIGEST, ref: ARM64_REFERENCE }),
+      expectedMessage: baseContractMismatch("digest", "reference"),
+      rejectedValues: [ARM64_DIGEST, ARM64_REFERENCE],
+    },
+    {
+      label: "self-consistent opposite-platform metadata",
+      metadata: resolutionMetadata({
         architecture: "arm64",
         digest: ARM64_DIGEST,
         ref: ARM64_REFERENCE,
       }),
-      /did not use the published linux\/amd64 base digest/,
-    ],
-    [
-      "a different image repository",
-      resolutionMetadata({ imageName: "ghcr.io/example/base" }),
-      BASE_CONTRACT_MISMATCH,
-    ],
-    [
-      "a fallback resolution source",
-      resolutionMetadata({ source: "latest" }),
-      BASE_CONTRACT_MISMATCH,
-    ],
-    [
-      "a pinned fallback reference",
-      resolutionMetadata({ pinnedRemoteRef: AMD64_REFERENCE }),
-      BASE_CONTRACT_MISMATCH,
-    ],
-    [
-      "an unsupported platform",
-      resolutionMetadata({ architecture: "ppc64le" }),
-      /did not use the published linux\/amd64 base digest/,
-    ],
-  ])("rejects %s", (_label, metadata, expectedError) => {
+      expectedMessage: PLATFORM_MISMATCH,
+      rejectedValues: [ARM64_DIGEST, ARM64_REFERENCE],
+    },
+    {
+      label: "a different image repository",
+      metadata: resolutionMetadata({ imageName: "ghcr.io/example/base" }),
+      expectedMessage: baseContractMismatch("image", "reference binding"),
+      rejectedValues: ["ghcr.io/example/base"],
+    },
+    {
+      label: "a fallback resolution source",
+      metadata: resolutionMetadata({ source: "latest" }),
+      expectedMessage: baseContractMismatch("source"),
+      rejectedValues: ["latest"],
+    },
+    {
+      label: "a pinned fallback reference",
+      metadata: resolutionMetadata({ pinnedRemoteRef: AMD64_REFERENCE }),
+      expectedMessage: baseContractMismatch("pinned reference"),
+      rejectedValues: [AMD64_REFERENCE],
+    },
+    {
+      label: "an unsupported platform",
+      metadata: resolutionMetadata({ architecture: "ppc64le" }),
+      expectedMessage: PLATFORM_MISMATCH,
+      rejectedValues: ["ppc64le"],
+    },
+  ])("rejects $label", ({ metadata, expectedMessage, rejectedValues }) => {
     const contract = parseDcodeBaseImagePublicationEvidence(
       publicationEvidence(),
       publicationEnvironment(),
     );
-
-    expect(() =>
+    const message = thrownMessage(() =>
       verifyDcodeBaseImageRuntimeEvidence(
         contract,
         "nemoclaw-langchain-deepagents-code:e2e",
         metadata,
       ),
-    ).toThrow(expectedError);
+    );
+
+    expect(message).toBe(expectedMessage);
+    expect(rejectedValues.filter((value) => message.includes(value))).toEqual([]);
   });
 });

--- a/test/e2e/support/dcode-base-image-runtime-evidence.test.ts
+++ b/test/e2e/support/dcode-base-image-runtime-evidence.test.ts
@@ -272,6 +272,12 @@ describe("Deep Agents Code published base runtime evidence", () => {
       rejectedValues: [],
     },
     {
+      label: "an unsupported metadata schema version",
+      metadata: resolutionMetadata({ schema: 2 }),
+      expectedMessage: baseContractMismatch("schema"),
+      rejectedValues: ["2"],
+    },
+    {
       label: "the publication index instead of the selected platform",
       metadata: resolutionMetadata({ digest: INDEX_DIGEST, ref: INDEX_REFERENCE }),
       expectedMessage: baseContractMismatch("digest", "reference"),

--- a/test/e2e/support/dcode-base-image-runtime-evidence.test.ts
+++ b/test/e2e/support/dcode-base-image-runtime-evidence.test.ts
@@ -21,6 +21,7 @@ const AMD64_REFERENCE = `${DCODE_BASE_IMAGE}@${AMD64_DIGEST}`;
 const ARM64_REFERENCE = `${DCODE_BASE_IMAGE}@${ARM64_DIGEST}`;
 const CANDIDATE_REVISION = "d".repeat(40);
 const PUBLICATION_REVISION = "e".repeat(40);
+const BASE_CONTRACT_MISMATCH = /does not match the published linux\/amd64 base-image contract/;
 
 function publicationEnvironment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
@@ -111,6 +112,25 @@ describe("Deep Agents Code published base runtime evidence", () => {
       source: "override",
       sourceRevision: PUBLICATION_REVISION,
     });
+  });
+
+  it("reports only mismatched base-image resolution field names (#9386)", () => {
+    const contract = parseDcodeBaseImagePublicationEvidence(
+      publicationEvidence(),
+      publicationEnvironment(),
+    );
+
+    expect(() =>
+      verifyDcodeBaseImageRuntimeEvidence(
+        contract,
+        "nemoclaw-langchain-deepagents-code:e2e",
+        resolutionMetadata({
+          source: "source-sha",
+          digest: INDEX_DIGEST,
+          ref: INDEX_REFERENCE,
+        }),
+      ),
+    ).toThrow(/mismatched fields: source, digest, reference/);
   });
 
   it("rejects the publication index instead of the validated platform reference (#9386)", () => {
@@ -229,12 +249,12 @@ describe("Deep Agents Code published base runtime evidence", () => {
     [
       "the publication index instead of the selected platform",
       resolutionMetadata({ digest: INDEX_DIGEST, ref: INDEX_REFERENCE }),
-      /did not use the published linux\/amd64 base digest/,
+      BASE_CONTRACT_MISMATCH,
     ],
     [
       "the opposite platform digest for amd64",
       resolutionMetadata({ digest: ARM64_DIGEST, ref: ARM64_REFERENCE }),
-      /did not use the published linux\/amd64 base digest/,
+      BASE_CONTRACT_MISMATCH,
     ],
     [
       "self-consistent opposite-platform metadata",
@@ -248,17 +268,17 @@ describe("Deep Agents Code published base runtime evidence", () => {
     [
       "a different image repository",
       resolutionMetadata({ imageName: "ghcr.io/example/base" }),
-      /did not use the published linux\/amd64 base digest/,
+      BASE_CONTRACT_MISMATCH,
     ],
     [
       "a fallback resolution source",
       resolutionMetadata({ source: "latest" }),
-      /did not use the published linux\/amd64 base digest/,
+      BASE_CONTRACT_MISMATCH,
     ],
     [
       "a pinned fallback reference",
       resolutionMetadata({ pinnedRemoteRef: AMD64_REFERENCE }),
-      /did not use the published linux\/amd64 base digest/,
+      BASE_CONTRACT_MISMATCH,
     ],
     [
       "an unsupported platform",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Deep Agents Code named rebuilds read the current sandbox's base-image resolution metadata but did not pass it to the replacement-image preflight. Completion evidence then found non-null `linux/amd64` metadata that did not match the published base-image contract, but the failed run did not record which final values differed. This change revalidates and retains the recorded published base-image reference when no explicit override or refresh is requested.

## Related Issue

Related to #9386

## Changes

- Pass the current sandbox's recorded base-image resolution metadata into Deep Agents Code image preparation.
- Reuse recorded metadata only when it describes an exact immutable digest in the official repository. Revalidate the same metadata through the existing no-fallback remote trust lease before Dockerfile patching.
- Preserve explicit base-image override and refresh precedence. For missing or non-override metadata, NemoClaw retains the existing candidate-resolution and local-build behavior.
- Report mismatch labels for completion-evidence checks without printing rejected metadata values.
- Add regression coverage for the complete named-rebuild handoff, invalid repositories, refresh precedence, revalidation failure, cleanup, and redacted completion diagnostics.
- Documentation impact: none. This restores the documented recorded-resolution rebuild behavior. Existing command, configuration, default, and workflow documentation remains accurate.

## Regression Evidence

- Automatic run [32115664698](https://github.com/NVIDIA/NemoClaw/actions/runs/32115664698), Deep Agents Code job [95653484522](https://github.com/NVIDIA/NemoClaw/actions/runs/32115664698/job/95653484522), tested main commit `23c1afb389d5fa3c82d1b27641f095a2f459b744` after #9418 merged.
- Onboarding, lifecycle checks, fresh onboarding, and all cloud checks passed. The thread auto-approval check completed both named rebuilds (`thread-opt-in`, then `disabled`) and reported `6 passed, 0 failed`.
- Final completion evidence failed in 21 ms with `Deep Agents Code sandbox image did not use the published linux/amd64 base digest`. The artifact and old compound diagnostic did not serialize the rejected metadata fields, so the final source, digest, and reference values remain unknown. Source-tag re-resolution is an inference from repository source and the exact checkout tag, not an observed final metadata field.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent review receipt below, bound to commit `331dfc5e5c5e76529eb19f677fde6c0854a41df2` and base `17e0c1f17f642fbe348f8cc3daf95bf724309086`
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: `PR review advisor (Nemotron 3 Ultra)` [job 95676763761](https://github.com/NVIDIA/NemoClaw/actions/runs/32126058280/job/95676763761) failed because the advisor SDK emitted text before its required terminology tool completed. The [published commit-bound advisor receipt](https://github.com/NVIDIA/NemoClaw/pull/9456#issuecomment-5326647931) records zero findings and no required follow-up; the maintainer monitor accepted no rerun.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
  - `npm exec -- vitest run --project cli src/lib/actions/sandbox/rebuild-dcode-base-image-lease.test.ts src/lib/actions/sandbox/rebuild-dcode-orchestrator.test.ts --testTimeout=30000` — 13/13 passed
  - `npm exec -- vitest run --project e2e-support test/e2e/support/dcode-base-image-runtime-evidence.test.ts` — 22/22 passed
  - `npm run typecheck:cli` — passed
  - `npm run test:changed` — growth lane 32/32 and changed lane 124/124 passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: broad gate not run; targeted suites, CLI typecheck, and `npm run test:changed` passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Independent Review Receipts

- Correctness and simplicity: PASS. Reviewed commit `331dfc5e5c5e76529eb19f677fde6c0854a41df2` and its complete seven-file diff against immutable base `17e0c1f17f642fbe348f8cc3daf95bf724309086`; no findings.
- Sensitive path: PASS. Reviewed the same commit and base. The review confirmed exact repository, digest, reference, resolution-key, image-identity, platform, ABI, and runtime validation; explicit override and refresh precedence; no-fallback lease enforcement; and lease/environment cleanup. Invalid or ambiguous metadata fails closed; no findings.
- Documentation writer: PASS (`no-docs-needed`). Reviewed the same commit and base. Existing documentation already covers recorded base-image reuse and explicit refresh bypass; all changed diagnostic and test text is accurate.

## Live E2E Acceptance

- [ ] The `ubuntu-repo-cloud-langchain-deepagents-code` target passes once for the commit under review, including both named rebuilds and final published `linux/amd64` metadata evidence.
- [ ] The same target passes a second serial qualification run for the same commit.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
