### PR TITLE
test(e2e): use bounded Hermes terminal fetch

### DIFF
--- a/test/e2e/live/common-egress-agent-helpers.ts
+++ b/test/e2e/live/common-egress-agent-helpers.ts
@@ -13,10 +13,18 @@ import {
   type BoundedRetryResult,
   type RetryEvidence,
   type RetryFailureClass,
+  type RetryIdempotence,
 } from "../fixtures/retry-policy.ts";
 import { isTransientProviderValidationFailure } from "./network-policy-transient-provider.ts";
 
 export const COMMON_EGRESS_TEST_TIMEOUT_MS = 40 * 60_000;
+export const HERMES_API_SESSION_ID_PATTERN = "api-[0-9a-f]{16}";
+export const HERMES_TOOL_PROOF_SHELL_SUCCESS =
+  'test "$chat_rc" -eq 0 && test "$messages_rc" -eq 0 && test "$proof_rc" -eq 0';
+export const HERMES_SENSITIVE_PROBE_OPTIONS = Object.freeze({
+  captureLimitBytes: 4096,
+  persistArtifacts: false,
+});
 
 interface AgentJsonDoc {
   payloads?: Array<{ text?: unknown }>;
@@ -139,9 +147,22 @@ interface HermesAgentAssertionResult extends OpenClawAgentAssertionResult {
   httpStatus: string;
 }
 
+export interface HermesToolExecutionProof {
+  schemaVersion: 1;
+  messagesHttpStatus: string;
+  sessionRecordFound: boolean;
+  exactTerminalCallCount: number;
+  otherToolCallCount: number;
+  matchingToolResultCount: number;
+  otherToolResultCount: number;
+  successfulToolResultCount: number;
+  passed: boolean;
+}
+
 interface AgentAssertionRetryOptions {
   attempts: number;
   delayMs: (attempt: number) => number;
+  idempotence?: RetryIdempotence;
   onEvidence: (evidence: RetryEvidence) => Promise<void> | void;
   run: (attempt: number) => Promise<AgentAssertionAttempt>;
   sleep?: (milliseconds: number) => Promise<void>;
@@ -171,7 +192,7 @@ export function runHermesAgentAssertionRetry(
   return runBoundedRetry({
     operation: "common-egress.hermes-agent",
     owner: "hermes-agent",
-    idempotence: "read-only",
+    idempotence: options.idempotence ?? "read-only",
     maxAttempts: options.attempts,
     delayMs: options.delayMs,
     onEvidence: options.onEvidence,
@@ -1030,6 +1051,52 @@ export function parseChatContent(raw: string): string {
   const choice = doc.choices?.[0];
   const content = choice?.message?.content ?? choice?.message?.reasoning_content ?? choice?.text;
   return typeof content === "string" ? content.trim() : "";
+}
+
+export function parseHermesToolExecutionProof(raw: string): HermesToolExecutionProof | null {
+  const marker = "__NEMOCLAW_HERMES_TOOL_PROOF__=";
+  const encoded = raw
+    .split("\n")
+    .filter((line) => line.startsWith(marker))
+    .at(-1)
+    ?.slice(marker.length);
+  if (!encoded) return null;
+
+  try {
+    const proof = JSON.parse(encoded) as Record<string, unknown>;
+    const expectedKeys = [
+      "exactTerminalCallCount",
+      "matchingToolResultCount",
+      "messagesHttpStatus",
+      "otherToolCallCount",
+      "otherToolResultCount",
+      "passed",
+      "schemaVersion",
+      "sessionRecordFound",
+      "successfulToolResultCount",
+    ];
+    const counts = [
+      proof.exactTerminalCallCount,
+      proof.otherToolCallCount,
+      proof.otherToolResultCount,
+      proof.matchingToolResultCount,
+      proof.successfulToolResultCount,
+    ];
+    if (
+      Object.keys(proof).sort().join(",") !== expectedKeys.sort().join(",") ||
+      proof.schemaVersion !== 1 ||
+      typeof proof.messagesHttpStatus !== "string" ||
+      !/^\d{3}$/u.test(proof.messagesHttpStatus) ||
+      typeof proof.sessionRecordFound !== "boolean" ||
+      typeof proof.passed !== "boolean" ||
+      !counts.every((value) => Number.isInteger(value) && Number(value) >= 0)
+    ) {
+      return null;
+    }
+    return proof as unknown as HermesToolExecutionProof;
+  } catch {
+    return null;
+  }
 }
 
 function compactAgentReply(value: string): string {

--- a/test/e2e/live/common-egress-agent.test.ts
+++ b/test/e2e/live/common-egress-agent.test.ts
@@ -26,10 +26,13 @@ import { CLI_DIST_ENTRYPOINT, CLI_ENTRYPOINT, REPO_ROOT } from "../fixtures/path
 import type { SecretStore } from "../fixtures/secrets.ts";
 import type { ShellProbeResult } from "../fixtures/shell-probe.ts";
 import {
-  classifyHermesAgentAssertion,
   classifyPreContractProviderValidationSkip,
   COMMON_EGRESS_TEST_TIMEOUT_MS,
-  parseChatContent,
+  type HermesToolExecutionProof,
+  HERMES_API_SESSION_ID_PATTERN,
+  HERMES_SENSITIVE_PROBE_OPTIONS,
+  HERMES_TOOL_PROOF_SHELL_SUCCESS,
+  parseHermesToolExecutionProof,
   runHermesAgentAssertionRetry,
 } from "./common-egress-agent-helpers.ts";
 import {
@@ -55,8 +58,28 @@ const OPENCLAW_PERSONAL_SANDBOX =
 const HERMES_SANDBOX = process.env.NEMOCLAW_COMMON_EGRESS_HERMES_SANDBOX ?? "e2e-hm-open";
 const CHAT_MODEL = process.env.NEMOCLAW_MODEL ?? "nvidia/nemotron-3-super-120b-a12b";
 const ONBOARD_TIMEOUT_MS = 25 * 60_000;
-const HERMES_AGENT_TIMEOUT_MS = 150_000;
-const HERMES_AGENT_ATTEMPTS = 3;
+const HERMES_AGENT_TIMEOUT_MS = 180_000;
+const HERMES_REFERENCE_RESULT_PATH = "/tmp/nemoclaw-c3-wikidata.json";
+const HERMES_REFERENCE_COMMAND =
+  "/usr/bin/curl -fsS --proto '=https' --max-time 20 --max-filesize 65536 --remove-on-error -o /tmp/nemoclaw-c3-wikidata.json 'https://www.wikidata.org/w/api.php?action=wbgetentities&ids=Q30&props=labels&languages=en&format=json'";
+const HERMES_TOOL_EXECUTION_PROOF_SCRIPT = fs.readFileSync(
+  path.join(import.meta.dirname, "hermes-tool-execution-proof.py"),
+  "utf8",
+);
+const HERMES_REFERENCE_RESULT_CHECK = `\
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+with path.open("rb") as source:
+    raw = source.read(65537)
+if len(raw) > 65536:
+    raise SystemExit(1)
+document = json.loads(raw)
+label = document.get("entities", {}).get("Q30", {}).get("labels", {}).get("en", {}).get("value")
+raise SystemExit(0 if document.get("success") == 1 and label == "United States" else 1)
+`;
 const KEEP_SANDBOX =
   process.env.NEMOCLAW_E2E_KEEP_SANDBOX === "1" ||
   process.env.NEMOCLAW_COMMON_EGRESS_KEEP_SANDBOX === "1";
@@ -114,14 +137,6 @@ function httpStatusFromResponse(raw: string): string {
       ?.replace("__NEMOCLAW_HTTP_STATUS__=", "")
       .trim() || "000"
   );
-}
-
-function httpBodyFromResponse(raw: string): string {
-  return raw
-    .split("\n")
-    .filter((line) => !line.startsWith("__NEMOCLAW_HTTP_STATUS__="))
-    .join("\n")
-    .trim();
 }
 
 function isMissingSandboxOutput(output: string): boolean {
@@ -413,25 +428,29 @@ async function addPolicyPreset(
 }
 
 function buildHermesReferencePrompt(): string {
-  return String.raw`Use your terminal tool to run this Python check exactly once:
-python3 - <<'PY'
-import json
-import urllib.request
+  return `Use your terminal tool to run exactly this command once:
+${HERMES_REFERENCE_COMMAND}
+Do not run any other tool or command. Do not fetch any other URL.`;
+}
 
-url = "https://www.wikidata.org/w/api.php?action=wbgetentities&ids=Q30&props=labels&languages=en&format=json"
-with urllib.request.urlopen(url, timeout=20) as response:
-    doc = json.load(response)
-ok = doc.get("success") == 1 and doc.get("entities", {}).get("Q30", {}).get("labels", {}).get("en", {}).get("value") == "United States"
-print("HERMES_REFERENCE_AGENT_OK" if ok else "HERMES_REFERENCE_AGENT_BAD")
-PY
-After the command completes, reply exactly HERMES_REFERENCE_AGENT_OK if that exact token appeared. Do not fetch any other URL.`;
+function emptyHermesToolExecutionProof(): HermesToolExecutionProof {
+  return {
+    schemaVersion: 1,
+    messagesHttpStatus: "000",
+    sessionRecordFound: false,
+    exactTerminalCallCount: 0,
+    otherToolCallCount: 0,
+    matchingToolResultCount: 0,
+    otherToolResultCount: 0,
+    successfulToolResultCount: 0,
+    passed: false,
+  };
 }
 
 async function runHermesAgentAssertion(
   sandbox: SandboxClient,
   artifacts: ArtifactSink,
   args: {
-    expected: string;
     label: string;
     prompt: string;
     sandboxName: string;
@@ -446,56 +465,71 @@ async function runHermesAgentAssertion(
     "set -a",
     "[ ! -f /sandbox/.hermes/.env ] || . /sandbox/.hermes/.env",
     "set +a",
-    "tmp=$(mktemp)",
-    `if [ -n "\${API_SERVER_KEY:-}" ]; then code=$(curl -sS -o "$tmp" -w '%{http_code}' --max-time 120 http://localhost:8642/v1/chat/completions -H 'Content-Type: application/json' -H "Authorization: Bearer \${API_SERVER_KEY}" -d ${shellQuote(
+    "headers=$(mktemp)",
+    "messages=$(mktemp)",
+    `cleanup() { rm -f "$headers" "$messages"; unset API_SERVER_KEY; }`,
+    "trap cleanup EXIT",
+    `trap 'exit 1' HUP INT TERM`,
+    "chat_code=000",
+    "messages_code=000",
+    "messages_rc=1",
+    `if [ -n "\${API_SERVER_KEY:-}" ]; then chat_code=$(curl -sS -D "$headers" -o /dev/null -w '%{http_code}' --max-time 120 --max-filesize 2097152 http://localhost:8642/v1/chat/completions -H 'Content-Type: application/json' -H "Authorization: Bearer \${API_SERVER_KEY}" -d ${shellQuote(
       payload,
-    )}); else code=$(curl -sS -o "$tmp" -w '%{http_code}' --max-time 120 http://localhost:8642/v1/chat/completions -H 'Content-Type: application/json' -d ${shellQuote(
+    )}); else chat_code=$(curl -sS -D "$headers" -o /dev/null -w '%{http_code}' --max-time 120 --max-filesize 2097152 http://localhost:8642/v1/chat/completions -H 'Content-Type: application/json' -d ${shellQuote(
       payload,
     )}); fi`,
-    "rc=$?",
-    'cat "$tmp"',
-    'rm -f "$tmp"',
-    `printf '\\n__NEMOCLAW_HTTP_STATUS__=%s\\n' "\${code:-000}"`,
-    'exit "$rc"',
+    "chat_rc=$?",
+    `session_id=$(awk 'tolower($1) == "x-hermes-session-id:" { gsub(/\\r/, "", $2); print $2 }' "$headers" | tail -n 1)`,
+    `if printf '%s\\n' "$session_id" | grep -Eq '^${HERMES_API_SESSION_ID_PATTERN}$'; then if [ -n "\${API_SERVER_KEY:-}" ]; then messages_code=$(curl -sS -o "$messages" -w '%{http_code}' --max-time 30 --max-filesize 2097152 "http://localhost:8642/api/sessions/\${session_id}/messages" -H "Authorization: Bearer \${API_SERVER_KEY}"); messages_rc=$?; else messages_code=$(curl -sS -o "$messages" -w '%{http_code}' --max-time 30 --max-filesize 2097152 "http://localhost:8642/api/sessions/\${session_id}/messages"); messages_rc=$?; fi; fi`,
+    "unset API_SERVER_KEY",
+    `python3 -I -c ${shellQuote(HERMES_TOOL_EXECUTION_PROOF_SCRIPT)} "$messages" ${shellQuote(
+      HERMES_REFERENCE_COMMAND,
+    )} "\${messages_code:-000}"`,
+    "proof_rc=$?",
+    `printf '__NEMOCLAW_HTTP_STATUS__=%s\\n' "\${chat_code:-000}"`,
+    HERMES_TOOL_PROOF_SHELL_SUCCESS,
   ].join("; ");
 
   let lastFailure = "";
   const execution = await runHermesAgentAssertionRetry({
-    attempts: HERMES_AGENT_ATTEMPTS,
-    delayMs: () => 5_000,
+    attempts: 1,
+    delayMs: () => 0,
+    idempotence: "reconciled-mutation",
     onEvidence: async (evidence) => {
       await artifacts.writeJson(`retry/${args.label}-agent-retry-evidence.json`, evidence);
     },
     run: async (attempt) => {
       const agent = await sandbox.execShell(args.sandboxName, trustedSandboxShellScript(remote), {
-        artifactName: `${args.label}-hermes-agent-attempt-${attempt}`,
         env: commandEnv(),
+        ...HERMES_SENSITIVE_PROBE_OPTIONS,
         timeoutMs: HERMES_AGENT_TIMEOUT_MS,
       });
       const response = text(agent);
       const httpStatus = httpStatusFromResponse(response);
-      const body = httpBodyFromResponse(response);
-      let reply = "";
-      try {
-        reply = parseChatContent(body);
-      } catch {
-        reply = "";
-      }
-      lastFailure = `exit=${agent.exitCode} http=${httpStatus} reply='${reply.slice(
-        0,
-        240,
-      )}' body='${body.slice(0, 240)}'`;
-      return classifyHermesAgentAssertion({
-        exitCode: agent.exitCode,
-        expected: args.expected,
-        httpStatus,
-        reply,
-        response,
+      const toolProof = parseHermesToolExecutionProof(response) ?? emptyHermesToolExecutionProof();
+      const result = await sandbox.exec(
+        args.sandboxName,
+        ["python3", "-I", "-c", HERMES_REFERENCE_RESULT_CHECK, HERMES_REFERENCE_RESULT_PATH],
+        {
+          artifactName: `${args.label}-result-attempt-${attempt}`,
+          env: commandEnv(),
+          timeoutMs: 30_000,
+        },
+      );
+      const artifactPassed = result.exitCode === 0;
+      await artifacts.writeJson(`actions/${args.label}-attempt-${attempt}.json`, {
+        ...toolProof,
+        artifactPassed,
       });
+      lastFailure = `exit=${agent.exitCode} http=${httpStatus} toolProof=${toolProof.passed} artifact=${artifactPassed}`;
+      return {
+        passed: agent.exitCode === 0 && httpStatus === "200" && toolProof.passed && artifactPassed,
+        failureClass: "deterministic",
+      };
     },
   });
   if (execution.outcome === "passed") return;
-  throw new Error(`${args.label}: expected ${args.expected}, got ${lastFailure}`);
+  throw new Error(`${args.label}: bounded terminal proof failed: ${lastFailure}`);
 }
 
 const openClawTest = process.env.NEMOCLAW_COMMON_EGRESS_SKIP_OPENCLAW === "1" ? test.skip : test;
@@ -727,7 +761,8 @@ After web_fetch returns, reply exactly REFERENCE_AGENT_OK if the fetched respons
         contract: [
           "Hermes open onboarding applies public-reference common-egress endpoints",
           "Hermes open onboarding applies all Hermes Nous managed-tool policy presets",
-          "the Hermes API-server agent path fetches Wikidata through its terminal tool",
+          "the Hermes session records one successful exact terminal fetch and no other tool call",
+          "the terminal fetch produces the expected bounded Wikidata result",
         ],
       });
       await registerSandboxCleanup(cleanup, artifacts, host, sandbox, HERMES_SANDBOX);
