### PR TITLE
fix(onboard): accept agent credential placeholder aliases

### DIFF
--- a/src/lib/messaging/channels/built-ins.ts
+++ b/src/lib/messaging/channels/built-ins.ts
@@ -2,22 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ChannelManifestRegistry } from "../manifest";
-import { createChannelManifestRegistry } from "../manifest";
-import { discordManifest } from "./discord/manifest";
-import { googlechatManifest } from "./googlechat/manifest";
-import { slackManifest } from "./slack/manifest";
-import { teamsManifest } from "./teams/manifest";
-import { telegramManifest } from "./telegram/manifest";
-import { wechatManifest } from "./wechat/manifest";
-import { whatsappManifest } from "./whatsapp/manifest";
+import { createChannelManifestRegistry } from "../manifest/registry.ts";
+import { discordManifest } from "./discord/manifest.ts";
+import { googlechatManifest } from "./googlechat/manifest.ts";
+import { slackManifest } from "./slack/manifest.ts";
+import { teamsManifest } from "./teams/manifest.ts";
+import { telegramManifest } from "./telegram/manifest.ts";
+import { wechatManifest } from "./wechat/manifest.ts";
+import { whatsappManifest } from "./whatsapp/manifest.ts";
 
-export { discordManifest } from "./discord/manifest";
-export { googlechatManifest } from "./googlechat/manifest";
-export { slackManifest } from "./slack/manifest";
-export { teamsManifest } from "./teams/manifest";
-export { telegramManifest } from "./telegram/manifest";
-export { wechatManifest } from "./wechat/manifest";
-export { whatsappManifest } from "./whatsapp/manifest";
+export { discordManifest } from "./discord/manifest.ts";
+export { googlechatManifest } from "./googlechat/manifest.ts";
+export { slackManifest } from "./slack/manifest.ts";
+export { teamsManifest } from "./teams/manifest.ts";
+export { telegramManifest } from "./telegram/manifest.ts";
+export { wechatManifest } from "./wechat/manifest.ts";
+export { whatsappManifest } from "./whatsapp/manifest.ts";
 
 export const BUILT_IN_CHANNEL_MANIFESTS = [
   telegramManifest,

--- a/src/lib/messaging/channels/metadata.test.ts
+++ b/src/lib/messaging/channels/metadata.test.ts
@@ -16,6 +16,7 @@ import {
   listBuiltInMessagingChannelManifests,
   listMessagingChannelsWithoutCredentials,
   listMessagingConfigEnvKeys,
+  listMessagingCredentialEnvAssignments,
   listMessagingPackageInstallSpecs,
   listMessagingProviderNamesForChannel,
   listOpenClawManagedChannelNames,
@@ -68,6 +69,29 @@ describe("built-in messaging channel metadata", () => {
       "demo-slack-app",
     ]);
     expect(listMessagingChannelsWithoutCredentials()).toEqual(["whatsapp", "googlechat"]);
+  });
+
+  it("derives credential environment assignments from manifest render metadata", () => {
+    expect(
+      listMessagingCredentialEnvAssignments({ agent: "hermes" })
+        .filter(({ sourceEnvKey, targetEnvKey }) => sourceEnvKey !== targetEnvKey)
+        .map(({ channelId, sourceEnvKey, targetEnvKey }) => ({
+          channelId,
+          sourceEnvKey,
+          targetEnvKey,
+        })),
+    ).toEqual([
+      {
+        channelId: "wechat",
+        sourceEnvKey: "WECHAT_BOT_TOKEN",
+        targetEnvKey: "WEIXIN_TOKEN",
+      },
+      {
+        channelId: "teams",
+        sourceEnvKey: "MSTEAMS_APP_PASSWORD",
+        targetEnvKey: "TEAMS_CLIENT_SECRET",
+      },
+    ]);
   });
 
   it("resolves config env keys from manifests and compatibility aliases from metadata", () => {

--- a/src/lib/messaging/channels/metadata.test.ts
+++ b/src/lib/messaging/channels/metadata.test.ts
@@ -92,6 +92,11 @@ describe("built-in messaging channel metadata", () => {
         targetEnvKey: "TEAMS_CLIENT_SECRET",
       },
     ]);
+    expect(
+      listMessagingCredentialEnvAssignments({ agent: "openclaw" }).filter(
+        ({ channelId }) => channelId === "teams",
+      ),
+    ).toEqual([]);
   });
 
   it("resolves config env keys from manifests and compatibility aliases from metadata", () => {

--- a/src/lib/messaging/channels/metadata.ts
+++ b/src/lib/messaging/channels/metadata.ts
@@ -115,6 +115,7 @@ export function listMessagingCredentialEnvAssignments(
       ]),
     );
     return manifest.render.flatMap((render) => {
+      if (options.agent && render.agent !== options.agent) return [];
       if (render.kind !== "env-lines") return [];
       return render.lines.flatMap((line) => {
         const separator = line.indexOf("=");

--- a/src/lib/messaging/channels/metadata.ts
+++ b/src/lib/messaging/channels/metadata.ts
@@ -35,6 +35,14 @@ export interface MessagingCredentialMetadata {
   readonly primary: boolean;
 }
 
+export interface MessagingCredentialEnvAssignmentMetadata {
+  readonly channelId: string;
+  readonly agent: MessagingAgentId;
+  readonly sourceEnvKey: string;
+  readonly targetEnvKey: string;
+  readonly placeholder: string;
+}
+
 export interface MessagingConfigEnvMetadata {
   readonly channelId: string;
   readonly inputId: string;
@@ -94,6 +102,37 @@ export function listMessagingCredentialMetadata(
       primary: credential.primary === true,
     })),
   );
+}
+
+export function listMessagingCredentialEnvAssignments(
+  options: MessagingManifestMetadataOptions = {},
+): MessagingCredentialEnvAssignmentMetadata[] {
+  return selectManifests(options).flatMap((manifest) => {
+    const credentialsByTemplate = new Map(
+      manifest.credentials.map((credential) => [
+        `{{credential.${credential.id}.placeholder}}`,
+        credential,
+      ]),
+    );
+    return manifest.render.flatMap((render) => {
+      if (render.kind !== "env-lines") return [];
+      return render.lines.flatMap((line) => {
+        const separator = line.indexOf("=");
+        if (separator <= 0) return [];
+        const credential = credentialsByTemplate.get(line.slice(separator + 1));
+        if (!credential) return [];
+        return [
+          {
+            channelId: manifest.id,
+            agent: render.agent,
+            sourceEnvKey: credential.providerEnvKey,
+            targetEnvKey: line.slice(0, separator),
+            placeholder: credential.placeholder,
+          },
+        ];
+      });
+    });
+  });
 }
 
 export function getMessagingCredentialEnvKeysByChannel(

--- a/src/lib/messaging/channels/metadata.ts
+++ b/src/lib/messaging/channels/metadata.ts
@@ -8,7 +8,7 @@ import type {
   ChannelPolicyPresetSpec,
   MessagingAgentId,
 } from "../manifest";
-import { BUILT_IN_CHANNEL_MANIFESTS } from "./built-ins";
+import { BUILT_IN_CHANNEL_MANIFESTS } from "./built-ins.ts";
 
 const CONFIG_ENV_ALIASES_BY_ENV_KEY: Readonly<Record<string, readonly string[]>> = {
   DISCORD_SERVER_ID: ["DISCORD_SERVER_IDS"],

--- a/src/lib/messaging/plan-validation.test.ts
+++ b/src/lib/messaging/plan-validation.test.ts
@@ -249,6 +249,25 @@ describe("parseSandboxMessagingPlan", () => {
     ).toBeNull();
   });
 
+  it("rejects agent render entries owned by a different plan agent", () => {
+    expect(
+      parseSandboxMessagingPlan(
+        makePlan({
+          agentRender: [
+            {
+              channelId: "telegram",
+              agent: "hermes",
+              target: "~/.hermes/.env",
+              kind: "env-lines",
+              lines: [],
+              templateRefs: [],
+            },
+          ],
+        }),
+      ),
+    ).toBeNull();
+  });
+
   it("rejects a lone noncanonical channel id even when related ids are canonical", () => {
     const source = makePlan();
     expect(

--- a/src/lib/messaging/plan-validation.ts
+++ b/src/lib/messaging/plan-validation.ts
@@ -117,6 +117,7 @@ export function parseSandboxMessagingPlan(
   }
   if (
     !hasCanonicalChannelReferences(value.credentialBindings) ||
+    !hasMatchingAgentRenderEntries(value.agentRender, value.agent) ||
     !hasCanonicalChannelReferences(value.agentRender) ||
     !hasCanonicalChannelReferences(value.buildSteps) ||
     !hasCanonicalChannelReferences(value.stateUpdates) ||
@@ -132,6 +133,13 @@ export function parseSandboxMessagingPlan(
       value as MaybeCompactMessagingPlan,
       options.environment,
     ),
+  );
+}
+
+function hasMatchingAgentRenderEntries(value: unknown, agent: string): boolean {
+  return (
+    !Array.isArray(value) ||
+    value.every((render) => isObjectRecord(render) && render.agent === agent)
   );
 }
 

--- a/src/lib/onboard/managed-startup-profile.test.ts
+++ b/src/lib/onboard/managed-startup-profile.test.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { HERMES_API_PORT_RANGE_END, HERMES_API_PORT_RANGE_START } from "../core/ports";
+import { listMessagingCredentialEnvAssignments } from "../messaging/channels/metadata";
 import {
   decodeManagedStartupProfile,
   encodeManagedStartupProfile,
@@ -762,8 +763,9 @@ describe("managed startup profile", () => {
                   "SLACK_BOT_TOKEN=xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
                   "DISCORD_BOT_TOKEN=openshell:resolve:env:DISCORD_BOT_TOKEN",
                   "TELEGRAM_BOT_TOKEN=openshell:resolve:env:v1_TELEGRAM_BOT_TOKEN",
-                  "TEAMS_CLIENT_SECRET=openshell:resolve:env:MSTEAMS_APP_PASSWORD",
-                  "WEIXIN_TOKEN=openshell:resolve:env:WECHAT_BOT_TOKEN",
+                  ...listMessagingCredentialEnvAssignments({ agent: "hermes" })
+                    .filter(({ sourceEnvKey, targetEnvKey }) => sourceEnvKey !== targetEnvKey)
+                    .map(({ targetEnvKey, placeholder }) => `${targetEnvKey}=${placeholder}`),
                 ],
                 templateRefs: ["credential.slackBotToken.placeholder"],
               },
@@ -777,10 +779,7 @@ describe("managed startup profile", () => {
   it.each([
     ["a raw credential", `SLACK_BOT_TOKEN=xoxb-${"a".repeat(32)}`],
     ["a malformed assignment", "SLACK_BOT_TOKEN =openshell:resolve:env:SLACK_BOT_TOKEN"],
-    [
-      "more than one assignment",
-      "SLACK_BOT_TOKEN=openshell:resolve:env:SLACK_BOT_TOKEN=FORGED",
-    ],
+    ["more than one assignment", "SLACK_BOT_TOKEN=openshell:resolve:env:SLACK_BOT_TOKEN=FORGED"],
     [
       "a placeholder assigned to a non-credential environment key",
       "CHANNEL_NAME=openshell:resolve:env:SLACK_BOT_TOKEN",

--- a/src/lib/onboard/managed-startup-profile.test.ts
+++ b/src/lib/onboard/managed-startup-profile.test.ts
@@ -735,10 +735,10 @@ describe("managed startup profile", () => {
   it("accepts schema-owned messaging pins, placeholders, and credential environment aliases (#9355)", () => {
     expect(() =>
       validateManagedStartupProfile({
-        ...OPENCLAW_PROFILE,
+        ...HERMES_PROFILE,
         messaging: {
           plan: {
-            ...OPENCLAW_PROFILE.messaging.plan,
+            ...HERMES_PROFILE.messaging.plan,
             buildSteps: [
               {
                 channelId: "slack",
@@ -753,7 +753,7 @@ describe("managed startup profile", () => {
               },
             ],
             agentRender: [
-              ...OPENCLAW_PROFILE.messaging.plan.agentRender,
+              ...HERMES_PROFILE.messaging.plan.agentRender,
               {
                 channelId: "slack",
                 agent: "hermes",
@@ -777,6 +777,12 @@ describe("managed startup profile", () => {
   });
 
   it.each([
+    ...listMessagingCredentialEnvAssignments({ agent: "hermes" })
+      .filter(({ sourceEnvKey, targetEnvKey }) => sourceEnvKey !== targetEnvKey)
+      .map(({ targetEnvKey, placeholder }) => [
+        "a cross-agent credential environment alias",
+        `${targetEnvKey}=${placeholder}`,
+      ] as const),
     ["a raw credential", `SLACK_BOT_TOKEN=xoxb-${"a".repeat(32)}`],
     ["a malformed assignment", "SLACK_BOT_TOKEN =openshell:resolve:env:SLACK_BOT_TOKEN"],
     ["more than one assignment", "SLACK_BOT_TOKEN=openshell:resolve:env:SLACK_BOT_TOKEN=FORGED"],
@@ -792,7 +798,7 @@ describe("managed startup profile", () => {
       "a placeholder assigned to an unapproved credential environment key",
       "AWS_SECRET_ACCESS_KEY=openshell:resolve:env:MSTEAMS_APP_PASSWORD",
     ],
-  ])("rejects %s in messaging environment lines (#9355)", (_label, line) => {
+  ] as const)("rejects %s in messaging environment lines (#9355)", (_label, line) => {
     expect(() =>
       validateManagedStartupProfile({
         ...OPENCLAW_PROFILE,
@@ -802,7 +808,7 @@ describe("managed startup profile", () => {
             agentRender: [
               {
                 channelId: "slack",
-                agent: "hermes",
+                agent: "openclaw",
                 target: "~/.hermes/.env",
                 kind: "env-lines",
                 lines: [line],
@@ -812,7 +818,7 @@ describe("managed startup profile", () => {
           },
         },
       }),
-    ).toThrow(/credential-shaped string data/);
+    ).toThrow(/credential-shaped string data|credential environment alias/);
   });
 
   it.each([

--- a/src/lib/onboard/managed-startup-profile.test.ts
+++ b/src/lib/onboard/managed-startup-profile.test.ts
@@ -731,7 +731,7 @@ describe("managed startup profile", () => {
     ).toThrow(/credential-shaped field name/);
   });
 
-  it("accepts schema-owned messaging pins, placeholders, and agent aliases (#9355)", () => {
+  it("accepts schema-owned messaging pins, placeholders, and credential environment aliases (#9355)", () => {
     expect(() =>
       validateManagedStartupProfile({
         ...OPENCLAW_PROFILE,
@@ -763,6 +763,7 @@ describe("managed startup profile", () => {
                   "DISCORD_BOT_TOKEN=openshell:resolve:env:DISCORD_BOT_TOKEN",
                   "TELEGRAM_BOT_TOKEN=openshell:resolve:env:v1_TELEGRAM_BOT_TOKEN",
                   "TEAMS_CLIENT_SECRET=openshell:resolve:env:MSTEAMS_APP_PASSWORD",
+                  "WEIXIN_TOKEN=openshell:resolve:env:WECHAT_BOT_TOKEN",
                 ],
                 templateRefs: ["credential.slackBotToken.placeholder"],
               },
@@ -787,6 +788,10 @@ describe("managed startup profile", () => {
     [
       "a placeholder with a noncanonical provider environment key",
       "SLACK_BOT_TOKEN=openshell:resolve:env:slack_bot_token",
+    ],
+    [
+      "a placeholder assigned to an unapproved credential environment key",
+      "AWS_SECRET_ACCESS_KEY=openshell:resolve:env:MSTEAMS_APP_PASSWORD",
     ],
   ])("rejects %s in messaging environment lines (#9355)", (_label, line) => {
     expect(() =>

--- a/src/lib/onboard/managed-startup-profile.test.ts
+++ b/src/lib/onboard/managed-startup-profile.test.ts
@@ -753,7 +753,6 @@ describe("managed startup profile", () => {
               },
             ],
             agentRender: [
-              ...HERMES_PROFILE.messaging.plan.agentRender,
               {
                 channelId: "slack",
                 agent: "hermes",
@@ -818,7 +817,7 @@ describe("managed startup profile", () => {
           },
         },
       }),
-    ).toThrow(/credential-shaped string data|credential environment alias/);
+    ).toThrow(/credential-shaped string data/);
   });
 
   it.each([

--- a/src/lib/onboard/managed-startup-profile.test.ts
+++ b/src/lib/onboard/managed-startup-profile.test.ts
@@ -9,7 +9,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { HERMES_API_PORT_RANGE_END, HERMES_API_PORT_RANGE_START } from "../core/ports";
-import { listMessagingCredentialEnvAssignments } from "../messaging/channels/metadata";
+import { listMessagingCredentialEnvAssignments } from "../messaging/channels/metadata.ts";
 import {
   decodeManagedStartupProfile,
   encodeManagedStartupProfile,

--- a/src/lib/onboard/managed-startup-profile.test.ts
+++ b/src/lib/onboard/managed-startup-profile.test.ts
@@ -731,7 +731,7 @@ describe("managed startup profile", () => {
     ).toThrow(/credential-shaped field name/);
   });
 
-  it("accepts schema-owned messaging package pins and credential placeholder lines (#9355)", () => {
+  it("accepts schema-owned messaging pins, placeholders, and agent aliases (#9355)", () => {
     expect(() =>
       validateManagedStartupProfile({
         ...OPENCLAW_PROFILE,
@@ -762,6 +762,7 @@ describe("managed startup profile", () => {
                   "SLACK_BOT_TOKEN=xoxb-OPENSHELL-RESOLVE-ENV-SLACK_BOT_TOKEN",
                   "DISCORD_BOT_TOKEN=openshell:resolve:env:DISCORD_BOT_TOKEN",
                   "TELEGRAM_BOT_TOKEN=openshell:resolve:env:v1_TELEGRAM_BOT_TOKEN",
+                  "TEAMS_CLIENT_SECRET=openshell:resolve:env:MSTEAMS_APP_PASSWORD",
                 ],
                 templateRefs: ["credential.slackBotToken.placeholder"],
               },
@@ -776,12 +777,16 @@ describe("managed startup profile", () => {
     ["a raw credential", `SLACK_BOT_TOKEN=xoxb-${"a".repeat(32)}`],
     ["a malformed assignment", "SLACK_BOT_TOKEN =openshell:resolve:env:SLACK_BOT_TOKEN"],
     [
-      "a placeholder for a different environment key",
-      "SLACK_BOT_TOKEN=openshell:resolve:env:DISCORD_BOT_TOKEN",
+      "more than one assignment",
+      "SLACK_BOT_TOKEN=openshell:resolve:env:SLACK_BOT_TOKEN=FORGED",
     ],
     [
-      "a versioned placeholder for a different environment key",
-      "SLACK_BOT_TOKEN=openshell:resolve:env:v1_DISCORD_BOT_TOKEN",
+      "a placeholder assigned to a non-credential environment key",
+      "CHANNEL_NAME=openshell:resolve:env:SLACK_BOT_TOKEN",
+    ],
+    [
+      "a placeholder with a noncanonical provider environment key",
+      "SLACK_BOT_TOKEN=openshell:resolve:env:slack_bot_token",
     ],
   ])("rejects %s in messaging environment lines (#9355)", (_label, line) => {
     expect(() =>

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -1045,8 +1045,11 @@ function isMessagingCredentialPlaceholderAssignment(
   const separator = value.indexOf("=");
   if (separator <= 0 || value.indexOf("=", separator + 1) !== -1) return false;
   const envKey = value.slice(0, separator);
-  const placeholderEnvKey = messagingCredentialPlaceholderEnvKey(value.slice(separator + 1));
-  return CREDENTIAL_ENV_NAME_PATTERN.test(envKey) && envKey === placeholderEnvKey;
+  const placeholder = value.slice(separator + 1);
+  return (
+    CREDENTIAL_ENV_NAME_PATTERN.test(envKey) &&
+    MESSAGING_CREDENTIAL_PLACEHOLDER_RE.test(placeholder)
+  );
 }
 
 function isMessagingRuntimeEnvAliasPath(path: readonly string[]): boolean {

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -4,7 +4,7 @@
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { TextDecoder } from "node:util";
-import { listMessagingCredentialEnvAssignments } from "../../messaging/channels/metadata";
+import { listMessagingCredentialEnvAssignments } from "../../messaging/channels/metadata.ts";
 import { isValidDcodeUpstreamProvider } from "./dcode-upstream-provider.ts";
 
 /**

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -60,11 +60,17 @@ const NON_SECRET_KEY_METADATA_NAMES = new Set([
 ]);
 const MESSAGING_CREDENTIAL_PLACEHOLDER_RE =
   /^(?:openshell:resolve:env:|[A-Za-z0-9]+-OPENSHELL-RESOLVE-ENV-)(?:v[0-9]+_)?[A-Z][A-Z0-9_]*$/u;
-const MESSAGING_CREDENTIAL_ENV_ALIASES = new Set(
-  listMessagingCredentialEnvAssignments()
-    .filter(({ sourceEnvKey, targetEnvKey }) => sourceEnvKey !== targetEnvKey)
-    .map(({ sourceEnvKey, targetEnvKey }) => `${sourceEnvKey}\0${targetEnvKey}`),
-);
+const MESSAGING_CREDENTIAL_ENV_ALIASES = (() => {
+  const aliases = new Map<string, Set<string>>();
+  for (const { agent, sourceEnvKey, targetEnvKey } of listMessagingCredentialEnvAssignments()) {
+    if (sourceEnvKey === targetEnvKey) continue;
+    const key = `${sourceEnvKey}\0${targetEnvKey}`;
+    const agents = aliases.get(key) ?? new Set<string>();
+    agents.add(agent);
+    aliases.set(key, agents);
+  }
+  return aliases;
+})();
 const JSON_ARRAY_INDEX_SEGMENT_RE = /^\[(?:0|[1-9][0-9]*)\]$/u;
 const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
   /nvapi-[A-Za-z0-9_-]{10,}/u,
@@ -1061,6 +1067,33 @@ function isMessagingCredentialPlaceholderAssignment(
   );
 }
 
+function assertMessagingCredentialAliasAgents(
+  plan: Record<string, unknown>,
+  selectedAgent: ManagedStartupAgent,
+): void {
+  if (!Array.isArray(plan.agentRender)) return;
+  for (const render of plan.agentRender) {
+    if (!isPlainObject(render) || !Array.isArray(render.lines)) continue;
+    for (const line of render.lines) {
+      if (typeof line !== "string") continue;
+      const separator = line.indexOf("=");
+      if (separator <= 0) continue;
+      const targetEnvKey = line.slice(0, separator);
+      const sourceEnvKey = messagingCredentialPlaceholderEnvKey(line.slice(separator + 1));
+      if (sourceEnvKey === null || sourceEnvKey === targetEnvKey) continue;
+      const allowedAgents = MESSAGING_CREDENTIAL_ENV_ALIASES.get(
+        `${sourceEnvKey}\0${targetEnvKey}`,
+      );
+      if (
+        allowedAgents !== undefined &&
+        (render.agent !== selectedAgent || !allowedAgents.has(selectedAgent))
+      ) {
+        invalid("messaging credential environment alias must match the selected render agent");
+      }
+    }
+  }
+}
+
 function isMessagingRuntimeEnvAliasPath(path: readonly string[]): boolean {
   return (
     path.length === 5 &&
@@ -2050,6 +2083,9 @@ export function validateManagedStartupProfile(value: unknown): ManagedStartupPro
       messagingPlan.agent !== agent)
   ) {
     invalid("messaging.plan must be a version 1 plan for the selected agent");
+  }
+  if (messagingPlan !== null) {
+    assertMessagingCredentialAliasAgents(messagingPlan, agent);
   }
 
   const corporateCa = requireRecord(profile.corporateCa, "corporateCa");

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -59,6 +59,10 @@ const NON_SECRET_KEY_METADATA_NAMES = new Set([
 ]);
 const MESSAGING_CREDENTIAL_PLACEHOLDER_RE =
   /^(?:openshell:resolve:env:|[A-Za-z0-9]+-OPENSHELL-RESOLVE-ENV-)(?:v[0-9]+_)?[A-Z][A-Z0-9_]*$/u;
+const MESSAGING_CREDENTIAL_ENV_ALIASES = [
+  ["MSTEAMS_APP_PASSWORD", "TEAMS_CLIENT_SECRET"],
+  ["WECHAT_BOT_TOKEN", "WEIXIN_TOKEN"],
+] as const;
 const JSON_ARRAY_INDEX_SEGMENT_RE = /^\[(?:0|[1-9][0-9]*)\]$/u;
 const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
   /nvapi-[A-Za-z0-9_-]{10,}/u,
@@ -1046,9 +1050,15 @@ function isMessagingCredentialPlaceholderAssignment(
   if (separator <= 0 || value.indexOf("=", separator + 1) !== -1) return false;
   const envKey = value.slice(0, separator);
   const placeholder = value.slice(separator + 1);
+  const placeholderEnvKey = messagingCredentialPlaceholderEnvKey(placeholder);
   return (
     CREDENTIAL_ENV_NAME_PATTERN.test(envKey) &&
-    MESSAGING_CREDENTIAL_PLACEHOLDER_RE.test(placeholder)
+    placeholderEnvKey !== null &&
+    (envKey === placeholderEnvKey ||
+      MESSAGING_CREDENTIAL_ENV_ALIASES.some(
+        ([sourceEnvKey, targetEnvKey]) =>
+          placeholderEnvKey === sourceEnvKey && envKey === targetEnvKey,
+      ))
   );
 }
 

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -4,6 +4,7 @@
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { TextDecoder } from "node:util";
+import { listMessagingCredentialEnvAssignments } from "../../messaging/channels/metadata";
 import { isValidDcodeUpstreamProvider } from "./dcode-upstream-provider.ts";
 
 /**
@@ -59,10 +60,11 @@ const NON_SECRET_KEY_METADATA_NAMES = new Set([
 ]);
 const MESSAGING_CREDENTIAL_PLACEHOLDER_RE =
   /^(?:openshell:resolve:env:|[A-Za-z0-9]+-OPENSHELL-RESOLVE-ENV-)(?:v[0-9]+_)?[A-Z][A-Z0-9_]*$/u;
-const MESSAGING_CREDENTIAL_ENV_ALIASES = [
-  ["MSTEAMS_APP_PASSWORD", "TEAMS_CLIENT_SECRET"],
-  ["WECHAT_BOT_TOKEN", "WEIXIN_TOKEN"],
-] as const;
+const MESSAGING_CREDENTIAL_ENV_ALIASES = new Set(
+  listMessagingCredentialEnvAssignments()
+    .filter(({ sourceEnvKey, targetEnvKey }) => sourceEnvKey !== targetEnvKey)
+    .map(({ sourceEnvKey, targetEnvKey }) => `${sourceEnvKey}\0${targetEnvKey}`),
+);
 const JSON_ARRAY_INDEX_SEGMENT_RE = /^\[(?:0|[1-9][0-9]*)\]$/u;
 const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
   /nvapi-[A-Za-z0-9_-]{10,}/u,
@@ -1055,10 +1057,7 @@ function isMessagingCredentialPlaceholderAssignment(
     CREDENTIAL_ENV_NAME_PATTERN.test(envKey) &&
     placeholderEnvKey !== null &&
     (envKey === placeholderEnvKey ||
-      MESSAGING_CREDENTIAL_ENV_ALIASES.some(
-        ([sourceEnvKey, targetEnvKey]) =>
-          placeholderEnvKey === sourceEnvKey && envKey === targetEnvKey,
-      ))
+      MESSAGING_CREDENTIAL_ENV_ALIASES.has(`${placeholderEnvKey}\0${envKey}`))
   );
 }
 

--- a/src/lib/onboard/managed-startup/profile.ts
+++ b/src/lib/onboard/managed-startup/profile.ts
@@ -60,17 +60,11 @@ const NON_SECRET_KEY_METADATA_NAMES = new Set([
 ]);
 const MESSAGING_CREDENTIAL_PLACEHOLDER_RE =
   /^(?:openshell:resolve:env:|[A-Za-z0-9]+-OPENSHELL-RESOLVE-ENV-)(?:v[0-9]+_)?[A-Z][A-Z0-9_]*$/u;
-const MESSAGING_CREDENTIAL_ENV_ALIASES = (() => {
-  const aliases = new Map<string, Set<string>>();
-  for (const { agent, sourceEnvKey, targetEnvKey } of listMessagingCredentialEnvAssignments()) {
-    if (sourceEnvKey === targetEnvKey) continue;
-    const key = `${sourceEnvKey}\0${targetEnvKey}`;
-    const agents = aliases.get(key) ?? new Set<string>();
-    agents.add(agent);
-    aliases.set(key, agents);
-  }
-  return aliases;
-})();
+const MESSAGING_CREDENTIAL_ENV_ALIASES = new Set(
+  listMessagingCredentialEnvAssignments()
+    .filter(({ sourceEnvKey, targetEnvKey }) => sourceEnvKey !== targetEnvKey)
+    .map(({ agent, sourceEnvKey, targetEnvKey }) => `${agent}\0${sourceEnvKey}\0${targetEnvKey}`),
+);
 const JSON_ARRAY_INDEX_SEGMENT_RE = /^\[(?:0|[1-9][0-9]*)\]$/u;
 const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
   /nvapi-[A-Za-z0-9_-]{10,}/u,
@@ -1040,6 +1034,7 @@ function containsMessagingCredentialPlaceholder(value: string): boolean {
 }
 
 function isMessagingCredentialPlaceholderAssignment(
+  selectedAgent: unknown,
   path: readonly string[],
   value: string,
 ): boolean {
@@ -1063,35 +1058,11 @@ function isMessagingCredentialPlaceholderAssignment(
     CREDENTIAL_ENV_NAME_PATTERN.test(envKey) &&
     placeholderEnvKey !== null &&
     (envKey === placeholderEnvKey ||
-      MESSAGING_CREDENTIAL_ENV_ALIASES.has(`${placeholderEnvKey}\0${envKey}`))
+      (typeof selectedAgent === "string" &&
+        MESSAGING_CREDENTIAL_ENV_ALIASES.has(
+          `${selectedAgent}\0${placeholderEnvKey}\0${envKey}`,
+        )))
   );
-}
-
-function assertMessagingCredentialAliasAgents(
-  plan: Record<string, unknown>,
-  selectedAgent: ManagedStartupAgent,
-): void {
-  if (!Array.isArray(plan.agentRender)) return;
-  for (const render of plan.agentRender) {
-    if (!isPlainObject(render) || !Array.isArray(render.lines)) continue;
-    for (const line of render.lines) {
-      if (typeof line !== "string") continue;
-      const separator = line.indexOf("=");
-      if (separator <= 0) continue;
-      const targetEnvKey = line.slice(0, separator);
-      const sourceEnvKey = messagingCredentialPlaceholderEnvKey(line.slice(separator + 1));
-      if (sourceEnvKey === null || sourceEnvKey === targetEnvKey) continue;
-      const allowedAgents = MESSAGING_CREDENTIAL_ENV_ALIASES.get(
-        `${sourceEnvKey}\0${targetEnvKey}`,
-      );
-      if (
-        allowedAgents !== undefined &&
-        (render.agent !== selectedAgent || !allowedAgents.has(selectedAgent))
-      ) {
-        invalid("messaging credential environment alias must match the selected render agent");
-      }
-    }
-  }
 }
 
 function isMessagingRuntimeEnvAliasPath(path: readonly string[]): boolean {
@@ -1493,6 +1464,7 @@ function assertPayloadStructureAndCredentialShapes(root: unknown): void {
     path: readonly string[];
   }> = [{ value: root, depth: 0, path: [] }];
   const allowedRuntimeAliasIndexes = new Set<string>();
+  const selectedAgent = isPlainObject(root) ? ownDataPropertyValue(root, "agent") : undefined;
   let discoveredNodes = 1;
   let observedBytes = 0;
 
@@ -1522,7 +1494,11 @@ function assertPayloadStructureAndCredentialShapes(root: unknown): void {
       if (
         !isAllowedMessagingRuntimeAliasStringPath(current.path, allowedRuntimeAliasIndexes) &&
         !isMessagingCredentialPlaceholder(current.path, current.value) &&
-        !isMessagingCredentialPlaceholderAssignment(current.path, current.value) &&
+        !isMessagingCredentialPlaceholderAssignment(
+          selectedAgent,
+          current.path,
+          current.value,
+        ) &&
         (valueLooksLikeSecret(current.value) ||
           containsMessagingCredentialPlaceholder(current.value))
       ) {
@@ -2084,10 +2060,6 @@ export function validateManagedStartupProfile(value: unknown): ManagedStartupPro
   ) {
     invalid("messaging.plan must be a version 1 plan for the selected agent");
   }
-  if (messagingPlan !== null) {
-    assertMessagingCredentialAliasAgents(messagingPlan, agent);
-  }
-
   const corporateCa = requireRecord(profile.corporateCa, "corporateCa");
   rejectUnknownKeys(corporateCa, CORPORATE_CA_KEYS, "corporateCa");
   const bundleSha256 = corporateCa.bundleSha256;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The managed startup profile validator required each messaging environment key to match its credential placeholder key. Hermes renders approved Teams and WeChat credentials through runtime-specific names, so this change derives those canonical assignments from trusted built-in channel manifests while preserving fail-closed validation for raw, malformed, and misplaced credential data.

## Related Issue
Fixes #9355

## Changes
- Accept a credential-shaped environment assignment at `messaging.plan.agentRender[*].lines[*]` when its right-hand side is one canonical OpenShell credential placeholder.
- Derive permitted cross-name credential assignments from built-in manifest env-line render metadata instead of maintaining a second alias registry in the generic validator.
- Bind each derived alias to its manifest render agent and reject cross-agent plan/render reuse through messaging plan ownership validation.
- Keep the manifest metadata path loadable by raw Node ESM consumers through explicit TypeScript specifiers.
- Cover the stock Teams and WeChat assignments through manifest-derived test inputs.
- Continue rejecting raw credentials, malformed or repeated assignments, non-credential environment targets, noncanonical placeholders, unapproved cross-key assignments, the same placeholder data outside the schema-owned path, and invalid package pins.
- Close the detection gap: the earlier regression coverage exercised equal-name credential assignments but did not include agent-specific environment aliases.

## Acceptance Criteria
- [x] The focused managed-startup profile and manifest metadata regressions pass on the PR head.
- [x] The exact scenario that failed in E2E run 32132319706 at `messaging.plan.agentRender[12].lines[1]` passes on the PR head — [exact-head job](https://github.com/NVIDIA/NemoClaw/actions/runs/32168947125/job/95817924125).
- [x] Complete unfiltered trusted E2E was executed on the PR head, with passing exact-head evidence for all affected messaging/startup targets — [run](https://github.com/NVIDIA/NemoClaw/actions/runs/32168947125).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/generate-managed-startup-profile-fixture.test.ts src/lib/messaging/channels/metadata.test.ts src/lib/messaging/plan-validation.test.ts src/lib/onboard/managed-startup-profile.test.ts` (194 passed)
- [x] Applicable broad gate passed — `npm run build:cli`, `npm run lint`, and repository checks passed
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of messaging credential placeholders during startup configuration.
  * Added support for Teams and WeChat credential environment aliases.
  * Enforced valid credential environment names and approved credential placeholders.
  * Correctly handles multiple assignments and rejects placeholders on non-credential or noncanonical keys.
  * Rejects aliases associated with unselected or unauthorized messaging agents.
  * Improved recognition of credential mappings while safely ignoring malformed or unmatched entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
