### PR TITLE
fix(e2e): preserve local registry authority

### DIFF
--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -63,7 +63,7 @@
     },
     {
       "file": "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",
-      "test": "keeps actionlint and live E2E on Ubuntu 26.04 and Podman 5.7 (#9006)",
+      "test": "keeps live E2E on the accepted rootless runtime and local registry authority (#9006)",
       "category": "compatibility"
     },
     {

--- a/test/e2e/live/portable-profile-rootless-linux.test.ts
+++ b/test/e2e/live/portable-profile-rootless-linux.test.ts
@@ -127,7 +127,9 @@ async function main(progress: TestProgress): Promise<void> {
   assert.equal(process.platform, "linux", "portable profile E2E requires Linux");
   assert.notEqual(process.getuid?.(), 0, "portable profile E2E must run without root privileges");
 
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-e2e-"));
+  const root = fs.mkdtempSync(
+    path.join(os.userInfo().homedir, ".nemoclaw-portable-e2e-"),
+  );
   const home = path.join(root, "home");
   const binDir = path.join(root, "bin");
   const stateDir = path.join(root, "gateway-state");
@@ -136,6 +138,7 @@ async function main(progress: TestProgress): Promise<void> {
   const gatewayAliasPresentBefore = run("ip", ["-o", "-4", "address", "show", "dev", "lo"])
     .split("\n")
     .some((line) => line.includes(`inet ${PORTABLE_HOST_GATEWAY_IP}/32`));
+  fs.mkdirSync(home, { recursive: true, mode: 0o700 });
   fs.mkdirSync(binDir, { recursive: true, mode: 0o700 });
   installPortableProfileSystemctlShim(binDir);
 
@@ -155,12 +158,21 @@ async function main(progress: TestProgress): Promise<void> {
     assert.equal(installerDockerHost, `unix://${runtimeDir}/podman/podman.sock`);
 
     progress.phase("prepare the rootless container runtime");
-    preparePortableExperimentalHost(process.env);
+    const prepared = preparePortableExperimentalHost(process.env, { home });
+    assert.equal(prepared?.authority.configHome, configHome);
     assert.equal(process.env.DOCKER_HOST, `unix://${runtimeDir}/podman/podman.sock`);
     assert.equal(fs.statSync(path.join(runtimeDir, "podman")).mode & 0o777, 0o700);
     assert.match(
       fs.readFileSync(String(process.env.CONTAINERS_CONF), "utf-8"),
       /default_rootless_network_cmd = "pasta"/,
+    );
+    const registryConfig = path.join(
+      configHome,
+      "containers/registries.conf.d/99-nemoclaw-portable.conf",
+    );
+    assert.equal(
+      fs.readFileSync(registryConfig, "utf-8"),
+      '[[registry]]\nlocation = "localhost:5000"\ninsecure = true\n',
     );
     assert.match(
       run("ip", ["-o", "-4", "address", "show", "dev", "lo"]),

--- a/test/e2e/live/portable-profile-rootless-linux.test.ts
+++ b/test/e2e/live/portable-profile-rootless-linux.test.ts
@@ -14,11 +14,13 @@ import * as importedPortableHostPreparation from "../../../src/lib/onboard/exper
 import * as importedSandboxPrebuild from "../../../src/lib/onboard/sandbox-prebuild.ts";
 import * as importedBuildContext from "../../../src/lib/sandbox/build-context.ts";
 import {
+  DOCKER_NETWORK_IPAM_INSPECT_FORMAT,
+  parseDockerNetworkIpamEntries,
   PORTABLE_DOCKER_NETWORK_NAME,
   PORTABLE_DOCKER_NETWORK_SUBNET,
   PORTABLE_HOST_GATEWAY_IP,
   PORTABLE_REGISTRY_IP,
-} from "../../../src/lib/onboard/experimental/portable-profile.ts";
+} from "../../../src/lib/onboard/docker-driver-platform.ts";
 import { test } from "../fixtures/e2e-test.ts";
 import {
   cleanupPortableHostGatewayAlias,
@@ -212,18 +214,20 @@ async function main(progress: TestProgress): Promise<void> {
       run("podman", ["image", "inspect", "--format", "{{.Id}}", imageRef]),
       /^(?:sha256:)?[a-f0-9]{64}$/,
     );
-    assert.equal(
-      run("podman", [
-        "network",
-        "inspect",
-        "--format",
-        "{{range .Subnets}}{{println .Subnet}}{{end}}",
-        PORTABLE_DOCKER_NETWORK_NAME,
-      ]),
-      PORTABLE_DOCKER_NETWORK_SUBNET,
+    assert.deepEqual(
+      parseDockerNetworkIpamEntries(
+        run("docker", [
+          "network",
+          "inspect",
+          "--format",
+          DOCKER_NETWORK_IPAM_INSPECT_FORMAT,
+          PORTABLE_DOCKER_NETWORK_NAME,
+        ]),
+      )?.map(({ subnet }) => subnet),
+      [PORTABLE_DOCKER_NETWORK_SUBNET],
     );
     assert.equal(
-      run("podman", [
+      run("docker", [
         "inspect",
         "--format",
         `{{with index .NetworkSettings.Networks ${JSON.stringify(PORTABLE_DOCKER_NETWORK_NAME)}}}{{.IPAddress}}{{end}}`,

--- a/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
+++ b/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
@@ -78,5 +78,8 @@ describe("portable profile rootless runtime workflow", () => {
     expect(liveTest).toContain("preparePortableExperimentalHost(process.env, { home });");
     expect(liveTest).toContain("assert.equal(prepared?.authority.configHome, configHome);");
     expect(liveTest).toContain('location = "localhost:5000"\\ninsecure = true');
+    expect(liveTest).toContain("DOCKER_NETWORK_IPAM_INSPECT_FORMAT");
+    expect(liveTest).toContain("parseDockerNetworkIpamEntries(");
+    expect(liveTest).not.toContain("{{range .Subnets}}");
   });
 });

--- a/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
+++ b/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
@@ -1,17 +1,23 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import { readYaml, type Workflow } from "../../helpers/e2e-workflow-contract";
 
 describe("portable profile rootless runtime workflow", () => {
-  // source-shape-contract: compatibility -- Actionlint and the workflow must share Ubuntu 26.04 while the workflow compiles the candidate catalogue, pins Podman 5.7, and corrects the pasta AppArmor policy before live E2E
-  it("keeps actionlint and live E2E on Ubuntu 26.04 and Podman 5.7 (#9006)", () => {
+  // source-shape-contract: compatibility -- The workflow and live fixture must keep the accepted OS, Podman, AppArmor, and HTTP local-registry authorities aligned before live E2E
+  it("keeps live E2E on the accepted rootless runtime and local registry authority (#9006)", () => {
     const actionlint = readYaml<{ "self-hosted-runner"?: { labels?: string[] } }>(
       ".github/actionlint.yaml",
     );
     const workflow = readYaml<Workflow>(".github/workflows/portable-profile-e2e.yaml");
+    const liveTest = fs.readFileSync(
+      "test/e2e/live/portable-profile-rootless-linux.test.ts",
+      "utf-8",
+    );
     const job = workflow.jobs["rootless-linux"];
     const steps = job?.steps ?? [];
     const provision = steps.find(
@@ -63,5 +69,11 @@ describe("portable profile rootless runtime workflow", () => {
     expect(policy).toContain('if ! grep -Eq "$signal_rule" "$pasta_profile"; then');
     expect(policy).toContain('test "$(grep -Ec "$signal_rule" "$pasta_profile")" -eq 1');
     expect(policy).toContain('apparmor_parser -r "$pasta_profile"');
+    expect(liveTest).toContain(
+      'path.join(os.userInfo().homedir, ".nemoclaw-portable-e2e-")',
+    );
+    expect(liveTest).toContain("preparePortableExperimentalHost(process.env, { home });");
+    expect(liveTest).toContain("assert.equal(prepared?.authority.configHome, configHome);");
+    expect(liveTest).toContain('location = "localhost:5000"\\ninsecure = true');
   });
 });

--- a/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
+++ b/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
@@ -72,6 +72,9 @@ describe("portable profile rootless runtime workflow", () => {
     expect(liveTest).toContain(
       'path.join(os.userInfo().homedir, ".nemoclaw-portable-e2e-")',
     );
+    expect(liveTest).not.toMatch(
+      /mkdtempSync\(\s*path\.join\(os\.tmpdir\(\),\s*["']nemoclaw-portable-e2e-/,
+    );
     expect(liveTest).toContain("preparePortableExperimentalHost(process.env, { home });");
     expect(liveTest).toContain("assert.equal(prepared?.authority.configHome, configHome);");
     expect(liveTest).toContain('location = "localhost:5000"\\ninsecure = true');

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -188,6 +188,12 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     ),
   },
   {
+    pattern: /(?:^|\/)test\/e2e\/live\/portable-profile-rootless-linux\.test\.ts$/,
+    testsToRun: runTests(
+      "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",
+    ),
+  },
+  {
     pattern: /(?:^|\/)test\/e2e\/fixtures\/portable-profile-systemctl-shim\.sh$/,
     testsToRun: runTests("test/e2e/support/portable-profile-systemctl-shim.test.ts"),
   },

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -203,6 +203,9 @@ describe("Vitest opaque-input watch triggers", () => {
       "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",
       "test/e2e/support/portable-profile-systemctl-shim.test.ts",
     ]);
+    expect(triggeredBy("test/e2e/live/portable-profile-rootless-linux.test.ts")).toEqual([
+      "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",
+    ]);
     expect(triggeredBy("test/e2e/fixtures/portable-profile-systemctl-shim.sh")).toEqual([
       "test/e2e/support/portable-profile-systemctl-shim.test.ts",
     ]);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Portable host preparation already writes the HTTP authority for the managed local registry. The automatic rootless fixture selected a temporary home that Podman inherited but preparation did not, so Podman defaulted `localhost:5000` to HTTPS. The fixture now prepares and verifies the same isolated home authority before publishing or pulling the sandbox image.

## Related Issue

Fixes #9006

## Changes

- Create the rootless fixture under the current user home and pass its isolated home to Portable host preparation.
- Require the returned configuration authority and exact `localhost:5000` insecure-registry fragment before image publication.
- Use the production-owned Docker-compatible IPAM format and parser over the same rootless Podman socket for network authority inspection.
- Add a deterministic source contract and watch trigger so fixture changes exercise the HTTP local-registry authority check.
- Preserve Ubuntu 26.04, exact Podman 5.7 provisioning, and the pasta AppArmor correction.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent exact-commit review of `fb62559216c54e7fda46a2d0b7b2a7d9eed5bb37` passed all nine security categories with no findings. It confirmed that the HTTP exception remains limited to `localhost:5000` and does not weaken remote registry TLS. Independent documentation-writer review also passed with disposition `docs-not-needed`.
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: [`cli-test-shards (9)`](https://github.com/NVIDIA/NemoClaw/actions/runs/32341863245/job/96342469112) repeated the unrelated Node.js heap OOM after the other 11 shards passed; [maintainer approval](https://github.com/NVIDIA/NemoClaw/pull/9711#pullrequestreview-4980008957) accepts the exact PR commit with remaining CI continuing independently. No follow-up issue was required by the approval.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this PR does not change `scripts/prepare-dgx-station-host.sh`.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts` passed 1/1; `npx vitest run --project integration test/vitest-watch-triggers.test.ts` passed 46/46; the contract failed first before the fixture supplied its home authority.
- [x] Applicable broad gate passed — `npm run test:changed -- --reporter=default` passed 32 growth guardrails and the affected E2E-support contract; `npm run checks:repository` and `npm run typecheck:cli` passed.
- [x] Exact live proof passed — [`E2E / Portable Profile`](https://github.com/NVIDIA/NemoClaw/actions/runs/32341885978) passed for `fb62559216c54e7fda46a2d0b7b2a7d9eed5bb37`, including the [`rootless-linux` job](https://github.com/NVIDIA/NemoClaw/actions/runs/32341885978/job/96342491700).
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved validation for portable-profile rootless Linux workflows.
  * Added checks for temporary home-directory setup, prepared host configuration, network configuration, and local registry settings.
  * Updated compatibility checks to reflect the accepted rootless runtime and registry authorities.
  * Added automatic watch coverage so related workflow tests run when the portable-profile test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
