### PR TITLE
fix(rebuild): carry host mounts into the recreate session

### DIFF
--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -349,6 +349,12 @@ The rerun takes one of these actions:
 - It continues creation when the recorded OpenShell gateway explicitly reports the source sandbox as absent.
 - It accepts an existing replacement only when its live identity and sandbox registry generation match the journal.
 
+A mount-free journal written before NemoClaw bound host-mount identity remains resumable.
+An older journal for a rebuild with one or more host mounts stops as incompatible, even when the visible mount settings are unchanged, because it cannot prove the original host source identity.
+Preserve the live sandbox, onboarding session, printed backup, exact error, and the sandbox name, gateway, and journal phase from the `Journaled replacement` diagnostic.
+Do not change the target settings, edit the session, or delete the same-name sandbox.
+Ask a NemoClaw maintainer to review that retained recovery state before taking another recovery action.
+
 An accepted replacement is not deleted again.
 <AgentOnly variant="hermes">
 A rerun that accepts a journaled Hermes replacement checks for any retained NemoClaw gate before it retires the replacement journal.
@@ -369,6 +375,7 @@ NemoClaw fails closed when the selected gateway, replacement settings, durable s
 The error names the sandbox and the mismatch that stopped recovery.
 Do not delete a same-name sandbox to bypass this check.
 Inspect the named OpenShell gateway and sandbox, correct the reported drift, and rerun the original command.
+Visible settings cannot correct the legacy host-mount journal case described above.
 
 A same-name recreation started by `$$nemoclaw onboard` uses the same replacement journal.
 If that recreation is interrupted after the `Journaled replacement` message, rerun the original onboarding command with the same target settings.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -3623,6 +3623,9 @@ If OpenShell does not confirm absence within the bounded wait, including when ga
 Restore OpenShell connectivity and confirm the sandbox's live state before you retry, and keep the printed backup path for recovery.
 Before deletion, rebuild records a replacement journal that binds the operation to the recorded gateway, source identity, and target settings.
 Rerunning the same rebuild continues from the recorded boundary or accepts the proven replacement instead of deleting it again.
