### PR TITLE
test(installer): use private Hermes fixture root

### DIFF
--- a/test/install-hermes-portable-active.test.ts
+++ b/test/install-hermes-portable-active.test.ts
@@ -42,6 +42,13 @@ const BUILD_SETTINGS = {
   toolDisclosure: "direct",
 } as const;
 
+function createPrivateFixtureRoot(): string {
+  const homeDir = fs.realpathSync(os.homedir());
+  const fixtureRoot = fs.mkdtempSync(path.join(homeDir, ".nemoclaw-hermes-admission-"));
+  fs.chmodSync(fixtureRoot, 0o700);
+  return fixtureRoot;
+}
+
 function cloneWithInstaller(
   installer: string,
   ref: string,
@@ -72,9 +79,41 @@ function cloneWithInstaller(
 }
 
 describe("Hermes portable installer admission", testTimeoutOptions(60_000), () => {
+  it.each([
+    { access: "group", mode: 0o720 },
+    { access: "other", mode: 0o702 },
+  ])(
+    "rejects a source beneath a $access-writable GitHub workspace ancestor (#9211)",
+    ({ mode }) => {
+      const fixtureRoot = createPrivateFixtureRoot();
+      const githubWorkRoot = path.join(fixtureRoot, "home", "runner", "work");
+      const workspaceRoot = path.join(githubWorkRoot, "NemoClaw", "NemoClaw");
+      const checkout = path.join(workspaceRoot, "source");
+
+      try {
+        fs.mkdirSync(workspaceRoot, { recursive: true, mode: 0o700 });
+        const sourceRevision = spawnSync("git", ["rev-parse", "HEAD"], {
+          cwd: ROOT,
+          encoding: "utf8",
+        }).stdout.trim();
+        cloneWithInstaller(CURL_PIPE_INSTALLER, sourceRevision, checkout, "0077");
+        makeHermesPortableCheckoutPrivate(checkout);
+        const sourceRoot = fs.realpathSync(checkout);
+        expect(
+          createHermesPortableBuildContextPlan(sourceRoot, BUILD_SETTINGS).authority.sourceRevision,
+        ).toBe(sourceRevision);
+        fs.chmodSync(githubWorkRoot, mode);
+        expect(() => createHermesPortableBuildContextPlan(sourceRoot, BUILD_SETTINGS)).toThrow(
+          "Hermes portable build context source root directory chain is unsafe",
+        );
+      } finally {
+        fs.rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("activates one schema-5 receipt from a private checkout and validates both installer sources (#9211)", async () => {
-    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-admission-"));
-    fs.chmodSync(fixtureRoot, 0o700);
+    const fixtureRoot = createPrivateFixtureRoot();
     const stateDir = path.join(fixtureRoot, "state");
     const homeDir = path.join(fixtureRoot, "home");
     fs.mkdirSync(stateDir, { mode: 0o700 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Hermes Portable installer regression now creates its source checkout beneath a private user-home directory chain instead of a writable temporary-directory ancestor. The production source-authority validator remains unchanged and fail-closed.

## Related Issue

Related to #9211 and the post-merge CI failure from #9571.

## Changes

- Create the installer fixture beneath a real `0700` user-home directory.
- Prove that private ancestry is accepted by the production build-context planner.
- Prove that group- and other-writable GitHub-workspace-like ancestors remain rejected.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `CI=true npx vitest run --project installer-integration test/install-hermes-portable-active.test.ts` passed 3/3
- [ ] Applicable broad gate passed — Not applicable to this one-file installer fixture repair; `npm run test:changed`, `npm run typecheck:cli`, `npm run lint`, and `npm run test:projects:check` passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

The corrective PR must not merge until CI for commit `3bf16964a340c96d2624258468a2d5aff1e96ecc` reaches a terminal state and every required check passes.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security validation for portable Hermes builds by rejecting sources located in group- or publicly writable GitHub Actions workspace directories.
  * Enhanced temporary test directory handling to use securely isolated locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->