### PR TITLE
test(windows): separate trusted path oracle

### DIFF
--- a/test/bootstrap-windows.test.ts
+++ b/test/bootstrap-windows.test.ts
@@ -173,15 +173,10 @@ $env:ProgramFiles = 'C:\\Users\\tester\\attacker-controlled'
 . ${JSON.stringify(BOOTSTRAP_WINDOWS)}
 
 $trustedProgramFiles = [Environment]::GetFolderPath([Environment+SpecialFolder]::ProgramFiles)
-$trustedMachineRoot = if ($trustedProgramFiles) {
-    "$trustedProgramFiles\\Docker\\Docker"
-} else {
-    'C:\\Program Files\\Docker\\Docker'
-}
 
 [pscustomobject]@{
     machineRoot = $script:DockerDesktopMachineRoot
-    trustedMachineRoot = $trustedMachineRoot
+    trustedProgramFiles = $trustedProgramFiles
     usesCallerPath = $script:DockerDesktopMachineRoot.StartsWith($env:ProgramFiles, [System.StringComparison]::OrdinalIgnoreCase)
 } | ConvertTo-Json -Compress
 `,
@@ -190,7 +185,10 @@ $trustedMachineRoot = if ($trustedProgramFiles) {
       expect(result.stderr).toBe("");
       const parsed = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1) ?? "{}");
       expect(parsed.usesCallerPath).toBe(false);
-      expect(parsed.machineRoot).toBe(parsed.trustedMachineRoot);
+      const trustedRoot = parsed.trustedProgramFiles || "C:\\Program Files";
+      const trustedPrefix = `${trustedRoot}\\`;
+      expect(parsed.machineRoot.startsWith(trustedPrefix)).toBe(true);
+      expect(parsed.machineRoot.slice(trustedPrefix.length)).toBe("Docker\\Docker");
     },
   );
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Separates the privileged Docker Desktop path oracle from the bootstrap path construction after PR #9683. The test now verifies the trusted Program Files prefix and exact `Docker\\Docker` suffix independently, so a matching implementation and expectation change cannot hide a machine-root regression. Production Windows bootstrap behavior is unchanged.

E2E root cause: `bootstrap-windows tests / Docker Desktop path assertions / host-platform path semantics on macOS`
Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/32312339289 (run `32312339289`, attempt 1)
Failed job: `macOS compatibility (1/4)` ([`96257900908`](https://github.com/NVIDIA/NemoClaw/actions/runs/32312339289/job/96257900908))
Signature: three Windows Docker Desktop path assertions used host-platform path semantics on macOS
Scope: one root cause; follow-up to the unresolved trusted-root oracle review on PR #9683

## Changes

- Export only the trusted Program Files value from PowerShell.
- Assert the trusted prefix and exact `Docker\\Docker` suffix separately in TypeScript.
- Keep `scripts/bootstrap-windows.ps1` and production behavior unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security review passed for `1787bb63042babba7213fd82feaec29354ec2d8d`; production bootstrap code is unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — equivalent upstream-bound pre-commit, commitlint, and pre-push commands passed; the normal pre-push hook also passed during publication.
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/bootstrap-windows.test.ts` collected 32 tests and skipped them because PowerShell is unavailable locally. PR CI provides the Windows-capable macOS result.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Windows Docker environment validation by checking that Docker is installed within the trusted Program Files directory.
  * Added verification that the detected Docker machine root uses the expected `Docker\Docker` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->