### PR TITLE
fix(uninstall): stop the Bedrock Runtime adapter during uninstall

### DIFF
--- a/src/lib/actions/uninstall/openrouter-runtime-adapter-cleanup.test.ts
+++ b/src/lib/actions/uninstall/openrouter-runtime-adapter-cleanup.test.ts
@@ -42,6 +42,8 @@ const OPENROUTER_RUNTIME_ADAPTER_CMDLINE =
   "/usr/bin/node /home/test/NemoClaw/dist/lib/inference/openrouter-runtime-adapter-entry.js\n";
 const HTTPS_PIN_RUNTIME_ADAPTER_CMDLINE =
   "/usr/bin/node /home/test/NemoClaw/dist/lib/inference/https-pin-runtime-adapter.js\n";
+const BEDROCK_RUNTIME_ADAPTER_CMDLINE =
+  "/usr/bin/node /home/test/NemoClaw/scripts/bedrock-runtime-adapter.mts\n";
 
 type RunStub = (args: readonly string[]) => RunResult | null;
 
@@ -289,5 +291,82 @@ describe("HTTPS Pin Runtime adapter uninstall cleanup", () => {
     expect(result.exitCode).toBe(0);
     expect(lsofPorts).toContain(":12038");
     expect(killed).not.toContain(99997);
+  });
+});
+
+describe("Bedrock Runtime adapter uninstall cleanup", () => {
+  it("kills the adapter via its persisted PID before the state directory is deleted", () => {
+    const logs: string[] = [];
+    const killed: number[] = [];
+    const exited = new Set<number>();
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-uninstall-bedrock-"));
+    const pidFile = path.join(tmpHome, ".nemoclaw", "bedrock-runtime-adapter.pid");
+    fs.mkdirSync(path.dirname(pidFile), { recursive: true });
+    fs.writeFileSync(pidFile, "44325\n");
+
+    try {
+      const result = runUninstallPlan(
+        { assumeYes: true, deleteModels: false, keepOpenShell: true },
+        {
+          commandExists: () => true,
+          env: { HOME: tmpHome, LOGNAME: "testuser" } as NodeJS.ProcessEnv,
+          existsSync: (target) => target === pidFile,
+          isTty: false,
+          kill: (pid) => {
+            killed.push(pid);
+            exited.add(pid);
+            return true;
+          },
+          log: (line) => logs.push(line),
+          rmSync: vi.fn(),
+          run: runStub({
+            ps: psStub("44325", { exited, cmdline: BEDROCK_RUNTIME_ADAPTER_CMDLINE }),
+          }),
+          runDocker: () => ok(""),
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(killed).toContain(44325);
+      expect(logs).toContain("Stopped Bedrock Runtime adapter 44325");
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it("scans its configured port but never kills a foreign process", () => {
+    const killed: number[] = [];
+    const lsofPorts: string[] = [];
+    const result = runUninstallPlan(
+      { assumeYes: true, deleteModels: false, keepOpenShell: true },
+      {
+        commandExists: () => true,
+        env: {
+          HOME: "/tmp/nemoclaw-uninstall-test-bedrock-foreign",
+          LOGNAME: "testuser",
+          NEMOCLAW_BEDROCK_RUNTIME_ADAPTER_PORT: "12036",
+        } as NodeJS.ProcessEnv,
+        existsSync: () => false,
+        isTty: false,
+        kill: (pid) => {
+          killed.push(pid);
+          return true;
+        },
+        log: vi.fn(),
+        rmSync: vi.fn(),
+        run: runStub({
+          lsof: lsofPortStub(lsofPorts, new Map([[":12036", ok("99996\n")]])),
+          ps: psStub("99996", {
+            exited: new Set(),
+            cmdline: "/usr/sbin/nginx -g daemon off;\n",
+          }),
+        }),
+        runDocker: () => ok(""),
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(lsofPorts).toContain(":12036");
+    expect(killed).not.toContain(99996);
   });
 });

--- a/src/lib/actions/uninstall/openrouter-runtime-adapter-cleanup.ts
+++ b/src/lib/actions/uninstall/openrouter-runtime-adapter-cleanup.ts
@@ -29,6 +29,8 @@ const OPENROUTER_RUNTIME_ADAPTER_CMDLINE_MARK = "openrouter-runtime-adapter";
 const DEFAULT_OPENROUTER_RUNTIME_ADAPTER_PORT = 11437;
 const HTTPS_PIN_RUNTIME_ADAPTER_CMDLINE_MARK = "https-pin-runtime-adapter";
 const DEFAULT_HTTPS_PIN_RUNTIME_ADAPTER_PORT = 11438;
+const BEDROCK_RUNTIME_ADAPTER_CMDLINE_MARK = "bedrock-runtime-adapter";
+const DEFAULT_BEDROCK_RUNTIME_ADAPTER_PORT = 11436;
 
 type RuntimeAdapterDescriptor = {
   cmdlineMark: string;
@@ -190,6 +192,25 @@ export function stopHttpsPinRuntimeAdapter(
       envPort: "NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_PORT",
       label: "HTTPS Pin Runtime adapter",
       pidFile: "https-pin-runtime-adapter.pid",
+    },
+    options,
+  );
+}
+
+export function stopBedrockRuntimeAdapter(
+  paths: Pick<UninstallPaths, "nemoclawStateDir">,
+  runtime: RuntimeAdapterCleanupRuntime,
+  options: { scanOrphans?: boolean } = {},
+): void {
+  stopRuntimeAdapter(
+    paths,
+    runtime,
+    {
+      cmdlineMark: BEDROCK_RUNTIME_ADAPTER_CMDLINE_MARK,
+      defaultPort: DEFAULT_BEDROCK_RUNTIME_ADAPTER_PORT,
+      envPort: "NEMOCLAW_BEDROCK_RUNTIME_ADAPTER_PORT",
+      label: "Bedrock Runtime adapter",
+      pidFile: "bedrock-runtime-adapter.pid",
     },
     options,
   );

--- a/src/lib/actions/uninstall/run-plan.ts
+++ b/src/lib/actions/uninstall/run-plan.ts
@@ -72,6 +72,7 @@ import {
 } from "../../state/gateway-registry";
 import { stopHermesForwardWatchers } from "./hermes-forward-watcher-cleanup";
 import {
+  stopBedrockRuntimeAdapter,
   stopHttpsPinRuntimeAdapter,
   stopOpenRouterRuntimeAdapter,
 } from "./openrouter-runtime-adapter-cleanup";
@@ -2790,6 +2791,9 @@ function executePlan(
       }
       stopOllamaAuthProxy(paths, runtime, !scopedToSelectedGateway);
       stopOpenRouterRuntimeAdapter(paths, runtime, {
+        scanOrphans: !scopedToSelectedGateway,
+      });
+      stopBedrockRuntimeAdapter(paths, runtime, {
         scanOrphans: !scopedToSelectedGateway,
       });
       if (scopedToSelectedGateway) {


### PR DESCRIPTION
## Summary

`nemoclaw uninstall` stopped the OpenRouter and HTTPS Pin runtime adapters but had no code path for the Bedrock Runtime adapter, which onboard starts as a detached host process on port 11436 through the same `local-adapter-lifecycle` helpers. The adapter survived uninstall holding the port, and the State step then deleted `~/.nemoclaw/bedrock-runtime-adapter.pid`, so no later run could find it. Uninstall now stops it alongside its two siblings.

## Related Issue

Fixes #9552

## Changes

- Add `stopBedrockRuntimeAdapter` to `src/lib/actions/uninstall/openrouter-runtime-adapter-cleanup.ts`. It is a third descriptor passed to the module's existing generic `stopRuntimeAdapter`, identical in shape to `stopOpenRouterRuntimeAdapter` and `stopHttpsPinRuntimeAdapter`.
- Call it from the "Stopping services" step in `src/lib/actions/uninstall/run-plan.ts`, next to the OpenRouter call, with the same `scanOrphans: !scopedToSelectedGateway` scoping. Both adapters persist into the gateway-scoped state root, so the scoped uninstall path performs no port-wide scan for either.
- Extend `openrouter-runtime-adapter-cleanup.test.ts` with a `Bedrock Runtime adapter uninstall cleanup` block owning the same two scenarios the HTTPS Pin block owns: the persisted PID is stopped, and a foreign process on the configured port is not.

No new abstraction or configuration is introduced; the shared helper is reused unchanged, so the other two adapters are unaffected. Because this is an uninstall path that signals processes, the change is deliberately narrow: the helper still requires both `pidOwnedByCurrentUser` and a command line containing `bedrock-runtime-adapter` before it sends a signal, and the second test case pins that guard.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

This touches the uninstall path, which signals processes and removes state, so it is marked sensitive and needs maintainer review. Both added tests fail on `main`: the first reports `expected [] to include 44325` because nothing signals the Bedrock PID, and the second reports that the scanned port list `[':11435', ':11437', ':11438', ':4000']` does not include the configured Bedrock port.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Targeted tests, whole uninstall lane:

```
npx vitest run --project cli src/lib/actions/uninstall/ --testTimeout=60000

Test Files  1 failed | 20 passed (21)
     Tests  312 passed | 1 skipped (313)
```

The one failure is `portable-runtime-cleanup.test.ts > completed-onboarding writer exclusion`, a file this branch does not touch. It reproduces identically on a checkout with no uninstall changes at all, so it is a local timing artifact of that test's `.ready` marker poll rather than a regression from this change.

Repository gates:

```
npx prek run --from-ref <base> --to-ref HEAD
  -> Codebase growth guardrails Passed, Source-shape test budget Passed,
     Repository checks Passed, NEMOCLAW_* env-var documentation gate Passed,
     Oxfmt Passed, Oxlint fixes Passed, gitleaks Passed
npm --prefix nemoclaw run typecheck     -> clean
npx commitlint --from HEAD~1 --to HEAD  -> exit 0
```

The broad `npm test` gate is not checked: this adds one descriptor and one call site, with no runtime or test-harness change.

---

Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Uninstall now automatically stops the Bedrock runtime adapter.
  * Cleanup recognizes the adapter’s configured port and process settings, including custom port configurations.
  * Orphaned adapter processes are detected and cleaned up safely without terminating unrelated processes.

* **Bug Fixes**
  * Improved uninstall cleanup reliability by supporting persisted process tracking for the Bedrock runtime adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->