### PR TITLE
fix(images): preserve DCode base resolution metadata

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -444,6 +444,8 @@ jobs:
               --sbom=false \
               --file "$BASE_DOCKERFILE" \
               --tag "$LOCAL_BASE_REFERENCE" \
+              --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+              --label "org.opencontainers.image.revision=${CANDIDATE_SHA}" \
               --output "type=docker,dest=${local_base_archive}" \
               --output "type=oci,dest=${local_base_oci_archive}" \
               .
@@ -461,6 +463,8 @@ jobs:
               exit 1
             fi
             printf 'ref=%s\n' "$LOCAL_BASE_REFERENCE" >> "$GITHUB_OUTPUT"
+            printf 'identity_ref=%s@%s\n' "$BASE_REPOSITORY" "$local_base_oci_digest" >> "$GITHUB_OUTPUT"
+            printf 'source_revision=%s\n' "$CANDIDATE_SHA" >> "$GITHUB_OUTPUT"
             printf 'local=true\n' >> "$GITHUB_OUTPUT"
             printf 'oci=%s@%s\n' "$local_base_oci" "$local_base_oci_digest" >> "$GITHUB_OUTPUT"
             printf '### %s PR base\n\nLocally built from `%s` at `%s`.\n' \
@@ -505,9 +509,37 @@ jobs:
             exit 1
           fi
           printf 'ref=%s\n' "$reference" >> "$GITHUB_OUTPUT"
+          printf 'identity_ref=%s\n' "$reference" >> "$GITHUB_OUTPUT"
           printf 'local=false\n' >> "$GITHUB_OUTPUT"
           printf '### %s PR base\n\n`%s`\n' "$DISPLAY_NAME" "$reference" \
             >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Export immutable Deep Agents Code base resolution labels
+        id: dcode-base-resolution
+        if: matrix.agent == 'langchain-deepagents-code'
+        shell: bash
+        env:
+          BASE_IDENTITY_REFERENCE: ${{ steps.base.outputs.identity_ref }}
+          BASE_INSPECT_REFERENCE: ${{ steps.base.outputs.ref }}
+          BASE_IS_LOCAL: ${{ steps.base.outputs.local }}
+          BASE_LOCAL_OCI_RECEIPT: ${{ steps.base.outputs.oci }}
+          BASE_SOURCE_REVISION: ${{ steps.base.outputs.source_revision }}
+        run: |
+          set -euo pipefail
+          local_receipt_args=()
+          expected_revision_args=()
+          if [ "$BASE_IS_LOCAL" = "true" ]; then
+            local_receipt_args+=(--local-oci-receipt "$BASE_LOCAL_OCI_RECEIPT")
+            expected_revision_args+=(--expected-source-revision "$BASE_SOURCE_REVISION")
+          fi
+          node --experimental-strip-types --no-warnings \
+            scripts/checks/export-dcode-base-resolution-label.mts \
+            --reference "$BASE_IDENTITY_REFERENCE" \
+            --inspect-reference "$BASE_INSPECT_REFERENCE" \
+            --platform linux/amd64 \
+            --output "$GITHUB_OUTPUT" \
+            "${local_receipt_args[@]}" \
+            "${expected_revision_args[@]}"
 
       - name: Validate PR managed-image build args
         shell: bash
@@ -526,15 +558,25 @@ jobs:
         if: steps.base.outputs.local == 'true'
         shell: bash
         env:
+          AGENT: ${{ matrix.agent }}
           BASE_IMAGE: ${{ steps.base.outputs.ref }}
           CANDIDATE_SHA: ${{ github.event.pull_request.head.sha }}
           DOCKERFILE: ${{ matrix.dockerfile }}
           IMAGE_REFERENCE: ${{ matrix.image }}:${{ github.event.pull_request.head.sha }}
+          RESOLUTION_KEY: ${{ steps.dcode-base-resolution.outputs.resolution_key }}
+          RESOLUTION_LABEL: ${{ steps.dcode-base-resolution.outputs.resolution_label }}
         run: |
           set -euo pipefail
           # The base resolver loads a changed base into Docker's local image
           # store. Keep this consumer on that same store: a Buildx container
           # builder otherwise treats the local-only reference as Docker Hub.
