### PR TITLE
test(onboard): fail closed on unscripted child prompts

### DIFF
--- a/test/helpers/onboard-child-runtime.test.ts
+++ b/test/helpers/onboard-child-runtime.test.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { onboardChildRuntimeSource } from "./onboard-child-runtime.js";
+
+type PromptTarget = {
+  prompt?: (message: string, options?: { secret?: boolean }) => Promise<string>;
+};
+
+type PromptQueueRuntime = {
+  installPromptQueue: (
+    target: PromptTarget,
+    configuredAnswers: readonly string[],
+  ) => {
+    answers: string[];
+    messages: string[];
+    prompts: Array<{ message: string; secret: boolean }>;
+  };
+};
+
+function loadPromptQueueRuntime(): PromptQueueRuntime {
+  return new Function(
+    `${onboardChildRuntimeSource}\nreturn { installPromptQueue };`,
+  )() as PromptQueueRuntime;
+}
+
+describe("onboard child prompt queue", () => {
+  it("fails when a child scenario asks an unscripted question", async () => {
+    const target: PromptTarget = {};
+    const { messages, prompts } = loadPromptQueueRuntime().installPromptQueue(target, []);
+
+    assert.ok(target.prompt);
+    await assert.rejects(
+      target.prompt("  Unexpected question: ", { secret: true }),
+      /Unexpected prompt after scripted answers were exhausted:   Unexpected question:/,
+    );
+    assert.deepEqual(messages, ["  Unexpected question: "]);
+    assert.deepEqual(prompts, [{ message: "  Unexpected question: ", secret: true }]);
+  });
+});

