### PR TITLE
fix(hermes): allow reviewed unattended Wikidata read

### DIFF
--- a/agents/hermes/Dockerfile
+++ b/agents/hermes/Dockerfile
@@ -86,6 +86,7 @@ COPY agents/hermes/patch-gateway-process-identity.py /opt/nemoclaw-hermes-config
 COPY agents/hermes/patch-cron-execution-runtime.py /opt/nemoclaw-hermes-config/patch-cron-execution-runtime.py
 COPY agents/hermes/patch-cron-restore-drain.py /opt/nemoclaw-hermes-config/patch-cron-restore-drain.py
 COPY agents/hermes/patch-neutral-platform-env-activation.py /opt/nemoclaw-hermes-config/patch-neutral-platform-env-activation.py
+COPY agents/hermes/patch-unattended-approval.py /opt/nemoclaw-hermes-config/patch-unattended-approval.py
 COPY agents/hermes/host/managed-tool-gateway-matrix.json /opt/nemoclaw-hermes-config/managed-tool-gateway-matrix.json
 COPY src/lib/hermes-managed-route.ts /src/lib/hermes-managed-route.ts
 COPY src/lib/tool-disclosure.ts /src/lib/tool-disclosure.ts
@@ -114,6 +115,9 @@ COPY agents/hermes/patch-hermes-sqlite-temp-store.py /usr/local/lib/nemoclaw/pat
 COPY agents/hermes/patch-discord-recovery-permissions.py /usr/local/lib/nemoclaw/patch-hermes-discord-recovery-permissions.py
 COPY agents/hermes/patch-profile-policy-defaults.py /usr/local/lib/nemoclaw/patch-hermes-profile-policy-defaults.py
 COPY agents/hermes/managed_policy.py /usr/local/lib/nemoclaw/managed_policy.py
+COPY --chmod=0555 agents/hermes/hermes-wikidata-reference-read /usr/local/lib/nemoclaw/hermes-wikidata-reference-read
+COPY --chmod=0444 agents/hermes/nemoclaw_unattended_approval.py /opt/hermes/tools/nemoclaw_unattended_approval.py
+COPY --chmod=0444 agents/hermes/unattended-approval-policy.json /usr/local/share/nemoclaw/hermes-unattended-approval-policy.json
 COPY agents/hermes/patch-langfuse-credentials.mts /usr/local/lib/nemoclaw/patch-hermes-langfuse-credentials.mts
 COPY agents/hermes/seed-dashboard-config.py /usr/local/lib/nemoclaw/seed-hermes-dashboard-config.py
 COPY agents/hermes/runtime-config-guard.py /usr/local/lib/nemoclaw/hermes-runtime-config-guard.py
@@ -211,6 +215,7 @@ RUN if [ -n "${NEMOCLAW_CORPORATE_CA_B64}" ]; then \
 
 # Cross-stage root copies are accepted by Docker's legacy builder and create
 # one final-image layer while preserving metadata on existing parent paths.
+# hadolint ignore=DL3067
 COPY --from=hermes-npm-patch-payload / /
 
 # A published base can lag the source patch in Dockerfile.base. Apply only the
