### PR TITLE
fix(inference): drop the retired DeepSeek V4 Pro from the featured menu

### DIFF
--- a/src/lib/inference/nvidia-featured-models.test.ts
+++ b/src/lib/inference/nvidia-featured-models.test.ts
@@ -315,6 +315,34 @@ describe("NVIDIA featured model catalog", () => {
     );
   });
 
+  it("filters the retired DeepSeek V4 Pro entry the featured feed still lists (#9611)", () => {
+    const options = getNvidiaFeaturedModelPromptOptions(null, {
+      runCurlProbeImpl: () => ({
+        ok: true,
+        httpStatus: 200,
+        curlStatus: 0,
+        body: JSON.stringify({
+          "featured-models": [
+            { model: "nvidia/nemotron-3-ultra-550b-a55b", "model-name": "Nemotron 3 Ultra 550B" },
+            { model: "nemotron-3-super-120b-a12b", "model-name": "Nemotron 3 Super 120B" },
+            { model: "z-ai/glm-5.2", "model-name": "GLM 5.2" },
+            { model: "minimaxai/minimax-m3", "model-name": "Minimax M3" },
+            { model: "deepseek-ai/deepseek-v4-pro", "model-name": "DeepSeek V4 Pro" },
+          ],
+        }),
+        stderr: "",
+        message: "",
+      }),
+    });
+
+    expect(options.cloudModelOptions.map((option) => option.id)).toEqual([
+      "nvidia/nemotron-3-ultra-550b-a55b",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "z-ai/glm-5.2",
+      "minimaxai/minimax-m3",
+    ]);
+  });
+
   it("reuses one featured catalog lookup but recomputes defaults across onboarding retries", () => {
     let probeCount = 0;
     const loadOptions = createNvidiaFeaturedModelPromptOptionsLoader({

--- a/src/lib/inference/nvidia-featured-models.ts
+++ b/src/lib/inference/nvidia-featured-models.ts
@@ -18,6 +18,7 @@ export const NVIDIA_FEATURED_MODELS_URL =
 const RETIRED_NVIDIA_FEATURED_MODEL_IDS = new Set([
   "z-ai/glm-5.1", // Retired from NVIDIA Endpoints in #6069.
   "moonshotai/kimi-k2.6", // Catalogs still list it after its backing route was removed.
+  "deepseek-ai/deepseek-v4-pro", // Retired from NVIDIA Endpoints on 2026-08-07; its route returns HTTP 410.
 ]);
 const MAX_NVIDIA_FEATURED_CATALOG_BYTES = 1024 * 1024;
 const MAX_NVIDIA_FEATURED_MODELS = 100;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
The onboard wizard listed `deepseek-ai/deepseek-v4-pro` in the NVIDIA Endpoints featured model menu after NVIDIA retired the model, so a user who picked it completed onboarding and then failed on the first inference call. The wizard builds that menu from NVIDIA's public featured feed, which still advertises the retired entry, so this change adds the model ID to the featured-catalog retirement deny-list. The menu now shows only the live entries.

## Related Issue
Fixes #9611

## Changes
- Add `deepseek-ai/deepseek-v4-pro` to `RETIRED_NVIDIA_FEATURED_MODEL_IDS` in `src/lib/inference/nvidia-featured-models.ts`. This is a data entry in the existing deny-list, not a new abstraction or fallback path; the deny-list and its policy comment already exist for models whose catalogs outlive their routes.
- Add one regression test in `src/lib/inference/nvidia-featured-models.test.ts` that drives `getNvidiaFeaturedModelPromptOptions` with the current live feed payload and asserts the rendered menu keeps the four live entries and drops the retired one.

Deliberately unchanged, with reasons:

- `isDeepSeekV4ProModel` in `src/lib/inference/openai-probe-models.ts` and the matching blueprint payload rule stay. Commit 778811df3 set this precedent when it retired Kimi K2.6: the retirement is scoped to NVIDIA Endpoints, and those branches still serve custom and compatible routes that host the same model ID. The manual `Other...` entry path also stays open, and it is already covered because `validateNvidiaEndpointModel` checks the authenticated `/v1/models` catalog, which no longer lists the model.
- `CLOUD_MODEL_OPTIONS` needs no edit. It never contained this model, and `src/lib/inference/config.test.ts` already asserts its absence.
- The `it.each` case in `config.test.ts` titled `retires %s only from the NVIDIA Endpoints picker` was not extended, because it also asserts the model remains in `HERMES_PROVIDER_MODEL_OPTIONS`, and this model was never in that list.

Known side effect, consistent with existing behavior: `src/lib/onboard/setup-nim-flow.ts` assigns `openRouterFeaturedModels = nvidiaFeaturedModels`, so the OpenRouter picker shares this deny-list and also stops offering the ID. `moonshotai/kimi-k2.6` is already denied under the same shared session, so this PR introduces no new coupling.

### Runtime evidence
Collected against `https://integrate.api.nvidia.com/v1` on 2026-08-19 with a valid key:

- `GET /v1/models`: HTTP 200, 102 models, `deepseek-ai/deepseek-v4-pro` absent. This matches the count in the issue report.
- `POST /v1/chat/completions` with that model: HTTP 410, body `{"type":"about:blank","title":"Gone","status":410,"detail":"The model 'deepseek-ai/deepseek-v4-pro' has reached its end of life on 2026-08-07T09:00:00Z and is no longer available."}`. NVIDIA reports the exact retirement timestamp, which confirms the 2026-08-07 date in the issue.
- `GET https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json`: HTTP 200, 5 entries, still including `deepseek-ai/deepseek-v4-pro`. The regression test uses this exact payload.

Two corrections to the issue report, both minor: the reported menu is produced by the live feed rather than a bundled catalog JSON, and the same shared session means the OpenRouter picker was affected as well, which the report does not mention.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: sensitive-path review remains on the normal approval path
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: not applicable, `scripts/prepare-dgx-station-host.sh` is unchanged
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/inference src/lib/onboard/nvidia-featured-model-selection.test.ts src/lib/onboard/setup-nim-flow.test.ts` passed 2129 tests across 103 files; `npx vitest run --project integration test/onboard-selection.test.ts` passed 67 tests; `npm run typecheck:cli` and `npm run checks:repository` passed. Reverting only the source change fails the new test and leaves the other 17 in that file passing.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run; the change is one deny-list entry with no runtime or harness surface
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Deferred documentation
`docs/inference/model-capability-audit.mdx` records retired NVIDIA Endpoints routes and carries a row for Kimi K2.6 from the precedent commit, but has no row for this model. That row is proposed for `Docs / Post-Merge Catch-Up`. `test/model-capability-audit-doc.test.ts` asserts the state vocabulary, evidence field names, header row, and navigation entries only, so it does not require a row per retired model and deferral cannot redden CI. No other page needs an edit: `docs/inference/choose-model.mdx` already states that NVIDIA Endpoints excludes retired choices and corrects catalog lag, and `docs/inference/use-nvidia-endpoints.mdx` documents the bundled fallback list, which this change does not touch.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the retired DeepSeek V4 Pro model from NVIDIA featured-model selections.
  * Preserved other featured models, including Nemotron models with canonicalized identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->