### PR TITLE
fix(onboard): inject Docker executable into state mutation harness

### DIFF
--- a/src/lib/onboard/runtime-provider/docker-operation-authority.test.ts
+++ b/src/lib/onboard/runtime-provider/docker-operation-authority.test.ts
@@ -343,6 +343,16 @@ describe("Docker operation authority", () => {
     );
   });
 
+  it("fails closed when the fixed PATH has no Docker executable", () => {
+    expect(() =>
+      createDockerOperationAuthority("sandbox-lifecycle", {
+        HOME: "/tmp/nemoclaw-home",
+        DOCKER_HOST: "unix:///tmp/nemoclaw-docker.sock",
+        PATH: fakeExecutableRoot(),
+      }),
+    ).toThrow("Docker operation could not resolve one absolute Docker executable");
+  });
+
   it("rejects plaintext remote TCP before issuing a daemon command", () => {
     const capture = contextCapture("unix:///var/run/docker.sock");
 

--- a/src/lib/onboard/runtime-provider/docker-state-mutation.test.ts
+++ b/src/lib/onboard/runtime-provider/docker-state-mutation.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -51,6 +52,16 @@ afterEach(() => {
 });
 
 describe("Docker runtime-provider state mutation surface", () => {
+  it("uses one harness-owned absolute Docker executable", () => {
+    const runtime = harness();
+    runtime.authority.engine.capture(["version"]);
+    const executable = runtime.capture.mock.calls[0]?.[0] as string;
+
+    expect(path.isAbsolute(executable)).toBe(true);
+    expect(executable.startsWith(`${runtime.root}${path.sep}`)).toBe(true);
+    expect(runtime.context.environment).toMatchObject({ PATH: path.dirname(executable) });
+  });
+
   it("resolves one full labeled runtime and records authority only on synchronous acquire", () => {
     const runtime = harness();
     const surface = createDockerStateMutationSurface({

--- a/src/lib/onboard/runtime-provider/docker-state-mutation.test.ts
+++ b/src/lib/onboard/runtime-provider/docker-state-mutation.test.ts
@@ -58,8 +58,8 @@ describe("Docker runtime-provider state mutation surface", () => {
     const executable = runtime.capture.mock.calls[0]?.[0] as string;
 
     expect(path.isAbsolute(executable)).toBe(true);
-    expect(executable.startsWith(`${runtime.root}${path.sep}`)).toBe(true);
-    expect(runtime.context.environment).toMatchObject({ PATH: path.dirname(executable) });
+    expect(executable).toBe(fs.realpathSync(path.join(runtime.root, "bin", "docker")));
+    expect(runtime.context.environment).toMatchObject({ PATH: path.join(runtime.root, "bin") });
   });
 
   it("resolves one full labeled runtime and records authority only on synchronous acquire", () => {

--- a/test/helpers/docker-state-mutation-harness.ts
+++ b/test/helpers/docker-state-mutation-harness.ts
@@ -32,6 +32,7 @@ export const DOCKER_STATE_MUTATION_PROJECTION_SHA256 = "b".repeat(64);
 export const DOCKER_STATE_MUTATION_STATE_ROOT = "/sandbox/.hermes";
 export const DOCKER_STATE_MUTATION_LIFECYCLE_GENERATION = "generation-7";
 const SANDBOX_ID = "sandbox-alpha-id";
+const DOCKER_EXECUTABLE_SOURCE = "#!/bin/sh\nexit 1\n";
 const PODMAN_EXECUTABLE_BYTES = Buffer.from("qualified-podman-state-mutation", "utf8");
 const PODMAN_SOCKET_AUTHORITY = {
   directoryChain: [],
@@ -80,6 +81,13 @@ function temporaryRoot(): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-docker-state-mutation-"));
   roots.push(root);
   return root;
+}
+
+function createDockerExecutableSearchPath(root: string): string {
+  const directory = path.join(root, "bin");
+  fs.mkdirSync(directory, { mode: 0o700 });
+  fs.writeFileSync(path.join(directory, "docker"), DOCKER_EXECUTABLE_SOURCE, { mode: 0o700 });
+  return directory;
 }
 
 export function cleanupDockerStateMutationRoots(): void {
@@ -375,6 +383,7 @@ function createContainerStateMutationHarness(
           HOME: "/tmp/nemoclaw-home",
           DOCKER_CONFIG: "/tmp/nemoclaw-docker",
           DOCKER_HOST: "unix:///tmp/nemoclaw-docker.sock",
+          PATH: createDockerExecutableSearchPath(root),
         }
       : { HOME: "/tmp/nemoclaw-home" };
   const dockerAuthority =


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Docker state-mutation test harness now creates one private Docker fixture executable under each temporary root and supplies only its directory as `PATH`. macOS and WSL hosts without Docker can reach the state-mutation assertions. Production executable qualification is unchanged, and a fixed `PATH` without Docker still fails closed.

E2E root cause: docker-state-mutation harness / operation-authority construction / missing injected absolute Docker executable on macOS and WSL
Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/32312339289 (run 32312339289, attempt 1)
Failed jobs: WSL compatibility (1/4) (96257900847, https://github.com/NVIDIA/NemoClaw/actions/runs/32312339289/job/96257900847), macOS compatibility (1/4) (96257900908, https://github.com/NVIDIA/NemoClaw/actions/runs/32312339289/job/96257900908)
Signature: `Docker operation could not resolve one absolute Docker executable.` at `docker-operation-authority.ts:379`
Scope: one root cause

## Changes

- Create a mode-0700 Docker fixture executable beneath each harness temporary root and inject its directory as the harness `PATH`.
- Assert that the operation authority captures the exact harness-owned absolute executable.
- Preserve explicit negative coverage for a fixed `PATH` that has no Docker executable.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent security review of `0f609b2d49fdbf10d04307dac408431e73e193b2` passed all nine categories with no findings. Production authority code is unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- Result: `no-docs-needed`
- Evidence: The change is limited to tests and a test helper. The existing trust-boundary page already documents qualified absolute Docker executables and the fixed `PATH` contract. No command, flag, default, configuration, API, protocol, policy schema, or supported user-visible behavior changes.
- Reviewed commit: `0f609b2d49fdbf10d04307dac408431e73e193b2`

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — Docker-free `PATH`: `docker-state-mutation.test.ts` passed 30/30; related deterministic authority and state-mutation tests passed 101/101; `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; the correction is confined to a deterministic test helper and focused CLI tests. Normal hooks and PR CI provide the broader gates.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker runtime safety by ensuring operations fail closed when no valid Docker executable is available.
  * Ensured Docker execution uses the intended absolute executable, preventing unintended binaries from being selected through `PATH`.

* **Tests**
  * Added coverage for invalid Docker executable configurations and controlled executable resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->