### PR TITLE
test(e2e): classify disabled Telegram entries as unconfigured

### DIFF
--- a/test/e2e/live/channels-add-remove-helpers.ts
+++ b/test/e2e/live/channels-add-remove-helpers.ts
@@ -14,5 +14,5 @@ export interface OpenClawTelegramState {
 }
 
 export function openClawHasConfiguredTelegram(state: OpenClawTelegramState): boolean {
-  return state.channelEnabled || state.pluginEnabled;
+  return state.channelEnabled && state.pluginEnabled;
 }

--- a/test/e2e/live/channels-add-remove-helpers.ts
+++ b/test/e2e/live/channels-add-remove-helpers.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Pure Telegram-state predicate shared by the channels-add-remove live E2E
+// target and its PR-collected unit test. The live probe emits only booleans so
+// it does not expose credential-bearing OpenClaw configuration.
+
+export interface OpenClawTelegramState {
+  accountEnabled: boolean;
+  channelEnabled: boolean;
+  channelPresent: boolean;
+  pluginEnabled: boolean;
+  pluginPresent: boolean;
+}
+
+export function openClawHasConfiguredTelegram(state: OpenClawTelegramState): boolean {
+  return state.channelEnabled || state.pluginEnabled;
+}

--- a/test/e2e/live/channels-add-remove.test.ts
+++ b/test/e2e/live/channels-add-remove.test.ts
@@ -576,8 +576,8 @@ test(
     expect(openClawHasConfiguredTelegram(removedTelegram)).toBe(false);
     expect(removedTelegram).toMatchObject({
       accountEnabled: false,
+      channelEnabled: false,
       channelPresent: false,
-      pluginPresent: false,
     });
     await expectProvider(host, "absent", "phase-6-provider-get-after-remove");
     await expectPolicyPreset(host, "telegram", "not-applied", "phase-6-policy-list-after-remove");

--- a/test/e2e/live/channels-add-remove.test.ts
+++ b/test/e2e/live/channels-add-remove.test.ts
@@ -16,6 +16,10 @@ import {
 import { expect, test } from "../fixtures/e2e-test.ts";
 import { startFakeOpenAiCompatibleServer } from "../fixtures/fake-openai-compatible.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
+import {
+  openClawHasConfiguredTelegram,
+  type OpenClawTelegramState,
+} from "./channels-add-remove-helpers.ts";
 
 // Preserve the user-visible contract: onboard OpenClaw without messaging,
 // add Telegram later, rebuild through the real CLI/OpenShell boundary, verify
@@ -286,7 +290,7 @@ async function expectProvider(
 async function readOpenClawTelegramState(
   sandbox: SandboxClient,
   artifactName: string,
-): Promise<JsonRecord> {
+): Promise<OpenClawTelegramState> {
   const result = await sandbox.exec(
     SANDBOX_NAME,
     [
@@ -312,7 +316,7 @@ async function readOpenClawTelegramState(
   );
   assertExitZero(result, "read /sandbox/.openclaw/openclaw.json");
   const output = stripAnsi(result.stdout).trim().split(/\r?\n/).at(-1) ?? "";
-  return JSON.parse(output) as JsonRecord;
+  return JSON.parse(output) as OpenClawTelegramState;
 }
 
 /** Detect an active policy preset in the human-readable policy listing. */
@@ -469,13 +473,8 @@ test(
       sandbox,
       "phase-2-openclaw-json-baseline",
     );
-    expect(baselineTelegram).toEqual({
-      accountEnabled: false,
-      channelEnabled: false,
-      channelPresent: true,
-      pluginEnabled: false,
-      pluginPresent: false,
-    });
+    expect(openClawHasConfiguredTelegram(baselineTelegram)).toBe(false);
+    expect(baselineTelegram.accountEnabled).toBe(false);
     await expectPolicyPreset(host, "telegram", "not-applied", "phase-2-policy-list-baseline");
 
     progress.phase("add Telegram and rebuild sandbox");
@@ -521,12 +520,11 @@ test(
       sandbox,
       "phase-4-openclaw-json-after-add",
     );
-    expect(activeTelegram).toEqual({
+    expect(openClawHasConfiguredTelegram(activeTelegram)).toBe(true);
+    expect(activeTelegram).toMatchObject({
       accountEnabled: true,
       channelEnabled: true,
-      channelPresent: true,
       pluginEnabled: true,
-      pluginPresent: true,
     });
     await expectProvider(host, "present", "phase-4-provider-get-after-add");
     expectHostTelegramConfig("after add+rebuild");
@@ -575,11 +573,10 @@ test(
       sandbox,
       "phase-6-openclaw-json-after-remove",
     );
-    expect(removedTelegram).toEqual({
+    expect(openClawHasConfiguredTelegram(removedTelegram)).toBe(false);
+    expect(removedTelegram).toMatchObject({
       accountEnabled: false,
-      channelEnabled: false,
       channelPresent: false,
-      pluginEnabled: false,
       pluginPresent: false,
     });
     await expectProvider(host, "absent", "phase-6-provider-get-after-remove");

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -286,6 +286,7 @@
     {
       "live": "test/e2e/live/channels-add-remove.test.ts",
       "fast": [
+        "test/e2e/support/channels-add-remove-helpers.test.ts",
         "test/e2e/support/e2e-cleanup-resources.test.ts",
         "test/e2e/support/e2e-clients.test.ts"
       ]

--- a/test/e2e/support/channels-add-remove-helpers.test.ts
+++ b/test/e2e/support/channels-add-remove-helpers.test.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  openClawHasConfiguredTelegram,
+  type OpenClawTelegramState,
+} from "../live/channels-add-remove-helpers.ts";
+
+const UNCONFIGURED: OpenClawTelegramState = {
+  accountEnabled: false,
+  channelEnabled: false,
+  channelPresent: true,
+  pluginEnabled: false,
+  pluginPresent: true,
+};
+
+describe("channels-add-remove Telegram configuration predicate", () => {
+  it("treats bundled disabled channel and plugin entries as unconfigured (#9361)", () => {
+    expect(openClawHasConfiguredTelegram(UNCONFIGURED)).toBe(false);
+  });
+
+  it.each([
+    ["enabled channel", { channelEnabled: true }],
+    ["enabled plugin", { pluginEnabled: true }],
+  ])("detects an %s as configured (#9361)", (_case, overrides) => {
+    expect(openClawHasConfiguredTelegram({ ...UNCONFIGURED, ...overrides })).toBe(true);
+  });
+
+  it("treats removed channel and plugin entries as unconfigured (#9361)", () => {
+    expect(
+      openClawHasConfiguredTelegram({
+        ...UNCONFIGURED,
+        channelPresent: false,
+        pluginPresent: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/test/e2e/support/channels-add-remove-helpers.test.ts
+++ b/test/e2e/support/channels-add-remove-helpers.test.ts
@@ -21,19 +21,29 @@ describe("channels-add-remove Telegram configuration predicate", () => {
     expect(openClawHasConfiguredTelegram(UNCONFIGURED)).toBe(false);
   });
 
-  it.each([
-    ["enabled channel", { channelEnabled: true }],
-    ["enabled plugin", { pluginEnabled: true }],
-  ])("detects an %s as configured (#9361)", (_case, overrides) => {
-    expect(openClawHasConfiguredTelegram({ ...UNCONFIGURED, ...overrides })).toBe(true);
+  it("detects an enabled channel and plugin as configured (#9361)", () => {
+    expect(
+      openClawHasConfiguredTelegram({
+        ...UNCONFIGURED,
+        channelEnabled: true,
+        pluginEnabled: true,
+      }),
+    ).toBe(true);
   });
 
-  it("treats removed channel and plugin entries as unconfigured (#9361)", () => {
+  it.each([
+    ["enabled channel without plugin activation", { channelEnabled: true }],
+    ["enabled plugin without channel activation", { pluginEnabled: true }],
+  ])("treats %s as unconfigured (#9361)", (_case, overrides) => {
+    expect(openClawHasConfiguredTelegram({ ...UNCONFIGURED, ...overrides })).toBe(false);
+  });
+
+  it("treats a removed channel with a bundled enabled plugin as unconfigured (#9361)", () => {
     expect(
       openClawHasConfiguredTelegram({
         ...UNCONFIGURED,
         channelPresent: false,
-        pluginPresent: false,
+        pluginEnabled: true,
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The `channels-add-remove` live E2E treated a bundled Telegram plugin as active configuration. Managed OpenClaw can retain that plugin after the Telegram channel is removed, so the test now requires both channel and plugin activation while keeping independent account, provider, policy, registry, and channel-removal checks.

## Related Issue

Fixes #9361

## Changes

- Classify Telegram as configured only when both its channel and plugin are enabled.
- Keep active-account checks after add and physical channel-absence checks after remove without treating a bundled plugin capability as registration.
- Add fast regression coverage for disabled bundled entries, one-sided activation, full activation, and the observed post-remove bundled-plugin state. Register it as the live target's mock-parity evidence.

## Acceptance Criteria

- [x] Disabled bundled Telegram entries are classified as unconfigured, while full channel and plugin activation is detected.
- [x] Fast regression and mock/live parity coverage pass on the current change set.
- [x] The protected `channels-add-remove` E2E that failed in the issue's prior run passes against final PR head `3fa031378322f411a81e759213eac4fc6189ba5c`: [exact-head run 32151284482](https://github.com/NVIDIA/NemoClaw/actions/runs/32151284482).
- [x] Final CI, both PR Review Advisor lanes, CodeRabbit, and independent human review are green on the final PR head.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer review of commit `3fa031378322f411a81e759213eac4fc6189ba5c` confirmed that the boolean-only test probe does not change production messaging, credential, policy, or external-write behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `vitest run --project e2e-support test/e2e/support/channels-add-remove-helpers.test.ts` passed 5 tests; `tsx scripts/checks/e2e-mock-parity.mts --base origin/main --head HEAD` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>
