### PR TITLE
fix(onboard): validate retired gateway evidence

### DIFF
--- a/.github/workflows/podman-cpu-proof.yaml
+++ b/.github/workflows/podman-cpu-proof.yaml
@@ -474,6 +474,7 @@ jobs:
             esac
           done < <(podman --url "$endpoint" secret ls --format '{{.Name}}' 2>/dev/null || true)
           podman --url "$endpoint" network rm openshell-docker 2>/dev/null || true
+          # gateway-alias-cleanup
           portable_host_gateway_ip=""
           if portable_host_gateway_ip="$(
             node --input-type=module --eval '

--- a/docs/inference/set-up-openai-compatible-endpoint.mdx
+++ b/docs/inference/set-up-openai-compatible-endpoint.mdx
@@ -138,6 +138,23 @@ It carries authenticated mTLS plus sandbox-JWT callbacks to OpenShell on port `8
 The managed local registry uses the distinct address `169.254.1.3` on port `5000`.
 Keeping the host-gateway address outside the sandbox subnet prevents a Portable workload from receiving that address.
 
+<Warning>
+If Portable onboarding reports that the retired `169.254.1.2/32` address is still assigned to the loopback interface, remove only that exact assignment:
+
+```bash
+sudo ip address delete 169.254.1.2/32 dev lo
+```
+
+Rerun Portable onboarding:
+
+```bash
+$$nemoclaw onboard --experimental-profile portable
+```
+
+Do not run the loopback deletion command when onboarding reports another interface or prefix.
+Investigate and resolve the conflicting assignment before you rerun onboarding.
+</Warning>
+
 The portable profile handles the descriptor as follows:
 
 | Descriptor state | Onboarding result |

--- a/src/lib/onboard/experimental/portable-host-preparation.test.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.test.ts
@@ -32,6 +32,13 @@ function result(status = 0, stdout = ""): SpawnResult {
   return { status, stdout, stderr: "" } as SpawnResult;
 }
 
+const NO_RETIRED_GATEWAY_EVIDENCE = JSON.stringify([
+  { ifname: "lo", addr_info: [{ family: "inet", local: "127.0.0.1", prefixlen: 8 }] },
+]);
+const RETIRED_LOOPBACK_EVIDENCE = JSON.stringify([
+  { ifname: "lo", addr_info: [{ family: "inet", local: "169.254.1.2", prefixlen: 32 }] },
+]);
+
 function runtimeAuthority(
   homeDir: string,
   socketPath = "/run/user/1001/podman/podman.sock",
@@ -95,7 +102,10 @@ function preparePortableExperimentalHost(
           : docker,
       ip:
         deps.ip ??
-        (() => result(0, `1: lo    inet ${PORTABLE_HOST_GATEWAY_IP}/32 scope global lo\n`)),
+        ((args) =>
+          args[0] === "-j"
+            ? result(0, NO_RETIRED_GATEWAY_EVIDENCE)
+            : result(0, `1: lo    inet ${PORTABLE_HOST_GATEWAY_IP}/32 scope global lo\n`)),
       sudo: deps.sudo ?? (() => result()),
       // Tests run on hosts without the /sys/fs/cgroup hierarchy the portable
       // CPU-delegation preflight reads; default to a passing stub and inject
@@ -384,8 +394,10 @@ describe("preparePortableExperimentalHost", () => {
       .mockReturnValueOnce(result(0, JSON.stringify([{ Subnet: PORTABLE_DOCKER_NETWORK_SUBNET }]))) // retry network inspect: reuse
       .mockReturnValueOnce(result(1)) // retry registry inspect: absent
       .mockReturnValueOnce(result()); // retry registry run
-    const ip = vi.fn(() =>
-      result(0, `1: lo    inet ${PORTABLE_HOST_GATEWAY_IP}/32 scope global lo\n`),
+    const ip = vi.fn((args: readonly string[]) =>
+      args[0] === "-j"
+        ? result(0, NO_RETIRED_GATEWAY_EVIDENCE)
+        : result(0, `1: lo    inet ${PORTABLE_HOST_GATEWAY_IP}/32 scope global lo\n`),
     );
     const sudo = vi.fn(() => result());
     const env: NodeJS.ProcessEnv = { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" };
@@ -464,13 +476,15 @@ describe("preparePortableExperimentalHost", () => {
         }
       },
     );
-    const ip = vi.fn(() =>
-      result(
-        0,
-        hostGatewayConfigured
-          ? `1: lo    inet ${PORTABLE_HOST_GATEWAY_IP}/32 scope global lo\n`
-          : "1: lo    inet 127.0.0.1/8 scope host lo\n",
-      ),
+    const ip = vi.fn((args: readonly string[]) =>
+      args[0] === "-j"
+        ? result(0, NO_RETIRED_GATEWAY_EVIDENCE)
+        : result(
+            0,
+            hostGatewayConfigured
+              ? `1: lo    inet ${PORTABLE_HOST_GATEWAY_IP}/32 scope global lo\n`
+              : "1: lo    inet 127.0.0.1/8 scope host lo\n",
+          ),
     );
     const sudo = vi.fn(() => {
       commands.push("add host gateway");
@@ -489,11 +503,19 @@ describe("preparePortableExperimentalHost", () => {
   });
 
   it.each([
-    ["missing network", false, "1: lo    inet 169.254.1.2/32 scope global lo\n"],
+    ["missing network", false, RETIRED_LOOPBACK_EVIDENCE],
     [
       "existing network and replacement gateway",
       true,
-      `1: lo    inet 169.254.1.2/32 scope global lo\n1: lo    inet ${PORTABLE_HOST_GATEWAY_IP}/32 scope global lo\n`,
+      JSON.stringify([
+        {
+          ifname: "lo",
+          addr_info: [
+            { family: "inet", local: "169.254.1.2", prefixlen: 32 },
+            { family: "inet", local: PORTABLE_HOST_GATEWAY_IP, prefixlen: 32 },
+          ],
+        },
+      ]),
     ],
   ])(
     "rejects the retired gateway alias before inspecting the %s (#9587)",
@@ -534,12 +556,69 @@ describe("preparePortableExperimentalHost", () => {
       preparePortableExperimentalHost(
         { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
         portablePreparationDeps(home, docker, {
-          ip: () => result(0, "2: eth0    inet 169.254.1.2/24 scope global eth0\n"),
+          ip: () =>
+            result(
+              0,
+              JSON.stringify([
+                {
+                  ifname: "eth0",
+                  addr_info: [{ family: "inet", local: "169.254.1.2", prefixlen: 24 }],
+                },
+              ]),
+            ),
           sudo,
         }),
       ),
     ).toThrow(/retired portable host gateway address 169\.254\.1\.2 has a conflicting/u);
     expect(docker.mock.calls.map(([args]) => args)).toEqual([["--version"]]);
+    expect(sudo).not.toHaveBeenCalled();
+  });
+
+  it.each<[string, SpawnResult, RegExp]>([
+    [
+      "nonzero address inspection",
+      result(2, "permission denied"),
+      /Inspecting the retired portable host gateway address failed: permission denied/u,
+    ],
+    [
+      "address inspection process failure",
+      { ...result(), error: new Error("address inspection interrupted") },
+      /Inspecting the retired portable host gateway address failed: address inspection interrupted/u,
+    ],
+    [
+      "malformed target assignment",
+      result(0, '[{"ifname":"lo","addr_info":[{"family":"inet","local":"169.254.1.2"}]}]'),
+      /inspection returned invalid or ambiguous output/u,
+    ],
+    ["wholly invalid successful output", result(0, "not-json"), /invalid or ambiguous output/u],
+    [
+      "multiple target assignments",
+      result(
+        0,
+        JSON.stringify([
+          { ifname: "lo", addr_info: [{ family: "inet", local: "169.254.1.2", prefixlen: 32 }] },
+          { ifname: "eth0", addr_info: [{ family: "inet", local: "169.254.1.2", prefixlen: 24 }] },
+        ]),
+      ),
+      /has a conflicting host assignment/u,
+    ],
+  ])("rejects %s before Portable network mutation (#9587)", (_case, inspection, error) => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-"));
+    tempDirs.push(home);
+    const docker = vi.fn<(args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult>(() =>
+      result(),
+    );
+    const ip = vi.fn(() => inspection);
+    const sudo = vi.fn(() => result());
+
+    expect(() =>
+      preparePortableExperimentalHost(
+        { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
+        portablePreparationDeps(home, docker, { ip, sudo }),
+      ),
+    ).toThrow(error);
+    expect(docker.mock.calls.map(([args]) => args)).toEqual([["--version"]]);
+    expect(ip).toHaveBeenCalledTimes(1);
     expect(sudo).not.toHaveBeenCalled();
   });
 
@@ -553,7 +632,7 @@ describe("preparePortableExperimentalHost", () => {
       .mockReturnValueOnce(result(0, `1 true ${PORTABLE_REGISTRY_IP}`));
     const ip = vi
       .fn<(args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult>()
-      .mockReturnValueOnce(result())
+      .mockReturnValueOnce(result(0, NO_RETIRED_GATEWAY_EVIDENCE))
       .mockReturnValueOnce(result())
       .mockReturnValueOnce(
         result(0, `1: lo    inet ${PORTABLE_HOST_GATEWAY_IP}/32 scope global lo\n`),
@@ -568,7 +647,7 @@ describe("preparePortableExperimentalHost", () => {
     );
 
     expect(ip.mock.calls.map(([args]) => args)).toEqual([
-      ["-o", "-4", "address", "show"],
+      ["-j", "-4", "address", "show"],
       ["-o", "-4", "address", "show"],
       ["-o", "-4", "address", "show"],
     ]);
@@ -586,12 +665,18 @@ describe("preparePortableExperimentalHost", () => {
       result(),
     );
     const sudo = vi.fn(() => result());
+    const ip = vi
+      .fn<(args: readonly string[], env: NodeJS.ProcessEnv) => SpawnResult>()
+      .mockReturnValueOnce(result(0, NO_RETIRED_GATEWAY_EVIDENCE))
+      .mockReturnValueOnce(
+        result(0, `2: eth0    inet ${PORTABLE_HOST_GATEWAY_IP}/32 scope global eth0\n`),
+      );
 
     expect(() =>
       preparePortableExperimentalHost(
         { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
         portablePreparationDeps(home, docker, {
-          ip: () => result(0, `2: eth0    inet ${PORTABLE_HOST_GATEWAY_IP}/32 scope global eth0\n`),
+          ip,
           sudo,
         }),
       ),

--- a/src/lib/onboard/experimental/portable-host-preparation.test.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.test.ts
@@ -590,6 +590,22 @@ describe("preparePortableExperimentalHost", () => {
       result(0, '[{"ifname":"lo","addr_info":[{"family":"inet","local":"169.254.1.2"}]}]'),
       /inspection returned invalid or ambiguous output/u,
     ],
+    [
+      "malformed non-target assignment beside target evidence",
+      result(
+        0,
+        JSON.stringify([
+          {
+            ifname: "lo",
+            addr_info: [
+              { family: "inet", local: "169.254.1.2", prefixlen: 32 },
+              { family: "inet", local: "127.0.0.1" },
+            ],
+          },
+        ]),
+      ),
+      /inspection returned invalid or ambiguous output/u,
+    ],
     ["wholly invalid successful output", result(0, "not-json"), /invalid or ambiguous output/u],
     [
       "multiple target assignments",

--- a/src/lib/onboard/experimental/portable-host-preparation.ts
+++ b/src/lib/onboard/experimental/portable-host-preparation.ts
@@ -3,6 +3,7 @@
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { isIP } from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -110,6 +111,10 @@ function requireCommand(result: SpawnResult, description: string): void {
   throw new Error(`${description} failed: ${commandDetail(result)}`);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
  * The portable profile points DOCKER_HOST at the rootless Podman socket but still
  * drives the managed registry — and the rest of onboarding's runtime preflight —
@@ -154,25 +159,75 @@ function portableHostGatewayAliasState(
   );
 }
 
+function retiredPortableHostGatewayAliasState(
+  output: string,
+): "absent" | "configured" | "conflicting" {
+  const parsed: unknown = JSON.parse(output);
+  if (!Array.isArray(parsed)) throw new Error("invalid address evidence");
+  const assignments: Array<{ interfaceName: string; prefix: number }> = [];
+  for (const interfaceEntry of parsed) {
+    if (
+      !isRecord(interfaceEntry) ||
+      typeof interfaceEntry.ifname !== "string" ||
+      interfaceEntry.ifname.length === 0 ||
+      !Array.isArray(interfaceEntry.addr_info)
+    ) {
+      throw new Error("invalid address evidence");
+    }
+    for (const addressEntry of interfaceEntry.addr_info) {
+      if (
+        !isRecord(addressEntry) ||
+        addressEntry.family !== "inet" ||
+        typeof addressEntry.local !== "string" ||
+        isIP(addressEntry.local) !== 4 ||
+        !Number.isInteger(addressEntry.prefixlen) ||
+        Number(addressEntry.prefixlen) < 0 ||
+        Number(addressEntry.prefixlen) > 32
+      ) {
+        throw new Error("invalid address evidence");
+      }
+      if (addressEntry.local === RETIRED_PORTABLE_HOST_GATEWAY_IP) {
+        assignments.push({
+          interfaceName: interfaceEntry.ifname,
+          prefix: Number(addressEntry.prefixlen),
+        });
+      }
+    }
+  }
+  if (assignments.length === 0) return "absent";
+  if (
+    assignments.length === 1 &&
+    assignments[0]?.interfaceName === "lo" &&
+    assignments[0].prefix === 32
+  ) {
+    return "configured";
+  }
+  return "conflicting";
+}
+
 function rejectRetiredPortableHostGatewayAlias(
   env: NodeJS.ProcessEnv,
   ip: NonNullable<PortableHostPreparationDeps["ip"]>,
 ): void {
-  const result = ip(["-o", "-4", "address", "show"], env);
+  const result = ip(["-j", "-4", "address", "show"], env);
   requireCommand(result, "Inspecting the retired portable host gateway address");
-  let state: "absent" | "configured";
+  let state: "absent" | "configured" | "conflicting";
   try {
-    state = portableHostGatewayAliasState(
-      String(result.stdout ?? ""),
-      RETIRED_PORTABLE_HOST_GATEWAY_IP,
-    );
+    state = retiredPortableHostGatewayAliasState(String(result.stdout ?? ""));
   } catch {
+    throw new Error(
+      "The retired portable host gateway address inspection returned invalid or ambiguous output. " +
+        "Refusing to change Portable networking; investigate the host address assignments, then rerun " +
+        "`nemoclaw onboard --experimental-profile portable`.",
+    );
+  }
+  if (state === "absent") return;
+  if (state === "conflicting") {
     throw new Error(
       `The retired portable host gateway address ${RETIRED_PORTABLE_HOST_GATEWAY_IP} has a conflicting host assignment. ` +
         "Resolve that assignment, then rerun `nemoclaw onboard --experimental-profile portable`.",
     );
   }
-  if (state === "absent") return;
   throw new Error(
     `The retired portable host gateway address ${RETIRED_PORTABLE_HOST_GATEWAY_IP}/32 is still assigned to loopback. ` +
       `Remove it with \`sudo ip address delete ${RETIRED_PORTABLE_HOST_GATEWAY_IP}/32 dev lo\`, then rerun ` +

