### PR TITLE
fix(onboard): preserve managed agent identity on reuse

### DIFF
--- a/src/lib/actions/sandbox/stopped-sandbox-backup.test.ts
+++ b/src/lib/actions/sandbox/stopped-sandbox-backup.test.ts
@@ -255,6 +255,25 @@ describe("backupStartedSandboxState", () => {
     expect(sleep).toHaveBeenCalledTimes(2);
   });
 
+  it("allows managed startup to exceed the legacy eight-second readiness window (#9356)", async () => {
+    vi.useFakeTimers();
+    adapterMocks.backupWithAuthority
+      .mockReturnValueOnce(unreachable)
+      .mockReturnValueOnce(unreachable)
+      .mockReturnValueOnce(unreachable)
+      .mockReturnValueOnce(unreachable)
+      .mockReturnValueOnce(unreachable)
+      .mockReturnValueOnce(unreachable)
+      .mockReturnValueOnce(ok);
+
+    const pending = backupStartedSandboxState("my-sb");
+    await vi.runAllTimersAsync();
+
+    await expect(pending).resolves.toEqual(ok);
+    expect(adapterMocks.backupWithAuthority).toHaveBeenCalledTimes(7);
+    vi.useRealTimers();
+  });
+
   it("returns a non-transport failure without retrying", async () => {
     const backup = vi.fn().mockReturnValue(denied);
     const sleep = vi.fn().mockResolvedValue(undefined);

--- a/src/lib/actions/sandbox/stopped-sandbox-backup.ts
+++ b/src/lib/actions/sandbox/stopped-sandbox-backup.ts
@@ -183,6 +183,9 @@ interface BackupRetryDeps {
   delayMs: number;
 }
 
+const STARTED_BACKUP_READY_TIMEOUT_MS = 90_000;
+const STARTED_BACKUP_RETRY_DELAY_MS = 2_000;
+
 const defaultBackupRetryDeps: BackupRetryDeps = {
   backup: (name) =>
     snapshotBackup.backupSandboxStateWithManagedAuthority(
@@ -193,13 +196,16 @@ const defaultBackupRetryDeps: BackupRetryDeps = {
       },
     ),
   sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
-  attempts: 5,
-  delayMs: 2000,
+  // Managed-profile containers run their provider-owned startup before the
+  // OpenShell SSH transport becomes reachable. Keep this inside backup-all's
+  // 180-second command budget while allowing a cold managed restart to finish.
+  attempts: Math.floor(STARTED_BACKUP_READY_TIMEOUT_MS / STARTED_BACKUP_RETRY_DELAY_MS) + 1,
+  delayMs: STARTED_BACKUP_RETRY_DELAY_MS,
 };
 
 /**
  * Back up a sandbox whose container was just started. The container's SSH
- * endpoint can take a few seconds to answer after `docker start`, so retry
+ * endpoint can take up to the managed cold-start window after `docker start`, so retry
  * while — and only while — the result is a transport-level `unreachable`
  * failure. Every other outcome (success, permission failure, precondition)
  * is returned as-is on first sight.

--- a/src/lib/onboard/runtime-provider/snapshot.test.ts
+++ b/src/lib/onboard/runtime-provider/snapshot.test.ts
@@ -567,7 +567,7 @@ function dockerLifecycleCapture(
   containerId = "c".repeat(64),
   overrides: { status?: string; paused?: boolean; restartCount?: number } = {},
 ) {
-  return vi.fn(() => ({
+  return vi.fn((_command: string, _args: string[], _timeout?: number) => ({
     status: 0,
     stdout: JSON.stringify([
       containerId,
@@ -579,6 +579,24 @@ function dockerLifecycleCapture(
     ]),
     stderr: "",
   }));
+}
+
+function dockerRestoreCapture(
+  restoreResult: {
+    status: number;
+    stdout: string;
+    stderr: string;
+    error?: Error;
+  } = {
+    status: 0,
+    stdout: "[managed-startup] verified profile completion\n",
+    stderr: "",
+  },
+) {
+  const lifecycleCapture = dockerLifecycleCapture();
+  return vi.fn((command: string, args: string[], timeout?: number) =>
+    args[0] === "exec" ? restoreResult : lifecycleCapture(command, args, timeout),
+  );
 }
 
 describe("Docker provider snapshot evidence", () => {
@@ -727,21 +745,19 @@ describe("Docker provider snapshot evidence", () => {
   });
 
   it.each(["openclaw", "hermes", "langchain-deepagents-code"] as const)(
-    "runs the in-sandbox %s profile verifier and fails closed on refusal",
+    "runs the exact-container %s profile verifier and fails closed on refusal",
     (agent) => {
       const authority = {
         agent,
         profileFingerprint: managedProfile.profileFingerprint,
       };
-      const captureOpenShell = vi.fn(() => ({
+      const captureHostCommand = dockerRestoreCapture({
         status: 0,
-        output: `[managed-startup] verified ${agent} profile completion\n`,
-        stdout: "",
+        stdout: `[managed-startup] verified ${agent} profile completion\n`,
         stderr: "",
-      }));
+      });
       const dependencies = {
-        captureHostCommand: dockerLifecycleCapture(),
-        captureOpenShell: captureOpenShell as never,
+        captureHostCommand,
         queryRuntimeSnapshot: () => dockerSnapshot(),
       };
       const surface = requireSupportedSurface(
@@ -757,18 +773,19 @@ describe("Docker provider snapshot evidence", () => {
       });
       const receipt = surface.restore(target, preflight, source, authority);
       expect(receipt.managedProfile).toEqual(authority);
-      expect(captureOpenShell).toHaveBeenCalledWith(
+      expect(captureHostCommand).toHaveBeenCalledWith(
+        "docker",
         [
-          "sandbox",
           "exec",
-          "--name",
-          "alpha",
-          "-g",
-          "nemoclaw-18080",
-          "--no-tty",
-          "--timeout",
-          "10",
-          "--",
+          "--user",
+          "root",
+          "c".repeat(64),
+          "/usr/bin/env",
+          "-i",
+          "HOME=/root",
+          "LANG=C.UTF-8",
+          "LC_ALL=C.UTF-8",
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
           "/usr/local/bin/node",
           "/usr/local/lib/nemoclaw/managed-startup-image-runtime.cjs",
           "--verify-completion",
@@ -777,22 +794,17 @@ describe("Docker provider snapshot evidence", () => {
           "--profile-fingerprint",
           authority.profileFingerprint,
         ],
-        expect.objectContaining({
-          ignoreError: true,
-          includeStderr: true,
-          timeout: 15_000,
-        }),
+        15_000,
       );
 
       const denied = requireSupportedSurface(
         createDockerRuntimeProviderSnapshotSurface("docker", {
           ...dependencies,
-          captureOpenShell: (() => ({
+          captureHostCommand: dockerRestoreCapture({
             status: 1,
-            output: "profile mismatch",
             stdout: "",
-            stderr: "",
-          })) as never,
+            stderr: "profile mismatch",
+          }),
         }),
       );
       const deniedPreflight = denied.preflight("restore", target);

--- a/src/lib/onboard/runtime-provider/snapshot.test.ts
+++ b/src/lib/onboard/runtime-provider/snapshot.test.ts
@@ -503,45 +503,46 @@ describe("OpenShell snapshot observation", () => {
     ).toBe(expected);
   });
 
-  it.each(
-    [
-        { status: 1, output: "not found", stdout: "", stderr: "" },
-        {
-          status: 0,
-          signal: "SIGTERM",
-          output: "Id: sandbox-id\nState: Ready\nGeneration: generation-1\n",
-          stdout: "",
-          stderr: "",
-        },
-      ],
-  )("rejects mismatched provider, failed inspection, or missing generation [case %#]", (result) => {
-    const capture = vi.fn();
-    expect(() =>
-      observeOpenShellRuntimeSnapshot(sandbox({ openshellDriver: "docker" }), "mxc", {
-        capture: capture as never,
-      }),
-    ).toThrow(/belongs to another runtime provider/u);
-    expect(capture).not.toHaveBeenCalled();
+  it.each([
+    { status: 1, output: "not found", stdout: "", stderr: "" },
+    {
+      status: 0,
+      signal: "SIGTERM",
+      output: "Id: sandbox-id\nState: Ready\nGeneration: generation-1\n",
+      stdout: "",
+      stderr: "",
+    },
+  ])(
+    "rejects mismatched provider, failed inspection, or missing generation [case %#]",
+    (result) => {
+      const capture = vi.fn();
+      expect(() =>
+        observeOpenShellRuntimeSnapshot(sandbox({ openshellDriver: "docker" }), "mxc", {
+          capture: capture as never,
+        }),
+      ).toThrow(/belongs to another runtime provider/u);
+      expect(capture).not.toHaveBeenCalled();
 
-    expect(() =>
-      observeOpenShellRuntimeSnapshot(sandbox(), "mxc", {
-        capture: (() => result) as never,
-        observeAcceleration: () => ({ kind: "none" }),
-      }),
-    ).toThrow(/runtime identity could not be inspected/u);
+      expect(() =>
+        observeOpenShellRuntimeSnapshot(sandbox(), "mxc", {
+          capture: (() => result) as never,
+          observeAcceleration: () => ({ kind: "none" }),
+        }),
+      ).toThrow(/runtime identity could not be inspected/u);
 
-    expect(() =>
-      observeOpenShellRuntimeSnapshot(sandbox(), "mxc", {
-        capture: (() => ({
-          status: 0,
-          output: "Id: sandbox-id\nState: Ready\n",
-          stdout: "",
-          stderr: "",
-        })) as never,
-        observeAcceleration: () => ({ kind: "none" }),
-      }),
-    ).toThrow(/lifecycle generation cannot be represented/u);
-  });
+      expect(() =>
+        observeOpenShellRuntimeSnapshot(sandbox(), "mxc", {
+          capture: (() => ({
+            status: 0,
+            output: "Id: sandbox-id\nState: Ready\n",
+            stdout: "",
+            stderr: "",
+          })) as never,
+          observeAcceleration: () => ({ kind: "none" }),
+        }),
+      ).toThrow(/lifecycle generation cannot be represented/u);
+    },
+  );
 });
 
 function dockerSnapshot(
@@ -768,6 +769,7 @@ describe("Docker provider snapshot evidence", () => {
           "--timeout",
           "10",
           "--",
+          "/usr/local/bin/node",
           "/usr/local/lib/nemoclaw/managed-startup-image-runtime.cjs",
           "--verify-completion",
           "--agent",

--- a/src/lib/onboard/runtime-provider/snapshot.test.ts
+++ b/src/lib/onboard/runtime-provider/snapshot.test.ts
@@ -798,7 +798,7 @@ describe("Docker provider snapshot evidence", () => {
       const deniedPreflight = denied.preflight("restore", target);
       const deniedSource = snapshotSource(deniedPreflight, source.runtime);
       expect(() => denied.restore(target, deniedPreflight, deniedSource, authority)).toThrow(
-        /managed profile restoration could not be proven/u,
+        /managed profile restoration could not be proven \(status=1; output=profile mismatch\)/u,
       );
     },
   );

--- a/src/lib/onboard/runtime-provider/snapshot.test.ts
+++ b/src/lib/onboard/runtime-provider/snapshot.test.ts
@@ -120,7 +120,11 @@ describe("runtime provider snapshot surface", () => {
       managedProfile,
     );
 
-    expect(restoreManagedProfile).toHaveBeenCalledWith(target, managedProfile);
+    expect(restoreManagedProfile).toHaveBeenCalledWith(
+      target,
+      managedProfile,
+      observation().runtime,
+    );
     expect(receipt).toMatchObject({
       providerId: "mxc",
       sandboxName: "alpha",
@@ -756,9 +760,10 @@ describe("Docker provider snapshot evidence", () => {
         stdout: `[managed-startup] verified ${agent} profile completion\n`,
         stderr: "",
       });
+      const queryRuntimeSnapshot = vi.fn(() => dockerSnapshot());
       const dependencies = {
         captureHostCommand,
-        queryRuntimeSnapshot: () => dockerSnapshot(),
+        queryRuntimeSnapshot,
       };
       const surface = requireSupportedSurface(
         createDockerRuntimeProviderSnapshotSurface("docker", dependencies),
@@ -773,6 +778,7 @@ describe("Docker provider snapshot evidence", () => {
       });
       const receipt = surface.restore(target, preflight, source, authority);
       expect(receipt.managedProfile).toEqual(authority);
+      expect(queryRuntimeSnapshot).toHaveBeenCalledTimes(3);
       expect(captureHostCommand).toHaveBeenCalledWith(
         "docker",
         [
@@ -814,4 +820,30 @@ describe("Docker provider snapshot evidence", () => {
       );
     },
   );
+
+  it("sanitizes verifier failure diagnostics", () => {
+    const denied = requireSupportedSurface(
+      createDockerRuntimeProviderSnapshotSurface("docker", {
+        captureHostCommand: dockerRestoreCapture({
+          status: 1,
+          stdout: "",
+          stderr: "\u001b]0;unsafe\u0007profile \u001b[31mmismatch\u001b[0m\u0000",
+          error: new Error("\u009b31mspawn\u009b0m\u0001 failed"),
+        }),
+        queryRuntimeSnapshot: () => dockerSnapshot(),
+      }),
+    );
+    const target = sandbox({ openshellDriver: "docker" });
+    const preflight = denied.preflight("restore", target);
+    const source = snapshotSource(preflight, {
+      schemaVersion: 1,
+      providerId: "docker",
+      runtime: { kind: "docker-container", handle: "c".repeat(64) },
+      acceleration: { kind: "none" },
+    });
+
+    expect(() => denied.restore(target, preflight, source, managedProfile)).toThrow(
+      /status=1; error=spawn failed; output=profile mismatch\)/u,
+    );
+  });
 });

--- a/src/lib/onboard/runtime-provider/snapshot.ts
+++ b/src/lib/onboard/runtime-provider/snapshot.ts
@@ -36,6 +36,7 @@ const SANDBOX_ID_PATTERN = /^[A-Za-z0-9._-]{1,512}$/u;
 const DOCKER_CONTAINER_ID_PATTERN = /^[a-f0-9]{64}$/u;
 const MANAGED_STARTUP_RUNTIME_EXECUTABLE =
   "/usr/local/lib/nemoclaw/managed-startup-image-runtime.cjs";
+const MANAGED_STARTUP_NODE_EXECUTABLE = "/usr/local/bin/node";
 const LIFECYCLE_GENERATION_PATTERN = /^[A-Za-z0-9._:/=-]{1,512}$/u;
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/gu;
 const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/u;
@@ -111,6 +112,7 @@ function gatewayScopedManagedProfileVerifyArgs(
     "--timeout",
     "10",
     "--",
+    MANAGED_STARTUP_NODE_EXECUTABLE,
     MANAGED_STARTUP_RUNTIME_EXECUTABLE,
     "--verify-completion",
     "--agent",

--- a/src/lib/onboard/runtime-provider/snapshot.ts
+++ b/src/lib/onboard/runtime-provider/snapshot.ts
@@ -36,6 +36,8 @@ const SANDBOX_ID_PATTERN = /^[A-Za-z0-9._-]{1,512}$/u;
 const DOCKER_CONTAINER_ID_PATTERN = /^[a-f0-9]{64}$/u;
 const MANAGED_STARTUP_RUNTIME_EXECUTABLE =
   "/usr/local/lib/nemoclaw/managed-startup-image-runtime.cjs";
+// Dockerfile copies and validates this exact final-image path; the managed
+// startup hold and bootstrap trampoline invoke the same 0444 runtime through it.
 const MANAGED_STARTUP_NODE_EXECUTABLE = "/usr/local/bin/node";
 const LIFECYCLE_GENERATION_PATTERN = /^[A-Za-z0-9._:/=-]{1,512}$/u;
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/gu;
@@ -125,6 +127,27 @@ function gatewayScopedManagedProfileVerifyArgs(
 
 function cleanOutput(value: string): string {
   return value.replace(ANSI_PATTERN, "");
+}
+
+function managedProfileVerificationFailureDetail(
+  result: ReturnType<typeof captureOpenshell>,
+): string {
+  // This command accepts only a validated agent and secret-free profile hash;
+  // bound its fixed-runtime diagnostic so restore failures remain actionable.
+  const output = cleanOutput(result.output || "")
+    .replace(/\s+/gu, " ")
+    .trim();
+  const error = cleanOutput(result.error?.message ?? "")
+    .replace(/\s+/gu, " ")
+    .trim();
+  return [
+    `status=${result.status ?? "unknown"}`,
+    ...(result.signal ? [`signal=${result.signal}`] : []),
+    ...(error ? [`error=${error}`] : []),
+    ...(output ? [`output=${output}`] : []),
+  ]
+    .join("; ")
+    .slice(0, 1024);
 }
 
 function parseSandboxId(output: string): string | null {
@@ -417,7 +440,7 @@ export function verifyOpenShellManagedProfileRestore(
   );
   if (result.status !== 0 || result.error || result.signal) {
     throw new RuntimeProviderSnapshotError(
-      `sandbox '${sandbox.name}' managed profile restoration could not be proven`,
+      `sandbox '${sandbox.name}' managed profile restoration could not be proven (${managedProfileVerificationFailureDetail(result)})`,
     );
   }
   return createHash("sha256")

--- a/src/lib/onboard/runtime-provider/snapshot.ts
+++ b/src/lib/onboard/runtime-provider/snapshot.ts
@@ -82,7 +82,6 @@ export interface DockerRuntimeSnapshotDependencies {
     args: string[],
     timeout?: number,
   ) => RuntimeProviderCommandCapture;
-  readonly captureOpenShell: typeof captureOpenshell;
   readonly queryRuntimeSnapshot: (
     sandboxName: string,
   ) => OpenShellDockerSandboxRuntimeSnapshotQuery;
@@ -102,47 +101,21 @@ function gatewayScopedSandboxGetArgs(sandbox: SandboxEntry): string[] {
     : ["sandbox", "get", sandbox.name];
 }
 
-function gatewayScopedManagedProfileVerifyArgs(
-  sandbox: SandboxEntry,
-  authority: RuntimeProviderManagedProfileRestoreAuthority,
-): string[] {
-  const args = ["sandbox", "exec", "--name", sandbox.name];
-  const gatewayName = resolveSandboxGatewayName(sandbox);
-  if (gatewayName) args.push("-g", gatewayName);
-  args.push(
-    "--no-tty",
-    "--timeout",
-    "10",
-    "--",
-    MANAGED_STARTUP_NODE_EXECUTABLE,
-    MANAGED_STARTUP_RUNTIME_EXECUTABLE,
-    "--verify-completion",
-    "--agent",
-    authority.agent,
-    "--profile-fingerprint",
-    authority.profileFingerprint,
-  );
-  return args;
-}
-
 function cleanOutput(value: string): string {
   return value.replace(ANSI_PATTERN, "");
 }
 
-function managedProfileVerificationFailureDetail(
-  result: ReturnType<typeof captureOpenshell>,
-): string {
+function managedProfileVerificationFailureDetail(result: RuntimeProviderCommandCapture): string {
   // This command accepts only a validated agent and secret-free profile hash;
   // bound its fixed-runtime diagnostic so restore failures remain actionable.
-  const output = cleanOutput(result.output || "")
+  const output = cleanOutput([result.stderr, result.stdout].filter(Boolean).join("\n"))
     .replace(/\s+/gu, " ")
     .trim();
   const error = cleanOutput(result.error?.message ?? "")
     .replace(/\s+/gu, " ")
     .trim();
   return [
-    `status=${result.status ?? "unknown"}`,
-    ...(result.signal ? [`signal=${result.signal}`] : []),
+    `status=${result.status}`,
     ...(error ? [`error=${error}`] : []),
     ...(output ? [`output=${output}`] : []),
   ]
@@ -421,24 +394,52 @@ export function observeDockerRuntimeSnapshot(
   };
 }
 
-export function verifyOpenShellManagedProfileRestore(
+export function verifyDockerManagedProfileRestore(
   sandbox: SandboxEntry,
   authorityValue: RuntimeProviderManagedProfileRestoreAuthority,
-  dependencies: Pick<DockerRuntimeSnapshotDependencies, "captureOpenShell">,
+  dependencies: Pick<
+    DockerRuntimeSnapshotDependencies,
+    "captureHostCommand" | "queryRuntimeSnapshot"
+  >,
 ): string {
   const authority = normalizeRuntimeProviderManagedProfileRestoreAuthority(authorityValue);
   if (!authority) {
     throw new RuntimeProviderSnapshotError("managed profile restore authority is invalid");
   }
-  const result = dependencies.captureOpenShell(
-    gatewayScopedManagedProfileVerifyArgs(sandbox, authority),
-    {
-      ignoreError: true,
-      includeStderr: true,
-      timeout: 15_000,
-    },
+  const snapshot = dependencies.queryRuntimeSnapshot(sandbox.name);
+  if (!snapshot.ok || !DOCKER_CONTAINER_ID_PATTERN.test(snapshot.containerId)) {
+    throw new RuntimeProviderSnapshotError(
+      `sandbox '${sandbox.name}' exact Docker runtime identity could not be inspected`,
+    );
+  }
+  // The completion handoff is deliberately root-owned under /run/nemoclaw and
+  // therefore outside an ordinary Landlock-confined sandbox exec. The Docker
+  // provider pins this fixed verifier to the exact live container ID, runs no
+  // user-supplied command, and clears the inherited host environment.
+  const result = dependencies.captureHostCommand(
+    "docker",
+    [
+      "exec",
+      "--user",
+      "root",
+      snapshot.containerId,
+      "/usr/bin/env",
+      "-i",
+      "HOME=/root",
+      "LANG=C.UTF-8",
+      "LC_ALL=C.UTF-8",
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      MANAGED_STARTUP_NODE_EXECUTABLE,
+      MANAGED_STARTUP_RUNTIME_EXECUTABLE,
+      "--verify-completion",
+      "--agent",
+      authority.agent,
+      "--profile-fingerprint",
+      authority.profileFingerprint,
+    ],
+    15_000,
   );
-  if (result.status !== 0 || result.error || result.signal) {
+  if (result.status !== 0 || result.error) {
     throw new RuntimeProviderSnapshotError(
       `sandbox '${sandbox.name}' managed profile restoration could not be proven (${managedProfileVerificationFailureDetail(result)})`,
     );
@@ -450,7 +451,7 @@ export function verifyOpenShellManagedProfileRestore(
     .update("\0", "utf8")
     .update(authority.profileFingerprint, "utf8")
     .update("\0", "utf8")
-    .update(cleanOutput(result.output || ""), "utf8")
+    .update(cleanOutput(result.stdout), "utf8")
     .digest("hex");
 }
 
@@ -692,13 +693,12 @@ export function createDockerRuntimeProviderSnapshotSurface(
 ): RuntimeProviderSnapshotSurface {
   const resolved = {
     captureHostCommand: dependencies.captureHostCommand,
-    captureOpenShell: dependencies.captureOpenShell ?? captureOpenshell,
     queryRuntimeSnapshot:
       dependencies.queryRuntimeSnapshot ?? queryOpenShellDockerSandboxRuntimeSnapshot,
   };
   return createRuntimeProviderSnapshotSurface(providerId, {
     observe: (sandbox, id) => observeDockerRuntimeSnapshot(sandbox, id, resolved),
     restoreManagedProfile: (sandbox, authority) =>
-      verifyOpenShellManagedProfileRestore(sandbox, authority, resolved),
+      verifyDockerManagedProfileRestore(sandbox, authority, resolved),
   });
 }

--- a/src/lib/onboard/runtime-provider/snapshot.ts
+++ b/src/lib/onboard/runtime-provider/snapshot.ts
@@ -42,6 +42,9 @@ const MANAGED_STARTUP_NODE_EXECUTABLE = "/usr/local/bin/node";
 const LIFECYCLE_GENERATION_PATTERN = /^[A-Za-z0-9._:/=-]{1,512}$/u;
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/gu;
 const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/u;
+const CONTROL_CHARACTERS_GLOBAL = /[\u0000-\u001f\u007f-\u009f]/gu;
+const TERMINAL_CONTROL_SEQUENCE =
+  /(?:\u001b\[[0-?]*[ -/]*[@-~]|\u009b[0-?]*[ -/]*[@-~]|(?:\u001b\]|\u009d)(?:[^\u0007\u001b\u009c]|\u001b(?!\\))*(?:\u0007|\u001b\\|\u009c)|\u001b[ -/]*[@-~])/gu;
 
 export interface RuntimeProviderSnapshotObservation {
   readonly lifecycleState: RuntimeProviderSnapshotLifecycleState;
@@ -57,6 +60,7 @@ export type RuntimeProviderSnapshotObserver = (
 export type RuntimeProviderManagedProfileRestorer = (
   sandbox: SandboxEntry,
   authority: RuntimeProviderManagedProfileRestoreAuthority,
+  runtime: RuntimeProviderRuntimeReceipt,
 ) => string;
 
 export interface RuntimeProviderSnapshotDriver {
@@ -105,13 +109,17 @@ function cleanOutput(value: string): string {
   return value.replace(ANSI_PATTERN, "");
 }
 
+function cleanDiagnostic(value: string): string {
+  return value.replace(TERMINAL_CONTROL_SEQUENCE, "").replace(CONTROL_CHARACTERS_GLOBAL, "");
+}
+
 function managedProfileVerificationFailureDetail(result: RuntimeProviderCommandCapture): string {
   // This command accepts only a validated agent and secret-free profile hash;
   // bound its fixed-runtime diagnostic so restore failures remain actionable.
-  const output = cleanOutput([result.stderr, result.stdout].filter(Boolean).join("\n"))
+  const output = cleanDiagnostic([result.stderr, result.stdout].filter(Boolean).join("\n"))
     .replace(/\s+/gu, " ")
     .trim();
-  const error = cleanOutput(result.error?.message ?? "")
+  const error = cleanDiagnostic(result.error?.message ?? "")
     .replace(/\s+/gu, " ")
     .trim();
   return [
@@ -397,17 +405,19 @@ export function observeDockerRuntimeSnapshot(
 export function verifyDockerManagedProfileRestore(
   sandbox: SandboxEntry,
   authorityValue: RuntimeProviderManagedProfileRestoreAuthority,
-  dependencies: Pick<
-    DockerRuntimeSnapshotDependencies,
-    "captureHostCommand" | "queryRuntimeSnapshot"
-  >,
+  runtimeValue: RuntimeProviderRuntimeReceipt,
+  dependencies: Pick<DockerRuntimeSnapshotDependencies, "captureHostCommand">,
 ): string {
   const authority = normalizeRuntimeProviderManagedProfileRestoreAuthority(authorityValue);
   if (!authority) {
     throw new RuntimeProviderSnapshotError("managed profile restore authority is invalid");
   }
-  const snapshot = dependencies.queryRuntimeSnapshot(sandbox.name);
-  if (!snapshot.ok || !DOCKER_CONTAINER_ID_PATTERN.test(snapshot.containerId)) {
+  const runtime = normalizeRuntimeProviderRuntimeReceipt(runtimeValue);
+  if (
+    !runtime ||
+    runtime.runtime.kind !== "docker-container" ||
+    !DOCKER_CONTAINER_ID_PATTERN.test(runtime.runtime.handle)
+  ) {
     throw new RuntimeProviderSnapshotError(
       `sandbox '${sandbox.name}' exact Docker runtime identity could not be inspected`,
     );
@@ -422,7 +432,7 @@ export function verifyDockerManagedProfileRestore(
       "exec",
       "--user",
       "root",
-      snapshot.containerId,
+      runtime.runtime.handle,
       "/usr/bin/env",
       "-i",
       "HOME=/root",
@@ -567,6 +577,7 @@ function validateRestoreRequest(
   readonly expected: RuntimeProviderSnapshotPreflightReceipt;
   readonly source: RuntimeProviderSnapshotRestoreSource;
   readonly managedProfile: RuntimeProviderManagedProfileRestoreAuthority;
+  readonly observed: RuntimeProviderSnapshotObservation;
 } {
   const expected = requireStablePreflight(preflightValue, providerId, "restore", sandbox);
   const source = normalizeRuntimeProviderSnapshotRestoreSource(sourceValue);
@@ -605,7 +616,7 @@ function validateRestoreRequest(
       `sandbox '${sandbox.name}' cannot represent the snapshot acceleration state`,
     );
   }
-  return { expected, source, managedProfile };
+  return { expected, source, managedProfile, observed };
 }
 
 export function createRuntimeProviderSnapshotSurface(
@@ -644,7 +655,7 @@ export function createRuntimeProviderSnapshotSurface(
       validateRestoreRequest(providerId, driver, sandbox, preflight, source, managedProfile);
     },
     restore(sandbox, preflight, sourceValue, managedProfileValue) {
-      const { expected, source, managedProfile } = validateRestoreRequest(
+      const { expected, source, managedProfile, observed } = validateRestoreRequest(
         providerId,
         driver,
         sandbox,
@@ -652,7 +663,7 @@ export function createRuntimeProviderSnapshotSurface(
         sourceValue,
         managedProfileValue,
       );
-      const providerProof = driver.restoreManagedProfile(sandbox, managedProfile);
+      const providerProof = driver.restoreManagedProfile(sandbox, managedProfile, observed.runtime);
       if (
         typeof providerProof !== "string" ||
         providerProof.trim() === "" ||
@@ -698,7 +709,7 @@ export function createDockerRuntimeProviderSnapshotSurface(
   };
   return createRuntimeProviderSnapshotSurface(providerId, {
     observe: (sandbox, id) => observeDockerRuntimeSnapshot(sandbox, id, resolved),
-    restoreManagedProfile: (sandbox, authority) =>
-      verifyDockerManagedProfileRestore(sandbox, authority, resolved),
+    restoreManagedProfile: (sandbox, authority, runtime) =>
+      verifyDockerManagedProfileRestore(sandbox, authority, runtime, resolved),
   });
 }

--- a/src/lib/onboard/sandbox-registry-metadata.test.ts
+++ b/src/lib/onboard/sandbox-registry-metadata.test.ts
@@ -138,9 +138,10 @@ describe("sandbox registry metadata", () => {
       runCaptureOpenshell: () => "openshell 0.0.44",
     });
 
+    // A different derived identity proves the recorded null is explicit rather than absent.
     helpers.updateReusedSandboxMetadata(
       "alpha",
-      openclawAgent("2026.5.22"),
+      { name: "hermes", expectedVersion: "1.0.0" } as AgentDefinition,
       "new-model",
       "nvidia-prod",
       18789,

--- a/src/lib/onboard/sandbox-registry-metadata.test.ts
+++ b/src/lib/onboard/sandbox-registry-metadata.test.ts
@@ -206,6 +206,41 @@ describe("sandbox registry metadata", () => {
     expect(entry && authority.readManagedWorkloadAuthority(entry)?.agent).toBe("openclaw");
   });
 
+  it("records the derived agent when a reused legacy entry omits agent (#9356)", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "nemoclaw-reuse-missing-agent-"));
+    process.env.HOME = tmpDir;
+    vi.resetModules();
+
+    const configDir = join(tmpDir, ".nemoclaw");
+    const registryFile = join(configDir, "sandboxes.json");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      registryFile,
+      JSON.stringify({
+        sandboxes: {
+          alpha: {
+            name: "alpha",
+            model: "old-model",
+            provider: "old-provider",
+          },
+        },
+        defaultSandbox: "alpha",
+      }),
+    );
+
+    const helpers = await makeHelpers("docker");
+    helpers.updateReusedSandboxMetadata(
+      "alpha",
+      { name: "hermes", expectedVersion: "1.0.0" } as AgentDefinition,
+      "new-model",
+      "nvidia-prod",
+      18789,
+    );
+
+    const persisted = JSON.parse(readFileSync(registryFile, "utf8"));
+    expect(persisted.sandboxes.alpha.agent).toBe("hermes");
+  });
+
   it("persists a reused terminal sandbox without a dashboard port for host allocation (#7020)", async () => {
     tmpDir = mkdtempSync(join(tmpdir(), "nemoclaw-reuse-terminal-metadata-"));
     process.env.HOME = tmpDir;

--- a/src/lib/onboard/sandbox-registry-metadata.test.ts
+++ b/src/lib/onboard/sandbox-registry-metadata.test.ts
@@ -1,11 +1,20 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { managedStartupE2eProfile } from "../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
 import type { AgentDefinition } from "../agent/defs";
+import type { SandboxWorkloadReceipt } from "../state/registry/types";
+import {
+  MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
+  MANAGED_IMAGE_REPOSITORIES,
+  MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
+} from "./managed-image/contract";
+import { encodeManagedStartupProfile } from "./managed-startup/profile";
 import type { SandboxGpuConfig } from "./sandbox-gpu-mode";
 
 /**
@@ -33,6 +42,28 @@ function openclawAgent(expectedVersion: string): AgentDefinition {
   } as AgentDefinition;
 }
 
+function managedOpenclawWorkload(): Extract<
+  SandboxWorkloadReceipt,
+  { readonly kind: "managed-image" }
+> {
+  const encodedProfile = encodeManagedStartupProfile(managedStartupE2eProfile("openclaw"));
+  return {
+    schemaVersion: 1,
+    kind: "managed-image",
+    reference: `${MANAGED_IMAGE_REPOSITORIES.openclaw}@sha256:${"a".repeat(64)}`,
+    platform: "linux/amd64",
+    release: "v0.0.100",
+    sourceRevision: "d".repeat(40),
+    sourceCohort: "ghrun-9356-1",
+    capabilityContractVersion: MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
+    startupProfileContractVersion: MANAGED_IMAGE_STARTUP_PROFILE_CONTRACT_VERSION,
+    encodedProfile,
+    startupProfileSha256: createHash("sha256").update(encodedProfile, "utf8").digest("hex"),
+    credentialProxyReplayRequired: false,
+    shared: true,
+  };
+}
+
 const GPU_OFF: SandboxGpuConfig = {
   hostGpuDetected: false,
   hostGpuPlatform: null,
@@ -53,7 +84,7 @@ describe("sandbox registry metadata", () => {
     vi.resetModules();
   });
 
-  it("preserves the recorded agent version when reusing an existing sandbox", async () => {
+  it("preserves legacy OpenClaw identity and version when reusing a sandbox (#9356)", async () => {
     tmpDir = mkdtempSync(join(tmpdir(), "nemoclaw-reuse-metadata-"));
     process.env.HOME = tmpDir;
     vi.resetModules();
@@ -71,7 +102,14 @@ describe("sandbox registry metadata", () => {
             name: "alpha",
             model: "old-model",
             provider: "old-provider",
+            agent: null,
             agentVersion: "2026.5.18",
+            workload: {
+              schemaVersion: 1,
+              kind: "legacy-dockerfile",
+              reference: "custom-openclaw:latest",
+              shared: false,
+            },
           },
         },
         defaultSandbox: "alpha",
@@ -84,7 +122,14 @@ describe("sandbox registry metadata", () => {
       name: "alpha",
       model: "old-model",
       provider: "old-provider",
+      agent: null,
       agentVersion: "2026.5.18",
+      workload: {
+        schemaVersion: 1,
+        kind: "legacy-dockerfile",
+        reference: "custom-openclaw:latest",
+        shared: false,
+      },
     });
 
     const helpers = metadata.createSandboxRegistryMetadataHelpers({
@@ -105,9 +150,59 @@ describe("sandbox registry metadata", () => {
       expect.objectContaining({
         model: "new-model",
         provider: "nvidia-prod",
+        agent: null,
         agentVersion: "2026.5.18",
       }),
     );
+  });
+
+  it("preserves explicit managed OpenClaw authority when reusing a sandbox (#9356)", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "nemoclaw-reuse-managed-openclaw-"));
+    process.env.HOME = tmpDir;
+    vi.resetModules();
+
+    const configDir = join(tmpDir, ".nemoclaw");
+    const registryFile = join(configDir, "sandboxes.json");
+    const workload = managedOpenclawWorkload();
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      registryFile,
+      JSON.stringify({
+        sandboxes: {
+          alpha: {
+            name: "alpha",
+            model: "old-model",
+            provider: "old-provider",
+            agent: "openclaw",
+            agentVersion: "2026.5.18",
+            imageTag: workload.reference,
+            workload,
+          },
+        },
+        defaultSandbox: "alpha",
+      }),
+    );
+
+    const metadata = await import("./sandbox-registry-metadata");
+    const registry = await import("../state/registry");
+    const authority = await import("./workload/authority");
+    const helpers = metadata.createSandboxRegistryMetadataHelpers({
+      getOpenShellComputeDriverName: () => "docker",
+      getInstalledOpenshellVersion: () => "0.0.44",
+      runCaptureOpenshell: () => "openshell 0.0.44",
+    });
+
+    helpers.updateReusedSandboxMetadata(
+      "alpha",
+      openclawAgent("2026.5.22"),
+      "new-model",
+      "nvidia-prod",
+      18789,
+    );
+
+    const entry = registry.getSandbox("alpha");
+    expect(entry?.agent).toBe("openclaw");
+    expect(entry && authority.readManagedWorkloadAuthority(entry)?.agent).toBe("openclaw");
   });
 
   it("persists a reused terminal sandbox without a dashboard port for host allocation (#7020)", async () => {
@@ -188,16 +283,16 @@ describe("getSandboxRuntimeRegistryFields openshellDriver", () => {
     expect(fields.openshellDriver).toBe("kubernetes");
   });
 
-  it.each([
-    "podman",
-    "mxc",
-  ])("passes the resolved %s driver through to registry metadata (#7744)", async (driverName) => {
-    const helpers = await makeHelpers(driverName);
+  it.each(["podman", "mxc"])(
+    "passes the resolved %s driver through to registry metadata (#7744)",
+    async (driverName) => {
+      const helpers = await makeHelpers(driverName);
 
-    const fields = helpers.getSandboxRuntimeRegistryFields(GPU_OFF);
+      const fields = helpers.getSandboxRuntimeRegistryFields(GPU_OFF);
 
-    expect(fields.openshellDriver).toBe(driverName);
-  });
+      expect(fields.openshellDriver).toBe(driverName);
+    },
+  );
 
   it("resolves driver identity when metadata is recorded rather than at module load (#7744)", async () => {
     const metadata = await import("./sandbox-registry-metadata");

--- a/src/lib/onboard/sandbox-registry-metadata.ts
+++ b/src/lib/onboard/sandbox-registry-metadata.ts
@@ -98,7 +98,7 @@ export function createSandboxRegistryMetadataHelpers(
     registry.updateSandbox(sandboxName, {
       ...selectionUpdates,
       dashboardPort,
-      agent: agentFields.agent,
+      agent: existingEntry?.agent ?? agentFields.agent,
       agentVersion: existingEntry?.agentVersion ?? null,
       ...(sandboxGpuConfig ? getSandboxRuntimeRegistryFields(sandboxGpuConfig) : {}),
     });

--- a/src/lib/onboard/sandbox-registry-metadata.ts
+++ b/src/lib/onboard/sandbox-registry-metadata.ts
@@ -98,7 +98,7 @@ export function createSandboxRegistryMetadataHelpers(
     registry.updateSandbox(sandboxName, {
       ...selectionUpdates,
       dashboardPort,
-      agent: existingEntry?.agent ?? agentFields.agent,
+      agent: existingEntry?.agent !== undefined ? existingEntry.agent : agentFields.agent,
       agentVersion: existingEntry?.agentVersion ?? null,
       ...(sandboxGpuConfig ? getSandboxRuntimeRegistryFields(sandboxGpuConfig) : {}),
     });

--- a/test/e2e/live/snapshot-commands-helpers.ts
+++ b/test/e2e/live/snapshot-commands-helpers.ts
@@ -20,6 +20,7 @@ export type SnapshotGatewayProbeClassification =
 export type SnapshotRestoreResultClassification =
   | "restored"
   | "restored-pairing-unverified"
+  | "managed-clone-rebind-required"
   | "command-failure"
   | "missing-restored-marker";
 
@@ -71,8 +72,35 @@ export function classifySnapshotRestoreResult(result: {
   ) {
     return "restored-pairing-unverified";
   }
+  if (
+    result.exitCode !== null &&
+    result.exitCode !== 0 &&
+    /requires managed-profile clone rebind/i.test(output) &&
+    /Destination '.+' was not changed/i.test(output)
+  ) {
+    return "managed-clone-rebind-required";
+  }
   if (result.exitCode !== 0) return "command-failure";
   return /\bRestored\b/.test(output) ? "restored" : "missing-restored-marker";
+}
+
+export async function verifySnapshotCloneResult(
+  classification: SnapshotRestoreResultClassification,
+  branches: {
+    readonly managedCloneDormancy: () => Promise<void>;
+    readonly restoredLegacyClone: () => Promise<void>;
+  },
+): Promise<void> {
+  switch (classification) {
+    case "managed-clone-rebind-required":
+      await branches.managedCloneDormancy();
+      return;
+    case "restored":
+      await branches.restoredLegacyClone();
+      return;
+    default:
+      throw new Error(`Unexpected snapshot clone result classification: ${classification}`);
+  }
 }
 
 /**

--- a/test/e2e/live/snapshot-commands-helpers.ts
+++ b/test/e2e/live/snapshot-commands-helpers.ts
@@ -84,25 +84,6 @@ export function classifySnapshotRestoreResult(result: {
   return /\bRestored\b/.test(output) ? "restored" : "missing-restored-marker";
 }
 
-export async function verifySnapshotCloneResult(
-  classification: SnapshotRestoreResultClassification,
-  branches: {
-    readonly managedCloneDormancy: () => Promise<void>;
-    readonly restoredLegacyClone: () => Promise<void>;
-  },
-): Promise<void> {
-  switch (classification) {
-    case "managed-clone-rebind-required":
-      await branches.managedCloneDormancy();
-      return;
-    case "restored":
-      await branches.restoredLegacyClone();
-      return;
-    default:
-      throw new Error(`Unexpected snapshot clone result classification: ${classification}`);
-  }
-}
-
 /**
  * Builds the child env for the snapshot-commands live target.
  *

--- a/test/e2e/live/snapshot-commands.test.ts
+++ b/test/e2e/live/snapshot-commands.test.ts
@@ -29,6 +29,7 @@ import {
   classifySnapshotGatewayProbe,
   classifySnapshotRestoreResult,
   type SnapshotInferenceFixture,
+  verifySnapshotCloneResult,
 } from "./snapshot-commands-helpers.ts";
 import { scanSnapshotCredentialLeaks } from "./snapshot-credential-scanner.ts";
 
@@ -314,855 +315,903 @@ function snapshotManifestDirectories(): string[] {
     .sort();
 }
 
-test("snapshot commands preserve create/list/latest restore/targeted restore/no-leak lifecycle", {
-  timeout: LIVE_TIMEOUT_MS,
-  meta: {
-    e2ePhases: [
-      "confirm Docker and start hermetic inference",
-      "onboard the snapshot sandbox",
-      "create and list the first snapshot",
-      "destroy, freshly onboard, and restore canonical OpenClaw workspace files",
-      "restore the first snapshot into a clone",
-      "verify the restored clone state and gateway pairing",
-      "create a second snapshot from changed workspace",
-      "restore latest and timestamped snapshots",
-      "audit snapshot credentials and command help",
-      "back up a stopped sandbox and restore its snapshot",
-      "back up protected credentials and restore Shields",
-      "record snapshot lifecycle evidence",
-    ],
+test(
+  "snapshot commands preserve create/list/latest restore/targeted restore/no-leak lifecycle",
+  {
+    timeout: LIVE_TIMEOUT_MS,
+    meta: {
+      e2ePhases: [
+        "confirm Docker and start hermetic inference",
+        "onboard the snapshot sandbox",
+        "create and list the first snapshot",
+        "destroy, freshly onboard, and restore canonical OpenClaw workspace files",
+        "restore the first snapshot into a clone",
+        "verify the restored clone state and gateway pairing",
+        "create a second snapshot from changed workspace",
+        "restore latest and timestamped snapshots",
+        "audit snapshot credentials and command help",
+        "back up a stopped sandbox and restore its snapshot",
+        "back up protected credentials and restore Shields",
+        "record snapshot lifecycle evidence",
+      ],
+    },
   },
-}, async ({ artifacts, cleanup, host, progress, sandbox, skip }) => {
-  await artifacts.target.declare({
-    id: "snapshot-commands",
-    boundary: "install.sh + nemoclaw snapshot commands + openshell sandbox exec",
-    sandboxName: SANDBOX_NAME,
-    backupDir: BACKUP_DIR,
-    contracts: [
-      "install.sh onboards a live OpenClaw sandbox",
-      "onboard authenticates to a hermetic compatible inference endpoint",
-      "snapshot create reports Snapshot v<N> created",
-      "snapshot list shows versioned snapshots and parseable timestamps",
-      "snapshot restore recovers canonical OpenClaw USER.md and SOUL.md after destroy and fresh same-name onboarding",
-      "baseline exclusions remain active in registry and live policy across rebuild",
-      "snapshot restore --to carries baseline exclusions into clone registry and live policy",
-      "snapshot restore --to returns only after restored gateway pairing is authenticated",
-      "post-restore clone verification sends one clone-fixture request, stores its unique session only in the clone, and sends no source-sandbox negative-control request",
-      "latest snapshot restore recovers latest workspace state",
-      "snapshot restore recovers state from workspace-* prefix directories",
-      "timestamp-targeted restore recovers the first snapshot state",
-      "snapshot directory excludes credential-bearing env/json files",
-      "snapshot help advertises create/list/restore",
-      "strict backup-all starts a stopped Docker sandbox, creates a snapshot, and returns it to exited state",
-      "backup-all stores a sanitized copy of root-owned credentials, restores Shields UP, and does not store the API key",
-    ],
-  });
+  async ({ artifacts, cleanup, host, progress, sandbox, skip }) => {
+    await artifacts.target.declare({
+      id: "snapshot-commands",
+      boundary: "install.sh + nemoclaw snapshot commands + openshell sandbox exec",
+      sandboxName: SANDBOX_NAME,
+      backupDir: BACKUP_DIR,
+      contracts: [
+        "install.sh onboards a live OpenClaw sandbox",
+        "onboard authenticates to a hermetic compatible inference endpoint",
+        "snapshot create reports Snapshot v<N> created",
+        "snapshot list shows versioned snapshots and parseable timestamps",
+        "snapshot restore recovers canonical OpenClaw USER.md and SOUL.md after destroy and fresh same-name onboarding",
+        "baseline exclusions remain active in registry and live policy across rebuild",
+        "legacy snapshot restore --to carries baseline exclusions into clone registry and live policy; managed snapshots refuse before destination effects until clone rebind is activated",
+        "legacy snapshot restore --to returns only after restored gateway pairing is authenticated",
+        "post-restore legacy clone verification sends one clone-fixture request, stores its unique session only in the clone, and sends no source-sandbox negative-control request",
+        "latest snapshot restore recovers latest workspace state",
+        "snapshot restore recovers state from workspace-* prefix directories",
+        "timestamp-targeted restore recovers the first snapshot state",
+        "snapshot directory excludes credential-bearing env/json files",
+        "snapshot help advertises create/list/restore",
+        "strict backup-all starts a stopped Docker sandbox, creates a snapshot, and returns it to exited state",
+        "backup-all stores a sanitized copy of root-owned credentials, restores Shields UP, and does not store the API key",
+      ],
+    });
 
-  const dockerInfo = await host.command("docker", ["info"], {
-    artifactName: "phase-0-docker-info",
-    env: buildAvailabilityProbeEnv(),
-    timeoutMs: 30_000,
-  });
-  if (dockerInfo.exitCode !== 0) {
-    if (process.env.GITHUB_ACTIONS === "true") {
-      throw new Error(`Docker is required for snapshot commands E2E: ${resultText(dockerInfo)}`);
-    }
-    skip(`Docker is required for snapshot commands E2E: ${resultText(dockerInfo)}`);
-  }
-
-  const inference = await startFakeOpenAiCompatibleServer({
-    apiKey: INFERENCE_API_KEY,
-    host: "0.0.0.0",
-    model: INFERENCE_MODEL,
-    progress,
-    publicHost: "host.openshell.internal",
-    requireAuth: true,
-    requireAuthModels: true,
-  });
-  cleanup.trackDisposable("close snapshot commands compatible inference fixture", async () => {
-    await artifacts.writeJson("compatible-inference-requests.json", inference.requests());
-    await inference.close();
-  });
-  const inferenceConfig = {
-    apiKey: INFERENCE_API_KEY,
-    endpointUrl: inference.baseUrl,
-    model: INFERENCE_MODEL,
-  };
-
-  cleanup.trackGateway(host, "nemoclaw", {
-    artifactName: "cleanup-openshell-gateway-destroy",
-    env: commandEnv(),
-    timeoutMs: 60_000,
-  });
-  cleanup.trackDisposable(`delete OpenShell sandbox ${SANDBOX_NAME}`, () =>
-    sandbox.cleanupSandbox(SANDBOX_NAME, {
-      artifactName: "cleanup-openshell-sandbox-delete",
-      env: commandEnv(),
-      timeoutMs: 60_000,
-    }),
-  );
-  cleanup.trackSandbox(host, SANDBOX_NAME, {
-    artifactName: "cleanup-nemoclaw-destroy",
-    env: commandEnv(),
-    timeoutMs: 120_000,
-  });
-  cleanup.trackDisposable(`delete OpenShell sandbox ${CLONE_SANDBOX_NAME}`, () =>
-    sandbox.cleanupSandbox(CLONE_SANDBOX_NAME, {
-      artifactName: "cleanup-clone-openshell-sandbox-delete",
-      env: commandEnv(),
-      timeoutMs: 60_000,
-    }),
-  );
-  cleanup.trackSandbox(host, CLONE_SANDBOX_NAME, {
-    artifactName: "cleanup-clone-nemoclaw-destroy",
-    env: commandEnv(),
-    timeoutMs: 120_000,
-  });
-
-  await precleanSnapshotSandbox(host, sandbox, CLONE_SANDBOX_NAME, "pre-cleanup-clone");
-  await precleanSnapshotSandbox(host, sandbox, SANDBOX_NAME, "pre-cleanup");
-  await precleanSnapshotGateway(sandbox, "pre-cleanup");
-  fs.rmSync(BACKUP_DIR, { recursive: true, force: true });
-
-  progress.phase("onboard the snapshot sandbox");
-  const install = await host.command("bash", ["install.sh", "--non-interactive", "--fresh"], {
-    artifactName: "phase-1-install-nemoclaw",
-    cwd: REPO_ROOT,
-    env: commandEnv(inferenceConfig),
-    redactionValues: [INFERENCE_API_KEY],
-    timeoutMs: 20 * 60_000,
-  });
-  expect(install.exitCode, resultText(install)).toBe(0);
-
-  const authenticatedInference = await sandbox.execShell(
-    SANDBOX_NAME,
-    trustedSandboxShellScript(
-      `curl -fsS --max-time 60 https://inference.local/v1/chat/completions -H 'Content-Type: application/json' --data '${JSON.stringify(
-        {
-          model: INFERENCE_MODEL,
-          messages: [{ role: "user", content: "reply with OK" }],
-          max_tokens: 8,
-        },
-      )}'`,
-    ),
-    {
-      artifactName: "phase-1-authenticated-inference-post",
-      env: commandEnv(),
-      timeoutMs: 90_000,
-    },
-  );
-  expect(
-    authenticatedInference.exitCode,
-    `${authenticatedInference.stdout}\n${authenticatedInference.stderr}`,
-  ).toBe(0);
-  expect(inference.requests()).toContainEqual(
-    expect.objectContaining({
-      auth: "ok",
-      model: INFERENCE_MODEL,
-      path: "/v1/chat/completions",
-    }),
-  );
-
-  const cliProbe = await host.command(
-    "bash",
-    ["-lc", "command -v nemoclaw && command -v openshell"],
-    {
-      artifactName: "phase-1-cli-probe",
-      env: commandEnv(),
+    const dockerInfo = await host.command("docker", ["info"], {
+      artifactName: "phase-0-docker-info",
+      env: buildAvailabilityProbeEnv(),
       timeoutMs: 30_000,
-    },
-  );
-  expect(cliProbe.exitCode, resultText(cliProbe)).toBe(0);
-  expect(cliProbe.stdout).toContain("nemoclaw");
-  expect(cliProbe.stdout).toContain("openshell");
+    });
+    if (dockerInfo.exitCode !== 0) {
+      if (process.env.GITHUB_ACTIONS === "true") {
+        throw new Error(`Docker is required for snapshot commands E2E: ${resultText(dockerInfo)}`);
+      }
+      skip(`Docker is required for snapshot commands E2E: ${resultText(dockerInfo)}`);
+    }
 
-  const excludeBaseline = await host.command(
-    "nemoclaw",
-    [SANDBOX_NAME, "policy", "exclude", BASELINE_EXCLUSION_KEY, "--force"],
-    {
-      artifactName: "phase-2-policy-exclude-baseline",
+    const inference = await startFakeOpenAiCompatibleServer({
+      apiKey: INFERENCE_API_KEY,
+      host: "0.0.0.0",
+      model: INFERENCE_MODEL,
+      progress,
+      publicHost: "host.openshell.internal",
+      requireAuth: true,
+      requireAuthModels: true,
+    });
+    cleanup.trackDisposable("close snapshot commands compatible inference fixture", async () => {
+      await artifacts.writeJson("compatible-inference-requests.json", inference.requests());
+      await inference.close();
+    });
+    const inferenceConfig = {
+      apiKey: INFERENCE_API_KEY,
+      endpointUrl: inference.baseUrl,
+      model: INFERENCE_MODEL,
+    };
+
+    cleanup.trackGateway(host, "nemoclaw", {
+      artifactName: "cleanup-openshell-gateway-destroy",
       env: commandEnv(),
       timeoutMs: 60_000,
-    },
-  );
-  expect(excludeBaseline.exitCode, resultText(excludeBaseline)).toBe(0);
-  await expectBaselineExclusionAgreement(host, sandbox, SANDBOX_NAME, "phase-2-after-exclude");
+    });
+    cleanup.trackDisposable(`delete OpenShell sandbox ${SANDBOX_NAME}`, () =>
+      sandbox.cleanupSandbox(SANDBOX_NAME, {
+        artifactName: "cleanup-openshell-sandbox-delete",
+        env: commandEnv(),
+        timeoutMs: 60_000,
+      }),
+    );
+    cleanup.trackSandbox(host, SANDBOX_NAME, {
+      artifactName: "cleanup-nemoclaw-destroy",
+      env: commandEnv(),
+      timeoutMs: 120_000,
+    });
+    cleanup.trackDisposable(`delete OpenShell sandbox ${CLONE_SANDBOX_NAME}`, () =>
+      sandbox.cleanupSandbox(CLONE_SANDBOX_NAME, {
+        artifactName: "cleanup-clone-openshell-sandbox-delete",
+        env: commandEnv(),
+        timeoutMs: 60_000,
+      }),
+    );
+    cleanup.trackSandbox(host, CLONE_SANDBOX_NAME, {
+      artifactName: "cleanup-clone-nemoclaw-destroy",
+      env: commandEnv(),
+      timeoutMs: 120_000,
+    });
 
-  const rebuild = await host.command("nemoclaw", [SANDBOX_NAME, "rebuild", "--yes"], {
-    artifactName: "phase-2-rebuild-with-baseline-exclusion",
-    env: commandEnv(),
-    timeoutMs: 15 * 60_000,
-  });
-  expect(rebuild.exitCode, resultText(rebuild)).toBe(0);
-  await expectBaselineExclusionAgreement(host, sandbox, SANDBOX_NAME, "phase-2-after-rebuild");
+    await precleanSnapshotSandbox(host, sandbox, CLONE_SANDBOX_NAME, "pre-cleanup-clone");
+    await precleanSnapshotSandbox(host, sandbox, SANDBOX_NAME, "pre-cleanup");
+    await precleanSnapshotGateway(sandbox, "pre-cleanup");
+    fs.rmSync(BACKUP_DIR, { recursive: true, force: true });
 
-  const markerContent = `SNAPSHOT_E2E_${Date.now()}`;
-  const secondContent = `SNAPSHOT_E2E_SECOND_${Date.now()}`;
-  const userContent = `SNAPSHOT_E2E_USER_${Date.now()}`;
-  const soulContent = `SNAPSHOT_E2E_SOUL_${Date.now()}`;
+    progress.phase("onboard the snapshot sandbox");
+    const install = await host.command("bash", ["install.sh", "--non-interactive", "--fresh"], {
+      artifactName: "phase-1-install-nemoclaw",
+      cwd: REPO_ROOT,
+      env: commandEnv(inferenceConfig),
+      redactionValues: [INFERENCE_API_KEY],
+      timeoutMs: 20 * 60_000,
+    });
+    expect(install.exitCode, resultText(install)).toBe(0);
 
-  const writeMarker = await sandbox.exec(
-    SANDBOX_NAME,
-    [
-      "sh",
-      "-lc",
-      `set -eu
+    const authenticatedInference = await sandbox.execShell(
+      SANDBOX_NAME,
+      trustedSandboxShellScript(
+        `curl -fsS --max-time 60 https://inference.local/v1/chat/completions -H 'Content-Type: application/json' --data '${JSON.stringify(
+          {
+            model: INFERENCE_MODEL,
+            messages: [{ role: "user", content: "reply with OK" }],
+            max_tokens: 8,
+          },
+        )}'`,
+      ),
+      {
+        artifactName: "phase-1-authenticated-inference-post",
+        env: commandEnv(),
+        timeoutMs: 90_000,
+      },
+    );
+    expect(
+      authenticatedInference.exitCode,
+      `${authenticatedInference.stdout}\n${authenticatedInference.stderr}`,
+    ).toBe(0);
+    expect(inference.requests()).toContainEqual(
+      expect.objectContaining({
+        auth: "ok",
+        model: INFERENCE_MODEL,
+        path: "/v1/chat/completions",
+      }),
+    );
+
+    const cliProbe = await host.command(
+      "bash",
+      ["-lc", "command -v nemoclaw && command -v openshell"],
+      {
+        artifactName: "phase-1-cli-probe",
+        env: commandEnv(),
+        timeoutMs: 30_000,
+      },
+    );
+    expect(cliProbe.exitCode, resultText(cliProbe)).toBe(0);
+    expect(cliProbe.stdout).toContain("nemoclaw");
+    expect(cliProbe.stdout).toContain("openshell");
+
+    const excludeBaseline = await host.command(
+      "nemoclaw",
+      [SANDBOX_NAME, "policy", "exclude", BASELINE_EXCLUSION_KEY, "--force"],
+      {
+        artifactName: "phase-2-policy-exclude-baseline",
+        env: commandEnv(),
+        timeoutMs: 60_000,
+      },
+    );
+    expect(excludeBaseline.exitCode, resultText(excludeBaseline)).toBe(0);
+    await expectBaselineExclusionAgreement(host, sandbox, SANDBOX_NAME, "phase-2-after-exclude");
+
+    const rebuild = await host.command("nemoclaw", [SANDBOX_NAME, "rebuild", "--yes"], {
+      artifactName: "phase-2-rebuild-with-baseline-exclusion",
+      env: commandEnv(),
+      timeoutMs: 15 * 60_000,
+    });
+    expect(rebuild.exitCode, resultText(rebuild)).toBe(0);
+    await expectBaselineExclusionAgreement(host, sandbox, SANDBOX_NAME, "phase-2-after-rebuild");
+
+    const markerContent = `SNAPSHOT_E2E_${Date.now()}`;
+    const secondContent = `SNAPSHOT_E2E_SECOND_${Date.now()}`;
+    const userContent = `SNAPSHOT_E2E_USER_${Date.now()}`;
+    const soulContent = `SNAPSHOT_E2E_SOUL_${Date.now()}`;
+
+    const writeMarker = await sandbox.exec(
+      SANDBOX_NAME,
+      [
+        "sh",
+        "-lc",
+        `set -eu
 test "$OPENCLAW_WORKSPACE_DIR" = ${JSON.stringify(OPENCLAW_WORKSPACE_PATH)}
 mkdir -p "$OPENCLAW_WORKSPACE_DIR" /sandbox/.openclaw/workspace-research
 printf '%s' ${JSON.stringify(markerContent)} > ${JSON.stringify(MARKER_FILE)}
 printf '%s' ${JSON.stringify(markerContent)} > ${JSON.stringify(PREFIX_MARKER)}
 printf '%s' ${JSON.stringify(userContent)} > "$OPENCLAW_WORKSPACE_DIR/USER.md"
 printf '%s' ${JSON.stringify(soulContent)} > "$OPENCLAW_WORKSPACE_DIR/SOUL.md"`,
-    ],
-    {
-      artifactName: "phase-2-write-marker",
+      ],
+      {
+        artifactName: "phase-2-write-marker",
+        env: commandEnv(),
+        timeoutMs: 60_000,
+      },
+    );
+    expect(writeMarker.exitCode, resultText(writeMarker)).toBe(0);
+    await expectSandboxFileContent(
+      sandbox,
+      SANDBOX_NAME,
+      MARKER_FILE,
+      markerContent,
+      "phase-2-read-marker",
+    );
+    await expectSandboxFileContent(
+      sandbox,
+      SANDBOX_NAME,
+      USER_FILE,
+      userContent,
+      "phase-2-read-user-file",
+    );
+    await expectSandboxFileContent(
+      sandbox,
+      SANDBOX_NAME,
+      SOUL_FILE,
+      soulContent,
+      "phase-2-read-soul-file",
+    );
+
+    progress.phase("create and list the first snapshot");
+    const firstCreate = await host.command("nemoclaw", [SANDBOX_NAME, "snapshot", "create"], {
+      artifactName: "phase-3-snapshot-create-first",
+      env: commandEnv(),
+      timeoutMs: 120_000,
+    });
+    expect(firstCreate.exitCode, resultText(firstCreate)).toBe(0);
+    expect(resultText(firstCreate)).toMatch(/Snapshot v\d+.*created/);
+    expect(resultText(firstCreate)).toContain("rebuild-backups");
+
+    const list = await host.command("nemoclaw", [SANDBOX_NAME, "snapshot", "list"], {
+      artifactName: "phase-4-snapshot-list",
       env: commandEnv(),
       timeoutMs: 60_000,
-    },
-  );
-  expect(writeMarker.exitCode, resultText(writeMarker)).toBe(0);
-  await expectSandboxFileContent(
-    sandbox,
-    SANDBOX_NAME,
-    MARKER_FILE,
-    markerContent,
-    "phase-2-read-marker",
-  );
-  await expectSandboxFileContent(
-    sandbox,
-    SANDBOX_NAME,
-    USER_FILE,
-    userContent,
-    "phase-2-read-user-file",
-  );
-  await expectSandboxFileContent(
-    sandbox,
-    SANDBOX_NAME,
-    SOUL_FILE,
-    soulContent,
-    "phase-2-read-soul-file",
-  );
+    });
+    expect(list.exitCode, resultText(list)).toBe(0);
+    expect(resultText(list)).toContain("snapshot(s)");
+    const timestamp = firstSnapshotTimestamp(resultText(list));
+    await artifacts.writeJson("phase-4-first-snapshot.json", { timestamp });
 
-  progress.phase("create and list the first snapshot");
-  const firstCreate = await host.command("nemoclaw", [SANDBOX_NAME, "snapshot", "create"], {
-    artifactName: "phase-3-snapshot-create-first",
-    env: commandEnv(),
-    timeoutMs: 120_000,
-  });
-  expect(firstCreate.exitCode, resultText(firstCreate)).toBe(0);
-  expect(resultText(firstCreate)).toMatch(/Snapshot v\d+.*created/);
-  expect(resultText(firstCreate)).toContain("rebuild-backups");
-
-  const list = await host.command("nemoclaw", [SANDBOX_NAME, "snapshot", "list"], {
-    artifactName: "phase-4-snapshot-list",
-    env: commandEnv(),
-    timeoutMs: 60_000,
-  });
-  expect(list.exitCode, resultText(list)).toBe(0);
-  expect(resultText(list)).toContain("snapshot(s)");
-  const timestamp = firstSnapshotTimestamp(resultText(list));
-  await artifacts.writeJson("phase-4-first-snapshot.json", { timestamp });
-
-  progress.phase("destroy, freshly onboard, and restore canonical OpenClaw workspace files");
-  const destroySource = await host.command("nemoclaw", [SANDBOX_NAME, "destroy", "--yes"], {
-    artifactName: "phase-4-destroy-source",
-    env: commandEnv(),
-    timeoutMs: 120_000,
-  });
-  expect(destroySource.exitCode, resultText(destroySource)).toBe(0);
-
-  const freshOnboard = await host.command(
-    "nemoclaw",
-    ["onboard", "--fresh", "--non-interactive", "--yes", "--yes-i-accept-third-party-software"],
-    {
-      artifactName: "phase-4-fresh-onboard-source",
-      env: commandEnv(inferenceConfig),
-      redactionValues: [INFERENCE_API_KEY],
-      timeoutMs: 20 * 60_000,
-    },
-  );
-  expect(freshOnboard.exitCode, resultText(freshOnboard)).toBe(0);
-
-  const reapplyBaselineExclusion = await host.command(
-    "nemoclaw",
-    [SANDBOX_NAME, "policy", "exclude", BASELINE_EXCLUSION_KEY, "--force"],
-    {
-      artifactName: "phase-4-reapply-baseline-exclusion",
+    progress.phase("destroy, freshly onboard, and restore canonical OpenClaw workspace files");
+    const destroySource = await host.command("nemoclaw", [SANDBOX_NAME, "destroy", "--yes"], {
+      artifactName: "phase-4-destroy-source",
       env: commandEnv(),
-      timeoutMs: 60_000,
-    },
-  );
-  expect(reapplyBaselineExclusion.exitCode, resultText(reapplyBaselineExclusion)).toBe(0);
-  await expectBaselineExclusionAgreement(
-    host,
-    sandbox,
-    SANDBOX_NAME,
-    "phase-4-after-reapplying-baseline-exclusion",
-  );
+      timeoutMs: 120_000,
+    });
+    expect(destroySource.exitCode, resultText(destroySource)).toBe(0);
 
-  const replacementHasNoSnapshotMarkers = await sandbox.exec(
-    SANDBOX_NAME,
-    [
-      "sh",
-      "-lc",
-      `set -eu
+    const freshOnboard = await host.command(
+      "nemoclaw",
+      ["onboard", "--fresh", "--non-interactive", "--yes", "--yes-i-accept-third-party-software"],
+      {
+        artifactName: "phase-4-fresh-onboard-source",
+        env: commandEnv(inferenceConfig),
+        redactionValues: [INFERENCE_API_KEY],
+        timeoutMs: 20 * 60_000,
+      },
+    );
+    expect(freshOnboard.exitCode, resultText(freshOnboard)).toBe(0);
+
+    const reapplyBaselineExclusion = await host.command(
+      "nemoclaw",
+      [SANDBOX_NAME, "policy", "exclude", BASELINE_EXCLUSION_KEY, "--force"],
+      {
+        artifactName: "phase-4-reapply-baseline-exclusion",
+        env: commandEnv(),
+        timeoutMs: 60_000,
+      },
+    );
+    expect(reapplyBaselineExclusion.exitCode, resultText(reapplyBaselineExclusion)).toBe(0);
+    await expectBaselineExclusionAgreement(
+      host,
+      sandbox,
+      SANDBOX_NAME,
+      "phase-4-after-reapplying-baseline-exclusion",
+    );
+
+    const replacementHasNoSnapshotMarkers = await sandbox.exec(
+      SANDBOX_NAME,
+      [
+        "sh",
+        "-lc",
+        `set -eu
 ! grep -F ${JSON.stringify(userContent)} ${JSON.stringify(USER_FILE)}
 ! grep -F ${JSON.stringify(soulContent)} ${JSON.stringify(SOUL_FILE)}
 test ! -e ${JSON.stringify(MARKER_FILE)}`,
-    ],
-    {
-      artifactName: "phase-4-verify-fresh-workspace",
-      env: commandEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  expect(
-    replacementHasNoSnapshotMarkers.exitCode,
-    resultText(replacementHasNoSnapshotMarkers),
-  ).toBe(0);
-
-  const replacementRestore = await host.command(
-    "nemoclaw",
-    [SANDBOX_NAME, "snapshot", "restore", timestamp],
-    {
-      artifactName: "phase-4-restore-source-after-fresh-onboard",
-      env: commandEnv(),
-      timeoutMs: 120_000,
-    },
-  );
-  expect(classifySnapshotRestoreResult(replacementRestore)).toBe("restored");
-  await expectSandboxFileContent(
-    sandbox,
-    SANDBOX_NAME,
-    MARKER_FILE,
-    markerContent,
-    "phase-4-read-restored-source-marker",
-  );
-  await expectSandboxFileContent(
-    sandbox,
-    SANDBOX_NAME,
-    USER_FILE,
-    userContent,
-    "phase-4-read-restored-user-file",
-  );
-  await expectSandboxFileContent(
-    sandbox,
-    SANDBOX_NAME,
-    SOUL_FILE,
-    soulContent,
-    "phase-4-read-restored-soul-file",
-  );
-  await expectBaselineExclusionAgreement(
-    host,
-    sandbox,
-    SANDBOX_NAME,
-    "phase-4-restored-source-baseline-exclusion",
-  );
-
-  progress.phase("restore the first snapshot into a clone");
-  const cloneRestore = await host.command(
-    "nemoclaw",
-    [SANDBOX_NAME, "snapshot", "restore", timestamp, "--to", CLONE_SANDBOX_NAME, "--yes"],
-    {
-      artifactName: "phase-4-snapshot-restore-to-clone",
-      env: commandEnv(),
-      timeoutMs: 5 * 60_000,
-    },
-  );
-  const cloneRestoreResult = classifySnapshotRestoreResult(cloneRestore);
-  progress.phase("verify the restored clone state and gateway pairing");
-  expect(cloneRestoreResult).toBe("restored");
-  await expectSandboxFileContent(
-    sandbox,
-    CLONE_SANDBOX_NAME,
-    MARKER_FILE,
-    markerContent,
-    "phase-4-read-clone-marker",
-  );
-  await expectBaselineExclusionAgreement(
-    host,
-    sandbox,
-    CLONE_SANDBOX_NAME,
-    "phase-4-clone-baseline-exclusion",
-  );
-  try {
-    const installSourcePairingNegativeControl = await sandbox.exec(
-      SANDBOX_NAME,
-      ["sh", "-lc", `set -eu; umask 077; : > ${JSON.stringify(SOURCE_PAIRING_NEGATIVE_CONTROL)}`],
+      ],
       {
-        artifactName: "phase-4-install-source-pairing-negative-control",
+        artifactName: "phase-4-verify-fresh-workspace",
         env: commandEnv(),
         timeoutMs: 30_000,
       },
     );
     expect(
-      installSourcePairingNegativeControl.exitCode,
-      "source-pairing-negative-control-setup-failed",
+      replacementHasNoSnapshotMarkers.exitCode,
+      resultText(replacementHasNoSnapshotMarkers),
     ).toBe(0);
-    const clonePairingRequestOffset = inference.requests().length;
-    const pairingSessionId = await expectAuthenticatedGatewayPairing(
-      sandbox,
-      CLONE_SANDBOX_NAME,
-      inferenceConfig,
-      "phase-4-verify-clone-gateway-pairing",
-    );
-    const pairingRequestDelta = inference.requests().slice(clonePairingRequestOffset);
-    const clonePairingRequests = pairingRequestDelta.filter(
-      (request) => request.path === "/v1/chat/completions" && request.model === INFERENCE_MODEL,
-    );
-    const sourcePairingNegativeControlRequests = pairingRequestDelta.filter(
-      (request) =>
-        request.path === "/v1/chat/completions" &&
-        request.model === SOURCE_PAIRING_NEGATIVE_CONTROL_MODEL,
-    );
-    await expectSandboxSessionPresence(
-      sandbox,
-      CLONE_SANDBOX_NAME,
-      pairingSessionId,
-      true,
-      "phase-4-verify-clone-session-owner",
-    );
-    await expectSandboxSessionPresence(
-      sandbox,
-      SANDBOX_NAME,
-      pairingSessionId,
-      false,
-      "phase-4-verify-source-session-non-owner",
-    );
-    await artifacts.writeJson("phase-4-pairing-inference-request-deltas.json", {
-      cloneAuthenticatedCount: clonePairingRequests.filter((request) => request.auth === "ok")
-        .length,
-      cloneSessionOwned: true,
-      sourceNegativeControlCount: sourcePairingNegativeControlRequests.length,
-      sourceSessionOwned: false,
-    });
-    expect(clonePairingRequests.length, "clone-pairing-inference-request-count").toBe(1);
-    expect(
-      clonePairingRequests[0]?.auth === "ok" &&
-        clonePairingRequests[0]?.model === INFERENCE_MODEL &&
-        clonePairingRequests[0]?.path === "/v1/chat/completions",
-      "clone-pairing-inference-request-classification",
-    ).toBe(true);
-    expect(
-      sourcePairingNegativeControlRequests.length,
-      "source-pairing-negative-control-request-count",
-    ).toBe(0);
-  } finally {
-    const removeSourcePairingNegativeControl = await sandbox.exec(
-      SANDBOX_NAME,
-      ["rm", "-f", SOURCE_PAIRING_NEGATIVE_CONTROL],
+
+    const replacementRestore = await host.command(
+      "nemoclaw",
+      [SANDBOX_NAME, "snapshot", "restore", timestamp],
       {
-        artifactName: "phase-4-remove-source-pairing-negative-control",
+        artifactName: "phase-4-restore-source-after-fresh-onboard",
+        env: commandEnv(),
+        timeoutMs: 120_000,
+      },
+    );
+    expect(classifySnapshotRestoreResult(replacementRestore)).toBe("restored");
+    await expectSandboxFileContent(
+      sandbox,
+      SANDBOX_NAME,
+      MARKER_FILE,
+      markerContent,
+      "phase-4-read-restored-source-marker",
+    );
+    await expectSandboxFileContent(
+      sandbox,
+      SANDBOX_NAME,
+      USER_FILE,
+      userContent,
+      "phase-4-read-restored-user-file",
+    );
+    await expectSandboxFileContent(
+      sandbox,
+      SANDBOX_NAME,
+      SOUL_FILE,
+      soulContent,
+      "phase-4-read-restored-soul-file",
+    );
+    await expectBaselineExclusionAgreement(
+      host,
+      sandbox,
+      SANDBOX_NAME,
+      "phase-4-restored-source-baseline-exclusion",
+    );
+
+    progress.phase("restore the first snapshot into a clone");
+    const cloneRestore = await host.command(
+      "nemoclaw",
+      [SANDBOX_NAME, "snapshot", "restore", timestamp, "--to", CLONE_SANDBOX_NAME, "--yes"],
+      {
+        artifactName: "phase-4-snapshot-restore-to-clone",
+        env: commandEnv(),
+        timeoutMs: 5 * 60_000,
+      },
+    );
+    const cloneRestoreResult = classifySnapshotRestoreResult(cloneRestore);
+    progress.phase("verify the restored clone state and gateway pairing");
+    await verifySnapshotCloneResult(cloneRestoreResult, {
+      managedCloneDormancy: async () => {
+        expect(resultText(cloneRestore)).toContain(
+          `restoring '${SANDBOX_NAME}' as '${CLONE_SANDBOX_NAME}' requires managed-profile clone rebind`,
+        );
+        expect(resultText(cloneRestore)).toContain(
+          `Destination '${CLONE_SANDBOX_NAME}' was not changed`,
+        );
+        const absentManagedClone = await host.command(
+          "openshell",
+          ["sandbox", "get", "-g", "nemoclaw", CLONE_SANDBOX_NAME],
+          {
+            artifactName: "phase-4-managed-clone-remains-absent",
+            env: commandEnv(),
+            timeoutMs: 30_000,
+          },
+        );
+        expect(absentManagedClone.exitCode, "managed-clone-dormancy-destination-exists").not.toBe(
+          0,
+        );
+        await artifacts.writeJson("phase-4-managed-clone-dormancy.json", {
+          classification: cloneRestoreResult,
+          destinationAbsent: true,
+        });
+      },
+      restoredLegacyClone: async () => {
+        await expectSandboxFileContent(
+          sandbox,
+          CLONE_SANDBOX_NAME,
+          MARKER_FILE,
+          markerContent,
+          "phase-4-read-clone-marker",
+        );
+        await expectBaselineExclusionAgreement(
+          host,
+          sandbox,
+          CLONE_SANDBOX_NAME,
+          "phase-4-clone-baseline-exclusion",
+        );
+        try {
+          const installSourcePairingNegativeControl = await sandbox.exec(
+            SANDBOX_NAME,
+            [
+              "sh",
+              "-lc",
+              `set -eu; umask 077; : > ${JSON.stringify(SOURCE_PAIRING_NEGATIVE_CONTROL)}`,
+            ],
+            {
+              artifactName: "phase-4-install-source-pairing-negative-control",
+              env: commandEnv(),
+              timeoutMs: 30_000,
+            },
+          );
+          expect(
+            installSourcePairingNegativeControl.exitCode,
+            "source-pairing-negative-control-setup-failed",
+          ).toBe(0);
+          const clonePairingRequestOffset = inference.requests().length;
+          const pairingSessionId = await expectAuthenticatedGatewayPairing(
+            sandbox,
+            CLONE_SANDBOX_NAME,
+            inferenceConfig,
+            "phase-4-verify-clone-gateway-pairing",
+          );
+          const pairingRequestDelta = inference.requests().slice(clonePairingRequestOffset);
+          const clonePairingRequests = pairingRequestDelta.filter(
+            (request) =>
+              request.path === "/v1/chat/completions" && request.model === INFERENCE_MODEL,
+          );
+          const sourcePairingNegativeControlRequests = pairingRequestDelta.filter(
+            (request) =>
+              request.path === "/v1/chat/completions" &&
+              request.model === SOURCE_PAIRING_NEGATIVE_CONTROL_MODEL,
+          );
+          await expectSandboxSessionPresence(
+            sandbox,
+            CLONE_SANDBOX_NAME,
+            pairingSessionId,
+            true,
+            "phase-4-verify-clone-session-owner",
+          );
+          await expectSandboxSessionPresence(
+            sandbox,
+            SANDBOX_NAME,
+            pairingSessionId,
+            false,
+            "phase-4-verify-source-session-non-owner",
+          );
+          await artifacts.writeJson("phase-4-pairing-inference-request-deltas.json", {
+            cloneAuthenticatedCount: clonePairingRequests.filter((request) => request.auth === "ok")
+              .length,
+            cloneSessionOwned: true,
+            sourceNegativeControlCount: sourcePairingNegativeControlRequests.length,
+            sourceSessionOwned: false,
+          });
+          expect(clonePairingRequests.length, "clone-pairing-inference-request-count").toBe(1);
+          expect(
+            clonePairingRequests[0]?.auth === "ok" &&
+              clonePairingRequests[0]?.model === INFERENCE_MODEL &&
+              clonePairingRequests[0]?.path === "/v1/chat/completions",
+            "clone-pairing-inference-request-classification",
+          ).toBe(true);
+          expect(
+            sourcePairingNegativeControlRequests.length,
+            "source-pairing-negative-control-request-count",
+          ).toBe(0);
+        } finally {
+          const removeSourcePairingNegativeControl = await sandbox.exec(
+            SANDBOX_NAME,
+            ["rm", "-f", SOURCE_PAIRING_NEGATIVE_CONTROL],
+            {
+              artifactName: "phase-4-remove-source-pairing-negative-control",
+              env: commandEnv(),
+              timeoutMs: 30_000,
+            },
+          );
+          expect(
+            removeSourcePairingNegativeControl.exitCode,
+            "source-pairing-negative-control-cleanup-failed",
+          ).toBe(0);
+        }
+        const destroyClone = await host.command(
+          "nemoclaw",
+          [CLONE_SANDBOX_NAME, "destroy", "--yes"],
+          {
+            artifactName: "phase-4-destroy-clone",
+            env: commandEnv(),
+            timeoutMs: 120_000,
+          },
+        );
+        expect(destroyClone.exitCode, resultText(destroyClone)).toBe(0);
+      },
+    });
+
+    progress.phase("create a second snapshot from changed workspace");
+    const modify = await sandbox.exec(
+      SANDBOX_NAME,
+      ["sh", "-lc", `rm -f ${MARKER_FILE} && printf '%s' '${secondContent}' > ${SECOND_MARKER}`],
+      {
+        artifactName: "phase-5-modify-workspace",
+        env: commandEnv(),
+        timeoutMs: 60_000,
+      },
+    );
+    expect(modify.exitCode, resultText(modify)).toBe(0);
+
+    const firstGone = await sandbox.exec(SANDBOX_NAME, ["sh", "-lc", `test ! -e ${MARKER_FILE}`], {
+      artifactName: "phase-5-first-marker-gone",
+      env: commandEnv(),
+      timeoutMs: 30_000,
+    });
+    expect(firstGone.exitCode, resultText(firstGone)).toBe(0);
+
+    const secondCreate = await host.command("nemoclaw", [SANDBOX_NAME, "snapshot", "create"], {
+      artifactName: "phase-5-snapshot-create-second",
+      env: commandEnv(),
+      timeoutMs: 120_000,
+    });
+    expect(secondCreate.exitCode, resultText(secondCreate)).toBe(0);
+    expect(resultText(secondCreate)).toMatch(/Snapshot v\d+.*created/);
+
+    const perturb = await sandbox.exec(
+      SANDBOX_NAME,
+      [
+        "sh",
+        "-lc",
+        `rm -f ${SECOND_MARKER} ${PREFIX_MARKER} && printf '%s' 'BROKEN' > ${MARKER_FILE}`,
+      ],
+      {
+        artifactName: "phase-5-perturb-workspace",
+        env: commandEnv(),
+        timeoutMs: 60_000,
+      },
+    );
+    expect(perturb.exitCode, resultText(perturb)).toBe(0);
+
+    progress.phase("restore latest and timestamped snapshots");
+    const latestRestore = await host.command("nemoclaw", [SANDBOX_NAME, "snapshot", "restore"], {
+      artifactName: "phase-6-snapshot-restore-latest",
+      env: commandEnv(),
+      timeoutMs: 120_000,
+    });
+    expect(classifySnapshotRestoreResult(latestRestore)).toBe("restored");
+    await expectSandboxFileContent(
+      sandbox,
+      SANDBOX_NAME,
+      SECOND_MARKER,
+      secondContent,
+      "phase-6-read-second-marker-after-latest-restore",
+    );
+    await expectSandboxFileContent(
+      sandbox,
+      SANDBOX_NAME,
+      PREFIX_MARKER,
+      markerContent,
+      "phase-6-read-prefix-marker-after-latest-restore",
+    );
+    const firstGoneAfterLatest = await sandbox.exec(
+      SANDBOX_NAME,
+      ["sh", "-lc", `test ! -e ${MARKER_FILE}`],
+      {
+        artifactName: "phase-6-first-marker-absent-after-latest-restore",
         env: commandEnv(),
         timeoutMs: 30_000,
       },
     );
-    expect(
-      removeSourcePairingNegativeControl.exitCode,
-      "source-pairing-negative-control-cleanup-failed",
-    ).toBe(0);
-  }
-  const destroyClone = await host.command("nemoclaw", [CLONE_SANDBOX_NAME, "destroy", "--yes"], {
-    artifactName: "phase-4-destroy-clone",
-    env: commandEnv(),
-    timeoutMs: 120_000,
-  });
-  expect(destroyClone.exitCode, resultText(destroyClone)).toBe(0);
+    expect(firstGoneAfterLatest.exitCode, resultText(firstGoneAfterLatest)).toBe(0);
 
-  progress.phase("create a second snapshot from changed workspace");
-  const modify = await sandbox.exec(
-    SANDBOX_NAME,
-    ["sh", "-lc", `rm -f ${MARKER_FILE} && printf '%s' '${secondContent}' > ${SECOND_MARKER}`],
-    {
-      artifactName: "phase-5-modify-workspace",
+    const targetedRestore = await host.command(
+      "nemoclaw",
+      [SANDBOX_NAME, "snapshot", "restore", timestamp],
+      {
+        artifactName: "phase-7-snapshot-restore-first-timestamp",
+        env: commandEnv(),
+        timeoutMs: 120_000,
+      },
+    );
+    expect(classifySnapshotRestoreResult(targetedRestore)).toBe("restored");
+    await expectSandboxFileContent(
+      sandbox,
+      SANDBOX_NAME,
+      MARKER_FILE,
+      markerContent,
+      "phase-7-read-first-marker-after-targeted-restore",
+    );
+    const secondGone = await sandbox.exec(
+      SANDBOX_NAME,
+      ["sh", "-lc", `test ! -e ${SECOND_MARKER}`],
+      {
+        artifactName: "phase-7-second-marker-absent-after-targeted-restore",
+        env: commandEnv(),
+        timeoutMs: 30_000,
+      },
+    );
+    expect(secondGone.exitCode, resultText(secondGone)).toBe(0);
+
+    progress.phase("audit snapshot credentials and command help");
+    const credentialLeaks = scanSnapshotCredentialLeaks(BACKUP_DIR);
+    await artifacts.writeJson("phase-8-credential-scan.json", {
+      backupDir: BACKUP_DIR,
+      leakedFiles: credentialLeaks,
+    });
+    expect(credentialLeaks).toEqual([]);
+
+    const help = await host.command("nemoclaw", [SANDBOX_NAME, "snapshot"], {
+      artifactName: "phase-9-snapshot-help",
+      env: commandEnv(),
+      timeoutMs: 30_000,
+    });
+    expect(help.exitCode, resultText(help)).toBe(0);
+    expect(resultText(help)).toContain("snapshot create");
+    expect(resultText(help)).toContain("snapshot list");
+    expect(resultText(help)).toContain("snapshot restore");
+
+    progress.phase("back up a stopped sandbox and restore its snapshot");
+    const snapshotsBeforeStoppedBackup = snapshotManifestDirectories();
+    const stoppedContainerId = await onlySandboxContainerId(
+      host,
+      SANDBOX_NAME,
+      "phase-10-stopped-backup-container-lookup",
+    );
+
+    const stop = await host.command("docker", ["stop", stoppedContainerId], {
+      artifactName: "phase-10-stop-sandbox-container",
       env: commandEnv(),
       timeoutMs: 60_000,
-    },
-  );
-  expect(modify.exitCode, resultText(modify)).toBe(0);
+    });
+    expect(stop.exitCode, resultText(stop)).toBe(0);
 
-  const firstGone = await sandbox.exec(SANDBOX_NAME, ["sh", "-lc", `test ! -e ${MARKER_FILE}`], {
-    artifactName: "phase-5-first-marker-gone",
-    env: commandEnv(),
-    timeoutMs: 30_000,
-  });
-  expect(firstGone.exitCode, resultText(firstGone)).toBe(0);
+    const strictBackup = await host.command("nemoclaw", ["backup-all"], {
+      artifactName: "phase-10-strict-backup-all-stopped",
+      env: { ...commandEnv(), NEMOCLAW_REQUIRE_ALL_SANDBOX_BACKUPS: "1" },
+      timeoutMs: 180_000,
+    });
+    expect(strictBackup.exitCode, resultText(strictBackup)).toBe(0);
+    expect(resultText(strictBackup)).toContain(`Starting stopped sandbox '${SANDBOX_NAME}'`);
+    expect(resultText(strictBackup)).toContain(`Returned '${SANDBOX_NAME}' to its stopped state`);
+    expect(resultText(strictBackup)).toContain("1 backed up, 0 failed, 0 skipped");
 
-  const secondCreate = await host.command("nemoclaw", [SANDBOX_NAME, "snapshot", "create"], {
-    artifactName: "phase-5-snapshot-create-second",
-    env: commandEnv(),
-    timeoutMs: 120_000,
-  });
-  expect(secondCreate.exitCode, resultText(secondCreate)).toBe(0);
-  expect(resultText(secondCreate)).toMatch(/Snapshot v\d+.*created/);
+    const finalContainerState = await host.command(
+      "docker",
+      ["inspect", "--format", "{{.State.Status}}", stoppedContainerId],
+      {
+        artifactName: "phase-10-final-container-state",
+        env: commandEnv(),
+        timeoutMs: 30_000,
+      },
+    );
+    expect(finalContainerState.exitCode, resultText(finalContainerState)).toBe(0);
+    expect(finalContainerState.stdout.trim()).toBe("exited");
 
-  const perturb = await sandbox.exec(
-    SANDBOX_NAME,
-    [
-      "sh",
-      "-lc",
-      `rm -f ${SECOND_MARKER} ${PREFIX_MARKER} && printf '%s' 'BROKEN' > ${MARKER_FILE}`,
-    ],
-    {
-      artifactName: "phase-5-perturb-workspace",
-      env: commandEnv(),
-      timeoutMs: 60_000,
-    },
-  );
-  expect(perturb.exitCode, resultText(perturb)).toBe(0);
+    const snapshotsAfterStoppedBackup = snapshotManifestDirectories();
+    const stoppedBackupSnapshots = snapshotsAfterStoppedBackup.filter(
+      (entry) => !snapshotsBeforeStoppedBackup.includes(entry),
+    );
+    expect(stoppedBackupSnapshots).toHaveLength(1);
+    const stoppedBackupTimestamp = stoppedBackupSnapshots[0] as string;
+    const stoppedBackupManifest = JSON.parse(
+      fs.readFileSync(
+        path.join(BACKUP_DIR, stoppedBackupTimestamp, "rebuild-manifest.json"),
+        "utf8",
+      ),
+    ) as { sandboxName?: unknown; backedUpDirs?: unknown };
+    expect(stoppedBackupManifest.sandboxName).toBe(SANDBOX_NAME);
+    expect(stoppedBackupManifest.backedUpDirs).toEqual(expect.arrayContaining(["workspace"]));
 
-  progress.phase("restore latest and timestamped snapshots");
-  const latestRestore = await host.command("nemoclaw", [SANDBOX_NAME, "snapshot", "restore"], {
-    artifactName: "phase-6-snapshot-restore-latest",
-    env: commandEnv(),
-    timeoutMs: 120_000,
-  });
-  expect(classifySnapshotRestoreResult(latestRestore)).toBe("restored");
-  await expectSandboxFileContent(
-    sandbox,
-    SANDBOX_NAME,
-    SECOND_MARKER,
-    secondContent,
-    "phase-6-read-second-marker-after-latest-restore",
-  );
-  await expectSandboxFileContent(
-    sandbox,
-    SANDBOX_NAME,
-    PREFIX_MARKER,
-    markerContent,
-    "phase-6-read-prefix-marker-after-latest-restore",
-  );
-  const firstGoneAfterLatest = await sandbox.exec(
-    SANDBOX_NAME,
-    ["sh", "-lc", `test ! -e ${MARKER_FILE}`],
-    {
-      artifactName: "phase-6-first-marker-absent-after-latest-restore",
-      env: commandEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  expect(firstGoneAfterLatest.exitCode, resultText(firstGoneAfterLatest)).toBe(0);
-
-  const targetedRestore = await host.command(
-    "nemoclaw",
-    [SANDBOX_NAME, "snapshot", "restore", timestamp],
-    {
-      artifactName: "phase-7-snapshot-restore-first-timestamp",
+    // The stopped backup above is the recovery source, so recreate without taking another live backup.
+    const rebuildAfterStoppedBackup = await host.command(
+      "nemoclaw",
+      [SANDBOX_NAME, "rebuild", "--yes", "--force"],
+      {
+        artifactName: "phase-10-rebuild-for-stopped-snapshot-restore",
+        env: commandEnv(),
+        timeoutMs: 15 * 60_000,
+      },
+    );
+    expect(rebuildAfterStoppedBackup.exitCode, resultText(rebuildAfterStoppedBackup)).toBe(0);
+    const rebuiltContainerId = await onlySandboxContainerId(
+      host,
+      SANDBOX_NAME,
+      "phase-10-rebuilt-container-lookup",
+    );
+    // Verify the full delivery chain before the test mutates and restores the stopped-sandbox backup.
+    const recoveryStatus = await host.command("nemoclaw", [SANDBOX_NAME, "status", "--json"], {
+      artifactName: "phase-10-recover-rebuilt-sandbox-delivery",
       env: commandEnv(),
       timeoutMs: 120_000,
-    },
-  );
-  expect(classifySnapshotRestoreResult(targetedRestore)).toBe("restored");
-  await expectSandboxFileContent(
-    sandbox,
-    SANDBOX_NAME,
-    MARKER_FILE,
-    markerContent,
-    "phase-7-read-first-marker-after-targeted-restore",
-  );
-  const secondGone = await sandbox.exec(SANDBOX_NAME, ["sh", "-lc", `test ! -e ${SECOND_MARKER}`], {
-    artifactName: "phase-7-second-marker-absent-after-targeted-restore",
-    env: commandEnv(),
-    timeoutMs: 30_000,
-  });
-  expect(secondGone.exitCode, resultText(secondGone)).toBe(0);
+    });
+    expect(recoveryStatus.exitCode, resultText(recoveryStatus)).toBe(0);
+    expect(JSON.parse(recoveryStatus.stdout)).toMatchObject({
+      found: true,
+      phase: "Ready",
+      gatewayState: "present",
+      inferenceHealth: {
+        ok: true,
+        probed: true,
+      },
+      failureLayer: null,
+    });
+    const perturbAfterStoppedBackup = await sandbox.exec(
+      SANDBOX_NAME,
+      ["sh", "-lc", `printf '%s' 'BROKEN_AFTER_STOPPED_BACKUP' > ${MARKER_FILE}`],
+      {
+        artifactName: "phase-10-perturb-after-stopped-backup",
+        env: commandEnv(),
+        timeoutMs: 30_000,
+      },
+    );
+    expect(perturbAfterStoppedBackup.exitCode, resultText(perturbAfterStoppedBackup)).toBe(0);
+    const restoreStoppedBackup = await host.command(
+      "nemoclaw",
+      [SANDBOX_NAME, "snapshot", "restore", stoppedBackupTimestamp],
+      {
+        artifactName: "phase-10-restore-stopped-backup",
+        env: commandEnv(),
+        timeoutMs: 120_000,
+      },
+    );
+    expect(classifySnapshotRestoreResult(restoreStoppedBackup)).toBe("restored");
+    await expectSandboxFileContent(
+      sandbox,
+      SANDBOX_NAME,
+      MARKER_FILE,
+      markerContent,
+      "phase-10-read-marker-after-stopped-backup-restore",
+    );
+    expect(scanSnapshotCredentialLeaks(BACKUP_DIR)).toEqual([]);
+    await artifacts.writeJson("phase-10-stopped-backup-proof.json", {
+      containerId: stoppedContainerId,
+      finalContainerState: finalContainerState.stdout.trim(),
+      stoppedBackupTimestamp,
+    });
 
-  progress.phase("audit snapshot credentials and command help");
-  const credentialLeaks = scanSnapshotCredentialLeaks(BACKUP_DIR);
-  await artifacts.writeJson("phase-8-credential-scan.json", {
-    backupDir: BACKUP_DIR,
-    leakedFiles: credentialLeaks,
-  });
-  expect(credentialLeaks).toEqual([]);
+    progress.phase("back up protected credentials and restore Shields");
+    const writeProtectedCredential = await sandbox.exec(
+      SANDBOX_NAME,
+      [
+        "sh",
+        "-lc",
+        'mkdir -p "$1" && printf %s "$2" >"$3"',
+        "write-protected-credential",
+        PROTECTED_CREDENTIALS_DIR,
+        PROTECTED_CREDENTIAL_FIXTURE,
+        PROTECTED_CREDENTIAL_FILE,
+      ],
+      {
+        artifactName: "phase-11-write-protected-credential",
+        env: commandEnv(),
+        redactionValues: [INFERENCE_API_KEY],
+        timeoutMs: 30_000,
+      },
+    );
+    expect(writeProtectedCredential.exitCode, resultText(writeProtectedCredential)).toBe(0);
 
-  const help = await host.command("nemoclaw", [SANDBOX_NAME, "snapshot"], {
-    artifactName: "phase-9-snapshot-help",
-    env: commandEnv(),
-    timeoutMs: 30_000,
-  });
-  expect(help.exitCode, resultText(help)).toBe(0);
-  expect(resultText(help)).toContain("snapshot create");
-  expect(resultText(help)).toContain("snapshot list");
-  expect(resultText(help)).toContain("snapshot restore");
-
-  progress.phase("back up a stopped sandbox and restore its snapshot");
-  const snapshotsBeforeStoppedBackup = snapshotManifestDirectories();
-  const stoppedContainerId = await onlySandboxContainerId(
-    host,
-    SANDBOX_NAME,
-    "phase-10-stopped-backup-container-lookup",
-  );
-
-  const stop = await host.command("docker", ["stop", stoppedContainerId], {
-    artifactName: "phase-10-stop-sandbox-container",
-    env: commandEnv(),
-    timeoutMs: 60_000,
-  });
-  expect(stop.exitCode, resultText(stop)).toBe(0);
-
-  const strictBackup = await host.command("nemoclaw", ["backup-all"], {
-    artifactName: "phase-10-strict-backup-all-stopped",
-    env: { ...commandEnv(), NEMOCLAW_REQUIRE_ALL_SANDBOX_BACKUPS: "1" },
-    timeoutMs: 180_000,
-  });
-  expect(strictBackup.exitCode, resultText(strictBackup)).toBe(0);
-  expect(resultText(strictBackup)).toContain(`Starting stopped sandbox '${SANDBOX_NAME}'`);
-  expect(resultText(strictBackup)).toContain(`Returned '${SANDBOX_NAME}' to its stopped state`);
-  expect(resultText(strictBackup)).toContain("1 backed up, 0 failed, 0 skipped");
-
-  const finalContainerState = await host.command(
-    "docker",
-    ["inspect", "--format", "{{.State.Status}}", stoppedContainerId],
-    {
-      artifactName: "phase-10-final-container-state",
-      env: commandEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  expect(finalContainerState.exitCode, resultText(finalContainerState)).toBe(0);
-  expect(finalContainerState.stdout.trim()).toBe("exited");
-
-  const snapshotsAfterStoppedBackup = snapshotManifestDirectories();
-  const stoppedBackupSnapshots = snapshotsAfterStoppedBackup.filter(
-    (entry) => !snapshotsBeforeStoppedBackup.includes(entry),
-  );
-  expect(stoppedBackupSnapshots).toHaveLength(1);
-  const stoppedBackupTimestamp = stoppedBackupSnapshots[0] as string;
-  const stoppedBackupManifest = JSON.parse(
-    fs.readFileSync(path.join(BACKUP_DIR, stoppedBackupTimestamp, "rebuild-manifest.json"), "utf8"),
-  ) as { sandboxName?: unknown; backedUpDirs?: unknown };
-  expect(stoppedBackupManifest.sandboxName).toBe(SANDBOX_NAME);
-  expect(stoppedBackupManifest.backedUpDirs).toEqual(expect.arrayContaining(["workspace"]));
-
-  // The stopped backup above is the recovery source, so recreate without taking another live backup.
-  const rebuildAfterStoppedBackup = await host.command(
-    "nemoclaw",
-    [SANDBOX_NAME, "rebuild", "--yes", "--force"],
-    {
-      artifactName: "phase-10-rebuild-for-stopped-snapshot-restore",
-      env: commandEnv(),
-      timeoutMs: 15 * 60_000,
-    },
-  );
-  expect(rebuildAfterStoppedBackup.exitCode, resultText(rebuildAfterStoppedBackup)).toBe(0);
-  const rebuiltContainerId = await onlySandboxContainerId(
-    host,
-    SANDBOX_NAME,
-    "phase-10-rebuilt-container-lookup",
-  );
-  // Verify the full delivery chain before the test mutates and restores the stopped-sandbox backup.
-  const recoveryStatus = await host.command("nemoclaw", [SANDBOX_NAME, "status", "--json"], {
-    artifactName: "phase-10-recover-rebuilt-sandbox-delivery",
-    env: commandEnv(),
-    timeoutMs: 120_000,
-  });
-  expect(recoveryStatus.exitCode, resultText(recoveryStatus)).toBe(0);
-  expect(JSON.parse(recoveryStatus.stdout)).toMatchObject({
-    found: true,
-    phase: "Ready",
-    gatewayState: "present",
-    inferenceHealth: {
-      ok: true,
-      probed: true,
-    },
-    failureLayer: null,
-  });
-  const perturbAfterStoppedBackup = await sandbox.exec(
-    SANDBOX_NAME,
-    ["sh", "-lc", `printf '%s' 'BROKEN_AFTER_STOPPED_BACKUP' > ${MARKER_FILE}`],
-    {
-      artifactName: "phase-10-perturb-after-stopped-backup",
-      env: commandEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  expect(perturbAfterStoppedBackup.exitCode, resultText(perturbAfterStoppedBackup)).toBe(0);
-  const restoreStoppedBackup = await host.command(
-    "nemoclaw",
-    [SANDBOX_NAME, "snapshot", "restore", stoppedBackupTimestamp],
-    {
-      artifactName: "phase-10-restore-stopped-backup",
-      env: commandEnv(),
-      timeoutMs: 120_000,
-    },
-  );
-  expect(classifySnapshotRestoreResult(restoreStoppedBackup)).toBe("restored");
-  await expectSandboxFileContent(
-    sandbox,
-    SANDBOX_NAME,
-    MARKER_FILE,
-    markerContent,
-    "phase-10-read-marker-after-stopped-backup-restore",
-  );
-  expect(scanSnapshotCredentialLeaks(BACKUP_DIR)).toEqual([]);
-  await artifacts.writeJson("phase-10-stopped-backup-proof.json", {
-    containerId: stoppedContainerId,
-    finalContainerState: finalContainerState.stdout.trim(),
-    stoppedBackupTimestamp,
-  });
-
-  progress.phase("back up protected credentials and restore Shields");
-  const writeProtectedCredential = await sandbox.exec(
-    SANDBOX_NAME,
-    [
-      "sh",
-      "-lc",
-      'mkdir -p "$1" && printf %s "$2" >"$3"',
-      "write-protected-credential",
-      PROTECTED_CREDENTIALS_DIR,
-      PROTECTED_CREDENTIAL_FIXTURE,
-      PROTECTED_CREDENTIAL_FILE,
-    ],
-    {
-      artifactName: "phase-11-write-protected-credential",
-      env: commandEnv(),
-      redactionValues: [INFERENCE_API_KEY],
-      timeoutMs: 30_000,
-    },
-  );
-  expect(writeProtectedCredential.exitCode, resultText(writeProtectedCredential)).toBe(0);
-
-  const lockForProtectedBackup = await host.command("nemoclaw", [SANDBOX_NAME, "shields", "up"], {
-    artifactName: "phase-11-shields-up-before-protected-backup",
-    env: commandEnv(),
-    redactionValues: [INFERENCE_API_KEY],
-    timeoutMs: 120_000,
-  });
-  expect(lockForProtectedBackup.exitCode, resultText(lockForProtectedBackup)).toBe(0);
-  expect(resultText(lockForProtectedBackup)).toContain("Lockdown active");
-  cleanup.trackDisposable(`restore Shields UP for ${SANDBOX_NAME} before destroy`, async () => {
-    const restore = await host.command("nemoclaw", [SANDBOX_NAME, "shields", "up"], {
-      artifactName: "cleanup-shields-up-after-protected-backup",
+    const lockForProtectedBackup = await host.command("nemoclaw", [SANDBOX_NAME, "shields", "up"], {
+      artifactName: "phase-11-shields-up-before-protected-backup",
       env: commandEnv(),
       redactionValues: [INFERENCE_API_KEY],
       timeoutMs: 120_000,
     });
-    expect(restore.exitCode, resultText(restore)).toBe(0);
-    expect(resultText(restore)).toMatch(/Lockdown (?:is already )?active/);
-  });
-  await expectShieldsUp(host, "phase-11-shields-status-before-protected-backup");
+    expect(lockForProtectedBackup.exitCode, resultText(lockForProtectedBackup)).toBe(0);
+    expect(resultText(lockForProtectedBackup)).toContain("Lockdown active");
+    cleanup.trackDisposable(`restore Shields UP for ${SANDBOX_NAME} before destroy`, async () => {
+      const restore = await host.command("nemoclaw", [SANDBOX_NAME, "shields", "up"], {
+        artifactName: "cleanup-shields-up-after-protected-backup",
+        env: commandEnv(),
+        redactionValues: [INFERENCE_API_KEY],
+        timeoutMs: 120_000,
+      });
+      expect(restore.exitCode, resultText(restore)).toBe(0);
+      expect(resultText(restore)).toMatch(/Lockdown (?:is already )?active/);
+    });
+    await expectShieldsUp(host, "phase-11-shields-status-before-protected-backup");
 
-  const protectedDirBeforeBackup = await rootSandboxPathMetadata(
-    host,
-    rebuiltContainerId,
-    PROTECTED_CREDENTIALS_DIR,
-    "phase-11-protected-credentials-dir-before-backup",
-  );
-  // Confidentiality roots remain search-only for the sandbox group; every
-  // descendant stays root-only and unreadable to the sandbox.
-  expect(protectedDirBeforeBackup).toEqual({ mode: "710", owner: "root:sandbox" });
-  const protectedFileBeforeBackup = await rootSandboxPathMetadata(
-    host,
-    rebuiltContainerId,
-    PROTECTED_CREDENTIAL_FILE,
-    "phase-11-protected-credential-file-before-backup",
-  );
-  expect(protectedFileBeforeBackup).toEqual({ mode: "600", owner: "root:root" });
-
-  const unreadableBeforeBackup = await sandbox.exec(
-    SANDBOX_NAME,
-    ["cat", PROTECTED_CREDENTIAL_FILE],
-    {
-      artifactName: "phase-11-protected-credential-unreadable-before-backup",
-      env: commandEnv(),
-      redactionValues: [INFERENCE_API_KEY],
-      timeoutMs: 30_000,
-    },
-  );
-  expect(unreadableBeforeBackup.exitCode, resultText(unreadableBeforeBackup)).not.toBe(0);
-  expect(resultText(unreadableBeforeBackup)).not.toContain(INFERENCE_API_KEY);
-
-  const snapshotsBeforeProtectedBackup = snapshotManifestDirectories();
-  const protectedBackup = await host.command("nemoclaw", ["backup-all"], {
-    artifactName: "phase-11-backup-all-protected-credentials",
-    env: { ...commandEnv(), NEMOCLAW_REQUIRE_ALL_SANDBOX_BACKUPS: "1" },
-    redactionValues: [INFERENCE_API_KEY],
-    timeoutMs: 180_000,
-  });
-  expect(protectedBackup.exitCode, resultText(protectedBackup)).toBe(0);
-  expect(resultText(protectedBackup)).toContain("Shields are UP");
-  expect(resultText(protectedBackup)).toContain("temporarily unlocking for backup-all");
-  expect(resultText(protectedBackup)).toContain("Re-applying shields lockdown");
-  expect(resultText(protectedBackup)).toContain("Shields restored to UP");
-  expect(resultText(protectedBackup)).toContain("1 backed up, 0 failed, 0 skipped");
-
-  const snapshotsAfterProtectedBackup = snapshotManifestDirectories();
-  const protectedBackupSnapshots = snapshotsAfterProtectedBackup.filter(
-    (entry) => !snapshotsBeforeProtectedBackup.includes(entry),
-  );
-  expect(protectedBackupSnapshots).toHaveLength(1);
-  const protectedBackupTimestamp = protectedBackupSnapshots[0] as string;
-  const protectedBackupPath = path.join(BACKUP_DIR, protectedBackupTimestamp);
-  const protectedBackupManifest = JSON.parse(
-    fs.readFileSync(path.join(protectedBackupPath, "rebuild-manifest.json"), "utf8"),
-  ) as { sandboxName?: unknown; backedUpDirs?: unknown };
-  expect(protectedBackupManifest.sandboxName).toBe(SANDBOX_NAME);
-  expect(protectedBackupManifest.backedUpDirs).toEqual(
-    expect.arrayContaining(["credentials", "workspace"]),
-  );
-  expect(fs.existsSync(path.join(protectedBackupPath, "openclaw.json"))).toBe(true);
-  expect(
-    fs.readFileSync(
-      path.join(protectedBackupPath, "workspace", path.basename(MARKER_FILE)),
-      "utf8",
-    ),
-  ).toBe(markerContent);
-
-  const backedUpCredentialPath = path.join(
-    protectedBackupPath,
-    "credentials",
-    path.basename(PROTECTED_CREDENTIAL_FILE),
-  );
-  const backedUpCredentialText = fs.readFileSync(backedUpCredentialPath, "utf8");
-  const backedUpCredential = JSON.parse(backedUpCredentialText) as {
-    apiKey?: unknown;
-    marker?: unknown;
-  };
-  expect(backedUpCredential.apiKey).toBe("[STRIPPED_BY_MIGRATION]");
-  expect(backedUpCredential.marker).toBe(PROTECTED_CREDENTIAL_MARKER);
-  expect(backedUpCredentialText).not.toContain(INFERENCE_API_KEY);
-  expect(scanSnapshotCredentialLeaks(protectedBackupPath)).toEqual([]);
-
-  await expectShieldsUp(host, "phase-11-shields-status-after-protected-backup");
-  expect(
-    await rootSandboxPathMetadata(
+    const protectedDirBeforeBackup = await rootSandboxPathMetadata(
       host,
       rebuiltContainerId,
       PROTECTED_CREDENTIALS_DIR,
-      "phase-11-protected-credentials-dir-after-backup",
-    ),
-  ).toEqual({ mode: "710", owner: "root:sandbox" });
-  expect(
-    await rootSandboxPathMetadata(
+      "phase-11-protected-credentials-dir-before-backup",
+    );
+    // Confidentiality roots remain search-only for the sandbox group; every
+    // descendant stays root-only and unreadable to the sandbox.
+    expect(protectedDirBeforeBackup).toEqual({ mode: "710", owner: "root:sandbox" });
+    const protectedFileBeforeBackup = await rootSandboxPathMetadata(
       host,
       rebuiltContainerId,
       PROTECTED_CREDENTIAL_FILE,
-      "phase-11-protected-credential-file-after-backup",
-    ),
-  ).toEqual({ mode: "600", owner: "root:root" });
-  const unreadableAfterBackup = await sandbox.exec(
-    SANDBOX_NAME,
-    ["cat", PROTECTED_CREDENTIAL_FILE],
-    {
-      artifactName: "phase-11-protected-credential-unreadable-after-backup",
-      env: commandEnv(),
-      redactionValues: [INFERENCE_API_KEY],
-      timeoutMs: 30_000,
-    },
-  );
-  expect(unreadableAfterBackup.exitCode, resultText(unreadableAfterBackup)).not.toBe(0);
-  expect(resultText(unreadableAfterBackup)).not.toContain(INFERENCE_API_KEY);
-  expect(fs.existsSync(SHIELDS_TIMER_FILE)).toBe(false);
+      "phase-11-protected-credential-file-before-backup",
+    );
+    expect(protectedFileBeforeBackup).toEqual({ mode: "600", owner: "root:root" });
 
-  progress.phase("record snapshot lifecycle evidence");
-  await artifacts.target.complete({
-    id: "snapshot-commands",
-    status: "passed",
-    firstSnapshotTimestamp: timestamp,
-    baselineExclusionKey: BASELINE_EXCLUSION_KEY,
-    cloneSandboxName: CLONE_SANDBOX_NAME,
-    stoppedBackupTimestamp,
-    protectedBackupTimestamp,
-    backupDir: BACKUP_DIR,
-  });
-});
+    const unreadableBeforeBackup = await sandbox.exec(
+      SANDBOX_NAME,
+      ["cat", PROTECTED_CREDENTIAL_FILE],
+      {
+        artifactName: "phase-11-protected-credential-unreadable-before-backup",
+        env: commandEnv(),
+        redactionValues: [INFERENCE_API_KEY],
+        timeoutMs: 30_000,
+      },
+    );
+    expect(unreadableBeforeBackup.exitCode, resultText(unreadableBeforeBackup)).not.toBe(0);
+    expect(resultText(unreadableBeforeBackup)).not.toContain(INFERENCE_API_KEY);
+
+    const snapshotsBeforeProtectedBackup = snapshotManifestDirectories();
+    const protectedBackup = await host.command("nemoclaw", ["backup-all"], {
+      artifactName: "phase-11-backup-all-protected-credentials",
+      env: { ...commandEnv(), NEMOCLAW_REQUIRE_ALL_SANDBOX_BACKUPS: "1" },
+      redactionValues: [INFERENCE_API_KEY],
+      timeoutMs: 180_000,
+    });
+    expect(protectedBackup.exitCode, resultText(protectedBackup)).toBe(0);
+    expect(resultText(protectedBackup)).toContain("Shields are UP");
+    expect(resultText(protectedBackup)).toContain("temporarily unlocking for backup-all");
+    expect(resultText(protectedBackup)).toContain("Re-applying shields lockdown");
+    expect(resultText(protectedBackup)).toContain("Shields restored to UP");
+    expect(resultText(protectedBackup)).toContain("1 backed up, 0 failed, 0 skipped");
+
+    const snapshotsAfterProtectedBackup = snapshotManifestDirectories();
+    const protectedBackupSnapshots = snapshotsAfterProtectedBackup.filter(
+      (entry) => !snapshotsBeforeProtectedBackup.includes(entry),
+    );
+    expect(protectedBackupSnapshots).toHaveLength(1);
+    const protectedBackupTimestamp = protectedBackupSnapshots[0] as string;
+    const protectedBackupPath = path.join(BACKUP_DIR, protectedBackupTimestamp);
+    const protectedBackupManifest = JSON.parse(
+      fs.readFileSync(path.join(protectedBackupPath, "rebuild-manifest.json"), "utf8"),
+    ) as { sandboxName?: unknown; backedUpDirs?: unknown };
+    expect(protectedBackupManifest.sandboxName).toBe(SANDBOX_NAME);
+    expect(protectedBackupManifest.backedUpDirs).toEqual(
+      expect.arrayContaining(["credentials", "workspace"]),
+    );
+    expect(fs.existsSync(path.join(protectedBackupPath, "openclaw.json"))).toBe(true);
+    expect(
+      fs.readFileSync(
+        path.join(protectedBackupPath, "workspace", path.basename(MARKER_FILE)),
+        "utf8",
+      ),
+    ).toBe(markerContent);
+
+    const backedUpCredentialPath = path.join(
+      protectedBackupPath,
+      "credentials",
+      path.basename(PROTECTED_CREDENTIAL_FILE),
+    );
+    const backedUpCredentialText = fs.readFileSync(backedUpCredentialPath, "utf8");
+    const backedUpCredential = JSON.parse(backedUpCredentialText) as {
+      apiKey?: unknown;
+      marker?: unknown;
+    };
+    expect(backedUpCredential.apiKey).toBe("[STRIPPED_BY_MIGRATION]");
+    expect(backedUpCredential.marker).toBe(PROTECTED_CREDENTIAL_MARKER);
+    expect(backedUpCredentialText).not.toContain(INFERENCE_API_KEY);
+    expect(scanSnapshotCredentialLeaks(protectedBackupPath)).toEqual([]);
+
+    await expectShieldsUp(host, "phase-11-shields-status-after-protected-backup");
+    expect(
+      await rootSandboxPathMetadata(
+        host,
+        rebuiltContainerId,
+        PROTECTED_CREDENTIALS_DIR,
+        "phase-11-protected-credentials-dir-after-backup",
+      ),
+    ).toEqual({ mode: "710", owner: "root:sandbox" });
+    expect(
+      await rootSandboxPathMetadata(
+        host,
+        rebuiltContainerId,
+        PROTECTED_CREDENTIAL_FILE,
+        "phase-11-protected-credential-file-after-backup",
+      ),
+    ).toEqual({ mode: "600", owner: "root:root" });
+    const unreadableAfterBackup = await sandbox.exec(
+      SANDBOX_NAME,
+      ["cat", PROTECTED_CREDENTIAL_FILE],
+      {
+        artifactName: "phase-11-protected-credential-unreadable-after-backup",
+        env: commandEnv(),
+        redactionValues: [INFERENCE_API_KEY],
+        timeoutMs: 30_000,
+      },
+    );
+    expect(unreadableAfterBackup.exitCode, resultText(unreadableAfterBackup)).not.toBe(0);
+    expect(resultText(unreadableAfterBackup)).not.toContain(INFERENCE_API_KEY);
+    expect(fs.existsSync(SHIELDS_TIMER_FILE)).toBe(false);
+
+    progress.phase("record snapshot lifecycle evidence");
+    await artifacts.target.complete({
+      id: "snapshot-commands",
+      status: "passed",
+      firstSnapshotTimestamp: timestamp,
+      baselineExclusionKey: BASELINE_EXCLUSION_KEY,
+      cloneSandboxName: CLONE_SANDBOX_NAME,
+      cloneRestoreResult,
+      stoppedBackupTimestamp,
+      protectedBackupTimestamp,
+      backupDir: BACKUP_DIR,
+    });
+  },
+);

--- a/test/e2e/live/snapshot-commands.test.ts
+++ b/test/e2e/live/snapshot-commands.test.ts
@@ -29,7 +29,6 @@ import {
   classifySnapshotGatewayProbe,
   classifySnapshotRestoreResult,
   type SnapshotInferenceFixture,
-  verifySnapshotCloneResult,
 } from "./snapshot-commands-helpers.ts";
 import { scanSnapshotCredentialLeaks } from "./snapshot-credential-scanner.ts";
 
@@ -675,8 +674,8 @@ test ! -e ${JSON.stringify(MARKER_FILE)}`,
     );
     const cloneRestoreResult = classifySnapshotRestoreResult(cloneRestore);
     progress.phase("verify the restored clone state and gateway pairing");
-    await verifySnapshotCloneResult(cloneRestoreResult, {
-      managedCloneDormancy: async () => {
+    switch (cloneRestoreResult) {
+      case "managed-clone-rebind-required": {
         expect(resultText(cloneRestore)).toContain(
           `restoring '${SANDBOX_NAME}' as '${CLONE_SANDBOX_NAME}' requires managed-profile clone rebind`,
         );
@@ -699,8 +698,9 @@ test ! -e ${JSON.stringify(MARKER_FILE)}`,
           classification: cloneRestoreResult,
           destinationAbsent: true,
         });
-      },
-      restoredLegacyClone: async () => {
+        break;
+      }
+      case "restored": {
         await expectSandboxFileContent(
           sandbox,
           CLONE_SANDBOX_NAME,
@@ -806,8 +806,11 @@ test ! -e ${JSON.stringify(MARKER_FILE)}`,
           },
         );
         expect(destroyClone.exitCode, resultText(destroyClone)).toBe(0);
-      },
-    });
+        break;
+      }
+      default:
+        throw new Error(`Unexpected snapshot clone result classification: ${cloneRestoreResult}`);
+    }
 
     progress.phase("create a second snapshot from changed workspace");
     const modify = await sandbox.exec(

--- a/test/e2e/live/snapshot-commands.test.ts
+++ b/test/e2e/live/snapshot-commands.test.ts
@@ -663,6 +663,17 @@ test ! -e ${JSON.stringify(MARKER_FILE)}`,
     );
 
     progress.phase("restore the first snapshot into a clone");
+    const selectedSnapshot = JSON.parse(
+      fs.readFileSync(path.join(BACKUP_DIR, timestamp, "rebuild-manifest.json"), "utf8"),
+    ) as { workload?: { kind?: unknown } };
+    const expectedCloneRestoreResult =
+      selectedSnapshot.workload?.kind === "managed-image"
+        ? "managed-clone-rebind-required"
+        : "restored";
+    await artifacts.writeJson("phase-4-clone-restore-expectation.json", {
+      classification: expectedCloneRestoreResult,
+      workloadKind: selectedSnapshot.workload?.kind ?? null,
+    });
     const cloneRestore = await host.command(
       "nemoclaw",
       [SANDBOX_NAME, "snapshot", "restore", timestamp, "--to", CLONE_SANDBOX_NAME, "--yes"],
@@ -673,8 +684,9 @@ test ! -e ${JSON.stringify(MARKER_FILE)}`,
       },
     );
     const cloneRestoreResult = classifySnapshotRestoreResult(cloneRestore);
+    expect(cloneRestoreResult).toBe(expectedCloneRestoreResult);
     progress.phase("verify the restored clone state and gateway pairing");
-    switch (cloneRestoreResult) {
+    switch (expectedCloneRestoreResult) {
       case "managed-clone-rebind-required": {
         expect(resultText(cloneRestore)).toContain(
           `restoring '${SANDBOX_NAME}' as '${CLONE_SANDBOX_NAME}' requires managed-profile clone rebind`,

--- a/test/e2e/support/snapshot-commands-helpers.test.ts
+++ b/test/e2e/support/snapshot-commands-helpers.test.ts
@@ -8,6 +8,7 @@ import {
   buildSnapshotCommandEnv,
   classifySnapshotGatewayProbe,
   classifySnapshotRestoreResult,
+  verifySnapshotCloneResult,
 } from "../live/snapshot-commands-helpers.ts";
 
 const HOSTED_FLAG = "NEMOCLAW_E2E_USE_HOSTED_INFERENCE";
@@ -145,6 +146,15 @@ describe("snapshot restore result classification", () => {
     ],
     [
       {
+        exitCode: 1,
+        stdout: "",
+        stderr:
+          "restoring 'source' as 'clone' requires managed-profile clone rebind. Destination 'clone' was not changed. secret-output",
+      },
+      "managed-clone-rebind-required",
+    ],
+    [
+      {
         exitCode: null,
         stdout: "State restored into 'clone', but gateway pairing could not be verified.",
         stderr: "scope-upgrade-pending secret-output",
@@ -158,5 +168,34 @@ describe("snapshot restore result classification", () => {
 
     expect(classification).toBe(expected);
     expect(classification).not.toContain("secret-output");
+  });
+});
+
+describe("snapshot clone verification routing", () => {
+  it.each([
+    ["managed-clone-rebind-required", "managed"],
+    ["restored", "legacy"],
+  ] as const)("routes %s to its exact supported branch", async (classification, expected) => {
+    const invoked: string[] = [];
+
+    await verifySnapshotCloneResult(classification, {
+      managedCloneDormancy: async () => {
+        invoked.push("managed");
+      },
+      restoredLegacyClone: async () => {
+        invoked.push("legacy");
+      },
+    });
+
+    expect(invoked).toEqual([expected]);
+  });
+
+  it("rejects every other restore result", async () => {
+    await expect(
+      verifySnapshotCloneResult("command-failure", {
+        managedCloneDormancy: async () => undefined,
+        restoredLegacyClone: async () => undefined,
+      }),
+    ).rejects.toThrow(/Unexpected snapshot clone result classification: command-failure/u);
   });
 });

--- a/test/e2e/support/snapshot-commands-helpers.test.ts
+++ b/test/e2e/support/snapshot-commands-helpers.test.ts
@@ -8,7 +8,6 @@ import {
   buildSnapshotCommandEnv,
   classifySnapshotGatewayProbe,
   classifySnapshotRestoreResult,
-  verifySnapshotCloneResult,
 } from "../live/snapshot-commands-helpers.ts";
 
 const HOSTED_FLAG = "NEMOCLAW_E2E_USE_HOSTED_INFERENCE";
@@ -168,34 +167,5 @@ describe("snapshot restore result classification", () => {
 
     expect(classification).toBe(expected);
     expect(classification).not.toContain("secret-output");
-  });
-});
-
-describe("snapshot clone verification routing", () => {
-  it.each([
-    ["managed-clone-rebind-required", "managed"],
-    ["restored", "legacy"],
-  ] as const)("routes %s to its exact supported branch", async (classification, expected) => {
-    const invoked: string[] = [];
-
-    await verifySnapshotCloneResult(classification, {
-      managedCloneDormancy: async () => {
-        invoked.push("managed");
-      },
-      restoredLegacyClone: async () => {
-        invoked.push("legacy");
-      },
-    });
-
-    expect(invoked).toEqual([expected]);
-  });
-
-  it("rejects every other restore result", async () => {
-    await expect(
-      verifySnapshotCloneResult("command-failure", {
-        managedCloneDormancy: async () => undefined,
-        restoredLegacyClone: async () => undefined,
-      }),
-    ).rejects.toThrow(/Unexpected snapshot clone result classification: command-failure/u);
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Preserve the registry's recorded agent identity when onboarding reuses an existing sandbox. Managed OpenClaw rows now retain the explicit `openclaw` authority required by their workload receipt, while legacy and custom OpenClaw rows remain `agent: null`.

## Related Issue

Closes #9356

## Changes

- Preserve an existing explicit sandbox agent during reuse metadata updates instead of replacing it with OpenClaw's legacy neutral value.
- Add a managed-image receipt regression that proves reuse retains explicit OpenClaw authority and remains readable by the lifecycle authority boundary.
- Extend the legacy/custom reuse test to prove its existing neutral identity and recorded version remain unchanged.
- Verify managed startup completion through the provider-owned Docker path, pinned to the immutable container receipt accepted by restore validation, with a fixed Node.js runtime, cleared environment, and bounded sanitized diagnostics.
- Allow stopped managed-profile containers up to 90 seconds to complete provider-owned cold startup before `backup-all` declares their SSH transport unreachable.
- Bind the live snapshot clone expectation to the selected snapshot's pre-command workload receipt, preserving legacy clone coverage while proving managed clone-rebind dormancy leaves the destination absent.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer self-review against the security and state-safety rubric confirmed that the change preserves receipt-bound durable identity, does not derive identity from ambient input, and adds no migration, credential handling, or lifecycle mutation.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — full pre-commit, commitlint, and pre-push TypeScript gates passed on the exact head.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — registry/onboard tests (76 passed); managed-image integration (1 passed); runtime-provider snapshot/registry tests (39 passed); stopped-backup/maintenance/growth tests (98 passed); snapshot helper/growth tests (53 passed); CLI/shared TypeScript checks passed.
- [ ] Applicable broad gate passed — Not applicable: this is a focused metadata-preservation fix with targeted lifecycle and managed-image integration coverage; the PR's normal CI remains required before merge.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Pre-merge Acceptance

- [x] Exact verified evidence candidate [`362beeddd32cd2c99f229e79a8529f965c3c5c5d`](https://github.com/NVIDIA/NemoClaw/commit/362beeddd32cd2c99f229e79a8529f965c3c5c5d), containing base cohort `23c1afb389d5fa3c82d1b27641f095a2f459b744` and this PR's verified head `18c425f2961c6fbba90028f2b11971b19bfeb2d3`, passes all four scenarios that failed in run 32132319706:
  - Snapshot restore: [focused run 32166604026](https://github.com/NVIDIA/NemoClaw/actions/runs/32166604026) (`SUCCESS`) and [unfiltered job 95809621446](https://github.com/NVIDIA/NemoClaw/actions/runs/32166610790/job/95809621446) (`SUCCESS`).
  - Credential-generation window: [focused job 95809084929](https://github.com/NVIDIA/NemoClaw/actions/runs/32166607333/job/95809084929) (`SUCCESS`) and [unfiltered job 95809618739](https://github.com/NVIDIA/NemoClaw/actions/runs/32166610790/job/95809618739) (`SUCCESS`).
  - Gateway reuse/double onboarding: [focused job 95809085213](https://github.com/NVIDIA/NemoClaw/actions/runs/32166607333/job/95809085213) (`SUCCESS`) and [unfiltered job 95809621625](https://github.com/NVIDIA/NemoClaw/actions/runs/32166610790/job/95809621625) (`SUCCESS`).
  - Full OpenClaw: [focused job 95809085508](https://github.com/NVIDIA/NemoClaw/actions/runs/32166607333/job/95809085508) (`SUCCESS`) and [unfiltered job 95809622229](https://github.com/NVIDIA/NemoClaw/actions/runs/32166610790/job/95809622229) (`SUCCESS`).

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of reused sandbox metadata by preserving existing agent information and legacy values.
  * Enhanced managed-profile verification with reliable Docker-based checks and clearer, sanitized failure diagnostics.
  * Extended startup backup retries to accommodate slower managed-container launches.
  * Improved snapshot restore handling for managed-profile clone rebind requirements.
  * Improved runtime compatibility across Docker, Kubernetes, Podman, and MxC environments.

* **Tests**
  * Expanded coverage for managed workloads, metadata reuse, snapshot restoration, and runtime-specific behavior.
  * Added validation for restoration errors, command execution, timeouts, retry behavior, and diagnostic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
