### PR TITLE
fix(images): preserve DCode base resolution metadata

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -444,6 +444,8 @@ jobs:
               --sbom=false \
               --file "$BASE_DOCKERFILE" \
               --tag "$LOCAL_BASE_REFERENCE" \
+              --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+              --label "org.opencontainers.image.revision=${CANDIDATE_SHA}" \
               --output "type=docker,dest=${local_base_archive}" \
               --output "type=oci,dest=${local_base_oci_archive}" \
               .
@@ -461,6 +463,8 @@ jobs:
               exit 1
             fi
             printf 'ref=%s\n' "$LOCAL_BASE_REFERENCE" >> "$GITHUB_OUTPUT"
+            printf 'identity_ref=%s@%s\n' "$BASE_REPOSITORY" "$local_base_oci_digest" >> "$GITHUB_OUTPUT"
+            printf 'source_revision=%s\n' "$CANDIDATE_SHA" >> "$GITHUB_OUTPUT"
             printf 'local=true\n' >> "$GITHUB_OUTPUT"
             printf 'oci=%s@%s\n' "$local_base_oci" "$local_base_oci_digest" >> "$GITHUB_OUTPUT"
             printf '### %s PR base\n\nLocally built from `%s` at `%s`.\n' \
@@ -505,9 +509,37 @@ jobs:
             exit 1
           fi
           printf 'ref=%s\n' "$reference" >> "$GITHUB_OUTPUT"
+          printf 'identity_ref=%s\n' "$reference" >> "$GITHUB_OUTPUT"
           printf 'local=false\n' >> "$GITHUB_OUTPUT"
           printf '### %s PR base\n\n`%s`\n' "$DISPLAY_NAME" "$reference" \
             >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Export immutable Deep Agents Code base resolution labels
+        id: dcode-base-resolution
+        if: matrix.agent == 'langchain-deepagents-code'
+        shell: bash
+        env:
+          BASE_IDENTITY_REFERENCE: ${{ steps.base.outputs.identity_ref }}
+          BASE_INSPECT_REFERENCE: ${{ steps.base.outputs.ref }}
+          BASE_IS_LOCAL: ${{ steps.base.outputs.local }}
+          BASE_LOCAL_OCI_RECEIPT: ${{ steps.base.outputs.oci }}
+          BASE_SOURCE_REVISION: ${{ steps.base.outputs.source_revision }}
+        run: |
+          set -euo pipefail
+          local_receipt_args=()
+          expected_revision_args=()
+          if [ "$BASE_IS_LOCAL" = "true" ]; then
+            local_receipt_args+=(--local-oci-receipt "$BASE_LOCAL_OCI_RECEIPT")
+            expected_revision_args+=(--expected-source-revision "$BASE_SOURCE_REVISION")
+          fi
+          node --experimental-strip-types --no-warnings \
+            scripts/checks/export-dcode-base-resolution-label.mts \
+            --reference "$BASE_IDENTITY_REFERENCE" \
+            --inspect-reference "$BASE_INSPECT_REFERENCE" \
+            --platform linux/amd64 \
+            --output "$GITHUB_OUTPUT" \
+            "${local_receipt_args[@]}" \
+            "${expected_revision_args[@]}"
 
       - name: Validate PR managed-image build args
         shell: bash
@@ -526,15 +558,25 @@ jobs:
         if: steps.base.outputs.local == 'true'
         shell: bash
         env:
+          AGENT: ${{ matrix.agent }}
           BASE_IMAGE: ${{ steps.base.outputs.ref }}
           CANDIDATE_SHA: ${{ github.event.pull_request.head.sha }}
           DOCKERFILE: ${{ matrix.dockerfile }}
           IMAGE_REFERENCE: ${{ matrix.image }}:${{ github.event.pull_request.head.sha }}
+          RESOLUTION_KEY: ${{ steps.dcode-base-resolution.outputs.resolution_key }}
+          RESOLUTION_LABEL: ${{ steps.dcode-base-resolution.outputs.resolution_label }}
         run: |
           set -euo pipefail
           # The base resolver loads a changed base into Docker's local image
           # store. Keep this consumer on that same store: a Buildx container
           # builder otherwise treats the local-only reference as Docker Hub.
+          resolution_labels=()
+          if [ "$AGENT" = "langchain-deepagents-code" ]; then
+            resolution_labels+=(
+              --label "com.nvidia.nemoclaw.base-resolution-key=${RESOLUTION_KEY}"
+              --label "com.nvidia.nemoclaw.base-resolution=${RESOLUTION_LABEL}"
+            )
+          fi
           docker build \
             --platform linux/amd64 \
             --file "$DOCKERFILE" \
@@ -547,6 +589,7 @@ jobs:
             --label "io.nvidia.nemoclaw.managed-image.startup-profile=1" \
             --label "io.nvidia.nemoclaw.managed-image.capabilities=1" \
             --label "io.nvidia.nemoclaw.managed-image.cohort=ghrun-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            "${resolution_labels[@]}" \
             --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
             --build-arg "NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1" \
             --build-arg "NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root" \
@@ -571,6 +614,8 @@ jobs:
             io.nvidia.nemoclaw.managed-image.startup-profile=1
             io.nvidia.nemoclaw.managed-image.capabilities=1
             io.nvidia.nemoclaw.managed-image.cohort=ghrun-${{ github.run_id }}-${{ github.run_attempt }}
+            ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution-key={0}', steps.dcode-base-resolution.outputs.resolution_key) || '' }}
+            ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution={0}', steps.dcode-base-resolution.outputs.resolution_label) || '' }}
           build-args: |
             BASE_IMAGE=${{ steps.base.outputs.ref }}
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
@@ -587,6 +632,8 @@ jobs:
           IMAGE_REFERENCE: ${{ matrix.image }}:${{ github.event.pull_request.head.sha }}
           PLATFORM: linux/amd64
           PUBLICATION_COHORT: ghrun-${{ github.run_id }}-${{ github.run_attempt }}
+          RESOLUTION_KEY: ${{ steps.dcode-base-resolution.outputs.resolution_key }}
+          RESOLUTION_LABEL: ${{ steps.dcode-base-resolution.outputs.resolution_label }}
         run: |
           set -euo pipefail
           image_json="$(docker image inspect "$IMAGE_REFERENCE")"
@@ -627,6 +674,17 @@ jobs:
                  .[0].Config.Labels["org.opencontainers.image.revision"] == $revision
                ' <<< "$image_json" >/dev/null; then
             echo "ERROR: PR managed image contract does not match the exact build identity." >&2
+            exit 1
+          fi
+          if [ "$AGENT" = "langchain-deepagents-code" ] &&
+             ! jq -e \
+               --arg key "$RESOLUTION_KEY" \
+               --arg metadata "$RESOLUTION_LABEL" '
+                 length == 1 and
+                 .[0].Config.Labels["com.nvidia.nemoclaw.base-resolution-key"] == $key and
+                 .[0].Config.Labels["com.nvidia.nemoclaw.base-resolution"] == $metadata
+               ' <<< "$image_json" >/dev/null; then
+            echo "ERROR: Deep Agents Code managed image lost immutable base resolution metadata." >&2
             exit 1
           fi
 
@@ -755,6 +813,8 @@ jobs:
             io.nvidia.nemoclaw.managed-image.startup-profile=1
             io.nvidia.nemoclaw.managed-image.capabilities=1
             io.nvidia.nemoclaw.managed-image.cohort=ghrun-${{ github.run_id }}-${{ github.run_attempt }}
+            ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution-key={0}', steps.dcode-base-resolution.outputs.resolution_key) || '' }}
+            ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution={0}', steps.dcode-base-resolution.outputs.resolution_label) || '' }}
           build-args: |
             BASE_IMAGE=${{ steps.base.outputs.local == 'true' && 'nemoclaw-pr-base' || steps.base.outputs.ref }}
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
@@ -776,6 +836,8 @@ jobs:
           COHORT: ghrun-${{ github.run_id }}-${{ github.run_attempt }}
           DIGEST: ${{ steps.publish.outputs.digest }}
           IMAGE: ${{ matrix.repository }}
