### PR TITLE
fix(policy): fail invalid interactive preset input

### DIFF
--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -2004,8 +2004,8 @@ function askPreset(question: string): Promise<string> {
 /**
  * Interactive preset picker for the `policy-remove` command. Prompts on
  * stderr and resolves to the chosen preset name, or `null` if the user
- * cancels. Invalid input returns `null` with process exit status 1. Rejects
- * with `code: "EOF"` when stdin closes before an answer (see `askPreset`).
+ * cancels or enters an invalid selection. Rejects with `code: "EOF"` when
+ * stdin closes before an answer (see `askPreset`).
  */
 async function selectForRemoval(
   items: PresetInfo[],
@@ -2024,10 +2024,13 @@ async function selectForRemoval(
   process.stderr.write("\n");
   const trimmed = (await askPreset("  Choose preset to remove: ")).trim();
   if (!trimmed) return null;
-  const item = /^\d+$/.test(trimmed) ? appliedItems[Number(trimmed) - 1] : undefined;
+  if (!/^\d+$/.test(trimmed)) {
+    process.stderr.write("\n  Invalid preset number.\n");
+    return null;
+  }
+  const item = appliedItems[Number(trimmed) - 1];
   if (!item) {
     process.stderr.write("\n  Invalid preset number.\n");
-    process.exitCode = 1;
     return null;
   }
   return item.name;

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -2004,8 +2004,8 @@ function askPreset(question: string): Promise<string> {
 /**
  * Interactive preset picker for the `policy-remove` command. Prompts on
  * stderr and resolves to the chosen preset name, or `null` if the user
- * cancels or enters an invalid selection. Rejects with `code: "EOF"` when
- * stdin closes before an answer (see `askPreset`).
+ * cancels. Invalid input returns `null` with process exit status 1. Rejects
+ * with `code: "EOF"` when stdin closes before an answer (see `askPreset`).
  */
 async function selectForRemoval(
   items: PresetInfo[],
@@ -2024,13 +2024,10 @@ async function selectForRemoval(
   process.stderr.write("\n");
   const trimmed = (await askPreset("  Choose preset to remove: ")).trim();
   if (!trimmed) return null;
-  if (!/^\d+$/.test(trimmed)) {
-    process.stderr.write("\n  Invalid preset number.\n");
-    return null;
-  }
-  const item = appliedItems[Number(trimmed) - 1];
+  const item = /^\d+$/.test(trimmed) ? appliedItems[Number(trimmed) - 1] : undefined;
   if (!item) {
     process.stderr.write("\n  Invalid preset number.\n");
+    process.exitCode = 1;
     return null;
   }
   return item.name;
@@ -2773,8 +2770,9 @@ function presetContentMatchesGateway(sandboxName: string, presetContent: string)
 /**
  * Interactive preset picker for the `policy add` command. Prints the
  * presets on stderr (● applied, ○ not applied), prompts for a number, and
- * resolves to the chosen preset name or `null` on cancel. Rejects with
- * `code: "EOF"` when stdin closes before an answer (see `askPreset`).
+ * resolves to the chosen preset name or `null` on cancel. Invalid input
+ * returns `null` with process exit status 1. Rejects with `code: "EOF"` when
+ * stdin closes before an answer (see `askPreset`).
  */
 async function selectFromList(
   items: PresetInfo[],
@@ -2793,13 +2791,10 @@ async function selectFromList(
   const trimmed = (await askPreset(question)).trim();
   const effectiveInput = trimmed || (defaultNum ? String(defaultNum) : "");
   if (!effectiveInput) return null;
-  if (!/^\d+$/.test(effectiveInput)) {
-    process.stderr.write("\n  Invalid preset number.\n");
-    return null;
-  }
-  const item = items[Number(effectiveInput) - 1];
+  const item = /^\d+$/.test(effectiveInput) ? items[Number(effectiveInput) - 1] : undefined;
   if (!item) {
     process.stderr.write("\n  Invalid preset number.\n");
+    process.exitCode = 1;
     return null;
   }
   if (applied.includes(item.name)) {

--- a/test/policy-preset-picker.test.ts
+++ b/test/policy-preset-picker.test.ts
@@ -322,18 +322,18 @@ describe("policy preset pickers", () => {
       expect(result.selected).toBeNull();
     });
 
-    it("rejects non-numeric input with a failure status (#9742)", async () => {
+    it("rejects non-numeric input", async () => {
       const result = await runSelectionPrompt("selectForRemoval", "npm\n", {
         applied: ["npm"],
       });
       expect(result.stderr).toContain("Invalid preset number");
-      expect(result).toMatchObject({ selected: null, exitCode: 1 });
+      expect(result.selected).toBeNull();
     });
 
-    it("rejects out-of-range number with a failure status (#9742)", async () => {
+    it("rejects out-of-range number", async () => {
       const result = await runSelectionPrompt("selectForRemoval", "99\n", { applied: ["npm"] });
       expect(result.stderr).toContain("Invalid preset number");
-      expect(result).toMatchObject({ selected: null, exitCode: 1 });
+      expect(result.selected).toBeNull();
     });
 
     it("selects second preset when both are applied", async () => {

--- a/test/policy-preset-picker.test.ts
+++ b/test/policy-preset-picker.test.ts
@@ -33,6 +33,8 @@ async function runSelectionPrompt(
   input: string,
   { applied = [] }: AppliedOptions = {},
 ) {
+  const originalExitCode = process.exitCode;
+  process.exitCode = undefined;
   const stderr: string[] = [];
   const counts = { ref: 0, pause: 0, unref: 0 };
   const stdin = process.stdin as typeof process.stdin & {
@@ -88,10 +90,12 @@ async function runSelectionPrompt(
     return {
       selected,
       stderr: stderr.join(""),
+      exitCode: process.exitCode,
       counts,
       close,
     };
   } finally {
+    process.exitCode = originalExitCode;
     stdin.ref = original.ref;
     stdin.pause = original.pause;
     stdin.unref = original.unref;
@@ -254,18 +258,18 @@ describe("policy preset pickers", () => {
       expect(result.selected).toBeNull();
     });
 
-    it("rejects out-of-range preset number", async () => {
+    it("rejects out-of-range preset number with a failure status (#9742)", async () => {
       const result = await runSelectionPrompt("selectFromList", "99\n");
 
       expect(result.stderr).toContain("Invalid preset number.");
-      expect(result.selected).toBeNull();
+      expect(result).toMatchObject({ selected: null, exitCode: 1 });
     });
 
-    it("rejects non-numeric preset input", async () => {
+    it("rejects non-numeric preset input with a failure status (#9742)", async () => {
       const result = await runSelectionPrompt("selectFromList", "npm\n");
 
       expect(result.stderr).toContain("Invalid preset number.");
-      expect(result.selected).toBeNull();
+      expect(result).toMatchObject({ selected: null, exitCode: 1 });
     });
 
     it("prints numbered list with applied markers, legend, and default prompt", async () => {
@@ -318,18 +322,18 @@ describe("policy preset pickers", () => {
       expect(result.selected).toBeNull();
     });
 
-    it("rejects non-numeric input", async () => {
+    it("rejects non-numeric input with a failure status (#9742)", async () => {
       const result = await runSelectionPrompt("selectForRemoval", "npm\n", {
         applied: ["npm"],
       });
       expect(result.stderr).toContain("Invalid preset number");
-      expect(result.selected).toBeNull();
+      expect(result).toMatchObject({ selected: null, exitCode: 1 });
     });
 
-    it("rejects out-of-range number", async () => {
+    it("rejects out-of-range number with a failure status (#9742)", async () => {
       const result = await runSelectionPrompt("selectForRemoval", "99\n", { applied: ["npm"] });
       expect(result.stderr).toContain("Invalid preset number");
-      expect(result.selected).toBeNull();
+      expect(result).toMatchObject({ selected: null, exitCode: 1 });
     });
 
     it("selects second preset when both are applied", async () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Invalid interactive policy preset input printed an error but returned success because the picker represented rejection as a normal cancellation. This change preserves the existing diagnostic and no-mutation behavior while returning exit status 1.

## Related Issue

Fixes #9742

## Changes

- Consolidate non-numeric and out-of-range preset validation into one `policy-add` failure path.
- Set the process exit status to 1 when interactive preset input is invalid.
- Extend the existing picker tests to cover failure status for both rejected input forms.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Local security-rubric review confirmed that rejected terminal input stops before preset loading or policy mutation. No credential, network, authentication, or authorization control changed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/policy-preset-picker.test.ts` (19 passed); `npx vitest run --project cli src/lib/actions/sandbox/policy-channel-policy.test.ts` (31 passed); `npx vitest run --project package-contract test/package-contract/cli/policy-prompt-eof.test.ts` (2 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid preset additions now consistently report a failed operation with exit status `1`, including nonnumeric input.
  * Invalid preset removals no longer incorrectly set a failure exit status.
  * Cancellation remains distinct from invalid input.

* **Tests**
  * Updated coverage to verify failure status for invalid additions and correct handling of preset removals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->