--- a/test/e2e/live/portable-cpu-delegation-proof.test.ts
+++ b/test/e2e/live/portable-cpu-delegation-proof.test.ts
@@ -154,6 +154,30 @@ function proveAdmission(
       commandResult(0, `1 true ${PORTABLE_REGISTRY_IP}`),
     ],
   ]);
+  const ipResults: ReadonlyMap<string, readonly [string, SpawnResult]> = new Map([
+    [
+      JSON.stringify(["-j", "-4", "address", "show"]),
+      [
+        "retired portable host gateway address inspection",
+        commandResult(
+          0,
+          JSON.stringify([
+            {
+              ifname: "lo",
+              addr_info: [{ family: "inet", local: "127.0.0.1", prefixlen: 8 }],
+            },
+          ]),
+        ),
+      ],
+    ],
+    [
+      JSON.stringify(["-o", "-4", "address", "show"]),
+      [
+        "portable host gateway address inspection",
+        commandResult(0, `1: lo    inet ${PORTABLE_HOST_GATEWAY_IP}/32 scope global lo\n`),
+      ],
+    ],
+  ]);
   try {
     const prepared = preparePortableExperimentalHost(
       { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
@@ -190,9 +214,10 @@ function proveAdmission(
           return result;
         },
         ip: (args) => {
-          assert.deepEqual(args, ["-o", "-4", "address", "show"]);
-          effects.push("portable host gateway address inspection");
-          return commandResult(0, `1: lo    inet ${PORTABLE_HOST_GATEWAY_IP}/32 scope global lo\n`);
+          const result = ipResults.get(JSON.stringify(args));
+          assert.ok(result, `Unexpected host address proof command: ${args.join(" ")}`);
+          effects.push(result[0]);
+          return result[1];
         },
         sudo: () => assert.fail("Existing portable host gateway address must not require sudo."),
       },

--- a/test/e2e/support/podman-cpu-proof-workflow.test.ts
+++ b/test/e2e/support/podman-cpu-proof-workflow.test.ts
@@ -946,7 +946,7 @@ describe("native Podman CPU proof workflow", () => {
       expect(fs.readFileSync(githubEnv, "utf8")).toBe("");
 
       const cleanup = namedStep("Clean up rootless Podman runtime").run ?? "";
-      const gatewayCleanupStart = cleanup.indexOf('portable_host_gateway_ip=""');
+      const gatewayCleanupStart = cleanup.indexOf("# gateway-alias-cleanup");
       expect(gatewayCleanupStart).toBeGreaterThanOrEqual(0);
       const gatewayCleanup = cleanup.slice(gatewayCleanupStart);
       const runCleanup = async (env: NodeJS.ProcessEnv) => {
@@ -958,7 +958,7 @@ describe("native Podman CPU proof workflow", () => {
             clearTimeout(timer);
             resolve(true);
           });
-          timer = setTimeout(() => resolve(false), 1_000);
+          timer = setTimeout(() => resolve(false), 10_000);
         });
         const result = run(gatewayCleanup, {
           ...env,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

PR #9641 separated the Portable host gateway from the sandbox subnet, but its final upgrade-safety repair was not included in the merge.
This post-merge correction makes evidence for the retired `169.254.1.2/32` alias fail closed before Portable network mutation and documents the exact operator recovery path.

## Related Issue

Follow-up to merged #9641 for closed #9587.

## Changes

- Inspect host IPv4 assignments with `ip -j -4 address show` and validate the complete JSON shape before treating the retired gateway alias as absent.
- Reject command failures, malformed evidence, conflicting assignments, and multiple target assignments before Portable network, loopback alias, registry, or privileged mutation.
- Tell operators to remove only the exact retired `169.254.1.2/32` loopback assignment reported by onboarding, then rerun Portable onboarding; other interfaces or prefixes require investigation.
- Keep rootless Podman service cleanup independent of gateway-authority lookup, give the behavioral test a stable cleanup marker, and allow ten seconds for service termination on loaded CI runners.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent nine-category security review and independent five-gate regression review both passed exact commit `532b60a43273f5457a97fc08796c5df2c313ada5` with no findings
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: the inherited `env-var-docs` pre-commit failure is narrowly waived because current main documents `NEMOCLAW_BEDROCK_RUNTIME_ADAPTER_PORT` and `NEMOCLAW_HTTPS_PIN_RUNTIME_ADAPTER_PORT` while retaining their stale allowlist entries; this PR changes neither affected file, and a separate maintainer-owned follow-up owns that cleanup

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Security Review

- Result: PASS with no findings across all nine categories.
- Reviewed commit: `532b60a43273f5457a97fc08796c5df2c313ada5`.
- Scope: retired-alias evidence parsing, pre-mutation failure boundaries, privileged command guidance, #9578 ordering, #9632 listener constraints, rootless Podman socket ownership, workflow cleanup, and unchanged authentication and TLS boundaries.

## Independent Regression Review

- Result: PASS on all five publication gates.
- Reviewed commit: `532b60a43273f5457a97fc08796c5df2c313ada5`.
- Exact patch: six paths, 227 insertions, 28 deletions; tree `500acf1a90e73fe132c0e31f23e06a44d104127d`; current-main binary diff SHA-256 `f9b4df4178ac034303521c2421c0ee5f7549d79c00f4344f9eb6283a5153892e`.

## Documentation Writer Review

- [x] Independent documentation writer review completed
- Result: `docs-updated`; PASS with no findings.
- Evidence: the owning endpoint page and generated OpenClaw, Hermes, and LangChain Deep Agents Code variants were reviewed at exact commit `532b60a43273f5457a97fc08796c5df2c313ada5`. The test-only repair needs no additional documentation; agent-variant synchronization and the docs build passed with 0 errors and 2 pre-existing warnings.
- Review surface: exact retired-loopback cleanup, conflicting-interface and prefix safety boundary, Portable onboarding retry, and all three generated agent command variants.
<!-- docs-review-head-sha: 532b60a43 -->
<!-- docs-review-agents-blob-sha: 513518cdf -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — commitlint and pre-push passed; every applicable pre-commit hook passed except the narrowly waived inherited current-main `env-var-docs` failure recorded above
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: focused CLI 46 tests, E2E-support 29 tests, E2E phase selection 131 tests across 86 files, and growth guardrails 32 tests passed; the exact live proof loaded successfully and was skipped because its Linux/systemd target is unavailable locally
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: a full broad suite is not applicable to this six-file post-merge correction; CLI typecheck, repository checks, source-shape check, exact diff check, focused runtime lanes, and deterministic workflow gates passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors and 2 pre-existing warnings
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Portable onboarding detection of stale or conflicting gateway assignments.
  - Added validation for malformed or ambiguous network address information with actionable errors.
  - Improved cleanup verification reliability and increased the service-stop timeout for runtime cleanup checks.
  - Preserved correct handling of current gateway assignments while identifying retired or conflicting configurations.

- **Documentation**
  - Added guidance for safely removing stale loopback assignments before rerunning Portable onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->