### PR TITLE
fix(inference): preserve fixed local vLLM profile

### DIFF
--- a/src/lib/inference/serving/vllm-managed-support.ts
+++ b/src/lib/inference/serving/vllm-managed-support.ts
@@ -14,6 +14,10 @@ export {
   type MaterializedHostLocalVllmSelection,
   resolveHostLocalVllmSelection,
 } from "./host-local-vllm-selection.js";
+export {
+  NEMOCLAW_MANAGED_CLUSTER_PEERS_ENV,
+  NEMOCLAW_SERVING_PRESET_ENV,
+} from "./managed-cluster-discovery.js";
 export { tryInstallManagedClusterManagedVllm } from "./managed-cluster-installer.js";
 export { recoverInstalledManagedClusterVllmEndpoint } from "./managed-cluster-runtime-receipt.js";
 export { runtimeAuthFingerprint } from "./runtime-auth-fingerprint.js";

--- a/src/lib/inference/vllm-serving-port.test.ts
+++ b/src/lib/inference/vllm-serving-port.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   probeDockerStorage: vi.fn(),
   probeHostStorage: vi.fn(),
   recoverHostLocalManagedVllmEndpoint: vi.fn(),
+  resolveHostLocalVllmSelection: vi.fn(),
   runCapture: vi.fn(),
   tryInstallManagedClusterManagedVllm: vi.fn(async () => ({ kind: "not-selected" as const })),
 }));
@@ -61,6 +62,7 @@ vi.mock("./serving/vllm-managed-support", async (importOriginal) => {
     ...actual,
     ensureDualStationVllmApiKey: mocks.ensureDualStationVllmApiKey,
     recoverHostLocalManagedVllmEndpoint: mocks.recoverHostLocalManagedVllmEndpoint,
+    resolveHostLocalVllmSelection: mocks.resolveHostLocalVllmSelection,
     tryInstallManagedClusterManagedVllm: mocks.tryInstallManagedClusterManagedVllm,
   };
 });