@@ -753,8 +788,17 @@ After web_fetch returns, reply exactly REFERENCE_AGENT_OK if the fetched respons
         "/modal",
       ]);
       progress.phase("fetch Wikidata with Hermes agent");
+      const staleResult = await sandbox.exec(
+        HERMES_SANDBOX,
+        ["rm", "-f", HERMES_REFERENCE_RESULT_PATH],
+        {
+          artifactName: "c3-agent-reference-clear-result",
+          env: commandEnv(),
+          timeoutMs: 30_000,
+        },
+      );
+      expect(staleResult.exitCode, text(staleResult)).toBe(0);
       await runHermesAgentAssertion(sandbox, artifacts, {
-        expected: "HERMES_REFERENCE_AGENT_OK",
         label: "c3-agent-reference",
         prompt: buildHermesReferencePrompt(),
         sandboxName: HERMES_SANDBOX,

--- a/test/e2e/live/hermes-tool-execution-proof.py
+++ b/test/e2e/live/hermes-tool-execution-proof.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Reduce a Hermes session response to fixed E2E tool-execution proof."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+MARKER = "__NEMOCLAW_HERMES_TOOL_PROOF__="
+MAX_MESSAGES_BYTES = 2 * 1024 * 1024
+
+
+def _empty_proof(http_status: str) -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "messagesHttpStatus": http_status,
+        "sessionRecordFound": False,
+        "exactTerminalCallCount": 0,
+        "otherToolCallCount": 0,
+        "matchingToolResultCount": 0,
+        "otherToolResultCount": 0,
+        "successfulToolResultCount": 0,
+        "passed": False,
+    }
+
+
+def _read_document(path: Path) -> object:
+    with path.open("rb") as source:
+        raw = source.read(MAX_MESSAGES_BYTES + 1)
+    if len(raw) > MAX_MESSAGES_BYTES:
+        raise ValueError("session response exceeds the size limit")
+    return json.loads(raw)
+
+
+def _tool_arguments(tool_call: object) -> tuple[str, object] | None:
+    if not isinstance(tool_call, dict):
+        return None
+    function = tool_call.get("function")
+    if not isinstance(function, dict):
+        return None
+    name = function.get("name")
+    arguments = function.get("arguments")
+    if not isinstance(name, str):
+        return None
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            return None
+    return name, arguments
+
+
+def project(path: Path, expected_command: str, http_status: str) -> dict[str, object]:
+    proof = _empty_proof(http_status)
+    try:
+        document = _read_document(path)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return proof
+    if not isinstance(document, dict) or not isinstance(document.get("data"), list):
+        return proof
+
+    proof["sessionRecordFound"] = True
+    matching_ids: set[str] = set()
+    exact_call_count = 0
+    other_calls = 0
+    for message in document["data"]:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        tool_calls = message.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            parsed = _tool_arguments(tool_call)
+            call_id = tool_call.get("id") if isinstance(tool_call, dict) else None
+            exact = (
+                parsed == ("terminal", {"command": expected_command})
+                and isinstance(call_id, str)
+                and bool(call_id)
+            )
+            if exact:
+                exact_call_count += 1
+                matching_ids.add(call_id)
+            else:
+                other_calls += 1
+
+    matching_results = 0
+    other_results = 0
+    successful_results = 0
+    for message in document["data"]:
+        if not isinstance(message, dict) or message.get("role") != "tool":
+            continue
+        if (
+            message.get("tool_name") != "terminal"
+            or message.get("tool_call_id") not in matching_ids
+        ):
+            other_results += 1
+            continue
+        matching_results += 1
+        content = message.get("content")
+        if isinstance(content, str):
+            try:
+                content = json.loads(content)
+            except json.JSONDecodeError:
+                content = None
+        if (
+            isinstance(content, dict)
+            and type(content.get("exit_code")) is int
+            and content.get("exit_code") == 0
+            and content.get("error") is None
+        ):
+            successful_results += 1
+
+    proof.update(
+        {
+            "exactTerminalCallCount": exact_call_count,
+            "otherToolCallCount": other_calls,
+            "matchingToolResultCount": matching_results,
+            "otherToolResultCount": other_results,
+            "successfulToolResultCount": successful_results,
+        }
+    )
+    proof["passed"] = (
+        http_status == "200"
+        and exact_call_count == 1
+        and other_calls == 0
+        and matching_results == 1
+        and other_results == 0
+        and successful_results == 1
+    )
+    return proof
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        return 2
+    proof = project(Path(sys.argv[1]), sys.argv[2], sys.argv[3])
+    print(f"{MARKER}{json.dumps(proof, separators=(',', ':'))}")
+    return 0 if proof["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/e2e/support/common-egress-agent-helpers.test.ts
+++ b/test/e2e/support/common-egress-agent-helpers.test.ts
@@ -15,9 +15,13 @@ import {
   classifyHermesAgentAssertion,
   classifyOpenClawAgentAssertion,
   classifyPreContractProviderValidationSkip,
+  HERMES_API_SESSION_ID_PATTERN,
+  HERMES_SENSITIVE_PROBE_OPTIONS,
+  HERMES_TOOL_PROOF_SHELL_SUCCESS,
   isHermesTransientAgentFailure,
   nvdaPersonalStockReplyMatchesEvidence,
   parseChatContent,
+  parseHermesToolExecutionProof,
   parseNvdaPersonalStockReply,
   parseOpenClawAgentText,
   parseOpenClawToolEvidence,
@@ -40,6 +44,68 @@ const STOCK_REPLY = {
   source_url: STOCK_SOURCE_URL,
   as_of: "2026-08-17T15:59:00Z",
 } satisfies NvdaPersonalStockReply;
+const HERMES_TOOL_PROOF_SCRIPT = join(
+  import.meta.dirname,
+  "..",
+  "live",
+  "hermes-tool-execution-proof.py",
+);
+const HERMES_REFERENCE_COMMAND =
+  "/usr/bin/curl -fsS --proto '=https' --max-time 20 --max-filesize 65536 --remove-on-error -o /tmp/nemoclaw-c3-wikidata.json 'https://www.wikidata.org/w/api.php?action=wbgetentities&ids=Q30&props=labels&languages=en&format=json'";
+
+function runHermesToolProof(body: string | Buffer | null, httpStatus = "200") {
+  const directory = mkdtempSync(join(tmpdir(), "hermes-tool-proof-"));
+  const messagesPath = join(directory, "messages.json");
+  const writeBody = body === null ? () => undefined : () => writeFileSync(messagesPath, body);
+  writeBody();
+  try {
+    return spawnSync(
+      "python3",
+      ["-I", HERMES_TOOL_PROOF_SCRIPT, messagesPath, HERMES_REFERENCE_COMMAND, httpStatus],
+      { encoding: "utf8", timeout: 5000 },
+    );
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+function projectHermesToolProof(messages: unknown, httpStatus = "200") {
+  return runHermesToolProof(JSON.stringify({ data: messages }), httpStatus);
+}
+
+function hermesToolMessages(
+  overrides: {
+    command?: string;
+    extraCalls?: unknown[];
+    extraResults?: unknown[];
+    resultCallId?: string;
+    resultContent?: unknown;
+    resultToolName?: string;
+  } = {},
+) {
+  return [
+    {
+      role: "assistant",
+      tool_calls: [
+        {
+          id: "call-reference",
+          function: {
+            name: "terminal",
+            arguments: JSON.stringify({ command: overrides.command ?? HERMES_REFERENCE_COMMAND }),
+          },
+        },
+        ...(overrides.extraCalls ?? []),
+      ],
+    },
+    {
+      role: "tool",
+      tool_call_id: overrides.resultCallId ?? "call-reference",
+      tool_name: overrides.resultToolName ?? "terminal",
+      content: overrides.resultContent ?? JSON.stringify({ output: "", exit_code: 0, error: null }),
+    },
+    ...(overrides.extraResults ?? []),
+  ];
+}
 
 function stockPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -873,6 +939,166 @@ describe("common-egress agent parsing and classification helpers", () => {
         JSON.stringify({ choices: [{ message: { content: "HERMES_REFERENCE_AGENT_OK" } }] }),
       ),
     ).toBe("HERMES_REFERENCE_AGENT_OK");
+  });
+
+  it("reduces one persisted Hermes terminal execution to bounded proof (#9528)", () => {
+    const result = projectHermesToolProof([
+      { role: "user", content: "prompt-with-API_SERVER_KEY=private-api-key" },
+      ...hermesToolMessages({
+        resultContent: JSON.stringify({
+          output: "private-fetched-body-and-terminal-output",
+          exit_code: 0,
+          error: null,
+        }),
+      }),
+      { role: "assistant", content: "private-assistant-response" },
+    ]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(parseHermesToolExecutionProof(result.stdout)).toEqual({
+      schemaVersion: 1,
+      messagesHttpStatus: "200",
+      sessionRecordFound: true,
+      exactTerminalCallCount: 1,
+      otherToolCallCount: 0,
+      matchingToolResultCount: 1,
+      otherToolResultCount: 0,
+      successfulToolResultCount: 1,
+      passed: true,
+    });
+    expect(result.stdout).not.toContain("private-api-key");
+    expect(result.stdout).not.toContain("private-fetched-body-and-terminal-output");
+    expect(result.stdout).not.toContain("private-assistant-response");
+    expect(result.stdout).not.toContain("www.wikidata.org");
+  });
+
+  it("disables shell artifacts for the Hermes prompt and session probe (#9528)", () => {
+    expect(HERMES_SENSITIVE_PROBE_OPTIONS).toEqual({
+      captureLimitBytes: 4096,
+      persistArtifacts: false,
+    });
+  });
+
+  it.each([
+    ["accepts shell proof after every subprocess succeeds", 0, 0, 0, true],
+    ["rejects shell proof after the chat transfer fails", 1, 0, 0, false],
+    ["rejects shell proof after the session transfer fails", 0, 63, 0, false],
+    ["rejects shell proof after the reducer fails", 0, 0, 1, false],
+  ])("%s (#9528)", (_name, chatRc, messagesRc, proofRc, passed) => {
+    const result = spawnSync(
+      "sh",
+      [
+        "-c",
+        `chat_rc=$1; messages_rc=$2; proof_rc=$3; ${HERMES_TOOL_PROOF_SHELL_SUCCESS}`,
+        "--",
+        String(chatRc),
+        String(messagesRc),
+        String(proofRc),
+      ],
+      { encoding: "utf8", timeout: 5000 },
+    );
+
+    expect(result.status === 0).toBe(passed);
+  });
+
+  it.each([
+    {
+      name: "changed command",
+      messages: hermesToolMessages({ command: "/usr/bin/curl https://example.com" }),
+    },
+    {
+      name: "duplicate exact tool call",
+      messages: hermesToolMessages({
+        extraCalls: [
+          {
+            id: "call-reference-duplicate",
+            function: {
+              name: "terminal",
+              arguments: JSON.stringify({ command: HERMES_REFERENCE_COMMAND }),
+            },
+          },
+        ],
+      }),
+    },
+    {
+      name: "other tool call",
+      messages: hermesToolMessages({
+        extraCalls: [
+          {
+            id: "call-other",
+            function: { name: "read_file", arguments: JSON.stringify({ path: "/tmp/result" }) },
+          },
+        ],
+      }),
+    },
+    {
+      name: "mismatched tool result ID",
+      messages: hermesToolMessages({ resultCallId: "call-other" }),
+    },
+    {
+      name: "mismatched tool result name",
+      messages: hermesToolMessages({ resultToolName: "read_file" }),
+    },
+    {
+      name: "unmatched extra tool result",
+      messages: hermesToolMessages({
+        extraResults: [
+          {
+            role: "tool",
+            tool_call_id: "call-other",
+            tool_name: "terminal",
+            content: JSON.stringify({ output: "private-extra-output", exit_code: 0, error: null }),
+          },
+        ],
+      }),
+    },
+    {
+      name: "nonzero tool result",
+      messages: hermesToolMessages({
+        resultContent: JSON.stringify({
+          output: "private-terminal-output",
+          exit_code: 1,
+          error: null,
+        }),
+      }),
+    },
+    {
+      name: "malformed tool result",
+      messages: hermesToolMessages({ resultContent: "private-malformed-output" }),
+    },
+  ])("rejects a Hermes session with $name (#9528)", ({ messages }) => {
+    const result = projectHermesToolProof(messages);
+
+    expect(result.status).toBe(1);
+    expect(parseHermesToolExecutionProof(result.stdout)).toMatchObject({ passed: false });
+    expect(result.stdout).not.toContain("private-terminal-output");
+    expect(result.stdout).not.toContain("private-malformed-output");
+    expect(result.stdout).not.toContain("private-extra-output");
+  });
+
+  it.each([
+    { name: "missing", body: null },
+    { name: "malformed", body: '{"data":[' },
+    { name: "oversized", body: Buffer.alloc(2 * 1024 * 1024 + 1, "private-session") },
+  ])("rejects a $name Hermes session response without exposing it (#9528)", ({ body }) => {
+    const result = runHermesToolProof(body);
+
+    expect(result.status).toBe(1);
+    expect(parseHermesToolExecutionProof(result.stdout)).toMatchObject({
+      sessionRecordFound: false,
+      passed: false,
+    });
+    expect(result.stdout).not.toContain("private-session");
+  });
+
+  it.each([
+    ["api-0123456789abcdef", true],
+    ["api-0123456789abcde", false],
+    ["api-0123456789abcdef/../messages", false],
+    ["api-0123456789abcdef\r\nAuthorization: leaked", false],
+    ["api-0123456789abcdeg", false],
+  ])("accepts only a bounded Hermes API session ID [case %#] (#9528)", (sessionId, expected) => {
+    expect(new RegExp(`^${HERMES_API_SESSION_ID_PATTERN}$`, "u").test(sessionId)).toBe(expected);
   });
 
   it("expected-token matching ignores model line breaks", () => {

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -66,6 +66,10 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     ),
   },
   {
+    pattern: /(?:^|\/)test\/e2e\/live\/hermes-tool-execution-proof\.py$/,
+    testsToRun: runTests("test/e2e/support/common-egress-agent-helpers.test.ts"),
+  },
+  {
     pattern:
       /(?:^|\/)(?:agents\/pi\/(?:Dockerfile(?:\.base)?|dependency-review\.md|generate-config\.ts|manifest\.yaml|policy-additions\.yaml|start\.sh|pi-runtime\/package(?:-lock)?\.json)|\.github\/workflows\/(?:managed-images|base-image)\.yaml)$/,
     testsToRun: runTests("test/pi-candidate-runtime-artifacts.test.ts"),

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -46,6 +46,7 @@ const OPAQUE_INPUTS = [
   "agents/hermes/Dockerfile",
   "agents/langchain-deepagents-code/Dockerfile",
   "agents/hermes/policy-additions.yaml",
+  "test/e2e/live/hermes-tool-execution-proof.py",
   "src/lib/messaging/channels/telegram/policy/openclaw.yaml",
   "nemoclaw-blueprint/policies/presets/local-inference.yaml",
   "nemoclaw-blueprint/policies/presets/claude-code.yaml",
@@ -86,14 +87,12 @@ function triggeredBy(relativePath: string): string[] {
 }
 
 describe("Vitest opaque-input watch triggers", () => {
-  it.each(
-    [
-        ".github/actions/docker-auth-setup/action.yaml",
-        ".github/actions/docker-auth-cleanup/action.yaml",
-        ".github/scripts/docker-auth-setup.sh",
-        ".github/scripts/docker-auth-cleanup.sh",
-      ],
-  )("maps current opaque inputs to their direct contract tests [%s] (#6692)", (authPath) => {
+  it.each([
+    ".github/actions/docker-auth-setup/action.yaml",
+    ".github/actions/docker-auth-cleanup/action.yaml",
+    ".github/scripts/docker-auth-setup.sh",
+    ".github/scripts/docker-auth-cleanup.sh",
+  ])("maps current opaque inputs to their direct contract tests [%s] (#6692)", (authPath) => {
     expect(triggeredBy("managed-inference/recipes/vllm.example.managed-cluster.v1.yaml")).toEqual([
       "src/lib/inference/serving/catalog.test.ts",
       "src/lib/inference/serving/resolver.test.ts",
@@ -112,6 +111,9 @@ describe("Vitest opaque-input watch triggers", () => {
     expect(triggeredBy("agents/hermes/policy-additions.yaml")).toEqual([
       "src/lib/onboard/initial-policy-real-policy.test.ts",
       "src/lib/onboard/initial-policy.test.ts",
+    ]);
+    expect(triggeredBy("test/e2e/live/hermes-tool-execution-proof.py")).toEqual([
+      "test/e2e/support/common-egress-agent-helpers.test.ts",
     ]);
     expect(triggeredBy("src/lib/messaging/channels/telegram/policy/openclaw.yaml")).toEqual([
       "src/lib/messaging/channels/policy.test.ts",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Hermes C3 E2E asked the agent to run a Python heredoc, which pinned Hermes correctly routes to manual approval. This changes only the existing test: it requests one bounded direct `curl`, proves the exact terminal execution from Hermes's persisted session record, and validates the downloaded JSON separately.

No Hermes image, managed policy, approval rule, product wrapper, or live target is added.

## Related Issue

Fixes #9528

## Changes

- replace the approval-gated Python heredoc with one HTTPS-only, time-bounded, size-bounded `curl` command
- require one exact persisted terminal call, no other tool calls, and one linked successful result
- validate the bounded Wikidata JSON artifact without using assistant response text as proof
- keep the API key, session ID, prompt, raw messages, tool arguments, terminal output, chat body, and fetched body out of retained artifacts
- run one agent attempt and retain a bounded pass or failure report

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent nine-category security review of exact commit `3b49fdf2b12c37535b0dac4a82269fe01b68f68c`: PASS with no blockers
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — E2E-support 63/63; watch-trigger integration 43/43; `npm run test:changed` passed
- [ ] Applicable broad gate passed — full E2E-support: 3,042 passed and six unrelated local-environment cases failed on macOS, including `systemd`, BSD `find`, and existing five-second workflow timeouts; CI remains authoritative
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Documentation Writer Review

- [x] Documentation writer reviewed the completed changes
- Result: `no-docs-needed`
- Commit: `3b49fdf2b12c37535b0dac4a82269fe01b68f68c`
- Base: `ea912e746b7de4565aaeeef480f7742828e96ea4`
- Evidence: Test-only E2E evidence collection; public and repository documentation remain accurate.
- Agent: Codex Desktop

<!-- docs-review-head-sha: 3b49fdf2b -->
<!-- docs-review-agents-blob-sha: 513518cdf -->

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hermes validation for terminal tool execution, session identifiers, command results, and downloaded artifacts.
  * Invalid, incomplete, mismatched, or unsafe session responses are now rejected reliably.
  * Retry behavior is bounded and defaults to read-only operation.

* **Tests**
  * Added comprehensive coverage for successful proofs, failures, malformed responses, sensitive-output redaction, and strict validation.
  * Updated automated test triggers to run proof validation whenever the related utility changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->