### PR TITLE
fix(hermes): migrate dashboard state before gateway health

### DIFF
--- a/agents/hermes/start.sh
+++ b/agents/hermes/start.sh
@@ -3482,6 +3482,11 @@ prepare_restricted_log /tmp/gateway.log gateway:gateway 600
 # shellcheck disable=SC2119
 validate_tmp_permissions
 
+# Migrate and seed the dashboard profile before Hermes reads the shared home.
+# Waiting until dashboard launch leaves restored legacy state in the gateway's
+# HERMES_HOME during its readiness check.
+prepare_hermes_dashboard_home sandbox:sandbox || exit 1
+
 # Start Hermes gateway. Messaging egress goes directly through OpenShell.
 launch_hermes_gateway
 start_gateway_log_stream

--- a/test/hermes-mcp-integrity-state.test.ts
+++ b/test/hermes-mcp-integrity-state.test.ts
@@ -26,7 +26,7 @@ const TRANSACTION = path.join(
 );
 const START = path.join(import.meta.dirname, "..", "agents", "hermes", "start.sh");
 
-function runHermesRootMcpStartup(opts: { commitStatus: 0 | 1; dashboardStatus?: 0 | 1 }) {
+function runHermesRootMcpStartup(opts: { commitStatus: 0 | 1; dashboardSeedStatus?: 0 | 23 }) {
   const source = fs.readFileSync(START, "utf-8");
   const startupBlock = source.match(
     /^prepare_hermes_dashboard_home sandbox:sandbox \|\| exit 1$\n[\s\S]*?^launch_hermes_gateway\nstart_gateway_log_stream\nwait_for_hermes_gateway_internal "\$GATEWAY_PID"\nensure_hermes_supervised_auxiliaries\nfinalize_tirith_marker_retry\nif ! commit_hermes_mcp_applied_if_pending; then\n[\s\S]*?^restore_hermes_config_permissions_after_dashboard_start$/m,
@@ -36,13 +36,34 @@ function runHermesRootMcpStartup(opts: { commitStatus: 0 | 1; dashboardStatus?: 
 
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-mcp-root-start-"));
   const scriptPath = path.join(tempDir, "run.sh");
+  const fakePython = path.join(tempDir, "fake-python.sh");
+  const hermesHome = path.join(tempDir, ".hermes");
+  const dashboardHome = path.join(hermesHome, "profiles", "dashboard-home");
+  fs.writeFileSync(
+    fakePython,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'printf "dashboard-profile\\n"',
+      'if [ "${NEMOCLAW_TEST_STEPPED_DOWN:-0}" != 1 ]; then exit 99; fi',
+      `exit ${opts.dashboardSeedStatus ?? 0}`,
+    ].join("\n"),
+    { mode: 0o700 },
+  );
   fs.writeFileSync(
     scriptPath,
     [
       "#!/usr/bin/env bash",
       "set -euo pipefail",
       'trace() { printf "%s\\n" "$*"; }',
-      `prepare_hermes_dashboard_home() { trace dashboard-profile; return ${opts.dashboardStatus ?? 0}; }`,
+      'id() { [ "${1:-}" = "-u" ] && printf "0\\n" || command id "$@"; }',
+      extractShellFunction(source, "prepare_hermes_dashboard_home"),
+      `HERMES_DIR=${bashPrintfQ(hermesHome)}`,
+      `HERMES_DASHBOARD_HOME=${bashPrintfQ(dashboardHome)}`,
+      `_HERMES_PYTHON=${bashPrintfQ(fakePython)}`,
+      `_HERMES_DASHBOARD_CONFIG_SEEDER=${bashPrintfQ(path.join(tempDir, "seed-dashboard-config.py"))}`,
+      `_HERMES_MANAGED_POLICY=${bashPrintfQ(path.join(tempDir, "managed-policy.json"))}`,
+      "STEP_DOWN_PREFIX_SANDBOX=(env NEMOCLAW_TEST_STEPPED_DOWN=1)",
       'launch_hermes_gateway() { GATEWAY_PID=4242; trace "launch:$GATEWAY_PID"; }',
       "start_gateway_log_stream() { trace log-stream; }",
       'wait_for_hermes_gateway_internal() { trace "health:$1"; }',
@@ -608,9 +629,12 @@ print(json.dumps({"state": state, "config_reads": config_reads}))
   });
 
   it("fails root startup closed when dashboard profile preparation fails", () => {
-    const failure = runHermesRootMcpStartup({ commitStatus: 0, dashboardStatus: 1 });
+    const failure = runHermesRootMcpStartup({ commitStatus: 0, dashboardSeedStatus: 23 });
     expect(failure.status).toBe(1);
     expect(failure.stdout.trim().split("\n")).toEqual(["dashboard-profile"]);
+    expect(failure.stderr).toContain(
+      "[dashboard] ERROR: config seed exited 23; refusing dashboard startup",
+    );
     expect(failure.stdout).not.toContain("launch:");
   });
 

--- a/test/hermes-mcp-integrity-state.test.ts
+++ b/test/hermes-mcp-integrity-state.test.ts
@@ -76,12 +76,14 @@ function runHermesRootMcpStartup(opts: { commitStatus: 0 | 1; dashboardSeedStatu
     ].join("\n"),
     { mode: 0o700 },
   );
+  const env = { ...process.env };
+  delete env.NEMOCLAW_TEST_STEPPED_DOWN;
 
   try {
     return spawnSync("bash", [scriptPath], {
       encoding: "utf-8",
       timeout: 5000,
-      env: process.env,
+      env,
     });
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
@@ -631,11 +633,12 @@ print(json.dumps({"state": state, "config_reads": config_reads}))
   it("fails root startup closed when dashboard profile preparation fails", () => {
     const failure = runHermesRootMcpStartup({ commitStatus: 0, dashboardSeedStatus: 23 });
     expect(failure.status).toBe(1);
-    expect(failure.stdout.trim().split("\n")).toEqual(["dashboard-profile"]);
+    expect(failure.stdout).toContain("dashboard-profile");
     expect(failure.stderr).toContain(
       "[dashboard] ERROR: config seed exited 23; refusing dashboard startup",
     );
     expect(failure.stdout).not.toContain("launch:");
+    expect(failure.stdout).not.toContain("startup-complete");
   });
 
   it("fails root startup closed when the applied-state commit fails after gateway health", () => {

--- a/test/hermes-mcp-integrity-state.test.ts
+++ b/test/hermes-mcp-integrity-state.test.ts
@@ -26,10 +26,10 @@ const TRANSACTION = path.join(
 );
 const START = path.join(import.meta.dirname, "..", "agents", "hermes", "start.sh");
 
-function runHermesRootMcpStartup(commitStatus: 0 | 1) {
+function runHermesRootMcpStartup(opts: { commitStatus: 0 | 1; dashboardStatus?: 0 | 1 }) {
   const source = fs.readFileSync(START, "utf-8");
   const startupBlock = source.match(
-    /^launch_hermes_gateway\nstart_gateway_log_stream\nwait_for_hermes_gateway_internal "\$GATEWAY_PID"\nensure_hermes_supervised_auxiliaries\nfinalize_tirith_marker_retry\nif ! commit_hermes_mcp_applied_if_pending; then\n[\s\S]*?^restore_hermes_config_permissions_after_dashboard_start$/m,
+    /^prepare_hermes_dashboard_home sandbox:sandbox \|\| exit 1$\n[\s\S]*?^launch_hermes_gateway\nstart_gateway_log_stream\nwait_for_hermes_gateway_internal "\$GATEWAY_PID"\nensure_hermes_supervised_auxiliaries\nfinalize_tirith_marker_retry\nif ! commit_hermes_mcp_applied_if_pending; then\n[\s\S]*?^restore_hermes_config_permissions_after_dashboard_start$/m,
   )?.[0];
   expect(startupBlock).toBeDefined();
   const startupScript = startupBlock as string;
@@ -42,11 +42,12 @@ function runHermesRootMcpStartup(commitStatus: 0 | 1) {
       "#!/usr/bin/env bash",
       "set -euo pipefail",
       'trace() { printf "%s\\n" "$*"; }',
+      `prepare_hermes_dashboard_home() { trace dashboard-profile; return ${opts.dashboardStatus ?? 0}; }`,
       'launch_hermes_gateway() { GATEWAY_PID=4242; trace "launch:$GATEWAY_PID"; }',
       "start_gateway_log_stream() { trace log-stream; }",
       'wait_for_hermes_gateway_internal() { trace "health:$1"; }',
       "ensure_hermes_supervised_auxiliaries() { trace auxiliaries; }\nfinalize_tirith_marker_retry() { trace tirith-finalize; }",
-      `commit_hermes_mcp_applied_if_pending() { trace commit-applied; return ${commitStatus}; }`,
+      `commit_hermes_mcp_applied_if_pending() { trace commit-applied; return ${opts.commitStatus}; }`,
       "stop_hermes_gateway_fail_closed() { trace stop-fail-closed; }",
       "restore_hermes_config_permissions_after_dashboard_start() { trace restore-permissions; }",
       startupScript,
@@ -590,10 +591,11 @@ print(json.dumps({"state": state, "config_reads": config_reads}))
     expect(JSON.parse(result.stdout)).toEqual({ state: "current", config_reads: 1 });
   });
 
-  it("commits pending state after root gateway health before continuing startup", () => {
-    const success = runHermesRootMcpStartup(0);
+  it("prepares the dashboard profile before root gateway health and applied-state commit", () => {
+    const success = runHermesRootMcpStartup({ commitStatus: 0 });
     expect(success.status, success.stderr).toBe(0);
     expect(success.stdout.trim().split("\n")).toEqual([
+      "dashboard-profile",
       "launch:4242",
       "log-stream",
       "health:4242",
@@ -605,10 +607,18 @@ print(json.dumps({"state": state, "config_reads": config_reads}))
     ]);
   });
 
+  it("fails root startup closed when dashboard profile preparation fails", () => {
+    const failure = runHermesRootMcpStartup({ commitStatus: 0, dashboardStatus: 1 });
+    expect(failure.status).toBe(1);
+    expect(failure.stdout.trim().split("\n")).toEqual(["dashboard-profile"]);
+    expect(failure.stdout).not.toContain("launch:");
+  });
+
   it("fails root startup closed when the applied-state commit fails after gateway health", () => {
-    const failure = runHermesRootMcpStartup(1);
+    const failure = runHermesRootMcpStartup({ commitStatus: 1 });
     expect(failure.status).toBe(1);
     expect(failure.stdout.trim().split("\n")).toEqual([
+      "dashboard-profile",
       "launch:4242",
       "log-stream",
       "health:4242",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Root-separated Hermes startup now migrates and seeds the dashboard profile before it launches the gateway. Previously, restored legacy dashboard state remained in the shared Hermes home during gateway startup and could prevent the API health listener from binding.

## Changes

- Run the existing sandbox-identity dashboard seeder before the root gateway launch.
- Stop startup before creating a gateway child when dashboard profile preparation fails.
- Extend the root startup behavior test to enforce migration ordering and the failure boundary.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed the root-to-sandbox identity step-down, legacy symlink and collision refusals, root and non-root startup siblings, and the no-child-on-failure state. Existing migration security tests pass.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx --no-install vitest run --project integration test/hermes-start-config-integrity.test.ts test/seed-hermes-dashboard-config.test.ts test/hermes-dashboard-profile-migration-security.test.ts` passed 53 tests. Focused `test/hermes-mcp-integrity-state.test.ts` startup-order selection passed 3 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hermes now prepares and seeds the dashboard profile before launching the gateway.
  * Startup waits for dashboard migration to complete before reading shared settings.
  * Startup now fails safely if dashboard preparation cannot be completed.
  * Improved startup error handling provides clearer feedback when dashboard preparation fails and prevents the gateway from launching in an incomplete state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->