### PR TITLE
fix(onboard): honor credential retry navigation

### DIFF
--- a/src/lib/onboard/validation-recovery-prompt.test.ts
+++ b/src/lib/onboard/validation-recovery-prompt.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
 
 import { createValidationRecoveryPromptHelpers } from "./validation-recovery-prompt";
 
@@ -27,6 +28,19 @@ function createRecoveryPrompt(answers: string[]) {
   return { exitError, helpers, prompt };
 }
 
+function expectCredentialPromptWasSecret(
+  prompt: ReturnType<typeof createRecoveryPrompt>["prompt"],
+) {
+  expect(prompt).toHaveBeenCalledWith("  OpenAI API key: ", { secret: true });
+}
+
+function expectHelpBeforeSelectionReturn(log: MockInstance<typeof console.log>) {
+  const messages = log.mock.calls.map(([message]) => message);
+  expect(
+    messages.indexOf("  Type back to choose a different provider, or exit to quit."),
+  ).toBeLessThan(messages.indexOf("  Returning to provider selection."));
+}
+
 describe("validation recovery credential prompt", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -43,7 +57,7 @@ describe("validation recovery credential prompt", () => {
     ).resolves.toBe("selection");
 
     expect(process.env.OPENAI_API_KEY).toBe("sk-bad");
-    expect(prompt).toHaveBeenCalledTimes(2);
+    expectCredentialPromptWasSecret(prompt);
     expect(log).toHaveBeenCalledWith("  Returning to provider selection.");
   });
 
