### PR TITLE
fix(onboard): record the NEMOCLAW_TRACE flag the trace collector acted on

### DIFF
--- a/src/lib/onboard/tracing.ts
+++ b/src/lib/onboard/tracing.ts
@@ -6,8 +6,6 @@ import * as trace from "../trace";
 
 type TraceFn<T> = () => T;
 
-const TRACE_TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
-
 export const ONBOARD_TRACE_PHASE_NAMES = {
   preflight: "nemoclaw.onboard.phase.preflight",
   gateway: "nemoclaw.onboard.phase.gateway",
@@ -28,14 +26,6 @@ export interface OnboardTraceHandle {
   span: ReturnType<NonNullable<ReturnType<typeof trace.getTraceCollector>>["startSpan"]> | null;
 }
 
-export function isTruthyTraceEnv(value: unknown): boolean {
-  return TRACE_TRUTHY_VALUES.has(
-    String(value ?? "")
-      .trim()
-      .toLowerCase(),
-  );
-}
-
 function hasTracePath(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
@@ -50,7 +40,7 @@ export function startOnboardTrace(
     fresh: opts.fresh === true,
     non_interactive: opts.nonInteractive === true || env.NEMOCLAW_NON_INTERACTIVE === "1",
     agent: opts.agent || env.NEMOCLAW_AGENT || null,
-    trace_enabled: isTruthyTraceEnv(env.NEMOCLAW_TRACE),
+    trace_enabled: trace.isTraceFlagEnabled(env.NEMOCLAW_TRACE),
     trace_file_enabled: hasTracePath(env.NEMOCLAW_TRACE_FILE),
     trace_dir_enabled: hasTracePath(env.NEMOCLAW_TRACE_DIR),
   });

--- a/src/lib/trace.test.ts
+++ b/src/lib/trace.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { runCurlProbe } from "./adapters/http/probe";
+import { finishOnboardTrace, startOnboardTrace } from "./onboard/tracing";
 import {
   addTraceEvent,
   flushTrace,
@@ -206,11 +207,18 @@ describe("onboard trace artifacts", () => {
     }
   });
 
-  it("treats false-like NEMOCLAW_TRACE values as disabled", () => {
+  it("treats false-like NEMOCLAW_TRACE values as disabled and records the flag it acted on", () => {
     process.env[TRACE_ENABLED_ENV] = "false";
     resetTraceForTests();
-
     expect(getTraceCollector()).toBeNull();
+
+    // "2" enables the collector without being canonically truthy; the span must agree.
+    process.env[TRACE_ENABLED_ENV] = "2";
+    withTraceFile((traceFile) => {
+      finishOnboardTrace(startOnboardTrace({}, process.env), true);
+      const root = readTraceArtifact(traceFile).resource_spans[0].scope_spans[0].spans[0];
+      expect(root.attributes.trace_enabled).toBe(true);
+    });
   });
 
   it("removes the registered exit listener when resetting tests", () => {

--- a/src/lib/trace.test.ts
+++ b/src/lib/trace.test.ts
@@ -213,12 +213,24 @@ describe("onboard trace artifacts", () => {
     expect(getTraceCollector()).toBeNull();
 
     // "2" enables the collector without being canonically truthy; the span must agree.
-    process.env[TRACE_ENABLED_ENV] = "2";
-    withTraceFile((traceFile) => {
-      finishOnboardTrace(startOnboardTrace({}, process.env), true);
+    const originalCwd = process.cwd();
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-trace-noncanonical-"));
+    try {
+      process.chdir(tmpDir);
+      process.env[TRACE_ENABLED_ENV] = "2";
+      resetTraceForTests();
+
+      const handle = startOnboardTrace({}, process.env);
+      const traceFile = handle.collector?.outputPath ?? "";
+      expect(traceFile).toContain(path.join(".e2e", "traces", "nemoclaw-trace-"));
+      finishOnboardTrace(handle, true);
+
       const root = readTraceArtifact(traceFile).resource_spans[0].scope_spans[0].spans[0];
       expect(root.attributes.trace_enabled).toBe(true);
-    });
+    } finally {
+      process.chdir(originalCwd);
+      fs.rmSync(tmpDir, { force: true, recursive: true });
+    }
   });
 
   it("removes the registered exit listener when resetting tests", () => {

--- a/src/lib/trace.ts
+++ b/src/lib/trace.ts
@@ -161,7 +161,7 @@ export function sanitizeTraceAttributes(attributes: Record<string, unknown> = {}
   return safe;
 }
 
-function isTraceFlagEnabled(value: string | undefined): boolean {
+export function isTraceFlagEnabled(value: string | undefined): boolean {
   const normalized = value?.trim().toLowerCase();
   if (!normalized) return false;
   return !["0", "false", "no", "off"].includes(normalized);


### PR DESCRIPTION
## Summary

`NEMOCLAW_TRACE` was parsed by two predicates that disagree, so a value such as `2`, `y`, or
`enabled` produced a trace file whose own root span recorded `trace_enabled: false`. This
deletes the duplicate predicate and reads the flag through the one that decides whether the
trace file exists, so the recorded attribute now matches the run that wrote it. No run starts
or stops tracing differently.

## Related Issue

Fixes #9515

## Changes

- `src/lib/onboard/tracing.ts`: delete `TRACE_TRUTHY_VALUES` and `isTruthyTraceEnv`, and set
  the `nemoclaw.onboard` root span's `trace_enabled` from `trace.isTraceFlagEnabled` instead.
  `isTruthyTraceEnv` had exactly one consumer (that attribute) and no test, so nothing else
  changes. The file already imported `../trace`, so this adds no module dependency.
- `src/lib/trace.ts`: export the existing `isTraceFlagEnabled` so it can be the single parser.
  Its rule is unchanged.
- `src/lib/trace.test.ts`: extend the existing case that owns the `NEMOCLAW_TRACE` enable and
  disable contract. It keeps its false-like assertion and now also asserts that a run with
  `NEMOCLAW_TRACE=2` records `trace_enabled: true` in the flushed artifact. No new test file
  and no new scaffolding.

`isTraceFlagEnabled` is the predicate that survives because it is the one with effect —
`resolveTracePath` consults it to decide whether a collector and a trace file exist. It also
matches the other denylist flag parsers under `src/lib`
(`onboard/openclaw-otel-policy-presets.ts:20`, `onboard/managed-startup/profile-builder.ts:207`,
`actions/sandbox/agent/passthrough.ts:461`). Other flag parsers in the tree are tri-state — an
explicit truthy set, an explicit falsy set, and a separate default (`sandbox-base-image.ts:93`,
`onboard/sandbox-prebuild.ts:170`, `onboard/managed-startup/profile-builder.ts:200`) — so they do
not settle the direction either way. Routing `resolveTracePath` through the narrower allowlist
instead would stop producing traces for values that produce them today, which is a behavior change
rather than a fix.

Net line delta: **-2** (production **-10**, test **+8**).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

Documentation needs no update: every published mention of the variable uses
`NEMOCLAW_TRACE=1` — `docs/deployment/install-openclaw-plugins.mdx:280`,
`docs/reference/commands.mdx:968`, `:5016`, `:5021` (plus prose cross-references at `:5034` and
`:5055`), and `scripts/bench/README.md:50` — and that value behaves exactly as before.

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: onboarding telemetry only; requesting maintainer review through the normal process
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The trace attribute now uses the existing NEMOCLAW_TRACE predicate. Existing command documentation remains accurate.
- Agent: Pi CLI
<!-- docs-review-head-sha: 81a3532fe5e3ae4839fa20b1bb054eac5bcac878 -->
<!-- docs-review-agents-blob-sha: 993bdd85043ac24bc3b6605521d7acc4de665945 -->
## DGX Station Hardware Evidence

Not applicable — `scripts/prepare-dgx-station-host.sh` is unchanged.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/trace.test.ts` — 9 passed. The extended case fails before the production change (`AssertionError: expected false to be true`) and passes after. `npx vitest run --project integration test/bench/bench.test.ts` — 49 passed. `npx vitest run --project integration test/scorecard-trace-timing.test.ts test/source-architecture.test.ts` — 22 passed. `npm run typecheck:cli` clean, `npx oxlint` on the three changed files clean.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable; this changes one predicate and one span attribute, not the runtime or test harness
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved trace collection flag handling during onboarding.
  - The value `"false"` now correctly disables tracing, while numeric values such as `"2"` enable it.
  - Completed onboarding traces now accurately record whether tracing was enabled.

- **Tests**
  - Expanded coverage for trace flag behavior, including disabled and enabled states.
  - Added verification that completed traces contain accurate trace-enabled metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
