### PR TITLE
fix(inference): enable owned llama.cpp publication

### DIFF
--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -298,7 +298,7 @@ jobs:
             and (.environment | type) == "string" and (.environment | length) > 0
             and (.model.hostPath | type) == "string" and (.model.hostPath | startswith("/"))
             and .gpu == {vendor:"nvidia", fullOffload:true, cpuFallback:"reject"}
-            and .probes == ["health", "completion"]
+            and .probes == ["health","models","properties","metrics","disabled-surfaces","synchronous-chat","streaming-chat","usage","structured-output","tool-call","tool-result-continuation","context-window","authentication","malformed-request","request-body-limit","cancellation","client-timeout","log-redaction"]
           ' <<< "$QUALIFICATION" >/dev/null; then
             echo "ERROR: protected DGX Spark qualification infrastructure is incomplete." >&2
             exit 1

--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -288,9 +288,10 @@ jobs:
             exit 1
           fi
           if ! jq -e '
-            (keys | sort) == ["environment", "execution", "gpu", "model", "platform", "probes", "profile", "recipeRef", "required", "runner"]
+            (keys | sort) == ["environment", "execution", "gpu", "model", "platform", "probeBounds", "probes", "profile", "recipeRef", "requestGuard", "required", "runner"]
             and .required == true
             and .execution == "enabled"
+            and .requestGuard == "required"
             and .profile == "dgx-spark-gb10-single"
             and .recipeRef == "llama-cpp.nemotron-3-nano-30b-a3b.spark-single.v1"
             and .platform == "linux/arm64"
@@ -298,6 +299,7 @@ jobs:
             and (.environment | type) == "string" and (.environment | length) > 0
             and (.model.hostPath | type) == "string" and (.model.hostPath | startswith("/"))
             and .gpu == {vendor:"nvidia", fullOffload:true, cpuFallback:"reject"}
+            and .probeBounds == {cancellationMaxTokens:4096,clientTimeoutMilliseconds:250,maxResponseBytes:16777216,maxStreamEvents:512,maxTokens:{synchronousChat:16,streamingChat:32,structuredOutput:64,toolCall:256,toolResultContinuation:64}}
             and .probes == ["health","models","properties","metrics","disabled-surfaces","synchronous-chat","streaming-chat","usage","structured-output","tool-call","tool-result-continuation","context-window","authentication","malformed-request","request-body-limit","cancellation","client-timeout","log-redaction"]
           ' <<< "$QUALIFICATION" >/dev/null; then
             echo "ERROR: protected DGX Spark qualification infrastructure is incomplete." >&2

--- a/managed-inference/images/llama-cpp/image.yaml
+++ b/managed-inference/images/llama-cpp/image.yaml
@@ -13,7 +13,7 @@ spec:
   repository: ghcr.io/nvidia/nemoclaw/llama-cpp-server
 
   publication:
-    enabled: false
+    enabled: true
     trigger: workflow_dispatch
     allowedRef: refs/heads/main
     repository: ghcr.io/nvidia/nemoclaw/llama-cpp-server

