### PR TITLE
fix(onboard): exclude Hermes Portable from managed activation

### DIFF
--- a/src/lib/onboard/managed-workload/onboard-orchestration.test.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.test.ts
@@ -99,37 +99,53 @@ describe("managed workload onboard orchestration", () => {
     expect(
       shouldActivateStockManagedRuntime({
         portableLifecycle: false,
+        hermesPortableLifecycle: false,
         agentName: "openclaw",
       }),
     ).toBe(true);
     expect(
       shouldActivateStockManagedRuntime({
         portableLifecycle: false,
+        hermesPortableLifecycle: false,
         agentName: "hermes",
       }),
     ).toBe(true);
     expect(
       shouldActivateStockManagedRuntime({
         portableLifecycle: false,
+        hermesPortableLifecycle: false,
         agentName: "langchain-deepagents-code",
       }),
     ).toBe(true);
     expect(
       shouldActivateStockManagedRuntime({
         portableLifecycle: true,
+        hermesPortableLifecycle: false,
         agentName: "openclaw",
       }),
     ).toBe(false);
     expect(
       shouldActivateStockManagedRuntime({
         portableLifecycle: false,
+        hermesPortableLifecycle: false,
         agentName: "nemocua",
       }),
     ).toBe(false);
     expect(
       shouldActivateStockManagedRuntime({
         portableLifecycle: false,
+        hermesPortableLifecycle: false,
         agentName: "pi",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not activate stock managed images for Hermes Portable (#9634)", () => {
+    expect(
+      shouldActivateStockManagedRuntime({
+        portableLifecycle: false,
+        hermesPortableLifecycle: true,
+        agentName: "hermes",
       }),
     ).toBe(false);
   });

--- a/src/lib/onboard/managed-workload/onboard-orchestration.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.ts
@@ -148,9 +148,14 @@ export interface ManagedWorkloadOnboardRuntime {
 
 export function shouldActivateStockManagedRuntime(input: {
   readonly portableLifecycle: boolean;
+  readonly hermesPortableLifecycle: boolean;
   readonly agentName: string;
 }): boolean {
-  return !input.portableLifecycle && isShippedManagedImageAgent(input.agentName);
+  return (
+    !input.portableLifecycle &&
+    !input.hermesPortableLifecycle &&
+    isShippedManagedImageAgent(input.agentName)
+  );
 }
 
 export function assertPortableManagedBootstrapNotSelected(

--- a/src/lib/onboard/sandbox-create/orchestration.ts
+++ b/src/lib/onboard/sandbox-create/orchestration.ts
@@ -406,6 +406,7 @@ export function createSandboxWithBaseImageResolution(runtime: SandboxCreateOrche
           tempManagedRuntime ||
           managedWorkloadOnboard.shouldActivateStockManagedRuntime({
             portableLifecycle: sandboxGpuCreateFlow.resolvePortableLifecycleMode(agent),
+            hermesPortableLifecycle: agentCreateInput.hermesPortableLifecycle,
             agentName: requestedAgentName,
           }),
         tempManagedRuntimeCatalog,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Stock managed-runtime activation accepted Hermes Portable because the decision input only carried the OpenClaw portable lifecycle flag. This PR carries the Hermes Portable lifecycle into that decision, preserving the shipped Hermes Dockerfile path while leaving normal shipped-agent managed activation and the fail-closed guard unchanged. The activation unit test now covers the separate Hermes Portable flag that prior coverage omitted.

## Related Issue

Fixes #9634

Stacked on #9323. Supports #9140.

## Changes

- Pass the Hermes Portable lifecycle selection into the stock managed-runtime activation decision.
- Exclude OpenClaw Portable and Hermes Portable while retaining managed activation for shipped non-Portable agents.
- Add focused regression coverage for Hermes Portable activation selection.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/managed-workload/onboard-orchestration.test.ts` (8 passed); `npx vitest run --project cli src/lib/onboard/sandbox-gpu-create-flow-hermes-portable.test.ts` (8 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
