### PR TITLE
fix(advisor): combine submit validation errors

### DIFF
--- a/test/pr-review-advisor-submission-tools.test.ts
+++ b/test/pr-review-advisor-submission-tools.test.ts
@@ -1083,8 +1083,11 @@ describe("PR review advisor submission tools", () => {
     expect(submission.result()).toBeNull();
   });
 
-  it("reports receipt and terminology errors before one submit repair", async () => {
-    const submission = controller();
+  it("reports draft errors together before one submit repair", async () => {
+    let returnInvalidE2e = true;
+    const submission = controller(new Map(), (draft) =>
+      returnInvalidE2e ? { ...draft, coverage: null } : draft,
+    );
     const draft = receipt({
       decisions: [terminologyDecision("missing-trace")],
       noChangesReason: null,
@@ -1102,11 +1105,13 @@ describe("PR review advisor submission tools", () => {
     expect(failure).toBeInstanceOf(Error);
     expect(failure?.message).toContain("acceptanceCoverage[1] does not report a concern");
     expect(failure?.message).toContain("securityCategories[1] does not report a concern");
+    expect(failure?.message).toContain("normalized E2E failed schema validation");
     expect(failure?.message).toContain("Unknown terminology trace missing-trace");
     expect(submission.findingSnapshot()).toEqual({ version: 1, findings: [] });
     expect(submission.terminologySnapshot()).toMatchObject({ revision: 0 });
     expect(submission.result()).toBeNull();
 
+    returnInvalidE2e = false;
     await execute(submission, RECORD_REVIEW_RECEIPT_TOOL, receipt());
     await expect(execute(submission, SUBMIT_REVIEW_TOOL, {})).resolves.toMatchObject({
       terminate: true,

--- a/test/pr-review-advisor-submission-tools.test.ts
+++ b/test/pr-review-advisor-submission-tools.test.ts
@@ -134,6 +134,20 @@ function receipt(
     reviewCompleteness: { limitations: [], requiresHumanReview: true },
   };
 }
+function terminologyDecision(traceId: string) {
+  return {
+    term: "review receipt",
+    change: "introduced",
+    disposition: "justified",
+    meaning: "The complete structured review sections.",
+    contrast: "Unlike drafts, this is complete.",
+    existingTerm: null,
+    semanticImpact: "evidence",
+    recommendation: "Keep the contrast explicit.",
+    traceId,
+    source: { file: "tools/pr-review-advisor/review-submission.mts", line: 9 },
+  };
+}
 function e2e() {
   return {
     coverage: {
@@ -1069,6 +1083,36 @@ describe("PR review advisor submission tools", () => {
     expect(submission.result()).toBeNull();
   });
 
+  it("reports receipt and terminology errors before one submit repair", async () => {
+    const submission = controller();
+    const draft = receipt({
+      decisions: [terminologyDecision("missing-trace")],
+      noChangesReason: null,
+    });
+    draft.acceptanceCoverage[0].findingId = "F-001";
+    draft.securityCategories[0].findingId = "F-001";
+    await execute(submission, RECORD_FINDINGS_TOOL, { findings: [finding()] });
+    await execute(submission, RECORD_REVIEW_RECEIPT_TOOL, draft);
+    await execute(submission, RECOMMEND_E2E_TOOL, e2e());
+
+    const failure = await execute(submission, SUBMIT_REVIEW_TOOL, {}).then(
+      () => null,
+      (error: unknown) => error as Error,
+    );
+    expect(failure).toBeInstanceOf(Error);
+    expect(failure?.message).toContain("acceptanceCoverage[1] does not report a concern");
+    expect(failure?.message).toContain("securityCategories[1] does not report a concern");
+    expect(failure?.message).toContain("Unknown terminology trace missing-trace");
+    expect(submission.findingSnapshot()).toEqual({ version: 1, findings: [] });
+    expect(submission.terminologySnapshot()).toMatchObject({ revision: 0 });
+    expect(submission.result()).toBeNull();
+
+    await execute(submission, RECORD_REVIEW_RECEIPT_TOOL, receipt());
+    await expect(execute(submission, SUBMIT_REVIEW_TOOL, {})).resolves.toMatchObject({
+      terminate: true,
+    });
+  });
+
   it.each([
     ["null", null, 7],
     ["blank", "   ", 7],
@@ -1277,20 +1321,7 @@ describe("PR review advisor submission tools", () => {
       submission,
       RECORD_REVIEW_RECEIPT_TOOL,
       receipt({
-        decisions: [
-          {
-            term: trace.term,
-            change: "introduced",
-            disposition: "justified",
-            meaning: "The complete structured review sections.",
-            contrast: "Unlike drafts, this is complete.",
-            existingTerm: null,
-            semanticImpact: "evidence",
-            recommendation: "Keep the contrast explicit.",
-            traceId: trace.id,
-            source: { file: "tools/pr-review-advisor/review-submission.mts", line: 9 },
-          },
-        ],
+        decisions: [terminologyDecision(trace.id)],
         noChangesReason: null,
       }),
     );
@@ -1324,20 +1355,7 @@ describe("PR review advisor submission tools", () => {
       submission,
       RECORD_REVIEW_RECEIPT_TOOL,
       receipt({
-        decisions: [
-          {
-            term: "review receipt",
-            change: "introduced",
-            disposition: "justified",
-            meaning: "The complete structured review sections.",
-            contrast: "Unlike drafts, this is complete.",
-            existingTerm: null,
-            semanticImpact: "evidence",
-            recommendation: "Keep the contrast explicit.",
-            traceId: trace.id,
-            source: { file: "tools/pr-review-advisor/review-submission.mts", line: 9 },
-          },
-        ],
+        decisions: [terminologyDecision(trace.id)],
         noChangesReason: null,
       }),
     );

--- a/tools/pr-review-advisor/review-submission.mts
+++ b/tools/pr-review-advisor/review-submission.mts
@@ -317,6 +317,7 @@ export function createReviewSubmissionController({
   const reviewReceiptSchema = createReviewReceiptSchema(securityCategoryNames);
   const ajv = new Ajv2020({ allErrors: true, strict: false });
   const validateReceipt = ajv.compile(reviewReceiptSchema);
+  const validateE2e = ajv.compile(e2eSchema);
   const validate = ajv.compile(schema);
 
   const recordFindings = defineTool({
@@ -429,9 +430,15 @@ export function createReviewSubmissionController({
       await captureValidationIssue(validationIssues, () =>
         validateSecurityCategories(receiptDraft!.securityCategories, securityCategoryNames),
       );
-      const normalizedE2e = await captureValidationIssue(validationIssues, () =>
-        normalizeE2e(structuredClone(e2eDraft!), metadata),
-      );
+      const normalizedE2e = await captureValidationIssue(validationIssues, async () => {
+        const normalized = await normalizeE2e(structuredClone(e2eDraft!), metadata);
+        if (!validateE2e(normalized)) {
+          throw new Error(
+            `submit_review normalized E2E failed schema validation: ${ajv.errorsText(validateE2e.errors)}`,
+          );
+        }
+        return normalized;
+      });
       const candidateTerminology = createTerminologyLedger(metadata.headSha);
       const traces =
         typeof terminologyTraces === "function" ? terminologyTraces() : terminologyTraces;

--- a/tools/pr-review-advisor/review-submission.mts
+++ b/tools/pr-review-advisor/review-submission.mts
@@ -412,23 +412,49 @@ export function createReviewSubmissionController({
       ].filter(Boolean);
       if (missing.length > 0) throw new Error(`submit_review requires: ${missing.join(", ")}`);
 
-      validateReceiptFindingReferences(receiptDraft!, findingsDraft!);
-      const candidateFindingSnapshot = validateReviewFindingSubmission(
-        findingsDraft!,
-        repositoryRoot,
+      const validationIssues = await receiptFindingReferenceIssues(receiptDraft!, findingsDraft!);
+      const candidateFindingSnapshot = await captureValidationIssue(validationIssues, () =>
+        validateReviewFindingSubmission(findingsDraft!, repositoryRoot),
       );
-      const openFindings = candidateFindingSnapshot.findings;
-      validateSecurityCategories(receiptDraft!.securityCategories, securityCategoryNames);
-      const summary = canonicalSummary(
-        receiptDraft!.summary,
-        openFindings,
-        metadata.deterministic.hasOpenPrReplacement,
+      const openFindings = candidateFindingSnapshot?.findings;
+      const summary = openFindings
+        ? await captureValidationIssue(validationIssues, () =>
+            canonicalSummary(
+              receiptDraft!.summary,
+              openFindings,
+              metadata.deterministic.hasOpenPrReplacement,
+            ),
+          )
+        : undefined;
+      await captureValidationIssue(validationIssues, () =>
+        validateSecurityCategories(receiptDraft!.securityCategories, securityCategoryNames),
       );
-      const normalizedE2e = await normalizeE2e(structuredClone(e2eDraft!), metadata);
+      const normalizedE2e = await captureValidationIssue(validationIssues, () =>
+        normalizeE2e(structuredClone(e2eDraft!), metadata),
+      );
       const candidateTerminology = createTerminologyLedger(metadata.headSha);
       const traces =
         typeof terminologyTraces === "function" ? terminologyTraces() : terminologyTraces;
-      candidateTerminology.commit(receiptDraft!.terminologyReview, traces);
+      await captureValidationIssue(validationIssues, () =>
+        candidateTerminology.commit(receiptDraft!.terminologyReview, traces),
+      );
+      if (openFindings) {
+        const qualityIssues = reviewQualityIssues({
+          findings: openFindings,
+          securityCategories: receiptDraft!.securityCategories,
+        });
+        if (qualityIssues.length > 0) {
+          validationIssues.push(
+            `submit_review result failed review quality validation: ${qualityIssues.join("; ")}`,
+          );
+        }
+      }
+      if (validationIssues.length > 0) {
+        throw new Error(`submit_review failed validation: ${validationIssues.join("; ")}`);
+      }
+      if (!candidateFindingSnapshot || !openFindings || !summary || !normalizedE2e) {
+        throw new Error("submit_review validation did not assemble every candidate section");
+      }
       const publicReceipt = publicReceiptDraft(receiptDraft!, metadata.deterministic.testDepth);
       const result = {
         version: 1,
@@ -442,15 +468,6 @@ export function createReviewSubmissionController({
         terminologyReview: candidateTerminology.snapshot().review,
         e2e: normalizedE2e,
       };
-      const qualityIssues = reviewQualityIssues({
-        findings: openFindings,
-        securityCategories: receiptDraft!.securityCategories,
-      });
-      if (qualityIssues.length > 0) {
-        throw new Error(
-          `submit_review result failed review quality validation: ${qualityIssues.join("; ")}`,
-        );
-      }
       if (!validate(result)) {
         const reason = (validate.errors ?? [])
           .map((error) => `${error.instancePath || "/"} ${error.message}`)
@@ -539,37 +556,45 @@ function findingPair(finding: CandidateFindingInput): string {
   return `${finding.category}:${finding.basis.kind}`;
 }
 
-function validateReceiptFindingReferences(
+async function receiptFindingReferenceIssues(
   receipt: DraftReceipt,
   findings: readonly CandidateFindingInput[],
-): void {
+): Promise<string[]> {
   const findingsById = new Map(findings.map((finding, index) => [findingId(index), finding]));
-  validateConcernEntries(
-    "acceptanceCoverage",
-    receipt.acceptanceCoverage,
-    findingsById,
-    (entry) => entry.status === "partial" || entry.status === "missing",
-    (finding) => ACCEPTANCE_FINDING_PAIRS.has(findingPair(finding)),
-    (entry) => `acceptance:${String(entry.clause)}`,
-    (entry) => (entry.status === "missing" ? "blocker" : "warning"),
+  const issues: string[] = [];
+  await captureValidationIssue(issues, () =>
+    validateConcernEntries(
+      "acceptanceCoverage",
+      receipt.acceptanceCoverage,
+      findingsById,
+      (entry) => entry.status === "partial" || entry.status === "missing",
+      (finding) => ACCEPTANCE_FINDING_PAIRS.has(findingPair(finding)),
+      (entry) => `acceptance:${String(entry.clause)}`,
+      (entry) => (entry.status === "missing" ? "blocker" : "warning"),
+    ),
   );
-  validateConcernEntries(
-    "securityCategories",
-    receipt.securityCategories,
-    findingsById,
-    (entry) => entry.verdict === "warning" || entry.verdict === "fail",
-    (finding) => SECURITY_FINDING_PAIRS.has(findingPair(finding)),
-    (entry) => `security:${String(entry.category)}`,
-    (entry) => (entry.verdict === "fail" ? "blocker" : "warning"),
+  await captureValidationIssue(issues, () =>
+    validateConcernEntries(
+      "securityCategories",
+      receipt.securityCategories,
+      findingsById,
+      (entry) => entry.verdict === "warning" || entry.verdict === "fail",
+      (finding) => SECURITY_FINDING_PAIRS.has(findingPair(finding)),
+      (entry) => `security:${String(entry.category)}`,
+      (entry) => (entry.verdict === "fail" ? "blocker" : "warning"),
+    ),
   );
-  validateConcernEntries(
-    "sourceOfTruthReview",
-    receipt.sourceOfTruthReview,
-    findingsById,
-    (entry) => entry.status === "needs_followup" || entry.status === "missing",
-    (finding) => SOURCE_OF_TRUTH_FINDING_CATEGORIES.has(finding.category),
-    (entry) => `source-of-truth:${String(entry.surface)}`,
+  await captureValidationIssue(issues, () =>
+    validateConcernEntries(
+      "sourceOfTruthReview",
+      receipt.sourceOfTruthReview,
+      findingsById,
+      (entry) => entry.status === "needs_followup" || entry.status === "missing",
+      (finding) => SOURCE_OF_TRUTH_FINDING_CATEGORIES.has(finding.category),
+      (entry) => `source-of-truth:${String(entry.surface)}`,
+    ),
   );
+  return issues;
 }
 
 function validateConcernEntries(
@@ -621,6 +646,18 @@ function validateConcernEntries(
         `${section}[${index + 1}] references ${findingId} with severity ${finding.severity}; ${String(entry.status ?? entry.verdict)} requires ${requiredSeverity}${requiredSeverity === "warning" ? " or blocker" : ""}`,
       );
     }
+  }
+}
+
+async function captureValidationIssue<T>(
+  issues: string[],
+  validate: () => T | Promise<T>,
+): Promise<T | undefined> {
+  try {
+    return await validate();
+  } catch (error: unknown) {
+    issues.push(error instanceof Error ? error.message : String(error));
+    return undefined;
   }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make failed PR Review Advisor submissions report independently actionable validation problems together. Models can now repair receipt and terminology issues within the protocol's single allowed retry instead of discovering one error per attempt, as occurred in [Actions run 32392136223](https://github.com/NVIDIA/NemoClaw/actions/runs/32392136223/job/96500519599?pr=9238).

## Changes

- Collect validation failures across receipt sections, findings, the canonical summary, security inventory, end-to-end normalization, terminology decisions, and review quality.
- Preserve canonical receipt state until the complete validation pass succeeds, without relaxing the one-repair submission protocol.
- Add regression coverage that returns multiple receipt and terminology errors together and succeeds after one corrected submission.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — `npm run validate:pr` passed after refreshing `origin/main`.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/pr-review-advisor-submission-tools.test.ts test/advisor-session-context-tools.test.ts test/advisor-session-runner.test.ts` (131 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Review submissions now report all detected validation issues together, including receipt, findings, summary, security, terminology, end-to-end validation, and review-quality errors.
  * Invalid submissions no longer partially update review state; changes remain atomic until all corrections are made.
  * Corrected receipts and validation details are now rechecked consistently, including normalized end-to-end results, allowing valid submissions to complete successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->