### PR TITLE
fix(runtime): acquire managed Hermes root helper

### DIFF
--- a/scripts/runtime-state-mutation-control.py
+++ b/scripts/runtime-state-mutation-control.py
@@ -2543,6 +2543,18 @@ def _stop_reference(reference: ProcessReference) -> None:
     _wait_for_reference_state(reference, ("T", "t"))
 
 
+def _wait_for_host_stopped_supervisor(reference: ProcessReference) -> ProcessIdentity:
+    deadline = time.monotonic() + PROCESS_STATE_SECONDS
+    while True:
+        process = _recapture_reference(reference, "supervisor-identity-drift")
+        if process.state in ("T", "t"):
+            return process
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            _fail("supervisor-not-host-stopped")
+        time.sleep(min(POLL_SECONDS, remaining))
+
+
 def _allowed_writer_map(
     allowed: tuple[ProcessReference, ...],
 ) -> dict[int, ProcessReference]:
@@ -2662,8 +2674,13 @@ def _hold_exact_processes(
     expected_mount_namespace: str,
     activation: ActivationProof | None,
 ) -> None:
-    _prove_fence_shape(fence, expected_mount_namespace)
-    _stop_reference(fence.supervisor)
+    _supervisor, _start = _prove_fence_shape(fence, expected_mount_namespace)
+    # PID-namespace init accepts SIGSTOP only from an ancestor PID namespace.
+    # The provider must therefore stop the exact persisted runtime through its
+    # host-side engine authority before invoking this root helper. Keep the
+    # helper responsible for proving that boundary and for fencing every
+    # workload writer inside the already-proven private namespace.
+    _wait_for_host_stopped_supervisor(fence.supervisor)
     _stop_reference(fence.start)
     if activation is not None:
         persistent = set(activation.persistent_pids)
@@ -3670,8 +3687,8 @@ def _retire_activation_tree(
     marker: dict[str, object], runtime_fd: int, activation: ActivationProof
 ) -> None:
     fence = _fence_from_value(marker["fence"])
-    _prove_fence_shape(fence, str(marker["mountNamespace"]))
-    _stop_reference(fence.supervisor)
+    _supervisor, _start = _prove_fence_shape(fence, str(marker["mountNamespace"]))
+    _wait_for_host_stopped_supervisor(fence.supervisor)
     _stop_reference(fence.start)
     for reference in activation.processes:
         if not _reference_is_terminated(reference):
@@ -3814,23 +3831,17 @@ def _release_activation_hold(durable_fd: int, marker: dict[str, object]) -> None
         _fail("activation-marker-invalid")
     _verify_activation_checkpoint(marker, fence, activation)
     _publish_activation_release(durable_fd, marker, fence, activation)
-    supervisor, _start = _prove_fence_shape(fence, str(marker["mountNamespace"]))
-    if supervisor.state in ("T", "t"):
-        persistent = set(activation.persistent_pids)
-        for reference in activation.processes:
-            if _reference_is_terminated(reference):
-                if reference.pid in persistent:
-                    _fail("activation-process-drift")
-                continue
-            _resume_reference(reference)
-        _resume_reference(fence.start)
-        _prove_released_activation(marker, fence, activation)
-        supervisor = _recapture_reference(fence.supervisor, "supervisor-identity-drift")
-        if supervisor.state not in ("T", "t"):
-            _fail("release-order-ambiguous")
-        _signal_exact_process(supervisor, signal.SIGCONT)
-        _wait_for_reference_running(fence.supervisor)
-        return
+    _supervisor, _start = _prove_fence_shape(
+        fence, str(marker["mountNamespace"])
+    )
+    persistent = set(activation.persistent_pids)
+    for reference in activation.processes:
+        if _reference_is_terminated(reference):
+            if reference.pid in persistent:
+                _fail("activation-process-drift")
+            continue
+        _resume_reference(reference)
+    _resume_reference(fence.start)
     _prove_released_activation(marker, fence, activation)
 
 