--- a/test/helpers/onboard-child-runtime.test.ts
+++ b/test/helpers/onboard-child-runtime.test.ts
@@ -29,14 +29,19 @@ function loadPromptQueueRuntime(): PromptQueueRuntime {
 describe("onboard child prompt queue", () => {
   it("fails when a child scenario asks an unscripted question", async () => {
     const target: PromptTarget = {};
-    const { messages, prompts } = loadPromptQueueRuntime().installPromptQueue(target, []);
+    const { messages, prompts } = loadPromptQueueRuntime().installPromptQueue(target, ["answer"]);
 
     assert.ok(target.prompt);
+    const prompt = target.prompt;
+    assert.equal(await prompt("  Expected question: "), "answer");
     await assert.rejects(
-      target.prompt("  Unexpected question: ", { secret: true }),
+      prompt("  Unexpected question: ", { secret: true }),
       /Unexpected prompt after scripted answers were exhausted:   Unexpected question:/,
     );
-    assert.deepEqual(messages, ["  Unexpected question: "]);
-    assert.deepEqual(prompts, [{ message: "  Unexpected question: ", secret: true }]);
+    assert.deepEqual(messages, ["  Expected question: ", "  Unexpected question: "]);
+    assert.deepEqual(prompts, [
+      { message: "  Expected question: ", secret: false },
+      { message: "  Unexpected question: ", secret: true },
+    ]);
   });
 });

--- a/test/helpers/onboard-child-runtime.ts
+++ b/test/helpers/onboard-child-runtime.ts
@@ -27,7 +27,10 @@ function installPromptQueue(target, configuredAnswers) {
   target.prompt = async (message, options = {}) => {
     messages.push(message);
     prompts.push({ message, secret: options.secret === true });
-    return answers.shift() ?? "";
+    if (answers.length === 0) {
+      throw new Error("Unexpected prompt after scripted answers were exhausted: " + message);
+    }
+    return answers.shift();
   };
   return { answers, messages, prompts };
 }

--- a/test/onboard-selection.test.ts
+++ b/test/onboard-selection.test.ts
@@ -19,6 +19,7 @@ import {
   applyOllamaRuntimeContextWindow,
   resetOllamaRuntimeContextWindowAutoState,
 } from "../src/lib/inference/ollama-runtime-context.js";
+import { SMALLEST_OLLAMA_MODEL_TAG } from "../src/lib/inference/ollama-model-registry.js";
 import {
   validateAnthropicModel,
   validateOpenAiLikeModel,
@@ -1417,14 +1418,15 @@ child_process.spawnSync = (cmd, args, opts) => {
 
 const runCommands = [];
 const shellCommands = [];
+let managedOllamaStarted = false;
 const { messages } = installPromptQueue(credentials, ["8", "1"]);
 credentials.ensureApiKey = async () => {};
 runner.runCapture = (command) => {
   const cmd = Array.isArray(command) ? command.join(" ") : command;
   const ollamaMetadata = supportedOllamaHostMetadataOutput(cmd); if (ollamaMetadata) return ollamaMetadata;
-  if (cmd.includes("127.0.0.1:11434/api/tags")) return "";
+  if (cmd.includes("127.0.0.1:11434/api/tags"))
+    return managedOllamaStarted ? ${JSON.stringify(JSON.stringify({ models: [{ name: SMALLEST_OLLAMA_MODEL_TAG }] }))} : "";
   if (cmd.includes("127.0.0.1:8000/v1/models")) return "";
-  if (cmd.includes("ollama list")) return "qwen3:8b  abc  5 GB  now";
   if (cmd.includes("ps")) return "node ollama-auth-proxy.js";
   if (cmd.includes("api/generate")) return '{"response":"hello"}';
   return "";
@@ -1435,16 +1437,14 @@ runner.run = (command) => {
 };
 runner.runShell = (command) => {
   shellCommands.push(command);
+  managedOllamaStarted ||= command.includes("OLLAMA_HOST=127.0.0.1:11434 ollama serve");
   return { status: 0 };
 };
 
 Object.defineProperty(process, "platform", { value: "linux" });
 platform.isWsl = () => false;
 wait.sleepSeconds = () => {};
-// installOllamaSystem probes loopback at tries=1 before launching, then
-// waits at tries=10 after launch. The fake curl in these tests answers 200
-// to any URL, so real waitForHttp would short-circuit the manual launch.
-// Differentiate by tries count.
+// Fail the tries=1 pre-launch probe; pass the tries=10 post-launch probe.
 wait.waitForHttp = (_url, tries) => (tries ?? 0) > 1;
 
 const { setupNim } = require(${onboardPath});
@@ -3434,8 +3434,8 @@ nimMod.startNimContainerByName = () => "container-123";
 nimMod.waitForNimHealth = () => true;
 nimMod.isNgcLoggedIn = () => true;
 
-// Select option 8 (nim-local), then model 1
-const { messages } = installPromptQueue(credentials, ["8", "1"]);
+// Select option 8 (nim-local), then model 1, and enter the NGC credential.
+const { messages } = installPromptQueue(credentials, ["8", "1", "ngc-test"]);
 credentials.ensureApiKey = async () => {};
 runner.runCapture = (command) => {
   // Normalize: onboard.ts still sends strings, local-inference.ts sends arrays.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

An onboarding integration child could turn one unplanned prompt into an unbounded validation loop. In CI run `32338590616`, job `96333047063`, the managed-Ollama fixture returned no installed model after launch, the scripted answer queue ran out at the download confirmation, and the empty fallback repeatedly returned to model selection until Node.js exhausted its 4 GB heap.

Scripted child prompts now stop at the first missing answer. The managed-Ollama fixture also publishes its registry-owned model only after the loopback launch, so the scenario completes without a download detour.

## Changes

- Reject an onboarding child prompt after its scripted answer queue is exhausted.
- Cover the fail-closed prompt boundary without starting a child process.
- Model the managed Ollama `/api/tags` inventory after the recorded loopback launch.
- Provide the existing NIM override scenario's NGC test credential explicitly.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — full provider-selection and prompt-helper coverage: 68/68; focused post-budget edit: 2/2; growth guardrails: 32/32; Vitest project membership: 2480 files across 7 projects. The failed CI scenario also completes in 2.5 seconds with coverage instrumentation.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not applicable; the shared helper has seven consumers, all within the fully executed provider-selection file, and no production source changed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt handling so unexpected or exhausted scripted prompts now produce a clear error instead of an empty response.
  * Updated onboarding checks to correctly detect locally managed model availability after startup.
  * Improved local model test coverage, including credential handling and secret-prompt metadata validation.

* **Tests**
  * Added coverage for prompt queues, recorded messages, secret prompts, and delayed model startup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->