### PR TITLE
test(cli): track provider reservation rollback

### DIFF
--- a/test/package-contract/cli/credentials-cli-command.test.ts
+++ b/test/package-contract/cli/credentials-cli-command.test.ts
@@ -407,17 +407,24 @@ describe("credentials oclif commands", () => {
     }
   });
 
-  it("credentials add does not record an extra provider when the gateway rejects the call", async () => {
+  it("credentials add rolls back its provider reservation when the gateway rejects the call", async () => {
     process.env.TAVILY_API_KEY = "tvly-test-12345";
-    const extraProviderCalls: string[] = [];
+    const reservationCalls: string[] = [];
+    const extraProviders = new Set<string>();
     installRuntimeBridge({
       runOpenshell: (args) =>
         args.includes("profile")
           ? { status: 0, stdout: "" }
           : { status: 1, stderr: "gateway unavailable" },
       recordExtraProvider: (name) => {
-        extraProviderCalls.push(name);
-        return true;
+        reservationCalls.push(`record:${name}`);
+        const sizeBefore = extraProviders.size;
+        extraProviders.add(name);
+        return extraProviders.size !== sizeBefore;
+      },
+      forgetExtraProvider: (name) => {
+        reservationCalls.push(`forget:${name}`);
+        return extraProviders.delete(name);
       },
     });
     const { CredentialsAddCommand } = loadCommands();
@@ -437,7 +444,8 @@ describe("credentials oclif commands", () => {
         ),
       );
 
-      expect(extraProviderCalls).toEqual([]);
+      expect(reservationCalls).toEqual(["record:tavily-search", "forget:tavily-search"]);
+      expect([...extraProviders]).toEqual([]);
     } finally {
       delete process.env.TAVILY_API_KEY;
     }

--- a/test/package-contract/cli/credentials-cli-command.test.ts
+++ b/test/package-contract/cli/credentials-cli-command.test.ts
@@ -409,21 +409,24 @@ describe("credentials oclif commands", () => {
 
   it("credentials add rolls back its provider reservation when the gateway rejects the call", async () => {
     process.env.TAVILY_API_KEY = "tvly-test-12345";
-    const reservationCalls: string[] = [];
+    const lifecycleCalls: string[] = [];
     const extraProviders = new Set<string>();
+    const rejectGatewayCall = () => {
+      expect(extraProviders.has("tavily-search")).toBe(true);
+      lifecycleCalls.push("gateway:tavily-search");
+      return { status: 1, stderr: "gateway unavailable" };
+    };
     installRuntimeBridge({
       runOpenshell: (args) =>
-        args.includes("profile")
-          ? { status: 0, stdout: "" }
-          : { status: 1, stderr: "gateway unavailable" },
+        args.includes("profile") ? { status: 0, stdout: "" } : rejectGatewayCall(),
       recordExtraProvider: (name) => {
-        reservationCalls.push(`record:${name}`);
+        lifecycleCalls.push(`record:${name}`);
         const sizeBefore = extraProviders.size;
         extraProviders.add(name);
         return extraProviders.size !== sizeBefore;
       },
       forgetExtraProvider: (name) => {
-        reservationCalls.push(`forget:${name}`);
+        lifecycleCalls.push(`forget:${name}`);
         return extraProviders.delete(name);
       },
     });
@@ -444,7 +447,11 @@ describe("credentials oclif commands", () => {
         ),
       );
 
-      expect(reservationCalls).toEqual(["record:tavily-search", "forget:tavily-search"]);
+      expect(lifecycleCalls).toEqual([
+        "record:tavily-search",
+        "gateway:tavily-search",
+        "forget:tavily-search",
+      ]);
       expect([...extraProviders]).toEqual([]);
     } finally {
       delete process.env.TAVILY_API_KEY;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The compiled credentials contract expected a failed gateway call to avoid the provider registry entirely. Credentials registration now intentionally reserves the provider before the gateway mutation, so the contract instead verifies that failure removes that provisional reservation.

## Changes

- Track provisional provider state in the compiled CLI contract fixture.
- Require a failed gateway mutation to record and then forget the same provider, leaving no provider registered.
- Bind the regression to [CI run 32211381563](https://github.com/NVIDIA/NemoClaw/actions/runs/32211381563), build-typecheck job 95944650991, which failed at `credentials-cli-command.test.ts:440` with `expected [ 'tavily-search' ] to deeply equal []`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent review is pending. This patch changes only the compiled credentials test harness; credential values, production registry behavior, and gateway access are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run --project package-contract test/package-contract/cli/credentials-cli-command.test.ts --testTimeout=30000`: the changed rollback case passed and 24/25 file tests passed. One unrelated macOS host-authority case failed because the local gateway lifecycle could not be revalidated; Linux CI is pending.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded credential-management coverage for failed credential additions.
  * Verified that temporary provider reservations exist before gateway processing and are correctly rolled back after registration failures.
  * Recorded gateway failures in the operation lifecycle.
  * Confirmed failed operations do not leave behind unintended provider state, improving confidence in recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->