### PR TITLE
perf(e2e): shorten token rotation live seam

### DIFF
--- a/test/credential-rotation.test.ts
+++ b/test/credential-rotation.test.ts
@@ -328,6 +328,7 @@ describe("credential rotation detection", () => {
         { name: D, envKey: "SLACK_APP_TOKEN", token: "sl-app-new" },
       ]);
 
+      expect(result.changed).toBe(true);
       expect(result.changedProviders).toEqual([C, D]);
       expect(result.changedProviders).not.toContain(A);
       expect(result.changedProviders).not.toContain(B);

--- a/test/credential-rotation.test.ts
+++ b/test/credential-rotation.test.ts
@@ -264,6 +264,7 @@ describe("credential rotation detection", () => {
     const A = "multi-telegram-bridge";
     const B = "multi-discord-bridge";
     const C = "multi-slack-bridge";
+    const D = "multi-slack-app";
 
     it("names ONLY provider A and excludes unchanged siblings B and C", () => {
       vi.spyOn(registry, "getSandbox").mockReturnValue(
@@ -307,6 +308,30 @@ describe("credential rotation detection", () => {
 
       expect(result.changedProviders).toEqual([B]);
       expect(result.changedProviders.join(", ")).toBe(B);
+      vi.restoreAllMocks();
+    });
+
+    it("names both Slack providers and excludes unchanged Telegram and Discord siblings", () => {
+      vi.spyOn(registry, "getSandbox").mockReturnValue(
+        makePlanEntry("multi-sandbox", [
+          { providerEnvKey: "TELEGRAM_BOT_TOKEN", credentialHash: hashCredentialOrThrow("tg-same") },
+          { providerEnvKey: "DISCORD_BOT_TOKEN", credentialHash: hashCredentialOrThrow("dc-same") },
+          { providerEnvKey: "SLACK_BOT_TOKEN", credentialHash: hashCredentialOrThrow("sl-bot-old") },
+          { providerEnvKey: "SLACK_APP_TOKEN", credentialHash: hashCredentialOrThrow("sl-app-old") },
+        ]),
+      );
+
+      const result = detectMessagingCredentialRotation("multi-sandbox", [
+        { name: A, envKey: "TELEGRAM_BOT_TOKEN", token: "tg-same" },
+        { name: B, envKey: "DISCORD_BOT_TOKEN", token: "dc-same" },
+        { name: C, envKey: "SLACK_BOT_TOKEN", token: "sl-bot-new" },
+        { name: D, envKey: "SLACK_APP_TOKEN", token: "sl-app-new" },
+      ]);
+
+      expect(result.changedProviders).toEqual([C, D]);
+      expect(result.changedProviders).not.toContain(A);
+      expect(result.changedProviders).not.toContain(B);
+      expect(result.changedProviders.join(", ")).toBe(`${C}, ${D}`);
       vi.restoreAllMocks();
     });
 

--- a/test/e2e/live/token-rotation.test.ts
+++ b/test/e2e/live/token-rotation.test.ts
@@ -127,26 +127,15 @@ function expectCredentialHash(envKey: string): void {
   ).toBeGreaterThan(0);
 }
 
-function expectRotationOutput(
-  output: string,
-  expectedProviders: readonly string[],
-  forbiddenProviders: readonly string[],
-): void {
+function expectTelegramRotationOutput(output: string): void {
   const rotationLine = output
     .split(/\r?\n/)
     .find((line) => line.includes("Messaging credential(s) rotated:"));
   expect(rotationLine, output).toBeTruthy();
-  for (const provider of expectedProviders) {
-    expect(rotationLine, `rotation line should name ${provider}: ${rotationLine}`).toContain(
-      provider,
-    );
-  }
-  for (const provider of forbiddenProviders) {
-    expect(
-      rotationLine,
-      `rotation line should not name ${provider}: ${rotationLine}`,
-    ).not.toContain(provider);
-  }
+  expect(rotationLine).toContain(`${SANDBOX_NAME}-telegram-bridge`);
+  expect(rotationLine).not.toContain(`${SANDBOX_NAME}-discord-bridge`);
+  expect(rotationLine).not.toContain(`${SANDBOX_NAME}-slack-bridge`);
+  expect(rotationLine).not.toContain(`${SANDBOX_NAME}-slack-app`);
   expect(output).toContain("Rebuilding sandbox to propagate new credentials");
 }
 
@@ -490,14 +479,11 @@ test(
       expect(provider.exitCode, resultText(provider)).toBe(0);
     }
 
-    [
-      "TELEGRAM_BOT_TOKEN",
-      "DISCORD_BOT_TOKEN",
-      "SLACK_BOT_TOKEN",
-      "SLACK_APP_TOKEN",
-    ].forEach((envKey) => {
-      expectCredentialHash(envKey);
-    });
+    ["TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN", "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"].forEach(
+      (envKey) => {
+        expectCredentialHash(envKey);
+      },
+    );
     await assertSandboxRunning(host, "phase-1-sandbox-running-after-install");
 
     progress.phase("rotate only the Telegram provider");
@@ -509,15 +495,7 @@ test(
     );
     const telegramText = resultText(telegram);
     expect(telegram.exitCode, telegramText).toBe(0);
-    expectRotationOutput(
-      telegramText,
-      [`${SANDBOX_NAME}-telegram-bridge`],
-      [
-        `${SANDBOX_NAME}-discord-bridge`,
-        `${SANDBOX_NAME}-slack-bridge`,
-        `${SANDBOX_NAME}-slack-app`,
-      ],
-    );
+    expectTelegramRotationOutput(telegramText);
     await assertSandboxRunning(host, "phase-2-sandbox-running-after-telegram-rotation");
 
     progress.phase("reuse the sandbox and record rotation evidence");
@@ -533,11 +511,7 @@ test(
     );
     const afterTelegramSameText = resultText(afterTelegramSame);
     expect(afterTelegramSame.exitCode, afterTelegramSameText).toBe(0);
-    await assertSandboxReused(
-      host,
-      beforeTelegramReuseId,
-      "phase-3-after-same-telegram",
-    );
+    await assertSandboxReused(host, beforeTelegramReuseId, "phase-3-after-same-telegram");
 
     await artifacts.target.complete({
       id: "token-rotation",

--- a/test/e2e/live/token-rotation.test.ts
+++ b/test/e2e/live/token-rotation.test.ts
@@ -447,7 +447,7 @@ test(
 
     // OpenShell removes each deployment image during credential-driven
     // recreation. Retain one test-owned tag so Docker can reuse the identical
-    // OpenClaw/plugin layers across the three rotations; token values remain in
+    // OpenClaw/plugin layers for the retained rotation; token values remain in
     // gateway providers and are never baked into this image.
     const cacheImageTag = `nemoclaw-token-rotation-cache:${process.pid}`;
     const retainBuildCache = await host.command(

--- a/test/e2e/live/token-rotation.test.ts
+++ b/test/e2e/live/token-rotation.test.ts
@@ -299,10 +299,6 @@ test(
         "confirm Docker and start hermetic inference",
         "install the sandbox and confirm provider hashes",
         "rotate only the Telegram provider",
-        "reuse the sandbox after the unchanged Telegram token",
-        "rotate only the Discord provider",
-        "reuse the sandbox after the unchanged Discord token",
-        "rotate only the Slack providers",
         "reuse the sandbox and record rotation evidence",
       ],
     },
@@ -359,8 +355,6 @@ test(
         "first onboard stores messaging credential hashes and creates provider attachments",
         "rotating Telegram rebuilds and names only telegram-bridge",
         "unchanged tokens reuse the sandbox",
-        "rotating Discord rebuilds and names only discord-bridge",
-        "rotating Slack bot/app credentials rebuilds and names slack-bridge and slack-app only",
       ],
     });
 
@@ -526,7 +520,7 @@ test(
     );
     await assertSandboxRunning(host, "phase-2-sandbox-running-after-telegram-rotation");
 
-    progress.phase("reuse the sandbox after the unchanged Telegram token");
+    progress.phase("reuse the sandbox and record rotation evidence");
     const beforeTelegramReuseId = await sandboxIdentity(
       host,
       "phase-3-before-same-telegram-identity",
@@ -545,71 +539,6 @@ test(
       "phase-3-after-same-telegram",
     );
 
-    progress.phase("rotate only the Discord provider");
-    const discord = await runOnboard(
-      host,
-      fakeOpenAI.baseUrl,
-      { ...TOKEN_A, telegram: TOKEN_B.telegram, discord: TOKEN_B.discord },
-      "phase-4-rotate-discord",
-    );
-    const discordText = resultText(discord);
-    expect(discord.exitCode, discordText).toBe(0);
-    expectRotationOutput(
-      discordText,
-      [`${SANDBOX_NAME}-discord-bridge`],
-      [
-        `${SANDBOX_NAME}-telegram-bridge`,
-        `${SANDBOX_NAME}-slack-bridge`,
-        `${SANDBOX_NAME}-slack-app`,
-      ],
-    );
-    await assertSandboxRunning(host, "phase-4-sandbox-running-after-discord-rotation");
-
-    progress.phase("reuse the sandbox after the unchanged Discord token");
-    const beforeDiscordReuseId = await sandboxIdentity(
-      host,
-      "phase-5-before-same-discord-identity",
-    );
-    const afterDiscordSame = await runOnboard(
-      host,
-      fakeOpenAI.baseUrl,
-      { ...TOKEN_A, telegram: TOKEN_B.telegram, discord: TOKEN_B.discord },
-      "phase-5-same-after-discord",
-    );
-    const afterDiscordSameText = resultText(afterDiscordSame);
-    expect(afterDiscordSame.exitCode, afterDiscordSameText).toBe(0);
-    await assertSandboxReused(
-      host,
-      beforeDiscordReuseId,
-      "phase-5-after-same-discord",
-    );
-
-    progress.phase("rotate only the Slack providers");
-    const slack = await runOnboard(host, fakeOpenAI.baseUrl, TOKEN_B, "phase-6-rotate-slack");
-    const slackText = resultText(slack);
-    expect(slack.exitCode, slackText).toBe(0);
-    expectRotationOutput(
-      slackText,
-      [`${SANDBOX_NAME}-slack-bridge`, `${SANDBOX_NAME}-slack-app`],
-      [`${SANDBOX_NAME}-telegram-bridge`, `${SANDBOX_NAME}-discord-bridge`],
-    );
-    await assertSandboxRunning(host, "phase-6-sandbox-running-after-slack-rotation");
-
-    progress.phase("reuse the sandbox and record rotation evidence");
-    const beforeSlackReuseId = await sandboxIdentity(
-      host,
-      "phase-7-before-same-slack-identity",
-    );
-    const afterSlackSame = await runOnboard(
-      host,
-      fakeOpenAI.baseUrl,
-      TOKEN_B,
-      "phase-7-same-after-slack",
-    );
-    const afterSlackSameText = resultText(afterSlackSame);
-    expect(afterSlackSame.exitCode, afterSlackSameText).toBe(0);
-    await assertSandboxReused(host, beforeSlackReuseId, "phase-7-after-same-slack");
-
     await artifacts.target.complete({
       id: "token-rotation",
       sandboxName: SANDBOX_NAME,
@@ -617,8 +546,6 @@ test(
         providersCreated: true,
         credentialHashesStored: true,
         telegramRotationIsolated: true,
-        discordRotationIsolated: true,
-        slackRotationIsolated: true,
         unchangedTokensReuseSandbox: true,
       },
     });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Shorten the token-rotation live E2E to one changed-token rebuild and one unchanged-token reuse cycle. This carries the reviewed change from #9247 onto an NVIDIA-owned branch so the protected token-rotation run can execute without weakening the workflow credential boundary.

## Related Issue

Closes #7918

## Changes

- Preserve the real four-provider installation, registry, and durable credential-hash checks.
- Keep one Telegram rotation and immediate reuse cycle while removing duplicate Discord and Slack live repetitions after the maintainer decision in #7918.
- Preserve Discord selective-provider coverage and add fast coverage that both Slack sibling providers rotate together while unchanged providers are excluded.
- Preserve Ho Lim and Prekshi Vyas as the commit authors, retain their sign-offs, and link each carried commit to its source in #9247.
- Documentation review: no public documentation update is needed because only internal test coverage and runtime change.
- Size review: +39/-113 across two test files; not flagged as a large increase.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The complete two-file diff changes fake-token E2E coverage only. It retains all provider creation and durable hash checks, keeps one real rebuild and reuse boundary, adds the missing Slack sibling fast contract, and changes no production code, credential value, permission, or external-input path. Security review passes secrets, validation, authorization, dependencies, logging, data protection, configuration, testing, and system boundaries.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/credential-rotation.test.ts` passed 18 tests; `npm run test:e2e-phases:check` validated 131 tests across 86 files. The protected token-rotation run will be dispatched from this PR.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded credential-rotation coverage for simultaneous Slack credential updates, confirming changed providers are reported accurately while unchanged providers remain excluded.
  * Refined end-to-end token-rotation checks for Telegram, including reuse of unchanged sandbox credentials.
  * Strengthened validation of rotation results, progress details, completion states, credential consistency, and build-cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->