### PR TITLE
fix(status): stop attributing an upstream credential rejection to the sandbox route

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -2025,6 +2025,15 @@ It uses a 3-second connection timeout, a 5-second total timeout, and an 8-token 
 If the request reaches the time limit, NemoClaw reports the provider as `not probed` and leaves model health unverified instead of reporting it as unhealthy.
 These checks are diagnostic only and do not override the authoritative `inference.local` result or determine the command exit status.
 
+The `Inference (upstream)` check authenticates with the host credential that NemoClaw resolves for the provider, such as `NVIDIA_INFERENCE_API_KEY`.
+The gateway stores the provider credential that the sandbox route uses.
+The CLI cannot read the stored value back, so the two credentials can hold different secrets.
+When the `inference.local` route has already served the inference request, an `unauthorized` result on `Inference (upstream)` describes the host credential.
+NemoClaw then reports that check as `not probed` and names both credential sources.
+An `Inference (upstream)` check that fails for another reason, such as `unreachable`, still reports its own state.
+Local backend and auth proxy checks, such as `Inference (auth proxy)`, always report their own state and their own repair step.
+`$$nemoclaw <name> doctor` sends no inference request, so it always reports the `Inference (upstream)` state that it measured.
+
 Local providers add host-side backend diagnostics.
 For Local Ollama, the command can also print an `Inference (auth proxy)` diagnostic when a proxy token is available.
 Use these diagnostics to identify a failing auxiliary hop after checking the main `Inference` line.

--- a/src/lib/actions/sandbox/inference-route-health.ts
+++ b/src/lib/actions/sandbox/inference-route-health.ts
@@ -102,13 +102,43 @@ export async function probeSandboxInferenceGatewayHealth(
   };
 }
 
