### PR TITLE
fix(onboard): honor back and exit at the credential re-entry prompt

### DIFF
--- a/src/lib/onboard/credential-navigation.test.ts
+++ b/src/lib/onboard/credential-navigation.test.ts
@@ -83,7 +83,7 @@ describe("credential prompt navigation helpers", () => {
       throw new Error("unexpected exit");
     }) as unknown as () => never;
     vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const { promptValidationRecovery } = createValidationRecoveryPromptHelpers({
       isNonInteractive: () => false,
       prompt: async () => answers.shift() ?? "",
@@ -104,6 +104,11 @@ describe("credential prompt navigation helpers", () => {
       expect(process.env.OPENAI_API_KEY).toBeUndefined();
       expect(answers).toEqual([]);
       expect(exitOnboardFromPrompt).not.toHaveBeenCalled();
+      // The escape route is the contract here, so a bare required-field notice is not enough:
+      // the re-prompt has to name both ways out of the loop.
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringMatching(/is required\..*\bback\b.*\bexit\b/),
+      );
     } finally {
       delete process.env.OPENAI_API_KEY;
       vi.restoreAllMocks();

--- a/src/lib/onboard/credential-navigation.test.ts
+++ b/src/lib/onboard/credential-navigation.test.ts
@@ -4,12 +4,14 @@
 import { describe, expect, it, vi } from "vitest";
 
 import * as credentials from "../credentials/store";
+import { validateNvidiaApiKeyValue } from "../validation";
 import {
   BACK_TO_SELECTION,
   replaceNamedCredential,
   returningToProviderSelection,
   shouldReturnToProviderSelection,
 } from "./credential-navigation";
+import { createValidationRecoveryPromptHelpers } from "./validation-recovery-prompt";
 
 describe("credential prompt navigation helpers", () => {
   it("treats both the shared back sentinel and credential back intents as provider-selection navigation", () => {
@@ -71,6 +73,39 @@ describe("credential prompt navigation helpers", () => {
         expect.any(Function),
       );
     } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("returns to provider selection instead of staging back as the re-entered API key (#3697)", async () => {
+    const answers = ["retry", "", "back"];
+    const exitOnboardFromPrompt = vi.fn(() => {
+      throw new Error("unexpected exit");
+    }) as unknown as () => never;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { promptValidationRecovery } = createValidationRecoveryPromptHelpers({
+      isNonInteractive: () => false,
+      prompt: async () => answers.shift() ?? "",
+      validateNvidiaApiKeyValue: (key, credentialEnv) =>
+        validateNvidiaApiKeyValue(key, credentialEnv ?? undefined),
+      getTransportRecoveryMessage: () => "",
+      exitOnboardFromPrompt,
+    });
+    delete process.env.OPENAI_API_KEY;
+    try {
+      await expect(
+        promptValidationRecovery(
+          "OpenAI",
+          { kind: "credential", retry: "credential" },
+          "OPENAI_API_KEY",
+        ),
+      ).resolves.toBe("selection");
+      expect(process.env.OPENAI_API_KEY).toBeUndefined();
+      expect(answers).toEqual([]);
+      expect(exitOnboardFromPrompt).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.OPENAI_API_KEY;
       vi.restoreAllMocks();
     }
   });

--- a/src/lib/onboard/credential-navigation.test.ts
+++ b/src/lib/onboard/credential-navigation.test.ts
@@ -105,10 +105,11 @@ describe("credential prompt navigation helpers", () => {
       expect(answers).toEqual([]);
       expect(exitOnboardFromPrompt).not.toHaveBeenCalled();
       // The escape route is the contract here, so a bare required-field notice is not enough:
-      // the re-prompt has to name both ways out of the loop.
-      expect(consoleError).toHaveBeenCalledWith(
-        expect.stringMatching(/is required\..*\bback\b.*\bexit\b/),
-      );
+      // the re-prompt has to name both ways out of the loop, in either order.
+      const [[requiredMessage]] = consoleError.mock.calls;
+      expect(requiredMessage).toContain("is required.");
+      expect(requiredMessage).toContain("back");
+      expect(requiredMessage).toContain("exit");
     } finally {
       delete process.env.OPENAI_API_KEY;
       vi.restoreAllMocks();

--- a/src/lib/onboard/validation-recovery-prompt.ts
+++ b/src/lib/onboard/validation-recovery-prompt.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { normalizeCredentialValue, saveCredential } from "../credentials/store";
+import { getCredentialPromptIntent, saveCredential } from "../credentials/store";
+import { BACK_TO_SELECTION, type BackToSelection, isBackToSelection } from "../navigation";
 import type { ProbeRecovery } from "../validation-recovery";
 
 export interface ValidationRecoveryPromptDeps {
@@ -18,7 +19,7 @@ export interface ValidationRecoveryPromptHelpers {
     label: string,
     helpUrl?: string | null,
     validator?: ((value: string) => string | null) | null,
-  ): Promise<string>;
+  ): Promise<string | BackToSelection>;
   promptValidationRecovery(
     label: string,
     recovery: ProbeRecovery,
@@ -35,7 +36,7 @@ export function createValidationRecoveryPromptHelpers(
     label: string,
     helpUrl: string | null = null,
     validator: ((value: string) => string | null) | null = null,
-  ): Promise<string> {
+  ): Promise<string | BackToSelection> {
     if (helpUrl) {
       console.log("");
       console.log(`  Get your ${label} from: ${helpUrl}`);
@@ -43,9 +44,12 @@ export function createValidationRecoveryPromptHelpers(
     }
 
     while (true) {
-      const key = normalizeCredentialValue(await deps.prompt(`  ${label}: `, { secret: true }));
+      const intent = getCredentialPromptIntent(await deps.prompt(`  ${label}: `, { secret: true }));
+      if (intent.kind === "exit") deps.exitOnboardFromPrompt();
+      if (intent.kind === "back") return BACK_TO_SELECTION;
+      const key = intent.kind === "credential" ? intent.value : "";
       if (!key) {
-        console.error(`  ${label} is required.`);
+        console.error(`  ${label} is required. Type back to change provider, or exit to quit.`);
         continue;
       }
       const validationError = typeof validator === "function" ? validator(key) : null;
@@ -103,8 +107,13 @@ export function createValidationRecoveryPromptHelpers(
       if (looksLikeToken) {
         console.log("  ⚠️  That looks like an API key — do not paste credentials here.");
         console.log("  Treating as 'retry'. You will be prompted to enter the key securely.");
-        await replaceNamedCredential(credentialEnv, `${label} API key`, helpUrl, validator);
-        return "credential";
+        const pasted = await replaceNamedCredential(
+          credentialEnv,
+          `${label} API key`,
+          helpUrl,
+          validator,
+        );
+        return isBackToSelection(pasted) ? "selection" : "credential";
       }
       if (choice === "back") {
         console.log("  Returning to provider selection.");
@@ -115,8 +124,13 @@ export function createValidationRecoveryPromptHelpers(
         deps.exitOnboardFromPrompt();
       }
       if (choice === "" || choice === "retry") {
-        await replaceNamedCredential(credentialEnv, `${label} API key`, helpUrl, validator);
-        return "credential";
+        const replaced = await replaceNamedCredential(
+          credentialEnv,
+          `${label} API key`,
+          helpUrl,
+          validator,
+        );
+        return isBackToSelection(replaced) ? "selection" : "credential";
       }
       console.log("  Please choose a provider/model again.");
       console.log("");


### PR DESCRIPTION
## Summary

The onboarding recovery menu advertises `back (change provider)` and `exit`, then the credential
re-entry prompt it opens stages those words as the API key. `back`, `exit`, `quit`, and `?` were each
saved into the provider's credential environment variable and registered with the OpenShell gateway,
and an empty answer looped on `is required` with no offered escape. The re-entry prompt now classifies
answers with `getCredentialPromptIntent`, the same classifier the canonical credential-navigation
helpers use: `back` returns to provider selection, `exit` and `quit` quit onboarding, and `?`, `help`,
or an empty line re-prompt with an escape hint.

## Related Issue

Fixes #9557

## Changes

- `src/lib/onboard/validation-recovery-prompt.ts`: the private `replaceNamedCredential` reads its
  answer through `getCredentialPromptIntent` instead of `normalizeCredentialValue`, which only trims
  whitespace and classified nothing. `exit` calls `deps.exitOnboardFromPrompt()`; `back` returns the
  shared `BACK_TO_SELECTION` sentinel from `src/lib/navigation.ts`; `help` and empty re-prompt with a
  hint naming the escapes. Both call sites map the sentinel to the existing `"selection"` outcome, so
  `promptValidationRecovery`'s return type is unchanged. `normalizeCredentialValue` had no other use
  in the file and was removed from the import.
- `src/lib/onboard/credential-navigation.test.ts`: extend `describe("credential prompt navigation
  helpers")` with a case driving the real `promptValidationRecovery` through menu `retry` → empty →
  `back`, asserting the outcome is `selection`, that the credential env var is never staged, that
  every scripted answer was consumed (so the empty answer looped and was escapable), and that exit
  was not called.

No new abstraction, configuration, fallback, or compatibility path. `getCredentialPromptIntent` is
already exported from `../credentials/store`, which this file already imported, so this adds no
dependency edge there. The one new edge is to `src/lib/navigation.ts`, which has no
`ci/source-architecture-budget.json` override and therefore the default fan-in cap of 20; it goes
from 6 to 7.

Scope note: the outer recovery menu in the same file already handled `back` and `exit` correctly and
is unchanged. Only the inner re-entry prompt was affected.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/onboard/credential-navigation.test.ts` → 5 passed; `npx vitest run --project integration test/onboard-selection.test.ts` → 67 passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Behavior before and after

Driving the shipped helper with the menu answered `retry` and the re-entry prompt answered with each
navigation word.

Before:

```
typed "back" -> outcome="credential" OPENAI_API_KEY="back"
typed "exit" -> outcome="credential" OPENAI_API_KEY="exit"
typed "quit" -> outcome="credential" OPENAI_API_KEY="quit"
typed "?"    -> outcome="credential" OPENAI_API_KEY="?"
```

After:

```
typed "back" -> outcome="selection"  OPENAI_API_KEY=undefined
typed "exit" -> onboarding exit       OPENAI_API_KEY=undefined
typed "quit" -> onboarding exit       OPENAI_API_KEY=undefined
typed "?"    -> re-prompts, escapable OPENAI_API_KEY=undefined
```

The added test fails on the parent commit with
`AssertionError: expected 'credential' to be 'selection'` and passes with this change.

### Prior art

The same class was fixed for the first-entry credential prompt in #3697 and again for the NVIDIA API
key prompt in #9404 / #9427. #9427 changed `src/lib/onboard.ts`,
`src/lib/onboard/nvidia-featured-model-selection.ts`,
`src/lib/onboard/nvidia-featured-model-selection.test.ts`, and
`src/lib/onboard/setup-nim-selection.ts`; it did not reach
`src/lib/onboard/validation-recovery-prompt.ts`. This applies the same intent-classifier approach to
that remaining prompt.

Related but distinct: #6005 requests a general back-navigation key at every wizard step and is
labeled `needs: design`. This change is narrower — a prompt that already advertises `back` and `exit`
in its own menu text now honors them — and does not depend on that design decision.

---
Signed-off-by: Udaya Tejas <udayatejas2004@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential recovery during onboarding.
  * Selecting “Back” after entering an empty API key now correctly returns to provider selection without saving invalid input or exiting onboarding.
  * Updated prompts to clearly distinguish retry, back, and exit actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->