@@ -362,6 +367,7 @@ RUN _hermes_certifi=$(/opt/hermes/.venv/bin/python -c 'import certifi; print(cer
 ENV HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=1
 ENV HERMES_TUI_DIR="/opt/hermes/ui-tui"
 
+# hadolint ignore=DL3067
 COPY --from=hermes-agent-payload / /
 
 # Ensure the NemoClaw plugin for Hermes is readable.
@@ -378,14 +384,41 @@ RUN find /opt/nemoclaw-hermes-config -type d -exec chmod 755 {} + \
         /scripts/patch-bundled-npm-tar.mts \
     && chmod -R a+rX /src/lib/messaging
 
-ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=89f530da6a8296c8bab449a2a324d8efedca1a90b04a5e0f57cf9203ed2011cd
+ARG NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256=aab93555dcf5250e675c32a44d532a7f1487a5bc6e38a0d92c746db32354035c
 # hadolint ignore=DL4006
 RUN printf '%s  %s\n' \
         "$NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256" /opt/nemoclaw-hermes-config/image-build-probes.py \
     | sha256sum -c - \
     || { echo "ERROR: image-build-probes.py hash mismatch (update NEMOCLAW_HERMES_IMAGE_BUILD_PROBES_SHA256)" >&2; exit 1; }
 
+# hadolint ignore=DL3067
 COPY --from=hermes-runtime-payload / /
+
+# Hermes v0.19.0 classifies Python heredocs as script execution and waits for
+# terminal approval in API-server sessions. Install one root-owned, no-argument
+# Wikidata read and bypass approval only for its exact absolute invocation.
+# Hardline, sudo, and user-defined deny rules retain precedence. The upstream
+# source hash and exact patch anchors force review before a Hermes upgrade.
+ARG NEMOCLAW_HERMES_UNATTENDED_APPROVAL_PATCHER_SHA256=05f5a33788a73b1b41ea5e426e5097cfdea59d59db1af46b014b8cce40efd028
+ARG NEMOCLAW_HERMES_UNATTENDED_APPROVAL_HELPER_SHA256=3f89915a31ce0ed6092b8190f649310034eae58ce815b60b057cc09ad9c19b64
+ARG NEMOCLAW_HERMES_UNATTENDED_APPROVAL_POLICY_SHA256=bab6ce927534052dcbadbbf4a83010a439c5f2b6dd644c98942d1327fb37abe8
+ARG NEMOCLAW_HERMES_WIKIDATA_READ_SHA256=b9ea2f464028ffdf72c6086facb91568e13c23e7c36d6a2ce2c489d6b7a3ad73
+ARG NEMOCLAW_HERMES_APPROVAL_SOURCE_SHA256=f35c78aa0b56c82cafe0242bb886c4f9679bf55219776a105131dceba2ce9672
+# hadolint ignore=DL4006
+RUN printf '%s  %s\n' \
+        "$NEMOCLAW_HERMES_UNATTENDED_APPROVAL_PATCHER_SHA256" /opt/nemoclaw-hermes-config/patch-unattended-approval.py \
+        "$NEMOCLAW_HERMES_UNATTENDED_APPROVAL_HELPER_SHA256" /opt/hermes/tools/nemoclaw_unattended_approval.py \
+        "$NEMOCLAW_HERMES_UNATTENDED_APPROVAL_POLICY_SHA256" /usr/local/share/nemoclaw/hermes-unattended-approval-policy.json \
+        "$NEMOCLAW_HERMES_WIKIDATA_READ_SHA256" /usr/local/lib/nemoclaw/hermes-wikidata-reference-read \
+        "$NEMOCLAW_HERMES_APPROVAL_SOURCE_SHA256" /opt/hermes/tools/approval.py \
+    | sha256sum -c - \
+    || { echo "ERROR: Hermes unattended approval source identity mismatch" >&2; exit 1; }
+RUN /usr/bin/python3 -I \
+        /opt/nemoclaw-hermes-config/patch-unattended-approval.py \
+        /opt/hermes/tools/approval.py \
+        --hermes-semver 0.19.0 \
+    && /opt/hermes/.venv/bin/python -I \
+        /opt/nemoclaw-hermes-config/image-build-probes.py unattended-approval-policy
 
 # Keep the root-owned managed-startup handoff in this image-only layer. The
 # following permissions block is replayed on the host by regression tests.
@@ -695,6 +728,7 @@ RUN printf '%s  %s\n' \
 # The wrapper's shebang pins `/usr/bin/python3 -I` (isolated mode); fail the
 # build if that absolute path is missing or non-executable so a base-image
 # upgrade that drops it cannot ship a wrapper that ENOEXECs at runtime.
+# hadolint ignore=DL3067
 COPY --from=hermes-wrapper-payload / /
 
 RUN test -x /usr/bin/python3 \
@@ -835,6 +869,7 @@ RUN --network=none --mount=from=hermes-managed-teams-wheels,target=/opt/nemoclaw
 
 WORKDIR /sandbox
 RUN test "$(id -u sandbox):$(id -g sandbox):$(pwd)" = "998:999:/sandbox"
+# hadolint ignore=DL3066
 USER sandbox
 
 # Set up blueprint for local resolution
@@ -856,6 +891,7 @@ RUN HERMES_HOME=/sandbox/.hermes /usr/local/bin/hermes doctor --fix \
     fi \
     && rm -rf /sandbox/.cache
 
+# hadolint ignore=DL3066
 USER root
 
 # Install the generated policy manifest outside the mutable Hermes home. Python
@@ -920,6 +956,7 @@ RUN set -eu; \
         /opt/hermes/.venv/bin/python -I \
         /opt/nemoclaw-hermes-config/image-build-probes.py profile-policy
 
+# hadolint ignore=DL3066
 USER sandbox
 
 # Prove that the installed dashboard seeder carries every reviewed policy value
@@ -967,7 +1004,7 @@ ENV HERMES_ENVIRONMENT_HINT="You are running inside an NVIDIA OpenShell sandbox,
 # supplementary sandbox-group membership and create Hermes v0.14 runtime dirs
 # without being able to remove sticky-protected config files. Shields-up applies
 # 444 root:root + chattr +i.
-# hadolint ignore=DL3002
+# hadolint ignore=DL3002,DL3066
 USER root
 
 # Flatten stale published base images that still contain the old .hermes-data
@@ -1399,6 +1436,9 @@ RUN check_metadata() { \
     && check_metadata /usr/local/lib/nemoclaw/patch-hermes-profile-policy-defaults.py 'root:root 755' \
     && check_metadata /usr/local/lib/nemoclaw/managed_policy.py 'root:root 444' \
     && check_metadata /usr/local/share/nemoclaw/hermes-managed-policy.json 'root:root 444' \
+    && check_metadata /opt/hermes/tools/nemoclaw_unattended_approval.py 'root:root 444' \
+    && check_metadata /usr/local/share/nemoclaw/hermes-unattended-approval-policy.json 'root:root 444' \
+    && check_metadata /usr/local/lib/nemoclaw/hermes-wikidata-reference-read 'root:root 555' \
     && test ! -L /usr/local/bin/nemoclaw-managed-bootstrap \
     && check_metadata /usr/local/bin/nemoclaw-managed-bootstrap 'root:root 755' \
     && test ! -L /usr/local/lib/nemoclaw/managed-bootstrap-trampoline.sh \

--- a/agents/hermes/hermes-wikidata-reference-read
+++ b/agents/hermes/hermes-wikidata-reference-read
@@ -1,0 +1,97 @@
+#!/usr/bin/python3 -I
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Perform the fixed Wikidata read reviewed for the Hermes reference E2E."""
+
+import json
+import os
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+URL = (
+    "https://www.wikidata.org/w/api.php?"
+    "action=wbgetentities&ids=Q30&props=labels&languages=en&format=json"
+)
+RESULT_PATH = Path("/tmp/nemoclaw-hermes-wikidata-reference-read.json")
+MAX_RESPONSE_BYTES = 65_536
+
+
+class _RejectRedirects(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, *_args, **_kwargs):
+        return None
+
+
+def _open_response():
+    opener = urllib.request.build_opener(_RejectRedirects())
+    return opener.open(URL, timeout=20)
+
+
+def _fetch_document() -> object:
+    with _open_response() as response:
+        if response.geturl() != URL:
+            raise ValueError("Wikidata response URL changed")
+        raw = response.read(MAX_RESPONSE_BYTES + 1)
+    if len(raw) > MAX_RESPONSE_BYTES:
+        raise ValueError("Wikidata response exceeds the size limit")
+    return json.loads(raw)
+
+
+def _write_result() -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=RESULT_PATH.parent,
+        prefix=f".{RESULT_PATH.name}.",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as target:
+            json.dump(
+                {
+                    "schemaVersion": 1,
+                    "entity": "Q30",
+                    "label": "United States",
+                    "status": "ok",
+                },
+                target,
+                separators=(",", ":"),
+            )
+            target.write("\n")
+            target.flush()
+            os.fsync(target.fileno())
+        os.chmod(temporary_path, 0o600)
+        os.replace(temporary_path, RESULT_PATH)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def main() -> int:
+    if len(sys.argv) != 1:
+        print("HERMES_REFERENCE_AGENT_BAD")
+        return 2
+    try:
+        document = _fetch_document()
+    except (OSError, UnicodeDecodeError, urllib.error.URLError, ValueError):
+        print("HERMES_REFERENCE_AGENT_BAD")
+        return 1
+    if not isinstance(document, dict):
+        print("HERMES_REFERENCE_AGENT_BAD")
+        return 1
+    ok = (
+        document.get("success") == 1
+        and document.get("entities", {})
+        .get("Q30", {})
+        .get("labels", {})
+        .get("en", {})
+        .get("value")
+        == "United States"
+    )
+    if ok:
+        _write_result()
+    print("HERMES_REFERENCE_AGENT_OK" if ok else "HERMES_REFERENCE_AGENT_BAD")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/hermes/image-build-probes.py
+++ b/agents/hermes/image-build-probes.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -72,6 +73,82 @@ def verify_profile_policy() -> None:
         assert _resolve_pre_update_backup_mode(args) == expected_backup_mode
     finally:
         hermes_config.load_config = original_load_config
+
+
+def verify_unattended_approval_policy() -> None:
+    from tools import approval
+    from tools.nemoclaw_unattended_approval import (
+        POLICY_PATH,
+        _load_policy,
+        is_reviewed_unattended_command,
+        reviewed_unattended_action_decision,
+    )
+
+    platform, command = _load_policy(POLICY_PATH)
+    assert platform == "api_server"
+    assert command == "/usr/local/lib/nemoclaw/hermes-wikidata-reference-read"
+    assert is_reviewed_unattended_command(command, platform)
+    assert not is_reviewed_unattended_command(f"{command} --help", platform)
+    assert not is_reviewed_unattended_command(command, "local")
+    assert reviewed_unattended_action_decision(command, platform) == "allow"
+    assert reviewed_unattended_action_decision(command, "local") == "deny"
+    assert reviewed_unattended_action_decision(f"{command} --help", platform) is None
+
+    original_platform = approval._get_session_platform
+    original_gateway = approval._is_gateway_approval_context
+    original_deny = approval._match_user_deny_rule
+    original_cron = os.environ.get("HERMES_CRON_SESSION")
+    try:
+        approval._get_session_platform = lambda: platform
+        approval._is_gateway_approval_context = lambda: True
+        os.environ.pop("HERMES_CRON_SESSION", None)
+        decision = approval.check_all_command_guards(
+            command, "local", has_host_access=False
+        )
+        assert decision == {"approved": True, "message": None}
+
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        assert not approval.check_all_command_guards(
+            command, "local", has_host_access=False
+        ).get("approved")
+        os.environ.pop("HERMES_CRON_SESSION")
+
+        for env_type, has_host_access in (
+            ("ssh", False),
+            ("docker", True),
+            ("docker", False),
+        ):
+            assert not approval.check_all_command_guards(
+                command, env_type, has_host_access=has_host_access
+            ).get("approved")
+
+        approval._get_session_platform = lambda: "slack"
+        assert not approval.check_all_command_guards(
+            command, "local", has_host_access=False
+        ).get("approved")
+        approval._get_session_platform = lambda: platform
+        approval._is_gateway_approval_context = lambda: False
+        assert not approval.check_all_command_guards(
+            command, "local", has_host_access=False
+        ).get("approved")
+        approval._is_gateway_approval_context = lambda: True
+
+        approval._match_user_deny_rule = lambda _command: "*"
+        denied = approval.check_all_command_guards(command, "local")
+        assert denied.get("approved") is False
+        assert denied.get("user_deny") is True
+        approval._match_user_deny_rule = original_deny
+
+        hardline = approval.check_all_command_guards("rm -rf /", "local")
+        assert hardline.get("approved") is False
+    finally:
+        approval._get_session_platform = original_platform
+        approval._is_gateway_approval_context = original_gateway
+        approval._match_user_deny_rule = original_deny
+        if original_cron is None:
+            os.environ.pop("HERMES_CRON_SESSION", None)
+        else:
+            os.environ["HERMES_CRON_SESSION"] = original_cron
 
 
 def verify_gateway_runtime_metadata() -> None:
@@ -405,6 +482,7 @@ COMMANDS: dict[str, Callable[[], None]] = {
     "profile-policy": verify_profile_policy,
     "session-delete": verify_session_delete,
     "session-preview": verify_session_preview,
+    "unattended-approval-policy": verify_unattended_approval_policy,
 }
 
 

--- a/agents/hermes/nemoclaw_unattended_approval.py
+++ b/agents/hermes/nemoclaw_unattended_approval.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Decide whether one exact Hermes command is the reviewed unattended action."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+POLICY_PATH = Path("/usr/local/share/nemoclaw/hermes-unattended-approval-policy.json")
+REVIEWED_COMMAND = "/usr/local/lib/nemoclaw/hermes-wikidata-reference-read"
+_MAX_POLICY_BYTES = 8_192
+
+
+def _load_policy(
+    path: Path,
+    *,
+    trusted_uid: int = 0,
+    trusted_gid: int = 0,
+) -> tuple[str, str]:
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise ValueError("platform cannot reject policy symlinks")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError("policy is not a regular file")
+        if metadata.st_uid != trusted_uid or metadata.st_gid != trusted_gid:
+            raise ValueError("policy ownership is not trusted")
+        if stat.S_IMODE(metadata.st_mode) != 0o444:
+            raise ValueError("policy mode is not read-only")
+        if metadata.st_size > _MAX_POLICY_BYTES:
+            raise ValueError("policy exceeds the size limit")
+        with os.fdopen(descriptor, "rb", closefd=False) as source:
+            raw = source.read(_MAX_POLICY_BYTES + 1)
+    finally:
+        os.close(descriptor)
+
+    policy = json.loads(raw.decode("utf-8"))
+    if set(policy) != {"schemaVersion", "wikidataReferenceRead"}:
+        raise ValueError("policy fields changed")
+    if type(policy["schemaVersion"]) is not int or policy["schemaVersion"] != 1:
+        raise ValueError("policy schema is unsupported")
+    action = policy["wikidataReferenceRead"]
+    if not isinstance(action, dict) or set(action) != {"platform", "command"}:
+        raise ValueError("reviewed action fields changed")
+    platform = action["platform"]
+    command = action["command"]
+    if not isinstance(platform, str) or not isinstance(command, str):
+        raise ValueError("reviewed action values must be strings")
+    return platform, command
+
+
+def reviewed_unattended_action_decision(
+    command: str,
+    platform: str,
+    *,
+    policy_path: Path = POLICY_PATH,
+    trusted_uid: int = 0,
+    trusted_gid: int = 0,
+) -> str | None:
+    """Return allow or deny for the reviewed action, or None for other commands."""
+    if command != REVIEWED_COMMAND:
+        return None
+    try:
+        expected_platform, expected_command = _load_policy(
+            policy_path,
+            trusted_uid=trusted_uid,
+            trusted_gid=trusted_gid,
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError):
+        return "deny"
+    if expected_command != REVIEWED_COMMAND:
+        return "deny"
+    return "allow" if platform == expected_platform else "deny"
+
+
+def is_reviewed_unattended_command(
+    command: str,
+    platform: str,
+    *,
+    policy_path: Path = POLICY_PATH,
+    trusted_uid: int = 0,
+    trusted_gid: int = 0,
+) -> bool:
+    """Return true only for the exact command, platform, and trusted policy file."""
+    return (
+        reviewed_unattended_action_decision(
+            command,
+            platform,
+            policy_path=policy_path,
+            trusted_uid=trusted_uid,
+            trusted_gid=trusted_gid,
+        )
+        == "allow"
+    )

--- a/agents/hermes/patch-unattended-approval.py
+++ b/agents/hermes/patch-unattended-approval.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Add NemoClaw's exact reviewed-action hook to pinned Hermes v0.19.0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+HERMES_SEMVER = "0.19.0"
+HERMES_APPROVAL_SHA256 = "f35c78aa0b56c82cafe0242bb886c4f9679bf55219776a105131dceba2ce9672"
+
+IMPORT_ANCHOR = "from tools.interrupt import is_interrupted\n"
+IMPORT_PATCH = (
+    IMPORT_ANCHOR
+    + "from tools.nemoclaw_unattended_approval import reviewed_unattended_action_decision\n"
+)
+CONTEXT_ANCHOR = '''    # Skip isolated container backends for both checks. Docker stops skipping
+    # once host paths are bind-mounted into the sandbox.
+    if _should_skip_container_guards(env_type, has_host_access=has_host_access):
+        return {"approved": True, "message": None}
+'''
+CONTEXT_PATCH = '''    # NemoClaw recognizes one exact, root-owned read-only action before
+    # Hermes' isolated-container fast path so it cannot use a broader backend.
+    reviewed_action = reviewed_unattended_action_decision(
+        command, _get_session_platform()
+    )
+    reviewed_context = (
+        reviewed_action == "allow"
+        and env_type == "local"
+        and not has_host_access
+        and not env_var_enabled("HERMES_CRON_SESSION")
+        and _is_gateway_approval_context()
+    )
+    if reviewed_action is not None and not reviewed_context:
+        return {
+            "approved": False,
+            "message": (
+                "BLOCKED: reviewed unattended action is limited to a non-cron "
+                "API gateway request on the local backend without host access."
+            ),
+        }
+
+    # Skip isolated container backends for both checks. Docker stops skipping
+    # once host paths are bind-mounted into the sandbox.
+    if _should_skip_container_guards(env_type, has_host_access=has_host_access):
+        return {"approved": True, "message": None}
+'''
+GUARD_ANCHOR = '''    deny_pattern = _match_user_deny_rule(command)
+    if deny_pattern is not None:
+        logger.warning("User deny rule %r blocked command: %s",
+                       deny_pattern, command[:200])
+        return _user_deny_block_result(deny_pattern)
+
+    # --yolo or approvals.mode=off: bypass all approval prompts.
+'''
+GUARD_PATCH = '''    deny_pattern = _match_user_deny_rule(command)
+    if deny_pattern is not None:
+        logger.warning("User deny rule %r blocked command: %s",
+                       deny_pattern, command[:200])
+        return _user_deny_block_result(deny_pattern)
+
+    # The backend and gateway checks above already bound this exact action.
+    # Hardline, sudo, and user deny guards retain precedence before approval.
+    if reviewed_context:
+        return {"approved": True, "message": None}
+
+    # --yolo or approvals.mode=off: bypass all approval prompts.
+'''
+
+
+def patch_file(path: Path, hermes_semver: str) -> None:
+    if hermes_semver != HERMES_SEMVER:
+        raise SystemExit(
+            f"ERROR: unattended approval patch supports Hermes {HERMES_SEMVER}, got {hermes_semver}"
+        )
+    source_bytes = path.read_bytes()
+    actual_hash = hashlib.sha256(source_bytes).hexdigest()
+    if actual_hash != HERMES_APPROVAL_SHA256:
+        raise SystemExit(
+            "ERROR: Hermes approval source identity changed; review the unattended action hook "
+            "before updating HERMES_APPROVAL_SHA256 "
+            f"(expected {HERMES_APPROVAL_SHA256}; got {actual_hash})"
+        )
+    source = source_bytes.decode("utf-8")
+    for label, old, new in (
+        ("import", IMPORT_ANCHOR, IMPORT_PATCH),
+        ("context", CONTEXT_ANCHOR, CONTEXT_PATCH),
+        ("guard", GUARD_ANCHOR, GUARD_PATCH),
+    ):
+        if source.count(old) != 1 or source.count(new) != 0:
+            raise SystemExit(f"ERROR: Hermes approval {label} source shape changed")
+        source = source.replace(old, new)
+    path.write_text(source, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path")
+    parser.add_argument("--hermes-semver", required=True)
+    args = parser.parse_args()
+    patch_file(Path(args.path), args.hermes_semver)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/hermes/unattended-approval-policy.json
+++ b/agents/hermes/unattended-approval-policy.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "wikidataReferenceRead": {
+    "platform": "api_server",
+    "command": "/usr/local/lib/nemoclaw/hermes-wikidata-reference-read"
+  }
+}

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -77,6 +77,16 @@
       "category": "security"
     },
     {
+      "file": "test/hermes-unattended-approval.test.ts",
+      "test": "allows only the reviewed Wikidata read in an API-server session (#9528)",
+      "category": "security"
+    },
+    {
+      "file": "test/hermes-unattended-approval.test.ts",
+      "test": "fails closed when the reviewed policy file can be changed or redirected (#9528)",
+      "category": "security"
+    },
+    {
       "file": "test/muse-glimmer-vllm-image-provenance.test.ts",
       "test": "rejects %s",
       "category": "security"

--- a/internal/security-reviews/hermes-0.19.0-dependency-review.md
+++ b/internal/security-reviews/hermes-0.19.0-dependency-review.md
@@ -84,6 +84,21 @@ Python remains `>=3.11,<3.14`, and the JavaScript runtime remains Node.js `>=20`
 Hermes 0.19 changes an omitted approval mode from manual authorization to smart authorization, which can consult an auxiliary model before authorizing a flagged command.
 NemoClaw now writes `approvals.mode: manual` explicitly so an authorization-policy change requires its own product and security decision.
 
+Issue `#9528` adds one bounded exception for the existing Hermes public-reference E2E.
+The image applies an exact-source patch only when the pinned Hermes 0.19.0 `tools/approval.py` SHA-256 is `f35c78aa0b56c82cafe0242bb886c4f9679bf55219776a105131dceba2ce9672`.
+The patch recognizes the fixed `/usr/local/lib/nemoclaw/hermes-wikidata-reference-read` action before Hermes' isolated-container shortcut, then denies that action unless the request is a non-cron API gateway session using the local terminal backend without host access.
+Hardline, sudo-password, and user-defined deny rules still run before the bounded approval.
+SSH, Docker with or without host access, cron, non-API gateway platforms, ordinary local sessions, changed commands, extra arguments, and missing or untrusted policy state do not receive the exception.
+Other commands retain Hermes' existing approval behavior.
+
+The reviewed wrapper is root-owned, read-only to the sandbox user, accepts no arguments, and fetches only the fixed Wikidata `Q30` label endpoint.
+It rejects redirects and final URL changes, reads at most 65,536 response bytes before JSON parsing, validates the exact entity and label, and writes a fixed result record.
+The live E2E treats that record as secondary evidence.
+Its primary evidence is the Hermes API session database exposed by the session-messages endpoint, with API authentication when the gateway configures a key: a bounded in-sandbox reducer requires exactly one persisted `terminal` tool call with the fixed command, no other tool calls, and one matching successful tool result.
+Only the schema version, a three-digit HTTP status, four counts, and two Boolean match fields leave the sandbox; the session identifier, complete messages, tool arguments, tool output, and credentials do not.
+The E2E shell loads `API_SERVER_KEY` from the runtime-owned `/sandbox/.hermes/.env` file and uses it only for the two localhost API requests when the key is present.
+The credential remains inside the sandbox, the shell environment is discarded when the command exits, and the runtime-owned credential file is unchanged.
+
 Hermes 0.19 also makes the `browser_console(expression=...)` sensitive-primitive denylist opt-in through `browser.restrict_evaluate`, defaulting it to `false`.
 The outgoing release restricted cookies, storage, clipboard, form values, and network primitives unless a user explicitly enabled unsafe evaluation.
 Because NemoClaw exposes the browser toolset, generated configuration now writes `browser.restrict_evaluate: true` to preserve that fail-closed posture; broadening page-context JavaScript evaluation requires a separate security decision.

--- a/test/e2e/live/common-egress-agent-helpers.ts
+++ b/test/e2e/live/common-egress-agent-helpers.ts
@@ -139,6 +139,17 @@ interface HermesAgentAssertionResult extends OpenClawAgentAssertionResult {
   httpStatus: string;
 }
 
+export interface HermesToolExecutionProof {
+  schemaVersion: 1;
+  messagesHttpStatus: string;
+  sessionRecordFound: boolean;
+  exactTerminalCallCount: number;
+  otherToolCallCount: number;
+  matchingToolResultCount: number;
+  successfulToolResultCount: number;
+  passed: boolean;
+}
+
 interface AgentAssertionRetryOptions {
   attempts: number;
   delayMs: (attempt: number) => number;
@@ -1030,6 +1041,50 @@ export function parseChatContent(raw: string): string {
   const choice = doc.choices?.[0];
   const content = choice?.message?.content ?? choice?.message?.reasoning_content ?? choice?.text;
   return typeof content === "string" ? content.trim() : "";
+}
+
+export function parseHermesToolExecutionProof(raw: string): HermesToolExecutionProof | null {
+  const marker = "__NEMOCLAW_HERMES_TOOL_PROOF__=";
+  const encoded = raw
+    .split("\n")
+    .filter((line) => line.startsWith(marker))
+    .at(-1)
+    ?.slice(marker.length);
+  if (!encoded) return null;
+
+  try {
+    const proof = JSON.parse(encoded) as Record<string, unknown>;
+    const keys = [
+      "exactTerminalCallCount",
+      "matchingToolResultCount",
+      "messagesHttpStatus",
+      "otherToolCallCount",
+      "passed",
+      "schemaVersion",
+      "sessionRecordFound",
+      "successfulToolResultCount",
+    ];
+    const counts = [
+      proof.exactTerminalCallCount,
+      proof.otherToolCallCount,
+      proof.matchingToolResultCount,
+      proof.successfulToolResultCount,
+    ];
+    if (
+      Object.keys(proof).sort().join(",") !== keys.sort().join(",") ||
+      proof.schemaVersion !== 1 ||
+      typeof proof.messagesHttpStatus !== "string" ||
+      !/^\d{3}$/u.test(proof.messagesHttpStatus) ||
+      typeof proof.sessionRecordFound !== "boolean" ||
+      typeof proof.passed !== "boolean" ||
+      !counts.every((value) => Number.isInteger(value) && Number(value) >= 0)
+    ) {
+      return null;
+    }
+    return proof as unknown as HermesToolExecutionProof;
+  } catch {
+    return null;
+  }
 }
 
 function compactAgentReply(value: string): string {

--- a/test/e2e/live/common-egress-agent.test.ts
+++ b/test/e2e/live/common-egress-agent.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 import { describe } from "vitest";
+import hermesUnattendedApprovalPolicy from "../../../agents/hermes/unattended-approval-policy.json" with { type: "json" };
 import { shellQuote } from "../../../src/lib/core/shell-quote.ts";
 import type { ArtifactSink } from "../fixtures/artifacts.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
@@ -30,6 +31,7 @@ import {
   classifyPreContractProviderValidationSkip,
   COMMON_EGRESS_TEST_TIMEOUT_MS,
   parseChatContent,
+  parseHermesToolExecutionProof,
   runHermesAgentAssertionRetry,
 } from "./common-egress-agent-helpers.ts";
 import {
@@ -57,6 +59,30 @@ const CHAT_MODEL = process.env.NEMOCLAW_MODEL ?? "nvidia/nemotron-3-super-120b-a
 const ONBOARD_TIMEOUT_MS = 25 * 60_000;
 const HERMES_AGENT_TIMEOUT_MS = 150_000;
 const HERMES_AGENT_ATTEMPTS = 3;
+const HERMES_WIKIDATA_RESULT_PATH = "/tmp/nemoclaw-hermes-wikidata-reference-read.json";
+const HERMES_TOOL_EXECUTION_PROOF_SCRIPT = fs.readFileSync(
+  path.join(import.meta.dirname, "hermes-tool-execution-proof.py"),
+  "utf8",
+);
+const HERMES_WIKIDATA_RESULT_CHECK = `\
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+with path.open("rb") as source:
+    raw = source.read(4097)
+if len(raw) > 4096:
+    raise SystemExit(1)
+observed = json.loads(raw)
+expected = {
+    "schemaVersion": 1,
+    "entity": "Q30",
+    "label": "United States",
+    "status": "ok",
+}
+raise SystemExit(0 if observed == expected else 1)
+`;
 const KEEP_SANDBOX =
   process.env.NEMOCLAW_E2E_KEEP_SANDBOX === "1" ||
   process.env.NEMOCLAW_COMMON_EGRESS_KEEP_SANDBOX === "1";
@@ -119,7 +145,11 @@ function httpStatusFromResponse(raw: string): string {
 function httpBodyFromResponse(raw: string): string {
   return raw
     .split("\n")
-    .filter((line) => !line.startsWith("__NEMOCLAW_HTTP_STATUS__="))
+    .filter(
+      (line) =>
+        !line.startsWith("__NEMOCLAW_HTTP_STATUS__=") &&
+        !line.startsWith("__NEMOCLAW_HERMES_TOOL_PROOF__="),
+    )
     .join("\n")
     .trim();
 }
@@ -413,18 +443,10 @@ async function addPolicyPreset(
 }
 
 function buildHermesReferencePrompt(): string {
-  return String.raw`Use your terminal tool to run this Python check exactly once:
-python3 - <<'PY'
-import json
-import urllib.request
-
-url = "https://www.wikidata.org/w/api.php?action=wbgetentities&ids=Q30&props=labels&languages=en&format=json"
-with urllib.request.urlopen(url, timeout=20) as response:
-    doc = json.load(response)
-ok = doc.get("success") == 1 and doc.get("entities", {}).get("Q30", {}).get("labels", {}).get("en", {}).get("value") == "United States"
-print("HERMES_REFERENCE_AGENT_OK" if ok else "HERMES_REFERENCE_AGENT_BAD")
-PY
-After the command completes, reply exactly HERMES_REFERENCE_AGENT_OK if that exact token appeared. Do not fetch any other URL.`;
+  const command = hermesUnattendedApprovalPolicy.wikidataReferenceRead.command;
+  return `Use your terminal tool to run this Python check exactly once:
+${command}
+Do not run any other command or fetch any other URL.`;
 }
 
 async function runHermesAgentAssertion(
@@ -433,8 +455,11 @@ async function runHermesAgentAssertion(
   args: {
     expected: string;
     label: string;
+    observeOutcome?: (attempt: number) => Promise<{ detail: string; passed: boolean }>;
     prompt: string;
+    requiredToolCommand?: string;
     sandboxName: string;
+    attempts?: number;
   },
 ): Promise<void> {
   const payload = JSON.stringify({
@@ -442,26 +467,42 @@ async function runHermesAgentAssertion(
     messages: [{ role: "user", content: args.prompt }],
     max_tokens: 300,
   });
+  const captureSession = args.requiredToolCommand !== undefined;
+  const responseHeaders = captureSession ? ' -D "$headers"' : "";
+  const proofCommands = args.requiredToolCommand
+    ? [
+        `session_id=$(awk 'tolower($1) == "x-hermes-session-id:" { gsub(/\\r/, "", $2); print $2 }' "$headers" | tail -n 1)`,
+        "messages_code=000",
+        `if printf '%s\\n' "$session_id" | grep -Eq '^api-[0-9a-f]{16}$'; then if [ -n "\${API_SERVER_KEY:-}" ]; then messages_code=$(curl -sS -o "$messages" -w '%{http_code}' --max-time 30 --max-filesize 2097152 "http://localhost:8642/api/sessions/\${session_id}/messages" -H "Authorization: Bearer \${API_SERVER_KEY}"); else messages_code=$(curl -sS -o "$messages" -w '%{http_code}' --max-time 30 --max-filesize 2097152 "http://localhost:8642/api/sessions/\${session_id}/messages"); fi; fi`,
+        `python3 -I -c ${shellQuote(HERMES_TOOL_EXECUTION_PROOF_SCRIPT)} "$messages" ${shellQuote(
+          args.requiredToolCommand,
+        )} "\${messages_code:-000}"`,
+        "proof_rc=$?",
+        'if [ "$proof_rc" -ne 0 ]; then rc="$proof_rc"; fi',
+      ]
+    : [];
   const remote = [
     "set -a",
     "[ ! -f /sandbox/.hermes/.env ] || . /sandbox/.hermes/.env",
     "set +a",
     "tmp=$(mktemp)",
-    `if [ -n "\${API_SERVER_KEY:-}" ]; then code=$(curl -sS -o "$tmp" -w '%{http_code}' --max-time 120 http://localhost:8642/v1/chat/completions -H 'Content-Type: application/json' -H "Authorization: Bearer \${API_SERVER_KEY}" -d ${shellQuote(
+    ...(captureSession ? ["headers=$(mktemp)", "messages=$(mktemp)"] : []),
+    `if [ -n "\${API_SERVER_KEY:-}" ]; then code=$(curl -sS -o "$tmp" -w '%{http_code}' --max-time 120${responseHeaders} http://localhost:8642/v1/chat/completions -H 'Content-Type: application/json' -H "Authorization: Bearer \${API_SERVER_KEY}" -d ${shellQuote(
       payload,
-    )}); else code=$(curl -sS -o "$tmp" -w '%{http_code}' --max-time 120 http://localhost:8642/v1/chat/completions -H 'Content-Type: application/json' -d ${shellQuote(
+    )}); else code=$(curl -sS -o "$tmp" -w '%{http_code}' --max-time 120${responseHeaders} http://localhost:8642/v1/chat/completions -H 'Content-Type: application/json' -d ${shellQuote(
       payload,
     )}); fi`,
     "rc=$?",
-    'cat "$tmp"',
-    'rm -f "$tmp"',
+    ...(captureSession ? [] : ['cat "$tmp"']),
+    ...proofCommands,
+    captureSession ? 'rm -f "$tmp" "$headers" "$messages"' : 'rm -f "$tmp"',
     `printf '\\n__NEMOCLAW_HTTP_STATUS__=%s\\n' "\${code:-000}"`,
     'exit "$rc"',
   ].join("; ");
 
   let lastFailure = "";
   const execution = await runHermesAgentAssertionRetry({
-    attempts: HERMES_AGENT_ATTEMPTS,
+    attempts: args.attempts ?? HERMES_AGENT_ATTEMPTS,
     delayMs: () => 5_000,
     onEvidence: async (evidence) => {
       await artifacts.writeJson(`retry/${args.label}-agent-retry-evidence.json`, evidence);
@@ -475,23 +516,55 @@ async function runHermesAgentAssertion(
       const response = text(agent);
       const httpStatus = httpStatusFromResponse(response);
       const body = httpBodyFromResponse(response);
+      const toolProof = args.requiredToolCommand
+        ? parseHermesToolExecutionProof(response)
+        : undefined;
       let reply = "";
       try {
         reply = parseChatContent(body);
       } catch {
         reply = "";
       }
-      lastFailure = `exit=${agent.exitCode} http=${httpStatus} reply='${reply.slice(
-        0,
-        240,
-      )}' body='${body.slice(0, 240)}'`;
-      return classifyHermesAgentAssertion({
-        exitCode: agent.exitCode,
-        expected: args.expected,
-        httpStatus,
-        reply,
-        response,
-      });
+      lastFailure = args.requiredToolCommand
+        ? await artifacts
+            .writeJson(
+              `${args.label}-hermes-tool-execution-attempt-${attempt}.json`,
+              toolProof ?? {
+                schemaVersion: 1,
+                messagesHttpStatus: "000",
+                sessionRecordFound: false,
+                exactTerminalCallCount: 0,
+                otherToolCallCount: 0,
+                matchingToolResultCount: 0,
+                successfulToolResultCount: 0,
+                passed: false,
+              },
+            )
+            .then(
+              () =>
+                `exit=${agent.exitCode} http=${httpStatus} toolProof=${JSON.stringify(toolProof)}`,
+            )
+        : `exit=${agent.exitCode} http=${httpStatus} reply='${reply.slice(
+            0,
+            240,
+          )}' body='${body.slice(0, 240)}'`;
+      const observation = args.observeOutcome ? await args.observeOutcome(attempt) : undefined;
+      lastFailure = observation ? `${lastFailure} outcome='${observation.detail}'` : lastFailure;
+      return observation
+        ? {
+            passed:
+              agent.exitCode === 0 &&
+              httpStatus === "200" &&
+              observation.passed &&
+              (toolProof?.passed ?? args.requiredToolCommand === undefined),
+          }
+        : classifyHermesAgentAssertion({
+            exitCode: agent.exitCode,
+            expected: args.expected,
+            httpStatus,
+            reply,
+            response,
+          });
     },
   });
   if (execution.outcome === "passed") return;
@@ -727,7 +800,8 @@ After web_fetch returns, reply exactly REFERENCE_AGENT_OK if the fetched respons
         contract: [
           "Hermes open onboarding applies public-reference common-egress endpoints",
           "Hermes open onboarding applies all Hermes Nous managed-tool policy presets",
-          "the Hermes API-server agent path fetches Wikidata through its terminal tool",
+          "the Hermes API session records one successful exact reviewed terminal action",
+          "the reviewed action produces the fixed Wikidata result artifact",
         ],
       });
       await registerSandboxCleanup(cleanup, artifacts, host, sandbox, HERMES_SANDBOX);
@@ -753,10 +827,37 @@ After web_fetch returns, reply exactly REFERENCE_AGENT_OK if the fetched respons
         "/modal",
       ]);
       progress.phase("fetch Wikidata with Hermes agent");
+      const staleResult = await sandbox.exec(
+        HERMES_SANDBOX,
+        ["rm", "-f", HERMES_WIKIDATA_RESULT_PATH],
+        {
+          artifactName: "c3-agent-reference-clear-result",
+          env: commandEnv(),
+          timeoutMs: 30_000,
+        },
+      );
+      expect(staleResult.exitCode, text(staleResult)).toBe(0);
       await runHermesAgentAssertion(sandbox, artifacts, {
-        expected: "HERMES_REFERENCE_AGENT_OK",
+        attempts: 1,
+        expected: "validated Wikidata result artifact",
         label: "c3-agent-reference",
+        observeOutcome: async (attempt) => {
+          const result = await sandbox.exec(
+            HERMES_SANDBOX,
+            ["python3", "-I", "-c", HERMES_WIKIDATA_RESULT_CHECK, HERMES_WIKIDATA_RESULT_PATH],
+            {
+              artifactName: `c3-agent-reference-result-attempt-${attempt}`,
+              env: commandEnv(),
+              timeoutMs: 30_000,
+            },
+          );
+          return {
+            detail: `fixed-result-check-exit=${result.exitCode}`,
+            passed: result.exitCode === 0,
+          };
+        },
         prompt: buildHermesReferencePrompt(),
+        requiredToolCommand: hermesUnattendedApprovalPolicy.wikidataReferenceRead.command,
         sandboxName: HERMES_SANDBOX,
       });
       await artifacts.target.complete({

--- a/test/e2e/live/hermes-tool-execution-proof.py
+++ b/test/e2e/live/hermes-tool-execution-proof.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Reduce a Hermes session response to fixed E2E tool-execution proof."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+MARKER = "__NEMOCLAW_HERMES_TOOL_PROOF__="
+MAX_MESSAGES_BYTES = 2 * 1024 * 1024
+
+
+def _empty_proof(http_status: str) -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "messagesHttpStatus": http_status,
+        "sessionRecordFound": False,
+        "exactTerminalCallCount": 0,
+        "otherToolCallCount": 0,
+        "matchingToolResultCount": 0,
+        "successfulToolResultCount": 0,
+        "passed": False,
+    }
+
+
+def _read_document(path: Path) -> object:
+    with path.open("rb") as source:
+        raw = source.read(MAX_MESSAGES_BYTES + 1)
+    if len(raw) > MAX_MESSAGES_BYTES:
+        raise ValueError("session response exceeds the size limit")
+    return json.loads(raw)
+
+
+def _tool_arguments(tool_call: object) -> tuple[str, object] | None:
+    if not isinstance(tool_call, dict):
+        return None
+    function = tool_call.get("function")
+    if not isinstance(function, dict):
+        return None
+    name = function.get("name")
+    arguments = function.get("arguments")
+    if not isinstance(name, str):
+        return None
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            return None
+    return name, arguments
+
+
+def project(path: Path, expected_command: str, http_status: str) -> dict[str, object]:
+    proof = _empty_proof(http_status)
+    try:
+        document = _read_document(path)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return proof
+    if not isinstance(document, dict) or not isinstance(document.get("data"), list):
+        return proof
+
+    proof["sessionRecordFound"] = True
+    matching_ids: set[str] = set()
+    exact_call_count = 0
+    other_calls = 0
+    for message in document["data"]:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            parsed = _tool_arguments(tool_call)
+            call_id = tool_call.get("id") if isinstance(tool_call, dict) else None
+            exact = (
+                parsed == ("terminal", {"command": expected_command})
+                and isinstance(call_id, str)
+                and bool(call_id)
+            )
+            if exact:
+                exact_call_count += 1
+                matching_ids.add(call_id)
+            else:
+                other_calls += 1
+
+    matching_results = 0
+    successful_results = 0
+    for message in document["data"]:
+        if (
+            not isinstance(message, dict)
+            or message.get("role") != "tool"
+            or message.get("tool_name") != "terminal"
+            or message.get("tool_call_id") not in matching_ids
+        ):
+            continue
+        matching_results += 1
+        content = message.get("content")
+        if isinstance(content, str):
+            try:
+                content = json.loads(content)
+            except json.JSONDecodeError:
+                content = None
+        if (
+            isinstance(content, dict)
+            and type(content.get("exit_code")) is int
+            and content.get("exit_code") == 0
+            and content.get("error") is None
+        ):
+            successful_results += 1
+
+    proof.update(
+        {
+            "exactTerminalCallCount": exact_call_count,
+            "otherToolCallCount": other_calls,
+            "matchingToolResultCount": matching_results,
+            "successfulToolResultCount": successful_results,
+        }
+    )
+    proof["passed"] = (
+        http_status == "200"
+        and exact_call_count == 1
+        and other_calls == 0
+        and matching_results == 1
+        and successful_results == 1
+    )
+    return proof
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        return 2
+    proof = project(Path(sys.argv[1]), sys.argv[2], sys.argv[3])
+    print(f"{MARKER}{json.dumps(proof, separators=(',', ':'))}")
+    return 0 if proof["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/e2e/support/common-egress-agent-helpers.test.ts
+++ b/test/e2e/support/common-egress-agent-helpers.test.ts
@@ -18,6 +18,7 @@ import {
   isHermesTransientAgentFailure,
   nvdaPersonalStockReplyMatchesEvidence,
   parseChatContent,
+  parseHermesToolExecutionProof,
   parseNvdaPersonalStockReply,
   parseOpenClawAgentText,
   parseOpenClawToolEvidence,
@@ -40,6 +41,64 @@ const STOCK_REPLY = {
   source_url: STOCK_SOURCE_URL,
   as_of: "2026-08-17T15:59:00Z",
 } satisfies NvdaPersonalStockReply;
+const HERMES_TOOL_PROOF_SCRIPT = join(
+  import.meta.dirname,
+  "..",
+  "live",
+  "hermes-tool-execution-proof.py",
+);
+const HERMES_REVIEWED_COMMAND = "/usr/local/lib/nemoclaw/hermes-wikidata-reference-read";
+
+function runHermesToolProof(body: string | Buffer | null, httpStatus = "200") {
+  const directory = mkdtempSync(join(tmpdir(), "hermes-tool-proof-"));
+  const messagesPath = join(directory, "messages.json");
+  const writeBody = body === null ? () => undefined : () => writeFileSync(messagesPath, body);
+  writeBody();
+  try {
+    return spawnSync(
+      "python3",
+      ["-I", HERMES_TOOL_PROOF_SCRIPT, messagesPath, HERMES_REVIEWED_COMMAND, httpStatus],
+      { encoding: "utf8", timeout: 5000 },
+    );
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+function projectHermesToolProof(messages: unknown, httpStatus = "200") {
+  return runHermesToolProof(JSON.stringify({ data: messages }), httpStatus);
+}
+
+function hermesToolMessages(
+  overrides: {
+    extraCalls?: unknown[];
+    resultCallId?: string;
+    resultContent?: unknown;
+    resultToolName?: string;
+  } = {},
+) {
+  return [
+    {
+      role: "assistant",
+      tool_calls: [
+        {
+          id: "call-reviewed",
+          function: {
+            name: "terminal",
+            arguments: JSON.stringify({ command: HERMES_REVIEWED_COMMAND }),
+          },
+        },
+        ...(overrides.extraCalls ?? []),
+      ],
+    },
+    {
+      role: "tool",
+      tool_call_id: overrides.resultCallId ?? "call-reviewed",
+      tool_name: overrides.resultToolName ?? "terminal",
+      content: overrides.resultContent ?? JSON.stringify({ output: "", exit_code: 0, error: null }),
+    },
+  ];
+}
 
 function stockPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -874,6 +933,162 @@ describe("common-egress agent parsing and classification helpers", () => {
       ),
     ).toBe("HERMES_REFERENCE_AGENT_OK");
   });
+
+  it("reduces the persisted Hermes session to bounded tool-execution proof (#9528)", () => {
+    const result = projectHermesToolProof([
+      { role: "user", content: "credential-that-must-not-leave-the-sandbox" },
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "call-reviewed",
+            function: {
+              name: "terminal",
+              arguments: JSON.stringify({ command: HERMES_REVIEWED_COMMAND }),
+            },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        tool_call_id: "call-reviewed",
+        tool_name: "terminal",
+        content: JSON.stringify({
+          output: "HERMES_REFERENCE_AGENT_OK",
+          exit_code: 0,
+          error: null,
+        }),
+      },
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).not.toContain("credential-that-must-not-leave-the-sandbox");
+    expect(result.stdout).not.toContain("HERMES_REFERENCE_AGENT_OK");
+    expect(parseHermesToolExecutionProof(result.stdout)).toEqual({
+      schemaVersion: 1,
+      messagesHttpStatus: "200",
+      sessionRecordFound: true,
+      exactTerminalCallCount: 1,
+      otherToolCallCount: 0,
+      matchingToolResultCount: 1,
+      successfulToolResultCount: 1,
+      passed: true,
+    });
+  });
+
+  it("rejects a Hermes session with another tool call (#9528)", () => {
+    const result = projectHermesToolProof([
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "call-reviewed",
+            function: {
+              name: "terminal",
+              arguments: JSON.stringify({ command: HERMES_REVIEWED_COMMAND }),
+            },
+          },
+          {
+            id: "call-other",
+            function: { name: "terminal", arguments: JSON.stringify({ command: "id" }) },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        tool_call_id: "call-reviewed",
+        tool_name: "terminal",
+        content: JSON.stringify({ output: "", exit_code: 0, error: null }),
+      },
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(parseHermesToolExecutionProof(result.stdout)).toMatchObject({
+      exactTerminalCallCount: 1,
+      otherToolCallCount: 1,
+      passed: false,
+    });
+  });
+
+  it.each([
+    {
+      name: "duplicate exact tool call",
+      messages: hermesToolMessages({
+        extraCalls: [
+          {
+            id: "call-reviewed",
+            function: {
+              name: "terminal",
+              arguments: JSON.stringify({ command: HERMES_REVIEWED_COMMAND }),
+            },
+          },
+        ],
+      }),
+    },
+    {
+      name: "mismatched tool call id",
+      messages: hermesToolMessages({ resultCallId: "call-other" }),
+    },
+    {
+      name: "mismatched tool name",
+      messages: hermesToolMessages({ resultToolName: "read_file" }),
+    },
+    {
+      name: "nonzero tool result",
+      messages: hermesToolMessages({
+        resultContent: JSON.stringify({ output: "private-output", exit_code: 1, error: null }),
+      }),
+    },
+    {
+      name: "malformed tool result",
+      messages: hermesToolMessages({ resultContent: "private-malformed-output" }),
+    },
+  ])("rejects $name without exposing the session body (#9528)", ({ messages }) => {
+    const result = projectHermesToolProof(messages);
+
+    expect(result.status).toBe(1);
+    expect(parseHermesToolExecutionProof(result.stdout)).toMatchObject({ passed: false });
+    expect(result.stdout).not.toContain("private-output");
+    expect(result.stdout).not.toContain("private-malformed-output");
+  });
+
+  it.each([
+    { name: "missing", body: null },
+    { name: "malformed", body: '{"data":[' },
+    {
+      name: "oversized",
+      body: Buffer.alloc(2 * 1024 * 1024 + 1, "private-oversized-session"),
+    },
+  ])("rejects a $name Hermes session response without exposing it (#9528)", ({ body }) => {
+    const result = runHermesToolProof(body);
+
+    expect(result.status).toBe(1);
+    expect(parseHermesToolExecutionProof(result.stdout)).toMatchObject({
+      sessionRecordFound: false,
+      passed: false,
+    });
+    expect(result.stdout).not.toContain("private-oversized-session");
+  });
+
+  it.each([
+    ["api-0123456789abcdef", true],
+    ["api-0123456789abcde", false],
+    ["api-0123456789abcdef/../messages", false],
+    ["api-0123456789abcdef\r\nAuthorization: leaked", false],
+    ["api-0123456789abcdeg", false],
+  ])(
+    "accepts only the bounded Hermes API session header [case %#] (#9528)",
+    (sessionId, expected) => {
+      const result = spawnSync(
+        "sh",
+        ["-c", "printf '%s\\n' \"$1\" | grep -Eq '^api-[0-9a-f]{16}$'", "--", sessionId],
+        { encoding: "utf8", timeout: 5000 },
+      );
+
+      expect(result.status === 0).toBe(expected);
+      expect(result.stdout).toBe("");
+    },
+  );
 
   it("expected-token matching ignores model line breaks", () => {
     expect(agentReplyContainsToken("REFER\nENCE_AGENT_OK", "REFERENCE_AGENT_OK")).toBe(true);

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -51,12 +51,30 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
   {
     pattern: /(?:^|\/)(agents\/(?:hermes|langchain-deepagents-code)\/)?Dockerfile$/,
     testsToRun: (_file, match) =>
-      match[1]
-        ? ["src/lib/onboard/managed-startup-profile.test.ts"]
-        : [
+      match[1] === "agents/hermes/"
+        ? [
             "src/lib/onboard/managed-startup-profile.test.ts",
-            "src/lib/sandbox/optimized-build-context-copy-sources.test.ts",
-          ],
+            "test/hermes-image-build-probes.test.ts",
+            "test/hermes-unattended-approval.test.ts",
+          ]
+        : match[1]
+          ? ["src/lib/onboard/managed-startup-profile.test.ts"]
+          : [
+              "src/lib/onboard/managed-startup-profile.test.ts",
+              "src/lib/sandbox/optimized-build-context-copy-sources.test.ts",
+            ],
+  },
+  {
+    pattern:
+      /(?:^|\/)agents\/hermes\/(?:hermes-wikidata-reference-read|image-build-probes\.py|nemoclaw_unattended_approval\.py|patch-unattended-approval\.py|unattended-approval-policy\.json)$/,
+    testsToRun: runTests(
+      "test/hermes-image-build-probes.test.ts",
+      "test/hermes-unattended-approval.test.ts",
+    ),
+  },
+  {
+    pattern: /(?:^|\/)test\/e2e\/live\/hermes-tool-execution-proof\.py$/,
+    testsToRun: runTests("test/e2e/support/common-egress-agent-helpers.test.ts"),
   },
   {
     pattern: /(?:^|\/)agents\/hermes\/policy-additions\.yaml$/,

--- a/test/hermes-image-build-probes.test.ts
+++ b/test/hermes-image-build-probes.test.ts
@@ -27,6 +27,7 @@ const commands = [
   "neutral-platform-inertness",
   "profile-policy",
   "session-preview",
+  "unattended-approval-policy",
 ] as const;
 
 describe("Hermes image build probes", () => {

--- a/test/hermes-unattended-approval.test.ts
+++ b/test/hermes-unattended-approval.test.ts
@@ -1,0 +1,442 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+import policy from "../agents/hermes/unattended-approval-policy.json" with { type: "json" };
+
+const root = path.join(import.meta.dirname, "..");
+const helper = path.join(root, "agents", "hermes", "nemoclaw_unattended_approval.py");
+const patcher = path.join(root, "agents", "hermes", "patch-unattended-approval.py");
+const wikidataRead = path.join(root, "agents", "hermes", "hermes-wikidata-reference-read");
+
+function policyAllows(policyPath: string, command: string, platform: string): boolean {
+  const harness = `\
+import importlib.util
+import os
+import pathlib
+import sys
+
+spec = importlib.util.spec_from_file_location("nemoclaw_unattended_approval", sys.argv[1])
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+allowed = module.is_reviewed_unattended_command(
+    sys.argv[3],
+    sys.argv[4],
+    policy_path=pathlib.Path(sys.argv[2]),
+    trusted_uid=os.getuid(),
+    trusted_gid=os.getgid(),
+)
+raise SystemExit(0 if allowed else 3)
+`;
+  const result = spawnSync(
+    "python3",
+    ["-I", "-c", harness, helper, policyPath, command, platform],
+    {
+      encoding: "utf8",
+      timeout: 5000,
+    },
+  );
+  return result.status === 0;
+}
+
+function withPolicy(run: (policyPath: string) => void) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-unattended-approval-"));
+  const policyPath = path.join(directory, "policy.json");
+  fs.writeFileSync(policyPath, `${JSON.stringify(policy)}\n`, { mode: 0o444 });
+  try {
+    run(policyPath);
+  } finally {
+    fs.chmodSync(policyPath, 0o644);
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+const sourceFixture = `\
+from tools.interrupt import is_interrupted
+
+def check_all_command_guards(command, env_type, approval_callback=None,
+                             has_host_access=False):
+    # Skip isolated container backends for both checks. Docker stops skipping
+    # once host paths are bind-mounted into the sandbox.
+    if _should_skip_container_guards(env_type, has_host_access=has_host_access):
+        return {"approved": True, "message": None}
+
+    is_hardline, hardline_desc = detect_hardline_command(command)
+    if is_hardline:
+        return _hardline_block_result(hardline_desc)
+
+    is_sudo_guess, sudo_guess_desc = _check_sudo_stdin_guard(command)
+    if is_sudo_guess:
+        return _sudo_stdin_block_result(sudo_guess_desc)
+
+    deny_pattern = _match_user_deny_rule(command)
+    if deny_pattern is not None:
+        logger.warning("User deny rule %r blocked command: %s",
+                       deny_pattern, command[:200])
+        return _user_deny_block_result(deny_pattern)
+
+    # --yolo or approvals.mode=off: bypass all approval prompts.
+    return {"approved": False}
+`;
+
+function patchSource(source: string, semver = "0.19.0") {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-approval-patch-"));
+  const sourcePath = path.join(directory, "approval.py");
+  fs.writeFileSync(sourcePath, source);
+  const hash = createHash("sha256").update(source).digest("hex");
+  const harness = `\
+import importlib.util
+import pathlib
+import sys
+
+spec = importlib.util.spec_from_file_location("patch_unattended_approval", sys.argv[1])
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+module.HERMES_APPROVAL_SHA256 = sys.argv[4]
+module.patch_file(pathlib.Path(sys.argv[2]), sys.argv[3])
+`;
+  const result = spawnSync("python3", ["-I", "-c", harness, patcher, sourcePath, semver, hash], {
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  const patched = fs.readFileSync(sourcePath, "utf8");
+  fs.rmSync(directory, { force: true, recursive: true });
+  return { ...result, patched };
+}
+
+describe("Hermes unattended approval policy", () => {
+  it("keeps the reviewed wrapper fixed to the Wikidata Q30 result (#9528)", () => {
+    const harness = `\
+import importlib.machinery
+import importlib.util
+import io
+import json
+import pathlib
+import sys
+import tempfile
+
+loader = importlib.machinery.SourceFileLoader("wikidata_read", sys.argv[1])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+assert spec
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)
+
+class Response(io.BytesIO):
+    def __enter__(self):
+        return self
+    def __exit__(self, *_args):
+        self.close()
+    def geturl(self):
+        return module.URL
+
+def open_response():
+    return Response(b'{"success":1,"entities":{"Q30":{"labels":{"en":{"value":"United States"}}}}}')
+
+module._open_response = open_response
+module.sys.argv = [sys.argv[1]]
+with tempfile.TemporaryDirectory() as directory:
+    module.RESULT_PATH = pathlib.Path(directory) / "result.json"
+    status = module.main()
+    assert json.loads(module.RESULT_PATH.read_text()) == {
+        "schemaVersion": 1,
+        "entity": "Q30",
+        "label": "United States",
+        "status": "ok",
+    }
+raise SystemExit(status)
+`;
+    const result = spawnSync("python3", ["-I", "-c", harness, wikidataRead], {
+      encoding: "utf8",
+      timeout: 5000,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe("HERMES_REFERENCE_AGENT_OK\n");
+  });
+
+  it.each(["redirect", "oversized"])(
+    "rejects a %s Wikidata response without writing a result (#9528)",
+    (responseCase) => {
+      const harness = `\
+import importlib.machinery
+import importlib.util
+import io
+import pathlib
+import sys
+import tempfile
+
+loader = importlib.machinery.SourceFileLoader("wikidata_read", sys.argv[1])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+assert spec
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)
+
+class Response(io.BytesIO):
+    def __init__(self, payload, final_url):
+        super().__init__(payload)
+        self.final_url = final_url
+    def __enter__(self):
+        return self
+    def __exit__(self, *_args):
+        self.close()
+    def geturl(self):
+        return self.final_url
+
+assert module._RejectRedirects().redirect_request(None, None, None, None, None, None, None) is None
+if sys.argv[2] == "redirect":
+    response = Response(b'{}', "https://redirected.invalid/result")
+else:
+    response = Response(b'x' * (module.MAX_RESPONSE_BYTES + 1), module.URL)
+module._open_response = lambda: response
+module.sys.argv = [sys.argv[1]]
+with tempfile.TemporaryDirectory() as directory:
+    module.RESULT_PATH = pathlib.Path(directory) / "result.json"
+    status = module.main()
+    assert status == 1
+    assert not module.RESULT_PATH.exists()
+raise SystemExit(0)
+`;
+      const result = spawnSync("python3", ["-I", "-c", harness, wikidataRead, responseCase], {
+        encoding: "utf8",
+        timeout: 5000,
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toBe("HERMES_REFERENCE_AGENT_BAD\n");
+    },
+  );
+
+  // source-shape-contract: security -- Executes the shipped approval helper against root-owned read-only policy bytes to prove the exact authorization boundary
+  it("allows only the reviewed Wikidata read in an API-server session (#9528)", () => {
+    withPolicy((policyPath) => {
+      const action = policy.wikidataReferenceRead;
+      expect(policyAllows(policyPath, action.command, action.platform)).toBe(true);
+    });
+  });
+
+  it.each([
+    [policy.wikidataReferenceRead.command, "local"],
+    [`${policy.wikidataReferenceRead.command} --help`, "api_server"],
+    [`${policy.wikidataReferenceRead.command}; echo extra`, "api_server"],
+    [`sudo ${policy.wikidataReferenceRead.command}`, "api_server"],
+  ])(
+    "denies an invocation outside the reviewed command and platform [case %#] (#9528)",
+    (command, platform) => {
+      withPolicy((policyPath) => {
+        expect(policyAllows(policyPath, command, platform)).toBe(false);
+      });
+    },
+  );
+
+  // source-shape-contract: security -- Mutating policy metadata and symlink topology proves the shipped authorization helper rejects untrusted state
+  it("fails closed when the reviewed policy file can be changed or redirected (#9528)", () => {
+    withPolicy((policyPath) => {
+      fs.chmodSync(policyPath, 0o644);
+      expect(policyAllows(policyPath, policy.wikidataReferenceRead.command, "api_server")).toBe(
+        false,
+      );
+
+      const target = `${policyPath}.target`;
+      fs.renameSync(policyPath, target);
+      fs.symlinkSync(target, policyPath);
+      expect(policyAllows(policyPath, policy.wikidataReferenceRead.command, "api_server")).toBe(
+        false,
+      );
+      fs.unlinkSync(policyPath);
+      fs.renameSync(target, policyPath);
+    });
+  });
+
+  it("patches only the version-bound guard after unconditional denials (#9528)", () => {
+    const result = patchSource(sourceFixture);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.patched).toContain(
+      "from tools.nemoclaw_unattended_approval import reviewed_unattended_action_decision",
+    );
+    const context = result.patched.indexOf("reviewed_action =");
+    const containerSkip = result.patched.indexOf("if _should_skip_container_guards(");
+    const deny = result.patched.indexOf("return _user_deny_block_result(deny_pattern)");
+    const reviewed = result.patched.indexOf("if reviewed_context:");
+    const yolo = result.patched.indexOf("# --yolo or approvals.mode=off");
+    expect(context).toBeLessThan(containerSkip);
+    expect(deny).toBeLessThan(reviewed);
+    expect(reviewed).toBeLessThan(yolo);
+    expect(result.patched.match(/reviewed_unattended_action_decision\(/gu)).toHaveLength(1);
+  });
+
+  it("executes the patched guard only in the reviewed local API context (#9528)", () => {
+    const patched = patchSource(sourceFixture);
+    expect(patched.status, patched.stderr).toBe(0);
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-patched-approval-"));
+    const sourcePath = path.join(directory, "approval.py");
+    fs.writeFileSync(sourcePath, patched.patched);
+    const harness = `\
+import importlib.util
+import json
+import sys
+import types
+
+tools = types.ModuleType("tools")
+tools.__path__ = []
+interrupt = types.ModuleType("tools.interrupt")
+interrupt.is_interrupted = lambda: False
+reviewed = types.ModuleType("tools.nemoclaw_unattended_approval")
+command = "/usr/local/lib/nemoclaw/hermes-wikidata-reference-read"
+reviewed.reviewed_unattended_action_decision = lambda candidate, platform: (
+    ("allow" if platform == "api_server" else "deny") if candidate == command else None
+)
+sys.modules["tools"] = tools
+sys.modules["tools.interrupt"] = interrupt
+sys.modules["tools.nemoclaw_unattended_approval"] = reviewed
+
+spec = importlib.util.spec_from_file_location("patched_approval", sys.argv[1])
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+module.logger = types.SimpleNamespace(warning=lambda *_args, **_kwargs: None)
+module._hardline_block_result = lambda _description: {"approved": False}
+module._sudo_stdin_block_result = lambda _description: {"approved": False}
+module._user_deny_block_result = lambda _pattern: {"approved": False}
+
+cases = json.loads(sys.argv[2])
+observed = []
+for case in cases:
+    module._get_session_platform = lambda case=case: case["platform"]
+    module._is_gateway_approval_context = lambda case=case: case["gateway"]
+    module.env_var_enabled = lambda name, case=case: (
+        name == "HERMES_CRON_SESSION" and case["cron"]
+    )
+    module._should_skip_container_guards = lambda env_type, has_host_access=False: (
+        env_type == "docker" and not has_host_access
+    )
+    module.detect_hardline_command = lambda _command, case=case: (
+        case.get("hardline", False), "blocked"
+    )
+    module._check_sudo_stdin_guard = lambda _command: (False, "")
+    module._match_user_deny_rule = lambda _command, case=case: (
+        "*" if case.get("user_deny", False) else None
+    )
+    decision = module.check_all_command_guards(
+        case.get("command", command),
+        case["env_type"],
+        has_host_access=case["host_access"],
+    )
+    observed.append(bool(decision.get("approved")))
+print(json.dumps(observed))
+`;
+    const cases = [
+      {
+        platform: "api_server",
+        gateway: true,
+        cron: false,
+        env_type: "local",
+        host_access: false,
+      },
+      {
+        platform: "api_server",
+        gateway: true,
+        cron: true,
+        env_type: "local",
+        host_access: false,
+      },
+      {
+        platform: "api_server",
+        gateway: true,
+        cron: false,
+        env_type: "ssh",
+        host_access: false,
+      },
+      {
+        platform: "api_server",
+        gateway: true,
+        cron: false,
+        env_type: "docker",
+        host_access: true,
+      },
+      {
+        platform: "api_server",
+        gateway: true,
+        cron: false,
+        env_type: "docker",
+        host_access: false,
+      },
+      {
+        platform: "slack",
+        gateway: true,
+        cron: false,
+        env_type: "local",
+        host_access: false,
+      },
+      {
+        platform: "api_server",
+        gateway: false,
+        cron: false,
+        env_type: "local",
+        host_access: false,
+      },
+      {
+        platform: "api_server",
+        gateway: true,
+        cron: false,
+        env_type: "local",
+        host_access: false,
+        hardline: true,
+      },
+      {
+        platform: "api_server",
+        gateway: true,
+        cron: false,
+        env_type: "local",
+        host_access: false,
+        user_deny: true,
+      },
+      {
+        command: "printf safe",
+        platform: "slack",
+        gateway: true,
+        cron: false,
+        env_type: "docker",
+        host_access: false,
+      },
+    ];
+    try {
+      const result = spawnSync(
+        "python3",
+        ["-I", "-c", harness, sourcePath, JSON.stringify(cases)],
+        {
+          encoding: "utf8",
+          timeout: 5000,
+        },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual([
+        true,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+      ]);
+    } finally {
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects an unreviewed Hermes version or approval source shape (#9528)", () => {
+    expect(patchSource(sourceFixture, "0.20.0").status).toBe(1);
+    expect(patchSource(sourceFixture.replace("# --yolo", "# changed")).status).toBe(1);
+  });
+});

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -44,6 +44,12 @@ const OPAQUE_INPUTS = [
   "managed-inference/recipes/vllm.example.managed-cluster.v1.yaml",
   "Dockerfile",
   "agents/hermes/Dockerfile",
+  "agents/hermes/hermes-wikidata-reference-read",
+  "agents/hermes/image-build-probes.py",
+  "agents/hermes/nemoclaw_unattended_approval.py",
+  "agents/hermes/patch-unattended-approval.py",
+  "agents/hermes/unattended-approval-policy.json",
+  "test/e2e/live/hermes-tool-execution-proof.py",
   "agents/langchain-deepagents-code/Dockerfile",
   "agents/hermes/policy-additions.yaml",
   "src/lib/messaging/channels/telegram/policy/openclaw.yaml",
@@ -86,14 +92,12 @@ function triggeredBy(relativePath: string): string[] {
 }
 
 describe("Vitest opaque-input watch triggers", () => {
-  it.each(
-    [
-        ".github/actions/docker-auth-setup/action.yaml",
-        ".github/actions/docker-auth-cleanup/action.yaml",
-        ".github/scripts/docker-auth-setup.sh",
-        ".github/scripts/docker-auth-cleanup.sh",
-      ],
-  )("maps current opaque inputs to their direct contract tests [%s] (#6692)", (authPath) => {
+  it.each([
+    ".github/actions/docker-auth-setup/action.yaml",
+    ".github/actions/docker-auth-cleanup/action.yaml",
+    ".github/scripts/docker-auth-setup.sh",
+    ".github/scripts/docker-auth-cleanup.sh",
+  ])("maps current opaque inputs to their direct contract tests [%s] (#6692)", (authPath) => {
     expect(triggeredBy("managed-inference/recipes/vllm.example.managed-cluster.v1.yaml")).toEqual([
       "src/lib/inference/serving/catalog.test.ts",
       "src/lib/inference/serving/resolver.test.ts",
@@ -105,6 +109,8 @@ describe("Vitest opaque-input watch triggers", () => {
     ]);
     expect(triggeredBy("agents/hermes/Dockerfile")).toEqual([
       "src/lib/onboard/managed-startup-profile.test.ts",
+      "test/hermes-image-build-probes.test.ts",
+      "test/hermes-unattended-approval.test.ts",
     ]);
     expect(triggeredBy("agents/langchain-deepagents-code/Dockerfile")).toEqual([
       "src/lib/onboard/managed-startup-profile.test.ts",
@@ -234,6 +240,25 @@ describe("Vitest opaque-input watch triggers", () => {
     ]);
     expect(triggeredBy("ci/platform-vitest-macos-requirements.lock")).toEqual([
       "test/platform-vitest-main-workflow.test.ts",
+    ]);
+  });
+
+  it.each([
+    "agents/hermes/hermes-wikidata-reference-read",
+    "agents/hermes/image-build-probes.py",
+    "agents/hermes/nemoclaw_unattended_approval.py",
+    "agents/hermes/patch-unattended-approval.py",
+    "agents/hermes/unattended-approval-policy.json",
+  ])("maps Hermes unattended approval input %s to its direct tests (#9528)", (approvalPath) => {
+    expect(triggeredBy(approvalPath)).toEqual([
+      "test/hermes-image-build-probes.test.ts",
+      "test/hermes-unattended-approval.test.ts",
+    ]);
+  });
+
+  it("maps the Hermes tool proof reducer to its direct E2E-support test (#9528)", () => {
+    expect(triggeredBy("test/e2e/live/hermes-tool-execution-proof.py")).toEqual([
+      "test/e2e/support/common-egress-agent-helpers.test.ts",
     ]);
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hermes API-server gateway sessions can now run one reviewed, read-only Wikidata action without waiting for a human terminal approval. The approval boundary is the exact absolute invocation of a root-owned wrapper in a non-cron local gateway with no host access. Every altered command, other execution context, untrusted policy, and existing denial remains fail-closed.

## Related Issue

Fixes #9528

## Changes

- Install a root-owned, no-argument Wikidata wrapper that fixes the URL, rejects redirects and responses larger than 64 KiB, validates the Q30 result, and atomically writes a mode-0600 result artifact only after a valid fetch.
- Add a root-owned, read-only policy and descriptor-safe matcher for the exact wrapper invocation. Using Hermes's generic interpreter allowlist would approve a dangerous command class, so the existing configuration boundary cannot express this one reviewed action safely.
- Patch the pinned Hermes v0.19.0 guard after hardline, sudo, and user-deny checks. Approval requires a non-cron local `api_server` gateway request with no host access. Exact source hashes and patch anchors fail the image build when the upstream approval boundary changes.
- Update the existing C3 E2E, without adding a target, to prove one exact terminal call and its successful tool result through the persisted Hermes session record. The fetched-result artifact is secondary evidence.
- Keep API keys, session IDs, raw messages, command output, and result bodies inside the sandbox. Only the schema version, three-digit HTTP status, four counts, and two Boolean fields leave it. The E2E loads `API_SERVER_KEY` from the runtime-owned sandbox file, uses it only for two localhost requests, and leaves the file unchanged.
- Add deterministic execution-context, policy, guard-precedence, wrapper, session-proof, image-probe, opaque-input, and build-integrity coverage.
- Record the bounded Hermes v0.19.0 approval exception and evidence contract in the internal dependency review.
- Add eight lint-only annotations for existing whole-stage `COPY` and named `USER` instructions that become blocking when this Dockerfile is checked. These annotations do not change image behavior.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent repository security review completed against the exact execution-context binding, version-pinned guard patch, root-owned policy and wrapper, denial precedence, network bounds, persisted session proof, redaction, and sibling command behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: `internal/security-reviews/hermes-0.19.0-dependency-review.md` records the bounded approval exception, exact upstream source, safe execution context, wrapper network limits, persisted session evidence, and redaction contract. Public documentation remains unchanged because no supported user command, option, or configuration changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 5542aca33 -->
<!-- docs-review-agents-blob-sha: 513518cdf -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 4 focused files passed 155 tests. `npm run test:changed` passed 32 growth guardrails and 61 affected tests. The documentation-review repair passed 105 focused tests across 3 files. Repository checks, docs, Hadolint, Oxlint, Python compilation, and the exact pinned-source patch and compilation passed. Normal pre-commit and commit-message hooks passed on the final candidate.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a controlled unattended-approval workflow for one reviewed Hermes action.
  * Added a secure Wikidata reference lookup with strict validation and fixed result output.
  * Restricted approvals by command, platform, session context, policy integrity, and environment access.

* **Bug Fixes**
  * Invalid, altered, unauthorized, or unsafe requests now fail closed.

* **Tests**
  * Expanded image, policy, integration, and end-to-end coverage for approval boundaries and tool execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->