### PR TITLE
fix(onboard): keep portable sandboxes off the Docker-labeled recreation

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2840,8 +2840,8 @@ const sandboxCreateIntentResolver = sandboxCreateIntentResolution.createSandboxC
   filterEnabledChannelsByAgent,
   defaultPolicyPath: path.join(ROOT, "nemoclaw-blueprint", "policies", "openclaw-sandbox.yaml"),
   getAgentPolicyPath: (agent) => (agent ? agentOnboard.getAgentPolicyPath(agent) : null),
-  resolveGpuPlan: (config, agent) =>
-    dockerGpuSandboxCreate.resolveAgentPlan(config, agent, isLinuxDockerDriverGatewayEnabled()),
+  resolveGpuPlan: (config) =>
+    dockerGpuSandboxCreate.resolveProfileGpuCreatePlan(config, isLinuxDockerDriverGatewayEnabled()),
   appendResourceCreateArgs: (args, resourceProfile) =>
     appendResourceFlagsForProfile(args, resourceProfile, getOpenshellBinary(), {
       isNonInteractive,

--- a/src/lib/onboard/docker-gpu-sandbox-create-plan.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create-plan.ts
@@ -32,9 +32,8 @@ export function resetIsDockerDesktopWslRuntimeCache(): void {
   cachedDockerDesktopWslRuntime = null;
 }
 
-export function resolveAgentPlan(
+export function resolveProfileGpuCreatePlan(
   config: DockerGpuSandboxConfig,
-  _agent: { name?: string | null } | null,
   dockerDriverGateway: boolean,
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,

--- a/src/lib/onboard/docker-gpu-sandbox-create-plan.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create-plan.ts
@@ -34,15 +34,18 @@ export function resetIsDockerDesktopWslRuntimeCache(): void {
 
 export function resolveAgentPlan(
   config: DockerGpuSandboxConfig,
-  agent: { name?: string | null } | null,
+  _agent: { name?: string | null } | null,
   dockerDriverGateway: boolean,
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
 ): DockerGpuSandboxCreatePlan {
   return resolveDockerGpuSandboxCreatePlan(config, {
     dockerDriverGateway,
-    portableLifecycle:
-      isPortableExperimentalProfile(env) && (agent?.name ?? "openclaw") === "openclaw",
+    // Rootless Podman owns every portable sandbox regardless of agent: the
+    // compatibility recreation discovers containers by docker-driver labels
+    // and can never match a podman-driver sandbox (#9462), so keep the whole
+    // profile on native GPU injection, not only OpenClaw (#9068).
+    portableLifecycle: isPortableExperimentalProfile(env),
     env,
     platform,
   });

--- a/src/lib/onboard/docker-gpu-sandbox-create-route-plan.test.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create-route-plan.test.ts
@@ -156,7 +156,7 @@ describe("resolveDockerGpuSandboxCreatePlan", () => {
     expect(log).not.toHaveBeenCalledWith(expect.stringMatching(/compatibility-only/iu));
   });
 
-  it("keeps non-OpenClaw portable agents on their existing GPU route (#9068)", () => {
+  it("honors an explicit non-portable lifecycle flag at the create-plan boundary (#9068)", () => {
     const result = resolveDockerGpuSandboxCreatePlan(
       { sandboxGpuEnabled: true },
       {
@@ -165,7 +165,6 @@ describe("resolveDockerGpuSandboxCreatePlan", () => {
         portableLifecycle: false,
         env: {
           NEMOCLAW_DOCKER_GPU_PATCH: "1",
-          NEMOCLAW_EXPERIMENTAL_PROFILE: "portable",
         },
         platform: "linux",
       },
@@ -174,7 +173,7 @@ describe("resolveDockerGpuSandboxCreatePlan", () => {
     expect(result.gpuRoutePlan).toBe("compatibility-only");
   });
 
-  it("selects the portable lifecycle route only for OpenClaw (#9068)", () => {
+  it("keeps every portable agent on native GPU lifecycle operations (#9462)", () => {
     const env = {
       NEMOCLAW_DOCKER_GPU_PATCH: "1",
       NEMOCLAW_EXPERIMENTAL_PROFILE: "portable",
@@ -191,6 +190,29 @@ describe("resolveDockerGpuSandboxCreatePlan", () => {
         env,
         "linux",
       ).gpuRoutePlan,
-    ).toBe("compatibility-only");
+    ).toBe("native-only");
+    expect(
+      resolveAgentPlan(
+        { sandboxGpuEnabled: true },
+        { name: "langchain-deepagents-code" },
+        true,
+        env,
+        "linux",
+      ).gpuRoutePlan,
+    ).toBe("native-only");
+  });
+
+  it("keeps portable Jetson hosts off the compatibility-only default (#9462)", () => {
+    const env = { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" };
+
+    expect(
+      resolveAgentPlan(
+        { sandboxGpuEnabled: true, hostGpuPlatform: "jetson" },
+        { name: "hermes" },
+        true,
+        env,
+        "linux",
+      ).gpuRoutePlan,
+    ).toBe("native-only");
   });
 });

--- a/src/lib/onboard/docker-gpu-sandbox-create-route-plan.test.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create-route-plan.test.ts
@@ -5,8 +5,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   type DockerGpuRoutePlan,
-  resolveAgentPlan,
   resolveDockerGpuSandboxCreatePlan,
+  resolveProfileGpuCreatePlan,
 } from "./docker-gpu-sandbox-create";
 
 describe("resolveDockerGpuSandboxCreatePlan", () => {
@@ -173,44 +173,23 @@ describe("resolveDockerGpuSandboxCreatePlan", () => {
     expect(result.gpuRoutePlan).toBe("compatibility-only");
   });
 
-  it("keeps every portable agent on native GPU lifecycle operations (#9462)", () => {
-    const env = {
-      NEMOCLAW_DOCKER_GPU_PATCH: "1",
-      NEMOCLAW_EXPERIMENTAL_PROFILE: "portable",
-    };
-
-    expect(resolveAgentPlan({ sandboxGpuEnabled: true }, null, true, env, "linux").gpuRoutePlan).toBe(
-      "native-only",
-    );
+  it("keeps the portable profile on native GPU routing at the resolver boundary (#9462)", () => {
     expect(
-      resolveAgentPlan(
+      resolveProfileGpuCreatePlan(
         { sandboxGpuEnabled: true },
-        { name: "hermes" },
         true,
-        env,
-        "linux",
-      ).gpuRoutePlan,
-    ).toBe("native-only");
-    expect(
-      resolveAgentPlan(
-        { sandboxGpuEnabled: true },
-        { name: "langchain-deepagents-code" },
-        true,
-        env,
+        { NEMOCLAW_DOCKER_GPU_PATCH: "1", NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
         "linux",
       ).gpuRoutePlan,
     ).toBe("native-only");
   });
 
   it("keeps portable Jetson hosts off the compatibility-only default (#9462)", () => {
-    const env = { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" };
-
     expect(
-      resolveAgentPlan(
+      resolveProfileGpuCreatePlan(
         { sandboxGpuEnabled: true, hostGpuPlatform: "jetson" },
-        { name: "hermes" },
         true,
-        env,
+        { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
         "linux",
       ).gpuRoutePlan,
     ).toBe("native-only");

--- a/src/lib/onboard/docker-gpu-sandbox-create.ts
+++ b/src/lib/onboard/docker-gpu-sandbox-create.ts
@@ -35,7 +35,7 @@ export type { DockerGpuRoutePlan, SelectedDockerGpuRoute } from "./docker-gpu-ro
 export {
   isDockerDesktopWslRuntime,
   resetIsDockerDesktopWslRuntimeCache,
-  resolveAgentPlan,
+  resolveProfileGpuCreatePlan,
   resolveDockerGpuSandboxCreatePlan,
 } from "./docker-gpu-sandbox-create-plan";
 

--- a/src/lib/onboard/docker-startup-command-agent.test.ts
+++ b/src/lib/onboard/docker-startup-command-agent.test.ts
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import type { AgentDefinition } from "../agent/defs";
+import {
+  DCODE_DOCKER_ULIMITS,
+  resolveDockerStartupCommandPatch,
+} from "./docker-startup-command-agent";
+import { resolveAgentCreateInput } from "./sandbox-gpu-create-flow";
+
+const PORTABLE_ENV: NodeJS.ProcessEnv = { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" };
+const DEFAULT_ENV: NodeJS.ProcessEnv = {};
+
+const agent = (name: string) => ({ name }) as AgentDefinition;
+
+describe("resolveDockerStartupCommandPatch", () => {
+  it.each(["openclaw", "hermes", "langchain-deepagents-code"])(
+    "keeps restart-safe persistence for %s on a default-profile docker-driver gateway",
+    (name) => {
+      expect(resolveDockerStartupCommandPatch(agent(name), true, DEFAULT_ENV)).toMatchObject({
+        persistStartupCommand: true,
+      });
+    },
+  );
+
+  it.each(["openclaw", "hermes", "langchain-deepagents-code"])(
+    "disables the Docker restart-safe recreation for %s under the portable profile (#9462)",
+    (name) => {
+      expect(resolveDockerStartupCommandPatch(agent(name), true, PORTABLE_ENV)).toMatchObject({
+        persistStartupCommand: false,
+      });
+    },
+  );
+
+  it("keeps the DCode ulimit contract visible under the portable profile", () => {
+    expect(
+      resolveDockerStartupCommandPatch(agent("langchain-deepagents-code"), true, PORTABLE_ENV)
+        .requiredUlimits,
+    ).toEqual(DCODE_DOCKER_ULIMITS);
+  });
+
+  it("stays fully disabled off the docker-driver gateway regardless of profile", () => {
+    expect(resolveDockerStartupCommandPatch(agent("hermes"), false, PORTABLE_ENV)).toEqual({
+      persistStartupCommand: false,
+      requiredUlimits: null,
+    });
+    expect(resolveDockerStartupCommandPatch(agent("hermes"), false, DEFAULT_ENV)).toEqual({
+      persistStartupCommand: false,
+      requiredUlimits: null,
+    });
+  });
+
+  it("treats a missing agent as OpenClaw for the portable gate", () => {
+    expect(resolveDockerStartupCommandPatch(null, true, PORTABLE_ENV)).toMatchObject({
+      persistStartupCommand: false,
+    });
+    expect(resolveDockerStartupCommandPatch(null, true, DEFAULT_ENV)).toMatchObject({
+      persistStartupCommand: true,
+    });
+  });
+});
+
+describe("resolveAgentCreateInput portable persistence", () => {
+  it("keeps portable non-OpenClaw agents off the Docker recreation path (#9462)", () => {
+    expect(resolveAgentCreateInput(agent("hermes"), true, PORTABLE_ENV)).toMatchObject({
+      portableLifecycle: false,
+      persistStartupCommand: false,
+    });
+    expect(
+      resolveAgentCreateInput(agent("langchain-deepagents-code"), true, PORTABLE_ENV),
+    ).toMatchObject({
+      portableLifecycle: false,
+      persistStartupCommand: false,
+    });
+  });
+});

--- a/src/lib/onboard/docker-startup-command-agent.ts
+++ b/src/lib/onboard/docker-startup-command-agent.ts
@@ -3,6 +3,7 @@
 
 import type { AgentDefinition } from "../agent/defs";
 import type { DockerUlimit } from "./docker-gpu-patch-types";
+import { isPortableExperimentalProfile } from "./experimental/portable-profile";
 
 const DCODE_AGENT_NAME = "langchain-deepagents-code";
 
@@ -17,6 +18,7 @@ export const DCODE_DOCKER_ULIMITS: readonly DockerUlimit[] = [
 export function resolveDockerStartupCommandPatch(
   agent: AgentDefinition | null | undefined,
   dockerDriverGateway: boolean | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
 ): {
   persistStartupCommand: boolean;
   requiredUlimits: readonly DockerUlimit[] | null;
@@ -25,9 +27,18 @@ export function resolveDockerStartupCommandPatch(
     return { persistStartupCommand: false, requiredUlimits: null };
   }
   const agentName = agent?.name ?? "openclaw";
+  const requiredUlimits = agentName === DCODE_AGENT_NAME ? DCODE_DOCKER_ULIMITS : null;
+  // The restart-safe recreation discovers the sandbox with docker-driver
+  // labels (openshell.ai/managed-by), but the portable profile registers the
+  // gateway with the podman driver, whose containers never carry that label —
+  // the recreation can only fail after Ready (#9462). Portable+OpenClaw
+  // persistence is owned by the portable lifecycle instead (#9176).
+  if (isPortableExperimentalProfile(env)) {
+    return { persistStartupCommand: false, requiredUlimits };
+  }
   return {
     persistStartupCommand:
       agentName === "openclaw" || agentName === "hermes" || agentName === DCODE_AGENT_NAME,
-    requiredUlimits: agentName === DCODE_AGENT_NAME ? DCODE_DOCKER_ULIMITS : null,
+    requiredUlimits,
   };
 }

--- a/src/lib/onboard/sandbox-create-intent-resolution.ts
+++ b/src/lib/onboard/sandbox-create-intent-resolution.ts
@@ -45,7 +45,7 @@ export interface SandboxCreateIntentResolverDeps<Agent, ResourceProfile> {
   filterEnabledChannelsByAgent(enabledChannels: string[] | null, agent: Agent): string[] | null;
   defaultPolicyPath: string;
   getAgentPolicyPath(agent: Agent): string | null;
-  resolveGpuPlan(config: SandboxGpuCreateConfig, agent: Agent): {
+  resolveGpuPlan(config: SandboxGpuCreateConfig): {
     gpuRoutePlan: DockerGpuRoutePlan;
     logMessage: string | null;
   };
@@ -116,7 +116,6 @@ export function createSandboxCreateIntentResolver<
     const messaging = await prepareMessagingCapabilities(input);
     const { gpuRoutePlan, logMessage: sandboxGpuLogMessage } = deps.resolveGpuPlan(
       input.sandboxGpuConfig,
-      input.agent,
     );
     const resourceCreateArgs: string[] = [];
     deps.appendResourceCreateArgs(resourceCreateArgs, input.resourceProfile);

--- a/src/lib/onboard/sandbox-create-step.test.ts
+++ b/src/lib/onboard/sandbox-create-step.test.ts
@@ -168,6 +168,34 @@ describe("runSandboxCreateStep", () => {
     );
   });
 
+  it("gates restart-safe persistence on the step's own portable env, not process.env (#9462)", async () => {
+    const launch = makeLaunch({
+      sandboxStartupCommand: ["env", "nemoclaw-start"],
+    });
+    const patch = makePatch();
+    const deps = makeDeps(launch, patch, { status: 0, output: "created" });
+
+    await runSandboxCreateStep(
+      makeContext({
+        agent: { name: "hermes" } as SandboxCreateStepContext["agent"],
+        env: { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
+        prebuild: {
+          buildCtx: "/tmp/ctx",
+          buildId: "b1",
+          dockerDriverGateway: true,
+          origin: "generated",
+        },
+      }),
+      deps,
+    );
+
+    expect(deps.createDockerGpuPatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        persistStartupCommand: false,
+      }),
+    );
+  });
+
   it("persists DCode startup with its exact Docker resource limits", async () => {
     const launch = makeLaunch({
       sandboxStartupCommand: ["env", "nemoclaw-start"],

--- a/src/lib/onboard/sandbox-create-step.ts
+++ b/src/lib/onboard/sandbox-create-step.ts
@@ -97,6 +97,7 @@ export async function runSandboxCreateStep(
   const startupCommandPatch = resolveDockerStartupCommandPatch(
     context.agent,
     context.prebuild.dockerDriverGateway,
+    context.env,
   );
   const deferRestartSafeCutover =
     startupCommandPatch.persistStartupCommand && !context.useDockerGpuPatch;

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -208,12 +208,12 @@ describe("resolveAgentCreateInput", () => {
     const env = { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" };
 
     expect(resolveAgentCreateInput(null, true, env)).toMatchObject({
-      persistStartupCommand: true,
+      persistStartupCommand: false,
       portableLifecycle: true,
     });
     expect(resolveAgentCreateInput({ name: "hermes" } as AgentDefinition, true, env)).toMatchObject(
       {
-        persistStartupCommand: true,
+        persistStartupCommand: false,
         portableLifecycle: false,
       },
     );

--- a/src/lib/onboard/sandbox-gpu-create-flow.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.ts
@@ -78,7 +78,7 @@ export function resolveAgentCreateInput(
   env: NodeJS.ProcessEnv = process.env,
 ) {
   return {
-    ...resolveDockerStartupCommandPatch(agent, dockerDriverGateway),
+    ...resolveDockerStartupCommandPatch(agent, dockerDriverGateway, env),
     portableLifecycle: resolvePortableLifecycleMode(agent, env),
   };
 }


### PR DESCRIPTION
## Summary

On the portable (rootless Podman) profile, the Docker-lifecycle container recreation discovers the sandbox with docker-driver labels (`openshell.ai/managed-by=openshell`). Podman-driver containers never carry that label, so whenever the recreation runs it can only fail after the sandbox reaches Ready — `Could not find OpenShell Docker container for sandbox '<name>'` — and onboarding exits before registration on GPU hosts.

**Root cause note:** the issue's stated hypothesis (missing `DOCKER_HOST` injection) was investigated and refuted. The podman socket is set on `process.env` by portable host preparation before creation and forwarded to every docker spawn through the subprocess-env allowlist; the failing query hit the correct daemon and matched zero label rows. The QA artifact supports this: the diagnostics collector writes `docker-ps.txt` only when `docker ps` succeeds with output, so its presence proves a successful query with zero matches, not a wrong daemon.

**Relationship to #9176:** the exact QA reproduction (default agent, native route, v0.0.109) was already fixed on `main` by #9176, which rerouted portable+OpenClaw onto the podman-safe lifecycle and deliberately left other agents unchanged. Two paths of the same defect remained live on `main`:

1. **Restart-safe startup-command persistence** — `resolveDockerStartupCommandPatch` still enabled the recreation for `hermes` and `langchain-deepagents-code` under the portable profile. This also reproduces the non-GPU symptom QA reported (route `none`, recreation ran for "restart-safe startup").
2. **Compatibility GPU route** — `resolveAgentPlan` forced native-only routing for portable+OpenClaw only, so portable + other agents could still be routed into the compatibility recreation: Jetson hosts select it **by default** (no env opt-in), Docker Desktop WSL detection selects it, and `NEMOCLAW_DOCKER_GPU_PATCH=1`/`fallback` select it explicitly.

This PR extends both gates from OpenClaw-only to the whole portable profile. With persistence off and the route native, the recreation transaction is disabled (`recreationEnabled` is false) and `ensureApplied` is a no-op — the exact behavior #9176 shipped for OpenClaw.

## Changes

- `src/lib/onboard/docker-startup-command-agent.ts` — `resolveDockerStartupCommandPatch` takes `env` (default `process.env`) and returns `persistStartupCommand: false` under the portable profile; the DCode ulimit contract stays visible for the callers that read it.
- `src/lib/onboard/sandbox-gpu-create-flow.ts` — `resolveAgentCreateInput` threads its `env` into the resolver.
- `src/lib/onboard/docker-gpu-sandbox-create-plan.ts` — `resolveAgentPlan` applies the portable native-only route plan to every agent, not only OpenClaw.
- Tests: new focused `docker-startup-command-agent.test.ts` (the flow test file is at its line budget); corrected the #9068 pins that asserted the defective contract; new route-plan cases covering portable+hermes/dcode with `NEMOCLAW_DOCKER_GPU_PATCH=1` and the portable Jetson default.

## Test plan

- Red→green on unfixed source: portable persistence disable (5 cases), portable route plan for non-OpenClaw agents and Jetson default (2 cases).
- Blast radius green: `sandbox-gpu-create-flow`, `docker-startup-command-sandbox-create`, `sandbox-create-step`, `managed-bootstrap/docker-runtime`, `docker-gpu-sandbox-create-route-plan`, `build-context` (99 tests), plus `growth-guardrails` and `pr-risk-plan` (153 tests).
- `npm run typecheck:cli`, `oxlint`, `format:check`: clean.

## Noted limitations

- Portable + non-OpenClaw agents lose Docker-side restart-safe startup persistence rather than gaining a podman-side equivalent; a podman-native persistence path (what #9176 built for OpenClaw) is follow-up work.
- The recreation's best-effort container lookup still collapses "daemon unreachable" and "zero label matches" into one message; a status-bearing lookup (`queryOpenShellDockerSandboxContainers`) is a worthwhile diagnosability follow-up but touches many pinned tests, so it is not bundled here.

Fixes #9462

Signed-off-by: Dongni Yang <dongniy@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portable profile routing across supported agents and Jetson hosts.
  * Ensured portable profiles consistently disable startup-command persistence while preserving required runtime limits.
  * Preserved compatibility routing when a non-portable lifecycle is explicitly selected.
  * Improved onboarding behavior when agent details are unavailable.
  * Ensured portable settings are applied consistently across onboarding steps and environments.

* **Tests**
  * Expanded coverage for portable and non-portable routing, startup persistence, runtime limits, and agent creation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->