### PR TITLE
fix(inference): settle OpenClaw pairing after route changes

### DIFF
--- a/src/lib/actions/inference-set-gateway-restart.ts
+++ b/src/lib/actions/inference-set-gateway-restart.ts
@@ -211,11 +211,13 @@ export function finalizeInferenceMutation<T extends InferenceResultForGateway>(
       !result.inSandboxConfigSynced
         ? " (in-sandbox sync incomplete)"
         : openClawGatewayRestartRequired
-          ? " (gateway restart pending)"
-          : ""
+          ? " (gateway restart and pairing convergence pending)"
+          : openClawPairingConvergenceRequired
+            ? " (pairing convergence pending)"
+            : ""
     }`,
   };
-  if (openClawGatewayRestartRequired) {
+  if (openClawGatewayRestartRequired || openClawPairingConvergenceRequired) {
     appendPostCommitInferenceAudit(deps, auditEntry);
   } else {
     deps.appendAuditEntry(auditEntry);

--- a/src/lib/actions/inference-set-gateway-restart.ts
+++ b/src/lib/actions/inference-set-gateway-restart.ts
@@ -6,12 +6,113 @@ import type { ConfigObject } from "../security/credential-filter";
 import type { ShieldsAuditEntry } from "../shields/audit";
 import { type InferenceApi, readOpenClawPrimaryRouteApi } from "./inference-route-api";
 import { InferenceSetError } from "./inference-set-error";
+import {
+  runPortableOpenClawPairingApproval,
+  runPortableOpenClawPairingRequestProducer,
+  type PortableOpenClawPairingApprovalReceipt,
+} from "./sandbox/auto-pair-approval";
 import type { GatewayRestartResult } from "./sandbox/gateway-restart";
+import {
+  observeOpenClawPairingSettlement,
+  type OpenClawPairingSettlementObservation,
+} from "./sandbox/launch-readiness/openclaw-pairing-qualification";
+
+export type InferenceSetOpenClawPairingTarget = {
+  readonly sandboxName: string;
+  readonly gatewayName: string;
+  readonly openclawVersion: string;
+  readonly stateDirectory: string;
+};
+
+export type InferenceSetOpenClawPairingFailureLayer =
+  | "initial-state-unavailable"
+  | "final-state-unavailable"
+  | "final-state-unsettled"
+  | "pairing-operation-failed"
+  | "pairing-target-unavailable"
+  | `approval-${Exclude<PortableOpenClawPairingApprovalReceipt, "approved">}`;
+
+export type InferenceSetOpenClawPairingResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly failureLayer: InferenceSetOpenClawPairingFailureLayer };
+
+export type InferenceSetOpenClawPairingDeps = {
+  observePairing: (
+    target: InferenceSetOpenClawPairingTarget,
+  ) => OpenClawPairingSettlementObservation;
+  publishScopeRequest: (target: InferenceSetOpenClawPairingTarget) => void;
+  approveScopeRequest: (
+    target: InferenceSetOpenClawPairingTarget,
+    deviceIdentitySha256: string,
+  ) => PortableOpenClawPairingApprovalReceipt;
+};
+
+const defaultOpenClawPairingDeps: InferenceSetOpenClawPairingDeps = {
+  observePairing: (target) =>
+    observeOpenClawPairingSettlement(
+      target.sandboxName,
+      target.gatewayName,
+      target.openclawVersion,
+      target.stateDirectory,
+    ),
+  publishScopeRequest: (target) =>
+    runPortableOpenClawPairingRequestProducer(target.sandboxName, target.gatewayName),
+  approveScopeRequest: (target, deviceIdentitySha256) =>
+    runPortableOpenClawPairingApproval(
+      target.sandboxName,
+      target.gatewayName,
+      deviceIdentitySha256,
+    ),
+};
+
+/**
+ * Reconcile the local OpenClaw CLI device after an inference route change.
+ *
+ * The state observer accepts only the exact operator pairing/read/write projection.
+ * The request producer runs only for a pairing-only device. The approval helper then
+ * binds one allowlisted request to the observed device identity. A final state read,
+ * not command output, decides whether the inference switch can report success.
+ */
+export function settleInferenceSetOpenClawPairing(
+  target: InferenceSetOpenClawPairingTarget,
+  deps: InferenceSetOpenClawPairingDeps = defaultOpenClawPairingDeps,
+): InferenceSetOpenClawPairingResult {
+  let initial: OpenClawPairingSettlementObservation;
+  try {
+    initial = deps.observePairing(target);
+  } catch {
+    return { ok: false, failureLayer: "initial-state-unavailable" };
+  }
+  if (initial.state === "settled") return { ok: true };
+
+  let approval: PortableOpenClawPairingApprovalReceipt;
+  try {
+    deps.publishScopeRequest(target);
+    approval = deps.approveScopeRequest(target, initial.deviceIdentitySha256);
+  } catch {
+    return { ok: false, failureLayer: "pairing-operation-failed" };
+  }
+
+  let final: OpenClawPairingSettlementObservation;
+  try {
+    final = deps.observePairing(target);
+  } catch {
+    return { ok: false, failureLayer: "final-state-unavailable" };
+  }
+  if (final.state === "settled") return { ok: true };
+  return {
+    ok: false,
+    failureLayer: approval === "approved" ? "final-state-unsettled" : `approval-${approval}`,
+  };
+}
 
 export interface InferenceGatewayRestartDeps {
   appendAuditEntry: (entry: ShieldsAuditEntry) => void;
   log: (message: string) => void;
   restartSandboxGateway: (sandboxName: string) => GatewayRestartResult;
+  settleOpenClawPairing: (
+    target: InferenceSetOpenClawPairingTarget,
+  ) => InferenceSetOpenClawPairingResult;
 }
 
 interface InferenceResultForGateway {
@@ -33,17 +134,25 @@ interface InferenceResultForGateway {
 export interface InferenceMutation<T extends InferenceResultForGateway> {
   result: T;
   openClawGatewayRestartRequired: boolean;
+  openClawPairing:
+    | { readonly state: "not-required" }
+    | { readonly state: "required"; readonly target: InferenceSetOpenClawPairingTarget }
+    | { readonly state: "target-unavailable" };
 }
 
-// SOURCE_OF_TRUTH_REVIEW (cross-family OpenClaw restart; gateway regression
-// #4504, OpenClaw 2026.6.10 adopted in #5595): that version hot-reloads model
+// SOURCE_OF_TRUTH_REVIEW (OpenClaw post-switch convergence; gateway regressions
+// #4504 and #9527): OpenClaw 2026.6.10 adopted in #5595 hot-reloads model
 // identity but retains request shaping when the API family changes. NemoClaw
-// therefore restarts only after the route, config, and integrity hash commit,
-// and outside the config transition lock. Unit coverage proves restart,
-// no-restart, redaction, audit-failure, and post-commit recovery behavior;
-// openclaw-inference-switch live coverage proves gateway health and forwarding.
-// Remove this coordination when the minimum supported OpenClaw hot-reloads
-// request shaping across API-family changes, keeping the tests until then.
+// restarts only after the route, config, and integrity hash commit. Every
+// changed OpenClaw route then requires exact local device-scope convergence
+// before the command reports success. Both operations run outside the config
+// transition lock and inside the sandbox lifecycle lock. Unit coverage proves
+// restart, no-restart, scope convergence, redaction, audit-failure, and
+// post-commit recovery behavior. The openclaw-inference-switch live target
+// proves gateway health and forwarding. Remove the restart when the minimum
+// supported OpenClaw hot-reloads request shaping across API-family changes.
+// Remove pairing settlement when OpenClaw no longer requires a separate
+// allowlisted device-scope upgrade after a route change.
 
 export function defaultInferenceGatewayRestart(sandboxName: string): GatewayRestartResult {
   const recovery: typeof import("./sandbox/process-recovery") = require("./sandbox/process-recovery");
@@ -78,18 +187,21 @@ export function finalizeInferenceMutation<T extends InferenceResultForGateway>(
     agentName: string;
     configChanged: boolean;
     nextApi: string;
+    openClawPairingTarget?: InferenceSetOpenClawPairingTarget;
     previousApi: InferenceApi | null;
     result: T;
   },
   deps: Pick<InferenceGatewayRestartDeps, "appendAuditEntry" | "log">,
 ): InferenceMutation<T> {
-  const { agentName, configChanged, nextApi, previousApi, result } = options;
+  const { agentName, configChanged, nextApi, openClawPairingTarget, previousApi, result } = options;
   const openClawGatewayRestartRequired =
     agentName === "openclaw" &&
     configChanged &&
     result.inSandboxConfigSynced &&
     previousApi !== null &&
     previousApi !== nextApi;
+  const openClawPairingConvergenceRequired =
+    agentName === "openclaw" && configChanged && result.inSandboxConfigSynced;
 
   const auditEntry: ShieldsAuditEntry = {
     action: "inference_set",
@@ -112,7 +224,12 @@ export function finalizeInferenceMutation<T extends InferenceResultForGateway>(
   // A Hermes switch whose Web Dashboard profile did not converge is not fully
   // applied, so withhold the success line (the caller already warned) (#6893).
   const hermesDashboardStale = agentName === "hermes" && result.dashboardConverged === false;
-  if (result.inSandboxConfigSynced && !openClawGatewayRestartRequired && !hermesDashboardStale) {
+  if (
+    result.inSandboxConfigSynced &&
+    !openClawGatewayRestartRequired &&
+    !openClawPairingConvergenceRequired &&
+    !hermesDashboardStale
+  ) {
     deps.log(
       agentName === "hermes"
         ? `  Inference route synced for '${result.sandboxName}': ${result.model}`
@@ -120,43 +237,79 @@ export function finalizeInferenceMutation<T extends InferenceResultForGateway>(
     );
   }
 
-  return { result, openClawGatewayRestartRequired };
+  return {
+    result,
+    openClawGatewayRestartRequired,
+    openClawPairing: !openClawPairingConvergenceRequired
+      ? { state: "not-required" }
+      : openClawPairingTarget
+        ? { state: "required", target: openClawPairingTarget }
+        : { state: "target-unavailable" },
+  };
 }
 
-export function completeInferenceGatewayRestart<T extends InferenceResultForGateway>(
+export function completeInferencePostCommit<T extends InferenceResultForGateway>(
   mutation: InferenceMutation<T>,
   deps: InferenceGatewayRestartDeps,
 ): void {
-  if (!mutation.openClawGatewayRestartRequired) return;
-
   const { result } = mutation;
-  deps.log(
-    `  Restarting the OpenClaw gateway in '${result.sandboxName}' to apply the new inference API family...`,
-  );
-  let restartFailure: string | null = null;
-  try {
-    const restart = deps.restartSandboxGateway(result.sandboxName);
-    if (!restart.ok) restartFailure = restart.failureLayer;
-  } catch {
-    restartFailure = "restart exception";
+  if (mutation.openClawGatewayRestartRequired) {
+    deps.log(
+      `  Restarting the OpenClaw gateway in '${result.sandboxName}' to apply the new inference API family...`,
+    );
+    let restartFailure: string | null = null;
+    try {
+      const restart = deps.restartSandboxGateway(result.sandboxName);
+      if (!restart.ok) restartFailure = restart.failureLayer;
+    } catch {
+      restartFailure = "restart exception";
+    }
+    if (restartFailure) {
+      appendPostCommitInferenceAudit(deps, {
+        action: "inference_set",
+        sandbox: result.sandboxName,
+        timestamp: new Date().toISOString(),
+        reason: `inference set openclaw:${result.provider}:${result.model} (config committed; gateway restart failed: ${restartFailure})`,
+      });
+      throw new InferenceSetError(
+        `Inference route and config were updated for '${result.sandboxName}', but the managed OpenClaw gateway restart/recovery did not complete successfully. ` +
+          `The committed route was not rolled back. Retry with '${CLI_NAME} ${result.sandboxName} gateway restart'.`,
+      );
+    }
   }
-  if (restartFailure) {
+  const pairingMutation = mutation.openClawPairing;
+  if (pairingMutation.state === "not-required") return;
+  let pairing: InferenceSetOpenClawPairingResult;
+  if (pairingMutation.state === "target-unavailable") {
+    pairing = { ok: false, failureLayer: "pairing-target-unavailable" };
+  } else {
+    try {
+      pairing = deps.settleOpenClawPairing(pairingMutation.target);
+    } catch {
+      pairing = { ok: false, failureLayer: "pairing-operation-failed" };
+    }
+  }
+  if (!pairing.ok) {
     appendPostCommitInferenceAudit(deps, {
       action: "inference_set",
       sandbox: result.sandboxName,
       timestamp: new Date().toISOString(),
-      reason: `inference set openclaw:${result.provider}:${result.model} (config committed; gateway restart failed: ${restartFailure})`,
+      reason: `inference set openclaw:${result.provider}:${result.model} (config committed; ${
+        mutation.openClawGatewayRestartRequired ? "gateway restart completed; " : ""
+      }pairing convergence failed: ${pairing.failureLayer})`,
     });
     throw new InferenceSetError(
-      `Inference route and config were updated for '${result.sandboxName}', but the managed OpenClaw gateway restart/recovery did not complete successfully. ` +
-        `The committed route was not rolled back. Retry with '${CLI_NAME} ${result.sandboxName} gateway restart'.`,
+      `Inference route and config were updated for '${result.sandboxName}', but OpenClaw gateway pairing did not converge (${pairing.failureLayer}). ` +
+        `The committed route was not rolled back. Run '${CLI_NAME} ${result.sandboxName} doctor --fix', then retry the agent turn.`,
     );
   }
   appendPostCommitInferenceAudit(deps, {
     action: "inference_set",
     sandbox: result.sandboxName,
     timestamp: new Date().toISOString(),
-    reason: `inference set openclaw:${result.provider}:${result.model} (gateway restart completed)`,
+    reason: `inference set openclaw:${result.provider}:${result.model} (${
+      mutation.openClawGatewayRestartRequired ? "gateway restart and " : ""
+    }pairing convergence completed)`,
   });
   deps.log(`  Inference route synced for '${result.sandboxName}': ${result.primaryModelRef}`);
 }

--- a/src/lib/actions/inference-set-openclaw-gateway-restart.test.ts
+++ b/src/lib/actions/inference-set-openclaw-gateway-restart.test.ts
@@ -92,6 +92,12 @@ describe("runInferenceSet OpenClaw gateway restart", () => {
     });
     expect(deps.calls.restartSandboxGateway).toHaveBeenCalledOnce();
     expect(deps.calls.restartSandboxGateway).toHaveBeenCalledWith("alpha");
+    expect(deps.calls.settleOpenClawPairing).toHaveBeenCalledWith({
+      sandboxName: "alpha",
+      gatewayName: "nemoclaw",
+      openclawVersion: "",
+      stateDirectory: "/sandbox/.openclaw",
+    });
     const auditReasons = deps.calls.appendAuditEntry.mock.calls.map(([entry]) =>
       String(entry.reason),
     );
@@ -99,7 +105,7 @@ describe("runInferenceSet OpenClaw gateway restart", () => {
       "inference set openclaw:compatible-anthropic-endpoint:claude-sonnet-proxy (gateway restart pending)",
     );
     expect(auditReasons).toContain(
-      "inference set openclaw:compatible-anthropic-endpoint:claude-sonnet-proxy (gateway restart completed)",
+      "inference set openclaw:compatible-anthropic-endpoint:claude-sonnet-proxy (gateway restart and pairing convergence completed)",
     );
     expect(deps.calls.log).toHaveBeenCalledWith(
       "  Inference route synced for 'alpha': anthropic/claude-sonnet-proxy",
@@ -108,10 +114,12 @@ describe("runInferenceSet OpenClaw gateway restart", () => {
       "  Warning: could not record the post-commit inference audit entry for 'alpha'.",
     );
     const restartOrder = deps.calls.restartSandboxGateway.mock.invocationCallOrder[0] ?? 0;
+    const pairingOrder = deps.calls.settleOpenClawPairing.mock.invocationCallOrder[0] ?? 0;
     expect(deps.calls.writeSandboxConfig.mock.invocationCallOrder[0]).toBeLessThan(restartOrder);
     expect(deps.calls.recomputeSandboxConfigHash.mock.invocationCallOrder[0]).toBeLessThan(
       restartOrder,
     );
+    expect(restartOrder).toBeLessThan(pairingOrder);
   });
 
   it("does not restart OpenClaw when the requested route is already current (#4504)", async () => {
@@ -146,6 +154,7 @@ describe("runInferenceSet OpenClaw gateway restart", () => {
     expect(result.configChanged).toBe(false);
     expect(result.inSandboxConfigSynced).toBe(true);
     expect(deps.calls.restartSandboxGateway).not.toHaveBeenCalled();
+    expect(deps.calls.settleOpenClawPairing).not.toHaveBeenCalled();
   });
 
   it("reports a post-commit restart failure without rolling state back (#4504)", async () => {
@@ -191,6 +200,7 @@ describe("runInferenceSet OpenClaw gateway restart", () => {
     );
 
     expect(deps.calls.restartSandboxGateway).toHaveBeenCalledWith("alpha");
+    expect(deps.calls.settleOpenClawPairing).not.toHaveBeenCalled();
     expect(deps.calls.writeSandboxConfig).toHaveBeenCalledOnce();
     expect(deps.calls.recomputeSandboxConfigHash).toHaveBeenCalledOnce();
     expect(deps.calls.updateSandbox.mock.calls.at(-1)).toEqual([
@@ -214,6 +224,113 @@ describe("runInferenceSet OpenClaw gateway restart", () => {
     expect(deps.calls.log.mock.calls.map(([line]) => String(line)).join("\n")).not.toContain(
       "Inference route synced",
     );
+  });
+
+  it("fails a committed cross-family switch when pairing does not converge (#9527)", async () => {
+    const config: ConfigObject = {
+      agents: { defaults: { model: { primary: "openai/nvidia/model-a" } } },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://inference.local/v1",
+            api: "openai-completions",
+            models: [{ id: "nvidia/model-a", name: "openai/nvidia/model-a" }],
+          },
+        },
+      },
+    };
+    const deps = createDeps({
+      config,
+      session: baseSession({
+        provider: "compatible-anthropic-endpoint",
+        model: "claude-sonnet-proxy",
+        endpointUrl: "https://anthropic-compatible.example/v1",
+        credentialEnv: "COMPATIBLE_ANTHROPIC_API_KEY",
+        preferredInferenceApi: "anthropic-messages",
+      }),
+      settleOpenClawPairing: () => ({
+        ok: false,
+        failureLayer: "approval-rejected",
+      }),
+    });
+
+    await expect(
+      runInferenceSet(
+        {
+          provider: "compatible-anthropic-endpoint",
+          model: "claude-sonnet-proxy",
+          noVerify: true,
+        },
+        deps,
+      ),
+    ).rejects.toThrow(
+      "OpenClaw gateway pairing did not converge (approval-rejected). The committed route was not rolled back.",
+    );
+
+    expect(deps.calls.restartSandboxGateway).toHaveBeenCalledOnce();
+    expect(deps.calls.settleOpenClawPairing).toHaveBeenCalledOnce();
+    expect(deps.calls.writeSandboxConfig).toHaveBeenCalledOnce();
+    expect(deps.calls.recomputeSandboxConfigHash).toHaveBeenCalledOnce();
+    expect(deps.calls.updateSandbox.mock.calls.at(-1)).toEqual([
+      "alpha",
+      expect.objectContaining({
+        provider: "compatible-anthropic-endpoint",
+        model: "claude-sonnet-proxy",
+      }),
+    ]);
+    expect(deps.calls.log.mock.calls.map(([line]) => String(line)).join("\n")).not.toContain(
+      "Inference route synced",
+    );
+    expect(deps.calls.appendAuditEntry.mock.calls.map(([entry]) => String(entry.reason))).toContain(
+      "inference set openclaw:compatible-anthropic-endpoint:claude-sonnet-proxy (config committed; gateway restart completed; pairing convergence failed: approval-rejected)",
+    );
+  });
+
+  it("does not expose pairing command output from a post-commit failure (#9527)", async () => {
+    const config: ConfigObject = {
+      agents: { defaults: { model: { primary: "openai/nvidia/model-a" } } },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://inference.local/v1",
+            api: "openai-completions",
+            models: [{ id: "nvidia/model-a", name: "openai/nvidia/model-a" }],
+          },
+        },
+      },
+    };
+    const deps = createDeps({
+      config,
+      session: baseSession({
+        provider: "compatible-anthropic-endpoint",
+        model: "claude-sonnet-proxy",
+        endpointUrl: "https://anthropic-compatible.example/v1",
+        credentialEnv: "COMPATIBLE_ANTHROPIC_API_KEY",
+        preferredInferenceApi: "anthropic-messages",
+      }),
+      settleOpenClawPairing: () => {
+        throw new Error("token=do-not-report");
+      },
+    });
+
+    const failure = await runInferenceSet(
+      {
+        provider: "compatible-anthropic-endpoint",
+        model: "claude-sonnet-proxy",
+        noVerify: true,
+      },
+      deps,
+    ).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain("pairing-operation-failed");
+    expect((failure as Error).message).not.toContain("do-not-report");
+    expect(
+      deps.calls.appendAuditEntry.mock.calls.map(([entry]) => String(entry.reason)).join("\n"),
+    ).toContain("pairing convergence failed: pairing-operation-failed");
+    expect(
+      deps.calls.appendAuditEntry.mock.calls.map(([entry]) => String(entry.reason)).join("\n"),
+    ).not.toContain("do-not-report");
   });
 
   it("restarts when leaving a legacy Anthropic route without provider.api (#4504)", async () => {

--- a/src/lib/actions/inference-set-openclaw-gateway-restart.test.ts
+++ b/src/lib/actions/inference-set-openclaw-gateway-restart.test.ts
@@ -102,7 +102,7 @@ describe("runInferenceSet OpenClaw gateway restart", () => {
       String(entry.reason),
     );
     expect(auditReasons).toContain(
-      "inference set openclaw:compatible-anthropic-endpoint:claude-sonnet-proxy (gateway restart pending)",
+      "inference set openclaw:compatible-anthropic-endpoint:claude-sonnet-proxy (gateway restart and pairing convergence pending)",
     );
     expect(auditReasons).toContain(
       "inference set openclaw:compatible-anthropic-endpoint:claude-sonnet-proxy (gateway restart and pairing convergence completed)",
@@ -215,7 +215,7 @@ describe("runInferenceSet OpenClaw gateway restart", () => {
       String(entry.reason),
     );
     expect(auditReasons).toContain(
-      "inference set openclaw:compatible-anthropic-endpoint:claude-sonnet-proxy (gateway restart pending)",
+      "inference set openclaw:compatible-anthropic-endpoint:claude-sonnet-proxy (gateway restart and pairing convergence pending)",
     );
     expect(auditReasons).toContain(
       "inference set openclaw:compatible-anthropic-endpoint:claude-sonnet-proxy (config committed; gateway restart failed: health timeout)",

--- a/src/lib/actions/inference-set-openclaw-pairing.test.ts
+++ b/src/lib/actions/inference-set-openclaw-pairing.test.ts
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  completeInferencePostCommit,
+  finalizeInferenceMutation,
+  type InferenceSetOpenClawPairingDeps,
+  type InferenceSetOpenClawPairingTarget,
+  settleInferenceSetOpenClawPairing,
+} from "./inference-set-gateway-restart";
+
+const TARGET: InferenceSetOpenClawPairingTarget = {
+  sandboxName: "alpha",
+  gatewayName: "nemoclaw-8080",
+  openclawVersion: "2026.7.1",
+  stateDirectory: "/sandbox/.openclaw",
+};
+const DEVICE_IDENTITY_SHA256 = "a".repeat(64);
+
+function observation(state: "settled" | "pairing-only") {
+  return { state, deviceIdentitySha256: DEVICE_IDENTITY_SHA256 } as const;
+}
+
+function pairingDeps(
+  options: {
+    observePairing?: InferenceSetOpenClawPairingDeps["observePairing"];
+    approval?: ReturnType<InferenceSetOpenClawPairingDeps["approveScopeRequest"]>;
+  } = {},
+): InferenceSetOpenClawPairingDeps {
+  return {
+    observePairing: vi.fn(options.observePairing ?? (() => observation("settled"))),
+    publishScopeRequest: vi.fn(),
+    approveScopeRequest: vi.fn(() => options.approval ?? "approved"),
+  };
+}
+
+describe("settleInferenceSetOpenClawPairing", () => {
+  it("accepts exact settled scope state without publishing a request (#9527)", () => {
+    const deps = pairingDeps();
+
+    expect(settleInferenceSetOpenClawPairing(TARGET, deps)).toEqual({ ok: true });
+    expect(deps.publishScopeRequest).not.toHaveBeenCalled();
+    expect(deps.approveScopeRequest).not.toHaveBeenCalled();
+  });
+
+  it("approves one device-bound request and requires final settled state (#9527)", () => {
+    const order: string[] = [];
+    const deps = pairingDeps();
+    vi.mocked(deps.observePairing).mockImplementation(() => {
+      order.push("observe");
+      const state = order.length === 1 ? "pairing-only" : "settled";
+      return { state, deviceIdentitySha256: DEVICE_IDENTITY_SHA256 };
+    });
+    vi.mocked(deps.publishScopeRequest).mockImplementation(() => order.push("publish"));
+    vi.mocked(deps.approveScopeRequest).mockImplementation(() => {
+      order.push("approve");
+      return "approved";
+    });
+
+    expect(settleInferenceSetOpenClawPairing(TARGET, deps)).toEqual({ ok: true });
+    expect(deps.publishScopeRequest).toHaveBeenCalledWith(TARGET);
+    expect(deps.approveScopeRequest).toHaveBeenCalledWith(TARGET, DEVICE_IDENTITY_SHA256);
+    expect(order).toEqual(["observe", "publish", "approve", "observe"]);
+  });
+
+  it("accepts an ambiguous approval only when final state is settled (#9527)", () => {
+    const deps = pairingDeps({
+      observePairing: vi
+        .fn()
+        .mockReturnValueOnce(observation("pairing-only"))
+        .mockReturnValueOnce(observation("settled")),
+      approval: "ambiguous",
+    });
+
+    expect(settleInferenceSetOpenClawPairing(TARGET, deps)).toEqual({ ok: true });
+  });
+
+  it("rejects unavailable initial state without exposing observer output (#9527)", () => {
+    const deps = pairingDeps({
+      observePairing: vi.fn(() => {
+        throw new Error("token=do-not-report");
+      }),
+    });
+
+    const result = settleInferenceSetOpenClawPairing(TARGET, deps);
+
+    expect(result).toEqual({ ok: false, failureLayer: "initial-state-unavailable" });
+    expect(JSON.stringify(result)).not.toContain("do-not-report");
+    expect(deps.publishScopeRequest).not.toHaveBeenCalled();
+    expect(deps.approveScopeRequest).not.toHaveBeenCalled();
+  });
+
+  it("reports approval-rejected when scope state stays pairing-only (#9527)", () => {
+    const deps = pairingDeps({
+      observePairing: vi.fn(() => observation("pairing-only")),
+      approval: "rejected",
+    });
+
+    expect(settleInferenceSetOpenClawPairing(TARGET, deps)).toEqual({
+      ok: false,
+      failureLayer: "approval-rejected",
+    });
+  });
+
+  it("rejects approved scope state that does not settle (#9527)", () => {
+    const deps = pairingDeps({
+      observePairing: vi.fn(() => observation("pairing-only")),
+    });
+
+    expect(settleInferenceSetOpenClawPairing(TARGET, deps)).toEqual({
+      ok: false,
+      failureLayer: "final-state-unsettled",
+    });
+  });
+
+  it("collapses request publication errors into a credential-free classification (#9527)", () => {
+    const deps = pairingDeps({
+      observePairing: vi.fn(() => observation("pairing-only")),
+    });
+    vi.mocked(deps.publishScopeRequest).mockImplementation(() => {
+      throw new Error("credential=do-not-report");
+    });
+
+    const result = settleInferenceSetOpenClawPairing(TARGET, deps);
+
+    expect(result).toEqual({ ok: false, failureLayer: "pairing-operation-failed" });
+    expect(JSON.stringify(result)).not.toContain("do-not-report");
+    expect(deps.approveScopeRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects unavailable final state after one approval attempt (#9527)", () => {
+    const deps = pairingDeps({
+      observePairing: vi
+        .fn()
+        .mockReturnValueOnce(observation("pairing-only"))
+        .mockImplementationOnce(() => {
+          throw new Error("raw paired state");
+        }),
+    });
+
+    expect(settleInferenceSetOpenClawPairing(TARGET, deps)).toEqual({
+      ok: false,
+      failureLayer: "final-state-unavailable",
+    });
+    expect(deps.approveScopeRequest).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when required convergence has no pairing target (#9527)", () => {
+    const appendAuditEntry = vi.fn();
+    const log = vi.fn();
+    const settleOpenClawPairing = vi.fn(() => ({ ok: true }) as const);
+    const mutation = finalizeInferenceMutation(
+      {
+        agentName: "openclaw",
+        configChanged: true,
+        nextApi: "openai-completions",
+        previousApi: "openai-completions",
+        result: {
+          sandboxName: "alpha",
+          provider: "nvidia-prod",
+          model: "nvidia/model-b",
+          primaryModelRef: "inference/nvidia/model-b",
+          inSandboxConfigSynced: true,
+        },
+      },
+      { appendAuditEntry, log },
+    );
+
+    expect(() =>
+      completeInferencePostCommit(mutation, {
+        appendAuditEntry,
+        log,
+        restartSandboxGateway: vi.fn(
+          () =>
+            ({
+              ok: true,
+              restarted: true,
+              healthPassed: true,
+              forwardRecovered: true,
+            }) as const,
+        ),
+        settleOpenClawPairing,
+      }),
+    ).toThrow("OpenClaw gateway pairing did not converge (pairing-target-unavailable)");
+    expect(settleOpenClawPairing).not.toHaveBeenCalled();
+    expect(log.mock.calls.flat().join("\n")).not.toContain("Inference route synced");
+    expect(appendAuditEntry.mock.calls.map(([entry]) => String(entry.reason))).toContain(
+      "inference set openclaw:nvidia-prod:nvidia/model-b (config committed; pairing convergence failed: pairing-target-unavailable)",
+    );
+  });
+});

--- a/src/lib/actions/inference-set-openclaw-pairing.test.ts
+++ b/src/lib/actions/inference-set-openclaw-pairing.test.ts
@@ -77,6 +77,18 @@ describe("settleInferenceSetOpenClawPairing", () => {
     expect(settleInferenceSetOpenClawPairing(TARGET, deps)).toEqual({ ok: true });
   });
 
+  it("rejects an ambiguous approval when final state stays pairing-only (#9527)", () => {
+    const deps = pairingDeps({
+      observePairing: vi.fn(() => observation("pairing-only")),
+      approval: "ambiguous",
+    });
+
+    expect(settleInferenceSetOpenClawPairing(TARGET, deps)).toEqual({
+      ok: false,
+      failureLayer: "approval-ambiguous",
+    });
+  });
+
   it("rejects unavailable initial state without exposing observer output (#9527)", () => {
     const deps = pairingDeps({
       observePairing: vi.fn(() => {

--- a/src/lib/actions/inference-set-openclaw-run.test.ts
+++ b/src/lib/actions/inference-set-openclaw-run.test.ts
@@ -91,6 +91,12 @@ describe("runInferenceSet OpenClaw routing", () => {
       inSandboxConfigSynced: true,
     });
     expect(deps.calls.restartSandboxGateway).not.toHaveBeenCalled();
+    expect(deps.calls.settleOpenClawPairing).toHaveBeenCalledWith({
+      sandboxName: "alpha",
+      gatewayName: "nemoclaw",
+      openclawVersion: "",
+      stateDirectory: "/sandbox/.openclaw",
+    });
   });
 
   it("preserves same-provider Bedrock Runtime adapter routing for OpenClaw switches", async () => {

--- a/src/lib/actions/inference-set-openclaw-run.test.ts
+++ b/src/lib/actions/inference-set-openclaw-run.test.ts
@@ -7,7 +7,7 @@ import { runInferenceSet } from "./inference-set";
 import { baseSession, createDeps, OPENCLAW_TARGET } from "./inference-set.test-support";
 
 describe("runInferenceSet OpenClaw routing", () => {
-  it("updates OpenShell, OpenClaw config, registry, and the matching onboard session", async () => {
+  it("completes a same-API switch and pairing when audit persistence fails (#9527)", async () => {
     const config: ConfigObject = {
       agents: { defaults: { model: { primary: "inference/moonshotai/kimi-k2.6" } } },
       models: {
@@ -20,6 +20,9 @@ describe("runInferenceSet OpenClaw routing", () => {
       },
     };
     const deps = createDeps({ config, session: baseSession() });
+    deps.calls.appendAuditEntry.mockImplementationOnce(() => {
+      throw new Error("audit storage unavailable");
+    });
 
     const result = await runInferenceSet(
       {
@@ -78,7 +81,16 @@ describe("runInferenceSet OpenClaw routing", () => {
       expect.objectContaining({
         action: "inference_set",
         sandbox: "alpha",
-        reason: "inference set openclaw:nvidia-prod:nvidia/nemotron-3-super-120b-a12b",
+        reason:
+          "inference set openclaw:nvidia-prod:nvidia/nemotron-3-super-120b-a12b (pairing convergence pending)",
+      }),
+    );
+    expect(deps.calls.appendAuditEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "inference_set",
+        sandbox: "alpha",
+        reason:
+          "inference set openclaw:nvidia-prod:nvidia/nemotron-3-super-120b-a12b (pairing convergence completed)",
       }),
     );
     expect(result).toMatchObject({
@@ -97,6 +109,9 @@ describe("runInferenceSet OpenClaw routing", () => {
       openclawVersion: "",
       stateDirectory: "/sandbox/.openclaw",
     });
+    expect(deps.calls.log).toHaveBeenCalledWith(
+      "  Warning: could not record the post-commit inference audit entry for 'alpha'.",
+    );
   });
 
   it("preserves same-provider Bedrock Runtime adapter routing for OpenClaw switches", async () => {

--- a/src/lib/actions/inference-set.test-support.ts
+++ b/src/lib/actions/inference-set.test-support.ts
@@ -138,6 +138,7 @@ export function createDeps(options: {
   probeSandboxRoute?: InferenceSetDeps["probeSandboxRoute"];
   updateSandbox?: InferenceSetDeps["updateSandbox"];
   restartSandboxGateway?: InferenceSetDeps["restartSandboxGateway"];
+  settleOpenClawPairing?: InferenceSetDeps["settleOpenClawPairing"];
   seedHermesDashboardConfigResult?: "converged" | "absent" | "failed";
   withGatewayRouteMutationLock?: InferenceSetDeps["withGatewayRouteMutationLock"];
 }): InferenceSetDeps & {
@@ -162,6 +163,7 @@ export function createDeps(options: {
     probeSandboxRoute: ReturnType<typeof vi.fn>;
     sleep: ReturnType<typeof vi.fn>;
     restartSandboxGateway: ReturnType<typeof vi.fn>;
+    settleOpenClawPairing: ReturnType<typeof vi.fn>;
     withGatewayRouteMutationLock: ReturnType<typeof vi.fn>;
   };
   getSession: () => Session | null;
@@ -232,6 +234,7 @@ export function createDeps(options: {
           forwardRecovered: true,
         })),
     ),
+    settleOpenClawPairing: vi.fn(options.settleOpenClawPairing ?? (() => ({ ok: true }) as const)),
     withGatewayRouteMutationLock: vi.fn(
       options.withGatewayRouteMutationLock ??
         (async (_gatewayName: string, operation: () => Promise<unknown> | unknown) =>
@@ -272,6 +275,7 @@ export function createDeps(options: {
     withGatewayRouteMutationLock:
       calls.withGatewayRouteMutationLock as InferenceSetDeps["withGatewayRouteMutationLock"],
     restartSandboxGateway: calls.restartSandboxGateway,
+    settleOpenClawPairing: calls.settleOpenClawPairing,
     calls,
     getSession: () => session,
   };

--- a/src/lib/actions/inference-set.ts
+++ b/src/lib/actions/inference-set.ts
@@ -63,12 +63,13 @@ import {
   openshellReportsProviderNotFound,
 } from "./inference-set-error";
 import {
-  completeInferenceGatewayRestart,
+  completeInferencePostCommit,
   defaultInferenceGatewayRestart,
   finalizeInferenceMutation,
   type InferenceGatewayRestartDeps,
   type InferenceMutation,
   readPreviousOpenClawInferenceApi,
+  settleInferenceSetOpenClawPairing,
 } from "./inference-set-gateway-restart";
 import {
   type InferenceSetSandboxRouteProbe,
@@ -280,6 +281,7 @@ function defaultDeps(): InferenceSetDeps {
     sleep: sleepInferenceSetRouteConvergence,
     withGatewayRouteMutationLock,
     restartSandboxGateway: defaultInferenceGatewayRestart,
+    settleOpenClawPairing: settleInferenceSetOpenClawPairing,
     isSandboxConfigMutable: (sandboxName) => {
       const { isShieldsDown }: typeof import("../shields") = require("../shields");
       return isShieldsDown(sandboxName, true);
@@ -1401,6 +1403,15 @@ async function runInferenceSetWithoutHostLock(
         agentName,
         configChanged: patched.changed,
         nextApi: patched.route.inferenceApi,
+        openClawPairingTarget:
+          agentName === "openclaw"
+            ? {
+                sandboxName,
+                gatewayName: expectedGatewayName,
+                openclawVersion: entry.agentVersion ?? "",
+                stateDirectory: target.configDir,
+              }
+            : undefined,
         previousApi: previousOpenClawInferenceApi,
         result: {
           sandboxName,
@@ -1501,10 +1512,11 @@ export async function runInferenceSet(
         ),
       ),
     );
-    // Release the config transition lock before the managed restart reacquires
-    // it, but retain the outer sandbox lifecycle lock so another process cannot
-    // destroy/recreate this name between the committed write and restart.
-    completeInferenceGatewayRestart(mutation, deps);
+    // Release the config transition lock before post-commit gateway work
+    // reacquires its own route state. Retain the outer sandbox lifecycle lock
+    // so another process cannot replace this sandbox between the committed
+    // write, an optional restart, and device-scope convergence.
+    completeInferencePostCommit(mutation, deps);
     if (mutation.result.dashboardConverged === false) {
       throw new InferenceSetError(
         `Inference route and main Hermes config were updated for '${mutation.result.sandboxName}', ` +

--- a/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.test.ts
+++ b/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.test.ts
@@ -219,6 +219,24 @@ describe("OpenClaw launch-readiness pairing qualification", () => {
       expect(JSON.stringify([settled, pairingOnly])).not.toContain(publicKey);
     });
 
+    it("observes settlement without version provenance but keeps qualification version-bound (#9527)", () => {
+      const deps = {
+        getOpenshellBinary: () => "openshell",
+        readApprovalPolicy: () => POLICY,
+        spawnSync: localScriptSpawn as typeof spawnSync,
+      };
+
+      expect(
+        observeOpenClawPairingSettlement("alpha", "nemoclaw-8080", "", stateDirectory, deps),
+      ).toEqual({
+        state: "settled",
+        deviceIdentitySha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      });
+      expect(() =>
+        observeOpenClawPairingQualification("alpha", "nemoclaw-8080", "", stateDirectory, deps),
+      ).toThrow("OpenClaw pairing qualification is unavailable");
+    });
+
     it("accepts the exact canonical Ed25519 public-key PEM representation (#9207)", () => {
       const identityPath = path.join(stateDirectory, "identity", "device.json");
       writeJson(identityPath, {

--- a/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.ts
+++ b/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.ts
@@ -580,7 +580,11 @@ function runOpenClawPairingObservation(
 ): { readonly output: string; readonly policy: string } {
   const approvalPolicy = (execDeps?.readApprovalPolicy ?? readAutoPairApprovalPolicyModule)();
   const normalizedVersion = openclawVersion.trim();
-  if (!approvalPolicy || !normalizedVersion || normalizedVersion.length > 128) {
+  if (
+    !approvalPolicy ||
+    normalizedVersion.length > 128 ||
+    (mode === "qualification" && !normalizedVersion)
+  ) {
     throw new OpenClawPairingQualificationError();
   }
   const approvalPolicyModuleB64 = Buffer.from(approvalPolicy, "utf8").toString("base64");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

An OpenClaw provider switch now verifies that the local CLI device has the exact managed-gateway scopes before the command reports success. This prevents a correct reply from being accepted through embedded fallback while a gateway scope upgrade remains pending.

## Related Issue

Fixes #9527

## Changes

- Reconcile the exact `operator` pairing, read, and write scope projection after every changed, synchronized OpenClaw route. Cross-API switches restart first; same-API switches converge without a restart; unchanged routes and Hermes do neither.
- Reuse the existing device-bound request producer and allowlisted approval policy. Route/config commit alone cannot prove that the next OpenClaw turn will use the managed gateway, so final observed scope state is the success boundary.
- Fail closed with fixed, redacted classifications for missing targets, unavailable or malformed state, rejected approvals, and unsettled final state. No workflow retry or broader scope allowlist was added.
- Keep pairing convergence reachable when append-only audit persistence fails after the route commit, while logging the audit failure and recording explicit pairing-pending state when persistence succeeds.
- Cover the settlement function and inference-set coordination, including no-write settled state, one bounded pairing-only approval, restart ordering, no-restart convergence, missing-target refusal, and legacy entries without version metadata.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed against the repository security rubric. The change reuses the existing exact client, role, scope, and device-identity allowlist; unknown state fails closed; raw gateway output and credentials do not enter errors or audit records.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: This restores the existing provider-switch and managed-gateway contract without changing a documented command, option, or recovery procedure.
- Agent: Codex Desktop
<!-- docs-review-head-sha: d9e57ce30 -->
<!-- docs-review-agents-blob-sha: 513518cdf -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 21 focused inference-set and pairing files passed 302 tests; after the final fail-closed repair, 4 directly affected files passed 54 tests. The review repair passed 19 focused tests across 3 files. CLI typecheck, CLI and plugin builds, Oxlint, Oxfmt, normal commit hooks, and the pre-push CLI typecheck passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenClaw configuration changes now automatically reconcile device pairing after a successful gateway restart.
  * Pairing status and restart outcomes are recorded in audit messages.

* **Bug Fixes**
  * Prevented premature success messages when recovery is incomplete.
  * Improved handling of unavailable, rejected, ambiguous, and non-converging pairing states.
  * Sanitized pairing-operation details in user-visible errors and audit records.

* **Tests**
  * Expanded coverage for restart ordering, pairing outcomes, missing targets, and version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->