### PR TITLE
fix(onboard): advise a larger model when the native context caps Ollama

### DIFF
--- a/docs/inference/configure-model-limits.mdx
+++ b/docs/inference/configure-model-limits.mdx
@@ -58,8 +58,11 @@ When NemoClaw starts Local Ollama on macOS or Linux, it requests at least `64000
 Fresh onboarding then verifies the loaded model's actual `context_length` through `/api/ps`.
 Resumed onboarding and sandbox rebuilds warm the exact recorded Ollama model and repeat this verification before reusing its route.
 When `NEMOCLAW_CONTEXT_WINDOW` is larger than `64000`, the Ollama runtime must provide at least that larger value.
-Onboarding stops before building the sandbox when Ollama reports a smaller, missing, or malformed value and shows the required `OLLAMA_CONTEXT_LENGTH` value for restarting Ollama.
-Setting `NEMOCLAW_CONTEXT_WINDOW` does not raise the Ollama daemon's runtime context or bypass this check.
+When Ollama reports a smaller runtime value, NemoClaw queries `/api/show` for the selected model's native context window.
+If the model's native context window is below the requirement, onboarding stops and tells you to select a model that meets the reported requirement.
+If the model can meet the requirement, or NemoClaw cannot read its native context window, onboarding instead shows the required `OLLAMA_CONTEXT_LENGTH` value for restarting Ollama.
+A missing or malformed runtime value also produces the daemon restart guidance.
+Setting `NEMOCLAW_CONTEXT_WINDOW` does not raise the model's native context window or the Ollama daemon's runtime context, and it does not bypass this check.
 
 </AgentOnly>
 

--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -138,7 +138,10 @@ Resumed onboarding and sandbox rebuilds warm the exact recorded Ollama model and
 
 When `NEMOCLAW_CONTEXT_WINDOW` is unset, NemoClaw writes the verified runtime value as `model.context_length` in `/sandbox/.hermes/config.yaml`.
 An explicit `NEMOCLAW_CONTEXT_WINDOW` must be at least `64000`; NemoClaw writes that value only when the loaded model reports at least the same context length.
-If an existing or unmanaged daemon reports less, omits the value, or returns a malformed value, onboarding stops before building the sandbox and shows the required `OLLAMA_CONTEXT_LENGTH` value for restarting Ollama.
+If an existing or unmanaged daemon reports less than the requirement, NemoClaw queries `/api/show` for the selected model's native context window.
+If the model's native context window is below the requirement, onboarding stops and tells you to select a model that meets the reported requirement.
+If the model can meet the requirement, or NemoClaw cannot read its native context window, onboarding instead shows the required `OLLAMA_CONTEXT_LENGTH` value for restarting Ollama.
+A missing or malformed runtime value also produces the daemon restart guidance.
 </AgentOnly>
 
 ## Use Windows-Host Ollama from WSL
@@ -302,7 +305,8 @@ When Ollama reports a context length below `16384` and `NEMOCLAW_CONTEXT_WINDOW`
 <AgentOnly variant="hermes">
 When `NEMOCLAW_CONTEXT_WINDOW` is unset, NemoClaw writes a valid loaded-model context length of at least `64000` as `model.context_length`.
 When you set a larger value explicitly, the loaded model must report at least that value before NemoClaw writes the explicit value.
-When the runtime value is lower or cannot be verified, onboarding stops and tells you which `OLLAMA_CONTEXT_LENGTH` value to use when restarting the host daemon before retrying.
+When the runtime value is lower, onboarding checks `/api/show` and either asks you to select a model that meets the reported requirement or gives daemon restart guidance.
+When the runtime value cannot be verified, onboarding shows the required `OLLAMA_CONTEXT_LENGTH` value for restarting the host daemon before retrying.
 </AgentOnly>
 
 If the initial validation times out during a cold load, NemoClaw retries once with a 300-second probe budget.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -3334,9 +3334,14 @@ During onboarding, NemoClaw verifies the loaded model's actual `context_length` 
 Resumed onboarding and sandbox rebuilds warm the exact recorded Ollama model and repeat this check before reusing its route.
 Resume stops when that recorded model is missing, Ollama is unreachable, model warm-up fails, or the runtime context cannot be verified.
 If you set `NEMOCLAW_CONTEXT_WINDOW` above `64000`, the loaded model must provide at least that larger value.
-If the runtime value is too small, missing, or malformed, onboarding stops before sandbox creation and asks you to restart the host daemon with the required context length.
-`NEMOCLAW_CONTEXT_WINDOW` controls Hermes prompt budgeting; it does not change the Ollama daemon or bypass this runtime check.
-Force a larger context length:
+If the runtime value is below the requirement, NemoClaw queries Ollama's `/api/show` endpoint for the selected model's native context window.
+If the model's native context window is below the requirement, onboarding stops and tells you to select a model that meets the reported requirement.
+`OLLAMA_CONTEXT_LENGTH` cannot raise a model above its native context window.
+If the model can meet the requirement, or NemoClaw cannot read its native context window, onboarding instead shows the required `OLLAMA_CONTEXT_LENGTH` value for restarting the host daemon.
+A missing or malformed runtime value also produces the daemon restart guidance.
+`NEMOCLAW_CONTEXT_WINDOW` controls Hermes prompt budgeting; it does not raise the model's native context window or the Ollama daemon's runtime context, and it does not bypass this check.
+Use the daemon restart command only when onboarding shows a required `OLLAMA_CONTEXT_LENGTH` value.
+The example uses the Hermes minimum; replace `64000` with the larger value from onboarding when applicable.
 
 ```bash
 pkill -f 'ollama serve'

