### PR TITLE
fix(docs): remove documented variables from allowlist

### DIFF
--- a/ci/env-var-doc-allowlist.json
+++ b/ci/env-var-doc-allowlist.json
@@ -16,20 +16,12 @@
     "reason": "Internal Vitest-only sentinel that prevents hermetic CLI tests with fake OpenShell binaries from reading the host's real Docker gateway image. Production users should not set it."
   },
   {
-    "name": "NEMOCLAW_BEDROCK_RUNTIME_ADAPTER_PORT",
-    "reason": "Internal child-process setting used only when launching the hidden Bedrock Runtime adapter. Users should configure Bedrock through the existing custom Anthropic endpoint flow instead."
-  },
-  {
     "name": "NEMOCLAW_BEDROCK_RUNTIME_ENDPOINT_URL",
     "reason": "Internal child-process setting used only to pass the auto-detected Bedrock Runtime endpoint to the hidden local adapter. Not a public user-facing configuration knob."
   },
   {
     "name": "NEMOCLAW_BEDROCK_RUNTIME_REGION",
     "reason": "Internal child-process setting used only to pass the resolved Bedrock Runtime region to the hidden local adapter. Users should rely on the endpoint URL or standard AWS region environment variables."
-  },
-  {
-    "name": "NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_PORT",
-    "reason": "Internal child-process setting used only when launching the hidden HTTPS Pin Runtime adapter. The port is a fixed internal constant, not a public user-facing configuration knob."
   },
   {
     "name": "NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_CONTROL_TOKEN",


### PR DESCRIPTION
## Summary

Removes two invalid environment-variable documentation allowlist entries after #9642 documented the corresponding runtime-adapter ports. This restores the documentation gate and changes no product behavior or product scope.

## Changes

- Remove `NEMOCLAW_BEDROCK_RUNTIME_ADAPTER_PORT` from the internal-only documentation allowlist.
- Remove `NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_PORT` from the internal-only documentation allowlist.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the repository environment-variable documentation gate rejects documented variables that remain in this allowlist.
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx tsx scripts/check-env-var-docs.mts` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable to a two-entry allowlist cleanup.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed obsolete Bedrock Runtime and HTTPS Pin Runtime adapter port environment variables from the CI documentation allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
