### PR TITLE
fix(cli): warn on incomplete inference route

### DIFF
--- a/src/lib/actions/sandbox/doctor-inference.test.ts
+++ b/src/lib/actions/sandbox/doctor-inference.test.ts
@@ -33,6 +33,27 @@ function upstream(overrides: Partial<ProviderHealthStatus> = {}): ProviderHealth
 
 describe("doctor inference checks", () => {
   it.each([
+    ["nvidia-prod", "nvidia/nemotron", "ok"],
+    ["nvidia-prod", "unknown", "warn"],
+    ["unknown", "nvidia/nemotron", "warn"],
+    ["unknown", "unknown", "warn"],
+  ] as const)("reports %s / %s inference route as %s (#9435)", async (provider, model, status) => {
+    const checks = await collectInferenceChecks("alpha", { provider, model }, false, {
+      probeProviderHealthImpl: () => null,
+      includeServingProcessCheck: false,
+    });
+
+    expect(checks[0]).toEqual({
+      group: "Inference",
+      label: "Route",
+      status,
+      detail: `${provider} / ${model}`,
+      hint:
+        status === "ok" ? undefined : "run `nemoclaw alpha status` after the gateway is healthy",
+    });
+  });
+
+  it.each([
     ["running", "ok", false],
     ["preparing", "warn", true],
     ["stopped", "warn", true],

--- a/src/lib/actions/sandbox/doctor-inference.ts
+++ b/src/lib/actions/sandbox/doctor-inference.ts
@@ -95,7 +95,7 @@ function pushInferenceHealthCheck(
 }
 
 function inferenceRouteCheck(sandboxName: string, route: DoctorInferenceRoute): DoctorCheck {
-  const known = route.provider !== "unknown" || route.model !== "unknown";
+  const known = route.provider !== "unknown" && route.model !== "unknown";
   return {
     group: "Inference",
     label: "Route",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`sandbox doctor` previously reported the inference route as `ok` when only the provider or model was known. It now requires both fields and preserves the existing warning and recovery hint for either half-resolved state.

## Related Issue

Fixes #9435

## Changes

- Require both provider and model before the doctor Route check reports `ok`.
- Cover complete, provider-only, model-only, and fully unknown routes with exact status, detail, and hint assertions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior; justification:
- [ ] Tests not applicable; justification:
- [ ] Docs updated for user-facing behavior changes
- [x] Docs not applicable; justification: Existing docs already define inference routes through provider and model and explain that doctor warnings do not fail the command.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded; reviewer/approval link/justification: https://github.com/NVIDIA/NemoClaw/pull/9473#pullrequestreview-4962470691
- [ ] Non-success, skipped, or missing CI check accepted by maintainer; check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change corrects an undocumented half-route classification. The sandbox doctor command documentation already describes the supported route and warning behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: fc7faffb8 -->
<!-- docs-review-agents-blob-sha: 993bdd850 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above; command/result or justification: `npx vitest run --project cli src/lib/actions/sandbox/doctor-inference.test.ts` passed 22 tests at `fc7faffb8`. Both half-resolved cases failed before the fix.
- [ ] Applicable broad gate passed: `npm test` for broad runtime or shared test-harness changes; `npm run check` for repository-wide validation or coverage changes. Command/result: not applicable; the two-file change tightens one pure diagnostic classification and adds its focused boundary tests.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inference route health reporting by requiring both the provider and model to be recognized.
  - Unrecognized or partially identified routes now show a warning with guidance to check gateway health.
  - Added coverage for recognized, unknown, and mixed provider/model combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
