### PR TITLE
fix(install): fail closed when no SHA-256 tool can verify the nvm installer

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2170,8 +2170,8 @@ install_nodejs() {
   elif command_exists shasum; then
     actual_hash="$(shasum -a 256 "$nvm_tmp" | awk '{print $1}')"
   else
-    warn "No SHA-256 tool found — skipping nvm integrity check"
-    actual_hash="$NVM_SHA256" # allow execution
+    rm -f "$nvm_tmp"
+    error "No SHA-256 tool available — cannot verify nvm installer integrity"
   fi
   if [[ "$actual_hash" != "$NVM_SHA256" ]]; then
     rm -f "$nvm_tmp"


### PR DESCRIPTION
## Summary

When the host has neither `sha256sum` nor `shasum`, the nvm bootstrap in `scripts/install.sh` assigned the expected digest to the actual digest and continued. The comparison immediately after can then never fail, so the installer printed `nvm installer integrity verified` and executed a downloaded script whose integrity had not been checked. This changes that branch to fail closed, matching the behavior `verify_downloaded_script` in the same file already implements.

## Related Issue

None.

## Changes

- `scripts/install.sh`: in `install_node_via_nvm`, the no-digest-tool branch now removes the temporary file and calls `error` instead of setting `actual_hash="$NVM_SHA256"`.

Before, the branch read:

```sh
else
  warn "No SHA-256 tool found — skipping nvm integrity check"
  actual_hash="$NVM_SHA256" # allow execution
fi
if [[ "$actual_hash" != "$NVM_SHA256" ]]; then
  ...
fi
info "nvm installer integrity verified"
spin "Installing nvm..." bash "$nvm_tmp"
```

The warning was accurate that the check was skipped, but control then fell through to the success message and the execution, so the operator-visible outcome was an integrity claim the code had not established.

This mirrors `verify_downloaded_script` (same file), which already errors with `No SHA-256 tool available — cannot verify $label integrity` when it holds an expected hash and finds no digest tool. The root `install.sh` bootstrap makes the same choice. This change makes the nvm path consistent with both.

Behavior change worth calling out: on a host with `curl` but no SHA-256 utility, `nemoclaw install` now stops instead of proceeding. That is the intent of a pinned digest, and every platform the installer targets ships one of the two tools (`sha256sum` via coreutils on Linux, `shasum` with the base Perl install on macOS), so this should not affect a supported host. Happy to gate it behind an explicit opt-out flag instead if maintainers prefer.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: the changed branch is reachable only on a host lacking both `sha256sum` and `shasum`, and `scripts/install.sh` has no shell test harness in-tree; the change is a two-line substitution that replaces a self-satisfying comparison with the existing `error` path used by the sibling helper. `shellcheck` and `npm run validate:pr` both pass.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: requesting maintainer review — this is the installer's integrity gate.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — `npm run validate:pr` exited 0 against `origin/main` at `7d516f2`, with `shellcheck` running on the changed file.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx shellcheck scripts/install.sh` → clean.
- [ ] Applicable broad gate passed — not applicable; single-branch change in one shell function.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Net diff is zero lines (2 replaced by 2).

---
Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer security by stopping installation when integrity verification tools are unavailable.
  * Temporary installer files are now removed before reporting the verification error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->