### PR TITLE
fix(e2e): accept supervised dashboard recovery proof

### DIFF
--- a/test/e2e/live/dashboard-remote-bind-env.ts
+++ b/test/e2e/live/dashboard-remote-bind-env.ts
@@ -28,14 +28,19 @@ export function buildDashboardRemoteBindEnv(
 }
 
 export function dashboardRemoteBindConnectStarted(
-  result: { exitCode: number | null; stdout: string; stderr: string },
+  result: {
+    exitCode: number | null;
+    stdout: string;
+    stderr: string;
+    timedOut?: boolean;
+  },
   sandboxName: string,
   dashboardPort: string,
 ): boolean {
   const output = stripAnsi(`${result.stdout}\n${result.stderr}`);
   return (
     result.exitCode === 0 ||
-    (result.exitCode === null &&
+    ((result.exitCode === null || result.timedOut === true) &&
       (output.includes("Dashboard port forward re-established.") ||
         (output.includes(`Forwarding port ${dashboardPort}`) &&
           output.includes(`sandbox ${sandboxName}`))))

--- a/test/e2e/support/dashboard-remote-bind-env.test.ts
+++ b/test/e2e/support/dashboard-remote-bind-env.test.ts
@@ -54,13 +54,9 @@ describe("dashboard remote-bind E2E environment", () => {
       stderr: "client_loop: send disconnect: Broken pipe\n",
     };
 
-    expect(
-      dashboardRemoteBindConnectStarted(
-        timedOutRecovery,
-        "e2e-dashboard-bind",
-        "18789",
-      ),
-    ).toBe(true);
+    expect(dashboardRemoteBindConnectStarted(timedOutRecovery, "e2e-dashboard-bind", "18789")).toBe(
+      true,
+    );
   });
 
   it("rejects a connect result with no numeric exit code and no forward proof", () => {
@@ -70,6 +66,36 @@ describe("dashboard remote-bind E2E environment", () => {
           exitCode: null,
           stdout: "Connecting to sandbox...\n",
           stderr: "",
+        },
+        "e2e-dashboard-bind",
+        "18789",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a completed nonzero connect even when it printed recovery proof (#9606)", () => {
+    expect(
+      dashboardRemoteBindConnectStarted(
+        {
+          exitCode: 1,
+          timedOut: false,
+          stdout: "Dashboard port forward re-established.\n",
+          stderr: "connect failed\n",
+        },
+        "e2e-dashboard-bind",
+        "18789",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a timed-out interactive connect without background-forward proof (#9606)", () => {
+    expect(
+      dashboardRemoteBindConnectStarted(
+        {
+          exitCode: 143,
+          timedOut: true,
+          stdout: "Connecting to sandbox...\n",
+          stderr: "client_loop: send disconnect: Broken pipe\n",
         },
         "e2e-dashboard-bind",
         "18789",

--- a/test/e2e/support/dashboard-remote-bind-env.test.ts
+++ b/test/e2e/support/dashboard-remote-bind-env.test.ts
@@ -46,6 +46,23 @@ describe("dashboard remote-bind E2E environment", () => {
     ).toBe(true);
   });
 
+  it("accepts recovery proof after the interactive connect reaches its test deadline (#9606)", () => {
+    const timedOutRecovery = {
+      exitCode: 143,
+      timedOut: true,
+      stdout: "\u001B[32m✓\u001B[0m Dashboard port forward re-established.\n",
+      stderr: "client_loop: send disconnect: Broken pipe\n",
+    };
+
+    expect(
+      dashboardRemoteBindConnectStarted(
+        timedOutRecovery,
+        "e2e-dashboard-bind",
+        "18789",
+      ),
+    ).toBe(true);
+  });
+
   it("rejects a connect result with no numeric exit code and no forward proof", () => {
     expect(
       dashboardRemoteBindConnectStarted(


### PR DESCRIPTION
## Summary

The dashboard remote-bind target could restore its missing port forward but still fail when the supervised interactive `connect` process reached the test deadline and returned numeric SIGTERM status 143. This change accepts the existing recovery proof for an explicitly timed-out connect, while ordinary nonzero completion and a timeout without recovery proof remain failures. The live target still requires direct OpenShell forward state, all-interface binding, security-audit evidence, and registered cleanup before success.

E2E root cause: `dashboard-recovery-proof-numeric-timeout-status`  
Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/32330051811 (attempt 1)  
Failed job: Shared E2E / dashboard-remote-bind (https://github.com/NVIDIA/NemoClaw/actions/runs/32330051811/job/96309077300)  
Immutable artifact: `9392893216`, `sha256:e2e105e1b0cd5510556e0bdaace2e7600cbc838bffcbf466ccdddbe77ad837dc`  
Failure signature: `timedOut: true`, `exitCode: 143`, and `Dashboard port forward re-established.` were reported together, but the helper accepted recovery proof only when `exitCode === null`.

## Related Issue

Fixes #9606

## Changes

- Accept the existing dashboard recovery proof when the supervised connect result is explicitly timed out.
- Reject ordinary completed nonzero results even when they contain the recovery phrase.
- Reject timed-out results that do not contain the recovery proof.
- Preserve the independent live forward-list, all-interface bind, security-audit, and cleanup checks as final authority.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent nine-category security review passed on `8a975157e858f6a64c6134fff2681f0ca34d6991` with no findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/dashboard-remote-bind-env.test.ts`: 7/7 passed on `8a975157e`.
- [x] Applicable broad gate passed — `npm run typecheck:cli` and `npm run checks:repository` passed on the current-main candidate; a broad runtime suite is not required for this two-file E2E fixture change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The change affects only E2E evidence classification and regression coverage. It changes no supported CLI, configuration, workflow, default, or user-visible product behavior.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 8a975157e -->
<!-- docs-review-agents-blob-sha: 513518cdf -->

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
