### PR TITLE
fix(inference): ignore terminal state in Docker authority

### DIFF
--- a/src/lib/onboard/runtime-provider/docker-operation-authority.test.ts
+++ b/src/lib/onboard/runtime-provider/docker-operation-authority.test.ts
@@ -168,6 +168,25 @@ describe("Docker operation authority", () => {
     expect(second.engine.capture(["version"]).stdout).toBe("unset\nunset\nunset\n");
   });
 
+  it("keeps host-local inference authority stable across terminal attachment changes (#9599)", () => {
+    const executableRoot = fakeDocker("qualified");
+    const environment = {
+      HOME: "/tmp/nemoclaw-home",
+      DOCKER_HOST: "unix:///tmp/nemoclaw-docker.sock",
+      PATH: executableRoot,
+    };
+    const interactive = createDockerOperationAuthority("host-local-inference", {
+      ...environment,
+      TERM: "xterm-256color",
+    });
+    const detached = createDockerOperationAuthority("host-local-inference", environment);
+
+    expect(detached.engine.authorityId).toBe(interactive.engine.authorityId);
+    expect(dockerOperationBindingSha256(detached.engine)).toBe(
+      dockerOperationBindingSha256(interactive.engine),
+    );
+  });
+
   it("fails closed when an earlier Docker credential helper appears", () => {
     const executableRoot = fakeDocker("qualified");
     const prefixRoot = fakeExecutableRoot();

--- a/src/lib/onboard/runtime-provider/docker-operation-authority.ts
+++ b/src/lib/onboard/runtime-provider/docker-operation-authority.ts
@@ -68,7 +68,6 @@ const DOCKER_COMMAND_ENV_NAMES = new Set([
   "SHELL",
   "PATH",
   "SSH_AUTH_SOCK",
-  "TERM",
   "HOSTNAME",
   "LANG",
   "TMPDIR",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Managed llama.cpp authority persisted during interactive onboarding included terminal attachment state, so later `status` and `doctor` commands could calculate a different authority in a detached session. This change excludes `TERM` from Docker authority while preserving the checks that detect genuine endpoint, executable, delegated-command, credential-helper, provider, operation, and binding drift.

## Related Issue

Fixes #9599

## Changes

- Add a regression test proving host-local inference authority remains stable when `TERM` is present during onboarding and absent during later diagnostics.
- Stop forwarding and hashing `TERM` as part of the qualified Docker command environment.
- Preserve fail-closed authority checks for Docker state that can change which daemon or executable NemoClaw uses.

The detection gap was a missing terminal-attachment case. Existing tests covered irrelevant `PATH` additions and SSH session metadata changes, but not `TERM`, even though it varied between the interactive wizard and later detached diagnostics.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The change removes only non-semantic terminal attachment state. Docker endpoint, executable identity, delegated-command set, credential-helper identity, provider, operation, and binding checks remain unchanged, and existing negative tests still cover genuine authority drift.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/runtime-provider/docker-operation-authority.test.ts src/lib/inference/llama-cpp/managed-status.test.ts src/lib/actions/sandbox/doctor-inference.test.ts src/lib/actions/sandbox/status.test.ts src/lib/onboard/setup-nim-flow-managed-llama-cpp-profile.test.ts` passed 78 tests in 5 files. The new regression failed before the production edit because the two authority IDs differed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification: `npm run typecheck:cli`, `npm run test:titles:check`, `npm run test:projects:check`, `npm run checks:repository`, scoped format checking, and `git diff --check` passed. Independent documentation review found no documentation change necessary because the current guides already describe the intended healthy `status` and `doctor` result.

<!-- docs-review-disposition: no-docs-needed -->
<!-- docs-review-head-sha: 107563eee -->
<!-- docs-review-agents-blob-sha: 513518cdf -->

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented terminal attachment changes from altering host-local inference authority identifiers and binding digests.
  * Docker operations no longer include terminal-related environment details when determining authority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->