### PR TITLE
fix(inference): validate reused model and reasoning health

### DIFF
--- a/src/lib/actions/sandbox/inference-invocation-probe.test.ts
+++ b/src/lib/actions/sandbox/inference-invocation-probe.test.ts
@@ -90,6 +90,20 @@ describe("sandbox inference invocation probe", () => {
     expect(probeSandboxInferenceInvocation(input, { execute })).toEqual({ ok: true });
   });
 
+  it("accepts a reasoning-only response when the reply budget ends before content", () => {
+    const body = JSON.stringify({
+      choices: [
+        {
+          finish_reason: "length",
+          message: { content: null, reasoning_content: null, reasoning: "Planning the reply." },
+        },
+      ],
+    });
+    const execute = vi.fn(() => ({ status: 0, stdout: `200\n${body}`, stderr: "" }));
+
+    expect(probeSandboxInferenceInvocation(input, { execute })).toEqual({ ok: true });
+  });
+
   it.each([
     ["openai-completions", '{"choices":[{"message":{"content":"OK"}}]}'],
     [

--- a/src/lib/inference/health.test.ts
+++ b/src/lib/inference/health.test.ts
@@ -296,9 +296,10 @@ describe("inference health", () => {
       ["numeric streaming delta", 'data: {"choices":[{"delta":{"content":123}}]}\n'],
       ["a null content field and no tool call", '{"choices":[{"message":{"content":null}}]}'],
       [
-        "a null reasoning field and no tool call",
+        "a null reasoning_content field and no tool call",
         '{"choices":[{"message":{"reasoning_content":null}}]}',
       ],
+      ["a null reasoning field and no tool call", '{"choices":[{"message":{"reasoning":null}}]}'],
       ["a null refusal field and no tool call", '{"choices":[{"message":{"refusal":null}}]}'],
     ])("rejects a Chat Completions response with %s", (_description, body) => {
       const result = probeRemoteProviderHealth("openai-api", {
@@ -327,6 +328,19 @@ describe("inference health", () => {
       expect(result?.probed).toBe(true);
       expect(result?.failureLabel).toBeUndefined();
       expect(result?.detail).toContain("succeeded");
+    });
+
+    it("accepts a reasoning-only Chat Completions response", () => {
+      const result = probeRemoteProviderHealth("openai-api", {
+        model: "reasoning-model",
+        getCredentialImpl: () => "sk-test-secret",
+        runCurlProbeImpl: () =>
+          httpOk(
+            '{"choices":[{"finish_reason":"length","message":{"content":null,"reasoning":"Planning the reply."}}]}',
+          ),
+      });
+
+      expect(result).toMatchObject({ ok: true, probed: true });
     });
 
     it.each([

--- a/src/lib/inference/health.ts
+++ b/src/lib/inference/health.ts
@@ -289,7 +289,7 @@ function validateChatCompletionsResponse(body: string): InferenceResponseValidat
     return hasChatCompletionsChoice(parsed, false)
       ? { ok: true }
       : notChatCompletionsResult(
-          "no choice carried a message with text content, reasoning, a refusal, or tool calls",
+          "no choice carried a message with text content, reasoning_content, reasoning, a refusal, or tool calls",
         );
   }
 

--- a/src/lib/inference/health.ts
+++ b/src/lib/inference/health.ts
@@ -216,7 +216,7 @@ function hasValidChatMessageFields(
   allowStreamingDelta: boolean,
 ): boolean {
   let recognizedField = false;
-  for (const field of ["content", "reasoning_content", "refusal"] as const) {
+  for (const field of ["content", "reasoning_content", "reasoning", "refusal"] as const) {
     if (!(field in message)) continue;
     const value = message[field];
     const valid =
@@ -289,7 +289,7 @@ function validateChatCompletionsResponse(body: string): InferenceResponseValidat
     return hasChatCompletionsChoice(parsed, false)
       ? { ok: true }
       : notChatCompletionsResult(
-          "no choice carried a message with text content, a refusal, or tool calls",
+          "no choice carried a message with text content, reasoning, a refusal, or tool calls",
         );
   }
 

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -109,6 +109,8 @@ import {
   type StorageProbeResult,
 } from "./vllm-storage";
 
+export { selectVllmModelFromEnv } from "./vllm-models";
+
 // Per-platform install recipe. Add new platforms by appending an entry to
 // the profile table at the bottom of this file. The menu key in onboard.ts
 // stays "install-vllm" regardless of platform.

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2438,6 +2438,7 @@ function getSetupNimDeps(): SetupNimDeps {
     handleInstallOllamaSelection,
     installVllm: setupNimFlow.withServingPortGuard(vllmInference.installVllm, checkPortAvailable),
     handleVllmSelection,
+    selectVllmModelFromEnv: vllmInference.selectVllmModelFromEnv,
     handleRoutedSelection,
     coerceAgentInferenceApi: inferenceConfig.coerceAgentInferenceApi,
     resolveAgentInferenceApi: inferenceConfig.resolveAgentInferenceApi,
@@ -2451,7 +2452,6 @@ function getSetupNimDeps(): SetupNimDeps {
 }
 const setupNim = setupNimFlow.createSetupNim(getSetupNimDeps());
 // ── Step 4: Inference provider ───────────────────────────────────
-
 function getSetupInferenceDeps(): SetupInferenceDeps {
   return {
     checkGatewayRouteCompatibility,

--- a/src/lib/onboard/__test-helpers__/setup-nim-flow.ts
+++ b/src/lib/onboard/__test-helpers__/setup-nim-flow.ts
@@ -129,6 +129,7 @@ export function makeDeps(overrides: Partial<SetupNimFlowDeps> = {}): SetupNimFlo
     handleInstallOllamaSelection: async () => unexpected("Ollama install selection"),
     installVllm: async () => unexpected("vLLM install"),
     handleVllmSelection: async () => unexpected("vLLM selection"),
+    selectVllmModelFromEnv: () => null,
     handleRoutedSelection: async () => unexpected("routed selection"),
     coerceAgentInferenceApi: (_agent, preferredInferenceApi) => preferredInferenceApi,
     resolveAgentInferenceApi: (_agentName, _provider, preferredInferenceApi) =>

--- a/src/lib/onboard/setup-nim-flow-serving-profile.test.ts
+++ b/src/lib/onboard/setup-nim-flow-serving-profile.test.ts
@@ -29,8 +29,9 @@ function runningVllmHostState() {
   });
 }
 
-function acceptVllmSelection() {
+function acceptVllmSelection(observedModels?: unknown[]) {
   return vi.fn<SetupNimFlowDeps["handleVllmSelection"]>(async (state) => {
+    observedModels?.push(state.model);
     state.provider = "vllm";
     state.model = "muse-glimmer";
     state.endpointUrl = "http://127.0.0.1:8000/v1";
@@ -43,6 +44,7 @@ function acceptVllmSelection() {
 async function selectAgainstRunningVllm(
   handleVllmSelection: ReturnType<typeof acceptVllmSelection>,
   resolveRequestedServingProfileModel: SetupNimFlowDeps["resolveRequestedServingProfileModel"],
+  selectVllmModelFromEnv: SetupNimFlowDeps["selectVllmModelFromEnv"] = () => null,
 ) {
   const setupNim = createSetupNim(
     makeDeps({
@@ -51,6 +53,7 @@ async function selectAgainstRunningVllm(
       detectInferenceProviderHostState: () => runningVllmHostState(),
       handleVllmSelection,
       resolveRequestedServingProfileModel,
+      selectVllmModelFromEnv,
     }),
   );
   const sparkGpu = { platform: "spark" } as unknown as Parameters<typeof setupNim>[0];
@@ -83,6 +86,22 @@ describe("serving profile onboarding against a running vLLM", () => {
     expect(handleVllmSelection).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ servingProfileModel: null }),
+    );
+  });
+
+  it("passes an explicit managed model to the running-server selection", async () => {
+    const observedModels: unknown[] = [];
+    const handleVllmSelection = acceptVllmSelection(observedModels);
+
+    await selectAgainstRunningVllm(handleVllmSelection, () => null, () => ({
+      id: "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4",
+      servedModelId: "nvidia-nemotron-3.5-lightning-30b-a3b-nvfp4",
+    }));
+
+    expect(observedModels).toEqual(["nvidia-nemotron-3.5-lightning-30b-a3b-nvfp4"]);
+    expect(handleVllmSelection).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ managedInstall: false }),
     );
   });
 

--- a/src/lib/onboard/setup-nim-flow.ts
+++ b/src/lib/onboard/setup-nim-flow.ts
@@ -217,6 +217,9 @@ export interface SetupNimFlowDeps {
   resolveRequestedServingProfileModel?(
     env?: NodeJS.ProcessEnv,
   ): RequestedServingProfileModel | null;
+  selectVllmModelFromEnv?(
+    env?: NodeJS.ProcessEnv,
+  ): { id: string; servedModelId?: string } | null;
   handleRoutedSelection(state: SetupNimSelectionState): Promise<SetupNimSelectionResult>;
   coerceAgentInferenceApi(
     agent: AgentDefinition | null,
@@ -543,6 +546,32 @@ function requestedVllmServingProfileModel(
 ): RequestedServingProfileModel | null {
   const requested = (resolve ?? resolveRequestedServingProfileModel)();
   return requested?.backend === "vllm" ? requested : null;
+}
+
+/** Model ID that an explicit managed-vLLM model selection exposes through `/v1/models`. */
+function requestedManagedVllmModel(
+  resolve: SetupNimFlowDeps["selectVllmModelFromEnv"],
+): string | null {
+  if (!resolve) throw new Error("Managed vLLM model selection could not be resolved.");
+  const requested = resolve();
+  return requested?.servedModelId ?? requested?.id ?? null;
+}
+
+function resolveInitialVllmSelectionModel(input: {
+  preparedState: SetupNimSelectionState | null;
+  requestedProvider: string | null;
+  requestedModel: string | null;
+  recoveredModel: string | null;
+  selectVllmModelFromEnv: SetupNimFlowDeps["selectVllmModelFromEnv"];
+}): SetupNimSelectionState["model"] {
+  return (
+    input.preparedState?.model ??
+    input.requestedModel ??
+    (input.preparedState === null && input.requestedProvider === "install-vllm"
+      ? requestedManagedVllmModel(input.selectVllmModelFromEnv)
+      : null) ??
+    input.recoveredModel
+  );
 }
 
 async function resolveFreshHermesPortableOllamaSelection(input: {
@@ -1105,7 +1134,13 @@ export function createSetupNim(
         }
         if (selected.key === "vllm") {
           const state = preparedVllmState ?? createSelectionState();
-          state.model = preparedVllmState?.model ?? requestedModel ?? recoveredModel;
+          state.model = resolveInitialVllmSelectionModel({
+            preparedState: preparedVllmState,
+            requestedProvider,
+            requestedModel,
+            recoveredModel,
+            selectVllmModelFromEnv: deps.selectVllmModelFromEnv,
+          });
           // A requested profile reaches this branch two ways: its own install
           // finished, or `install-vllm` collapsed onto a server that was already
           // listening. The second path runs no install, so nothing seeds a

--- a/test/onboard-selection-vllm.test.ts
+++ b/test/onboard-selection-vllm.test.ts
@@ -583,7 +583,7 @@ const { setupNim } = require(${onboardPath});
     assert.doesNotMatch(result.stderr, /INSTALL_VLLM_CALLED/);
   });
 
-  it("logs a note when NEMOCLAW_PROVIDER=install-vllm is overridden by a running vLLM server (#3765)", () => {
+  it("rejects a running vLLM model that differs from NEMOCLAW_VLLM_MODEL", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-install-vllm-running-"));
     const scriptPath = path.join(tmpDir, "install-vllm-running-check.js");
@@ -607,8 +607,14 @@ runner.runCapture = (command) => {
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   if (cmd.includes("command -v ollama")) return "";
   if (cmd.includes("127.0.0.1:11434/api/tags")) return "";
-  // vLLM probe succeeds → vllmRunning becomes true.
-  if (cmd.includes("127.0.0.1:8000/v1/models")) return '{"data":[]}';
+  if (cmd.includes("127.0.0.1:8000/v1/models")) {
+    return JSON.stringify({
+      data: [{
+        id: "muse-glimmer",
+        root: "Inferact/Muse-Glimmer-30B-NVFP4-W4A4",
+      }],
+    });
+  }
   if (cmd.includes("docker images")) return "";
   return "";
 };
@@ -616,13 +622,11 @@ runner.runCapture = (command) => {
 const { setupNim } = require(${onboardPath});
 
 (async () => {
-  try {
-    await setupNim({ type: "nvidia" }, null);
-  } catch (e) {
-    // Downstream paths (model probe, gateway, etc.) are not mocked here; we
-    // only care about the menu-build log emitted before any failure.
-  }
-})();
+  await setupNim({ type: "nvidia" }, null);
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 `;
     fs.writeFileSync(scriptPath, script);
 
@@ -634,14 +638,15 @@ const { setupNim } = require(${onboardPath});
         HOME: tmpDir,
         NEMOCLAW_NON_INTERACTIVE: "1",
         NEMOCLAW_PROVIDER: "install-vllm",
+        NEMOCLAW_VLLM_MODEL: "nemotron-3.5-lightning-30b",
         NEMOCLAW_EXPERIMENTAL: "1",
       },
     });
 
-    assert.match(
-      result.stdout,
-      /NEMOCLAW_PROVIDER=install-vllm requested, but vLLM is already running on localhost:8000 — selecting the running instance\./,
-    );
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Detected vLLM model 'muse-glimmer' does not match/);
+    assert.match(result.stderr, /nvidia-nemotron-3\.5-lightning-30b-a3b-nvfp4/);
+    assert.doesNotMatch(result.stdout, /Detected model:/);
   });
 
   it("adopts an existing Ultra served alias during Station express (#7023)", () => {
@@ -721,7 +726,6 @@ const { setupNim } = require(${onboardPath});
         NEMOCLAW_NON_INTERACTIVE: "1",
         NEMOCLAW_PROVIDER: "install-vllm",
         NEMOCLAW_VLLM_MODEL: "nemotron-3-ultra-550b-a55b",
-        NEMOCLAW_MODEL: "nvidia/nemotron-3-ultra-550b-a55b",
       },
     });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Managed vLLM onboarding now honors an explicit `NEMOCLAW_VLLM_MODEL` when a server is already running, rejecting a mismatched served model instead of silently reusing it. Inference health checks now also recognize reasoning-only Chat Completions responses, preventing false negatives when the output token budget ends before assistant content is emitted.

## Changes

- Inject the existing vLLM catalog selector into the onboarding flow so a collapsed `install-vllm` request carries the selected model's served identity into the existing runtime compatibility check. This reuses the declarative catalog instead of duplicating model metadata, and onboarding tests cover matching and mismatched running-server paths.
- Fail closed when the explicit managed-vLLM model cannot be resolved, and leave an already-running mismatched runtime untouched rather than disrupting other sandboxes.
- Accept a non-null string `message.reasoning` payload under the same validation rules as `reasoning_content`; health and sandbox invocation-probe tests retain rejection coverage for null-only and malformed responses.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed explicit model selection, runtime identity comparison, route-adoption ordering, response-envelope validation, and credential boundaries. The change adds no credential, endpoint-policy, or route-mutation behavior.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli --maxWorkers=1 src/lib/onboard/setup-nim-flow-serving-profile.test.ts src/lib/inference/health.test.ts src/lib/actions/sandbox/inference-invocation-probe.test.ts` (87 passed); `npx vitest run --project integration --maxWorkers=1 test/onboard-selection-vllm.test.ts` (7 passed). Live Brev RTX PRO Server 6000 validation reported Lightning healthy, rejected an explicit Muse request against the running Lightning model, and left Lightning healthy.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
