### PR TITLE
fix(e2e): compile managed inference catalogue for Portable rootless tests

### DIFF
--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -54,6 +54,9 @@ jobs:
       - name: Install root dependencies
         run: npm ci --ignore-scripts
 
+      - name: Compile managed-inference catalogue
+        run: npm run catalog:compile
+
       - name: Build shared policy boundary
         run: npm run build:policy-boundary
 

--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Install root dependencies
         run: npm ci --ignore-scripts
 
-      - name: Compile managed-inference catalogue
+      - name: Compile managed inference catalogue
         run: npm run catalog:compile
 
       - name: Build shared policy boundary

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -63,7 +63,7 @@
     },
     {
       "file": "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",
-      "test": "compiles the managed-inference catalogue after dependencies and before the live test (#9680)",
+      "test": "compiles the managed inference catalogue after dependency installation and before the live E2E test (#9680)",
       "category": "compatibility"
     },
     {

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -62,6 +62,11 @@
       "category": "security"
     },
     {
+      "file": "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",
+      "test": "compiles the managed-inference catalogue after dependencies and before the live test (#9680)",
+      "category": "compatibility"
+    },
+    {
       "file": "test/growth-guardrails-workflow-boundary.test.ts",
       "test": "runs the trusted Vitest guardrails against pull request data",
       "category": "security"

--- a/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
+++ b/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
@@ -13,8 +13,8 @@ function rootlessLinuxStep(name: string): WorkflowStep {
 }
 
 describe("portable profile rootless runtime workflow", () => {
-  // source-shape-contract: compatibility -- Rootless Vitest must compile the exact candidate catalogue before imports run
-  it("compiles the managed-inference catalogue after dependencies and before the live test (#9680)", () => {
+  // source-shape-contract: compatibility -- The rootless workflow must compile the exact candidate managed inference catalogue before the live E2E test imports it
+  it("compiles the managed inference catalogue after dependency installation and before the live E2E test (#9680)", () => {
     const workflow = readYaml<Workflow>(".github/workflows/portable-profile-e2e.yaml");
     const steps = workflow.jobs["rootless-linux"]?.steps ?? [];
     const dependencyInstallIndex = steps.findIndex(

--- a/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
+++ b/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
@@ -13,6 +13,23 @@ function rootlessLinuxStep(name: string): WorkflowStep {
 }
 
 describe("portable profile rootless runtime workflow", () => {
+  // source-shape-contract: compatibility -- Rootless Vitest must compile the exact candidate catalogue before imports run
+  it("compiles the managed-inference catalogue after dependencies and before the live test (#9680)", () => {
+    const workflow = readYaml<Workflow>(".github/workflows/portable-profile-e2e.yaml");
+    const steps = workflow.jobs["rootless-linux"]?.steps ?? [];
+    const dependencyInstallIndex = steps.findIndex(
+      (step) => step.name === "Install root dependencies",
+    );
+    const catalogueCompileIndex = steps.findIndex((step) => step.run === "npm run catalog:compile");
+    const liveTestIndex = steps.findIndex(
+      (step) => step.name === "Exercise portable profile in the rootless environment",
+    );
+
+    expect(dependencyInstallIndex).toBeGreaterThanOrEqual(0);
+    expect(catalogueCompileIndex).toBeGreaterThan(dependencyInstallIndex);
+    expect(liveTestIndex).toBeGreaterThan(catalogueCompileIndex);
+  });
+
   it("uses Ubuntu's Podman package with its installed OCI runtime", () => {
     const provision = rootlessLinuxStep("Provision restricted rootless Linux runtime").run ?? "";
     const packageInstallIndex = provision.indexOf("sudo apt-get install");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Portable `rootless-linux` job now compiles the exact candidate managed inference catalogue before its live Vitest command. Previously, module import failed before test execution because `dist/managed-inference/catalog.json` did not exist.

E2E root cause: `Portable rootless workflow / test preparation / compiled managed inference catalogue is absent`
Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/32315705181 (run `32315705181`, attempt `1`)
Failed job: `rootless-linux` (`96267314399`, https://github.com/NVIDIA/NemoClaw/actions/runs/32315705181/job/96267314399)
Signature: `ENOENT` for `dist/managed-inference/catalog.json` during test-module import; Vitest reported zero tests
Scope: one root cause

## Related Issue

Fixes #9680

## Changes

- Run `npm run catalog:compile` after locked root dependency installation and before the Portable rootless live test.
- Add a deterministic contract that fails when managed inference catalogue compilation is absent or ordered after the live E2E test.
- Allowlist the workflow contract as a compatibility source-shape exception because GitHub Actions executes the ordered steps.

The change adds no dependency, retry, fallback, or alternate test path. It does not change the live test command.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent nine-category security review passed for latest PR commit `a123709d174a2814543e60646c173b0d35e0fbe5` against base `bae5c76e80e5a50bd73fbc1d799fa27ea6f25fbf`; no findings
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

Fail-first result: `vitest run --project e2e-support test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts` failed with `catalogueCompileIndex = -1`; one contract failed and one sibling contract passed.

Documentation disposition: public documentation is not required. This change prepares an existing experimental E2E job and does not change user-visible NemoClaw behavior.

Independent documentation review: `PASS` and `DOCS_NOT_NEEDED` for latest PR commit `a123709d174a2814543e60646c173b0d35e0fbe5`; no findings.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run clean:cli`, `npm run catalog:compile`, and `test -s dist/managed-inference/catalog.json` passed in sequence; `npx vitest run --project e2e-support test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts --reporter=verbose` passed 1 file and 2 tests; `npm run source-shape:check` and `npm run build:cli` passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable; the diff changes one workflow preparation step and its focused deterministic contract
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Latest PR commit: `a123709d174a2814543e60646c173b0d35e0fbe5`
PR base SHA: `bae5c76e80e5a50bd73fbc1d799fa27ea6f25fbf`

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage to verify the rootless portable-profile workflow performs required setup steps in the correct order.
  * Added compatibility coverage for compiling the managed inference catalogue before live workflow tests.

* **Chores**
  * Updated continuous integration workflows to compile the managed inference catalogue before building and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->