+          resolution_labels=()
+          if [ "$AGENT" = "langchain-deepagents-code" ]; then
+            resolution_labels+=(
+              --label "com.nvidia.nemoclaw.base-resolution-key=${RESOLUTION_KEY}"
+              --label "com.nvidia.nemoclaw.base-resolution=${RESOLUTION_LABEL}"
+            )
+          fi
           docker build \
             --platform linux/amd64 \
             --file "$DOCKERFILE" \
@@ -547,6 +589,7 @@ jobs:
             --label "io.nvidia.nemoclaw.managed-image.startup-profile=1" \
             --label "io.nvidia.nemoclaw.managed-image.capabilities=1" \
             --label "io.nvidia.nemoclaw.managed-image.cohort=ghrun-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            "${resolution_labels[@]}" \
             --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
             --build-arg "NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1" \
             --build-arg "NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root" \
@@ -571,6 +614,8 @@ jobs:
             io.nvidia.nemoclaw.managed-image.startup-profile=1
             io.nvidia.nemoclaw.managed-image.capabilities=1
             io.nvidia.nemoclaw.managed-image.cohort=ghrun-${{ github.run_id }}-${{ github.run_attempt }}
+            ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution-key={0}', steps.dcode-base-resolution.outputs.resolution_key) || '' }}
+            ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution={0}', steps.dcode-base-resolution.outputs.resolution_label) || '' }}
           build-args: |
             BASE_IMAGE=${{ steps.base.outputs.ref }}
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
@@ -587,6 +632,8 @@ jobs:
           IMAGE_REFERENCE: ${{ matrix.image }}:${{ github.event.pull_request.head.sha }}
           PLATFORM: linux/amd64
           PUBLICATION_COHORT: ghrun-${{ github.run_id }}-${{ github.run_attempt }}
+          RESOLUTION_KEY: ${{ steps.dcode-base-resolution.outputs.resolution_key }}
+          RESOLUTION_LABEL: ${{ steps.dcode-base-resolution.outputs.resolution_label }}
         run: |
           set -euo pipefail
           image_json="$(docker image inspect "$IMAGE_REFERENCE")"
@@ -627,6 +674,17 @@ jobs:
                  .[0].Config.Labels["org.opencontainers.image.revision"] == $revision
                ' <<< "$image_json" >/dev/null; then
             echo "ERROR: PR managed image contract does not match the exact build identity." >&2
+            exit 1
+          fi
+          if [ "$AGENT" = "langchain-deepagents-code" ] &&
+             ! jq -e \
+               --arg key "$RESOLUTION_KEY" \
+               --arg metadata "$RESOLUTION_LABEL" '
+                 length == 1 and
+                 .[0].Config.Labels["com.nvidia.nemoclaw.base-resolution-key"] == $key and
+                 .[0].Config.Labels["com.nvidia.nemoclaw.base-resolution"] == $metadata
+               ' <<< "$image_json" >/dev/null; then
+            echo "ERROR: Deep Agents Code managed image lost immutable base resolution metadata." >&2
             exit 1
           fi
 
@@ -755,6 +813,8 @@ jobs:
             io.nvidia.nemoclaw.managed-image.startup-profile=1
             io.nvidia.nemoclaw.managed-image.capabilities=1
             io.nvidia.nemoclaw.managed-image.cohort=ghrun-${{ github.run_id }}-${{ github.run_attempt }}
+            ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution-key={0}', steps.dcode-base-resolution.outputs.resolution_key) || '' }}
+            ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution={0}', steps.dcode-base-resolution.outputs.resolution_label) || '' }}
           build-args: |
             BASE_IMAGE=${{ steps.base.outputs.local == 'true' && 'nemoclaw-pr-base' || steps.base.outputs.ref }}
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
@@ -776,6 +836,8 @@ jobs:
           COHORT: ghrun-${{ github.run_id }}-${{ github.run_attempt }}
           DIGEST: ${{ steps.publish.outputs.digest }}
           IMAGE: ${{ matrix.repository }}
+          RESOLUTION_KEY: ${{ steps.dcode-base-resolution.outputs.resolution_key }}
+          RESOLUTION_LABEL: ${{ steps.dcode-base-resolution.outputs.resolution_label }}
         run: |
           set -euo pipefail
           [[ "$CANDIDATE_SHA" =~ ^[a-f0-9]{40}$ ]] || {
@@ -794,6 +856,23 @@ jobs:
             exit 1
           }
           scripts/checks/pull-public-exact-digest.sh "$reference" linux/amd64