--- a/scripts/runtime-state-mutation-control.py
+++ b/scripts/runtime-state-mutation-control.py
@@ -2674,7 +2674,7 @@ def _hold_exact_processes(
     expected_mount_namespace: str,
     activation: ActivationProof | None,
 ) -> None:
-    _supervisor, _start = _prove_fence_shape(fence, expected_mount_namespace)
+    _prove_fence_shape(fence, expected_mount_namespace)
     # PID-namespace init accepts SIGSTOP only from an ancestor PID namespace.
     # The provider must therefore stop the exact persisted runtime through its
     # host-side engine authority before invoking this root helper. Keep the
@@ -3687,7 +3687,7 @@ def _retire_activation_tree(
     marker: dict[str, object], runtime_fd: int, activation: ActivationProof
 ) -> None:
     fence = _fence_from_value(marker["fence"])
-    _supervisor, _start = _prove_fence_shape(fence, str(marker["mountNamespace"]))
+    _prove_fence_shape(fence, str(marker["mountNamespace"]))
     _wait_for_host_stopped_supervisor(fence.supervisor)
     _stop_reference(fence.start)
     for reference in activation.processes:
@@ -3831,9 +3831,7 @@ def _release_activation_hold(durable_fd: int, marker: dict[str, object]) -> None
         _fail("activation-marker-invalid")
     _verify_activation_checkpoint(marker, fence, activation)
     _publish_activation_release(durable_fd, marker, fence, activation)
-    _supervisor, _start = _prove_fence_shape(
-        fence, str(marker["mountNamespace"])
-    )
+    _prove_fence_shape(fence, str(marker["mountNamespace"]))
     persistent = set(activation.persistent_pids)
     for reference in activation.processes:
         if _reference_is_terminated(reference):

--- a/src/lib/onboard/runtime-provider/docker-state-mutation.test.ts
+++ b/src/lib/onboard/runtime-provider/docker-state-mutation.test.ts
@@ -265,6 +265,7 @@ describe("Docker state mutation owner", () => {
       "activate",
       "release",
     ]);
