### PR TITLE
refactor(inference): make the catalog own vLLM profiles

### DIFF
--- a/managed-inference/models/vllm.deepseek-r1-distill-llama-70b.v1.yaml
+++ b/managed-inference/models/vllm.deepseek-r1-distill-llama-70b.v1.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingModel
+metadata:
+  id: vllm.deepseek-r1-distill-llama-70b.v1
+  displayName: DeepSeek-R1 Distill Llama 70B
+spec:
+  id: deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  revision: b1c0b44b4369b597ad119a196caf79a9c40e141e
+  environmentValue: deepseek-r1-distill-70b
+  displayName: DeepSeek-R1 Distill Llama 70B
+  menuOrder: 20
+  servedName: deepseek-ai/DeepSeek-R1-Distill-Llama-70B
+  downloadSizeBytes: 141000000000
+  gated: true
+  installFastSafetensors: true
+  preparation:
+    ref: none/v1
+  probePolicyRef: nvidia.endpoint-validation.standard/v1
+  capabilities:
+    chatCompletions: true
+    streaming: true
+    toolCalls: true
+    structuredOutputs: false
+    reasoning: true
+    multimodal: false

--- a/managed-inference/models/vllm.deepseek-v4-flash-0731.v1.yaml
+++ b/managed-inference/models/vllm.deepseek-v4-flash-0731.v1.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingModel
+metadata:
+  id: vllm.deepseek-v4-flash-0731.v1
+  displayName: DeepSeek V4 Flash 0731
+spec:
+  id: deepseek-ai/DeepSeek-V4-Flash-0731
+  revision: 9e165c30e2704aec5d9d593cce3eebd58bbef1cb
+  environmentValue: deepseek-v4-flash-0731
+  displayName: DeepSeek V4 Flash 0731
+  menuOrder: 90
+  servedName: deepseek-v4-flash-0731
+  downloadSizeBytes: 166898661074
+  gated: false
+  installFastSafetensors: false
+  preparation:
+    ref: snapshot-copy-and-exact-text-replacement/v1
+    snapshotCopy:
+      sourcePath: encoding/encoding_dsv4.py
+      digest: sha256:abc0d26120250dda0ae077dc64aa28836026e61e970854aaeb792445e6a0dde6
+      targetPath: /usr/local/lib/python3.12/dist-packages/vllm/tokenizers/deepseek_v4_encoding.py
+    exactTextReplacement:
+      targetPath: /usr/local/lib/python3.12/dist-packages/vllm/tokenizers/deepseek_v4.py
+      expectedText: |2-
+                    elif reasoning_effort in ("max", "xhigh"):
+                        reasoning_effort = "max"
+                    else:
+                        reasoning_effort = "high"
+      replacementText: |2-
+                    elif reasoning_effort in ("max", "xhigh"):
+                        reasoning_effort = "max"
+                    elif reasoning_effort == "high":
+                        reasoning_effort = "high"
+                    else:
+                        reasoning_effort = "low"
+  probePolicyRef: nvidia.endpoint-validation.standard/v1
+  capabilities:
+    chatCompletions: true
+    streaming: true
+    toolCalls: true
+    structuredOutputs: false
+    reasoning: true
+    multimodal: false

--- a/managed-inference/models/vllm.deepseek-v4-flash.v1.yaml
+++ b/managed-inference/models/vllm.deepseek-v4-flash.v1.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingModel
+metadata:
+  id: vllm.deepseek-v4-flash.v1
+  displayName: DeepSeek V4 Flash
+spec:
+  id: deepseek-ai/DeepSeek-V4-Flash
+  revision: 60d8d70770c6776ff598c94bb586a859a38244f1
+  environmentValue: deepseek-v4-flash
+  displayName: DeepSeek V4 Flash
+  menuOrder: 40
+  servedName: deepseek-ai/DeepSeek-V4-Flash
+  downloadSizeBytes: 352381000000
+  gated: false
+  installFastSafetensors: true
+  preparation:
+    ref: none/v1
+  probePolicyRef: nvidia.endpoint-validation.extended/v1
+  capabilities:
+    chatCompletions: true
+    streaming: true
+    toolCalls: true
+    structuredOutputs: false
+    reasoning: true
+    multimodal: false

--- a/managed-inference/models/vllm.muse-glimmer-30b-nvfp4-w4a4.v1.yaml
+++ b/managed-inference/models/vllm.muse-glimmer-30b-nvfp4-w4a4.v1.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingModel
+metadata:
+  id: vllm.muse-glimmer-30b-nvfp4-w4a4.v1
+  displayName: Muse Glimmer 30B NVFP4 W4A4
+spec:
+  id: Inferact/Muse-Glimmer-30B-NVFP4-W4A4
+  revision: d35cb79050f419c457611b1cee5c5d15b176f285
+  environmentValue: muse-glimmer-30b
+  displayName: Muse Glimmer 30B NVFP4 W4A4 [Experimental]
+  menuOrder: 70
+  servedName: muse-glimmer
+  downloadSizeBytes: 25447097878
+  gated: false
+  installFastSafetensors: false
+  preparation:
+    ref: none/v1
+  probePolicyRef: nvidia.endpoint-validation.standard/v1
+  capabilities:
+    chatCompletions: true
+    streaming: true
+    toolCalls: true
+    structuredOutputs: false
+    reasoning: true
+    multimodal: false

--- a/managed-inference/models/vllm.nemotron-3-nano-4b-fp8.v1.yaml
+++ b/managed-inference/models/vllm.nemotron-3-nano-4b-fp8.v1.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingModel
+metadata:
+  id: vllm.nemotron-3-nano-4b-fp8.v1
+  displayName: NVIDIA Nemotron-3 Nano 4B FP8
+spec:
+  id: nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8
+  revision: 3fe6dab75665a93884214ad4b1b95cf02717d081
+  environmentValue: nemotron-3-nano-4b
+  displayName: NVIDIA Nemotron-3 Nano 4B FP8
+  menuOrder: 30
+  servedName: nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8
+  downloadSizeBytes: 5280000000
+  gated: false
+  installFastSafetensors: true
+  preparation:
+    ref: none/v1
+  probePolicyRef: nvidia.endpoint-validation.standard/v1
+  capabilities:
+    chatCompletions: true
+    streaming: true
+    toolCalls: true
+    structuredOutputs: false
+    reasoning: true
+    multimodal: false

--- a/managed-inference/models/vllm.nemotron-3-ultra-550b-a55b-nvfp4.v1.yaml
+++ b/managed-inference/models/vllm.nemotron-3-ultra-550b-a55b-nvfp4.v1.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingModel
+metadata:
+  id: vllm.nemotron-3-ultra-550b-a55b-nvfp4.v1
+  displayName: NVIDIA Nemotron 3 Ultra 550B NVFP4
+spec:
+  id: nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
+  revision: 183968f87ae4cedce3039313cac1fd43d112c578
+  environmentValue: nemotron-3-ultra-550b-a55b
+  displayName: NVIDIA Nemotron 3 Ultra 550B NVFP4
+  menuOrder: 50
+  servedName: nvidia/nemotron-3-ultra-550b-a55b
+  downloadSizeBytes: 352381245521
+  gated: false
+  installFastSafetensors: false
+  preparation:
+    ref: none/v1
+  probePolicyRef: nvidia.endpoint-validation.standard/v1
+  capabilities:
+    chatCompletions: true
+    streaming: true
+    toolCalls: true
+    structuredOutputs: false
+    reasoning: true
+    multimodal: false

--- a/managed-inference/models/vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.v1.yaml
+++ b/managed-inference/models/vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.v1.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingModel
+metadata:
+  id: vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.v1
+  displayName: NVIDIA Nemotron 3.5 Lightning 30B-A3B NVFP4
+spec:
+  id: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
+  revision: 0dcd680e5585c791728c83342b311d0a0026dbeb
+  environmentValue: nemotron-3.5-lightning-30b
+  displayName: NVIDIA Nemotron 3.5 Lightning 30B-A3B NVFP4 [Experimental]
+  menuOrder: 80
+  servedName: nvidia-nemotron-3.5-lightning-30b-a3b-nvfp4
+  downloadSizeBytes: 21561882284
+  gated: false
+  installFastSafetensors: false
+  preparation:
+    ref: none/v1
+  probePolicyRef: nvidia.endpoint-validation.standard/v1
+  capabilities:
+    chatCompletions: true
+    streaming: true
+    toolCalls: true
+    structuredOutputs: false
+    reasoning: true
+    multimodal: false

--- a/managed-inference/models/vllm.qwen3-6-27b-fp8.v1.yaml
+++ b/managed-inference/models/vllm.qwen3-6-27b-fp8.v1.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingModel
+metadata:
+  id: vllm.qwen3-6-27b-fp8.v1
+  displayName: Qwen3.6 27B FP8
+spec:
+  id: Qwen/Qwen3.6-27B-FP8
+  revision: e89b16ebf1988b3d6befa7de50abc2d76f26eb09
+  environmentValue: qwen3.6-27b
+  displayName: Qwen3.6 27B FP8
+  menuOrder: 10
+  servedName: Qwen/Qwen3.6-27B-FP8
+  downloadSizeBytes: 30900000000
+  gated: false
+  installFastSafetensors: true
+  preparation:
+    ref: none/v1
+  probePolicyRef: nvidia.endpoint-validation.standard/v1
+  capabilities:
+    chatCompletions: true
+    streaming: true
+    toolCalls: true
+    structuredOutputs: false
+    reasoning: true
+    multimodal: false

--- a/managed-inference/models/vllm.qwen3-6-35b-a3b-nvfp4.v1.yaml
+++ b/managed-inference/models/vllm.qwen3-6-35b-a3b-nvfp4.v1.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingModel
+metadata:
+  id: vllm.qwen3-6-35b-a3b-nvfp4.v1
+  displayName: Qwen3.6 35B-A3B NVFP4
+spec:
+  id: nvidia/Qwen3.6-35B-A3B-NVFP4
+  revision: 491c2f1ea524c639598bf8fa787a93fed5a6fbce
+  environmentValue: qwen3.6-35b-a3b-nvfp4
+  displayName: Qwen3.6 35B-A3B NVFP4
+  menuOrder: 60
+  servedName: nvidia/Qwen3.6-35B-A3B-NVFP4
+  downloadSizeBytes: 23500000000
+  gated: false
+  installFastSafetensors: true
+  preparation:
+    ref: none/v1
+  probePolicyRef: nvidia.endpoint-validation.standard/v1
+  capabilities:
+    chatCompletions: true
+    streaming: true
+    toolCalls: true
+    structuredOutputs: false
+    reasoning: true
+    multimodal: false

--- a/managed-inference/presets/llama-cpp.dgx-spark-gb10.single.muse-glimmer-30b.yaml
+++ b/managed-inference/presets/llama-cpp.dgx-spark-gb10.single.muse-glimmer-30b.yaml
@@ -8,6 +8,9 @@ metadata:
   id: llama-cpp.dgx-spark-gb10.single.muse-glimmer-30b
   displayName: Meta Muse Glimmer 30B on one DGX Spark
   supportState: experimental
+  validation:
+    level: schema
+    evidence: managed-inference-catalog-compiler-v1
 
 spec:
   selection: automatic

--- a/managed-inference/presets/llama-cpp.dgx-spark-gb10.single.nemotron-3-nano-30b-a3b.yaml
+++ b/managed-inference/presets/llama-cpp.dgx-spark-gb10.single.nemotron-3-nano-30b-a3b.yaml
@@ -8,6 +8,9 @@ metadata:
   id: llama-cpp.dgx-spark-gb10.single.nemotron-3-nano-30b-a3b
   displayName: NVIDIA Nemotron 3 Nano 30B-A3B on one DGX Spark
   supportState: experimental
+  validation:
+    level: schema
+    evidence: managed-inference-catalog-compiler-v1
 
 spec:
   selection: automatic

--- a/managed-inference/presets/llama-cpp.linux-amd64-nvidia.single.nemotron-3-nano-30b-a3b.yaml
+++ b/managed-inference/presets/llama-cpp.linux-amd64-nvidia.single.nemotron-3-nano-30b-a3b.yaml
@@ -8,6 +8,9 @@ metadata:
   id: llama-cpp.linux-amd64-nvidia.single.nemotron-3-nano-30b-a3b
   displayName: NVIDIA Nemotron 3 Nano 30B-A3B on one Linux x86_64 NVIDIA GPU
   supportState: experimental
+  validation:
+    level: schema
+    evidence: managed-inference-catalog-compiler-v1
 
 spec:
   selection: automatic

--- a/managed-inference/presets/local-model-profile.vllm.spark.v1.yaml
+++ b/managed-inference/presets/local-model-profile.vllm.spark.v1.yaml
@@ -7,6 +7,9 @@ kind: ServingPreset
 metadata:
   id: local-model-profile.vllm.spark.v1
   displayName: Local model profile with vLLM
+  validation:
+    level: schema
+    evidence: managed-inference-catalog-compiler-v1
 
 spec:
   selection: disabled
@@ -98,4 +101,7 @@ spec:
 
   plan:
     backend: vllm
+    platform: spark
+    interactive: false
     recipeRef: vllm.qwen3-6-35b-a3b-nvfp4.spark-single.v1
+    installPolicyRef: vllm.fixed-authenticated/v1

--- a/managed-inference/presets/vllm.dgx-spark-gb10.dual.deepseek-v4-flash-0731.yaml
+++ b/managed-inference/presets/vllm.dgx-spark-gb10.dual.deepseek-v4-flash-0731.yaml
@@ -8,6 +8,9 @@ metadata:
   id: vllm.dgx-spark-gb10.dual.deepseek-v4-flash-0731
   displayName: DeepSeek V4 Flash 0731 on two DGX Sparks
   supportState: experimental
+  validation:
+    level: schema
+    evidence: managed-inference-catalog-compiler-v1
 
 spec:
   selection: automatic
@@ -76,6 +79,8 @@ spec:
 
   plan:
     backend: vllm
+    platform: spark
+    interactive: false
     recipeRef: vllm.deepseek-v4-flash-0731.spark-dual.v1
     bindings:
       sparkTopology:

--- a/managed-inference/presets/vllm.dgx-spark-gb10.single.deepseek-r1-distill-llama-70b.yaml
+++ b/managed-inference/presets/vllm.dgx-spark-gb10.single.deepseek-r1-distill-llama-70b.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.dgx-spark-gb10.single.deepseek-r1-distill-llama-70b
+  displayName: DeepSeek-R1 Distill Llama 70B on one DGX Spark
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: explicit-only
+  priority: 500
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: qualification
+          id: host.platform.dgx_spark
+          status: qualified
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.dgx_spark
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: spark
+    interactive: true
+    recipeRef: vllm.deepseek-r1-distill-llama-70b.optimized-arm64-single.v1

--- a/managed-inference/presets/vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4.yaml
+++ b/managed-inference/presets/vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4.yaml
@@ -8,6 +8,9 @@ metadata:
   id: vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4
   displayName: Muse Glimmer 30B NVFP4 W4A4 on one DGX Spark
   supportState: experimental
+  validation:
+    level: schema
+    evidence: managed-inference-catalog-compiler-v1
 
 spec:
   selection: explicit-only
@@ -103,4 +106,6 @@ spec:
 
   plan:
     backend: vllm
+    platform: spark
+    interactive: true
     recipeRef: vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1

--- a/managed-inference/presets/vllm.dgx-spark-gb10.single.nemotron-3-nano-4b-fp8.yaml
+++ b/managed-inference/presets/vllm.dgx-spark-gb10.single.nemotron-3-nano-4b-fp8.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.dgx-spark-gb10.single.nemotron-3-nano-4b-fp8
+  displayName: NVIDIA Nemotron-3 Nano 4B FP8 on one DGX Spark
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: explicit-only
+  priority: 500
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: qualification
+          id: host.platform.dgx_spark
+          status: qualified
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.dgx_spark
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: spark
+    interactive: true
+    recipeRef: vllm.nemotron-3-nano-4b-fp8.optimized-arm64-single.v1

--- a/managed-inference/presets/vllm.dgx-spark-gb10.single.nemotron-3.5-lightning-30b-a3b-nvfp4.yaml
+++ b/managed-inference/presets/vllm.dgx-spark-gb10.single.nemotron-3.5-lightning-30b-a3b-nvfp4.yaml
@@ -8,6 +8,9 @@ metadata:
   id: vllm.dgx-spark-gb10.single.nemotron-3.5-lightning-30b-a3b-nvfp4
   displayName: NVIDIA Nemotron 3.5 Lightning 30B-A3B NVFP4 on one DGX Spark
   supportState: experimental
+  validation:
+    level: schema
+    evidence: managed-inference-catalog-compiler-v1
 
 spec:
   selection: explicit-only
@@ -103,4 +106,6 @@ spec:
 
   plan:
     backend: vllm
+    platform: spark
+    interactive: false
     recipeRef: vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.spark-single.v1

--- a/managed-inference/presets/vllm.dgx-spark-gb10.single.qwen3-6-27b-fp8.yaml
+++ b/managed-inference/presets/vllm.dgx-spark-gb10.single.qwen3-6-27b-fp8.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.dgx-spark-gb10.single.qwen3-6-27b-fp8
+  displayName: Qwen3.6 27B FP8 on one DGX Spark
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: explicit-only
+  priority: 500
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: qualification
+          id: host.platform.dgx_spark
+          status: qualified
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.dgx_spark
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: spark
+    interactive: true
+    recipeRef: vllm.qwen3-6-27b-fp8.optimized-arm64-single.v1

--- a/managed-inference/presets/vllm.dgx-spark-gb10.single.qwen3-6-35b-a3b-nvfp4.yaml
+++ b/managed-inference/presets/vllm.dgx-spark-gb10.single.qwen3-6-35b-a3b-nvfp4.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.dgx-spark-gb10.single.qwen3-6-35b-a3b-nvfp4
+  displayName: Qwen3.6 35B-A3B NVFP4 on one DGX Spark
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: automatic
+  priority: 550
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: qualification
+          id: host.platform.dgx_spark
+          status: qualified
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.dgx_spark
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: spark
+    interactive: true
+    recipeRef: vllm.qwen3-6-35b-a3b-nvfp4.spark-single.v1

--- a/managed-inference/presets/vllm.dgx-station-gb300.single.deepseek-r1-distill-llama-70b.yaml
+++ b/managed-inference/presets/vllm.dgx-station-gb300.single.deepseek-r1-distill-llama-70b.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.dgx-station-gb300.single.deepseek-r1-distill-llama-70b
+  displayName: DeepSeek-R1 Distill Llama 70B on one DGX Station
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: explicit-only
+  priority: 500
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: qualification
+          id: host.platform.dgx_station
+          status: qualified
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.dgx_station
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: station
+    interactive: true
+    recipeRef: vllm.deepseek-r1-distill-llama-70b.optimized-arm64-single.v1

--- a/managed-inference/presets/vllm.dgx-station-gb300.single.deepseek-v4-flash.yaml
+++ b/managed-inference/presets/vllm.dgx-station-gb300.single.deepseek-v4-flash.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.dgx-station-gb300.single.deepseek-v4-flash
+  displayName: DeepSeek V4 Flash on one DGX Station
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: automatic
+  priority: 550
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: qualification
+          id: host.platform.dgx_station
+          status: qualified
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.dgx_station
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: station
+    interactive: true
+    recipeRef: vllm.deepseek-v4-flash.station-arm64-single.v1

--- a/managed-inference/presets/vllm.dgx-station-gb300.single.nemotron-3-nano-4b-fp8.yaml
+++ b/managed-inference/presets/vllm.dgx-station-gb300.single.nemotron-3-nano-4b-fp8.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.dgx-station-gb300.single.nemotron-3-nano-4b-fp8
+  displayName: NVIDIA Nemotron-3 Nano 4B FP8 on one DGX Station
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: explicit-only
+  priority: 500
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: qualification
+          id: host.platform.dgx_station
+          status: qualified
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.dgx_station
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: station
+    interactive: true
+    recipeRef: vllm.nemotron-3-nano-4b-fp8.optimized-arm64-single.v1

--- a/managed-inference/presets/vllm.dgx-station-gb300.single.nemotron-3-ultra-550b-a55b-nvfp4.yaml
+++ b/managed-inference/presets/vllm.dgx-station-gb300.single.nemotron-3-ultra-550b-a55b-nvfp4.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.dgx-station-gb300.single.nemotron-3-ultra-550b-a55b-nvfp4
+  displayName: NVIDIA Nemotron 3 Ultra 550B NVFP4 on one DGX Station
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: explicit-only
+  priority: 540
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: qualification
+          id: host.platform.dgx_station
+          status: qualified
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.dgx_station
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: station
+    interactive: true
+    recipeRef: vllm.nemotron-3-ultra-550b-a55b-nvfp4.station-arm64-single.v1

--- a/managed-inference/presets/vllm.dgx-station-gb300.single.qwen3-6-27b-fp8.yaml
+++ b/managed-inference/presets/vllm.dgx-station-gb300.single.qwen3-6-27b-fp8.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.dgx-station-gb300.single.qwen3-6-27b-fp8
+  displayName: Qwen3.6 27B FP8 on one DGX Station
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: explicit-only
+  priority: 500
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: qualification
+          id: host.platform.dgx_station
+          status: qualified
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.dgx_station
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: station
+    interactive: true
+    recipeRef: vllm.qwen3-6-27b-fp8.optimized-arm64-single.v1

--- a/managed-inference/presets/vllm.linux-amd64-nvidia.single.deepseek-r1-distill-llama-70b.yaml
+++ b/managed-inference/presets/vllm.linux-amd64-nvidia.single.deepseek-r1-distill-llama-70b.yaml
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.linux-amd64-nvidia.single.deepseek-r1-distill-llama-70b
+  displayName: DeepSeek-R1 Distill Llama 70B on one Linux x86_64 NVIDIA GPU
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: explicit-only
+  priority: 300
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: x64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: linux
+    interactive: true
+    recipeRef: vllm.deepseek-r1-distill-llama-70b.linux-amd64-single.v1

--- a/managed-inference/presets/vllm.linux-amd64-nvidia.single.nemotron-3-nano-4b-fp8.yaml
+++ b/managed-inference/presets/vllm.linux-amd64-nvidia.single.nemotron-3-nano-4b-fp8.yaml
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.linux-amd64-nvidia.single.nemotron-3-nano-4b-fp8
+  displayName: NVIDIA Nemotron-3 Nano 4B FP8 on one Linux x86_64 NVIDIA GPU
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: automatic
+  priority: 300
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: x64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: linux
+    interactive: true
+    recipeRef: vllm.nemotron-3-nano-4b-fp8.linux-amd64-single.v1

--- a/managed-inference/presets/vllm.linux-amd64-nvidia.single.qwen3-6-27b-fp8.yaml
+++ b/managed-inference/presets/vllm.linux-amd64-nvidia.single.qwen3-6-27b-fp8.yaml
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.linux-amd64-nvidia.single.qwen3-6-27b-fp8
+  displayName: Qwen3.6 27B FP8 on one Linux x86_64 NVIDIA GPU
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: explicit-only
+  priority: 300
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: x64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: linux
+    interactive: true
+    recipeRef: vllm.qwen3-6-27b-fp8.linux-amd64-single.v1

--- a/managed-inference/presets/vllm.linux-arm64-nvidia.single.deepseek-r1-distill-llama-70b.yaml
+++ b/managed-inference/presets/vllm.linux-arm64-nvidia.single.deepseek-r1-distill-llama-70b.yaml
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.linux-arm64-nvidia.single.deepseek-r1-distill-llama-70b
+  displayName: DeepSeek-R1 Distill Llama 70B on one Linux arm64 NVIDIA GPU
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: explicit-only
+  priority: 300
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: linux
+    interactive: true
+    recipeRef: vllm.deepseek-r1-distill-llama-70b.linux-arm64-single.v1

--- a/managed-inference/presets/vllm.linux-arm64-nvidia.single.nemotron-3-nano-4b-fp8.yaml
+++ b/managed-inference/presets/vllm.linux-arm64-nvidia.single.nemotron-3-nano-4b-fp8.yaml
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.linux-arm64-nvidia.single.nemotron-3-nano-4b-fp8
+  displayName: NVIDIA Nemotron-3 Nano 4B FP8 on one Linux arm64 NVIDIA GPU
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: automatic
+  priority: 300
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: linux
+    interactive: true
+    recipeRef: vllm.nemotron-3-nano-4b-fp8.linux-arm64-single.v1

--- a/managed-inference/presets/vllm.linux-arm64-nvidia.single.qwen3-6-27b-fp8.yaml
+++ b/managed-inference/presets/vllm.linux-arm64-nvidia.single.qwen3-6-27b-fp8.yaml
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.linux-arm64-nvidia.single.qwen3-6-27b-fp8
+  displayName: Qwen3.6 27B FP8 on one Linux arm64 NVIDIA GPU
+  supportState: supported
+  validation:
+    level: hardware
+    evidence: preexisting-supported-profile-v0.0.109
+
+spec:
+  selection: explicit-only
+  priority: 300
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: linux
+    interactive: true
+    recipeRef: vllm.qwen3-6-27b-fp8.linux-arm64-single.v1

--- a/managed-inference/presets/vllm.n1x.single.qwen3-6-35b-a3b-nvfp4.yaml
+++ b/managed-inference/presets/vllm.n1x.single.qwen3-6-35b-a3b-nvfp4.yaml
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingPreset
+
+metadata:
+  id: vllm.n1x.single.qwen3-6-35b-a3b-nvfp4
+  displayName: Qwen3.6 35B-A3B NVFP4 on one N1x
+  supportState: experimental
+  validation:
+    level: schema
+    evidence: managed-inference-catalog-compiler-v1
+
+spec:
+  selection: automatic
+  priority: 550
+
+  requirements:
+    all:
+      - readiness:
+          scope: everyNode
+          kind: qualification
+          id: host.platform.n1x
+          status: qualified
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.platform.n1x
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.daemon_reachable
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.runtime_supported
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.docker.storage_compatible
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.nvidia_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.container_toolkit_available
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: capability
+          id: host.gpu.cdi_healthy
+          state: present
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.platform
+          comparison:
+            operator: equals
+            value: linux
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.os.architecture
+          comparison:
+            operator: equals
+            value: arm64
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.docker.runtime
+          comparison:
+            operator: equals
+            value: docker
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.count
+          comparison:
+            operator: at-least
+            value: 1
+      - readiness:
+          scope: everyNode
+          kind: observation
+          id: host.gpu.driver_version
+          comparison:
+            operator: version-at-least
+            value: 580.65.06
+
+  plan:
+    backend: vllm
+    platform: n1x
+    interactive: true
+    recipeRef: vllm.qwen3-6-35b-a3b-nvfp4.spark-single.v1

--- a/managed-inference/recipes/vllm.deepseek-r1-distill-llama-70b.linux-amd64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.deepseek-r1-distill-llama-70b.linux-amd64-single.v1.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingRecipe
+
+metadata:
+  id: vllm.deepseek-r1-distill-llama-70b.linux-amd64-single.v1
+  displayName: DeepSeek-R1 Distill Llama 70B with vLLM on Linux amd64
+
+spec:
+  backend: vllm
+
+  modelRef: vllm.deepseek-r1-distill-llama-70b.v1
+  runtime:
+    image: nvcr.io/nvidia/vllm@sha256:7be6c2f676c36059a494fe17254e69ae5c677535ba6191044e5fc8e42a91c773
+    imageDownloadSizeBytes: 8928665752
+    minimumComputeCapability: 0
+    minimumGpuMemoryBytes: 141000000000
+    pullTimeoutSeconds: 43200
+    architecture: amd64
+    networkMode: bridge
+    ipcMode: host
+    sharedMemoryBytes: 68719476736
+    gpuRequest: all
+    devices: []
+    ulimits:
+      memlock: -1
+      stackBytes: 67108864
+    modelCache:
+      source: huggingface-cache
+      target: /root/.cache/huggingface
+    temporaryFilesystems: []
+    environment: {}
+
+  execution:
+    materializerRef: vllm.host-local/v1
+    lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
+
+  serve:
+    authentication: bearer
+    directInstall:
+      authentication: none
+      fixedArguments: false
+      catalogReceipt: false
+    executable: /usr/local/bin/vllm
+    arguments:
+      - name: --max-model-len
+        value: 32768
+      - name: --gpu-memory-utilization
+        value: 0.7
+      - name: --max-num-seqs
+        value: 4
+      - name: --reasoning-parser
+        value: deepseek_r1
+      - name: --enable-auto-tool-choice
+      - name: --tool-call-parser
+        value: hermes
+
+  readiness:
+    timeoutSeconds: 1800
+    expectedModel: deepseek-ai/DeepSeek-R1-Distill-Llama-70B

--- a/managed-inference/recipes/vllm.deepseek-r1-distill-llama-70b.linux-arm64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.deepseek-r1-distill-llama-70b.linux-arm64-single.v1.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingRecipe
+
+metadata:
+  id: vllm.deepseek-r1-distill-llama-70b.linux-arm64-single.v1
+  displayName: DeepSeek-R1 Distill Llama 70B with vLLM on Linux arm64
+
+spec:
+  backend: vllm
+
+  modelRef: vllm.deepseek-r1-distill-llama-70b.v1
+  runtime:
+    image: nvcr.io/nvidia/vllm@sha256:447995cbb57e6c7cf792cab95e9852e5f62b5fb6d2f39e030fa4eda9a54eadb4
+    imageDownloadSizeBytes: 9278081698
+    minimumComputeCapability: 0
+    minimumGpuMemoryBytes: 141000000000
+    pullTimeoutSeconds: 43200
+    architecture: arm64
+    networkMode: bridge
+    ipcMode: host
+    sharedMemoryBytes: 68719476736
+    gpuRequest: all
+    devices: []
+    ulimits:
+      memlock: -1
+      stackBytes: 67108864
+    modelCache:
+      source: huggingface-cache
+      target: /root/.cache/huggingface
+    temporaryFilesystems: []
+    environment: {}
+
+  execution:
+    materializerRef: vllm.host-local/v1
+    lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
+
+  serve:
+    authentication: bearer
+    directInstall:
+      authentication: none
+      fixedArguments: false
+      catalogReceipt: false
+    executable: /usr/local/bin/vllm
+    arguments:
+      - name: --max-model-len
+        value: 32768
+      - name: --gpu-memory-utilization
+        value: 0.7
+      - name: --max-num-seqs
+        value: 4
+      - name: --reasoning-parser
+        value: deepseek_r1
+      - name: --enable-auto-tool-choice
+      - name: --tool-call-parser
+        value: hermes
+
+  readiness:
+    timeoutSeconds: 1800
+    expectedModel: deepseek-ai/DeepSeek-R1-Distill-Llama-70B

--- a/managed-inference/recipes/vllm.deepseek-r1-distill-llama-70b.optimized-arm64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.deepseek-r1-distill-llama-70b.optimized-arm64-single.v1.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingRecipe
+
+metadata:
+  id: vllm.deepseek-r1-distill-llama-70b.optimized-arm64-single.v1
+  displayName: DeepSeek-R1 Distill Llama 70B with vLLM on optimized arm64 hardware
+
+spec:
+  backend: vllm
+
+  modelRef: vllm.deepseek-r1-distill-llama-70b.v1
+  runtime:
+    image: nvcr.io/nvidia/vllm@sha256:9204569b17ee4c0eff75194b8e6e458479c8aee18953b5ab9cf359fcdac659e2
+    imageDownloadSizeBytes: 9603085145
+    imageUnpackedSizeBytes: 27658526720
+    minimumComputeCapability: 0
+    minimumGpuMemoryBytes: 141000000000
+    pullTimeoutSeconds: 43200
+    architecture: arm64
+    networkMode: bridge
+    ipcMode: host
+    sharedMemoryBytes: 68719476736
+    gpuRequest: all
+    devices: []
+    ulimits:
+      memlock: -1
+      stackBytes: 67108864
+    modelCache:
+      source: huggingface-cache
+      target: /root/.cache/huggingface
+    temporaryFilesystems: []
+    environment: {}
+
+  execution:
+    materializerRef: vllm.host-local/v1
+    lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
+
+  serve:
+    authentication: bearer
+    directInstall:
+      authentication: none
+      fixedArguments: false
+      catalogReceipt: false
+    executable: /usr/local/bin/vllm
+    arguments:
+      - name: --max-model-len
+        value: 32768
+      - name: --gpu-memory-utilization
+        value: 0.7
+      - name: --max-num-seqs
+        value: 4
+      - name: --reasoning-parser
+        value: deepseek_r1
+      - name: --enable-auto-tool-choice
+      - name: --tool-call-parser
+        value: hermes
+
+  readiness:
+    timeoutSeconds: 1800
+    expectedModel: deepseek-ai/DeepSeek-R1-Distill-Llama-70B

--- a/managed-inference/recipes/vllm.deepseek-v4-flash-0731.spark-dual.v1.yaml
+++ b/managed-inference/recipes/vllm.deepseek-v4-flash-0731.spark-dual.v1.yaml
@@ -18,37 +18,12 @@ spec:
       schemaVersion: 1
       outputSchema: nemoclaw.nvidia.com/managed-cluster-topology/v1
 
-  model:
-    id: deepseek-ai/DeepSeek-V4-Flash-0731
-    revision: 9e165c30e2704aec5d9d593cce3eebd58bbef1cb
-    servedName: deepseek-v4-flash-0731
-    downloadSizeBytes: 166898661074
-    gated: false
-    installFastSafetensors: false
-    preparation:
-      ref: snapshot-copy-and-exact-text-replacement/v1
-      snapshotCopy:
-        sourcePath: encoding/encoding_dsv4.py
-        digest: sha256:abc0d26120250dda0ae077dc64aa28836026e61e970854aaeb792445e6a0dde6
-        targetPath: /usr/local/lib/python3.12/dist-packages/vllm/tokenizers/deepseek_v4_encoding.py
-      exactTextReplacement:
-        targetPath: /usr/local/lib/python3.12/dist-packages/vllm/tokenizers/deepseek_v4.py
-        expectedText: |-
-          elif reasoning_effort in ("max", "xhigh"):
-                          reasoning_effort = "max"
-                      else:
-                          reasoning_effort = "high"
-        replacementText: |-
-          elif reasoning_effort in ("max", "xhigh"):
-                          reasoning_effort = "max"
-                      elif reasoning_effort == "high":
-                          reasoning_effort = "high"
-                      else:
-                          reasoning_effort = "low"
-
+  modelRef: vllm.deepseek-v4-flash-0731.v1
   runtime:
     image: ghcr.io/anemll/dspark-vllm-gx10@sha256:a83948492cf13df455170fb42885f5ef4db54fefe0feff0f841ecbff464ac9d8
     imageDownloadSizeBytes: 9787537825
+    minimumComputeCapability: 121
+    minimumGpuMemoryBytes: 83449330537
     architecture: arm64
     networkMode: host
     ipcMode: host

--- a/managed-inference/recipes/vllm.deepseek-v4-flash.station-arm64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.deepseek-v4-flash.station-arm64-single.v1.yaml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingRecipe
+
+metadata:
+  id: vllm.deepseek-v4-flash.station-arm64-single.v1
+  displayName: DeepSeek V4 Flash with vLLM on DGX Station
+
+spec:
+  backend: vllm
+
+  modelRef: vllm.deepseek-v4-flash.v1
+  runtime:
+    image: nvcr.io/nvidia/vllm@sha256:9204569b17ee4c0eff75194b8e6e458479c8aee18953b5ab9cf359fcdac659e2
+    imageDownloadSizeBytes: 9603085145
+    imageUnpackedSizeBytes: 27658526720
+    minimumComputeCapability: 100
+    minimumGpuMemoryBytes: 352381000000
+    pullTimeoutSeconds: 43200
+    architecture: arm64
+    networkMode: bridge
+    ipcMode: host
+    sharedMemoryBytes: 68719476736
+    gpuRequest: all
+    devices: []
+    ulimits:
+      memlock: -1
+      stackBytes: 67108864
+    modelCache:
+      source: huggingface-cache
+      target: /root/.cache/huggingface
+    temporaryFilesystems: []
+    environment: {}
+
+  execution:
+    materializerRef: vllm.host-local/v1
+    lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
+
+  serve:
+    authentication: bearer
+    directInstall:
+      authentication: none
+      fixedArguments: false
+      catalogReceipt: false
+    executable: /usr/local/bin/vllm
+    arguments:
+      - name: --max-model-len
+        value: 1048576
+      - name: --kv-cache-dtype
+        value: fp8
+      - name: --block-size
+        value: 256
+      - name: --enable-prefix-caching
+      - name: --gpu-memory-utilization
+        value: 0.92
+      - name: --compilation-config
+        value: '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}'
+      - name: --attention_config.use_fp4_indexer_cache
+        value: "True"
+      - name: --tokenizer-mode
+        value: deepseek_v4
+      - name: --tool-call-parser
+        value: deepseek_v4
+      - name: --enable-auto-tool-choice
+      - name: --reasoning-parser
+        value: deepseek_v4
+      - name: --no-disable-hybrid-kv-cache-manager
+      - name: --disable-uvicorn-access-log
+      - name: --max-cudagraph-capture-size
+        value: 128
+      - name: --speculative-config
+        value: '{"method":"mtp","num_speculative_tokens":3}'
+      - name: --max-num-batched-tokens
+        value: 8192
+      - name: --max-num-seqs
+        value: 16
+      - name: --prefix-cache-retention-interval
+        value: auto
+
+  readiness:
+    timeoutSeconds: 1800
+    expectedModel: deepseek-ai/DeepSeek-V4-Flash

--- a/managed-inference/recipes/vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1.yaml
+++ b/managed-inference/recipes/vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1.yaml
@@ -11,19 +11,12 @@ metadata:
 spec:
   backend: vllm
 
-  model:
-    id: Inferact/Muse-Glimmer-30B-NVFP4-W4A4
-    revision: d35cb79050f419c457611b1cee5c5d15b176f285
-    servedName: muse-glimmer
-    downloadSizeBytes: 25447097878
-    gated: false
-    installFastSafetensors: false
-    preparation:
-      ref: none/v1
-
+  modelRef: vllm.muse-glimmer-30b-nvfp4-w4a4.v1
   runtime:
     image: vllm/vllm-openai@sha256:677afd5bf3b4bb9881f91e107af7098f8410726b4c05b25cb4a815900b398204
     imageDownloadSizeBytes: 9699710136
+    minimumComputeCapability: 121
+    minimumGpuMemoryBytes: 25447097878
     pullTimeoutSeconds: 3600
     architecture: arm64
     networkMode: bridge
@@ -43,9 +36,14 @@ spec:
   execution:
     materializerRef: vllm.host-local/v1
     lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
 
   serve:
     authentication: bearer
+    directInstall:
+      authentication: bearer
+      fixedArguments: true
+      catalogReceipt: true
     executable: /usr/local/bin/vllm
     arguments:
       - name: --max-model-len

--- a/managed-inference/recipes/vllm.nemotron-3-nano-4b-fp8.linux-amd64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.nemotron-3-nano-4b-fp8.linux-amd64-single.v1.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingRecipe
+
+metadata:
+  id: vllm.nemotron-3-nano-4b-fp8.linux-amd64-single.v1
+  displayName: NVIDIA Nemotron-3 Nano 4B FP8 with vLLM on Linux amd64
+
+spec:
+  backend: vllm
+
+  modelRef: vllm.nemotron-3-nano-4b-fp8.v1
+  runtime:
+    image: nvcr.io/nvidia/vllm@sha256:7be6c2f676c36059a494fe17254e69ae5c677535ba6191044e5fc8e42a91c773
+    imageDownloadSizeBytes: 8928665752
+    minimumComputeCapability: 89
+    minimumGpuMemoryBytes: 5280000000
+    pullTimeoutSeconds: 43200
+    architecture: amd64
+    networkMode: bridge
+    ipcMode: host
+    sharedMemoryBytes: 68719476736
+    gpuRequest: all
+    devices: []
+    ulimits:
+      memlock: -1
+      stackBytes: 67108864
+    modelCache:
+      source: huggingface-cache
+      target: /root/.cache/huggingface
+    temporaryFilesystems: []
+    environment: {}
+
+  execution:
+    materializerRef: vllm.host-local/v1
+    lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
+
+  serve:
+    authentication: bearer
+    directInstall:
+      authentication: none
+      fixedArguments: false
+      catalogReceipt: false
+    executable: /usr/local/bin/vllm
+    arguments:
+      - name: --max-model-len
+        value: 262144
+      - name: --gpu-memory-utilization
+        value: 0.7
+      - name: --reasoning-parser
+        value: nemotron_v3
+      - name: --load-format
+        value: fastsafetensors
+      - name: --enable-auto-tool-choice
+      - name: --tool-call-parser
+        value: qwen3_coder
+
+  readiness:
+    timeoutSeconds: 1800
+    expectedModel: nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8

--- a/managed-inference/recipes/vllm.nemotron-3-nano-4b-fp8.linux-arm64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.nemotron-3-nano-4b-fp8.linux-arm64-single.v1.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingRecipe
+
+metadata:
+  id: vllm.nemotron-3-nano-4b-fp8.linux-arm64-single.v1
+  displayName: NVIDIA Nemotron-3 Nano 4B FP8 with vLLM on Linux arm64
+
+spec:
+  backend: vllm
+
+  modelRef: vllm.nemotron-3-nano-4b-fp8.v1
+  runtime:
+    image: nvcr.io/nvidia/vllm@sha256:447995cbb57e6c7cf792cab95e9852e5f62b5fb6d2f39e030fa4eda9a54eadb4
+    imageDownloadSizeBytes: 9278081698
+    minimumComputeCapability: 89
+    minimumGpuMemoryBytes: 5280000000
+    pullTimeoutSeconds: 43200
+    architecture: arm64
+    networkMode: bridge
+    ipcMode: host
+    sharedMemoryBytes: 68719476736
+    gpuRequest: all
+    devices: []
+    ulimits:
+      memlock: -1
+      stackBytes: 67108864
+    modelCache:
+      source: huggingface-cache
+      target: /root/.cache/huggingface
+    temporaryFilesystems: []
+    environment: {}
+
+  execution:
+    materializerRef: vllm.host-local/v1
+    lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
+
+  serve:
+    authentication: bearer
+    directInstall:
+      authentication: none
+      fixedArguments: false
+      catalogReceipt: false
+    executable: /usr/local/bin/vllm
+    arguments:
+      - name: --max-model-len
+        value: 262144
+      - name: --gpu-memory-utilization
+        value: 0.7
+      - name: --reasoning-parser
+        value: nemotron_v3
+      - name: --load-format
+        value: fastsafetensors
+      - name: --enable-auto-tool-choice
+      - name: --tool-call-parser
+        value: qwen3_coder
+
+  readiness:
+    timeoutSeconds: 1800
+    expectedModel: nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8

--- a/managed-inference/recipes/vllm.nemotron-3-nano-4b-fp8.optimized-arm64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.nemotron-3-nano-4b-fp8.optimized-arm64-single.v1.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingRecipe
+
+metadata:
+  id: vllm.nemotron-3-nano-4b-fp8.optimized-arm64-single.v1
+  displayName: NVIDIA Nemotron-3 Nano 4B FP8 with vLLM on optimized arm64 hardware
+
+spec:
+  backend: vllm
+
+  modelRef: vllm.nemotron-3-nano-4b-fp8.v1
+  runtime:
+    image: nvcr.io/nvidia/vllm@sha256:9204569b17ee4c0eff75194b8e6e458479c8aee18953b5ab9cf359fcdac659e2
+    imageDownloadSizeBytes: 9603085145
+    imageUnpackedSizeBytes: 27658526720
+    minimumComputeCapability: 89
+    minimumGpuMemoryBytes: 5280000000
+    pullTimeoutSeconds: 43200
+    architecture: arm64
+    networkMode: bridge
+    ipcMode: host
+    sharedMemoryBytes: 68719476736
+    gpuRequest: all
+    devices: []
+    ulimits:
+      memlock: -1
+      stackBytes: 67108864
+    modelCache:
+      source: huggingface-cache
+      target: /root/.cache/huggingface
+    temporaryFilesystems: []
+    environment: {}
+
+  execution:
+    materializerRef: vllm.host-local/v1
+    lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
+
+  serve:
+    authentication: bearer
+    directInstall:
+      # Preserve the legacy interactive appliance install surface; fixed managed
+      # profiles opt into bearer auth through an allowlisted install policy.
+      authentication: none
+      fixedArguments: false
+      catalogReceipt: false
+    executable: /usr/local/bin/vllm
+    arguments:
+      - name: --max-model-len
+        value: 262144
+      - name: --gpu-memory-utilization
+        value: 0.7
+      - name: --reasoning-parser
+        value: nemotron_v3
+      - name: --load-format
+        value: fastsafetensors
+      - name: --enable-auto-tool-choice
+      - name: --tool-call-parser
+        value: qwen3_coder
+
+  readiness:
+    timeoutSeconds: 1800
+    expectedModel: nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8

--- a/managed-inference/recipes/vllm.nemotron-3-ultra-550b-a55b-nvfp4.station-arm64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.nemotron-3-ultra-550b-a55b-nvfp4.station-arm64-single.v1.yaml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingRecipe
+
+metadata:
+  id: vllm.nemotron-3-ultra-550b-a55b-nvfp4.station-arm64-single.v1
+  displayName: NVIDIA Nemotron 3 Ultra 550B NVFP4 with vLLM on DGX Station
+
+spec:
+  backend: vllm
+
+  modelRef: vllm.nemotron-3-ultra-550b-a55b-nvfp4.v1
+  runtime:
+    image: vllm/vllm-openai@sha256:0fec7ec5f3e6bc168e54899935fb0557da908a4832a1dbc88e2debcf2f889416
+    imageDownloadSizeBytes: 10670087425
+    minimumComputeCapability: 100
+    minimumGpuMemoryBytes: 352381245521
+    pullTimeoutSeconds: 43200
+    architecture: arm64
+    networkMode: bridge
+    ipcMode: host
+    sharedMemoryBytes: 17179869184
+    gpuRequest: all
+    devices: []
+    ulimits:
+      memlock: -1
+      stackBytes: 67108864
+    modelCache:
+      source: huggingface-cache
+      target: /root/.cache/huggingface
+    temporaryFilesystems: []
+    environment:
+      VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: "1"
+      VLLM_NVFP4_GEMM_BACKEND: flashinfer-trtllm
+
+  execution:
+    materializerRef: vllm.host-local/v1
+    lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.station-pair-optional/v1
+    stationPair:
+      image: vllm/vllm-openai@sha256:2cc49b81319f7a66a33dd8bd63a7bfddae079122b33ce51989b6828a1f038c37
+      imageDownloadSizeBytes: 10238912364
+      servedName: nemotron-ultra
+      nodeCount: 2
+      tensorParallelSize: 1
+      pipelineParallelSize: 2
+      loadTimeoutSeconds: 7200
+
+  serve:
+    authentication: bearer
+    directInstall:
+      # Preserve the legacy interactive Station install surface; fixed managed
+      # profiles opt into bearer auth through an allowlisted install policy.
+      authentication: none
+      fixedArguments: false
+      catalogReceipt: false
+    executable: /usr/local/bin/vllm
+    arguments:
+      - name: --max-model-len
+        value: 262144
+      - name: --cpu-offload-gb
+        value: 150
+      - name: --cpu-offload-params
+        value: experts
+      - name: --kernel-config
+        value: '{"enable_flashinfer_autotune":false}'
+      - name: --speculative-config
+        value: '{"method":"nemotron_h_mtp","num_speculative_tokens":3}'
+      - name: --max-num-seqs
+        value: 256
+      - name: --gpu-memory-utilization
+        value: 0.9
+      - name: --reasoning-parser
+        value: nemotron_v3
+      - name: --enable-auto-tool-choice
+      - name: --tool-call-parser
+        value: qwen3_coder
+      - name: --default-chat-template-kwargs
+        value: '{"enable_thinking":true,"force_nonempty_content":true}'
+
+  readiness:
+    timeoutSeconds: 3600
+    expectedModel: nvidia/nemotron-3-ultra-550b-a55b

--- a/managed-inference/recipes/vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.spark-single.v1.yaml
+++ b/managed-inference/recipes/vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.spark-single.v1.yaml
@@ -11,19 +11,12 @@ metadata:
 spec:
   backend: vllm
 
-  model:
-    id: nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
-    revision: 0dcd680e5585c791728c83342b311d0a0026dbeb
-    servedName: nvidia-nemotron-3.5-lightning-30b-a3b-nvfp4
-    downloadSizeBytes: 21561882284
-    gated: false
-    installFastSafetensors: false
-    preparation:
-      ref: none/v1
-
+  modelRef: vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.v1
   runtime:
     image: vllm/vllm-openai@sha256:3af90144a0926e5c5fe46ee16e5201e763dd854538b9d7ce433755f11dadaf78
     imageDownloadSizeBytes: 12691539532
+    minimumComputeCapability: 121
+    minimumGpuMemoryBytes: 21561882284
     pullTimeoutSeconds: 3600
     architecture: arm64
     networkMode: bridge
@@ -46,9 +39,14 @@ spec:
   execution:
     materializerRef: vllm.host-local/v1
     lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
 
   serve:
     authentication: bearer
+    directInstall:
+      authentication: bearer
+      fixedArguments: true
+      catalogReceipt: true
     executable: /usr/local/bin/vllm
     arguments:
       - name: --max-model-len

--- a/managed-inference/recipes/vllm.qwen3-6-27b-fp8.linux-amd64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.qwen3-6-27b-fp8.linux-amd64-single.v1.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingRecipe
+
+metadata:
+  id: vllm.qwen3-6-27b-fp8.linux-amd64-single.v1
+  displayName: Qwen3.6 27B FP8 with vLLM on Linux amd64
+
+spec:
+  backend: vllm
+
+  modelRef: vllm.qwen3-6-27b-fp8.v1
+  runtime:
+    image: nvcr.io/nvidia/vllm@sha256:7be6c2f676c36059a494fe17254e69ae5c677535ba6191044e5fc8e42a91c773
+    imageDownloadSizeBytes: 8928665752
+    minimumComputeCapability: 89
+    minimumGpuMemoryBytes: 30900000000
+    pullTimeoutSeconds: 43200
+    architecture: amd64
+    networkMode: bridge
+    ipcMode: host
+    sharedMemoryBytes: 68719476736
+    gpuRequest: all
+    devices: []
+    ulimits:
+      memlock: -1
+      stackBytes: 67108864
+    modelCache:
+      source: huggingface-cache
+      target: /root/.cache/huggingface
+    temporaryFilesystems: []
+    environment: {}
+
+  execution:
+    materializerRef: vllm.host-local/v1
+    lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
+
+  serve:
+    authentication: bearer
+    directInstall:
+      authentication: none
+      fixedArguments: false
+      catalogReceipt: false
+    executable: /usr/local/bin/vllm
+    arguments:
+      - name: --max-model-len
+        value: 262144
+      - name: --gpu-memory-utilization
+        value: 0.7
+      - name: --max-num-seqs
+        value: 4
+      - name: --reasoning-parser
+        value: qwen3
+      - name: --enable-auto-tool-choice
+      - name: --tool-call-parser
+        value: qwen3_coder
+      - name: --load-format
+        value: fastsafetensors
+      - name: --enable-prefix-caching
+
+  readiness:
+    timeoutSeconds: 1800
+    expectedModel: Qwen/Qwen3.6-27B-FP8

--- a/managed-inference/recipes/vllm.qwen3-6-27b-fp8.linux-arm64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.qwen3-6-27b-fp8.linux-arm64-single.v1.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingRecipe
+
+metadata:
+  id: vllm.qwen3-6-27b-fp8.linux-arm64-single.v1
+  displayName: Qwen3.6 27B FP8 with vLLM on Linux arm64
+
+spec:
+  backend: vllm
+
+  modelRef: vllm.qwen3-6-27b-fp8.v1
+  runtime:
+    image: nvcr.io/nvidia/vllm@sha256:447995cbb57e6c7cf792cab95e9852e5f62b5fb6d2f39e030fa4eda9a54eadb4
+    imageDownloadSizeBytes: 9278081698
+    minimumComputeCapability: 89
+    minimumGpuMemoryBytes: 30900000000
+    pullTimeoutSeconds: 43200
+    architecture: arm64
+    networkMode: bridge
+    ipcMode: host
+    sharedMemoryBytes: 68719476736
+    gpuRequest: all
+    devices: []
+    ulimits:
+      memlock: -1
+      stackBytes: 67108864
+    modelCache:
+      source: huggingface-cache
+      target: /root/.cache/huggingface
+    temporaryFilesystems: []
+    environment: {}
+
+  execution:
+    materializerRef: vllm.host-local/v1
+    lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
+
+  serve:
+    authentication: bearer
+    directInstall:
+      authentication: none
+      fixedArguments: false
+      catalogReceipt: false
+    executable: /usr/local/bin/vllm
+    arguments:
+      - name: --max-model-len
+        value: 262144
+      - name: --gpu-memory-utilization
+        value: 0.7
+      - name: --max-num-seqs
+        value: 4
+      - name: --reasoning-parser
+        value: qwen3
+      - name: --enable-auto-tool-choice
+      - name: --tool-call-parser
+        value: qwen3_coder
+      - name: --load-format
+        value: fastsafetensors
+      - name: --enable-prefix-caching
+
+  readiness:
+    timeoutSeconds: 1800
+    expectedModel: Qwen/Qwen3.6-27B-FP8

--- a/managed-inference/recipes/vllm.qwen3-6-27b-fp8.optimized-arm64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.qwen3-6-27b-fp8.optimized-arm64-single.v1.yaml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingRecipe
+
+metadata:
+  id: vllm.qwen3-6-27b-fp8.optimized-arm64-single.v1
+  displayName: Qwen3.6 27B FP8 with vLLM on optimized arm64 hardware
+
+spec:
+  backend: vllm
+
+  modelRef: vllm.qwen3-6-27b-fp8.v1
+  runtime:
+    image: nvcr.io/nvidia/vllm@sha256:9204569b17ee4c0eff75194b8e6e458479c8aee18953b5ab9cf359fcdac659e2
+    imageDownloadSizeBytes: 9603085145
+    imageUnpackedSizeBytes: 27658526720
+    minimumComputeCapability: 89
+    minimumGpuMemoryBytes: 30900000000
+    pullTimeoutSeconds: 43200
+    architecture: arm64
+    networkMode: bridge
+    ipcMode: host
+    sharedMemoryBytes: 68719476736
+    gpuRequest: all
+    devices: []
+    ulimits:
+      memlock: -1
+      stackBytes: 67108864
+    modelCache:
+      source: huggingface-cache
+      target: /root/.cache/huggingface
+    temporaryFilesystems: []
+    environment: {}
+
+  execution:
+    materializerRef: vllm.host-local/v1
+    lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
+
+  serve:
+    authentication: bearer
+    directInstall:
+      authentication: none
+      fixedArguments: false
+      catalogReceipt: false
+    executable: /usr/local/bin/vllm
+    arguments:
+      - name: --max-model-len
+        value: 262144
+      - name: --gpu-memory-utilization
+        value: 0.7
+      - name: --max-num-seqs
+        value: 4
+      - name: --reasoning-parser
+        value: qwen3
+      - name: --enable-auto-tool-choice
+      - name: --tool-call-parser
+        value: qwen3_coder
+      - name: --load-format
+        value: fastsafetensors
+      - name: --enable-prefix-caching
+
+  readiness:
+    timeoutSeconds: 1800
+    expectedModel: Qwen/Qwen3.6-27B-FP8

--- a/managed-inference/recipes/vllm.qwen3-6-35b-a3b-nvfp4.spark-single.v1.yaml
+++ b/managed-inference/recipes/vllm.qwen3-6-35b-a3b-nvfp4.spark-single.v1.yaml
@@ -11,19 +11,13 @@ metadata:
 spec:
   backend: vllm
 
-  model:
-    id: nvidia/Qwen3.6-35B-A3B-NVFP4
-    revision: 491c2f1ea524c639598bf8fa787a93fed5a6fbce
-    servedName: nvidia/Qwen3.6-35B-A3B-NVFP4
-    downloadSizeBytes: 23500000000
-    gated: false
-    installFastSafetensors: false
-    preparation:
-      ref: none/v1
-
+  modelRef: vllm.qwen3-6-35b-a3b-nvfp4.v1
   runtime:
     image: nvcr.io/nvidia/vllm@sha256:9204569b17ee4c0eff75194b8e6e458479c8aee18953b5ab9cf359fcdac659e2
     imageDownloadSizeBytes: 9603085145
+    imageUnpackedSizeBytes: 27658526720
+    minimumComputeCapability: 121
+    minimumGpuMemoryBytes: 23500000000
     pullTimeoutSeconds: 43200
     architecture: arm64
     networkMode: bridge
@@ -43,9 +37,14 @@ spec:
   execution:
     materializerRef: vllm.host-local/v1
     lifecycleRef: vllm.host-local.lifecycle/v1
+    orchestrationRef: vllm.host-local.standard/v1
 
   serve:
     authentication: bearer
+    directInstall:
+      authentication: none
+      fixedArguments: false
+      catalogReceipt: false
     executable: /usr/local/bin/vllm
     arguments:
       - name: --max-model-len
@@ -74,6 +73,8 @@ spec:
         value: qwen3_coder
       - name: --reasoning-parser
         value: qwen3
+      - name: --load-format
+        value: fastsafetensors
 
   readiness:
     timeoutSeconds: 1800

--- a/managed-inference/schemas/catalog.schema.json
+++ b/managed-inference/schemas/catalog.schema.json
@@ -9,17 +9,22 @@
     "compilerVersion",
     "sourceRevision",
     "readinessSchemaRef",
+    "models",
     "recipes",
     "presets",
     "sources",
     "catalogDigest"
   ],
   "properties": {
-    "schemaVersion": { "const": "1.0.0" },
-    "compilerVersion": { "const": "1.2.0" },
+    "schemaVersion": { "const": "1.1.0" },
+    "compilerVersion": { "const": "1.4.0" },
     "sourceRevision": { "type": "string", "pattern": "^[0-9a-f]{40,64}$" },
     "readinessSchemaRef": {
       "const": "https://github.com/NVIDIA/NemoClaw/schemas/system-readiness.schema.json"
+    },
+    "models": {
+      "type": "array",
+      "items": { "$ref": "model.schema.json" }
     },
     "recipes": {
       "type": "array",
@@ -37,10 +42,10 @@
         "properties": {
           "path": {
             "type": "string",
-            "pattern": "^managed-inference/(?:recipes|presets)/.+\\.ya?ml$",
+            "pattern": "^managed-inference/(?:models|recipes|presets)/.+\\.ya?ml$",
             "maxLength": 512
           },
-          "kind": { "enum": ["ServingRecipe", "ServingPreset"] },
+          "kind": { "enum": ["ServingModel", "ServingRecipe", "ServingPreset"] },
           "id": { "type": "string", "minLength": 1, "maxLength": 160 },
           "digest": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
         },

--- a/managed-inference/schemas/model.schema.json
+++ b/managed-inference/schemas/model.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/NVIDIA/NemoClaw/managed-inference/schemas/model.schema.json",
+  "$comment": "SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\nSPDX-License-Identifier: Apache-2.0",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": { "const": "nemoclaw.nvidia.com/managed-inference/v1" },
+    "kind": { "const": "ServingModel" },
+    "metadata": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": { "$ref": "#/$defs/stableId" },
+        "displayName": { "type": "string", "minLength": 1, "maxLength": 128 }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "type": "object",
+      "required": ["id", "revision", "environmentValue", "displayName", "menuOrder", "servedName", "downloadSizeBytes", "gated", "installFastSafetensors", "preparation", "capabilities", "probePolicyRef"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$", "maxLength": 256 },
+        "revision": { "type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64}|sha256:[0-9a-f]{64})$" },
+        "environmentValue": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$" },
+        "displayName": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "menuOrder": { "type": "integer", "minimum": 0, "maximum": 1000000 },
+        "servedName": { "$ref": "#/$defs/stableId" },
+        "downloadSizeBytes": { "$ref": "#/$defs/positiveSafeInteger" },
+        "gated": { "type": "boolean" },
+        "installFastSafetensors": { "type": "boolean" },
+        "preparation": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["ref"],
+              "properties": { "ref": { "const": "none/v1" } },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": ["ref", "snapshotCopy", "exactTextReplacement"],
+              "properties": {
+                "ref": { "const": "snapshot-copy-and-exact-text-replacement/v1" },
+                "snapshotCopy": {
+                  "type": "object",
+                  "required": ["sourcePath", "digest", "targetPath"],
+                  "properties": {
+                    "sourcePath": { "$ref": "#/$defs/relativePath" },
+                    "digest": { "$ref": "#/$defs/sha256" },
+                    "targetPath": { "$ref": "#/$defs/absolutePath" }
+                  },
+                  "additionalProperties": false
+                },
+                "exactTextReplacement": {
+                  "type": "object",
+                  "required": ["targetPath", "expectedText", "replacementText"],
+                  "properties": {
+                    "targetPath": { "$ref": "#/$defs/absolutePath" },
+                    "expectedText": { "type": "string", "minLength": 1, "maxLength": 16384 },
+                    "replacementText": { "type": "string", "minLength": 1, "maxLength": 16384 }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "capabilities": {
+          "type": "object",
+          "required": ["chatCompletions", "streaming", "toolCalls", "structuredOutputs", "reasoning", "multimodal"],
+          "properties": {
+            "chatCompletions": { "type": "boolean" },
+            "streaming": { "type": "boolean" },
+            "toolCalls": { "type": "boolean" },
+            "structuredOutputs": { "type": "boolean" },
+            "reasoning": { "type": "boolean" },
+            "multimodal": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        },
+        "probePolicyRef": { "$ref": "#/$defs/stableId" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "stableId": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9._/-]{0,159}$" },
+    "positiveSafeInteger": { "type": "integer", "minimum": 1, "maximum": 9007199254740991 },
+    "sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "relativePath": { "type": "string", "minLength": 1, "maxLength": 512, "pattern": "^(?!/)(?!\\.{1,2}(?:/|$))(?!.*(?:^|/)\\.{1,2}(?:/|$))[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$" },
+    "absolutePath": { "type": "string", "minLength": 2, "maxLength": 512, "pattern": "^/(?!.*(?:^|/)\\.{1,2}(?:/|$))[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$" }
+  }
+}

--- a/managed-inference/schemas/preset.schema.json
+++ b/managed-inference/schemas/preset.schema.json
@@ -3,12 +3,7 @@
   "$id": "https://github.com/NVIDIA/NemoClaw/managed-inference/schemas/preset.schema.json",
   "$comment": "SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\nSPDX-License-Identifier: Apache-2.0",
   "type": "object",
-  "required": [
-    "apiVersion",
-    "kind",
-    "metadata",
-    "spec"
-  ],
+  "required": ["apiVersion", "kind", "metadata", "spec"],
   "properties": {
     "apiVersion": {
       "const": "nemoclaw.nvidia.com/managed-inference/v1"
@@ -21,18 +16,10 @@
     },
     "spec": {
       "type": "object",
-      "required": [
-        "selection",
-        "priority",
-        "plan"
-      ],
+      "required": ["selection", "priority", "plan"],
       "properties": {
         "selection": {
-          "enum": [
-            "automatic",
-            "explicit-only",
-            "disabled"
-          ]
+          "enum": ["automatic", "explicit-only", "disabled"]
         },
         "priority": {
           "type": "integer",
@@ -44,9 +31,7 @@
         },
         "requirements": {
           "type": "object",
-          "required": [
-            "all"
-          ],
+          "required": ["all"],
           "properties": {
             "all": {
               "type": "array",
@@ -77,16 +62,22 @@
         },
         "plan": {
           "type": "object",
-          "required": [
-            "backend",
-            "recipeRef"
-          ],
+          "required": ["backend", "recipeRef"],
           "properties": {
             "backend": {
               "$ref": "#/$defs/token"
             },
             "recipeRef": {
               "$ref": "#/$defs/stableId"
+            },
+            "installPolicyRef": {
+              "$ref": "#/$defs/stableId"
+            },
+            "platform": {
+              "enum": ["spark", "station", "n1x", "linux"]
+            },
+            "interactive": {
+              "type": "boolean"
             },
             "bindings": {
               "type": "object",
@@ -110,9 +101,7 @@
   "$defs": {
     "metadata": {
       "type": "object",
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "properties": {
         "id": {
           "$ref": "#/$defs/stableId"
@@ -123,11 +112,16 @@
           "maxLength": 128
         },
         "supportState": {
-          "enum": [
-            "supported",
-            "experimental",
-            "disabled"
-          ]
+          "enum": ["supported", "experimental", "disabled"]
+        },
+        "validation": {
+          "type": "object",
+          "required": ["level", "evidence"],
+          "properties": {
+            "level": { "enum": ["schema", "software", "hardware"] },
+            "evidence": { "$ref": "#/$defs/stableId" }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -145,11 +139,7 @@
       "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
     },
     "scope": {
-      "enum": [
-        "controller",
-        "everyNode",
-        "anyNode"
-      ]
+      "enum": ["controller", "everyNode", "anyNode"]
     },
     "state": {
       "type": "string",
@@ -157,18 +147,11 @@
     },
     "readinessQualificationRequirement": {
       "type": "object",
-      "required": [
-        "readiness"
-      ],
+      "required": ["readiness"],
       "properties": {
         "readiness": {
           "type": "object",
-          "required": [
-            "scope",
-            "kind",
-            "id",
-            "status"
-          ],
+          "required": ["scope", "kind", "id", "status"],
           "properties": {
             "scope": {
               "$ref": "#/$defs/scope"
@@ -190,27 +173,17 @@
     },
     "readinessStateRequirement": {
       "type": "object",
-      "required": [
-        "readiness"
-      ],
+      "required": ["readiness"],
       "properties": {
         "readiness": {
           "type": "object",
-          "required": [
-            "scope",
-            "kind",
-            "id",
-            "state"
-          ],
+          "required": ["scope", "kind", "id", "state"],
           "properties": {
             "scope": {
               "$ref": "#/$defs/scope"
             },
             "kind": {
-              "enum": [
-                "observation",
-                "capability"
-              ]
+              "enum": ["observation", "capability"]
             },
             "id": {
               "$ref": "#/$defs/stableId"
@@ -226,30 +199,16 @@
     },
     "factRequirement": {
       "type": "object",
-      "required": [
-        "fact",
-        "state",
-        "operator",
-        "value"
-      ],
+      "required": ["fact", "state", "operator", "value"],
       "properties": {
         "fact": {
           "$ref": "#/$defs/stableId"
         },
         "state": {
-          "enum": [
-            "present",
-            "absent"
-          ]
+          "enum": ["present", "absent"]
         },
         "operator": {
-          "enum": [
-            "equals",
-            "oneOf",
-            "atLeast",
-            "atMost",
-            "between"
-          ]
+          "enum": ["equals", "oneOf", "atLeast", "atMost", "between"]
         },
         "value": {
           "oneOf": [
@@ -291,17 +250,11 @@
     },
     "topologyRequirement": {
       "type": "object",
-      "required": [
-        "topologyQualification"
-      ],
+      "required": ["topologyQualification"],
       "properties": {
         "topologyQualification": {
           "type": "object",
-          "required": [
-            "id",
-            "schemaVersion",
-            "status"
-          ],
+          "required": ["id", "schemaVersion", "status"],
           "properties": {
             "id": {
               "$ref": "#/$defs/stableId"
@@ -321,17 +274,11 @@
     },
     "presetTopologyBinding": {
       "type": "object",
-      "required": [
-        "valueFromTopologyQualification"
-      ],
+      "required": ["valueFromTopologyQualification"],
       "properties": {
         "valueFromTopologyQualification": {
           "type": "object",
-          "required": [
-            "id",
-            "schemaVersion",
-            "output"
-          ],
+          "required": ["id", "schemaVersion", "output"],
           "properties": {
             "id": {
               "$ref": "#/$defs/stableId"
@@ -376,24 +323,14 @@
     },
     "readinessComparisonRequirement": {
       "type": "object",
-      "required": [
-        "readiness"
-      ],
+      "required": ["readiness"],
       "properties": {
         "readiness": {
           "type": "object",
-          "required": [
-            "scope",
-            "kind",
-            "id",
-            "comparison"
-          ],
+          "required": ["scope", "kind", "id", "comparison"],
           "properties": {
             "scope": {
-              "enum": [
-                "controller",
-                "everyNode"
-              ]
+              "enum": ["controller", "everyNode"]
             },
             "kind": {
               "const": "observation"
@@ -405,10 +342,7 @@
               "oneOf": [
                 {
                   "type": "object",
-                  "required": [
-                    "operator",
-                    "value"
-                  ],
+                  "required": ["operator", "value"],
                   "properties": {
                     "operator": {
                       "const": "equals"
@@ -421,10 +355,7 @@
                 },
                 {
                   "type": "object",
-                  "required": [
-                    "operator",
-                    "values"
-                  ],
+                  "required": ["operator", "values"],
                   "properties": {
                     "operator": {
                       "const": "one-of"
@@ -443,10 +374,7 @@
                 },
                 {
                   "type": "object",
-                  "required": [
-                    "operator",
-                    "value"
-                  ],
+                  "required": ["operator", "value"],
                   "properties": {
                     "operator": {
                       "const": "at-least"
@@ -461,10 +389,7 @@
                 },
                 {
                   "type": "object",
-                  "required": [
-                    "operator",
-                    "value"
-                  ],
+                  "required": ["operator", "value"],
                   "properties": {
                     "operator": {
                       "const": "version-at-least"

--- a/managed-inference/schemas/recipe.schema.json
+++ b/managed-inference/schemas/recipe.schema.json
@@ -23,8 +23,11 @@
       "type": "object",
       "required": [
         "backend",
-        "model",
         "execution"
+      ],
+      "anyOf": [
+        { "required": ["model"], "properties": { "model": {} } },
+        { "required": ["modelRef"], "properties": { "modelRef": {} } }
       ],
       "properties": {
         "backend": {
@@ -57,6 +60,20 @@
               "type": "string",
               "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64}|sha256:[0-9a-f]{64})$"
             },
+            "environmentValue": {
+              "type": "string",
+              "pattern": "^[a-z0-9][a-z0-9._-]{0,127}$"
+            },
+            "displayName": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128
+            },
+            "menuOrder": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1000000
+            },
             "servedName": {
               "$ref": "#/$defs/stableId"
             },
@@ -71,6 +88,12 @@
             },
             "preparation": {
               "$ref": "#/$defs/modelPreparation"
+            },
+            "capabilities": {
+              "$ref": "https://github.com/NVIDIA/NemoClaw/managed-inference/schemas/model.schema.json#/properties/spec/properties/capabilities"
+            },
+            "probePolicyRef": {
+              "$ref": "#/$defs/adapterId"
             },
             "files": {
               "type": "array",
@@ -119,6 +142,9 @@
           },
           "additionalProperties": false
         },
+        "modelRef": {
+          "$ref": "#/$defs/stableId"
+        },
         "runtime": {
           "type": "object",
           "properties": {
@@ -127,6 +153,17 @@
               "pattern": "^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*(?::[0-9]+)?/)?(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*@sha256:[0-9a-f]{64}$"
             },
             "imageDownloadSizeBytes": {
+              "$ref": "#/$defs/positiveSafeInteger"
+            },
+            "imageUnpackedSizeBytes": {
+              "$ref": "#/$defs/positiveSafeInteger"
+            },
+            "minimumComputeCapability": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 999
+            },
+            "minimumGpuMemoryBytes": {
               "$ref": "#/$defs/positiveSafeInteger"
             },
             "pullTimeoutSeconds": {
@@ -353,6 +390,23 @@
             "lifecycleRef": {
               "$ref": "#/$defs/adapterId"
             },
+            "orchestrationRef": {
+              "$ref": "#/$defs/adapterId"
+            },
+            "stationPair": {
+              "type": "object",
+              "required": ["image", "imageDownloadSizeBytes", "servedName", "nodeCount", "tensorParallelSize", "pipelineParallelSize", "loadTimeoutSeconds"],
+              "properties": {
+                "image": { "$ref": "#/$defs/imageDigest" },
+                "imageDownloadSizeBytes": { "$ref": "#/$defs/positiveSafeInteger" },
+                "servedName": { "$ref": "#/$defs/stableId" },
+                "nodeCount": { "const": 2 },
+                "tensorParallelSize": { "type": "integer", "minimum": 1, "maximum": 1024 },
+                "pipelineParallelSize": { "type": "integer", "minimum": 1, "maximum": 1024 },
+                "loadTimeoutSeconds": { "type": "integer", "minimum": 1, "maximum": 86400 }
+              },
+              "additionalProperties": false
+            },
             "topologyBinding": {
               "$ref": "#/$defs/bindingName"
             },
@@ -391,6 +445,29 @@
             "authentication": {
               "$ref": "#/$defs/token"
             },
+            "directInstall": {
+              "type": "object",
+              "required": [
+                "authentication",
+                "fixedArguments",
+                "catalogReceipt"
+              ],
+              "properties": {
+                "authentication": {
+                  "enum": [
+                    "none",
+                    "bearer"
+                  ]
+                },
+                "fixedArguments": {
+                  "type": "boolean"
+                },
+                "catalogReceipt": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
             "executable": {
               "$ref": "#/$defs/absolutePath"
             },
@@ -405,7 +482,7 @@
                 "properties": {
                   "name": {
                     "type": "string",
-                    "pattern": "^--[a-z0-9][a-z0-9-]*$",
+                    "pattern": "^--[a-z0-9][a-z0-9._-]*$",
                     "maxLength": 128
                   },
                   "value": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:watch": "npm run catalog:compile && vitest watch --project cli --project plugin --project e2e-support",
     "test:shuffle": "npm run catalog:compile && vitest run --project cli --project plugin --project e2e-support --sequence.shuffle.tests --coverage=false",
     "test:diagnose:leaks": "npm run catalog:compile && vitest run --project cli --project plugin --project e2e-support --detectAsyncLeaks --coverage=false --reporter=default --reporter=hanging-process",
-    "test:e2e-phases:check": "npm run build:policy-boundary && node --experimental-strip-types --no-warnings tools/e2e/check-semantic-phases.mts",
+    "test:e2e-phases:check": "npm run catalog:compile && npm run build:policy-boundary && node --experimental-strip-types --no-warnings tools/e2e/check-semantic-phases.mts",
     "test:runtime-audit": "tsx scripts/audit-test-runtime.mts",
     "test:integration": "npm run clean:cli && npm run build:cli && vitest run --project integration --project installer-integration",
     "test:package": "npm run clean:cli && npm --prefix nemoclaw run clean && npm run build:cli && npm --prefix nemoclaw run build && vitest run --project package-contract",

--- a/scripts/checks/export-llama-cpp-image-config.mts
+++ b/scripts/checks/export-llama-cpp-image-config.mts
@@ -168,6 +168,7 @@ const recipePath = path.join(
   "recipes",
   "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1.yaml",
 );
+const modelSchemaPath = path.join(repoRoot, "managed-inference", "schemas", "model.schema.json");
 const recipeSchemaPath = path.join(repoRoot, "managed-inference", "schemas", "recipe.schema.json");
 
 const nvidiaCudaDigestReference = /^docker\.io\/nvidia\/cuda@sha256:[0-9a-f]{64}$/u;
@@ -243,7 +244,9 @@ function parseQualificationRecipe(
   }
   const value = document.toJS({ maxAliasCount: 0 }) as unknown;
   const schema = JSON.parse(schemaSource) as object;
-  const validate = new Ajv2020({ allErrors: true, strict: true }).compile(schema);
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  ajv.addSchema(JSON.parse(fs.readFileSync(modelSchemaPath, "utf8")) as object);
+  const validate = ajv.compile(schema);
   if (!validate(value)) {
     const details = (validate.errors ?? [])
       .map((error) => `${error.instancePath || "/"} ${error.message ?? "is invalid"}`)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5292,7 +5292,7 @@ station_managed_dual_head_running() {
     "$running" == "true" &&
     "$managed" == "true" &&
     "$role" == "head" &&
-    "$schema" == "2" &&
+    "$schema" == "3" &&
     "$cluster" =~ ^[a-f0-9]{64}$ &&
     "$launch_contract" =~ ^[a-f0-9]{64}$ &&
     "$api_fingerprint" =~ ^[a-f0-9]{64}$ &&

--- a/src/lib/inference/nim.ts
+++ b/src/lib/inference/nim.ts
@@ -576,6 +576,9 @@ export function detectGpu(deps: DetectGpuDeps = {}): GpuDetection | null {
           nimCapable: canRunNimWithMemory(totalMemoryMB),
           platform,
           spark: platform === "spark",
+          ...(platform === "spark" || platform === "n1x" || platform === "jetson"
+            ? { unifiedMemory: true }
+            : {}),
           // The proof-passed ARM64 N1X GPU is memory-shared like Jetson and
           // cannot serve a computeIntensive model in-loop, so tag it
           // computeConstrained to exclude those Ollama bootstrap models (#3707).

--- a/src/lib/inference/onboard-probes.ts
+++ b/src/lib/inference/onboard-probes.ts
@@ -50,12 +50,14 @@ const { probeOpenAiLikeEndpointWithValidationSession } = require("./openai-valid
 const {
   getChatCompletionsProbePayload,
   getChatCompletionsToolProbePayload,
+  EXTENDED_NVIDIA_ENDPOINT_PROBE_POLICY,
   isDeepSeekV4ProModel,
   isKimiK26Model,
   isReasoningOnlyLengthResponse,
   STRICT_TOOL_PROBE_INITIAL_TOKENS,
   STRICT_TOOL_PROBE_RETRY_TOKEN_LADDER,
   strictToolProbeReasoningRetryMessage,
+  vllmProbePolicyForModel,
 } = require("./openai-probe-models");
 const {
   buildValidationProbeTimingProfile,
@@ -67,7 +69,6 @@ const {
   getCurlMaxTimeSeconds,
   getProbeProcessTimeoutMs,
 } = require("./probe-http-helpers");
-
 const {
   getCurlTimingArgs,
   runCurlProbe,
@@ -106,8 +107,6 @@ function openAiLikeFailureFromError(error) {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────
-
-const EXTENDED_NVIDIA_ENDPOINT_VALIDATION_MODELS = new Set(["deepseek-ai/deepseek-v4-flash"]);
 
 // Hostnames that are normally meant for the sandbox/container host boundary.
 // host.openshell.internal only resolves inside the OpenShell sandbox network,
@@ -507,7 +506,9 @@ function probeChatCompletionsToolCalling(endpointUrl, model, apiKey, options = {
 
 // ── OpenAI-like probe ────────────────────────────────────────────
 function needsExtendedNvidiaEndpointValidationBudget(model) {
-  return EXTENDED_NVIDIA_ENDPOINT_VALIDATION_MODELS.has(String(model || "").toLowerCase());
+  return (
+    vllmProbePolicyForModel(String(model || "")) === EXTENDED_NVIDIA_ENDPOINT_PROBE_POLICY
+  );
 }
 
 function getChatCompletionsProbeTimingArgs(model, opts) {

--- a/src/lib/inference/openai-probe-models.ts
+++ b/src/lib/inference/openai-probe-models.ts
@@ -2,6 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { MIN_PROBE_REPLY_TOKENS, resolveMaxTokensField } from "./max-tokens-field";
+import { loadManagedInferenceCatalog } from "./serving/catalog-loader";
+
+export const STANDARD_NVIDIA_ENDPOINT_PROBE_POLICY =
+  "nvidia.endpoint-validation.standard/v1";
+export const EXTENDED_NVIDIA_ENDPOINT_PROBE_POLICY =
+  "nvidia.endpoint-validation.extended/v1";
+
+export function vllmProbePolicyForModel(model: string): string {
+  const normalized = model.trim().toLowerCase();
+  const matches = loadManagedInferenceCatalog().models.filter(({ spec }) =>
+    [spec.id, spec.environmentValue, spec.servedName].some(
+      (candidate) => candidate.toLowerCase() === normalized,
+    ),
+  );
+  if (matches.length > 1) {
+    throw new Error(`Managed vLLM catalog has ambiguous probe policies for model ${model}.`);
+  }
+  return matches[0]?.spec.probePolicyRef ?? STANDARD_NVIDIA_ENDPOINT_PROBE_POLICY;
+}
 
 export const STRICT_TOOL_PROBE_INITIAL_TOKENS = 256;
 // Reasoning-heavy models can spend the whole output budget on their reasoning

--- a/src/lib/inference/serving/adapter-registry.test.ts
+++ b/src/lib/inference/serving/adapter-registry.test.ts
@@ -197,6 +197,36 @@ describe("managed inference adapter registries", () => {
     );
   });
 
+  it("validates declarative direct-install authentication and receipt combinations", () => {
+    const withDirectInstall = (
+      authentication: "none" | "bearer",
+      fixedArguments: boolean,
+      catalogReceipt: boolean,
+    ): ManagedInferenceServingRecipe => {
+      const recipe = shippedLightningRecipe();
+      return {
+        ...recipe,
+        spec: {
+          ...recipe.spec,
+          serve: {
+            ...recipe.spec.serve,
+            directInstall: { authentication, fixedArguments, catalogReceipt },
+          },
+        },
+      } as ManagedInferenceServingRecipe;
+    };
+
+    expect(
+      getManagedInferenceRecipeRegistrationError(withDirectInstall("none", true, true)),
+    ).toMatch(/valid declarative direct-install policy/u);
+    expect(
+      getManagedInferenceRecipeRegistrationError(withDirectInstall("none", false, false)),
+    ).toBeUndefined();
+    expect(
+      getManagedInferenceRecipeRegistrationError(withDirectInstall("bearer", true, true)),
+    ).toBeUndefined();
+  });
+
   it("rejects schema-valid values that the registered adapter cannot execute", () => {
     const recipe = shippedRecipe();
     const unsupportedCache = {

--- a/src/lib/inference/serving/adapter-registry.ts
+++ b/src/lib/inference/serving/adapter-registry.ts
@@ -15,20 +15,48 @@ import type {
   ServingCatalogRegistries,
   ServingReadinessRegistryValue,
   ServingRecipe,
+  VllmDirectInstallPolicy,
 } from "./types.js";
 
-export const MANAGED_CLUSTER_VLLM_MATERIALIZER_REF = "vllm.managed-cluster/v1" as const;
-export const MANAGED_CLUSTER_VLLM_LIFECYCLE_REF = "vllm.managed-cluster.lifecycle/v1" as const;
+export const MANAGED_CLUSTER_VLLM_MATERIALIZER_REF =
+  "vllm.managed-cluster/v1" as const;
+export const MANAGED_CLUSTER_VLLM_LIFECYCLE_REF =
+  "vllm.managed-cluster.lifecycle/v1" as const;
 export const HOST_LOCAL_VLLM_MATERIALIZER_REF = "vllm.host-local/v1" as const;
-export const HOST_LOCAL_VLLM_LIFECYCLE_REF = "vllm.host-local.lifecycle/v1" as const;
-export const LLAMA_CPP_HOST_LOCAL_RECEIPT_REF = "llama-cpp.host-local.receipt/v1" as const;
-export const LLAMA_CPP_HOST_LOCAL_MATERIALIZER_REF = "llama-cpp.host-local/v1" as const;
-export const LLAMA_CPP_HOST_LOCAL_LIFECYCLE_REF = "llama-cpp.host-local.lifecycle/v1" as const;
-export const LLAMA_CPP_SERVER_READINESS_REF = "llama-cpp.server-readiness/v1" as const;
+export const HOST_LOCAL_VLLM_LIFECYCLE_REF =
+  "vllm.host-local.lifecycle/v1" as const;
+export const VLLM_FIXED_AUTHENTICATED_INSTALL_POLICY_REF =
+  "vllm.fixed-authenticated/v1" as const;
+export const LLAMA_CPP_HOST_LOCAL_RECEIPT_REF =
+  "llama-cpp.host-local.receipt/v1" as const;
+export const LLAMA_CPP_HOST_LOCAL_MATERIALIZER_REF =
+  "llama-cpp.host-local/v1" as const;
+export const LLAMA_CPP_HOST_LOCAL_LIFECYCLE_REF =
+  "llama-cpp.host-local.lifecycle/v1" as const;
+export const LLAMA_CPP_SERVER_READINESS_REF =
+  "llama-cpp.server-readiness/v1" as const;
 export const SNAPSHOT_COPY_AND_EXACT_TEXT_REPLACEMENT_PREPARATION_REF =
   "snapshot-copy-and-exact-text-replacement/v1" as const;
 export const NO_PREPARATION_REF = "none/v1" as const;
-export const MANAGED_CLUSTER_HUGGING_FACE_CACHE_SOURCE = "huggingface-cache" as const;
+export const MANAGED_CLUSTER_HUGGING_FACE_CACHE_SOURCE =
+  "huggingface-cache" as const;
+
+const VLLM_INSTALL_POLICIES = new Map<string, VllmDirectInstallPolicy>([
+  [
+    VLLM_FIXED_AUTHENTICATED_INSTALL_POLICY_REF,
+    {
+      authentication: "bearer",
+      fixedArguments: true,
+      catalogReceipt: true,
+    },
+  ],
+]);
+
+export function getManagedInferenceVllmInstallPolicy(
+  ref: string,
+): VllmDirectInstallPolicy | undefined {
+  return VLLM_INSTALL_POLICIES.get(ref);
+}
 
 export function containerPathContains(parent: string, child: string): boolean {
   return child === parent || child.startsWith(`${parent}/`);
@@ -54,7 +82,9 @@ export interface ManagedInferenceMaterializerDescriptor {
     readonly schemaVersion: number;
     readonly outputSchema: string;
   };
-  validateRecipe(recipe: ManagedInferenceRuntimeServingRecipe): string | undefined;
+  validateRecipe(
+    recipe: ManagedInferenceRuntimeServingRecipe,
+  ): string | undefined;
 }
 
 export interface ManagedInferenceLifecycleDescriptor {
@@ -63,19 +93,24 @@ export interface ManagedInferenceLifecycleDescriptor {
   readonly acceptedMaterializerRefs: readonly string[];
   readonly acceptedPlanSchemas: readonly string[];
   readonly secretHandlePermissions: readonly string[];
-  validateRecipe(recipe: ManagedInferenceRuntimeServingRecipe): string | undefined;
+  validateRecipe(
+    recipe: ManagedInferenceRuntimeServingRecipe,
+  ): string | undefined;
 }
 
 export interface ManagedInferencePreparationDescriptor {
   readonly ref: string;
   readonly backend: string;
   readonly phase: "container-before-exec";
-  validateRecipe(recipe: ManagedInferenceRuntimeServingRecipe): string | undefined;
+  validateRecipe(
+    recipe: ManagedInferenceRuntimeServingRecipe,
+  ): string | undefined;
 }
 
 const MANAGED_CLUSTER_TOPOLOGY_OUTPUT_SCHEMA =
   "nemoclaw.nvidia.com/managed-cluster-topology/v1" as const;
-const MANAGED_CLUSTER_PLAN_SCHEMA = "nemoclaw.nvidia.com/managed-cluster-vllm-plan/v1" as const;
+const MANAGED_CLUSTER_PLAN_SCHEMA =
+  "nemoclaw.nvidia.com/managed-cluster-vllm-plan/v1" as const;
 const LOWERCASE_STABLE_ID = /^[a-z0-9][a-z0-9._/-]{0,159}$/u;
 const STABLE_ID = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,159}$/u;
 const PINNED_IMAGE =
@@ -86,6 +121,7 @@ const SAFE_ENVIRONMENT_NAME = /^[A-Z][A-Z0-9_]{0,127}$/u;
 const HOST_LOCAL_SAFE_ARGUMENT_VALUE = /^[A-Za-z0-9_@%+=:,./{}[\]"-]+$/u;
 const HOST_LOCAL_SAFE_ENVIRONMENT_VALUE = /^[A-Za-z0-9_@%+=:,./-]+$/u;
 const SHA256_DIGEST = /^sha256:[0-9a-f]{64}$/u;
+const VLLM_ENVIRONMENT_VALUE = /^[a-z0-9][a-z0-9._-]{0,127}$/u;
 const MANAGED_CLUSTER_MATERIALIZER_OWNED_ENVIRONMENT = new Set([
   "GLOO_SOCKET_IFNAME",
   "HEADLESS",
@@ -100,7 +136,10 @@ const MANAGED_CLUSTER_MATERIALIZER_OWNED_ENVIRONMENT = new Set([
   "VLLM_API_KEY",
   "VLLM_HOST_IP",
 ]);
-const HOST_LOCAL_MATERIALIZER_OWNED_ENVIRONMENT = new Set(["HF_HOME", "VLLM_API_KEY"]);
+const HOST_LOCAL_MATERIALIZER_OWNED_ENVIRONMENT = new Set([
+  "HF_HOME",
+  "VLLM_API_KEY",
+]);
 const HOST_LOCAL_MATERIALIZER_OWNED_ARGUMENTS = new Set([
   "--api-key",
   "--data-parallel-size",
@@ -118,20 +157,27 @@ const HOST_LOCAL_MATERIALIZER_OWNED_ARGUMENTS = new Set([
   "--tensor-parallel-size",
 ]);
 
-export function isManagedClusterMaterializerOwnedEnvironment(name: string): boolean {
+export function isManagedClusterMaterializerOwnedEnvironment(
+  name: string,
+): boolean {
   return MANAGED_CLUSTER_MATERIALIZER_OWNED_ENVIRONMENT.has(name);
 }
 
 export function isManagedClusterInferenceServingRecipe(
   recipe: ManagedInferenceRuntimeServingRecipe,
 ): recipe is ManagedInferenceServingRecipe {
-  return recipe.spec.execution.materializerRef === MANAGED_CLUSTER_VLLM_MATERIALIZER_REF;
+  return (
+    recipe.spec.execution.materializerRef ===
+    MANAGED_CLUSTER_VLLM_MATERIALIZER_REF
+  );
 }
 
 export function isHostLocalInferenceServingRecipe(
   recipe: ManagedInferenceRuntimeServingRecipe,
 ): recipe is HostLocalInferenceServingRecipe {
-  return recipe.spec.execution.materializerRef === HOST_LOCAL_VLLM_MATERIALIZER_REF;
+  return (
+    recipe.spec.execution.materializerRef === HOST_LOCAL_VLLM_MATERIALIZER_REF
+  );
 }
 
 export function isLlamaCppServingRecipe(
@@ -139,7 +185,8 @@ export function isLlamaCppServingRecipe(
 ): recipe is LlamaCppServingRecipe {
   return (
     recipe.spec.backend === "install-llama-cpp" &&
-    recipe.spec.execution.materializerRef === LLAMA_CPP_HOST_LOCAL_MATERIALIZER_REF &&
+    recipe.spec.execution.materializerRef ===
+      LLAMA_CPP_HOST_LOCAL_MATERIALIZER_REF &&
     recipe.spec.execution.lifecycleRef === LLAMA_CPP_HOST_LOCAL_LIFECYCLE_REF
   );
 }
@@ -155,7 +202,9 @@ function positiveIntegerArgument(
   name: string,
   maximum = Number.MAX_SAFE_INTEGER,
 ): number | undefined {
-  const matches = recipe.spec.serve.arguments.filter((argument) => argument.name === name);
+  const matches = recipe.spec.serve.arguments.filter(
+    (argument) => argument.name === name,
+  );
   if (matches.length !== 1) return undefined;
   const value = matches[0]!.value;
   const parsed =
@@ -164,16 +213,52 @@ function positiveIntegerArgument(
       : typeof value === "string" && /^\d+$/u.test(value)
         ? Number(value)
         : Number.NaN;
-  return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= maximum ? parsed : undefined;
+  return Number.isSafeInteger(parsed) && parsed > 0 && parsed <= maximum
+    ? parsed
+    : undefined;
+}
+
+function validateDeclarativeVllmModel(
+  recipe: ManagedInferenceServingRecipe | HostLocalInferenceServingRecipe,
+): string | undefined {
+  const { model, runtime } = recipe.spec;
+  if (
+    !VLLM_ENVIRONMENT_VALUE.test(model.environmentValue) ||
+    typeof model.displayName !== "string" ||
+    model.displayName.trim() !== model.displayName ||
+    model.displayName.length === 0 ||
+    !Number.isSafeInteger(model.menuOrder) ||
+    model.menuOrder < 0
+  ) {
+    return "vLLM recipe requires a model environment value, display name, and non-negative menu order";
+  }
+  if (
+    !Number.isSafeInteger(runtime.minimumComputeCapability) ||
+    runtime.minimumComputeCapability < 0 ||
+    runtime.minimumComputeCapability > 999
+  ) {
+    return "vLLM recipe requires a bounded minimum compute capability or zero for no floor";
+  }
+  if (
+    runtime.minimumGpuMemoryBytes !== undefined &&
+    (!Number.isSafeInteger(runtime.minimumGpuMemoryBytes) ||
+      runtime.minimumGpuMemoryBytes <= 0)
+  ) {
+    return "vLLM recipe requires a positive GPU memory floor";
+  }
+  return undefined;
 }
 
 function validateManagedClusterMaterializerRecipe(
   recipe: ManagedInferenceRuntimeServingRecipe,
 ): string | undefined {
-  if (recipe.spec.backend !== "vllm") return "managed cluster materializer requires backend vllm";
+  if (recipe.spec.backend !== "vllm")
+    return "managed cluster materializer requires backend vllm";
   if (!isManagedClusterInferenceServingRecipe(recipe)) {
     return "recipe does not select the managed cluster materializer";
   }
+  const declarativeModelError = validateDeclarativeVllmModel(recipe);
+  if (declarativeModelError) return declarativeModelError;
   const { execution } = recipe.spec;
   if (
     !Number.isSafeInteger(execution.nodeCount) ||
@@ -183,7 +268,8 @@ function validateManagedClusterMaterializerRecipe(
     execution.tensorParallelSize < 1 ||
     !Number.isSafeInteger(execution.pipelineParallelSize) ||
     execution.pipelineParallelSize < 1 ||
-    execution.tensorParallelSize * execution.pipelineParallelSize !== execution.nodeCount ||
+    execution.tensorParallelSize * execution.pipelineParallelSize !==
+      execution.nodeCount ||
     execution.distributedExecutorBackend !== "mp"
   ) {
     return "managed cluster materializer requires a bounded node count equal to TP times PP with the mp backend";
@@ -200,7 +286,10 @@ function validateManagedClusterMaterializerRecipe(
     return "managed cluster materializer requires arm64 host networking, host IPC, and bearer authentication";
   }
   const apiPort = positiveIntegerArgument(recipe, "--port", 65_535);
-  if (apiPort === undefined || positiveIntegerArgument(recipe, "--max-model-len") === undefined) {
+  if (
+    apiPort === undefined ||
+    positiveIntegerArgument(recipe, "--max-model-len") === undefined
+  ) {
     return "managed cluster materializer requires one valid --port and one positive --max-model-len";
   }
   if (
@@ -222,13 +311,18 @@ function validateManagedClusterMaterializerRecipe(
   if (recipe.spec.model.installFastSafetensors) {
     return "managed cluster immutable-image materializer cannot install fastsafetensors at launch";
   }
-  if (recipe.spec.runtime.modelCache.source !== MANAGED_CLUSTER_HUGGING_FACE_CACHE_SOURCE) {
+  if (
+    recipe.spec.runtime.modelCache.source !==
+    MANAGED_CLUSTER_HUGGING_FACE_CACHE_SOURCE
+  ) {
     return "managed cluster materializer requires the Hugging Face cache source";
   }
   if (
     !safeAbsoluteContainerPath(recipe.spec.serve.executable) ||
     !safeAbsoluteContainerPath(recipe.spec.runtime.modelCache.target) ||
-    recipe.spec.runtime.devices.some((device) => !safeAbsoluteContainerPath(device)) ||
+    recipe.spec.runtime.devices.some(
+      (device) => !safeAbsoluteContainerPath(device),
+    ) ||
     recipe.spec.runtime.temporaryFilesystems.some(
       ({ target }) => !safeAbsoluteContainerPath(target),
     )
@@ -247,13 +341,20 @@ function validateManagedClusterMaterializerRecipe(
     recipe.spec.runtime.imageDownloadSizeBytes,
     recipe.spec.runtime.sharedMemoryBytes,
     recipe.spec.runtime.ulimits.stackBytes,
-    ...recipe.spec.runtime.temporaryFilesystems.map(({ sizeBytes }) => sizeBytes),
+    ...recipe.spec.runtime.temporaryFilesystems.map(
+      ({ sizeBytes }) => sizeBytes,
+    ),
   ];
-  if (resourceValues.some((value) => !Number.isSafeInteger(value) || value <= 0)) {
+  if (
+    resourceValues.some((value) => !Number.isSafeInteger(value) || value <= 0)
+  ) {
     return "managed cluster recipe resource values must be positive safe integers";
   }
   const memlock = recipe.spec.runtime.ulimits.memlock;
-  if (typeof memlock === "number" && (!Number.isSafeInteger(memlock) || memlock < -1)) {
+  if (
+    typeof memlock === "number" &&
+    (!Number.isSafeInteger(memlock) || memlock < -1)
+  ) {
     return "managed cluster memlock value must be -1 or a non-negative safe integer";
   }
   if (
@@ -267,7 +368,8 @@ function validateManagedClusterMaterializerRecipe(
   }
   if (
     Object.values(recipe.spec.runtime.environment).some(
-      (value) => Buffer.byteLength(value, "utf8") > 4_096 || value.includes("\0"),
+      (value) =>
+        Buffer.byteLength(value, "utf8") > 4_096 || value.includes("\0"),
     )
   ) {
     return "managed cluster environment values must be bounded text without NUL bytes";
@@ -300,7 +402,8 @@ function validateManagedClusterLifecycleRecipe(
   }
   const materializerError = validateManagedClusterMaterializerRecipe(recipe);
   if (materializerError) return materializerError;
-  return recipe.spec.execution.lifecycleRef === MANAGED_CLUSTER_VLLM_LIFECYCLE_REF
+  return recipe.spec.execution.lifecycleRef ===
+    MANAGED_CLUSTER_VLLM_LIFECYCLE_REF
     ? undefined
     : "recipe does not select the managed cluster lifecycle";
 }
@@ -308,9 +411,25 @@ function validateManagedClusterLifecycleRecipe(
 function validateHostLocalVllmMaterializerRecipe(
   recipe: HostLocalInferenceServingRecipe,
 ): string | undefined {
-  if (recipe.spec.backend !== "vllm") return "host-local vLLM materializer requires backend vllm";
-  if (recipe.spec.execution.materializerRef !== HOST_LOCAL_VLLM_MATERIALIZER_REF) {
+  if (recipe.spec.backend !== "vllm")
+    return "host-local vLLM materializer requires backend vllm";
+  if (
+    recipe.spec.execution.materializerRef !== HOST_LOCAL_VLLM_MATERIALIZER_REF
+  ) {
     return "recipe does not select the host-local vLLM materializer";
+  }
+  const declarativeModelError = validateDeclarativeVllmModel(recipe);
+  if (declarativeModelError) return declarativeModelError;
+  const directInstall = recipe.spec.serve.directInstall;
+  if (
+    !directInstall ||
+    (directInstall.authentication !== "none" &&
+      directInstall.authentication !== "bearer") ||
+    typeof directInstall.fixedArguments !== "boolean" ||
+    typeof directInstall.catalogReceipt !== "boolean" ||
+    (directInstall.catalogReceipt && directInstall.authentication !== "bearer")
+  ) {
+    return "host-local vLLM requires a valid declarative direct-install policy";
   }
   const execution = recipe.spec.execution;
   if (
@@ -328,8 +447,8 @@ function validateHostLocalVllmMaterializerRecipe(
     return "host-local vLLM materializer does not accept topology bindings";
   }
   const runtime = recipe.spec.runtime;
-  if (runtime.architecture !== "arm64") {
-    return "host-local vLLM materializer requires an arm64 runtime";
+  if (runtime.architecture !== "arm64" && runtime.architecture !== "amd64") {
+    return "host-local vLLM materializer requires an arm64 or amd64 runtime";
   }
   if (
     runtime.networkMode !== "bridge" ||
@@ -352,7 +471,9 @@ function validateHostLocalVllmMaterializerRecipe(
     !safeAbsoluteContainerPath(recipe.spec.serve.executable) ||
     !safeAbsoluteContainerPath(runtime.modelCache.target) ||
     runtime.devices.some((device) => !safeAbsoluteContainerPath(device)) ||
-    runtime.temporaryFilesystems.some(({ target }) => !safeAbsoluteContainerPath(target))
+    runtime.temporaryFilesystems.some(
+      ({ target }) => !safeAbsoluteContainerPath(target),
+    )
   ) {
     return "host-local vLLM runtime paths must be normalized absolute container paths";
   }
@@ -365,15 +486,17 @@ function validateHostLocalVllmMaterializerRecipe(
   }
   if (
     recipe.spec.serve.executable !== "/usr/local/bin/vllm" ||
-    recipe.spec.model.preparation.ref !== NO_PREPARATION_REF ||
-    recipe.spec.model.installFastSafetensors
+    recipe.spec.model.preparation.ref !== NO_PREPARATION_REF
   ) {
     return "host-local vLLM requires the registered executable without model preparation";
   }
   if (recipe.spec.readiness.expectedModel !== recipe.spec.model.servedName) {
     return "host-local vLLM readiness must expect the served model ID";
   }
-  if (!STABLE_ID.test(recipe.spec.model.id) || !STABLE_ID.test(recipe.spec.model.servedName)) {
+  if (
+    !STABLE_ID.test(recipe.spec.model.id) ||
+    !STABLE_ID.test(recipe.spec.model.servedName)
+  ) {
     return "host-local vLLM model identifiers do not match the registered format";
   }
   if (positiveIntegerArgument(recipe, "--max-model-len") === undefined) {
@@ -389,7 +512,8 @@ function validateHostLocalVllmMaterializerRecipe(
   if (
     Object.keys(recipe.spec.runtime.environment).some(
       (name) =>
-        !SAFE_ENVIRONMENT_NAME.test(name) || HOST_LOCAL_MATERIALIZER_OWNED_ENVIRONMENT.has(name),
+        !SAFE_ENVIRONMENT_NAME.test(name) ||
+        HOST_LOCAL_MATERIALIZER_OWNED_ENVIRONMENT.has(name),
     )
   ) {
     return "host-local vLLM recipe overrides a materializer-owned environment value";
@@ -402,10 +526,15 @@ function validateHostLocalVllmMaterializerRecipe(
     runtime.ulimits.stackBytes,
     ...runtime.temporaryFilesystems.map(({ sizeBytes }) => sizeBytes),
   ];
-  if (resourceValues.some((value) => !Number.isSafeInteger(value) || value <= 0)) {
+  if (
+    resourceValues.some((value) => !Number.isSafeInteger(value) || value <= 0)
+  ) {
     return "host-local vLLM resource values must be positive safe integers";
   }
-  if (runtime.ulimits.memlock !== -1 && runtime.ulimits.memlock !== "unlimited") {
+  if (
+    runtime.ulimits.memlock !== -1 &&
+    runtime.ulimits.memlock !== "unlimited"
+  ) {
     return "host-local vLLM memlock must be unlimited";
   }
   if (
@@ -455,13 +584,15 @@ interface NoPreparationInput {
   readonly ref: typeof NO_PREPARATION_REF;
 }
 
-type ManagedInferencePreparationInput = SnapshotPreparationInput | NoPreparationInput;
+type ManagedInferencePreparationInput =
+  SnapshotPreparationInput | NoPreparationInput;
 
 function recipePreparation(
   recipe: ManagedInferenceRuntimeServingRecipe,
 ): ManagedInferencePreparationInput | undefined {
-  const preparation = (recipe.spec.model as unknown as { readonly preparation?: unknown })
-    .preparation;
+  const preparation = (
+    recipe.spec.model as unknown as { readonly preparation?: unknown }
+  ).preparation;
   return typeof preparation === "object" && preparation !== null
     ? (preparation as ManagedInferencePreparationInput)
     : undefined;
@@ -482,7 +613,11 @@ function safeRelativeSnapshotPath(value: unknown): value is string {
     value.length > 0 &&
     value.length <= 4096 &&
     !value.startsWith("/") &&
-    value.split("/").every((component) => component && component !== "." && component !== "..") &&
+    value
+      .split("/")
+      .every(
+        (component) => component && component !== "." && component !== "..",
+      ) &&
     !/[\u0000-\u001f\u007f]/u.test(value)
   );
 }
@@ -495,7 +630,9 @@ function safeAbsoluteContainerPath(value: unknown): value is string {
     value
       .split("/")
       .slice(1)
-      .every((component) => component && component !== "." && component !== "..") &&
+      .every(
+        (component) => component && component !== "." && component !== "..",
+      ) &&
     !/[\u0000-\u001f\u007f]/u.test(value)
   );
 }
@@ -503,17 +640,23 @@ function safeAbsoluteContainerPath(value: unknown): value is string {
 function validateSnapshotPreparationRecipe(
   recipe: ManagedInferenceRuntimeServingRecipe,
 ): string | undefined {
-  if (recipe.spec.backend !== "vllm") return "snapshot preparation requires backend vllm";
+  if (recipe.spec.backend !== "vllm")
+    return "snapshot preparation requires backend vllm";
   const preparation = recipePreparation(recipe);
   if (
-    preparation?.ref !== SNAPSHOT_COPY_AND_EXACT_TEXT_REPLACEMENT_PREPARATION_REF ||
+    preparation?.ref !==
+      SNAPSHOT_COPY_AND_EXACT_TEXT_REPLACEMENT_PREPARATION_REF ||
     !hasExactKeys(preparation, ["exactTextReplacement", "ref", "snapshotCopy"])
   ) {
     return "recipe does not select the snapshot preparation operation";
   }
   if (
     !preparation.snapshotCopy ||
-    !hasExactKeys(preparation.snapshotCopy, ["digest", "sourcePath", "targetPath"]) ||
+    !hasExactKeys(preparation.snapshotCopy, [
+      "digest",
+      "sourcePath",
+      "targetPath",
+    ]) ||
     !safeRelativeSnapshotPath(preparation.snapshotCopy.sourcePath) ||
     !SHA256_DIGEST.test(preparation.snapshotCopy.digest) ||
     !safeAbsoluteContainerPath(preparation.snapshotCopy.targetPath)
@@ -523,7 +666,11 @@ function validateSnapshotPreparationRecipe(
   const replacement = preparation.exactTextReplacement;
   if (
     !replacement ||
-    !hasExactKeys(replacement, ["expectedText", "replacementText", "targetPath"]) ||
+    !hasExactKeys(replacement, [
+      "expectedText",
+      "replacementText",
+      "targetPath",
+    ]) ||
     !safeAbsoluteContainerPath(replacement.targetPath) ||
     typeof replacement.expectedText !== "string" ||
     typeof replacement.replacementText !== "string" ||
@@ -543,9 +690,11 @@ function validateSnapshotPreparationRecipe(
 function validateNoPreparationRecipe(
   recipe: ManagedInferenceRuntimeServingRecipe,
 ): string | undefined {
-  if (recipe.spec.backend !== "vllm") return "empty preparation requires backend vllm";
+  if (recipe.spec.backend !== "vllm")
+    return "empty preparation requires backend vllm";
   const preparation = recipePreparation(recipe);
-  return preparation?.ref === NO_PREPARATION_REF && hasExactKeys(preparation, ["ref"])
+  return preparation?.ref === NO_PREPARATION_REF &&
+    hasExactKeys(preparation, ["ref"])
     ? undefined
     : "recipe does not select the empty preparation operation";
 }
@@ -629,7 +778,9 @@ function registry<T>(
   for (const entry of entries) {
     const id = key(entry);
     if (result.has(id))
-      throw new Error(`duplicate managed inference ${label} registry entry ${id}`);
+      throw new Error(
+        `duplicate managed inference ${label} registry entry ${id}`,
+      );
     result.set(id, entry);
   }
   return result;
@@ -640,9 +791,21 @@ const TOPOLOGY_REGISTRY = registry(
   ({ id, schemaVersion }) => `${id}@${String(schemaVersion)}`,
   "topology qualification",
 );
-const MATERIALIZER_REGISTRY = registry(MATERIALIZER_DESCRIPTORS, ({ ref }) => ref, "materializer");
-const LIFECYCLE_REGISTRY = registry(LIFECYCLE_DESCRIPTORS, ({ ref }) => ref, "lifecycle");
-const PREPARATION_REGISTRY = registry(PREPARATION_DESCRIPTORS, ({ ref }) => ref, "preparation");
+const MATERIALIZER_REGISTRY = registry(
+  MATERIALIZER_DESCRIPTORS,
+  ({ ref }) => ref,
+  "materializer",
+);
+const LIFECYCLE_REGISTRY = registry(
+  LIFECYCLE_DESCRIPTORS,
+  ({ ref }) => ref,
+  "lifecycle",
+);
+const PREPARATION_REGISTRY = registry(
+  PREPARATION_DESCRIPTORS,
+  ({ ref }) => ref,
+  "preparation",
+);
 
 export function listManagedInferenceTopologyQualificationDescriptors(): readonly ManagedInferenceTopologyQualificationDescriptor[] {
   return [...TOPOLOGY_DESCRIPTORS];
@@ -695,11 +858,15 @@ export function getManagedInferenceRecipeRegistrationError(
   if (!materializer) {
     return `unknown materializer ${recipe.spec.execution.materializerRef}`;
   }
-  const lifecycle = getManagedInferenceLifecycleDescriptor(recipe.spec.execution.lifecycleRef);
-  if (!lifecycle) return `unknown lifecycle ${recipe.spec.execution.lifecycleRef}`;
+  const lifecycle = getManagedInferenceLifecycleDescriptor(
+    recipe.spec.execution.lifecycleRef,
+  );
+  if (!lifecycle)
+    return `unknown lifecycle ${recipe.spec.execution.lifecycleRef}`;
   const preparationRef = recipePreparation(recipe)?.ref ?? "";
   const preparation = getManagedInferencePreparationDescriptor(preparationRef);
-  if (!preparation) return `unknown preparation ${preparationRef || "(missing)"}`;
+  if (!preparation)
+    return `unknown preparation ${preparationRef || "(missing)"}`;
   return (
     materializer.validateRecipe(recipe) ??
     lifecycle.validateRecipe(recipe) ??
@@ -707,28 +874,63 @@ export function getManagedInferenceRecipeRegistrationError(
   );
 }
 
-const SERVING_READINESS_REGISTRY: ServingCatalogRegistries["readiness"] = new Map<
-  string,
-  ServingReadinessRegistryValue
->([
-  ["host.os.platform", { kind: "observation", valueType: "string", role: "operating-system" }],
-  ["host.os.architecture", { kind: "observation", valueType: "string", role: "architecture" }],
-  ["host.docker.runtime", { kind: "observation", valueType: "string", role: "container-runtime" }],
-  ["host.gpu.count", { kind: "observation", valueType: "number", role: "gpu-count" }],
-  [
-    "host.gpu.driver_version",
-    { kind: "observation", valueType: "version", role: "driver-version" },
-  ],
-  ["host.platform.dgx_spark", new Set(["qualification", "capability"] as const)],
-  ["host.platform.supported", "capability"],
-  ["host.docker.available", "capability"],
-  ["host.docker.daemon_reachable", "capability"],
-  ["host.docker.runtime_supported", "capability"],
-  ["host.docker.storage_compatible", "capability"],
-  ["host.gpu.nvidia_available", "capability"],
-  ["host.gpu.container_toolkit_available", "capability"],
-  ["host.gpu.cdi_healthy", "capability"],
-] as const);
+const SERVING_READINESS_REGISTRY: ServingCatalogRegistries["readiness"] =
+  new Map<string, ServingReadinessRegistryValue>([
+    [
+      "host.os.platform",
+      { kind: "observation", valueType: "string", role: "operating-system" },
+    ],
+    [
+      "host.os.architecture",
+      { kind: "observation", valueType: "string", role: "architecture" },
+    ],
+    [
+      "host.docker.runtime",
+      { kind: "observation", valueType: "string", role: "container-runtime" },
+    ],
+    [
+      "host.gpu.count",
+      { kind: "observation", valueType: "number", role: "gpu-count" },
+    ],
+    [
+      "host.gpu.driver_version",
+      { kind: "observation", valueType: "version", role: "driver-version" },
+    ],
+    [
+      "host.gpu.memory_total_bytes",
+      { kind: "observation", valueType: "number" },
+    ],
+    [
+      "host.gpu.memory_available_bytes",
+      { kind: "observation", valueType: "number" },
+    ],
+    [
+      "host.gpu.memory_per_device_bytes",
+      { kind: "observation", valueType: "number" },
+    ],
+    ["host.gpu.unified_memory", { kind: "observation", valueType: "boolean" }],
+    [
+      "host.gpu.compute_constrained",
+      { kind: "observation", valueType: "boolean" },
+    ],
+    [
+      "host.platform.dgx_spark",
+      new Set(["qualification", "capability"] as const),
+    ],
+    [
+      "host.platform.dgx_station",
+      new Set(["qualification", "capability"] as const),
+    ],
+    ["host.platform.n1x", new Set(["qualification", "capability"] as const)],
+    ["host.platform.supported", "capability"],
+    ["host.docker.available", "capability"],
+    ["host.docker.daemon_reachable", "capability"],
+    ["host.docker.runtime_supported", "capability"],
+    ["host.docker.storage_compatible", "capability"],
+    ["host.gpu.nvidia_available", "capability"],
+    ["host.gpu.container_toolkit_available", "capability"],
+    ["host.gpu.cdi_healthy", "capability"],
+  ] as const);
 
 export function getManagedInferenceServingCatalogRegistries(): ServingCatalogRegistries {
   return {
@@ -742,6 +944,15 @@ export function getManagedInferenceServingCatalogRegistries(): ServingCatalogReg
       LLAMA_CPP_HOST_LOCAL_LIFECYCLE_REF,
     ]),
     readinessContracts: new Set([LLAMA_CPP_SERVER_READINESS_REF]),
+    installPolicies: new Set(VLLM_INSTALL_POLICIES.keys()),
+    probePolicies: new Set([
+      "nvidia.endpoint-validation.standard/v1",
+      "nvidia.endpoint-validation.extended/v1",
+    ]),
+    orchestrations: new Set([
+      "vllm.host-local.standard/v1",
+      "vllm.station-pair-optional/v1",
+    ]),
     readiness: SERVING_READINESS_REGISTRY,
     facts: new Set(["cluster.nodeCount"]),
     topologyQualifications: new Map(
@@ -755,9 +966,12 @@ export function getManagedInferenceServingCatalogRegistries(): ServingCatalogReg
     ),
     validateRecipe: (recipe: ServingRecipe) => {
       if (
-        recipe.spec.execution.materializerRef !== MANAGED_CLUSTER_VLLM_MATERIALIZER_REF &&
-        recipe.spec.execution.lifecycleRef !== MANAGED_CLUSTER_VLLM_LIFECYCLE_REF &&
-        recipe.spec.execution.materializerRef !== HOST_LOCAL_VLLM_MATERIALIZER_REF &&
+        recipe.spec.execution.materializerRef !==
+          MANAGED_CLUSTER_VLLM_MATERIALIZER_REF &&
+        recipe.spec.execution.lifecycleRef !==
+          MANAGED_CLUSTER_VLLM_LIFECYCLE_REF &&
+        recipe.spec.execution.materializerRef !==
+          HOST_LOCAL_VLLM_MATERIALIZER_REF &&
         recipe.spec.execution.lifecycleRef !== HOST_LOCAL_VLLM_LIFECYCLE_REF
       ) {
         return undefined;

--- a/src/lib/inference/serving/catalog-loader.test.ts
+++ b/src/lib/inference/serving/catalog-loader.test.ts
@@ -20,47 +20,26 @@ import {
 import type { CompiledServingCatalog, ServingPreset, ServingRecipe } from "./types";
 
 const EMPTY_CATALOG: CompiledServingCatalog = {
-  schemaVersion: "1.0.0",
-  compilerVersion: "1.2.0",
+  schemaVersion: "1.1.0",
+  compilerVersion: "1.4.0",
   sourceRevision: "a".repeat(40),
   readinessSchemaRef: "https://github.com/NVIDIA/NemoClaw/schemas/system-readiness.schema.json",
+  models: [],
   recipes: [],
   presets: [],
   sources: [],
   catalogDigest: `sha256:${"b".repeat(64)}`,
 };
-const EXPECTED_MANAGED_RECIPE_IDS = [
-  "llama-cpp.muse-glimmer-30b.spark-single.v1",
-  "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1",
-  "vllm.deepseek-v4-flash-0731.spark-dual.v1",
-  "vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1",
-  "vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.spark-single.v1",
-  "vllm.qwen3-6-35b-a3b-nvfp4.spark-single.v1",
-];
-const EXPECTED_MANAGED_PRESET_IDS = [
-  "llama-cpp.dgx-spark-gb10.single.muse-glimmer-30b",
-  "llama-cpp.dgx-spark-gb10.single.nemotron-3-nano-30b-a3b",
-  "llama-cpp.linux-amd64-nvidia.single.nemotron-3-nano-30b-a3b",
-  "local-model-profile.vllm.spark.v1",
-  "vllm.dgx-spark-gb10.dual.deepseek-v4-flash-0731",
-  "vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4",
-  "vllm.dgx-spark-gb10.single.nemotron-3.5-lightning-30b-a3b-nvfp4",
-];
-const EXPECTED_MANAGED_SOURCE_IDS = [
-  "llama-cpp.dgx-spark-gb10.single.muse-glimmer-30b",
-  "llama-cpp.dgx-spark-gb10.single.nemotron-3-nano-30b-a3b",
-  "llama-cpp.linux-amd64-nvidia.single.nemotron-3-nano-30b-a3b",
-  "local-model-profile.vllm.spark.v1",
-  "vllm.dgx-spark-gb10.dual.deepseek-v4-flash-0731",
-  "vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4",
-  "vllm.dgx-spark-gb10.single.nemotron-3.5-lightning-30b-a3b-nvfp4",
-  "llama-cpp.muse-glimmer-30b.spark-single.v1",
-  "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1",
-  "vllm.deepseek-v4-flash-0731.spark-dual.v1",
-  "vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1",
-  "vllm.nemotron-3.5-lightning-30b-a3b-nvfp4.spark-single.v1",
-  "vllm.qwen3-6-35b-a3b-nvfp4.spark-single.v1",
-];
+const MANAGED_MATERIALIZER_REFS: ReadonlySet<string> = new Set([
+  HOST_LOCAL_VLLM_MATERIALIZER_REF,
+  LLAMA_CPP_HOST_LOCAL_MATERIALIZER_REF,
+  MANAGED_CLUSTER_VLLM_MATERIALIZER_REF,
+]);
+const MANAGED_LIFECYCLE_REFS: ReadonlySet<string> = new Set([
+  HOST_LOCAL_VLLM_LIFECYCLE_REF,
+  LLAMA_CPP_HOST_LOCAL_LIFECYCLE_REF,
+  MANAGED_CLUSTER_VLLM_LIFECYCLE_REF,
+]);
 
 const INCOMPLETE_MANAGED_RECIPE: ServingRecipe = {
   apiVersion: "nemoclaw.nvidia.com/managed-inference/v1",
@@ -124,13 +103,44 @@ function managedCatalogValidationError(catalog: CompiledServingCatalog): string 
   }
 }
 
-function expectManagedRuntimeDefinitions(catalog: CompiledServingCatalog): void {
+function expectManagedRuntimeDefinitions(
+  catalog: CompiledServingCatalog,
+  servingCatalog: CompiledServingCatalog = loadServingCatalog(),
+): void {
   const { catalogDigest, ...catalogContents } = catalog;
+  const expectedRecipes = servingCatalog.recipes.filter(
+    ({ spec }) =>
+      MANAGED_MATERIALIZER_REFS.has(spec.execution.materializerRef) ||
+      MANAGED_LIFECYCLE_REFS.has(spec.execution.lifecycleRef),
+  );
+  const expectedRecipeIds = new Set(expectedRecipes.map(({ metadata }) => metadata.id));
+  const expectedModelIds = new Set(
+    expectedRecipes.flatMap(({ spec }) => (spec.modelRef ? [spec.modelRef] : [])),
+  );
+  const expectedPresets = servingCatalog.presets.filter(({ spec }) =>
+    expectedRecipeIds.has(spec.plan.recipeRef),
+  );
+  const expectedDefinitionIds = new Set([
+    ...expectedModelIds,
+    ...expectedRecipeIds,
+    ...expectedPresets.map(({ metadata }) => metadata.id),
+  ]);
 
   expect(catalogDigest).toBe(servingCatalogDigest(catalogContents));
-  expect(catalog.recipes.map(({ metadata }) => metadata.id)).toEqual(EXPECTED_MANAGED_RECIPE_IDS);
-  expect(catalog.presets.map(({ metadata }) => metadata.id)).toEqual(EXPECTED_MANAGED_PRESET_IDS);
-  expect(catalog.sources.map(({ id }) => id)).toEqual(EXPECTED_MANAGED_SOURCE_IDS);
+  expect(catalog.recipes.map(({ metadata }) => metadata.id)).toEqual(
+    expectedRecipes.map(({ metadata }) => metadata.id),
+  );
+  expect(catalog.models.map(({ metadata }) => metadata.id)).toEqual(
+    servingCatalog.models
+      .filter(({ metadata }) => expectedModelIds.has(metadata.id))
+      .map(({ metadata }) => metadata.id),
+  );
+  expect(catalog.presets.map(({ metadata }) => metadata.id)).toEqual(
+    expectedPresets.map(({ metadata }) => metadata.id),
+  );
+  expect(catalog.sources.map(({ id }) => id)).toEqual(
+    servingCatalog.sources.filter(({ id }) => expectedDefinitionIds.has(id)).map(({ id }) => id),
+  );
 }
 
 describe("managed inference catalog loader", () => {

--- a/src/lib/inference/serving/catalog-loader.ts
+++ b/src/lib/inference/serving/catalog-loader.ts
@@ -37,6 +37,7 @@ function loadSchemas(rootDir: string): ServingCatalogSchemas {
   const schemaRoot = join(rootDir, "managed-inference", "schemas");
   return {
     catalog: readJson(join(schemaRoot, "catalog.schema.json")),
+    model: readJson(join(schemaRoot, "model.schema.json")),
     preset: readJson(join(schemaRoot, "preset.schema.json")),
     recipe: readJson(join(schemaRoot, "recipe.schema.json")),
   };
@@ -115,11 +116,19 @@ export function managedInferenceCatalogFromServingCatalog(
 ): CompiledManagedInferenceCatalog {
   const recipes = catalog.recipes.filter(isManagedInferenceRecipeCandidate);
   const recipeIds = new Set(recipes.map(({ metadata }) => metadata.id));
+  const modelIds = new Set(
+    recipes.flatMap((recipe) => (recipe.spec.modelRef ? [recipe.spec.modelRef] : [])),
+  );
+  const models = catalog.models.filter(({ metadata }) => modelIds.has(metadata.id));
   const presets = catalog.presets.filter((preset) => recipeIds.has(preset.spec.plan.recipeRef));
-  const definitionIds = new Set([...recipeIds, ...presets.map(({ metadata }) => metadata.id)]);
+  const definitionIds = new Set([
+    ...modelIds,
+    ...recipeIds,
+    ...presets.map(({ metadata }) => metadata.id),
+  ]);
   const sources = catalog.sources.filter(({ id }) => definitionIds.has(id));
   const { catalogDigest: _catalogDigest, ...catalogContents } = catalog;
-  const payload = { ...catalogContents, recipes, presets, sources };
+  const payload = { ...catalogContents, models, recipes, presets, sources };
   const managedCatalog = { ...payload, catalogDigest: servingCatalogDigest(payload) };
   assertManagedInferenceCatalog(managedCatalog);
   return managedCatalog;

--- a/src/lib/inference/serving/catalog.test.ts
+++ b/src/lib/inference/serving/catalog.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import catalogSchema from "../../../../managed-inference/schemas/catalog.schema.json" with { type: "json" };
+import modelSchema from "../../../../managed-inference/schemas/model.schema.json" with { type: "json" };
 import presetSchema from "../../../../managed-inference/schemas/preset.schema.json" with { type: "json" };
 import recipeSchema from "../../../../managed-inference/schemas/recipe.schema.json" with { type: "json" };
 import {
@@ -21,6 +22,7 @@ const IMAGE_DIGEST = "b".repeat(64);
 const MODEL_REVISION = "c".repeat(40);
 const SCHEMAS: ServingCatalogSchemas = {
   catalog: catalogSchema,
+  model: modelSchema,
   preset: presetSchema,
   recipe: recipeSchema,
 };
@@ -29,20 +31,82 @@ const REGISTRIES: ServingCatalogRegistries = {
   materializers: new Set(["test.materializer/v1"]),
   lifecycles: new Set(["test.lifecycle/v1"]),
   readinessContracts: new Set(["test.readiness/v1"]),
+  installPolicies: new Set(["test.install-policy/v1"]),
+  probePolicies: new Set(["nvidia.endpoint-validation.standard/v1"]),
   readiness: new Map([
     ["test.runtime.present", { kind: "capability" }],
     ["test.runtime.other", { kind: "capability" }],
-    ["test.os", { kind: "observation", valueType: "string", role: "operating-system" }],
-    ["test.architecture", { kind: "observation", valueType: "string", role: "architecture" }],
+    [
+      "test.os",
+      { kind: "observation", valueType: "string", role: "operating-system" },
+    ],
+    [
+      "test.architecture",
+      { kind: "observation", valueType: "string", role: "architecture" },
+    ],
     [
       "test.container-runtime",
       { kind: "observation", valueType: "string", role: "container-runtime" },
     ],
-    ["test.gpu-count", { kind: "observation", valueType: "number", role: "gpu-count" }],
-    ["test.driver-version", { kind: "observation", valueType: "version", role: "driver-version" }],
+    [
+      "test.gpu-count",
+      { kind: "observation", valueType: "number", role: "gpu-count" },
+    ],
+    [
+      "test.driver-version",
+      { kind: "observation", valueType: "version", role: "driver-version" },
+    ],
     ["test.agent.qualified", { kind: "qualification" }],
   ]),
 };
+
+function modelSource(
+  id = "test.model.v1",
+  probePolicyRef = "nvidia.endpoint-validation.standard/v1",
+): ServingCatalogSource {
+  return {
+    path: `managed-inference/models/test/${id}.yaml`,
+    contents: `
+apiVersion: nemoclaw.nvidia.com/managed-inference/v1
+kind: ServingModel
+metadata:
+  id: ${id}
+spec:
+  id: test/catalog-model
+  revision: ${MODEL_REVISION}
+  environmentValue: catalog-model
+  displayName: Catalog model
+  menuOrder: 1
+  servedName: catalog-model
+  downloadSizeBytes: 1024
+  gated: false
+  installFastSafetensors: false
+  preparation:
+    ref: none/v1
+  probePolicyRef: ${probePolicyRef}
+  capabilities:
+    chatCompletions: true
+    streaming: true
+    toolCalls: true
+    structuredOutputs: false
+    reasoning: true
+    multimodal: false
+`,
+  };
+}
+
+function referencedRecipeSource(
+  modelRef = "test.model.v1",
+  id = "test.recipe.v1",
+): ServingCatalogSource {
+  const source = recipeSource(id);
+  const start = source.contents.indexOf("  model:\n");
+  const end = source.contents.indexOf("  runtime:\n", start);
+  return {
+    ...source,
+    contents: `${source.contents.slice(0, start)}  modelRef: ${modelRef}\n${source.contents.slice(end)}`,
+  };
+}
 
 function recipeSource(
   id = "test.recipe.v1",
@@ -234,7 +298,9 @@ spec:
   };
 }
 
-function llamaCppPresetSource(selection = "explicit-only"): ServingCatalogSource {
+function llamaCppPresetSource(
+  selection = "explicit-only",
+): ServingCatalogSource {
   return {
     path: "managed-inference/presets/test/test.llama.preset.yaml",
     contents: `
@@ -301,7 +367,10 @@ function replaceSource(
   return { ...source, contents };
 }
 
-function compile(sources: readonly ServingCatalogSource[], registries = REGISTRIES) {
+function compile(
+  sources: readonly ServingCatalogSource[],
+  registries = REGISTRIES,
+) {
   return compileTrustedServingCatalog({
     sources,
     sourceRevision: SOURCE_REVISION,
@@ -310,7 +379,10 @@ function compile(sources: readonly ServingCatalogSource[], registries = REGISTRI
   });
 }
 
-function requireValidationFailure(run: () => void, expectedMessage: string): void {
+function requireValidationFailure(
+  run: () => void,
+  expectedMessage: string,
+): void {
   expect(run).toThrow(expectedMessage);
 }
 
@@ -322,17 +394,129 @@ describe("managed inference serving catalog compiler", () => {
     const first = compile([recipe, preset]);
     const second = compile([preset, recipe]);
 
-    expect(serializeCompiledServingCatalog(first)).toBe(serializeCompiledServingCatalog(second));
+    expect(serializeCompiledServingCatalog(first)).toBe(
+      serializeCompiledServingCatalog(second),
+    );
     expect(first.readinessSchemaRef).toBe(
       "https://github.com/NVIDIA/NemoClaw/schemas/system-readiness.schema.json",
     );
-    expect(first.compilerVersion).toBe("1.2.0");
-    expect(first.recipes.map((definition) => definition.metadata.id)).toEqual(["test.recipe.v1"]);
-    expect(first.presets.map((definition) => definition.metadata.id)).toEqual(["test.preset.auto"]);
+    expect(first.compilerVersion).toBe("1.4.0");
+    expect(first.recipes.map((definition) => definition.metadata.id)).toEqual([
+      "test.recipe.v1",
+    ]);
+    expect(first.presets.map((definition) => definition.metadata.id)).toEqual([
+      "test.preset.auto",
+    ]);
     expect(first.sources.map((source) => source.path)).toEqual([
       "managed-inference/presets/test/test.preset.auto.yaml",
       "managed-inference/recipes/test/test.recipe.v1.yaml",
     ]);
+  });
+
+  it("expands reusable model definitions into recipes and catalog provenance", () => {
+    const catalog = compile([
+      modelSource(),
+      referencedRecipeSource(),
+      presetSource(),
+    ]);
+
+    expect(catalog.models).toHaveLength(1);
+    expect(catalog.recipes[0]).toMatchObject({
+      spec: {
+        modelRef: "test.model.v1",
+        model: {
+          id: "test/catalog-model",
+          capabilities: { toolCalls: true, reasoning: true },
+        },
+      },
+    });
+    expect(catalog.sources.map(({ kind }) => kind)).toContain("ServingModel");
+  });
+
+  it("rejects unknown, unused, mismatched, and unregistered model contracts", () => {
+    expect(() => compile([referencedRecipeSource("test.missing.v1")])).toThrow(
+      "references unknown model test.missing.v1",
+    );
+    expect(() => compile([modelSource()])).toThrow(
+      "is not referenced by a recipe",
+    );
+    expect(() =>
+      compile([
+        modelSource(),
+        replaceSource(
+          referencedRecipeSource(),
+          "  modelRef: test.model.v1",
+          `  modelRef: test.model.v1\n  model:\n    id: test/other\n    revision: ${MODEL_REVISION}`,
+        ),
+      ]),
+    ).toThrow("model does not match test.model.v1");
+    expect(() =>
+      compile([
+        modelSource("test.model.v1", "nvidia.endpoint-validation.unknown/v1"),
+        referencedRecipeSource(),
+      ]),
+    ).toThrow("references unknown probe policy");
+  });
+
+  it("validates referenced install policies and restricts them to host-local vLLM", () => {
+    expect(() =>
+      compile([
+        recipeSource(),
+        replaceSource(
+          presetSource(),
+          "    recipeRef: test.recipe.v1",
+          "    recipeRef: test.recipe.v1\n    installPolicyRef: test.unknown/v1",
+        ),
+      ]),
+    ).toThrow("references unknown install policy test.unknown/v1");
+
+    expect(() =>
+      compile([
+        recipeSource(),
+        replaceSource(
+          presetSource(),
+          "    recipeRef: test.recipe.v1",
+          "    recipeRef: test.recipe.v1\n    installPolicyRef: test.install-policy/v1",
+        ),
+      ]),
+    ).toThrow("can only select an install policy for a host-local vLLM recipe");
+  });
+
+  it("rejects model selection aliases that collide across identity fields", () => {
+    const secondModelWithId = replaceSource(
+      modelSource("test.second-model.v1"),
+      "  id: test/catalog-model",
+      "  id: test/second-model",
+    );
+    const secondModelWithEnvironment = replaceSource(
+      secondModelWithId,
+      "  environmentValue: catalog-model",
+      "  environmentValue: second-model",
+    );
+    const collidingModel = replaceSource(
+      secondModelWithEnvironment,
+      "  servedName: catalog-model",
+      "  servedName: test/catalog-model",
+    );
+    expect(() =>
+      compile([
+        modelSource(),
+        collidingModel,
+        referencedRecipeSource(),
+        referencedRecipeSource("test.second-model.v1", "test.recipe.second.v1"),
+      ]),
+    ).toThrow("share selection alias test/catalog-model");
+  });
+
+  it("requires hardware evidence before a preset can claim supported status", () => {
+    const supported = replaceSource(
+      presetSource(),
+      "metadata:\n  id: test.preset.auto",
+      "metadata:\n  id: test.preset.auto\n  supportState: supported",
+    );
+    expect(() => compile([recipeSource(), supported])).toThrow(
+      "cannot be supported without hardware validation evidence",
+    );
   });
 
   it("compiles a complete synthetic llama.cpp recipe and explicit-only preset (#8181)", () => {
@@ -342,7 +526,9 @@ describe("managed inference serving catalog compiler", () => {
     const first = compile([recipe, preset]);
     const second = compile([preset, recipe]);
 
-    expect(serializeCompiledServingCatalog(first)).toBe(serializeCompiledServingCatalog(second));
+    expect(serializeCompiledServingCatalog(first)).toBe(
+      serializeCompiledServingCatalog(second),
+    );
     expect(first.recipes[0]?.spec).toMatchObject({
       providerId: "llama-cpp-local",
       server: { technology: "llama.cpp" },
@@ -374,27 +560,47 @@ describe("managed inference serving catalog compiler", () => {
       capabilities: { agents: [], protocols: ["openai-completions"] },
     });
     expect(first.presets[0]?.spec.selection).toBe("explicit-only");
-    expect(first.sources.every((source) => /^sha256:[0-9a-f]{64}$/.test(source.digest))).toBe(true);
+    expect(
+      first.sources.every((source) =>
+        /^sha256:[0-9a-f]{64}$/.test(source.digest),
+      ),
+    ).toBe(true);
     expect(first.catalogDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
   });
 
   it.each([
-    ["a missing server source revision", `      revision: ${"e".repeat(40)}\n`, ""],
+    [
+      "a missing server source revision",
+      `      revision: ${"e".repeat(40)}\n`,
+      "",
+    ],
     [
       "a mutable server source revision",
       `      revision: ${"e".repeat(40)}`,
       "      revision: main",
     ],
-    ["a mutable model revision", `    revision: ${"f".repeat(40)}`, "    revision: latest"],
+    [
+      "a mutable model revision",
+      `    revision: ${"f".repeat(40)}`,
+      "    revision: latest",
+    ],
     ["a missing GGUF digest", `        digest: sha256:${"1".repeat(64)}\n`, ""],
     ["a missing GGUF byte size", "        sizeBytes: 4294967296\n", ""],
-    ["a non-GGUF file", "      - path: test-model.Q4_K_M.gguf", "      - path: model.bin"],
+    [
+      "a non-GGUF file",
+      "      - path: test-model.Q4_K_M.gguf",
+      "      - path: model.bin",
+    ],
     [
       "an unsupported acquisition transport",
       "      ref: hugging-face-exact-file/v1",
       "      ref: arbitrary-url/v1",
     ],
-    ["a required acquisition credential", "        mode: optional", "        mode: required"],
+    [
+      "a required acquisition credential",
+      "        mode: optional",
+      "        mode: required",
+    ],
     [
       "an arbitrary acquisition endpoint",
       "      ref: hugging-face-exact-file/v1",
@@ -405,9 +611,21 @@ describe("managed inference serving catalog compiler", () => {
       "        environment: HF_TOKEN",
       "        environment: HF_TOKEN\n        token: test-secret",
     ],
-    ["a private cache owner", "      sharing: host-user", "      sharing: owner-only"],
-    ["deleting the shared cache", "      cleanup: preserve", "      cleanup: delete"],
-    ["unverified cache reuse", "      reuse: verify-exact-file", "      reuse: trust-existing"],
+    [
+      "a private cache owner",
+      "      sharing: host-user",
+      "      sharing: owner-only",
+    ],
+    [
+      "deleting the shared cache",
+      "      cleanup: preserve",
+      "      cleanup: delete",
+    ],
+    [
+      "unverified cache reuse",
+      "      reuse: verify-exact-file",
+      "      reuse: trust-existing",
+    ],
     [
       "a mutable server image",
       `    image: registry.example/test/llama-server@sha256:${"2".repeat(64)}`,
@@ -419,15 +637,27 @@ describe("managed inference serving catalog compiler", () => {
       "      baseImage: registry.example/nvidia/cuda:12.8",
     ],
     ["incomplete platform coverage", "      - linux/arm64\n", ""],
-    ["a missing image byte size", "    imageDownloadSizeBytes: 1073741824\n", ""],
+    [
+      "a missing image byte size",
+      "    imageDownloadSizeBytes: 1073741824\n",
+      "",
+    ],
     ["missing process limits", "      pidsLimit: 256\n", ""],
     [
       "an embedded credential",
       `      revision: ${"e".repeat(40)}`,
       `      revision: ${"e".repeat(40)}\n      credential: test-secret`,
     ],
-    ["a host model path", "      - path: test-model.Q4_K_M.gguf", "      - path: /tmp/model.gguf"],
-    ["shell syntax", "    chatTemplate: nemotron-v3-embedded", "    chatTemplate: $(id)"],
+    [
+      "a host model path",
+      "      - path: test-model.Q4_K_M.gguf",
+      "      - path: /tmp/model.gguf",
+    ],
+    [
+      "shell syntax",
+      "    chatTemplate: nemotron-v3-embedded",
+      "    chatTemplate: $(id)",
+    ],
     [
       "environment expansion",
       "    chatTemplate: nemotron-v3-embedded",
@@ -439,32 +669,69 @@ describe("managed inference serving catalog compiler", () => {
       "    protocol: openai-responses",
     ],
     ["CPU fallback", "      cpuFallback: reject", "      cpuFallback: allow"],
-    ["external network exposure", "    networkExposure: loopback", "    networkExposure: lan"],
+    [
+      "external network exposure",
+      "    networkExposure: loopback",
+      "    networkExposure: lan",
+    ],
     ["missing authentication", "    authentication: bearer\n", ""],
     ["a missing guard limit", "      shutdownTimeoutSeconds: 25\n", ""],
-    ["a colliding guard port", "      upstreamPort: 8082", "      upstreamPort: 8081"],
+    [
+      "a colliding guard port",
+      "      upstreamPort: 8082",
+      "      upstreamPort: 8081",
+    ],
     ["an unsafe KV cache type", "      key: f16", "      key: q4_0"],
-    ["disabled flash attention", "    flashAttention: enabled", "    flashAttention: disabled"],
+    [
+      "disabled flash attention",
+      "    flashAttention: enabled",
+      "    flashAttention: disabled",
+    ],
     [
       "enabled speculative decoding",
       "    speculativeDecoding: disabled",
       "    speculativeDecoding: enabled",
     ],
     ["server egress", "    egress: disabled", "    egress: enabled"],
-    ["a remote model source", "    modelSource: verified-local", "    modelSource: remote"],
+    [
+      "a remote model source",
+      "    modelSource: verified-local",
+      "    modelSource: remote",
+    ],
     [
       "an arbitrary launch argument",
       "    protocol: openai-completions",
       "    protocol: openai-completions\n    arguments:\n      - name: --unsafe",
     ],
-    ["an unsupported capability", "    responsesApi: false", "    responsesApi: true"],
-    ["a malformed agent qualification", "    agents: []", "    agents: [openclaw]"],
-    ["a path-based served model name", "    servedName: test-model", "    servedName: test/model"],
-  ])("rejects %s in a llama.cpp recipe (#8181)", (_case, expected, replacement) => {
-    const recipe = replaceSource(llamaCppRecipeSource(), expected, replacement);
+    [
+      "an unsupported capability",
+      "    responsesApi: false",
+      "    responsesApi: true",
+    ],
+    [
+      "a malformed agent qualification",
+      "    agents: []",
+      "    agents: [openclaw]",
+    ],
+    [
+      "a path-based served model name",
+      "    servedName: test-model",
+      "    servedName: test/model",
+    ],
+  ])(
+    "rejects %s in a llama.cpp recipe (#8181)",
+    (_case, expected, replacement) => {
+      const recipe = replaceSource(
+        llamaCppRecipeSource(),
+        expected,
+        replacement,
+      );
 
-    expect(() => compile([recipe])).toThrow("does not satisfy the ServingRecipe schema");
-  });
+      expect(() => compile([recipe])).toThrow(
+        "does not satisfy the ServingRecipe schema",
+      );
+    },
+  );
 
   it.each([
     [
@@ -503,11 +770,20 @@ describe("managed inference serving catalog compiler", () => {
       `    authentication: bearer
     executable: /usr/local/bin/llama-server`,
     ],
-  ])("rejects generic-only %s in a llama.cpp recipe (#8173)", (_case, expected, replacement) => {
-    const recipe = replaceSource(llamaCppRecipeSource(), expected, replacement);
+  ])(
+    "rejects generic-only %s in a llama.cpp recipe (#8173)",
+    (_case, expected, replacement) => {
+      const recipe = replaceSource(
+        llamaCppRecipeSource(),
+        expected,
+        replacement,
+      );
 
-    expect(() => compile([recipe])).toThrow("does not satisfy the ServingRecipe schema");
-  });
+      expect(() => compile([recipe])).toThrow(
+        "does not satisfy the ServingRecipe schema",
+      );
+    },
+  );
 
   it.each([
     [
@@ -531,11 +807,16 @@ describe("managed inference serving catalog compiler", () => {
       sharing: host-user
       cleanup: preserve`,
     ],
-  ])("rejects llama.cpp model %s on a generic recipe (#8279)", (_field, expected, replacement) => {
-    const recipe = replaceSource(recipeSource(), expected, replacement);
+  ])(
+    "rejects llama.cpp model %s on a generic recipe (#8279)",
+    (_field, expected, replacement) => {
+      const recipe = replaceSource(recipeSource(), expected, replacement);
 
-    expect(() => compile([recipe])).toThrow("does not satisfy the ServingRecipe schema");
-  });
+      expect(() => compile([recipe])).toThrow(
+        "does not satisfy the ServingRecipe schema",
+      );
+    },
+  );
 
   it("rejects a llama.cpp readiness model that differs from the served name (#8181)", () => {
     const wrongExpectedModel = replaceSource(
@@ -562,17 +843,30 @@ describe("managed inference serving catalog compiler", () => {
   });
 
   it.each([
-    ["a backend that does not match llama.cpp", "  backend: install-llama-cpp", "  backend: vllm"],
+    [
+      "a backend that does not match llama.cpp",
+      "  backend: install-llama-cpp",
+      "  backend: vllm",
+    ],
     [
       "a GGUF byte size above Number.MAX_SAFE_INTEGER",
       "        sizeBytes: 4294967296",
       "        sizeBytes: 9007199254740992",
     ],
-  ])("rejects %s in the typed llama.cpp contract (#8181)", (_case, expected, replacement) => {
-    const recipe = replaceSource(llamaCppRecipeSource(), expected, replacement);
+  ])(
+    "rejects %s in the typed llama.cpp contract (#8181)",
+    (_case, expected, replacement) => {
+      const recipe = replaceSource(
+        llamaCppRecipeSource(),
+        expected,
+        replacement,
+      );
 
-    expect(() => compile([recipe])).toThrow("does not satisfy the ServingRecipe schema");
-  });
+      expect(() => compile([recipe])).toThrow(
+        "does not satisfy the ServingRecipe schema",
+      );
+    },
+  );
 
   it("reserves the install-llama-cpp backend for typed llama.cpp recipes (#8181)", () => {
     const escapedRecipe = replaceSource(
@@ -581,20 +875,38 @@ describe("managed inference serving catalog compiler", () => {
       "  backend: install-llama-cpp",
     );
 
-    expect(() => compile([escapedRecipe])).toThrow("does not satisfy the ServingRecipe schema");
+    expect(() => compile([escapedRecipe])).toThrow(
+      "does not satisfy the ServingRecipe schema",
+    );
   });
 
   it.each([
-    ["receipt contract", { receipts: new Set<string>() }, "unknown receipt contract"],
-    ["materializer", { materializers: new Set<string>() }, "unknown materializer"],
-    ["lifecycle adapter", { lifecycles: new Set<string>() }, "unknown lifecycle adapter"],
-    ["readiness contract", { readinessContracts: new Set<string>() }, "unknown readiness contract"],
+    [
+      "receipt contract",
+      { receipts: new Set<string>() },
+      "unknown receipt contract",
+    ],
+    [
+      "materializer",
+      { materializers: new Set<string>() },
+      "unknown materializer",
+    ],
+    [
+      "lifecycle adapter",
+      { lifecycles: new Set<string>() },
+      "unknown lifecycle adapter",
+    ],
+    [
+      "readiness contract",
+      { readinessContracts: new Set<string>() },
+      "unknown readiness contract",
+    ],
   ])(
     "rejects a llama.cpp recipe with an unknown %s reference (#8181)",
     (_name, registry, message) => {
-      expect(() => compile([llamaCppRecipeSource()], { ...REGISTRIES, ...registry })).toThrow(
-        message,
-      );
+      expect(() =>
+        compile([llamaCppRecipeSource()], { ...REGISTRIES, ...registry }),
+      ).toThrow(message);
     },
   );
 
@@ -609,16 +921,22 @@ describe("managed inference serving catalog compiler", () => {
       "  readiness:\n    contractRef: test.readiness/v1\n",
     );
 
-    expect(() => compile([receiptRecipe], { ...REGISTRIES, receipts: new Set() })).toThrow(
-      "unknown receipt contract test.receipt/v1",
-    );
     expect(() =>
-      compile([readinessRecipe], { ...REGISTRIES, readinessContracts: new Set() }),
+      compile([receiptRecipe], { ...REGISTRIES, receipts: new Set() }),
+    ).toThrow("unknown receipt contract test.receipt/v1");
+    expect(() =>
+      compile([readinessRecipe], {
+        ...REGISTRIES,
+        readinessContracts: new Set(),
+      }),
     ).toThrow("unknown readiness contract test.readiness/v1");
   });
 
   it("accepts automatic selection for a llama.cpp recipe", () => {
-    const catalog = compile([llamaCppRecipeSource(), llamaCppPresetSource("automatic")]);
+    const catalog = compile([
+      llamaCppRecipeSource(),
+      llamaCppPresetSource("automatic"),
+    ]);
 
     expect(catalog.presets[0]?.spec.selection).toBe("automatic");
   });
@@ -630,9 +948,9 @@ describe("managed inference serving catalog compiler", () => {
       "  plan:",
     );
 
-    expect(() => compile([llamaCppRecipeSource(), presetWithoutReadiness])).toThrow(
-      "must declare readiness requirements for llama.cpp recipe",
-    );
+    expect(() =>
+      compile([llamaCppRecipeSource(), presetWithoutReadiness]),
+    ).toThrow("must declare readiness requirements for llama.cpp recipe");
   });
 
   it("allows an explicit llama.cpp preset to narrow a multiarch image to arm64 (#8173)", () => {
@@ -695,7 +1013,10 @@ describe("managed inference serving catalog compiler", () => {
       format: deepseek
       mode: auto`,
     ],
-    ["missing arguments for embedded Jinja", "    chatTemplate: model-embedded-jinja"],
+    [
+      "missing arguments for embedded Jinja",
+      "    chatTemplate: model-embedded-jinja",
+    ],
     [
       "an unsupported embedded-Jinja reasoning strength",
       `    chatTemplate: model-embedded-jinja
@@ -721,15 +1042,31 @@ describe("managed inference serving catalog compiler", () => {
   });
 
   it.each([
-    ["operating-system", "            value: linux", "            value: windows"],
+    [
+      "operating-system",
+      "            value: linux",
+      "            value: windows",
+    ],
     ["architecture", "              - arm64", "              - riscv64"],
-    ["container-runtime", "            value: docker", "            value: podman"],
+    [
+      "container-runtime",
+      "            value: docker",
+      "            value: podman",
+    ],
     ["gpu-count", "            value: 1", "            value: 0"],
-    ["driver-version", "            value: 570.0.0", "            value: 1.0.0"],
+    [
+      "driver-version",
+      "            value: 570.0.0",
+      "            value: 1.0.0",
+    ],
   ])(
     "rejects a llama.cpp preset whose %s contradicts its recipe (#8181)",
     (role, expected, replacement) => {
-      const preset = replaceSource(llamaCppPresetSource(), expected, replacement);
+      const preset = replaceSource(
+        llamaCppPresetSource(),
+        expected,
+        replacement,
+      );
 
       expect(() => compile([llamaCppRecipeSource(), preset])).toThrow(
         `must require ${role} matching llama.cpp recipe`,
@@ -819,7 +1156,9 @@ describe("managed inference serving catalog compiler", () => {
         qualificationRef: test.other.qualified`,
     );
 
-    expect(() => compile([duplicateAgent])).toThrow("repeats agent capability test.agent");
+    expect(() => compile([duplicateAgent])).toThrow(
+      "repeats agent capability test.agent",
+    );
   });
 
   it("rejects duplicate and contradictory readiness requirements (#8181)", () => {
@@ -852,11 +1191,19 @@ describe("managed inference serving catalog compiler", () => {
 
   it("rejects a readiness comparison whose value type conflicts with its registry entry (#8181)", () => {
     const readiness = new Map(REGISTRIES.readiness);
-    readiness.set("test.gpu-count", { kind: "observation", valueType: "string" });
+    readiness.set("test.gpu-count", {
+      kind: "observation",
+      valueType: "string",
+    });
 
     expect(() =>
-      compile([llamaCppRecipeSource(), llamaCppPresetSource()], { ...REGISTRIES, readiness }),
-    ).toThrow("compares test.gpu-count as number, but the readiness registry declares string");
+      compile([llamaCppRecipeSource(), llamaCppPresetSource()], {
+        ...REGISTRIES,
+        readiness,
+      }),
+    ).toThrow(
+      "compares test.gpu-count as number, but the readiness registry declares string",
+    );
   });
 
   it("rejects duplicate definition IDs and dangling recipe references (#8144)", () => {
@@ -864,7 +1211,9 @@ describe("managed inference serving catalog compiler", () => {
       ...recipeSource(),
       path: "managed-inference/recipes/test/duplicate.yaml",
     };
-    expect(() => compile([recipeSource(), duplicate])).toThrow("ID test.recipe.v1 is duplicated");
+    expect(() => compile([recipeSource(), duplicate])).toThrow(
+      "ID test.recipe.v1 is duplicated",
+    );
     expect(() =>
       compile([
         recipeSource(),
@@ -898,7 +1247,11 @@ describe("managed inference serving catalog compiler", () => {
     (revision) => {
       expect(() =>
         compile([
-          replaceSource(recipeSource(), `revision: ${MODEL_REVISION}`, `revision: ${revision}`),
+          replaceSource(
+            recipeSource(),
+            `revision: ${MODEL_REVISION}`,
+            `revision: ${revision}`,
+          ),
         ]),
       ).not.toThrow();
     },
@@ -909,7 +1262,11 @@ describe("managed inference serving catalog compiler", () => {
     (revision) => {
       expect(() =>
         compile([
-          replaceSource(recipeSource(), `revision: ${MODEL_REVISION}`, `revision: ${revision}`),
+          replaceSource(
+            recipeSource(),
+            `revision: ${MODEL_REVISION}`,
+            `revision: ${revision}`,
+          ),
         ]),
       ).toThrow("does not satisfy the ServingRecipe schema");
     },
@@ -937,14 +1294,18 @@ describe("managed inference serving catalog compiler", () => {
       "      - name: --port\n        value: 8081",
       "      - name: --port\n        value: 8081\n      - name: --port\n        value: 8082",
     );
-    expect(() => compile([duplicateArgument])).toThrow("repeats structured argument --port");
+    expect(() => compile([duplicateArgument])).toThrow(
+      "repeats structured argument --port",
+    );
 
     const duplicateModelFile = replaceSource(
       recipeSource("test.recipe.duplicate-model-file"),
       `      - path: model.gguf\n        digest: sha256:${"d".repeat(64)}`,
       `      - path: model.gguf\n        digest: sha256:${"d".repeat(64)}\n      - path: model.gguf\n        digest: sha256:${"e".repeat(64)}`,
     );
-    expect(() => compile([duplicateModelFile])).toThrow("repeats model file model.gguf");
+    expect(() => compile([duplicateModelFile])).toThrow(
+      "repeats model file model.gguf",
+    );
   });
 
   it.each([
@@ -956,7 +1317,9 @@ describe("managed inference serving catalog compiler", () => {
     "C:\\model.gguf",
   ])("rejects the noncanonical model path %j (#8144)", (path) => {
     expect(() =>
-      compile([replaceSource(recipeSource(), "path: model.gguf", `path: ${path}`)]),
+      compile([
+        replaceSource(recipeSource(), "path: model.gguf", `path: ${path}`),
+      ]),
     ).toThrow("does not satisfy the ServingRecipe schema");
   });
 
@@ -982,7 +1345,10 @@ describe("managed inference serving catalog compiler", () => {
         recipeSource(),
         {
           ...mismatchedKind,
-          contents: mismatchedKind.contents.replace("kind: capability", "kind: observation"),
+          contents: mismatchedKind.contents.replace(
+            "kind: capability",
+            "kind: observation",
+          ),
         },
       ]),
     ).toThrow(
@@ -1017,7 +1383,9 @@ describe("managed inference serving catalog compiler", () => {
   });
 
   it("accepts only compiled JSON whose digest matches its content (#8144)", () => {
-    const serialized = serializeCompiledServingCatalog(compile([recipeSource(), presetSource()]));
+    const serialized = serializeCompiledServingCatalog(
+      compile([recipeSource(), presetSource()]),
+    );
     const parsed = parseCompiledServingCatalogJson(serialized, SCHEMAS);
     const tampered = serialized.replace("test/model", "test/other-model");
     requireValidationFailure(
@@ -1027,6 +1395,17 @@ describe("managed inference serving catalog compiler", () => {
     requireValidationFailure(
       () => parseCompiledServingCatalogJson("apiVersion: v1", SCHEMAS),
       "is not valid JSON",
+    );
+    requireValidationFailure(
+      () =>
+        parseCompiledServingCatalogJson(
+          serialized.replace(
+            '"schemaVersion":"1.1.0"',
+            '"schemaVersion":"2.0.0"',
+          ),
+          SCHEMAS,
+        ),
+      "must be rebuilt as 1.1.0",
     );
 
     expect(parsed.catalogDigest).toMatch(/^sha256:[0-9a-f]{64}$/);

--- a/src/lib/inference/serving/catalog.ts
+++ b/src/lib/inference/serving/catalog.ts
@@ -4,19 +4,24 @@
 import { createHash } from "node:crypto";
 import { posix } from "node:path";
 
-import Ajv2020, { type AnySchema, type ValidateFunction } from "ajv/dist/2020.js";
+import Ajv2020, {
+  type AnySchema,
+  type ValidateFunction,
+} from "ajv/dist/2020.js";
 import { parseDocument } from "yaml";
 
 import { compileLlamaCppGgufCachePlan } from "../llama-cpp/gguf-cache-plan";
 import type {
   CompiledServingCatalog,
   CompiledServingCatalogPayload,
+  HostLocalInferenceServingRecipe,
   LlamaCppServingRecipe,
   ServingCatalogRegistries,
   ServingCatalogSchemas,
   ServingCatalogSource,
   ServingCatalogSourceProvenance,
   ServingDefinitionKind,
+  ServingModelDefinition,
   ServingPreset,
   ServingReadinessComparison,
   ServingReadinessObservationRole,
@@ -27,18 +32,22 @@ import type {
 } from "./types";
 
 const API_VERSION = "nemoclaw.nvidia.com/managed-inference/v1" as const;
-const CATALOG_SCHEMA_VERSION = "1.0.0" as const;
-const COMPILER_VERSION = "1.2.0" as const;
+const CATALOG_SCHEMA_VERSION = "1.1.0" as const;
+const COMPILER_VERSION = "1.4.0" as const;
 const READINESS_SCHEMA_REF =
   "https://github.com/NVIDIA/NemoClaw/schemas/system-readiness.schema.json" as const;
 const RECIPE_SCHEMA_ID =
   "https://github.com/NVIDIA/NemoClaw/managed-inference/schemas/recipe.schema.json";
+const MODEL_SCHEMA_ID =
+  "https://github.com/NVIDIA/NemoClaw/managed-inference/schemas/model.schema.json";
 const PRESET_SCHEMA_ID =
   "https://github.com/NVIDIA/NemoClaw/managed-inference/schemas/preset.schema.json";
-const CATALOG_SOURCE_PATTERN = /^managed-inference\/(recipes|presets)\/.+\.ya?ml$/;
+const CATALOG_SOURCE_PATTERN =
+  /^managed-inference\/(models|recipes|presets)\/.+\.ya?ml$/;
 
 interface CatalogValidators {
   catalog: ValidateFunction;
+  model: ValidateFunction;
   preset: ValidateFunction;
   recipe: ValidateFunction;
 }
@@ -55,6 +64,35 @@ export class ServingCatalogValidationError extends Error {
     super(message);
     this.name = "ServingCatalogValidationError";
   }
+}
+
+export type ServingCatalogSchemaCompatibility =
+  | {
+      readonly compatible: true;
+      readonly version: typeof CATALOG_SCHEMA_VERSION;
+    }
+  | { readonly compatible: false; readonly reason: string };
+
+/** Compiled catalogs are build artifacts. Rebuild any version other than the reader's exact contract. */
+export function checkServingCatalogSchemaVersion(
+  schemaVersion: unknown,
+): ServingCatalogSchemaCompatibility {
+  if (
+    typeof schemaVersion !== "string" ||
+    !/^\d+\.\d+\.\d+$/u.test(schemaVersion)
+  ) {
+    return {
+      compatible: false,
+      reason: "serving catalog schemaVersion must use major.minor.patch",
+    };
+  }
+  if (schemaVersion !== CATALOG_SCHEMA_VERSION) {
+    return {
+      compatible: false,
+      reason: `serving catalog schema ${schemaVersion} must be rebuilt as ${CATALOG_SCHEMA_VERSION}`,
+    };
+  }
+  return { compatible: true, version: CATALOG_SCHEMA_VERSION };
 }
 
 function compareCanonicalText(left: string, right: string): number {
@@ -83,19 +121,31 @@ export function servingCatalogDigest(value: unknown): string {
 
 function createValidators(schemas: ServingCatalogSchemas): CatalogValidators {
   const ajv = new Ajv2020({ allErrors: true, strict: true });
+  ajv.addSchema(schemas.model as AnySchema);
   ajv.addSchema(schemas.recipe as AnySchema);
   ajv.addSchema(schemas.preset as AnySchema);
+  const model = ajv.getSchema(MODEL_SCHEMA_ID);
   const recipe = ajv.getSchema(RECIPE_SCHEMA_ID);
   const preset = ajv.getSchema(PRESET_SCHEMA_ID);
-  if (!recipe || !preset) {
-    throw new ServingCatalogValidationError("Serving catalog schemas have invalid identifiers.");
+  if (!model || !recipe || !preset) {
+    throw new ServingCatalogValidationError(
+      "Serving catalog schemas have invalid identifiers.",
+    );
   }
-  return { recipe, preset, catalog: ajv.compile(schemas.catalog as AnySchema) };
+  return {
+    model,
+    recipe,
+    preset,
+    catalog: ajv.compile(schemas.catalog as AnySchema),
+  };
 }
 
 function validationDetails(validate: ValidateFunction): string {
   return (validate.errors ?? [])
-    .map((error) => `${error.instancePath || "/"} ${error.message ?? "is invalid"}`)
+    .map(
+      (error) =>
+        `${error.instancePath || "/"} ${error.message ?? "is invalid"}`,
+    )
     .join("; ");
 }
 
@@ -103,10 +153,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function parseTrustedYaml(source: ServingCatalogSource): Record<string, unknown> {
+function parseTrustedYaml(
+  source: ServingCatalogSource,
+): Record<string, unknown> {
   let document;
   try {
-    document = parseDocument(source.contents, { strict: true, uniqueKeys: true });
+    document = parseDocument(source.contents, {
+      strict: true,
+      uniqueKeys: true,
+    });
   } catch (error) {
     throw new ServingCatalogValidationError(
       `${source.path} is not valid YAML: ${error instanceof Error ? error.message : String(error)}`,
@@ -126,7 +181,9 @@ function parseTrustedYaml(source: ServingCatalogSource): Record<string, unknown>
     );
   }
   if (!isRecord(value)) {
-    throw new ServingCatalogValidationError(`${source.path} must contain one YAML mapping.`);
+    throw new ServingCatalogValidationError(
+      `${source.path} must contain one YAML mapping.`,
+    );
   }
   return value;
 }
@@ -138,22 +195,43 @@ function definitionIdentity(
   const kind = value.kind;
   const metadata = value.metadata;
   const id = isRecord(metadata) ? metadata.id : undefined;
-  if ((kind !== "ServingRecipe" && kind !== "ServingPreset") || typeof id !== "string") {
+  if (
+    (kind !== "ServingModel" &&
+      kind !== "ServingRecipe" &&
+      kind !== "ServingPreset") ||
+    typeof id !== "string"
+  ) {
     throw new ServingCatalogValidationError(
-      `${source.path} must declare a ServingRecipe or ServingPreset with metadata.id.`,
+      `${source.path} must declare a ServingModel, ServingRecipe, or ServingPreset with metadata.id.`,
     );
   }
   return { kind, id };
 }
 
-function isLlamaCppServingRecipe(recipe: ServingRecipe): recipe is LlamaCppServingRecipe {
+function isLlamaCppServingRecipe(
+  recipe: ServingRecipe,
+): recipe is LlamaCppServingRecipe {
   return recipe.spec.providerId === "llama-cpp-local";
+}
+
+function isHostLocalVllmRecipe(
+  recipe: ServingRecipe,
+): recipe is HostLocalInferenceServingRecipe {
+  return (
+    recipe.spec.backend === "vllm" &&
+    recipe.spec.execution.materializerRef === "vllm.host-local/v1" &&
+    recipe.spec.execution.lifecycleRef === "vllm.host-local.lifecycle/v1"
+  );
 }
 
 function isReadinessRegistryEntry(
   registered: ServingReadinessRegistryValue,
 ): registered is ServingReadinessRegistryEntry {
-  return typeof registered === "object" && registered !== null && "kind" in registered;
+  return (
+    typeof registered === "object" &&
+    registered !== null &&
+    "kind" in registered
+  );
 }
 
 function readinessKindMatches(
@@ -175,7 +253,8 @@ function readinessDescriptor(
   registered: ServingReadinessRegistryValue | undefined,
   kind: ServingReadinessRequirement["readiness"]["kind"],
 ): ServingReadinessRegistryEntry | undefined {
-  if (registered === undefined || !readinessKindMatches(registered, kind)) return undefined;
+  if (registered === undefined || !readinessKindMatches(registered, kind))
+    return undefined;
   return isReadinessRegistryEntry(registered) ? registered : { kind };
 }
 
@@ -199,9 +278,34 @@ function validateRecipeSemantics(
       `Recipe ${recipe.metadata.id} references unknown lifecycle adapter ${lifecycleRef}.`,
     );
   }
+  const orchestrationRef = recipe.spec.execution.orchestrationRef;
+  if (orchestrationRef && !registries.orchestrations?.has(orchestrationRef)) {
+    throw new ServingCatalogValidationError(
+      `Recipe ${recipe.metadata.id} references unknown orchestration ${orchestrationRef}.`,
+    );
+  }
+  const stationPair = recipe.spec.execution.stationPair;
+  if (
+    (orchestrationRef === "vllm.station-pair-optional/v1") !==
+    (stationPair !== undefined)
+  ) {
+    throw new ServingCatalogValidationError(
+      `Recipe ${recipe.metadata.id} must declare Station-pair configuration exactly when it selects the Station-pair orchestration.`,
+    );
+  }
+
+  const probePolicyRef = recipe.spec.model.probePolicyRef;
+  if (probePolicyRef && !registries.probePolicies?.has(probePolicyRef)) {
+    throw new ServingCatalogValidationError(
+      `Recipe ${recipe.metadata.id} references unknown probe policy ${probePolicyRef}.`,
+    );
+  }
 
   const readinessContractRef = recipe.spec.readiness?.contractRef;
-  if (readinessContractRef && !registries.readinessContracts.has(readinessContractRef)) {
+  if (
+    readinessContractRef &&
+    !registries.readinessContracts.has(readinessContractRef)
+  ) {
     throw new ServingCatalogValidationError(
       `Recipe ${recipe.metadata.id} references unknown readiness contract ${readinessContractRef}.`,
     );
@@ -263,7 +367,12 @@ function validateRecipeSemantics(
         );
       }
       agents.add(agent.id);
-      if (!readinessDescriptor(registries.readiness.get(agent.qualificationRef), "qualification")) {
+      if (
+        !readinessDescriptor(
+          registries.readiness.get(agent.qualificationRef),
+          "qualification",
+        )
+      ) {
         throw new ServingCatalogValidationError(
           `Recipe ${recipe.metadata.id} references unknown agent qualification ${agent.qualificationRef} for ${agent.id}.`,
         );
@@ -278,7 +387,9 @@ function validateRecipeSemantics(
     registrationError = "does not satisfy its registered adapter contract";
   }
   if (registrationError) {
-    throw new ServingCatalogValidationError(`Recipe ${recipe.metadata.id}: ${registrationError}.`);
+    throw new ServingCatalogValidationError(
+      `Recipe ${recipe.metadata.id}: ${registrationError}.`,
+    );
   }
 }
 
@@ -287,14 +398,19 @@ function comparisonValueType(
 ): "boolean" | "number" | "string" | "version" | "mixed" {
   if (comparison.operator === "at-least") return "number";
   if (comparison.operator === "version-at-least") return "version";
-  const values = comparison.operator === "one-of" ? comparison.values : [comparison.value];
+  const values =
+    comparison.operator === "one-of" ? comparison.values : [comparison.value];
   const types = new Set(values.map((value) => typeof value));
   if (types.size !== 1) return "mixed";
   const [type] = types;
-  return type === "boolean" || type === "number" || type === "string" ? type : "mixed";
+  return type === "boolean" || type === "number" || type === "string"
+    ? type
+    : "mixed";
 }
 
-function readinessRequirementKey(requirement: ServingReadinessRequirement): string {
+function readinessRequirementKey(
+  requirement: ServingReadinessRequirement,
+): string {
   const readiness = requirement.readiness;
   return `${readiness.scope}:${readiness.kind}:${readiness.id}`;
 }
@@ -303,12 +419,21 @@ function validatePresetRequirements(
   preset: ServingPreset,
   registries: ServingCatalogRegistries,
 ): void {
+  if (
+    preset.metadata.supportState === "supported" &&
+    preset.metadata.validation?.level !== "hardware"
+  ) {
+    throw new ServingCatalogValidationError(
+      `Preset ${preset.metadata.id} cannot be supported without hardware validation evidence.`,
+    );
+  }
   const requirements = new Set<string>();
   const requirementsByEntity = new Map<string, string>();
   for (const requirement of preset.spec.requirements?.all ?? []) {
     const requirementKey = canonicalServingCatalogJson(requirement);
     if (requirements.has(requirementKey)) {
-      const requirementLabel = "readiness" in requirement ? "readiness requirement" : "requirement";
+      const requirementLabel =
+        "readiness" in requirement ? "readiness requirement" : "requirement";
       throw new ServingCatalogValidationError(
         `Preset ${preset.metadata.id} repeats ${requirementLabel} ${requirementKey}.`,
       );
@@ -358,7 +483,10 @@ function validatePresetRequirements(
       continue;
     }
     const key = `${requirement.topologyQualification.id}@${String(requirement.topologyQualification.schemaVersion)}`;
-    if (registries.topologyQualifications && !registries.topologyQualifications.has(key)) {
+    if (
+      registries.topologyQualifications &&
+      !registries.topologyQualifications.has(key)
+    ) {
       throw new ServingCatalogValidationError(
         `Preset ${preset.metadata.id} references unknown topology qualification ${key}.`,
       );
@@ -366,12 +494,18 @@ function validatePresetRequirements(
   }
 }
 
-function canonicalReadinessComparison(comparison: ServingReadinessComparison): string {
-  if (comparison.operator !== "one-of") return canonicalServingCatalogJson(comparison);
+function canonicalReadinessComparison(
+  comparison: ServingReadinessComparison,
+): string {
+  if (comparison.operator !== "one-of")
+    return canonicalServingCatalogJson(comparison);
   return canonicalServingCatalogJson({
     ...comparison,
     values: [...comparison.values].sort((left, right) =>
-      compareCanonicalText(canonicalServingCatalogJson(left), canonicalServingCatalogJson(right)),
+      compareCanonicalText(
+        canonicalServingCatalogJson(left),
+        canonicalServingCatalogJson(right),
+      ),
     ),
   });
 }
@@ -383,7 +517,10 @@ function llamaCppReadinessComparisonMatches(
   expected: ServingReadinessComparison,
 ): boolean {
   if (role !== "architecture" || actual.operator !== "equals") {
-    return canonicalReadinessComparison(actual) === canonicalReadinessComparison(expected);
+    return (
+      canonicalReadinessComparison(actual) ===
+      canonicalReadinessComparison(expected)
+    );
   }
   const architecture = actual.value === "x64" ? "amd64" : actual.value;
   return (
@@ -399,20 +536,34 @@ function validateLlamaCppPreset(
   preset: ServingPreset,
   registries: ServingCatalogRegistries,
 ): void {
-  const expectedComparisons = new Map<ServingReadinessObservationRole, ServingReadinessComparison>([
+  const expectedComparisons = new Map<
+    ServingReadinessObservationRole,
+    ServingReadinessComparison
+  >([
     ["operating-system", { operator: "equals", value: "linux" }],
     [
       "architecture",
       {
         operator: "one-of",
-        values: recipe.spec.runtime.platforms.map((platform) => platform.slice("linux/".length)),
+        values: recipe.spec.runtime.platforms.map((platform) =>
+          platform.slice("linux/".length),
+        ),
       },
     ],
-    ["container-runtime", { operator: "equals", value: recipe.spec.runtime.containerRuntime }],
-    ["gpu-count", { operator: "at-least", value: recipe.spec.runtime.gpu.count }],
+    [
+      "container-runtime",
+      { operator: "equals", value: recipe.spec.runtime.containerRuntime },
+    ],
+    [
+      "gpu-count",
+      { operator: "at-least", value: recipe.spec.runtime.gpu.count },
+    ],
     [
       "driver-version",
-      { operator: "version-at-least", value: recipe.spec.runtime.cuda.minimumDriverVersion },
+      {
+        operator: "version-at-least",
+        value: recipe.spec.runtime.cuda.minimumDriverVersion,
+      },
     ],
   ]);
   const seenRoles = new Set<ServingReadinessObservationRole>();
@@ -421,12 +572,17 @@ function validateLlamaCppPreset(
   for (const requirement of preset.spec.requirements?.all ?? []) {
     if (!("readiness" in requirement)) continue;
     const { readiness } = requirement;
-    if (readiness.kind === "qualification" && readiness.status === "qualified") {
+    if (
+      readiness.kind === "qualification" &&
+      readiness.status === "qualified"
+    ) {
       qualified.add(readiness.id);
     }
     const registered = registries.readiness.get(readiness.id);
-    if (registered === undefined || !isReadinessRegistryEntry(registered)) continue;
-    if (registered.kind !== "observation" || registered.role === undefined) continue;
+    if (registered === undefined || !isReadinessRegistryEntry(registered))
+      continue;
+    if (registered.kind !== "observation" || registered.role === undefined)
+      continue;
     const expected = expectedComparisons.get(registered.role);
     if (!expected) continue;
     if (seenRoles.has(registered.role)) {
@@ -437,7 +593,12 @@ function validateLlamaCppPreset(
     seenRoles.add(registered.role);
     if (
       !("comparison" in readiness) ||
-      !llamaCppReadinessComparisonMatches(recipe, registered.role, readiness.comparison, expected)
+      !llamaCppReadinessComparisonMatches(
+        recipe,
+        registered.role,
+        readiness.comparison,
+        expected,
+      )
     ) {
       throw new ServingCatalogValidationError(
         `Preset ${preset.metadata.id} must require ${registered.role} matching llama.cpp recipe ${recipe.metadata.id}.`,
@@ -502,7 +663,9 @@ function validateCatalogSemantics(
   presets: readonly ServingPreset[],
   registries: ServingCatalogRegistries,
 ): void {
-  const recipesById = new Map(recipes.map((recipe) => [recipe.metadata.id, recipe]));
+  const recipesById = new Map(
+    recipes.map((recipe) => [recipe.metadata.id, recipe]),
+  );
   for (const preset of presets) {
     const recipe = recipesById.get(preset.spec.plan.recipeRef);
     if (!recipe) {
@@ -515,6 +678,20 @@ function validateCatalogSemantics(
         `Preset ${preset.metadata.id} selects backend ${preset.spec.plan.backend}, but recipe ${recipe.metadata.id} uses ${recipe.spec.backend}.`,
       );
     }
+    const installPolicyRef = preset.spec.plan.installPolicyRef;
+    if (
+      installPolicyRef &&
+      !registries.installPolicies?.has(installPolicyRef)
+    ) {
+      throw new ServingCatalogValidationError(
+        `Preset ${preset.metadata.id} references unknown install policy ${installPolicyRef}.`,
+      );
+    }
+    if (installPolicyRef && !isHostLocalVllmRecipe(recipe)) {
+      throw new ServingCatalogValidationError(
+        `Preset ${preset.metadata.id} can only select an install policy for a host-local vLLM recipe.`,
+      );
+    }
     if (isLlamaCppServingRecipe(recipe)) {
       if ((preset.spec.requirements?.all.length ?? 0) === 0) {
         throw new ServingCatalogValidationError(
@@ -522,6 +699,20 @@ function validateCatalogSemantics(
         );
       }
       validateLlamaCppPreset(recipe, preset, registries);
+    }
+    if (isHostLocalVllmRecipe(recipe)) {
+      const platform = preset.spec.plan.platform;
+      if (!platform) {
+        throw new ServingCatalogValidationError(
+          `Preset ${preset.metadata.id} must declare its vLLM platform.`,
+        );
+      }
+      const architecture = recipe.spec.runtime?.architecture;
+      if (platform !== "linux" && architecture !== "arm64") {
+        throw new ServingCatalogValidationError(
+          `Preset ${preset.metadata.id} requires an arm64 recipe for ${platform}.`,
+        );
+      }
     }
     validateBindings(preset, recipe, registries);
     const nodeCount = (preset.spec.requirements?.all ?? []).find(
@@ -531,7 +722,11 @@ function validateCatalogSemantics(
         requirement.operator === "equals" &&
         typeof requirement.value === "number",
     );
-    if (nodeCount && "fact" in nodeCount && recipe.spec.execution.nodeCount !== nodeCount.value) {
+    if (
+      nodeCount &&
+      "fact" in nodeCount &&
+      recipe.spec.execution.nodeCount !== nodeCount.value
+    ) {
       throw new ServingCatalogValidationError(
         `Preset ${preset.metadata.id} node-count requirement does not match recipe ${recipe.metadata.id}.`,
       );
@@ -557,9 +752,39 @@ function validateCatalogSemantics(
     }
     automaticSelectors.set(key, preset.metadata.id);
   }
+
+  const modelVariants = new Map<string, string>();
+  for (const preset of presets) {
+    if (
+      preset.spec.selection === "disabled" ||
+      preset.spec.plan.backend !== "vllm"
+    )
+      continue;
+    const recipe = recipesById.get(preset.spec.plan.recipeRef);
+    if (!recipe || !isHostLocalVllmRecipe(recipe)) continue;
+    const environmentValue = recipe.spec.model.environmentValue;
+    const platform = preset.spec.plan.platform;
+    const architecture = recipe.spec.runtime?.architecture;
+    if (!environmentValue || !platform || !architecture) continue;
+    const key = canonicalServingCatalogJson({
+      environmentValue,
+      platform,
+      architecture,
+      priority: preset.spec.priority,
+    });
+    const previous = modelVariants.get(key);
+    if (previous) {
+      throw new ServingCatalogValidationError(
+        `vLLM presets ${previous} and ${preset.metadata.id} define the same model and hardware priority.`,
+      );
+    }
+    modelVariants.set(key, preset.metadata.id);
+  }
 }
 
-function catalogPayload(catalog: CompiledServingCatalog): CompiledServingCatalogPayload {
+function catalogPayload(
+  catalog: CompiledServingCatalog,
+): CompiledServingCatalogPayload {
   const { catalogDigest: _catalogDigest, ...payload } = catalog;
   return payload;
 }
@@ -568,7 +793,10 @@ export function compileTrustedServingCatalog(
   options: CompileServingCatalogOptions,
 ): CompiledServingCatalog {
   const validators = createValidators(options.schemas);
+  const models: ServingModelDefinition[] = [];
+  const recipeValues: Record<string, unknown>[] = [];
   const recipes: ServingRecipe[] = [];
+  const presetValues: Record<string, unknown>[] = [];
   const presets: ServingPreset[] = [];
   const sources: ServingCatalogSourceProvenance[] = [];
   const definitionIds = new Set<string>();
@@ -583,47 +811,137 @@ export function compileTrustedServingCatalog(
       .some((segment) => segment === "" || segment === "." || segment === "..");
     if (!sourceMatch || hasUnsafeSegment) {
       throw new ServingCatalogValidationError(
-        `Catalog source ${source.path} is outside managed-inference/recipes or managed-inference/presets.`,
+        `Catalog source ${source.path} is outside managed-inference/models, managed-inference/recipes, or managed-inference/presets.`,
       );
     }
     if (sourcePaths.has(source.path)) {
-      throw new ServingCatalogValidationError(`Catalog source path ${source.path} is duplicated.`);
+      throw new ServingCatalogValidationError(
+        `Catalog source path ${source.path} is duplicated.`,
+      );
     }
     sourcePaths.add(source.path);
 
     const value = parseTrustedYaml(source);
     const { kind, id } = definitionIdentity(source, value);
-    const expectedDirectory = kind === "ServingRecipe" ? "recipes" : "presets";
+    const expectedDirectory =
+      kind === "ServingModel"
+        ? "models"
+        : kind === "ServingRecipe"
+          ? "recipes"
+          : "presets";
     if (sourceMatch[1] !== expectedDirectory) {
       throw new ServingCatalogValidationError(
         `${source.path} must place ${kind} definitions under managed-inference/${expectedDirectory}.`,
       );
     }
-    const validate = kind === "ServingRecipe" ? validators.recipe : validators.preset;
+    const validate =
+      kind === "ServingModel"
+        ? validators.model
+        : kind === "ServingRecipe"
+          ? validators.recipe
+          : validators.preset;
     if (!validate(value)) {
       throw new ServingCatalogValidationError(
         `${source.path} does not satisfy the ${kind} schema: ${validationDetails(validate)}`,
       );
     }
     if (definitionIds.has(id)) {
-      throw new ServingCatalogValidationError(`Serving definition ID ${id} is duplicated.`);
+      throw new ServingCatalogValidationError(
+        `Serving definition ID ${id} is duplicated.`,
+      );
     }
     definitionIds.add(id);
 
-    if (kind === "ServingRecipe") {
-      const recipe = value as unknown as ServingRecipe;
-      validateRecipeSemantics(recipe, options.registries);
-      recipes.push(recipe);
-    } else {
-      const preset = value as unknown as ServingPreset;
-      validatePresetRequirements(preset, options.registries);
-      presets.push(preset);
-    }
-    sources.push({ path: source.path, kind, id, digest: servingCatalogDigest(value) });
+    if (kind === "ServingModel")
+      models.push(value as unknown as ServingModelDefinition);
+    else if (kind === "ServingRecipe") recipeValues.push(value);
+    else presetValues.push(value);
+    sources.push({
+      path: source.path,
+      kind,
+      id,
+      digest: servingCatalogDigest(value),
+    });
   }
 
-  recipes.sort((left, right) => compareCanonicalText(left.metadata.id, right.metadata.id));
-  presets.sort((left, right) => compareCanonicalText(left.metadata.id, right.metadata.id));
+  const modelsById = new Map(models.map((model) => [model.metadata.id, model]));
+  const modelAliases = new Map<string, string>();
+  for (const model of models) {
+    for (const [field, value] of [
+      ["id", model.spec.id],
+      ["environmentValue", model.spec.environmentValue],
+      ["servedName", model.spec.servedName],
+    ] as const) {
+      const key = value.toLowerCase();
+      const previous = modelAliases.get(key);
+      if (previous && previous !== model.metadata.id) {
+        throw new ServingCatalogValidationError(
+          `Serving models ${previous} and ${model.metadata.id} share selection alias ${value} (${field}).`,
+        );
+      }
+      modelAliases.set(key, model.metadata.id);
+    }
+  }
+  const referencedModels = new Set<string>();
+  for (const value of recipeValues) {
+    const spec = value.spec;
+    if (!isRecord(spec)) {
+      throw new ServingCatalogValidationError(
+        "Serving recipe spec must be an object.",
+      );
+    }
+    const modelRef = spec.modelRef;
+    let resolved = value;
+    if (typeof modelRef === "string") {
+      const model = modelsById.get(modelRef);
+      if (!model) {
+        throw new ServingCatalogValidationError(
+          `Recipe ${String((value.metadata as { id?: unknown } | undefined)?.id ?? "(unknown)")} references unknown model ${modelRef}.`,
+        );
+      }
+      referencedModels.add(modelRef);
+      if (
+        spec.model &&
+        canonicalServingCatalogJson(spec.model) !==
+          canonicalServingCatalogJson(model.spec)
+      ) {
+        throw new ServingCatalogValidationError(
+          `Recipe ${String((value.metadata as { id?: unknown } | undefined)?.id ?? "(unknown)")} model does not match ${modelRef}.`,
+        );
+      }
+      resolved = { ...value, spec: { ...spec, model: model.spec } };
+      if (!validators.recipe(resolved)) {
+        throw new ServingCatalogValidationError(
+          `Expanded recipe ${String((value.metadata as { id?: unknown } | undefined)?.id ?? "(unknown)")} is invalid: ${validationDetails(validators.recipe)}`,
+        );
+      }
+    }
+    const recipe = resolved as unknown as ServingRecipe;
+    validateRecipeSemantics(recipe, options.registries);
+    recipes.push(recipe);
+  }
+  for (const value of presetValues) {
+    const preset = value as unknown as ServingPreset;
+    validatePresetRequirements(preset, options.registries);
+    presets.push(preset);
+  }
+  for (const model of models) {
+    if (!referencedModels.has(model.metadata.id)) {
+      throw new ServingCatalogValidationError(
+        `Serving model ${model.metadata.id} is not referenced by a recipe.`,
+      );
+    }
+  }
+
+  models.sort((left, right) =>
+    compareCanonicalText(left.metadata.id, right.metadata.id),
+  );
+  recipes.sort((left, right) =>
+    compareCanonicalText(left.metadata.id, right.metadata.id),
+  );
+  presets.sort((left, right) =>
+    compareCanonicalText(left.metadata.id, right.metadata.id),
+  );
   validateCatalogSemantics(recipes, presets, options.registries);
 
   const payload: CompiledServingCatalogPayload = {
@@ -631,6 +949,7 @@ export function compileTrustedServingCatalog(
     compilerVersion: COMPILER_VERSION,
     sourceRevision: options.sourceRevision,
     readinessSchemaRef: READINESS_SCHEMA_REF,
+    models,
     recipes,
     presets,
     sources,
@@ -659,6 +978,12 @@ export function parseCompiledServingCatalogJson(
       `Compiled serving catalog is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
+  const compatibility = checkServingCatalogSchemaVersion(
+    isRecord(value) ? value.schemaVersion : undefined,
+  );
+  if (!compatibility.compatible) {
+    throw new ServingCatalogValidationError(compatibility.reason);
+  }
   const validators = createValidators(schemas);
   if (!validators.catalog(value)) {
     throw new ServingCatalogValidationError(
@@ -675,7 +1000,9 @@ export function parseCompiledServingCatalogJson(
   return catalog;
 }
 
-export function serializeCompiledServingCatalog(catalog: CompiledServingCatalog): string {
+export function serializeCompiledServingCatalog(
+  catalog: CompiledServingCatalog,
+): string {
   return `${canonicalServingCatalogJson(catalog)}\n`;
 }
 

--- a/src/lib/inference/serving/generate-catalog.ts
+++ b/src/lib/inference/serving/generate-catalog.ts
@@ -21,6 +21,7 @@ function loadSchemas(rootDir: string): ServingCatalogSchemas {
   const schemaRoot = join(rootDir, "managed-inference", "schemas");
   return {
     catalog: readJson(join(schemaRoot, "catalog.schema.json")),
+    model: readJson(join(schemaRoot, "model.schema.json")),
     preset: readJson(join(schemaRoot, "preset.schema.json")),
     recipe: readJson(join(schemaRoot, "recipe.schema.json")),
   };
@@ -38,6 +39,7 @@ function discoverYamlFiles(directory: string): string[] {
 function loadSources(rootDir: string): ServingCatalogSource[] {
   const managedInferenceRoot = join(rootDir, "managed-inference");
   const files = [
+    ...discoverYamlFiles(join(managedInferenceRoot, "models")),
     ...discoverYamlFiles(join(managedInferenceRoot, "recipes")),
     ...discoverYamlFiles(join(managedInferenceRoot, "presets")),
   ];

--- a/src/lib/inference/serving/host-local-vllm-materialization.ts
+++ b/src/lib/inference/serving/host-local-vllm-materialization.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import os from "node:os";
+import path from "node:path";
+
+import type { HostLocalInferenceServingRecipe } from "./types.js";
+
+const MATERIALIZER_OWNED_ARGUMENTS = new Set([
+  "--host",
+  "--port",
+  "--revision",
+  "--served-model-name",
+  "--max-model-len",
+  "--tensor-parallel-size",
+  "--pipeline-parallel-size",
+  "--data-parallel-size",
+]);
+
+export function hostLocalVllmModelArguments(recipe: HostLocalInferenceServingRecipe): string[] {
+  return recipe.spec.serve.arguments.flatMap(({ name, value }) => {
+    if (MATERIALIZER_OWNED_ARGUMENTS.has(name)) return [];
+    return value === undefined ? [name] : [name, String(value)];
+  });
+}
+
+export function hostLocalVllmDockerRunArguments(recipe: HostLocalInferenceServingRecipe): string[] {
+  const { devices, gpuRequest, ipcMode, sharedMemoryBytes, temporaryFilesystems, ulimits } =
+    recipe.spec.runtime;
+  const memlock = ulimits.memlock === "unlimited" ? -1 : ulimits.memlock;
+  return [
+    "--gpus",
+    gpuRequest,
+    "--ipc",
+    ipcMode,
+    "--mount",
+    `type=bind,source=${path.join(os.homedir(), ".cache", "huggingface", "hub")},target=${recipe.spec.runtime.modelCache.target}/hub,readonly`,
+    "--shm-size",
+    `${String(sharedMemoryBytes)}b`,
+    "--ulimit",
+    `memlock=${String(memlock)}`,
+    "--ulimit",
+    `stack=${String(ulimits.stackBytes)}`,
+    ...devices.flatMap((device) => ["--device", device]),
+    ...temporaryFilesystems.flatMap(({ target, sizeBytes, mode, options }) => [
+      "--tmpfs",
+      `${target}:${[...options, `size=${String(sizeBytes)}`, `mode=${mode}`].join(",")}`,
+    ]),
+  ];
+}

--- a/src/lib/inference/serving/host-local-vllm-selection.test.ts
+++ b/src/lib/inference/serving/host-local-vllm-selection.test.ts
@@ -6,10 +6,11 @@ import os from "node:os";
 import path from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { VllmProfile } from "../vllm.js";
+import { computeCapabilityPreflight, type VllmProfile } from "../vllm.js";
 import {
   HOST_LOCAL_VLLM_LIFECYCLE_REF,
   HOST_LOCAL_VLLM_MATERIALIZER_REF,
+  VLLM_FIXED_AUTHENTICATED_INSTALL_POLICY_REF,
 } from "./adapter-registry.js";
 import { resolveHostLocalVllmSelection } from "./host-local-vllm-selection.js";
 import { fixtureManagedClusterSelection } from "./managed-cluster-fixture.test-support.js";
@@ -40,15 +41,34 @@ function hostLocalSelection(): ResolvedHostLocalInferenceSelection {
         materializerRef: HOST_LOCAL_VLLM_MATERIALIZER_REF,
         lifecycleRef: HOST_LOCAL_VLLM_LIFECYCLE_REF,
       },
+      serve: {
+        ...spec.serve,
+        directInstall: {
+          authentication: "none",
+          fixedArguments: false,
+          catalogReceipt: false,
+        },
+      },
     },
   } satisfies HostLocalInferenceServingRecipe;
-  return { ...selection, selection: "explicit", recipe };
+  const preset = {
+    ...selection.preset,
+    spec: {
+      ...selection.preset.spec,
+      plan: {
+        ...selection.preset.spec.plan,
+        installPolicyRef: VLLM_FIXED_AUTHENTICATED_INSTALL_POLICY_REF,
+      },
+    },
+  };
+  return { ...selection, selection: "explicit", preset, recipe };
 }
 
 function baseProfile(): VllmProfile {
   return {
     name: "DGX Spark",
     platform: "spark",
+    architecture: "arm64",
     image: `example.invalid/vllm@sha256:${"a".repeat(64)}`,
     imageDownloadSizeBytes: 1,
     defaultModel: {} as never,
@@ -76,12 +96,20 @@ describe("host-local vLLM selection", () => {
       recipeId: selection.recipe.metadata.id,
       profile: {
         image: selection.recipe.spec.runtime.image,
+        minComputeCapability: selection.recipe.spec.runtime.minimumComputeCapability,
+        minGpuMemoryBytes: selection.recipe.spec.runtime.minimumGpuMemoryBytes,
         servingCatalog: {
           presetDigest: selection.presetDigest,
           recipeDigest: selection.recipeDigest,
         },
       },
-      model: { id: selection.recipe.spec.model.id },
+      model: {
+        id: selection.recipe.spec.model.id,
+        runtime: {
+          minComputeCapability: selection.recipe.spec.runtime.minimumComputeCapability,
+          minGpuMemoryBytes: selection.recipe.spec.runtime.minimumGpuMemoryBytes,
+        },
+      },
     });
     expect(mocks.resolveManagedInferenceServing).toHaveBeenCalledOnce();
     expect(mocks.resolveManagedInferenceServing).toHaveBeenCalledWith(
@@ -90,7 +118,10 @@ describe("host-local vLLM selection", () => {
         intent: { preset: selection.preset.metadata.id },
       }),
     );
-    assert(result.kind === "selected", "expected a selected host-local profile");
+    assert(
+      result.kind === "selected",
+      "expected a selected host-local profile",
+    );
     expect(result.model.runtime?.dockerRunArgs).toContain(
       `type=bind,source=${path.join(os.homedir(), ".cache", "huggingface", "hub")},target=${selection.recipe.spec.runtime.modelCache.target}/hub,readonly`,
     );
@@ -102,21 +133,71 @@ describe("host-local vLLM selection", () => {
       HF_HUB_OFFLINE: "1",
       TRANSFORMERS_OFFLINE: "1",
     });
+    expect(result.model).toMatchObject({
+      fixedServeCommand: true,
+      managedBearerAuth: true,
+    });
+    expect(
+      computeCapabilityPreflight(
+        result.model,
+        [1],
+        result.profile.minComputeCapability,
+      ),
+    ).toMatchObject({ ok: false });
+  });
+
+  it("routes a direct model slug through the same readiness resolver", () => {
+    const selection = hostLocalSelection();
+    mocks.resolveManagedInferenceServing.mockReturnValue(selection);
+
+    const result = resolveHostLocalVllmSelection(baseProfile(), {
+      NEMOCLAW_VLLM_MODEL: selection.recipe.spec.model.environmentValue,
+    });
+
+    expect(result).toMatchObject({
+      kind: "selected",
+      presetId: selection.preset.metadata.id,
+    });
+    expect(mocks.resolveManagedInferenceServing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: {
+          provider: "vllm",
+          vllmModel: selection.recipe.spec.model.environmentValue,
+        },
+      }),
+    );
+  });
+
+  it("uses provider-scoped automatic resolution for non-interactive defaults", () => {
+    const selection = hostLocalSelection();
+    mocks.resolveManagedInferenceServing.mockReturnValue(selection);
+
+    expect(
+      resolveHostLocalVllmSelection(baseProfile(), {}, { automatic: true }),
+    ).toMatchObject({
+      kind: "selected",
+    });
+    expect(mocks.resolveManagedInferenceServing).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: { provider: "vllm" } }),
+    );
   });
 
   it.each([
     ["NEMOCLAW_VLLM_MODEL", "another-model"],
     ["NEMOCLAW_VLLM_EXTRA_ARGS_JSON", '["--max-model-len","4096"]'],
-  ] as const)("rejects a preset conflict with %s before catalog resolution", (name, value) => {
-    const result = resolveHostLocalVllmSelection(baseProfile(), {
-      NEMOCLAW_SERVING_PRESET: "spark.host-local",
-      [name]: value,
-    });
+  ] as const)(
+    "rejects a preset conflict with %s before catalog resolution",
+    (name, value) => {
+      const result = resolveHostLocalVllmSelection(baseProfile(), {
+        NEMOCLAW_SERVING_PRESET: "spark.host-local",
+        [name]: value,
+      });
 
-    expect(result).toEqual({
-      kind: "rejected",
-      reason: `NEMOCLAW_SERVING_PRESET conflicts with ${name}`,
-    });
-    expect(mocks.resolveManagedInferenceServing).not.toHaveBeenCalled();
-  });
+      expect(result).toEqual({
+        kind: "rejected",
+        reason: `NEMOCLAW_SERVING_PRESET conflicts with ${name}`,
+      });
+      expect(mocks.resolveManagedInferenceServing).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/lib/inference/serving/host-local-vllm-selection.ts
+++ b/src/lib/inference/serving/host-local-vllm-selection.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import os from "node:os";
-import path from "node:path";
 
 import { getBuildIdentity } from "../../core/version.js";
 import { createHostReadinessReport } from "../../readiness/host.js";
@@ -12,24 +11,19 @@ import { VLLM_EXTRA_ARGS_ENV } from "../vllm-models.js";
 import {
   HOST_LOCAL_VLLM_LIFECYCLE_REF,
   HOST_LOCAL_VLLM_MATERIALIZER_REF,
+  getManagedInferenceVllmInstallPolicy,
   isHostLocalInferenceServingRecipe,
 } from "./adapter-registry.js";
+import {
+  hostLocalVllmDockerRunArguments,
+  hostLocalVllmModelArguments,
+} from "./host-local-vllm-materialization.js";
 import { resolveManagedInferenceServing } from "./resolver.js";
 import type {
   HostLocalInferenceServingRecipe,
+  ManagedInferenceReadinessSource,
   ResolvedHostLocalInferenceSelection,
 } from "./types.js";
-
-const MATERIALIZER_OWNED_ARGUMENTS = new Set([
-  "--host",
-  "--port",
-  "--revision",
-  "--served-model-name",
-  "--max-model-len",
-  "--tensor-parallel-size",
-  "--pipeline-parallel-size",
-  "--data-parallel-size",
-]);
 
 export interface MaterializedHostLocalVllmSelection {
   readonly profile: VllmProfile;
@@ -63,37 +57,6 @@ function positiveIntegerArgument(
   return parsed;
 }
 
-function modelArguments(selection: ResolvedHostLocalInferenceSelection): string[] {
-  return (selection.recipe.spec.serve?.arguments ?? []).flatMap(({ name, value }) => {
-    if (MATERIALIZER_OWNED_ARGUMENTS.has(name)) return [];
-    return value === undefined ? [name] : [name, String(value)];
-  });
-}
-
-function dockerRunArguments(recipe: HostLocalInferenceServingRecipe): string[] {
-  const { devices, sharedMemoryBytes, temporaryFilesystems, ulimits } = recipe.spec.runtime;
-  const memlock = ulimits.memlock === "unlimited" ? -1 : ulimits.memlock;
-  return [
-    "--gpus",
-    recipe.spec.runtime.gpuRequest,
-    "--ipc",
-    recipe.spec.runtime.ipcMode,
-    "--mount",
-    `type=bind,source=${path.join(os.homedir(), ".cache", "huggingface", "hub")},target=${recipe.spec.runtime.modelCache.target}/hub,readonly`,
-    "--shm-size",
-    `${String(sharedMemoryBytes)}b`,
-    "--ulimit",
-    `memlock=${String(memlock)}`,
-    "--ulimit",
-    `stack=${String(ulimits.stackBytes)}`,
-    ...devices.flatMap((device) => ["--device", device]),
-    ...temporaryFilesystems.flatMap(({ target, sizeBytes, mode, options }) => [
-      "--tmpfs",
-      `${target}:${[...options, `size=${String(sizeBytes)}`, `mode=${mode}`].join(",")}`,
-    ]),
-  ];
-}
-
 export function materializeHostLocalVllmSelection(
   selection: ResolvedHostLocalInferenceSelection,
   baseProfile: VllmProfile,
@@ -101,15 +64,31 @@ export function materializeHostLocalVllmSelection(
   const { recipe, preset } = selection;
   if (
     recipe.spec.backend !== "vllm" ||
-    recipe.spec.execution.materializerRef !== HOST_LOCAL_VLLM_MATERIALIZER_REF ||
+    recipe.spec.execution.materializerRef !==
+      HOST_LOCAL_VLLM_MATERIALIZER_REF ||
     recipe.spec.execution.lifecycleRef !== HOST_LOCAL_VLLM_LIFECYCLE_REF
   ) {
     throw new Error("selected serving preset is not a host-local vLLM recipe");
   }
-  if (baseProfile.platform !== "spark") {
-    throw new Error("host-local vLLM serving presets are currently qualified only for DGX Spark");
-  }
   const runtime = recipe.spec.runtime;
+  const directInstall = preset.spec.plan.installPolicyRef
+    ? getManagedInferenceVllmInstallPolicy(preset.spec.plan.installPolicyRef)
+    : recipe.spec.serve.directInstall;
+  const hostArchitecture = baseProfile.architecture ?? process.arch;
+  const expectedRuntimeArchitecture =
+    hostArchitecture === "x64"
+      ? "amd64"
+      : hostArchitecture === "arm64"
+        ? "arm64"
+        : null;
+  if (
+    !expectedRuntimeArchitecture ||
+    runtime.architecture !== expectedRuntimeArchitecture
+  ) {
+    throw new Error(
+      `host-local vLLM recipe architecture ${runtime.architecture} does not match host architecture ${hostArchitecture}`,
+    );
+  }
   const servedModelId = recipe.spec.model.servedName;
   if (
     !runtime?.image ||
@@ -119,9 +98,12 @@ export function materializeHostLocalVllmSelection(
     !recipe.spec.model.downloadSizeBytes ||
     recipe.spec.model.gated === undefined ||
     recipe.spec.model.installFastSafetensors === undefined ||
+    !directInstall ||
     !recipe.spec.readiness?.timeoutSeconds
   ) {
-    throw new Error("host-local vLLM recipe is missing required runtime or model fields");
+    throw new Error(
+      "host-local vLLM recipe is missing required runtime or model fields",
+    );
   }
   const serveEnvironment = {
     ...runtime.environment,
@@ -131,28 +113,37 @@ export function materializeHostLocalVllmSelection(
   };
   const model: VllmModelDef = {
     id: recipe.spec.model.id,
-    label: recipe.metadata.displayName ?? recipe.metadata.id,
-    envValue: preset.metadata.id,
+    label: recipe.spec.model.displayName,
+    envValue: recipe.spec.model.environmentValue,
     downloadSizeBytes: recipe.spec.model.downloadSizeBytes,
     maxModelLen: positiveIntegerArgument(selection, "--max-model-len"),
     revision: recipe.spec.model.revision,
     servedModelId,
-    modelArgs: modelArguments(selection),
+    modelArgs: hostLocalVllmModelArguments(recipe),
     gated: recipe.spec.model.gated,
-    platforms: ["spark"],
-    ...(Object.keys(serveEnvironment).length > 0 ? { serveEnv: serveEnvironment } : {}),
+    platforms: [baseProfile.platform],
+    minComputeCapability: runtime.minimumComputeCapability,
+    ...(Object.keys(serveEnvironment).length > 0
+      ? { serveEnv: serveEnvironment }
+      : {}),
     runtime: {
       image: runtime.image,
       imageDownloadSizeBytes: runtime.imageDownloadSizeBytes,
       modelDownloadSizeBytes: recipe.spec.model.downloadSizeBytes,
       loadTimeoutSec: recipe.spec.readiness.timeoutSeconds,
       pullTimeoutSec: runtime.pullTimeoutSeconds,
-      dockerRunArgs: dockerRunArguments(recipe),
+      minComputeCapability: runtime.minimumComputeCapability,
+      minGpuMemoryBytes: runtime.minimumGpuMemoryBytes,
+      dockerRunArgs: hostLocalVllmDockerRunArguments(recipe),
       dockerRunArgsMode: "replace",
     },
     installFastSafetensors: recipe.spec.model.installFastSafetensors,
-    managedBearerAuth: true,
-    fixedServeCommand: true,
+    ...(directInstall.authentication === "bearer"
+      ? { managedBearerAuth: true as const }
+      : {}),
+    ...(directInstall.fixedArguments
+      ? { fixedServeCommand: true as const }
+      : {}),
   };
   return {
     presetId: preset.metadata.id,
@@ -162,18 +153,26 @@ export function materializeHostLocalVllmSelection(
       ...baseProfile,
       image: runtime.image,
       imageDownloadSizeBytes: runtime.imageDownloadSizeBytes,
-      imageUnpackedSizeBytes: undefined,
+      imageUnpackedSizeBytes:
+        runtime.imageUnpackedSizeBytes ??
+        (runtime.image === baseProfile.image
+          ? baseProfile.imageUnpackedSizeBytes
+          : undefined),
       pullTimeoutSec: runtime.pullTimeoutSeconds,
       loadTimeoutSec: recipe.spec.readiness.timeoutSeconds,
       modelDownloadSizeBytes: recipe.spec.model.downloadSizeBytes,
+      minComputeCapability: runtime.minimumComputeCapability,
+      minGpuMemoryBytes: runtime.minimumGpuMemoryBytes,
       defaultModel: model,
-      servingCatalog: {
-        catalogDigest: selection.catalogDigest,
-        presetId: preset.metadata.id,
-        presetDigest: selection.presetDigest,
-        recipeId: recipe.metadata.id,
-        recipeDigest: selection.recipeDigest,
-      },
+      servingCatalog: directInstall.catalogReceipt
+        ? {
+            catalogDigest: selection.catalogDigest,
+            presetId: preset.metadata.id,
+            presetDigest: selection.presetDigest,
+            recipeId: recipe.metadata.id,
+            recipeDigest: selection.recipeDigest,
+          }
+        : undefined,
     },
   };
 }
@@ -181,10 +180,16 @@ export function materializeHostLocalVllmSelection(
 export function resolveHostLocalVllmSelection(
   baseProfile: VllmProfile,
   env: NodeJS.ProcessEnv = process.env,
+  options: {
+    readonly automatic?: boolean;
+    readonly readinessReports?: readonly ManagedInferenceReadinessSource[];
+  } = {},
 ): HostLocalVllmSelectionResult {
   const presetId = String(env.NEMOCLAW_SERVING_PRESET ?? "").trim();
-  if (!presetId) return { kind: "not-selected" };
-  if (String(env.NEMOCLAW_VLLM_MODEL ?? "").trim()) {
+  const model = String(env.NEMOCLAW_VLLM_MODEL ?? "").trim();
+  if (!presetId && !model && !options.automatic)
+    return { kind: "not-selected" };
+  if (presetId && model) {
     return {
       kind: "rejected",
       reason: "NEMOCLAW_SERVING_PRESET conflicts with NEMOCLAW_VLLM_MODEL",
@@ -193,25 +198,39 @@ export function resolveHostLocalVllmSelection(
   if (String(env[VLLM_EXTRA_ARGS_ENV] ?? "").trim()) {
     return {
       kind: "rejected",
-      reason: `NEMOCLAW_SERVING_PRESET conflicts with ${VLLM_EXTRA_ARGS_ENV}`,
+      reason: `${presetId ? "NEMOCLAW_SERVING_PRESET" : "NEMOCLAW_VLLM_MODEL"} conflicts with ${VLLM_EXTRA_ARGS_ENV}`,
     };
   }
-  const report = createHostReadinessReport(getBuildIdentity());
+  const readinessReports =
+    options.readinessReports ??
+    ([
+      {
+        nodeId: os.hostname(),
+        report: createHostReadinessReport(getBuildIdentity()),
+      },
+    ] satisfies readonly ManagedInferenceReadinessSource[]);
   const resolution = resolveManagedInferenceServing({
-    readinessReports: [{ nodeId: os.hostname(), report }],
+    readinessReports,
     topologyQualifications: [],
-    intent: { preset: presetId },
+    intent: presetId
+      ? { preset: presetId }
+      : model
+        ? { provider: "vllm", vllmModel: model }
+        : { provider: "vllm" },
   });
   if (resolution.outcome !== "selected") {
     return { kind: "rejected", reason: resolution.message };
   }
   if ("topologyQualification" in resolution) {
-    return { kind: "rejected", reason: `Serving preset ${presetId} requires a managed topology.` };
+    return {
+      kind: "rejected",
+      reason: `Serving preset ${resolution.preset.metadata.id} requires a managed topology.`,
+    };
   }
   if (!isHostLocalInferenceServingRecipe(resolution.recipe)) {
     return {
       kind: "rejected",
-      reason: `Serving preset ${presetId} is not a host-local vLLM preset.`,
+      reason: `Serving preset ${resolution.preset.metadata.id} is not a host-local vLLM preset.`,
     };
   }
   try {
@@ -224,7 +243,10 @@ export function resolveHostLocalVllmSelection(
       preset: resolution.preset,
       recipe: resolution.recipe,
     };
-    return { kind: "selected", ...materializeHostLocalVllmSelection(vllmResolution, baseProfile) };
+    return {
+      kind: "selected",
+      ...materializeHostLocalVllmSelection(vllmResolution, baseProfile),
+    };
   } catch (error) {
     return { kind: "rejected", reason: (error as Error).message };
   }

--- a/src/lib/inference/serving/managed-cluster-materialize.test.ts
+++ b/src/lib/inference/serving/managed-cluster-materialize.test.ts
@@ -214,6 +214,7 @@ function syntheticSecondProfile(
   ];
   const catalogContents = {
     compilerVersion: baseCatalog.compilerVersion,
+    models: baseCatalog.models,
     presets: [...baseCatalog.presets, preset],
     recipes: [...baseCatalog.recipes, recipe],
     readinessSchemaRef: baseCatalog.readinessSchemaRef,

--- a/src/lib/inference/serving/profile-list.test.ts
+++ b/src/lib/inference/serving/profile-list.test.ts
@@ -32,6 +32,7 @@ describe("serving profile discovery", () => {
         topology: expect.any(String),
         selectionMode: expect.stringMatching(/^(automatic|explicit-only|disabled)$/u),
         supportState: expect.stringMatching(/^(supported|experimental|disabled)$/u),
+        validationLevel: expect.stringMatching(/^(schema|software|hardware)$/u),
         compatible: expect.any(Boolean),
       });
       expect(
@@ -52,6 +53,8 @@ describe("serving profile discovery", () => {
         topology: "single-host",
         selectionMode: "explicit-only",
         supportState: "experimental",
+        validationLevel: "hardware",
+        validationEvidence: "test-evidence",
         estimatedImageDownloadBytes: 2 * 1024 ** 3,
         estimatedModelDownloadBytes: 3 * 1024 ** 3,
         compatible: false,
@@ -61,8 +64,26 @@ describe("serving profile discovery", () => {
 
     expect(output).toContain("vllm.spark.example  Example profile");
     expect(output).toContain("selection=explicit-only support=experimental");
+    expect(output).toContain("validation=hardware:test-evidence");
     expect(output).toContain("image=2.0 GiB model-download=3.0 GiB");
     expect(output).toContain("incompatible: Host requirement is not met.");
+  });
+
+  it("reuses one immutable readiness snapshot across every profile evaluation", () => {
+    const catalog = loadServingCatalog();
+    const readinessReports = [] as const;
+    const observed: unknown[] = [];
+
+    listServingProfiles(catalog, {
+      readinessReports,
+      evaluateCompatibility: (_catalog, _preset, _recipe, reports) => {
+        observed.push(reports);
+        return { compatible: true, incompatibilityReason: null };
+      },
+    });
+
+    expect(observed).toHaveLength(catalog.presets.length);
+    expect(observed.every((reports) => reports === readinessReports)).toBe(true);
   });
 
   it("escapes an untrusted profile candidate in diagnostics (#8384)", () => {

--- a/src/lib/inference/serving/profile-list.ts
+++ b/src/lib/inference/serving/profile-list.ts
@@ -9,6 +9,7 @@ import { loadServingCatalog, managedInferenceCatalogFromServingCatalog } from ".
 import { resolveManagedInferenceServing } from "./resolver.js";
 import type {
   CompiledServingCatalog,
+  ManagedInferenceReadinessSource,
   ServingPreset,
   ServingRecipe,
   ServingSelectionPolicy,
@@ -23,6 +24,8 @@ export interface ServingProfileListEntry {
   readonly topology: string;
   readonly selectionMode: ServingSelectionPolicy;
   readonly supportState: ServingSupportState;
+  readonly validationLevel?: "schema" | "software" | "hardware" | "unverified";
+  readonly validationEvidence?: string | null;
   readonly estimatedImageDownloadBytes: number | null;
   readonly estimatedModelDownloadBytes: number | null;
   readonly compatible: boolean;
@@ -68,6 +71,7 @@ function compatibility(
   catalog: CompiledServingCatalog,
   preset: ServingPreset,
   recipe: ServingRecipe,
+  readinessReports: readonly ManagedInferenceReadinessSource[],
 ): { compatible: boolean; incompatibilityReason: string | null } {
   if (preset.spec.selection === "disabled" || supportState(preset) === "disabled") {
     return { compatible: false, incompatibilityReason: "Profile is disabled." };
@@ -80,12 +84,7 @@ function compatibility(
   }
   const resolution = resolveManagedInferenceServing(
     {
-      readinessReports: [
-        {
-          nodeId: os.hostname(),
-          report: createHostReadinessReport(getBuildIdentity()),
-        },
-      ],
+      readinessReports,
       topologyQualifications: [],
       intent: { preset: preset.metadata.id },
     },
@@ -98,6 +97,7 @@ function compatibility(
 
 export interface ListServingProfilesOptions {
   readonly evaluateCompatibility?: typeof compatibility;
+  readonly readinessReports?: readonly ManagedInferenceReadinessSource[];
 }
 
 export interface ResolveServingProfileOptions {
@@ -150,6 +150,12 @@ export function listServingProfiles(
   catalog: CompiledServingCatalog = loadServingCatalog(),
   options: ListServingProfilesOptions = {},
 ): ServingProfileListEntry[] {
+  const readinessReports = options.readinessReports ?? [
+    {
+      nodeId: os.hostname(),
+      report: createHostReadinessReport(getBuildIdentity()),
+    },
+  ];
   return [...catalog.presets]
     .sort((left, right) => left.metadata.id.localeCompare(right.metadata.id))
     .map((preset) => {
@@ -163,6 +169,8 @@ export function listServingProfiles(
           topology: "unknown",
           selectionMode: preset.spec.selection,
           supportState: supportState(preset),
+          validationLevel: preset.metadata.validation?.level ?? "unverified",
+          validationEvidence: preset.metadata.validation?.evidence ?? null,
           estimatedImageDownloadBytes: null,
           estimatedModelDownloadBytes: null,
           compatible: false,
@@ -182,9 +190,16 @@ export function listServingProfiles(
         topology: topologyLabel(recipe),
         selectionMode: preset.spec.selection,
         supportState: supportState(preset),
+        validationLevel: preset.metadata.validation?.level ?? "unverified",
+        validationEvidence: preset.metadata.validation?.evidence ?? null,
         estimatedImageDownloadBytes: imageDownloadBytes,
         estimatedModelDownloadBytes: modelDownloadBytes(recipe),
-        ...(options.evaluateCompatibility ?? compatibility)(catalog, preset, recipe),
+        ...(options.evaluateCompatibility ?? compatibility)(
+          catalog,
+          preset,
+          recipe,
+          readinessReports,
+        ),
       };
     });
 }
@@ -204,7 +219,7 @@ export function renderServingProfiles(entries: readonly ServingProfileListEntry[
       return [
         `${entry.id}  ${entry.displayName}`,
         `  backend=${entry.backend} model=${entry.model} topology=${entry.topology}`,
-        `  selection=${entry.selectionMode} support=${entry.supportState} image=${formatBytes(entry.estimatedImageDownloadBytes)} model-download=${formatBytes(entry.estimatedModelDownloadBytes)}`,
+        `  selection=${entry.selectionMode} support=${entry.supportState} validation=${entry.validationLevel ?? "unverified"}${entry.validationEvidence ? `:${entry.validationEvidence}` : ""} image=${formatBytes(entry.estimatedImageDownloadBytes)} model-download=${formatBytes(entry.estimatedModelDownloadBytes)}`,
         `  ${availability}`,
       ].join("\n");
     })

--- a/src/lib/inference/serving/resolver.test.ts
+++ b/src/lib/inference/serving/resolver.test.ts
@@ -81,7 +81,10 @@ function shippedFixtureCatalog(): CompiledManagedInferenceCatalog {
 
 function hostLocalFixtureCatalog(): CompiledManagedInferenceCatalog {
   const catalog = shippedCatalog();
-  const sourceRecipe = catalog.recipes.find(isHostLocalInferenceServingRecipe);
+  const sourceRecipe = catalog.recipes.find(
+    (recipe): recipe is HostLocalInferenceServingRecipe =>
+      isHostLocalInferenceServingRecipe(recipe) && recipe.spec.runtime.architecture === "arm64",
+  );
   expect(sourceRecipe).toBeDefined();
   const sourcePreset = catalog.presets.find(
     ({ spec }) => spec.plan.recipeRef === sourceRecipe!.metadata.id,
@@ -121,27 +124,32 @@ function catalogReadinessEntities(
     "readiness" in requirement ? [requirement.readiness] : [],
   );
   return {
-    observations: readinessRequirements.flatMap((readiness) =>
-      readiness.kind !== "observation"
-        ? []
-        : "state" in readiness
-          ? [
-              {
-                id: readiness.id,
-                state: readiness.state as SystemReadinessReport["observations"][number]["state"],
-              },
-            ]
-          : [
-              {
-                id: readiness.id,
-                state: "present" as const,
-                value:
-                  readiness.comparison.operator === "one-of"
-                    ? readiness.comparison.values[0]
-                    : readiness.comparison.value,
-              },
-            ],
-    ),
+    observations: [
+      ...readinessRequirements.flatMap((readiness) =>
+        readiness.kind !== "observation"
+          ? []
+          : "state" in readiness
+            ? [
+                {
+                  id: readiness.id,
+                  state: readiness.state as SystemReadinessReport["observations"][number]["state"],
+                },
+              ]
+            : [
+                {
+                  id: readiness.id,
+                  state: "present" as const,
+                  value:
+                    readiness.comparison.operator === "one-of"
+                      ? readiness.comparison.values[0]
+                      : readiness.comparison.value,
+                },
+              ],
+      ),
+      { id: "host.gpu.unified_memory", state: "present", value: true },
+      { id: "host.gpu.memory_total_bytes", state: "present", value: 500_000_000_000 },
+      { id: "host.gpu.memory_per_device_bytes", state: "present", value: 500_000_000_000 },
+    ],
     capabilities: readinessRequirements.flatMap((readiness) =>
       readiness.kind === "capability"
         ? [
@@ -332,6 +340,54 @@ describe("managed inference resolver", () => {
     expect(result).not.toHaveProperty("topologyQualification");
   });
 
+  it("resolves a direct model slug only after its full host requirements match", () => {
+    const catalog = hostLocalFixtureCatalog();
+    const recipe = catalog.recipes[0] as HostLocalInferenceServingRecipe;
+    const report = readinessReport({}, catalog.presets[0]!);
+    const result = resolveManagedInferenceServing(
+      {
+        readinessReports: [{ nodeId: "host", report }],
+        topologyQualifications: [],
+        intent: { provider: "vllm", vllmModel: recipe.spec.model.environmentValue },
+        now: NOW,
+      },
+      catalog,
+    );
+
+    expect(result).toMatchObject({
+      outcome: "selected",
+      selection: "explicit",
+      preset: { metadata: { id: catalog.presets[0]!.metadata.id } },
+    });
+  });
+
+  it("rejects a direct model before materialization when GPU memory is below its floor", () => {
+    const catalog = hostLocalFixtureCatalog();
+    const recipe = catalog.recipes[0] as HostLocalInferenceServingRecipe;
+    const base = readinessReport({}, catalog.presets[0]!);
+    const report = {
+      ...base,
+      observations: base.observations.map((observation) =>
+        observation.id === "host.gpu.memory_total_bytes" ||
+        observation.id === "host.gpu.memory_per_device_bytes"
+          ? { ...observation, value: 1 }
+          : observation,
+      ),
+    } as SystemReadinessReport;
+
+    expect(
+      resolveManagedInferenceServing(
+        {
+          readinessReports: [{ nodeId: "host", report }],
+          topologyQualifications: [],
+          intent: { vllmModel: recipe.spec.model.environmentValue },
+          now: NOW,
+        },
+        catalog,
+      ),
+    ).toMatchObject({ outcome: "rejected", code: "requirements-not-met" });
+  });
+
   it("materializes a host-local selection into the existing single-Spark runtime (#8246)", () => {
     const catalog = hostLocalFixtureCatalog();
     const presetId = catalog.presets[0]!.metadata.id;
@@ -351,6 +407,7 @@ describe("managed inference resolver", () => {
     const baseProfile = {
       name: "DGX Spark",
       platform: "spark",
+      architecture: "arm64",
       image: "example.invalid/vllm@sha256:" + "a".repeat(64),
       imageDownloadSizeBytes: 1,
       defaultModel: {} as never,
@@ -366,16 +423,15 @@ describe("managed inference resolver", () => {
       recipeId: catalog.recipes[0]!.metadata.id,
       profile: {
         platform: "spark",
-        servingCatalog: {
-          presetId,
-          recipeId: catalog.recipes[0]!.metadata.id,
-        },
       },
       model: {
         id: catalog.recipes[0]!.spec.model.id,
         platforms: ["spark"],
       },
     });
+    expect(selected.profile.servingCatalog).toBeUndefined();
+    expect(selected.model.managedBearerAuth).toBeUndefined();
+    expect(selected.model.fixedServeCommand).toBeUndefined();
   });
 
   it("selects the shipped automatic preset from catalog data", () => {
@@ -629,6 +685,17 @@ describe("managed inference resolver", () => {
             { id: "host.os.architecture", state: "present", value: "arm64" },
             { id: "host.gpu.count", state: "present", value: 1 },
             { id: "host.gpu.driver_version", state: "present", value: "580.65.06" },
+            { id: "host.gpu.unified_memory", state: "present", value: true },
+            {
+              id: "host.gpu.memory_total_bytes",
+              state: "present",
+              value: 500_000_000_000,
+            },
+            {
+              id: "host.gpu.memory_per_device_bytes",
+              state: "present",
+              value: 500_000_000_000,
+            },
           ],
         }),
       }));
@@ -750,22 +817,41 @@ describe("managed inference resolver", () => {
     expect(Object.isFrozen(selected.topologyQualification.output)).toBe(true);
   });
 
-  it.each([
-    { name: "provider", intent: { provider: "vllm" } },
-    { name: "model", intent: { vllmModel: "another/model" } },
-    {
-      name: "extra arguments",
-      intent: { vllmExtraArguments: ["--another-option"] },
-    },
-  ])("leaves existing $name intent authoritative for automatic selection", ({ intent }) => {
+  it("leaves unmodeled extra arguments authoritative for automatic selection", () => {
     expect(
       resolveManagedInferenceServing({
         readinessReports: [],
         topologyQualifications: [],
-        intent,
+        intent: { vllmExtraArguments: ["--another-option"] },
         now: NOW,
       }),
     ).toMatchObject({ outcome: "no-match", code: "explicit-intent" });
+  });
+
+  it("ignores blank extra arguments during declarative selection", () => {
+    expect(
+      resolveManagedInferenceServing(
+        resolverInput({ intent: { vllmExtraArguments: ["", "   "] } }),
+      ),
+    ).toMatchObject({ outcome: "selected" });
+  });
+
+  it.each([
+    { intent: { provider: "vllm" }, outcome: "no-match", code: "requirements-not-met" },
+    {
+      intent: { vllmModel: "another/model" },
+      outcome: "rejected",
+      code: "requirements-not-met",
+    },
+  ] as const)("routes declarative provider and model intent through selection", (expected) => {
+    expect(
+      resolveManagedInferenceServing({
+        readinessReports: [],
+        topologyQualifications: [],
+        intent: expected.intent,
+        now: NOW,
+      }),
+    ).toMatchObject({ outcome: expected.outcome, code: expected.code });
   });
 
   it("rejects an unknown explicit preset", () => {

--- a/src/lib/inference/serving/resolver.ts
+++ b/src/lib/inference/serving/resolver.ts
@@ -69,11 +69,18 @@ function compareStrings(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
 }
 
-function explicitIntentWithoutPreset(intent: ManagedInferenceSelectionIntent): boolean {
+function unmanagedExplicitIntent(intent: ManagedInferenceSelectionIntent): boolean {
+  return intent.vllmExtraArguments?.some(hasText) ?? false;
+}
+
+function recipeMatchesModelIntent(
+  recipe: ManagedInferenceRuntimeServingRecipe,
+  model: string,
+): boolean {
   return (
-    hasText(intent.provider) ||
-    hasText(intent.vllmModel) ||
-    (intent.vllmExtraArguments?.length ?? 0) > 0
+    model === recipe.spec.model.id ||
+    model === recipe.spec.model.servedName ||
+    ("environmentValue" in recipe.spec.model && model === recipe.spec.model.environmentValue)
   );
 }
 
@@ -347,6 +354,36 @@ function evaluateRequirements<TOutput>(
   return { outcome: "matched", topologyQualifications: matchedTopologies };
 }
 
+function runtimeMemoryRequirementError(
+  recipe: ManagedInferenceRuntimeServingRecipe,
+  reports: readonly ManagedInferenceReadinessSource[],
+): string | undefined {
+  const minimum =
+    recipe.spec.runtime && "minimumGpuMemoryBytes" in recipe.spec.runtime
+      ? recipe.spec.runtime.minimumGpuMemoryBytes
+      : undefined;
+  if (minimum === undefined) return undefined;
+  for (const { nodeId, report } of reports) {
+    const observationValue = (id: string): unknown => {
+      const matches = report.observations.filter((observation) => observation.id === id);
+      return matches.length === 1 && matches[0]!.state === "present"
+        ? matches[0]!.value
+        : undefined;
+    };
+    const unified = observationValue("host.gpu.unified_memory") === true;
+    const available = observationValue(
+      unified ? "host.gpu.memory_total_bytes" : "host.gpu.memory_per_device_bytes",
+    );
+    if (typeof available !== "number") {
+      return `${nodeId}: GPU memory capacity could not be determined.`;
+    }
+    if (available < minimum) {
+      return `${nodeId}: GPU memory capacity ${String(available)} is below the recipe minimum ${String(minimum)} bytes.`;
+    }
+  }
+  return undefined;
+}
+
 function intentCompatibilityError(
   intent: ManagedInferenceSelectionIntent,
   preset: ManagedInferenceServingPreset,
@@ -357,12 +394,11 @@ function intentCompatibilityError(
   }
   if (
     hasText(intent.vllmModel) &&
-    intent.vllmModel !== recipe.spec.model.id &&
-    intent.vllmModel !== recipe.spec.model.servedName
+    !recipeMatchesModelIntent(recipe, intent.vllmModel)
   ) {
     return `model ${intent.vllmModel} conflicts with preset ${preset.metadata.id}`;
   }
-  if ((intent.vllmExtraArguments?.length ?? 0) > 0) {
+  if (unmanagedExplicitIntent(intent)) {
     return `extra vLLM arguments conflict with preset ${preset.metadata.id}`;
   }
   return undefined;
@@ -425,6 +461,8 @@ function matchingCandidate<TOutput>(
     input.topologyQualifications,
   );
   if (requirements.outcome !== "matched") return requirements;
+  const memoryError = runtimeMemoryRequirementError(recipe, input.readinessReports);
+  if (memoryError) return { outcome: "unmet", message: memoryError };
   const materializer = getManagedInferenceMaterializerDescriptor(
     recipe.spec.execution.materializerRef,
   );
@@ -498,7 +536,8 @@ export function resolveManagedInferenceServing<TOutput>(
 ): ManagedInferenceResolution<TOutput> {
   const intent = input.intent ?? {};
   const explicitPresetId = hasText(intent.preset) ? intent.preset : undefined;
-  if (!explicitPresetId && explicitIntentWithoutPreset(intent)) {
+  const explicitModel = hasText(intent.vllmModel) ? intent.vllmModel : undefined;
+  if (!explicitPresetId && unmanagedExplicitIntent(intent)) {
     return {
       outcome: "no-match",
       code: "explicit-intent",
@@ -556,6 +595,56 @@ export function resolveManagedInferenceServing<TOutput>(
             : "requirements-not-met",
       message: evaluated.message,
     };
+  }
+
+  if (explicitModel) {
+    const modelPresets = catalog.presets.filter((preset) => {
+      if (preset.spec.selection === "disabled") return false;
+      return recipeMatchesModelIntent(recipeForPreset(catalog, preset), explicitModel);
+    });
+    if (modelPresets.length === 0) {
+      return {
+        outcome: "rejected",
+        code: "requirements-not-met",
+        message: `No managed vLLM profile defines model ${explicitModel}.`,
+      };
+    }
+
+    const matching: MatchingCandidate<TOutput>[] = [];
+    let firstFailure: Exclude<
+      ReturnType<typeof matchingCandidate<TOutput>>,
+      { readonly outcome: "matched" }
+    > | undefined;
+    for (const compiledPreset of modelPresets) {
+      const evaluated = matchingCandidate(catalog, compiledPreset, input);
+      if (evaluated.outcome === "matched") matching.push(evaluated.candidate);
+      else firstFailure ??= evaluated;
+    }
+    if (matching.length === 0) {
+      return {
+        outcome: "rejected",
+        code: firstFailure?.outcome === "invalid-topology" ? "invalid-topology" : "requirements-not-met",
+        message:
+          firstFailure?.message ?? `No compatible managed vLLM profile defines model ${explicitModel}.`,
+      };
+    }
+    matching.sort(
+      (left, right) =>
+        right.priority - left.priority ||
+        compareStrings(left.preset.metadata.id, right.preset.metadata.id),
+    );
+    const highestPriority = matching[0]!.priority;
+    const tied = matching.filter(({ priority }) => priority === highestPriority);
+    if (tied.length !== 1) {
+      return {
+        outcome: "rejected",
+        code: "ambiguous-selection",
+        message: `Managed vLLM model ${explicitModel} is ambiguous at priority ${String(
+          highestPriority,
+        )}: ${tied.map(({ preset }) => preset.metadata.id).join(", ")}.`,
+      };
+    }
+    return selectedResolution(catalog, tied[0]!, "explicit");
   }
 
   const matching: MatchingCandidate<TOutput>[] = [];

--- a/src/lib/inference/serving/types.ts
+++ b/src/lib/inference/serving/types.ts
@@ -3,7 +3,8 @@
 
 import type { SystemReadinessReport } from "../../readiness/types.js";
 
-export type ServingDefinitionKind = "ServingRecipe" | "ServingPreset";
+export type ServingDefinitionKind =
+  "ServingModel" | "ServingRecipe" | "ServingPreset";
 export type ServingSelectionPolicy = "automatic" | "explicit-only" | "disabled";
 export type ServingSupportState = "supported" | "experimental" | "disabled";
 
@@ -30,7 +31,8 @@ export interface ServingProfileProvenance {
   readonly estimatedImageDownloadBytes: number | null;
   readonly estimatedModelDownloadBytes: number | null;
 }
-export type ReadinessEntityKind = "observation" | "capability" | "qualification";
+export type ReadinessEntityKind =
+  "observation" | "capability" | "qualification";
 export type ReadinessValueType = "boolean" | "number" | "string" | "version";
 export type ServingReadinessObservationRole =
   | "operating-system"
@@ -43,6 +45,29 @@ export interface ServingMetadata {
   readonly id: string;
   readonly displayName?: string;
   readonly supportState?: ServingSupportState;
+  readonly validation?: {
+    readonly level: "schema" | "software" | "hardware";
+    readonly evidence: string;
+  };
+}
+
+export interface ServingModelCapabilities {
+  readonly chatCompletions: boolean;
+  readonly streaming: boolean;
+  readonly toolCalls: boolean;
+  readonly structuredOutputs: boolean;
+  readonly reasoning: boolean;
+  readonly multimodal: boolean;
+}
+
+export interface ServingModelDefinition {
+  readonly apiVersion: "nemoclaw.nvidia.com/managed-inference/v1";
+  readonly kind: "ServingModel";
+  readonly metadata: Pick<ServingMetadata, "id" | "displayName">;
+  readonly spec: ManagedInferenceServingRecipe["spec"]["model"] & {
+    readonly capabilities: ServingModelCapabilities;
+    readonly probePolicyRef: string;
+  };
 }
 
 export interface ServingArgument {
@@ -80,6 +105,25 @@ export interface ServingTemporaryFilesystem {
   readonly options: readonly string[];
 }
 
+export interface VllmDirectInstallPolicy {
+  /** Authentication used by the legacy NEMOCLAW_VLLM_MODEL install surface. */
+  readonly authentication: "none" | "bearer";
+  /** Whether VLLM_EXTRA_ARGS is rejected for the direct install surface. */
+  readonly fixedArguments: boolean;
+  /** Whether the direct install surface owns a catalog lifecycle receipt. */
+  readonly catalogReceipt: boolean;
+}
+
+export interface ServingStationPairOrchestration {
+  readonly image: string;
+  readonly imageDownloadSizeBytes: number;
+  readonly servedName: string;
+  readonly nodeCount: 2;
+  readonly tensorParallelSize: number;
+  readonly pipelineParallelSize: number;
+  readonly loadTimeoutSeconds: number;
+}
+
 export interface ManagedInferenceServingRecipe {
   readonly apiVersion: "nemoclaw.nvidia.com/managed-inference/v1";
   readonly kind: "ServingRecipe";
@@ -90,16 +134,28 @@ export interface ManagedInferenceServingRecipe {
     readonly model: {
       readonly id: string;
       readonly revision: string;
+      readonly environmentValue: string;
+      readonly displayName: string;
+      readonly menuOrder: number;
       readonly servedName: string;
-      readonly files?: readonly { readonly path: string; readonly digest: string }[];
+      readonly files?: readonly {
+        readonly path: string;
+        readonly digest: string;
+      }[];
       readonly downloadSizeBytes: number;
       readonly gated: boolean;
       readonly installFastSafetensors: boolean;
       readonly preparation: ServingModelPreparation;
+      readonly capabilities?: ServingModelCapabilities;
+      readonly probePolicyRef?: string;
     };
+    readonly modelRef?: string;
     readonly runtime: {
       readonly image: string;
       readonly imageDownloadSizeBytes: number;
+      readonly imageUnpackedSizeBytes?: number;
+      readonly minimumComputeCapability: number;
+      readonly minimumGpuMemoryBytes?: number;
       readonly pullTimeoutSeconds: number;
       readonly architecture: string;
       readonly networkMode: string;
@@ -122,6 +178,8 @@ export interface ManagedInferenceServingRecipe {
     readonly execution: {
       readonly materializerRef: string;
       readonly lifecycleRef: string;
+      readonly orchestrationRef?: string;
+      readonly stationPair?: ServingStationPairOrchestration;
       readonly topologyBinding: string;
       readonly nodeCount: number;
       readonly tensorParallelSize: number;
@@ -133,6 +191,7 @@ export interface ManagedInferenceServingRecipe {
       readonly authentication: string;
       readonly executable: string;
       readonly arguments: readonly ServingArgument[];
+      readonly directInstall?: VllmDirectInstallPolicy;
     };
     readonly readiness: {
       readonly timeoutSeconds: number;
@@ -142,8 +201,10 @@ export interface ManagedInferenceServingRecipe {
 }
 
 /** A single-host vLLM recipe, with cluster-only inputs unavailable by construction. */
-export interface HostLocalInferenceServingRecipe
-  extends Omit<ManagedInferenceServingRecipe, "spec"> {
+export interface HostLocalInferenceServingRecipe extends Omit<
+  ManagedInferenceServingRecipe,
+  "spec"
+> {
   readonly spec: Omit<
     ManagedInferenceServingRecipe["spec"],
     "backend" | "bindings" | "execution"
@@ -153,6 +214,8 @@ export interface HostLocalInferenceServingRecipe
     readonly execution: {
       readonly materializerRef: "vllm.host-local/v1";
       readonly lifecycleRef: "vllm.host-local.lifecycle/v1";
+      readonly orchestrationRef?: string;
+      readonly stationPair?: ServingStationPairOrchestration;
       readonly topologyBinding?: never;
       readonly nodeCount?: never;
       readonly tensorParallelSize?: never;
@@ -183,20 +246,34 @@ interface GenericServingRecipe extends ServingRecipeEnvelope {
     readonly model: {
       readonly id: string;
       readonly revision: string;
+      readonly environmentValue?: string;
+      readonly displayName?: string;
+      readonly menuOrder?: number;
       readonly servedName?: string;
-      readonly files?: readonly { readonly path: string; readonly digest: string }[];
+      readonly files?: readonly {
+        readonly path: string;
+        readonly digest: string;
+      }[];
       readonly downloadSizeBytes?: number;
       readonly gated?: boolean;
       readonly installFastSafetensors?: boolean;
       readonly preparation?: ServingModelPreparation;
+      readonly capabilities?: ServingModelCapabilities;
+      readonly probePolicyRef?: string;
     };
-    readonly runtime?: Partial<ManagedInferenceServingRecipe["spec"]["runtime"]> & {
+    readonly modelRef?: string;
+    readonly runtime?: Partial<
+      ManagedInferenceServingRecipe["spec"]["runtime"]
+    > & {
       readonly components?: Readonly<Record<string, string>>;
+      readonly minimumComputeCapability?: number;
     };
     readonly execution: {
       readonly receiptRef?: string;
       readonly materializerRef: string;
       readonly lifecycleRef: string;
+      readonly orchestrationRef?: string;
+      readonly stationPair?: ServingStationPairOrchestration;
       readonly topologyBinding?: string;
       readonly nodeCount?: number;
       readonly tensorParallelSize?: number;
@@ -208,6 +285,7 @@ interface GenericServingRecipe extends ServingRecipeEnvelope {
       readonly authentication?: string;
       readonly executable?: string;
       readonly arguments?: readonly ServingArgument[];
+      readonly directInstall?: Partial<VllmDirectInstallPolicy>;
     };
     readonly readiness?: {
       readonly contractRef?: string;
@@ -224,7 +302,10 @@ export interface LlamaCppServingRecipe extends ServingRecipeEnvelope {
     readonly bindings?: never;
     readonly server: {
       readonly technology: "llama.cpp";
-      readonly source: { readonly repository: string; readonly revision: string };
+      readonly source: {
+        readonly repository: string;
+        readonly revision: string;
+      };
     };
     readonly model: {
       readonly id: string;
@@ -253,7 +334,9 @@ export interface LlamaCppServingRecipe extends ServingRecipeEnvelope {
         readonly sharing: "host-user";
         readonly cleanup: "preserve";
       };
+      readonly probePolicyRef?: never;
     };
+    readonly modelRef?: never;
     readonly runtime: {
       readonly image: string;
       readonly imageDownloadSizeBytes: number;
@@ -262,7 +345,10 @@ export interface LlamaCppServingRecipe extends ServingRecipeEnvelope {
       readonly networkExposure: "loopback";
       readonly restartPolicy: "unless-stopped";
       readonly hosts: 1;
-      readonly cuda: { readonly baseImage: string; readonly minimumDriverVersion: string };
+      readonly cuda: {
+        readonly baseImage: string;
+        readonly minimumDriverVersion: string;
+      };
       readonly gpu: {
         readonly vendor: "nvidia";
         readonly count: 1;
@@ -279,6 +365,8 @@ export interface LlamaCppServingRecipe extends ServingRecipeEnvelope {
       readonly receiptRef: string;
       readonly materializerRef: string;
       readonly lifecycleRef: string;
+      readonly orchestrationRef?: never;
+      readonly stationPair?: never;
       readonly nodeCount?: never;
     };
     readonly serve: {
@@ -346,7 +434,10 @@ export interface LlamaCppServingRecipe extends ServingRecipeEnvelope {
       readonly multimodalProjection: "disabled";
     };
     readonly capabilities: {
-      readonly agents: readonly { readonly id: string; readonly qualificationRef: string }[];
+      readonly agents: readonly {
+        readonly id: string;
+        readonly qualificationRef: string;
+      }[];
       readonly protocols: readonly ["openai-completions"];
       readonly streaming: boolean;
       readonly toolCalls: boolean;
@@ -364,7 +455,10 @@ export type ServingRecipe = GenericServingRecipe | LlamaCppServingRecipe;
 
 export type ServingReadinessComparison =
   | { readonly operator: "equals"; readonly value: string | number | boolean }
-  | { readonly operator: "one-of"; readonly values: readonly (string | number | boolean)[] }
+  | {
+      readonly operator: "one-of";
+      readonly values: readonly (string | number | boolean)[];
+    }
   | { readonly operator: "at-least"; readonly value: number }
   | { readonly operator: "version-at-least"; readonly value: string };
 
@@ -394,7 +488,8 @@ export type ServingReadinessRequirement =
       };
     };
 
-export type ServingFactValue = string | number | boolean | readonly (string | number | boolean)[];
+export type ServingFactValue =
+  string | number | boolean | readonly (string | number | boolean)[];
 
 export interface ServingFactRequirement {
   readonly fact: string;
@@ -432,11 +527,18 @@ export interface ManagedInferenceServingPreset {
     readonly selection: ServingSelectionPolicy;
     readonly priority: number;
     readonly featureGate?: string;
-    readonly requirements: { readonly all: readonly ServingPresetRequirement[] };
+    readonly requirements: {
+      readonly all: readonly ServingPresetRequirement[];
+    };
     readonly plan: {
       readonly backend: string;
       readonly recipeRef: string;
-      readonly bindings?: Readonly<Record<string, ServingPresetTopologyBinding>>;
+      readonly installPolicyRef?: string;
+      readonly platform?: "spark" | "station" | "n1x" | "linux";
+      readonly interactive?: boolean;
+      readonly bindings?: Readonly<
+        Record<string, ServingPresetTopologyBinding>
+      >;
     };
   };
 }
@@ -449,11 +551,18 @@ export interface ServingPreset {
     readonly selection: ServingSelectionPolicy;
     readonly priority: number;
     readonly featureGate?: string;
-    readonly requirements?: { readonly all: readonly ServingPresetRequirement[] };
+    readonly requirements?: {
+      readonly all: readonly ServingPresetRequirement[];
+    };
     readonly plan: {
       readonly backend: string;
       readonly recipeRef: string;
-      readonly bindings?: Readonly<Record<string, ServingPresetTopologyBinding>>;
+      readonly installPolicyRef?: string;
+      readonly platform?: "spark" | "station" | "n1x" | "linux";
+      readonly interactive?: boolean;
+      readonly bindings?: Readonly<
+        Record<string, ServingPresetTopologyBinding>
+      >;
     };
   };
 }
@@ -466,10 +575,11 @@ export interface ServingCatalogSourceProvenance {
 }
 
 export interface CompiledServingCatalogPayload {
-  readonly schemaVersion: "1.0.0";
-  readonly compilerVersion: "1.2.0";
+  readonly schemaVersion: "1.1.0";
+  readonly compilerVersion: "1.4.0";
   readonly sourceRevision: string;
   readonly readinessSchemaRef: "https://github.com/NVIDIA/NemoClaw/schemas/system-readiness.schema.json";
+  readonly models: readonly ServingModelDefinition[];
   readonly recipes: readonly ServingRecipe[];
   readonly presets: readonly ServingPreset[];
   readonly sources: readonly ServingCatalogSourceProvenance[];
@@ -486,6 +596,7 @@ export interface ServingCatalogSource {
 
 export interface ServingCatalogSchemas {
   readonly catalog: object;
+  readonly model: object;
   readonly preset: object;
   readonly recipe: object;
 }
@@ -511,9 +622,15 @@ export interface ServingCatalogRegistries {
   readonly materializers: ReadonlySet<string>;
   readonly lifecycles: ReadonlySet<string>;
   readonly readinessContracts: ReadonlySet<string>;
+  readonly installPolicies?: ReadonlySet<string>;
+  readonly probePolicies?: ReadonlySet<string>;
+  readonly orchestrations?: ReadonlySet<string>;
   readonly readiness: ReadonlyMap<string, ServingReadinessRegistryValue>;
   readonly facts?: ReadonlySet<string>;
-  readonly topologyQualifications?: ReadonlyMap<string, ServingTopologyRegistryEntry>;
+  readonly topologyQualifications?: ReadonlyMap<
+    string,
+    ServingTopologyRegistryEntry
+  >;
   readonly validateRecipe?: (recipe: ServingRecipe) => string | undefined;
 }
 
@@ -526,9 +643,12 @@ export type ManagedInferenceFactValue = ServingFactValue;
 export type ManagedInferenceFactRequirement = ServingFactRequirement;
 export type ManagedInferenceTopologyRequirement = ServingTopologyRequirement;
 export type ManagedInferencePresetRequirement = ServingPresetRequirement;
-export type ManagedInferencePresetTopologyBinding = ServingPresetTopologyBinding;
-export interface CompiledManagedInferenceCatalog
-  extends Omit<CompiledServingCatalog, "presets" | "recipes"> {
+export type ManagedInferencePresetTopologyBinding =
+  ServingPresetTopologyBinding;
+export interface CompiledManagedInferenceCatalog extends Omit<
+  CompiledServingCatalog,
+  "presets" | "recipes"
+> {
   readonly presets: readonly ManagedInferenceServingPreset[];
   readonly recipes: readonly ManagedInferenceRuntimeServingRecipe[];
 }
@@ -548,7 +668,9 @@ const MATERIALIZER_OWNED_SERVE_ARGUMENTS = new Set([
   "--tensor-parallel-size",
 ]);
 
-export function isManagedInferenceMaterializerOwnedArgument(name: string): boolean {
+export function isManagedInferenceMaterializerOwnedArgument(
+  name: string,
+): boolean {
   return MATERIALIZER_OWNED_SERVE_ARGUMENTS.has(name);
 }
 

--- a/src/lib/inference/vllm-compute-capability.test.ts
+++ b/src/lib/inference/vllm-compute-capability.test.ts
@@ -62,8 +62,10 @@ import {
   computeCapabilityPreflight,
   detectVllmProfile,
   formatComputeCapability,
-  installVllm,
+  installVllm as installVllmProduction,
+  type InstallVllmOptions,
   readGpuComputeCapabilities,
+  type VllmProfile,
 } from "./vllm";
 import {
   applyVllmInstallProbeDefaults,
@@ -71,10 +73,15 @@ import {
   mockDockerSpawnSuccess,
   resetVllmInstallEnv,
   type VllmInstallSpies,
+  withVllmInstallTestReadiness,
 } from "./vllm-install.test-support";
 import { VLLM_MODELS } from "./vllm-models";
 
 const READY_MODELS_RESPONSE = '{"data":[]}';
+
+function installVllm(profile: VllmProfile, options: InstallVllmOptions) {
+  return installVllmProduction(profile, withVllmInstallTestReadiness(profile, options));
+}
 
 function mockHostCommands(options: { computeCap: string; curl?: string }): void {
   mocks.runCapture.mockImplementation((cmd: readonly string[]) => {
@@ -216,7 +223,11 @@ describe("managed vLLM GPU compute capability preflight", () => {
   });
 
   it.each(quantizedModels)("declares a minimum compute capability for $id (#8307)", (model) => {
-    expect(model.minComputeCapability).toBeGreaterThanOrEqual(89);
+    // NVIDIA's published Lightning recipe explicitly covers A100 (8.0);
+    // device-specific runtime variants may raise this floor (Spark uses 12.1).
+    const expectedMinimum =
+      model.envValue === "nemotron-3.5-lightning-30b" ? 80 : 89;
+    expect(model.minComputeCapability).toBeGreaterThanOrEqual(expectedMinimum);
   });
 });
 

--- a/src/lib/inference/vllm-install-storage.test.ts
+++ b/src/lib/inference/vllm-install-storage.test.ts
@@ -60,7 +60,12 @@ vi.mock("./serving/vllm-managed-support", async (importOriginal) => {
   };
 });
 
-import { detectVllmProfile, installVllm } from "./vllm";
+import {
+  detectVllmProfile,
+  installVllm as installVllmProduction,
+  type InstallVllmOptions,
+  type VllmProfile,
+} from "./vllm";
 import {
   applyVllmInstallProbeDefaults,
   createVllmInstallSpies,
@@ -69,7 +74,12 @@ import {
   mockSuccessfulVllmInstall,
   resetVllmInstallEnv,
   type VllmInstallSpies,
+  withVllmInstallTestReadiness,
 } from "./vllm-install.test-support";
+
+function installVllm(profile: VllmProfile, options: InstallVllmOptions) {
+  return installVllmProduction(profile, withVllmInstallTestReadiness(profile, options));
+}
 
 beforeEach(() => {
   applyVllmInstallProbeDefaults(mocks);

--- a/src/lib/inference/vllm-install.test-support.ts
+++ b/src/lib/inference/vllm-install.test-support.ts
@@ -16,6 +16,15 @@ import os from "node:os";
 import path from "node:path";
 
 import { type Mock, type MockInstance, vi } from "vitest";
+import type {
+  QualificationStatus,
+  ReadinessState,
+  SystemReadinessReport,
+} from "../readiness/types.js";
+import { isHostLocalInferenceServingRecipe } from "./serving/adapter-registry.js";
+import { loadManagedInferenceCatalog } from "./serving/catalog-loader.js";
+import type { ManagedInferenceReadinessSource } from "./serving/types.js";
+import type { InstallVllmOptions, VllmProfile } from "./vllm.js";
 
 export type VllmInstallMocks = {
   dockerCapture: Mock;
@@ -48,6 +57,123 @@ export type VllmInstallSpies = {
 };
 
 export const MANAGED_CONTAINER_ID = "a".repeat(64);
+
+/** Build fresh, catalog-shaped readiness evidence for downstream install unit tests. */
+export function vllmInstallTestReadiness(
+  profile: VllmProfile,
+  modelIntent = String(process.env.NEMOCLAW_VLLM_MODEL ?? "").trim(),
+): readonly ManagedInferenceReadinessSource[] {
+  const expectedArchitecture = profile.architecture === "x64" ? "amd64" : profile.architecture;
+  const catalog = loadManagedInferenceCatalog();
+  const candidates = catalog.presets.flatMap((preset) => {
+    if (preset.spec.plan.backend !== "vllm" || preset.spec.plan.platform !== profile.platform) {
+      return [];
+    }
+    const recipe = catalog.recipes.find(
+      ({ metadata }) => metadata.id === preset.spec.plan.recipeRef,
+    );
+    if (
+      !recipe ||
+      !isHostLocalInferenceServingRecipe(recipe) ||
+      recipe.spec.runtime.architecture !== expectedArchitecture
+    ) {
+      return [];
+    }
+    const requestedModel = modelIntent || profile.defaultModel.envValue;
+    const aliases = [
+      recipe.spec.model.id,
+      recipe.spec.model.environmentValue,
+      recipe.spec.model.servedName,
+    ];
+    return aliases.some((value) => value.toLowerCase() === requestedModel.toLowerCase())
+      ? [{ preset, recipe }]
+      : [];
+  });
+  if (candidates.length === 0) {
+    throw new Error(
+      `No host-local catalog fixture matches ${modelIntent || profile.defaultModel.envValue} on ${profile.platform}/${String(expectedArchitecture)}`,
+    );
+  }
+  const { preset } = candidates.sort(
+    (left, right) => right.preset.spec.priority - left.preset.spec.priority,
+  )[0]!;
+  const observations = new Map<string, SystemReadinessReport["observations"][number]>();
+  const capabilities = new Map<string, SystemReadinessReport["capabilities"][number]>();
+  const qualifications = new Map<string, SystemReadinessReport["qualifications"][number]>();
+  for (const requirement of preset.spec.requirements.all) {
+    if (!("readiness" in requirement)) continue;
+    const readiness = requirement.readiness;
+    if (readiness.kind === "observation") {
+      observations.set(
+        readiness.id,
+        "state" in readiness
+          ? { id: readiness.id, state: readiness.state as ReadinessState }
+          : {
+              id: readiness.id,
+              state: "present",
+              value:
+                readiness.comparison.operator === "one-of"
+                  ? readiness.comparison.values[0]
+                  : readiness.comparison.value,
+            },
+      );
+    } else if (readiness.kind === "capability") {
+      capabilities.set(readiness.id, {
+        id: readiness.id,
+        state: readiness.state as ReadinessState,
+      });
+    } else if ("status" in readiness) {
+      qualifications.set(readiness.id, {
+        id: readiness.id,
+        status: readiness.status as QualificationStatus,
+      });
+    }
+  }
+  const unifiedMemory = profile.platform !== "linux";
+  observations.set("host.gpu.unified_memory", {
+    id: "host.gpu.unified_memory",
+    state: "present",
+    value: unifiedMemory,
+  });
+  observations.set("host.gpu.memory_total_bytes", {
+    id: "host.gpu.memory_total_bytes",
+    state: "present",
+    value: 1_000_000_000_000,
+  });
+  observations.set("host.gpu.memory_per_device_bytes", {
+    id: "host.gpu.memory_per_device_bytes",
+    state: "present",
+    value: 1_000_000_000_000,
+  });
+  const report = {
+    schemaVersion: "1.1.0",
+    status: "supported",
+    exitCode: 0,
+    mutated: false,
+    provenance: {
+      nemoclawVersion: "0.1.0",
+      sourceRevision: "0".repeat(40),
+      observedAt: new Date().toISOString(),
+    },
+    observations: [...observations.values()],
+    capabilities: [...capabilities.values()],
+    qualifications: [...qualifications.values()],
+    findings: [],
+    evidence: [],
+  } satisfies SystemReadinessReport;
+  return [{ nodeId: "vllm-install-test-host", report }];
+}
+
+export function withVllmInstallTestReadiness(
+  profile: VllmProfile,
+  options: InstallVllmOptions,
+): InstallVllmOptions {
+  return {
+    resolveManagedBridgeHost: () => "172.18.0.1",
+    ...options,
+    readinessReports: vllmInstallTestReadiness(profile),
+  };
+}
 
 export function vllmContainerRow(
   containerName: string,

--- a/src/lib/inference/vllm-managed-cluster-runtime-receipt.test.ts
+++ b/src/lib/inference/vllm-managed-cluster-runtime-receipt.test.ts
@@ -144,6 +144,7 @@ function catalogWithUnrelatedProfile(): CompiledManagedInferenceCatalog {
   ] as const;
   const contents = {
     compilerVersion: current.compilerVersion,
+    models: current.models,
     presets: [...current.presets, unrelatedPreset],
     recipes: [...current.recipes, unrelatedRecipe],
     readinessSchemaRef: current.readinessSchemaRef,

--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -3,20 +3,155 @@
 
 import { describe, expect, it } from "vitest";
 
+import { vllmProbePolicyForModel } from "./openai-probe-models";
+import { loadManagedInferenceCatalog } from "./serving/catalog-loader";
+import type {
+  HostLocalInferenceServingRecipe,
+  ServingModelPreparation,
+} from "./serving/types";
 import {
   assertGatedModelAccess,
   buildNemotronUltraDistributedServeCommand,
   buildVllmServeCommand,
+  defaultVllmModelForPlatform,
   DEFAULT_VLLM_MODEL,
   modelsForPlatform,
   parseVllmExtraServeArgs,
   preflightVllmModelEnv,
   selectVllmModelFromEnv,
+  STATION_PAIR_OPTIONAL_ORCHESTRATION,
   VLLM_EXTRA_ARGS_ENV,
   VLLM_MODELS,
+  vllmModelsFromCatalog,
+  vllmModelForOrchestration,
 } from "./vllm-models";
 
 describe("vllm model registry", () => {
+  it("maps every generated runtime variant to a compiled catalog preset", () => {
+    const catalog = loadManagedInferenceCatalog();
+    const presetIds = new Set(catalog.presets.map(({ metadata }) => metadata.id));
+    const runtimeVariants = VLLM_MODELS.flatMap((model) => model.runtimeVariants ?? []);
+    const runtimePresetIds = runtimeVariants.map(({ catalogPresetId }) => catalogPresetId);
+
+    expect(runtimeVariants.length).toBeGreaterThan(0);
+    expect(runtimePresetIds.filter((presetId) => !presetIds.has(presetId!))).toEqual([]);
+    expect(new Set(runtimePresetIds).size).toBe(runtimeVariants.length);
+    expect(new Set(VLLM_MODELS.map((model) => model.envValue)).size).toBe(VLLM_MODELS.length);
+  });
+
+  it.each(VLLM_MODELS)("derives capabilities and probe policy for $envValue", (model) => {
+    expect(model.capabilities).toMatchObject({
+      chatCompletions: true,
+      toolCalls: true,
+    });
+    expect(model.probePolicyRef).toMatch(/^nvidia\.endpoint-validation\./u);
+    expect(model.runtimeVariants?.length).toBeGreaterThan(0);
+  });
+
+  it.each(
+    VLLM_MODELS.flatMap((model) =>
+      (model.runtimeVariants ?? []).map((variant) => [model.envValue, variant] as const),
+    ),
+  )("derives a qualified catalog runtime for %s [case %#]", (_model, variant) => {
+    expect(variant.catalogPresetId).toMatch(/^vllm\./u);
+    expect(variant.platforms).toHaveLength(1);
+    expect(variant.architectures).toHaveLength(1);
+  });
+
+  it("discovers special orchestration and probe behavior through catalog references", () => {
+    const stationPairModel = vllmModelForOrchestration(
+      STATION_PAIR_OPTIONAL_ORCHESTRATION,
+      "station",
+      "arm64",
+    );
+
+    expect(stationPairModel?.runtimeVariants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          orchestrationRef: STATION_PAIR_OPTIONAL_ORCHESTRATION,
+          stationPair: expect.objectContaining({
+            nodeCount: 2,
+            pipelineParallelSize: 2,
+          }),
+        }),
+      ]),
+    );
+    expect(vllmProbePolicyForModel("deepseek-ai/deepseek-v4-flash")).toBe(
+      "nvidia.endpoint-validation.extended/v1",
+    );
+    expect(vllmProbePolicyForModel("unknown/model")).toBe("nvidia.endpoint-validation.standard/v1");
+  });
+
+  it("adds a model through catalog data without a TypeScript registry edit", () => {
+    const catalog = loadManagedInferenceCatalog();
+    const sourceRecipe = catalog.recipes.find(
+      ({ metadata }) => metadata.id === "vllm.nemotron-3-nano-4b-fp8.linux-amd64-single.v1",
+    ) as HostLocalInferenceServingRecipe;
+    const sourcePreset = catalog.presets.find(
+      ({ spec }) => spec.plan.recipeRef === sourceRecipe.metadata.id,
+    )!;
+    const recipeId = "vllm.catalog-only-test-model.linux-amd64-single.v1";
+    const addedRecipe: HostLocalInferenceServingRecipe = {
+      ...sourceRecipe,
+      metadata: {
+        ...sourceRecipe.metadata,
+        id: recipeId,
+        displayName: "Catalog-only test model",
+      },
+      spec: {
+        ...sourceRecipe.spec,
+        model: {
+          ...sourceRecipe.spec.model,
+          id: "test/catalog-only-model",
+          environmentValue: "catalog-only-model",
+          displayName: "Catalog-only model",
+          menuOrder: 999,
+          servedName: "catalog-only-model",
+        },
+        readiness: {
+          ...sourceRecipe.spec.readiness,
+          expectedModel: "catalog-only-model",
+        },
+      },
+    };
+    const addedPreset = {
+      ...sourcePreset,
+      metadata: {
+        ...sourcePreset.metadata,
+        id: "vllm.linux-amd64-nvidia.single.catalog-only-test-model",
+        displayName: "Catalog-only test model on Linux x86_64",
+      },
+      spec: {
+        ...sourcePreset.spec,
+        selection: "explicit-only" as const,
+        plan: { ...sourcePreset.spec.plan, recipeRef: recipeId },
+      },
+    };
+
+    const models = vllmModelsFromCatalog({
+      ...catalog,
+      recipes: [...catalog.recipes, addedRecipe],
+      presets: [...catalog.presets, addedPreset],
+    });
+
+    expect(models.find(({ envValue }) => envValue === "catalog-only-model")).toMatchObject({
+      id: "test/catalog-only-model",
+      label: "Catalog-only model",
+      platforms: ["linux"],
+      requireRuntimeVariant: true,
+    });
+  });
+
+  it.each([
+    ["spark", "arm64", "qwen3.6-35b-a3b-nvfp4"],
+    ["station", "arm64", "deepseek-v4-flash"],
+    ["n1x", "arm64", "qwen3.6-35b-a3b-nvfp4"],
+    ["linux", "x64", "nemotron-3-nano-4b"],
+    ["linux", "arm64", "nemotron-3-nano-4b"],
+  ] as const)("selects the catalog default for %s/%s", (platform, architecture, expected) => {
+    expect(defaultVllmModelForPlatform(platform, architecture).envValue).toBe(expected);
+  });
+
   it("starts directly with setup when the serving environment is empty (#8246)", () => {
     const command = buildVllmServeCommand({
       id: "test/model",
@@ -52,6 +187,7 @@ describe("vllm model registry", () => {
       "nemotron-3-ultra-550b-a55b": 352_381_245_521,
       "qwen3.6-35b-a3b-nvfp4": 23_500_000_000,
       "muse-glimmer-30b": 25_447_097_878,
+      "nemotron-3.5-lightning-30b": 21_561_882_284,
     });
   });
 
@@ -96,48 +232,67 @@ describe("vllm model registry", () => {
     ).toEqual(deepseek);
   });
 
+  it("preserves Python indentation in the DeepSeek V4 tokenizer patch", () => {
+    const model = loadManagedInferenceCatalog().models.find(
+      ({ metadata }) => metadata.id === "vllm.deepseek-v4-flash-0731.v1",
+    );
+    const preparation = model?.spec.preparation as Extract<
+      ServingModelPreparation,
+      { readonly ref: "snapshot-copy-and-exact-text-replacement/v1" }
+    >;
+
+    expect(preparation.exactTextReplacement.expectedText).toBe(
+      '            elif reasoning_effort in ("max", "xhigh"):\n' +
+        '                reasoning_effort = "max"\n' +
+        "            else:\n" +
+        '                reasoning_effort = "high"',
+    );
+    expect(preparation.exactTextReplacement.replacementText).toBe(
+      '            elif reasoning_effort in ("max", "xhigh"):\n' +
+        '                reasoning_effort = "max"\n' +
+        '            elif reasoning_effort == "high":\n' +
+        '                reasoning_effort = "high"\n' +
+        "            else:\n" +
+        '                reasoning_effort = "low"',
+    );
+  });
+
   it("pins the DGX Station Nemotron Ultra serving recipe", () => {
     const ultra = VLLM_MODELS.find((m) => m.envValue === "nemotron-3-ultra-550b-a55b");
     expect(ultra).toBeDefined();
     expect(ultra!.id).toBe("nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4");
     expect(ultra!.revision).toBe("183968f87ae4cedce3039313cac1fd43d112c578");
     expect(ultra!.servedModelId).toBe("nvidia/nemotron-3-ultra-550b-a55b");
-    expect(ultra!.runtime).toEqual({
+    expect(ultra!.runtime).toMatchObject({
       image:
         "vllm/vllm-openai@sha256:0fec7ec5f3e6bc168e54899935fb0557da908a4832a1dbc88e2debcf2f889416",
       imageDownloadSizeBytes: 10_670_087_425,
       modelDownloadSizeBytes: 352_381_245_521,
       loadTimeoutSec: 3600,
-      dockerRunArgs: ["--shm-size", "16g", "--ulimit", "memlock=-1", "--ulimit", "stack=67108864"],
+      dockerRunArgs: expect.arrayContaining([
+        "--gpus",
+        "all",
+        "--shm-size",
+        "17179869184b",
+        "--ulimit",
+        "memlock=-1",
+      ]),
+      dockerRunArgsMode: "replace",
+      minComputeCapability: 100,
+      minGpuMemoryBytes: 352_381_245_521,
+      pullTimeoutSec: 43_200,
     });
 
     const cmd = buildVllmServeCommand(ultra!);
-    expect(cmd).toBe(
-      [
-        "export VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY=1",
-        "&& export VLLM_NVFP4_GEMM_BACKEND=flashinfer-trtllm",
-        "&& vllm serve nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
-        "--tensor-parallel-size 1",
-        "--pipeline-parallel-size 1",
-        "--data-parallel-size 1",
-        "--port 8000",
-        "--trust-remote-code",
-        "--max-model-len 262144",
-        "--revision 183968f87ae4cedce3039313cac1fd43d112c578",
-        "--served-model-name nvidia/nemotron-3-ultra-550b-a55b",
-        "--host 0.0.0.0",
-        "--cpu-offload-gb 150",
-        "--cpu-offload-params experts",
-        `--kernel_config '{"enable_flashinfer_autotune": false}'`,
-        `--speculative-config '{"method":"nemotron_h_mtp","num_speculative_tokens":3}'`,
-        "--max-num-seqs 256",
-        "--gpu-memory-utilization 0.9",
-        "--reasoning-parser nemotron_v3",
-        "--enable-auto-tool-choice",
-        "--tool-call-parser qwen3_coder",
-        `--default-chat-template-kwargs '{"enable_thinking":true,"force_nonempty_content":true}'`,
-      ].join(" "),
-    );
+    expect(cmd).toContain("export VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY=1");
+    expect(cmd).toContain("export VLLM_NVFP4_GEMM_BACKEND=flashinfer-trtllm");
+    expect(cmd).toContain("vllm serve nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4");
+    expect(cmd).toContain("--max-model-len 262144");
+    expect(cmd).toContain("--revision 183968f87ae4cedce3039313cac1fd43d112c578");
+    expect(cmd).toContain("--cpu-offload-gb 150");
+    expect(cmd).toContain(`--kernel-config '{"enable_flashinfer_autotune":false}'`);
+    expect(cmd).toContain("--reasoning-parser nemotron_v3");
+    expect(cmd).not.toContain("--trust-remote-code");
   });
 
   it("builds the pinned two-Station Nemotron Ultra vLLM v0.25.1 Ray head command", () => {
@@ -157,11 +312,14 @@ describe("vllm model registry", () => {
     expect(cmd).toContain("--distributed-executor-backend ray");
     expect(cmd).toContain("--kv-cache-dtype fp8");
     expect(cmd).toContain("--max-model-len 262144");
+    expect(cmd).not.toContain("--trust-remote-code");
     expect(cmd).toContain("--distributed-timeout-seconds 7200");
     expect(cmd).toContain("--served-model-name nemotron-ultra");
     expect(cmd).toContain("--host 192.168.240.1");
+    expect(cmd).toContain("--port 8000");
     expect(cmd).toContain("--max-num-seqs 256");
     expect(cmd).toContain("--gpu-memory-utilization 0.9");
+    expect(cmd).not.toContain("--kernel-config");
     expect(cmd).not.toContain("--kernel_config");
     expect(cmd).not.toContain("--speculative-config");
     expect(cmd).not.toContain("--cpu-offload");
@@ -214,25 +372,35 @@ describe("vllm model registry", () => {
 
   it("rejects an unknown NEMOCLAW_VLLM_MODEL with a helpful message", () => {
     expect(() =>
-      selectVllmModelFromEnv({ NEMOCLAW_VLLM_MODEL: "made-up-model" } as NodeJS.ProcessEnv),
+      selectVllmModelFromEnv({
+        NEMOCLAW_VLLM_MODEL: "made-up-model",
+      } as NodeJS.ProcessEnv),
     ).toThrow(/Unknown NEMOCLAW_VLLM_MODEL='made-up-model'/);
   });
 
   it("treats an empty NEMOCLAW_VLLM_MODEL the same as unset", () => {
-    expect(selectVllmModelFromEnv({ NEMOCLAW_VLLM_MODEL: "   " } as NodeJS.ProcessEnv)).toBeNull();
+    expect(
+      selectVllmModelFromEnv({
+        NEMOCLAW_VLLM_MODEL: "   ",
+      } as NodeJS.ProcessEnv),
+    ).toBeNull();
   });
 
   it("passes the gated check when HF_TOKEN is present", () => {
     const deepseek = VLLM_MODELS.find((m) => m.envValue === "deepseek-r1-distill-70b");
     expect(() =>
-      assertGatedModelAccess(deepseek!, { HF_TOKEN: "hf_abc" } as NodeJS.ProcessEnv),
+      assertGatedModelAccess(deepseek!, {
+        HF_TOKEN: "hf_abc",
+      } as NodeJS.ProcessEnv),
     ).not.toThrow();
   });
 
   it("accepts HUGGING_FACE_HUB_TOKEN as an equivalent token", () => {
     const deepseek = VLLM_MODELS.find((m) => m.envValue === "deepseek-r1-distill-70b");
     expect(() =>
-      assertGatedModelAccess(deepseek!, { HUGGING_FACE_HUB_TOKEN: "hf_abc" } as NodeJS.ProcessEnv),
+      assertGatedModelAccess(deepseek!, {
+        HUGGING_FACE_HUB_TOKEN: "hf_abc",
+      } as NodeJS.ProcessEnv),
     ).not.toThrow();
   });
 
@@ -341,7 +509,7 @@ describe("vllm model registry", () => {
     expect(cmd).toContain("--data-parallel-size 1");
     expect(cmd).toContain("--port 8000");
     expect(cmd).toContain("--kv-cache-dtype fp8");
-    expect(cmd).toContain("--trust-remote-code");
+    expect(cmd).not.toContain("--trust-remote-code");
     expect(cmd).toContain("--block-size 256");
     expect(cmd).toContain("--enable-prefix-caching");
     expect(cmd).toContain("--gpu-memory-utilization 0.92");
@@ -464,12 +632,7 @@ describe("vllm model registry", () => {
       installFastSafetensors: false,
       trustRemoteCode: false,
       managedBearerAuth: true,
-      runtime: {
-        image:
-          "vllm/vllm-openai@sha256:677afd5bf3b4bb9881f91e107af7098f8410726b4c05b25cb4a815900b398204",
-        imageDownloadSizeBytes: 9_699_710_136,
-        modelDownloadSizeBytes: 25_447_097_878,
-      },
+      requireRuntimeVariant: true,
     });
 
     const command = buildVllmServeCommand(muse!);
@@ -489,6 +652,24 @@ describe("vllm model registry", () => {
     expect(command).not.toContain("--speculative-config");
     expect(command).not.toContain("pip install");
   });
+
+  it("pins the published Lightning parser baseline for DGX Spark", () => {
+    const lightning = VLLM_MODELS.find((model) => model.envValue === "nemotron-3.5-lightning-30b");
+
+    expect(lightning).toMatchObject({
+      id: "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4",
+      platforms: ["spark"],
+      pickerPlatforms: [],
+      minComputeCapability: 121,
+      requireRuntimeVariant: true,
+    });
+    const command = buildVllmServeCommand(lightning!);
+    expect(command).toContain("--mamba-backend flashinfer");
+    expect(command).toContain("--tool-call-parser step3p5");
+    expect(command).toContain("--reasoning-parser step3p5");
+    expect(command).toContain("--moe-backend marlin");
+    expect(command).toContain("--speculative-config");
+  });
 });
 
 describe("modelsForPlatform", () => {
@@ -505,6 +686,7 @@ describe("modelsForPlatform", () => {
     expect(slugs).toContain("nemotron-3-nano-4b");
     expect(slugs).toContain("deepseek-r1-distill-70b");
     expect(slugs).toContain("muse-glimmer-30b");
+    expect(slugs).not.toContain("nemotron-3.5-lightning-30b");
     expect(slugs).not.toContain("deepseek-v4-flash");
   });
 
@@ -517,22 +699,24 @@ describe("modelsForPlatform", () => {
     expect(slugs).toContain("nemotron-3-ultra-550b-a55b");
     expect(slugs).not.toContain("qwen3.6-35b-a3b-nvfp4");
     expect(slugs).not.toContain("muse-glimmer-30b");
+    expect(slugs).not.toContain("nemotron-3.5-lightning-30b");
   });
 
-  it("omits arch-specific entries from the generic Linux profile", () => {
+  it("keeps newly added Linux compatibility paths out of the interactive picker", () => {
     const slugs = modelsForPlatform("linux").map((m) => m.envValue);
     expect(slugs).toContain("qwen3.6-27b");
     expect(slugs).toContain("nemotron-3-nano-4b");
     expect(slugs).toContain("deepseek-r1-distill-70b");
     expect(slugs).not.toContain("qwen3.6-35b-a3b-nvfp4");
     expect(slugs).not.toContain("muse-glimmer-30b");
+    expect(slugs).not.toContain("nemotron-3.5-lightning-30b");
     expect(slugs).not.toContain("deepseek-v4-flash");
   });
 
   it("preserves registry order so callers can stably mark the recommended entry", () => {
-    const registryOrder = VLLM_MODELS.filter((m) => m.platforms.includes("spark")).map(
-      (m) => m.envValue,
-    );
+    const registryOrder = VLLM_MODELS.filter((m) =>
+      (m.pickerPlatforms ?? m.platforms).includes("spark"),
+    ).map((m) => m.envValue);
     expect(modelsForPlatform("spark").map((m) => m.envValue)).toEqual(registryOrder);
   });
 });
@@ -540,9 +724,11 @@ describe("modelsForPlatform", () => {
 describe("parseVllmExtraServeArgs", () => {
   it("returns no extra args when the env var is unset or blank", () => {
     expect(parseVllmExtraServeArgs({} as NodeJS.ProcessEnv)).toEqual([]);
-    expect(parseVllmExtraServeArgs({ [VLLM_EXTRA_ARGS_ENV]: "  " } as NodeJS.ProcessEnv)).toEqual(
-      [],
-    );
+    expect(
+      parseVllmExtraServeArgs({
+        [VLLM_EXTRA_ARGS_ENV]: "  ",
+      } as NodeJS.ProcessEnv),
+    ).toEqual([]);
   });
 
   it("parses a JSON array of extra vLLM serve argument tokens", () => {
@@ -582,12 +768,16 @@ describe("parseVllmExtraServeArgs", () => {
 
 describe("preflightVllmModelEnv", () => {
   it("succeeds when NEMOCLAW_VLLM_MODEL is unset", () => {
-    expect(preflightVllmModelEnv({} as NodeJS.ProcessEnv)).toEqual({ ok: true });
+    expect(preflightVllmModelEnv({} as NodeJS.ProcessEnv)).toEqual({
+      ok: true,
+    });
   });
 
   it("succeeds for a recognised non-gated slug", () => {
     expect(
-      preflightVllmModelEnv({ NEMOCLAW_VLLM_MODEL: "qwen3.6-27b" } as NodeJS.ProcessEnv),
+      preflightVllmModelEnv({
+        NEMOCLAW_VLLM_MODEL: "qwen3.6-27b",
+      } as NodeJS.ProcessEnv),
     ).toEqual({ ok: true });
   });
 

--- a/src/lib/inference/vllm-models.ts
+++ b/src/lib/inference/vllm-models.ts
@@ -29,13 +29,40 @@
 
 import net from "node:net";
 
+import { isHostLocalInferenceServingRecipe } from "./serving/adapter-registry.js";
+import { managedInferenceDigest } from "./serving/catalog-integrity.js";
+import { loadManagedInferenceCatalog } from "./serving/catalog-loader.js";
+import {
+  hostLocalVllmDockerRunArguments,
+  hostLocalVllmModelArguments,
+} from "./serving/host-local-vllm-materialization.js";
+import type {
+  CompiledManagedInferenceCatalog,
+  HostLocalInferenceServingRecipe,
+  ManagedInferenceServingPreset,
+  ServingArgument,
+  ServingModelCapabilities,
+  ServingStationPairOrchestration,
+} from "./serving/types.js";
+
 export type VllmPlatform = "spark" | "station" | "n1x" | "linux";
+export const STATION_PAIR_OPTIONAL_ORCHESTRATION = "vllm.station-pair-optional/v1";
+
+export interface VllmServingCatalogIdentity {
+  readonly catalogDigest: string;
+  readonly presetId: string;
+  readonly presetDigest: string;
+  readonly recipeId: string;
+  readonly recipeDigest: string;
+}
 
 export interface VllmRuntimeOverride {
   /** Model-specific runtime image, pinned by digest. */
   image: string;
   /** Compressed size of the selected platform manifest. */
   imageDownloadSizeBytes: number;
+  /** Measured uncompressed layer size for the exact image digest, when known. */
+  imageUnpackedSizeBytes?: number;
   /** Size of the pinned Hugging Face snapshot used for cache preflight. */
   modelDownloadSizeBytes?: number;
   /** Maximum time to wait for this model to become ready after launch. */
@@ -46,24 +73,60 @@ export interface VllmRuntimeOverride {
   dockerRunArgsMode?: "append" | "replace";
   /** Maximum time allowed for the immutable image pull. */
   pullTimeoutSec?: number;
+  /** Runtime-specific GPU floor, overriding the model-wide default. */
+  minComputeCapability?: number;
+  /** Minimum GPU or unified-memory capacity declared by the recipe. */
+  minGpuMemoryBytes?: number;
+  /** Catalog identity that produced this runtime. */
+  servingCatalog?: VllmServingCatalogIdentity;
+  /** Catalog preset that declared this runtime, independent of receipt ownership. */
+  catalogPresetId?: string;
+  /** Allowlisted orchestration adapter selected by the catalog recipe. */
+  orchestrationRef?: string;
+  /** Typed data consumed only by the allowlisted Station-pair adapter. */
+  stationPair?: ServingStationPairOrchestration;
 }
 
-export const NEMOTRON_ULTRA_STATION_IMAGE = {
-  tag: "vllm/vllm-openai:v0.22.0",
-  arm64: {
-    ref: "vllm/vllm-openai@sha256:0fec7ec5f3e6bc168e54899935fb0557da908a4832a1dbc88e2debcf2f889416",
-    downloadSizeBytes: 10_670_087_425,
-  },
-} as const;
-
-/** Runtime pinned from the published dual-DGX-Station playbook. */
-export const NEMOTRON_ULTRA_DUAL_STATION_IMAGE = {
-  tag: "vllm/vllm-openai:v0.25.1-aarch64",
-  arm64: {
-    ref: "vllm/vllm-openai@sha256:2cc49b81319f7a66a33dd8bd63a7bfddae079122b33ce51989b6828a1f038c37",
-    downloadSizeBytes: 10_238_912_364,
-  },
-} as const;
+/**
+ * A runtime override qualified for a host platform and architecture.
+ *
+ * Entries are ordered from general to specific. The resolver selects the last
+ * matching entry, which lets a conservative Linux baseline precede a
+ * device-specific optimized runtime without making an ARM64 image the fallback
+ * for an x86_64 host.
+ */
+export interface VllmRuntimeVariant extends VllmRuntimeOverride {
+  /** Higher-priority variants override the general hardware baseline. */
+  priority: number;
+  /** NemoClaw platform profiles this runtime can serve. */
+  platforms?: readonly VllmPlatform[];
+  /** Node.js host architectures this image was built for. */
+  architectures?: readonly NodeJS.Architecture[];
+  /** Model arguments supplied by this recipe. */
+  modelArgs: readonly string[];
+  /** Recipe-specific context length. */
+  maxModelLen: number;
+  /** Immutable model revision supplied by this recipe. */
+  revision: string;
+  /** Served model name supplied by this recipe. */
+  servedModelId: string;
+  /** Recipe environment passed to the serving process. */
+  serveEnv: Readonly<Record<string, string>>;
+  /** Whether startup installs the fastsafetensors extra. */
+  installFastSafetensors: boolean;
+  /** Direct installs may opt into a fixed serving command. */
+  fixedServeCommand?: true;
+  /** Direct installs may opt into managed bearer authentication. */
+  managedBearerAuth?: true;
+  /** Catalog images do not receive an implicit remote-code flag. */
+  trustRemoteCode: false;
+  /** Preset selection policy used for automatic hardware defaults. */
+  selection: "automatic" | "explicit-only";
+  /** Whether the interactive model picker displays this variant. */
+  interactive: boolean;
+  /** Catalog preset that declared this runtime. */
+  catalogPresetId: string;
+}
 
 export interface VllmModelDef {
   /** Hugging Face model id (also passed to `vllm serve`). */
@@ -81,18 +144,21 @@ export interface VllmModelDef {
   /** Stable model name exposed by the local OpenAI-compatible endpoint. */
   servedModelId?: string;
   /** Model-specific flags appended after the shared serving flags. */
-  modelArgs: string[];
+  modelArgs: readonly string[];
   /** True when the upstream HF repo requires accepting a licence. */
   gated: boolean;
   /**
-   * Platforms whose interactive picker should offer this entry. Models with
-   * platform-specific flags (the NVFP4 MoE checkpoint targets `sm_121a` only,
-   * the very large V4 Flash recipe wants Station-class VRAM) appear only on
-   * profiles they can actually run on. Direct `NEMOCLAW_VLLM_MODEL`
-   * overrides bypass the picker filter, so `runVllmInstall` rejects any
-   * override outside this list before the image pull and model download.
+   * Platforms on which managed vLLM may serve this entry. Direct
+   * `NEMOCLAW_VLLM_MODEL` overrides are checked against this list before an
+   * image pull or model download.
    */
   platforms: readonly VllmPlatform[];
+  /**
+   * Optional narrower list for the interactive picker. This keeps a newly
+   * added compatibility path explicit-only until it has completed broader
+   * hardware qualification without blocking an intentional env override.
+   */
+  pickerPlatforms?: readonly VllmPlatform[];
   minComputeCapability?: number;
   /**
    * Environment variables exported immediately before `vllm serve` (e.g.
@@ -100,9 +166,13 @@ export interface VllmModelDef {
    * `export K=V && …` so they apply to the serve process inside the
    * container shell.
    */
-  serveEnv?: Record<string, string>;
+  serveEnv?: Readonly<Record<string, string>>;
   /** Runtime overrides for recipes that cannot use the platform image. */
   runtime?: VllmRuntimeOverride;
+  /** Ordered, compatibility-qualified runtime overrides. */
+  runtimeVariants?: readonly VllmRuntimeVariant[];
+  /** Refuse the platform baseline when no runtime variant matches. */
+  requireRuntimeVariant?: true;
   /** Whether startup must install vLLM's fastsafetensors extra. Defaults to true. */
   installFastSafetensors?: boolean;
   /** Disable remote model code for a runtime image that contains native model support. */
@@ -111,290 +181,357 @@ export interface VllmModelDef {
   managedBearerAuth?: true;
   /** Reject environment-provided model and serving-argument overrides. */
   fixedServeCommand?: true;
+  /** Model behavior used by endpoint validation and agent compatibility checks. */
+  capabilities?: ServingModelCapabilities;
+  /** Allowlisted endpoint probe budget policy. */
+  probePolicyRef?: string;
 }
 
-export const VLLM_MODELS: readonly VllmModelDef[] = [
-  {
-    id: "Qwen/Qwen3.6-27B-FP8",
-    label: "Qwen3.6 27B FP8",
-    envValue: "qwen3.6-27b",
-    downloadSizeBytes: 30_900_000_000,
-    maxModelLen: 262144,
-    modelArgs: [
-      "--gpu-memory-utilization",
-      "0.7",
-      "--max-num-seqs",
-      "4",
-      "--reasoning-parser",
-      "qwen3",
-      "--enable-auto-tool-choice",
-      "--tool-call-parser",
-      "qwen3_coder",
-      "--load-format",
-      "fastsafetensors",
-      "--enable-prefix-caching",
-    ],
-    gated: false,
-    platforms: ["spark", "station", "linux"],
-    minComputeCapability: 89,
-  },
-  {
-    id: "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
-    label: "DeepSeek-R1 Distill Llama 70B",
-    envValue: "deepseek-r1-distill-70b",
-    downloadSizeBytes: 141_000_000_000,
-    maxModelLen: 32768,
-    modelArgs: [
-      "--gpu-memory-utilization",
-      "0.7",
-      "--max-num-seqs",
-      "4",
-      "--reasoning-parser",
-      "deepseek_r1",
-      "--enable-auto-tool-choice",
-      "--tool-call-parser",
-      "hermes",
-    ],
-    gated: true,
-    platforms: ["spark", "station", "linux"],
-  },
-  {
-    id: "nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8",
-    label: "NVIDIA Nemotron-3 Nano 4B FP8",
-    envValue: "nemotron-3-nano-4b",
-    downloadSizeBytes: 5_280_000_000,
-    // Matches the model card's `max_position_embeddings` and the vLLM
-    // example NVIDIA publishes for this checkpoint. The previous value
-    // (262000) was an undocumented round-down with no headroom rationale.
-    maxModelLen: 262144,
-    // `--enable-auto-tool-choice` + `--tool-call-parser qwen3_coder` match
-    // the vLLM launch example on the model card at
-    // https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8. Without
-    // them a plain completion succeeds (HTTP 200) but any agent request
-    // that sends `tool_choice: "auto"` fails HTTP 400 with vLLM's
-    // "'auto' tool choice requires --enable-auto-tool-choice and
-    // --tool-call-parser to be set" (#6314) — which blocks every agent
-    // tool-call flow on the generic-Linux managed vLLM default (Spark and
-    // Station defaults already pin their own tool-call parser).
-    //
-    // `--reasoning-parser nemotron_v3` is likewise part of that same model
-    // card launch recipe: Nemotron-3-Nano is a reasoning model that emits a
-    // `<think>…</think>` trace. Without a reasoning parser vLLM leaves the
-    // trace — including the bare `</think>` marker the chat template does not
-    // pair with an opening `<think>` — inline in `content`, and the agent's
-    // streaming parser mishandles that orphan marker into an empty turn that
-    // wedges the session (#6915). `nemotron_v3` is a built-in parser in the
-    // pinned NGC vLLM image (it subclasses the DeepSeek-R1 parser) and moves
-    // the trace out of `content`, so no plugin file is required. The Spark and
-    // Station defaults already pin their own reasoning parser.
-    modelArgs: [
-      "--gpu-memory-utilization",
-      "0.7",
-      "--reasoning-parser",
-      "nemotron_v3",
-      "--load-format",
-      "fastsafetensors",
-      "--enable-auto-tool-choice",
-      "--tool-call-parser",
-      "qwen3_coder",
-    ],
-    gated: false,
-    platforms: ["spark", "station", "linux"],
-    minComputeCapability: 89,
-  },
-  {
-    id: "deepseek-ai/DeepSeek-V4-Flash",
-    label: "DeepSeek V4 Flash",
-    envValue: "deepseek-v4-flash",
-    downloadSizeBytes: 352_381_000_000,
-    maxModelLen: 1048576,
-    modelArgs: [
-      "--kv-cache-dtype",
-      "fp8",
-      "--block-size",
-      "256",
-      "--enable-prefix-caching",
-      "--gpu-memory-utilization",
-      "0.92",
-      "--compilation-config",
-      `{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}`,
-      "--attention_config.use_fp4_indexer_cache",
-      "True",
-      "--tokenizer-mode",
-      "deepseek_v4",
-      "--tool-call-parser",
-      "deepseek_v4",
-      "--enable-auto-tool-choice",
-      "--reasoning-parser",
-      "deepseek_v4",
-      "--no-disable-hybrid-kv-cache-manager",
-      "--disable-uvicorn-access-log",
-      "--max-cudagraph-capture-size",
-      "128",
-      "--speculative-config",
-      `{"method":"mtp","num_speculative_tokens":3}`,
-      "--max-num-batched-tokens",
-      "8192",
-      "--max-num-seqs",
-      "16",
-      "--prefix-cache-retention-interval",
-      "auto",
-    ],
-    gated: false,
-    platforms: ["station"],
-    minComputeCapability: 100,
-  },
-  {
-    id: "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
-    label: "NVIDIA Nemotron 3 Ultra 550B NVFP4",
-    envValue: "nemotron-3-ultra-550b-a55b",
-    downloadSizeBytes: 352_381_245_521,
-    maxModelLen: 262144,
-    revision: "183968f87ae4cedce3039313cac1fd43d112c578",
-    // Keep the route identity aligned with NemoClaw's existing managed
-    // Nemotron Ultra compatibility manifests and request adapters.
-    servedModelId: "nvidia/nemotron-3-ultra-550b-a55b",
-    modelArgs: [
-      "--host",
-      "0.0.0.0",
-      "--cpu-offload-gb",
-      "150",
-      "--cpu-offload-params",
-      "experts",
-      "--kernel_config",
-      `{"enable_flashinfer_autotune": false}`,
-      "--speculative-config",
-      `{"method":"nemotron_h_mtp","num_speculative_tokens":3}`,
-      "--max-num-seqs",
-      "256",
-      "--gpu-memory-utilization",
-      "0.9",
-      "--reasoning-parser",
-      "nemotron_v3",
-      "--enable-auto-tool-choice",
-      "--tool-call-parser",
-      "qwen3_coder",
-      "--default-chat-template-kwargs",
-      `{"enable_thinking":true,"force_nonempty_content":true}`,
-    ],
-    gated: false,
-    platforms: ["station"],
-    minComputeCapability: 100,
-    serveEnv: {
-      VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: "1",
-      VLLM_NVFP4_GEMM_BACKEND: "flashinfer-trtllm",
-    },
-    runtime: {
-      image: NEMOTRON_ULTRA_STATION_IMAGE.arm64.ref,
-      imageDownloadSizeBytes: NEMOTRON_ULTRA_STATION_IMAGE.arm64.downloadSizeBytes,
-      modelDownloadSizeBytes: 352_381_245_521,
-      loadTimeoutSec: 3600,
-      // The single-host runtime keeps NemoClaw's bridge-networked local-
-      // inference boundary. The qualified dual-Station lifecycle intentionally
-      // builds a separate host-networked launch contract for NCCL/RDMA.
-      dockerRunArgs: ["--shm-size", "16g", "--ulimit", "memlock=-1", "--ulimit", "stack=67108864"],
-    },
-    // The digest-pinned vLLM image already contains the serving package, and
-    // this recipe does not use the fastsafetensors load format. Avoid mutating
-    // the reviewed runtime from the package index when the container starts.
-    installFastSafetensors: false,
-  },
-  {
-    id: "nvidia/Qwen3.6-35B-A3B-NVFP4",
-    label: "Qwen3.6 35B-A3B NVFP4",
-    envValue: "qwen3.6-35b-a3b-nvfp4",
-    downloadSizeBytes: 23_500_000_000,
-    maxModelLen: 262144,
-    // Additive flags on top of the shared serving defaults. The shared flags
-    // already cover --tensor-parallel-size/--pipeline-parallel-size/
-    // --data-parallel-size (all 1 — harmless on one Spark or N1x host),
-    // --port 8000, and --trust-remote-code; --max-model-len comes from
-    // maxModelLen above.
-    modelArgs: [
-      "--gpu-memory-utilization",
-      "0.4",
-      "--dtype",
-      "auto",
-      "--quantization",
-      "modelopt",
-      "--kv-cache-dtype",
-      "fp8",
-      "--attention-backend",
-      "flashinfer",
-      "--moe-backend",
-      "marlin",
-      "--max-num-seqs",
-      "4",
-      "--max-num-batched-tokens",
-      "8192",
-      "--enable-chunked-prefill",
-      "--async-scheduling",
-      "--enable-prefix-caching",
-      "--enable-auto-tool-choice",
-      // `qwen3_coder`, not `qwen3_xml` (#6457). On DGX Spark this checkpoint's
-      // tool-call frames do not round-trip through vLLM's `qwen3_xml` parser: it
-      // logs `qwen3xml_tool_parser.py:303 Error when parsing XML elements: not
-      // well-formed (invalid token)` and emits truncated/extra-`}` tool
-      // arguments, so Deep Agents Code headless (`dcode -n`) tool calls fail
-      // with `POST /v1/chat/completions 400 Bad Request`
-      // (`json.decoder.JSONDecodeError: Extra data`) and `dcode` exits 1.
-      // `qwen3_coder` matches this Qwen3.6-family checkpoint's emitted tool-call
-      // format — the parser the other Qwen3.6 recipes in this registry already
-      // use (Qwen3.6-27B-FP8, Nemotron-3-Nano-4B). Validated end-to-end on real
-      // DGX Spark (GB10); see PR verification notes for the `dcode -n` transcript.
-      "--tool-call-parser",
-      "qwen3_coder",
-      "--reasoning-parser",
-      "qwen3",
-      // Keep MTP speculative decoding opt-in on DGX Spark. It increases the
-      // managed profile's cold-start memory pressure and long-context risk
-      // without being required for correct model or tool-call behavior (#7127).
-      "--load-format",
-      "fastsafetensors",
-    ],
-    gated: false,
-    platforms: ["spark", "n1x"],
-    minComputeCapability: 121,
-  },
-  {
-    id: "Inferact/Muse-Glimmer-30B-NVFP4-W4A4",
-    label: "Muse Glimmer 30B NVFP4 W4A4 [Experimental]",
-    envValue: "muse-glimmer-30b",
-    downloadSizeBytes: 25_447_097_878,
-    maxModelLen: 32768,
-    revision: "d35cb79050f419c457611b1cee5c5d15b176f285",
-    servedModelId: "muse-glimmer",
-    modelArgs: [
-      "--gpu-memory-utilization",
-      "0.75",
-      "--max-num-seqs",
-      "1",
-      "--max-num-batched-tokens",
-      "4096",
-      "--enable-auto-tool-choice",
-      "--tool-call-parser",
-      "muse_glimmer",
-      "--reasoning-parser",
-      "muse_glimmer",
-      "--generation-config",
-      "auto",
-    ],
-    gated: false,
-    platforms: ["spark"],
-    minComputeCapability: 121,
-    runtime: {
-      image:
-        "vllm/vllm-openai@sha256:677afd5bf3b4bb9881f91e107af7098f8410726b4c05b25cb4a815900b398204",
-      imageDownloadSizeBytes: 9_699_710_136,
-      modelDownloadSizeBytes: 25_447_097_878,
-    },
-    installFastSafetensors: false,
-    trustRemoteCode: false,
-    managedBearerAuth: true,
-  },
-] as const;
+interface CatalogModelVariant {
+  readonly id: string;
+  readonly label: string;
+  readonly envValue: string;
+  readonly menuOrder: number;
+  readonly downloadSizeBytes: number;
+  readonly gated: boolean;
+  readonly capabilities?: ServingModelCapabilities;
+  readonly probePolicyRef?: string;
+  readonly platform: VllmPlatform;
+  readonly variant: VllmRuntimeVariant;
+}
 
-export const DEFAULT_VLLM_MODEL: VllmModelDef = VLLM_MODELS[0];
+function argumentValue(arguments_: readonly ServingArgument[], name: string): string | undefined {
+  const matches = arguments_.filter((argument) => argument.name === name);
+  if (matches.length !== 1) return undefined;
+  const value = matches[0]!.value;
+  return value === undefined ? undefined : String(value);
+}
+
+function nodeArchitecture(architecture: string): NodeJS.Architecture {
+  if (architecture === "amd64") return "x64";
+  if (architecture === "arm64") return "arm64";
+  throw new Error(`Managed vLLM recipe uses unsupported architecture ${architecture}.`);
+}
+
+function catalogModelVariant(
+  catalogDigest: string,
+  preset: ManagedInferenceServingPreset,
+  recipe: HostLocalInferenceServingRecipe,
+): CatalogModelVariant {
+  const maxModelLen = Number(argumentValue(recipe.spec.serve.arguments, "--max-model-len"));
+  if (!Number.isSafeInteger(maxModelLen) || maxModelLen <= 0) {
+    throw new Error(`Managed vLLM recipe ${recipe.metadata.id} has no valid --max-model-len.`);
+  }
+  const platform = preset.spec.plan.platform;
+  if (!platform) {
+    throw new Error(`Managed vLLM preset ${preset.metadata.id} has no platform.`);
+  }
+  const serveEnv = {
+    ...recipe.spec.runtime.environment,
+    HF_HOME: recipe.spec.runtime.modelCache.target,
+    HF_HUB_OFFLINE: "1",
+    TRANSFORMERS_OFFLINE: "1",
+  };
+  const directInstall = recipe.spec.serve.directInstall;
+  if (!directInstall) {
+    throw new Error(`Managed vLLM recipe ${recipe.metadata.id} has no direct-install policy.`);
+  }
+  const servingCatalog = {
+    catalogDigest,
+    presetId: preset.metadata.id,
+    presetDigest: managedInferenceDigest(preset),
+    recipeId: recipe.metadata.id,
+    recipeDigest: managedInferenceDigest(recipe),
+  };
+  return {
+    id: recipe.spec.model.id,
+    label: recipe.spec.model.displayName,
+    envValue: recipe.spec.model.environmentValue,
+    menuOrder: recipe.spec.model.menuOrder,
+    downloadSizeBytes: recipe.spec.model.downloadSizeBytes,
+    gated: recipe.spec.model.gated,
+    capabilities: recipe.spec.model.capabilities,
+    probePolicyRef: recipe.spec.model.probePolicyRef,
+    platform,
+    variant: {
+      priority: preset.spec.priority,
+      platforms: [platform],
+      architectures: [nodeArchitecture(recipe.spec.runtime.architecture)],
+      image: recipe.spec.runtime.image,
+      imageDownloadSizeBytes: recipe.spec.runtime.imageDownloadSizeBytes,
+      imageUnpackedSizeBytes: recipe.spec.runtime.imageUnpackedSizeBytes,
+      modelDownloadSizeBytes: recipe.spec.model.downloadSizeBytes,
+      loadTimeoutSec: recipe.spec.readiness.timeoutSeconds,
+      pullTimeoutSec: recipe.spec.runtime.pullTimeoutSeconds,
+      minComputeCapability:
+        recipe.spec.runtime.minimumComputeCapability > 0
+          ? recipe.spec.runtime.minimumComputeCapability
+          : undefined,
+      minGpuMemoryBytes: recipe.spec.runtime.minimumGpuMemoryBytes,
+      dockerRunArgs: hostLocalVllmDockerRunArguments(recipe),
+      dockerRunArgsMode: "replace",
+      modelArgs: hostLocalVllmModelArguments(recipe),
+      maxModelLen,
+      revision: recipe.spec.model.revision,
+      servedModelId: recipe.spec.model.servedName,
+      serveEnv,
+      installFastSafetensors: recipe.spec.model.installFastSafetensors,
+      ...(directInstall.fixedArguments ? { fixedServeCommand: true as const } : {}),
+      ...(directInstall.authentication === "bearer"
+        ? { managedBearerAuth: true as const }
+        : {}),
+      trustRemoteCode: false,
+      selection: preset.spec.selection === "automatic" ? "automatic" : "explicit-only",
+      interactive: preset.spec.plan.interactive !== false,
+      catalogPresetId: preset.metadata.id,
+      orchestrationRef: recipe.spec.execution.orchestrationRef,
+      stationPair: recipe.spec.execution.stationPair,
+      ...(directInstall.catalogReceipt ? { servingCatalog } : {}),
+    },
+  };
+}
+
+function assertSameCatalogModel(left: CatalogModelVariant, right: CatalogModelVariant): void {
+  const fields = [
+    "id",
+    "label",
+    "envValue",
+    "menuOrder",
+    "downloadSizeBytes",
+    "gated",
+    "probePolicyRef",
+  ] as const;
+  const mismatch = fields.find((field) => left[field] !== right[field]);
+  if (mismatch) {
+    throw new Error(
+      `Managed vLLM recipes for ${left.envValue} disagree on model field ${mismatch}.`,
+    );
+  }
+  if (JSON.stringify(left.capabilities) !== JSON.stringify(right.capabilities)) {
+    throw new Error(
+      `Managed vLLM recipes for ${left.envValue} disagree on model field capabilities.`,
+    );
+  }
+}
+
+export function vllmModelsFromCatalog(
+  catalog: CompiledManagedInferenceCatalog,
+): readonly VllmModelDef[] {
+  const recipes = new Map(catalog.recipes.map((recipe) => [recipe.metadata.id, recipe]));
+  const variants = catalog.presets.flatMap((preset) => {
+    if (preset.spec.selection === "disabled" || preset.spec.plan.backend !== "vllm") return [];
+    const recipe = recipes.get(preset.spec.plan.recipeRef);
+    if (!recipe || !isHostLocalInferenceServingRecipe(recipe)) return [];
+    return [catalogModelVariant(catalog.catalogDigest, preset, recipe)];
+  });
+  const grouped = new Map<string, CatalogModelVariant[]>();
+  for (const variant of variants) {
+    const entries = grouped.get(variant.envValue) ?? [];
+    if (entries[0]) assertSameCatalogModel(entries[0], variant);
+    entries.push(variant);
+    grouped.set(variant.envValue, entries);
+  }
+  return [...grouped.values()]
+    .map((entries): VllmModelDef => {
+      const ordered = [...entries].sort(
+        (left, right) =>
+          left.variant.priority - right.variant.priority ||
+          left.variant.catalogPresetId.localeCompare(right.variant.catalogPresetId),
+      );
+      const base = ordered[0]!;
+      const platformOrder: readonly VllmPlatform[] = ["spark", "station", "n1x", "linux"];
+      const supportedPlatforms = new Set(ordered.map(({ platform }) => platform));
+      const platforms = platformOrder.filter((platform) => supportedPlatforms.has(platform));
+      const pickerPlatformSet = new Set(
+        ordered
+          .filter(({ variant }) => variant.interactive)
+          .map(({ platform }) => platform),
+      );
+      const pickerPlatforms = [
+        ...platformOrder.filter((platform) => pickerPlatformSet.has(platform)),
+      ];
+      const runtime =
+        ordered.length === 1
+          ? {
+              image: base.variant.image,
+              imageDownloadSizeBytes: base.variant.imageDownloadSizeBytes,
+              imageUnpackedSizeBytes: base.variant.imageUnpackedSizeBytes,
+              modelDownloadSizeBytes: base.variant.modelDownloadSizeBytes,
+              loadTimeoutSec: base.variant.loadTimeoutSec,
+              dockerRunArgs: base.variant.dockerRunArgs,
+              dockerRunArgsMode: base.variant.dockerRunArgsMode,
+              pullTimeoutSec: base.variant.pullTimeoutSec,
+              minComputeCapability: base.variant.minComputeCapability,
+              minGpuMemoryBytes: base.variant.minGpuMemoryBytes,
+              orchestrationRef: base.variant.orchestrationRef,
+              stationPair: base.variant.stationPair,
+            }
+          : undefined;
+      const computeCapabilityFloors = ordered.flatMap(({ variant }) =>
+        variant.minComputeCapability === undefined ? [] : [variant.minComputeCapability],
+      );
+      return {
+        id: base.id,
+        label: base.label,
+        envValue: base.envValue,
+        downloadSizeBytes: base.downloadSizeBytes,
+        maxModelLen: base.variant.maxModelLen,
+        revision: base.variant.revision,
+        servedModelId: base.variant.servedModelId,
+        modelArgs: base.variant.modelArgs,
+        serveEnv: base.variant.serveEnv,
+        gated: base.gated,
+        platforms,
+        pickerPlatforms,
+        minComputeCapability:
+          computeCapabilityFloors.length > 0 ? Math.min(...computeCapabilityFloors) : undefined,
+        runtimeVariants: ordered.map(({ variant }) => variant),
+        requireRuntimeVariant: true,
+        ...(runtime ? { runtime } : {}),
+        installFastSafetensors: base.variant.installFastSafetensors,
+        fixedServeCommand: base.variant.fixedServeCommand,
+        managedBearerAuth: base.variant.managedBearerAuth,
+        trustRemoteCode: base.variant.trustRemoteCode,
+        capabilities: base.capabilities,
+        probePolicyRef: base.probePolicyRef,
+      };
+    })
+    .sort((left, right) => {
+      const leftOrder = grouped.get(left.envValue)![0]!.menuOrder;
+      const rightOrder = grouped.get(right.envValue)![0]!.menuOrder;
+      return leftOrder - rightOrder || left.envValue.localeCompare(right.envValue);
+    });
+}
+
+export const VLLM_MODELS: readonly VllmModelDef[] = vllmModelsFromCatalog(
+  loadManagedInferenceCatalog(),
+);
+
+const defaultVllmModel = VLLM_MODELS[0];
+if (!defaultVllmModel) {
+  throw new Error("Managed inference catalog has no host-local vLLM models.");
+}
+export const DEFAULT_VLLM_MODEL: VllmModelDef = defaultVllmModel;
+
+/**
+ * Rank a runtime platform declaration for a target host. Every specialized
+ * NVIDIA appliance is still a Linux host, so a Linux declaration is the
+ * baseline when no appliance-specific recipe exists. Exact declarations win.
+ */
+export function vllmPlatformSpecificity(
+  platforms: readonly VllmPlatform[] | undefined,
+  target: VllmPlatform,
+): number {
+  if (!platforms || platforms.length === 0) return 0;
+  if (platforms.includes(target)) return 2;
+  if (target !== "linux" && platforms.includes("linux")) return 1;
+  return -1;
+}
+
+export function vllmModelForOrchestration(
+  orchestrationRef: string,
+  platform: VllmPlatform,
+  architecture: NodeJS.Architecture = process.arch,
+): VllmModelDef | undefined {
+  const matches = VLLM_MODELS.filter((model) =>
+    (model.runtimeVariants ?? []).some(
+      (variant) =>
+        variant.orchestrationRef === orchestrationRef &&
+        vllmPlatformSpecificity(variant.platforms, platform) >= 0 &&
+        (!variant.architectures || variant.architectures.includes(architecture)),
+    ),
+  );
+  if (matches.length > 1) {
+    throw new Error(
+      `Managed vLLM catalog has ambiguous ${orchestrationRef} models for ${platform} on ${architecture}.`,
+    );
+  }
+  return matches[0];
+}
+
+export function vllmModelUsesOrchestration(
+  model: VllmModelDef,
+  orchestrationRef: string,
+  platform: VllmPlatform,
+  architecture: NodeJS.Architecture = process.arch,
+): boolean {
+  return (model.runtimeVariants ?? []).some(
+    (variant) =>
+      variant.orchestrationRef === orchestrationRef &&
+      vllmPlatformSpecificity(variant.platforms, platform) >= 0 &&
+      (!variant.architectures || variant.architectures.includes(architecture)),
+  );
+}
+
+export function vllmStationPairForOrchestration(
+  model: VllmModelDef,
+  orchestrationRef: string,
+  platform: VllmPlatform,
+  architecture: NodeJS.Architecture = process.arch,
+): ServingStationPairOrchestration | undefined {
+  const matches = (model.runtimeVariants ?? []).filter(
+    (variant) =>
+      variant.orchestrationRef === orchestrationRef &&
+      vllmPlatformSpecificity(variant.platforms, platform) >= 0 &&
+      (!variant.architectures || variant.architectures.includes(architecture)),
+  );
+  if (matches.length > 1) {
+    throw new Error(
+      `Managed vLLM catalog has ambiguous ${orchestrationRef} runtimes for ${model.envValue} on ${platform}/${architecture}.`,
+    );
+  }
+  return matches[0]?.stationPair;
+}
+
+function defaultVllmCandidateForPlatform(
+  platform: VllmPlatform,
+  architecture: NodeJS.Architecture = process.arch,
+): { readonly model: VllmModelDef; readonly variant: VllmRuntimeVariant } {
+  const candidates = VLLM_MODELS.flatMap((model) =>
+    (model.runtimeVariants ?? [])
+      .filter(
+        (variant) =>
+          variant.selection === "automatic" &&
+          vllmPlatformSpecificity(variant.platforms, platform) >= 0 &&
+          (!variant.architectures || variant.architectures.includes(architecture)),
+      )
+      .map((variant) => ({ model, variant })),
+  ).sort(
+    (left, right) =>
+      vllmPlatformSpecificity(right.variant.platforms, platform) -
+        vllmPlatformSpecificity(left.variant.platforms, platform) ||
+      right.variant.priority - left.variant.priority ||
+      left.model.envValue.localeCompare(right.model.envValue),
+  );
+  if (candidates.length === 0) {
+    throw new Error(`Managed vLLM catalog has no automatic ${platform} model for ${architecture}.`);
+  }
+  if (
+    candidates[1] &&
+    vllmPlatformSpecificity(candidates[1].variant.platforms, platform) ===
+      vllmPlatformSpecificity(candidates[0]!.variant.platforms, platform) &&
+    candidates[1].variant.priority === candidates[0]!.variant.priority
+  ) {
+    throw new Error(
+      `Managed vLLM catalog has ambiguous automatic ${platform} models at priority ${String(candidates[0]!.variant.priority)}.`,
+    );
+  }
+  return candidates[0]!;
+}
+
+export function defaultVllmModelForPlatform(
+  platform: VllmPlatform,
+  architecture: NodeJS.Architecture = process.arch,
+): VllmModelDef {
+  return defaultVllmCandidateForPlatform(platform, architecture).model;
+}
+
+export function defaultVllmRuntimeForPlatform(
+  platform: VllmPlatform,
+  architecture: NodeJS.Architecture = process.arch,
+): VllmRuntimeVariant {
+  return defaultVllmCandidateForPlatform(platform, architecture).variant;
+}
 
 /**
  * Subset of the registry that should appear in the interactive picker for a
@@ -402,7 +539,9 @@ export const DEFAULT_VLLM_MODEL: VllmModelDef = VLLM_MODELS[0];
  * the recommended entry by id rather than position.
  */
 export function modelsForPlatform(platform: VllmPlatform): readonly VllmModelDef[] {
-  return VLLM_MODELS.filter((model) => model.platforms.includes(platform));
+  return VLLM_MODELS.filter((model) =>
+    (model.pickerPlatforms ?? model.platforms).includes(platform),
+  );
 }
 
 const HF_TOKEN_ENV_KEYS = ["HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"] as const;
@@ -626,40 +765,46 @@ export function buildNemotronUltraDistributedServeCommand(
     throw new Error("Nemotron Ultra Ray head nodeAddr must match masterAddr.");
   }
 
-  const model = VLLM_MODELS.find(
-    (candidate) => candidate.envValue === "nemotron-3-ultra-550b-a55b",
-  );
-  if (!model?.revision || !model.servedModelId) {
+  const model = vllmModelForOrchestration(STATION_PAIR_OPTIONAL_ORCHESTRATION, "station", "arm64");
+  const stationPair = model
+    ? vllmStationPairForOrchestration(
+        model,
+        STATION_PAIR_OPTIONAL_ORCHESTRATION,
+        "station",
+        "arm64",
+      )
+    : undefined;
+  if (!model?.revision || !stationPair) {
     throw new Error(
-      "Nemotron Ultra distributed serving requires a pinned revision and served model id.",
+      "Station-pair distributed serving requires a pinned revision and orchestration config.",
     );
   }
 
-  const sharedArgs = rewriteVllmArgs(SHARED_VLLM_ARGS, {
-    "--tensor-parallel-size": "1",
-    "--pipeline-parallel-size": "2",
+  const sharedArgs = rewriteVllmArgs(FIXED_HOST_LOCAL_VLLM_ARGS, {
+    "--tensor-parallel-size": String(stationPair.tensorParallelSize),
+    "--pipeline-parallel-size": String(stationPair.pipelineParallelSize),
   });
   const modelArgs = rewriteVllmArgs(
     model.modelArgs,
     {
-      // Rank 0 binds only to the selected direct-attach RoCE address. This
-      // keeps the API off the management network while still giving the
-      // OpenShell route a host-reachable endpoint. The lifecycle also enables
-      // vLLM bearer authentication. The Ray worker exposes no API.
-      "--host": masterAddr,
       "--max-num-seqs": "256",
       "--gpu-memory-utilization": "0.9",
     },
     new Set([
       "--cpu-offload-gb",
       "--cpu-offload-params",
-      "--kernel_config",
+      "--kernel-config",
       "--speculative-config",
       "--default-chat-template-kwargs",
     ]),
   );
   const args = [
     ...sharedArgs,
+    // Rank 0 binds only to the selected direct-attach RoCE address. This
+    // keeps the API off the management network while still giving the
+    // OpenShell route a host-reachable endpoint. The Ray worker exposes no API.
+    "--host",
+    masterAddr,
     "--distributed-executor-backend",
     "ray",
     "--kv-cache-dtype",
@@ -672,7 +817,7 @@ export function buildNemotronUltraDistributedServeCommand(
     "--revision",
     model.revision,
     "--served-model-name",
-    "nemotron-ultra",
+    stationPair.servedName,
     ...modelArgs,
   ];
   const bootstrap = [
@@ -714,7 +859,7 @@ export function buildNemotronUltraDistributedServeCommand(
     "    time.sleep(5)",
     "print(ray.cluster_resources())",
     "PY",
-    `exec vllm serve ${model.id} ${args.join(" ")}`,
+    `exec vllm serve ${[model.id, ...args].map(shellQuote).join(" ")}`,
   ].join("\n");
 }
 

--- a/src/lib/inference/vllm-runtime-selection.test.ts
+++ b/src/lib/inference/vllm-runtime-selection.test.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { detectVllmProfile, resolveVllmModelRuntime } from "./vllm";
+import { VLLM_MODELS } from "./vllm-models";
+
+describe("vLLM catalog runtime selection", () => {
+  it("prefers a device-specific optimized recipe over the general Linux baseline", () => {
+    const sparkProfile = detectVllmProfile({
+      platform: "spark",
+      type: "nvidia",
+    })!;
+    const qwen = VLLM_MODELS.find((model) => model.envValue === "qwen3.6-27b")!;
+    const optimized = resolveVllmModelRuntime(sparkProfile, qwen, "arm64");
+
+    expect(optimized.model.runtime?.catalogPresetId).toBe(
+      "vllm.dgx-spark-gb10.single.qwen3-6-27b-fp8",
+    );
+
+    const linuxBaselineOnly = {
+      ...qwen,
+      platforms: ["linux" as const],
+      runtimeVariants: qwen.runtimeVariants?.filter(
+        (variant) => variant.platforms?.includes("linux") && variant.architectures?.includes("x64"),
+      ),
+    };
+    const stationLikeX64Profile = {
+      ...detectVllmProfile({ platform: "linux", type: "nvidia" })!,
+      name: "Linux appliance",
+      platform: "station" as const,
+      architecture: "x64" as const,
+    };
+    const fallback = resolveVllmModelRuntime(stationLikeX64Profile, linuxBaselineOnly, "x64");
+
+    expect(fallback.model.runtime?.catalogPresetId).toBe(
+      "vllm.linux-amd64-nvidia.single.qwen3-6-27b-fp8",
+    );
+  });
+});

--- a/src/lib/inference/vllm-station-cluster-lifecycle.test.ts
+++ b/src/lib/inference/vllm-station-cluster-lifecycle.test.ts
@@ -26,6 +26,7 @@ import {
   DUAL_STATION_VLLM_GPU_SMOKE_LABEL,
   DUAL_STATION_VLLM_HEAD_CONTAINER_NAME,
   DUAL_STATION_VLLM_LAUNCH_CONTRACT_LABEL,
+  DUAL_STATION_VLLM_LAUNCH_SCHEMA,
   DUAL_STATION_VLLM_LAUNCH_SCHEMA_LABEL,
   DUAL_STATION_VLLM_MANAGED_LABEL,
   DUAL_STATION_VLLM_ROLE_LABEL,
@@ -160,7 +161,7 @@ function fakeContainer(
       [DUAL_STATION_VLLM_CLUSTER_LABEL]: dualStationVllmClusterId(fixturePlan()),
       [DUAL_STATION_VLLM_GPU_LABEL]:
         role === "head" ? fixturePlan().local.gpu.uuid : fixturePlan().peer.gpu.uuid,
-      [DUAL_STATION_VLLM_LAUNCH_SCHEMA_LABEL]: "2",
+      [DUAL_STATION_VLLM_LAUNCH_SCHEMA_LABEL]: DUAL_STATION_VLLM_LAUNCH_SCHEMA,
       [DUAL_STATION_VLLM_LAUNCH_CONTRACT_LABEL]: dualStationVllmLaunchContract(fixturePlan(), role),
       [DUAL_STATION_VLLM_API_KEY_FINGERPRINT_LABEL]: API_KEY_FINGERPRINT,
       [DUAL_STATION_VLLM_TRANSACTION_LABEL]: TRANSACTION_ID,
@@ -304,7 +305,7 @@ describe("dual-Station managed vLLM run argv", () => {
     expect(args).toContain(plan.runtime.image);
     expect(dockerValues(args, "--label")).toEqual(
       expect.arrayContaining([
-        `${DUAL_STATION_VLLM_LAUNCH_SCHEMA_LABEL}=2`,
+        `${DUAL_STATION_VLLM_LAUNCH_SCHEMA_LABEL}=${DUAL_STATION_VLLM_LAUNCH_SCHEMA}`,
         `${DUAL_STATION_VLLM_LAUNCH_CONTRACT_LABEL}=${dualStationVllmLaunchContract(plan, role)}`,
         `${DUAL_STATION_VLLM_API_KEY_FINGERPRINT_LABEL}=${API_KEY_FINGERPRINT}`,
         `${DUAL_STATION_VLLM_TRANSACTION_LABEL}=${TRANSACTION_ID}`,

--- a/src/lib/inference/vllm-station-cluster-lifecycle.ts
+++ b/src/lib/inference/vllm-station-cluster-lifecycle.ts
@@ -60,7 +60,7 @@ const SAFE_GPU_UUID_PATTERN = /^GPU-[A-Za-z0-9-]{8,123}$/;
 const GPU_SMOKE_NONCE_PATTERN = /^[a-f0-9]{32}$/;
 const TRANSACTION_ID_PATTERN = /^[a-f0-9]{32}$/;
 const GPU_SMOKE_CONTAINER_PREFIX = "nemoclaw-vllm-gpu-smoke";
-export const DUAL_STATION_VLLM_LAUNCH_SCHEMA = "2";
+export const DUAL_STATION_VLLM_LAUNCH_SCHEMA = "3";
 const VLLM_FINGERPRINT_CONTEXT = "nemoclaw-dual-station-vllm-api-key\0";
 // Compatibility bridge for schema-less single-Station Ultra containers from
 // the v0.0.86 rollback window before dual launch schema 1.

--- a/src/lib/inference/vllm-station-cluster.ts
+++ b/src/lib/inference/vllm-station-cluster.ts
@@ -8,7 +8,11 @@ import path from "node:path";
 import { buildSubprocessEnv } from "../subprocess-env";
 import { isDgxStationGb300Product } from "./dgx-station-identity";
 import { buildVllmSshTransportEnv } from "./vllm-docker-env";
-import { NEMOTRON_ULTRA_DUAL_STATION_IMAGE, VLLM_MODELS } from "./vllm-models";
+import {
+  STATION_PAIR_OPTIONAL_ORCHESTRATION,
+  vllmModelForOrchestration,
+  vllmStationPairForOrchestration,
+} from "./vllm-models";
 import {
   type DualStationSshBinding,
   dualStationPinnedSshArgs,
@@ -40,19 +44,34 @@ const CANONICAL_SSH_HOST_PATTERN =
   /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/;
 const CANONICAL_SSH_USERNAME_PATTERN = /^[A-Za-z_][A-Za-z0-9._-]*$/;
 
-const ultraModel = VLLM_MODELS.find((model) => model.envValue === "nemotron-3-ultra-550b-a55b");
+const ultraModel = vllmModelForOrchestration(
+  STATION_PAIR_OPTIONAL_ORCHESTRATION,
+  "station",
+  "arm64",
+);
 if (!ultraModel?.revision) {
-  throw new Error("Nemotron Ultra must have an immutable Hugging Face revision");
+  throw new Error("The Station-pair model must have an immutable Hugging Face revision");
+}
+const stationPair = vllmStationPairForOrchestration(
+  ultraModel,
+  STATION_PAIR_OPTIONAL_ORCHESTRATION,
+  "station",
+  "arm64",
+);
+if (!stationPair) {
+  throw new Error("The Station-pair orchestration must have a typed runtime configuration");
 }
 
 export const DUAL_STATION_VLLM_RUNTIME = Object.freeze({
-  image: NEMOTRON_ULTRA_DUAL_STATION_IMAGE.arm64.ref,
+  image: stationPair.image,
+  imageDownloadSizeBytes: stationPair.imageDownloadSizeBytes,
   modelId: ultraModel.id,
   modelRevision: ultraModel.revision,
-  servedModelId: "nemotron-ultra",
-  tensorParallelSize: 1 as const,
-  pipelineParallelSize: 2 as const,
-  nodeCount: 2 as const,
+  servedModelId: stationPair.servedName,
+  tensorParallelSize: stationPair.tensorParallelSize,
+  pipelineParallelSize: stationPair.pipelineParallelSize,
+  nodeCount: stationPair.nodeCount,
+  loadTimeoutSeconds: stationPair.loadTimeoutSeconds,
 });
 
 export interface StationGpuProbe {

--- a/src/lib/inference/vllm.test.ts
+++ b/src/lib/inference/vllm.test.ts
@@ -27,7 +27,9 @@ const mocks = vi.hoisted(() => ({
     kind: "not-selected",
   })),
   runCapture: vi.fn(),
-  tryInstallManagedClusterManagedVllm: vi.fn(async () => ({ kind: "not-selected" as const })),
+  tryInstallManagedClusterManagedVllm: vi.fn(async () => ({
+    kind: "not-selected" as const,
+  })),
 }));
 
 vi.mock("../runner", async (importOriginal) => ({
@@ -86,7 +88,7 @@ import {
   NEMOCLAW_VLLM_CONTAINER_NAME,
   NEMOCLAW_VLLM_MANAGED_LABEL,
   pullImage,
-  resolveVllmRuntimeProfile,
+  resolveVllmModelRuntime,
   resolveVllmServedModelId,
   VLLM_IMAGES,
 } from "./vllm";
@@ -116,7 +118,9 @@ beforeEach(() => {
     message: "",
   });
   mocks.resolveHostLocalVllmSelection.mockReturnValue({ kind: "not-selected" });
-  mocks.tryInstallManagedClusterManagedVllm.mockResolvedValue({ kind: "not-selected" });
+  mocks.tryInstallManagedClusterManagedVllm.mockResolvedValue({
+    kind: "not-selected",
+  });
 });
 
 function currentHostIdentity(): string | null {
@@ -172,9 +176,10 @@ describe("managed vLLM image distribution boundary", () => {
       )
       .filter((ref): ref is string => ref !== null),
   );
-  const runtimeRefs = VLLM_MODELS.map((model) => model.runtime?.image).filter(
-    (ref): ref is string => typeof ref === "string",
-  );
+  const runtimeRefs = VLLM_MODELS.flatMap((model) => [
+    ...(model.runtime?.image ? [model.runtime.image] : []),
+    ...(model.runtimeVariants ?? []).map((runtime) => runtime.image),
+  ]);
   const managedImageRefs = [...new Set([...platformRefs, ...runtimeRefs])];
 
   it("accepts repository-qualified immutable registry digests", () => {
@@ -226,7 +231,6 @@ describe("vLLM profile detection", () => {
     vi.clearAllMocks();
   });
 
-
   it("resolves Nemotron Ultra to the pinned Station runtime on the bridge network", () => {
     mocks.getGpuIndicesByName.mockReturnValue([0]);
     const profile = detectVllmProfile({ platform: "station", type: "nvidia" });
@@ -234,7 +238,8 @@ describe("vLLM profile detection", () => {
 
     expect(profile).not.toBeNull();
     expect(ultra).toBeDefined();
-    const runtime = resolveVllmRuntimeProfile(profile!, ultra!);
+    const resolved = resolveVllmModelRuntime(profile!, ultra!);
+    const runtime = resolved.profile;
     expect(runtime.image).toBe(
       "vllm/vllm-openai@sha256:0fec7ec5f3e6bc168e54899935fb0557da908a4832a1dbc88e2debcf2f889416",
     );
@@ -242,44 +247,42 @@ describe("vLLM profile detection", () => {
     expect(runtime.imageUnpackedSizeBytes).toBeUndefined();
     expect(runtime.modelDownloadSizeBytes).toBe(352_381_245_521);
     expect(runtime.loadTimeoutSec).toBe(3600);
-    expect(runtime.buildDockerRunFlags!()).toEqual(
-      expect.arrayContaining(["--gpus", "device=0", "--shm-size", "16g"]),
+    expect(runtime.dockerRunFlags).toEqual(
+      expect.arrayContaining(["--gpus", "device=0", "--shm-size", "17179869184b"]),
     );
 
-    const flags = runtime.buildDockerRunFlags!();
-    const args = buildVllmRunArgs(runtime, ultra!, flags, {} as NodeJS.ProcessEnv);
-    expect(args).toEqual([
-      "--pull=never",
-      "--init",
-      "--restart",
-      "unless-stopped",
-      "--gpus",
-      "device=0",
-      "--ipc=host",
-      "-v",
-      `${path.join(os.homedir(), ".cache", "huggingface")}:/root/.cache/huggingface`,
-      "-e",
-      "HF_HOME=/root/.cache/huggingface",
-      "--shm-size",
-      "16g",
-      "--ulimit",
-      "memlock=-1",
-      "--ulimit",
-      "stack=67108864",
-      "--label",
-      `${NEMOCLAW_VLLM_MANAGED_LABEL}=true`,
-      "-p",
-      "8000:8000",
-      "--name",
-      NEMOCLAW_VLLM_CONTAINER_NAME,
-      "--entrypoint",
-      "/bin/bash",
-      runtime.image,
-      "-lc",
-      buildVllmServeCommand(ultra!, {} as NodeJS.ProcessEnv),
-    ]);
+    const args = buildVllmRunArgs(
+      runtime,
+      resolved.model,
+      runtime.dockerRunFlags,
+      {} as NodeJS.ProcessEnv,
+    );
+    expect(args).toEqual(
+      expect.arrayContaining([
+        "--pull=never",
+        "--init",
+        "--restart",
+        "unless-stopped",
+        "--gpus",
+        "device=0",
+        "--shm-size",
+        "17179869184b",
+        "--ulimit",
+        "memlock=-1",
+        "--label",
+        `${NEMOCLAW_VLLM_MANAGED_LABEL}=true`,
+        "-p",
+        "8000:8000",
+        "--name",
+        NEMOCLAW_VLLM_CONTAINER_NAME,
+        "--entrypoint",
+        "/bin/bash",
+        runtime.image,
+        "-lc",
+        buildVllmServeCommand(resolved.model, {} as NodeJS.ProcessEnv),
+      ]),
+    );
   });
-
 
   it("resolves Muse Glimmer to its authenticated DGX Spark runtime", () => {
     const profile = detectVllmProfile({ platform: "spark", type: "nvidia" });
@@ -287,7 +290,8 @@ describe("vLLM profile detection", () => {
 
     expect(profile).not.toBeNull();
     expect(muse).toBeDefined();
-    const runtime = resolveVllmRuntimeProfile(profile!, muse!);
+    const resolved = resolveVllmModelRuntime(profile!, muse!);
+    const runtime = resolved.profile;
     expect(runtime.image).toBe(
       "vllm/vllm-openai@sha256:677afd5bf3b4bb9881f91e107af7098f8410726b4c05b25cb4a815900b398204",
     );
@@ -297,7 +301,7 @@ describe("vLLM profile detection", () => {
     const apiKey = "a".repeat(64);
     const args = buildVllmRunArgs(
       runtime,
-      muse!,
+      resolved.model,
       runtime.dockerRunFlags,
       { VLLM_API_KEY: apiKey },
       "172.18.0.1",
@@ -308,7 +312,6 @@ describe("vLLM profile detection", () => {
     expect(args).toEqual(expect.arrayContaining(["--env", "VLLM_API_KEY", runtime.image]));
     expect(args).not.toContain(apiKey);
   });
-
 
   it("generic-Linux default model pins the tool-call flags (#6314)", () => {
     // Regression for #6314: without --enable-auto-tool-choice + --tool-call-parser,
@@ -367,17 +370,35 @@ describe("vLLM image pull", () => {
   it.each([
     [
       "stall timeout",
-      { status: 124, signal: "SIGTERM", output: "", timedOut: true, timeoutKind: "stall" },
+      {
+        status: 124,
+        signal: "SIGTERM",
+        output: "",
+        timedOut: true,
+        timeoutKind: "stall",
+      },
       "docker pull stalled with no progress",
     ],
     [
       "max timeout",
-      { status: 124, signal: "SIGTERM", output: "", timedOut: true, timeoutKind: "max" },
+      {
+        status: 124,
+        signal: "SIGTERM",
+        output: "",
+        timedOut: true,
+        timeoutKind: "max",
+      },
       "docker pull exceeded 43200s safety budget",
     ],
     [
       "non-timeout failure",
-      { status: 17, signal: null, output: "", timedOut: false, timeoutKind: null },
+      {
+        status: 17,
+        signal: null,
+        output: "",
+        timedOut: false,
+        timeoutKind: null,
+      },
       "docker pull failed (exit 17)",
     ],
   ])("maps %s to the install failure reason", async (_name, result, reason) => {
@@ -532,7 +553,6 @@ describe("vLLM run command", () => {
   });
 });
 
-
 describe("installVllm model resolution", () => {
   let logSpy: VllmInstallSpies["logSpy"];
   let errSpy: VllmInstallSpies["errSpy"];
@@ -626,6 +646,12 @@ describe("installVllm model resolution", () => {
     const profile = {
       ...detectVllmProfile({ platform: "station", type: "nvidia" })!,
       image: `sha256:${"a".repeat(64)}`,
+      defaultModel: {
+        ...detectVllmProfile({ platform: "station", type: "nvidia" })!.defaultModel,
+        runtime: undefined,
+        runtimeVariants: undefined,
+        requireRuntimeVariant: undefined,
+      },
     };
     const promptFn = vi.fn<(q: string) => Promise<string>>();
     const beforeInstall = vi.fn();
@@ -727,6 +753,29 @@ describe("installVllm model resolution", () => {
     expect(errors).toContain("DeepSeek V4 Flash is not supported on Linux + NVIDIA GPU");
   });
 
+  it("accepts the optimized Lightning recipe on DGX Spark", async () => {
+    process.env.NEMOCLAW_VLLM_MODEL = "nemotron-3.5-lightning-30b";
+    const profile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
+    const beforeInstall = vi.fn();
+    mockSuccessfulVllmInstall(mocks, profile.containerName);
+
+    const result = await installVllm(profile, {
+      hasImage: true,
+      nonInteractive: true,
+      promptFn: vi.fn(),
+      beforeInstall,
+    });
+
+    expect(result).toEqual({ ok: false });
+    expect(beforeInstall).toHaveBeenCalledWith("nvidia-nemotron-3.5-lightning-30b-a3b-nvfp4");
+    expect(mocks.dockerPullWithProgressWatchdog).toHaveBeenCalledWith(
+      "vllm/vllm-openai@sha256:3af90144a0926e5c5fe46ee16e5201e763dd854538b9d7ce433755f11dadaf78",
+      expect.any(Object),
+    );
+    const errors = errSpy.mock.calls.map((call: unknown[]) => String(call[0])).join("\n");
+    expect(errors).not.toContain("is not supported on DGX Spark");
+  });
+
   it("still accepts a platform-matched override on its own platform (#7358)", async () => {
     process.env.NEMOCLAW_VLLM_MODEL = "qwen3.6-35b-a3b-nvfp4";
     const profile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
@@ -816,7 +865,9 @@ describe("installVllm model resolution", () => {
       recursive: true,
     });
     const [runArgs] = mocks.dockerRunDetached.mock.calls[0] as [string[]];
-    expect(runArgs).toEqual(expect.arrayContaining(["--shm-size", "16g", "-p", "8000:8000"]));
+    expect(runArgs).toEqual(
+      expect.arrayContaining(["--shm-size", "17179869184b", "-p", "8000:8000"]),
+    );
     expect(runArgs).not.toContain("--network");
     expect(runArgs.at(-1)).toContain("--cpu-offload-gb 150");
     expect(runArgs.at(-1)).toContain("--reasoning-parser nemotron_v3");
@@ -900,7 +951,10 @@ describe("installVllm model resolution", () => {
   });
 
   it("persists exact profile ownership before authenticating a catalog-selected runtime (#8246)", async () => {
-    const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
+    const baseProfile = detectVllmProfile({
+      platform: "spark",
+      type: "nvidia",
+    })!;
     const servingCatalog = {
       catalogDigest: `sha256:${"1".repeat(64)}`,
       presetId: "vllm.dgx-spark-gb10.single.example",
@@ -908,7 +962,10 @@ describe("installVllm model resolution", () => {
       recipeId: "vllm.dgx-spark-gb10.single.example",
       recipeDigest: `sha256:${"3".repeat(64)}`,
     };
-    const model = { ...baseProfile.defaultModel, managedBearerAuth: true as const };
+    const model = {
+      ...baseProfile.defaultModel,
+      managedBearerAuth: true as const,
+    };
     const profile = { ...baseProfile, defaultModel: model, servingCatalog };
     mocks.resolveHostLocalVllmSelection.mockReturnValue({
       kind: "selected",
@@ -1012,7 +1069,9 @@ describe("installVllm model resolution", () => {
     ambientDockerOptions.forEach((options) => {
       expect(options).toEqual(
         expect.objectContaining({
-          env: expect.objectContaining({ DOCKER_CONTEXT: "local-test-context" }),
+          env: expect.objectContaining({
+            DOCKER_CONTEXT: "local-test-context",
+          }),
         }),
       );
     });
@@ -1022,7 +1081,10 @@ describe("installVllm model resolution", () => {
     process.env.DOCKER_CONTEXT = "remote-builder";
     process.env.DOCKER_HOST = "ssh://remote.example.test";
     process.env.DOCKER_CONFIG = "/tmp/remote-docker-config";
-    const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
+    const baseProfile = detectVllmProfile({
+      platform: "spark",
+      type: "nvidia",
+    })!;
     const servingCatalog = {
       catalogDigest: `sha256:${"1".repeat(64)}`,
       presetId: "local-model-profile.vllm.spark.v1",
@@ -1030,7 +1092,10 @@ describe("installVllm model resolution", () => {
       recipeId: "vllm.qwen3-6-35b-a3b-nvfp4.spark-single.v1",
       recipeDigest: `sha256:${"3".repeat(64)}`,
     };
-    const model = { ...baseProfile.defaultModel, managedBearerAuth: true as const };
+    const model = {
+      ...baseProfile.defaultModel,
+      managedBearerAuth: true as const,
+    };
     const profile = { ...baseProfile, defaultModel: model, servingCatalog };
     mocks.resolveHostLocalVllmSelection.mockReturnValue({
       kind: "selected",
@@ -1051,7 +1116,10 @@ describe("installVllm model resolution", () => {
 
     expect(result).toEqual({ ok: false });
     expect(mocks.probeDockerStorage).toHaveBeenCalledWith(
-      expect.objectContaining({ dockerContext: "default", dockerHost: undefined }),
+      expect.objectContaining({
+        dockerContext: "default",
+        dockerHost: undefined,
+      }),
     );
     const dockerAdapterOptions = [
       ...mocks.dockerImageInspectFormat.mock.calls.map((call) => call[2]),
@@ -1158,7 +1226,9 @@ describe("installVllm model resolution", () => {
     expect(downloadArgs).toEqual(expect.arrayContaining(["-e", "HF_TOKEN"]));
     expect(downloadArgs.join(" ")).not.toContain(token);
     expect(downloadOpts).toEqual(
-      expect.objectContaining({ env: expect.objectContaining({ HF_TOKEN: token }) }),
+      expect.objectContaining({
+        env: expect.objectContaining({ HF_TOKEN: token }),
+      }),
     );
     expect(mocks.dockerRunDetached).toHaveBeenCalledTimes(1);
     const [args, opts] = mocks.dockerRunDetached.mock.calls[0] as [
@@ -1243,12 +1313,16 @@ describe("installVllm model resolution", () => {
       source: "HF_TOKEN",
     });
     expect(
-      hfDownloadAuthentication({ HUGGING_FACE_HUB_TOKEN: token } as NodeJS.ProcessEnv),
+      hfDownloadAuthentication({
+        HUGGING_FACE_HUB_TOKEN: token,
+      } as NodeJS.ProcessEnv),
     ).toEqual({
       authenticated: true,
       source: "HUGGING_FACE_HUB_TOKEN",
     });
-    expect(hfDownloadAuthentication({} as NodeJS.ProcessEnv)).toEqual({ authenticated: false });
+    expect(hfDownloadAuthentication({} as NodeJS.ProcessEnv)).toEqual({
+      authenticated: false,
+    });
   });
 
   it("replaces only an existing managed container by its inspected ID", async () => {
@@ -1345,10 +1419,19 @@ describe("installVllm model resolution", () => {
   });
 
   it("rejects invalid profile run flags before launching the long-lived container", async () => {
-    const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
+    const baseProfile = detectVllmProfile({
+      platform: "spark",
+      type: "nvidia",
+    })!;
     const profile = {
       ...baseProfile,
       buildDockerRunFlags: () => ["--label", ""],
+      defaultModel: {
+        ...baseProfile.defaultModel,
+        runtime: undefined,
+        runtimeVariants: undefined,
+        requireRuntimeVariant: undefined,
+      },
     };
     mockSuccessfulVllmInstall(mocks, profile.containerName);
     mocks.dockerImageInspectFormat.mockReturnValue("sha256:cached-image");

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -57,19 +57,26 @@ import {
 import {
   assertGatedModelAccess,
   buildVllmServeCommand,
-  NEMOTRON_ULTRA_DUAL_STATION_IMAGE,
-  NEMOTRON_ULTRA_STATION_IMAGE,
+  defaultVllmModelForPlatform,
+  defaultVllmRuntimeForPlatform,
+  STATION_PAIR_OPTIONAL_ORCHESTRATION,
   parseVllmExtraServeArgs,
   VLLM_EXTRA_ARGS_ENV,
   VLLM_MODELS,
+  vllmModelForOrchestration,
+  vllmModelUsesOrchestration,
+  vllmPlatformSpecificity,
   type VllmModelDef,
   type VllmPlatform,
+  type VllmRuntimeOverride,
+  type VllmRuntimeVariant,
 } from "./vllm-models";
 import {
   type DualStationVllmPlan,
   NEMOCLAW_DGX_STATION_PEER_ENV,
   probeDualStationVllmCapability,
 } from "./vllm-station-cluster";
+import type { ManagedInferenceReadinessSource } from "./serving/types";
 import {
   areDualStationManagedVllmContainersRunning,
   cleanupDualStationManagedVllm,
@@ -111,6 +118,8 @@ export interface VllmProfile {
   // filters the registry. Decoupled from `name` so future user-facing label
   // tweaks don't change which models are offered.
   platform: VllmPlatform;
+  /** Qualified host architecture for this platform profile. */
+  architecture?: NodeJS.Architecture;
   image: string; // platform-specific image pinned by digest
   // Compressed size of that exact platform manifest. The storage preflight
   // adds unpacking and pull-staging headroom.
@@ -139,6 +148,10 @@ export interface VllmProfile {
   // Optional pinned model snapshot size. Model-specific runtime overrides use
   // this to guard the host Hugging Face cache before a cold download.
   modelDownloadSizeBytes?: number;
+  /** GPU floor selected by a compatibility-qualified model runtime. */
+  minComputeCapability?: number;
+  /** Minimum GPU or unified-memory capacity selected by the runtime recipe. */
+  minGpuMemoryBytes?: number;
   servingCatalog?: {
     catalogDigest: string;
     presetId: string;
@@ -148,59 +161,33 @@ export interface VllmProfile {
   };
 }
 
-interface VllmImageCatalogEntry {
-  downloadSizeBytes: number;
-  ref: string;
-  unpackedSizeBytes?: number;
-}
-
 const VLLM_WRITABLE_ALLOWANCE_BYTES = 816_000_000;
 
-// Platform manifests and decimal compressed sizes published by NGC for the
-// named release tags. Pinning the digest makes a cache hit authoritative: an
-// explicit pull cannot begin downloading different same-tag layers. Unpacked
-// sizes are digest-catalog values measured ahead of time because OCI metadata
-// does not publish exact uncompressed byte counts.
+// Compatibility export for image-boundary checks. Runtime image identity and
+// size are owned by catalog recipes, including optional orchestration images.
 export const VLLM_IMAGES = {
-  vllm022: NEMOTRON_ULTRA_STATION_IMAGE,
-  ngc2603Post1: {
-    tag: "nvcr.io/nvidia/vllm:26.03.post1-py3",
-    amd64: {
-      ref: "nvcr.io/nvidia/vllm@sha256:7be6c2f676c36059a494fe17254e69ae5c677535ba6191044e5fc8e42a91c773",
-      downloadSizeBytes: 8_928_665_752,
-    },
-    arm64: {
-      ref: "nvcr.io/nvidia/vllm@sha256:447995cbb57e6c7cf792cab95e9852e5f62b5fb6d2f39e030fa4eda9a54eadb4",
-      downloadSizeBytes: 9_278_081_698,
-    },
-  },
-  ngc2605Post1: {
-    tag: "nvcr.io/nvidia/vllm:26.05.post1-py3",
-    arm64: {
-      ref: "nvcr.io/nvidia/vllm@sha256:9204569b17ee4c0eff75194b8e6e458479c8aee18953b5ab9cf359fcdac659e2",
-      downloadSizeBytes: 9_603_085_145,
-      unpackedSizeBytes: 27_658_526_720,
-    },
-  },
+  catalog: Object.fromEntries(
+    VLLM_MODELS.flatMap((model) =>
+      (model.runtimeVariants ?? []).flatMap((runtime, index) => [
+        [
+          `${model.envValue}-${String(index)}`,
+          { ref: runtime.image, downloadSizeBytes: runtime.imageDownloadSizeBytes },
+        ],
+        ...(runtime.stationPair
+          ? [
+              [
+                `${model.envValue}-${String(index)}-station-pair`,
+                {
+                  ref: runtime.stationPair.image,
+                  downloadSizeBytes: runtime.stationPair.imageDownloadSizeBytes,
+                },
+              ],
+            ]
+          : []),
+      ]),
+    ),
+  ),
 } as const;
-
-function nemotronNanoModel(): VllmModelDef {
-  const match = VLLM_MODELS.find((m) => m.envValue === "nemotron-3-nano-4b");
-  if (!match) throw new Error("vllm-models registry is missing the nemotron-3-nano-4b entry");
-  return match;
-}
-
-function deepseekV4FlashModel(): VllmModelDef {
-  const match = VLLM_MODELS.find((m) => m.envValue === "deepseek-v4-flash");
-  if (!match) throw new Error("vllm-models registry is missing the deepseek-v4-flash entry");
-  return match;
-}
-
-function qwen35bNvfp4Model(): VllmModelDef {
-  const match = VLLM_MODELS.find((m) => m.envValue === "qwen3.6-35b-a3b-nvfp4");
-  if (!match) throw new Error("vllm-models registry is missing the qwen3.6-35b-a3b-nvfp4 entry");
-  return match;
-}
 
 const HF_TOKEN_SETTINGS_URL = "https://huggingface.co/settings/tokens";
 const VLLM_LAUNCH_HEARTBEAT_MS = 30_000;
@@ -297,26 +284,30 @@ function printHfRateLimitRecovery(): void {
   );
 }
 
+const sparkDefaultRuntime = defaultVllmRuntimeForPlatform("spark", "arm64");
 const SPARK_PROFILE: VllmProfile = {
   name: "DGX Spark",
   platform: "spark",
-  image: VLLM_IMAGES.ngc2605Post1.arm64.ref,
-  imageDownloadSizeBytes: VLLM_IMAGES.ngc2605Post1.arm64.downloadSizeBytes,
-  imageUnpackedSizeBytes: VLLM_IMAGES.ngc2605Post1.arm64.unpackedSizeBytes,
-  defaultModel: qwen35bNvfp4Model(),
+  architecture: "arm64",
+  image: sparkDefaultRuntime.image,
+  imageDownloadSizeBytes: sparkDefaultRuntime.imageDownloadSizeBytes,
+  imageUnpackedSizeBytes: sparkDefaultRuntime.imageUnpackedSizeBytes,
+  defaultModel: defaultVllmModelForPlatform("spark", "arm64"),
   containerName: NEMOCLAW_VLLM_CONTAINER_NAME,
   dockerRunFlags: vllmDockerRunFlags(),
   pullTimeoutSec: 12 * 60 * 60,
   loadTimeoutSec: 1800,
 };
 
+const n1xDefaultRuntime = defaultVllmRuntimeForPlatform("n1x", "arm64");
 const N1X_PROFILE: VllmProfile = {
   name: "N1x",
   platform: "n1x",
-  image: SPARK_PROFILE.image,
-  imageDownloadSizeBytes: SPARK_PROFILE.imageDownloadSizeBytes,
-  imageUnpackedSizeBytes: SPARK_PROFILE.imageUnpackedSizeBytes,
-  defaultModel: qwen35bNvfp4Model(),
+  architecture: "arm64",
+  image: n1xDefaultRuntime.image,
+  imageDownloadSizeBytes: n1xDefaultRuntime.imageDownloadSizeBytes,
+  imageUnpackedSizeBytes: n1xDefaultRuntime.imageUnpackedSizeBytes,
+  defaultModel: defaultVllmModelForPlatform("n1x", "arm64"),
   containerName: NEMOCLAW_VLLM_CONTAINER_NAME,
   dockerRunFlags: SPARK_PROFILE.dockerRunFlags,
   pullTimeoutSec: SPARK_PROFILE.pullTimeoutSec,
@@ -324,13 +315,15 @@ const N1X_PROFILE: VllmProfile = {
 };
 
 // DGX Station.
+const stationDefaultRuntime = defaultVllmRuntimeForPlatform("station", "arm64");
 const STATION_PROFILE: VllmProfile = {
   name: "DGX Station",
   platform: "station",
-  image: VLLM_IMAGES.ngc2605Post1.arm64.ref,
-  imageDownloadSizeBytes: VLLM_IMAGES.ngc2605Post1.arm64.downloadSizeBytes,
-  imageUnpackedSizeBytes: VLLM_IMAGES.ngc2605Post1.arm64.unpackedSizeBytes,
-  defaultModel: deepseekV4FlashModel(),
+  architecture: "arm64",
+  image: stationDefaultRuntime.image,
+  imageDownloadSizeBytes: stationDefaultRuntime.imageDownloadSizeBytes,
+  imageUnpackedSizeBytes: stationDefaultRuntime.imageUnpackedSizeBytes,
+  defaultModel: defaultVllmModelForPlatform("station", "arm64"),
   containerName: NEMOCLAW_VLLM_CONTAINER_NAME,
   dockerRunFlags: SPARK_PROFILE.dockerRunFlags,
   buildDockerRunFlags: () => {
@@ -351,21 +344,20 @@ const STATION_PROFILE: VllmProfile = {
 
 // Generic discrete-GPU Linux. Uses a small nemotron model that fits on
 // most GPUs.
-const genericLinuxImage: VllmImageCatalogEntry | null =
-  process.arch === "arm64"
-    ? VLLM_IMAGES.ngc2603Post1.arm64
-    : process.arch === "x64"
-      ? VLLM_IMAGES.ngc2603Post1.amd64
-      : null;
+const genericLinuxRuntime =
+  process.arch === "arm64" || process.arch === "x64"
+    ? defaultVllmRuntimeForPlatform("linux", process.arch)
+    : null;
 
-const GENERIC_LINUX_PROFILE: VllmProfile | null = genericLinuxImage
+const GENERIC_LINUX_PROFILE: VllmProfile | null = genericLinuxRuntime
   ? {
       name: "Linux + NVIDIA GPU",
       platform: "linux",
-      image: genericLinuxImage.ref,
-      imageDownloadSizeBytes: genericLinuxImage.downloadSizeBytes,
-      imageUnpackedSizeBytes: genericLinuxImage.unpackedSizeBytes,
-      defaultModel: nemotronNanoModel(),
+      architecture: process.arch,
+      image: genericLinuxRuntime.image,
+      imageDownloadSizeBytes: genericLinuxRuntime.imageDownloadSizeBytes,
+      imageUnpackedSizeBytes: genericLinuxRuntime.imageUnpackedSizeBytes,
+      defaultModel: defaultVllmModelForPlatform("linux", process.arch),
       containerName: NEMOCLAW_VLLM_CONTAINER_NAME,
       dockerRunFlags: SPARK_PROFILE.dockerRunFlags,
       pullTimeoutSec: SPARK_PROFILE.pullTimeoutSec,
@@ -439,8 +431,9 @@ export function formatComputeCapability(capability: number): string {
 export function computeCapabilityPreflight(
   model: VllmModelDef,
   capabilities: number[] = readGpuComputeCapabilities(),
+  runtimeMinimum: number | undefined = model.minComputeCapability,
 ): { ok: true } | { ok: false; reason: string } {
-  const required = model.minComputeCapability;
+  const required = runtimeMinimum;
   if (required === undefined) return { ok: true };
   if (capabilities.length === 0) return { ok: true };
   const lowest = Math.min(...capabilities);
@@ -589,16 +582,77 @@ export function buildVllmRunArgs(
   ];
 }
 
-export function resolveVllmRuntimeProfile(profile: VllmProfile, model: VllmModelDef): VllmProfile {
-  const runtime = model.runtime;
+function selectedVllmRuntime(
+  profile: VllmProfile,
+  model: VllmModelDef,
+  architecture: NodeJS.Architecture = profile.architecture ?? process.arch,
+): VllmRuntimeOverride | VllmRuntimeVariant | undefined {
+  const matchingVariants = (model.runtimeVariants ?? [])
+    .filter(
+      (candidate) =>
+        vllmPlatformSpecificity(candidate.platforms, profile.platform) >= 0 &&
+        (!candidate.architectures || candidate.architectures.includes(architecture)),
+    )
+    .sort(
+      (left, right) =>
+        vllmPlatformSpecificity(left.platforms, profile.platform) -
+          vllmPlatformSpecificity(right.platforms, profile.platform) ||
+        left.priority - right.priority ||
+        (left.catalogPresetId ?? "").localeCompare(right.catalogPresetId ?? ""),
+    );
+  const runtime = matchingVariants.at(-1) ?? model.runtime;
+  if (model.requireRuntimeVariant && !runtime) {
+    throw new Error(
+      `${model.label} has no managed vLLM runtime for ${profile.name} on ${architecture}.`,
+    );
+  }
+  return runtime;
+}
+
+function replaceCatalogGpuRequest(
+  profile: VllmProfile,
+  runtime: VllmRuntimeOverride,
+  extraRunArgs: string[],
+): string[] {
+  if (runtime.dockerRunArgsMode !== "replace" || !profile.buildDockerRunFlags) {
+    return extraRunArgs;
+  }
+  if (!runtime.catalogPresetId) return extraRunArgs;
+  const platformFlags = profile.buildDockerRunFlags();
+  const platformGpuIndex = platformFlags.indexOf("--gpus");
+  const recipeGpuIndex = extraRunArgs.indexOf("--gpus");
+  if (
+    platformGpuIndex < 0 ||
+    platformGpuIndex === platformFlags.length - 1 ||
+    recipeGpuIndex < 0 ||
+    recipeGpuIndex === extraRunArgs.length - 1
+  ) {
+    throw new Error(`${profile.name} did not produce one declarative GPU request.`);
+  }
+  const replaced = [...extraRunArgs];
+  replaced[recipeGpuIndex + 1] = platformFlags[platformGpuIndex + 1]!;
+  return replaced;
+}
+
+function applyVllmRuntimeProfile(
+  profile: VllmProfile,
+  model: VllmModelDef,
+  runtime: VllmRuntimeOverride | VllmRuntimeVariant | undefined,
+): VllmProfile {
   let resolved = profile;
   if (runtime) {
-    const extraRunArgs = [...(runtime.dockerRunArgs ?? [])];
+    const extraRunArgs = replaceCatalogGpuRequest(
+      profile,
+      runtime,
+      [...(runtime.dockerRunArgs ?? [])],
+    );
     resolved = {
       ...profile,
       image: runtime.image,
       imageDownloadSizeBytes: runtime.imageDownloadSizeBytes,
-      imageUnpackedSizeBytes: undefined,
+      imageUnpackedSizeBytes:
+        runtime.imageUnpackedSizeBytes ??
+        (runtime.image === profile.image ? profile.imageUnpackedSizeBytes : undefined),
       modelDownloadSizeBytes: runtime.modelDownloadSizeBytes ?? profile.modelDownloadSizeBytes,
       loadTimeoutSec: runtime.loadTimeoutSec ?? profile.loadTimeoutSec,
       dockerRunFlags:
@@ -612,10 +666,47 @@ export function resolveVllmRuntimeProfile(profile: VllmProfile, model: VllmModel
             ? () => [...profile.buildDockerRunFlags!(), ...extraRunArgs]
             : undefined,
       pullTimeoutSec: runtime.pullTimeoutSec ?? profile.pullTimeoutSec,
+      minComputeCapability: runtime.minComputeCapability ?? model.minComputeCapability,
+      minGpuMemoryBytes: runtime.minGpuMemoryBytes,
+      servingCatalog: runtime.servingCatalog ?? profile.servingCatalog,
     };
   }
   assertVllmRegistryDigestRef(resolved.image);
   return resolved;
+}
+
+export function resolveVllmRuntimeProfile(
+  profile: VllmProfile,
+  model: VllmModelDef,
+  architecture: NodeJS.Architecture = profile.architecture ?? process.arch,
+): VllmProfile {
+  return applyVllmRuntimeProfile(profile, model, selectedVllmRuntime(profile, model, architecture));
+}
+
+export function resolveVllmModelRuntime(
+  profile: VllmProfile,
+  model: VllmModelDef,
+  architecture: NodeJS.Architecture = profile.architecture ?? process.arch,
+): { profile: VllmProfile; model: VllmModelDef } {
+  const runtime = selectedVllmRuntime(profile, model, architecture);
+  const resolvedProfile = applyVllmRuntimeProfile(profile, model, runtime);
+  if (!runtime || !("modelArgs" in runtime)) return { profile: resolvedProfile, model };
+  return {
+    profile: resolvedProfile,
+    model: {
+      ...model,
+      maxModelLen: runtime.maxModelLen,
+      revision: runtime.revision,
+      servedModelId: runtime.servedModelId,
+      modelArgs: runtime.modelArgs,
+      serveEnv: runtime.serveEnv,
+      installFastSafetensors: runtime.installFastSafetensors,
+      fixedServeCommand: runtime.fixedServeCommand,
+      managedBearerAuth: runtime.managedBearerAuth,
+      trustRemoteCode: runtime.trustRemoteCode,
+      runtime,
+    },
+  };
 }
 
 const SHA256_IMAGE_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
@@ -1458,12 +1549,14 @@ function ensureHfCacheDir(model: VllmModelDef): { ok: true } | { ok: false; reas
   return { ok: true };
 }
 
-interface InstallVllmOptions {
+export interface InstallVllmOptions {
   hasImage: boolean;
   nonInteractive: boolean;
   promptFn: (q: string) => Promise<string>;
   beforeInstall?: (modelId: string) => void;
   resolveManagedBridgeHost?: (dockerEnv: Record<string, string>) => string;
+  /** Reuse an already-collected readiness snapshot instead of probing the host again. */
+  readinessReports?: readonly ManagedInferenceReadinessSource[];
   /**
    * Injected rather than imported so this module does not take a dependency on
    * the onboard preflight layer. onboard.ts supplies the same probe the gateway
@@ -1546,13 +1639,9 @@ async function runVllmInstall(
   opts: InstallVllmOptions,
   hostLocalSelection?: MaterializedHostLocalVllmSelection,
 ): Promise<{ ok: boolean }> {
+  const explicitModel = String(process.env.NEMOCLAW_VLLM_MODEL ?? "").trim();
+  const configuredPeer = String(process.env[NEMOCLAW_DGX_STATION_PEER_ENV] ?? "").trim();
   if (profile.defaultModel.fixedServeCommand) {
-    if (String(process.env.NEMOCLAW_VLLM_MODEL ?? "").trim()) {
-      console.error(
-        "  vLLM install failed: this local model profile does not accept NEMOCLAW_VLLM_MODEL.",
-      );
-      return { ok: false };
-    }
     if (String(process.env[VLLM_EXTRA_ARGS_ENV] ?? "").trim()) {
       console.error(
         `  vLLM install failed: this local model profile does not accept ${VLLM_EXTRA_ARGS_ENV}.`,
@@ -1584,8 +1673,11 @@ async function runVllmInstall(
       );
   if (managedCluster.kind === "handled") return managedCluster.result;
 
-  if (!hostLocalSelection) {
-    const selected = resolveHostLocalVllmSelection(profile);
+  if (!hostLocalSelection && !(profile.platform === "station" && configuredPeer)) {
+    const selected = resolveHostLocalVllmSelection(profile, process.env, {
+      automatic: opts.nonInteractive,
+      readinessReports: opts.readinessReports,
+    });
     if (selected.kind === "rejected") {
       console.error(`  vLLM install failed: ${selected.reason}`);
       return { ok: false };
@@ -1597,27 +1689,30 @@ async function runVllmInstall(
 
   let dualStationPlan: DualStationVllmPlan | null = null;
   let peerModelSnapshot: "ready" | "staging-required" | null = null;
-  const explicitModel = String(process.env.NEMOCLAW_VLLM_MODEL ?? "").trim();
-  const configuredPeer = String(process.env[NEMOCLAW_DGX_STATION_PEER_ENV] ?? "").trim();
-  const ultra =
+  const pairedModel =
     profile.platform === "station" && configuredPeer
-      ? VLLM_MODELS.find((candidate) => candidate.envValue === "nemotron-3-ultra-550b-a55b")
+      ? vllmModelForOrchestration(
+          STATION_PAIR_OPTIONAL_ORCHESTRATION,
+          "station",
+          profile.architecture ?? process.arch,
+        )
       : undefined;
 
   if (profile.platform === "station" && configuredPeer) {
-    if (!ultra) {
-      console.error("  vLLM install failed: Nemotron Ultra is missing from the model registry");
+    if (!pairedModel) {
+      console.error("  vLLM install failed: the Station-pair model is missing from the catalog");
       return { ok: false };
     }
     const normalizedExplicitModel = explicitModel.toLowerCase();
     if (
       normalizedExplicitModel &&
-      normalizedExplicitModel !== ultra.envValue.toLowerCase() &&
-      normalizedExplicitModel !== ultra.id.toLowerCase()
+      normalizedExplicitModel !== pairedModel.envValue.toLowerCase() &&
+      normalizedExplicitModel !== pairedModel.id.toLowerCase() &&
+      normalizedExplicitModel !== pairedModel.servedModelId?.toLowerCase()
     ) {
       console.error(
         `  vLLM install failed: ${NEMOCLAW_DGX_STATION_PEER_ENV} requires the DGX Station dual-serving model. ` +
-          "Unset NEMOCLAW_VLLM_MODEL or select nemotron-3-ultra-550b-a55b; the explicit model override remains authoritative.",
+          `Unset NEMOCLAW_VLLM_MODEL or select ${pairedModel.envValue}; the explicit model override remains authoritative.`,
       );
       return { ok: false };
     }
@@ -1626,7 +1721,7 @@ async function runVllmInstall(
   // stays focused on the docker side effects. Gated-model access is checked
   // there before any docker work happens.
   let resolved: Awaited<ReturnType<typeof resolveVllmInstallModel>>;
-  if (profile.platform === "station" && configuredPeer && !explicitModel && ultra) {
+  if (profile.platform === "station" && configuredPeer && !explicitModel && pairedModel) {
     const capability = probeDualStationVllmCapability();
     if (capability.kind !== "ready") {
       const reason =
@@ -1637,7 +1732,7 @@ async function runVllmInstall(
       return { ok: false };
     }
     resolved = await resolveVllmInstallModel(
-      { ...profile, defaultModel: ultra },
+      { ...profile, defaultModel: pairedModel },
       {
         // A qualified explicit peer is the model-selection signal. The normal
         // resolver still owns access validation, but no second model choice is
@@ -1664,28 +1759,73 @@ async function runVllmInstall(
     });
   }
   if (!resolved) return { ok: false };
-  const { model, source: modelSource } = resolved;
+  if (!hostLocalSelection && resolved.source === "picker") {
+    const selected = resolveHostLocalVllmSelection(profile, {
+      ...process.env,
+      NEMOCLAW_VLLM_MODEL: resolved.model.envValue,
+    }, {
+      readinessReports: opts.readinessReports,
+    });
+    if (selected.kind === "rejected") {
+      console.error(`  vLLM install failed: ${selected.reason}`);
+      return { ok: false };
+    }
+    if (selected.kind === "selected") {
+      return await runVllmInstall(selected.profile, opts, selected);
+    }
+  }
+  let { model } = resolved;
+  const { source: modelSource } = resolved;
   // Platform-restricted models are filtered out of the interactive picker,
   // but a direct NEMOCLAW_VLLM_MODEL override bypasses that filter, so this
   // gate is the only platform enforcement on the env-override path. It must
   // reject every wrong-platform model, not just runtime-carrying ones — an
   // NVFP4 Spark checkpoint or a 352 GB Station recipe cannot serve here and
   // must fail before the image pull and download (#7358).
-  if (!model.platforms.includes(profile.platform)) {
+  const architecture = profile.architecture ?? process.arch;
+  const usesStationPair = vllmModelUsesOrchestration(
+    model,
+    STATION_PAIR_OPTIONAL_ORCHESTRATION,
+    profile.platform,
+    architecture,
+  );
+  const hasCompatibleRuntime = (model.runtimeVariants ?? []).some(
+    (variant) =>
+      vllmPlatformSpecificity(variant.platforms, profile.platform) >= 0 &&
+      (!variant.architectures || variant.architectures.includes(architecture)),
+  );
+  if (
+    (model.runtimeVariants?.length && !hasCompatibleRuntime) ||
+    (!model.runtimeVariants?.length && !model.platforms.includes(profile.platform))
+  ) {
     console.error(`  vLLM install failed: ${model.label} is not supported on ${profile.name}`);
     return { ok: false };
   }
   let runtimeProfile: VllmProfile;
-  try {
-    runtimeProfile = resolveVllmRuntimeProfile(profile, model);
-  } catch (err) {
-    console.error(`  vLLM install failed: ${(err as Error).message}`);
-    return { ok: false };
+  if (
+    hostLocalSelection ||
+    (profile.platform === "station" &&
+      configuredPeer.length > 0 &&
+      usesStationPair)
+  ) {
+    runtimeProfile = profile;
+  } else {
+    try {
+      const runtime = resolveVllmModelRuntime(profile, model);
+      runtimeProfile = runtime.profile;
+      model = runtime.model;
+    } catch (err) {
+      console.error(`  vLLM install failed: ${(err as Error).message}`);
+      return { ok: false };
+    }
   }
 
   let extraServeArgs: string[];
   let servedModelId: string;
   try {
+    if (model.fixedServeCommand && String(process.env[VLLM_EXTRA_ARGS_ENV] ?? "").trim()) {
+      throw new Error(`this managed vLLM recipe does not accept ${VLLM_EXTRA_ARGS_ENV}`);
+    }
     extraServeArgs = parseVllmExtraServeArgs();
     servedModelId = resolveVllmServedModelId(model.servedModelId ?? model.id, extraServeArgs);
   } catch (err) {
@@ -1693,7 +1833,7 @@ async function runVllmInstall(
     return { ok: false };
   }
 
-  if (profile.platform === "station" && model.envValue === "nemotron-3-ultra-550b-a55b") {
+  if (profile.platform === "station" && usesStationPair) {
     if (!dualStationPlan) {
       const capability = probeDualStationVllmCapability();
       if (capability.kind === "unavailable") {
@@ -1710,9 +1850,9 @@ async function runVllmInstall(
       runtimeProfile = {
         ...runtimeProfile,
         image: dualStationPlan.runtime.image,
-        imageDownloadSizeBytes: NEMOTRON_ULTRA_DUAL_STATION_IMAGE.arm64.downloadSizeBytes,
+        imageDownloadSizeBytes: dualStationPlan.runtime.imageDownloadSizeBytes,
         imageUnpackedSizeBytes: undefined,
-        loadTimeoutSec: 7200,
+        loadTimeoutSec: dualStationPlan.runtime.loadTimeoutSeconds,
       };
       if (VLLM_PORT !== 8000) {
         console.error(
@@ -1795,7 +1935,11 @@ async function runVllmInstall(
     return { ok: false };
   }
 
-  const capability = computeCapabilityPreflight(model);
+  const capability = computeCapabilityPreflight(
+    model,
+    readGpuComputeCapabilities(),
+    runtimeProfile.minComputeCapability,
+  );
   if (!capability.ok) {
     console.error(`  vLLM install failed: ${capability.reason}`);
     return { ok: false };

--- a/src/lib/onboard/local-model-profile/onboarder.test.ts
+++ b/src/lib/onboard/local-model-profile/onboarder.test.ts
@@ -50,6 +50,7 @@ describe("dedicated local model profile onboarder", () => {
       return { ok: true };
     });
     const onboard = createLocalModelProfileOnboarder({
+      env: {},
       installVllm,
       handleVllmSelection,
       prompt: vi.fn(async () => ""),

--- a/src/lib/onboard/station-express-resume.ts
+++ b/src/lib/onboard/station-express-resume.ts
@@ -6,7 +6,12 @@ import path from "node:path";
 
 import { isErrnoException } from "../core/errno";
 import { detectNvidiaPlatform, type NvidiaPlatform } from "../inference/nim";
-import { selectVllmModelFromEnv, type VllmModelDef } from "../inference/vllm-models";
+import {
+  selectVllmModelFromEnv,
+  STATION_PAIR_OPTIONAL_ORCHESTRATION,
+  type VllmModelDef,
+  vllmStationPairForOrchestration,
+} from "../inference/vllm-models";
 import { NAME_MAX_LENGTH, NAME_VALID_PATTERN } from "../name-validation";
 import { getNemoclawStateRoot, resolveHome, STATE_DIR_NAME } from "../state/state-root";
 import { isSafeModelId } from "../validation";
@@ -99,8 +104,6 @@ const BOUND_RECEIPT_INTENT_KEYS =
 const SPARK_INTENT_KEYS = "kind,sandboxName,version";
 const SPARK_INTENT_KEYS_WITH_MODEL = "kind,model,sandboxName,version";
 const SPARK_EXPRESS_PROVIDER = "install-vllm";
-const STATION_ULTRA_ENV_VALUE = "nemotron-3-ultra-550b-a55b";
-const STATION_ULTRA_DUAL_SERVED_MODEL = "nemotron-ultra";
 const STATION_EXPRESS_INSTALLER_RESUME_FILE = "station-express-resume";
 const STATION_EXPRESS_RETIREMENT_CLAIM_PREFIX = `${STATION_EXPRESS_INSTALLER_RESUME_FILE}.retiring-`;
 const STATION_EXPRESS_RETIREMENT_CLAIM_RECEIPT = "receipt";
@@ -157,15 +160,21 @@ function qualifiedDualStationServedModel(
   env: NodeJS.ProcessEnv,
   model: VllmModelDef,
 ): string | null {
+  const stationPair = vllmStationPairForOrchestration(
+    model,
+    STATION_PAIR_OPTIONAL_ORCHESTRATION,
+    "station",
+    "arm64",
+  );
   if (
-    model.envValue !== STATION_ULTRA_ENV_VALUE ||
+    !stationPair ||
     String(env.NEMOCLAW_DGX_STATION_PEER ?? "").trim().length === 0 ||
     String(env.NEMOCLAW_DGX_STATION_SSH_BINDING ?? "").trim().length === 0
   ) {
     return null;
   }
   const selected = String(env.NEMOCLAW_MODEL ?? "").trim();
-  return selected === STATION_ULTRA_DUAL_SERVED_MODEL ? selected : null;
+  return selected === stationPair.servedName ? selected : null;
 }
 
 function identifiesCheckpoint(model: VllmModelDef, value: string): boolean {

--- a/src/lib/readiness/host.ts
+++ b/src/lib/readiness/host.ts
@@ -59,6 +59,11 @@ export interface HostObservations {
   hasNvidiaGpu: boolean;
   nvidiaGpuCount?: number;
   nvidiaDriverVersion?: string;
+  nvidiaGpuMemoryTotalBytes?: number;
+  nvidiaGpuMemoryAvailableBytes?: number;
+  nvidiaGpuMemoryPerDeviceBytes?: number;
+  nvidiaGpuUnifiedMemory?: boolean;
+  nvidiaGpuComputeConstrained?: boolean;
   hostGpuPlatform?: NvidiaPlatform;
   nvidiaContainerToolkitInstalled: boolean;
   dockerCdiSpecDirs: readonly string[];
@@ -80,7 +85,19 @@ export interface CollectHostObservationsOptions {
   architecture?: string;
   detectGpu?: () =>
     | (Pick<GpuDetection, "count" | "wslDockerDesktopGpuProofPassed"> &
-        Partial<Pick<GpuDetection, "platform" | "type">>)
+        Partial<
+          Pick<
+            GpuDetection,
+            | "platform"
+            | "type"
+            | "gpus"
+            | "totalMemoryMB"
+            | "availableMemoryMB"
+            | "perGpuMB"
+            | "unifiedMemory"
+            | "computeConstrained"
+          >
+        >)
     | null;
   detectNvidiaDriverVersion?: () => string | undefined;
   detectHostGpuPlatform?: () => NvidiaPlatform;
@@ -108,6 +125,7 @@ function adaptHostAssessment(
   hostGpuPlatform?: NvidiaPlatform,
   nvidiaGpuCount?: number,
   nvidiaDriverVersion?: string,
+  gpu?: ReturnType<NonNullable<CollectHostObservationsOptions["detectGpu"]>>,
   platformIdentity?: PlatformIdentity,
   wslDockerDesktopGpuProofPassed?: boolean,
 ): HostObservations {
@@ -135,6 +153,18 @@ function adaptHostAssessment(
     hasNvidiaGpu,
     nvidiaGpuCount,
     nvidiaDriverVersion,
+    nvidiaGpuMemoryTotalBytes:
+      gpu?.totalMemoryMB === undefined ? undefined : gpu.totalMemoryMB * 1024 * 1024,
+    nvidiaGpuMemoryAvailableBytes:
+      gpu?.availableMemoryMB === undefined ? undefined : gpu.availableMemoryMB * 1024 * 1024,
+    nvidiaGpuMemoryPerDeviceBytes:
+      gpu?.gpus?.length
+        ? Math.min(...gpu.gpus.map(({ memoryMB }) => memoryMB)) * 1024 * 1024
+        : gpu?.perGpuMB === undefined
+          ? undefined
+          : gpu.perGpuMB * 1024 * 1024,
+    nvidiaGpuUnifiedMemory: gpu?.unifiedMemory,
+    nvidiaGpuComputeConstrained: gpu?.computeConstrained,
     hostGpuPlatform,
     nvidiaContainerToolkitInstalled: host.nvidiaContainerToolkitInstalled,
     dockerCdiSpecDirs: [...host.dockerCdiSpecDirs],
@@ -216,6 +246,7 @@ function observeHost(
             ? options.detectNvidiaDriverVersion()
             : detectNvidiaDriverVersion({ runCaptureImpl })
           : undefined,
+        gpu,
         (
           options.collectPlatformIdentity ??
           (() => collectPlatformIdentity(options.platformIdentityOptions))
@@ -280,6 +311,11 @@ function unknownProjection(evidenceIds: readonly string[]): {
     "host.gpu.nvidia",
     "host.gpu.count",
     "host.gpu.driver_version",
+    "host.gpu.memory_total_bytes",
+    "host.gpu.memory_available_bytes",
+    "host.gpu.memory_per_device_bytes",
+    "host.gpu.unified_memory",
+    "host.gpu.compute_constrained",
     "host.gpu.container_toolkit",
     "host.gpu.nvidia_runtime",
     "host.gpu.cdi",
@@ -415,6 +451,26 @@ export function projectHostReadiness(
       observation(
         "host.gpu.driver_version",
         host.hasNvidiaGpu ? host.nvidiaDriverVersion : undefined,
+      ),
+      observation(
+        "host.gpu.memory_total_bytes",
+        host.hasNvidiaGpu ? host.nvidiaGpuMemoryTotalBytes : undefined,
+      ),
+      observation(
+        "host.gpu.memory_available_bytes",
+        host.hasNvidiaGpu ? host.nvidiaGpuMemoryAvailableBytes : undefined,
+      ),
+      observation(
+        "host.gpu.memory_per_device_bytes",
+        host.hasNvidiaGpu ? host.nvidiaGpuMemoryPerDeviceBytes : undefined,
+      ),
+      observation(
+        "host.gpu.unified_memory",
+        host.hasNvidiaGpu ? host.nvidiaGpuUnifiedMemory : undefined,
+      ),
+      observation(
+        "host.gpu.compute_constrained",
+        host.hasNvidiaGpu ? host.nvidiaGpuComputeConstrained : undefined,
       ),
       observation(
         "host.gpu.container_toolkit",

--- a/test/docker-authority-profile.test.ts
+++ b/test/docker-authority-profile.test.ts
@@ -66,7 +66,15 @@ describe("Docker authority readiness", () => {
         assess: () => host(runtime),
         architecture: "arm64",
         now: () => NOW,
-        detectGpu: () => ({ count: 1, platform: "spark", type: "nvidia" }),
+        detectGpu: () => ({
+          count: 1,
+          platform: "spark",
+          type: "nvidia",
+          totalMemoryMB: 128 * 1024,
+          availableMemoryMB: 128 * 1024,
+          perGpuMB: 128 * 1024,
+          unifiedMemory: true,
+        }),
         detectNvidiaDriverVersion: () => "580.65.06",
         collectPlatformIdentity: () => ({
           nvidiaPlatform: "spark",

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -41,7 +41,7 @@ function runTests(...tests: string[]): () => string[] {
 
 export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
   {
-    pattern: /(?:^|\/)managed-inference\/(?:presets|recipes|schemas)\/[^/]+\.(?:json|yaml)$/,
+    pattern: /(?:^|\/)managed-inference\/(?:models|presets|recipes|schemas)\/[^/]+\.(?:json|yaml)$/,
     testsToRun: runTests(
       "src/lib/inference/serving/catalog.test.ts",
       "src/lib/inference/serving/resolver.test.ts",

--- a/test/install-station-controller-binding.test.ts
+++ b/test/install-station-controller-binding.test.ts
@@ -321,7 +321,7 @@ printf 'MIGRATE=%s REUSE=%s\\n' "$_STATION_EXPRESS_MIGRATING_LEGACY_HEAD" "$_STA
         "true",
         "true",
         "head",
-        "2",
+        "3",
         "c".repeat(64),
         "d".repeat(64),
         "e".repeat(64),

--- a/test/managed-inference-catalog-compiler.test.ts
+++ b/test/managed-inference-catalog-compiler.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 import catalogSchema from "../managed-inference/schemas/catalog.schema.json" with { type: "json" };
+import modelSchema from "../managed-inference/schemas/model.schema.json" with { type: "json" };
 import presetSchema from "../managed-inference/schemas/preset.schema.json" with { type: "json" };
 import recipeSchema from "../managed-inference/schemas/recipe.schema.json" with { type: "json" };
 import { getManagedInferenceServingCatalogRegistries } from "../src/lib/inference/serving/adapter-registry.js";
@@ -33,7 +34,7 @@ const MUSE_PROFILE_ID = "vllm.dgx-spark-gb10.single.muse-glimmer-30b-nvfp4-w4a4"
 const MUSE_RECIPE_ID = "vllm.muse-glimmer-30b-nvfp4-w4a4.spark-single.v1";
 
 function catalogSources(): ServingCatalogSource[] {
-  return (["presets", "recipes"] as const).flatMap((kind) => {
+  return (["models", "presets", "recipes"] as const).flatMap((kind) => {
     const directory = path.join(REPOSITORY_ROOT, "managed-inference", kind);
     return readdirSync(directory)
       .filter((name) => name.endsWith(".yaml"))
@@ -50,6 +51,7 @@ function compile(sources: readonly ServingCatalogSource[]) {
     sourceRevision: "a".repeat(40),
     schemas: {
       catalog: catalogSchema,
+      model: modelSchema,
       preset: presetSchema,
       recipe: recipeSchema,
     },

--- a/test/package-contract/managed-inference-catalog.test.ts
+++ b/test/package-contract/managed-inference-catalog.test.ts
@@ -10,6 +10,7 @@ import { parseCompiledServingCatalogJson } from "../../dist/lib/inference/servin
 import catalogSchema from "../../managed-inference/schemas/catalog.schema.json" with {
   type: "json",
 };
+import modelSchema from "../../managed-inference/schemas/model.schema.json" with { type: "json" };
 import presetSchema from "../../managed-inference/schemas/preset.schema.json" with { type: "json" };
 import recipeSchema from "../../managed-inference/schemas/recipe.schema.json" with { type: "json" };
 import { createPackageFixture } from "./helpers/package-fixture";
@@ -24,6 +25,7 @@ describe("compiled managed inference serving catalog", () => {
     );
     parseCompiledServingCatalogJson(source, {
       catalog: catalogSchema,
+      model: modelSchema,
       preset: presetSchema,
       recipe: recipeSchema,
     });
@@ -45,6 +47,7 @@ describe("compiled managed inference serving catalog", () => {
 
       expect(files).toContain("dist/managed-inference/catalog.json");
       expect(files).toContain("managed-inference/schemas/catalog.schema.json");
+      expect(files).toContain("managed-inference/schemas/model.schema.json");
       expect(files).toContain("managed-inference/schemas/recipe.schema.json");
       expect(files).toContain("managed-inference/schemas/preset.schema.json");
     } finally {

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -41,6 +41,7 @@ const E2E_WORKFLOW_CONTRACTS = [
 ] as const;
 
 const OPAQUE_INPUTS = [
+  "managed-inference/models/example.yaml",
   "managed-inference/recipes/vllm.example.managed-cluster.v1.yaml",
   "Dockerfile",
   "agents/hermes/Dockerfile",
@@ -94,6 +95,11 @@ describe("Vitest opaque-input watch triggers", () => {
         ".github/scripts/docker-auth-cleanup.sh",
       ],
   )("maps current opaque inputs to their direct contract tests [%s] (#6692)", (authPath) => {
+    expect(triggeredBy("managed-inference/models/example.yaml")).toEqual([
+      "src/lib/inference/serving/catalog.test.ts",
+      "src/lib/inference/serving/resolver.test.ts",
+      "test/managed-inference-catalog-compiler.test.ts",
+    ]);
     expect(triggeredBy("managed-inference/recipes/vllm.example.managed-cluster.v1.yaml")).toEqual([
       "src/lib/inference/serving/catalog.test.ts",
       "src/lib/inference/serving/resolver.test.ts",


### PR DESCRIPTION
## Summary

Move the existing managed vLLM model and hardware profile matrix into the compiled managed-inference catalog. Runtime selection, profile listing, model preparation, and probe policy now derive from the same declarative source instead of duplicating model-specific TypeScript branches.

This foundation preserves the current supported matrix. It does not add Linux Muse Glimmer or Nemotron 3.5 Lightning profiles and does not change vLLM or llama.cpp port behavior.

Depends on #9660, which refreshes the llama.cpp image's Ubuntu curl package tuple. This PR does not otherwise change the llama.cpp image.

Design context: [managed inference catalog](https://github.com/NVIDIA/NemoClaw/discussions/7636) and [declarative profile migration](https://github.com/NVIDIA/NemoClaw/discussions/8379).

## Changes

- Add versioned model YAML resources and a model schema to the managed-inference catalog compiler.
- Migrate the currently supported Spark, Station, N1x, and generic Linux vLLM profiles and recipes into YAML.
- Derive the vLLM registry, runtime variants, defaults, preparation steps, orchestration references, and endpoint probe policies from compiled catalog data.
- Route explicit provider/model intent through declarative requirements and materialize selected host-local recipes into the existing runtime boundary.
- Add host architecture, compute capability, GPU memory, and unified-memory facts used by catalog qualification.
- Add compiler, resolver, registry, materialization, profile-list, runtime-selection, and package-contract coverage. The catalog-only model test protects the requirement that a new model/profile can be discovered without editing the TypeScript registry.

The compiler boundary is required because catalog resources are consumed by the CLI, packaged artifact, profile list, resolver, and runtime launcher. Keeping independent TypeScript model tables would allow those consumers to drift and would continue requiring code changes for each profile.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Existing profile migration only.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `460/460` focused CLI tests, `52/52` integration tests, and `2/2` package-contract tests passed. CI-regression coverage also passed for `112/112` llama.cpp image tests, `80/80` Station preparation tests, `14/14` Station controller tests, `3/3` onboarder tests, and `1/1` Docker-authority test.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification:

- `npm run catalog:compile`
- `npm run catalog:check`
- `npm run build:cli`
- `npm run typecheck:cli`
- `npm run validate:pr`

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
