### PR TITLE
fix(sandbox): align launch forward ports

### DIFF
--- a/src/lib/actions/sandbox/forward-recovery.ts
+++ b/src/lib/actions/sandbox/forward-recovery.ts
@@ -41,7 +41,11 @@ import {
   getHermesDashboardRecoveryConfig,
 } from "./hermes-dashboard-recovery";
 
-type SandboxPortAgent = { forwardPort?: unknown; runtime?: { kind?: unknown } } | null;
+type SandboxPortAgent = {
+  forwardPort?: unknown;
+  forward_ports?: unknown;
+  runtime?: { kind?: unknown };
+} | null;
 
 type SandboxPortDeps = {
   getSandbox?: typeof registry.getSandbox;
@@ -416,6 +420,31 @@ export function recoverMessagingHostForward(
   return recovered;
 }
 
+function resolveDeclaredAgentForwardPorts(
+  sandbox: ReturnType<typeof registry.getSandbox>,
+  primaryPort: number,
+  agent: SandboxPortAgent,
+  hermesDashboardPort: number | null,
+): number[] {
+  const declared = agent?.forward_ports;
+  if (!Array.isArray(declared)) return [];
+  const covered = new Set<number>([primaryPort]);
+  if (isValidPort(agent?.forwardPort)) covered.add(agent.forwardPort);
+  if (isValidPort(hermesDashboardPort)) covered.add(hermesDashboardPort);
+  const ports: number[] = [];
+  for (const candidate of declared) {
+    if (typeof candidate !== "number") continue;
+    if (!Number.isInteger(candidate) || candidate < 1024 || candidate > 65535) continue;
+    if (covered.has(candidate)) continue;
+    const port =
+      candidate === HERMES_OPENAI_API_PORT ? resolveSandboxHermesApiPort(sandbox ?? {}) : candidate;
+    if (covered.has(port)) continue;
+    covered.add(port);
+    ports.push(port);
+  }
+  return ports;
+}
+
 /**
  * Re-establish every declared `forward_ports` entry on the active agent
  * manifest that is not already owned by another recovery helper. The
@@ -437,27 +466,17 @@ export function ensureDeclaredAgentForwardPortsHealthy(
 ): boolean | null {
   const agent = agentRuntime.getSessionAgent(sandboxName);
   if (!agent) return null;
-  const declared = (agent as { forward_ports?: unknown }).forward_ports;
-  if (!Array.isArray(declared) || declared.length === 0) return null;
   const hermesDashboard = getHermesDashboardRecoveryConfig(sandboxName);
   const sandbox = registry.getSandbox(sandboxName);
-  const skipSet = new Set<number>([primaryPort]);
-  // The manifest's own primary entry is the default dashboard port. This
-  // sandbox's dashboard forward lives at primaryPort and is recovered by
-  // ensureSandboxPortForward, so the default must not be probed again.
-  if (isValidPort(agent.forwardPort)) skipSet.add(agent.forwardPort);
-  if (hermesDashboard && Number.isInteger(hermesDashboard.publicPort)) {
-    skipSet.add(hermesDashboard.publicPort);
-  }
-  let sawCovered = false;
+  const ports = resolveDeclaredAgentForwardPorts(
+    sandbox,
+    primaryPort,
+    agent,
+    hermesDashboard?.publicPort ?? null,
+  );
+  if (ports.length === 0) return null;
   let allHealthy = true;
-  for (const candidate of declared) {
-    if (typeof candidate !== "number") continue;
-    if (!Number.isInteger(candidate) || candidate < 1024 || candidate > 65535) continue;
-    if (skipSet.has(candidate)) continue;
-    const port =
-      candidate === HERMES_OPENAI_API_PORT ? resolveSandboxHermesApiPort(sandbox ?? {}) : candidate;
-    sawCovered = true;
+  for (const port of ports) {
     const health = isSandboxPortForwardHealthy(sandboxName, port);
     if (health === true) continue;
     if (health === "occupied") {
@@ -468,7 +487,6 @@ export function ensureDeclaredAgentForwardPortsHealthy(
       allHealthy = false;
     }
   }
-  if (!sawCovered) return null;
   return allHealthy;
 }
 
@@ -493,18 +511,13 @@ export function areSandboxLaunchForwardsHealthy(
   if (hermesDashboard) requiredPorts.add(hermesDashboard.publicPort);
   const messagingForward = getSandboxMessagingHostForward(sandboxName);
   if (messagingForward) requiredPorts.add(messagingForward.port);
-  const declared = (agent as { forward_ports?: unknown } | null)?.forward_ports;
-  if (Array.isArray(declared)) {
-    for (const candidate of declared) {
-      if (
-        typeof candidate === "number" &&
-        Number.isInteger(candidate) &&
-        candidate >= 1024 &&
-        candidate <= 65535
-      ) {
-        requiredPorts.add(candidate);
-      }
-    }
+  for (const port of resolveDeclaredAgentForwardPorts(
+    sandbox,
+    primaryPort,
+    agent,
+    hermesDashboard?.publicPort ?? null,
+  )) {
+    requiredPorts.add(port);
   }
   const result = captureOpenshell(["forward", "list", "--gateway", owningGatewayName], {
     ignoreError: true,

--- a/test/cli/connect-recovery.test.ts
+++ b/test/cli/connect-recovery.test.ts
@@ -375,7 +375,7 @@ describe("CLI connect recovery process contracts", () => {
     },
   );
 
-  it("recovers stopped Hermes agents through privileged Docker control instead of SSH", async () => {
+  it("recovers a stopped Hermes Agent gateway with its assigned forwards through privileged Docker control (#9716)", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-connect-probe-agent-"));
     const localBin = path.join(home, "bin");
     const openshellCalls = path.join(home, "openshell-calls");
@@ -383,7 +383,12 @@ describe("CLI connect recovery process contracts", () => {
     const sshCalls = path.join(home, "ssh-calls");
     const stateFile = path.join(home, "probe-state");
     fs.mkdirSync(localBin, { recursive: true });
-    writeSandboxRegistry(home, { ...launchReadinessRegistryFixture(), agent: "hermes" });
+    writeSandboxRegistry(home, {
+      ...launchReadinessRegistryFixture(),
+      agent: "hermes",
+      dashboardPort: 18790,
+      hermesApiPort: 8643,
+    });
     fs.writeFileSync(stateFile, "stopped");
     fs.writeFileSync(
       path.join(localBin, "openshell"),
@@ -415,7 +420,7 @@ describe("CLI connect recovery process contracts", () => {
         '  echo UNEXPECTED_SSH_CONFIG >> "$calls"',
         "  exit 1",
         "fi",
-        'if [ "$1" = "forward" ] && [ "$2" = "list" ]; then { echo "alpha 127.0.0.1 18789 12345 running"; echo "alpha 127.0.0.1 8642 12346 running"; }; exit 0; fi',
+        'if [ "$1" = "forward" ] && [ "$2" = "list" ]; then { echo "control 127.0.0.1 18789 12345 running"; echo "control 127.0.0.1 8642 12346 running"; echo "alpha 127.0.0.1 18790 12347 running"; echo "alpha 127.0.0.1 8643 12348 running"; }; exit 0; fi',
         'if [ "$1" = "forward" ]; then exit 99; fi',
         ...launchReadinessObservationStubLines,
         "exit 0",
@@ -424,7 +429,7 @@ describe("CLI connect recovery process contracts", () => {
     );
     writeGatewayControlDockerStub(localBin, { callsFile: dockerCalls, stateFile });
     writeRecordingCommand(localBin, "ssh", sshCalls, 98);
-    const stopForwardListeners = await startForwardListeners([18789, 8642]);
+    const stopForwardListeners = await startForwardListeners([18790, 8643]);
 
     try {
       const result = runWithEnv("alpha connect --probe-only", {

--- a/test/launch-readiness-forward-observation.test.ts
+++ b/test/launch-readiness-forward-observation.test.ts
@@ -48,6 +48,34 @@ beta  127.0.0.1  18790  12346  running`,
   });
 });
 
+it("checks sandbox-owned Hermes forwards instead of manifest defaults (#9716)", () => {
+  mockLaunchForwardObservation({
+    status: 0,
+    output: `SANDBOX  BIND  PORT  PID  STATUS
+alpha  127.0.0.1  18789  12345  running
+alpha  127.0.0.1  8642  12346  running
+beta  127.0.0.1  18790  12347  running
+beta  127.0.0.1  8643  12348  running`,
+  });
+  vi.mocked(agentRuntime.getSessionAgent).mockReturnValue({
+    name: "hermes",
+    runtime: { kind: "gateway" },
+    forwardPort: 18789,
+    forward_ports: [18789, 8642],
+  } as never);
+  vi.mocked(registry.getSandbox).mockReturnValue({
+    name: "beta",
+    agent: "hermes",
+    dashboardPort: 18790,
+    hermesApiPort: 8643,
+    gatewayName: "nemoclaw",
+    gatewayPort: 8080,
+  });
+
+  expect(areSandboxLaunchForwardsHealthy("beta", "nemoclaw")).toBe(true);
+  expect(vi.mocked(forwardHealth.isLocalForwardReachable).mock.calls).toEqual([[18790], [8643]]);
+});
+
 it("rejects a reachable listener when the owning forward row is missing (#8942)", () => {
   mockLaunchForwardObservation({
     status: 0,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->\n## Summary\n<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->\nLaunch-readiness validation now resolves agent-declared forwards to the sandbox's assigned dashboard and Hermes API ports, matching recovery. Healthy Hermes sandboxes no longer fail  or  when manifest defaults belong to another sandbox. Public documentation and CLI text already describe the assigned-port contract, so no user-facing wording changes are required.\n\n## Related Issue\n<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->\nFixes #9716\n\n## Changes\n<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->\n- Adds one shared declared-forward resolver used by recovery and the read-only launch-readiness observer. Keeping the projection shared prevents the two consumers from diverging again.\n- Excludes the manifest's primary dashboard default and maps the Hermes API default to the registered sandbox port.\n- Extends focused observation and spawned CLI recovery tests with sibling-owned manifest defaults and assigned target ports.\n\n## Type of Change\n\n- [x] Code change (feature, bug fix, or refactor)\n- [ ] Code change with doc updates\n- [ ] Doc only (prose changes, no code sample modifications)\n- [ ] Doc only (includes code sample changes)\n\n## Quality Gates\n<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->\n- [x] Tests added or updated for changed behavior\n- [ ] Existing tests cover changed behavior — justification:\n- [ ] Tests not applicable — justification:\n- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)\n- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: https://github.com/NVIDIA/NemoClaw/pull/9729#issuecomment-5354645788\n- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:\n\n## DGX Station Hardware Evidence\n<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->\n- [ ] Tested on DGX Station\n- Tested commit: Not applicable;  is unchanged.\n- Station profile/scenario: Not applicable.\n- Result: Not applicable.\n- Supporting evidence: Not applicable.\n\n## Verification\n<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->\n- [x] PR description includes a  line and every commit appears as  in GitHub\n- [x] Normal , , and  hooks passed, or 
> nemoclaw@0.1.0 validate:pr
> npx prek run --from-ref origin/main --to-ref HEAD --stage pre-commit && npx commitlint --from origin/main --to HEAD && npx prek run --from-ref origin/main --to-ref HEAD --stage pre-push

Running hooks for `tmp/codex-8583-preflight-98b/final-shard-1`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/final-shard-2`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/linux-shard-1`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-1`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-2`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-3`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-4`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-5`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-6`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-7`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-8`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-1`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-2`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-3`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-4`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-5`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-6`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-7`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-8`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/workspace`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `.`:
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Oxfmt....................................................................Passed
Oxlint fixes.............................................................Passed
check for merge conflicts................................................Passed
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key.......................................................Passed
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable..........................Passed
Oxlint type-aware rules..............................(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks........................................................Passed
NEMOCLAW_* env-var documentation gate....................................Passed
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...................................................Passed
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.................................................Failed
- hook id: source-shape-test-budget
- exit code: 1

  > nemoclaw@0.1.0 source-shape:check
  > tsx scripts/find-source-shape-tests.mts --check

  node:fs:1795
    const stats = binding.stat(
                          ^

  Error: ENOENT: no such file or directory, stat '/Users/akumaria/dev/NemoClaw/tmp/codex-8583-preflight-98b/container-tmp-1/nemoclaw-vitest-pN5Z9P/nemoclaw-creds-YA1Auq/.nemoclaw/credentials.json'
      at statSync (node:fs:1795:25)
      at walkFiles (/Users/akumaria/dev/NemoClaw/scripts/find-source-shape-tests.mts:109:19)
      at walkFiles.next (<anonymous>)
      at walkFiles (/Users/akumaria/dev/NemoClaw/scripts/find-source-shape-tests.mts:111:14)
      at walkFiles.next (<anonymous>)
      at walkFiles (/Users/akumaria/dev/NemoClaw/scripts/find-source-shape-tests.mts:111:14)
      at walkFiles.next (<anonymous>)
      at walkFiles (/Users/akumaria/dev/NemoClaw/scripts/find-source-shape-tests.mts:111:14)
      at walkFiles.next (<anonymous>)
      at walkFiles (/Users/akumaria/dev/NemoClaw/scripts/find-source-shape-tests.mts:111:14) {
    errno: -2,
    code: 'ENOENT',
    syscall: 'stat',
    path: '/Users/akumaria/dev/NemoClaw/tmp/codex-8583-preflight-98b/container-tmp-1/nemoclaw-vitest-pN5Z9P/nemoclaw-creds-YA1Auq/.nemoclaw/credentials.json'
  }

  Node.js v24.19.0
Codebase growth guardrails...............................................Failed
- hook id: codebase-growth-guardrails
- exit code: 1

  RUN  v4.1.9 /Users/akumaria/dev/NemoClaw

   ❯ |integration| test/growth-guardrails.test.ts (25 tests | 5 skipped) 225ms

   Test Files  1 failed (1)
        Tests  20 passed | 5 skipped (25)
     Start at  03:27:37
     Duration  584ms (transform 85ms, setup 23ms, import 124ms, tests 225ms, environment 0ms)


  ⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯

   FAIL  |integration| test/growth-guardrails.test.ts > codebase growth guardrails
  Error: spawnSync git ENOBUFS
   ❯ loadLocalDiff test/helpers/growth-guardrail-diff.ts:122:21
      120|   const files = parseChangedFiles(changed);
      121|   const known = new Set(files.map(({ filename }) => filename));
      122|   const untracked = execFileSync("git", ["ls-files", "--others", "--ex…
         |                     ^
      123|     cwd: REPO_ROOT,
      124|     encoding: "utf8",
   ❯ loadGrowthGuardrailDiff test/helpers/growth-guardrail-diff.ts:173:23
   ❯ test/growth-guardrails.test.ts:41:18

  ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
Test (skills YAML)...................................(no files to check)Skipped passed after refreshing  when hooks were skipped or unavailable\n- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:\n  - 
 RUN  v4.1.9 /Users/akumaria/dev/NemoClaw


 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  03:28:06
   Duration  1.86s (transform 585ms, setup 29ms, import 1.63s, tests 3ms, environment 0ms) — 5 passed.\n  - 
 RUN  v4.1.9 /Users/akumaria/dev/NemoClaw


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  03:28:08
   Duration  10.46s (transform 793ms, setup 28ms, import 1.84s, tests 8.40s, environment 0ms) — 5 passed.\n  - 
 RUN  v4.1.9 /Users/akumaria/dev/NemoClaw


 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  03:28:19
   Duration  933ms (transform 311ms, setup 147ms, import 14ms, tests 706ms, environment 0ms) — 3 passed.\n- [ ] Applicable broad gate passed — 
> nemoclaw@0.1.0 test
> npm run clean:cli && npm --prefix nemoclaw run clean && npm run build:cli && npm --prefix nemoclaw run build && vitest run --project cli --project integration --project installer-integration --project package-contract --project plugin --project e2e-support


> nemoclaw@0.1.0 clean:cli
> node -e "require('node:fs').rmSync('dist', { recursive: true, force: true })"


> nemoclaw@0.1.0 clean
> rm -rf dist/


> nemoclaw@0.1.0 build:cli
> npm run build:policy-boundary && tsc -p tsconfig.src.json && node dist/lib/core/generate-build-identity.js && node dist/lib/inference/serving/generate-catalog.js && node dist/lib/cli/generate-oclif-metadata-manifest.js && if find nemoclaw-blueprint/scripts -name '*.ts' -print -quit | grep -q .; then tsc -p nemoclaw-blueprint/tsconfig.json; fi


> nemoclaw@0.1.0 build:policy-boundary
> tsc -p nemoclaw/tsconfig.shared.json


> nemoclaw@0.1.0 build
> tsc


 RUN  v4.1.9 /Users/akumaria/dev/NemoClaw

 ❯ |cli| src/lib/state/state-file-key-merge-file-safety.test.ts (10 tests | 7 failed) 1343ms
     × executes the full production command with backup TOML only on stdin 184ms
     × rejects a symlink in a config parent ancestor through the production command 334ms
     × rejects symlink, hardlink, and inode swaps of its private stage before replacement [symlink] 136ms
     × rejects symlink, hardlink, and inode swaps of its private stage before replacement [hardlink] 133ms
     × rejects symlink, hardlink, and inode swaps of its private stage before replacement [regular] 129ms
     × refuses to replace a current config whose inode changes after validation 117ms
     × refuses to replace a current config modified in place after validation 114ms
 ❯ |cli| src/lib/state/state-file-key-merge-behavior.test.ts (11 tests | 11 failed) 1643ms
     × uses the shipped Deep Agents ownership policy to restore display preferences with fresh managed routing 178ms
     × produces byte-identical, deterministically ordered output on repeated runs with the same inputs 240ms
     × drops free-form, executable, routing, and unknown backup data 279ms
     × leaves the fresh config untouched when the backup is malformed 112ms
     × leaves the current file untouched when a required fresh table is missing 110ms
     × requires the declared fresh headers before replacing the current file 111ms
     × enforces integer bounds and drops out-of-range values 119ms
     × enforces string max_length and rejects non-string values 114ms
     × keeps a fresh scalar when an old nested preference no longer has a table parent 134ms
     × preserves every safe leading comment after validating managed headers 117ms
     × rejects unsafe metadata in an extra leading comment 127ms
 ❯ |cli| src/lib/actions/sandbox/gateway-restart-hermes-drift.test.ts (2 tests | 1 failed) 347ms
   × detects real Hermes config/hash drift without mutating the inspected fixture 344ms
 ❯ |cli| src/lib/actions/uninstall/run-plan-other-gateway-report.test.ts (6 tests | 1 failed) 1363ms
     × returns nonzero when the orphan gateway-process scan cannot run 310ms
 ❯ |cli| src/lib/onboard/created-sandbox-finalization.test.ts (10 tests | 2 failed) 2870ms
     × merges stale backup preferences before live validation and registry publication (#6311) 1038ms
     × warns but verifies and registers after a partial workspace restore (#6311) 921ms
 ❯ |cli| src/lib/actions/uninstall/run-plan-portable-runtime.test.ts (31 tests | 4 failed) 15097ms
     × rejects HOME gateway-limit before generic effects (#9189) 494ms
     × rejects HOME gateway-file before generic effects (#9189) 205ms
     × rejects HOME receipt-inventory before generic effects (#9189) 196ms
     × rejects HOME orphan-binding before generic effects (#9189) 225ms
 ❯ |cli| src/lib/actions/sandbox/rebuild-flow-target-credentials.test.ts (14 tests | 1 failed) 16481ms
     × preserves legacy Brave web search during a nonmatching-session rebuild 5070ms
 ❯ |cli| src/lib/actions/sandbox/rebuild-dcode-base-image-lease.test.ts (5 tests | 1 failed) 15503ms
     × keeps the current base-image trust lease active through replacement preparation (#6195) 12476ms
 ❯ |cli| src/lib/actions/sandbox/auto-pair-approval-receipt.test.ts (11 tests | 1 failed) 4269ms
     × omits raw output from devices-list failure classifications [case 3] 627ms
 ❯ |cli| src/lib/actions/sandbox/rebuild-hermes-post-restore.test.ts (28 tests | 1 failed) 17135ms
     × fails instead of reporting readiness when restored state leaves the gateway down (#7084) 12181ms
Approved googlechat sender users/123456789
 ❯ |e2e-support| test/e2e/support/standard-profile-workflow-boundary.test.ts (11 tests | 1 failed) 669ms
     × writes normalized evidence and rejects successful empty runs 78ms
 ❯ |e2e-support| test/e2e/support/dockerhub-auth-workflow-boundary.test.ts (11 tests | 1 failed) 13865ms
     × executes the shared auth script with isolated config and bounded fail-closed retries 5814ms
 ❯ |e2e-support| test/e2e/support/channels-stop-start-googlechat-entry.test.ts (4 tests | 1 failed) 7572ms
     × loads through the standalone live-E2E module boundary (#7317) 7565ms
 ❯ |e2e-support| test/e2e/support/lifecycle-user-service.test.ts (5 tests | 3 failed) 31167ms
     × stages, enables, and removes the repository service without installer cleanup 155ms
     × uses an existing upstream service without staging a NemoClaw unit 40ms
     × selects a marked unit from an absolute custom XDG config root 30824ms
 ❯ |e2e-support| test/e2e/support/hermes-gpu-startup-fallback.test.ts (17 tests | 1 failed) 14014ms
     × preserves OpenShell version and capability detection without private wrapper env 5019ms
 ❯ |e2e-support| test/e2e/support/platform-parity-cloud-experimental.test.ts (43 tests | 1 failed) 28474ms
     × preserves the repeated env-unset pairs from the failed observability invocation 5955ms
 ❯ |e2e-support| test/e2e/support/hermes-workflow-boundary.test.ts (16 tests | 2 failed) 22159ms
     × restores daemon content, metadata, ownership, and runtime 8579ms
     × cleans private state after daemon restoration fails 9102ms
 ❯ |e2e-support| test/e2e/support/gpu-e2e-helpers.test.ts (41 tests | 6 failed) 39476ms
     × stops the Ollama system service before cleanup completes 5032ms
     × restarts the protected Ollama daemon through its installed system service 5027ms
     × stops when the restarted Ollama system service enters the failed state 5062ms
     × rejects an installed Ollama system service without restart permission 5020ms
     × restarts an available Ollama user service without a manual daemon 5028ms
     × starts a manual Ollama daemon when no service is available 5023ms
 ❯ |e2e-support| test/e2e/support/e2e-live-project-config.test.ts (3 tests | 1 failed) 6362ms
     × cleans and rebuilds the CLI before aggregate live E2E execution (#6692) 6358ms
 ❯ |e2e-support| test/e2e/support/launch-agent-turn.test.ts (42 tests | 1 failed | 23 skipped) 7710ms
   × intercepts one OpenClaw launch, preserves pass-through argv, and strips launch authority from filtered and inherited environments [case 0] (#9160) 2734ms
 ❯ |e2e-support| test/e2e/support/managed-image-protected-runtime-readiness.test.ts (34 tests | 3 failed) 60756ms
     × ignores login-shell logout hooks and reports successful readiness 5019ms
     × returns failure with a redacted tail of at most 200 Ollama log lines 5022ms
     × bounds one oversized Ollama log line while retaining the readiness failure 5065ms
 ❯ |e2e-support| test/e2e/support/workflow-plan.test.ts (77 tests | 2 failed) 59985ms
     × renders the selected targets and workflow jobs as a readable plan 5778ms
     × writes controller-selected jobs and targets through the CI-output path (#7031) 5041ms
 ❯ |e2e-support| test/e2e/support/native-runtime-qualification-account-lifecycle.test.ts (13 tests | 4 failed) 76523ms
     × rejects pre-existing accounts and stale subordinate-ID authorization before mutation 5612ms
     × records the exact private group when its numeric GID differs from the UID 12824ms
     × rolls back an account when identity validation fails before marker publication 15101ms
     × removes partial account setup and verifies subordinate-ID revocation 15194ms
 ❯ |e2e-support| test/e2e/support/portable-profile-systemctl-shim.test.ts (36 tests | 1 failed) 96662ms
     × preserves a launch record when initial gateway cleanup fails (#9208) 4196ms
 ❯ |package-contract| test/package-contract/cli/credentials-cli-command.test.ts (25 tests | 9 failed) 4598ms
     × deletes a provider credential with --yes 319ms
     × explains provider-name usage when reset receives an env var name 335ms
     × credentials add forwards env-key-only --credential to OpenShell provider create 304ms
     × credentials add redacts credential-shaped stderr on failure 341ms
     × credentials add reports an already-exists hint pointing at credentials reset 539ms
     × credentials add stops before provider create when bundled profile import fails 284ms
     × credentials reset redacts credential-shaped stderr from OpenShell failures 360ms
     × credentials reset cleans local state when the gateway provider is already absent 334ms
     × credentials reset cleans uppercase provider names when the gateway provider is already absent 346ms
 ❯ |installer-integration| test/install-express-wsl-ollama.test.ts (19 tests | 3 failed) 24940ms
     × maps Windows WSL express install to Windows-host Ollama under Docker Desktop 6084ms
     × maps Windows WSL express install to WSL-local Ollama under native Docker Engine 5786ms
     × uses a runtime-neutral WSL-local Ollama summary when the docker probe fails 5632ms
 ❯ |installer-integration| test/install-openshell-e2e-artifact.test.ts (3 tests | 3 failed) 31104ms
     × runs retained assets through the trusted installer without network fallback (#9051) 16208ms
     × rejects retained bytes that do not match their release checksum (#9051) 8031ms
     × blocks network fallback when a retained asset is a symbolic link (#9051) 6863ms
 ❯ |installer-integration| test/install-preflight-docker-bootstrap.test.ts (4 tests | 4 failed) 39888ms
     × reports when Docker is reachable for a non-docker-group Linux user 8370ms
     × prompts for newgrp when persisted docker membership is not active 13773ms
     × reports daemon reachability when the active shell already has docker 9942ms
     × skips docker group membership checks for root 7801ms
 ❯ |e2e-support| test/e2e/support/shared-e2e-workflow-boundary.test.ts (3 tests | 1 failed) 71638ms
     × keeps every tagged credential-free test visible to Vitest discovery 71192ms
 ❯ |package-contract| test/package-contract/onboard/invalid-nvidia-key.test.ts (3 tests | 1 failed) 12797ms
     × rejects the key without disclosure, a stack trace, external calls, or saved onboarding state [docker] (#7616) 5376ms
 ❯ |package-contract| test/package-contract/npm-link-or-shim.test.ts (4 tests | 1 failed) 9095ms
     × falls back to a wrapper script on npm link failure, preserving the Node directory 5097ms
 ❯ |installer-integration| test/install-managed-cli-reuse.test.ts (8 tests | 6 failed) 57705ms
     × creates owner-only managed state under an account umask of 0002 (#8795) 7917ms
     × repairs an existing group-accessible managed state root before cloning source (#8795) 9879ms
     × reuses an exact healthy managed source without clone, build, or link (#7898) 8600ms
     × builds a changed managed revision once across backup preparation and install (#7898) 5877ms
     × reuses the managed checkout on a later installer run after its own dependency install (#8305) 10555ms
     × warns and completes when the managed lockfile cannot be restored (#8305) 8157ms
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
PROGRESS:50:Configuring inference provider
PROGRESS:70:Setting inference route
PROGRESS:85:Saving run state
PROGRESS:100:Apply complete
Sandbox 'test-sandbox' is ready.
Inference: test-provider -> test-model @ https://api.example.com/v1
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
RUN_ID:nc-20260820-103346-aaaaaaaa
RUN_ID:nc-20260820-103346-aaaaaaaa
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
RUN_ID:nc-20260820-103346-aaaaaaaa
RUN_ID:nc-20260820-103346-aaaaaaaa
RUN_ID:nc-20260820-103346-aaaaaaaa
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
Sandbox 'test-sandbox' already exists, reusing.
PROGRESS:50:Configuring inference provider
Provider 'test-provider' already exists, reusing.
PROGRESS:70:Setting inference route
Inference route 'test-provider / test-model' is already active, reusing.
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
Sandbox 'test-sandbox' already exists, reusing.
PROGRESS:50:Configuring inference provider
Provider 'test-provider' already exists, reusing.
PROGRESS:70:Setting inference route
PROGRESS:85:Saving run state
PROGRESS:100:Apply complete
Sandbox 'test-sandbox' is ready.
Inference: test-provider -> test-model @ https://api.example.com/v1
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
Sandbox 'test-sandbox' already exists, reusing.
PROGRESS:50:Configuring inference provider
Provider 'test-provider' already exists, reusing.
PROGRESS:70:Setting inference route
PROGRESS:85:Saving run state
PROGRESS:100:Apply complete
Sandbox 'test-sandbox' is ready.
Inference: test-provider -> test-model @ https://api.example.com/v1
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
Sandbox 'test-sandbox' already exists, reusing.
PROGRESS:50:Configuring inference provider
Provider 'test-provider' already exists, reusing.
PROGRESS:70:Setting inference route
PROGRESS:85:Saving run state
PROGRESS:100:Apply complete
Sandbox 'test-sandbox' is ready.
Inference: test-provider -> test-model @ https://api.example.com/v1
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
Sandbox 'test-sandbox' already exists, reusing.
PROGRESS:50:Configuring inference provider
Provider 'test-provider' already exists, reusing.
PROGRESS:70:Setting inference route
Inference route 'test-provider / test-model' is already active, reusing.
PROGRESS:85:Saving run state
PROGRESS:100:Apply complete
Sandbox 'test-sandbox' is ready.
Inference: test-provider -> test-model @ https://api.example.com/v1
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
Sandbox 'test-sandbox' already exists, reusing.
PROGRESS:50:Configuring inference provider
Provider 'test-provider' already exists, reusing.
PROGRESS:70:Setting inference route
PROGRESS:85:Saving run state
PROGRESS:100:Apply complete
Sandbox 'test-sandbox' is ready.
Inference: test-provider -> test-model @ https://api.example.com/v1
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
PROGRESS:50:Configuring inference provider
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Validating blueprint
PROGRESS:20:Checking prerequisites
PROGRESS:100:Plan complete
{
  "run_id": "nc-20260820-103346-aaaaaaaa",
  "profile": "default",
  "sandbox": {
    "image": "openclaw",
    "name": "test-sandbox",
    "forward_ports": [
      18789
    ]
  },
  "inference": {
    "provider_type": "openai",
    "provider_name": "test-provider",
    "endpoint": "https://api.example.com/v1",
    "model": "test-model"
  },
  "router": {
    "enabled": false,
    "port": 4000
  },
  "policy_additions": {},
  "dry_run": false,
  "identity": {
    "provider_type": "okta-runtime-v1",
    "provider_name": "acme-okta-runtime",
    "credential_key": "OKTA_ACCESS_TOKEN"
  }
}
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
PROGRESS:50:Configuring inference provider
PROGRESS:70:Setting inference route
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
PROGRESS:50:Configuring inference provider
PROGRESS:70:Setting inference route
PROGRESS:78:Applying policy additions
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:20:Creating OpenClaw sandbox
PROGRESS:50:Configuring inference provider
PROGRESS:70:Setting inference route
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
Sandbox 'test-sandbox' already exists, reusing.
PROGRESS:50:Configuring inference provider
Provider 'test-provider' already exists, reusing.
PROGRESS:70:Setting inference route
Inference route 'test-provider / test-model' is already active, reusing.
PROGRESS:85:Saving run state
PROGRESS:100:Apply complete
Sandbox 'test-sandbox' is ready.
Inference: test-provider -> test-model @ https://api.example.com/v1
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:20:Removing runtime identity provider acme-okta-runtime
PROGRESS:60:Preserving unowned sandbox test-sandbox
PROGRESS:90:Cleaning up run state
PROGRESS:100:Rollback complete
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:60:Preserving unowned sandbox existing-sandbox
PROGRESS:90:Cleaning up run state
PROGRESS:100:Rollback complete
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
Sandbox 'test-sandbox' already exists, reusing.
PROGRESS:50:Configuring inference provider
PROGRESS:70:Setting inference route
PROGRESS:85:Saving run state
PROGRESS:100:Apply complete
Sandbox 'test-sandbox' is ready.
Inference: test-provider -> test-model @ https://api.example.com/v1
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:20:Removing runtime identity provider acme-okta-runtime
PROGRESS:60:Preserving unowned sandbox test-sandbox
PROGRESS:80:Removing inference provider test-provider
PROGRESS:90:Cleaning up run state
PROGRESS:100:Rollback complete
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:30:Stopping sandbox owned-sandbox
PROGRESS:60:Removing sandbox owned-sandbox
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:60:Preserving unowned sandbox test-sandbox
PROGRESS:80:Removing inference provider test-provider
RUN_ID:nc-20260820-103346-aaaaaaaa
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
PROGRESS:20:Creating OpenClaw sandbox
PROGRESS:50:Configuring inference provider
PROGRESS:70:Setting inference route
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:20:Removing runtime identity provider acme-okta-runtime
PROGRESS:60:Preserving unowned sandbox test-sandbox
PROGRESS:90:Cleaning up run state
PROGRESS:100:Rollback complete
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:10:Configuring runtime identity
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:20:Removing runtime identity provider acme-okta-runtime
PROGRESS:60:Preserving unowned sandbox test-sandbox
PROGRESS:90:Cleaning up run state
PROGRESS:100:Rollback complete
RUN_ID:nc-20260820-103346-aaaaaaaa
PROGRESS:20:Removing runtime identity provider acme-okta-runtime
PROGRESS:30:Stopping sandbox test-sandbox
PROGRESS:60:Removing sandbox test-sandbox
PROGRESS:80:Removing inference provider test-provider
PROGRESS:90:Cleaning up run state
PROGRESS:100:Rollback complete
RUN_ID:nc-20260820-103346-aaaaaaaa
 ❯ |installer-integration| test/install-station-pair-preparation.test.ts (79 tests | 6 failed) 67569ms
     × preserves matching revoked host keys in the pinned trust evidence 5444ms
     × uses only deterministic rail candidates without trust enrollment or network discovery [ssh-keyscan] 6011ms
     × uses only deterministic rail candidates without trust enrollment or network discovery [arp-scan] 5502ms
     × keeps forbidden discovery and trust enrollment unreachable through pair qualification [ssh-keyscan] 5757ms
     × keeps forbidden discovery and trust enrollment unreachable through pair qualification [arp-scan] 5831ms
     × keeps forbidden discovery and trust enrollment unreachable through pair qualification [avahi-browse] 6208ms
 ❯ |plugin| nemoclaw/src/security/snapshot-sanitizer-failure.test.ts (36 tests | 2 failed) 12014ms
     × rejects a persistent hard link created while sanitized config is installed 1180ms
     × rejects a transient hard-link mutation while sanitized config is installed 685ms
 ❯ |package-contract| test/package-contract/managed-image-registry-transport.test.ts (1 test | 1 failed) 58907ms
     × loads from the packed CLI after an omit-dev install (#7744) 58906ms
 ❯ |installer-integration| test/install-forward-restore-diagnostics.test.ts (14 tests | 14 failed) 110262ms
     × reports why the OpenShell forward start failed (#8884) 6763ms
     × omits the `OpenShell reported:` warning when the failed start printed no output (#8884) 9971ms
     × redacts a credential from an OpenShell forward-start diagnostic (#8884) 8728ms
     × removes terminal controls from an OpenShell forward-start diagnostic (#8884) 7901ms
     × redacts the complete diagnostic when the compiled redactor is unavailable (#8884) 6294ms
     × bounds a long OpenShell forward-start diagnostic (#8884) 6767ms
     × does not replace a forward that OpenShell lists as running when the health check fails (#8884) 12414ms
     × does not replace a forward that OpenShell lists as active when the health check fails (#8884) 8998ms
     × does not replace a forward that OpenShell colorizes as running (#8884) 7823ms
     × does not replace a forward that OpenShell colorizes as active (#8884) 7322ms
     × does not change a forward when OpenShell cannot list forwards (#8884) 6114ms
     × does not replace a forward with an unrecognized OpenShell status (#8884) 6878ms
     × does not run forward stop before starting a forward that OpenShell does not list (#8884) 7062ms
     × restarts a forward OpenShell reports as dead (#8884) 7223ms
 ❯ |installer-integration| test/install-preflight.test.ts (93 tests | 1 failed) 141652ms
     × source-checkout path does NOT call resolve_release_tag / git clone 5027ms
 ❯ |package-contract| test/package-contract/cli/public-cli-contracts.test.ts (3 tests | 1 failed) 199404ms
     × keeps compiled CLI commands aligned with their documentation headings (#7616) 120013ms
stdout | src/lib/agent/base-image-hermes-resolution.test.ts > Hermes base-image resolver integration > stages Hermes on aarch64 with a Dockerfile-pinned platform digest produced by the resolver path (#6313)
  Using Hermes Agent base image: ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:c0c149ed03b3e8fcd3e395558b22e871cd27c9966ea6faf04c0d2b94d0a821b9

stdout | src/lib/agent/base-image-hermes-resolution.test.ts > Hermes base-image resolver integration > reuses an outer resolver's pinned platform digest only during its rebuild lease (#7144)
  Using Hermes Agent base image: ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@sha256:c0c149ed03b3e8fcd3e395558b22e871cd27c9966ea6faf04c0d2b94d0a821b9

 ❯ |cli| src/lib/agent/base-image-hermes-resolution.test.ts (3 tests | 2 failed) 707790ms
     × stages Hermes on aarch64 with a Dockerfile-pinned platform digest produced by the resolver path (#6313) 486761ms
     × reuses an outer resolver's pinned platform digest only during its rebuild lease (#7144) 220971ms
 ❯ |integration| test/cli/destroy-gateway-cleanup.test.ts (12 tests | 5 failed | 2 skipped) 18391ms
     × uses the platform gateway default when the last sandbox is destroyed (#2166, #4662) 2228ms
     × honours NEMOCLAW_CLEANUP_GATEWAY=1 as the env-driven opt-in (#2166) 1859ms
     × fails destroy when openshell sandbox delete returns a real error 902ms
     × treats an already-missing sandbox as destroyed using the platform gateway default (#4662) 1894ms
     × deletes messaging providers when destroying a sandbox 1866ms
 ❯ |integration| test/langchain-deepagents-code-image.test.ts (114 tests | 1 failed) 16951ms
     × makes the base image enforce the reviewed hash-locked dependency set 7703ms
 ❯ |integration| test/dependency-upgrade-skill.test.ts (31 tests | 13 failed) 49108ms
     × binds canonical GitHub identity, peeled tags, releases, and the audit target 1372ms
     × rejects an in-range remote semantic-version tag missing from the local checkout 1482ms
     × ignores absent remote tag commits outside the proven target closure 1470ms
     × rejects an in-range local semantic-version tag absent from the remote inventory 1537ms
     × does not claim an unlisted release is absent without draft visibility 1438ms
     × distinguishes unknown draft visibility from proven full visibility 2471ms
     × records prereleases from every release-list page 1681ms
     × fails when a remote tag does not peel to the local endpoint commit 1162ms
     × binds github.com explicitly instead of inheriting GH_HOST 1456ms
     × fails when any remote identity changes during collection 1729ms
     × rejects malformed repository and release payloads 1277ms
     × rejects draft visibility contradictions 1335ms
     × preserves build-metadata tag identities from the remote inventory 1766ms
 ❯ |integration| test/langchain-deepagents-code-nemotron-profile-plugin.test.ts (31 tests | 7 failed) 8339ms
     × accepts the exact plugin, then rejects source substitution 263ms
     × rejects a malicious wrong harness-profile entry point 374ms
     × rejects unreviewed profile plugin license metadata 278ms
     × rejects a plugin distribution missing the harness-profile entry-point group 276ms
     × rejects an installed real plugin wheel with an unreviewed version 2200ms
     × layers managed aliases onto the built-in OpenRouter profile idempotently (#6653) 310ms
     × atomically registers one managed profile when plugin discovery races 300ms
 ❯ |integration| test/langchain-deepagents-code-direct-module-patch.test.ts (112 tests | 1 failed | 2 skipped) 58600ms
     × blocks TUI commands, credential screens, dotenv, OAuth, and install backends 548ms
 ❯ |integration| test/onboard-fsm-live-slices.test.ts (14 tests | 8 failed) 17840ms
     × enters the initial slice on fresh onboard runs 1509ms
     × enters the core slice after the initial slice reaches provider selection 1135ms
     × enters the final slice after the core slice reaches the branch state 1297ms
     × returns the post-recovery dashboard port after agent onboarding (#8214) 1149ms
     × enters the strict initial runner at preflight on an exact-state resume 1097ms
     × bypasses the strict core runner when fresh state is already past the core entry 1048ms
     × leaves ordinary policy tiers non-authoritative in the runOnboard machine [case 0] 1069ms
     × leaves ordinary policy tiers non-authoritative in the runOnboard machine [case 1] 942ms
 ❯ |integration| test/dependency-upgrade-skill-security.test.ts (17 tests | 1 failed) 11615ms
     × uses the frozen gh binary with a minimal environment 1027ms
 ❯ |integration| test/mcp-policy-key-ownership.test.ts (12 tests | 1 failed) 9168ms
     × does not delete an operator-owned same-key policy when add rolls back 879ms
 ❯ |integration| test/hermes-runtime-api-key.test.ts (49 tests | 42 failed) 9405ms
     × mints API_SERVER_KEY at startup and refreshes Hermes config hashes 219ms
     × refuses to mint an API key into a shields-up env 205ms
     × does not rotate an existing API_SERVER_KEY on restart 207ms
     × preserves export-prefixed API_SERVER_KEY lines 221ms
     × deduplicates an existing API_SERVER_KEY while preserving the first generated value 219ms
     × ensure_hermes_runtime_api_server_key rotates malformed existing API_SERVER_KEY values and refreshes hashes [case 0] 434ms
     × ensure_hermes_runtime_api_server_key rotates malformed existing API_SERVER_KEY values and refreshes hashes [case 1] 469ms
     × ensure_hermes_runtime_api_server_key rotates malformed existing API_SERVER_KEY values and refreshes hashes [case 2] 223ms
     × does not append missing provider placeholders without a runtime plan 94ms
     × does not append raw ambient Slack values without a runtime plan 91ms
     × does not normalize new-channel ambient placeholders without a runtime plan 89ms
     × preserves the exact OpenShell provider placeholder generation in Hermes .env [case 0] (#8893) 86ms
     × preserves the exact OpenShell provider placeholder generation in Hermes .env [case 1] (#8893) 87ms
     × does not rewrite API_SERVER_KEY or unrelated .env keys from ambient runtime env 87ms
     × appends missing provider placeholders from runtime plan credential bindings 86ms
     × upserts provider placeholders without duplicates and preserves export prefixes 89ms
     × does not rewrite an exact 'canonical' runtime placeholder already persisted in .env (#8893) 83ms
     × does not rewrite an exact 'revisioned' runtime placeholder already persisted in .env (#8893) 84ms
     × ignores 'a placeholder for another environment…' from the runtime environment (#8893) 89ms
     × ignores 'an overlong credential revision' from the runtime environment (#8893) 87ms
     × ignores 'a raw credential' from the runtime environment (#8893) 85ms
     × refuses to replace a sealed canonical placeholder without a rebuild or sandbox recreation (#8893) 88ms
     × uses manifest runtime aliases for Hermes Slack provider placeholders 90ms
     × ignores an overlong Slack credential revision before runtime alias matching (#8893) 84ms
     × refuses 'symlinked' runtime plans before refreshing Hermes provider placeholders 76ms
     × refuses 'hardlinked' runtime plans before refreshing Hermes provider placeholders 196ms
     × refuses 'group-writable' runtime plans before refreshing Hermes provider placeholders 71ms
     × refuses 'world-writable' runtime plans before refreshing Hermes provider placeholders 75ms
     × ignores Slack runtime aliases when Slack is 'inactive' 85ms
     × ignores Slack runtime aliases when Slack is 'disabled' 82ms
     × ignores Slack runtime aliases when Slack is 'disabledChannels' 82ms
     × rejects runtime-plan 'malformed providerEnvKey with newline' before rewriting .env 87ms
     × rejects runtime-plan 'malformed alias envKey with whitespace' before rewriting .env 86ms
     × rejects runtime-plan 'malformed alias envKey with equals' before rewriting .env 88ms
     × rejects runtime-plan alias 'raw secret values' before rewriting .env 88ms
     × rejects runtime-plan alias 'control characters in values' before rewriting .env 81ms
     × rejects runtime-plan alias 'control characters in messages' before rewriting .env 80ms
     × rejects runtime-plan alias 'invalid regexes' before rewriting .env 83ms
     × generates distinct API_SERVER_KEY values for separate sandbox homes 419ms
     × refuses a symlinked .env without modifying the symlink target 209ms
     × refuses a hardlinked .env without modifying the shared inode 221ms
     × refuses a symlinked config path before refreshing trusted hashes 210ms
 ❯ |integration| test/sandbox-provisioning.test.ts (60 tests | 1 failed) 5863ms
     × stages privileged lifecycle helpers with root-only Hermes image modes 165ms
 ❯ |integration| test/state-dir-guard.test.ts (63 tests | 16 failed | 1 skipped) 7377ms
     × rejects a plan with overlapping writable subpaths 60ms
     × creates and preserves a generic wildcard writable subpath 61ms
     × allows a symlink whose fully resolved target stays in a protected root 135ms
     × preserves the exact image-owned OpenClaw slack peer link across transitions 198ms
     × preserves the exact image-owned OpenClaw whatsapp peer link across transitions 189ms
     × rejects a managed extension peer link with a tampered target 72ms
     × rejects a managed extension peer link with a tampered locked runtime target 72ms
     × rejects a managed extension peer link with a traversal-shaped extension id 71ms
     × does not trust an OpenClaw peer target under a non-OpenClaw state root 66ms
     × rejects links from protected code into the writable sessions carveout 73ms
     × fresh-replaces locked files so an old writable FD cannot mutate the visible path 74ms
     × applies distinct confidentiality, workspace, and writable runtime modes 82ms
     × assigns the sandbox group to the confidentiality root only, while nested entries keep the root group (#7545) 69ms
     × creates a missing sessions carveout during lock so a first-boot agent can write sessions (#7545) 287ms
     × fails closed when a sessions entry appears between the carveout check and its mkdir (#7545) 65ms
     × keeps a regular-file sessions entry locked instead of creating a writable carveout (#7545) 73ms
 ❯ |integration| test/dcode-non-interactive-json.test.ts (10 tests | 1 failed) 6852ms
     × classifies cancellation and timeout independently (#7773) 1450ms
 ❯ |integration| test/langchain-deepagents-code-progressive-tool-disclosure.test.ts (17 tests | 6 failed) 7178ms
     × keeps only core tools visible and discovers name/description matches cumulatively 96ms
     × bounds broad catalog output, persisted discovery, and visible schemas deterministically 80ms
     × restores discovered tools after compaction and session reconstruction 86ms
     × isolates graph threads and local-subagent middleware instances 74ms
     × rejects duplicate callable names and non-managed reserved-name owners 74ms
     × patches the complete package and isolated main/subagent wiring idempotently 785ms
 ❯ |integration| test/hermes-mcp-integrity-state.test.ts (19 tests | 13 failed) 2461ms
     × uses the runtime canonicalizer for the build-time MCP seal 389ms
     × omits authenticated config bytes from integrity snapshot representations 181ms
     × returns current and pending through the guarded CLI status protocol 183ms
     × uses the atomic write outcome for compat applied-state commits 182ms
     × rejects unmanaged fields in the host inspection projection 82ms
     × reports a managed config match only after the gateway-applied state is current 41ms
     × refuses diverged root anchors and config races after integrity verification 46ms
     × derives the full config hash and MCP digest from one config snapshot 67ms
     × tracks add and removal as pending until the gateway-applied commit 59ms
     × refuses a second intent while a prior MCP transaction is incomplete 53ms
     × does not bless unrelated config or env drift while committing applied state 53ms
     × fails closed when both-mode apply sees stale compatibility state 61ms
     × fails closed on drift and malformed or missing MCP metadata 59ms
 ❯ |integration| test/onboard-prepared-gateway-handoff.test.ts (3 tests | 2 failed) 3032ms
     × preserves the recorded gateway into the initial onboard flow (#6195) 1040ms
     × scopes an ordinary onboard run to the default gateway (#6315) 1070ms
 ❯ |integration| test/onboard-inference-reconciliation.test.ts (21 tests | 1 failed) 4617ms
     × resolves a sandbox name before reconciling Hermes Provider on resume 1094ms
 ❯ |integration| test/hermes-doctor-config-hash.test.ts (3 tests | 1 failed) 1351ms
     × locks trusted gateway recovery preloads as image-owned read-only files 144ms
 ❯ |integration| test/cli/destroy-detach-order.test.ts (1 test | 1 failed) 2077ms
     × detaches every per-sandbox provider before sandbox delete on destroy 2076ms
 ❯ |integration| test/fixture-umask-normalization.test.ts (5 tests | 1 failed) 1184ms
   × does not weaken the guard: an explicitly group/world-writable config is still rejected (#6448) 64ms
 ❯ |integration| test/hermes-mcp-config-transaction.test.ts (31 tests | 31 failed) 2282ms
     × rejects raw credentials, plaintext targets, and non-boolean control flags 80ms
     × keeps Hermes and host MCP URL rejection boundaries in parity 81ms
     × rejects every OpenShell host alias when the Hermes validator is called directly 78ms
     × accepts a legacy host alias only for exact cleanup payloads 82ms
     × shares the host credential-name boundary while preserving exact cleanup (#6379) 74ms
     × accepts only HTTPS endpoint definitions with one OpenShell placeholder 69ms
     × rejects command, YAML-tag, and terminal-control injection without executing it 72ms
     × preserves falsey non-map YAML roots across mutation and reload transactions 69ms
     × emits bounded one-line errors with payload and runtime secrets redacted [case 0] 72ms
     × emits bounded one-line errors with payload and runtime secrets redacted [case 1] 67ms
     × emits bounded one-line errors with payload and runtime secrets redacted [case 2] 66ms
     × emits bounded one-line errors with payload and runtime secrets redacted [case 3] 67ms
     × emits bounded one-line errors with payload and runtime secrets redacted [case 4] 68ms
     × emits bounded one-line errors with payload and runtime secrets redacted [case 5] 69ms
     × refuses a locked config snapshot 72ms
     × blocks symlink, hardlink, permission, inode-race, and atomic-write guard bypasses 81ms
     × keeps config ownership and gateway lifecycle identities separated 76ms
     × treats edits to any managed field as drift during removal 74ms
     × treats a null same-name Hermes server as drift rather than absence 76ms
     × allows root reload control to signal only the gateway service identity 76ms
     × recognizes the wrapped Hermes gateway from its bounded PID record 70ms
     × rejects a FIFO gateway PID record without blocking 69ms
     × requires the public relay and stable identity before acknowledging reload health 70ms
     × trusts the current real Hermes launcher and retained compatibility paths 68ms
     × allows an ordinary same-UID sandbox exec to reload the trusted gateway 74ms
     × verifies strict and compatibility MCP hash state on an unchanged retry 78ms
     × rejects ordinary exec in a root-separated Hermes topology 73ms
     × rejects a same-UID bare gateway before mutating managed MCP state 69ms
     × does not mistake a one-shot nemoclaw-start wrapper for the service manager 76ms
     × runs a one-shot mutation through the stock OpenShell exec topology 77ms
     × restores config and hashes after both desired-config reload signals fail 85ms
 ❯ |integration| test/hermes-nonroot-strict-hash-reconciliation.test.ts (22 tests | 22 failed) 2441ms
     × admits only the installed, markerless, uniquely supervised non-root topology 65ms
     × admits only sandbox-owned writable private-live or canonical-mutable metadata (#2426) 61ms
     × reconciles only the generated startup API key from the private live posture and completes the config transaction (#2426) 86ms
     × reconciles only the generated startup API key from the canonical mutable posture and completes the config transaction (#2426) 86ms
     × reconciles the generated startup API key on the first shields-down transaction (#6381) 325ms
     × refuses strict reconciliation from the shields-up root-locked posture (#2426) 184ms
     × preserves the write-config shields-up refusal when the strict hash is current (#2426) 78ms
     × refuses an unproven source-helper topology 98ms
     × refuses a weak API key delta 86ms
     × refuses a export-prefixed API key delta 87ms
     × refuses a single-quoted API key delta 80ms
     × refuses a missing-final-newline API key delta 89ms
     × refuses a CRLF API key delta 90ms
     × refuses a duplicate API key delta 88ms
     × refuses a stale compatibility hash 92ms
     × refuses a strict hash with missing final LF 188ms
     × refuses a strict hash with CRLF records 91ms
     × binds non-root strict hash parsing to the live config path (#2426) 92ms
     × binds non-root strict hash parsing to the live environment path (#2426) 89ms
     × refuses any env drift beyond the generated API key 209ms
     × refuses config drift even when compat and the host read match it 88ms
     × keeps the host-read compare-and-swap requirement 91ms
 ❯ |integration| test/startup-process-identity.test.ts (4 tests | 2 failed) 1394ms
     × authenticates exactly one root namespace init and rejects stale or spoofed identities (#2426) 71ms
     × rejects a trusted script path smuggled in an unrelated argv (#6565) 219ms
 ❯ |integration| test/hermes-runtime-config-guard.test.ts (26 tests | 25 failed) 2340ms
     × rejects an incomplete home_channel before a sealed write transaction starts 239ms
     × creates an absent private runtime directory through its pinned parent 69ms
     × provisions only the fixed production state and lock pair 68ms
     × refuses unsafe runtime parents, children, symlinks, and non-root production 67ms
     × warns once for unsupported directory fsync and propagates real I/O failures 69ms
     × streams SHA-256 without materializing the entire file 77ms
     × rejects an oversized sparse input before issuing a read 71ms
     × bounds restart journals before publishing them 441ms
     × rejects a same-inode, same-size config rewrite between snapshots 68ms
     × writes strict and compatibility hashes from one stable input snapshot 67ms
     × rejects stale compatibility state before an applied-state commit without leaking secrets 66ms
     × leaves the strict trust anchor uncommitted if compatibility refresh is interrupted 69ms
     × logs only validated environment keys, never runtime-plan message content 73ms
     × keeps the exact state worker PID alive with 'the installed image plan during start…' 67ms
     × keeps the exact state worker PID alive with 'the explicit host plan during a live …' 73ms
     × refuses mutable takeover while the exact claimed worker is live 68ms
     × claims the expired mutable owner before freezing its namespace 68ms
     × freezes the parent before opening .hermes 70ms
     × rejects a cross-device .hermes without mutating the mounted child 66ms
     × rejects a supervisor argv polluted with the appended startup command (#6110) 67ms
     × fails closed under foreign PID 1 only for the installed guard entrypoint 69ms
     × permits degraded host actions only when NemoClaw PID 1 is non-root 64ms
     × authenticates the markerless OpenShell supervisor topology narrowly 67ms
     × accepts direct legacy and namespace-remapped markers only for their live startup identity 69ms
     × publishes a root-only marker containing the current PID 1 start time 67ms
 ❯ |integration| test/hermes-restart-config-seal-write-lock.test.ts (9 tests | 9 failed) 928ms
     × atomically binds a host config write to the bytes that were read and refreshes both hashes 110ms
     × accepts exactly 16 MiB at the size guard before validating filesystem state 109ms
     × rejects Hermes configuration input larger than 16 MiB without creating restart state 109ms
     × refuses to launder a stale host read and leaves the trusted config unchanged 99ms
     × refuses host config writes while shields are up and restores the locked posture 104ms
     × serializes restart sealing against a host-held shields mutation lock 100ms
     × recovers a dead mutation lock published before seal state creation 98ms
     × rejects a host config transaction while another Hermes mutation owns the lock 104ms
     × rolls back a config-write phase killed after rename but before strict hash refresh 94ms
 ❯ |integration| test/hermes-mcp-credential-boundary-manifest.test.ts (6 tests | 6 failed) 1626ms
     × fails closed when the manifest is missing 507ms
     × fails closed on a manifest for another OpenShell version 228ms
     × fails closed when rawChildValueKeys is missing 230ms
     × fails closed when rewrittenChildValueKeys is missing 225ms
     × fails closed when runtimeControlKeys is missing 222ms
     × fails closed when runtimeControlPrefixes is missing 213ms
 ❯ |integration| test/hermes-restart-config-seal-transition.test.ts (9 tests | 9 failed) 881ms
     × revokes pre-open writable fds while preserving trusted path bytes and strict hashes 103ms
     × revokes pre-open descriptors across shields lock and restores the mutable contract 97ms
     × holds the mutation lock through begin, apply, verification, and finish 89ms
     × keeps weakening fan-out inaccessible and keeps monotonic lock fan-out readable [case 0] 109ms
     × keeps weakening fan-out inaccessible and keeps monotonic lock fan-out readable [case 1] 97ms
     × retains the 0500 recursive clamp and resumes the same lock transaction 97ms
     × cold-resumes an applied lock transaction before its final commit 94ms
     × takes over an expired applied mutable transition only after its worker lease ends 92ms
     × hardens mutable modes and stale hashes from the frozen current bytes 103ms
 ❯ |integration| test/sandbox-rlimit-hooks.test.ts (9 tests | 1 failed) 805ms
     × stale Hermes base replay preserves effective connect-shell rlimit hooks 159ms
 ❯ |integration| test/openclaw-config-guard.test.ts (47 tests | 30 failed) 14097ms
     × keeps an exact locked parent and pair unchanged across idempotent relock 107ms
     × fresh-replaces both files on lock and unlock while preserving bytes, times, and xattrs 104ms
     × canonicalizes a stale mutable hash while strict preflight rejects a bad record path 82ms
     × retries config and hash as one pair when a writer interleaves their capture 89ms
     × rolls a failed unlock back to the complete locked parent, config, and file posture 76ms
     × clears descriptor-bound immutable flags for replacement and restores them on rollback 80ms
     × CAS-writes a fresh mutable config/hash pair and revokes stale descriptors 80ms
     × safely replaces a sandbox-precreated persistent journal symlink 82ms
     × refuses stale CAS and locked posture without changing either file 148ms
     × rolls back both mutable files when the second write-config replacement fails 86ms
     × recovers or fail-closes after kill-after-first-replace 80ms
     × finishes the committed replacement after interruption before mutable-directory commit 81ms
     × preserves a later gateway write with stale hash when committed cleanup was interrupted 80ms
     × seals and unseals mutable restart config with stale hash and stale descriptors 335ms
     × records shields-locked restart state without replacing or weakening the host seal 72ms
     × uses JSON5 validation for restart while locked posture still enforces hash coherence 482ms
     × recovers an interrupted restart seal at kill-seal-after-first-replace 632ms
     × recovers an interrupted restart seal at kill-seal-after-sealed-journal 541ms
     × recovers an interrupted restart seal at kill-seal-after-visible 342ms
     × recovers an interrupted restart unseal at kill-unseal-after-journal 659ms
     × recovers an interrupted restart unseal at kill-unseal-after-first-replace 353ms
     × recovers an interrupted restart unseal at kill-unseal-after-committed 332ms
     × recovers an interrupted restart unseal at kill-unseal-after-visible 372ms
     × quarantines planted journal entry types and a last-moment swap without vetoing lock 180ms
     × does not roll back after mutable handoff when journal cleanup fails 79ms
     × preserves gateway writes after a crash in failed-write rollback handoff 80ms
     × serializes mutations, rejects a live owner, and reclaims a stale owner record 350ms
     × enforces the installed-helper startup lease while retaining explicit old-image fallback 246ms
     × allows only authenticated no-capability non-root startup postures 89ms
     × keeps restart journal bounded near the maximum config size 3764ms
 ❯ |integration| test/openclaw-config-guard-absent-hash.test.ts (11 tests | 5 failed) 1090ms
     × locks from mutable by synthesizing the hash from openclaw.json 82ms
     × replaces openclaw.json so a retained writable descriptor cannot mutate the sealed config 78ms
     × relocks idempotently after a synthesized-hash lock without rewriting inodes 84ms
     × locks a pristine pair without recording a synthesized hash 267ms
     × keeps a locked-posture relock fail-closed when the hash was removed 86ms
 ❯ |integration| test/hermes-restart-config-seal-recovery.test.ts (10 tests | 7 failed | 2 skipped) 742ms
     × refuses to finish after the sealed Hermes directory is swapped 109ms
     × keeps the transaction sealed when abort finds a corrupted compatibility hash 99ms
     × revokes descriptors opened after mutable apply before rolling back to locked 104ms
     × rejects a foreign shields token and lets the owner abort to the exact prior posture 100ms
     × fails closed without replacing or locking paths when the strict hash is stale 106ms
     × does not bless a compat hash changed through a pre-open descriptor 108ms
     × preserves an already trusted shields-up directory posture across seal and unseal 98ms
 ❯ |integration| test/hermes-restart-config-seal-hostile-input.test.ts (8 tests | 8 failed) 825ms
     × contains an oversized sparse config.yaml without reading its logical payload 105ms
     × contains an oversized sparse .env without reading its logical payload 100ms
     × fresh-seals a hardlinked input and revokes the external writable inode 104ms
     × seals a hostile symlink config entry into a root-only unavailable posture 102ms
     × seals a hostile fifo config entry into a root-only unavailable posture 107ms
     × quarantines an outer .hermes symlink only after freezing /sandbox 102ms
     × quarantines an outer .hermes fifo only after freezing /sandbox 105ms
     × re-seals an applied mutable transition before recursive rollback 98ms
 ❯ |integration| test/hermes-dashboard-credential-launch.test.ts (5 tests | 5 failed) 716ms
     × supplies API_SERVER_KEY through process environment without copying it into argv or output (#8008) 149ms
     × preserves upstream optional authentication for a direct unmanaged dashboard launch 139ms
     × refuses a weak API server credential source without launching Hermes (#8008) 144ms
     × refuses a duplicate API server credential source without launching Hermes (#8008) 143ms
     × refuses a symlinked API server credential source without launching Hermes (#8008) 140ms
 ❯ |integration| test/hermes-neutral-platform-env-activation.test.ts (2 tests | 1 failed) 645ms
     × preserves explicit disables while leaving validated enabled platforms active 520ms
 ❯ |integration| test/runtime-state-mutation-control.test.ts (11 tests | 11 skipped) 279ms
 ❯ |integration| test/hermes-mcp-apply-race.test.ts (4 tests | 4 failed) 316ms
     × returns success when the gateway commits the apply-state hash before the transaction helper can 85ms
     × falls back to rollback when only the strict integrity anchor was committed 77ms
     × bounds repeated raced recovery snapshots before failing closed 73ms
     × rolls back when both anchors advance but the gateway reload did not complete 80ms
 ❯ |integration| test/hermes-mcp-reload-convergence.test.ts (8 tests | 8 failed) 621ms
     × re-kicks one revalidated gateway identity within the original reload deadline 85ms
     × does not re-kick without a currently trusted gateway identity 80ms
     × does not probe or accept an unmanaged replacement gateway 77ms
     × revalidates the managed parent after replacement health 76ms
     × attempts a vanished re-kick target only once 73ms
     × reports whether reload stopped at internal health, public relay, or stable identity 73ms
     × does not re-kick after a health probe exhausts the shared deadline 74ms
     × reports the furthest safe phase reached when reload exhausts its deadline 82ms
 ❯ |integration| test/growth-guardrails.test.ts (25 tests | 5 skipped) 623ms
 ❯ |integration| test/state-dir-guard-dashboard-profile.test.ts (2 tests | 2 failed) 153ms
     × keeps the Hermes dashboard profile writable and private while Shields are up (#7200) 79ms
     × keeps a dashboard-named OpenClaw profile inside the Shields boundary 73ms
 ❯ |integration| test/hermes-mcp-rollback-pending.test.ts (1 test | 1 failed) 77ms
     × keeps a failed runtime rollback pending until a healthy old-config reload 76ms
 ❯ |integration| test/hermes-mcp-force-cleanup.test.ts (1 test | 1 failed) 73ms
     × removes legacy percent-path entries by validated server name 71ms
 ❯ |integration| test/openclaw-gemini-inference-compat-runtime.test.ts (2 tests | 2 failed) 72ms
     × loads the generated plugin through OpenClaw runtime inspection (#8474) 25ms
     × applies the generated plugin to managed Google routing and tool results (#8474) 17ms
 ❯ |integration| test/langchain-deepagents-code-image-credentials.test.ts (187 tests | 1 failed) 48770ms
     × pins the OTLP endpoint accept/refuse contract on runtime and dotenv paths (#6466, #6538) 15885ms
 ❯ |integration| test/cli/dispatch-basics.test.ts (40 tests | 1 failed) 27880ms
     × agents parent shows command help instead of sandbox lookup 10137ms
 ❯ |integration| test/sandbox-sessions-admin-agent-cli.test.ts (5 tests | 1 failed) 19479ms
     × refuses `sessions reset` on a hermes sandbox instead of dispatching the OpenClaw gateway RPC 10053ms
version: 1
network_policies: {}
version: 1
network_policies: {}
version: 1
network_policies: {}
version: 1
network_policies: {}
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] started: serve compatible endpoint (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] child lifecycle 1: started (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] event: fake OpenAI-compatible server started (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] completed: serve compatible endpoint — passed in 0s (total 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] started: verify compatible endpoint (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] child lifecycle 1: exited-zero (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] event: fake OpenAI-compatible server stopped (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] completed: verify compatible endpoint — passed in 0s (total 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] started: serve compatible endpoint (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] child lifecycle 1: started (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] event: fake OpenAI-compatible server started (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] completed: serve compatible endpoint — passed in 0s (total 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] started: verify compatible endpoint (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] child lifecycle 1: exited-zero (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] event: fake OpenAI-compatible server stopped (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] completed: verify compatible endpoint — passed in 0s (total 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] started: serve compatible endpoint (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] child lifecycle 1: started (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] event: fake OpenAI-compatible server started (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] completed: serve compatible endpoint — passed in 0s (total 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] started: verify compatible endpoint (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] child lifecycle 1: exited-zero (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] event: fake OpenAI-compatible server stopped (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] completed: verify compatible endpoint — passed in 0s (total 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] started: serve compatible endpoint (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] child lifecycle 1: started (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] event: fake OpenAI-compatible server started (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] completed: serve compatible endpoint — passed in 0s (total 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] started: verify compatible endpoint (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] child lifecycle 1: exited-zero (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] event: fake OpenAI-compatible server stopped (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] completed: verify compatible endpoint — passed in 0s (total 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] started: serve compatible endpoint (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] child lifecycle 1: started (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] event: fake OpenAI-compatible server started (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 1/2] completed: serve compatible endpoint — passed in 0s (total 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] started: verify compatible endpoint (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] child lifecycle 1: exited-zero (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] event: fake OpenAI-compatible server stopped (total 0s; phase 0s)
[e2e target="compatible-endpoint-context-probe" scenario="compatible endpoint support"] [phase 2/2] completed: verify compatible endpoint — passed in 0s (total 0s)

 Test Files  83 failed | 2241 passed | 23 skipped (2347)
      Tests  417 failed | 34854 passed | 436 skipped (35707)
   Start at  03:28:31
   Duration  1660.74s (transform 114.33s, setup 753.83s, import 1236.50s, tests 7348.05s, environment 166ms) for broad runtime/test-harness changes; 
> nemoclaw@0.1.0 check
> npx prek run --all-files --stage pre-commit && npx prek run --all-files --stage manual

Running hooks for `tmp/codex-8583-preflight-98b/final-shard-1`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/final-shard-2`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/linux-shard-1`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-1`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-2`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-3`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-4`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-5`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-6`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-7`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/runner-shard-8`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-1`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-2`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-3`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-4`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-5`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-6`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-7`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/shard-8`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `tmp/codex-8583-preflight-98b/workspace`:
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
mixed line ending....................................(no files to check)Skipped
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.........................(no files to check)Skipped
SPDX license headers (insert if missing).............(no files to check)Skipped
shfmt................................................(no files to check)Skipped
Biome format.........................................(no files to check)Skipped
Biome lint fixes.....................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
check for added large files..........................(no files to check)Skipped
check for case conflicts.............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
detect private key...................................(no files to check)Skipped
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable......(no files to check)Skipped
Validate config files against JSON schemas...........(no files to check)Skipped
Validate managed inference catalog...................(no files to check)Skipped
Repository checks....................................(no files to check)Skipped
NEMOCLAW_* env-var documentation gate................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
hadolint.............................................(no files to check)Skipped
gitleaks (secret scan)...............................(no files to check)Skipped
markdownlint-cli2....................................(no files to check)Skipped
E2E semantic phase plans.............................(no files to check)Skipped
Source-shape test budget.............................(no files to check)Skipped
Test file size budget................................(no files to check)Skipped
Test (skills YAML)...................................(no files to check)Skipped

Running hooks for `.`:
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
Reject force-added ignored files.........................................Passed
Sync platform matrix to docs.............................................Passed
SPDX license headers (insert if missing).................................Passed
Files were modified by following hooks...................................Failed
  ┌ shfmt................................................................Passed
  └ Oxfmt................................................................Passed
Oxlint fixes.............................................................Passed
check for merge conflicts................................................Passed
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check yaml...............................................................Passed
check toml...............................................................Passed
check json...............................................................Passed
detect private key.......................................................Passed
check that executables have shebangs.....................................Passed
check that scripts with shebangs are executable..........................Passed
Oxlint type-aware rules..................................................Passed
Validate config files against JSON schemas...............................Passed
Validate managed inference catalog.......................................Passed
Repository checks........................................................Passed
NEMOCLAW_* env-var documentation gate....................................Passed
shellcheck...............................................................Passed
hadolint.................................................................Passed
gitleaks (secret scan)...................................................Passed
markdownlint-cli2........................................................Passed
E2E semantic phase plans.................................................Passed
Source-shape test budget.................................................Failed
- hook id: source-shape-test-budget
- exit code: 1

  > nemoclaw@0.1.0 source-shape:check
  > tsx scripts/find-source-shape-tests.mts --check

  node:fs:1795
    const stats = binding.stat(
                          ^

  Error: ENOENT: no such file or directory, stat '/Users/akumaria/dev/NemoClaw/tmp/codex-8583-preflight-98b/container-tmp-1/nemoclaw-vitest-pN5Z9P/nemoclaw-creds-YA1Auq/.nemoclaw/credentials.json'
      at statSync (node:fs:1795:25)
      at walkFiles (/Users/akumaria/dev/NemoClaw/scripts/find-source-shape-tests.mts:109:19)
      at walkFiles.next (<anonymous>)
      at walkFiles (/Users/akumaria/dev/NemoClaw/scripts/find-source-shape-tests.mts:111:14)
      at walkFiles.next (<anonymous>)
      at walkFiles (/Users/akumaria/dev/NemoClaw/scripts/find-source-shape-tests.mts:111:14)
      at walkFiles.next (<anonymous>)
      at walkFiles (/Users/akumaria/dev/NemoClaw/scripts/find-source-shape-tests.mts:111:14)
      at walkFiles.next (<anonymous>)
      at walkFiles (/Users/akumaria/dev/NemoClaw/scripts/find-source-shape-tests.mts:111:14) {
    errno: -2,
    code: 'ENOENT',
    syscall: 'stat',
    path: '/Users/akumaria/dev/NemoClaw/tmp/codex-8583-preflight-98b/container-tmp-1/nemoclaw-vitest-pN5Z9P/nemoclaw-creds-YA1Auq/.nemoclaw/credentials.json'
  }

  Node.js v24.19.0
Codebase growth guardrails...............................................Failed
- hook id: codebase-growth-guardrails
- exit code: 1

  RUN  v4.1.9 /Users/akumaria/dev/NemoClaw

   ❯ |integration| test/growth-guardrails.test.ts (25 tests | 5 skipped) 1520ms

   Test Files  1 failed (1)
        Tests  20 passed | 5 skipped (25)
     Start at  03:58:15
     Duration  2.77s (transform 343ms, setup 153ms, import 409ms, tests 1.52s, environment 0ms)


  ⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯

   FAIL  |integration| test/growth-guardrails.test.ts > codebase growth guardrails
  Error: spawnSync git ENOBUFS
   ❯ loadLocalDiff test/helpers/growth-guardrail-diff.ts:122:21
      120|   const files = parseChangedFiles(changed);
      121|   const known = new Set(files.map(({ filename }) => filename));
      122|   const untracked = execFileSync("git", ["ls-files", "--others", "--ex…
         |                     ^
      123|     cwd: REPO_ROOT,
      124|     encoding: "utf8",
   ❯ loadGrowthGuardrailDiff test/helpers/growth-guardrail-diff.ts:173:23
   ❯ test/growth-guardrails.test.ts:41:18

  ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
Test (skills YAML).......................................................Passed for repo-wide validation/coverage changes — command/result: Not applicable; this scoped resolver change is covered by focused function and spawned CLI tests.\n- [x] Quality Gates section completed with required justifications or waivers\n- [x] No secrets, API keys, or credentials committed\n- [ ] 
> nemoclaw@0.1.0 docs
> npm run docs:strict


> nemoclaw@0.1.0 docs:strict
> npm run docs:prepare && npm run docs:validate


> nemoclaw@0.1.0 docs:prepare
> npm run docs:sync-starter-prompt && tsx scripts/sync-agent-variant-docs.mts


> nemoclaw@0.1.0 docs:sync-starter-prompt
> tsx scripts/generate-starter-prompt.mts

Generated docs/_build/StarterPrompt.generated.mdx.
docs/_build/agent-variants/about/how-it-works.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/about/how-it-works.hermes.generated.mdx is already up to date
docs/_build/agent-variants/about/how-it-works.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/about/overview.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/about/overview.hermes.generated.mdx is already up to date
docs/_build/agent-variants/about/overview.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/configure-agents/progressive-tool-disclosure.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/configure-agents/progressive-tool-disclosure.hermes.generated.mdx is already up to date
docs/_build/agent-variants/configure-agents/progressive-tool-disclosure.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/deployment/deploy-to-headless-server.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/deployment/deploy-to-headless-server.hermes.generated.mdx is already up to date
docs/_build/agent-variants/deployment/deploy-to-headless-server.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/deployment/gateway-lifecycle-authority.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/deployment/gateway-lifecycle-authority.hermes.generated.mdx is already up to date
docs/_build/agent-variants/deployment/gateway-lifecycle-authority.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/deployment/set-up-mcp-bridge.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/deployment/set-up-mcp-bridge.hermes.generated.mdx is already up to date
docs/_build/agent-variants/deployment/set-up-mcp-bridge.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/get-started/dgx-station-preparation.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/get-started/dgx-station-preparation.hermes.generated.mdx is already up to date
docs/_build/agent-variants/get-started/dgx-station-preparation.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/get-started/prerequisites.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/get-started/prerequisites.hermes.generated.mdx is already up to date
docs/_build/agent-variants/get-started/prerequisites.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/get-started/windows-preparation.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/get-started/windows-preparation.hermes.generated.mdx is already up to date
docs/_build/agent-variants/get-started/windows-preparation.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-compatible-inference-api.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-compatible-inference-api.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-compatible-inference-api.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-inference-provider.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-inference-provider.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-inference-provider.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-local-inference-server.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-local-inference-server.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-local-inference-server.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-model.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-model.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-model.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/configure-inference-timeouts.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/configure-inference-timeouts.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/configure-inference-timeouts.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/configure-model-limits.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/configure-model-limits.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/configure-model-limits.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/custom-endpoint-security.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/custom-endpoint-security.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/custom-endpoint-security.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/how-inference-routing-works.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/how-inference-routing-works.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/how-inference-routing-works.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/model-capability-audit.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/model-capability-audit.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/model-capability-audit.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-anthropic-compatible-endpoint.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-anthropic-compatible-endpoint.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-anthropic-compatible-endpoint.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-llama-cpp.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-llama-cpp.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-llama-cpp.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-model-router.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-model-router.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-model-router.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-nvidia-nim.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-nvidia-nim.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-nvidia-nim.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-ollama.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-ollama.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-openai-compatible-endpoint.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-openai-compatible-endpoint.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-openai-compatible-endpoint.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm-on-two-dgx-sparks.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm-on-two-dgx-sparks.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm-on-two-dgx-sparks.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm-on-two-dgx-stations.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm-on-two-dgx-stations.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm-on-two-dgx-stations.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/switch-models.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/switch-models.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/switch-models.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/switch-providers.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/switch-providers.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/switch-providers.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/understand-provider-validation.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/understand-provider-validation.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/understand-provider-validation.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-anthropic.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-anthropic.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-anthropic.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-google-gemini.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-google-gemini.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-google-gemini.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-nvidia-endpoints.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-nvidia-endpoints.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-nvidia-endpoints.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-openai.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-openai.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-openai.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-openrouter.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-openrouter.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-openrouter.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-shared-gateway-routes.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-shared-gateway-routes.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-shared-gateway-routes.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/verify-inference-route.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/verify-inference-route.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/verify-inference-route.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/view-active-inference-route.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/view-active-inference-route.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/view-active-inference-route.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/add-channels-after-onboarding.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/add-channels-after-onboarding.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/add-mcp-server.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/add-mcp-server.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/add-mcp-server.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/backup-restore.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/backup-restore.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/backup-restore.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/enable-channels-during-onboarding.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/enable-channels-during-onboarding.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/gateway-lifecycle-control.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/gateway-lifecycle-control.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/lifecycle.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/lifecycle.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/lifecycle.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/manage-mcp-servers.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/manage-mcp-servers.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/manage-mcp-servers.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/manage-messaging-channels.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/manage-messaging-channels.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/messaging-channels.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/messaging-channels.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/recover-rebuild-sandboxes.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/recover-rebuild-sandboxes.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/recover-rebuild-sandboxes.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/run-sandboxes.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/run-sandboxes.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/run-sandboxes.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/runtime-controls.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/runtime-controls.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-discord.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-discord.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-microsoft-teams.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-microsoft-teams.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-slack.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-slack.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-telegram.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-telegram.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-wechat.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-wechat.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-whatsapp.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-whatsapp.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/transfer-state-manually.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/transfer-state-manually.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/transfer-state-manually.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/uninstall-nemoclaw.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/uninstall-nemoclaw.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/uninstall-nemoclaw.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/update-sandboxes.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/update-sandboxes.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/update-sandboxes.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/workspace-files.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/workspace-files.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/workspace-files.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/monitoring/monitor-sandbox-activity.hermes.generated.mdx is already up to date
docs/_build/agent-variants/monitoring/monitor-sandbox-activity.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/apply-policy-presets.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/apply-policy-presets.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/apply-policy-presets.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/approve-network-requests.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/approve-network-requests.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/approve-network-requests.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/change-baseline-network-policy.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/change-baseline-network-policy.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/change-baseline-network-policy.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/configure-raw-tls-passthrough.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/configure-raw-tls-passthrough.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/create-custom-policy-presets.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/create-custom-policy-presets.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/create-custom-policy-presets.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/customize-network-policy.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/customize-network-policy.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/customize-network-policy.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/explain-network-policy-to-agents.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/explain-network-policy-to-agents.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/integration-policy-examples.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/integration-policy-examples.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/replace-live-network-policy.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/replace-live-network-policy.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/replace-live-network-policy.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/set-up-gmail-with-an-app-password.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/set-up-gmail-with-an-app-password.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/architecture.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/architecture.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/architecture.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/cli-selection-guide.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/cli-selection-guide.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/cli-selection-guide.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/commands.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/commands.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/commands.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/enterprise-readiness.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/enterprise-readiness.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/enterprise-readiness.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/extension-taxonomy-sdk-readiness.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/extension-taxonomy-sdk-readiness.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/extension-taxonomy-sdk-readiness.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/host-files-and-state.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/host-files-and-state.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/host-files-and-state.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/network-policies.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/network-policies.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/network-policies.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/system-readiness.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/system-readiness.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/system-readiness.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/troubleshoot-mcp-servers.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/troubleshoot-mcp-servers.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/troubleshoot-mcp-servers.openclaw.generated.mdx is already up to date
Wrote docs/_build/agent-variants/reference/troubleshooting.deepagents.generated.mdx
Wrote docs/_build/agent-variants/reference/troubleshooting.hermes.generated.mdx
Wrote docs/_build/agent-variants/reference/troubleshooting.openclaw.generated.mdx
docs/_build/agent-variants/resources/agent-skills.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/resources/agent-skills.hermes.generated.mdx is already up to date
docs/_build/agent-variants/resources/agent-skills.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/resources/community-contributions.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/resources/community-contributions.hermes.generated.mdx is already up to date
docs/_build/agent-variants/resources/community-contributions.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/resources/engineer-agentic-documentation.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/resources/engineer-agentic-documentation.hermes.generated.mdx is already up to date
docs/_build/agent-variants/resources/engineer-agentic-documentation.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/resources/license.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/resources/license.hermes.generated.mdx is already up to date
docs/_build/agent-variants/resources/license.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/best-practices.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/best-practices.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/best-practices.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/configure-corporate-ca-trust.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/configure-corporate-ca-trust.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/configure-corporate-ca-trust.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/credential-rotation.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/credential-rotation.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/credential-storage.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/credential-storage.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/credential-storage.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/filesystem-controls.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/filesystem-controls.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/filesystem-controls.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/gateway-authentication-controls.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/gateway-authentication-controls.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/gateway-authentication-controls.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/process-controls.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/process-controls.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/process-controls.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/tcb-boundary.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/tcb-boundary.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/tcb-boundary.openclaw.generated.mdx is already up to date

> nemoclaw@0.1.0 docs:validate
> npm run docs:check-starter-prompt && npm run docs:check-agent-variants && npm run docs:check-routes && FERN_VERSION=$(node -p "require('./fern/fern.config.json').version") && cd fern && npx --yes "fern-api@${FERN_VERSION}" check


> nemoclaw@0.1.0 docs:check-starter-prompt
> tsx scripts/generate-starter-prompt.mts --check

Generated Starter Prompt snippet is current.

> nemoclaw@0.1.0 docs:check-agent-variants
> tsx scripts/sync-agent-variant-docs.mts --check

docs/_build/agent-variants/about/how-it-works.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/about/how-it-works.hermes.generated.mdx is already up to date
docs/_build/agent-variants/about/how-it-works.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/about/overview.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/about/overview.hermes.generated.mdx is already up to date
docs/_build/agent-variants/about/overview.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/configure-agents/progressive-tool-disclosure.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/configure-agents/progressive-tool-disclosure.hermes.generated.mdx is already up to date
docs/_build/agent-variants/configure-agents/progressive-tool-disclosure.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/deployment/deploy-to-headless-server.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/deployment/deploy-to-headless-server.hermes.generated.mdx is already up to date
docs/_build/agent-variants/deployment/deploy-to-headless-server.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/deployment/gateway-lifecycle-authority.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/deployment/gateway-lifecycle-authority.hermes.generated.mdx is already up to date
docs/_build/agent-variants/deployment/gateway-lifecycle-authority.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/deployment/set-up-mcp-bridge.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/deployment/set-up-mcp-bridge.hermes.generated.mdx is already up to date
docs/_build/agent-variants/deployment/set-up-mcp-bridge.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/get-started/dgx-station-preparation.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/get-started/dgx-station-preparation.hermes.generated.mdx is already up to date
docs/_build/agent-variants/get-started/dgx-station-preparation.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/get-started/prerequisites.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/get-started/prerequisites.hermes.generated.mdx is already up to date
docs/_build/agent-variants/get-started/prerequisites.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/get-started/windows-preparation.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/get-started/windows-preparation.hermes.generated.mdx is already up to date
docs/_build/agent-variants/get-started/windows-preparation.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-compatible-inference-api.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-compatible-inference-api.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-compatible-inference-api.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-inference-provider.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-inference-provider.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-inference-provider.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-local-inference-server.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-local-inference-server.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-local-inference-server.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-model.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-model.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/choose-model.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/configure-inference-timeouts.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/configure-inference-timeouts.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/configure-inference-timeouts.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/configure-model-limits.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/configure-model-limits.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/configure-model-limits.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/custom-endpoint-security.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/custom-endpoint-security.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/custom-endpoint-security.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/how-inference-routing-works.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/how-inference-routing-works.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/how-inference-routing-works.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/model-capability-audit.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/model-capability-audit.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/model-capability-audit.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-anthropic-compatible-endpoint.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-anthropic-compatible-endpoint.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-anthropic-compatible-endpoint.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-llama-cpp.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-llama-cpp.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-llama-cpp.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-model-router.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-model-router.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-model-router.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-nvidia-nim.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-nvidia-nim.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-nvidia-nim.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-ollama.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-ollama.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-openai-compatible-endpoint.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-openai-compatible-endpoint.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-openai-compatible-endpoint.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm-on-two-dgx-sparks.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm-on-two-dgx-sparks.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm-on-two-dgx-sparks.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm-on-two-dgx-stations.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm-on-two-dgx-stations.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm-on-two-dgx-stations.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/set-up-vllm.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/switch-models.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/switch-models.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/switch-models.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/switch-providers.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/switch-providers.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/switch-providers.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/understand-provider-validation.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/understand-provider-validation.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/understand-provider-validation.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-anthropic.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-anthropic.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-anthropic.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-google-gemini.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-google-gemini.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-google-gemini.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-nvidia-endpoints.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-nvidia-endpoints.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-nvidia-endpoints.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-openai.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-openai.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-openai.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-openrouter.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-openrouter.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-openrouter.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-shared-gateway-routes.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-shared-gateway-routes.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/use-shared-gateway-routes.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/verify-inference-route.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/verify-inference-route.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/verify-inference-route.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/inference/view-active-inference-route.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/inference/view-active-inference-route.hermes.generated.mdx is already up to date
docs/_build/agent-variants/inference/view-active-inference-route.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/add-channels-after-onboarding.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/add-channels-after-onboarding.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/add-mcp-server.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/add-mcp-server.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/add-mcp-server.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/backup-restore.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/backup-restore.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/backup-restore.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/enable-channels-during-onboarding.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/enable-channels-during-onboarding.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/gateway-lifecycle-control.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/gateway-lifecycle-control.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/lifecycle.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/lifecycle.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/lifecycle.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/manage-mcp-servers.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/manage-mcp-servers.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/manage-mcp-servers.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/manage-messaging-channels.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/manage-messaging-channels.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/messaging-channels.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/messaging-channels.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/recover-rebuild-sandboxes.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/recover-rebuild-sandboxes.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/recover-rebuild-sandboxes.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/run-sandboxes.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/run-sandboxes.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/run-sandboxes.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/runtime-controls.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/runtime-controls.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-discord.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-discord.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-microsoft-teams.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-microsoft-teams.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-slack.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-slack.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-telegram.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-telegram.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-wechat.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-wechat.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-whatsapp.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/set-up-whatsapp.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/transfer-state-manually.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/transfer-state-manually.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/transfer-state-manually.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/uninstall-nemoclaw.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/uninstall-nemoclaw.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/uninstall-nemoclaw.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/update-sandboxes.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/update-sandboxes.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/update-sandboxes.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/workspace-files.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/workspace-files.hermes.generated.mdx is already up to date
docs/_build/agent-variants/manage-sandboxes/workspace-files.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/monitoring/monitor-sandbox-activity.hermes.generated.mdx is already up to date
docs/_build/agent-variants/monitoring/monitor-sandbox-activity.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/apply-policy-presets.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/apply-policy-presets.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/apply-policy-presets.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/approve-network-requests.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/approve-network-requests.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/approve-network-requests.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/change-baseline-network-policy.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/change-baseline-network-policy.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/change-baseline-network-policy.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/configure-raw-tls-passthrough.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/configure-raw-tls-passthrough.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/create-custom-policy-presets.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/create-custom-policy-presets.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/create-custom-policy-presets.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/customize-network-policy.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/customize-network-policy.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/customize-network-policy.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/explain-network-policy-to-agents.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/explain-network-policy-to-agents.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/integration-policy-examples.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/integration-policy-examples.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/replace-live-network-policy.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/replace-live-network-policy.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/replace-live-network-policy.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/set-up-gmail-with-an-app-password.hermes.generated.mdx is already up to date
docs/_build/agent-variants/network-policy/set-up-gmail-with-an-app-password.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/architecture.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/architecture.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/architecture.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/cli-selection-guide.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/cli-selection-guide.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/cli-selection-guide.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/commands.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/commands.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/commands.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/enterprise-readiness.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/enterprise-readiness.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/enterprise-readiness.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/extension-taxonomy-sdk-readiness.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/extension-taxonomy-sdk-readiness.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/extension-taxonomy-sdk-readiness.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/host-files-and-state.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/host-files-and-state.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/host-files-and-state.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/network-policies.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/network-policies.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/network-policies.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/system-readiness.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/system-readiness.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/system-readiness.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/troubleshoot-mcp-servers.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/troubleshoot-mcp-servers.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/troubleshoot-mcp-servers.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/reference/troubleshooting.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/reference/troubleshooting.hermes.generated.mdx is already up to date
docs/_build/agent-variants/reference/troubleshooting.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/resources/agent-skills.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/resources/agent-skills.hermes.generated.mdx is already up to date
docs/_build/agent-variants/resources/agent-skills.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/resources/community-contributions.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/resources/community-contributions.hermes.generated.mdx is already up to date
docs/_build/agent-variants/resources/community-contributions.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/resources/engineer-agentic-documentation.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/resources/engineer-agentic-documentation.hermes.generated.mdx is already up to date
docs/_build/agent-variants/resources/engineer-agentic-documentation.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/resources/license.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/resources/license.hermes.generated.mdx is already up to date
docs/_build/agent-variants/resources/license.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/best-practices.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/best-practices.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/best-practices.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/configure-corporate-ca-trust.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/configure-corporate-ca-trust.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/configure-corporate-ca-trust.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/credential-rotation.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/credential-rotation.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/credential-storage.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/credential-storage.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/credential-storage.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/filesystem-controls.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/filesystem-controls.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/filesystem-controls.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/gateway-authentication-controls.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/gateway-authentication-controls.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/gateway-authentication-controls.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/process-controls.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/process-controls.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/process-controls.openclaw.generated.mdx is already up to date
docs/_build/agent-variants/security/tcb-boundary.deepagents.generated.mdx is already up to date
docs/_build/agent-variants/security/tcb-boundary.hermes.generated.mdx is already up to date
docs/_build/agent-variants/security/tcb-boundary.openclaw.generated.mdx is already up to date

> nemoclaw@0.1.0 docs:check-routes
> tsx scripts/check-docs-published-routes.mts

check-docs-published-routes: OK — 68 guarded page(s), native changelog links, and direct legacy redirects
Found 0 errors and 2 warnings in 0.000 seconds. Run fern check --warnings to print out the warnings not shown. builds without warnings (doc changes only)\n- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)\n- [ ] New doc pages include SPDX header and frontmatter (new pages only)\n\n---\n<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->\nSigned-off-by: Tinson Lai <tinsonl@nvidia.com>\n\n\n<!-- This is an auto-generated comment: release notes by coderabbit.ai -->\n\n## Summary by CodeRabbit\n\n* **Bug Fixes**\n  * Improved sandbox port recovery by recognizing valid declared ports and excluding ports reserved for dashboards and agents.\n  * Corrected Hermes API port translation during sandbox recovery and launch readiness checks.\n  * Recovery now safely skips cases where no valid uncovered ports are available.\n\n* **Tests**\n  * Added regression coverage for Hermes sandbox port validation and reachability checks using runtime-observed gateway settings.\n\n<!-- end of auto-generated comment: release notes by coderabbit.ai -->