@@ -57,7 +71,7 @@ describe("validation recovery credential prompt", () => {
     ).resolves.toBe("credential");
 
     expect(process.env.OPENAI_API_KEY).toBe("selection");
-    expect(prompt).toHaveBeenCalledTimes(2);
+    expectCredentialPromptWasSecret(prompt);
   });
 
   it("returns to provider selection from the paste-guard re-entry path (#9557)", async () => {
@@ -70,7 +84,7 @@ describe("validation recovery credential prompt", () => {
     ).resolves.toBe("selection");
 
     expect(process.env.OPENAI_API_KEY).toBe("sk-bad");
-    expect(prompt).toHaveBeenCalledTimes(2);
+    expectCredentialPromptWasSecret(prompt);
     expect(log).toHaveBeenCalledWith("  Returning to provider selection.");
   });
 
@@ -84,7 +98,7 @@ describe("validation recovery credential prompt", () => {
     ).rejects.toBe(exitError);
 
     expect(process.env.OPENAI_API_KEY).toBe("sk-bad");
-    expect(prompt).toHaveBeenCalledTimes(2);
+    expectCredentialPromptWasSecret(prompt);
   });
 
   it("exits onboarding when the re-entry prompt receives quit (#9557)", async () => {
@@ -97,7 +111,7 @@ describe("validation recovery credential prompt", () => {
     ).rejects.toBe(exitError);
 
     expect(process.env.OPENAI_API_KEY).toBe("sk-bad");
-    expect(prompt).toHaveBeenCalledTimes(2);
+    expectCredentialPromptWasSecret(prompt);
   });
 
   it("prints credential prompt help before accepting back at re-entry (#9557)", async () => {
@@ -110,10 +124,11 @@ describe("validation recovery credential prompt", () => {
     ).resolves.toBe("selection");
 
     expect(process.env.OPENAI_API_KEY).toBe("sk-bad");
-    expect(prompt).toHaveBeenCalledTimes(3);
+    expectCredentialPromptWasSecret(prompt);
     expect(log).toHaveBeenCalledWith(
       "  Type back to choose a different provider, or exit to quit.",
     );
+    expectHelpBeforeSelectionReturn(log);
   });
 
   it("prints credential prompt help for the help alias before accepting back (#9557)", async () => {
@@ -126,9 +141,10 @@ describe("validation recovery credential prompt", () => {
     ).resolves.toBe("selection");
 
     expect(process.env.OPENAI_API_KEY).toBe("sk-bad");
-    expect(prompt).toHaveBeenCalledTimes(3);
+    expectCredentialPromptWasSecret(prompt);
     expect(log).toHaveBeenCalledWith(
       "  Type back to choose a different provider, or exit to quit.",
     );
+    expectHelpBeforeSelectionReturn(log);
   });
 });

--- a/src/lib/onboard/validation-recovery-prompt.test.ts
+++ b/src/lib/onboard/validation-recovery-prompt.test.ts
@@ -8,7 +8,11 @@ import { createValidationRecoveryPromptHelpers } from "./validation-recovery-pro
 const CREDENTIAL_RECOVERY = { kind: "credential", retry: "credential" } as const;
 
 function createRecoveryPrompt(answers: string[]) {
-  const prompt = vi.fn(async () => answers.shift() ?? "");
+  const prompt = vi.fn(async () => {
+    const answer = answers.shift();
+    expect(answer, "Unexpected prompt call").toBeDefined();
+    return answer ?? "";
+  });
   const exitError = Object.assign(new Error("onboard exit"), { exitCode: 0 });
   const helpers = createValidationRecoveryPromptHelpers({
     isNonInteractive: () => false,
@@ -83,10 +87,39 @@ describe("validation recovery credential prompt", () => {
     expect(prompt).toHaveBeenCalledTimes(2);
   });
 
+  it("exits onboarding when the re-entry prompt receives quit (#9557)", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-bad");
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { exitError, helpers, prompt } = createRecoveryPrompt(["retry", "quit"]);
+
+    await expect(
+      helpers.promptValidationRecovery("OpenAI", CREDENTIAL_RECOVERY, "OPENAI_API_KEY"),
+    ).rejects.toBe(exitError);
+
+    expect(process.env.OPENAI_API_KEY).toBe("sk-bad");
+    expect(prompt).toHaveBeenCalledTimes(2);
+  });
+
   it("prints credential prompt help before accepting back at re-entry (#9557)", async () => {
     vi.stubEnv("OPENAI_API_KEY", "sk-bad");
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
     const { helpers, prompt } = createRecoveryPrompt(["retry", "?", "back"]);
+
+    await expect(
+      helpers.promptValidationRecovery("OpenAI", CREDENTIAL_RECOVERY, "OPENAI_API_KEY"),
+    ).resolves.toBe("selection");
+
+    expect(process.env.OPENAI_API_KEY).toBe("sk-bad");
+    expect(prompt).toHaveBeenCalledTimes(3);
+    expect(log).toHaveBeenCalledWith(
+      "  Type back to choose a different provider, or exit to quit.",
+    );
+  });
+
+  it("prints credential prompt help for the help alias before accepting back (#9557)", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-bad");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { helpers, prompt } = createRecoveryPrompt(["retry", "help", "back"]);
 
     await expect(
       helpers.promptValidationRecovery("OpenAI", CREDENTIAL_RECOVERY, "OPENAI_API_KEY"),

--- a/src/lib/onboard/validation-recovery-prompt.test.ts
+++ b/src/lib/onboard/validation-recovery-prompt.test.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createValidationRecoveryPromptHelpers } from "./validation-recovery-prompt";
+
+const CREDENTIAL_RECOVERY = { kind: "credential", retry: "credential" } as const;
+
+function createRecoveryPrompt(answers: string[]) {
+  const prompt = vi.fn(async () => answers.shift() ?? "");
+  const exitError = Object.assign(new Error("onboard exit"), { exitCode: 0 });
+  const helpers = createValidationRecoveryPromptHelpers({
+    isNonInteractive: () => false,
+    prompt,
+    validateNvidiaApiKeyValue: () => null,
+    getTransportRecoveryMessage: () => "  Transport failed.",
+    exitOnboardFromPrompt(): never {
+      throw exitError;
+    },
+  });
+
+  return { exitError, helpers, prompt };
+}
+
+describe("validation recovery credential prompt", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("returns to provider selection when the re-entry prompt receives back (#9557)", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-bad");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { helpers, prompt } = createRecoveryPrompt(["retry", "back"]);
+
+    await expect(
+      helpers.promptValidationRecovery("OpenAI", CREDENTIAL_RECOVERY, "OPENAI_API_KEY"),
+    ).resolves.toBe("selection");
+
+    expect(process.env.OPENAI_API_KEY).toBe("sk-bad");
+    expect(prompt).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledWith("  Returning to provider selection.");
+  });
+
+  it("exits onboarding when the re-entry prompt receives exit (#9557)", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-bad");
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { exitError, helpers, prompt } = createRecoveryPrompt(["retry", "exit"]);
+
+    await expect(
+      helpers.promptValidationRecovery("OpenAI", CREDENTIAL_RECOVERY, "OPENAI_API_KEY"),
+    ).rejects.toBe(exitError);
+
+    expect(process.env.OPENAI_API_KEY).toBe("sk-bad");
+    expect(prompt).toHaveBeenCalledTimes(2);
+  });
+
+  it("prints credential prompt help before accepting back at re-entry (#9557)", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-bad");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { helpers, prompt } = createRecoveryPrompt(["retry", "?", "back"]);
+
+    await expect(
+      helpers.promptValidationRecovery("OpenAI", CREDENTIAL_RECOVERY, "OPENAI_API_KEY"),
+    ).resolves.toBe("selection");
+
+    expect(process.env.OPENAI_API_KEY).toBe("sk-bad");
+    expect(prompt).toHaveBeenCalledTimes(3);
+    expect(log).toHaveBeenCalledWith(
+      "  Type back to choose a different provider, or exit to quit.",
+    );
+  });
+});