--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -41,6 +41,7 @@ import type {
 } from "./ollama-runtime-context";
 import {
   applyOllamaRuntimeContextWindow as applyOllamaRuntimeContextWindowWithHost,
+  fetchOllamaModelShowMetadata,
   getOllamaContextWindowFloorForAgent,
   MAX_AUTODETECTED_OLLAMA_CONTEXT_WINDOW,
   MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
@@ -1753,76 +1754,22 @@ export function probeOllamaModelCapabilities(
   model: string,
   runCaptureImpl?: RunCaptureFn,
 ): OllamaCapabilities {
-  const capture = runCaptureImpl ?? runCapture;
-  const host = getResolvedOllamaHost();
-  const body = JSON.stringify({ model });
-  let output: string;
-  try {
-    output = capture(
-      [
-        "curl",
-        "-sS",
-        "--connect-timeout",
-        "3",
-        "--max-time",
-        "5",
-        "-X",
-        "POST",
-        "-H",
-        "Content-Type: application/json",
-        "-d",
-        body,
-        `http://${host}:${OLLAMA_PORT}/api/show`,
-      ],
-      { ignoreError: true },
-    );
-  } catch (err) {
+  const metadata = fetchOllamaModelShowMetadata(model, getResolvedOllamaHost, runCaptureImpl);
+  if (!metadata.ok) {
     return {
       source: "unknown",
       capabilities: [],
       supportsTools: null,
-      rawError: err instanceof Error ? err.message : String(err),
+      rawError: metadata.error,
     };
   }
 
-  if (!output || !String(output).trim()) {
-    return {
-      source: "unknown",
-      capabilities: [],
-      supportsTools: null,
-      rawError: "empty response from /api/show",
-    };
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(String(output));
-  } catch (err) {
-    return {
-      source: "unknown",
-      capabilities: [],
-      supportsTools: null,
-      rawError: err instanceof Error ? err.message : "JSON parse error",
-    };
-  }
-
-  if (!parsed || typeof parsed !== "object") {
-    return {
-      source: "unknown",
-      capabilities: [],
-      supportsTools: null,
-      rawError: "unexpected /api/show payload shape",
-    };
-  }
-
-  const capsRaw = (parsed as { capabilities?: unknown }).capabilities;
+  const capsRaw = metadata.payload.capabilities;
   if (!Array.isArray(capsRaw)) {
     // Ollama returned a body but no capabilities array (older version,
     // custom registry, or shape change). Degrade to unknown.
     const errText =
-      typeof (parsed as { error?: unknown }).error === "string"
-        ? String((parsed as { error?: unknown }).error)
-        : "missing capabilities field";
+      typeof metadata.payload.error === "string" ? metadata.payload.error : "missing capabilities field";
     return {
       source: "unknown",
       capabilities: [],

--- a/src/lib/inference/ollama-runtime-context.test.ts
+++ b/src/lib/inference/ollama-runtime-context.test.ts
@@ -9,13 +9,21 @@ import {
   getOllamaContextWindowFloorForAgent,
   MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW,
   MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
+  type OllamaRuntimeRunCaptureFn,
+  parseOllamaNativeContextLength,
   parseOllamaRuntimeContextLength,
+  probeOllamaModelNativeContextLength,
   probeOllamaRuntimeModelStatus,
   resetOllamaRuntimeContextWindowAutoState,
   resolveOllamaRuntimeContextWindow,
 } from "./ollama-runtime-context";
 
 const getOllamaHost = () => "127.0.0.1";
+
+const makeOllamaCapture =
+  (psBody: string, showBody: string): OllamaRuntimeRunCaptureFn =>
+  (command) =>
+    command.some((arg) => String(arg).includes("/api/show")) ? showBody : psBody;
 
 type OllamaRuntimeContextFailure = Extract<
   ReturnType<typeof applyOllamaRuntimeContextWindow>,
@@ -262,6 +270,165 @@ describe("Ollama runtime context helpers", () => {
     expect(failure.message).toContain("required 131072-token window");
     expect(failure.message).toContain("OLLAMA_CONTEXT_LENGTH=131072");
     expect(env.NEMOCLAW_CONTEXT_WINDOW).toBe("131072");
+  });
+
+  it("advises a larger-context model when the native cap is below the Hermes requirement (#9458)", () => {
+    const env: NodeJS.ProcessEnv = {};
+    const result = applyOllamaRuntimeContextWindow("qwen2.5:0.5b", getOllamaHost, {
+      env,
+      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
+      logger: { log: () => {}, warn: () => {} },
+      runCaptureImpl: makeOllamaCapture(
+        JSON.stringify({ models: [{ name: "qwen2.5:0.5b", context_length: 32_768 }] }),
+        JSON.stringify({
+          model_info: { "general.architecture": "qwen2", "qwen2.context_length": 32_768 },
+        }),
+      ),
+    });
+
+    const failure = expectOllamaRuntimeContextFailure(result);
+    expect(failure.message).toContain("context_length=32768");
+    expect(failure.message).toContain("required 64000-token window");
+    expect(failure.message).toContain("native context is 32768 tokens");
+    expect(failure.message).toContain("Select a model whose native context is at least 64000");
+    expect(failure.message).not.toContain("OLLAMA_CONTEXT_LENGTH=64000");
+    expect(env.NEMOCLAW_CONTEXT_WINDOW).toBeUndefined();
+  });
+
+  it("keeps the daemon remediation when the model natively supports the requirement", () => {
+    const result = applyOllamaRuntimeContextWindow("llama3.1:8b", getOllamaHost, {
+      env: {},
+      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
+      logger: { log: () => {}, warn: () => {} },
+      runCaptureImpl: makeOllamaCapture(
+        JSON.stringify({ models: [{ name: "llama3.1:8b", context_length: 32_768 }] }),
+        JSON.stringify({
+          model_info: { "general.architecture": "llama", "llama.context_length": 131_072 },
+        }),
+      ),
+    });
+
+    const failure = expectOllamaRuntimeContextFailure(result);
+    expect(failure.message).toContain("OLLAMA_CONTEXT_LENGTH=64000");
+    expect(failure.message).not.toContain("Select a model");
+  });
+
+  it("keeps the daemon remediation when the native cap exactly equals the requirement", () => {
+    const result = applyOllamaRuntimeContextWindow("qwen2.5:14b", getOllamaHost, {
+      env: {},
+      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
+      logger: { log: () => {}, warn: () => {} },
+      runCaptureImpl: makeOllamaCapture(
+        JSON.stringify({ models: [{ name: "qwen2.5:14b", context_length: 32_768 }] }),
+        JSON.stringify({
+          model_info: { "general.architecture": "qwen2", "qwen2.context_length": 64_000 },
+        }),
+      ),
+    });
+
+    const failure = expectOllamaRuntimeContextFailure(result);
+    expect(failure.message).toContain("OLLAMA_CONTEXT_LENGTH=64000");
+    expect(failure.message).not.toContain("Select a model");
+  });
+
+  it.each([
+    ["an empty response", ""],
+    ["a malformed response", "not json"],
+    ["a response without model_info", JSON.stringify({ capabilities: ["tools"] })],
+  ])("keeps the daemon remediation when the native probe returns %s", (_caseName, showBody) => {
+    const result = applyOllamaRuntimeContextWindow("qwen2.5:0.5b", getOllamaHost, {
+      env: {},
+      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
+      logger: { log: () => {}, warn: () => {} },
+      runCaptureImpl: makeOllamaCapture(
+        JSON.stringify({ models: [{ name: "qwen2.5:0.5b", context_length: 32_768 }] }),
+        showBody,
+      ),
+    });
+
+    const failure = expectOllamaRuntimeContextFailure(result);
+    expect(failure.message).toContain("OLLAMA_CONTEXT_LENGTH=64000");
+    expect(failure.message).not.toContain("Select a model");
+  });
+
+  it("keeps the daemon remediation when the native probe capture throws", () => {
+    const psBody = JSON.stringify({ models: [{ name: "qwen2.5:0.5b", context_length: 32_768 }] });
+    const throwingCapture: OllamaRuntimeRunCaptureFn = (command) =>
+      command.some((arg) => String(arg).includes("/api/show"))
+        ? (() => {
+            throw new Error("curl exploded");
+          })()
+        : psBody;
+    const result = applyOllamaRuntimeContextWindow("qwen2.5:0.5b", getOllamaHost, {
+      env: {},
+      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
+      logger: { log: () => {}, warn: () => {} },
+      runCaptureImpl: throwingCapture,
+    });
+
+    const failure = expectOllamaRuntimeContextFailure(result);
+    expect(failure.message).toContain("OLLAMA_CONTEXT_LENGTH=64000");
+    expect(failure.message).not.toContain("Select a model");
+  });
+
+  it("parses the native context length from arch-prefixed model_info keys", () => {
+    expect(
+      parseOllamaNativeContextLength({
+        model_info: { "general.architecture": "qwen2", "qwen2.context_length": 32_768 },
+      }),
+    ).toBe(32_768);
+    expect(
+      parseOllamaNativeContextLength({
+        model_info: { "llama.context_length": "131072" },
+      }),
+    ).toBe(131_072);
+    expect(parseOllamaNativeContextLength({ model_info: {} })).toBeNull();
+    expect(parseOllamaNativeContextLength({})).toBeNull();
+    expect(parseOllamaNativeContextLength(null)).toBeNull();
+    expect(
+      parseOllamaNativeContextLength({
+        model_info: { "qwen2.context_length": "bogus" },
+      }),
+    ).toBeNull();
+    expect(
+      parseOllamaNativeContextLength({
+        model_info: { "qwen2.context_length": 10_000_000 },
+      }),
+    ).toBeNull();
+    expect(
+      parseOllamaNativeContextLength({
+        model_info: { "llama.context_length": 131_072, "qwen2.context_length": 32_768 },
+      }),
+    ).toBe(131_072);
+    expect(
+      parseOllamaNativeContextLength({
+        model_info: {
+          "general.architecture": "qwen2",
+          "qwen2.context_length": "bogus",
+          "llama.context_length": 131_072,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("probes /api/show with a POST naming the selected model", () => {
+    const commands: Array<readonly string[]> = [];
+    const status = probeOllamaModelNativeContextLength(
+      "qwen2.5:0.5b",
+      () => "host.docker.internal",
+      (command) => {
+        commands.push(command);
+        return JSON.stringify({
+          model_info: { "general.architecture": "qwen2", "qwen2.context_length": 32_768 },
+        });
+      },
+    );
+
+    expect(status).toEqual({ probed: true, nativeContextLength: 32_768 });
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toContain(`http://host.docker.internal:${OLLAMA_PORT}/api/show`);
+    expect(commands[0]).toContain("POST");
+    expect(commands[0]).toContain(JSON.stringify({ model: "qwen2.5:0.5b" }));
   });
 
   it("clears only stale auto-detected state when strict Hermes validation fails", () => {

--- a/src/lib/inference/ollama-runtime-context.test.ts
+++ b/src/lib/inference/ollama-runtime-context.test.ts
@@ -272,103 +272,83 @@ describe("Ollama runtime context helpers", () => {
     expect(env.NEMOCLAW_CONTEXT_WINDOW).toBe("131072");
   });
 
-  it("advises a larger-context model when the native cap is below the Hermes requirement (#9458)", () => {
+  const THROW_SHOW_BODY = "__throw__";
+  const showCapture = (showBody: string): OllamaRuntimeRunCaptureFn =>
+    makeOllamaCapture(
+      JSON.stringify({ models: [{ name: "qwen2.5:0.5b", context_length: 32_768 }] }),
+      showBody,
+    );
+  const throwingShowCapture: OllamaRuntimeRunCaptureFn = (command) =>
+    command.some((arg) => String(arg).includes("/api/show"))
+      ? (() => {
+          throw new Error("curl exploded");
+        })()
+      : JSON.stringify({ models: [{ name: "qwen2.5:0.5b", context_length: 32_768 }] });
+
+  it.each([
+    {
+      caseName: "native below the requirement advises a larger model (#9458)",
+      showBody: JSON.stringify({
+        model_info: { "general.architecture": "qwen2", "qwen2.context_length": 32_768 },
+      }),
+      contains: "Select a model whose native context is at least 64000",
+      notContains: "OLLAMA_CONTEXT_LENGTH=64000",
+    },
+    {
+      caseName: "native exactly equal keeps the daemon remediation",
+      showBody: JSON.stringify({
+        model_info: { "general.architecture": "qwen2", "qwen2.context_length": 64_000 },
+      }),
+      contains: "OLLAMA_CONTEXT_LENGTH=64000",
+      notContains: "Select a model",
+    },
+    {
+      caseName: "native above the requirement keeps the daemon remediation",
+      showBody: JSON.stringify({
+        model_info: { "general.architecture": "qwen2", "qwen2.context_length": 131_072 },
+      }),
+      contains: "OLLAMA_CONTEXT_LENGTH=64000",
+      notContains: "Select a model",
+    },
+    {
+      caseName: "an empty /api/show response keeps the daemon remediation",
+      showBody: "",
+      contains: "OLLAMA_CONTEXT_LENGTH=64000",
+      notContains: "Select a model",
+    },
+    {
+      caseName: "a malformed /api/show response keeps the daemon remediation",
+      showBody: "not json",
+      contains: "OLLAMA_CONTEXT_LENGTH=64000",
+      notContains: "Select a model",
+    },
+    {
+      caseName: "a response without model_info keeps the daemon remediation",
+      showBody: JSON.stringify({ capabilities: ["tools"] }),
+      contains: "OLLAMA_CONTEXT_LENGTH=64000",
+      notContains: "Select a model",
+    },
+    {
+      caseName: "a throwing /api/show capture keeps the daemon remediation",
+      showBody: THROW_SHOW_BODY,
+      contains: "OLLAMA_CONTEXT_LENGTH=64000",
+      notContains: "Select a model",
+    },
+  ])("$caseName", ({ showBody, contains, notContains }) => {
     const env: NodeJS.ProcessEnv = {};
     const result = applyOllamaRuntimeContextWindow("qwen2.5:0.5b", getOllamaHost, {
       env,
       contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
       logger: { log: () => {}, warn: () => {} },
-      runCaptureImpl: makeOllamaCapture(
-        JSON.stringify({ models: [{ name: "qwen2.5:0.5b", context_length: 32_768 }] }),
-        JSON.stringify({
-          model_info: { "general.architecture": "qwen2", "qwen2.context_length": 32_768 },
-        }),
-      ),
+      runCaptureImpl: showBody === THROW_SHOW_BODY ? throwingShowCapture : showCapture(showBody),
     });
 
     const failure = expectOllamaRuntimeContextFailure(result);
     expect(failure.message).toContain("context_length=32768");
     expect(failure.message).toContain("required 64000-token window");
-    expect(failure.message).toContain("native context is 32768 tokens");
-    expect(failure.message).toContain("Select a model whose native context is at least 64000");
-    expect(failure.message).not.toContain("OLLAMA_CONTEXT_LENGTH=64000");
+    expect(failure.message).toContain(contains);
+    expect(failure.message).not.toContain(notContains);
     expect(env.NEMOCLAW_CONTEXT_WINDOW).toBeUndefined();
-  });
-
-  it("keeps the daemon remediation when the model natively supports the requirement", () => {
-    const result = applyOllamaRuntimeContextWindow("llama3.1:8b", getOllamaHost, {
-      env: {},
-      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
-      logger: { log: () => {}, warn: () => {} },
-      runCaptureImpl: makeOllamaCapture(
-        JSON.stringify({ models: [{ name: "llama3.1:8b", context_length: 32_768 }] }),
-        JSON.stringify({
-          model_info: { "general.architecture": "llama", "llama.context_length": 131_072 },
-        }),
-      ),
-    });
-
-    const failure = expectOllamaRuntimeContextFailure(result);
-    expect(failure.message).toContain("OLLAMA_CONTEXT_LENGTH=64000");
-    expect(failure.message).not.toContain("Select a model");
-  });
-
-  it("keeps the daemon remediation when the native cap exactly equals the requirement", () => {
-    const result = applyOllamaRuntimeContextWindow("qwen2.5:14b", getOllamaHost, {
-      env: {},
-      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
-      logger: { log: () => {}, warn: () => {} },
-      runCaptureImpl: makeOllamaCapture(
-        JSON.stringify({ models: [{ name: "qwen2.5:14b", context_length: 32_768 }] }),
-        JSON.stringify({
-          model_info: { "general.architecture": "qwen2", "qwen2.context_length": 64_000 },
-        }),
-      ),
-    });
-
-    const failure = expectOllamaRuntimeContextFailure(result);
-    expect(failure.message).toContain("OLLAMA_CONTEXT_LENGTH=64000");
-    expect(failure.message).not.toContain("Select a model");
-  });
-
-  it.each([
-    ["an empty response", ""],
-    ["a malformed response", "not json"],
-    ["a response without model_info", JSON.stringify({ capabilities: ["tools"] })],
-  ])("keeps the daemon remediation when the native probe returns %s", (_caseName, showBody) => {
-    const result = applyOllamaRuntimeContextWindow("qwen2.5:0.5b", getOllamaHost, {
-      env: {},
-      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
-      logger: { log: () => {}, warn: () => {} },
-      runCaptureImpl: makeOllamaCapture(
-        JSON.stringify({ models: [{ name: "qwen2.5:0.5b", context_length: 32_768 }] }),
-        showBody,
-      ),
-    });
-
-    const failure = expectOllamaRuntimeContextFailure(result);
-    expect(failure.message).toContain("OLLAMA_CONTEXT_LENGTH=64000");
-    expect(failure.message).not.toContain("Select a model");
-  });
-
-  it("keeps the daemon remediation when the native probe capture throws", () => {
-    const psBody = JSON.stringify({ models: [{ name: "qwen2.5:0.5b", context_length: 32_768 }] });
-    const throwingCapture: OllamaRuntimeRunCaptureFn = (command) =>
-      command.some((arg) => String(arg).includes("/api/show"))
-        ? (() => {
-            throw new Error("curl exploded");
-          })()
-        : psBody;
-    const result = applyOllamaRuntimeContextWindow("qwen2.5:0.5b", getOllamaHost, {
-      env: {},
-      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
-      logger: { log: () => {}, warn: () => {} },
-      runCaptureImpl: throwingCapture,
-    });
-
-    const failure = expectOllamaRuntimeContextFailure(result);
-    expect(failure.message).toContain("OLLAMA_CONTEXT_LENGTH=64000");
-    expect(failure.message).not.toContain("Select a model");
   });
 
   it("parses the native context length for the declared model architecture (#9458)", () => {
@@ -424,7 +404,7 @@ describe("Ollama runtime context helpers", () => {
 
   it("probes /api/show with a POST naming the selected model", () => {
     const commands: Array<readonly string[]> = [];
-    const status = probeOllamaModelNativeContextLength(
+    const nativeContextLength = probeOllamaModelNativeContextLength(
       "qwen2.5:0.5b",
       () => "host.docker.internal",
       (command) => {
@@ -435,7 +415,8 @@ describe("Ollama runtime context helpers", () => {
       },
     );
 
-    expect(status).toEqual({ probed: true, nativeContextLength: 32_768 });
+    expect(nativeContextLength).toBe(32_768);
+    expect(probeOllamaModelNativeContextLength("qwen2.5:0.5b", getOllamaHost, () => "")).toBeNull();
     expect(commands).toHaveLength(1);
     expect(commands[0]).toContain(`http://host.docker.internal:${OLLAMA_PORT}/api/show`);
     expect(commands[0]).toContain("POST");

--- a/src/lib/inference/ollama-runtime-context.test.ts
+++ b/src/lib/inference/ollama-runtime-context.test.ts
@@ -371,7 +371,7 @@ describe("Ollama runtime context helpers", () => {
     expect(failure.message).not.toContain("Select a model");
   });
 
-  it("parses the native context length from arch-prefixed model_info keys", () => {
+  it("parses the native context length for the declared model architecture (#9458)", () => {
     expect(
       parseOllamaNativeContextLength({
         model_info: { "general.architecture": "qwen2", "qwen2.context_length": 32_768 },
@@ -379,9 +379,12 @@ describe("Ollama runtime context helpers", () => {
     ).toBe(32_768);
     expect(
       parseOllamaNativeContextLength({
-        model_info: { "llama.context_length": "131072" },
+        model_info: { "general.architecture": " llama ", "llama.context_length": "131072" },
       }),
     ).toBe(131_072);
+  });
+
+  it("rejects native context metadata without an exact architecture match (#9458)", () => {
     expect(parseOllamaNativeContextLength({ model_info: {} })).toBeNull();
     expect(parseOllamaNativeContextLength({})).toBeNull();
     expect(parseOllamaNativeContextLength(null)).toBeNull();
@@ -399,7 +402,15 @@ describe("Ollama runtime context helpers", () => {
       parseOllamaNativeContextLength({
         model_info: { "llama.context_length": 131_072, "qwen2.context_length": 32_768 },
       }),
-    ).toBe(131_072);
+    ).toBeNull();
+    expect(
+      parseOllamaNativeContextLength({
+        model_info: {
+          "general.architecture": "qwen2",
+          "llama.context_length": 131_072,
+        },
+      }),
+    ).toBeNull();
     expect(
       parseOllamaNativeContextLength({
         model_info: {

--- a/src/lib/inference/ollama-runtime-context.test.ts
+++ b/src/lib/inference/ollama-runtime-context.test.ts
@@ -351,6 +351,25 @@ describe("Ollama runtime context helpers", () => {
     expect(env.NEMOCLAW_CONTEXT_WINDOW).toBeUndefined();
   });
 
+  it("advises a larger model when the native cap sits above the auto-detect ceiling", () => {
+    const result = applyOllamaRuntimeContextWindow("qwen2.5:0.5b", getOllamaHost, {
+      env: {},
+      contextWindowFloor: 8_388_608,
+      logger: { log: () => {}, warn: () => {} },
+      runCaptureImpl: makeOllamaCapture(
+        JSON.stringify({ models: [{ name: "qwen2.5:0.5b", context_length: 4096 }] }),
+        JSON.stringify({
+          model_info: { "general.architecture": "qwen2", "qwen2.context_length": 6_291_456 },
+        }),
+      ),
+    });
+
+    const failure = expectOllamaRuntimeContextFailure(result);
+    expect(failure.message).toContain("native context is 6291456 tokens");
+    expect(failure.message).toContain("Select a model whose native context is at least 8388608");
+    expect(failure.message).not.toContain("OLLAMA_CONTEXT_LENGTH=8388608");
+  });
+
   it("parses the native context length for the declared model architecture (#9458)", () => {
     expect(
       parseOllamaNativeContextLength({
@@ -362,6 +381,11 @@ describe("Ollama runtime context helpers", () => {
         model_info: { "general.architecture": " llama ", "llama.context_length": "131072" },
       }),
     ).toBe(131_072);
+    expect(
+      parseOllamaNativeContextLength({
+        model_info: { "general.architecture": "qwen2", "qwen2.context_length": 6_291_456 },
+      }),
+    ).toBe(6_291_456);
   });
 
   it("rejects native context metadata without an exact architecture match (#9458)", () => {

--- a/src/lib/inference/ollama-runtime-context.ts
+++ b/src/lib/inference/ollama-runtime-context.ts
@@ -270,8 +270,11 @@ export function parseOllamaNativeContextLength(payload: unknown): number | null 
   const architecture =
     typeof info["general.architecture"] === "string" ? info["general.architecture"].trim() : "";
   if (!architecture) return null;
-  const parsed = parsePositiveInteger(info[`${architecture}.context_length`]);
-  return parsed && parsed <= MAX_AUTODETECTED_OLLAMA_CONTEXT_WINDOW ? parsed : null;
+  // No auto-detect ceiling here: it guards runtime adoption of /api/ps values,
+  // while this metadata only refines remediation wording. A safe-integer
+  // native value above the ceiling must still classify as model-limited when
+  // the required window is even larger.
+  return parsePositiveInteger(info[`${architecture}.context_length`]);
 }
 
 /**

--- a/src/lib/inference/ollama-runtime-context.ts
+++ b/src/lib/inference/ollama-runtime-context.ts
@@ -207,27 +207,19 @@ export interface OllamaNativeContextStatus {
  *
  * Ollama publishes the model card's `max_position_embeddings` under
  * `model_info["<architecture>.context_length"]` (e.g.
- * `qwen2.context_length`). Older daemons and custom registries may omit
- * `model_info` entirely, so every missing or malformed shape returns `null`
- * and callers fall back to the daemon-focused remediation.
+ * `qwen2.context_length`). The declared architecture and its exact associated
+ * key must both be present. Every missing or malformed shape returns `null`,
+ * so callers fall back to the daemon-focused remediation.
  */
 export function parseOllamaNativeContextLength(payload: unknown): number | null {
   const modelInfo = (payload as { model_info?: unknown } | null)?.model_info;
   if (!modelInfo || typeof modelInfo !== "object") return null;
   const info = modelInfo as Record<string, unknown>;
-  const architecture = info["general.architecture"];
-  const archKey = typeof architecture === "string" ? `${architecture}.context_length` : null;
-  const candidates =
-    archKey && archKey in info
-      ? [info[archKey]]
-      : Object.entries(info)
-          .filter(([key]) => key.endsWith(".context_length"))
-          .map(([, value]) => value);
-  for (const candidate of candidates) {
-    const parsed = parsePositiveInteger(candidate);
-    if (parsed && parsed <= MAX_AUTODETECTED_OLLAMA_CONTEXT_WINDOW) return parsed;
-  }
-  return null;
+  const architecture =
+    typeof info["general.architecture"] === "string" ? info["general.architecture"].trim() : "";
+  if (!architecture) return null;
+  const parsed = parsePositiveInteger(info[`${architecture}.context_length`]);
+  return parsed && parsed <= MAX_AUTODETECTED_OLLAMA_CONTEXT_WINDOW ? parsed : null;
 }
 
 /**
@@ -270,9 +262,7 @@ export function probeOllamaModelNativeContextLength(
   if (!output || !String(output).trim()) return { probed: false };
   try {
     const nativeContextLength = parseOllamaNativeContextLength(JSON.parse(String(output)));
-    return nativeContextLength
-      ? { probed: true, nativeContextLength }
-      : { probed: true };
+    return nativeContextLength ? { probed: true, nativeContextLength } : { probed: true };
   } catch {
     return { probed: false };
   }

--- a/src/lib/inference/ollama-runtime-context.ts
+++ b/src/lib/inference/ollama-runtime-context.ts
@@ -197,9 +197,61 @@ export function probeOllamaRuntimeModelStatus(
   }
 }
 
-export interface OllamaNativeContextStatus {
-  probed: boolean;
-  nativeContextLength?: number;
+export type OllamaShowMetadataResult =
+  | { ok: true; payload: Record<string, unknown> }
+  | { ok: false; error: string };
+
+/**
+ * The one Ollama `/api/show` metadata boundary. Owns request construction,
+ * timeout and capture behavior, JSON parsing, and the best-effort failure
+ * result. Consumers map `error` to their own fallback policy; none of them
+ * block on a probe failure.
+ */
+export function fetchOllamaModelShowMetadata(
+  model: string,
+  getOllamaHost: () => string,
+  runCaptureImpl?: OllamaRuntimeRunCaptureFn,
+): OllamaShowMetadataResult {
+  const capture = runCaptureImpl ?? runCapture;
+  const host = getOllamaHost();
+  let output: string;
+  try {
+    output = capture(
+      [
+        "curl",
+        ...buildValidatedCurlCommandArgs([
+          "-sS",
+          "--connect-timeout",
+          "3",
+          "--max-time",
+          "5",
+          "-X",
+          "POST",
+          "-H",
+          "Content-Type: application/json",
+          "-d",
+          JSON.stringify({ model }),
+          `http://${host}:${OLLAMA_PORT}/api/show`,
+        ]),
+      ],
+      { ignoreError: true },
+    );
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+  if (!output || !String(output).trim()) {
+    return { ok: false, error: "empty response from /api/show" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(String(output));
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "JSON parse error" };
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return { ok: false, error: "unexpected /api/show payload shape" };
+  }
+  return { ok: true, payload: parsed as Record<string, unknown> };
 }
 
 /**
@@ -224,48 +276,16 @@ export function parseOllamaNativeContextLength(payload: unknown): number | null 
 
 /**
  * Probe `/api/show` for the loaded model's native (architectural) context
- * length. Best-effort: any transport or shape failure reports an unprobed
- * status, never an error, because this only refines remediation wording.
+ * length. Best-effort: any transport or shape failure yields `null`, never an
+ * error, because this only refines remediation wording.
  */
 export function probeOllamaModelNativeContextLength(
   model: string,
   getOllamaHost: () => string,
   runCaptureImpl?: OllamaRuntimeRunCaptureFn,
-): OllamaNativeContextStatus {
-  const capture = runCaptureImpl ?? runCapture;
-  const host = getOllamaHost();
-  let output: string;
-  try {
-    output = capture(
-      [
-        "curl",
-        ...buildValidatedCurlCommandArgs([
-          "-sf",
-          "--connect-timeout",
-          "3",
-          "--max-time",
-          "5",
-          "-X",
-          "POST",
-          "-H",
-          "Content-Type: application/json",
-          "-d",
-          JSON.stringify({ model }),
-          `http://${host}:${OLLAMA_PORT}/api/show`,
-        ]),
-      ],
-      { ignoreError: true },
-    );
-  } catch {
-    return { probed: false };
-  }
-  if (!output || !String(output).trim()) return { probed: false };
-  try {
-    const nativeContextLength = parseOllamaNativeContextLength(JSON.parse(String(output)));
-    return nativeContextLength ? { probed: true, nativeContextLength } : { probed: true };
-  } catch {
-    return { probed: false };
-  }
+): number | null {
+  const metadata = fetchOllamaModelShowMetadata(model, getOllamaHost, runCaptureImpl);
+  return metadata.ok ? parseOllamaNativeContextLength(metadata.payload) : null;
 }
 
 export function resolveOllamaRuntimeContextWindow(
@@ -372,14 +392,13 @@ export function applyOllamaRuntimeContextWindow(
       // native cap itself is below the requirement, telling the user to
       // raise OLLAMA_CONTEXT_LENGTH sends them through a rerun that must
       // fail. Advise a larger-context model instead (#9458).
-      const nativeStatus = probeOllamaModelNativeContextLength(
+      const nativeContextLength = probeOllamaModelNativeContextLength(
         selectedModel,
         getOllamaHost,
         options.runCaptureImpl,
       );
-      const nativeContextLength = nativeStatus.nativeContextLength;
       const modelLimited =
-        nativeContextLength !== undefined && nativeContextLength < requiredContextWindow;
+        nativeContextLength !== null && nativeContextLength < requiredContextWindow;
       const reported =
         `Ollama reports context_length=${runtimeStatus.contextLength} for loaded model ` +
         `'${selectedModel}', below the required ${requiredContextWindow}-token window. `;

--- a/src/lib/inference/ollama-runtime-context.ts
+++ b/src/lib/inference/ollama-runtime-context.ts
@@ -4,9 +4,10 @@
 /**
  * Ollama runtime context-window helpers.
  *
- * Keep this module focused on data coming from Ollama's `/api/ps` runtime
- * boundary. Onboarding should call the narrow wrappers in `local.ts` instead
- * of re-implementing parsing or process-env state handling.
+ * Keep this module focused on data coming from Ollama's `/api/ps` and
+ * `/api/show` runtime boundaries. Onboarding should call the narrow wrappers
+ * in `local.ts` instead of re-implementing parsing or process-env state
+ * handling.
  */
 
 import { buildValidatedCurlCommandArgs } from "../adapters/http/curl-args";
@@ -196,6 +197,87 @@ export function probeOllamaRuntimeModelStatus(
   }
 }
 
+export interface OllamaNativeContextStatus {
+  probed: boolean;
+  nativeContextLength?: number;
+}
+
+/**
+ * Parse a model's native context length from an `/api/show` payload.
+ *
+ * Ollama publishes the model card's `max_position_embeddings` under
+ * `model_info["<architecture>.context_length"]` (e.g.
+ * `qwen2.context_length`). Older daemons and custom registries may omit
+ * `model_info` entirely, so every missing or malformed shape returns `null`
+ * and callers fall back to the daemon-focused remediation.
+ */
+export function parseOllamaNativeContextLength(payload: unknown): number | null {
+  const modelInfo = (payload as { model_info?: unknown } | null)?.model_info;
+  if (!modelInfo || typeof modelInfo !== "object") return null;
+  const info = modelInfo as Record<string, unknown>;
+  const architecture = info["general.architecture"];
+  const archKey = typeof architecture === "string" ? `${architecture}.context_length` : null;
+  const candidates =
+    archKey && archKey in info
+      ? [info[archKey]]
+      : Object.entries(info)
+          .filter(([key]) => key.endsWith(".context_length"))
+          .map(([, value]) => value);
+  for (const candidate of candidates) {
+    const parsed = parsePositiveInteger(candidate);
+    if (parsed && parsed <= MAX_AUTODETECTED_OLLAMA_CONTEXT_WINDOW) return parsed;
+  }
+  return null;
+}
+
+/**
+ * Probe `/api/show` for the loaded model's native (architectural) context
+ * length. Best-effort: any transport or shape failure reports an unprobed
+ * status, never an error, because this only refines remediation wording.
+ */
+export function probeOllamaModelNativeContextLength(
+  model: string,
+  getOllamaHost: () => string,
+  runCaptureImpl?: OllamaRuntimeRunCaptureFn,
+): OllamaNativeContextStatus {
+  const capture = runCaptureImpl ?? runCapture;
+  const host = getOllamaHost();
+  let output: string;
+  try {
+    output = capture(
+      [
+        "curl",
+        ...buildValidatedCurlCommandArgs([
+          "-sf",
+          "--connect-timeout",
+          "3",
+          "--max-time",
+          "5",
+          "-X",
+          "POST",
+          "-H",
+          "Content-Type: application/json",
+          "-d",
+          JSON.stringify({ model }),
+          `http://${host}:${OLLAMA_PORT}/api/show`,
+        ]),
+      ],
+      { ignoreError: true },
+    );
+  } catch {
+    return { probed: false };
+  }
+  if (!output || !String(output).trim()) return { probed: false };
+  try {
+    const nativeContextLength = parseOllamaNativeContextLength(JSON.parse(String(output)));
+    return nativeContextLength
+      ? { probed: true, nativeContextLength }
+      : { probed: true };
+  } catch {
+    return { probed: false };
+  }
+}
+
 export function resolveOllamaRuntimeContextWindow(
   model: string,
   currentContextWindow: string | null | undefined,
@@ -295,12 +377,31 @@ export function applyOllamaRuntimeContextWindow(
     }
     if (runtimeStatus.contextLength < requiredContextWindow) {
       clearPreviousAuto();
+      // OLLAMA_CONTEXT_LENGTH can only cap a model's context down, never
+      // raise it past the model card's max_position_embeddings. When the
+      // native cap itself is below the requirement, telling the user to
+      // raise OLLAMA_CONTEXT_LENGTH sends them through a rerun that must
+      // fail — advise a larger-context model instead (#9458).
+      const nativeStatus = probeOllamaModelNativeContextLength(
+        selectedModel,
+        getOllamaHost,
+        options.runCaptureImpl,
+      );
+      const nativeContextLength = nativeStatus.nativeContextLength;
+      const modelLimited =
+        nativeContextLength !== undefined && nativeContextLength < requiredContextWindow;
+      const reported =
+        `Ollama reports context_length=${runtimeStatus.contextLength} for loaded model ` +
+        `'${selectedModel}', below the required ${requiredContextWindow}-token window. `;
       return {
         ok: false,
-        message:
-          `Ollama reports context_length=${runtimeStatus.contextLength} for loaded model ` +
-          `'${selectedModel}', below the required ${requiredContextWindow}-token window. ` +
-          remediation,
+        message: modelLimited
+          ? reported +
+            `The model's native context is ${nativeContextLength} tokens, and ` +
+            `OLLAMA_CONTEXT_LENGTH cannot raise a model past its native cap. Select a model ` +
+            `whose native context is at least ${requiredContextWindow} tokens, then rerun ` +
+            `onboarding.`
+          : reported + remediation,
       };
     }
     if (hasExplicitContextWindow(userContextWindow)) {

--- a/src/lib/inference/ollama-runtime-context.ts
+++ b/src/lib/inference/ollama-runtime-context.ts
@@ -381,7 +381,7 @@ export function applyOllamaRuntimeContextWindow(
       // raise it past the model card's max_position_embeddings. When the
       // native cap itself is below the requirement, telling the user to
       // raise OLLAMA_CONTEXT_LENGTH sends them through a rerun that must
-      // fail — advise a larger-context model instead (#9458).
+      // fail. Advise a larger-context model instead (#9458).
       const nativeStatus = probeOllamaModelNativeContextLength(
         selectedModel,
         getOllamaHost,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The strict-floor Ollama context check previously recommended raising `OLLAMA_CONTEXT_LENGTH` for every below-floor result. That setting cannot raise a model past its native context capacity, so the advice could send users through a rerun that must fail.

This change probes the selected model's native context only after a below-required result. It advises a larger model when the declared architecture's exact context value is below the required floor. It preserves the existing daemon remediation when the model can satisfy the floor or when the native metadata is missing, malformed, ambiguous, or unavailable.

## Related Issue

Fixes #9458

## Changes

- `src/lib/inference/ollama-runtime-context.ts`: require a nonempty `general.architecture` value and read only its exact `<architecture>.context_length` field. Keep the daemon remediation for incomplete or ambiguous model metadata.
- `src/lib/inference/ollama-runtime-context.test.ts`: cover model-limited, daemon-limited, boundary, missing-architecture, wrong-architecture, malformed, and failed-probe behavior.
- `docs/inference/set-up-ollama.mdx`: explain when to choose a larger-context model and when to raise the Ollama daemon limit.
- `docs/inference/configure-model-limits.mdx`: distinguish model capacity from the daemon cap.
- `docs/reference/troubleshooting.mdx`: add the same diagnosis and safe recovery guidance.

The probe is best-effort and only refines the remediation text. It adds no new supported provider, configuration field, or fallback.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior; justification:
- [ ] Tests not applicable; justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable; justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded; reviewer/approval link/justification: exact-commit PASS review at https://github.com/NVIDIA/NemoClaw/pull/9460#pullrequestreview-4962847918
- [ ] Non-success, skipped, or missing CI check accepted by maintainer; check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Reviewed the five-file effective diff at `f89a2ea03`. Ollama native-context guidance now requires `general.architecture` and its exact `<architecture>.context_length`; incomplete or ambiguous metadata preserves the `OLLAMA_CONTEXT_LENGTH` daemon remediation. Verified `docs/inference/set-up-ollama.mdx`, `docs/inference/configure-model-limits.mdx`, `docs/reference/troubleshooting.mdx`, and their guide-variant scope. Focused CLI tests passed 33/33; CLI build, CLI typecheck, Oxfmt, and diff check passed. The unchanged docs previously built with 0 errors and 2 existing Fern warnings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: f89a2ea03 -->
<!-- docs-review-agents-blob-sha: 993bdd850 -->

## DGX Station Hardware Evidence

Not applicable. This PR does not change `scripts/prepare-dgx-station-host.sh`.

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above; command/result or justification: `npx vitest run --project cli src/lib/inference/ollama-runtime-context.test.ts` passed 33/33 at `f89a2ea03`; `npm run build:cli`, `npm run typecheck:cli`, Oxfmt, and `git diff --check` passed.
- [ ] Applicable broad gate passed: `npm test` for broad runtime or shared test-harness changes; `npm run check` for repository-wide validation or coverage changes. Command/result: not applicable; the change is confined to one inference diagnostic, its focused tests, and owning documentation. Fresh GitHub gates remain authoritative.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only); the unchanged docs previously built with 0 errors and 2 existing Fern warnings
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Ollama setup now checks a selected model’s native context capacity when runtime limits are too low.
  - Onboarding recommends a larger-context model when the selected model cannot meet requirements.
  - Model capability detection is more consistent, including tool support.

- **Bug Fixes**
  - Improved handling of missing, malformed, or unavailable context information.

- **Documentation**
  - Updated setup and troubleshooting guidance for context limits, model capacity, and restart requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->