### PR TITLE
fix(onboard): skip the systemd override for Windows-host Ollama on resume

### DIFF
--- a/src/lib/onboard/local-inference-topology.test.ts
+++ b/src/lib/onboard/local-inference-topology.test.ts
@@ -10,6 +10,7 @@ vi.mock("../inference/local", () => ({
   applyOllamaRuntimeContextWindow: vi.fn(),
   findReachableOllamaHost: vi.fn(),
   isLocalProviderHostHealthy: vi.fn(),
+  OLLAMA_LOCALHOST: "127.0.0.1",
   validateOllamaModel: vi.fn(),
 }));
 vi.mock("../inference/ollama/proxy", () => ({
@@ -164,7 +165,9 @@ describe("repairLocalInferenceSystemdOverrideOrExit (#6760)", () => {
     expect(mockedApplyRuntimeContext).toHaveBeenCalledWith(recordedModel, {
       contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
     });
-    expect(callOrder).toEqual(["systemd", "host", "warm", "runtime-context"]);
+    // The topology probe runs first so a Windows-host daemon can skip the
+    // override; the post-override probe still proves the restarted daemon (#8596).
+    expect(callOrder).toEqual(["host", "systemd", "host", "warm", "runtime-context"]);
   });
 
   it("preserves the legacy OpenClaw loopback-only repair", () => {
@@ -179,9 +182,47 @@ describe("repairLocalInferenceSystemdOverrideOrExit (#6760)", () => {
       isNonInteractive,
       contextWindowFloor: MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW,
     });
-    expect(mockedFindReachableHost).not.toHaveBeenCalled();
+    expect(mockedFindReachableHost).toHaveBeenCalledTimes(1);
     expect(mockedValidateModel).not.toHaveBeenCalled();
     expect(mockedApplyRuntimeContext).not.toHaveBeenCalled();
+  });
+
+  it("skips the Linux systemd loopback override for a Windows-host Ollama daemon on resume (#8596)", () => {
+    mockedFindReachableHost.mockReturnValue("host.docker.internal");
+
+    repairHermesResume();
+
+    expect(mockedEnsureSystemdOverride).not.toHaveBeenCalled();
+    expect(mockedValidateModel).toHaveBeenCalledWith(recordedModel);
+    expect(mockedApplyRuntimeContext).toHaveBeenCalledWith(recordedModel, {
+      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
+    });
+  });
+
+  it("still applies the override on resume when a loopback Ollama answers (#8596)", () => {
+    mockedFindReachableHost.mockReturnValue("127.0.0.1");
+
+    repairHermesResume();
+
+    expect(mockedEnsureSystemdOverride).toHaveBeenCalledWith({
+      isNonInteractive,
+      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
+    });
+  });
+
+  it("still applies the override on resume when no Ollama daemon answers (#8596)", () => {
+    mockedFindReachableHost.mockReturnValue(null);
+    mockedEnsureSystemdOverride.mockReturnValue("ready");
+
+    expectFailure(
+      repairHermesResume,
+      "Ollama is not reachable, so the recorded model's runtime context window cannot be verified.",
+    );
+
+    expect(mockedEnsureSystemdOverride).toHaveBeenCalledWith({
+      isNonInteractive,
+      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
+    });
   });
 
   it("rejects a strict resume when the recorded model is missing", () => {
@@ -195,7 +236,7 @@ describe("repairLocalInferenceSystemdOverrideOrExit (#6760)", () => {
         }),
       "The recorded Ollama model is missing, so its runtime context window cannot be verified.",
     );
-    expect(mockedFindReachableHost).not.toHaveBeenCalled();
+    expect(mockedFindReachableHost).toHaveBeenCalledTimes(1);
   });
 
   it("rejects a strict resume when Ollama is unreachable", () => {

--- a/src/lib/onboard/local-inference-topology.ts
+++ b/src/lib/onboard/local-inference-topology.ts
@@ -6,6 +6,7 @@ import {
   applyOllamaRuntimeContextWindow,
   findReachableOllamaHost,
   isLocalProviderHostHealthy,
+  OLLAMA_LOCALHOST,
   validateOllamaModel,
 } from "../inference/local";
 import { ensureOllamaAuthProxy, isProxyHealthy } from "../inference/ollama/proxy";
@@ -163,6 +164,14 @@ function failOllamaResumeRepair(message: string): never {
   throw new Error(message);
 }
 
+// True when Ollama answers on a non-loopback host, which on WSL means the
+// Windows-host daemon reached through host.docker.internal. Mirrors the
+// loopback check the model-list path already applies in inference/local.
+function respondingOllamaIsWindowsHost(): boolean {
+  const host = findReachableOllamaHost();
+  return host !== null && host !== OLLAMA_LOCALHOST;
+}
+
 // Repair the Ollama systemd loopback override for recorded ollama-local
 // providers. Agents with a strict context floor also warm the exact recorded
 // model and verify the running daemon before resume can skip provider setup.
@@ -173,11 +182,18 @@ export function repairLocalInferenceSystemdOverrideOrExit(
   const { provider, model, isNonInteractive } = options;
   if (provider !== "ollama-local") return;
   const contextWindowFloor = resolveOllamaContextWindowFloor(options.contextWindowFloor);
-  const state = ensureOllamaLoopbackSystemdOverride({ isNonInteractive, contextWindowFloor });
-  if (state === "failed") {
-    failOllamaResumeRepair(
-      "Ollama systemd restart did not recover after applying the loopback override.",
-    );
+  // A Windows-host Ollama daemon reached at host.docker.internal is not a Linux
+  // systemd service, so the override restarts an unrelated ollama.service and
+  // exits 1. Provider selection already skips it, but it records the same
+  // "ollama-local" provider for both topologies, so resume carries no Windows
+  // marker and has to re-derive the distinction here (#8596).
+  if (!respondingOllamaIsWindowsHost()) {
+    const state = ensureOllamaLoopbackSystemdOverride({ isNonInteractive, contextWindowFloor });
+    if (state === "failed") {
+      failOllamaResumeRepair(
+        "Ollama systemd restart did not recover after applying the loopback override.",
+      );
+    }
   }
   if (contextWindowFloor <= MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW) return;
   if (!model) {


### PR DESCRIPTION
## Summary

Onboard resume applied the Linux systemd loopback override for any recorded `ollama-local` provider, including a Windows-host daemon reached through `host.docker.internal`. The override targeted an unrelated WSL `ollama.service`, failed to restart it, and exited 1 during provider configuration. Resume now skips the override when Ollama answers on a non-loopback address, so a Windows-host reuse completes instead of exiting.

PR #8634 fixed this for the interactive `--fresh` selection path and recorded the resume path as a known limit that was safe to fix separately. This is that separate fix.

## Related Issue

Closes #8596

## Changes

- `src/lib/onboard/local-inference-topology.ts` — `repairLocalInferenceSystemdOverrideOrExit` gated only on `provider !== "ollama-local"` before calling `ensureOllamaLoopbackSystemdOverride`. It now derives the topology first and runs the override only for a loopback or absent daemon.
- Added `respondingOllamaIsWindowsHost`, which reuses the existing `findReachableOllamaHost` probe and the existing `OLLAMA_LOCALHOST` constant. This is the same loopback check the model-list path in `src/lib/inference/local.ts` already applies for the same reason, so it introduces no new abstraction or configuration.

Why resume has to re-derive the topology rather than read a recorded flag: `configureOllamaState` records the provider as `ollama-local` for both the Windows-host and the local-Linux path, so the recorded state carries no Windows marker for resume to consult.

The post-override reachability probe is unchanged and still runs after the override, so it continues to observe the daemon that systemd restarted.

Known limit, unchanged by this PR: under WSL mirrored networking a Windows daemon answers through the distro's `127.0.0.1`, so that topology stays on the systemd path. Distinguishing it needs the local-listener evidence provider selection collects (#9300), which is not available on the resume path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: https://github.com/NVIDIA/NemoClaw/pull/9697#issuecomment-5351357505 requested from maintainers as part of this review
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/onboard/local-inference-topology.test.ts` → 17 passed. Consumers: `npx vitest run --project cli src/lib/onboard/machine/ src/lib/onboard/setup-nim-ollama.test.ts src/lib/inference/local.test.ts` → 72 files, 988 passed. `npm run typecheck:cli` and `npm run checks:repository` pass.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable, the change is two files inside `src/lib/onboard/`
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### RED/GREEN

With the source restored to upstream and the new tests kept, `skips the Linux systemd loopback override for a Windows-host Ollama daemon on resume (#8596)` fails because the override runs. Four assertions fail in total, covering the new skip plus the probe-ordering changes. All pass with the change applied.

Pre-existing on `upstream/main` and unrelated to this change: `created-sandbox-finalization`, the four `experimental/hermes-portable-*` suites, `runtime-provider/docker-llama-cpp-managed-lifecycle`, `runtime-provider/docker-operation-authority`, and `runtime-provider/podman-state-mutation` fail at `7689b4a383` with this change fully reverted.

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ollama detection during resume.
  * Prevented unnecessary Linux service repairs when Ollama is reachable through a Windows host endpoint.
  * Preserved existing validation for unreachable services, loopback connections, and context-window settings.
  * Added checks before and after service repair to ensure local inference connectivity is handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