--- a/src/lib/onboard/validation-recovery-prompt.test.ts
+++ b/src/lib/onboard/validation-recovery-prompt.test.ts
@@ -43,6 +43,33 @@ describe("validation recovery credential prompt", () => {
     expect(log).toHaveBeenCalledWith("  Returning to provider selection.");
   });
 
+  it("stages selection when the re-entry prompt receives selection as a credential (#9557)", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-bad");
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { helpers, prompt } = createRecoveryPrompt(["retry", "selection"]);
+
+    await expect(
+      helpers.promptValidationRecovery("OpenAI", CREDENTIAL_RECOVERY, "OPENAI_API_KEY"),
+    ).resolves.toBe("credential");
+
+    expect(process.env.OPENAI_API_KEY).toBe("selection");
+    expect(prompt).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns to provider selection from the paste-guard re-entry path (#9557)", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-bad");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { helpers, prompt } = createRecoveryPrompt(["sk-pasted", "back"]);
+
+    await expect(
+      helpers.promptValidationRecovery("OpenAI", CREDENTIAL_RECOVERY, "OPENAI_API_KEY"),
+    ).resolves.toBe("selection");
+
+    expect(process.env.OPENAI_API_KEY).toBe("sk-bad");
+    expect(prompt).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledWith("  Returning to provider selection.");
+  });
+
   it("exits onboarding when the re-entry prompt receives exit (#9557)", async () => {
     vi.stubEnv("OPENAI_API_KEY", "sk-bad");
     vi.spyOn(console, "log").mockImplementation(() => undefined);

--- a/src/lib/onboard/validation-recovery-prompt.ts
+++ b/src/lib/onboard/validation-recovery-prompt.ts
@@ -12,13 +12,17 @@ export interface ValidationRecoveryPromptDeps {
   exitOnboardFromPrompt(): never;
 }
 
+export type ValidationRecoveryCredentialResult =
+  | { kind: "credential"; value: string }
+  | { kind: "selection" };
+
 export interface ValidationRecoveryPromptHelpers {
   replaceNamedCredential(
     envName: string,
     label: string,
     helpUrl?: string | null,
     validator?: ((value: string) => string | null) | null,
-  ): Promise<string | "selection">;
+  ): Promise<ValidationRecoveryCredentialResult>;
   promptValidationRecovery(
     label: string,
     recovery: ProbeRecovery,
@@ -35,7 +39,7 @@ export function createValidationRecoveryPromptHelpers(
     label: string,
     helpUrl: string | null = null,
     validator: ((value: string) => string | null) | null = null,
-  ): Promise<string | "selection"> {
+  ): Promise<ValidationRecoveryCredentialResult> {
     if (helpUrl) {
       console.log("");
       console.log(`  Get your ${label} from: ${helpUrl}`);
@@ -44,7 +48,7 @@ export function createValidationRecoveryPromptHelpers(
 
     while (true) {
       const intent = getCredentialPromptIntent(await deps.prompt(`  ${label}: `, { secret: true }));
-      if (intent.kind === "back") return "selection";
+      if (intent.kind === "back") return { kind: "selection" };
       if (intent.kind === "exit") deps.exitOnboardFromPrompt();
       if (intent.kind === "help") {
         console.log("  Type back to choose a different provider, or exit to quit.");
@@ -65,7 +69,7 @@ export function createValidationRecoveryPromptHelpers(
       console.log("");
       console.log("  Credential staged. Onboarding will register it with the OpenShell gateway.");
       console.log("");
-      return key;
+      return { kind: "credential", value: key };
     }
   }
 
@@ -116,7 +120,7 @@ export function createValidationRecoveryPromptHelpers(
           helpUrl,
           validator,
         );
-        if (result === "selection") {
+        if (result.kind === "selection") {
           console.log("  Returning to provider selection.");
           console.log("");
           return "selection";
@@ -138,7 +142,7 @@ export function createValidationRecoveryPromptHelpers(
           helpUrl,
           validator,
         );
-        if (result === "selection") {
+        if (result.kind === "selection") {
           console.log("  Returning to provider selection.");
           console.log("");
           return "selection";

--- a/src/lib/onboard/validation-recovery-prompt.ts
+++ b/src/lib/onboard/validation-recovery-prompt.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { normalizeCredentialValue, saveCredential } from "../credentials/store";
+import { getCredentialPromptIntent, saveCredential } from "../credentials/store";
 import type { ProbeRecovery } from "../validation-recovery";
 
 export interface ValidationRecoveryPromptDeps {
@@ -18,7 +18,7 @@ export interface ValidationRecoveryPromptHelpers {
     label: string,
     helpUrl?: string | null,
     validator?: ((value: string) => string | null) | null,
-  ): Promise<string>;
+  ): Promise<string | "selection">;
   promptValidationRecovery(
     label: string,
     recovery: ProbeRecovery,
@@ -35,7 +35,7 @@ export function createValidationRecoveryPromptHelpers(
     label: string,
     helpUrl: string | null = null,
     validator: ((value: string) => string | null) | null = null,
-  ): Promise<string> {
+  ): Promise<string | "selection"> {
     if (helpUrl) {
       console.log("");
       console.log(`  Get your ${label} from: ${helpUrl}`);
@@ -43,7 +43,14 @@ export function createValidationRecoveryPromptHelpers(
     }
 
     while (true) {
-      const key = normalizeCredentialValue(await deps.prompt(`  ${label}: `, { secret: true }));
+      const intent = getCredentialPromptIntent(await deps.prompt(`  ${label}: `, { secret: true }));
+      if (intent.kind === "back") return "selection";
+      if (intent.kind === "exit") deps.exitOnboardFromPrompt();
+      if (intent.kind === "help") {
+        console.log("  Type back to choose a different provider, or exit to quit.");
+        continue;
+      }
+      const key = intent.value;
       if (!key) {
         console.error(`  ${label} is required.`);
         continue;
@@ -103,7 +110,17 @@ export function createValidationRecoveryPromptHelpers(
       if (looksLikeToken) {
         console.log("  ⚠️  That looks like an API key — do not paste credentials here.");
         console.log("  Treating as 'retry'. You will be prompted to enter the key securely.");
-        await replaceNamedCredential(credentialEnv, `${label} API key`, helpUrl, validator);
+        const result = await replaceNamedCredential(
+          credentialEnv,
+          `${label} API key`,
+          helpUrl,
+          validator,
+        );
+        if (result === "selection") {
+          console.log("  Returning to provider selection.");
+          console.log("");
+          return "selection";
+        }
         return "credential";
       }
       if (choice === "back") {
@@ -115,7 +132,17 @@ export function createValidationRecoveryPromptHelpers(
         deps.exitOnboardFromPrompt();
       }
       if (choice === "" || choice === "retry") {
-        await replaceNamedCredential(credentialEnv, `${label} API key`, helpUrl, validator);
+        const result = await replaceNamedCredential(
+          credentialEnv,
+          `${label} API key`,
+          helpUrl,
+          validator,
+        );
+        if (result === "selection") {
+          console.log("  Returning to provider selection.");
+          console.log("");
+          return "selection";
+        }
         return "credential";
       }
       console.log("  Please choose a provider/model again.");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The provider-validation credential re-entry prompt now honors the navigation words that the preceding menu advertises. `back` returns to provider selection, `exit` and `quit` exit onboarding, and help input explains the available actions instead of staging those words as credentials.

## Related Issue
Fixes #9557

## Changes
- Reuse the credential prompt intent classifier in `validation-recovery-prompt.ts`.
- Return to provider selection when the re-entry prompt receives `back`.
- Exit onboarding when the re-entry prompt receives `exit` or `quit`.
- Print credential prompt help for `?` and `help`.
- Return a discriminated credential result so `selection` remains a valid credential value.
- Add focused prompt-helper regression tests for `back`, `exit`, `quit`, `?`, `help`, `selection` as a credential, the paste-guard re-entry path, unexpected extra prompts, secret credential re-entry, and help-before-return ordering.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Self-review completed. The change uses the existing credential prompt intent classifier, does not log credential values, and keeps credential staging limited to `kind: "credential"` input.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/validation-recovery-prompt.test.ts src/lib/onboard/credential-navigation.test.ts` passed, 2 files and 11 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: danielpolimac <danielpolimac@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential recovery during onboarding.
  * Back navigation now reliably returns to provider selection.
  * Exit, quit, help, and retry flows now behave consistently.
  * Preserved credentials and environment values are handled correctly when retrying validation.
  * Credential prompts continue to protect entered values during recovery.

* **Tests**
  * Added coverage for credential replacement, pasted credentials, navigation, help commands, exits, retries, and prompt exhaustion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->