### PR TITLE
test(windows): use Windows Docker path fixtures

### DIFF
--- a/test/bootstrap-windows.test.ts
+++ b/test/bootstrap-windows.test.ts
@@ -112,19 +112,17 @@ $script:events | ConvertTo-Json -Compress
     "resolves the per-user Docker Desktop path when no machine-wide install exists (#9087)",
     `
 $ErrorActionPreference = 'Stop'
-$env:ProgramFiles = 'C:\\Program Files'
 $env:LOCALAPPDATA = 'C:\\Users\\tester\\AppData\\Local'
 . ${JSON.stringify(BOOTSTRAP_WINDOWS)}
 
-$machineExe = 'C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe'
+$script:DockerDesktopMachineRoot = 'C:\\Program Files\\Docker\\Docker'
 $userExe = 'C:\\Users\\tester\\AppData\\Local\\Programs\\DockerDesktop\\Docker Desktop.exe'
 
 function Test-Path { param([string]$LiteralPath) return $LiteralPath -eq $userExe }
 
 [pscustomobject]@{
-    matchesUserInstall = ((Resolve-DockerDesktopPath -Component 'Desktop') -eq $userExe)
-    machineCheckedFirst = ((Get-DockerDesktopCandidatePath -Component 'Desktop')[0] -eq $machineExe)
-    candidateCount = @(Get-DockerDesktopCandidatePath -Component 'Desktop').Count
+    resolvedPath = Resolve-DockerDesktopPath -Component 'Desktop'
+    candidatePaths = @(Get-DockerDesktopCandidatePath -Component 'Desktop')
 } | ConvertTo-Json -Compress
 `,
     (result) => {
@@ -132,9 +130,12 @@ function Test-Path { param([string]$LiteralPath) return $LiteralPath -eq $userEx
       expect(result.stderr).toBe("");
       const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
       expect(parsed).toEqual({
-        matchesUserInstall: true,
-        machineCheckedFirst: true,
-        candidateCount: 2,
+        resolvedPath:
+          "C:\\Users\\tester\\AppData\\Local\\Programs\\DockerDesktop\\Docker Desktop.exe",
+        candidatePaths: [
+          "C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe",
+          "C:\\Users\\tester\\AppData\\Local\\Programs\\DockerDesktop\\Docker Desktop.exe",
+        ],
       });
     },
   );
@@ -143,23 +144,24 @@ function Test-Path { param([string]$LiteralPath) return $LiteralPath -eq $userEx
     "returns the machine-wide Docker Desktop path when both locations contain an install (#9087)",
     `
 $ErrorActionPreference = 'Stop'
-$env:ProgramFiles = 'C:\\Program Files'
 $env:LOCALAPPDATA = 'C:\\Users\\tester\\AppData\\Local'
 . ${JSON.stringify(BOOTSTRAP_WINDOWS)}
 
-$machineCli = 'C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe'
+$script:DockerDesktopMachineRoot = 'C:\\Program Files\\Docker\\Docker'
 
 function Test-Path { param([string]$LiteralPath) return $true }
 
 [pscustomobject]@{
-    matchesMachineInstall = ((Resolve-DockerDesktopPath -Component 'Cli') -eq $machineCli)
+    resolvedPath = Resolve-DockerDesktopPath -Component 'Cli'
 } | ConvertTo-Json -Compress
 `,
     (result) => {
       expect(result.status).toBe(0);
       expect(result.stderr).toBe("");
       const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
-      expect(parsed).toEqual({ matchesMachineInstall: true });
+      expect(parsed).toEqual({
+        resolvedPath: "C:\\Program Files\\Docker\\Docker\\resources\\bin\\docker.exe",
+      });
     },
   );
 
@@ -170,8 +172,16 @@ $ErrorActionPreference = 'Stop'
 $env:ProgramFiles = 'C:\\Users\\tester\\attacker-controlled'
 . ${JSON.stringify(BOOTSTRAP_WINDOWS)}
 
+$trustedProgramFiles = [Environment]::GetFolderPath([Environment+SpecialFolder]::ProgramFiles)
+$trustedMachineRoot = if ($trustedProgramFiles) {
+    "$trustedProgramFiles\\Docker\\Docker"
+} else {
+    'C:\\Program Files\\Docker\\Docker'
+}
+
 [pscustomobject]@{
     machineRoot = $script:DockerDesktopMachineRoot
+    trustedMachineRoot = $trustedMachineRoot
     usesCallerPath = $script:DockerDesktopMachineRoot.StartsWith($env:ProgramFiles, [System.StringComparison]::OrdinalIgnoreCase)
 } | ConvertTo-Json -Compress
 `,
@@ -180,7 +190,7 @@ $env:ProgramFiles = 'C:\\Users\\tester\\attacker-controlled'
       expect(result.stderr).toBe("");
       const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
       expect(parsed.usesCallerPath).toBe(false);
-      expect(parsed.machineRoot).toBe("C:\\Program Files\\Docker\\Docker");
+      expect(parsed.machineRoot).toBe(parsed.trustedMachineRoot);
     },
   );
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make the Windows bootstrap tests use explicit Windows Docker Desktop path fixtures instead of host-platform path semantics on macOS. Production Windows bootstrap behavior is unchanged, and the caller-controlled `ProgramFiles` rejection contract remains intact.

## Changes

- Pin Docker Desktop machine and per-user candidate assertions to exact Windows paths.
- Assert the selected Docker CLI path with Windows semantics.
- Keep the poisoned-`ProgramFiles` test tied to the trusted .NET system folder result.

E2E root cause: bootstrap-windows tests / Docker Desktop path assertions / host-platform path semantics on macOS

Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/32312339289 (run 32312339289, attempt 1)

Failed jobs: macOS compatibility (1/4) (96257900908, https://github.com/NVIDIA/NemoClaw/actions/runs/32312339289/job/96257900908)

Signature: `test/bootstrap-windows.test.ts` reported three failures because macOS PowerShell resolved the machine root through host-platform semantics while the tests expected Windows Docker Desktop paths.

Scope: one root cause

Independent documentation writer review: no docs needed. Only test expectations changed; production behavior and user-visible contracts are unchanged.

Independent security review: PASS across all nine categories at `4fa8f85a634cf9dcfae2a57f44829fdbcfa43599...b3ac10b06f469f474aa57d99e9572d4346580c0c`. The test-only diff preserves the trusted `.NET` `ProgramFiles` source and changes no production trust boundary or executable-authority behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — independent nine-category review PASS; the test-only diff preserves caller-controlled `ProgramFiles` rejection and changes no production path.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/bootstrap-windows.test.ts` collected all 32 cases locally, but skipped them because PowerShell is unavailable. PR CI is the required execution gate.
- [ ] Applicable broad gate passed — not applicable; this scoped test correction does not change runtime or test-harness behavior.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Windows bootstrap coverage for Docker Desktop discovery.
  * Added validation that privileged discovery uses the trusted system installation path.
  * Improved checks for machine-root configuration and resolved paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->