### PR TITLE
fix(e2e): report Launchable provenance mismatches

### DIFF
--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -657,7 +657,7 @@ describe("focused staging Brev Launchable lane", () => {
   }, 90_000);
 
   it("redacts a malformed boot-image value before retaining failure evidence", () => {
-    const credentialBearingValue = "token=guest-controlled-boot-secret";
+    const credentialBearingValue = "projects/1/global/images/guest-controlled-boot-secret";
     const boot = fixture({ bootImage: credentialBearingValue });
     const result = run(boot.env);
     expect(result.status).not.toBe(0);

--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -563,7 +563,7 @@ describe("focused staging Brev Launchable lane", () => {
         imageSelection: {
           status: "failed",
           expected: "projects/brevdevprod/global/images/nemoclaw-test-image",
-          observed: "projects/brevdevprod/global/images/wrong-image",
+          observed: "<redacted>",
         },
         runtimeProvenance: { status: "not-run", checks: [] },
         fullE2E: "not-run",
@@ -656,8 +656,9 @@ describe("focused staging Brev Launchable lane", () => {
     expect(fs.readFileSync(multiple.calls, "utf8")).not.toContain("full-e2e.test.ts");
   }, 90_000);
 
-  it("redacts a malformed boot-image value before retaining failure evidence", () => {
-    const credentialBearingValue = "projects/1/global/images/guest-controlled-boot-secret";
+  it("redacts a mismatched boot-image value before retaining failure evidence", () => {
+    const credentialBearingValue =
+      "projects/brevdevprod/global/images/guest-controlled-boot-secret";
     const boot = fixture({ bootImage: credentialBearingValue });
     const result = run(boot.env);
     expect(result.status).not.toBe(0);

--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -603,13 +603,13 @@ describe("focused staging Brev Launchable lane", () => {
         options: { sourceRepository: "example/NemoClaw" },
         field: "sourceRepository",
         expected: "NVIDIA/NemoClaw",
-        observed: "example/NemoClaw",
+        observed: "<redacted>",
       },
       {
         options: { sourcePath: "/home/ubuntu/NemoClaw" },
         field: "sourcePath",
         expected: "/opt/nemoclaw-image/NemoClaw",
-        observed: "/home/ubuntu/NemoClaw",
+        observed: "<redacted>",
       },
     ];
 
@@ -657,7 +657,7 @@ describe("focused staging Brev Launchable lane", () => {
   }, 90_000);
 
   it("redacts unconstrained runtime provenance before retaining or logging it", () => {
-    const credentialBearingValue = "token=guest-controlled-secret";
+    const credentialBearingValue = "NVIDIA/guest-controlled-secret";
     const boot = fixture({ sourceRepository: credentialBearingValue });
     const result = run(boot.env);
     expect(result.status).not.toBe(0);

--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -656,6 +656,30 @@ describe("focused staging Brev Launchable lane", () => {
     expect(fs.readFileSync(multiple.calls, "utf8")).not.toContain("full-e2e.test.ts");
   }, 90_000);
 
+  it("redacts a malformed boot-image value before retaining failure evidence", () => {
+    const credentialBearingValue = "token=guest-controlled-boot-secret";
+    const boot = fixture({ bootImage: credentialBearingValue });
+    const result = run(boot.env);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("booted image does not match the producer handoff");
+    expect(emittedOutput(result, boot.workDir)).not.toContain(credentialBearingValue);
+    expect(fs.readFileSync(boot.calls, "utf8")).not.toContain("full-e2e.test.ts");
+    const artifact = fs.readFileSync(path.join(boot.workDir, "launchable-e2e.json"), "utf8");
+    expect(artifact).not.toContain(credentialBearingValue);
+    expect(JSON.parse(artifact)).toMatchObject({
+      boot: { bootImage: "<redacted>" },
+      validation: {
+        imageSelection: {
+          status: "failed",
+          expected: "projects/brevdevprod/global/images/nemoclaw-test-image",
+          observed: "<redacted>",
+        },
+        runtimeProvenance: { status: "not-run", checks: [] },
+        fullE2E: "not-run",
+      },
+    });
+  });
+
   it("redacts unconstrained runtime provenance before retaining or logging it", () => {
     const credentialBearingValue = "NVIDIA/guest-controlled-secret";
     const boot = fixture({ sourceRepository: credentialBearingValue });

--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -476,6 +476,11 @@ describe("focused staging Brev Launchable lane", () => {
       candidateSha,
       fullE2e: "passed",
       producer: { runId: "123", status: "success" },
+      validation: {
+        imageSelection: { status: "passed" },
+        runtimeProvenance: { status: "passed" },
+        fullE2E: "passed",
+      },
       boot: {
         bootImage: "projects/brevdevprod/global/images/nemoclaw-test-image",
         sourcePath: "/opt/nemoclaw-image/NemoClaw",
@@ -488,7 +493,7 @@ describe("focused staging Brev Launchable lane", () => {
     });
   });
 
-  it("blocks E2E for a wrong receipt, incomplete readiness, or booted checkout mismatch", () => {
+  it("blocks workspace execution for a wrong receipt, incomplete readiness, or wrong boot image", () => {
     const receipt = fixture({ receiptSha: "b".repeat(40) });
     const receiptResult = run(receipt.env);
     expect(receiptResult.status).not.toBe(0);
@@ -522,25 +527,104 @@ describe("focused staging Brev Launchable lane", () => {
     expect(wrongImageResult.stderr).toContain("booted image does not match the producer handoff");
     expect(fs.readFileSync(wrongImage.calls, "utf8")).not.toContain("full-e2e.test.ts");
     expect(fs.existsSync(wrongImage.state)).toBe(false);
+    expect(
+      JSON.parse(fs.readFileSync(path.join(wrongImage.workDir, "launchable-e2e.json"), "utf8")),
+    ).toMatchObject({
+      validation: {
+        imageSelection: {
+          status: "failed",
+          expected: "projects/brevdevprod/global/images/nemoclaw-test-image",
+          observed: "projects/brevdevprod/global/images/wrong-image",
+        },
+        runtimeProvenance: { status: "not-run", checks: [] },
+        fullE2E: "not-run",
+      },
+    });
+  });
 
-    [
-      fixture({ repoSha: "b".repeat(40) }),
-      fixture({ provisionSha: "b".repeat(40) }),
-      fixture({ provisionImageRepositorySha: "c".repeat(40) }),
-      fixture({ repoClean: false }),
-      fixture({ runtimeOverrides: true }),
-      fixture({ schemaVersion: 2 }),
-      fixture({ sourceRepository: "example/NemoClaw" }),
-      fixture({ sourcePath: "/home/ubuntu/NemoClaw" }),
-    ].forEach((boot) => {
+  it("records and reports each runtime provenance mismatch before full E2E", () => {
+    const cases = [
+      {
+        options: { repoSha: "b".repeat(40) },
+        field: "repoSha",
+        expected: candidateSha,
+        observed: "b".repeat(40),
+      },
+      {
+        options: { provisionSha: "b".repeat(40) },
+        field: "provisionSha",
+        expected: candidateSha,
+        observed: "b".repeat(40),
+      },
+      {
+        options: { provisionImageRepositorySha: "c".repeat(40) },
+        field: "imageRepositorySha",
+        expected: "b".repeat(40),
+        observed: "c".repeat(40),
+      },
+      { options: { repoClean: false }, field: "repoClean", expected: true, observed: false },
+      {
+        options: { runtimeOverrides: true },
+        field: "runtimeOverrides",
+        expected: false,
+        observed: true,
+      },
+      { options: { schemaVersion: 2 }, field: "schemaVersion", expected: 1, observed: 2 },
+      {
+        options: { sourceRepository: "example/NemoClaw" },
+        field: "sourceRepository",
+        expected: "NVIDIA/NemoClaw",
+        observed: "example/NemoClaw",
+      },
+      {
+        options: { sourcePath: "/home/ubuntu/NemoClaw" },
+        field: "sourcePath",
+        expected: "/opt/nemoclaw-image/NemoClaw",
+        observed: "/home/ubuntu/NemoClaw",
+      },
+    ];
+
+    cases.forEach(({ options, field, expected, observed }) => {
+      const boot = fixture(options);
       const bootResult = run(boot.env);
       expect(bootResult.status).not.toBe(0);
-      expect(bootResult.stderr).toContain(
-        "booted image runtime does not match the producer handoff",
+      expect(emittedOutput(bootResult, boot.workDir)).toContain(
+        `Runtime provenance check failed: ${field} expected ${JSON.stringify(expected)}, observed ${JSON.stringify(observed)}`,
       );
       expect(fs.readFileSync(boot.calls, "utf8")).not.toContain("full-e2e.test.ts");
       expect(fs.existsSync(boot.state)).toBe(false);
+      const evidence = JSON.parse(
+        fs.readFileSync(path.join(boot.workDir, "launchable-e2e.json"), "utf8"),
+      );
+      expect(evidence.boot).toMatchObject({
+        bootImage: "projects/brevdevprod/global/images/nemoclaw-test-image",
+        [String(field)]: observed,
+      });
+      expect(evidence.validation).toMatchObject({
+        imageSelection: { status: "passed" },
+        runtimeProvenance: { status: "failed" },
+        fullE2E: "not-run",
+      });
+      expect(evidence.validation.runtimeProvenance.checks).toHaveLength(8);
+      expect(
+        evidence.validation.runtimeProvenance.checks.filter(
+          (check: { status: string }) => check.status === "failed",
+        ),
+      ).toEqual([{ field, expected, observed, status: "failed" }]);
     });
+
+    const multiple = fixture({
+      repoClean: false,
+      repoSha: "b".repeat(40),
+      runtimeOverrides: true,
+    });
+    const multipleResult = run(multiple.env);
+    const multipleOutput = emittedOutput(multipleResult, multiple.workDir);
+    expect(multipleResult.status).not.toBe(0);
+    expect(multipleOutput).toContain("Runtime provenance check failed: repoSha");
+    expect(multipleOutput).toContain("Runtime provenance check failed: repoClean");
+    expect(multipleOutput).toContain("Runtime provenance check failed: runtimeOverrides");
+    expect(fs.readFileSync(multiple.calls, "utf8")).not.toContain("full-e2e.test.ts");
   }, 90_000);
 
   it("reports E2E failure only after verified workspace cleanup", () => {
@@ -549,6 +633,16 @@ describe("focused staging Brev Launchable lane", () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("full E2E failed");
     expect(fs.existsSync(state)).toBe(false);
+    expect(
+      JSON.parse(fs.readFileSync(path.join(workDir, "launchable-e2e.json"), "utf8")),
+    ).toMatchObject({
+      fullE2e: "failed",
+      validation: {
+        imageSelection: { status: "passed" },
+        runtimeProvenance: { status: "passed" },
+        fullE2E: "failed",
+      },
+    });
     expect(JSON.parse(fs.readFileSync(path.join(workDir, "cleanup.json"), "utf8"))).toMatchObject({
       status: "ABSENT",
     });
@@ -820,6 +914,11 @@ describe("focused staging Brev Launchable lane", () => {
       candidateSha,
       boot: { bootImage: "projects/brevdevprod/global/images/nemoclaw-test-image" },
       fullE2e: "pending",
+      validation: {
+        imageSelection: { status: "passed" },
+        runtimeProvenance: { status: "not-run", checks: [] },
+        fullE2E: "not-run",
+      },
     });
   });
 

--- a/test/brev-launchable-e2e.test.ts
+++ b/test/brev-launchable-e2e.test.ts
@@ -470,9 +470,8 @@ describe("focused staging Brev Launchable lane", () => {
     expect(fs.readFileSync(path.join(workDir, "full-e2e.log"), "utf8")).not.toContain(
       "nvapi-test-value",
     );
-    expect(
-      JSON.parse(fs.readFileSync(path.join(workDir, "launchable-e2e.json"), "utf8")),
-    ).toMatchObject({
+    const evidence = JSON.parse(fs.readFileSync(path.join(workDir, "launchable-e2e.json"), "utf8"));
+    expect(evidence).toMatchObject({
       candidateSha,
       fullE2e: "passed",
       producer: { runId: "123", status: "success" },
@@ -491,6 +490,36 @@ describe("focused staging Brev Launchable lane", () => {
       },
       workspace: { id: "ws-1" },
     });
+    expect(evidence.validation.runtimeProvenance.checks).toEqual([
+      { field: "schemaVersion", expected: 1, observed: 1, status: "passed" },
+      {
+        field: "sourceRepository",
+        expected: "NVIDIA/NemoClaw",
+        observed: "NVIDIA/NemoClaw",
+        status: "passed",
+      },
+      {
+        field: "sourcePath",
+        expected: "/opt/nemoclaw-image/NemoClaw",
+        observed: "/opt/nemoclaw-image/NemoClaw",
+        status: "passed",
+      },
+      { field: "repoSha", expected: candidateSha, observed: candidateSha, status: "passed" },
+      {
+        field: "provisionSha",
+        expected: candidateSha,
+        observed: candidateSha,
+        status: "passed",
+      },
+      {
+        field: "imageRepositorySha",
+        expected: "b".repeat(40),
+        observed: "b".repeat(40),
+        status: "passed",
+      },
+      { field: "repoClean", expected: true, observed: true, status: "passed" },
+      { field: "runtimeOverrides", expected: false, observed: false, status: "passed" },
+    ]);
   });
 
   it("blocks workspace execution for a wrong receipt, incomplete readiness, or wrong boot image", () => {
@@ -626,6 +655,33 @@ describe("focused staging Brev Launchable lane", () => {
     expect(multipleOutput).toContain("Runtime provenance check failed: runtimeOverrides");
     expect(fs.readFileSync(multiple.calls, "utf8")).not.toContain("full-e2e.test.ts");
   }, 90_000);
+
+  it("redacts unconstrained runtime provenance before retaining or logging it", () => {
+    const credentialBearingValue = "token=guest-controlled-secret";
+    const boot = fixture({ sourceRepository: credentialBearingValue });
+    const result = run(boot.env);
+    expect(result.status).not.toBe(0);
+    const output = emittedOutput(result, boot.workDir);
+    expect(output).not.toContain(credentialBearingValue);
+    expect(output).toContain(
+      'Runtime provenance check failed: sourceRepository expected "NVIDIA/NemoClaw", observed "<redacted>"',
+    );
+    expect(fs.readFileSync(boot.calls, "utf8")).not.toContain("full-e2e.test.ts");
+    const artifact = fs.readFileSync(path.join(boot.workDir, "launchable-e2e.json"), "utf8");
+    expect(artifact).not.toContain(credentialBearingValue);
+    const evidence = JSON.parse(artifact);
+    expect(evidence.boot.sourceRepository).toBe("<redacted>");
+    expect(
+      evidence.validation.runtimeProvenance.checks.find(
+        (check: { field: string }) => check.field === "sourceRepository",
+      ),
+    ).toEqual({
+      field: "sourceRepository",
+      expected: "NVIDIA/NemoClaw",
+      observed: "<redacted>",
+      status: "failed",
+    });
+  });
 
   it("reports E2E failure only after verified workspace cleanup", () => {
     const { env, state, workDir } = fixture({ e2eFails: true });

--- a/tools/e2e/brev-launchable-e2e.sh
+++ b/tools/e2e/brev-launchable-e2e.sh
@@ -604,8 +604,24 @@ identity="$(timeout 300s brev exec "$INSTANCE_NAME" 'set -euo pipefail
     "{schemaVersion:\$schemaVersion,sourceRepository:\$sourceRepository,sourcePath:\$sourcePath,repoSha:\$repoSha,provisionSha:\$provisionSha,imageRepositorySha:\$imageRepositorySha,repoClean:\$repoClean,runtimeOverrides:\$runtimeOverrides}"' \
   | sed -n 's/^NEMOCLAW_IDENTITY=//p' | tail -n 1)"
 runtime_checks="$(jq -c --arg sha "$CANDIDATE_SHA" --arg imageRepositorySha "$image_repository_sha" '
+  def reported($field; $observed):
+    if $field == "schemaVersion" then
+      if ($observed | type) == "number" and $observed == ($observed | floor) and
+          $observed >= 0 and $observed <= 999 then $observed else "<redacted>" end
+    elif $field == "sourceRepository" then
+      if ($observed | type) == "string" and ($observed | length) <= 200 and
+          ($observed | test("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")) then $observed else "<redacted>" end
+    elif $field == "sourcePath" then
+      if ($observed | type) == "string" and ($observed | length) <= 256 and
+          ($observed | test("^/[A-Za-z0-9._/-]+$")) then $observed else "<redacted>" end
+    elif $field == "repoSha" or $field == "provisionSha" or $field == "imageRepositorySha" then
+      if ($observed | type) == "string" and ($observed | test("^[0-9a-f]{40}$")) then $observed else "<redacted>" end
+    elif $field == "repoClean" or $field == "runtimeOverrides" then
+      if ($observed | type) == "boolean" then $observed else "<redacted>" end
+    else "<redacted>"
+    end;
   def check($field; $expected; $observed):
-    {field:$field,expected:$expected,observed:$observed,
+    {field:$field,expected:$expected,observed:reported($field; $observed),
       status:(if $observed == $expected then "passed" else "failed" end)};
   [
     check("schemaVersion"; 1; .schemaVersion),
@@ -619,8 +635,10 @@ runtime_checks="$(jq -c --arg sha "$CANDIDATE_SHA" --arg imageRepositorySha "$im
   ]' <<<"$identity")" || die "booted image runtime identity is malformed"
 runtime_status="$(jq -r 'if all(.status == "passed") then "passed" else "failed" end' \
   <<<"$runtime_checks")"
+reported_identity="$(jq -c 'map({key:.field,value:.observed}) | from_entries' \
+  <<<"$runtime_checks")"
 
-jq --argjson identity "$identity" --arg status "$runtime_status" --argjson checks "$runtime_checks" '
+jq --argjson identity "$reported_identity" --arg status "$runtime_status" --argjson checks "$runtime_checks" '
   .boot += $identity | .validation.runtimeProvenance = {status:$status,checks:$checks}' \
   "$WORK_DIR/launchable-e2e.json" >"$WORK_DIR/launchable-e2e.tmp"
 mv "$WORK_DIR/launchable-e2e.tmp" "$WORK_DIR/launchable-e2e.json"

--- a/tools/e2e/brev-launchable-e2e.sh
+++ b/tools/e2e/brev-launchable-e2e.sh
@@ -569,7 +569,7 @@ else
 fi
 reported_boot_image="$(jq -Rr '
   if (length <= 256) and
-      test("^projects/[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?/global/images/[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$")
+      test("^projects/[a-z][a-z0-9-]{4,28}[a-z0-9]/global/images/[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$")
   then . else "<redacted>" end' <<<"$boot_image")"
 jq -n --arg candidateSha "$CANDIDATE_SHA" --arg producerRun "$producer_run" \
   --arg bootImage "$reported_boot_image" --arg expectedBootImage "$expected_boot_image" \

--- a/tools/e2e/brev-launchable-e2e.sh
+++ b/tools/e2e/brev-launchable-e2e.sh
@@ -562,13 +562,19 @@ boot_image="$(timeout 300s brev exec "$INSTANCE_NAME" 'set -euo pipefail
   | sed -n 's/^NEMOCLAW_BOOT_IMAGE=//p' | tail -n 1)"
 [ -n "$boot_image" ] || die "booted image identity is missing"
 
+if [ "$boot_image" = "$expected_boot_image" ]; then
+  image_selection_status=passed
+else
+  image_selection_status=failed
+fi
 jq -n --arg candidateSha "$CANDIDATE_SHA" --arg producerRun "$producer_run" \
-  --arg bootImage "$boot_image" --arg workspaceName "$INSTANCE_NAME" --arg workspaceId "$workspace_id" \
-  '{candidateSha:$candidateSha,producer:{runId:$producerRun,status:"success"},boot:{bootImage:$bootImage},workspace:{name:$workspaceName,id:$workspaceId},fullE2e:"pending"}' \
+  --arg bootImage "$boot_image" --arg expectedBootImage "$expected_boot_image" \
+  --arg imageSelectionStatus "$image_selection_status" \
+  --arg workspaceName "$INSTANCE_NAME" --arg workspaceId "$workspace_id" \
+  '{candidateSha:$candidateSha,producer:{runId:$producerRun,status:"success"},boot:{bootImage:$bootImage},workspace:{name:$workspaceName,id:$workspaceId},fullE2e:"pending",validation:{imageSelection:{status:$imageSelectionStatus,expected:$expectedBootImage,observed:$bootImage},runtimeProvenance:{status:"not-run",checks:[]},fullE2E:"not-run"}}' \
   >"$WORK_DIR/launchable-e2e.json"
 
-[ "$boot_image" = "$expected_boot_image" ] \
-  || die "booted image does not match the producer handoff"
+[ "$image_selection_status" = passed ] || die "booted image does not match the producer handoff"
 
 # Return the baked runtime receipt.
 # shellcheck disable=SC2016
@@ -597,18 +603,37 @@ identity="$(timeout 300s brev exec "$INSTANCE_NAME" 'set -euo pipefail
     --argjson runtimeOverrides "$runtime_overrides" \
     "{schemaVersion:\$schemaVersion,sourceRepository:\$sourceRepository,sourcePath:\$sourcePath,repoSha:\$repoSha,provisionSha:\$provisionSha,imageRepositorySha:\$imageRepositorySha,repoClean:\$repoClean,runtimeOverrides:\$runtimeOverrides}"' \
   | sed -n 's/^NEMOCLAW_IDENTITY=//p' | tail -n 1)"
-jq -e --arg sha "$CANDIDATE_SHA" --arg imageRepositorySha "$image_repository_sha" '
-  .schemaVersion == 1 and .sourceRepository == "NVIDIA/NemoClaw" and
-  .sourcePath == "/opt/nemoclaw-image/NemoClaw" and
-  .repoSha == $sha and .provisionSha == $sha and
-  .imageRepositorySha == $imageRepositorySha and
-  .repoClean == true and .runtimeOverrides == false' \
-  <<<"$identity" >/dev/null || die "booted image runtime does not match the producer handoff"
-source_path="$(jq -er .sourcePath <<<"$identity")"
+runtime_checks="$(jq -c --arg sha "$CANDIDATE_SHA" --arg imageRepositorySha "$image_repository_sha" '
+  def check($field; $expected; $observed):
+    {field:$field,expected:$expected,observed:$observed,
+      status:(if $observed == $expected then "passed" else "failed" end)};
+  [
+    check("schemaVersion"; 1; .schemaVersion),
+    check("sourceRepository"; "NVIDIA/NemoClaw"; .sourceRepository),
+    check("sourcePath"; "/opt/nemoclaw-image/NemoClaw"; .sourcePath),
+    check("repoSha"; $sha; .repoSha),
+    check("provisionSha"; $sha; .provisionSha),
+    check("imageRepositorySha"; $imageRepositorySha; .imageRepositorySha),
+    check("repoClean"; true; .repoClean),
+    check("runtimeOverrides"; false; .runtimeOverrides)
+  ]' <<<"$identity")" || die "booted image runtime identity is malformed"
+runtime_status="$(jq -r 'if all(.status == "passed") then "passed" else "failed" end' \
+  <<<"$runtime_checks")"
 
-jq --argjson identity "$identity" '.boot += $identity' \
+jq --argjson identity "$identity" --arg status "$runtime_status" --argjson checks "$runtime_checks" '
+  .boot += $identity | .validation.runtimeProvenance = {status:$status,checks:$checks}' \
   "$WORK_DIR/launchable-e2e.json" >"$WORK_DIR/launchable-e2e.tmp"
 mv "$WORK_DIR/launchable-e2e.tmp" "$WORK_DIR/launchable-e2e.json"
+
+if [ "$runtime_status" = failed ]; then
+  while IFS= read -r mismatch; do
+    log "Runtime provenance check failed: $mismatch"
+  done < <(jq -r '.[] | select(.status == "failed") |
+    "\(.field) expected \(.expected | tojson), observed \(.observed | tojson)"' \
+    <<<"$runtime_checks")
+  die "booted image runtime provenance failed"
+fi
+source_path="$(jq -er .sourcePath <<<"$identity")"
 
 # Run the existing suite from the baked checkout; no source copy, install, or rebuild.
 raw_log_directory="$(mktemp -d "${RUNNER_TEMP:-/tmp}/brev-launchable-e2e.XXXXXX")"
@@ -647,8 +672,12 @@ Path(source).unlink(missing_ok=True)
 PY
 raw_log=""
 if [ "$e2e_status" -ne 0 ] || ! grep -q '^NEMOCLAW_FULL_E2E_PASSED$' "$WORK_DIR/full-e2e.log"; then
+  jq '.fullE2e = "failed" | .validation.fullE2E = "failed"' \
+    "$WORK_DIR/launchable-e2e.json" >"$WORK_DIR/launchable-e2e.tmp"
+  mv "$WORK_DIR/launchable-e2e.tmp" "$WORK_DIR/launchable-e2e.json"
   die "full E2E failed"
 fi
-jq '.fullE2e = "passed"' "$WORK_DIR/launchable-e2e.json" >"$WORK_DIR/launchable-e2e.tmp"
+jq '.fullE2e = "passed" | .validation.fullE2E = "passed"' \
+  "$WORK_DIR/launchable-e2e.json" >"$WORK_DIR/launchable-e2e.tmp"
 mv "$WORK_DIR/launchable-e2e.tmp" "$WORK_DIR/launchable-e2e.json"
 log "Full E2E passed"

--- a/tools/e2e/brev-launchable-e2e.sh
+++ b/tools/e2e/brev-launchable-e2e.sh
@@ -567,8 +567,12 @@ if [ "$boot_image" = "$expected_boot_image" ]; then
 else
   image_selection_status=failed
 fi
+reported_boot_image="$(jq -Rr '
+  if (length <= 256) and
+      test("^projects/[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?/global/images/[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$")
+  then . else "<redacted>" end' <<<"$boot_image")"
 jq -n --arg candidateSha "$CANDIDATE_SHA" --arg producerRun "$producer_run" \
-  --arg bootImage "$boot_image" --arg expectedBootImage "$expected_boot_image" \
+  --arg bootImage "$reported_boot_image" --arg expectedBootImage "$expected_boot_image" \
   --arg imageSelectionStatus "$image_selection_status" \
   --arg workspaceName "$INSTANCE_NAME" --arg workspaceId "$workspace_id" \
   '{candidateSha:$candidateSha,producer:{runId:$producerRun,status:"success"},boot:{bootImage:$bootImage},workspace:{name:$workspaceName,id:$workspaceId},fullE2e:"pending",validation:{imageSelection:{status:$imageSelectionStatus,expected:$expectedBootImage,observed:$bootImage},runtimeProvenance:{status:"not-run",checks:[]},fullE2E:"not-run"}}' \

--- a/tools/e2e/brev-launchable-e2e.sh
+++ b/tools/e2e/brev-launchable-e2e.sh
@@ -564,13 +564,11 @@ boot_image="$(timeout 300s brev exec "$INSTANCE_NAME" 'set -euo pipefail
 
 if [ "$boot_image" = "$expected_boot_image" ]; then
   image_selection_status=passed
+  reported_boot_image="$boot_image"
 else
   image_selection_status=failed
+  reported_boot_image="<redacted>"
 fi
-reported_boot_image="$(jq -Rr '
-  if (length <= 256) and
-      test("^projects/[a-z][a-z0-9-]{4,28}[a-z0-9]/global/images/[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$")
-  then . else "<redacted>" end' <<<"$boot_image")"
 jq -n --arg candidateSha "$CANDIDATE_SHA" --arg producerRun "$producer_run" \
   --arg bootImage "$reported_boot_image" --arg expectedBootImage "$expected_boot_image" \
   --arg imageSelectionStatus "$image_selection_status" \

--- a/tools/e2e/brev-launchable-e2e.sh
+++ b/tools/e2e/brev-launchable-e2e.sh
@@ -609,11 +609,9 @@ runtime_checks="$(jq -c --arg sha "$CANDIDATE_SHA" --arg imageRepositorySha "$im
       if ($observed | type) == "number" and $observed == ($observed | floor) and
           $observed >= 0 and $observed <= 999 then $observed else "<redacted>" end
     elif $field == "sourceRepository" then
-      if ($observed | type) == "string" and ($observed | length) <= 200 and
-          ($observed | test("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")) then $observed else "<redacted>" end
+      if $observed == "NVIDIA/NemoClaw" then $observed else "<redacted>" end
     elif $field == "sourcePath" then
-      if ($observed | type) == "string" and ($observed | length) <= 256 and
-          ($observed | test("^/[A-Za-z0-9._/-]+$")) then $observed else "<redacted>" end
+      if $observed == "/opt/nemoclaw-image/NemoClaw" then $observed else "<redacted>" end
     elif $field == "repoSha" or $field == "provisionSha" or $field == "imageRepositorySha" then
       if ($observed | type) == "string" and ($observed | test("^[0-9a-f]{40}$")) then $observed else "<redacted>" end
     elif $field == "repoClean" or $field == "runtimeOverrides" then


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Exact staging Brev Launchable job currently combines eight runtime-provenance comparisons into one error and discards the rejected identity. This change records image selection, each provenance check, and the full E2E phase before failure while preserving the fail-closed inference credential boundary.

## Changes

- Record expected and observed boot-image identity with a separate image-selection status.
- Preserve the non-secret runtime identity and all eight field results before provenance validation can fail.
- Report every failed provenance check with its expected and observed JSON value.
- Record whether the full E2E passed, failed, or did not run without changing the existing successful receipt contract.
- Extend the no-cloud integration fixture to cover every individual mismatch, multiple simultaneous mismatches, phase evidence, credential denial, and workspace cleanup.

The escaped diagnostic gap came from one aggregate `jq` expression and a write that occurred only after the expression passed. Existing tests checked only the aggregate error. The new regression coverage checks the retained evidence and each field-level result.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer-directed diagnostic repair. Runtime-provenance failure still blocks the credential-bearing full E2E. Focused negative coverage confirms that no full E2E command runs and workspace cleanup confirms absence after each mismatch.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run --project integration test/brev-launchable-e2e.test.ts` passed 25 tests in 62.22 seconds.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; the changed behavior is isolated to one trusted shell harness and its no-cloud integration fixture.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new docs only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive validation evidence for boot-image selection and eight runtime provenance checks.
  * E2E reports now include per-field checks, expected and sanitized observed values, structured error states, and consolidated results.
  * Full E2E success or failure is recorded in the final report.
  * Multiple validation failures are collected and reported before execution is blocked.

* **Bug Fixes**
  * Improved handling of incorrect boot images, missing receipts, and runtime identity mismatches.
  * Workspace execution is blocked when required validation checks fail.
  * Untrusted provenance values are sanitized in diagnostics and saved evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->