### PR TITLE
docs: add contribution intake decision guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -30,6 +30,66 @@ body:
       required: false
 
   - type: textarea
+    id: scope
+    attributes:
+      label: Scope and Exclusions
+      description: |
+        What should be included, and what should stay out of scope?
+        Use "unknown" or "not applicable" with a short explanation when needed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: owner
+    attributes:
+      label: Proposed Ongoing Owner
+      description: |
+        Who would own compatibility, upgrades, security review, testing, and user support after merge?
+        Use "unknown" or "not applicable" with a short explanation when needed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: placement
+    attributes:
+      label: Requested Placement and Support Expectations
+      description: |
+        Should this live in canonical NemoClaw, NemoClaw Community, documentation, examples, tests, or another existing project area?
+        Describe the support expectation users should have after merge.
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation Plan
+      description: |
+        Which tests, checks, or live evidence should prove the behavior?
+        Use "unknown" with a short explanation when the validation boundary needs maintainer guidance.
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Supported Versions and Platforms
+      description: |
+        Which NemoClaw versions, operating systems, hardware targets, providers, sandboxes, or deployment modes should this support?
+        Use "not applicable" with a short explanation for changes that do not affect compatibility.
+    validations:
+      required: true
+
+  - type: textarea
+    id: security_privacy
+    attributes:
+      label: Security or Privacy Impact
+      description: |
+        Does this affect credentials, policy, sandboxing, networking, user data, logs, telemetry, or external services?
+        Use "none expected" with a short explanation when there is no expected impact.
+    validations:
+      required: true
+
+  - type: textarea
     id: implementation
     attributes:
       label: Implementation Idea
@@ -59,4 +119,6 @@ body:
         - label: I searched existing issues and this is not a duplicate
           required: true
         - label: I described the problem and desired behavior
+          required: true
+        - label: I included scope, ownership, placement, validation, compatibility, and security or privacy impact, using "unknown" or "not applicable" with explanations where needed
           required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -534,6 +534,20 @@ Before opening or approving such a PR, confirm that an accepted issue or design 
 If that decision is missing, stop implementation or review and request maintainer direction.
 Route independent solutions, complete use-case examples, and third-party integrations through [Community Solutions](docs/resources/community-contributions.mdx).
 
+Feature requests must provide enough information for that decision without creating a separate intake system. Use the GitHub feature-request template and answer each scope, ownership, placement, validation, compatibility, and security or privacy question. "Unknown" or "not applicable" is acceptable when it includes a short explanation.
+
+When maintainers accept, request changes to, defer, or decline substantive work, record the decision in the issue, discussion, or pull request before implementation proceeds. Use this public format:
+
+```text
+Decision: accept | request changes | defer | decline
+Reason:
+Placement:
+Accountable maintainer:
+Required validation plan:
+```
+
+For accepted substantive work, name one accountable maintainer and the required validation plan. Small documentation changes and low-risk fixes may still proceed directly to a pull request without a separate decision record.
+
 ### DCO Sign-Off
 
 This project requires a [Developer Certificate of Origin (DCO)](https://developercertificate.org/) sign-off declaration in every pull request description.


### PR DESCRIPTION
## Summary

- extend the feature request template with intake fields for scope, ownership, placement, validation, compatibility, and security/privacy impact
- add a lightweight maintainer decision record format to the product scope approval guidance
- keep small documentation and low-risk fixes eligible for direct PRs without a separate decision record

## Related issue

Fixes NVIDIA/NemoClaw#9659

## Validation

- `npm run docs:validate`
- `npm run validate:pr`

Signed-off-by: Glenn-Agent <glenn_agent@163.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added product-scope approval guidance for substantive pull requests.
  * Documented requirements for ownership, placement, validation, compatibility, and security/privacy considerations.
  * Added a standardized format for recording maintainer decisions and validation plans.

* **Chores**
  * Enhanced feature request templates with required planning fields and a more comprehensive review checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->