### PR TITLE
fix(connect): warn when Shields auto-relocks

### DIFF
--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -37,7 +37,7 @@
     "defaultMax": 20,
     "maxByFile": {
       "src/lib/actions/inference-set.ts": 32,
-      "src/lib/actions/sandbox/connect.ts": 41,
+      "src/lib/actions/sandbox/connect.ts": 40,
       "src/lib/actions/sandbox/destroy.ts": 29,
       "src/lib/actions/sandbox/doctor.ts": 30,
       "src/lib/actions/sandbox/status-snapshot.ts": 21,

--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -37,7 +37,7 @@
     "defaultMax": 20,
     "maxByFile": {
       "src/lib/actions/inference-set.ts": 32,
-      "src/lib/actions/sandbox/connect.ts": 40,
+      "src/lib/actions/sandbox/connect.ts": 42,
       "src/lib/actions/sandbox/destroy.ts": 29,
       "src/lib/actions/sandbox/doctor.ts": 30,
       "src/lib/actions/sandbox/status-snapshot.ts": 21,

--- a/src/lib/actions/sandbox/agent/connect-shields-relock-notice.test.ts
+++ b/src/lib/actions/sandbox/agent/connect-shields-relock-notice.test.ts
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ConnectShieldsRelockNoticeState,
+  pollConnectShieldsRelockNotice,
+} from "./connect-shields-relock-notice";
+
+function state(startedAtMs: number): ConnectShieldsRelockNoticeState {
+  return {
+    lastNotifiedRestoreMs: startedAtMs - 1,
+    sandboxName: "alpha beta",
+    startedAtMs,
+  };
+}
+
+describe("connected-session Shields auto-relock notice", () => {
+  it("prints one actionable warning for a new auto-relock event (#9453)", () => {
+    const startedAtMs = Date.parse("2026-08-18T17:00:00.000Z");
+    const readRecent = vi.fn(() => ({
+      kind: "event" as const,
+      event: { timestamp: "2026-08-18T17:00:20.000Z", timeoutSeconds: 20 },
+    }));
+    const writeNotice = vi.fn();
+
+    const afterFirstPoll = pollConnectShieldsRelockNotice(
+      state(startedAtMs),
+      readRecent,
+      writeNotice,
+    );
+    const afterSecondPoll = pollConnectShieldsRelockNotice(afterFirstPoll, readRecent, writeNotice);
+
+    expect(afterSecondPoll.lastNotifiedRestoreMs).toBe(Date.parse("2026-08-18T17:00:20.000Z"));
+    expect(writeNotice).toHaveBeenCalledOnce();
+    expect(writeNotice.mock.calls[0]?.[0]).toContain("Shields auto-relocked after 20s");
+    expect(writeNotice.mock.calls[0]?.[0]).toContain("restricted operations may now fail");
+    expect(writeNotice.mock.calls[0]?.[0]).toContain(
+      "nemoclaw 'alpha beta' shields down --timeout 20s",
+    );
+  });
+
+  it("ignores relock history from before this connected session (#9453)", () => {
+    const startedAtMs = Date.parse("2026-08-18T17:00:00.000Z");
+    const writeNotice = vi.fn();
+
+    const result = pollConnectShieldsRelockNotice(
+      state(startedAtMs),
+      () => ({
+        kind: "event",
+        event: { timestamp: "2026-08-18T16:59:59.999Z", timeoutSeconds: 20 },
+      }),
+      writeNotice,
+    );
+
+    expect(result).toEqual(state(startedAtMs));
+    expect(writeNotice).not.toHaveBeenCalled();
+  });
+
+  it("keeps the connected session available when audit visibility is degraded (#9453)", () => {
+    const startedAtMs = Date.parse("2026-08-18T17:00:00.000Z");
+    const writeNotice = vi.fn();
+
+    expect(
+      pollConnectShieldsRelockNotice(
+        state(startedAtMs),
+        () => ({ kind: "unreadable" }),
+        writeNotice,
+      ),
+    ).toEqual(state(startedAtMs));
+    expect(writeNotice).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/actions/sandbox/agent/connect-shields-relock-notice.test.ts
+++ b/src/lib/actions/sandbox/agent/connect-shields-relock-notice.test.ts
@@ -6,7 +6,6 @@ import type { ShieldsAutoRestoreReadResult } from "../../../shields/audit";
 import {
   type ConnectShieldsRelockNoticeState,
   pollConnectShieldsRelockNotice,
-  runConnectChildWithShieldsRelockNotice,
   startConnectShieldsRelockWatcher,
 } from "./connect-shields-relock-notice";
 
@@ -97,48 +96,5 @@ describe("connected-session Shields auto-relock notice", () => {
     vi.advanceTimersByTime(2_000);
     expect(readRecent).toHaveBeenCalledTimes(2);
     vi.useRealTimers();
-  });
-
-  it("stops the watcher after the shared child supervisor settles (#9453)", async () => {
-    const lifecycle: string[] = [];
-    const stop = vi.fn(() => lifecycle.push("stop"));
-    const startWatcher = vi.fn(() => {
-      lifecycle.push("start");
-      return { stop };
-    });
-    const runChild = vi.fn(async () => {
-      lifecycle.push("child");
-      return { status: 0 };
-    });
-
-    await expect(
-      runConnectChildWithShieldsRelockNotice(
-        "openshell",
-        ["sandbox", "connect", "alpha"],
-        { stdin: true },
-        "alpha",
-        true,
-        { runChild, startWatcher },
-      ),
-    ).resolves.toEqual({ status: 0 });
-
-    expect(lifecycle).toEqual(["start", "child", "stop"]);
-    expect(stop).toHaveBeenCalledOnce();
-  });
-
-  it("skips the watcher for non-OpenClaw sessions (#9453)", async () => {
-    const startWatcher = vi.fn();
-    const runChild = vi.fn(async () => ({ status: 0 }));
-
-    await runConnectChildWithShieldsRelockNotice(
-      "openshell",
-      ["sandbox", "connect", "alpha"],
-      {},
-      "alpha",
-      false,
-      { runChild, startWatcher },
-    );
-
-    expect(startWatcher).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/actions/sandbox/agent/connect-shields-relock-notice.test.ts
+++ b/src/lib/actions/sandbox/agent/connect-shields-relock-notice.test.ts
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it, vi } from "vitest";
+import type { ShieldsAutoRestoreReadResult } from "../../../shields/audit";
 import {
   type ConnectShieldsRelockNoticeState,
   pollConnectShieldsRelockNotice,
+  runConnectChildWithShieldsRelockNotice,
+  startConnectShieldsRelockWatcher,
 } from "./connect-shields-relock-notice";
 
 function state(startedAtMs: number): ConnectShieldsRelockNoticeState {
@@ -69,5 +72,73 @@ describe("connected-session Shields auto-relock notice", () => {
       ),
     ).toEqual(state(startedAtMs));
     expect(writeNotice).not.toHaveBeenCalled();
+  });
+
+  it("polls on the parent event loop and stops cleanly (#9453)", () => {
+    vi.useFakeTimers();
+    const startedAtMs = Date.parse("2026-08-18T17:00:00.000Z");
+    vi.setSystemTime(startedAtMs);
+    const readRecent = vi
+      .fn<(sandboxName: string) => ShieldsAutoRestoreReadResult>()
+      .mockReturnValueOnce({ kind: "none" })
+      .mockReturnValue({
+        kind: "event",
+        event: { timestamp: "2026-08-18T17:00:00.500Z", timeoutSeconds: 20 },
+      });
+    const writeNotice = vi.fn();
+
+    const watcher = startConnectShieldsRelockWatcher("alpha", readRecent, writeNotice);
+    expect(readRecent).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(1_000);
+    expect(writeNotice).toHaveBeenCalledOnce();
+
+    watcher?.stop();
+    vi.advanceTimersByTime(2_000);
+    expect(readRecent).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("stops the watcher after the shared child supervisor settles (#9453)", async () => {
+    const lifecycle: string[] = [];
+    const stop = vi.fn(() => lifecycle.push("stop"));
+    const startWatcher = vi.fn(() => {
+      lifecycle.push("start");
+      return { stop };
+    });
+    const runChild = vi.fn(async () => {
+      lifecycle.push("child");
+      return { status: 0 };
+    });
+
+    await expect(
+      runConnectChildWithShieldsRelockNotice(
+        "openshell",
+        ["sandbox", "connect", "alpha"],
+        { stdin: true },
+        "alpha",
+        true,
+        { runChild, startWatcher },
+      ),
+    ).resolves.toEqual({ status: 0 });
+
+    expect(lifecycle).toEqual(["start", "child", "stop"]);
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it("skips the watcher for non-OpenClaw sessions (#9453)", async () => {
+    const startWatcher = vi.fn();
+    const runChild = vi.fn(async () => ({ status: 0 }));
+
+    await runConnectChildWithShieldsRelockNotice(
+      "openshell",
+      ["sandbox", "connect", "alpha"],
+      {},
+      "alpha",
+      false,
+      { runChild, startWatcher },
+    );
+
+    expect(startWatcher).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/actions/sandbox/agent/connect-shields-relock-notice.ts
+++ b/src/lib/actions/sandbox/agent/connect-shields-relock-notice.ts
@@ -1,12 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { writeSync } from "node:fs";
-import { isMainThread, Worker, workerData } from "node:worker_threads";
 import {
   readRecentShieldsAutoRestore,
   type ShieldsAutoRestoreReadResult,
 } from "../../../shields/audit";
+import { runSandboxExecChild, type SandboxExecChildOptions, type SpawnLikeResult } from "../exec";
 import {
   formatShieldsDownRecoveryCommand,
   normalizeShieldsRelockTimeoutSeconds,
@@ -27,6 +26,12 @@ export interface ConnectShieldsRelockWatcher {
   stop(): void;
 }
 
+type ConnectChildRunner = (
+  binary: string,
+  args: readonly string[],
+  options: SandboxExecChildOptions,
+) => Promise<SpawnLikeResult>;
+
 function formatConnectShieldsRelockNotice(
   sandboxName: string,
   timeoutSeconds: number | null,
@@ -44,7 +49,7 @@ export function pollConnectShieldsRelockNotice(
   readRecent: ConnectShieldsRelockNoticeReader = (sandboxName) =>
     readRecentShieldsAutoRestore(sandboxName, CONNECT_SHIELDS_RELOCK_LOOKBACK_MS),
   writeNotice: (value: string) => void = (value) => {
-    writeSync(2, value);
+    process.stderr.write(value);
   },
 ): ConnectShieldsRelockNoticeState {
   const result = readRecent(state.sandboxName);
@@ -63,16 +68,32 @@ export function pollConnectShieldsRelockNotice(
 
 export function startConnectShieldsRelockWatcher(
   sandboxName: string,
+  readRecent: ConnectShieldsRelockNoticeReader = (name) =>
+    readRecentShieldsAutoRestore(name, CONNECT_SHIELDS_RELOCK_LOOKBACK_MS),
+  writeNotice: (value: string) => void = (value) => {
+    process.stderr.write(value);
+  },
 ): ConnectShieldsRelockWatcher | null {
   try {
-    const worker = new Worker(__filename, {
-      workerData: { sandboxName, startedAtMs: Date.now() },
-    });
-    worker.on("error", () => undefined);
-    worker.unref();
+    const startedAtMs = Date.now();
+    let state: ConnectShieldsRelockNoticeState = {
+      lastNotifiedRestoreMs: startedAtMs - 1,
+      sandboxName,
+      startedAtMs,
+    };
+    const poll = () => {
+      try {
+        state = pollConnectShieldsRelockNotice(state, readRecent, writeNotice);
+      } catch {
+        // Audit visibility is advisory. Keep the connected session available.
+      }
+    };
+    poll();
+    const timer = setInterval(poll, CONNECT_SHIELDS_RELOCK_POLL_MS);
+    timer.unref();
     return {
       stop(): void {
-        void worker.terminate().catch(() => undefined);
+        clearInterval(timer);
       },
     };
   } catch {
@@ -81,32 +102,23 @@ export function startConnectShieldsRelockWatcher(
   }
 }
 
-function runConnectShieldsRelockWatcher(): void {
-  const data = workerData as { sandboxName?: unknown; startedAtMs?: unknown };
-  if (
-    typeof data.sandboxName !== "string" ||
-    data.sandboxName.length < 1 ||
-    data.sandboxName.length > 255 ||
-    /[\0\r\n]/u.test(data.sandboxName) ||
-    typeof data.startedAtMs !== "number" ||
-    !Number.isFinite(data.startedAtMs)
-  ) {
-    return;
+export async function runConnectChildWithShieldsRelockNotice(
+  binary: string,
+  args: readonly string[],
+  options: SandboxExecChildOptions,
+  sandboxName: string,
+  watchShields: boolean,
+  deps: {
+    runChild?: ConnectChildRunner;
+    startWatcher?: typeof startConnectShieldsRelockWatcher;
+  } = {},
+): Promise<SpawnLikeResult> {
+  const watcher = watchShields
+    ? (deps.startWatcher ?? startConnectShieldsRelockWatcher)(sandboxName)
+    : null;
+  try {
+    return await (deps.runChild ?? runSandboxExecChild)(binary, args, options);
+  } finally {
+    watcher?.stop();
   }
-  let state: ConnectShieldsRelockNoticeState = {
-    lastNotifiedRestoreMs: data.startedAtMs - 1,
-    sandboxName: data.sandboxName,
-    startedAtMs: data.startedAtMs,
-  };
-  const poll = () => {
-    try {
-      state = pollConnectShieldsRelockNotice(state);
-    } catch {
-      // Audit visibility is advisory. Keep the connected session available.
-    }
-  };
-  poll();
-  setInterval(poll, CONNECT_SHIELDS_RELOCK_POLL_MS);
 }
-
-if (!isMainThread) runConnectShieldsRelockWatcher();

--- a/src/lib/actions/sandbox/agent/connect-shields-relock-notice.ts
+++ b/src/lib/actions/sandbox/agent/connect-shields-relock-notice.ts
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { writeSync } from "node:fs";
+import { isMainThread, Worker, workerData } from "node:worker_threads";
+import {
+  readRecentShieldsAutoRestore,
+  type ShieldsAutoRestoreReadResult,
+} from "../../../shields/audit";
+import {
+  formatShieldsDownRecoveryCommand,
+  normalizeShieldsRelockTimeoutSeconds,
+} from "./passthrough-shields-warning";
+
+const CONNECT_SHIELDS_RELOCK_LOOKBACK_MS = 10 * 60 * 1000;
+const CONNECT_SHIELDS_RELOCK_POLL_MS = 1000;
+
+type ConnectShieldsRelockNoticeReader = (sandboxName: string) => ShieldsAutoRestoreReadResult;
+
+export interface ConnectShieldsRelockNoticeState {
+  readonly lastNotifiedRestoreMs: number;
+  readonly sandboxName: string;
+  readonly startedAtMs: number;
+}
+
+export interface ConnectShieldsRelockWatcher {
+  stop(): void;
+}
+
+function formatConnectShieldsRelockNotice(
+  sandboxName: string,
+  timeoutSeconds: number | null,
+): string {
+  const safeTimeout = normalizeShieldsRelockTimeoutSeconds(timeoutSeconds);
+  const afterPart = safeTimeout === null ? "" : ` after ${String(safeTimeout)}s`;
+  return (
+    `\n  ⚠ Shields auto-relocked${afterPart}. This connected session remains open, but restricted operations may now fail.\n` +
+    `  Run \`${formatShieldsDownRecoveryCommand(sandboxName, safeTimeout)}\` on the host to lower Shields again.\n`
+  );
+}
+
+export function pollConnectShieldsRelockNotice(
+  state: ConnectShieldsRelockNoticeState,
+  readRecent: ConnectShieldsRelockNoticeReader = (sandboxName) =>
+    readRecentShieldsAutoRestore(sandboxName, CONNECT_SHIELDS_RELOCK_LOOKBACK_MS),
+  writeNotice: (value: string) => void = (value) => {
+    writeSync(2, value);
+  },
+): ConnectShieldsRelockNoticeState {
+  const result = readRecent(state.sandboxName);
+  if (result.kind !== "event") return state;
+  const restoreMs = new Date(result.event.timestamp).getTime();
+  if (
+    !Number.isFinite(restoreMs) ||
+    restoreMs < state.startedAtMs ||
+    restoreMs <= state.lastNotifiedRestoreMs
+  ) {
+    return state;
+  }
+  writeNotice(formatConnectShieldsRelockNotice(state.sandboxName, result.event.timeoutSeconds));
+  return { ...state, lastNotifiedRestoreMs: restoreMs };
+}
+
+export function startConnectShieldsRelockWatcher(
+  sandboxName: string,
+): ConnectShieldsRelockWatcher | null {
+  try {
+    const worker = new Worker(__filename, {
+      workerData: { sandboxName, startedAtMs: Date.now() },
+    });
+    worker.on("error", () => undefined);
+    worker.unref();
+    return {
+      stop(): void {
+        void worker.terminate().catch(() => undefined);
+      },
+    };
+  } catch {
+    // Advisory visibility must never prevent or terminate a connect session.
+    return null;
+  }
+}
+
+function runConnectShieldsRelockWatcher(): void {
+  const data = workerData as { sandboxName?: unknown; startedAtMs?: unknown };
+  if (
+    typeof data.sandboxName !== "string" ||
+    data.sandboxName.length < 1 ||
+    data.sandboxName.length > 255 ||
+    /[\0\r\n]/u.test(data.sandboxName) ||
+    typeof data.startedAtMs !== "number" ||
+    !Number.isFinite(data.startedAtMs)
+  ) {
+    return;
+  }
+  let state: ConnectShieldsRelockNoticeState = {
+    lastNotifiedRestoreMs: data.startedAtMs - 1,
+    sandboxName: data.sandboxName,
+    startedAtMs: data.startedAtMs,
+  };
+  const poll = () => {
+    try {
+      state = pollConnectShieldsRelockNotice(state);
+    } catch {
+      // Audit visibility is advisory. Keep the connected session available.
+    }
+  };
+  poll();
+  setInterval(poll, CONNECT_SHIELDS_RELOCK_POLL_MS);
+}
+
+if (!isMainThread) runConnectShieldsRelockWatcher();

--- a/src/lib/actions/sandbox/agent/connect-shields-relock-notice.ts
+++ b/src/lib/actions/sandbox/agent/connect-shields-relock-notice.ts
@@ -26,12 +26,6 @@ export interface ConnectShieldsRelockWatcher {
   stop(): void;
 }
 
-type ConnectChildRunner = (
-  binary: string,
-  args: readonly string[],
-  options: SandboxExecChildOptions,
-) => Promise<SpawnLikeResult>;
-
 function formatConnectShieldsRelockNotice(
   sandboxName: string,
   timeoutSeconds: number | null,
@@ -108,16 +102,10 @@ export async function runConnectChildWithShieldsRelockNotice(
   options: SandboxExecChildOptions,
   sandboxName: string,
   watchShields: boolean,
-  deps: {
-    runChild?: ConnectChildRunner;
-    startWatcher?: typeof startConnectShieldsRelockWatcher;
-  } = {},
 ): Promise<SpawnLikeResult> {
-  const watcher = watchShields
-    ? (deps.startWatcher ?? startConnectShieldsRelockWatcher)(sandboxName)
-    : null;
+  const watcher = watchShields ? startConnectShieldsRelockWatcher(sandboxName) : null;
   try {
-    return await (deps.runChild ?? runSandboxExecChild)(binary, args, options);
+    return await runSandboxExecChild(binary, args, options);
   } finally {
     watcher?.stop();
   }

--- a/src/lib/actions/sandbox/agent/passthrough-shields-warning.ts
+++ b/src/lib/actions/sandbox/agent/passthrough-shields-warning.ts
@@ -22,10 +22,10 @@ import {
 // - Presentation boundary: sandbox names are user-controlled command text and
 //   must remain shell-quoted. Direct stderr output is deliberate so the warning
 //   is visible in a one-shot CLI while machine-readable stdout stays clean.
-// - Source-fix constraint: an already-running in-sandbox TUI has no host CLI
-//   interception point. That surface needs an upstream structured relock error
-//   or a separate extend-on-activity design; this helper covers only host
-//   `nemoclaw <name> agent` dispatches.
+// - Source-fix constraint: this helper covers only host `nemoclaw <name> agent`
+//   dispatches. Connect-managed OpenClaw sessions use a separate bounded audit
+//   watcher. Sessions entered outside NemoClaw still need an upstream structured
+//   relock error or a separate extend-on-activity design.
 // - Regression tests cover validated/fallback timeouts, shell metacharacters
 //   and embedded quotes, real-file JSON stdout separation, unreadable/absent
 //   history, newer-down suppression, and terminal-runtime exclusion.
@@ -44,6 +44,23 @@ type ShieldsWarningProcess = {
 
 type RecentShieldsAutoRestoreReader = (sandboxName: string) => ShieldsAutoRestoreReadResult;
 
+export function normalizeShieldsRelockTimeoutSeconds(timeoutSeconds: number | null): number | null {
+  return timeoutSeconds !== null &&
+    Number.isInteger(timeoutSeconds) &&
+    timeoutSeconds >= 1 &&
+    timeoutSeconds <= 1800
+    ? timeoutSeconds
+    : null;
+}
+
+export function formatShieldsDownRecoveryCommand(
+  sandboxName: string,
+  timeoutSeconds: number | null,
+): string {
+  const safeTimeout = normalizeShieldsRelockTimeoutSeconds(timeoutSeconds);
+  return `${CLI_NAME} ${shellQuote(sandboxName)} shields down --timeout ${String(safeTimeout ?? 60)}s`;
+}
+
 function emitShieldsRelockWarning(
   proc: ShieldsWarningProcess,
   relock: ShieldsAutoRestoreEvent,
@@ -51,18 +68,10 @@ function emitShieldsRelockWarning(
 ): void {
   // Defend the user-facing command suggestion even when tests or future
   // callers inject an event without going through the audit reader.
-  const timeoutSeconds =
-    relock.timeoutSeconds !== null &&
-    Number.isInteger(relock.timeoutSeconds) &&
-    relock.timeoutSeconds >= 1 &&
-    relock.timeoutSeconds <= 1800
-      ? relock.timeoutSeconds
-      : null;
+  const timeoutSeconds = normalizeShieldsRelockTimeoutSeconds(relock.timeoutSeconds);
   const afterPart = timeoutSeconds !== null ? ` after ${String(timeoutSeconds)}s` : "";
-  const timeoutSuggestion =
-    timeoutSeconds !== null ? `--timeout ${String(timeoutSeconds)}s` : "--timeout 60s";
   proc.stderr.write(
-    `  ⚠ Shields auto-relocked${afterPart} — run \`${CLI_NAME} ${shellQuote(sandboxName)} shields down ${timeoutSuggestion}\` to extend.\n`,
+    `  ⚠ Shields auto-relocked${afterPart} — run \`${formatShieldsDownRecoveryCommand(sandboxName, timeoutSeconds)}\` to extend.\n`,
   );
 }
 

--- a/src/lib/actions/sandbox/connect-boundary-refusal.ts
+++ b/src/lib/actions/sandbox/connect-boundary-refusal.ts
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SpawnLikeResult } from "./exec";
-import { runConnectChildWithShieldsRelockNotice } from "./agent/connect-shields-relock-notice";
-import { prepareHermesLightTerminalSkin } from "./connect-hermes-light-skin";
 import {
   type GatewayRestartFailureLayer,
   gatewayIntegrityRepairLines,
@@ -16,25 +13,6 @@ import {
 } from "./mcp-bridge-hermes-reconciliation";
 
 type ConnectBoundaryContext = "Probe" | "Connect";
-type ConnectAgent = { name?: string } | null | undefined;
-
-export async function runInteractiveConnectSession(
-  binary: string,
-  sandboxName: string,
-  agent: ConnectAgent,
-  registeredAgent: string | null | undefined,
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-): Promise<SpawnLikeResult> {
-  prepareHermesLightTerminalSkin(sandboxName, agent, env);
-  return await runConnectChildWithShieldsRelockNotice(
-    binary,
-    ["sandbox", "connect", sandboxName],
-    { hostCwd: cwd, hostEnv: { ...env }, stdin: true },
-    sandboxName,
-    agent?.name === "openclaw" || registeredAgent === "openclaw",
-  );
-}
 
 /**
  * A managed recovery that failed on a deterministic integrity refusal cannot be

--- a/src/lib/actions/sandbox/connect-boundary-refusal.ts
+++ b/src/lib/actions/sandbox/connect-boundary-refusal.ts
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { SpawnLikeResult } from "./exec";
+import { runConnectChildWithShieldsRelockNotice } from "./agent/connect-shields-relock-notice";
+import { prepareHermesLightTerminalSkin } from "./connect-hermes-light-skin";
 import {
   type GatewayRestartFailureLayer,
   gatewayIntegrityRepairLines,
@@ -12,9 +15,26 @@ import {
   sanitizeHermesMcpReconciliationDetail,
 } from "./mcp-bridge-hermes-reconciliation";
 
-export { startConnectShieldsRelockWatcher } from "./agent/connect-shields-relock-notice";
-
 type ConnectBoundaryContext = "Probe" | "Connect";
+type ConnectAgent = { name?: string } | null | undefined;
+
+export async function runInteractiveConnectSession(
+  binary: string,
+  sandboxName: string,
+  agent: ConnectAgent,
+  registeredAgent: string | null | undefined,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): Promise<SpawnLikeResult> {
+  prepareHermesLightTerminalSkin(sandboxName, agent, env);
+  return await runConnectChildWithShieldsRelockNotice(
+    binary,
+    ["sandbox", "connect", sandboxName],
+    { hostCwd: cwd, hostEnv: { ...env }, stdin: true },
+    sandboxName,
+    agent?.name === "openclaw" || registeredAgent === "openclaw",
+  );
+}
 
 /**
  * A managed recovery that failed on a deterministic integrity refusal cannot be

--- a/src/lib/actions/sandbox/connect-boundary-refusal.ts
+++ b/src/lib/actions/sandbox/connect-boundary-refusal.ts
@@ -12,6 +12,8 @@ import {
   sanitizeHermesMcpReconciliationDetail,
 } from "./mcp-bridge-hermes-reconciliation";
 
+export { startConnectShieldsRelockWatcher } from "./agent/connect-shields-relock-notice";
+
 type ConnectBoundaryContext = "Probe" | "Connect";
 
 /**

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -49,6 +49,8 @@ describe("connectSandbox flow", () => {
   });
 
   it("runs readiness checks, recovery probes, auto-pair approval, and opens the OpenShell shell", async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
     const harness = createConnectHarness();
 
     await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(0)");
@@ -60,19 +62,19 @@ describe("connectSandbox flow", () => {
     expect(harness.checkAndRecoverSpy).toHaveBeenCalledWith("alpha");
     expect(harness.ensureOllamaAuthProxySpy).toHaveBeenCalledTimes(1);
     expect(harness.runAutoPairSpy).toHaveBeenCalledWith("alpha", "nemoclaw");
-    expect(harness.runConnectChildWithShieldsRelockNoticeSpy).toHaveBeenCalledWith(
+    expect(harness.runSandboxExecChildSpy).toHaveBeenCalledWith(
       "openshell",
       ["sandbox", "connect", "alpha"],
       expect.objectContaining({
         hostCwd: expect.any(String),
-        hostEnv: expect.any(Object),
         stdin: true,
       }),
-      "alpha",
-      true,
     );
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 1_000);
+    const watcherTimer = setIntervalSpy.mock.results[setIntervalSpy.mock.results.length - 1]?.value;
+    expect(clearIntervalSpy).toHaveBeenCalledWith(watcherTimer);
     expect(
-      harness.runConnectChildWithShieldsRelockNoticeSpy.mock.invocationCallOrder[0]!,
+      harness.runSandboxExecChildSpy.mock.invocationCallOrder[0]!,
     ).toBeLessThan(exitSpy.mock.invocationCallOrder[0]!);
     const output = harness.logSpy.mock.calls.map((call) => String(call[0])).join("\n");
     expect(output).toContain("existing SSH sessions");
@@ -81,6 +83,7 @@ describe("connectSandbox flow", () => {
   });
 
   it("does not watch Shields audit state for a terminal-runtime connect session (#9453)", async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
     const harness = createConnectHarness({
       agentName: "langchain-deepagents-code",
       sessionAgent: {
@@ -91,13 +94,12 @@ describe("connectSandbox flow", () => {
 
     await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(0)");
 
-    expect(harness.runConnectChildWithShieldsRelockNoticeSpy).toHaveBeenCalledWith(
+    expect(harness.runSandboxExecChildSpy).toHaveBeenCalledWith(
       "openshell",
       ["sandbox", "connect", "alpha"],
       expect.any(Object),
-      "alpha",
-      false,
     );
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 1_000);
   });
 
   it("uses the owning OpenShell gateway for auto-pair when an ambient gateway has the same sandbox name (#8942)", async () => {

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -60,19 +60,20 @@ describe("connectSandbox flow", () => {
     expect(harness.checkAndRecoverSpy).toHaveBeenCalledWith("alpha");
     expect(harness.ensureOllamaAuthProxySpy).toHaveBeenCalledTimes(1);
     expect(harness.runAutoPairSpy).toHaveBeenCalledWith("alpha", "nemoclaw");
-    expect(harness.spawnSyncSpy).toHaveBeenCalledWith(
+    expect(harness.runConnectChildWithShieldsRelockNoticeSpy).toHaveBeenCalledWith(
       "openshell",
       ["sandbox", "connect", "alpha"],
-      expect.objectContaining({ stdio: "inherit" }),
+      expect.objectContaining({
+        hostCwd: expect.any(String),
+        hostEnv: expect.any(Object),
+        stdin: true,
+      }),
+      "alpha",
+      true,
     );
-    expect(harness.startConnectShieldsRelockWatcherSpy).toHaveBeenCalledWith("alpha");
-    expect(harness.stopConnectShieldsRelockWatcherSpy).toHaveBeenCalledOnce();
-    expect(harness.spawnSyncSpy.mock.invocationCallOrder.at(-1)!).toBeLessThan(
-      harness.stopConnectShieldsRelockWatcherSpy.mock.invocationCallOrder[0]!,
-    );
-    expect(harness.stopConnectShieldsRelockWatcherSpy.mock.invocationCallOrder[0]!).toBeLessThan(
-      exitSpy.mock.invocationCallOrder[0]!,
-    );
+    expect(
+      harness.runConnectChildWithShieldsRelockNoticeSpy.mock.invocationCallOrder[0]!,
+    ).toBeLessThan(exitSpy.mock.invocationCallOrder[0]!);
     const output = harness.logSpy.mock.calls.map((call) => String(call[0])).join("\n");
     expect(output).toContain("existing SSH sessions");
     expect(output).toContain("Connecting to sandbox 'alpha'");
@@ -90,8 +91,13 @@ describe("connectSandbox flow", () => {
 
     await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(0)");
 
-    expect(harness.startConnectShieldsRelockWatcherSpy).not.toHaveBeenCalled();
-    expect(harness.stopConnectShieldsRelockWatcherSpy).not.toHaveBeenCalled();
+    expect(harness.runConnectChildWithShieldsRelockNoticeSpy).toHaveBeenCalledWith(
+      "openshell",
+      ["sandbox", "connect", "alpha"],
+      expect.any(Object),
+      "alpha",
+      false,
+    );
   });
 
   it("uses the owning OpenShell gateway for auto-pair when an ambient gateway has the same sandbox name (#8942)", async () => {

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -65,10 +65,33 @@ describe("connectSandbox flow", () => {
       ["sandbox", "connect", "alpha"],
       expect.objectContaining({ stdio: "inherit" }),
     );
+    expect(harness.startConnectShieldsRelockWatcherSpy).toHaveBeenCalledWith("alpha");
+    expect(harness.stopConnectShieldsRelockWatcherSpy).toHaveBeenCalledOnce();
+    expect(harness.spawnSyncSpy.mock.invocationCallOrder.at(-1)!).toBeLessThan(
+      harness.stopConnectShieldsRelockWatcherSpy.mock.invocationCallOrder[0]!,
+    );
+    expect(harness.stopConnectShieldsRelockWatcherSpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      exitSpy.mock.invocationCallOrder[0]!,
+    );
     const output = harness.logSpy.mock.calls.map((call) => String(call[0])).join("\n");
     expect(output).toContain("existing SSH sessions");
     expect(output).toContain("Connecting to sandbox 'alpha'");
     expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("does not watch Shields audit state for a terminal-runtime connect session (#9453)", async () => {
+    const harness = createConnectHarness({
+      agentName: "langchain-deepagents-code",
+      sessionAgent: {
+        name: "langchain-deepagents-code",
+        runtime: { kind: "terminal", interactive_command: "dcode", headless_command: "dcode -n" },
+      },
+    });
+
+    await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(0)");
+
+    expect(harness.startConnectShieldsRelockWatcherSpy).not.toHaveBeenCalled();
+    expect(harness.stopConnectShieldsRelockWatcherSpy).not.toHaveBeenCalled();
   });
 
   it("uses the owning OpenShell gateway for auto-pair when an ambient gateway has the same sandbox name (#8942)", async () => {
@@ -149,37 +172,42 @@ describe("connectSandbox flow", () => {
   it.each([
     ["SIGHUP", 129],
     ["SIGPIPE", 141],
-  ] as const)("restores the terminal and preserves the exit code when SSH ends with %s", async (signal, exitCode) => {
-    const setRawModeSpy = vi.fn();
-    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
-    Object.defineProperty(process.stdin, "setRawMode", {
-      configurable: true,
-      value: setRawModeSpy,
-    });
-    const harness = createConnectHarness({
-      agentName: "langchain-deepagents-code",
-      sessionAgent: {
-        name: "langchain-deepagents-code",
-        runtime: { kind: "terminal", interactive_command: "dcode", headless_command: "dcode -n" },
-      },
-      spawnSignal: signal,
-      spawnStatus: null,
-    });
+  ] as const)(
+    "restores the terminal and preserves the exit code when SSH ends with %s",
+    async (signal, exitCode) => {
+      const setRawModeSpy = vi.fn();
+      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+      Object.defineProperty(process.stdin, "setRawMode", {
+        configurable: true,
+        value: setRawModeSpy,
+      });
+      const harness = createConnectHarness({
+        agentName: "langchain-deepagents-code",
+        sessionAgent: {
+          name: "langchain-deepagents-code",
+          runtime: { kind: "terminal", interactive_command: "dcode", headless_command: "dcode -n" },
+        },
+        spawnSignal: signal,
+        spawnStatus: null,
+      });
 
-    await expect(harness.connectSandbox("alpha")).rejects.toThrow(`process.exit(${exitCode})`);
+      await expect(harness.connectSandbox("alpha")).rejects.toThrow(`process.exit(${exitCode})`);
 
-    expect(setRawModeSpy).toHaveBeenCalledWith(false);
-    expect(harness.spawnSyncSpy).toHaveBeenCalledWith(
-      "stty",
-      ["sane"],
-      expect.objectContaining({ stdio: ["inherit", "ignore", "ignore"] }),
-    );
-    const errorOutput = harness.errorSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
-    expect(errorOutput).toContain(
-      "Gateway connection lost. Reconnect with: nemoclaw alpha connect",
-    );
-    expect(exitSpy).toHaveBeenCalledWith(exitCode);
-  });
+      expect(setRawModeSpy).toHaveBeenCalledWith(false);
+      expect(harness.spawnSyncSpy).toHaveBeenCalledWith(
+        "stty",
+        ["sane"],
+        expect.objectContaining({ stdio: ["inherit", "ignore", "ignore"] }),
+      );
+      const errorOutput = harness.errorSpy.mock.calls
+        .map((call) => String(call[0] ?? ""))
+        .join("\n");
+      expect(errorOutput).toContain(
+        "Gateway connection lost. Reconnect with: nemoclaw alpha connect",
+      );
+      expect(exitSpy).toHaveBeenCalledWith(exitCode);
+    },
+  );
 
   it("prints reconnect guidance without terminal cleanup when stdin is not a TTY", async () => {
     const setRawModeSpy = vi.fn();
@@ -340,29 +368,30 @@ describe("connectSandbox flow", () => {
     );
   });
 
-  it.each([
-    401, 403, 404,
-  ])("rejects HTTP %i from inference.local for an Ollama recovery path (#8502)", async (httpStatus) => {
-    const response = `OK ${String(httpStatus)}`;
-    const harness = createConnectHarness({
-      inferenceGetOutput: "Provider: ollama-local\nModel: qwen3-vl:4b\n",
-      inferenceProbeResponses: [response, response],
-      registryEntry: { provider: "ollama-local", model: "qwen3-vl:4b" },
-    });
+  it.each([401, 403, 404])(
+    "rejects HTTP %i from inference.local for an Ollama recovery path (#8502)",
+    async (httpStatus) => {
+      const response = `OK ${String(httpStatus)}`;
+      const harness = createConnectHarness({
+        inferenceGetOutput: "Provider: ollama-local\nModel: qwen3-vl:4b\n",
+        inferenceProbeResponses: [response, response],
+        registryEntry: { provider: "ollama-local", model: "qwen3-vl:4b" },
+      });
 
-    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
-      "process.exit(1)",
-    );
+      await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+        "process.exit(1)",
+      );
 
-    expect(harness.errorSpy.mock.calls.flat().join("\n")).toContain(
-      "inference.local/v1/models must return HTTP 2xx",
-    );
-    expect(harness.probeLocalProviderHealthSpy).toHaveBeenCalledWith("ollama-local", {
-      skipOllamaAuthProxySubprobe: true,
-    });
-    expect(harness.probeOllamaAuthProxyHealthSpy).toHaveBeenCalledTimes(1);
-    expect(exitSpy).toHaveBeenCalledWith(1);
-  });
+      expect(harness.errorSpy.mock.calls.flat().join("\n")).toContain(
+        "inference.local/v1/models must return HTTP 2xx",
+      );
+      expect(harness.probeLocalProviderHealthSpy).toHaveBeenCalledWith("ollama-local", {
+        skipOllamaAuthProxySubprobe: true,
+      });
+      expect(harness.probeOllamaAuthProxyHealthSpy).toHaveBeenCalledTimes(1);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    },
+  );
 
   it("rechecks HTTP 2xx after repairing an Ollama inference route (#8502)", async () => {
     const harness = createConnectHarness({

--- a/src/lib/actions/sandbox/connect-hermes-light-theme.test.ts
+++ b/src/lib/actions/sandbox/connect-hermes-light-theme.test.ts
@@ -15,7 +15,7 @@ const REDACTED_URL_CANARY = "https://user:secret@example.test/hermes";
 type ConnectHarness = ReturnType<typeof createConnectHarness>;
 
 function connectCalls(harness: ConnectHarness, sandboxName = "alpha") {
-  return harness.runConnectChildWithShieldsRelockNoticeSpy.mock.calls.filter(
+  return harness.runSandboxExecChildSpy.mock.calls.filter(
     ([command, args]) =>
       command === "openshell" &&
       Array.isArray(args) &&
@@ -108,18 +108,10 @@ describe("Hermes sandbox connect light terminal skin", () => {
       display: { skin: NEMOCLAW_HERMES_LIGHT_SKIN_NAME },
     });
 
-    const connectCall = connectCalls(harness)[0];
-    expect(connectCall?.[2]).toEqual(
-      expect.objectContaining({
-        hostEnv: expect.objectContaining({
-          COLORFGBG: "0;15",
-          TERM_PROGRAM: "Apple_Terminal",
-        }),
-      }),
-    );
-    expect(connectCall?.[2]?.hostEnv).not.toEqual(
-      expect.objectContaining({ HERMES_TUI_LIGHT: "1" }),
-    );
+    expect(process.env.COLORFGBG).toBe("0;15");
+    expect(process.env.TERM_PROGRAM).toBe("Apple_Terminal");
+    expect(process.env.HERMES_TUI_LIGHT).not.toBe("1");
+    expect(connectCalls(harness)[0]?.[2]).not.toHaveProperty("hostEnv");
     expectConnectSucceeded(harness, exitSpy);
   });
 

--- a/src/lib/actions/sandbox/connect-hermes-light-theme.test.ts
+++ b/src/lib/actions/sandbox/connect-hermes-light-theme.test.ts
@@ -15,7 +15,7 @@ const REDACTED_URL_CANARY = "https://user:secret@example.test/hermes";
 type ConnectHarness = ReturnType<typeof createConnectHarness>;
 
 function connectCalls(harness: ConnectHarness, sandboxName = "alpha") {
-  return harness.spawnSyncSpy.mock.calls.filter(
+  return harness.runConnectChildWithShieldsRelockNoticeSpy.mock.calls.filter(
     ([command, args]) =>
       command === "openshell" &&
       Array.isArray(args) &&
@@ -111,13 +111,15 @@ describe("Hermes sandbox connect light terminal skin", () => {
     const connectCall = connectCalls(harness)[0];
     expect(connectCall?.[2]).toEqual(
       expect.objectContaining({
-        env: expect.objectContaining({
+        hostEnv: expect.objectContaining({
           COLORFGBG: "0;15",
           TERM_PROGRAM: "Apple_Terminal",
         }),
       }),
     );
-    expect(connectCall?.[2]?.env).not.toEqual(expect.objectContaining({ HERMES_TUI_LIGHT: "1" }));
+    expect(connectCall?.[2]?.hostEnv).not.toEqual(
+      expect.objectContaining({ HERMES_TUI_LIGHT: "1" }),
+    );
     expectConnectSucceeded(harness, exitSpy);
   });
 

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -61,9 +61,8 @@ import {
   exitOnMcpReconciliationRefusal,
   exitOnSecretBoundaryRefusal,
   printGatewayIntegrityRepairGuidance,
-  startConnectShieldsRelockWatcher,
+  runInteractiveConnectSession,
 } from "./connect-boundary-refusal";
-import { prepareHermesLightTerminalSkin } from "./connect-hermes-light-skin";
 import {
   assertSandboxGatewayRouteCompatible,
   buildGatewayInferenceGetArgs,
@@ -1433,20 +1432,14 @@ export async function connectSandbox(
     // OPENSHELL_SANDBOX) and covers every other interactive entry path too.
     console.log("");
   }
-  prepareHermesLightTerminalSkin(sandboxName, agent, process.env);
-  const shieldsRelockWatcher =
-    agent?.name === "openclaw" || sb?.agent === "openclaw"
-      ? startConnectShieldsRelockWatcher(sandboxName)
-      : null;
-  let result: ReturnType<typeof spawnSync>;
-  try {
-    result = spawnSync(getOpenshellBinary(), ["sandbox", "connect", sandboxName], {
-      stdio: "inherit",
-      cwd: ROOT,
-      env: { ...process.env },
-    });
-  } finally {
-    shieldsRelockWatcher?.stop();
-  }
+  const result = await runInteractiveConnectSession(
+    getOpenshellBinary(),
+    sandboxName,
+    agent,
+    sb?.agent,
+    ROOT,
+    process.env,
+  );
+  result.releaseSignals?.();
   exitWithConnectSpawnResult(sandboxName, result);
 }

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -3,9 +3,12 @@
 
 import { spawnSync } from "node:child_process";
 import { resolveOpenshell } from "../../adapters/openshell/resolve";
-import { captureOpenshell, getOpenshellBinary, runOpenshell } from "../../adapters/openshell/runtime";
 import {
-
+  captureOpenshell,
+  getOpenshellBinary,
+  runOpenshell,
+} from "../../adapters/openshell/runtime";
+import {
   OPENSHELL_INFERENCE_ROUTE_PROBE_TIMEOUT_MS,
   OPENSHELL_OPERATION_TIMEOUT_MS,
   OPENSHELL_PROBE_TIMEOUT_MS,
@@ -58,6 +61,7 @@ import {
   exitOnMcpReconciliationRefusal,
   exitOnSecretBoundaryRefusal,
   printGatewayIntegrityRepairGuidance,
+  startConnectShieldsRelockWatcher,
 } from "./connect-boundary-refusal";
 import { prepareHermesLightTerminalSkin } from "./connect-hermes-light-skin";
 import {
@@ -128,7 +132,6 @@ type SandboxListProbe = {
   status: number | null;
   output: string;
 };
-
 
 export type SandboxInferenceRouteProbe = {
   healthy: boolean;
@@ -440,7 +443,6 @@ function failIfGatewayBlocksConnectReadiness(sandboxName: string): void {
   }
 }
 
-
 function sleepSync(milliseconds: number): void {
   if (milliseconds <= 0) return;
   if (process.env.VITEST === "true" || process.env.NEMOCLAW_TEST_NO_SLEEP === "1") return;
@@ -481,7 +483,6 @@ export function probeSandboxInferenceRoute(
     },
   );
 }
-
 
 function shouldUseLegacyDnsProxyRepair(sb: SandboxEntry | null): boolean {
   // The legacy repair patches CoreDNS inside an `openshell-cluster-<name>`
@@ -992,9 +993,7 @@ export function restoreSandboxStartupState(sandboxName: string): SandboxStartupR
   const directRecoveryFailureDetail =
     "recoveryFailureDetail" in processCheck ? processCheck.recoveryFailureDetail : null;
   const recoveryFailureDetail = directRecoveryFailureDetail ?? reportedRecoveryFailureDetail;
-  const recoveryFailureLayer = directRecoveryFailureDetail
-    ? null
-    : reportedRecoveryFailureLayer;
+  const recoveryFailureLayer = directRecoveryFailureDetail ? null : reportedRecoveryFailureLayer;
   return Object.assign(processCheck, { recoveryFailureDetail, recoveryFailureLayer });
 }
 
@@ -1435,10 +1434,19 @@ export async function connectSandbox(
     console.log("");
   }
   prepareHermesLightTerminalSkin(sandboxName, agent, process.env);
-  const result = spawnSync(getOpenshellBinary(), ["sandbox", "connect", sandboxName], {
-    stdio: "inherit",
-    cwd: ROOT,
-    env: { ...process.env },
-  });
+  const shieldsRelockWatcher =
+    agent?.name === "openclaw" || sb?.agent === "openclaw"
+      ? startConnectShieldsRelockWatcher(sandboxName)
+      : null;
+  let result: ReturnType<typeof spawnSync>;
+  try {
+    result = spawnSync(getOpenshellBinary(), ["sandbox", "connect", sandboxName], {
+      stdio: "inherit",
+      cwd: ROOT,
+      env: { ...process.env },
+    });
+  } finally {
+    shieldsRelockWatcher?.stop();
+  }
   exitWithConnectSpawnResult(sandboxName, result);
 }

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -56,13 +56,14 @@ import {
   getActiveSandboxSessions,
 } from "../../state/sandbox-session";
 import { runSetupDnsProxy } from "../dns";
+import { runConnectChildWithShieldsRelockNotice } from "./agent/connect-shields-relock-notice";
 import { runConnectAutoPairApprovalPass } from "./auto-pair-approval";
 import {
   exitOnMcpReconciliationRefusal,
   exitOnSecretBoundaryRefusal,
   printGatewayIntegrityRepairGuidance,
-  runInteractiveConnectSession,
 } from "./connect-boundary-refusal";
+import { prepareHermesLightTerminalSkin } from "./connect-hermes-light-skin";
 import {
   assertSandboxGatewayRouteCompatible,
   buildGatewayInferenceGetArgs,
@@ -1432,13 +1433,13 @@ export async function connectSandbox(
     // OPENSHELL_SANDBOX) and covers every other interactive entry path too.
     console.log("");
   }
-  const result = await runInteractiveConnectSession(
+  prepareHermesLightTerminalSkin(sandboxName, agent, process.env);
+  const result = await runConnectChildWithShieldsRelockNotice(
     getOpenshellBinary(),
+    ["sandbox", "connect", sandboxName],
+    { hostCwd: ROOT, stdin: true },
     sandboxName,
-    agent,
-    sb?.agent,
-    ROOT,
-    process.env,
+    agent?.name === "openclaw" || sb?.agent === "openclaw",
   );
   result.releaseSignals?.();
   exitWithConnectSpawnResult(sandboxName, result);

--- a/src/lib/actions/sandbox/exec.ts
+++ b/src/lib/actions/sandbox/exec.ts
@@ -27,11 +27,16 @@ export type SandboxExecOptions = {
   stdin?: boolean;
 };
 
+export type SandboxExecChildOptions = SandboxExecOptions & {
+  hostCwd?: string;
+  hostEnv?: NodeJS.ProcessEnv;
+};
+
 export type SandboxExecGatewayRestart = (sandboxName: string) => { ok: boolean };
 
 export type SandboxExecAgentResolver = (sandboxName: string) => string | null;
 
-type SpawnLikeResult = {
+export type SpawnLikeResult = {
   status: number | null;
   signal?: NodeJS.Signals | null;
   error?: Error;
@@ -59,7 +64,7 @@ export type SandboxExecChild = {
 export type SandboxExecSpawner = (
   binary: string,
   args: readonly string[],
-  options: SandboxExecOptions,
+  options: SandboxExecChildOptions,
 ) => SandboxExecChild;
 
 export type SandboxExecSignalSource = {
@@ -238,7 +243,11 @@ export function cleanupOpenClawAfterExec(
 }
 
 const defaultSandboxExecSpawner: SandboxExecSpawner = (binary, args, options) =>
-  spawn(binary, [...args], { stdio: buildSandboxExecStdio(options) });
+  spawn(binary, [...args], {
+    stdio: buildSandboxExecStdio(options),
+    ...(options.hostCwd ? { cwd: options.hostCwd } : {}),
+    ...(options.hostEnv ? { env: options.hostEnv } : {}),
+  });
 
 const defaultSandboxExecSignalSource: SandboxExecSignalSource = {
   add: (signal, listener) => process.on(signal, listener),
@@ -248,7 +257,7 @@ const defaultSandboxExecSignalSource: SandboxExecSignalSource = {
 export async function runSandboxExecChild(
   binary: string,
   args: readonly string[],
-  options: SandboxExecOptions = {},
+  options: SandboxExecChildOptions = {},
   spawnChild: SandboxExecSpawner = defaultSandboxExecSpawner,
   signalSource: SandboxExecSignalSource = defaultSandboxExecSignalSource,
 ): Promise<SpawnLikeResult> {
@@ -402,10 +411,7 @@ function defaultResolveSandboxAgent(sandboxName: string): string | null {
   return entry.agent ?? "openclaw";
 }
 
-function googleChatPairingActivationFailureMessage(
-  cliName: string,
-  sandboxName: string,
-): string {
+function googleChatPairingActivationFailureMessage(cliName: string, sandboxName: string): string {
   return (
     `  Google Chat pairing approval committed for '${sandboxName}', but managed gateway activation failed. ` +
     `The approval was not rolled back. Run '${cliName} ${sandboxName} gateway restart' before testing the next message.`

--- a/test/support/connect-flow-test-harness.ts
+++ b/test/support/connect-flow-test-harness.ts
@@ -12,7 +12,8 @@ import type { ConfigObject } from "../../src/lib/security/credential-filter";
 import type { SandboxEntry } from "../../src/lib/state/registry";
 
 type ConnectSandbox = (typeof import("../../src/lib/actions/sandbox/connect"))["connectSandbox"];
-type RestoreSandboxStartupState = (typeof import("../../src/lib/actions/sandbox/connect"))["restoreSandboxStartupState"];
+type RestoreSandboxStartupState =
+  (typeof import("../../src/lib/actions/sandbox/connect"))["restoreSandboxStartupState"];
 type GatewayRouteMutationLock =
   (typeof import("../../src/lib/inference/gateway-route-mutation-lock"))["withGatewayRouteMutationLock"];
 type LaunchReadinessPublicationResult =
@@ -56,6 +57,8 @@ export type ConnectHarness = {
   runOpenshellSpy: MockInstance;
   runSetupDnsProxySpy: MockInstance;
   spawnSyncSpy: MockInstance;
+  startConnectShieldsRelockWatcherSpy: MockInstance;
+  stopConnectShieldsRelockWatcherSpy: MockInstance;
   withGatewayRouteMutationLockSpy: MockInstance;
   writeSandboxConfigSpy: MockInstance;
 };
@@ -167,6 +170,13 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
   const sandboxSession = requireDist("../../src/lib/state/sandbox-session.js");
   const vmDnsMonkeypatch = requireDist("../../src/lib/actions/sandbox/vm-dns-monkeypatch.js");
   const launchReadiness = requireDist("../../src/lib/actions/sandbox/launch-readiness.js");
+  const shieldsRelockNotice = requireDist(
+    "../../src/lib/actions/sandbox/agent/connect-shields-relock-notice.js",
+  );
+  const stopConnectShieldsRelockWatcherSpy = vi.fn();
+  const startConnectShieldsRelockWatcherSpy = vi
+    .spyOn(shieldsRelockNotice, "startConnectShieldsRelockWatcher")
+    .mockReturnValue({ stop: stopConnectShieldsRelockWatcherSpy });
 
   const inspectLaunchReadinessSpy = vi
     .spyOn(launchReadiness, "inspectLaunchReadiness")
@@ -383,6 +393,8 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
     runOpenshellSpy,
     runSetupDnsProxySpy,
     spawnSyncSpy,
+    startConnectShieldsRelockWatcherSpy,
+    stopConnectShieldsRelockWatcherSpy,
     withGatewayRouteMutationLockSpy,
     writeSandboxConfigSpy,
   };

--- a/test/support/connect-flow-test-harness.ts
+++ b/test/support/connect-flow-test-harness.ts
@@ -54,7 +54,7 @@ export type ConnectHarness = {
   resolveAgentConfigSpy: MockInstance;
   restoreSandboxStartupState: RestoreSandboxStartupState;
   runAutoPairSpy: MockInstance;
-  runConnectChildWithShieldsRelockNoticeSpy: MockInstance;
+  runSandboxExecChildSpy: MockInstance;
   runOpenshellSpy: MockInstance;
   runSetupDnsProxySpy: MockInstance;
   spawnSyncSpy: MockInstance;
@@ -169,11 +169,9 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
   const sandboxSession = requireDist("../../src/lib/state/sandbox-session.js");
   const vmDnsMonkeypatch = requireDist("../../src/lib/actions/sandbox/vm-dns-monkeypatch.js");
   const launchReadiness = requireDist("../../src/lib/actions/sandbox/launch-readiness.js");
-  const shieldsRelockNotice = requireDist(
-    "../../src/lib/actions/sandbox/agent/connect-shields-relock-notice.js",
-  );
-  const runConnectChildWithShieldsRelockNoticeSpy = vi
-    .spyOn(shieldsRelockNotice, "runConnectChildWithShieldsRelockNotice")
+  const sandboxExec = requireDist("../../src/lib/actions/sandbox/exec.js");
+  const runSandboxExecChildSpy = vi
+    .spyOn(sandboxExec, "runSandboxExecChild")
     .mockResolvedValue({
       status: spawnStatusFromOptions(options),
       signal: options.spawnSignal ?? null,
@@ -390,7 +388,7 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
     resolveAgentConfigSpy,
     restoreSandboxStartupState: requireDist(connectModulePath).restoreSandboxStartupState,
     runAutoPairSpy,
-    runConnectChildWithShieldsRelockNoticeSpy,
+    runSandboxExecChildSpy,
     settlePortablePairingSpy,
     runOpenshellSpy,
     runSetupDnsProxySpy,

--- a/test/support/connect-flow-test-harness.ts
+++ b/test/support/connect-flow-test-harness.ts
@@ -54,11 +54,10 @@ export type ConnectHarness = {
   resolveAgentConfigSpy: MockInstance;
   restoreSandboxStartupState: RestoreSandboxStartupState;
   runAutoPairSpy: MockInstance;
+  runConnectChildWithShieldsRelockNoticeSpy: MockInstance;
   runOpenshellSpy: MockInstance;
   runSetupDnsProxySpy: MockInstance;
   spawnSyncSpy: MockInstance;
-  startConnectShieldsRelockWatcherSpy: MockInstance;
-  stopConnectShieldsRelockWatcherSpy: MockInstance;
   withGatewayRouteMutationLockSpy: MockInstance;
   writeSandboxConfigSpy: MockInstance;
 };
@@ -173,10 +172,12 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
   const shieldsRelockNotice = requireDist(
     "../../src/lib/actions/sandbox/agent/connect-shields-relock-notice.js",
   );
-  const stopConnectShieldsRelockWatcherSpy = vi.fn();
-  const startConnectShieldsRelockWatcherSpy = vi
-    .spyOn(shieldsRelockNotice, "startConnectShieldsRelockWatcher")
-    .mockReturnValue({ stop: stopConnectShieldsRelockWatcherSpy });
+  const runConnectChildWithShieldsRelockNoticeSpy = vi
+    .spyOn(shieldsRelockNotice, "runConnectChildWithShieldsRelockNotice")
+    .mockResolvedValue({
+      status: spawnStatusFromOptions(options),
+      signal: options.spawnSignal ?? null,
+    });
 
   const inspectLaunchReadinessSpy = vi
     .spyOn(launchReadiness, "inspectLaunchReadiness")
@@ -389,12 +390,11 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
     resolveAgentConfigSpy,
     restoreSandboxStartupState: requireDist(connectModulePath).restoreSandboxStartupState,
     runAutoPairSpy,
+    runConnectChildWithShieldsRelockNoticeSpy,
     settlePortablePairingSpy,
     runOpenshellSpy,
     runSetupDnsProxySpy,
     spawnSyncSpy,
-    startConnectShieldsRelockWatcherSpy,
-    stopConnectShieldsRelockWatcherSpy,
     withGatewayRouteMutationLockSpy,
     writeSandboxConfigSpy,
   };


### PR DESCRIPTION
## Summary

OpenClaw sessions opened through `nemoclaw <sandbox> connect` now surface a warning when Shields auto-relock while the terminal connection is active. Connect now uses the existing asynchronous child supervisor, so the parent event loop can poll without a worker thread; audit-read failures remain advisory and never interrupt the session.

## Related Issue

Fixes #9453

## Changes

- Run `openshell sandbox connect` through the existing async child supervisor with inherited stdio and signal cleanup.
- Start a parent-event-loop watcher only for connect-managed OpenClaw sessions while the child owns the terminal.
- Poll the bounded Shields audit reader and emit one direct stderr warning for each new auto-relock event after the session begins.
- Include a shell-quoted, validated `shields down --timeout` recovery command and a safe timeout fallback.
- Clear the watcher in the child lifecycle's `finally` path before connect exit handling and preserve terminal-runtime behavior.
- Share recovery-command formatting with the existing one-shot agent warning and add unit/flow coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — at `25a7536900c9db5ece8a143e4a800b04f1e13b4d`, 107/107 watcher, connect-flow, terminal-skin, and shared child-supervisor tests passed locally; the earlier DGX Spark Ubuntu aarch64 behavior smoke at `437fe871b13e48c8b009afe48a25148208a67e75` emitted the expected warning and shell-quoted recovery command
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: the owning connect-prefix suite passed 177/177; source-architecture, TypeScript, commit hooks, and pre-push hooks passed
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recovery notices when Shields automatically relocks during an active sandbox connection.
  * Notices include actionable recovery guidance and avoid repeating stale or duplicate alerts.
  * Connected sessions now monitor relock events and cleanly stop monitoring when the session ends.
  * Improved sandbox command execution with support for working-directory and environment settings.

* **Bug Fixes**
  * Relock monitoring gracefully handles unavailable audit information without interrupting sessions.
  * Restricted recovery warnings to supported host agent workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->