### PR TITLE
test(messaging): bind Dockerfile plan fixture to agent

### DIFF
--- a/src/lib/onboard/dockerfile-patch.test.ts
+++ b/src/lib/onboard/dockerfile-patch.test.ts
@@ -707,7 +707,7 @@ describe("dockerfile patch helpers", () => {
         { channelId: "telegram", active: true },
       ],
       agentRender: [
-        { channelId: "discord", target: "openclaw.json", path: ["channels", "discord"] },
+        { agent: "openclaw", channelId: "discord", target: "config", path: ["discord"] },
       ],
     });
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-dockerfile-plan-"));


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
PR #9477 hardened messaging plan ownership so every `agentRender` entry must match the plan agent. Its existing Dockerfile patch fixture omitted that now-required ownership field, which made CLI shard 10 fail after the production fix was merged. This follow-up makes that fixture represent a valid OpenClaw plan.

## Related Issue
Follow-up to #9477 and #9355.

## Changes
- Bind the Dockerfile messaging-plan fixture render entry to the selected `openclaw` agent.
- Preserve the stricter production ownership validation merged in #9477.

## Acceptance Criteria
- [x] The exact Dockerfile patch test that failed in PR #9477 CI passes on this head.
- [x] The related messaging plan and managed-startup profile suites pass on this head.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run src/lib/onboard/dockerfile-patch.test.ts src/lib/messaging/plan-validation.test.ts src/lib/onboard/managed-startup-profile.test.ts` (209 passed)
- [x] Applicable broad gate passed — commit hooks, repository checks, growth guardrails, and CLI typecheck passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. -->
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the messaging-plan test fixture to reflect the current agent rendering configuration format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->