### PR TITLE
fix(shields): reclaim zombie lifecycle owners

### DIFF
--- a/src/lib/state/mcp-lifecycle-lock-identity.test.ts
+++ b/src/lib/state/mcp-lifecycle-lock-identity.test.ts
@@ -11,6 +11,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   classifyMcpLifecycleLock,
   isMcpLifecycleLockOwner,
+  readMcpLockHostIdentity,
+  readMcpLockPidNamespaceIdentity,
   type LockObservation,
   type McpLifecycleLockIdentityProbes,
   type McpLifecycleLockOwner,
@@ -93,6 +95,38 @@ function probes(
 }
 
 describe("MCP lifecycle lock identity properties", () => {
+  it("reclaims a zombie local owner without treating its PID as live", () => {
+    const localHostIdentity = readMcpLockHostIdentity();
+    const localPidNamespaceIdentity = readMcpLockPidNamespaceIdentity();
+    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    const readFileSync = vi.spyOn(fs, "readFileSync").mockImplementation((filePath) => {
+      expect(filePath).toBe("/proc/4242/stat");
+      return "4242 (shields timer) Z 1 2 3";
+    });
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    try {
+      expect(
+        classifyMcpLifecycleLock(
+          observation(
+            owner(4242, "linux:test-boot:10", {
+              hostIdentity: localHostIdentity,
+              pidNamespaceIdentity: localPidNamespaceIdentity,
+            }),
+          ),
+          SANDBOX_NAME,
+          0,
+          30_000,
+        ),
+      ).toBe("stale");
+      expect(kill).not.toHaveBeenCalled();
+    } finally {
+      kill.mockRestore();
+      readFileSync.mockRestore();
+      platform.mockRestore();
+    }
+  });
+
   it("keeps a matching live owner active across PID, start-tick, and clock boundaries", () => {
     fc.assert(
       fc.property(

--- a/src/lib/state/mcp-lifecycle-lock-identity.ts
+++ b/src/lib/state/mcp-lifecycle-lock-identity.ts
@@ -72,7 +72,27 @@ export function isMcpLifecycleLockOwner(value: unknown): value is McpLifecycleLo
   );
 }
 
+function readLinuxProcessState(pid: number): string | null {
+  if (process.platform !== "linux") return null;
+  try {
+    const statText = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+    const closeParen = statText.lastIndexOf(")");
+    if (closeParen < 0) return null;
+    return (
+      statText
+        .slice(closeParen + 2)
+        .trim()
+        .split(/\s+/)[0] ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
 function processIsAlive(pid: number): boolean {
+  // kill(pid, 0) succeeds for an unreaped zombie even though it can no longer
+  // own or release a lifecycle lock.
+  if (readLinuxProcessState(pid) === "Z") return false;
   try {
     process.kill(pid, 0);
     return true;


### PR DESCRIPTION
## Summary

Treat an unreaped Linux zombie as a dead MCP lifecycle-lock owner. Previously, kill(pid, 0) reported the zombie as present, so expired Shields timer recovery could wait on a lock that no process could release until the long lifecycle-lock timeout.

## Changes

- Read the Linux process state before the existing PID liveness probe.
- Classify state Z as dead while retaining the existing fail-closed fallback when process state cannot be read.
- Add a regression proving a zombie owner is reclaimed without being treated as a live PID.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a Signed-off-by line and every commit appears as Verified in GitHub
- [x] Normal pre-commit, commit-msg, and pre-push hooks passed
- [x] Targeted behavior tests pass: npx vitest run src/lib/state/mcp-lifecycle-lock-identity.test.ts test/mcp-lifecycle-lock.test.ts — 60/60 passed
- [ ] Applicable broad gate passed — not applicable to this focused lifecycle-lock liveness change
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] npm run docs builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lifecycle lock handling to recognize zombie processes as inactive.
  - Prevented unnecessary termination attempts when reclaiming locks owned by zombie processes.
  - Added safeguards for more accurate stale-lock detection on Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->