+A mount-free journal written before host-mount identity binding remains resumable.
+An older journal that used host mounts fails closed because it cannot prove the original host source identity, even when the visible mount settings are unchanged.
+Preserve the sandbox, onboarding session, printed backup, exact error, and `Journaled replacement` diagnostic, then follow the legacy journal guidance in [Continue an Interrupted Replacement](../manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes#continue-an-interrupted-replacement).
 Use `--verbose` to print the replacement identifier, gateway, and journal phase.
 Refer to [Continue an Interrupted Replacement](../manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes#continue-an-interrupted-replacement) for the recovery procedure and fail-closed conditions.
 When rebuild starts with shields up, NemoClaw opens a 30-minute shields-down window for backup and recreation.

--- a/src/lib/actions/sandbox/rebuild-recreate-journal.test.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-journal.test.ts
@@ -30,6 +30,12 @@ import {
 } from "./rebuild-recreate-journal";
 
 const SANDBOX_ID = "sbx-0d6f4c2a91";
+const HOST_MOUNT = {
+  source: "/srv/host-share",
+  target: "/sandbox/host-share",
+  readOnly: true,
+  sourceIdentity: { device: "66306", inode: "12345" },
+} as const;
 
 const NON_DEFAULT_TARGET = {
   sandboxName: "alpha",
@@ -62,6 +68,7 @@ const recreateOptions: RebuildRecreateOnboardOpts = {
   sandboxGpu: null,
   sandboxGpuDevice: null,
   controlUiPort: null,
+  hostMounts: [HOST_MOUNT],
   targetGatewayName: "nemoclaw-9090",
   targetGatewayPort: 9090,
   onboardLockAlreadyHeld: true,
@@ -129,6 +136,20 @@ describe("rebuild replacement target fingerprint", () => {
         ...recreateOptions,
         targetGatewayName: "nemoclaw",
         targetGatewayPort: 8080,
+      }),
+    ).not.toBe(fingerprintRebuildRecreateTargetIntent(recreateOptions));
+  });
+
+  it("changes when the replacement host mount identity changes (#9451)", () => {
+    expect(
+      fingerprintRebuildRecreateTargetIntent({
+        ...recreateOptions,
+        hostMounts: [
+          {
+            ...HOST_MOUNT,
+            sourceIdentity: { ...HOST_MOUNT.sourceIdentity, inode: "67890" },
+          },
+        ],
       }),
     ).not.toBe(fingerprintRebuildRecreateTargetIntent(recreateOptions));
   });
@@ -375,6 +396,28 @@ describe("rebuild replacement journal", () => {
         targetIntentFingerprint: fingerprintRebuildRecreateTargetIntent({
           ...recreateOptions,
           dcodeAutoApprovalMode: "thread-opt-in",
+        }),
+        log: vi.fn(),
+      }),
+    ).toThrow(/different recreate transaction in progress/);
+  });
+
+  it("refuses to resume a journal whose host mount identity changed (#9451)", () => {
+    open();
+
+    expect(() =>
+      openRebuildRecreateJournal({
+        target: NON_DEFAULT_TARGET,
+        expectedGatewayAuthority: STANDALONE_GATEWAY_AUTHORITY,
+        agentName: "langchain-deepagents-code",
+        targetIntentFingerprint: fingerprintRebuildRecreateTargetIntent({
+          ...recreateOptions,
+          hostMounts: [
+            {
+              ...HOST_MOUNT,
+              sourceIdentity: { ...HOST_MOUNT.sourceIdentity, inode: "67890" },
+            },
+          ],
         }),
         log: vi.fn(),
       }),

--- a/src/lib/actions/sandbox/rebuild-recreate-journal.test.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-journal.test.ts
@@ -36,6 +36,8 @@ const HOST_MOUNT = {
   readOnly: true,
   sourceIdentity: { device: "66306", inode: "12345" },
 } as const;
+const PRE_HOST_MOUNT_FINGERPRINT =
+  "99603c8bf987561b783e2f38a1dcf260703537e5a680cae2198605ab13e181fe";
 
 const NON_DEFAULT_TARGET = {
   sandboxName: "alpha",
@@ -138,6 +140,18 @@ describe("rebuild replacement target fingerprint", () => {
         targetGatewayPort: 8080,
       }),
     ).not.toBe(fingerprintRebuildRecreateTargetIntent(recreateOptions));
+  });
+
+  it("preserves the previous fingerprint for a replacement without host mounts (#9451)", () => {
+    expect(fingerprintRebuildRecreateTargetIntent({ ...recreateOptions, hostMounts: [] })).toBe(
+      PRE_HOST_MOUNT_FINGERPRINT,
+    );
+  });
+
+  it("separates a mounted replacement from the pre-binding fingerprint (#9451)", () => {
+    expect(fingerprintRebuildRecreateTargetIntent(recreateOptions)).not.toBe(
+      PRE_HOST_MOUNT_FINGERPRINT,
+    );
   });
 
   it("changes when the replacement host mount identity changes (#9451)", () => {

--- a/src/lib/actions/sandbox/rebuild-recreate-journal.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-journal.ts
@@ -76,6 +76,16 @@ export function fingerprintRebuildRecreateTargetIntent(
     | "policyTier"
   >,
 ): string {
+  const hostMounts = (options.hostMounts ?? []).map(
+    ({ source, target, readOnly, sourceIdentity }) => ({
+      source,
+      target,
+      readOnly,
+      sourceIdentity: sourceIdentity
+        ? { device: sourceIdentity.device, inode: sourceIdentity.inode }
+        : null,
+    }),
+  );
   return fingerprintSandboxRecreateValue({
     version: 1,
     agent: options.agent ?? null,
@@ -87,14 +97,10 @@ export function fingerprintRebuildRecreateTargetIntent(
     sandboxGpu: options.sandboxGpu,
     sandboxGpuDevice: options.sandboxGpuDevice,
     controlUiPort: options.controlUiPort,
-    hostMounts: (options.hostMounts ?? []).map(({ source, target, readOnly, sourceIdentity }) => ({
-      source,
-      target,
-      readOnly,
-      sourceIdentity: sourceIdentity
-        ? { device: sourceIdentity.device, inode: sourceIdentity.inode }
-        : null,
-    })),
+    // Preserve the version-1 fingerprint for existing mount-free journals.
+    // A previous journal with mounts did not bind their source identity and
+    // must remain incompatible with the stronger fingerprint.
+    ...(hostMounts.length > 0 ? { hostMounts } : {}),
     gatewayName: options.targetGatewayName,
     gatewayPort: options.targetGatewayPort,
     toolDisclosure: options.toolDisclosure,

--- a/src/lib/actions/sandbox/rebuild-recreate-journal.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-journal.ts
@@ -67,6 +67,7 @@ export function fingerprintRebuildRecreateTargetIntent(
     | "sandboxGpu"
     | "sandboxGpuDevice"
     | "controlUiPort"
+    | "hostMounts"
     | "targetGatewayName"
     | "targetGatewayPort"
     | "toolDisclosure"
@@ -86,6 +87,14 @@ export function fingerprintRebuildRecreateTargetIntent(
     sandboxGpu: options.sandboxGpu,
     sandboxGpuDevice: options.sandboxGpuDevice,
     controlUiPort: options.controlUiPort,
+    hostMounts: (options.hostMounts ?? []).map(({ source, target, readOnly, sourceIdentity }) => ({
+      source,
+      target,
+      readOnly,
+      sourceIdentity: sourceIdentity
+        ? { device: sourceIdentity.device, inode: sourceIdentity.inode }
+        : null,
+    })),
     gatewayName: options.targetGatewayName,
     gatewayPort: options.targetGatewayPort,
     toolDisclosure: options.toolDisclosure,

--- a/src/lib/actions/sandbox/rebuild-recreate-observability.test.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-observability.test.ts
@@ -266,6 +266,44 @@ describe("runRebuildRecreatePhase handoff", () => {
     }
   });
 
+  it("carries the recreate host mounts into the session inner onboard resumes (#9451)", async () => {
+    const hostMounts = [
+      {
+        source: "/srv/host-share",
+        target: "/sandbox/host-share",
+        readOnly: true as const,
+        sourceIdentity: { device: "66306", inode: "12345" },
+      },
+    ];
+    let recordedHostMounts: unknown;
+    let requestedHostMounts: unknown;
+    vi.spyOn(rebuildOnboardDependencies, "onboard").mockImplementation(async (options) => {
+      recordedHostMounts = onboardSession.loadSession()?.metadata.hostMounts;
+      requestedHostMounts = options.hostMounts;
+    });
+
+    await expect(
+      runRebuildRecreatePhase(makeInput({ recreateOptions: { ...recreateOptions, hostMounts } })),
+    ).resolves.toBe(true);
+
+    // Both sides of the resume host-mount comparison must agree; an empty
+    // recorded set aborted the resume after the old sandbox was deleted.
+    expect(recordedHostMounts).toEqual(hostMounts);
+    expect(requestedHostMounts).toEqual(hostMounts);
+    expect(recordedHostMounts).not.toBe(hostMounts);
+  });
+
+  it("records no host mounts when the recreate target declares none (#9451)", async () => {
+    let recordedHostMounts: unknown = "inner onboard was never reached";
+    vi.spyOn(rebuildOnboardDependencies, "onboard").mockImplementation(async () => {
+      recordedHostMounts = onboardSession.loadSession()?.metadata.hostMounts;
+    });
+
+    await expect(runRebuildRecreatePhase(makeInput())).resolves.toBe(true);
+
+    expect(recordedHostMounts).toBeUndefined();
+  });
+
   it("carries the journal authority instead of a stale preflight option (#7411)", async () => {
     let observedAuthority: unknown;
     vi.spyOn(rebuildOnboardDependencies, "onboard").mockImplementation(async (options) => {

--- a/src/lib/actions/sandbox/rebuild-recreate-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-phase.ts
@@ -14,6 +14,7 @@ import { deriveCheckpointFromSession } from "../../state/onboard-checkpoint-migr
 import type { Session } from "../../state/onboard-session";
 import * as onboardSession from "../../state/onboard-session";
 import * as registry from "../../state/registry";
+import { cloneSandboxHostMounts } from "../../state/registry/host-mount";
 import type { RebuildBackupManifest } from "./rebuild-backup-phase";
 import type { RebuildBail, RebuildLog } from "./rebuild-credential-preflight";
 import type { RebuildDurableConfig } from "./rebuild-durable-config";
@@ -175,7 +176,7 @@ export async function runRebuildRecreatePhase(input: RebuildRecreatePhaseInput):
           gatewayName: recreateOptions.targetGatewayName,
           fromDockerfile: storedFromDockerfile,
           ...(recreateOptions.hostMounts && recreateOptions.hostMounts.length > 0
-            ? { hostMounts: recreateOptions.hostMounts.map((mount) => ({ ...mount })) }
+            ? { hostMounts: cloneSandboxHostMounts(recreateOptions.hostMounts) }
             : {}),
         },
       }),

--- a/src/lib/actions/sandbox/rebuild-recreate-phase.ts
+++ b/src/lib/actions/sandbox/rebuild-recreate-phase.ts
@@ -166,9 +166,17 @@ export async function runRebuildRecreatePhase(input: RebuildRecreatePhaseInput):
         routerPid: resumeConfig.provider === "nvidia-router" ? sessionBefore?.routerPid : undefined,
         routerCredentialHash:
           resumeConfig.provider === "nvidia-router" ? sessionBefore?.routerCredentialHash : null,
+        // The inner resume compares its requested host mounts against this
+        // recorded metadata, so the reset must carry the same mounts the
+        // recreate options hand to onboard. Omitting them recorded an empty
+        // mount set and aborted the resume after the old sandbox was already
+        // deleted (#9451).
         metadata: {
           gatewayName: recreateOptions.targetGatewayName,
           fromDockerfile: storedFromDockerfile,
+          ...(recreateOptions.hostMounts && recreateOptions.hostMounts.length > 0
+            ? { hostMounts: recreateOptions.hostMounts.map((mount) => ({ ...mount })) }
+            : {}),
         },
       }),
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`nemoclaw <name> rebuild --yes` deleted a sandbox onboarded with `--host-mount` and then failed to recreate it. The recreate phase reset the onboarding session without carrying the host mounts forward, so the inner resume compared its requested mounts against an empty record and aborted after the old sandbox was already gone. Rebuild now carries the recreate host mounts into that reset, and a sandbox with a read-only host mount rebuilds successfully.

## Related Issue

Fixes #9451

## Changes

- `src/lib/actions/sandbox/rebuild-recreate-phase.ts`: include `hostMounts` in the session metadata written during the recreate reset, using the same mounts the recreate options hand to the inner onboard. `createSession` already accepts `metadata.hostMounts`; this call site was the only one that omitted it.
- `src/lib/actions/sandbox/rebuild-recreate-observability.test.ts`: add a regression test asserting the reset session carries the recreate host mounts at inner-onboard dispatch, plus a control test asserting no mounts are recorded when the recreate target declares none.
- `src/lib/actions/sandbox/rebuild-recreate-journal.ts`: bind every host mount's source, target, access mode, device, and inode identity into the replacement-journal target fingerprint.
- `src/lib/actions/sandbox/rebuild-recreate-journal.test.ts`: preserve the historical fingerprint for mount-free journals and prove that mounted journals bind source identity and reject inode drift.
- `docs/manage-sandboxes/recover-rebuild-sandboxes.mdx`: document that old mount-free journals resume, while pre-binding mounted journals stop because they cannot prove the original source identity, and give the safe preservation and escalation steps.
- `docs/reference/commands.mdx`: add the same legacy journal boundary to the rebuild command reference.

The follow-up preserves the existing fingerprint for mount-free journals. A pre-binding journal used with host mounts remains incompatible with the stronger mount-bound fingerprint and fails closed because it cannot prove the mount source identity. The change adds no configuration, fallback, or new abstraction.

Origin: the read-only host mount feature (#8280) added the requested side (`rebuild-gpu-opt-out.ts`) and the comparison (`resume-config.ts`) but did not update the recorded side in `rebuild-recreate-phase.ts`.

Scope note: verification also showed that the recovery commands the failure prints do not work, and that `snapshot restore` exits 0 while refusing to run. Those are separate defects in the failure path and are not addressed here; they will be filed as their own issues. This fix prevents a sandbox from reaching that state.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

The existing host-mount page states that rebuild reuses accepted mount declarations. The updated recovery and command pages now distinguish safe mount-free journal compatibility from an older mounted journal that cannot prove its original host source identity.

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior; justification:
- [ ] Tests not applicable; justification:
- [x] Docs updated for user-facing behavior changes
- [ ] Docs not applicable; justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded; reviewer/approval link/justification: PASS review of the latest PR commit at https://github.com/NVIDIA/NemoClaw/pull/9471#issuecomment-5331311180
- [ ] Non-success, skipped, or missing CI check accepted by maintainer; check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Independent documentation writer review completed
- Result: `docs-updated`
- Evidence: The latest PR commit was reviewed against the implemented rebuild-journal behavior and the NemoClaw writing and documentation guides. Focused rebuild tests passed 50/50. Documentation variant generation and `npm run docs` passed with 0 errors and 2 existing Fern warnings.
- Review: https://github.com/NVIDIA/NemoClaw/pull/9471#issuecomment-5331311474
- Reviewer: Codex Desktop

## DGX Station Hardware Evidence

Not applicable. This PR does not change `scripts/prepare-dgx-station-host.sh`.

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above; command/result or justification: on the latest PR commit, the two focused rebuild files passed 50/50; plugin and CLI builds, `npm run typecheck:cli`, `npm run checks:repository`, `npm run test:changed`, Oxfmt, documentation variant generation, `npm run docs` with 0 errors and 2 existing Fern warnings, and `git diff --check` also passed.
- [ ] Applicable broad gate passed: `npm test` for broad runtime or shared test-harness changes; `npm run check` for repository-wide validation or coverage changes. Command/result: not applicable; the six-file change is confined to rebuild host-mount session and journal behavior, focused tests, and owning documentation, with no shared test-harness or repository-wide surface change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only); it passed with 0 errors and 2 existing Fern warnings
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### End-to-end verification on a live host

Two runs on one x86_64 Ubuntu 24.04 host with OpenShell 0.0.101 and OpenClaw 2026.7.1, installed from the original two-file repair with `NEMOCLAW_REPO_ROOT="$(pwd)" bash install.sh`. Each run started from a fresh host state, and the two compared trees differed only by the original source file and its focused test. This evidence validates the rebuild handoff repair, not the later journal-compatibility or documentation follow-ups.

| | Without the fix | With the fix |
| --- | --- | --- |
| `rebuild --yes` exit code | 1 | 0 |
| Message | `Resumable state recorded host mounts '[]', not '[{...}]'` | no conflict; recreate completes |
| Sandbox on the gateway afterwards | `No sandboxes found` | `hostmount ... Ready` |
| Read a file through the mount afterwards | fails, sandbox not found | succeeds |
| `onboard-session.json` `metadata.hostMounts` after rebuild | absent | present |

The reproduction on the unfixed checkout matches the message reported in #9451. The last row is the field this change writes, read directly from the session file before and after the rebuild.

---
Signed-off-by: Hung Le <hple@nvidia.com>
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Host mounts are now preserved when rebuilding or recreating sandboxes.
  * Rebuild tracking recognizes changes to mounted host sources, including source identity and read-only settings.

* **Bug Fixes**
  * Prevented mount configuration from being lost during session resets.
  * Improved recovery safety by stopping when a mounted host source cannot be verified.

* **Documentation**
  * Clarified recovery behavior for older rebuild records, including when maintainer assistance is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