+          if [ "$AGENT" = "langchain-deepagents-code" ]; then
+            published_resolution_key="$(
+              docker image inspect \
+                --format '{{index .Config.Labels "com.nvidia.nemoclaw.base-resolution-key"}}' \
+                "$reference"
+            )"
+            published_resolution="$(
+              docker image inspect \
+                --format '{{index .Config.Labels "com.nvidia.nemoclaw.base-resolution"}}' \
+                "$reference"
+            )"
+            if [ "$published_resolution_key" != "$RESOLUTION_KEY" ] ||
+               [ "$published_resolution" != "$RESOLUTION_LABEL" ]; then
+              echo "ERROR: published Deep Agents Code image lost immutable base resolution metadata." >&2
+              exit 1
+            fi
+          fi
           release="$(git describe --tags --match 'v*' "$CANDIDATE_SHA")"
           contract_dir="$RUNNER_TEMP/managed-pr-contract"
           mkdir -p "$contract_dir"
@@ -1563,6 +1642,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.19.0
+
       - name: Restore exact base image contract
         shell: bash
         env:
@@ -1657,6 +1741,26 @@ jobs:
           )"
           docker buildx imagetools inspect "$platform_reference" >/dev/null
           printf 'ref=%s\n' "$platform_reference" >> "$GITHUB_OUTPUT"
+          jq -er '.sourceRevision' "$CONTRACT" |
+            sed 's/^/source_revision=/' >> "$GITHUB_OUTPUT"
+
+      - name: Export immutable Deep Agents Code base resolution labels
+        id: dcode-base-resolution
+        if: matrix.agent == 'langchain-deepagents-code'
+        shell: bash
+        env:
+          BASE_REFERENCE: ${{ steps.base.outputs.ref }}
+          BASE_SOURCE_REVISION: ${{ steps.base.outputs.source_revision }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          node --experimental-strip-types --no-warnings \
+            scripts/checks/export-dcode-base-resolution-label.mts \
+            --reference "$BASE_REFERENCE" \
+            --inspect-reference "$BASE_REFERENCE" \
+            --expected-source-revision "$BASE_SOURCE_REVISION" \
+            --platform "$PLATFORM" \
+            --output "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -1698,6 +1802,8 @@ jobs:
             io.nvidia.nemoclaw.managed-image.startup-profile=1
             io.nvidia.nemoclaw.managed-image.capabilities=1
             io.nvidia.nemoclaw.managed-image.cohort=${{ needs.publication-identity.outputs.cohort }}
+            ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution-key={0}', steps.dcode-base-resolution.outputs.resolution_key) || '' }}
+            ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution={0}', steps.dcode-base-resolution.outputs.resolution_label) || '' }}
           build-args: |
             BASE_IMAGE=${{ steps.base.outputs.ref }}
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
@@ -1722,6 +1828,8 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           PUBLICATION_COHORT: ${{ needs.publication-identity.outputs.cohort }}
           REQUIRED_BINARY: ${{ matrix.required_binary }}
+          RESOLUTION_KEY: ${{ steps.dcode-base-resolution.outputs.resolution_key }}
+          RESOLUTION_LABEL: ${{ steps.dcode-base-resolution.outputs.resolution_label }}
         run: |
           set -euo pipefail
           if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
@@ -1748,6 +1856,23 @@ jobs:
           if [ -n "$image_user" ] && [ "$image_user" != "root" ] && [ "$image_user" != "0" ]; then
             echo "ERROR: managed image OCI user must be uid 0 for OpenShell supervisor initialization: $image_user" >&2
             exit 1
+          fi
+          if [ "$AGENT" = "langchain-deepagents-code" ]; then
+            resolution_key_label="$(
+              docker image inspect \
+                --format '{{index .Config.Labels "com.nvidia.nemoclaw.base-resolution-key"}}' \
+                "$reference"
+            )"
+            resolution_label="$(
+              docker image inspect \
+                --format '{{index .Config.Labels "com.nvidia.nemoclaw.base-resolution"}}' \
+                "$reference"
+            )"
+            if [ "$resolution_key_label" != "$RESOLUTION_KEY" ] ||
+               [ "$resolution_label" != "$RESOLUTION_LABEL" ]; then
+              echo "ERROR: Deep Agents Code image lost immutable base resolution metadata." >&2
+              exit 1
+            fi
           fi
 
           agent_label="$(