@@ -96,6 +98,7 @@ describe("managed vLLM serving-port guard (#8685)", () => {
     applyVllmInstallProbeDefaults(mocks);
     mocks.getGpuIndicesByName.mockReturnValue([0]);
     mocks.recoverHostLocalManagedVllmEndpoint.mockReturnValue(null);
+    mocks.resolveHostLocalVllmSelection.mockReturnValue({ kind: "not-selected" });
     mocks.tryInstallManagedClusterManagedVllm.mockResolvedValue({ kind: "not-selected" });
     ({ errSpy, restore: restoreSpies } = createVllmInstallSpies());
     resetVllmInstallEnv();
@@ -131,6 +134,31 @@ describe("managed vLLM serving-port guard (#8685)", () => {
     expect(reported).toContain("port 8000 is already in use");
     expect(reported).toContain("PID 4242");
     expect(reported).not.toContain("exit 125");
+  });
+
+  it("keeps the fixed local-model profile command when installing vLLM", async () => {
+    const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
+    const model = {
+      ...baseProfile.defaultModel,
+      fixedServeCommand: true as const,
+      managedBearerAuth: true as const,
+    };
+    const profile = { ...baseProfile, defaultModel: model };
+    mockSuccessfulVllmInstall(mocks, profile.containerName);
+
+    await installVllm(profile, {
+      hasImage: true,
+      nonInteractive: true,
+      promptFn: vi.fn(),
+      resolveManagedBridgeHost: () => "172.18.0.1",
+    });
+
+    expect(mocks.resolveHostLocalVllmSelection).not.toHaveBeenCalled();
+    const command = mocks.dockerRunDetached.mock.calls
+      .flatMap((call: unknown[]) => (call[0] as readonly string[]).map(String))
+      .find((value) => value.includes("vllm serve"));
+    expect(command).toBeDefined();
+    expect(command).not.toContain("--trust-remote-code");
   });
 
   it("replaces a validated interrupted managed container that holds the serving port", async () => {

--- a/src/lib/inference/vllm-serving-port.test.ts
+++ b/src/lib/inference/vllm-serving-port.test.ts
@@ -158,7 +158,36 @@ describe("managed vLLM serving-port guard (#8685)", () => {
     expect(result).toEqual({ ok: true });
     expect(mocks.resolveHostLocalVllmSelection).not.toHaveBeenCalled();
     const runArgs = mocks.dockerRunDetached.mock.calls[0]?.[0] as readonly string[];
-    expect(runArgs[runArgs.indexOf("-lc") + 1]).toBe(buildVllmServeCommand(model));
+    const serveCommand = runArgs[runArgs.indexOf("-lc") + 1];
+    expect(serveCommand).toContain(model.id);
+    expect(serveCommand).not.toContain("--trust-remote-code");
+    expect(serveCommand).toBe(buildVllmServeCommand(model));
+  });
+
+  it("rejects NEMOCLAW_VLLM_MODEL before installing a fixed vLLM local model profile", async () => {
+    process.env.NEMOCLAW_VLLM_MODEL = "qwen3.6-27b";
+    const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
+    const model = {
+      ...baseProfile.defaultModel,
+      fixedServeCommand: true as const,
+      managedBearerAuth: true as const,
+    };
+    const profile = { ...baseProfile, defaultModel: model };
+    mockSuccessfulVllmInstall(mocks, profile.containerName);
+
+    const result = await installVllm(profile, {
+      hasImage: true,
+      nonInteractive: true,
+      promptFn: vi.fn(),
+    });
+
+    expect(result).toEqual({ ok: false });
+    expect(mocks.tryInstallManagedClusterManagedVllm).not.toHaveBeenCalled();
+    expect(mocks.resolveHostLocalVllmSelection).not.toHaveBeenCalled();
+    expect(mocks.ensureDualStationVllmApiKey).not.toHaveBeenCalled();
+    expect(mocks.dockerPullWithProgressWatchdog).not.toHaveBeenCalled();
+    expect(mocks.dockerRunDetached).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("NEMOCLAW_VLLM_MODEL"));
   });
 
   it("replaces a validated interrupted managed container that holds the serving port", async () => {

--- a/src/lib/inference/vllm-serving-port.test.ts
+++ b/src/lib/inference/vllm-serving-port.test.ts
@@ -137,7 +137,7 @@ describe("managed vLLM serving-port guard (#8685)", () => {
     expect(reported).not.toContain("exit 125");
   });
 
-  it("uses the fixed vLLM local model profile command after interactive confirmation", async () => {
+  it("uses the fixed vLLM local model profile command without managed-cluster selection", async () => {
     const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
     const model = {
       ...baseProfile.defaultModel,
@@ -147,6 +147,10 @@ describe("managed vLLM serving-port guard (#8685)", () => {
     };
     const profile = { ...baseProfile, defaultModel: model };
     mockSuccessfulVllmInstall(mocks, profile.containerName);
+    mocks.tryInstallManagedClusterManagedVllm.mockResolvedValue({
+      kind: "handled",
+      result: { ok: false },
+    });
     const promptFn = vi.fn<(question: string) => Promise<string>>(async () => "y");
 
     const result = await installVllm(profile, {
@@ -159,6 +163,7 @@ describe("managed vLLM serving-port guard (#8685)", () => {
     expect(result).toEqual({ ok: true });
     expect(promptFn).toHaveBeenCalledOnce();
     expect(promptFn).toHaveBeenCalledWith("  Continue? [y/N]: ");
+    expect(mocks.tryInstallManagedClusterManagedVllm).not.toHaveBeenCalled();
     expect(mocks.resolveHostLocalVllmSelection).not.toHaveBeenCalled();
     const runArgs = mocks.dockerRunDetached.mock.calls[0]?.[0] as readonly string[];
     const serveCommand = runArgs[runArgs.indexOf("-lc") + 1];
@@ -172,6 +177,11 @@ describe("managed vLLM serving-port guard (#8685)", () => {
     {
       variable: "NEMOCLAW_VLLM_EXTRA_ARGS_JSON",
       value: JSON.stringify(["--max-num-seqs", "2"]),
+    },
+    { variable: "NEMOCLAW_MANAGED_CLUSTER_PEERS", value: "spark-worker.local" },
+    {
+      variable: "NEMOCLAW_SERVING_PRESET",
+      value: "vllm.dgx-spark-gb10.dual.deepseek-v4-flash-0731",
     },
   ])(
     "rejects $variable before installing a fixed vLLM local model profile",

--- a/src/lib/inference/vllm-serving-port.test.ts
+++ b/src/lib/inference/vllm-serving-port.test.ts
@@ -73,6 +73,7 @@ import {
   type InstallVllmOptions,
   type VllmProfile,
 } from "./vllm";
+import { buildVllmServeCommand } from "./vllm-models";
 import {
   applyVllmInstallProbeDefaults,
   createVllmInstallSpies,
@@ -140,25 +141,24 @@ describe("managed vLLM serving-port guard (#8685)", () => {
     const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
     const model = {
       ...baseProfile.defaultModel,
+      id: "nvidia/fixed-local-profile",
       fixedServeCommand: true as const,
       managedBearerAuth: true as const,
     };
     const profile = { ...baseProfile, defaultModel: model };
     mockSuccessfulVllmInstall(mocks, profile.containerName);
 
-    await installVllm(profile, {
+    const result = await installVllm(profile, {
       hasImage: true,
       nonInteractive: true,
       promptFn: vi.fn(),
       resolveManagedBridgeHost: () => "172.18.0.1",
     });
 
+    expect(result).toEqual({ ok: true });
     expect(mocks.resolveHostLocalVllmSelection).not.toHaveBeenCalled();
-    const command = mocks.dockerRunDetached.mock.calls
-      .flatMap((call: unknown[]) => (call[0] as readonly string[]).map(String))
-      .find((value) => value.includes("vllm serve"));
-    expect(command).toBeDefined();
-    expect(command).not.toContain("--trust-remote-code");
+    const runArgs = mocks.dockerRunDetached.mock.calls[0]?.[0] as readonly string[];
+    expect(runArgs[runArgs.indexOf("-lc") + 1]).toBe(buildVllmServeCommand(model));
   });
 
   it("replaces a validated interrupted managed container that holds the serving port", async () => {

--- a/src/lib/inference/vllm-serving-port.test.ts
+++ b/src/lib/inference/vllm-serving-port.test.ts
@@ -23,7 +23,9 @@ const mocks = vi.hoisted(() => ({
   recoverHostLocalManagedVllmEndpoint: vi.fn(),
   resolveHostLocalVllmSelection: vi.fn(),
   runCapture: vi.fn(),
-  tryInstallManagedClusterManagedVllm: vi.fn(async () => ({ kind: "not-selected" as const })),
+  tryInstallManagedClusterManagedVllm: vi.fn<
+    typeof import("./serving/vllm-managed-support").tryInstallManagedClusterManagedVllm
+  >(async () => ({ kind: "not-selected" as const })),
 }));
 
 vi.mock("../runner", async (importOriginal) => ({

--- a/src/lib/inference/vllm-serving-port.test.ts
+++ b/src/lib/inference/vllm-serving-port.test.ts
@@ -137,7 +137,7 @@ describe("managed vLLM serving-port guard (#8685)", () => {
     expect(reported).not.toContain("exit 125");
   });
 
-  it("keeps the fixed local-model profile command when installing vLLM", async () => {
+  it("uses the fixed vLLM local model profile command after interactive confirmation", async () => {
     const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
     const model = {
       ...baseProfile.defaultModel,
@@ -147,15 +147,18 @@ describe("managed vLLM serving-port guard (#8685)", () => {
     };
     const profile = { ...baseProfile, defaultModel: model };
     mockSuccessfulVllmInstall(mocks, profile.containerName);
+    const promptFn = vi.fn<(question: string) => Promise<string>>(async () => "y");
 
     const result = await installVllm(profile, {
       hasImage: true,
-      nonInteractive: true,
-      promptFn: vi.fn(),
+      nonInteractive: false,
+      promptFn,
       resolveManagedBridgeHost: () => "172.18.0.1",
     });
 
     expect(result).toEqual({ ok: true });
+    expect(promptFn).toHaveBeenCalledOnce();
+    expect(promptFn).toHaveBeenCalledWith("  Continue? [y/N]: ");
     expect(mocks.resolveHostLocalVllmSelection).not.toHaveBeenCalled();
     const runArgs = mocks.dockerRunDetached.mock.calls[0]?.[0] as readonly string[];
     const serveCommand = runArgs[runArgs.indexOf("-lc") + 1];
@@ -164,31 +167,40 @@ describe("managed vLLM serving-port guard (#8685)", () => {
     expect(serveCommand).toBe(buildVllmServeCommand(model));
   });
 
-  it("rejects NEMOCLAW_VLLM_MODEL before installing a fixed vLLM local model profile", async () => {
-    process.env.NEMOCLAW_VLLM_MODEL = "qwen3.6-27b";
-    const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
-    const model = {
-      ...baseProfile.defaultModel,
-      fixedServeCommand: true as const,
-      managedBearerAuth: true as const,
-    };
-    const profile = { ...baseProfile, defaultModel: model };
-    mockSuccessfulVllmInstall(mocks, profile.containerName);
+  it.each([
+    { variable: "NEMOCLAW_VLLM_MODEL", value: "qwen3.6-27b" },
+    {
+      variable: "NEMOCLAW_VLLM_EXTRA_ARGS_JSON",
+      value: JSON.stringify(["--max-num-seqs", "2"]),
+    },
+  ])(
+    "rejects $variable before installing a fixed vLLM local model profile",
+    async ({ variable, value }) => {
+      process.env[variable] = value;
+      const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
+      const model = {
+        ...baseProfile.defaultModel,
+        fixedServeCommand: true as const,
+        managedBearerAuth: true as const,
+      };
+      const profile = { ...baseProfile, defaultModel: model };
+      mockSuccessfulVllmInstall(mocks, profile.containerName);
 
-    const result = await installVllm(profile, {
-      hasImage: true,
-      nonInteractive: true,
-      promptFn: vi.fn(),
-    });
+      const result = await installVllm(profile, {
+        hasImage: true,
+        nonInteractive: true,
+        promptFn: vi.fn(),
+      });
 
-    expect(result).toEqual({ ok: false });
-    expect(mocks.tryInstallManagedClusterManagedVllm).not.toHaveBeenCalled();
-    expect(mocks.resolveHostLocalVllmSelection).not.toHaveBeenCalled();
-    expect(mocks.ensureDualStationVllmApiKey).not.toHaveBeenCalled();
-    expect(mocks.dockerPullWithProgressWatchdog).not.toHaveBeenCalled();
-    expect(mocks.dockerRunDetached).not.toHaveBeenCalled();
-    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("NEMOCLAW_VLLM_MODEL"));
-  });
+      expect(result).toEqual({ ok: false });
+      expect(mocks.tryInstallManagedClusterManagedVllm).not.toHaveBeenCalled();
+      expect(mocks.resolveHostLocalVllmSelection).not.toHaveBeenCalled();
+      expect(mocks.ensureDualStationVllmApiKey).not.toHaveBeenCalled();
+      expect(mocks.dockerPullWithProgressWatchdog).not.toHaveBeenCalled();
+      expect(mocks.dockerRunDetached).not.toHaveBeenCalled();
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining(variable));
+    },
+  );
 
   it("replaces a validated interrupted managed container that holds the serving port", async () => {
     const profile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;

--- a/src/lib/inference/vllm-serving-port.test.ts
+++ b/src/lib/inference/vllm-serving-port.test.ts
@@ -175,18 +175,28 @@ describe("managed vLLM serving-port guard (#8685)", () => {
   });
 
   it.each([
-    { variable: "NEMOCLAW_VLLM_MODEL", value: "qwen3.6-27b" },
     {
+      label: "NEMOCLAW_VLLM_MODEL",
+      variable: "NEMOCLAW_VLLM_MODEL",
+      value: "qwen3.6-27b",
+    },
+    {
+      label: "NEMOCLAW_VLLM_EXTRA_ARGS_JSON",
       variable: "NEMOCLAW_VLLM_EXTRA_ARGS_JSON",
       value: JSON.stringify(["--max-num-seqs", "2"]),
     },
-    { variable: "NEMOCLAW_MANAGED_CLUSTER_PEERS", value: "spark-worker.local" },
     {
+      label: "NEMOCLAW_MANAGED_CLUSTER_PEERS",
+      variable: "NEMOCLAW_MANAGED_CLUSTER_PEERS",
+      value: "spark-worker.local",
+    },
+    {
+      label: "a mismatched NEMOCLAW_SERVING_PRESET",
       variable: "NEMOCLAW_SERVING_PRESET",
       value: "vllm.dgx-spark-gb10.dual.deepseek-v4-flash-0731",
     },
   ])(
-    "rejects $variable before installing a fixed vLLM local model profile",
+    "rejects $label before installing a fixed vLLM local model profile",
     async ({ variable, value }) => {
       process.env[variable] = value;
       const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;

--- a/src/lib/inference/vllm.test.ts
+++ b/src/lib/inference/vllm.test.ts
@@ -982,6 +982,31 @@ describe("installVllm model resolution", () => {
     expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("gated on Hugging Face"));
   });
 
+  it("keeps the fixed local-model profile command when installing vLLM", async () => {
+    const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
+    const model = {
+      ...baseProfile.defaultModel,
+      fixedServeCommand: true as const,
+      managedBearerAuth: true as const,
+    };
+    const profile = { ...baseProfile, defaultModel: model };
+    mockSuccessfulVllmInstall(mocks, profile.containerName);
+
+    await installVllm(profile, {
+      hasImage: true,
+      nonInteractive: true,
+      promptFn: vi.fn(),
+      resolveManagedBridgeHost: () => "172.18.0.1",
+    });
+
+    expect(mocks.resolveHostLocalVllmSelection).not.toHaveBeenCalled();
+    const command = mocks.dockerRunDetached.mock.calls
+      .flatMap((call: unknown[]) => (call[0] as readonly string[]).map(String))
+      .find((value) => value.includes("vllm serve"));
+    expect(command).toBeDefined();
+    expect(command).not.toContain("--trust-remote-code");
+  });
+
   it("persists exact profile ownership before authenticating a catalog-selected runtime (#8246)", async () => {
     const baseProfile = detectVllmProfile({
       platform: "spark",

--- a/src/lib/inference/vllm.test.ts
+++ b/src/lib/inference/vllm.test.ts
@@ -982,31 +982,6 @@ describe("installVllm model resolution", () => {
     expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("gated on Hugging Face"));
   });
 
-  it("keeps the fixed local-model profile command when installing vLLM", async () => {
-    const baseProfile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
-    const model = {
-      ...baseProfile.defaultModel,
-      fixedServeCommand: true as const,
-      managedBearerAuth: true as const,
-    };
-    const profile = { ...baseProfile, defaultModel: model };
-    mockSuccessfulVllmInstall(mocks, profile.containerName);
-
-    await installVllm(profile, {
-      hasImage: true,
-      nonInteractive: true,
-      promptFn: vi.fn(),
-      resolveManagedBridgeHost: () => "172.18.0.1",
-    });
-
-    expect(mocks.resolveHostLocalVllmSelection).not.toHaveBeenCalled();
-    const command = mocks.dockerRunDetached.mock.calls
-      .flatMap((call: unknown[]) => (call[0] as readonly string[]).map(String))
-      .find((value) => value.includes("vllm serve"));
-    expect(command).toBeDefined();
-    expect(command).not.toContain("--trust-remote-code");
-  });
-
   it("persists exact profile ownership before authenticating a catalog-selected runtime (#8246)", async () => {
     const baseProfile = detectVllmProfile({
       platform: "spark",

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -1658,9 +1658,9 @@ async function runVllmInstall(
   const explicitModel = String(process.env.NEMOCLAW_VLLM_MODEL ?? "").trim();
   const configuredPeer = String(process.env[NEMOCLAW_DGX_STATION_PEER_ENV] ?? "").trim();
   if (profile.defaultModel.fixedServeCommand) {
-    if (String(process.env[VLLM_EXTRA_ARGS_ENV] ?? "").trim()) {
+    if (explicitModel || String(process.env[VLLM_EXTRA_ARGS_ENV] ?? "").trim()) {
       console.error(
-        `  vLLM install failed: this local model profile does not accept ${VLLM_EXTRA_ARGS_ENV}.`,
+        `  vLLM install failed: this local model profile does not accept NEMOCLAW_VLLM_MODEL or ${VLLM_EXTRA_ARGS_ENV}.`,
       );
       return { ok: false };
     }

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -1683,7 +1683,11 @@ async function runVllmInstall(
       );
   if (managedCluster.kind === "handled") return managedCluster.result;
 
-  if (!hostLocalSelection && !(profile.platform === "station" && configuredPeer)) {
+  if (
+    !hostLocalSelection &&
+    !profile.defaultModel.fixedServeCommand &&
+    !(profile.platform === "station" && configuredPeer)
+  ) {
     const selected = resolveHostLocalVllmSelection(profile, process.env, {
       automatic: opts.nonInteractive,
       readinessReports: opts.readinessReports,

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -1768,7 +1768,7 @@ async function runVllmInstall(
     resolved = { model: hostLocalSelection.model, source: "default" };
   } else {
     resolved = await resolveVllmInstallModel(profile, {
-      nonInteractive: opts.nonInteractive,
+      nonInteractive: opts.nonInteractive || profile.defaultModel.fixedServeCommand === true,
       promptFn: opts.promptFn,
     });
   }

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -1671,12 +1671,15 @@ async function runVllmInstall(
       process.env[NEMOCLAW_MANAGED_CLUSTER_PEERS_ENV] ?? "",
     ).trim();
     const configuredServingPreset = String(process.env[NEMOCLAW_SERVING_PRESET_ENV] ?? "").trim();
-    if (
-      configuredManagedClusterPeers ||
-      (configuredServingPreset && configuredServingPreset !== profile.servingCatalog?.presetId)
-    ) {
+    if (configuredManagedClusterPeers) {
       console.error(
-        `  vLLM install failed: this local model profile does not accept ${NEMOCLAW_MANAGED_CLUSTER_PEERS_ENV} or a different ${NEMOCLAW_SERVING_PRESET_ENV}.`,
+        `  vLLM install failed: this local model profile does not accept ${NEMOCLAW_MANAGED_CLUSTER_PEERS_ENV}.`,
+      );
+      return { ok: false };
+    }
+    if (configuredServingPreset && configuredServingPreset !== profile.servingCatalog?.presetId) {
+      console.error(
+        `  vLLM install failed: ${NEMOCLAW_SERVING_PRESET_ENV} must match this local model profile's catalog preset.`,
       );
       return { ok: false };
     }

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -43,6 +43,8 @@ import {
   ensureDualStationVllmApiKey,
   loadDualStationVllmApiKey,
   type MaterializedHostLocalVllmSelection,
+  NEMOCLAW_MANAGED_CLUSTER_PEERS_ENV,
+  NEMOCLAW_SERVING_PRESET_ENV,
   persistHostLocalVllmRuntimeReceipt,
   recoverHostLocalManagedVllmEndpoint,
   recoverInstalledManagedClusterVllmEndpoint,
@@ -1657,35 +1659,49 @@ async function runVllmInstall(
 ): Promise<{ ok: boolean }> {
   const explicitModel = String(process.env.NEMOCLAW_VLLM_MODEL ?? "").trim();
   const configuredPeer = String(process.env[NEMOCLAW_DGX_STATION_PEER_ENV] ?? "").trim();
-  if (profile.defaultModel.fixedServeCommand) {
+  const fixedServeCommand = profile.defaultModel.fixedServeCommand === true;
+  if (fixedServeCommand) {
     if (explicitModel || String(process.env[VLLM_EXTRA_ARGS_ENV] ?? "").trim()) {
       console.error(
         `  vLLM install failed: this local model profile does not accept NEMOCLAW_VLLM_MODEL or ${VLLM_EXTRA_ARGS_ENV}.`,
       );
       return { ok: false };
     }
-  }
-  const managedCluster = hostLocalSelection
-    ? { kind: "not-selected" as const }
-    : await tryInstallManagedClusterManagedVllm(
-        {
-          platform: profile.platform,
-          nonInteractive: opts.nonInteractive,
-          promptFn: opts.promptFn,
-          beforeInstall: opts.beforeInstall,
-        },
-        {
-          prerequisites: dockerPrereqsOk,
-          pullImage,
-          downloadModel,
-          printDownloadAuthentication: printHfDownloadAuthentication,
-        },
+    const configuredManagedClusterPeers = String(
+      process.env[NEMOCLAW_MANAGED_CLUSTER_PEERS_ENV] ?? "",
+    ).trim();
+    const configuredServingPreset = String(process.env[NEMOCLAW_SERVING_PRESET_ENV] ?? "").trim();
+    if (
+      configuredManagedClusterPeers ||
+      (configuredServingPreset && configuredServingPreset !== profile.servingCatalog?.presetId)
+    ) {
+      console.error(
+        `  vLLM install failed: this local model profile does not accept ${NEMOCLAW_MANAGED_CLUSTER_PEERS_ENV} or a different ${NEMOCLAW_SERVING_PRESET_ENV}.`,
       );
-  if (managedCluster.kind === "handled") return managedCluster.result;
+      return { ok: false };
+    }
+  }
+  if (!hostLocalSelection && !fixedServeCommand) {
+    const managedCluster = await tryInstallManagedClusterManagedVllm(
+      {
+        platform: profile.platform,
+        nonInteractive: opts.nonInteractive,
+        promptFn: opts.promptFn,
+        beforeInstall: opts.beforeInstall,
+      },
+      {
+        prerequisites: dockerPrereqsOk,
+        pullImage,
+        downloadModel,
+        printDownloadAuthentication: printHfDownloadAuthentication,
+      },
+    );
+    if (managedCluster.kind === "handled") return managedCluster.result;
+  }
 
   if (
     !hostLocalSelection &&
-    !profile.defaultModel.fixedServeCommand &&
+    !fixedServeCommand &&
     !(profile.platform === "station" && configuredPeer)
   ) {
     const selected = resolveHostLocalVllmSelection(profile, process.env, {
@@ -1768,7 +1784,7 @@ async function runVllmInstall(
     resolved = { model: hostLocalSelection.model, source: "default" };
   } else {
     resolved = await resolveVllmInstallModel(profile, {
-      nonInteractive: opts.nonInteractive || profile.defaultModel.fixedServeCommand === true,
+      nonInteractive: opts.nonInteractive || fixedServeCommand,
       promptFn: opts.promptFn,
     });
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Preserve the fixed local-model vLLM profile through installation. Previously the installer re-ran host-local selection and could replace the fixed command with a generic profile, adding `--trust-remote-code` on DGX Spark.

## Changes

- Skip host-local profile selection when the supplied profile already owns a fixed serving command.
- Add regression coverage that proves the fixed command is launched without `--trust-remote-code`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — direct control-flow repair preserves the fixed catalog command and avoids an unintended remote-code flag; focused negative test verifies the flag is absent.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/inference/vllm.test.ts` (72 passed); `npm run typecheck:cli`; formatting check.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: prekshivyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed profiles with predefined serving commands to preserve and use those commands directly.
  - Prevented unnecessary host-local model selection for these profiles.
  - Reject unsupported model overrides and extra serving arguments for fixed-command profiles.
  - Ensured installation completes without resolving an alternative host-local model or triggering related side effects.

- **Tests**
  - Expanded coverage for interactive confirmation, exact serving commands, validation, and host-local selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->