+          RESOLUTION_KEY: ${{ steps.dcode-base-resolution.outputs.resolution_key }}
+          RESOLUTION_LABEL: ${{ steps.dcode-base-resolution.outputs.resolution_label }}
         run: |
           set -euo pipefail
           [[ "$CANDIDATE_SHA" =~ ^[a-f0-9]{40}$ ]] || {
@@ -794,6 +856,23 @@ jobs:
             exit 1
           }
           scripts/checks/pull-public-exact-digest.sh "$reference" linux/amd64
+          if [ "$AGENT" = "langchain-deepagents-code" ]; then
+            published_resolution_key="$(
+              docker image inspect \
+                --format '{{index .Config.Labels "com.nvidia.nemoclaw.base-resolution-key"}}' \
+                "$reference"
+            )"
+            published_resolution="$(
+              docker image inspect \
+                --format '{{index .Config.Labels "com.nvidia.nemoclaw.base-resolution"}}' \
+                "$reference"
+            )"
+            if [ "$published_resolution_key" != "$RESOLUTION_KEY" ] ||
+               [ "$published_resolution" != "$RESOLUTION_LABEL" ]; then
+              echo "ERROR: published Deep Agents Code image lost immutable base resolution metadata." >&2
+              exit 1
+            fi
+          fi
           release="$(git describe --tags --match 'v*' "$CANDIDATE_SHA")"
           contract_dir="$RUNNER_TEMP/managed-pr-contract"
           mkdir -p "$contract_dir"
@@ -1563,6 +1642,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.19.0
+
       - name: Restore exact base image contract
         shell: bash
         env:
@@ -1657,6 +1741,26 @@ jobs:
           )"
           docker buildx imagetools inspect "$platform_reference" >/dev/null
           printf 'ref=%s\n' "$platform_reference" >> "$GITHUB_OUTPUT"
+          jq -er '.sourceRevision' "$CONTRACT" |
+            sed 's/^/source_revision=/' >> "$GITHUB_OUTPUT"
+
+      - name: Export immutable Deep Agents Code base resolution labels
+        id: dcode-base-resolution
+        if: matrix.agent == 'langchain-deepagents-code'
+        shell: bash
+        env:
+          BASE_REFERENCE: ${{ steps.base.outputs.ref }}
+          BASE_SOURCE_REVISION: ${{ steps.base.outputs.source_revision }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          node --experimental-strip-types --no-warnings \
+            scripts/checks/export-dcode-base-resolution-label.mts \
+            --reference "$BASE_REFERENCE" \
+            --inspect-reference "$BASE_REFERENCE" \
+            --expected-source-revision "$BASE_SOURCE_REVISION" \
+            --platform "$PLATFORM" \
+            --output "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -1698,6 +1802,8 @@ jobs:
             io.nvidia.nemoclaw.managed-image.startup-profile=1
             io.nvidia.nemoclaw.managed-image.capabilities=1
             io.nvidia.nemoclaw.managed-image.cohort=${{ needs.publication-identity.outputs.cohort }}
+            ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution-key={0}', steps.dcode-base-resolution.outputs.resolution_key) || '' }}
+            ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution={0}', steps.dcode-base-resolution.outputs.resolution_label) || '' }}
           build-args: |
             BASE_IMAGE=${{ steps.base.outputs.ref }}
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
@@ -1722,6 +1828,8 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           PUBLICATION_COHORT: ${{ needs.publication-identity.outputs.cohort }}
           REQUIRED_BINARY: ${{ matrix.required_binary }}
+          RESOLUTION_KEY: ${{ steps.dcode-base-resolution.outputs.resolution_key }}
+          RESOLUTION_LABEL: ${{ steps.dcode-base-resolution.outputs.resolution_label }}
         run: |
           set -euo pipefail
           if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
@@ -1748,6 +1856,23 @@ jobs:
           if [ -n "$image_user" ] && [ "$image_user" != "root" ] && [ "$image_user" != "0" ]; then
             echo "ERROR: managed image OCI user must be uid 0 for OpenShell supervisor initialization: $image_user" >&2
             exit 1
+          fi
+          if [ "$AGENT" = "langchain-deepagents-code" ]; then
+            resolution_key_label="$(
+              docker image inspect \
+                --format '{{index .Config.Labels "com.nvidia.nemoclaw.base-resolution-key"}}' \
+                "$reference"
+            )"
+            resolution_label="$(
+              docker image inspect \
+                --format '{{index .Config.Labels "com.nvidia.nemoclaw.base-resolution"}}' \
+                "$reference"
+            )"
+            if [ "$resolution_key_label" != "$RESOLUTION_KEY" ] ||
+               [ "$resolution_label" != "$RESOLUTION_LABEL" ]; then
+              echo "ERROR: Deep Agents Code image lost immutable base resolution metadata." >&2
+              exit 1
+            fi
           fi
 
           agent_label="$(

