### PR TITLE
fix(cli): republish MCP credentials after policy binding

### DIFF
--- a/test/mcp-add-crash-consistency.test.ts
+++ b/test/mcp-add-crash-consistency.test.ts
@@ -17,6 +17,7 @@ type CrashBoundary =
   | "policy-drift"
   | "credential-collision"
   | "credential-command-race"
+  | "credential-revision-stale"
   | "registered-credential-collision"
   | "registered-late-collision"
   | "adapter"
@@ -39,6 +40,9 @@ includeSecret ? (process.env.FAKE_MCP_SECRET = "host-only-secret") : delete proc
 const fs = require("node:fs");
 const path = require("node:path");
 const crashAfter = ${JSON.stringify(crashAfter)};
+if (crashAfter === "credential-revision-stale") {
+  process.env.NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS = "1";
+}
 const marker = (name) => path.join(process.env.HOME, name + ".marker");
 const mark = (name) => fs.writeFileSync(marker(name), "yes\n", { mode: 0o600 });
 const marked = (name) => fs.existsSync(marker(name));
@@ -105,7 +109,12 @@ providerCommands.runOpenshellProviderCommand = (args) => {
         throw new Error("Unexpected provider update: " + args.join(" "));
       }
       setProviderVersion(providerVersion() + 1);
-      if (isCredentialUpdate) mark("updated");
+      if (isCredentialUpdate) {
+        mark("updated");
+        if (crashAfter === "credential-revision-stale" && marked("bound-policy")) {
+          mark("credential-revision-ready");
+        }
+      }
     }
     mark("provider");
     if (crashAfter === "registered-late-collision") registry.addExtraProvider("foreign-registered");
@@ -161,6 +170,7 @@ policies.applyPresetContent = () => {
   if (crashAfter === "policy-failure") return false;
   fs.appendFileSync(marker("policy-apply-log"), "apply\n", { mode: 0o600 });
   mark("policy");
+  if (marked("attached")) mark("bound-policy");
   if (crashAfter === "policy") process.exit(86);
   return true;
 };
@@ -181,7 +191,17 @@ processRecovery.executeSandboxExecCommand = (_sandbox, command) => {
   isPreupdateObservation && mark("observation");
   return {
     status: crashAfter === "preupdate-observation-forbidden" && isPreupdateObservation ? 1 : 0,
-    stdout: isObservation ? (marked("updated") ? "v" + providerVersion() : marked("provider") ? "v1" : "absent") : "",
+    stdout: isObservation
+      ? crashAfter === "credential-revision-stale"
+        ? marked("credential-revision-ready")
+          ? "v" + providerVersion()
+          : "absent"
+        : marked("updated")
+          ? "v" + providerVersion()
+          : marked("provider")
+            ? "v1"
+            : "absent"
+      : "",
     stderr: "",
   };
 };
@@ -786,6 +806,44 @@ describe("MCP add crash consistency", () => {
       });
       credentialChild?.kill();
       mcpChild?.kill();
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("commits one serialized duplicate add after a fresh exec observes the bound credential revision (#9764)", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-add-revision-race-"));
+    try {
+      const first = runAddProcess(home, "credential-revision-stale");
+      const second = runAddProcess(home, "credential-revision-stale");
+      const results = [first, second];
+      const winners = results.filter((result) => result.status === 0);
+      const duplicates = results.filter(
+        (result) =>
+          result.status === 2 &&
+          result.stderr.includes("MCP server 'fake' already exists on sandbox 'crash-test'"),
+      );
+
+      expect(winners, results.map((result) => result.stderr).join("\n")).toHaveLength(1);
+      expect(duplicates, results.map((result) => result.stderr).join("\n")).toHaveLength(1);
+      expect(results.map((result) => `${result.stdout}\n${result.stderr}`).join("\n")).not.toContain(
+        "host-only-secret",
+      );
+      expect(readBridge(home)).toMatchObject({
+        server: "fake",
+        env: ["FAKE_MCP_SECRET"],
+        policyName: "mcp-bridge-fake",
+      });
+      expect(readBridge(home).addState).toBeUndefined();
+      expect(fs.existsSync(path.join(home, "provider.marker"))).toBe(true);
+      expect(fs.existsSync(path.join(home, "policy.marker"))).toBe(true);
+      expect(fs.existsSync(path.join(home, "adapter.marker"))).toBe(true);
+
+      const removed = runRemoveProcess(home, false);
+      expect(removed.status, `${removed.stdout}\n${removed.stderr}`).toBe(0);
+      expect(fs.existsSync(path.join(home, "provider.marker"))).toBe(false);
+      expect(fs.existsSync(path.join(home, "policy.marker"))).toBe(false);
+      expect(fs.existsSync(path.join(home, "adapter.marker"))).toBe(false);
+    } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This draft reproduces an MCP add transaction in which fresh sandbox processes never observe the credential revision published after provider attachment and policy binding. Two serialized identical adds then both roll back instead of leaving one committed bridge for the second command to reject as a duplicate.

## Related Issue

Fixes #9764.

## Changes

- Add a process-boundary fixture that keeps the credential placeholder absent until an attached provider receives a credential-bearing update after the bound policy is active.
- Require two serialized identical adds to produce one committed winner, one duplicate rejection, coherent provider, policy, adapter, and registry state, recoverable removal, and no fixture-secret output.

E2E root cause: MCP bridge / provider credential-revision readiness / stale or absent FAKE_MCP_SECRET revision yields zero committed winners and incomplete rollback
Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/32393515799 (run 32393515799, attempt 1)
Failed jobs: mcp-bridge hermes (96508058767), mcp-bridge openclaw (96508058854), mcp-bridge deepagents (96508058868), openshell-credential-generation-window (96508059047)
Signature: fresh OpenShell processes never observe the expected placeholder credential revision after provider attachment or update, so both serialized adds fail and rollback
Scope: one root cause

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending product correction and exact-commit nine-category review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: not applicable.
- Result: not applicable.
- Supporting evidence: not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — fail-first command: `npm exec -- vitest run --project integration test/mcp-add-crash-consistency.test.ts`; result: 20 passed and the new #9764 case failed with zero winners and the expected credential-revision synchronization error.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
