### PR TITLE
fix(onboard): admit sticky temp checkout authority

### DIFF
--- a/src/lib/onboard/experimental/hermes-portable-build-context.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-build-context.test.ts
@@ -24,22 +24,6 @@ const BUILD_SETTINGS = {
 
 let stateDir: string;
 
-function emulatePrivateSourceAncestor(): void {
-  const original = fs.lstatSync;
-  const sharedTemporaryRoots = new Set([path.resolve("/tmp"), fs.realpathSync("/tmp")]);
-  vi.spyOn(fs, "lstatSync").mockImplementation(((target, options) => {
-    const stat = original(target, options as never);
-    return sharedTemporaryRoots.has(path.resolve(String(target)))
-      ? new Proxy(stat, {
-          get(value, property) {
-            const mode = BigInt(Reflect.get(value, "mode", value));
-            return property === "mode" ? mode & ~0o22n : Reflect.get(value, property, value);
-          },
-        })
-      : stat;
-  }) as typeof fs.lstatSync);
-}
-
 function contextInput() {
   return {
     sandboxName: "alpha",
@@ -77,8 +61,8 @@ function copyFixtureFile(
   );
 }
 
-function primaryCloneFixture(privateFileModes = false): string {
-  const requested = fs.mkdtempSync(path.join(stateDir, "primary-clone-"));
+function primaryCloneFixture(privateFileModes = false, parent = stateDir): string {
+  const requested = fs.mkdtempSync(path.join(parent, "primary-clone-"));
   const root = fs.realpathSync(requested);
   fs.chmodSync(root, 0o700);
   for (const entry of HERMES_PORTABLE_BUILD_CONTEXT_FILES) {
@@ -100,7 +84,6 @@ describe("Hermes portable staged build context", testTimeoutOptions(30_000), () 
   beforeEach(() => {
     stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-context-test-"));
     fs.chmodSync(stateDir, 0o700);
-    emulatePrivateSourceAncestor();
   });
 
   afterEach(() => {
@@ -282,6 +265,24 @@ describe("Hermes portable staged build context", testTimeoutOptions(30_000), () 
 
     expect(plan.authority.sourceRevision).toBe("b".repeat(40));
     expect(plan.authority.contextManifestSha256).toMatch(/^[a-f0-9]{64}$/u);
+  });
+
+  it("rejects a private checkout below a writable non-sticky ancestor (#9203)", () => {
+    const writableParent = fs.mkdtempSync(path.join(stateDir, "writable-parent-"));
+    const source = primaryCloneFixture(false, writableParent);
+    fs.chmodSync(writableParent, 0o777);
+
+    expect(() => createHermesPortableBuildContextPlan(source, BUILD_SETTINGS)).toThrow(
+      "source root directory chain is unsafe",
+    );
+  });
+
+  it("accepts a private checkout below an owner-controlled sticky ancestor", () => {
+    const stickyParent = fs.mkdtempSync(path.join(stateDir, "sticky-parent-"));
+    const source = primaryCloneFixture(false, stickyParent);
+    fs.chmodSync(stickyParent, 0o1777);
+
+    expect(() => createHermesPortableBuildContextPlan(source, BUILD_SETTINGS)).not.toThrow();
   });
 
   it.each([

--- a/src/lib/onboard/experimental/hermes-portable-build-context.ts
+++ b/src/lib/onboard/experimental/hermes-portable-build-context.ts
@@ -480,11 +480,14 @@ function captureDirectoryChain(directory: string): readonly DirectoryEvidence[] 
   let current = directory;
   for (;;) {
     const named = fs.lstatSync(current, { bigint: true });
+    const writableByAnotherIdentity = (named.mode & 0o22n) !== 0n;
+    const stickyOwnerBoundary =
+      (named.uid === 0n || named.uid === uid) && (named.mode & 0o1000n) !== 0n;
     if (
       !named.isDirectory() ||
       named.isSymbolicLink() ||
       (named.uid !== 0n && named.uid !== uid) ||
-      (named.mode & 0o22n) !== 0n ||
+      (writableByAnotherIdentity && !stickyOwnerBoundary) ||
       fs.realpathSync(current) !== current
     ) {
       fail("source root directory chain is unsafe");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Allow Hermes Portable build-context authority beneath a root- or current-user-owned sticky directory, such as Linux /tmp. This restores the production installer path while preserving rejection of ordinary writable ancestors.

## Changes

- Treat the sticky bit as an ownership boundary only when the directory is owned by root or the current user.
- Keep directory type, symlink, realpath, owner, and non-sticky writable-ancestor checks unchanged.
- Remove the test shim that hid Linux temporary-directory permissions.
- Add positive sticky-owner and negative writable-non-sticky regression coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — justification: the admission remains limited to root/current-user-owned sticky ancestors; owner, symlink, realpath, and non-sticky writable-ancestor rejection are unchanged and explicitly tested.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a Signed-off-by line and every commit appears as Verified in GitHub
- [x] Normal pre-commit, commit-msg, and pre-push hooks passed, or npm run validate:pr passed after refreshing origin/main when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set — 18/18 Hermes build-context tests and the exact installer-integration regression pass.
- [x] Applicable broad gate passed — npm run validate:pr, npm run checks:repository, and npm run typecheck:cli pass.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] npm run docs builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkout validation for writable ancestor directories.
  * Private checkouts are now accepted under sticky directories owned by root or the current user.
  * Checkouts under writable, non-sticky ancestors continue to be rejected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->