### PR TITLE
fix(onboard): probe the sandbox's own Hermes API port

### DIFF
--- a/src/lib/agent/onboard.test.ts
+++ b/src/lib/agent/onboard.test.ts
@@ -323,6 +323,11 @@ describe("agent setup session boundaries", () => {
     };
   }
 
+  beforeEach(() => {
+    getSandboxMock.mockReset();
+    getSandboxMock.mockReturnValue(null);
+  });
+
   afterEach(() => {
     mocks.run.mockReset();
     vi.restoreAllMocks();
@@ -465,6 +470,92 @@ describe("agent setup session boundaries", () => {
       "Agent gateway did not respond within 1s",
     );
     expect(context.recordStepComplete).not.toHaveBeenCalled();
+  });
+
+  // Per-sandbox Hermes API ports (#9739):
+  // - the manifest names the default port, 8642
+  // - a second sandbox on one host serves its API on its own allocated port
+  // - probing the manifest default there reaches nothing and times out
+  const hermesProbeAgent = makeAgent({
+    name: "hermes",
+    displayName: "Hermes Agent",
+    healthProbe: { url: "http://localhost:8642/health", port: 8642, timeout_seconds: 1 },
+  });
+
+  function probeUrlsFrom(
+    runCaptureOpenshell: ReturnType<typeof vi.fn<OnboardContext["runCaptureOpenshell"]>>,
+  ): string[] {
+    return runCaptureOpenshell.mock.calls
+      .map(([args]) => args)
+      .filter((args) => args.includes("curl"))
+      .map((args) => String(args[args.length - 1]));
+  }
+
+  it("probes the sandbox's own Hermes API port instead of the manifest default (#9739)", async () => {
+    getSandboxMock.mockReturnValue({ hermesApiPort: 8643 });
+    const runCaptureOpenshell = vi
+      .fn<OnboardContext["runCaptureOpenshell"]>(() => "ok")
+      .mockReturnValueOnce("NEMOCLAW_AGENT_BINARY_CHECK:ok");
+    const { context } = createAgentSetupContext(runCaptureOpenshell);
+
+    await handleAgentSetup(
+      "hermes-core-test",
+      "model-x",
+      "provider-x",
+      hermesProbeAgent,
+      false,
+      null,
+      context,
+    );
+
+    expect(probeUrlsFrom(runCaptureOpenshell)).toEqual(["http://localhost:8643/health"]);
+    expect(context.recordStepFailed).not.toHaveBeenCalled();
+    expect(context.recordStepComplete).toHaveBeenCalledWith("agent_setup", {
+      sandboxName: "hermes-core-test",
+      provider: "provider-x",
+      model: "model-x",
+    });
+  });
+
+  it("keeps the manifest probe port for a sandbox that owns the default API port (#9739)", async () => {
+    getSandboxMock.mockReturnValue({ hermesApiPort: 8642 });
+    const runCaptureOpenshell = vi
+      .fn<OnboardContext["runCaptureOpenshell"]>(() => "ok")
+      .mockReturnValueOnce("NEMOCLAW_AGENT_BINARY_CHECK:ok");
+    const { context } = createAgentSetupContext(runCaptureOpenshell);
+
+    await handleAgentSetup(
+      "hermes-first",
+      "model-x",
+      "provider-x",
+      hermesProbeAgent,
+      false,
+      null,
+      context,
+    );
+
+    expect(probeUrlsFrom(runCaptureOpenshell)).toEqual(["http://localhost:8642/health"]);
+    expect(context.recordStepFailed).not.toHaveBeenCalled();
+  });
+
+  it("retargets the resume health probe at the sandbox's own API port (#9739)", async () => {
+    getSandboxMock.mockReturnValue({ hermesApiPort: 8643 });
+    const runCaptureOpenshell = vi.fn<OnboardContext["runCaptureOpenshell"]>(() => "ok");
+    const { context } = createAgentSetupContext(runCaptureOpenshell);
+
+    await handleAgentSetup(
+      "hermes-core-test",
+      "model-x",
+      "provider-x",
+      hermesProbeAgent,
+      true,
+      null,
+      context,
+    );
+
+    expect(probeUrlsFrom(runCaptureOpenshell)).toEqual(["http://localhost:8643/health"]);
+    expect(context.skippedStepMessage).toHaveBeenCalledWith("agent_setup", "hermes-core-test");
+    expect(context.startRecordedStep).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/agent/onboard.test.ts
+++ b/src/lib/agent/onboard.test.ts
@@ -472,10 +472,7 @@ describe("agent setup session boundaries", () => {
     expect(context.recordStepComplete).not.toHaveBeenCalled();
   });
 
-  // Per-sandbox Hermes API ports (#9739):
-  // - the manifest names the default port, 8642
-  // - a second sandbox on one host serves its API on its own allocated port
-  // - probing the manifest default there reaches nothing and times out
+  // The manifest names 8642; a second sandbox is allocated its own port (#9739).
   const hermesProbeAgent = makeAgent({
     name: "hermes",
     displayName: "Hermes Agent",
@@ -529,6 +526,29 @@ describe("agent setup session boundaries", () => {
       "model-x",
       "provider-x",
       hermesProbeAgent,
+      false,
+      null,
+      context,
+    );
+
+    expect(probeUrlsFrom(runCaptureOpenshell)).toEqual(["http://localhost:8642/health"]);
+    expect(context.recordStepFailed).not.toHaveBeenCalled();
+  });
+
+  it("leaves a non-Hermes probe URL on its manifest port when the registry records a Hermes API port (#9739)", async () => {
+    getSandboxMock.mockReturnValue({ hermesApiPort: 8643 });
+    const runCaptureOpenshell = vi
+      .fn<OnboardContext["runCaptureOpenshell"]>(() => "ok")
+      .mockReturnValueOnce("NEMOCLAW_AGENT_BINARY_CHECK:ok");
+    const { context } = createAgentSetupContext(runCaptureOpenshell);
+
+    await handleAgentSetup(
+      "not-hermes",
+      "model-x",
+      "provider-x",
+      makeAgent({
+        healthProbe: { url: "http://localhost:8642/health", port: 8642, timeout_seconds: 1 },
+      }),
       false,
       null,
       context,

--- a/src/lib/agent/onboard.ts
+++ b/src/lib/agent/onboard.ts
@@ -26,7 +26,10 @@ import { getProviderSelectionConfig } from "../inference/config";
 import { normalizeInferenceSelection } from "../inference/selection";
 import { runSandboxConfigSync, sandboxConfigSyncArgs } from "../onboard/config-sync";
 import { isValidForwardPort } from "../onboard/dashboard-runtime";
-import { resolveSandboxHermesApiPort } from "../onboard/hermes-api-port";
+import {
+  resolveSandboxHermesApiPort,
+  retargetHermesApiPortInUrl,
+} from "../onboard/hermes-api-port";
 
 export {
   createHermesApiPortScopedSandboxEntryPoints,
@@ -413,6 +416,24 @@ export function isHealthProbeOk(result: string | null | undefined): boolean {
 }
 
 /**
+ * Resolve the health-probe URL to run inside `sandboxName`.
+ *
+ * - The manifest names the agent's default API port.
+ * - Hermes allocates a per-sandbox port from the 8642-8652 range, so a second
+ *   sandbox on one host serves its relay on another port. The manifest URL
+ *   would probe a port nothing listens on there (#9739).
+ * - Sandbox registration records the allocated port before agent setup runs,
+ *   so the registry answers for the sandbox being onboarded.
+ * - An agent with no per-sandbox port keeps the manifest URL unchanged.
+ */
+function resolveAgentHealthProbeUrl(sandboxName: string, probeUrl: string): string {
+  return retargetHermesApiPortInUrl(
+    probeUrl,
+    resolveSandboxHermesApiPort(registry.getSandbox(sandboxName) ?? {}),
+  );
+}
+
+/**
  * Handle the full agent setup step (step 7) including resume detection.
  * For non-OpenClaw agents: writes config into the sandbox and verifies
  * the agent's health probe.
@@ -505,6 +526,7 @@ export async function handleAgentSetup(
 
     const probe = agent.healthProbe;
     if (probe?.url) {
+      const probeUrl = resolveAgentHealthProbeUrl(sandboxName, probe.url);
       const result = runCaptureOpenshell(
         [
           "sandbox",
@@ -513,7 +535,7 @@ export async function handleAgentSetup(
           sandboxName,
           "--",
           "curl",
-          ...buildValidatedCurlCommandArgs(["-sf", "--max-time", "3", probe.url]),
+          ...buildValidatedCurlCommandArgs(["-sf", "--max-time", "3", probeUrl]),
         ],
         { ignoreError: true },
       );
@@ -581,6 +603,7 @@ export async function handleAgentSetup(
   const probe = agent.healthProbe;
   if (probe?.url) {
     const timeoutSecs = probe.timeout_seconds || 60;
+    const probeUrl = resolveAgentHealthProbeUrl(sandboxName, probe.url);
     console.log(`  Waiting for ${agent.displayName} gateway (up to ${timeoutSecs}s)...`);
     const healthy = waitForAgentGatewayReady({
       timeoutSeconds: timeoutSecs,
@@ -595,7 +618,7 @@ export async function handleAgentSetup(
             sandboxName,
             "--",
             "curl",
-            ...buildValidatedCurlCommandArgs(["-sf", "--max-time", "3", probe.url]),
+            ...buildValidatedCurlCommandArgs(["-sf", "--max-time", "3", probeUrl]),
           ],
           { ignoreError: true },
         );

--- a/src/lib/agent/onboard.ts
+++ b/src/lib/agent/onboard.ts
@@ -416,17 +416,16 @@ export function isHealthProbeOk(result: string | null | undefined): boolean {
 }
 
 /**
- * Resolve the health-probe URL to run inside `sandboxName`.
- *
- * - The manifest names the agent's default API port.
- * - Hermes allocates a per-sandbox port from the 8642-8652 range, so a second
- *   sandbox on one host serves its relay on another port. The manifest URL
- *   would probe a port nothing listens on there (#9739).
- * - Sandbox registration records the allocated port before agent setup runs,
- *   so the registry answers for the sandbox being onboarded.
- * - An agent with no per-sandbox port keeps the manifest URL unchanged.
+ * Hermes allocates a per-sandbox API port, so the manifest default names a port
+ * a second sandbox has no listener on (#9739). Step 6 records the allocated
+ * port before this step runs.
  */
-function resolveAgentHealthProbeUrl(sandboxName: string, probeUrl: string): string {
+function resolveAgentHealthProbeUrl(
+  agent: AgentDefinition,
+  sandboxName: string,
+  probeUrl: string,
+): string {
+  if (agent.name !== "hermes") return probeUrl;
   return retargetHermesApiPortInUrl(
     probeUrl,
     resolveSandboxHermesApiPort(registry.getSandbox(sandboxName) ?? {}),
@@ -526,7 +525,7 @@ export async function handleAgentSetup(
 
     const probe = agent.healthProbe;
     if (probe?.url) {
-      const probeUrl = resolveAgentHealthProbeUrl(sandboxName, probe.url);
+      const probeUrl = resolveAgentHealthProbeUrl(agent, sandboxName, probe.url);
       const result = runCaptureOpenshell(
         [
           "sandbox",
@@ -603,7 +602,7 @@ export async function handleAgentSetup(
   const probe = agent.healthProbe;
   if (probe?.url) {
     const timeoutSecs = probe.timeout_seconds || 60;
-    const probeUrl = resolveAgentHealthProbeUrl(sandboxName, probe.url);
+    const probeUrl = resolveAgentHealthProbeUrl(agent, sandboxName, probe.url);
     console.log(`  Waiting for ${agent.displayName} gateway (up to ${timeoutSecs}s)...`);
     const healthy = waitForAgentGatewayReady({
       timeoutSeconds: timeoutSecs,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Onboarding step 7 probed the Hermes Agent gateway at the API port named in the agent manifest. Hermes allocates a per-sandbox API port from the 8642-8652 range, so a second Hermes sandbox on one host serves its OpenAI-compatible API on another port and the probe reached a port with no listener. Step 7 now probes the port recorded for the sandbox, so onboarding completes and applies its policy presets instead of failing after the 90 second timeout while the gateway is running.

## Related Issue

Fixes #9739

## Changes

- `src/lib/agent/onboard.ts` adds `resolveAgentHealthProbeUrl`, which retargets the manifest health-probe URL at the API port recorded for the sandbox. Both probe call sites use it: the `--resume` fast path and the deadline wait that reports the timeout.
- The resolver reuses `retargetHermesApiPortInUrl` and `resolveSandboxHermesApiPort` from `src/lib/onboard/hermes-api-port.ts`. Forward recovery (`src/lib/actions/sandbox/forward-recovery.ts`) and deployment verification (`src/lib/onboard/dashboard.ts`) already resolve the same port through those functions, so this change adds no abstraction, configuration, fallback, migration, or compatibility path.
- The manifest keeps ownership of the probe URL, port, and timeout. `retargetHermesApiPortInUrl` rewrites a URL only when the URL names port 8642 and the registry records a different allocated port for that sandbox, so agents without a per-sandbox API port keep their manifest URL.
- Sandbox registration records the allocated port during step 6, before step 7 runs, so the registry answers for the sandbox being onboarded.
- `src/lib/agent/onboard.test.ts` adds three cases against `handleAgentSetup`: a sandbox with allocated port 8643 is probed at 8643, a sandbox on the default port keeps 8642, and the `--resume` fast path retargets the same way.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
  - `npx vitest run --project cli src/lib/agent/onboard.test.ts` — 25 passed.
  - `npx vitest run --project integration test/growth-guardrails.test.ts` — 32 passed.
  - Negative control: with `src/lib/agent/onboard.ts` restored to its merge-base content, the two retarget cases fail with `expected [ 'http://localhost:8642/health' ] to deeply equal [ 'http://localhost:8643/health' ]`.
  - Live A/B on one Ubuntu 24.04.4 x86_64 host with an NVIDIA L40. Both runs installed from a source checkout with `NEMOCLAW_REPO_ROOT="$(pwd)" bash install.sh`, and each started from a host with no NemoClaw binaries, state, containers, or bound ports.
  - Before the fix, at merge-base `c952909a34`: sandbox `my-hermes` onboarded and reported `Hermes Agent gateway is healthy`. A second sandbox `hermes-core-test` failed step 7 with `Hermes Agent gateway did not respond within 90s`, exited 1, and applied no policy presets. The registry recorded `hermesApiPort=8642` for `my-hermes` and `hermesApiPort=8643` for `hermes-core-test`. Inside the second sandbox, `socat TCP-LISTEN:8643 ... TCP:127.0.0.1:18642` was the only API relay, `curl http://localhost:8642/health` returned `000`, `curl http://localhost:8643/health` returned `200`, and `hermes -z "say ok"` answered `ok` with exit 0.
  - With the fix, at this branch: the second sandbox passed step 7 with `Hermes Agent gateway is healthy`, ran step 8, exited 0 in 56 seconds, and recorded 4 policy presets. The port layout inside the sandbox was unchanged: 8642 still returned `000` and 8643 still returned `200`, so the probe target changed rather than the runtime.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this change resolves one probe URL and is covered by the focused `handleAgentSetup` tests.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Hung Le <hple@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hermes agent health checks by using the correct sandbox-specific API port during onboarding and resume.
  * Preserved default behavior when no custom port is configured.
  * Left non-Hermes agents and connections without allocated ports unchanged.

* **Tests**
  * Added regression coverage for fresh setup, resume health checks, default ports, and per-sandbox port resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->