### PR TITLE
fix(e2e): publish service failure after cleanup

### DIFF
--- a/test/e2e/fixtures/portable-profile-systemctl-shim.sh
+++ b/test/e2e/fixtures/portable-profile-systemctl-shim.sh
@@ -1123,11 +1123,11 @@ async function startService() {
     );
   }
   if (processIdentityFailureRole === "service") {
+    await terminateProcessIdentity(processIdentity);
+    fs.rmSync(backendSocketPath, { force: true });
     if (processIdentityFailureRecord) {
       writeProcessRecord(processIdentityFailureRecord, processIdentity);
     }
-    await terminateProcessIdentity(processIdentity);
-    fs.rmSync(backendSocketPath, { force: true });
     throw new Error(
       `Portable profile fixture could not create the process identity record for service ${service.pid}.`,
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

[CI / Main run 32362597151](https://github.com/NVIDIA/NemoClaw/actions/runs/32362597151), [job 96405201157](https://github.com/NVIDIA/NemoClaw/actions/runs/32362597151/job/96405201157), exposed this root cause: `portable-profile systemctl fixture / injected service identity-record failure / diagnostic record published before backend exit`. The fixture now publishes the diagnostic record only after the owned backend process exits and its socket is removed.

## Related Issue

Related to #9006

## Changes

- Await the identity-validated backend termination before publishing the injected failure record.
- Remove the backend socket before publishing that record, so its existence signals completed fixture cleanup.
- Preserve the existing strict PID and socket assertions. No product code, retry, delay, or fallback changes.
- Documentation writer review: PASS; `docs-not-needed` because no user-facing behavior or explanatory text changes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `stops the owned backend when it cannot create the process identity record (#9006)` requires the published record to identify an inactive PID, with no service PID file or backend socket.
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent security review of `be0aa87b21a481caf95a0c15e2626f9b65754c61` passed all nine categories with no findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/portable-profile-systemctl-shim.test.ts --reporter=default` passed 36 tests. `npm run test-size:check` passed 32 tests. `npm run source-shape:check` and `npm run checks:repository` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service identity-record failure handling by terminating the affected Podman process and removing its backend socket before recording diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->