--- a/scripts/checks/export-dcode-base-resolution-label.mts
+++ b/scripts/checks/export-dcode-base-resolution-label.mts
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { appendFileSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DCODE_BASE_IMAGE = "ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base";
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const REVISION_PATTERN = /^[0-9a-f]{40}$/u;
+const GLIBC_PATTERN = /^[0-9]+[.][0-9]+$/u;
+const PLATFORM_PATTERN = /^linux\/(amd64|arm64)$/u;
+
+type DcodeBaseResolutionInput = {
+  imageName: string;
+  reference: string;
+  digest: string;
+  sourceRevision: string;
+  imageId: string;
+  os: string;
+  architecture: string;
+  platform: string;
+  glibcVersion: string;
+};
+
+type DockerImageInspect = {
+  Id?: unknown;
+  Os?: unknown;
+  Architecture?: unknown;
+  Config?: { Labels?: Record<string, unknown> } | null;
+};
+
+function fail(message: string): never {
+  throw new Error(`Deep Agents Code base-resolution label: ${message}`);
+}
+
+export function createDcodeBaseResolutionMetadata(input: DcodeBaseResolutionInput) {
+  if (input.imageName !== DCODE_BASE_IMAGE) fail("image repository is invalid");
+  if (!DIGEST_PATTERN.test(input.digest)) fail("platform digest is invalid");
+  if (input.reference !== `${input.imageName}@${input.digest}`) {
+    fail("reference is not bound to the immutable platform digest");
+  }
+  if (!PLATFORM_PATTERN.test(input.platform)) fail("platform is invalid");
+  const [os, architecture] = input.platform.split("/");
+  if (input.os !== os || input.architecture !== architecture) {
+    fail("inspected platform does not match the immutable contract");
+  }
+  if (!DIGEST_PATTERN.test(input.imageId)) fail("local image identity is invalid");
+  if (!REVISION_PATTERN.test(input.sourceRevision)) fail("source revision is invalid");
+  if (!GLIBC_PATTERN.test(input.glibcVersion)) fail("glibc version is invalid");
+
+  const authority = {
+    imageName: input.imageName,
+    ref: input.reference,
+    digest: input.digest,
+    sourceRevision: input.sourceRevision,
+    imageId: input.imageId,
+    os,
+    architecture,
+    glibcVersion: input.glibcVersion,
+    requireOpenshellSandboxAbi: true,
+    minGlibcVersion: "2.39",
+  };
+  return {
+    schema: 1,
+    key: createHash("sha256").update(JSON.stringify(authority)).digest("hex"),
+    ...authority,
+    source: "override",
+  };
+}
+
+export function encodeDcodeBaseResolutionMetadata(
+  metadata: ReturnType<typeof createDcodeBaseResolutionMetadata>,
+): string {
+  return Buffer.from(JSON.stringify(metadata), "utf8").toString("base64url");
+}
+
+function parseArguments(argv: string[]): Map<string, string> {
+  const values = new Map<string, string>();
+  const allowed = new Set<string>([
+    "reference",
+    "inspect-reference",
+    "platform",
+    "output",
+    "local-oci-receipt",
+    "expected-source-revision",
+  ]);
+  for (let index = 0; index < argv.length; index += 2) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+    const key = argument?.startsWith("--") ? argument.slice(2) : "";
+    if (!allowed.has(key) || value === undefined || values.has(key)) {
+      fail("arguments are invalid");
+    }
+    values.set(key, value);
+  }
+  for (const key of ["reference", "inspect-reference", "platform", "output"]) {
+    if (!values.get(key)) fail(`${key} is required`);
+  }
+  return values;
+}
+
+function requiredValue(values: Map<string, string>, key: string): string {
+  const value = values.get(key);
+  if (!value) fail(`${key} is required`);
+  return value;
+}
+
+function runDocker(arguments_: string[]): string {
+  return execFileSync("docker", arguments_, {
+    encoding: "utf8",
+    maxBuffer: 4 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function validateLocalOciReceipt(receipt: string, digest: string): void {
+  const separator = receipt.lastIndexOf("@sha256:");
+  if (separator < 1) fail("local OCI receipt is invalid");
+  const layoutRoot = receipt.slice(0, separator);
+  const receiptDigest = receipt.slice(separator + 1);
+  if (!path.isAbsolute(layoutRoot) || receiptDigest !== digest) {
+    fail("local OCI receipt does not match the immutable platform digest");
+  }
+  const index = JSON.parse(readFileSync(path.join(layoutRoot, "index.json"), "utf8")) as {
+    manifests?: Array<{ digest?: unknown }>;
+  };
+  if (
+    !Array.isArray(index.manifests) ||
+    index.manifests.length !== 1 ||
+    index.manifests[0]?.digest !== digest
+  ) {
+    fail("local OCI receipt does not contain the immutable platform manifest");
+  }
+}
+
+export function exportDcodeBaseResolutionLabel(argv: string[]) {
+  const values = parseArguments(argv);
+  const reference = requiredValue(values, "reference");
+  const inspectReference = requiredValue(values, "inspect-reference");
+  const platform = requiredValue(values, "platform");
+  const output = requiredValue(values, "output");
+  const localOciReceipt = values.get("local-oci-receipt");
+  const expectedSourceRevision = values.get("expected-source-revision");
+  const digest = reference.slice(reference.lastIndexOf("@") + 1);
+
+  if (reference !== `${DCODE_BASE_IMAGE}@${digest}` || !DIGEST_PATTERN.test(digest)) {
+    fail("reference is not an exact Deep Agents Code platform reference");
+  }
+  if (!PLATFORM_PATTERN.test(platform)) fail("platform is invalid");
+  if (expectedSourceRevision && !REVISION_PATTERN.test(expectedSourceRevision)) {
+    fail("expected source revision is invalid");
+  }
+  if (!path.isAbsolute(output) || /[\r\n]/u.test(output)) fail("output path is invalid");
+
+  if (inspectReference === reference) {
+    if (localOciReceipt) fail("remote inspection cannot use a local OCI receipt");
+    runDocker(["pull", "--platform", platform, reference]);
+  } else {
+    if (!localOciReceipt) fail("a mutable inspection reference needs its exact local OCI receipt");
+    validateLocalOciReceipt(localOciReceipt, digest);
+  }
+
+  const inspectedImages = JSON.parse(runDocker(["image", "inspect", inspectReference])) as unknown;
+  if (!Array.isArray(inspectedImages) || inspectedImages.length !== 1) {
+    fail("inspection did not return one image");
+  }
+  const inspected = inspectedImages[0] as DockerImageInspect;
+  const sourceRevision = inspected?.Config?.Labels?.["org.opencontainers.image.revision"];
+  if (typeof sourceRevision !== "string" || !REVISION_PATTERN.test(sourceRevision)) {
+    fail("inspected source revision is missing");
+  }
+  if (expectedSourceRevision && sourceRevision !== expectedSourceRevision) {
+    fail("inspected source revision does not match the immutable contract");
+  }
+  const glibcOutput = runDocker([
+    "run",
+    "--rm",
+    "--platform",
+    platform,
+    "--entrypoint",
+    "getconf",
+    inspectReference,
+    "GNU_LIBC_VERSION",
+  ]);
+  const glibcVersion = /^glibc ([0-9]+[.][0-9]+)$/u.exec(glibcOutput)?.[1] ?? "";
+  const imageId = inspected.Id;
+  const os = inspected.Os;
+  const architecture = inspected.Architecture;
+  if (typeof imageId !== "string" || typeof os !== "string" || typeof architecture !== "string") {
+    fail("inspected image identity is incomplete");
+  }
+  const metadata = createDcodeBaseResolutionMetadata({
+    imageName: DCODE_BASE_IMAGE,
+    reference,
+    digest,
+    sourceRevision,
+    imageId,
+    os,
+    architecture,
+    platform,
+    glibcVersion,
+  });
+  appendFileSync(
+    output,
+    `resolution_key=${metadata.key}\nresolution_label=${encodeDcodeBaseResolutionMetadata(metadata)}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+  return metadata;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  try {
+    exportDcodeBaseResolutionLabel(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : "Deep Agents Code label export failed");
+    process.exitCode = 1;
+  }
+}

--- a/src/lib/actions/sandbox/rebuild-base-image-resolution-flow.test.ts
+++ b/src/lib/actions/sandbox/rebuild-base-image-resolution-flow.test.ts
@@ -18,13 +18,14 @@ describe("rebuildSandbox base-image resolution flow", () => {
   it("passes the recorded Docker base-image hint and refresh env through ordinary preflight (#4680)", async () => {
     const restoreEnv = snapshotEnv(["NEMOCLAW_SANDBOX_BASE_IMAGE_REFRESH"]);
     process.env.NEMOCLAW_SANDBOX_BASE_IMAGE_REFRESH = "yes";
-    const resolutionHint: SandboxBaseImageResolutionMetadata = {
+    const resolutionHint: SandboxBaseImageResolutionMetadata & { sourceRevision: string } = {
       schema: 1,
       key: "hermes-base-key",
       imageName: "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base",
       ref: "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:resolved",
       digest: "sha256:resolved",
       source: "latest",
+      sourceRevision: "b".repeat(40),
       imageId: "sha256:local-image",
       os: "linux",
       architecture: "amd64",

--- a/src/lib/agent/base-image.ts
+++ b/src/lib/agent/base-image.ts
@@ -27,7 +27,7 @@ import { ROOT } from "../runner";
 import { SANDBOX_BUILD_CONTEXT_PREFIX } from "../sandbox/build-context";
 import {
   buildLocalBaseTag,
-  createSandboxBaseImageBuildProvenance,
+  createSandboxBaseImageBuildLabels,
   createSandboxBaseImageBuildProvenanceKey,
   createSandboxBaseImageResolutionKey,
   createSandboxBaseImageResolutionMetadata,
@@ -527,11 +527,7 @@ function localBaseImageBuildProvenance(options: ResolveBaseImageOptions): {
   labels: Record<string, string>;
   provenance: string;
 } {
-  const provenance = createSandboxBaseImageBuildProvenance(options);
-  return {
-    labels: { [SANDBOX_BASE_BUILD_PROVENANCE_LABEL]: provenance },
-    provenance,
-  };
+  return createSandboxBaseImageBuildLabels(options);
 }
 
 /**

--- a/src/lib/agent/deep-agents-code-base-image.test.ts
+++ b/src/lib/agent/deep-agents-code-base-image.test.ts
@@ -15,6 +15,7 @@ vi.mock("../adapters/docker", () => ({
 
 import {
   createDeepAgentsCodeBaseImageResolutionOptions,
+  DEEPAGENTS_CODE_SOURCE_REVISION_LABEL,
   deepAgentsCodeBaseImageMatchesVersion,
 } from "./deep-agents-code-base-image";
 
@@ -51,6 +52,7 @@ describe("Deep Agents Code base image compatibility", () => {
       ],
       validationDescription:
         "deepagents-code==9.8.7, dos2unix, and the immutable security package inventory",
+      sourceRevisionLabel: DEEPAGENTS_CODE_SOURCE_REVISION_LABEL,
     });
     expect(options?.validateImage?.("dcode-base:manifest-version")).toBe(true);
   });

--- a/src/lib/agent/deep-agents-code-base-image.ts
+++ b/src/lib/agent/deep-agents-code-base-image.ts
@@ -9,6 +9,7 @@ import { sandboxBaseImageHasSecurityInventory } from "../sandbox-base-image/secu
 import type { AgentDefinition } from "./defs";
 
 const DEEPAGENTS_CODE_DISTRIBUTION = "deepagents-code";
+export const DEEPAGENTS_CODE_SOURCE_REVISION_LABEL = "org.opencontainers.image.revision";
 const DEEPAGENTS_CODE_DOS2UNIX_PROBE_OK = "nemoclaw-dcode-dos2unix-ok";
 const DEEPAGENTS_CODE_BASE_IMAGE_PROBE_GUARDS = [
   "--network",
@@ -22,7 +23,7 @@ const DEEPAGENTS_CODE_BASE_IMAGE_PROBE_GUARDS = [
 
 type DeepAgentsCodeResolutionOptions = Pick<
   ResolveBaseImageOptions,
-  "inputPaths" | "validateImage" | "validationDescription"
+  "inputPaths" | "sourceRevisionLabel" | "validateImage" | "validationDescription"
 >;
 
 /**
@@ -107,6 +108,7 @@ export function createDeepAgentsCodeBaseImageResolutionOptions(
     // Retain the resolver's pre-existing global inputs alongside these agent
     // inputs. Per-agent cache-policy isolation is a separate cross-agent change.
     inputPaths: [path.join(agentRoot, "manifest.yaml"), path.join(agentRoot, "requirements.lock")],
+    sourceRevisionLabel: DEEPAGENTS_CODE_SOURCE_REVISION_LABEL,
     validateImage: (imageRef) =>
       deepAgentsCodeBaseImageMatchesVersion(imageRef, expectedVersion) &&
       deepAgentsCodeBaseImageHasDos2Unix(imageRef) &&

--- a/src/lib/sandbox-base-image-resolution.test.ts
+++ b/src/lib/sandbox-base-image-resolution.test.ts
@@ -45,6 +45,7 @@ vi.mock("./sandbox-base-image/source-identity", async (importOriginal) => ({
 import {
   createSandboxBaseImageBuildProvenanceKey,
   createSandboxBaseImageResolutionKey,
+  type DcodeSandboxBaseImageResolutionMetadata,
   OPENSHELL_SANDBOX_MIN_GLIBC,
   resolveSandboxBaseImage,
   SANDBOX_BASE_BUILD_PROVENANCE_LABEL,
@@ -56,6 +57,7 @@ const IMAGE_NAME = "ghcr.io/nvidia/nemoclaw/sandbox-base";
 const DIGEST = `sha256:${"a".repeat(64)}`;
 const REF = `${IMAGE_NAME}@${DIGEST}`;
 const IMAGE_ID = `sha256:${"b".repeat(64)}`;
+const SOURCE_REVISION_LABEL = "org.opencontainers.image.revision";
 
 function resolutionOptions() {
   return {
@@ -181,6 +183,118 @@ describe("sandbox base-image warm resolution", () => {
     expect(dockerMocks.pull).toHaveBeenCalled();
     expect(traceMocks.add).toHaveBeenCalledWith("nemoclaw.sandbox_base_image.cache_miss", {
       has_hint: true,
+    });
+  });
+
+  it("preserves receipt-owned source revision during forced DCode resolution (#9386)", () => {
+    const sourceRevision = "c".repeat(40);
+    const staleRevision = "d".repeat(40);
+    const options = {
+      ...resolutionOptions(),
+      label: "Deep Agents Code sandbox base image",
+      pinnedRemoteRef: REF,
+      preferPinnedRemoteRef: true,
+      sourceRevisionLabel: SOURCE_REVISION_LABEL,
+    };
+    const hint: DcodeSandboxBaseImageResolutionMetadata = {
+      schema: 1,
+      key: createSandboxBaseImageResolutionKey(options),
+      imageName: IMAGE_NAME,
+      ref: REF,
+      digest: DIGEST,
+      source: "pinned",
+      pinnedRemoteRef: REF,
+      imageId: IMAGE_ID,
+      os: "linux",
+      architecture: "amd64",
+      glibcVersion: null,
+      requireOpenshellSandboxAbi: false,
+      minGlibcVersion: OPENSHELL_SANDBOX_MIN_GLIBC,
+      sourceRevision: staleRevision,
+    };
+    dockerMocks.imageInspect.mockImplementation((ref: string) => ({
+      status: ref === REF ? 0 : 1,
+    }));
+    dockerMocks.imageInspectFormat.mockReturnValue(
+      JSON.stringify({
+        Id: IMAGE_ID,
+        RepoDigests: [REF],
+        Os: "linux",
+        Architecture: "amd64",
+        Config: { Labels: { [SOURCE_REVISION_LABEL]: sourceRevision } },
+      }),
+    );
+
+    const resolved = resolveSandboxBaseImage({
+      ...options,
+      env: { ...options.env, GITHUB_SHA: staleRevision },
+      resolutionHint: hint,
+      forceRefresh: true,
+    });
+
+    expect(resolved).toMatchObject({
+      ref: REF,
+      digest: DIGEST,
+      source: "pinned",
+      metadata: { sourceRevision },
+    });
+    expect(resolved?.metadata).not.toMatchObject({ sourceRevision: staleRevision });
+  });
+
+  it("fails closed when forced DCode resolution lacks its source receipt (#9386)", () => {
+    const options = {
+      ...resolutionOptions(),
+      label: "Deep Agents Code sandbox base image",
+      pinnedRemoteRef: REF,
+      preferPinnedRemoteRef: true,
+      sourceRevisionLabel: SOURCE_REVISION_LABEL,
+    };
+    dockerMocks.imageInspect.mockImplementation((ref: string) => ({
+      status: ref === REF ? 0 : 1,
+    }));
+
+    expect(() => resolveSandboxBaseImage({ ...options, forceRefresh: true })).toThrow(
+      "missing required immutable source revision metadata",
+    );
+  });
+
+  it("writes durable source authority onto a locally rebuilt DCode base (#9386)", () => {
+    const options = {
+      ...resolutionOptions(),
+      env: {
+        ...resolutionOptions().env,
+        GITHUB_SHA: "f".repeat(40),
+        NEMOCLAW_SANDBOX_BASE_LOCAL_BUILD: "1",
+      },
+      label: "Deep Agents Code sandbox base image",
+      sourceRevisionLabel: SOURCE_REVISION_LABEL,
+    };
+    let builtLabels: Record<string, string> = {};
+    sourceMocks.inputsDirty.mockReturnValue(true);
+    dockerMocks.build.mockImplementation(
+      (_dockerfile: string, _imageRef: string, _rootDir: string, buildOptions: unknown) => {
+        builtLabels = (buildOptions as { labels: Record<string, string> }).labels;
+        return { status: 0 };
+      },
+    );
+    dockerMocks.imageInspectFormat.mockImplementation(() =>
+      JSON.stringify({
+        Id: IMAGE_ID,
+        RepoDigests: [],
+        Os: "linux",
+        Architecture: "amd64",
+        Config: { Labels: builtLabels },
+      }),
+    );
+
+    const resolved = resolveSandboxBaseImage(options);
+    const receiptRevision = builtLabels[SOURCE_REVISION_LABEL];
+
+    expect(receiptRevision).toMatch(/^[0-9a-f]{40}$/u);
+    expect(receiptRevision).not.toBe(options.env.GITHUB_SHA);
+    expect(resolved).toMatchObject({
+      source: "local",
+      metadata: { sourceRevision: receiptRevision },
     });
   });
 

--- a/src/lib/sandbox-base-image.ts
+++ b/src/lib/sandbox-base-image.ts
@@ -10,6 +10,7 @@ import {
   dockerImageInspectFormat,
   dockerPull,
 } from "./adapters/docker";
+import { resolveSourceBuildIdentity } from "./core/version";
 import { ROOT, redact } from "./runner";
 import { imageMeetsMinimumGlibc } from "./sandbox-base-image/image-compatibility";
 import { withLocalBuildHeartbeat } from "./sandbox-base-image/local-build-heartbeat";
@@ -49,6 +50,24 @@ export * from "./sandbox-base-image/types";
 
 const BUILD_FAILURE_DIAGNOSTIC_LIMIT = 8_000;
 const BUILD_FAILURE_TRUNCATED_SUFFIX = "\n[diagnostic truncated]";
+
+export function createSandboxBaseImageBuildLabels(options: ResolveBaseImageOptions): {
+  labels: Record<string, string>;
+  provenance: string;
+} {
+  const provenance = createSandboxBaseImageBuildProvenance(options);
+  const labels: Record<string, string> = { [SANDBOX_BASE_BUILD_PROVENANCE_LABEL]: provenance };
+  if (options.sourceRevisionLabel) {
+    const sourceRevision = resolveSourceBuildIdentity({
+      rootDir: options.rootDir || ROOT,
+    }).sourceRevision;
+    if (!/^[0-9a-f]{40}$/u.test(sourceRevision)) {
+      throw new Error("Sandbox base build source revision is not a lowercase SHA");
+    }
+    labels[options.sourceRevisionLabel] = sourceRevision;
+  }
+  return { labels, provenance };
+}
 
 /**
  * Combine stderr + stdout from a captured `dockerBuild` failure and pass them
@@ -401,13 +420,12 @@ function resolveLocalCandidate(
   // `suppressOutput` keeps captured stdio out of the user's terminal.
   // On failure, surface the captured stderr so the user still gets a
   // useful diagnostic.
+  const buildLabels = createSandboxBaseImageBuildLabels(options);
   const buildResult = withLocalBuildHeartbeat(() =>
     dockerBuild(options.dockerfilePath, imageRef, options.rootDir || ROOT, {
       buildArgs: options.buildArgs,
 
-      labels: {
-        [SANDBOX_BASE_BUILD_PROVENANCE_LABEL]: createSandboxBaseImageBuildProvenance(options),
-      },
+      labels: buildLabels.labels,
       quiet: true,
       ignoreError: true,
       suppressOutput: true,

--- a/src/lib/sandbox-base-image/label-codec.ts
+++ b/src/lib/sandbox-base-image/label-codec.ts
@@ -7,6 +7,7 @@ import {
   SANDBOX_BASE_RESOLUTION_KEY_LABEL,
   SANDBOX_BASE_RESOLUTION_LABEL,
   SANDBOX_BASE_RESOLUTION_SCHEMA,
+  type DcodeSandboxBaseImageResolutionMetadata,
   type SandboxBaseImageResolution,
   type SandboxBaseImageResolutionMetadata,
 } from "./types";
@@ -15,6 +16,7 @@ import {
 // growth room while limiting work performed on an untrusted Docker label.
 export const MAX_ENCODED_RESOLUTION_LABEL_LENGTH = 8_192;
 const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+const SOURCE_REVISION_RE = /^[0-9a-f]{40}$/;
 const VALID_RESOLUTION_SOURCES = new Set<SandboxBaseImageResolution["source"]>(
   SANDBOX_BASE_IMAGE_RESOLUTION_SOURCES,
 );
@@ -29,6 +31,21 @@ export function readSandboxBaseImageResolutionMetadata(
   if (!labelsOutput) return null;
   try {
     return parseSandboxBaseImageResolutionLabels(JSON.parse(labelsOutput));
+  } catch {
+    return null;
+  }
+}
+
+export function readDcodeSandboxBaseImageResolutionMetadata(
+  sandboxImageRef: string | null | undefined,
+): DcodeSandboxBaseImageResolutionMetadata | null {
+  if (!sandboxImageRef) return null;
+  const labelsOutput = dockerImageInspectFormat("{{json .Config.Labels}}", sandboxImageRef, {
+    ignoreError: true,
+  });
+  if (!labelsOutput) return null;
+  try {
+    return parseDcodeSandboxBaseImageResolutionLabels(JSON.parse(labelsOutput));
   } catch {
     return null;
   }
@@ -73,6 +90,21 @@ export function parseSandboxBaseImageResolutionLabels(
   } catch {
     return null;
   }
+}
+
+export function parseDcodeSandboxBaseImageResolutionLabels(
+  labels: unknown,
+): DcodeSandboxBaseImageResolutionMetadata | null {
+  const metadata = parseSandboxBaseImageResolutionLabels(labels);
+  if (!metadata || !hasDcodeSourceRevision(metadata)) return null;
+  return metadata;
+}
+
+export function hasDcodeSourceRevision(
+  metadata: SandboxBaseImageResolutionMetadata,
+): metadata is DcodeSandboxBaseImageResolutionMetadata {
+  const sourceRevision = (metadata as unknown as Record<string, unknown>).sourceRevision;
+  return typeof sourceRevision === "string" && SOURCE_REVISION_RE.test(sourceRevision);
 }
 
 export function formatSandboxBaseImageResolutionLabels(

--- a/src/lib/sandbox-base-image/resolution-metadata.test.ts
+++ b/src/lib/sandbox-base-image/resolution-metadata.test.ts
@@ -23,6 +23,7 @@ import {
   reuseSandboxBaseImageResolutionHint,
 } from "./resolution-metadata";
 import type {
+  DcodeSandboxBaseImageResolutionMetadata,
   ResolveBaseImageOptions,
   SandboxBaseImageResolution,
   SandboxBaseImageResolutionMetadata,
@@ -32,6 +33,8 @@ const IMAGE_NAME = "ghcr.io/nvidia/nemoclaw/sandbox-base";
 const DIGEST = `sha256:${"a".repeat(64)}`;
 const REF = `${IMAGE_NAME}@${DIGEST}`;
 const KEY = "resolution-key";
+const SOURCE_REVISION_LABEL = "org.opencontainers.image.revision";
+const SOURCE_REVISION = "c".repeat(40);
 
 const inspected = {
   Id: `sha256:${"b".repeat(64)}`,
@@ -89,16 +92,14 @@ describe("sandbox base-image resolution metadata lifecycle", () => {
     });
   });
 
-  it.each([
-    "",
-    "not JSON",
-    "null",
-    '"primitive"',
-  ])("ignores unusable Docker inspect output %# (#4680)", (output) => {
-    mocks.dockerImageInspectFormat.mockReturnValue(output);
+  it.each(["", "not JSON", "null", '"primitive"'])(
+    "ignores unusable Docker inspect output %# (#4680)",
+    (output) => {
+      mocks.dockerImageInspectFormat.mockReturnValue(output);
 
-    expect(inspectLocalImageMetadata(REF)).toBeNull();
-  });
+      expect(inspectLocalImageMetadata(REF)).toBeNull();
+    },
+  );
 
   it("creates metadata for a digest-pinned image with matching local identity (#4680)", () => {
     mocks.dockerImageInspectFormat.mockReturnValue(JSON.stringify(inspected));
@@ -121,6 +122,45 @@ describe("sandbox base-image resolution metadata lifecycle", () => {
       metadata,
     );
   });
+
+  it("copies a required source revision from the inspected immutable image (#9386)", () => {
+    mocks.dockerImageInspectFormat.mockReturnValue(
+      JSON.stringify({
+        ...inspected,
+        Config: { Labels: { [SOURCE_REVISION_LABEL]: SOURCE_REVISION } },
+      }),
+    );
+
+    expect(
+      createSandboxBaseImageResolutionMetadata(
+        { ...options, sourceRevisionLabel: SOURCE_REVISION_LABEL },
+        KEY,
+        publishedResolution,
+      ),
+    ).toEqual({ ...metadata, sourceRevision: SOURCE_REVISION });
+  });
+
+  it.each([undefined, "main", "D".repeat(40)])(
+    "rejects a missing or malformed required source revision %# (#9386)",
+    (sourceRevision) => {
+      mocks.dockerImageInspectFormat.mockReturnValue(
+        JSON.stringify({
+          ...inspected,
+          Config: {
+            Labels: sourceRevision === undefined ? {} : { [SOURCE_REVISION_LABEL]: sourceRevision },
+          },
+        }),
+      );
+
+      expect(
+        createSandboxBaseImageResolutionMetadata(
+          { ...options, sourceRevisionLabel: SOURCE_REVISION_LABEL },
+          KEY,
+          publishedResolution,
+        ),
+      ).toBeNull();
+    },
+  );
 
   it("rejects sparse RepoDigests when the resolved reference is not the exact digest", () => {
     mocks.dockerImageInspectFormat.mockReturnValue(
@@ -189,6 +229,34 @@ describe("sandbox base-image resolution metadata lifecycle", () => {
       "nemoclaw.sandbox_base_image.cache_hit",
       expect.anything(),
     );
+  });
+
+  it("rejects a hint whose source revision differs from the inspected image (#9386)", () => {
+    mocks.dockerImageInspectFormat.mockReturnValue(
+      JSON.stringify({
+        ...inspected,
+        Config: { Labels: { [SOURCE_REVISION_LABEL]: "d".repeat(40) } },
+      }),
+    );
+
+    const dcodeMetadata: DcodeSandboxBaseImageResolutionMetadata = {
+      ...metadata,
+      sourceRevision: SOURCE_REVISION,
+    };
+
+    expect(
+      reuseSandboxBaseImageResolutionHint(
+        {
+          ...options,
+          sourceRevisionLabel: SOURCE_REVISION_LABEL,
+          resolutionHint: dcodeMetadata,
+        },
+        KEY,
+      ),
+    ).toBeNull();
+    expect(mocks.addTraceEvent).toHaveBeenCalledWith("nemoclaw.sandbox_base_image.cache_stale", {
+      reason: "source_revision_mismatch",
+    });
   });
 
   it("revalidates custom runtime requirements before reusing a hint (#4680)", () => {

--- a/src/lib/sandbox-base-image/resolution-metadata.ts
+++ b/src/lib/sandbox-base-image/resolution-metadata.ts
@@ -14,6 +14,19 @@ import {
   type SandboxBaseImageResolutionMetadata,
 } from "./types";
 
+const SOURCE_REVISION_RE = /^[0-9a-f]{40}$/;
+
+function inspectedSourceRevision(
+  inspected: LocalImageMetadata | null,
+  label: string | undefined,
+): string | null {
+  if (!label) return null;
+  const labels = inspected?.Config?.Labels;
+  if (!labels || typeof labels !== "object") return null;
+  const revision = (labels as Record<string, unknown>)[label];
+  return typeof revision === "string" && SOURCE_REVISION_RE.test(revision) ? revision : null;
+}
+
 export function inspectLocalImageMetadata(imageRef: string): LocalImageMetadata | null {
   const output = dockerImageInspectFormat("{{json .}}", imageRef, { ignoreError: true });
   if (!output) return null;
@@ -25,11 +38,7 @@ export function inspectLocalImageMetadata(imageRef: string): LocalImageMetadata 
   }
 }
 
-function isExactSameRepositoryDigestRef(
-  imageName: string,
-  digest: string,
-  ref: string,
-): boolean {
+function isExactSameRepositoryDigestRef(imageName: string, digest: string, ref: string): boolean {
   return /^sha256:[0-9a-f]{64}$/u.test(digest) && ref === `${imageName}@${digest}`;
 }
 
@@ -40,6 +49,7 @@ export function validateSandboxBaseImageResolutionMetadata(input: {
   pinnedRemoteRef?: string;
   requireOpenshellSandboxAbi: boolean;
   minGlibcVersion: string;
+  sourceRevisionLabel?: string;
   inspected: LocalImageMetadata | null;
 }): BaseImageResolutionValidation {
   const { metadata, inspected } = input;
@@ -72,6 +82,16 @@ export function validateSandboxBaseImageResolutionMetadata(input: {
   ) {
     return { ok: false, reason: "local_image_changed" };
   }
+  if (input.sourceRevisionLabel) {
+    const sourceRevision = (metadata as unknown as Record<string, unknown>).sourceRevision;
+    if (
+      typeof sourceRevision !== "string" ||
+      !SOURCE_REVISION_RE.test(sourceRevision) ||
+      inspectedSourceRevision(inspected, input.sourceRevisionLabel) !== sourceRevision
+    ) {
+      return { ok: false, reason: "source_revision_mismatch" };
+    }
+  }
   if (metadata.digest) {
     const expectedRepoDigest = `${input.imageName}@${metadata.digest}`;
     const repoDigests = Array.isArray(inspected.RepoDigests) ? inspected.RepoDigests : [];
@@ -96,6 +116,8 @@ export function createSandboxBaseImageResolutionMetadata(
   const osName = typeof inspected?.Os === "string" ? inspected.Os : "";
   const architecture = typeof inspected?.Architecture === "string" ? inspected.Architecture : "";
   if (!imageId || !osName || !architecture) return null;
+  const sourceRevision = inspectedSourceRevision(inspected, options.sourceRevisionLabel);
+  if (options.sourceRevisionLabel && !sourceRevision) return null;
 
   if (resolution.digest) {
     const expectedRepoDigest = `${options.imageName}@${resolution.digest}`;
@@ -122,6 +144,7 @@ export function createSandboxBaseImageResolutionMetadata(
     ref: resolution.ref,
     digest: resolution.digest,
     source: resolution.source,
+    ...(sourceRevision ? { sourceRevision } : {}),
     ...(resolution.pinnedRemoteRef ? { pinnedRemoteRef: resolution.pinnedRemoteRef } : {}),
     imageId,
     os: osName,
@@ -160,6 +183,11 @@ export function finalizeSandboxBaseImageResolution(
     }
   }
   const metadata = createSandboxBaseImageResolutionMetadata(options, key, locallyProvenResolution);
+  if (!metadata && options.sourceRevisionLabel) {
+    throw new Error(
+      `${options.label || "Sandbox base image"} is missing required immutable source revision metadata`,
+    );
+  }
   return metadata ? { ...locallyProvenResolution, metadata } : resolution;
 }
 
@@ -176,6 +204,7 @@ export function reuseSandboxBaseImageResolutionHint(
     pinnedRemoteRef: options.pinnedRemoteRef,
     requireOpenshellSandboxAbi: options.requireOpenshellSandboxAbi === true,
     minGlibcVersion: options.minGlibcVersion || OPENSHELL_SANDBOX_MIN_GLIBC,
+    sourceRevisionLabel: options.sourceRevisionLabel,
     inspected: inspectLocalImageMetadata(hint.ref),
   });
   if (!validation.ok) {

--- a/src/lib/sandbox-base-image/types.ts
+++ b/src/lib/sandbox-base-image/types.ts
@@ -36,6 +36,10 @@ export type SandboxBaseImageResolutionMetadata = {
   minGlibcVersion: string;
 };
 
+export type DcodeSandboxBaseImageResolutionMetadata = SandboxBaseImageResolutionMetadata & {
+  sourceRevision: string;
+};
+
 export type ResolveBaseImageOptions = {
   imageName: string;
   dockerfilePath: string;

--- a/src/lib/sandbox-base-image/types.ts
+++ b/src/lib/sandbox-base-image/types.ts
@@ -57,6 +57,7 @@ export type ResolveBaseImageOptions = {
   preferPinnedRemoteRef?: boolean;
   validateImage?: (imageRef: string) => boolean;
   validationDescription?: string;
+  sourceRevisionLabel?: string;
   resolutionHint?: SandboxBaseImageResolutionMetadata | null;
   forceRefresh?: boolean;
   trustedLocalOverride?: TrustedLocalBaseImageOverride;
@@ -94,5 +95,6 @@ export type BaseImageResolutionValidation =
         | "requirements_changed"
         | "abi_incompatible"
         | "local_image_changed"
-        | "repo_digest_missing";
+        | "repo_digest_missing"
+        | "source_revision_mismatch";
     };

--- a/test/e2e/live/dcode-base-image-runtime-evidence.ts
+++ b/test/e2e/live/dcode-base-image-runtime-evidence.ts
@@ -3,7 +3,10 @@
 
 import fs from "node:fs";
 
-import { readSandboxBaseImageResolutionMetadata } from "../../../src/lib/sandbox-base-image/label-codec.ts";
+import {
+  hasDcodeSourceRevision,
+  readDcodeSandboxBaseImageResolutionMetadata,
+} from "../../../src/lib/sandbox-base-image/label-codec.ts";
 import type { SandboxBaseImageResolutionMetadata } from "../../../src/lib/sandbox-base-image/types.ts";
 import {
   DCODE_BASE_IMAGE_TARGET_PLATFORM,
@@ -51,6 +54,15 @@ function exactKeys(value: Record<string, unknown>, expected: readonly string[], 
   if (JSON.stringify(Object.keys(value).sort()) !== JSON.stringify([...expected].sort())) {
     throw new Error(`${label} has unexpected fields`);
   }
+}
+
+function requireImmutableSourceRevision(metadata: SandboxBaseImageResolutionMetadata): string {
+  if (!hasDcodeSourceRevision(metadata)) {
+    throw new Error(
+      `Deep Agents Code sandbox image does not match the published ${DCODE_BASE_IMAGE_TARGET_PLATFORM} base-image contract (mismatched fields: source revision)`,
+    );
+  }
+  return metadata.sourceRevision;
 }
 
 export function parseDcodeBaseImagePublicationEvidence(
@@ -126,6 +138,7 @@ export function verifyDcodeBaseImageRuntimeEvidence(
       `Deep Agents Code sandbox image did not use the published ${DCODE_BASE_IMAGE_TARGET_PLATFORM} base digest`,
     );
   }
+  const sourceRevision = requireImmutableSourceRevision(metadata);
   const expectedDigest = contract.platformDigests[DCODE_BASE_IMAGE_TARGET_PLATFORM];
   const expectedReference = dcodeBaseImageReferenceForContract(contract);
   const mismatchedFields = [
@@ -136,6 +149,7 @@ export function verifyDcodeBaseImageRuntimeEvidence(
     metadata.digest !== expectedDigest ? "digest" : null,
     metadata.ref !== expectedReference ? "reference" : null,
     metadata.ref !== `${metadata.imageName}@${metadata.digest}` ? "reference binding" : null,
+    sourceRevision !== contract.sourceRevision ? "source revision" : null,
   ].filter((field): field is string => field !== null);
   if (mismatchedFields.length > 0) {
     throw new Error(
@@ -151,7 +165,7 @@ export function verifyDcodeBaseImageRuntimeEvidence(
     reference: expectedReference,
     sandboxImage,
     source: "override",
-    sourceRevision: contract.sourceRevision,
+    sourceRevision,
   };
 }
 
@@ -164,6 +178,6 @@ export function captureDcodeBaseImageRuntimeEvidence(
   return verifyDcodeBaseImageRuntimeEvidence(
     contract,
     sandboxImage,
-    readSandboxBaseImageResolutionMetadata(sandboxImage),
+    readDcodeSandboxBaseImageResolutionMetadata(sandboxImage),
   );
 }

--- a/test/e2e/support/dcode-base-image-runtime-evidence.test.ts
+++ b/test/e2e/support/dcode-base-image-runtime-evidence.test.ts
@@ -3,7 +3,10 @@
 
 import { describe, expect, it } from "vitest";
 
-import type { SandboxBaseImageResolutionMetadata } from "../../../src/lib/sandbox-base-image/types.ts";
+import type {
+  DcodeSandboxBaseImageResolutionMetadata,
+  SandboxBaseImageResolutionMetadata,
+} from "../../../src/lib/sandbox-base-image/types.ts";
 import { DCODE_BASE_IMAGE, DCODE_BASE_IMAGE_ENV } from "../fixtures/dcode-base-image.ts";
 import {
   DCODE_BASE_IMAGE_TARGET_ID,
@@ -49,8 +52,8 @@ function publicationEnvironment(overrides: NodeJS.ProcessEnv = {}): NodeJS.Proce
 }
 
 function resolutionMetadata(
-  overrides: Partial<SandboxBaseImageResolutionMetadata> = {},
-): SandboxBaseImageResolutionMetadata {
+  overrides: Partial<DcodeSandboxBaseImageResolutionMetadata> = {},
+): DcodeSandboxBaseImageResolutionMetadata {
   return {
     schema: 1,
     key: "resolution-key",
@@ -58,6 +61,7 @@ function resolutionMetadata(
     ref: DCODE_BASE_IMAGE_AMD64_REFERENCE,
     digest: DCODE_BASE_IMAGE_AMD64_DIGEST,
     source: "override",
+    sourceRevision: DCODE_BASE_IMAGE_SOURCE_REVISION,
     imageId: `sha256:${"e".repeat(64)}`,
     os: "linux",
     architecture: "amd64",
@@ -66,6 +70,12 @@ function resolutionMetadata(
     minGlibcVersion: "2.39",
     ...overrides,
   };
+}
+
+function resolutionMetadataWithoutSourceRevision(): SandboxBaseImageResolutionMetadata {
+  const metadata = resolutionMetadata();
+  delete (metadata as unknown as Record<string, unknown>).sourceRevision;
+  return metadata;
 }
 
 describe("Deep Agents Code published base runtime evidence", () => {
@@ -252,6 +262,27 @@ describe("Deep Agents Code published base runtime evidence", () => {
       metadata: null,
       expectedMessage: "Deep Agents Code sandbox image is missing base resolution metadata",
       rejectedValues: [],
+    },
+    {
+      label: "missing immutable source revision",
+      metadata: resolutionMetadataWithoutSourceRevision(),
+      expectedMessage: baseContractMismatch("source revision"),
+      rejectedValues: [],
+    },
+    {
+      label: "malformed immutable source revision",
+      metadata: {
+        ...resolutionMetadata(),
+        sourceRevision: "main",
+      } as SandboxBaseImageResolutionMetadata,
+      expectedMessage: baseContractMismatch("source revision"),
+      rejectedValues: ["main"],
+    },
+    {
+      label: "mismatched immutable source revision",
+      metadata: resolutionMetadata({ sourceRevision: "f".repeat(40) }),
+      expectedMessage: baseContractMismatch("source revision"),
+      rejectedValues: ["f".repeat(40)],
     },
     {
       label: "an unsupported metadata schema version",

--- a/test/e2e/support/dcode-base-resolution-label.test.ts
+++ b/test/e2e/support/dcode-base-resolution-label.test.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { parseDcodeSandboxBaseImageResolutionLabels } from "../../../src/lib/sandbox-base-image/label-codec.ts";
+import { SANDBOX_BASE_RESOLUTION_LABEL } from "../../../src/lib/sandbox-base-image/types.ts";
+import {
+  createDcodeBaseResolutionMetadata,
+  encodeDcodeBaseResolutionMetadata,
+} from "../../../scripts/checks/export-dcode-base-resolution-label.mts";
+
+const IMAGE = "ghcr.io/nvidia/nemoclaw/langchain-deepagents-code-sandbox-base";
+const DIGEST = `sha256:${"a".repeat(64)}`;
+const SOURCE_REVISION = "b".repeat(40);
+
+function authority(overrides: Record<string, unknown> = {}) {
+  return {
+    imageName: IMAGE,
+    reference: `${IMAGE}@${DIGEST}`,
+    digest: DIGEST,
+    sourceRevision: SOURCE_REVISION,
+    imageId: `sha256:${"c".repeat(64)}`,
+    os: "linux",
+    architecture: "amd64",
+    platform: "linux/amd64",
+    glibcVersion: "2.41",
+    ...overrides,
+  };
+}
+
+describe("Deep Agents Code managed-image base resolution label", () => {
+  it("serializes immutable base authority into a parseable final-image label (#9386)", () => {
+    const metadata = createDcodeBaseResolutionMetadata(authority());
+    const encoded = encodeDcodeBaseResolutionMetadata(metadata);
+
+    expect(
+      parseDcodeSandboxBaseImageResolutionLabels({ [SANDBOX_BASE_RESOLUTION_LABEL]: encoded }),
+    ).toEqual(metadata);
+    expect(metadata).toMatchObject({
+      imageName: IMAGE,
+      ref: `${IMAGE}@${DIGEST}`,
+      digest: DIGEST,
+      sourceRevision: SOURCE_REVISION,
+      os: "linux",
+      architecture: "amd64",
+      source: "override",
+    });
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["malformed", "main"],
+  ])("rejects %s source revision while parsing the untrusted label (#9386)", (_label, value) => {
+    const metadata = createDcodeBaseResolutionMetadata(authority());
+    const encoded = Buffer.from(
+      JSON.stringify({ ...metadata, sourceRevision: value }),
+      "utf8",
+    ).toString("base64url");
+
+    expect(
+      parseDcodeSandboxBaseImageResolutionLabels({ [SANDBOX_BASE_RESOLUTION_LABEL]: encoded }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["a mutable reference", { reference: `${IMAGE}:latest` }],
+    ["a mismatched platform", { architecture: "arm64" }],
+    ["a malformed revision", { sourceRevision: "main" }],
+  ])("fails closed for %s (#9386)", (_label, overrides) => {
+    expect(() => createDcodeBaseResolutionMetadata(authority(overrides))).toThrow(
+      /Deep Agents Code base-resolution label/u,
+    );
+  });
+});

--- a/test/e2e/support/dcode-base-resolution-workflow.test.ts
+++ b/test/e2e/support/dcode-base-resolution-workflow.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  managedPublisher,
+  readWorkflow,
+  required,
+  step,
+} from "../../helpers/managed-image-publication-workflow.ts";
+
+function prBuilder() {
+  return required(
+    readWorkflow("managed-images.yaml").jobs?.["pr-build-and-entrypoint"],
+    "managed-image workflow is missing its PR builder",
+  );
+}
+
+describe("Deep Agents Code base-resolution publication boundary (#9386)", () => {
+  it("carries the exact PR base authority through every final-image path", () => {
+    const publisher = prBuilder();
+    const resolver = step(publisher, "Resolve exact linux/amd64 PR base");
+    const exporter = step(publisher, "Export immutable Deep Agents Code base resolution labels");
+    const localBuild = step(publisher, "Build PR managed image from local base");
+    const registryBuild = step(publisher, "Build PR managed image from registry base");
+    const localContract = step(publisher, "Validate exact PR managed image contract");
+    const publishedContract = step(publisher, "Export exact published PR managed-image contract");
+
+    expect(resolver.run).toContain("identity_ref=%s@%s");
+    expect(resolver.run).toContain("source_revision=%s");
+    expect(exporter.if).toBe("matrix.agent == 'langchain-deepagents-code'");
+    expect(exporter.run).toContain("export-dcode-base-resolution-label.mts");
+    expect(exporter.run).toContain('--reference "$BASE_IDENTITY_REFERENCE"');
+    expect(exporter.run).toContain('--local-oci-receipt "$BASE_LOCAL_OCI_RECEIPT"');
+    expect(localBuild.run).toContain("com.nvidia.nemoclaw.base-resolution-key");
+    expect(localBuild.run).toContain("com.nvidia.nemoclaw.base-resolution");
+    expect(String(registryBuild.with?.labels)).toContain("com.nvidia.nemoclaw.base-resolution-key");
+    expect(String(registryBuild.with?.labels)).toContain("com.nvidia.nemoclaw.base-resolution");
+    expect(localContract.run).toContain("lost immutable base resolution metadata");
+    expect(publishedContract.run).toContain(
+      "published Deep Agents Code image lost immutable base resolution metadata",
+    );
+  });
+
+  it("carries contract-owned authority into exact production platform images", () => {
+    const publisher = managedPublisher(readWorkflow("managed-images.yaml"));
+    const node = step(publisher, "Set up Node.js");
+    const contract = step(publisher, "Validate exact base image contract");
+    const exporter = step(publisher, "Export immutable Deep Agents Code base resolution labels");
+    const build = step(publisher, "Build and push managed image by digest");
+    const validation = step(publisher, "Validate exact managed image before promotion");
+
+    expect(node.with?.["node-version"]).toBe("22.19.0");
+    expect(contract.run).toContain("source_revision=");
+    expect(exporter.if).toBe("matrix.agent == 'langchain-deepagents-code'");
+    expect(exporter.run).toContain('--reference "$BASE_REFERENCE"');
+    expect(exporter.run).toContain('--expected-source-revision "$BASE_SOURCE_REVISION"');
+    expect(String(build.with?.labels)).toContain("com.nvidia.nemoclaw.base-resolution-key");
+    expect(String(build.with?.labels)).toContain("com.nvidia.nemoclaw.base-resolution");
+    expect(validation.run).toContain(
+      "Deep Agents Code image lost immutable base resolution metadata",
+    );
+  });
+});

--- a/test/managed-image-pr-base-resolution.test.ts
+++ b/test/managed-image-pr-base-resolution.test.ts
@@ -95,6 +95,7 @@ exit 90
     DISPLAY_NAME: "OpenClaw",
     DOCKER_LOG: dockerLog,
     GITHUB_OUTPUT: output,
+    GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
     GITHUB_STEP_SUMMARY: summary,
     LOCAL_BASE_REFERENCE: "nemoclaw-managed-pr/openclaw-base:test",
     PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
@@ -109,11 +110,11 @@ exit 90
     });
     expect(result.status, result.stderr).toBe(0);
     expect(fs.readFileSync(output, "utf8")).toBe(
-      `ref=nemoclaw-managed-pr/openclaw-base:test\nlocal=true\noci=${temporaryRoot}/pr-base.oci@sha256:0000000000000000000000000000000000000000000000000000000000000000\n`,
+      `ref=nemoclaw-managed-pr/openclaw-base:test\nidentity_ref=ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:0000000000000000000000000000000000000000000000000000000000000000\nsource_revision=${candidateSha}\nlocal=true\noci=${temporaryRoot}/pr-base.oci@sha256:0000000000000000000000000000000000000000000000000000000000000000\n`,
     );
     const dockerCommands = fs.readFileSync(dockerLog, "utf8");
     expect(dockerCommands).toContain(
-      `buildx build --platform linux/amd64 --provenance=false --sbom=false --file Dockerfile.base --tag nemoclaw-managed-pr/openclaw-base:test --output type=docker,dest=${temporaryRoot}/pr-base.docker.tar --output type=oci,dest=${temporaryRoot}/pr-base.oci.tar .`,
+      `buildx build --platform linux/amd64 --provenance=false --sbom=false --file Dockerfile.base --tag nemoclaw-managed-pr/openclaw-base:test --label org.opencontainers.image.source=https://github.com/NVIDIA/NemoClaw --label org.opencontainers.image.revision=${candidateSha} --output type=docker,dest=${temporaryRoot}/pr-base.docker.tar --output type=oci,dest=${temporaryRoot}/pr-base.oci.tar .`,
     );
     expect(dockerCommands).toContain(`load --input ${temporaryRoot}/pr-base.docker.tar`);
     expect(dockerCommands).not.toContain("imagetools inspect");


### PR DESCRIPTION
## Summary

Preserve the exact Deep Agents Code base-image authority in the derived managed image so final E2E evidence can recover and validate it. The final image now carries parseable base-resolution labels sourced from a digest-pinned remote base or a receipt-bound local OCI layout, and exact-image publication checks fail if those labels are lost.

## Related Issue

Refs #9386. Stacked on #9323.

Related: #9140 and #7744.

## Changes

- Export repository, immutable platform reference and digest, source revision, image ID, OS/architecture, and glibc identity from the inspected exact DCode base.
- Attach the metadata to local PR, registry-backed PR, digest-published PR, and production managed-image builds, then verify it on the exact final image.
- Require the receipt-owned source revision in the shared DCode label parser and final evidence; missing, malformed, mutable, or mismatched authority remains fail-closed.
- Use one exporter for the PR and production publication consumers to avoid divergent authority encoding; focused label and workflow tests protect that shared seam.
- Prove rebuild/lifecycle forwarding preserves the complete receipt metadata.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending review
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 107 focused DCode publication, resolver refresh, local-build receipt, label/parser, final evidence, codec, and rebuild tests passed on the refreshed cutover base
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run; this is a narrow workflow/evidence seam and the full matrix was intentionally not run
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added immutable base-image identity and source-revision metadata to Deep Agents Code images.
  * Preserved and validated base-image metadata across local builds, registries, published images, and promotions.
  * Added clear validation for missing, malformed, or mismatched image revisions.
  * Production image workflows now include the required runtime tooling for metadata validation.

* **Bug Fixes**
  * Improved detection of stale or invalid base-image cache metadata.

* **Tests**
  * Expanded coverage for image metadata, rebuilds, publication workflows, and runtime validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->