### PR TITLE
ci: reduce contributor PR limit to five

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-fix-e2e-failures/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-fix-e2e-failures/SKILL.md
@@ -16,7 +16,7 @@ Continuously inspect automatic E2E results for `main`. Coordinate ownership and 
 2. Keep release operations out of scope. Never change, retag, publish, or otherwise touch a release, tag, or release artifact during this workflow. Route release work to the existing release workflow.
 3. Confirm maintainer authorization. Merge only when the request grants it. Otherwise, leave the PR `approval-ready` and continue the loop.
 4. Check Git and GitHub access. Follow [Git and GitHub Access Hard Stop](../_shared/git-github-hard-stop.md) on access failure.
-5. Fetch trusted `origin/main`. Read its PR-limit policy with `git show origin/main:.github/workflows/pr-limit.yaml`. For a non-exempt author, do not create a claim that would exceed the 10-open-PR limit.
+5. Fetch trusted `origin/main`. Read its PR-limit policy with `git show origin/main:.github/workflows/pr-limit.yaml`. For a non-exempt author, do not create a claim that would exceed the 5-open-PR limit.
 
 Do not declare success or end the loop because the queue is empty or the newest run passes. Wait for the next automatic `main` result.
 

--- a/.agents/skills/nemoclaw-maintainer-fix-e2e-failures/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-fix-e2e-failures/SKILL.md
@@ -16,7 +16,7 @@ Continuously inspect automatic E2E results for `main`. Coordinate ownership and 
 2. Keep release operations out of scope. Never change, retag, publish, or otherwise touch a release, tag, or release artifact during this workflow. Route release work to the existing release workflow.
 3. Confirm maintainer authorization. Merge only when the request grants it. Otherwise, leave the PR `approval-ready` and continue the loop.
 4. Check Git and GitHub access. Follow [Git and GitHub Access Hard Stop](../_shared/git-github-hard-stop.md) on access failure.
-5. Fetch trusted `origin/main`. Read its PR-limit policy with `git show origin/main:.github/workflows/pr-limit.yaml`. For a non-exempt author, do not create a claim that would exceed the 5-open-PR limit.
+5. Fetch trusted `origin/main`. Read its PR-limit policy with `git show origin/main:.github/workflows/pr-limit.yaml`. For a non-exempt author, do not create a claim that would exceed that limit.
 
 Do not declare success or end the loop because the queue is empty or the newest run passes. Wait for the next automatic `main` result.
 

--- a/.github/workflows/pr-limit.yaml
+++ b/.github/workflows/pr-limit.yaml
@@ -40,10 +40,10 @@ jobs:
 
           echo "Author $AUTHOR has $OPEN_COUNT open PR(s)"
 
-          if [ "$OPEN_COUNT" -gt 10 ]; then
+          if [ "$OPEN_COUNT" -gt 5 ]; then
             gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
-              "This repository limits contributors to 10 open pull requests. Please close or merge existing PRs before opening new ones."
+              "This repository limits contributors to 5 open pull requests. Please close or merge existing PRs before opening new ones."
             gh pr close "$PR_NUMBER" --repo "$REPO"
-            echo "::error::PR closed — author $AUTHOR exceeds the 10 open PR limit"
+            echo "::error::PR closed — author $AUTHOR exceeds the 5 open PR limit"
             exit 1
           fi

--- a/.github/workflows/pr-limit.yaml
+++ b/.github/workflows/pr-limit.yaml
@@ -27,6 +27,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
+          LIMIT=5
+
           # Core maintainers are exempt from the PR limit.
           EXEMPT="ericksoa kjw3 jacobtomlinson cv jyaunches"
           for user in $EXEMPT; do
@@ -40,10 +42,10 @@ jobs:
 
           echo "Author $AUTHOR has $OPEN_COUNT open PR(s)"
 
-          if [ "$OPEN_COUNT" -gt 5 ]; then
+          if [ "$OPEN_COUNT" -gt "$LIMIT" ]; then
             gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
-              "This repository limits contributors to 5 open pull requests. Please close or merge existing PRs before opening new ones."
+              "This repository limits contributors to $LIMIT open pull requests. Please close or merge existing PRs before opening new ones."
             gh pr close "$PR_NUMBER" --repo "$REPO"
-            echo "::error::PR closed — author $AUTHOR exceeds the 5 open PR limit"
+            echo "::error::PR closed — author $AUTHOR exceeds the $LIMIT open PR limit"
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,4 +344,4 @@ If the command trace contains no reviewer-request write, report the event as an 
 - Direct PRs follow `.github/PULL_REQUEST_TEMPLATE.md`; the managed documentation workflow uses its generated body
 - PRs that change `scripts/prepare-dgx-station-host.sh` must include reviewable DGX Station test evidence identifying the tested commit, Station profile or scenario, result, and a supporting link. Any maintainer may review the evidence; without acceptable evidence, the PR is not ready to approve or merge. Treat the evidence as human-reviewed, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must document the reason on the PR.
 - No secrets, API keys, or credentials committed
-- Apply the 10-open-PR limit from `.github/workflows/pr-limit.yaml` only to accounts that the workflow does not exempt
+- Apply the 5-open-PR limit from `.github/workflows/pr-limit.yaml` only to accounts that the workflow does not exempt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,4 +344,4 @@ If the command trace contains no reviewer-request write, report the event as an 
 - Direct PRs follow `.github/PULL_REQUEST_TEMPLATE.md`; the managed documentation workflow uses its generated body
 - PRs that change `scripts/prepare-dgx-station-host.sh` must include reviewable DGX Station test evidence identifying the tested commit, Station profile or scenario, result, and a supporting link. Any maintainer may review the evidence; without acceptable evidence, the PR is not ready to approve or merge. Treat the evidence as human-reviewed, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must document the reason on the PR.
 - No secrets, API keys, or credentials committed
-- Apply the 5-open-PR limit from `.github/workflows/pr-limit.yaml` only to accounts that the workflow does not exempt
+- Apply the open PR limit from `.github/workflows/pr-limit.yaml` only to accounts that the workflow does not exempt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -511,7 +511,7 @@ For Markdown docs routing, user-skill guidance, and release-prep documentation w
 
 ## Pull Requests
 
-We welcome contributions. Every PR requires maintainer review before merge. Contributors may have up to 10 open PRs at one time.
+We welcome contributions. Every PR requires maintainer review before merge. Contributors may have up to 5 open PRs at one time.
 Core maintainers listed in `.github/workflows/pr-limit.yaml` are exempt from this limit.
 Maintainers review pull requests according to project priority, security impact, release readiness, and reviewer availability.
 PRs that solve issues with Priority set to Urgent or High are more likely to receive earlier review when maintainers have capacity.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Reduce the open pull request limit for non-exempt contributors from 10 to 5. The workflow now closes a pull request when its author has more than 5 open pull requests, while the maintainer exemptions remain unchanged.

## Changes

- Change the enforcement threshold and contributor-facing workflow messages from 10 to 5.
- Update contributor and agent guidance to state the 5-open-PR limit.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: The change updates one declarative GitHub Actions threshold and its messages. Repository validation checks YAML syntax and guidance consistency.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent review confirmed that the workflow still uses quoted event values, does not execute pull request code, and retains pull-request-only permissions.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run checks:repository && git diff --check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Policy Updates**
  * The maximum number of simultaneously open pull requests for non-exempt contributors is now 5, reduced from 10.
  * Pull requests exceeding this limit may be automatically closed.
  * Maintainer exemptions remain unchanged.

* **Documentation**
  * Updated contribution guidance and project requirements to reflect the configured open-PR limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->