### PR TITLE
fix(recovery): wait for managed gateway startup

### DIFF
--- a/src/lib/actions/sandbox/process-recovery-managed-startup.test.ts
+++ b/src/lib/actions/sandbox/process-recovery-managed-startup.test.ts
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import * as openshellRuntime from "../../adapters/openshell/runtime";
+import * as agentRuntime from "../../agent/runtime";
+import * as registry from "../../state/registry";
+import * as forwardHealth from "./forward-health";
+import { checkAndRecoverSandboxProcesses } from "./process-recovery";
+
+const ACCEPTED_MANAGED_RECOVERY = {
+  status: 0,
+  stdout: `v1 ${"a".repeat(64)} complete ok 0 4242\nGATEWAY_PID=4242`,
+  stderr: "",
+} as const;
+
+function mockOpenClawSandbox(sandboxName: string): void {
+  vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue({
+    name: "openclaw",
+    displayName: "OpenClaw",
+    forwardPort: 18789,
+    healthProbe: {
+      url: "http://127.0.0.1:18789/health",
+      port: 18789,
+      timeout_seconds: 30,
+    },
+  } as never);
+  vi.spyOn(registry, "getSandbox").mockReturnValue({
+    name: sandboxName,
+    agent: "openclaw",
+    dashboardPort: 18789,
+    openshellDriver: "docker",
+  });
+}
+
+function mockRecoveredForward(sandboxName: string): void {
+  vi.spyOn(forwardHealth, "isLocalForwardReachable").mockReturnValue(true);
+  vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue({
+    status: 0,
+    output: `SANDBOX  BIND  PORT  PID  STATUS\n${sandboxName}  127.0.0.1  18789  12345  running`,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("checkAndRecoverSandboxProcesses managed startup", () => {
+  it.each(["SUPERVISOR_NOT_RUNNING", "PRIVILEGED_CONTROL_UNAVAILABLE", "GATEWAY_HEALTH_TIMEOUT"])(
+    "waits through the exact %s startup transition (#9466)",
+    (startupMarker) => {
+      const sandboxName = "startup-box";
+      mockOpenClawSandbox(sandboxName);
+      mockRecoveredForward(sandboxName);
+      vi.stubEnv("NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS", "0");
+      vi.stubEnv("NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS", "0");
+      const requestGatewaySupervisorAction = vi
+        .fn()
+        .mockReturnValueOnce({ status: 1, stdout: "", stderr: startupMarker })
+        .mockReturnValueOnce(ACCEPTED_MANAGED_RECOVERY);
+      const relaunchManagedSupervisorSessionImpl = vi.fn(() => null);
+
+      const result = checkAndRecoverSandboxProcesses(sandboxName, {
+        quiet: true,
+        isSandboxGatewayRunningImpl: () => false,
+        requestGatewaySupervisorAction,
+        relaunchManagedSupervisorSessionImpl,
+        waitForRecreatedSandboxOpenShellReadyImpl: () => true,
+      });
+
+      expect(result).toMatchObject({
+        checked: true,
+        wasRunning: false,
+        recovered: true,
+        forwardRecovered: true,
+      });
+      expect(requestGatewaySupervisorAction).toHaveBeenCalledTimes(2);
+      expect(relaunchManagedSupervisorSessionImpl).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not retry a managed-container identity mismatch (#9466)", () => {
+    const sandboxName = "identity-box";
+    mockOpenClawSandbox(sandboxName);
+    vi.stubEnv("NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS", "0");
+    const requestGatewaySupervisorAction = vi.fn(() => ({
+      status: 1,
+      stdout: "",
+      stderr:
+        `PRIVILEGED_CONTROL_UNAVAILABLE: OpenShell container identity changed for sandbox ` +
+        `'${sandboxName}'; refusing privileged execution against a different container.`,
+    }));
+    const relaunchManagedSupervisorSessionImpl = vi.fn(() => null);
+
+    const result = checkAndRecoverSandboxProcesses(sandboxName, {
+      quiet: true,
+      isSandboxGatewayRunningImpl: () => false,
+      requestGatewaySupervisorAction,
+      relaunchManagedSupervisorSessionImpl,
+    });
+
+    expect(result).toMatchObject({
+      checked: true,
+      wasRunning: false,
+      recovered: false,
+      forwardRecovered: false,
+    });
+    expect(requestGatewaySupervisorAction).toHaveBeenCalledOnce();
+    expect(relaunchManagedSupervisorSessionImpl).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -394,6 +394,16 @@ function isExactlyPendingManagedGatewayHealth(result: SandboxCommandResult | nul
   return lines.length === 1 && lines[0] === "GATEWAY_HEALTH_TIMEOUT";
 }
 
+function isExactlyManagedGatewayStartupTransition(
+  result: ManagedGatewaySupervisorActionResult | null,
+): boolean {
+  return (
+    isExactlyMissingManagedSupervisor(result) ||
+    isExactlyPendingManagedSupervisorControl(result) ||
+    isExactlyPendingManagedGatewayHealth(result)
+  );
+}
+
 function isExactlyRetryableManagedControlTransition(
   result: ManagedGatewaySupervisorActionResult | null,
 ): boolean {
@@ -428,10 +438,8 @@ export function waitForManagedGatewaySupervisor(
     const result = requestGatewaySupervisorAction(sandboxName, "probe", OPENSHELL_PROBE_TIMEOUT_MS);
     if (hasGatewayRecoveryMarker(result)) return true;
     if (
-      !isExactlyMissingManagedSupervisor(result) &&
+      !isExactlyManagedGatewayStartupTransition(result) &&
       !isExactlyRetryableManagedRecoveryFailure(result) &&
-      !isExactlyPendingManagedSupervisorControl(result) &&
-      !isExactlyPendingManagedGatewayHealth(result) &&
       !isExactlyRetryableManagedControlTransition(result)
     ) {
       return false;
@@ -683,14 +691,20 @@ function recoverSandboxProcesses(
       if (managedControlCompletion) return { kind: "managed", managedControlCompletion };
       if (hasGatewayRecoveryMarker(execResult)) return { kind: "managed" };
 
-      // PID 1 may replace the gateway between the host's stopped observation
-      // and the controller's process-tree capture. Retry only exact controller
+      // The restarted sandbox can report Ready before its managed controller
+      // and gateway finish starting. Retry only exact startup, controller
       // contention, status 137 with no output, and ID-bound Docker transition
-      // results. Integrity, configuration, and launch refusals are terminal.
+      // results. Identity, integrity, configuration, and launch refusals are
+      // diagnostic-bearing and remain terminal.
       if (isExactlyRetryableManagedRecoveryFailure(execResult)) {
         busyAttempts += 1;
         if (busyAttempts >= maxBusyAttempts) break;
-      } else if (!isExactlyRetryableManagedControlTransition(execResult)) break;
+      } else if (
+        !isExactlyManagedGatewayStartupTransition(execResult) &&
+        !isExactlyRetryableManagedControlTransition(execResult)
+      ) {
+        break;
+      }
       if (attempt === maxAttempts) break;
       sleepSeconds(retryIntervalSeconds);
     }

--- a/test/process-recovery-supervisor-relaunch.test.ts
+++ b/test/process-recovery-supervisor-relaunch.test.ts
@@ -546,7 +546,7 @@ describe("checkAndRecoverSandboxProcesses supervisor relaunch", () => {
     });
 
     expect(result).toMatchObject({ checked: true, wasRunning: false, recovered: false });
-    expect(requestGatewaySupervisorAction).toHaveBeenCalledOnce();
+    expect(requestGatewaySupervisorAction).toHaveBeenCalledTimes(11);
     expect(relaunchManagedSupervisorSessionImpl).toHaveBeenCalledWith(
       "legacy-box",
       expect.objectContaining({ quiet: false }),

--- a/test/sandbox-connect-inference/auto-pair-approval.test.ts
+++ b/test/sandbox-connect-inference/auto-pair-approval.test.ts
@@ -358,9 +358,15 @@ describe("sandbox connect scope-upgrade approval on recover/probe (#4504)", () =
         { launchReadinessRegistry: true },
       );
 
-      const result = runConnect(tmpDir, sandboxName, { OPENSHELL_TEST_GATEWAY_DOWN: "1" }, [
-        "--probe-only",
-      ]);
+      const result = runConnect(
+        tmpDir,
+        sandboxName,
+        {
+          OPENSHELL_TEST_GATEWAY_DOWN: "1",
+          NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS: "0",
+        },
+        ["--probe-only"],
+      );
       expect(result.status).toBe(1);
 
       const state = JSON.parse(fs.readFileSync(stateFile, "utf-8"));


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Wait through the managed gateway's exact bounded startup states after an OpenShell restart instead of treating them as terminal recovery failures. Diagnostic-bearing identity, integrity, configuration, and launch failures still fail closed without starting a fallback relaunch.

## Related Issue

Fixes #9466

## Changes

- Classify the three existing exact startup markers as managed recovery transitions: `SUPERVISOR_NOT_RUNNING`, `PRIVILEGED_CONTROL_UNAVAILABLE`, and `GATEWAY_HEALTH_TIMEOUT`.
- Reuse that exact classifier in the read-only supervisor wait and the bounded managed recovery loop.
- Add regression coverage proving each startup transition recovers through the sandbox-owned controller and a diagnostic-bearing container identity mismatch remains terminal.
- Update the persistent-startup-marker fallback test to cover exhaustion of all 11 bounded attempts before supervisor relaunch.
- Keep the gateway-down auto-pair fixture deterministic by disabling recovery polling delay for that negative-path test.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Both advisor lanes completed with zero findings (https://github.com/NVIDIA/NemoClaw/actions/runs/32153481291); CodeRabbit reviewed both commits with no actionable comments; no review threads exist.
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: Brave credential-gated jobs are out of scope per https://github.com/NVIDIA/NemoClaw/pull/9480#issuecomment-5331361621; the pre-existing gateway-guard fixture is tracked by #9364/#9463 and has green targeted evidence at https://github.com/NVIDIA/NemoClaw/actions/runs/32161524219.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: N/A; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: N/A
- Result: N/A
- Supporting evidence: N/A

## Acceptance Criteria

- [x] The exact `sandbox-survival` E2E reported in #9466 passes against PR head `67b8c3fd09a0ac5ce09a5ceded6b9e99b5fad3aa` — focused trusted run: https://github.com/NVIDIA/NemoClaw/actions/runs/32153536484.
- [x] The complete unfiltered PR E2E matrix was executed against the same exact head (https://github.com/NVIDIA/NemoClaw/actions/runs/32155429480); all transient non-Brave failures passed on exact-head retry (https://github.com/NVIDIA/NemoClaw/actions/runs/32163550680), with the documented Brave and independent gateway-guard exceptions above.
- [x] Required CI, both PR Review Advisors, CodeRabbit, human review state, and review threads are clear on the same exact head.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `vitest` CLI regression: 4/4; related CLI status: 19/19; integration primitives: 36/36; supervisor relaunch: 35/35; auto-pair approval: 9/9.
- [x] Applicable broad gate passed — required PR CI is green; exact-head sandbox-survival passed; the unfiltered matrix and exact-head non-Brave retry evidence are linked above.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed sandbox startup recovery when supervisors are unavailable, privileged controls are temporarily inaccessible, or gateway health is still pending.
  * Added bounded retries for transient startup, contention, and container-transition conditions.
  * Prevented retries when managed-container identity checks fail.
  * Improved recovery diagnostics for startup, identity, integrity, configuration, and launch failures.
  * Preserved safeguards against unintended container changes or supervisor relaunches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->