### PR TITLE
fix(onboard): preserve managed replacement diagnostics

### DIFF
--- a/src/lib/onboard/managed-bootstrap/docker.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker.test.ts
@@ -541,6 +541,69 @@ describe("Docker managed bootstrap adapter", () => {
     expect((failure as Error).message).not.toContain(secret);
   });
 
+  it("reports an exited replacement before exact rollback cleanup (#9465)", async () => {
+    const fake = fixture({ agent: "openclaw" });
+    const secret = "replacement-diagnostic-secret";
+    fake.deps.dockerLogs = vi.fn(() => `managed startup rejected SLACK_BOT_TOKEN=${secret}`);
+    const adapter = createDockerManagedBootstrapAdapter(fake.deps);
+    const { handle, request, snapshot } = authority("openclaw");
+    const prepared = await adapter.prepareBootstrapReplacement({
+      handle,
+      snapshot,
+      request,
+      replacementOptions: { values: {} },
+    });
+    const durable = durablePreparation(handle, snapshot, prepared);
+    const replacement = await adapter.activateBootstrapReplacement({
+      handle,
+      snapshot,
+      prepared,
+      durablePreparation: durable,
+    });
+    assert(fake.replacement?.State);
+    Object.assign(fake.replacement.State, {
+      Status: "exited",
+      Running: false,
+      ExitCode: 23,
+      FinishedAt: "2026-08-18T12:00:00.000Z",
+    });
+
+    const failure = await adapter
+      .awaitBootstrap({ handle, snapshot, replacement, timeoutSecs: 1 })
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain(`Replacement runtime ID: ${NEW_ID}.`);
+    expect((failure as Error).message).toContain(
+      "Replacement state: status=exited running=false exit_code=23 finished_at=2026-08-18T12:00:00.000Z.",
+    );
+    expect((failure as Error).message).toContain(
+      "managed startup rejected SLACK_BOT_TOKEN=<REDACTED>",
+    );
+    expect((failure as Error).message).not.toContain(secret);
+
+    await expect(
+      adapter.finalizeBootstrap({
+        outcome: "rollback",
+        handle,
+        snapshot,
+        prepared,
+        durablePreparation: durable,
+        replacement,
+        completion: null,
+      }),
+    ).rejects.toMatchObject({
+      name: "ManagedBootstrapOwnerCleanupRequiredError",
+      runtimeId: OLD_ID,
+    });
+    expect(fake.replacement).toBeNull();
+    expect(fake.original).toMatchObject({
+      Id: OLD_ID,
+      Name: "/openshell-alpha",
+      State: { Running: false },
+    });
+  });
+
   it("preserves commit validation failure details when the replacement cannot be quiesced", async () => {
     const fake = fixture({
       sharedState: "pending",
@@ -610,7 +673,7 @@ describe("Docker managed bootstrap adapter", () => {
         prepared,
         durablePreparation: durable,
       }),
-    ).rejects.toThrow("could not prove its exact replacement running");
+    ).rejects.toThrow("replacement after Docker start is not stably running");
     expect(fake.journal?.phase).toBe("cutover");
 
     const restarted = createDockerManagedBootstrapAdapter(fake.deps);

--- a/src/lib/onboard/managed-bootstrap/docker.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker.test.ts
@@ -511,7 +511,10 @@ describe("Docker managed bootstrap adapter", () => {
       return { status: 1 };
     });
     fake.deps.runCaptureOpenshell = vi.fn(() => "alpha Error");
-    fake.deps.dockerLogs = vi.fn(() => `managed startup failed with NVIDIA_API_KEY=${secret}`);
+    fake.deps.dockerLogs = vi.fn(
+      () =>
+        `${"oversized diagnostic context ".repeat(60)}managed startup failed with NVIDIA_API_KEY=${secret}`,
+    );
     const adapter = createDockerManagedBootstrapAdapter(fake.deps);
     const { handle, request, snapshot } = authority();
     const prepared = await adapter.prepareBootstrapReplacement({
@@ -539,6 +542,9 @@ describe("Docker managed bootstrap adapter", () => {
       "managed startup failed with NVIDIA_API_KEY=<REDACTED>",
     );
     expect((failure as Error).message).not.toContain(secret);
+    const redactedLogTail = (failure as Error).message.split("Redacted replacement log tail:\n")[1];
+    expect(redactedLogTail).toBeDefined();
+    expect(redactedLogTail!.length).toBeLessThanOrEqual(1_200);
   });
 
   it("reports an exited replacement before exact rollback cleanup (#9465)", async () => {
@@ -652,11 +658,30 @@ describe("Docker managed bootstrap adapter", () => {
   });
 
   it("publishes durable rollback authority before deleting the replacement after restart", async () => {
-    const fake = fixture({
-      dockerStartResults: {
-        [NEW_ID]: { status: 1, stderr: "injected start failure" },
+    const fake = fixture();
+    const secret = "post-start-provider-secret";
+    fake.deps.dockerLogs = vi.fn(() => `startup failed with NVIDIA_API_KEY=${secret}`);
+    const dockerStarts: Record<
+      string,
+      () => { status: number; stdout?: string; stderr: string }
+    > = {
+      [NEW_ID]: () => {
+        assert(fake.replacement?.State);
+        Object.assign(fake.replacement.State, {
+          Status: "exited",
+          Running: false,
+          ExitCode: 31,
+          FinishedAt: "2026-08-18T12:30:00.000Z",
+        });
+        return { status: 1, stderr: "injected start failure" };
       },
-    });
+      [OLD_ID]: () => {
+        assert(fake.original?.State);
+        Object.assign(fake.original.State, { Running: true });
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    };
+    fake.deps.dockerStart = vi.fn((id) => dockerStarts[id]!());
     const first = createDockerManagedBootstrapAdapter(fake.deps);
     const { handle, request: rootRequest, snapshot } = authority();
     const prepared = await first.prepareBootstrapReplacement({
@@ -666,14 +691,26 @@ describe("Docker managed bootstrap adapter", () => {
       replacementOptions: { values: {} },
     });
     const durable = durablePreparation(handle, snapshot, prepared);
-    await expect(
-      first.activateBootstrapReplacement({
+    const activationFailure = await first
+      .activateBootstrapReplacement({
         handle,
         snapshot,
         prepared,
         durablePreparation: durable,
-      }),
-    ).rejects.toThrow("replacement after Docker start is not stably running");
+      })
+      .catch((error: unknown) => error);
+    expect(activationFailure).toBeInstanceOf(Error);
+    expect((activationFailure as Error).message).toContain(
+      "replacement after Docker start is not stably running",
+    );
+    expect((activationFailure as Error).message).toContain(`Replacement runtime ID: ${NEW_ID}.`);
+    expect((activationFailure as Error).message).toContain(
+      "Replacement state: status=exited running=false exit_code=31 finished_at=2026-08-18T12:30:00.000Z.",
+    );
+    expect((activationFailure as Error).message).toContain(
+      "startup failed with NVIDIA_API_KEY=<REDACTED>",
+    );
+    expect((activationFailure as Error).message).not.toContain(secret);
     expect(fake.journal?.phase).toBe("cutover");
 
     const restarted = createDockerManagedBootstrapAdapter(fake.deps);

--- a/src/lib/onboard/managed-bootstrap/docker.test.ts
+++ b/src/lib/onboard/managed-bootstrap/docker.test.ts
@@ -316,6 +316,10 @@ describe("Docker managed bootstrap adapter", () => {
         metadata: handle.plan.metadata,
       }),
     ).rejects.toThrow("one exact persisted bootstrap identity");
+    expect(fake.replacement).toBeNull();
+    expect(fake.journal).toBeNull();
+    expect(fake.events).not.toContain("create:replacement");
+    expect(fake.events).not.toContain(`stop:${OLD_ID}`);
   });
 
   it("publishes durable commit authority before deleting the rollback backup after lost acknowledgements", async () => {
@@ -511,10 +515,11 @@ describe("Docker managed bootstrap adapter", () => {
       return { status: 1 };
     });
     fake.deps.runCaptureOpenshell = vi.fn(() => "alpha Error");
-    fake.deps.dockerLogs = vi.fn(
-      () =>
-        `${"oversized diagnostic context ".repeat(60)}managed startup failed with NVIDIA_API_KEY=${secret}`,
-    );
+    fake.deps.dockerLogs = vi.fn((id, options) => {
+      expect(id).toBe(NEW_ID);
+      expect(options).toEqual({ tail: 120, timeout: 2_000 });
+      return `${"oversized diagnostic context ".repeat(60)}managed startup failed with NVIDIA_API_KEY=${secret}`;
+    });
     const adapter = createDockerManagedBootstrapAdapter(fake.deps);
     const { handle, request, snapshot } = authority();
     const prepared = await adapter.prepareBootstrapReplacement({
@@ -547,10 +552,14 @@ describe("Docker managed bootstrap adapter", () => {
     expect(redactedLogTail!.length).toBeLessThanOrEqual(1_200);
   });
 
-  it("reports an exited replacement before exact rollback cleanup (#9465)", async () => {
+  it("reports an exited replacement through exact authorized cleanup (#9465)", async () => {
     const fake = fixture({ agent: "openclaw" });
     const secret = "replacement-diagnostic-secret";
-    fake.deps.dockerLogs = vi.fn(() => `managed startup rejected SLACK_BOT_TOKEN=${secret}`);
+    fake.deps.dockerLogs = vi.fn((id, options) => {
+      expect(id).toBe(NEW_ID);
+      expect(options).toEqual({ tail: 120, timeout: 2_000 });
+      return `managed startup rejected SLACK_BOT_TOKEN=${secret}`;
+    });
     const adapter = createDockerManagedBootstrapAdapter(fake.deps);
     const { handle, request, snapshot } = authority("openclaw");
     const prepared = await adapter.prepareBootstrapReplacement({
@@ -608,6 +617,22 @@ describe("Docker managed bootstrap adapter", () => {
       Name: "/openshell-alpha",
       State: { Running: false },
     });
+
+    fake.removeOriginalExternally();
+    await expect(adapter.recoverUnfinishedTransactions()).resolves.toMatchObject({
+      receipts: [
+        {
+          bootstrapIdentity: IDENTITY,
+          sourcePhase: "owner-cleanup-required",
+          outcome: "rolled-back",
+        },
+      ],
+      failures: [],
+    });
+    expect(fake.original).toBeNull();
+    expect(fake.replacement).toBeNull();
+    expect(fake.journal).toBeNull();
+    expect(fake.finalization?.phase).toBe("rolled-back");
   });
 
   it("preserves commit validation failure details when the replacement cannot be quiesced", async () => {
@@ -660,7 +685,11 @@ describe("Docker managed bootstrap adapter", () => {
   it("publishes durable rollback authority before deleting the replacement after restart", async () => {
     const fake = fixture();
     const secret = "post-start-provider-secret";
-    fake.deps.dockerLogs = vi.fn(() => `startup failed with NVIDIA_API_KEY=${secret}`);
+    fake.deps.dockerLogs = vi.fn((id, options) => {
+      expect(id).toBe(NEW_ID);
+      expect(options).toEqual({ tail: 120, timeout: 2_000 });
+      return `startup failed with NVIDIA_API_KEY=${secret}`;
+    });
     const dockerStarts: Record<
       string,
       () => { status: number; stdout?: string; stderr: string }

--- a/src/lib/onboard/managed-bootstrap/docker.ts
+++ b/src/lib/onboard/managed-bootstrap/docker.ts
@@ -264,6 +264,21 @@ function supervisorReconnectFailureDetail(runtimeId: string, deps: ResolvedDeps)
     .join(" ");
 }
 
+function replacementNotStableError(runtimeId: string, label: string, deps: ResolvedDeps): Error {
+  const evidence = captureDockerContainerFailureEvidence(runtimeId, deps);
+  const stateDetail = formatDockerContainerState(evidence.state).join(" ");
+  return new Error(
+    [
+      `Managed bootstrap Docker ${label} is not stably running.`,
+      `Replacement runtime ID: ${runtimeId}.`,
+      stateDetail ? `Replacement state: ${stateDetail}.` : "",
+      evidence.redactedLogTail ? `Redacted replacement log tail:\n${evidence.redactedLogTail}` : "",
+    ]
+      .filter(Boolean)
+      .join(" "),
+  );
+}
+
 function isExactMissingDockerContainer(containerId: string, result: DockerCommandResult): boolean {
   const escapedContainerId = containerId.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
   const patterns = [
@@ -1201,7 +1216,9 @@ function assertCompletedCutoverRuntimeState(
   assertTransactionOriginal(transaction, original);
   assertTransactionReplacement(transaction, replacement);
   assertExplicitlyStopped(original, "rollback backup");
-  assertStableRunning(replacement, "replacement");
+  if (!isStableRunning(replacement)) {
+    throw replacementNotStableError(transaction.replacementRuntimeId, "replacement", deps);
+  }
   if (
     dockerContainerName(original) !== transaction.backupName ||
     dockerContainerName(replacement) !== transaction.originalName
@@ -3575,13 +3592,16 @@ export function createDockerManagedBootstrapAdapter(
         const started = deps.dockerStart(prepared.preparedRuntimeId, options);
         const running = inspectExact(prepared.preparedRuntimeId, deps);
         assertTransactionReplacement(journal, running);
+        if (!isStableRunning(running)) {
+          throw replacementNotStableError(
+            journal.replacementRuntimeId,
+            "replacement after Docker start",
+            deps,
+          );
+        }
         const runningSpec = normalizeDockerManagedBootstrapLaunchSpec(running);
         if (
           dockerContainerName(running) !== journal.originalName ||
-          running.State?.Running !== true ||
-          running.State.Paused === true ||
-          running.State.Restarting === true ||
-          running.State.Dead === true ||
           runningSpec.canonicalJson !== prepared.expectedActivatedSpecCanonicalJson
         ) {
           throw new Error(
@@ -3649,13 +3669,16 @@ export function createDockerManagedBootstrapAdapter(
       }
       assertCompletedCutoverRuntimeState(journal, deps);
       const before = inspectExact(replacement.replacementRuntimeId, deps);
-      assertStableRunning(before, "replacement");
+      if (!isStableRunning(before)) {
+        throw replacementNotStableError(replacement.replacementRuntimeId, "replacement", deps);
+      }
       const beforeImageContentId = assertImage(before, replacement.image, deps);
       if (beforeImageContentId !== replacement.runtimeImageContentId) {
         throw new Error("Managed bootstrap Docker replacement image content changed.");
       }
       assertReplacementBoundary(before, handle, snapshot);
-      const supervisorReconnectTimeoutSecs = getDockerGpuSupervisorReconnectTimeoutSecs(timeoutSecs);
+      const supervisorReconnectTimeoutSecs =
+        getDockerGpuSupervisorReconnectTimeoutSecs(timeoutSecs);
       if (
         !waitForOpenShellSupervisorReconnect(
           handle.sandbox.sandboxName,
@@ -3675,7 +3698,13 @@ export function createDockerManagedBootstrapAdapter(
       }
       assertCompletedCutoverRuntimeState(afterWaitJournal, deps);
       const after = inspectExact(replacement.replacementRuntimeId, deps);
-      assertStableRunning(after, "completed replacement");
+      if (!isStableRunning(after)) {
+        throw replacementNotStableError(
+          replacement.replacementRuntimeId,
+          "completed replacement",
+          deps,
+        );
+      }
       if (assertImage(after, replacement.image, deps) !== replacement.runtimeImageContentId) {
         throw new Error("Managed bootstrap Docker completed image content changed.");
       }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Managed Docker replacement failures now report the exact transaction-owned container ID, exit state, and a bounded redacted log tail. This preserves the evidence needed to correct the messaging startup failure without weakening rollback or stable-running requirements.

## Related Issue

Closes #9465

## Changes

- Capture bounded Docker state and logs before each replacement-stability failure.
- Redact credential-bearing inspect and log values through the existing Docker diagnostic boundary.
- Prove that an exited replacement remains non-authoritative, is removed by exact ID, and leaves the rollback backup quiescent for owner cleanup.

## Acceptance Criteria

- [ ] The final PR head passes `openclaw-slack-pairing`, `hermes-slack`, and `token-rotation` together in one trusted E2E run.
- [ ] The final PR head passes the full unfiltered trusted E2E matrix.
- [ ] All CI checks, both PR Review Advisor lanes, CodeRabbit feedback, and review threads are complete without unresolved findings on that same head.
- [ ] Every PR commit is GitHub `Verified`, and the admin merge is pinned to the audited final head.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [final-head security review passed with no findings](https://github.com/NVIDIA/NemoClaw/pull/9475#issuecomment-5330115834).
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run --project cli src/lib/onboard/managed-bootstrap/docker.test.ts src/lib/onboard/docker-gpu-pre-rollback-diagnostics.test.ts src/lib/onboard/docker-gpu-patch-diagnostics-classification.test.ts` passed 3 files / 56 tests. `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run; CI remains pending.
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker replacement failure diagnostics with runtime status and safely redacted log details.
  * Enhanced rollback behavior to remove failed replacements while preserving and restarting original containers when needed.
  * Added clearer handling for replacements that exit or fail to become stable during startup.
  * Ensured cleanup requirements are reported when manual owner intervention is needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->