### PR TITLE
fix(e2e): pin Portable rootless Podman runtime

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+self-hosted-runner:
+  labels:
+    - ubuntu-26.04

--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -37,8 +37,10 @@ concurrency:
 
 jobs:
   rootless-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 25
+    env:
+      PODMAN_APT_VERSION: "5.7.0+ds2-3build1"
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -70,14 +72,17 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install --yes fuse-overlayfs passt podman slirp4netns uidmap
-          package_podman="/usr/bin/podman"
-          test -x "$package_podman"
-          runtime_bin="$(mktemp -d "${RUNNER_TEMP}/nemoclaw-rootless-runtime.XXXXXX")"
-          ln -s "$package_podman" "$runtime_bin/podman"
-          export PATH="$runtime_bin:$PATH"
-          printf '%s\n' "$runtime_bin" >> "$GITHUB_PATH"
-          test "$(readlink -f "$(command -v podman)")" = "$package_podman"
+          sudo apt-get install --yes \
+            apparmor \
+            fuse-overlayfs \
+            passt \
+            slirp4netns \
+            uidmap \
+            "podman=$PODMAN_APT_VERSION"
+          package_version="$(dpkg-query --show --showformat='${Version}' podman)"
+          version="$(podman --version)"
+          test "$package_version" = "$PODMAN_APT_VERSION"
+          test "$version" = "podman version 5.7.0"
           runtime_dir="/run/user/$(id -u)"
           sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" "$runtime_dir"
           if ! grep -q "^${USER}:" /etc/subuid; then
@@ -89,6 +94,22 @@ jobs:
           podman --version
           pasta --version
           docker --version
