### PR TITLE
ci: tolerate missing release tags

### DIFF
--- a/.github/workflows/label-merged-pr-release-target.yaml
+++ b/.github/workflows/label-merged-pr-release-target.yaml
@@ -289,6 +289,7 @@ jobs:
             async function refreshLatestRelease(expectedName, expectedCommit) {
               const releaseTags = await loadReleaseTags();
               const latest = releaseTags[0];
+              if (!latest) return { changed: true };
               const latestCommit = await peelReleaseTag(latest);
               return {
                 changed: latest.name !== expectedName || latestCommit !== expectedCommit,

--- a/.github/workflows/label-merged-pr-release-target.yaml
+++ b/.github/workflows/label-merged-pr-release-target.yaml
@@ -115,9 +115,6 @@ jobs:
                 return 0;
               });
 
-              if (releaseTags.length === 0) {
-                throw new Error('No strict semver release tags were found');
-              }
               return releaseTags;
             }
 
@@ -299,6 +296,10 @@ jobs:
             }
 
             async function reconcileReleaseTargets(releaseTags, restartCount = 0) {
+              if (releaseTags.length === 0) {
+                core.info('No strict semver release tags were found; no release target labels reconciled');
+                return;
+              }
               const latestRelease = releaseTags[0];
               const latestCommit = await peelReleaseTag(latestRelease);
               const main = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
@@ -334,6 +335,12 @@ jobs:
                 context.payload.pull_request,
               );
               const releaseTags = await loadReleaseTags();
+              if (releaseTags.length === 0) {
+                core.info(
+                  `No strict semver release tags were found; no release target label added to PR #${pullRequest.number}`,
+                );
+                return;
+              }
               const target = await resolveTargetForMerge(mergeSha, releaseTags);
               if (target) {
                 await applyTarget(pullRequest, target.label, target.boundary);

--- a/test/label-merged-pr-release-target-workflow.test.ts
+++ b/test/label-merged-pr-release-target-workflow.test.ts
@@ -528,16 +528,45 @@ describe("merged PR release target workflow", () => {
     harness.listTags
       .mockResolvedValueOnce({ data: [{ name: v10.name }] })
       .mockResolvedValue({ data: [] });
+    harness.compareCommitsWithBasehead.mockImplementation(
+      async ({ basehead }: { basehead: string }) => {
+        expect(basehead).toBe(`${v10.commitSha}...${MERGE_SHA}`);
+        return {
+          data: {
+            status: "ahead",
+            ahead_by: 1,
+            behind_by: 0,
+            total_commits: 1,
+            commits: [{ sha: MERGE_SHA }],
+          },
+        };
+      },
+    );
+    harness.listPullRequestsAssociatedWithCommit.mockResolvedValueOnce({
+      data: [
+        {
+          base: { ref: "main" },
+          labels: [],
+          merge_commit_sha: MERGE_SHA,
+          merged_at: "2026-07-04T00:00:00Z",
+          number: 123,
+        },
+      ],
+    });
 
     await runScript(harness);
 
+    expect(harness.listPullRequestsAssociatedWithCommit).toHaveBeenCalledWith(
+      expect.objectContaining({ commit_sha: MERGE_SHA }),
+    );
     expect(harness.warning).toHaveBeenCalledWith(
       "Newest release tag changed; restarting reconciliation",
     );
     expect(harness.info).toHaveBeenCalledWith(
       "No strict semver release tags were found; no release target labels reconciled",
     );
-    expect(harness.listTags).toHaveBeenCalledTimes(3);
+    expect(harness.getLabel).not.toHaveBeenCalled();
+    expect(harness.createLabel).not.toHaveBeenCalled();
     expect(harness.addLabels).not.toHaveBeenCalled();
   });
 

--- a/test/label-merged-pr-release-target-workflow.test.ts
+++ b/test/label-merged-pr-release-target-workflow.test.ts
@@ -521,6 +521,26 @@ describe("merged PR release target workflow", () => {
     );
   });
 
+  it("restarts reconciliation when the last release tag disappears during the audit (#9533)", async () => {
+    const harness = createHarness([{ name: "v0.0.10" }]);
+    const [v10] = harness.fixtures;
+    harness.context.eventName = "schedule";
+    harness.listTags
+      .mockResolvedValueOnce({ data: [{ name: v10.name }] })
+      .mockResolvedValue({ data: [] });
+
+    await runScript(harness);
+
+    expect(harness.warning).toHaveBeenCalledWith(
+      "Newest release tag changed; restarting reconciliation",
+    );
+    expect(harness.info).toHaveBeenCalledWith(
+      "No strict semver release tags were found; no release target labels reconciled",
+    );
+    expect(harness.listTags).toHaveBeenCalledTimes(3);
+    expect(harness.addLabels).not.toHaveBeenCalled();
+  });
+
   it("stops after two reconciliation restarts when release tags keep changing", async () => {
     const harness = createHarness(
       ["v0.0.13", "v0.0.12", "v0.0.11", "v0.0.10", "v0.0.9"].map((name) => ({ name })),

--- a/test/label-merged-pr-release-target-workflow.test.ts
+++ b/test/label-merged-pr-release-target-workflow.test.ts
@@ -241,6 +241,31 @@ describe("merged PR release target workflow", () => {
     });
   });
 
+  it("does not label a merged PR when the repository has no release tag boundary (#9533)", async () => {
+    const harness = createHarness([{ name: "latest" }]);
+
+    await runScript(harness);
+
+    expect(harness.addLabels).not.toHaveBeenCalled();
+    expect(harness.getRef).not.toHaveBeenCalled();
+    expect(harness.info).toHaveBeenCalledWith(
+      "No strict semver release tags were found; no release target label added to PR #123",
+    );
+  });
+
+  it("does not fail scheduled reconciliation when the repository has no release tag boundary (#9533)", async () => {
+    const harness = createHarness([{ name: "latest" }]);
+    harness.context.eventName = "schedule";
+
+    await runScript(harness);
+
+    expect(harness.addLabels).not.toHaveBeenCalled();
+    expect(harness.getBranch).not.toHaveBeenCalled();
+    expect(harness.info).toHaveBeenCalledWith(
+      "No strict semver release tags were found; no release target labels reconciled",
+    );
+  });
+
   it("does not label a PR already captured at the latest tag boundary", async () => {
     const harness = createHarness([
       { name: "v0.0.10", status: "identical" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The release-target workflow no longer fails scheduled runs when a repository has no strict semver release tags. It now reports that no release target labels were reconciled instead of throwing.

## Related Issue
Fixes #9533

## Changes
- Let `loadReleaseTags()` return an empty list when no strict `vX.Y.Z` tags exist.
- Make scheduled reconciliation exit 0 with an informational message when there is no release tag boundary.
- Make merged-PR labeling skip label creation when there is no release tag boundary.
- Treat a missing refreshed release tag as changed so scheduled reconciliation can restart and no-op.
- Add workflow contract tests for scheduled empty tags, merged-PR empty tags, disappearing release tags, and the no-label behavior when an eligible PR was found before the tag vanished.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/label-merged-pr-release-target-workflow.test.ts` passed, 1 file and 22 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: danielpolimac <danielpolimac@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-target handling for repositories without strict semantic-version release tags.
  * Merged pull requests and scheduled reconciliation now skip labeling when no valid release tag exists.
  * Missing release tags are detected during refresh, preventing outdated labeling actions.
* **Tests**
  * Added coverage for missing release tags, reconciliation restarts, and skipped label updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->