+    expect(runtime.supervisorSignals).toEqual(["SIGSTOP", "SIGCONT"]);
     expect(runtime.lifecycleStore.listUnfinished()).toEqual([]);
     const helperCalls = runtime.capture.mock.calls.filter(([, args]) =>
       args.includes("/usr/local/lib/nemoclaw/runtime-state-mutation-control.py"),
@@ -534,6 +535,46 @@ describe("Docker state mutation owner", () => {
     expect(runtime.lifecycleStore.listUnfinished()[0]?.phase).toBe("fence-established");
   });
 
+  it("host-stops the exact managed Hermes durable-volume runtime before helper acquire (#9485)", () => {
+    const runtime = harness({ stateMountType: "volume" });
+
+    const acquired = runtime.owner.acquire({ ...runtime.context, plan: plan() });
+
+    expect(acquired.providerHandle).toMatch(/^docker-state-mutation-v1:/u);
+    expect(runtime.state).toMatchObject({
+      mountDriver: "local",
+      mountName: "nemoclaw-hermes-alpha-state",
+      mountType: "volume",
+      supervisorStopped: true,
+    });
+    expect(runtime.supervisorSignals).toEqual(["SIGSTOP"]);
+    const commands = runtime.capture.mock.calls.map(([, args]) => {
+      const start = args.findIndex((value) => value === "container");
+      return start < 0 ? [] : args.slice(start);
+    });
+    const stop = commands.findIndex((args) => args[1] === "kill");
+    const acquire = commands.findIndex(
+      (args) =>
+        args[1] === "exec" &&
+        args.at(-2) === "/usr/local/lib/nemoclaw/runtime-state-mutation-control.py" &&
+        args.at(-1) === "acquire",
+    );
+    expect(commands[stop]).toEqual(["container", "kill", "--signal", "SIGSTOP", RUNTIME_ID]);
+    expect(runtime.capture.mock.calls.find(([, args]) => args[5] === "kill")?.[1]).toEqual([
+      "--config",
+      "/tmp/nemoclaw-docker",
+      "--host",
+      "unix:///tmp/nemoclaw-docker.sock",
+      "container",
+      "kill",
+      "--signal",
+      "SIGSTOP",
+      RUNTIME_ID,
+    ]);
+    expect(stop).toBeGreaterThanOrEqual(0);
+    expect(acquire).toBeGreaterThan(stop);
+  });
+
   it("recovers a durable-volume fence when acquire succeeds after its response is lost (#9485)", () => {
     const runtime = harness({ loseAcquireResponseOnce: true, stateMountType: "volume" });
     expect(runtime.state).toMatchObject({
@@ -551,6 +592,8 @@ describe("Docker state mutation owner", () => {
 
     expect(recovered?.providerHandle).toMatch(/^docker-state-mutation-v1:/u);
     expect(runtime.helperActions).toEqual(["acquire", "acquire"]);
+    expect(runtime.supervisorSignals).toEqual(["SIGSTOP", "SIGSTOP"]);
+    expect(runtime.state.supervisorStopped).toBe(true);
     expect(runtime.acquireRequests[1]).toBe(runtime.acquireRequests[0]);
     expect(runtime.lifecycleStore.listUnfinished()[0]?.phase).toBe("fence-established");
   });

--- a/src/lib/onboard/runtime-provider/docker-state-mutation.ts
+++ b/src/lib/onboard/runtime-provider/docker-state-mutation.ts
@@ -54,6 +54,7 @@ const HELPER_FAST_TIMEOUT_MS = 30_000;
 const HELPER_ACTIVATION_TIMEOUT_MS = 5 * 60_000;
 const HELPER_GUARD_TIMEOUT_MS = 15 * 60_000;
 const INSPECT_TIMEOUT_MS = 15_000;
+const SUPERVISOR_SIGNAL_TIMEOUT_MS = 15_000;
 const MAX_HELPER_TRANSPORT_BYTES = 128 * 1024;
 const MAX_INSPECTION_BYTES = 1024 * 1024;
 const MAX_MOUNTS = 256;
@@ -1016,6 +1017,32 @@ function helperCommand(runtimeId: string, action: HelperAction) {
   });
 }
 
+function supervisorSignalCommand(runtimeId: string, requestedSignal: "SIGSTOP" | "SIGCONT") {
+  return Object.freeze({
+    args: Object.freeze(["container", "kill", "--signal", requestedSignal, runtimeId]),
+    targetIndex: 4,
+  });
+}
+
+function signalSupervisorAuthorized(
+  scope: AuthorizedPersistedEngineLifecycle,
+  options: ContainerStateMutationOwnerOptions,
+  requestedSignal: "SIGSTOP" | "SIGCONT",
+): void {
+  // PID-namespace init can only be stopped from an ancestor namespace. Keep
+  // that one lifecycle operation on the authority-bound engine endpoint and
+  // expose neither a caller-authored signal nor a caller-authored command.
+  const result = scope.captureExact(
+    "target",
+    (runtimeId) => supervisorSignalCommand(runtimeId, requestedSignal),
+    SUPERVISOR_SIGNAL_TIMEOUT_MS,
+  );
+  requireCommandSuccess(
+    result,
+    `${options.providerDisplayName} host supervisor ${requestedSignal === "SIGSTOP" ? "stop" : "resume"}`,
+  );
+}
+
 function requireCommandSuccess(
   result: {
     readonly status: number;
@@ -1507,6 +1534,7 @@ function acquireAuthorizedReceipt(
   ) {
     fail("persisted state mutation intent does not match the lifecycle transaction");
   }
+  signalSupervisorAuthorized(scope, options, "SIGSTOP");
   const receipt = invokeHelperAuthorized(
     scope,
     options.providerId,
@@ -1656,6 +1684,7 @@ function releaseAuthorizedFence(
   validateReceipt(receipt, options, bindingSha256, before, scope.record);
   requireFenceReceipt(fence, receipt);
   sameActivationProof(proof, activationProofFromReceipt(receipt, fence.providerHandle));
+  signalSupervisorAuthorized(scope, options, "SIGCONT");
   const after = inspectAuthorized(scope, options);
   sameObservation(before, after);
 }

--- a/test/helpers/docker-state-mutation-harness.ts
+++ b/test/helpers/docker-state-mutation-harness.ts
@@ -152,6 +152,7 @@ export interface DockerStateMutationHarnessState {
   pidMode: string;
   privileged: boolean;
   overlayProc: boolean;
+  supervisorStopped: boolean;
 }
 
 function createContainerStateMutationHarness(
@@ -174,8 +175,10 @@ function createContainerStateMutationHarness(
     pidMode: "",
     privileged: false,
     overlayProc: false,
+    supervisorStopped: false,
   };
   const helperActions: string[] = [];
+  const supervisorSignals: string[] = [];
   const acquireRequests: string[] = [];
   let acquireDeferralsRemaining = options.deferAcquireOnce ? 1 : 0;
   let lostAcquireResponsesRemaining = options.loseAcquireResponseOnce ? 1 : 0;
@@ -274,6 +277,20 @@ function createContainerStateMutationHarness(
         stderr: "",
       };
     }
+    if (command[0] === "container" && command[1] === "kill") {
+      if (
+        command.length !== 5 ||
+        command[2] !== "--signal" ||
+        !["SIGSTOP", "SIGCONT"].includes(command[3] ?? "") ||
+        command[4] !== DOCKER_STATE_MUTATION_RUNTIME_ID
+      ) {
+        return { status: 1, stdout: "", stderr: "unauthorized supervisor command" };
+      }
+      const requestedSignal = command[3] as "SIGSTOP" | "SIGCONT";
+      supervisorSignals.push(requestedSignal);
+      state.supervisorStopped = requestedSignal === "SIGSTOP";
+      return { status: 0, stdout: `${DOCKER_STATE_MUTATION_RUNTIME_ID}\n`, stderr: "" };
+    }
     if (command[0] !== "container" || command[1] !== "exec") {
       return { status: 1, stdout: "", stderr: "unexpected command" };
     }
@@ -282,6 +299,9 @@ function createContainerStateMutationHarness(
     const serializedRequest = input?.toString("utf8") ?? "null";
     const request = JSON.parse(serializedRequest) as Record<string, unknown>;
     if (action === "acquire") {
+      if (!state.supervisorStopped) {
+        return { status: 1, stdout: "", stderr: "supervisor-not-host-stopped" };
+      }
       acquireRequests.push(serializedRequest);
       if (options.failAcquire) {
         return { status: 1, stdout: "", stderr: "helper marker unavailable" };
@@ -447,6 +467,7 @@ function createContainerStateMutationHarness(
     context,
     engineAuthorityStore,
     helperActions,
+    supervisorSignals,
     lifecycleStore,
     lifecycleGeneration,
     owner,

--- a/test/runtime-state-mutation-control.test.ts
+++ b/test/runtime-state-mutation-control.test.ts
@@ -187,9 +187,9 @@ def process(pid, state, parent, start, uid, command, inode):
 
 root_uid = control.ROOT_UID
 pid1 = process(1, "S", 0, "100", root_uid, (control.OPENSHELL_ARGV0,), 101)
+stopped_pid1 = process(1, "T", 0, "100", root_uid, (control.OPENSHELL_ARGV0,), 101)
 def start_process(pid, command):
     return process(pid, "S", 1, str(190 + pid), 1001, command, 100 + pid)
-
 start = start_process(10, (b"/bin/bash", control.NEMOCLAW_START_PATH, b"/bin/bash"))
 prefixed_start = start_process(11, (b"/bin/bash", b"--noprofile", control.NEMOCLAW_START_PATH))
 reordered_start = start_process(12, (b"/bin/bash", b"/bin/bash", control.NEMOCLAW_START_PATH))
@@ -514,6 +514,11 @@ control._capture_process = lambda pid: {
     77: gateway,
     78: auxiliary,
 }.get(pid)
+control.PROCESS_STATE_SECONDS = 0
+results["running_supervisor_hold"] = code(lambda: real_hold_exact_processes(fence, "mnt:[401]", activation))
+control.PROCESS_STATE_SECONDS = 5
+control._prove_fence_shape = lambda _fence, _mount: (stopped_pid1, start)
+control._recapture_reference = lambda reference, _code="fenced-process-drift": stopped_pid1 if reference.pid == 1 else {10: start, 77: gateway, 78: auxiliary}[reference.pid]
 real_hold_exact_processes(fence, "mnt:[401]", activation)
 results["hold_events"] = hold_events
 
@@ -831,8 +836,9 @@ control._recapture_reference = lambda reference, _code="fenced-process-drift": s
     by_release_pid[reference.pid]
 )
 def resume_reference(reference):
-    release_events.append(["resume", reference.pid])
-    release_states[reference.pid] = "S"
+    if release_states[reference.pid] in ("T", "t"):
+        release_events.append(["resume", reference.pid])
+        release_states[reference.pid] = "S"
     return state_process(by_release_pid[reference.pid])
 control._resume_reference = resume_reference
 control._prove_released_activation = lambda *_args: release_events.append(["health"])
@@ -1294,9 +1300,9 @@ describe("runtime state mutation controller", () => {
       discovered_pid1: 1,
       discovered_start: 10,
       wrong_pid1: "supervisor-unavailable",
+      running_supervisor_hold: "supervisor-not-host-stopped",
     });
     expect(harnessResult.hold_events).toEqual([
-      ["stop", 1],
       ["stop", 10],
       ["stop", 77],
       ["stop", 78],
@@ -1422,8 +1428,7 @@ describe("runtime state mutation controller", () => {
     });
   });
 
-  it("records release intent before resuming PID1 last and resolves retry ambiguity (#7744)", () => {
-    const sigcont = harnessResult.sigcont as number;
+  it("records release intent before resuming exact writers and leaves PID1 to host authority (#9485)", () => {
     expect(harnessResult).toMatchObject({
       release: "activation-proven",
       released_marker: true,
@@ -1440,7 +1445,6 @@ describe("runtime state mutation controller", () => {
       ["resume", 78],
       ["resume", 10],
       ["health"],
-      ["signal", 1, sigcont],
     ]);
     expect(harnessResult.release_retry_events).toEqual([
       ["verify-checkpoint"],
@@ -1453,7 +1457,6 @@ describe("runtime state mutation controller", () => {
       ["resume", 77],
       ["resume", 10],
       ["health"],
-      ["signal", 1, sigcont],
     ]);
     expect(harnessResult.persistent_exit_release).toBe("activation-process-drift");
     const events = harnessResult.state_events as unknown[][];


### PR DESCRIPTION
## Summary

- stop and resume only the exact persisted managed Hermes runtime through the authority-bound Docker endpoint
- keep helper receipt, fence, process identity, writer exclusion, rollback, recovery, and cleanup ownership intact
- leave legacy workloads on the existing no-op path and reject unreviewed managed startup commands

Refs #9485. Stacked on #9323.

Refs #9140 and #7744.

## Testing

- `vitest run test/runtime-state-mutation-control.test.ts src/lib/onboard/runtime-provider/docker-state-mutation.test.ts` (41 passed)
- `npm run build:cli`
- `npm run typecheck:cli`
- commit and pre-push hooks

No standalone E2E dispatch is requested for this child; normal stacked PR CI is authoritative.

Signed-off-by: Aaron Erickson <aerickson@nvidia.com>