+
+      - name: Apply Ubuntu pasta signal policy correction
+        shell: bash
+        run: |
+          set -euo pipefail
+          pasta_profile="/etc/apparmor.d/usr.bin.pasta"
+          signal_rule='^[[:space:]]*signal[[:space:]]+\(receive\)[[:space:]]+peer=podman,[[:space:]]*$'
+          test -f "$pasta_profile"
+          test "$(grep -Fc 'include <abstractions/pasta>' "$pasta_profile")" -eq 1
+          if ! grep -Eq "$signal_rule" "$pasta_profile"; then
+            sudo sed -i \
+              '/^[[:space:]]*include <abstractions\/pasta>[[:space:]]*$/a\  signal (receive) peer=podman,' \
+              "$pasta_profile"
+          fi
+          test "$(grep -Ec "$signal_rule" "$pasta_profile")" -eq 1
+          sudo apparmor_parser -r "$pasta_profile"
 
       - name: Exercise portable profile in the rootless environment
         env:

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -63,7 +63,7 @@
     },
     {
       "file": "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",
-      "test": "prepares Ubuntu 26.04, Podman 5.7, and the pasta AppArmor policy before the live E2E test (#9006)",
+      "test": "keeps actionlint and live E2E on Ubuntu 26.04 and Podman 5.7 (#9006)",
       "category": "compatibility"
     },
     {

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -63,7 +63,7 @@
     },
     {
       "file": "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",
-      "test": "compiles the managed inference catalogue after dependency installation and before the live E2E test (#9680)",
+      "test": "prepares Ubuntu 26.04, Podman 5.7, and the pasta AppArmor policy before the live E2E test (#9006)",
       "category": "compatibility"
     },
     {

--- a/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
+++ b/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
@@ -6,8 +6,11 @@ import { describe, expect, it } from "vitest";
 import { readYaml, type Workflow } from "../../helpers/e2e-workflow-contract";
 
 describe("portable profile rootless runtime workflow", () => {
-  // source-shape-contract: compatibility -- The workflow must compile the candidate catalogue, pin Ubuntu 26.04 and Podman 5.7, and correct the pasta AppArmor policy before the live E2E test
-  it("prepares Ubuntu 26.04, Podman 5.7, and the pasta AppArmor policy before the live E2E test (#9006)", () => {
+  // source-shape-contract: compatibility -- Actionlint and the workflow must share Ubuntu 26.04 while the workflow compiles the candidate catalogue, pins Podman 5.7, and corrects the pasta AppArmor policy before live E2E
+  it("keeps actionlint and live E2E on Ubuntu 26.04 and Podman 5.7 (#9006)", () => {
+    const actionlint = readYaml<{ "self-hosted-runner"?: { labels?: string[] } }>(
+      ".github/actionlint.yaml",
+    );
     const workflow = readYaml<Workflow>(".github/workflows/portable-profile-e2e.yaml");
     const job = workflow.jobs["rootless-linux"];
     const steps = job?.steps ?? [];
@@ -35,6 +38,7 @@ describe("portable profile rootless runtime workflow", () => {
     const runtimeVersionIndex = provision?.indexOf("podman --version") ?? -1;
 
     expect(job?.["runs-on"]).toBe("ubuntu-26.04");
+    expect(actionlint["self-hosted-runner"]?.labels).toContain("ubuntu-26.04");
     expect(job?.env?.PODMAN_APT_VERSION).toBe("5.7.0+ds2-3build1");
     expect(dependencyInstallIndex).toBeGreaterThanOrEqual(0);
     expect(catalogueCompileIndex).toBeGreaterThan(dependencyInstallIndex);

--- a/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
+++ b/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
@@ -36,9 +36,11 @@ describe("portable profile rootless runtime workflow", () => {
     const packageInstallIndex = provision?.indexOf("sudo apt-get install") ?? -1;
     const packageVersionIndex = provision?.indexOf("dpkg-query --show") ?? -1;
     const runtimeVersionIndex = provision?.indexOf("podman --version") ?? -1;
+    const actionlintLabels = actionlint["self-hosted-runner"]?.labels;
 
     expect(job?.["runs-on"]).toBe("ubuntu-26.04");
-    expect(actionlint["self-hosted-runner"]?.labels).toContain("ubuntu-26.04");
+    expect(Array.isArray(actionlintLabels)).toBe(true);
+    expect(actionlintLabels).toContain("ubuntu-26.04");
     expect(job?.env?.PODMAN_APT_VERSION).toBe("5.7.0+ds2-3build1");
     expect(dependencyInstallIndex).toBeGreaterThanOrEqual(0);
     expect(catalogueCompileIndex).toBeGreaterThan(dependencyInstallIndex);
@@ -54,6 +56,12 @@ describe("portable profile rootless runtime workflow", () => {
     expect(provision).toContain('test "$version" = "podman version 5.7.0"');
     expect(policy).toContain("/etc/apparmor.d/usr.bin.pasta");
     expect(policy).toContain("signal (receive) peer=podman,");
+    expect(policy).toContain('test -f "$pasta_profile"');
+    expect(policy).toContain(
+      `test "$(grep -Fc 'include <abstractions/pasta>' "$pasta_profile")" -eq 1`,
+    );
+    expect(policy).toContain('if ! grep -Eq "$signal_rule" "$pasta_profile"; then');
+    expect(policy).toContain('test "$(grep -Ec "$signal_rule" "$pasta_profile")" -eq 1');
     expect(policy).toContain('apparmor_parser -r "$pasta_profile"');
   });
 });

--- a/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
+++ b/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
@@ -3,48 +3,53 @@
 
 import { describe, expect, it } from "vitest";
 
-import { readYaml, type Workflow, type WorkflowStep } from "../../helpers/e2e-workflow-contract";
-
-function rootlessLinuxStep(name: string): WorkflowStep {
-  const workflow = readYaml<Workflow>(".github/workflows/portable-profile-e2e.yaml");
-  const step = workflow.jobs["rootless-linux"]?.steps?.find((candidate) => candidate.name === name);
-  expect(step).toBeDefined();
-  return step!;
-}
+import { readYaml, type Workflow } from "../../helpers/e2e-workflow-contract";
 
 describe("portable profile rootless runtime workflow", () => {
-  // source-shape-contract: compatibility -- The rootless workflow must compile the exact candidate managed inference catalogue before the live E2E test imports it
-  it("compiles the managed inference catalogue after dependency installation and before the live E2E test (#9680)", () => {
+  // source-shape-contract: compatibility -- The workflow must compile the candidate catalogue, pin Ubuntu 26.04 and Podman 5.7, and correct the pasta AppArmor policy before the live E2E test
+  it("prepares Ubuntu 26.04, Podman 5.7, and the pasta AppArmor policy before the live E2E test (#9006)", () => {
     const workflow = readYaml<Workflow>(".github/workflows/portable-profile-e2e.yaml");
-    const steps = workflow.jobs["rootless-linux"]?.steps ?? [];
+    const job = workflow.jobs["rootless-linux"];
+    const steps = job?.steps ?? [];
+    const provision = steps.find(
+      (step) => step.name === "Provision restricted rootless Linux runtime",
+    )?.run;
+    const policy = steps.find(
+      (step) => step.name === "Apply Ubuntu pasta signal policy correction",
+    )?.run;
     const dependencyInstallIndex = steps.findIndex(
       (step) => step.name === "Install root dependencies",
     );
     const catalogueCompileIndex = steps.findIndex((step) => step.run === "npm run catalog:compile");
+    const provisionIndex = steps.findIndex(
+      (step) => step.name === "Provision restricted rootless Linux runtime",
+    );
+    const policyIndex = steps.findIndex(
+      (step) => step.name === "Apply Ubuntu pasta signal policy correction",
+    );
     const liveTestIndex = steps.findIndex(
       (step) => step.name === "Exercise portable profile in the rootless environment",
     );
+    const packageInstallIndex = provision?.indexOf("sudo apt-get install") ?? -1;
+    const packageVersionIndex = provision?.indexOf("dpkg-query --show") ?? -1;
+    const runtimeVersionIndex = provision?.indexOf("podman --version") ?? -1;
 
+    expect(job?.["runs-on"]).toBe("ubuntu-26.04");
+    expect(job?.env?.PODMAN_APT_VERSION).toBe("5.7.0+ds2-3build1");
     expect(dependencyInstallIndex).toBeGreaterThanOrEqual(0);
     expect(catalogueCompileIndex).toBeGreaterThan(dependencyInstallIndex);
-    expect(liveTestIndex).toBeGreaterThan(catalogueCompileIndex);
-  });
-
-  it("uses Ubuntu's Podman package with its installed OCI runtime", () => {
-    const provision = rootlessLinuxStep("Provision restricted rootless Linux runtime").run ?? "";
-    const packageInstallIndex = provision.indexOf("sudo apt-get install");
-    const packagePodmanIndex = provision.indexOf('package_podman="/usr/bin/podman"');
-    const pathExportIndex = provision.indexOf('export PATH="$runtime_bin:$PATH"');
-    const jobPathIndex = provision.indexOf('printf \'%s\\n\' "$runtime_bin" >> "$GITHUB_PATH"');
-    const versionIndex = provision.indexOf("podman --version");
-
+    expect(provisionIndex).toBeGreaterThan(catalogueCompileIndex);
+    expect(policyIndex).toBeGreaterThan(provisionIndex);
+    expect(liveTestIndex).toBeGreaterThan(policyIndex);
     expect(packageInstallIndex).toBeGreaterThanOrEqual(0);
-    expect(provision).toMatch(/sudo apt-get install --yes .*\bpodman\b/);
-    expect(packagePodmanIndex).toBeGreaterThan(packageInstallIndex);
-    expect(provision).toContain('ln -s "$package_podman" "$runtime_bin/podman"');
-    expect(pathExportIndex).toBeGreaterThan(packagePodmanIndex);
-    expect(jobPathIndex).toBeGreaterThan(pathExportIndex);
-    expect(versionIndex).toBeGreaterThan(jobPathIndex);
-    expect(provision).toContain('test "$(readlink -f "$(command -v podman)")" = "$package_podman"');
+    expect(provision).toContain("apparmor");
+    expect(provision).toContain('"podman=$PODMAN_APT_VERSION"');
+    expect(packageVersionIndex).toBeGreaterThan(packageInstallIndex);
+    expect(runtimeVersionIndex).toBeGreaterThan(packageVersionIndex);
+    expect(provision).toContain('test "$package_version" = "$PODMAN_APT_VERSION"');
+    expect(provision).toContain('test "$version" = "podman version 5.7.0"');
+    expect(policy).toContain("/etc/apparmor.d/usr.bin.pasta");
+    expect(policy).toContain("signal (receive) peer=podman,");
+    expect(policy).toContain('apparmor_parser -r "$pasta_profile"');
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The automatic Portable rootless job previously accepted a moving Ubuntu image and unpinned Podman package, so it exercised an unvalidated Podman 4.9 runtime and failed during the first registry container start. This change pins the accepted Ubuntu 26.04 and Podman 5.7 matrix, applies the validated pasta AppArmor correction, and verifies the runtime contract before the live test starts.

## Related Issue

Fixes #9006

## Changes

- Run the `rootless-linux` job on Ubuntu 26.04 with the exact `5.7.0+ds2-3build1` Podman package and assert both package and runtime versions.
- Apply and verify the existing pasta signal policy correction before live product execution.
- Extend the workflow contract to protect catalogue compilation and the OS, package, policy, and live-test ordering.
- Configure actionlint to recognize the required `ubuntu-26.04` runner label and assert that the `rootless-linux` job uses it.
- Require actionlint labels to remain an array containing `ubuntu-26.04` and preserve the AppArmor file, include, conditional insertion, uniqueness, and reload guards.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent security review passed for commit `5e32afb3306affd96463caf656d1b8a87940336a`; see the [renewed exact-byte review receipt](https://github.com/NVIDIA/NemoClaw/pull/9694#issuecomment-5351426681).
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; no DGX Station host-preparation path changed.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — actionlint v1.7.12 reproduced the runner-label failure on `2b1bc9918` and passed the Portable and Podman CPU-proof workflows on `5e32afb33`; the targeted E2E-support workflow contract passed with the label-type and AppArmor guard assertions; source-shape and repository checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Independent documentation writer review: PASS with no findings for commit `5e32afb3306affd96463caf656d1b8a87940336a`. No user documentation is required. The diff changes GitHub Actions runner provisioning, actionlint configuration, and the workflow regression contract. It does not change supported product behavior or public documentation claims. See the [renewed exact-byte review receipt](https://github.com/NVIDIA/NemoClaw/pull/9694#issuecomment-5351426681).

<!-- docs-review-head-sha: 5e32afb33 -->
<!-- docs-review-agents-blob-sha: 513518cdf -->

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for the rootless Linux portable runtime on Ubuntu 26.04.
  * Added validation for Podman 5.7 package and binary versions, runtime provisioning order, catalogue compilation, and AppArmor policy configuration.
  * Consolidated workflow checks into a single contract test for more reliable compatibility verification.

* **Chores**
  * Updated compatibility tracking and workflow validation for Ubuntu 26.04, Podman 5.7, AppArmor, and Actionlint requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
