### PR TITLE
fix(onboard): bound WSL Ollama host probes

### DIFF
--- a/src/lib/onboard/provider-host-state.test.ts
+++ b/src/lib/onboard/provider-host-state.test.ts
@@ -65,18 +65,19 @@ function detectWithDeps(
 }
 
 describe("detectInferenceProviderHostState", () => {
-  it("suppresses local endpoint probes when route preflight disallows them (#6315)", () => {
+  it("suppresses local and Windows-host Ollama probes when provider discovery disables them (#6315, #9604)", () => {
     const runCapture = vi.fn<DetectInferenceProviderHostStateDeps["runCapture"]>(() => "{}");
     const findReachableOllamaHost = vi.fn(() => "127.0.0.1");
+    const detectWindowsHostOllama = vi.fn(() => ({
+      installed: true,
+      installedPath: "C:\\Ollama\\ollama.exe",
+      loopbackOnly: false,
+    }));
     const deps = buildDeps({
       runCapture,
       findReachableOllamaHost,
       isWsl: vi.fn(() => true),
-      detectWindowsHostOllama: vi.fn(() => ({
-        installed: true,
-        installedPath: "C:\\Ollama\\ollama.exe",
-        loopbackOnly: false,
-      })),
+      detectWindowsHostOllama,
     });
 
     const state = detectInferenceProviderHostState({
@@ -91,6 +92,7 @@ describe("detectInferenceProviderHostState", () => {
     });
 
     expect(findReachableOllamaHost).not.toHaveBeenCalled();
+    expect(detectWindowsHostOllama).not.toHaveBeenCalled();
     expect(state.ollamaRunning).toBe(false);
     expect(state.vllmRunning).toBe(false);
     expect(state.windowsOllamaReachable).toBe(false);

--- a/src/lib/onboard/provider-host-state.ts
+++ b/src/lib/onboard/provider-host-state.ts
@@ -253,7 +253,10 @@ export function detectInferenceProviderHostState(
   const windowsHostOllamaDockerRequirement = deps.getWindowsHostOllamaDockerRequirement(
     isWsl ? deps.getContainerRuntime() : null,
   );
-  const winOllamaState = deps.detectWindowsHostOllama();
+  const winOllamaState =
+    input.probeOllama === false
+      ? { installed: false, installedPath: "", loopbackOnly: false }
+      : deps.detectWindowsHostOllama();
   const hasWindowsOllama = winOllamaState.installed;
   const windowsOllamaReachable =
     input.probeOllama === false

--- a/src/lib/onboard/windows-host-ollama.test.ts
+++ b/src/lib/onboard/windows-host-ollama.test.ts
@@ -3,10 +3,13 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const runCapture = vi.fn<(cmd: readonly string[]) => string>(() => "");
+const runCapture = vi.fn<typeof import("../runner").runCapture>(() => "");
 
 vi.mock("../runner", () => ({
-  runCapture: (cmd: readonly string[]) => runCapture(cmd),
+  runCapture: (
+    cmd: readonly string[],
+    options?: Parameters<typeof import("../runner").runCapture>[1],
+  ) => runCapture(cmd, options),
 }));
 
 vi.mock("../platform", () => ({
@@ -60,5 +63,23 @@ describe("detectWindowsHostOllama", () => {
       installedPath: "",
       loopbackOnly: false,
     });
+  });
+
+  it("bounds each Windows-host PowerShell probe when the host does not respond (#9604)", () => {
+    const installedPath = "C:\\Users\\tester\\AppData\\Local\\Programs\\Ollama\\ollama.exe";
+    const outputs = [installedPath, "42", "127.0.0.1"];
+    runCapture.mockImplementation(() => outputs.shift() ?? "");
+
+    expect(detectWindowsHostOllama()).toEqual({
+      installed: true,
+      installedPath,
+      loopbackOnly: true,
+    });
+    expect(runCapture).toHaveBeenCalledTimes(3);
+    expect(runCapture.mock.calls.map(([, options]) => options)).toEqual([
+      { ignoreError: true, timeout: 5_000 },
+      { ignoreError: true, timeout: 5_000 },
+      { ignoreError: true, timeout: 5_000 },
+    ]);
   });
 });

--- a/src/lib/onboard/windows-host-ollama.test.ts
+++ b/src/lib/onboard/windows-host-ollama.test.ts
@@ -55,7 +55,7 @@ describe("detectWindowsHostOllama", () => {
     expect(runCapture).not.toHaveBeenCalled();
   });
 
-  it("returns uninstalled when all Windows Ollama probes miss", () => {
+  it("returns absent state when Windows-host probes do not respond (#9604)", () => {
     runCapture.mockImplementation(() => "");
 
     expect(detectWindowsHostOllama({ isWsl: () => true, runCapture })).toEqual({
@@ -63,17 +63,23 @@ describe("detectWindowsHostOllama", () => {
       installedPath: "",
       loopbackOnly: false,
     });
+    expect(runCapture).toHaveBeenCalledTimes(3);
+    expect(runCapture.mock.calls.map(([, options]) => options)).toEqual([
+      { ignoreError: true, timeout: 5_000 },
+      { ignoreError: true, timeout: 5_000 },
+      { ignoreError: true, timeout: 5_000 },
+    ]);
   });
 
-  it("bounds each Windows-host PowerShell probe when the host does not respond (#9604)", () => {
+  it("continues when the Windows-host port probe does not respond (#9604)", () => {
     const installedPath = "C:\\Users\\tester\\AppData\\Local\\Programs\\Ollama\\ollama.exe";
-    const outputs = [installedPath, "42", "127.0.0.1"];
+    const outputs = [installedPath, "42", ""];
     runCapture.mockImplementation(() => outputs.shift() ?? "");
 
     expect(detectWindowsHostOllama()).toEqual({
       installed: true,
       installedPath,
-      loopbackOnly: true,
+      loopbackOnly: false,
     });
     expect(runCapture).toHaveBeenCalledTimes(3);
     expect(runCapture.mock.calls.map(([, options]) => options)).toEqual([

--- a/src/lib/onboard/windows-host-ollama.ts
+++ b/src/lib/onboard/windows-host-ollama.ts
@@ -20,6 +20,7 @@ export interface WindowsHostOllamaState {
 }
 
 const POWERSHELL = "powershell.exe";
+const WINDOWS_HOST_OLLAMA_PROBE_TIMEOUT_MS = 5_000;
 
 const GET_COMMAND_OLLAMA =
   "Get-Command ollama.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source";
@@ -55,7 +56,12 @@ function resolveDeps(
 }
 
 function powershell(script: string, deps: DetectWindowsHostOllamaDeps): string {
-  return deps.runCapture([POWERSHELL, "-Command", script], { ignoreError: true }).trim();
+  return deps
+    .runCapture([POWERSHELL, "-Command", script], {
+      ignoreError: true,
+      timeout: WINDOWS_HOST_OLLAMA_PROBE_TIMEOUT_MS,
+    })
+    .trim();
 }
 
 function probeInstalledPath(deps: DetectWindowsHostOllamaDeps): string {
@@ -78,9 +84,7 @@ function probeInstalledPath(deps: DetectWindowsHostOllamaDeps): string {
 function probeLoopbackOnly(deps: DetectWindowsHostOllamaDeps): boolean {
   const pid = powershell(GET_PROCESS_OLLAMA_ID, deps);
   if (!pid) return false;
-  const listenAddrs = deps.runCapture([POWERSHELL, "-Command", GET_NETTCP_OLLAMA_LISTEN], {
-    ignoreError: true,
-  });
+  const listenAddrs = powershell(GET_NETTCP_OLLAMA_LISTEN, deps);
   return /127\.0\.0\.1/.test(listenAddrs) && !/0\.0\.0\.0|^::\s*$/m.test(listenAddrs);
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
On WSL, onboarding could block indefinitely while optional Windows-host Ollama discovery waited for PowerShell, including when hosted inference was selected.
This change skips Ollama discovery when provider discovery disables it and bounds every read-only Windows-host probe at five seconds.

## Related Issue
Fixes #9604.

## Changes
- Honor the existing `probeOllama: false` decision for Windows-host Ollama discovery.
- Apply a five-second timeout to every read-only PowerShell command in Windows-host Ollama discovery. A timeout or command failure now returns no detection evidence so onboarding can continue.
- Add regression tests that fail when provider discovery still invokes the disabled probe or any discovery PowerShell command lacks the timeout.
- Record the escaped-defect prevention at the source boundary. The earlier tests covered probe results but did not require a process timeout or assert that hosted inference skipped Windows-host discovery.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior, justification:
- [ ] Tests not applicable, justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded, reviewer/approval link/justification: The implementation review covered the WSL-to-Windows read-only process boundary. Commands use static argv, carry no credentials, make no external writes, and treat timeout or command failure as absent detection evidence.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer, check name, approval link, and follow-up issue:

## Documentation Writer Review
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: This repairs failure containment for an internal optional probe. It does not change a command, configuration, supported inference provider, or documented output.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 96a2e5bb0 -->
<!-- docs-review-agents-blob-sha: 513518cdf -->

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above, command/result or justification: `npx vitest run --config vitest.config.ts --project cli src/lib/onboard/windows-host-ollama.test.ts src/lib/onboard/provider-host-state.test.ts` passed 23/23. The timeout regression failed before the fix because all three PowerShell calls lacked `timeout`; the provider-state regression failed because `detectWindowsHostOllama` ran once with `probeOllama: false`.
- [ ] Applicable broad gate passed, `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes, command/result: Not run because this change updates two focused onboarding source units and their source tests. `npm run build:cli`, post-commit `npm run typecheck:cli`, `npm run checks:repository`, the 32-test growth-guardrail suite, and `npm run validate:pr` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows Ollama detection reliability with consistent five-second timeouts and error handling.
  - Correctly handles nonresponsive or incomplete detection responses without blocking provider discovery.
  - Prevented unnecessary Windows-host checks when Ollama probing is disabled.
  - Preserved existing provider discovery behavior when probing is enabled.
- **Tests**
  - Added coverage for disabled-probe behavior, timeout handling, nonresponsive probes, and successful Windows Ollama detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->