### PR TITLE
fix(onboard): preserve validation resume state

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -2810,8 +2810,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
     collector: null,
     span: null,
   };
-  let completed = false,
-    returnedNormally = false;
+  let completed = false, preserveDeferredExitSession = false, preserveIncompleteSession = false;
   try {
     await portableRetirementEntry.run(async () => {
       const lockedRuntime = await resumeRuntime.prepare(
@@ -2920,10 +2919,7 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
         process.exit(1);
       }
 
-      registerIncompleteOnboardExitHandlerForSession(
-        onboardSession,
-        () => completed || returnedNormally,
-      );
+      registerIncompleteOnboardExitHandlerForSession(onboardSession, () => completed || preserveIncompleteSession);
       const agent = await selectOnboardAgent({
         agentFlag: opts.agent,
         session,
@@ -3493,6 +3489,9 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
       }
       process.exitCode = completed ? 0 : 1;
     });
+  } catch (error) {
+    preserveDeferredExitSession = onboardSessionBootstrap.shouldPreserveIncompleteOnboardSession(error);
+    throw error;
   } finally {
     try {
       await hermesApiPortReservationScope.release();
@@ -3510,8 +3509,9 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
       restorePortableEnvScope();
       hostMountScope.restore();
     }
+    if (preserveDeferredExitSession) preserveIncompleteSession = true;
   }
-  returnedNormally = true;
+  preserveIncompleteSession = true;
 }
 
 module.exports = {

--- a/src/lib/onboard/abort-gateway-teardown.test.ts
+++ b/src/lib/onboard/abort-gateway-teardown.test.ts
@@ -26,12 +26,12 @@ describe("gatewayHasRegisteredSandbox", () => {
     expect(gatewayHasRegisteredSandbox("nemoclaw-8814", listSandboxes)).toBe(false);
   });
 
-  it("fails closed when a registry binding cannot be resolved", () => {
+  it("reports unknown ownership when a registry binding cannot be resolved", () => {
     const listSandboxes = () => ({
       sandboxes: [{ name: "alpha", gatewayName: "not-a-nemoclaw-gateway" }],
       defaultSandbox: "alpha" as string | null,
     });
-    expect(gatewayHasRegisteredSandbox("nemoclaw-8814", listSandboxes)).toBe(true);
+    expect(gatewayHasRegisteredSandbox("nemoclaw-8814", listSandboxes)).toBeNull();
   });
 });
 
@@ -39,7 +39,7 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
   it("skips teardown when a sandbox still owns the gateway", () => {
     const release = vi.fn();
     const remove = vi.fn();
-    const attempted = teardownOrphanManagedGatewayOnAbort({
+    const cleanupComplete = teardownOrphanManagedGatewayOnAbort({
       gatewayPort: 8814,
       gatewayName: "nemoclaw-8814",
       listSandboxes: () => ({
@@ -49,7 +49,7 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
       releaseManagedGatewayPort: release,
       removeGatewayRegistration: remove,
     });
-    expect(attempted).toBe(false);
+    expect(cleanupComplete).toBe(true);
     expect(release).not.toHaveBeenCalled();
     expect(remove).not.toHaveBeenCalled();
   });
@@ -58,7 +58,7 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
     const release = vi.fn();
     const remove = vi.fn();
     const log = vi.fn();
-    const attempted = teardownOrphanManagedGatewayOnAbort({
+    const cleanupComplete = teardownOrphanManagedGatewayOnAbort({
       gatewayPort: 8814,
       gatewayName: "nemoclaw-8814",
       listSandboxes: () => ({ sandboxes: [], defaultSandbox: null }),
@@ -76,7 +76,7 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
       removeGatewayRegistration: remove,
       log,
     });
-    expect(attempted).toBe(false);
+    expect(cleanupComplete).toBe(true);
     expect(release).not.toHaveBeenCalled();
     expect(remove).not.toHaveBeenCalled();
     expect(log.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
@@ -88,7 +88,7 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
     const release = vi.fn();
     const remove = vi.fn();
     const warn = vi.fn();
-    const attempted = teardownOrphanManagedGatewayOnAbort({
+    const cleanupComplete = teardownOrphanManagedGatewayOnAbort({
       gatewayPort: 8814,
       gatewayName: "nemoclaw-8814",
       listSandboxes: () => ({ sandboxes: [], defaultSandbox: null }),
@@ -99,11 +99,35 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
       removeGatewayRegistration: remove,
       warn,
     });
-    expect(attempted).toBe(false);
+    expect(cleanupComplete).toBe(false);
     expect(release).not.toHaveBeenCalled();
     expect(remove).not.toHaveBeenCalled();
     expect(warn.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
       "authority mismatch",
+    );
+  });
+
+  it("fails cleanup without teardown when sandbox ownership is unknown", () => {
+    const release = vi.fn();
+    const remove = vi.fn();
+    const warn = vi.fn();
+    const cleanupComplete = teardownOrphanManagedGatewayOnAbort({
+      gatewayPort: 8814,
+      gatewayName: "nemoclaw-8814",
+      listSandboxes: () => ({
+        sandboxes: [{ name: "alpha", gatewayName: "not-a-nemoclaw-gateway" }],
+        defaultSandbox: "alpha",
+      }),
+      releaseManagedGatewayPort: release,
+      removeGatewayRegistration: remove,
+      warn,
+    });
+
+    expect(cleanupComplete).toBe(false);
+    expect(release).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+    expect(warn.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
+      "sandbox gateway binding is unreadable",
     );
   });
 
@@ -116,9 +140,9 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
       scanned: true,
       skipped: false,
     }));
-    const remove = vi.fn();
+    const remove = vi.fn(() => true);
     const log = vi.fn();
-    const attempted = teardownOrphanManagedGatewayOnAbort({
+    const cleanupComplete = teardownOrphanManagedGatewayOnAbort({
       gatewayPort: 8814,
       gatewayName: "nemoclaw-8814",
       listSandboxes: () => ({ sandboxes: [], defaultSandbox: null }),
@@ -136,7 +160,7 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
       removeGatewayRegistration: remove,
       log,
     });
-    expect(attempted).toBe(true);
+    expect(cleanupComplete).toBe(true);
     expect(release).toHaveBeenCalledWith({ port: 8814 });
     expect(remove).toHaveBeenCalledWith("nemoclaw-8814");
     const output = log.mock.calls.map((call) => String(call[0])).join("\n");
@@ -148,7 +172,7 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
     const release = vi.fn();
     const remove = vi.fn();
     const warn = vi.fn();
-    const attempted = teardownOrphanManagedGatewayOnAbort({
+    const cleanupComplete = teardownOrphanManagedGatewayOnAbort({
       gatewayPort: 8814,
       gatewayName: "nemoclaw-8814",
       listSandboxes: () => {
@@ -158,7 +182,7 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
       removeGatewayRegistration: remove,
       warn,
     });
-    expect(attempted).toBe(false);
+    expect(cleanupComplete).toBe(false);
     expect(release).not.toHaveBeenCalled();
     expect(remove).not.toHaveBeenCalled();
     expect(warn.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
@@ -177,7 +201,7 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
     }));
     const remove = vi.fn();
     const warn = vi.fn();
-    const attempted = teardownOrphanManagedGatewayOnAbort({
+    const cleanupComplete = teardownOrphanManagedGatewayOnAbort({
       gatewayPort: 8814,
       gatewayName: "nemoclaw-8814",
       listSandboxes: () => ({ sandboxes: [], defaultSandbox: null }),
@@ -195,7 +219,7 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
       removeGatewayRegistration: remove,
       warn,
     });
-    expect(attempted).toBe(true);
+    expect(cleanupComplete).toBe(false);
     expect(release).toHaveBeenCalledWith({ port: 8814 });
     expect(remove).not.toHaveBeenCalled();
     expect(warn.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
@@ -209,7 +233,7 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
     });
     const remove = vi.fn();
     const warn = vi.fn();
-    const attempted = teardownOrphanManagedGatewayOnAbort({
+    const cleanupComplete = teardownOrphanManagedGatewayOnAbort({
       gatewayPort: 8814,
       gatewayName: "nemoclaw-8814",
       listSandboxes: () => ({ sandboxes: [], defaultSandbox: null }),
@@ -227,8 +251,76 @@ describe("teardownOrphanManagedGatewayOnAbort (#8952)", () => {
       removeGatewayRegistration: remove,
       warn,
     });
-    expect(attempted).toBe(true);
+    expect(cleanupComplete).toBe(false);
     expect(remove).not.toHaveBeenCalled();
     expect(warn.mock.calls.map((call) => String(call[0])).join("\n")).toContain("stop boom");
+  });
+
+  it("fails cleanup when gateway registration removal is not confirmed", () => {
+    const warn = vi.fn();
+    const cleanupComplete = teardownOrphanManagedGatewayOnAbort({
+      gatewayPort: 8814,
+      gatewayName: "nemoclaw-8814",
+      listSandboxes: () => ({ sandboxes: [], defaultSandbox: null }),
+      resolveAuthority: () => ({
+        gatewayName: "nemoclaw-8814",
+        gatewayPort: 8814,
+        mode: "nemoclaw-managed",
+        source: "standalone",
+        endpoint: null,
+        stateDir: null,
+        supervisor: null,
+        requiredCapabilities: [],
+      }),
+      releaseManagedGatewayPort: () => ({
+        port: 8814,
+        released: true,
+        stopped: [4242],
+        remaining: [],
+        scanned: true,
+        skipped: false,
+      }),
+      removeGatewayRegistration: () => false,
+      warn,
+    });
+
+    expect(cleanupComplete).toBe(false);
+    expect(warn.mock.calls.map((call) => String(call[0])).join("\n")).toContain(
+      "was not confirmed removed",
+    );
+  });
+
+  it("fails cleanup when gateway registration removal throws", () => {
+    const warn = vi.fn();
+    const cleanupComplete = teardownOrphanManagedGatewayOnAbort({
+      gatewayPort: 8814,
+      gatewayName: "nemoclaw-8814",
+      listSandboxes: () => ({ sandboxes: [], defaultSandbox: null }),
+      resolveAuthority: () => ({
+        gatewayName: "nemoclaw-8814",
+        gatewayPort: 8814,
+        mode: "nemoclaw-managed",
+        source: "standalone",
+        endpoint: null,
+        stateDir: null,
+        supervisor: null,
+        requiredCapabilities: [],
+      }),
+      releaseManagedGatewayPort: () => ({
+        port: 8814,
+        released: true,
+        stopped: [4242],
+        remaining: [],
+        scanned: true,
+        skipped: false,
+      }),
+      removeGatewayRegistration: () => {
+        throw new Error("remove boom");
+      },
+      warn,
+    });
+
+    expect(cleanupComplete).toBe(false);
+    expect(warn.mock.calls.map((call) => String(call[0])).join("\n")).toContain("remove boom");
   });
 });

--- a/src/lib/onboard/exit-step-failure.test.ts
+++ b/src/lib/onboard/exit-step-failure.test.ts
@@ -286,6 +286,44 @@ describe("incomplete-onboard --resume backstop (#6003)", () => {
     errorSpy.mockRestore();
   });
 
+  it("records signals as terminal after validation preservation is latched (#9732)", async () => {
+    const signalListeners = new Map<"SIGINT" | "SIGTERM", () => void>();
+    const kill = vi.fn();
+    const processLike = {
+      once: vi.fn(),
+      on: (signal: "SIGINT" | "SIGTERM", listener: () => void) => {
+        signalListeners.set(signal, listener);
+      },
+      removeListener: (signal: "SIGINT" | "SIGTERM", listener: () => void) => {
+        expect(signalListeners.get(signal)).toBe(listener);
+        signalListeners.delete(signal);
+      },
+      kill,
+      pid: 4242,
+    };
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    session.saveSession(session.createSession({ lastStepStarted: "preflight" }));
+
+    try {
+      registerIncompleteOnboardExitFailureHandler(
+        session,
+        () => true,
+        "Onboarding exited before the step completed.",
+        processLike,
+      );
+      signalListeners.get("SIGTERM")?.();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      const loaded = requireLoadedSession();
+      expect(loaded.status).toBe("failed");
+      expect(loaded.failure).toMatchObject({ step: "preflight", interrupted: true });
+      expect(loaded.machine.state).toBe("failed");
+      expect(kill).toHaveBeenCalledWith(4242, "SIGTERM");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it.skipIf(process.platform === "win32")(
     "prints the resume hint before re-raising SIGINT in a real subprocess",
     async () => {

--- a/src/lib/onboard/exit-step-failure.ts
+++ b/src/lib/onboard/exit-step-failure.ts
@@ -47,8 +47,8 @@ export function registerIncompleteOnboardExitFailureHandler(
   processLike: OnboardExitFailureProcessLike = process,
   portable = isPortableExperimentalProfile(),
 ): void {
-  const failIncompleteStep = (): void => {
-    if (isComplete()) return;
+  const failIncompleteStep = (force = false): void => {
+    if (!force && isComplete()) return;
     // A non-null return means a step was in progress, so surface the
     // profile-appropriate recovery command for exit paths that don't print
     // their own guidance (#6003, #8873). When an explicit cancel has already
@@ -80,7 +80,7 @@ export function registerIncompleteOnboardExitFailureHandler(
     setImmediate(() => {
       removeListener("SIGINT", onSigint);
       removeListener("SIGTERM", onSigterm);
-      failIncompleteStep();
+      failIncompleteStep(true);
       kill(pid, signal);
     });
   };

--- a/src/lib/onboard/gateway-destroy.ts
+++ b/src/lib/onboard/gateway-destroy.ts
@@ -41,34 +41,36 @@ export type AbortGatewayTeardownDeps = {
   listSandboxes?: typeof listRegisteredSandboxes;
   resolveAuthority?: typeof resolveGatewayTeardownAuthority;
   releaseManagedGatewayPort?: typeof releaseManagedGatewayPort;
-  removeGatewayRegistration?: (gatewayName: string) => void;
+  removeGatewayRegistration?: (gatewayName: string) => boolean;
   log?: (message: string) => void;
   warn?: (message: string) => void;
 };
 
-function defaultRemoveGatewayRegistration(gatewayName: string): void {
+function defaultRemoveGatewayRegistration(gatewayName: string): boolean {
   // Lazy require keeps unit tests free of openshell binary resolution.
   const runtime =
     require("../adapters/openshell/runtime") as typeof import("../adapters/openshell/runtime");
-  runtime.runOpenshell(["gateway", "remove", gatewayName], {
-    ignoreError: true,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  return (
+    runtime.runOpenshell(["gateway", "remove", gatewayName], {
+      ignoreError: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    }).status === 0
+  );
 }
 
 /**
- * True when any registered sandbox is bound to `gatewayName`. An unreadable
- * binding fails closed (treat as owned) so abort teardown never guesses.
+ * True when a registered sandbox is bound to `gatewayName`, false when none
+ * are bound, and null when a binding cannot be resolved.
  */
 export function gatewayHasRegisteredSandbox(
   gatewayName: string,
   listSandboxes: typeof listRegisteredSandboxes = listRegisteredSandboxes,
-): boolean {
+): boolean | null {
   for (const sandbox of listSandboxes().sandboxes) {
     try {
       if (resolveSandboxGatewayName(sandbox) === gatewayName) return true;
     } catch {
-      return true;
+      return null;
     }
   }
   return false;
@@ -79,7 +81,7 @@ export function gatewayHasRegisteredSandbox(
  * registration when no sandbox still owns that gateway. Never throws — callers
  * on fatal exit paths must still be able to `process.exit(1)` after a warning.
  *
- * @returns true when a teardown attempt ran (stop and/or remove).
+ * @returns true when teardown completed or no teardown was required.
  */
 export function teardownOrphanManagedGatewayOnAbort(deps: AbortGatewayTeardownDeps = {}): boolean {
   const log = deps.log ?? ((message: string) => console.error(message));
@@ -94,8 +96,15 @@ export function teardownOrphanManagedGatewayOnAbort(deps: AbortGatewayTeardownDe
     const release = deps.releaseManagedGatewayPort ?? releaseManagedGatewayPort;
     const removeRegistration = deps.removeGatewayRegistration ?? defaultRemoveGatewayRegistration;
 
-    if (gatewayHasRegisteredSandbox(gatewayName, listSandboxes)) {
+    const hasRegisteredSandbox = gatewayHasRegisteredSandbox(gatewayName, listSandboxes);
+    if (hasRegisteredSandbox === null) {
+      warn(
+        "  Skipping gateway teardown after onboard abort: sandbox gateway binding is unreadable.",
+      );
       return false;
+    }
+    if (hasRegisteredSandbox) {
+      return true;
     }
 
     try {
@@ -104,7 +113,7 @@ export function teardownOrphanManagedGatewayOnAbort(deps: AbortGatewayTeardownDe
         log(
           `  Keeping externally supervised OpenShell gateway '${gatewayName}' running after onboard abort.`,
         );
-        return false;
+        return true;
       }
     } catch (error) {
       if (error instanceof GatewayAuthorityError) {
@@ -121,11 +130,9 @@ export function teardownOrphanManagedGatewayOnAbort(deps: AbortGatewayTeardownDe
       `  Onboard aborted before a sandbox was created; releasing managed gateway '${gatewayName}' so provider credentials do not remain in a live process.`,
     );
 
-    let attempted = false;
     let releaseConfirmed = false;
     try {
       const result = release({ port });
-      attempted = true;
       releaseConfirmed = result.released;
       if (result.released && result.stopped.length > 0) {
         log(
@@ -137,7 +144,6 @@ export function teardownOrphanManagedGatewayOnAbort(deps: AbortGatewayTeardownDe
         );
       }
     } catch (error) {
-      attempted = true;
       warn(
         `  Gateway process stop after onboard abort failed: ${error instanceof Error ? error.message : String(error)}`,
       );
@@ -145,18 +151,23 @@ export function teardownOrphanManagedGatewayOnAbort(deps: AbortGatewayTeardownDe
 
     // Keep the OpenShell registration when the listener may still be up — it is
     // the supported recovery handle for a credential-bearing process.
-    if (!releaseConfirmed) return attempted;
+    if (!releaseConfirmed) return false;
 
     try {
-      removeRegistration(gatewayName);
-      attempted = true;
+      if (!removeRegistration(gatewayName)) {
+        warn(
+          `  Gateway registration '${gatewayName}' was not confirmed removed after onboard abort.`,
+        );
+        return false;
+      }
     } catch (error) {
       warn(
         `  Gateway registration remove after onboard abort failed: ${error instanceof Error ? error.message : String(error)}`,
       );
+      return false;
     }
 
-    return attempted;
+    return true;
   } catch (error) {
     // Warn and continue to fatal exit; do not hide a still-live listener.
     warn(

--- a/src/lib/onboard/inference-selection-validation.test.ts
+++ b/src/lib/onboard/inference-selection-validation.test.ts
@@ -17,6 +17,11 @@ const resumableValidationExit = {
   name: "OnboardDeferredExitError",
   preserveIncompleteSession: true,
 };
+const terminalValidationExit = {
+  code: 1,
+  name: "OnboardDeferredExitError",
+  preserveIncompleteSession: false,
+};
 
 describe("inference selection validation", () => {
   it.each([
@@ -219,7 +224,7 @@ describe("inference selection validation", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
     const promptValidationRecovery = vi.fn(async () => "selection" as const);
-    const teardownOrphanManagedGatewayOnAbort = vi.fn();
+    const teardownOrphanManagedGatewayOnAbort = vi.fn(() => true);
     const helpers = createInferenceSelectionValidationHelpers({
       isNonInteractive: () => true,
       agentProductName: () => "OpenClaw",
@@ -582,7 +587,7 @@ describe("inference selection validation", () => {
       probeAnthropicEndpoint,
       promptValidationRecovery: vi.fn(async () => "selection" as const),
       resolveEndpointHost: async () => [{ address: "169.254.169.254", family: 4 }],
-      teardownOrphanManagedGatewayOnAbort: vi.fn(),
+      teardownOrphanManagedGatewayOnAbort: vi.fn(() => true),
     });
 
     try {
@@ -605,7 +610,7 @@ describe("inference selection validation", () => {
 
   it("tears down an orphan managed gateway before non-interactive validation exit (#8952)", async () => {
     const originalExitCode = process.exitCode;
-    const teardownOrphanManagedGatewayOnAbort = vi.fn();
+    const teardownOrphanManagedGatewayOnAbort = vi.fn(() => true);
     const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     const helpers = createInferenceSelectionValidationHelpers({
@@ -636,7 +641,40 @@ describe("inference selection validation", () => {
     }
   });
 
-  it("still exits when abort teardown throws during non-interactive validation (#8952)", async () => {
+  it("keeps validation exit terminal when abort teardown is incomplete (#9732)", async () => {
+    const originalExitCode = process.exitCode;
+    const teardownOrphanManagedGatewayOnAbort = vi.fn(() => false);
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const helpers = createInferenceSelectionValidationHelpers({
+      isNonInteractive: () => true,
+      agentProductName: () => "OpenClaw",
+      getCredential: () => "test-key",
+      probeAnthropicEndpoint: vi.fn(),
+      teardownOrphanManagedGatewayOnAbort,
+      promptValidationRecovery: vi.fn(async () => "selection" as const),
+      resolveEndpointHost: async () => [{ address: "169.254.169.254", family: 4 }],
+    });
+
+    try {
+      await expect(
+        helpers.validateCustomAnthropicSelection(
+          "Custom Anthropic",
+          "https://metadata-name.example/v1",
+          "model-a",
+          "COMPATIBLE_ANTHROPIC_API_KEY",
+        ),
+      ).rejects.toMatchObject(terminalValidationExit);
+      expect(teardownOrphanManagedGatewayOnAbort).toHaveBeenCalledTimes(1);
+      expect(exit).not.toHaveBeenCalled();
+    } finally {
+      process.exitCode = originalExitCode;
+      exit.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it("keeps validation exit terminal when abort teardown throws (#8952)", async () => {
     const originalExitCode = process.exitCode;
     const teardownOrphanManagedGatewayOnAbort = vi.fn(() => {
       throw new Error("teardown boom");
@@ -661,7 +699,7 @@ describe("inference selection validation", () => {
           "model-a",
           "COMPATIBLE_ANTHROPIC_API_KEY",
         ),
-      ).rejects.toMatchObject(resumableValidationExit);
+      ).rejects.toMatchObject(terminalValidationExit);
       expect(teardownOrphanManagedGatewayOnAbort).toHaveBeenCalledTimes(1);
       expect(error.mock.calls.map((call) => String(call[0])).join("\n")).toContain("teardown boom");
       expect(exit).not.toHaveBeenCalled();
@@ -1003,7 +1041,7 @@ exit 0
       probeOpenAiLikeEndpoint,
       promptValidationRecovery,
       resolveEndpointHost: async () => [{ address: "93.184.216.34", family: 4 }],
-      teardownOrphanManagedGatewayOnAbort: vi.fn(),
+      teardownOrphanManagedGatewayOnAbort: vi.fn(() => true),
     });
 
     try {

--- a/src/lib/onboard/inference-selection-validation.test.ts
+++ b/src/lib/onboard/inference-selection-validation.test.ts
@@ -12,6 +12,11 @@ import { OnboardInferenceCapabilityCache } from "./inference-capability-cache";
 import { createInferenceSelectionValidationHelpers } from "./inference-selection-validation";
 
 const listen = useOpenAiValidationTestServers();
+const resumableValidationExit = {
+  code: 1,
+  name: "OnboardDeferredExitError",
+  preserveIncompleteSession: true,
+};
 
 describe("inference selection validation", () => {
   it.each([
@@ -235,8 +240,8 @@ describe("inference selection validation", () => {
           "meta/llama-3.3-70b-instruct",
           "NVIDIA_INFERENCE_API_KEY",
         ),
-      ).rejects.toThrow("Non-interactive endpoint validation failed.");
-      expect(exit).toHaveBeenCalledWith(1);
+      ).rejects.toMatchObject(resumableValidationExit);
+      expect(exit).not.toHaveBeenCalled();
       expect(process.exitCode).toBe(1);
       expect(promptValidationRecovery).not.toHaveBeenCalled();
       expect(teardownOrphanManagedGatewayOnAbort).toHaveBeenCalledOnce();
@@ -588,9 +593,9 @@ describe("inference selection validation", () => {
           "model-a",
           "COMPATIBLE_ANTHROPIC_API_KEY",
         ),
-      ).rejects.toThrow("Non-interactive endpoint validation failed.");
+      ).rejects.toMatchObject(resumableValidationExit);
       expect(probeAnthropicEndpoint).not.toHaveBeenCalled();
-      expect(exit).toHaveBeenCalledWith(1);
+      expect(exit).not.toHaveBeenCalled();
     } finally {
       process.exitCode = originalExitCode;
       exit.mockRestore();
@@ -621,12 +626,9 @@ describe("inference selection validation", () => {
           "model-a",
           "COMPATIBLE_ANTHROPIC_API_KEY",
         ),
-      ).rejects.toThrow("Non-interactive endpoint validation failed.");
+      ).rejects.toMatchObject(resumableValidationExit);
       expect(teardownOrphanManagedGatewayOnAbort).toHaveBeenCalledTimes(1);
-      expect(exit).toHaveBeenCalledWith(1);
-      expect(teardownOrphanManagedGatewayOnAbort.mock.invocationCallOrder[0]).toBeLessThan(
-        exit.mock.invocationCallOrder[0] ?? 0,
-      );
+      expect(exit).not.toHaveBeenCalled();
     } finally {
       process.exitCode = originalExitCode;
       exit.mockRestore();
@@ -659,13 +661,10 @@ describe("inference selection validation", () => {
           "model-a",
           "COMPATIBLE_ANTHROPIC_API_KEY",
         ),
-      ).rejects.toThrow("Non-interactive endpoint validation failed.");
+      ).rejects.toMatchObject(resumableValidationExit);
       expect(teardownOrphanManagedGatewayOnAbort).toHaveBeenCalledTimes(1);
       expect(error.mock.calls.map((call) => String(call[0])).join("\n")).toContain("teardown boom");
-      expect(exit).toHaveBeenCalledWith(1);
-      expect(teardownOrphanManagedGatewayOnAbort.mock.invocationCallOrder[0]).toBeLessThan(
-        exit.mock.invocationCallOrder[0] ?? 0,
-      );
+      expect(exit).not.toHaveBeenCalled();
     } finally {
       process.exitCode = originalExitCode;
       exit.mockRestore();
@@ -1017,8 +1016,8 @@ exit 0
           null,
           { intendedApi: "openai-completions" },
         ),
-      ).rejects.toThrow("Non-interactive endpoint validation failed.");
-      expect(exit).toHaveBeenCalledWith(1);
+      ).rejects.toMatchObject(resumableValidationExit);
+      expect(exit).not.toHaveBeenCalled();
       expect(promptValidationRecovery).not.toHaveBeenCalled();
       const errorOutput = error.mock.calls.map((args) => args.join(" ")).join("\n");
       expect(errorOutput).toContain(

--- a/src/lib/onboard/inference-selection-validation.ts
+++ b/src/lib/onboard/inference-selection-validation.ts
@@ -43,6 +43,7 @@ import { shouldForceCompletionsApi } from "../validation";
 import { getProbeRecovery } from "../validation-recovery";
 import { summarizeProbeForDisplay } from "./probe-diagnostics";
 import { normalizeReasoningFlag } from "./reasoning-mode";
+import { OnboardDeferredExitError } from "./session-bootstrap";
 
 export type EndpointValidationResult =
   | {
@@ -174,8 +175,7 @@ export function createInferenceSelectionValidationHelpers(
       );
     }
     process.exitCode = 1;
-    (process.exit as (code?: number) => void)(1);
-    throw new Error("Non-interactive endpoint validation failed.");
+    throw new OnboardDeferredExitError(1, { preserveIncompleteSession: true });
   }
 
   function printValidationFailure(

--- a/src/lib/onboard/inference-selection-validation.ts
+++ b/src/lib/onboard/inference-selection-validation.ts
@@ -92,7 +92,7 @@ export interface InferenceSelectionValidationDeps {
    * Optional abort teardown hook for tests. Production loads the helper lazily
    * so openshell binaries stay out of the validation unit graph.
    */
-  teardownOrphanManagedGatewayOnAbort?: () => void;
+  teardownOrphanManagedGatewayOnAbort?: () => boolean;
   promptValidationRecovery(
     label: string,
     recovery: ReturnType<typeof getProbeRecovery>,
@@ -159,15 +159,16 @@ export function createInferenceSelectionValidationHelpers(
 
   function exitNonInteractiveValidationFailure(): never {
     // #8952: tear down an unowned managed gateway before fatal exit.
+    let gatewayCleanupComplete = false;
     try {
       const teardown =
         deps.teardownOrphanManagedGatewayOnAbort ??
         (() => {
           const { teardownOrphanManagedGatewayOnAbort } =
             require("./gateway-destroy") as typeof import("./gateway-destroy");
-          teardownOrphanManagedGatewayOnAbort();
+          return teardownOrphanManagedGatewayOnAbort();
         });
-      teardown();
+      gatewayCleanupComplete = teardown();
     } catch (error) {
       // Helper never throws; this covers require/load / inject failures.
       console.error(
@@ -175,7 +176,9 @@ export function createInferenceSelectionValidationHelpers(
       );
     }
     process.exitCode = 1;
-    throw new OnboardDeferredExitError(1, { preserveIncompleteSession: true });
+    throw new OnboardDeferredExitError(1, {
+      preserveIncompleteSession: gatewayCleanupComplete,
+    });
   }
 
   function printValidationFailure(

--- a/src/lib/onboard/session-bootstrap.ts
+++ b/src/lib/onboard/session-bootstrap.ts
@@ -160,11 +160,13 @@ const ONBOARD_DEFERRED_EXIT_ERROR = Symbol.for("nemoclaw.onboard.deferred-exit-e
 export class OnboardDeferredExitError extends Error {
   readonly [ONBOARD_DEFERRED_EXIT_ERROR] = true;
   readonly code: number;
+  readonly preserveIncompleteSession: boolean;
 
-  constructor(code: number) {
+  constructor(code: number, options: { preserveIncompleteSession?: boolean } = {}) {
     super(`Onboarding requested exit ${String(code)}.`);
     this.name = "OnboardDeferredExitError";
     this.code = code;
+    this.preserveIncompleteSession = options.preserveIncompleteSession === true;
   }
 }
 
@@ -179,6 +181,10 @@ export function isOnboardDeferredExitError(error: unknown): error is OnboardDefe
     typeof candidate.code === "number" &&
     Number.isInteger(candidate.code)
   );
+}
+
+export function shouldPreserveIncompleteOnboardSession(error: unknown): boolean {
+  return isOnboardDeferredExitError(error) && error.preserveIncompleteSession;
 }
 
 interface DeferredExitOptions {

--- a/test/onboard-exit-handler.test.ts
+++ b/test/onboard-exit-handler.test.ts
@@ -101,7 +101,7 @@ describe("onboard exit handler registration", () => {
     expect(loaded.machine.state).toBe("init");
   });
 
-  it("preserves and resumes an incomplete validation session while unexpected exits still fail (#9732)", () => {
+  it("resumes clean validation exits while cleanup failures and unexpected exits stay terminal (#9732)", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const scriptPath = path.join(tmpDir, "onboard-exit-registration.cjs");
     const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
@@ -153,7 +153,8 @@ const validationHelpers = validation.createInferenceSelectionValidationHelpers({
     failures: [{ name: "Chat Completions API", httpStatus: 503 }],
   }),
   resolveEndpointHost: async () => [{ address: "93.184.216.34", family: 4 }],
-  teardownOrphanManagedGatewayOnAbort: () => {},
+  teardownOrphanManagedGatewayOnAbort: () =>
+    process.env.NEMOCLAW_TEST_EXIT_KIND !== "validation-cleanup-failure",
   promptValidationRecovery: async () => "selection",
 });
 
@@ -171,7 +172,7 @@ flowSlices.runInitialOnboardFlowSequence = async ({ context, runtime }) => {
     throw resumeSentinel;
   }
   await runtime.markStepStarted("preflight");
-  if (process.env.NEMOCLAW_TEST_EXIT_KIND === "validation") {
+  if (process.env.NEMOCLAW_TEST_EXIT_KIND?.startsWith("validation")) {
     await validationHelpers.validateCustomOpenAiLikeSelection(
       "Custom endpoint",
       "https://endpoint.test/v1",
@@ -202,7 +203,7 @@ const { onboard } = require(${onboardPath});
       console.log(JSON.stringify({ loaded, resumeEvidence, exitListeners: exitListeners.length }));
       return;
     }
-    const validationExit = process.env.NEMOCLAW_TEST_EXIT_KIND === "validation";
+    const validationExit = process.env.NEMOCLAW_TEST_EXIT_KIND?.startsWith("validation");
     if (
       (!validationExit && error !== sentinel && error?.message !== sentinel.message) ||
       (validationExit && error?.message !== "process.exit:1")
@@ -225,7 +226,10 @@ const { onboard } = require(${onboardPath});
 `,
     );
 
-    const runOnboard = (home: string, exitKind: "unexpected" | "validation" | "resume") =>
+    const runOnboard = (
+      home: string,
+      exitKind: "unexpected" | "validation" | "validation-cleanup-failure" | "resume",
+    ) =>
       spawnSync(process.execPath, [scriptPath, ...(exitKind === "resume" ? ["--resume"] : [])], {
         cwd: repoRoot,
         encoding: "utf8",
@@ -272,6 +276,22 @@ const { onboard } = require(${onboardPath});
     expect(validationPayload.loaded.machine.state).toBe("init");
     expect(validationPayload.loaded.checkpoint).not.toBeNull();
     expect(validationPayload.loaded.checkpoint?.machineState).toBe("init");
+
+    const cleanupFailureHome = path.join(tmpDir, "validation-cleanup-failure-home");
+    fs.mkdirSync(cleanupFailureHome);
+    const cleanupFailureResult = runOnboard(cleanupFailureHome, "validation-cleanup-failure");
+
+    expect(cleanupFailureResult.status, cleanupFailureResult.stderr).toBe(1);
+    const cleanupFailureLastLine = cleanupFailureResult.stdout.trim().split(/\n/).at(-1) ?? "";
+    const cleanupFailurePayload = JSON.parse(cleanupFailureLastLine) as {
+      loaded: ReturnType<typeof onboardSession.createSession>;
+      exitListeners: number;
+    };
+    expect(cleanupFailurePayload.exitListeners).toBeGreaterThanOrEqual(2);
+    expect(cleanupFailurePayload.loaded.steps.preflight.status).toBe("failed");
+    expect(cleanupFailurePayload.loaded.status).toBe("failed");
+    expect(cleanupFailurePayload.loaded.failure?.step).toBe("preflight");
+    expect(cleanupFailurePayload.loaded.machine.state).toBe("failed");
 
     const resumeResult = runOnboard(validationHome, "resume");
 

--- a/test/onboard-exit-handler.test.ts
+++ b/test/onboard-exit-handler.test.ts
@@ -101,7 +101,7 @@ describe("onboard exit handler registration", () => {
     expect(loaded.machine.state).toBe("init");
   });
 
-  it("onboard() registers incomplete nonzero exit handling after bootstrap", () => {
+  it("preserves an incomplete onboarding session after validation fails and records an unexpected exit as failed (#9732)", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const scriptPath = path.join(tmpDir, "onboard-exit-registration.cjs");
     const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
@@ -111,12 +111,16 @@ describe("onboard exit handler registration", () => {
     const sessionPath = JSON.stringify(
       path.join(repoRoot, "src", "lib", "state", "onboard-session.ts"),
     );
+    const validationPath = JSON.stringify(
+      path.join(repoRoot, "src", "lib", "onboard", "inference-selection-validation.ts"),
+    );
 
     fs.writeFileSync(
       scriptPath,
       `
 const flowSlices = require(${flowSlicesPath});
 const onboardSession = require(${sessionPath});
+const validation = require(${validationPath});
 const sentinel = new Error("stop-after-exit-registration");
 const exitListeners = [];
 const originalOnce = process.once;
@@ -133,8 +137,30 @@ process.exit = function exit(code) {
   throw new Error("process.exit:" + String(code));
 };
 
+const validationHelpers = validation.createInferenceSelectionValidationHelpers({
+  isNonInteractive: () => true,
+  agentProductName: () => "OpenClaw",
+  getCredential: () => "test-key",
+  probeOpenAiLikeEndpoint: async () => ({
+    ok: false,
+    failures: [{ name: "Chat Completions API", httpStatus: 503 }],
+  }),
+  resolveEndpointHost: async () => [{ address: "93.184.216.34", family: 4 }],
+  teardownOrphanManagedGatewayOnAbort: () => {},
+  promptValidationRecovery: async () => "selection",
+});
+
 flowSlices.runInitialOnboardFlowSequence = async ({ runtime }) => {
   await runtime.markStepStarted("preflight");
+  if (process.env.NEMOCLAW_TEST_EXIT_KIND === "validation") {
+    await validationHelpers.validateCustomOpenAiLikeSelection(
+      "Custom endpoint",
+      "https://endpoint.test/v1",
+      "model-a",
+      "COMPATIBLE_API_KEY",
+    );
+    throw new Error("expected validation exit");
+  }
   throw sentinel;
 };
 
@@ -151,7 +177,11 @@ const { onboard } = require(${onboardPath});
     });
     throw new Error("expected sentinel");
   } catch (error) {
-    if (error !== sentinel && error?.message !== sentinel.message) {
+    const validationExit = process.env.NEMOCLAW_TEST_EXIT_KIND === "validation";
+    if (
+      (!validationExit && error !== sentinel && error?.message !== sentinel.message) ||
+      (validationExit && error?.message !== "process.exit:1")
+    ) {
       throw error;
     }
     const exitHandler = exitListeners.at(-1);
@@ -170,18 +200,22 @@ const { onboard } = require(${onboardPath});
 `,
     );
 
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: repoRoot,
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        HOME: tmpDir,
-        PATH: ONBOARD_FIXTURE_PATH,
-        TMPDIR: tmpDir,
-        NEMOCLAW_TEST_NO_SLEEP: "1",
-      },
-      timeout: 60_000,
-    });
+    const runOnboard = (home: string, exitKind: "unexpected" | "validation") =>
+      spawnSync(process.execPath, [scriptPath], {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: home,
+          PATH: ONBOARD_FIXTURE_PATH,
+          TMPDIR: tmpDir,
+          NEMOCLAW_TEST_EXIT_KIND: exitKind,
+          NEMOCLAW_TEST_NO_SLEEP: "1",
+        },
+        timeout: 60_000,
+      });
+
+    const result = runOnboard(tmpDir, "unexpected");
 
     expect(result.status, result.stderr).toBe(0);
     const lastLine = result.stdout.trim().split(/\n/).at(-1) ?? "";
@@ -195,6 +229,24 @@ const { onboard } = require(${onboardPath});
     expect(payload.loaded.failure?.step).toBe("preflight");
     expect(payload.loaded.failure?.message).toBe("Onboarding exited before the step completed.");
     expect(payload.loaded.machine.state).toBe("failed");
+
+    const validationHome = path.join(tmpDir, "validation-home");
+    fs.mkdirSync(validationHome);
+    const validationResult = runOnboard(validationHome, "validation");
+
+    expect(validationResult.status, validationResult.stderr).toBe(1);
+    const validationLastLine = validationResult.stdout.trim().split(/\n/).at(-1) ?? "";
+    const validationPayload = JSON.parse(validationLastLine) as {
+      loaded: ReturnType<typeof onboardSession.createSession>;
+      exitListeners: number;
+    };
+    expect(validationPayload.exitListeners).toBeGreaterThanOrEqual(2);
+    expect(validationPayload.loaded.steps.preflight.status).toBe("in_progress");
+    expect(validationPayload.loaded.status).toBe("in_progress");
+    expect(validationPayload.loaded.failure).toBeNull();
+    expect(validationPayload.loaded.machine.state).toBe("init");
+    expect(validationPayload.loaded.checkpoint).not.toBeNull();
+    expect(validationPayload.loaded.checkpoint?.machineState).toBe("init");
   });
 
   it("onboard() preserves a resumable session after a normal incomplete result (#9048)", () => {

--- a/test/onboard-exit-handler.test.ts
+++ b/test/onboard-exit-handler.test.ts
@@ -101,7 +101,7 @@ describe("onboard exit handler registration", () => {
     expect(loaded.machine.state).toBe("init");
   });
 
-  it("preserves an incomplete onboarding session after validation fails and records an unexpected exit as failed (#9732)", () => {
+  it("preserves and resumes an incomplete validation session while unexpected exits still fail (#9732)", () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const scriptPath = path.join(tmpDir, "onboard-exit-registration.cjs");
     const onboardPath = JSON.stringify(path.join(repoRoot, "src", "lib", "onboard.ts"));
@@ -114,6 +114,9 @@ describe("onboard exit handler registration", () => {
     const validationPath = JSON.stringify(
       path.join(repoRoot, "src", "lib", "onboard", "inference-selection-validation.ts"),
     );
+    const resultPath = JSON.stringify(
+      path.join(repoRoot, "src", "lib", "onboard", "machine", "result.ts"),
+    );
 
     fs.writeFileSync(
       scriptPath,
@@ -121,10 +124,14 @@ describe("onboard exit handler registration", () => {
 const flowSlices = require(${flowSlicesPath});
 const onboardSession = require(${sessionPath});
 const validation = require(${validationPath});
+const { advanceTo } = require(${resultPath});
 const sentinel = new Error("stop-after-exit-registration");
+const resumeSentinel = new Error("stop-after-resume-checkpoint");
+const resumeRequested = process.argv.includes("--resume");
 const exitListeners = [];
 const originalOnce = process.once;
 const originalExit = process.exit;
+let resumeEvidence = null;
 
 process.once = function once(event, listener) {
   if (event === "exit") {
@@ -150,7 +157,19 @@ const validationHelpers = validation.createInferenceSelectionValidationHelpers({
   promptValidationRecovery: async () => "selection",
 });
 
-flowSlices.runInitialOnboardFlowSequence = async ({ runtime }) => {
+flowSlices.runInitialOnboardFlowSequence = async ({ context, runtime }) => {
+  if (resumeRequested) {
+    const before = await runtime.session();
+    await runtime.applyResult(advanceTo("preflight", { metadata: { state: before.machine.state } }));
+    const after = await runtime.session();
+    resumeEvidence = {
+      requested: context.resume,
+      sessionId: before.sessionId,
+      startingMachineState: before.machine.state,
+      continuedMachineState: after.machine.state,
+    };
+    throw resumeSentinel;
+  }
   await runtime.markStepStarted("preflight");
   if (process.env.NEMOCLAW_TEST_EXIT_KIND === "validation") {
     await validationHelpers.validateCustomOpenAiLikeSelection(
@@ -177,6 +196,12 @@ const { onboard } = require(${onboardPath});
     });
     throw new Error("expected sentinel");
   } catch (error) {
+    if (resumeRequested) {
+      if (error !== resumeSentinel && error?.message !== resumeSentinel.message) throw error;
+      const loaded = onboardSession.loadSession();
+      console.log(JSON.stringify({ loaded, resumeEvidence, exitListeners: exitListeners.length }));
+      return;
+    }
     const validationExit = process.env.NEMOCLAW_TEST_EXIT_KIND === "validation";
     if (
       (!validationExit && error !== sentinel && error?.message !== sentinel.message) ||
@@ -200,8 +225,8 @@ const { onboard } = require(${onboardPath});
 `,
     );
 
-    const runOnboard = (home: string, exitKind: "unexpected" | "validation") =>
-      spawnSync(process.execPath, [scriptPath], {
+    const runOnboard = (home: string, exitKind: "unexpected" | "validation" | "resume") =>
+      spawnSync(process.execPath, [scriptPath, ...(exitKind === "resume" ? ["--resume"] : [])], {
         cwd: repoRoot,
         encoding: "utf8",
         env: {
@@ -247,6 +272,29 @@ const { onboard } = require(${onboardPath});
     expect(validationPayload.loaded.machine.state).toBe("init");
     expect(validationPayload.loaded.checkpoint).not.toBeNull();
     expect(validationPayload.loaded.checkpoint?.machineState).toBe("init");
+
+    const resumeResult = runOnboard(validationHome, "resume");
+
+    expect(resumeResult.status, resumeResult.stderr).toBe(0);
+    const resumeLastLine = resumeResult.stdout.trim().split(/\n/).at(-1) ?? "";
+    const resumePayload = JSON.parse(resumeLastLine) as {
+      loaded: ReturnType<typeof onboardSession.createSession>;
+      resumeEvidence: {
+        requested: boolean;
+        sessionId: string;
+        startingMachineState: string;
+        continuedMachineState: string;
+      };
+      exitListeners: number;
+    };
+    expect(resumePayload.exitListeners).toBeGreaterThanOrEqual(2);
+    expect(resumePayload.resumeEvidence.requested).toBe(true);
+    expect(resumePayload.resumeEvidence.sessionId).toBe(validationPayload.loaded.sessionId);
+    expect(resumePayload.resumeEvidence.startingMachineState).toBe("init");
+    expect(resumePayload.resumeEvidence.continuedMachineState).toBe("preflight");
+    expect(resumePayload.loaded.status).toBe("in_progress");
+    expect(resumePayload.loaded.failure).toBeNull();
+    expect(resumePayload.loaded.machine.state).toBe("preflight");
   });
 
   it("onboard() preserves a resumable session after a normal incomplete result (#9048)", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Non-interactive inference validation failures now exit with status 1 while retaining the resumable onboarding session.
Unexpected exits and cleanup failures still record a terminal failure.
A documentation writer review confirmed that existing docs already describe this contract.

## Related Issue
Fixes #9732

## Changes
- Add a deferred-exit disposition that preserves an incomplete session only after cleanup completes.
- Keep the failure backstop for unexpected exceptions, process interruptions, and cleanup failures.
- Cover HTTP 503 validation failure and unexpected-exit paths at the child-process boundary.
- Update validation unit tests for every non-interactive exit branch.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed deferred-exit classification, cleanup ordering, session persistence, and unexpected-exit coverage. No credential, policy, network, or sandbox mutation changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
  - `npx vitest run --project integration test/onboard-exit-handler.test.ts`: 4 passed.
  - Targeted CLI test suite: 125 passed.
  - `npm run test:changed`: 1,940 passed across 133 files.
  - `npm run typecheck:cli`: passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; focused exit-state change has targeted and changed-test coverage.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation failures during onboarding now exit gracefully without forcibly terminating the process.
  * In-progress sessions are preserved when validation is deferred or cleanup completes successfully, allowing onboarding to resume later.
  * Sessions with incomplete cleanup are now marked as failed to prevent unsafe resumption.
  * Unexpected errors continue to be reported and recorded correctly.
  * Interrupted onboarding now records failed steps and restores the expected process signal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->