### PR TITLE
fix(onboard): validate Windows-host Ollama probe body

### DIFF
--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -363,7 +363,7 @@ export function probeVllmModels(
 // `{ "models": [...] }`. An empty array is fine — that just means no models
 // pulled yet — but a body that doesn't parse as JSON-with-array-`models` did
 // not come from Ollama and the probe should not call it healthy. (#4275)
-function isValidOllamaTagsResponseBody(body: string): boolean {
+export function isValidOllamaTagsResponseBody(body: string): boolean {
   if (!body) return false;
   try {
     const parsed = JSON.parse(body);

--- a/src/lib/onboard/provider-host-state.test.ts
+++ b/src/lib/onboard/provider-host-state.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./provider-host-state";
 
 const WINDOWS_OLLAMA_TAGS_URL = "http://host.docker.internal:11434/api/tags";
+const VALID_OLLAMA_TAGS_BODY = '{"models": [{"name": "llama3.2:latest"}]}';
 
 const SUPPORTED_WINDOWS_OLLAMA = {
   supported: true,
@@ -187,7 +188,7 @@ describe("detectInferenceProviderHostState", () => {
   it("detects Windows-host Ollama from Docker Desktop when WSL cannot reach it (#8127)", () => {
     const logs: string[] = [];
     const dockerCapture = vi.fn((command: string[]) =>
-      command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? "{}" : "",
+      command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? VALID_OLLAMA_TAGS_BODY : "",
     );
     const deps = buildDeps({
       isWsl: vi.fn(() => true),
@@ -260,6 +261,29 @@ describe("detectInferenceProviderHostState", () => {
     expect(state.ollamaInstallMenu.entry?.label).toBe("Install Ollama (WSL Linux)");
   });
 
+  it("does not treat a non-Ollama body from host.docker.internal as a live Windows daemon (#9348)", () => {
+    const deps = buildDeps({
+      isWsl: vi.fn(() => true),
+      getContainerRuntime: vi.fn<DetectInferenceProviderHostStateDeps["getContainerRuntime"]>(
+        () => "docker-desktop",
+      ),
+      detectWindowsHostOllama: vi.fn(() => ({
+        installed: true,
+        installedPath: "C:\\Users\\me\\AppData\\Local\\Programs\\Ollama\\ollama.exe",
+        loopbackOnly: false,
+      })),
+      dockerCapture: vi.fn<DetectInferenceProviderHostStateDeps["dockerCapture"]>(() =>
+        "<html>captive portal</html>",
+      ),
+    });
+
+    const state = detectWithDeps(deps);
+
+    expect(state.hasWindowsOllama).toBe(true);
+    expect(state.windowsOllamaReachable).toBe(false);
+    expect(state.ollamaInstallMenu.entry?.key).toBe("install-ollama");
+  });
+
   it("does not run the Windows-host probe without Docker Desktop WSL integration (#8127)", () => {
     const dockerCapture = vi.fn<DetectInferenceProviderHostStateDeps["dockerCapture"]>(() => "{}");
     const deps = buildDeps({
@@ -311,7 +335,9 @@ describe("detectInferenceProviderHostState", () => {
         if (joined.includes("wslinfo --networking-mode")) return "mirrored\n";
         return "";
       }),
-      dockerCapture: vi.fn((command) => (command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? "{}" : "")),
+      dockerCapture: vi.fn((command) =>
+        command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? VALID_OLLAMA_TAGS_BODY : "",
+      ),
       detectLocalTcpListener: vi.fn(() => false),
     });
 
@@ -346,7 +372,9 @@ describe("detectInferenceProviderHostState", () => {
       runCapture: vi.fn((command) =>
         command.join(" ").includes("wslinfo --networking-mode") ? "mirrored\n" : "",
       ),
-      dockerCapture: vi.fn((command) => (command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? "{}" : "")),
+      dockerCapture: vi.fn((command) =>
+        command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? VALID_OLLAMA_TAGS_BODY : "",
+      ),
       detectLocalTcpListener: vi.fn(() => true),
     });
 
@@ -380,7 +408,9 @@ describe("detectInferenceProviderHostState", () => {
       runCapture: vi.fn((command) =>
         command.join(" ").includes("wslinfo --networking-mode") ? "mirrored\n" : "",
       ),
-      dockerCapture: vi.fn((command) => (command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? "{}" : "")),
+      dockerCapture: vi.fn((command) =>
+        command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? VALID_OLLAMA_TAGS_BODY : "",
+      ),
       detectLocalTcpListener: vi.fn(() => null),
     });
 
@@ -403,7 +433,9 @@ describe("detectInferenceProviderHostState", () => {
       runCapture: vi.fn((command) =>
         command.join(" ").includes("wslinfo --networking-mode") ? "future-mode\n" : "",
       ),
-      dockerCapture: vi.fn((command) => (command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? "{}" : "")),
+      dockerCapture: vi.fn((command) =>
+        command.at(-1) === WINDOWS_OLLAMA_TAGS_URL ? VALID_OLLAMA_TAGS_BODY : "",
+      ),
       detectLocalTcpListener,
     });
 

--- a/src/lib/onboard/provider-host-state.ts
+++ b/src/lib/onboard/provider-host-state.ts
@@ -9,6 +9,7 @@ import {
   getLocalProviderAvailabilityEndpoint,
   getWindowsHostOllamaDockerReachabilityArgs,
   isLocalProviderProbeOutputHealthy,
+  isValidOllamaTagsResponseBody,
   OLLAMA_HOST_DOCKER_INTERNAL,
   OLLAMA_PORT,
 } from "../inference/local";
@@ -193,9 +194,13 @@ function probeWindowsOllamaReachable(input: {
   dockerCapture: DockerCapture;
 }): boolean {
   if (!input.isWsl || input.isWindowsHostOllama || !input.dockerRequirementSupported) return false;
-  return !!input.dockerCapture(getWindowsHostOllamaDockerReachabilityArgs(), {
+  // A successful Docker run is not enough: a captive proxy, a stale listener, or
+  // a stub on host.docker.internal can all answer with arbitrary 2xx bodies. Only
+  // a body in the Ollama `/api/tags` wire format proves the Windows daemon is live.
+  const body = input.dockerCapture(getWindowsHostOllamaDockerReachabilityArgs(), {
     ignoreError: true,
   });
+  return isValidOllamaTagsResponseBody(body);
 }
 
 function maybeWarnAboutDuplicateOllamaDaemons(input: {


### PR DESCRIPTION
The Windows-host Ollama reachability probe trusted any non-empty Docker capture as proof the daemon is live. A captive proxy, a stale listener, or a stub on host.docker.internal can answer with an arbitrary 2xx body that then fed isWindowsHostOllama and the install menu. Validate the /api/tags body against the Ollama wire format instead.

Refs: #9348

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [ ] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [ ] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Your Name <your-email@example.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows Ollama detection by verifying that the host response is a valid Ollama response.
  - Prevents unrelated services from being incorrectly recognized as reachable Ollama installations.
  - Preserves the local installation option when a valid Ollama service cannot be detected.

- **Tests**
  - Added coverage for valid Ollama responses and rejected non-Ollama responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->