--- a/scripts/checks/export-dcode-base-resolution-label.mts
+++ b/scripts/checks/export-dcode-base-resolution-label.mts
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { appendFileSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DCODE_BASE_IMAGE = "ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base";
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const REVISION_PATTERN = /^[0-9a-f]{40}$/u;
+const GLIBC_PATTERN = /^[0-9]+[.][0-9]+$/u;
+const PLATFORM_PATTERN = /^linux\/(amd64|arm64)$/u;
+
+type DcodeBaseResolutionInput = {
+  imageName: string;
+  reference: string;
+  digest: string;
+  sourceRevision: string;
+  imageId: string;
+  os: string;
+  architecture: string;
+  platform: string;
+  glibcVersion: string;
+};
+
+type DockerImageInspect = {
+  Id?: unknown;
+  Os?: unknown;
+  Architecture?: unknown;
+  Config?: { Labels?: Record<string, unknown> } | null;
+};
+
+function fail(message: string): never {
+  throw new Error(`Deep Agents Code base-resolution label: ${message}`);
+}
+
+export function createDcodeBaseResolutionMetadata(input: DcodeBaseResolutionInput) {
+  if (input.imageName !== DCODE_BASE_IMAGE) fail("image repository is invalid");
+  if (!DIGEST_PATTERN.test(input.digest)) fail("platform digest is invalid");
+  if (input.reference !== `${input.imageName}@${input.digest}`) {
+    fail("reference is not bound to the immutable platform digest");
+  }
+  if (!PLATFORM_PATTERN.test(input.platform)) fail("platform is invalid");
+  const [os, architecture] = input.platform.split("/");
+  if (input.os !== os || input.architecture !== architecture) {
+    fail("inspected platform does not match the immutable contract");
+  }
+  if (!DIGEST_PATTERN.test(input.imageId)) fail("local image identity is invalid");
+  if (!REVISION_PATTERN.test(input.sourceRevision)) fail("source revision is invalid");
+  if (!GLIBC_PATTERN.test(input.glibcVersion)) fail("glibc version is invalid");
+
+  const authority = {
+    imageName: input.imageName,
+    ref: input.reference,
+    digest: input.digest,
+    sourceRevision: input.sourceRevision,
+    imageId: input.imageId,
+    os,
+    architecture,
+    glibcVersion: input.glibcVersion,
+    requireOpenshellSandboxAbi: true,
+    minGlibcVersion: "2.39",
+  };
+  return {
+    schema: 1,
+    key: createHash("sha256").update(JSON.stringify(authority)).digest("hex"),
+    ...authority,
+    source: "override",
+  };
+}
+
+export function encodeDcodeBaseResolutionMetadata(
+  metadata: ReturnType<typeof createDcodeBaseResolutionMetadata>,
+): string {
+  return Buffer.from(JSON.stringify(metadata), "utf8").toString("base64url");
+}
+
+function parseArguments(argv: string[]): Map<string, string> {
+  const values = new Map<string, string>();
+  const allowed = new Set<string>([
+    "reference",
+    "inspect-reference",
+    "platform",
+    "output",
+    "local-oci-receipt",
+    "expected-source-revision",
+  ]);
+  for (let index = 0; index < argv.length; index += 2) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+    const key = argument?.startsWith("--") ? argument.slice(2) : "";
+    if (!allowed.has(key) || value === undefined || values.has(key)) {
+      fail("arguments are invalid");
+    }
+    values.set(key, value);
+  }
+  for (const key of ["reference", "inspect-reference", "platform", "output"]) {
+    if (!values.get(key)) fail(`${key} is required`);
+  }
+  return values;
+}
+
+function requiredValue(values: Map<string, string>, key: string): string {
+  const value = values.get(key);
+  if (!value) fail(`${key} is required`);
+  return value;
+}
+
+function runDocker(arguments_: string[]): string {
+  return execFileSync("docker", arguments_, {
+    encoding: "utf8",
+    maxBuffer: 4 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function validateLocalOciReceipt(receipt: string, digest: string): void {
+  const separator = receipt.lastIndexOf("@sha256:");
+  if (separator < 1) fail("local OCI receipt is invalid");
+  const layoutRoot = receipt.slice(0, separator);
+  const receiptDigest = receipt.slice(separator + 1);
+  if (!path.isAbsolute(layoutRoot) || receiptDigest !== digest) {
+    fail("local OCI receipt does not match the immutable platform digest");
+  }
+  const index = JSON.parse(readFileSync(path.join(layoutRoot, "index.json"), "utf8")) as {
+    manifests?: Array<{ digest?: unknown }>;
+  };
+  if (
+    !Array.isArray(index.manifests) ||
+    index.manifests.length !== 1 ||
+    index.manifests[0]?.digest !== digest
+  ) {
+    fail("local OCI receipt does not contain the immutable platform manifest");
+  }
+}
+
+export function exportDcodeBaseResolutionLabel(argv: string[]) {
+  const values = parseArguments(argv);
+  const reference = requiredValue(values, "reference");
+  const inspectReference = requiredValue(values, "inspect-reference");
+  const platform = requiredValue(values, "platform");
+  const output = requiredValue(values, "output");
+  const localOciReceipt = values.get("local-oci-receipt");
+  const expectedSourceRevision = values.get("expected-source-revision");
+  const digest = reference.slice(reference.lastIndexOf("@") + 1);
+
+  if (reference !== `${DCODE_BASE_IMAGE}@${digest}` || !DIGEST_PATTERN.test(digest)) {
+    fail("reference is not an exact Deep Agents Code platform reference");
+  }
+  if (!PLATFORM_PATTERN.test(platform)) fail("platform is invalid");
+  if (expectedSourceRevision && !REVISION_PATTERN.test(expectedSourceRevision)) {
+    fail("expected source revision is invalid");
+  }
+  if (!path.isAbsolute(output) || /[\r\n]/u.test(output)) fail("output path is invalid");
+
+  if (inspectReference === reference) {
+    if (localOciReceipt) fail("remote inspection cannot use a local OCI receipt");
+    runDocker(["pull", "--platform", platform, reference]);
+  } else {
+    if (!localOciReceipt) fail("a mutable inspection reference needs its exact local OCI receipt");
+    validateLocalOciReceipt(localOciReceipt, digest);
+  }
+
+  const inspectedImages = JSON.parse(runDocker(["image", "inspect", inspectReference])) as unknown;
+  if (!Array.isArray(inspectedImages) || inspectedImages.length !== 1) {
+    fail("inspection did not return one image");
+  }
+  const inspected = inspectedImages[0] as DockerImageInspect;
+  const sourceRevision = inspected?.Config?.Labels?.["org.opencontainers.image.revision"];
+  if (typeof sourceRevision !== "string" || !REVISION_PATTERN.test(sourceRevision)) {
+    fail("inspected source revision is missing");
+  }
+  if (expectedSourceRevision && sourceRevision !== expectedSourceRevision) {
+    fail("inspected source revision does not match the immutable contract");
+  }
+  const glibcOutput = runDocker([
+    "run",
+    "--rm",
+    "--platform",
+    platform,
+    "--entrypoint",
+    "getconf",
+    inspectReference,
+    "GNU_LIBC_VERSION",
+  ]);
+  const glibcVersion = /^glibc ([0-9]+[.][0-9]+)$/u.exec(glibcOutput)?.[1] ?? "";
+  const imageId = inspected.Id;
+  const os = inspected.Os;
+  const architecture = inspected.Architecture;
+  if (typeof imageId !== "string" || typeof os !== "string" || typeof architecture !== "string") {
+    fail("inspected image identity is incomplete");
+  }
+  const metadata = createDcodeBaseResolutionMetadata({
+    imageName: DCODE_BASE_IMAGE,
+    reference,
+    digest,
+    sourceRevision,
+    imageId,
+    os,
+    architecture,
+    platform,
+    glibcVersion,
+  });
+  appendFileSync(
+    output,
+    `resolution_key=${metadata.key}\nresolution_label=${encodeDcodeBaseResolutionMetadata(metadata)}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+  return metadata;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    exportDcodeBaseResolutionLabel(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : "Deep Agents Code label export failed");
+    process.exitCode = 1;
+  }
+}

--- a/src/lib/actions/sandbox/rebuild-base-image-resolution-flow.test.ts
+++ b/src/lib/actions/sandbox/rebuild-base-image-resolution-flow.test.ts
@@ -18,13 +18,14 @@ describe("rebuildSandbox base-image resolution flow", () => {
   it("passes the recorded Docker base-image hint and refresh env through ordinary preflight (#4680)", async () => {
     const restoreEnv = snapshotEnv(["NEMOCLAW_SANDBOX_BASE_IMAGE_REFRESH"]);
     process.env.NEMOCLAW_SANDBOX_BASE_IMAGE_REFRESH = "yes";
-    const resolutionHint: SandboxBaseImageResolutionMetadata = {
+    const resolutionHint: SandboxBaseImageResolutionMetadata & { sourceRevision: string } = {
       schema: 1,
       key: "hermes-base-key",
       imageName: "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base",
       ref: "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:resolved",
       digest: "sha256:resolved",
       source: "latest",
+      sourceRevision: "b".repeat(40),
       imageId: "sha256:local-image",
       os: "linux",
       architecture: "amd64",

--- a/test/e2e/live/dcode-base-image-runtime-evidence.ts
+++ b/test/e2e/live/dcode-base-image-runtime-evidence.ts
@@ -53,6 +53,16 @@ function exactKeys(value: Record<string, unknown>, expected: readonly string[], 
   }
 }
 
+function requireImmutableSourceRevision(metadata: SandboxBaseImageResolutionMetadata): string {
+  const sourceRevision = (metadata as unknown as Record<string, unknown>).sourceRevision;
+  if (typeof sourceRevision !== "string" || !REVISION_PATTERN.test(sourceRevision)) {
+    throw new Error(
+      `Deep Agents Code sandbox image does not match the published ${DCODE_BASE_IMAGE_TARGET_PLATFORM} base-image contract (mismatched fields: source revision)`,
+    );
+  }
+  return sourceRevision;
+}
+
 export function parseDcodeBaseImagePublicationEvidence(
   value: unknown,
   environment: NodeJS.ProcessEnv = process.env,
@@ -126,6 +136,7 @@ export function verifyDcodeBaseImageRuntimeEvidence(
       `Deep Agents Code sandbox image did not use the published ${DCODE_BASE_IMAGE_TARGET_PLATFORM} base digest`,
     );
   }
+  const sourceRevision = requireImmutableSourceRevision(metadata);
   const expectedDigest = contract.platformDigests[DCODE_BASE_IMAGE_TARGET_PLATFORM];
   const expectedReference = dcodeBaseImageReferenceForContract(contract);
   const mismatchedFields = [
@@ -136,6 +147,7 @@ export function verifyDcodeBaseImageRuntimeEvidence(
     metadata.digest !== expectedDigest ? "digest" : null,
     metadata.ref !== expectedReference ? "reference" : null,
     metadata.ref !== `${metadata.imageName}@${metadata.digest}` ? "reference binding" : null,
+    sourceRevision !== contract.sourceRevision ? "source revision" : null,
   ].filter((field): field is string => field !== null);
   if (mismatchedFields.length > 0) {
     throw new Error(
@@ -151,7 +163,7 @@ export function verifyDcodeBaseImageRuntimeEvidence(
     reference: expectedReference,
     sandboxImage,
     source: "override",
-    sourceRevision: contract.sourceRevision,
+    sourceRevision,
   };
 }
 

--- a/test/e2e/support/dcode-base-image-runtime-evidence.test.ts
+++ b/test/e2e/support/dcode-base-image-runtime-evidence.test.ts
@@ -49,8 +49,8 @@ function publicationEnvironment(overrides: NodeJS.ProcessEnv = {}): NodeJS.Proce
 }
 
 function resolutionMetadata(
-  overrides: Partial<SandboxBaseImageResolutionMetadata> = {},
-): SandboxBaseImageResolutionMetadata {
+  overrides: Partial<SandboxBaseImageResolutionMetadata & { sourceRevision: string }> = {},
+): SandboxBaseImageResolutionMetadata & { sourceRevision: string } {
   return {
     schema: 1,
     key: "resolution-key",
@@ -58,6 +58,7 @@ function resolutionMetadata(
     ref: DCODE_BASE_IMAGE_AMD64_REFERENCE,
     digest: DCODE_BASE_IMAGE_AMD64_DIGEST,
     source: "override",
+    sourceRevision: DCODE_BASE_IMAGE_SOURCE_REVISION,
     imageId: `sha256:${"e".repeat(64)}`,
     os: "linux",
     architecture: "amd64",
@@ -66,6 +67,12 @@ function resolutionMetadata(
     minGlibcVersion: "2.39",
     ...overrides,
   };
+}
+
+function resolutionMetadataWithoutSourceRevision(): SandboxBaseImageResolutionMetadata {
+  const metadata = resolutionMetadata();
+  delete (metadata as unknown as Record<string, unknown>).sourceRevision;
+  return metadata;
 }
 
 describe("Deep Agents Code published base runtime evidence", () => {
@@ -252,6 +259,27 @@ describe("Deep Agents Code published base runtime evidence", () => {
       metadata: null,
       expectedMessage: "Deep Agents Code sandbox image is missing base resolution metadata",
       rejectedValues: [],
+    },
+    {
+      label: "missing immutable source revision",
+      metadata: resolutionMetadataWithoutSourceRevision(),
+      expectedMessage: baseContractMismatch("source revision"),
+      rejectedValues: [],
+    },
+    {
+      label: "malformed immutable source revision",
+      metadata: {
+        ...resolutionMetadata(),
+        sourceRevision: "main",
+      } as SandboxBaseImageResolutionMetadata,
+      expectedMessage: baseContractMismatch("source revision"),
+      rejectedValues: ["main"],
+    },
+    {
+      label: "mismatched immutable source revision",
+      metadata: resolutionMetadata({ sourceRevision: "f".repeat(40) }),
+      expectedMessage: baseContractMismatch("source revision"),
+      rejectedValues: ["f".repeat(40)],
     },
     {
       label: "an unsupported metadata schema version",

--- a/test/e2e/support/dcode-base-resolution-label.test.ts
+++ b/test/e2e/support/dcode-base-resolution-label.test.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { parseSandboxBaseImageResolutionLabels } from "../../../src/lib/sandbox-base-image/label-codec.ts";
+import { SANDBOX_BASE_RESOLUTION_LABEL } from "../../../src/lib/sandbox-base-image/types.ts";
+import {
+  createDcodeBaseResolutionMetadata,
+  encodeDcodeBaseResolutionMetadata,
+} from "../../../scripts/checks/export-dcode-base-resolution-label.mts";
+
+const IMAGE = "ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base";
+const DIGEST = `sha256:${"a".repeat(64)}`;
+const SOURCE_REVISION = "b".repeat(40);
+
+function authority(overrides: Record<string, unknown> = {}) {
+  return {
+    imageName: IMAGE,
+    reference: `${IMAGE}@${DIGEST}`,
+    digest: DIGEST,
+    sourceRevision: SOURCE_REVISION,
+    imageId: `sha256:${"c".repeat(64)}`,
+    os: "linux",
+    architecture: "amd64",
+    platform: "linux/amd64",
+    glibcVersion: "2.41",
+    ...overrides,
+  };
+}
+
+describe("Deep Agents Code managed-image base resolution label", () => {
+  it("serializes immutable base authority into a parseable final-image label (#9386)", () => {
+    const metadata = createDcodeBaseResolutionMetadata(authority());
+    const encoded = encodeDcodeBaseResolutionMetadata(metadata);
+
+    expect(
+      parseSandboxBaseImageResolutionLabels({ [SANDBOX_BASE_RESOLUTION_LABEL]: encoded }),
+    ).toEqual(metadata);
+    expect(metadata).toMatchObject({
+      imageName: IMAGE,
+      ref: `${IMAGE}@${DIGEST}`,
+      digest: DIGEST,
+      sourceRevision: SOURCE_REVISION,
+      os: "linux",
+      architecture: "amd64",
+      source: "override",
+    });
+  });
+
+  it.each([
+    ["a mutable reference", { reference: `${IMAGE}:latest` }],
+    ["a mismatched platform", { architecture: "arm64" }],
+    ["a malformed revision", { sourceRevision: "main" }],
+  ])("fails closed for %s (#9386)", (_label, overrides) => {
+    expect(() => createDcodeBaseResolutionMetadata(authority(overrides))).toThrow(
+      /Deep Agents Code base-resolution label/u,
+    );
+  });
+});

--- a/test/e2e/support/dcode-base-resolution-workflow.test.ts
+++ b/test/e2e/support/dcode-base-resolution-workflow.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  managedPublisher,
+  readWorkflow,
+  required,
+  step,
+} from "../../helpers/managed-image-publication-workflow.ts";
+
+function prBuilder() {
+  return required(
+    readWorkflow("managed-images.yaml").jobs?.["pr-build-and-entrypoint"],
+    "managed-image workflow is missing its PR builder",
+  );
+}
+
+describe("Deep Agents Code base-resolution publication boundary (#9386)", () => {
+  it("carries the exact PR base authority through every final-image path", () => {
+    const publisher = prBuilder();
+    const resolver = step(publisher, "Resolve exact linux/amd64 PR base");
+    const exporter = step(publisher, "Export immutable Deep Agents Code base resolution labels");
+    const localBuild = step(publisher, "Build PR managed image from local base");
+    const registryBuild = step(publisher, "Build PR managed image from registry base");
+    const localContract = step(publisher, "Validate exact PR managed image contract");
+    const publishedContract = step(publisher, "Export exact published PR managed-image contract");
+
+    expect(resolver.run).toContain("identity_ref=%s@%s");
+    expect(resolver.run).toContain("source_revision=%s");
+    expect(exporter.if).toBe("matrix.agent == 'langchain-deepagents-code'");
+    expect(exporter.run).toContain("export-dcode-base-resolution-label.mts");
+    expect(exporter.run).toContain('--reference "$BASE_IDENTITY_REFERENCE"');
+    expect(exporter.run).toContain('--local-oci-receipt "$BASE_LOCAL_OCI_RECEIPT"');
+    expect(localBuild.run).toContain("com.nvidia.nemoclaw.base-resolution-key");
+    expect(localBuild.run).toContain("com.nvidia.nemoclaw.base-resolution");
+    expect(String(registryBuild.with?.labels)).toContain("com.nvidia.nemoclaw.base-resolution-key");
+    expect(String(registryBuild.with?.labels)).toContain("com.nvidia.nemoclaw.base-resolution");
+    expect(localContract.run).toContain("lost immutable base resolution metadata");
+    expect(publishedContract.run).toContain(
+      "published Deep Agents Code image lost immutable base resolution metadata",
+    );
+  });
+
+  it("carries contract-owned authority into exact production platform images", () => {
+    const publisher = managedPublisher(readWorkflow("managed-images.yaml"));
+    const node = step(publisher, "Set up Node.js");
+    const contract = step(publisher, "Validate exact base image contract");
+    const exporter = step(publisher, "Export immutable Deep Agents Code base resolution labels");
+    const build = step(publisher, "Build and push managed image by digest");
+    const validation = step(publisher, "Validate exact managed image before promotion");
+
+    expect(node.with?.["node-version"]).toBe("22.19.0");
+    expect(contract.run).toContain("source_revision=");
+    expect(exporter.if).toBe("matrix.agent == 'langchain-deepagents-code'");
+    expect(exporter.run).toContain('--reference "$BASE_REFERENCE"');
+    expect(exporter.run).toContain('--expected-source-revision "$BASE_SOURCE_REVISION"');
+    expect(String(build.with?.labels)).toContain("com.nvidia.nemoclaw.base-resolution-key");
+    expect(String(build.with?.labels)).toContain("com.nvidia.nemoclaw.base-resolution");
+    expect(validation.run).toContain(
+      "Deep Agents Code image lost immutable base resolution metadata",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Preserve the exact Deep Agents Code base-image authority in the derived managed image so final E2E evidence can recover and validate it. The final image now carries parseable base-resolution labels sourced from a digest-pinned remote base or a receipt-bound local OCI layout, and exact-image publication checks fail if those labels are lost.

## Related Issue

Refs #9386. Stacked on #9323.

Related: #9140 and #7744.

## Changes

- Export repository, immutable platform reference and digest, source revision, image ID, OS/architecture, and glibc identity from the inspected exact DCode base.
- Attach the metadata to local PR, registry-backed PR, digest-published PR, and production managed-image builds, then verify it on the exact final image.
- Require the receipt-owned source revision in final DCode evidence and keep missing, malformed, mutable, or mismatched authority fail-closed.
- Use one exporter for the PR and production publication consumers to avoid divergent authority encoding; focused label and workflow tests protect that shared seam.
- Prove rebuild/lifecycle forwarding preserves the complete receipt metadata.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending review
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `vitest run` on the DCode label, workflow boundary, final evidence, and rebuild flow tests: 32 passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run; this is a narrow workflow/evidence seam and the full matrix was intentionally not run
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