--- a/test/llama-cpp-dgx-spark-qualification-plan.test.ts
+++ b/test/llama-cpp-dgx-spark-qualification-plan.test.ts
@@ -35,6 +35,7 @@ function candidateRoot(options: { activation?: string; enabled?: boolean } = {})
   const imageDocument = YAML.parse(sourceImage) as {
     spec: {
       publication: {
+        enabled: boolean;
         qualification: {
           environment: string | null;
           execution: "disabled" | "enabled";
@@ -44,6 +45,7 @@ function candidateRoot(options: { activation?: string; enabled?: boolean } = {})
       };
     };
   };
+  imageDocument.spec.publication.enabled = options.enabled ?? false;
   const qualification = imageDocument.spec.publication.qualification;
   qualification.execution = options.enabled ? "enabled" : "disabled";
   qualification.runner = options.enabled ? "linux-arm64-gpu-dgx-spark-gb10-protected-1" : null;

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -51,7 +52,11 @@ const imageManifest = YAML.parse(
     "utf8",
   ),
 ) as {
-  spec?: { publication?: { qualification?: { probes?: string[] } } };
+  spec?: {
+    publication?: {
+      qualification?: { probeBounds?: unknown; probes?: string[] } & Record<string, unknown>;
+    };
+  };
 };
 const attestationWorkflow = YAML.parse(
   fs.readFileSync(
@@ -75,6 +80,19 @@ function namedStep(job: Job, name: string): Step {
     job.steps?.find((candidate) => candidate.name === name),
     `llama.cpp image workflow is missing '${name}'`,
   );
+}
+
+function publicationQualificationFilter(step: Step): string {
+  const source = required(step.run, "publication gate script is missing");
+  const match = /if ! jq -e '\n(?<filter>[\s\S]*?)\n' <<< "\$QUALIFICATION"/u.exec(source);
+  return required(match?.groups?.filter, "publication qualification jq filter is missing");
+}
+
+function runPublicationQualificationFilter(filter: string, value: unknown) {
+  return spawnSync("jq", ["-e", filter], {
+    encoding: "utf8",
+    input: JSON.stringify(value),
+  });
 }
 
 function permissionValues(value: string | Record<string, string> | undefined): string[] {
@@ -238,6 +256,24 @@ describe("llama.cpp image PR workflow", () => {
         ),
       )}`,
     );
+    const qualification = required(
+      imageManifest.spec?.publication?.qualification,
+      "publication qualification is missing",
+    );
+    const filter = publicationQualificationFilter(gateStep);
+    const valid = runPublicationQualificationFilter(filter, qualification);
+    expect(valid.status, valid.stderr).toBe(0);
+
+    const missingBounds = structuredClone(qualification);
+    delete missingBounds.probeBounds;
+    expect(runPublicationQualificationFilter(filter, missingBounds).status).not.toBe(0);
+
+    const driftedBounds = structuredClone(qualification);
+    driftedBounds.probeBounds = {
+      ...(driftedBounds.probeBounds as Record<string, unknown>),
+      clientTimeoutMilliseconds: 251,
+    };
+    expect(runPublicationQualificationFilter(filter, driftedBounds).status).not.toBe(0);
     expect(preflight.needs).toEqual(["config", "publication-gate"]);
     expect(preflight.permissions).toEqual({ packages: "read" });
     expect(

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -45,6 +45,14 @@ const repoRoot = path.resolve(import.meta.dirname, "..");
 const workflow = YAML.parse(
   fs.readFileSync(path.join(repoRoot, ".github", "workflows", "llama-cpp-image.yaml"), "utf8"),
 ) as Workflow;
+const imageManifest = YAML.parse(
+  fs.readFileSync(
+    path.join(repoRoot, "managed-inference", "images", "llama-cpp", "image.yaml"),
+    "utf8",
+  ),
+) as {
+  spec?: { publication?: { qualification?: { probes?: string[] } } };
+};
 const attestationWorkflow = YAML.parse(
   fs.readFileSync(
     path.join(repoRoot, ".github", "workflows", "llama-cpp-image-attest.yaml"),
@@ -212,14 +220,23 @@ describe("llama.cpp image PR workflow", () => {
     expect(gate.if).toContain("github.event_name == 'workflow_dispatch'");
     expect(gate.if).toContain("inputs.publish == true");
     expect(gate.permissions).toEqual({});
-    expect(namedStep(gate, "Enforce declarative publication boundary").run).toContain(
+    const gateStep = namedStep(gate, "Enforce declarative publication boundary");
+    expect(gateStep.run).toContain(
       'PUBLICATION_ENABLED" != "true"',
     );
-    expect(namedStep(gate, "Enforce declarative publication boundary").run).toContain(
+    expect(gateStep.run).toContain(
       'GITHUB_REPOSITORY" != "NVIDIA/NemoClaw"',
     );
-    expect(namedStep(gate, "Enforce declarative publication boundary").run).toContain(
+    expect(gateStep.run).toContain(
       'GITHUB_REF" != "$ALLOWED_REF"',
+    );
+    expect(gateStep.run).toContain(
+      `and .probes == ${JSON.stringify(
+        required(
+          imageManifest.spec?.publication?.qualification?.probes,
+          "publication qualification probes are missing",
+        ),
+      )}`,
     );
     expect(preflight.needs).toEqual(["config", "publication-gate"]);
     expect(preflight.permissions).toEqual({ packages: "read" });

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -151,6 +151,13 @@ function enablePublication(source: string): string {
   });
 }
 
+function addUnexpectedPublicationField(source: string): string {
+  const candidate = YAML.parse(source) as ImageManifest;
+  const publication = candidate.spec!.publication! as Record<string, unknown>;
+  publication.consumerAlias = "latest";
+  return YAML.stringify(candidate);
+}
+
 function configureManifestAnnotations(source: string, annotations: Record<string, string>): string {
   const candidate = YAML.parse(source) as { metadata: { annotations?: Record<string, string> } };
   candidate.metadata.annotations = annotations;
@@ -529,7 +536,7 @@ describe("declarative llama.cpp server image", () => {
   it.each([
     [
       "an unexpected publication field",
-      manifestSource.replace("    enabled: false", "    enabled: false\n    consumerAlias: latest"),
+      addUnexpectedPublicationField(manifestSource),
     ],
     ["automatic publication", manifestSource.replace("workflow_dispatch", "push")],
     ["an untrusted ref", manifestSource.replace("refs/heads/main", "refs/heads/release")],


### PR DESCRIPTION
## Summary

Enable the trusted, digest-first publication path for the NemoClaw-owned llama.cpp server image. Align the publication gate with the qualification probes already declared by the image manifest so the enabled workflow does not reject the current contract.

Publication remains manual, main-only, exact-digest based, and guarded by the existing public-package preflight and supply-chain evidence requirements. This does not change either production serving recipe or reopen #9600.

## Related Issue

Part of #8231.
Prerequisite for #9592.

## Changes

- Enable publication in the repository-owned llama.cpp image manifest.
- Update the trusted publication gate to accept the complete declarative DGX Spark probe inventory, including the request-body-limit probe from #9669.
- Bind the workflow regression test to the manifest-declared probe list and make dormant/enabled fixtures independent of the checked-in activation state.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed the manual-trigger, trusted-ref, declarative enablement, exact probe binding, least-privilege permissions, public-package preflight, digest-first publication, evidence, and no-consumer-alias boundaries in the complete diff. The change does not add credentials, PR registry writes, mutable aliases, or an automatic publication trigger.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this PR does not change `scripts/prepare-dgx-station-host.sh`.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — pre-commit and commit-msg passed. The pre-push CLI typecheck is blocked by an existing `origin/main` error in untouched `test/package-contract/managed-inference-catalog.test.ts:28`; the same command fails at base commit `7689b4a3`.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/llama-cpp-image.test.ts test/llama-cpp-image-workflow.test.ts test/llama-cpp-image-publication-evidence.test.ts test/llama-cpp-dgx-spark-qualification-plan.test.ts test/llama-cpp-dgx-spark-qualification-contract.test.ts --project integration` passed 89 tests.
- [x] Applicable broad gate passed — `npm run checks:repository` passed; `npm run test:changed` passed 32 growth guardrails and the changed CLI/plugin/e2e-support selection.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Prekshi Vyas <34834085+prekshivyas@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled publication of the llama.cpp server image.

* **Bug Fixes**
  * Strengthened publication qualification checks for required request guards and explicit probe limits.
  * Enforced complete qualification settings, including cancellation, timeout, response-size, stream-event, and token bounds.
  * Improved validation for unexpected publication configuration fields.

* **Tests**
  * Added coverage for enabled and disabled publication configurations.
  * Expanded checks for qualification settings, probe bounds, and publication requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->