### PR TITLE
fix(onboard): diagnose OpenShell deleting handoff

### DIFF
--- a/src/lib/onboard/docker-gpu-patch-diagnostics-classification.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-diagnostics-classification.test.ts
@@ -196,6 +196,45 @@ describe("Docker GPU patch diagnostics", () => {
     expect(result.headline).toContain("Provisioning");
   });
 
+  it("assigns OpenShell lifecycle ownership when a healthy container remains in Deleting (#9531)", () => {
+    const result = classify(
+      failureSnapshot("Deleting", {
+        Status: "running",
+        Running: true,
+        ExitCode: 0,
+        Health: { Status: "healthy" },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "sandbox_deleting_phase",
+      headline:
+        "OpenShell kept the sandbox in Deleting after the replacement container became healthy.",
+      summaryLines: expect.arrayContaining([
+        "sandbox_phase=Deleting",
+        "patched_container_status=running",
+        "patched_container_running=true",
+        "patched_container_exit_code=0",
+        "patched_container_health=healthy",
+        "lifecycle_authority=openshell",
+      ]),
+      hints: [
+        "OpenShell owns the sandbox lifecycle phase. NemoClaw does not accept Docker container health as lifecycle success.",
+      ],
+    });
+  });
+
+  it.each([
+    ["health is not healthy", { ...RUNNING, Health: { Status: "starting" } }],
+    ["container is not running", { Status: "exited", Running: false, ExitCode: 0 }],
+    ["container state is incomplete", RUNNING],
+  ])("does not assign OpenShell lifecycle ownership when %s (#9531)", (_case, state) => {
+    const result = classify(failureSnapshot("Deleting", state));
+
+    expect(result.kind).not.toBe("sandbox_deleting_phase");
+    expect(result.summaryLines).not.toContain("lifecycle_authority=openshell");
+  });
+
   it("prefers supervisor_unreachable over proof_failure when the sandbox is non-live but non-terminal", () => {
     const result = classify(
       failureSnapshot("Provisioning"),

--- a/src/lib/onboard/docker-gpu-patch-failure-print.test.ts
+++ b/src/lib/onboard/docker-gpu-patch-failure-print.test.ts
@@ -146,6 +146,7 @@ describe("Docker GPU patch failure reporting (#7996)", () => {
 
   it.each([
     "sandbox_error_phase",
+    "sandbox_deleting_phase",
     "supervisor_unreachable",
     "proof_failure",
   ] as const)("ignores a saved %s verdict after rollback", (kind) => {

--- a/src/lib/onboard/docker-gpu-patch-types.ts
+++ b/src/lib/onboard/docker-gpu-patch-types.ts
@@ -177,6 +177,7 @@ export type DockerGpuPatchSandboxSnapshot = {
 export type DockerGpuPatchFailureKind =
   | "patched_container_failed"
   | "sandbox_error_phase"
+  | "sandbox_deleting_phase"
   | "supervisor_unreachable"
   | "proof_failure"
   | "unknown";

--- a/src/lib/onboard/docker-gpu-patch.ts
+++ b/src/lib/onboard/docker-gpu-patch.ts
@@ -483,6 +483,15 @@ function patchedContainerLooksFailed(state: DockerContainerState | null): boolea
   return false;
 }
 
+function patchedContainerIsHealthyAndRunning(state: DockerContainerState | null): boolean {
+  return (
+    state?.Status?.toLowerCase() === "running" &&
+    state.Running === true &&
+    state.ExitCode === 0 &&
+    state.Health?.Status?.toLowerCase() === "healthy"
+  );
+}
+
 /**
  * Turn the snapshot + selected GPU mode into a user-facing classification
  * that distinguishes "the patched container itself died" from "the sandbox
@@ -504,6 +513,9 @@ export function classifyDockerGpuPatchFailure(
   if (selectedMode) lines.push(`patched_create_option=${selectedMode.label}`);
 
   const containerFailed = patchedContainerLooksFailed(snapshot.patchedContainerState);
+  const healthyContainerInDeletingPhase =
+    snapshot.sandboxPhase === "Deleting" &&
+    patchedContainerIsHealthyAndRunning(snapshot.patchedContainerState);
   const sandboxInErrorPhase = isFailurePhase(snapshot.sandboxPhase);
   const sandboxNotLive =
     !!snapshot.sandboxPhase && !SANDBOX_LIVE_PHASE_TOKENS.has(snapshot.sandboxPhase);
@@ -528,6 +540,14 @@ export function classifyDockerGpuPatchFailure(
   } else if (sandboxInErrorPhase) {
     kind = "sandbox_error_phase";
     headline = `OpenShell sandbox entered ${snapshot.sandboxPhase} phase before the GPU proof could run.`;
+  } else if (healthyContainerInDeletingPhase) {
+    kind = "sandbox_deleting_phase";
+    headline =
+      "OpenShell kept the sandbox in Deleting after the replacement container became healthy.";
+    lines.push("lifecycle_authority=openshell");
+    hints.push(
+      "OpenShell owns the sandbox lifecycle phase. NemoClaw does not accept Docker container health as lifecycle success.",
+    );
   } else if (sandboxNotLive && (snapshot.patchedContainerState || options.proofError)) {
     // Cover the non-live-but-non-terminal case (e.g. Provisioning / NotReady)
     // BEFORE the proof-error branch — a proof failing while the sandbox


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

When a patched Docker container is running and healthy but OpenShell leaves the sandbox in `Deleting`, NemoClaw now reports that lifecycle divergence as OpenShell-owned. The installer still fails closed and preserves its existing recovery state instead of treating Docker health as sandbox readiness.

## Related Issue

Refs #9531

## Changes

- Classify the exact `Deleting` plus running, healthy, exit-zero container state as `sandbox_deleting_phase`.
- Emit stable, redacted lifecycle evidence with `lifecycle_authority=openshell` and guidance that Docker health is not lifecycle success.
- Keep incomplete and near-miss states out of the ownership classification, and keep stale saved verdicts ignored after rollback.
- Record the upstream lifecycle owner in [NVIDIA/OpenShell#2117](https://github.com/NVIDIA/OpenShell/issues/2117). This PR does not change mutation, timeout, retry, rollback, backup, cleanup, or release behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed against the repository security rubric. Diagnostic redaction, fail-closed lifecycle judgment, rollback, and preserved-backup behavior are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing recovery, rollback, and cleanup guidance remains accurate. The new internal failure classification does not change the user recovery action.
- Agent: Codex Desktop
<!-- docs-review-head-sha: edc622189 -->
<!-- docs-review-agents-blob-sha: 513518cdf -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Focused Vitest, 2 files and 31 tests passed; `npm run typecheck:cli` and `npm run test:titles:check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation: `npm run test:changed` passed 4,624 tests. Two unrelated existing Deep Agents Code preference-merge assertions failed in `created-sandbox-finalization.test.ts`.

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostics for sandboxes stuck in the **Deleting** phase.
  - Healthy replacement containers are now correctly identified, with clearer status details and guidance.
  - Avoids misclassifying stopped, unhealthy, or health-unknown containers.
  - Ensures stale pre-rollback results are ignored when this condition is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->