+/**
+ * The upstream probe authenticates with the host credential this command
+ * resolves. The gateway stores the provider credential the sandbox route uses
+ * and does not return its value, so the two can hold different secrets. Once
+ * the route has served an inference request, a provider rejection of the host
+ * credential reports nothing about the sandbox route. Local backend and auth
+ * proxy hops carry their own probeLabel and keep their own remediation.
+ */
+function unattributedUpstreamProbe(probe: ProviderHealthStatus): ProviderHealthStatus {
+  const { failureLabel: _failureLabel, ...rest } = probe;
+  return {
+    ...rest,
+    ok: true,
+    probed: false,
+    detail:
+      `${probe.providerLabel} rejected the host credential this command resolved. The sandbox ` +
+      "route served an inference request with the provider credential stored in the gateway, so " +
+      "NemoClaw does not attribute this result to the sandbox route.",
+  };
+}
+
 function providerHealthDiagnostics(
   providerHealth: ProviderHealthStatus | null,
+  routeServedRequest: boolean,
 ): ProviderHealthStatus[] {
   if (!providerHealth) return [];
   const { subprobes = [], ...primary } = providerHealth;
   const labeledPrimary = primary.probeLabel ? primary : { ...primary, probeLabel: "upstream" };
-  return [labeledPrimary, ...subprobes];
+  return [labeledPrimary, ...subprobes].map((probe) =>
+    routeServedRequest &&
+    probe.probeLabel === "upstream" &&
+    probe.probed &&
+    !probe.ok &&
+    probe.failureLabel === "unauthorized"
+      ? unattributedUpstreamProbe(probe)
+      : probe,
+  );
 }
 
 function classifyInferenceInvocationFailureLabel(
@@ -176,7 +206,7 @@ export function buildSandboxInferenceRouteHealth(
   invocation: SandboxInferenceInvocationResult | null,
 ): ProviderHealthStatus {
   const endpoint = gateway?.endpoint ?? "https://inference.local/v1/models";
-  const diagnostics = providerHealthDiagnostics(providerHealth);
+  const diagnostics = providerHealthDiagnostics(providerHealth, Boolean(invocation?.ok));
   let routeHealth: ProviderHealthStatus;
   if (gateway?.ok && invocation) {
     routeHealth = buildInvokedRouteHealth(gateway, endpoint, invocation);

--- a/src/lib/actions/sandbox/inference-route-health.ts
+++ b/src/lib/actions/sandbox/inference-route-health.ts
@@ -117,7 +117,7 @@ function unattributedUpstreamProbe(probe: ProviderHealthStatus): ProviderHealthS
     ok: true,
     probed: false,
     detail:
-      `${probe.providerLabel} rejected the host credential this command resolved. The sandbox ` +
+      `${probe.detail} The sandbox ` +
       "route served an inference request with the provider credential stored in the gateway, so " +
       "NemoClaw does not attribute this result to the sandbox route.",
   };

--- a/src/lib/actions/sandbox/status-snapshot-inference-health.test.ts
+++ b/src/lib/actions/sandbox/status-snapshot-inference-health.test.ts
@@ -443,7 +443,9 @@ describe("collectSandboxStatusSnapshot inference route health", () => {
       probed: true,
       providerLabel: "NVIDIA Endpoints",
       endpoint: "https://integrate.api.nvidia.com/v1/chat/completions",
-      detail: "model invocation probe rejected the credential",
+      detail:
+        "NVIDIA Endpoints rejected the host credential in NVIDIA_INFERENCE_API_KEY. " +
+        "Check NVIDIA_INFERENCE_API_KEY where you run this command.",
       failureLabel: "unauthorized",
     };
 
@@ -459,6 +461,7 @@ describe("collectSandboxStatusSnapshot inference route health", () => {
     expect(upstream).toMatchObject({ ok: true, probed: false });
     expect(upstream?.failureLabel).toBeUndefined();
     expect(upstream?.detail).toContain("rejected the host credential");
+    expect(upstream?.detail).toContain("NVIDIA_INFERENCE_API_KEY");
     expect(upstream?.detail).toContain("provider credential stored in the gateway");
     expect(upstream?.detail).toContain("does not attribute this result to the sandbox route");
   });

--- a/src/lib/actions/sandbox/status-snapshot-inference-health.test.ts
+++ b/src/lib/actions/sandbox/status-snapshot-inference-health.test.ts
@@ -371,7 +371,7 @@ describe("collectSandboxStatusSnapshot inference route health", () => {
     expect(snapshot.inferenceHealth?.failureLabel).toBeUndefined();
   });
 
-  it("keeps an upstream subprobe failure out of the served-route verdict (#6846)", async () => {
+  it("keeps an unreachable upstream subprobe failure out of the served-route verdict (#6846)", async () => {
     const gateway: SandboxInferenceRouteHealth = {
       ok: true,
       endpoint: "https://inference.local/v1/models",
@@ -385,7 +385,7 @@ describe("collectSandboxStatusSnapshot inference route health", () => {
       providerLabel: "NVIDIA Endpoints",
       endpoint: "https://integrate.api.nvidia.com/v1/chat/completions",
       detail: "model invocation probe failed",
-      failureLabel: "unauthorized",
+      failureLabel: "unreachable",
     };
 
     const snapshot = await collectSandboxStatusSnapshot(
@@ -428,6 +428,137 @@ describe("collectSandboxStatusSnapshot inference route health", () => {
     expect(snapshot.inferenceHealth?.subprobes).toContainEqual(
       expect.objectContaining({ probeLabel: "route reachability", ok: true }),
     );
+  });
+
+  it("reports the upstream check as not probed after the provider rejected the host credential and the route served a request (#9595)", async () => {
+    const gateway: SandboxInferenceRouteHealth = {
+      ok: true,
+      endpoint: "https://inference.local/v1/models",
+      httpStatus: 200,
+      detail:
+        "Inference gateway responded HTTP 200 on https://inference.local/v1/models (full chain reachable).",
+    };
+    const providerHealth: ProviderHealthStatus = {
+      ok: false,
+      probed: true,
+      providerLabel: "NVIDIA Endpoints",
+      endpoint: "https://integrate.api.nvidia.com/v1/chat/completions",
+      detail: "model invocation probe rejected the credential",
+      failureLabel: "unauthorized",
+    };
+
+    const snapshot = await collectSandboxStatusSnapshot(
+      "alpha",
+      snapshotDeps(gateway, providerHealth),
+    );
+
+    expect(snapshot.inferenceHealth).toMatchObject({ ok: true });
+    const upstream = snapshot.inferenceHealth?.subprobes?.find(
+      (subprobe) => subprobe.probeLabel === "upstream",
+    );
+    expect(upstream).toMatchObject({ ok: true, probed: false });
+    expect(upstream?.failureLabel).toBeUndefined();
+    expect(upstream?.detail).toContain("rejected the host credential");
+    expect(upstream?.detail).toContain("provider credential stored in the gateway");
+    expect(upstream?.detail).toContain("does not attribute this result to the sandbox route");
+  });
+
+  it("keeps an unreachable upstream check after the route served a request (#9595)", async () => {
+    const gateway: SandboxInferenceRouteHealth = {
+      ok: true,
+      endpoint: "https://inference.local/v1/models",
+      httpStatus: 200,
+      detail:
+        "Inference gateway responded HTTP 200 on https://inference.local/v1/models (full chain reachable).",
+    };
+    const providerHealth: ProviderHealthStatus = {
+      ok: false,
+      probed: true,
+      providerLabel: "NVIDIA Endpoints",
+      endpoint: "https://integrate.api.nvidia.com/v1/chat/completions",
+      detail: "model invocation probe could not reach the endpoint",
+      failureLabel: "unreachable",
+    };
+
+    const snapshot = await collectSandboxStatusSnapshot(
+      "alpha",
+      snapshotDeps(gateway, providerHealth),
+    );
+
+    expect(snapshot.inferenceHealth?.subprobes).toContainEqual({
+      ...providerHealth,
+      probeLabel: "upstream",
+    });
+  });
+
+  it("keeps an unauthorized auth proxy subprobe after the route served a request (#9595)", async () => {
+    const gateway: SandboxInferenceRouteHealth = {
+      ok: true,
+      endpoint: "https://inference.local/v1/models",
+      httpStatus: 200,
+      detail:
+        "Inference gateway responded HTTP 200 on https://inference.local/v1/models (full chain reachable).",
+    };
+    const authProxy: ProviderHealthStatus = {
+      ok: false,
+      probed: true,
+      providerLabel: "Local Ollama",
+      probeLabel: "auth proxy",
+      endpoint: "http://127.0.0.1:11435/api/tags",
+      detail:
+        "Ollama auth proxy returned 401 — the persisted token is no longer accepted. " +
+        "Re-run `nemoclaw onboard` (Ollama path) to rotate the proxy token.",
+      failureLabel: "unauthorized",
+    };
+    const providerHealth: ProviderHealthStatus = {
+      ok: true,
+      probed: true,
+      providerLabel: "Local Ollama",
+      probeLabel: "ollama backend",
+      endpoint: "http://127.0.0.1:11434/api/tags",
+      detail: "Local Ollama is reachable.",
+      subprobes: [authProxy],
+    };
+
+    const snapshot = await collectSandboxStatusSnapshot(
+      "alpha",
+      snapshotDeps(gateway, providerHealth),
+    );
+
+    expect(snapshot.inferenceHealth?.subprobes).toContainEqual(authProxy);
+  });
+
+  it("keeps an unauthorized upstream check when the route did not serve a request (#9595)", async () => {
+    const gateway: SandboxInferenceRouteHealth = {
+      ok: true,
+      endpoint: "https://inference.local/v1/models",
+      httpStatus: 401,
+      detail:
+        "Inference gateway responded HTTP 401 on https://inference.local/v1/models (full chain reachable).",
+    };
+    const providerHealth: ProviderHealthStatus = {
+      ok: false,
+      probed: true,
+      providerLabel: "NVIDIA Endpoints",
+      endpoint: "https://integrate.api.nvidia.com/v1/chat/completions",
+      detail: "model invocation probe rejected the credential",
+      failureLabel: "unauthorized",
+    };
+
+    const snapshot = await collectSandboxStatusSnapshot(
+      "alpha",
+      snapshotDeps(gateway, providerHealth, {
+        ok: false,
+        detail: "sandbox inference invocation probe returned HTTP 401",
+        httpStatus: 401,
+      }),
+    );
+
+    expect(snapshot.inferenceHealth).toMatchObject({ ok: false, failureLabel: "unauthorized" });
+    expect(snapshot.inferenceHealth?.subprobes).toContainEqual({
+      ...providerHealth,
+      probeLabel: "upstream",
+    });
   });
 
   it("does not send an agent request when the route probe already failed", async () => {

--- a/src/lib/inference/health.test.ts
+++ b/src/lib/inference/health.test.ts
@@ -444,6 +444,20 @@ describe("inference health", () => {
       expect(result?.failureLabel).toBe("unauthorized");
     });
 
+    it("names the host credential environment variable when the provider rejects the request (#9595)", () => {
+      const result = probeRemoteProviderHealth("nvidia-prod", {
+        model: "meta/llama-3.3-70b-instruct",
+        getCredentialImpl: () => "nvapi-stale",
+        runCurlProbeImpl: () => httpUnauthorized(),
+      });
+
+      expect(result?.failureLabel).toBe("unauthorized");
+      expect(result?.detail).toContain("rejected the");
+      expect(result?.detail).toContain("host credential in NVIDIA_INFERENCE_API_KEY");
+      expect(result?.detail).toContain("not the provider credential stored in the gateway");
+      expect(result?.detail).not.toContain("Check your network connection");
+    });
+
     it("reports unhealthy on a non-auth HTTP failure", () => {
       const result = probeRemoteProviderHealth("openai-api", {
         model: "gpt-4o-mini",

--- a/src/lib/inference/health.ts
+++ b/src/lib/inference/health.ts
@@ -420,6 +420,14 @@ function buildInvocationProbeDetail(
       `as proof that the model ran. (${result.message})`
     );
   }
+  if (classifyHealthProbeFailureLabel(result) === "unauthorized") {
+    return (
+      `${endpoint} rejected the ${route} request. ` +
+      `This probe authenticates with the host credential in ${credentialEnv}, not the provider ` +
+      `credential stored in the gateway. Check ${credentialEnv} where you run this command. ` +
+      `(${result.message})`
+    );
+  }
   return (
     `${route} at ${endpoint} did not succeed. ` +
     `Check your network connection or ${credentialEnv}. (${result.message})`


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`$$nemoclaw <name> status` reported `Inference (upstream): unauthorized (HTTP 401)` whenever the host credential it resolves differed from the provider credential the gateway stores, even though the sandbox route had already served the inference request with the stored credential. The upstream check now reports `not probed` in that case and names both credential sources, so the operator is no longer directed at a credential that is not in the failing path.

## Related Issue

Fixes #9595

## Changes

- `src/lib/actions/sandbox/inference-route-health.ts`: `providerHealthDiagnostics` takes whether the route served an inference request. When it did and the `upstream` check reports `unauthorized`, that check becomes `ok: true`, `probed: false` with a detail naming the host credential, the stored provider credential, and the fact that NemoClaw does not attribute the result to the sandbox route.
- `src/lib/actions/sandbox/inference-route-health.ts`: local backend and auth proxy hops carry their own `probeLabel`, so the rewrite is scoped to `upstream` and leaves `Inference (auth proxy)` and `Inference (vllm backend)` reporting their own state and their own repair step.
- `src/lib/inference/health.ts`: an `unauthorized` model-invocation result now names the endpoint as the actor, states that the probe authenticates with the host credential in the credential environment variable rather than the provider credential stored in the gateway, and drops the network-connection advice that does not apply to a rejected credential.
- `docs/reference/commands.mdx`: states which credential each host-side check uses, why the two credentials can hold different secrets, when `Inference (upstream)` reports `not probed`, and that `doctor` always reports the state it measured because it sends no inference request.
- `src/lib/actions/sandbox/status-snapshot-inference-health.test.ts`: four tests covering the `not probed` rewrite, an unreachable upstream check, an unauthorized auth proxy subprobe, and an unauthorized upstream check when the route did not serve a request.
- `src/lib/inference/health.test.ts`: one test asserting the reworded `unauthorized` detail.

The rewrite is a reporting decision rather than a new fallback path, so its current requirement, consumer, and protecting test are:

- Current requirement: the OpenShell gateway is the system of record for provider credentials and does not return their values (`src/lib/credentials/store.ts`), so a host-side probe cannot authenticate with the credential the sandbox route uses. It can only report on the credential it resolves.
- Consumer: `buildSandboxInferenceRouteHealth`, reached from `collectSandboxStatusSnapshot` for `$$nemoclaw <name> status`.
- Why a direct change is insufficient: authenticating the probe with the stored provider credential would require a gateway path that returns credential values, which the credential design refuses.
- Protecting test: `reports the upstream check as not probed after the provider rejected the host credential and the route served a request (#9595)` and `keeps an unauthorized auth proxy subprobe after the route served a request (#9595)` in `src/lib/actions/sandbox/status-snapshot-inference-health.test.ts`.

One existing test changed. `keeps an upstream subprobe failure out of the served-route verdict (#6846)` used an `unauthorized` fixture, which is the exact reporting this change corrects. Its fixture is now `unreachable` and its title names that failure, so it still protects the #6846 contract that an upstream failure does not flip the served-route verdict.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: https://github.com/NVIDIA/NemoClaw/pull/9692#issuecomment-5351357491
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/actions/sandbox/status-snapshot-inference-health.test.ts src/lib/inference/health.test.ts src/lib/actions/sandbox/status-flow.test.ts src/lib/actions/sandbox/doctor-inference.test.ts` — 4 files, 145 passed. `npm run typecheck:cli` — 0 errors. `npm run docs` — fern check reports 0 errors and 2 warnings that main already reports.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inference health reporting when upstream providers reject credentials or cannot be reached.
  - Diagnostics now distinguish host credentials from gateway-stored credentials.
  - Unauthorized upstream results are handled separately when the sandbox route successfully serves an inference request.
  - Status and doctor checks now report route health and auxiliary provider failures independently.

- **Documentation**
  - Expanded command documentation with details about credential authentication, upstream failures, and differences between `status` and `doctor` diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

