### PR TITLE
fix(mcp): refresh credentials after observed absence

### DIFF
--- a/src/lib/actions/sandbox/mcp-bridge-add-restart.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-add-restart.ts
@@ -435,13 +435,13 @@ async function addMcpBridgeUnlocked(
     providerAttachAttempted = true;
     attachProvider(sandboxName, entry);
     applyGeneratedPolicy(sandboxName, entry, target);
-    refreshMcpProviderEnvironment(entry);
     waitForAttachedMcpCredential(sandboxName, entry, {
       ...(providerResult.action === "updated"
         ? {
             previousRevision: previousCredentialRevision,
           }
         : {}),
+      refreshAfterObservedAbsence: () => refreshMcpProviderEnvironment(entry),
     });
     // The adapter was proven absent above, so cleanup is safe even when a
     // command commits config and then fails during its runtime reload.

--- a/src/lib/actions/sandbox/mcp-bridge-provider-readiness.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-provider-readiness.ts
@@ -119,7 +119,10 @@ export function observeMcpCredentialRevision(
 export function waitForAttachedMcpCredential(
   sandboxName: string,
   entry: McpBridgeEntry,
-  options: { previousRevision?: McpCredentialRevisionObservation } = {},
+  options: {
+    previousRevision?: McpCredentialRevisionObservation;
+    refreshAfterObservedAbsence?: () => void;
+  } = {},
 ): void {
   assertAuthenticatedBridgeEntry(entry);
   const envName = entry.env[0];
@@ -133,12 +136,22 @@ export function waitForAttachedMcpCredential(
     process.env.NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS ?? "30",
     10,
   );
+  let refreshedAfterObservedAbsence = false;
   const ready = waitUntil(
     () => {
       // Each exec is a fresh OpenShell process. Only the bounded placeholder
       // classification crosses back to the host, where the comparison cannot
       // be influenced by a same-UID sandbox process rewriting a snapshot file.
-      const observation = tryObserveMcpCredentialRevision(sandboxName, envName);
+      let observation = tryObserveMcpCredentialRevision(sandboxName, envName);
+      if (
+        observation === "absent" &&
+        !refreshedAfterObservedAbsence &&
+        options.refreshAfterObservedAbsence
+      ) {
+        refreshedAfterObservedAbsence = true;
+        options.refreshAfterObservedAbsence();
+        observation = tryObserveMcpCredentialRevision(sandboxName, envName);
+      }
       return (
         observation !== null &&
         observation !== "absent" &&

--- a/src/lib/actions/sandbox/mcp-bridge-provider.test.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-provider.test.ts
@@ -351,8 +351,34 @@ alpha-mcp-slack   generic  1                 0
       stdout: "canonical",
       stderr: "",
     });
+    const refreshAfterObservedAbsence = vi.fn();
 
-    waitForAttachedMcpCredential("alpha", {
+    waitForAttachedMcpCredential(
+      "alpha",
+      {
+        server: "github",
+        agent: "openclaw",
+        adapter: "mcporter",
+        url: "https://mcp.example.test/mcp",
+        env: ["GITHUB_TOKEN"],
+        providerName: "alpha-mcp-github-0123456789abcdef",
+        providerId: "11111111-2222-4333-8444-555555555555",
+        policyName: "mcp-bridge-github",
+        addedAt: "2026-06-01T00:00:00.000Z",
+      },
+      { refreshAfterObservedAbsence },
+    );
+
+    const proofCommand = exec.mock.calls[0]?.[1] ?? "";
+    expect(proofCommand).toContain("\n");
+    expect(proofCommand).toContain("valid_placeholder");
+    expect(proofCommand).toContain("GITHUB_TOKEN");
+    expect(proofCommand).not.toContain("base64 -d");
+    expect(refreshAfterObservedAbsence).not.toHaveBeenCalled();
+  });
+
+  it("refreshes once after a fresh exec reports the credential absent (#9764)", () => {
+    const entry: McpBridgeEntry = {
       server: "github",
       agent: "openclaw",
       adapter: "mcporter",
@@ -362,13 +388,137 @@ alpha-mcp-slack   generic  1                 0
       providerId: "11111111-2222-4333-8444-555555555555",
       policyName: "mcp-bridge-github",
       addedAt: "2026-06-01T00:00:00.000Z",
+    };
+    const exec = vi
+      .spyOn(processRecovery, "executeSandboxExecCommand")
+      .mockReturnValueOnce({ status: 0, stdout: "absent", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "v12", stderr: "" });
+    const refreshAfterObservedAbsence = vi.fn();
+
+    waitForAttachedMcpCredential("alpha", entry, { refreshAfterObservedAbsence });
+
+    expect(refreshAfterObservedAbsence).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not repeat the refresh when the credential remains absent (#9764)", () => {
+    vi.stubEnv("NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS", "1");
+    const exec = vi.spyOn(processRecovery, "executeSandboxExecCommand").mockReturnValue({
+      status: 0,
+      stdout: "absent",
+      stderr: "",
+    });
+    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(1_000);
+    const refreshAfterObservedAbsence = vi.fn();
+
+    expect(() =>
+      waitForAttachedMcpCredential(
+        "alpha",
+        {
+          server: "github",
+          agent: "openclaw",
+          adapter: "mcporter",
+          url: "https://mcp.example.test/mcp",
+          env: ["GITHUB_TOKEN"],
+          providerName: "alpha-mcp-github-0123456789abcdef",
+          providerId: "11111111-2222-4333-8444-555555555555",
+          policyName: "mcp-bridge-github",
+          addedAt: "2026-06-01T00:00:00.000Z",
+        },
+        { refreshAfterObservedAbsence },
+      ),
+    ).toThrow(/did not synchronize the expected credential revision/);
+    expect(refreshAfterObservedAbsence).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ["unavailable", null],
+    ["malformed", { status: 0, stdout: "raw-secret", stderr: "" }],
+  ])("does not refresh when a credential observation is %s (#9764)", (_case, result) => {
+    vi.stubEnv("NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS", "1");
+    vi.spyOn(processRecovery, "executeSandboxExecCommand").mockReturnValue(result);
+    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(1_000);
+    const refreshAfterObservedAbsence = vi.fn();
+
+    expect(() =>
+      waitForAttachedMcpCredential(
+        "alpha",
+        {
+          server: "github",
+          agent: "openclaw",
+          adapter: "mcporter",
+          url: "https://mcp.example.test/mcp",
+          env: ["GITHUB_TOKEN"],
+          providerName: "alpha-mcp-github-0123456789abcdef",
+          providerId: "11111111-2222-4333-8444-555555555555",
+          policyName: "mcp-bridge-github",
+          addedAt: "2026-06-01T00:00:00.000Z",
+        },
+        { refreshAfterObservedAbsence },
+      ),
+    ).toThrow(/did not synchronize the expected credential revision/);
+    expect(refreshAfterObservedAbsence).not.toHaveBeenCalled();
+  });
+
+  it("propagates a credential refresh failure after observed absence (#9764)", () => {
+    vi.spyOn(processRecovery, "executeSandboxExecCommand").mockReturnValue({
+      status: 0,
+      stdout: "absent",
+      stderr: "",
+    });
+    const refreshAfterObservedAbsence = vi.fn(() => {
+      throw new Error("credential-free refresh failed");
     });
 
-    const proofCommand = exec.mock.calls[0]?.[1] ?? "";
-    expect(proofCommand).toContain("\n");
-    expect(proofCommand).toContain("valid_placeholder");
-    expect(proofCommand).toContain("GITHUB_TOKEN");
-    expect(proofCommand).not.toContain("base64 -d");
+    expect(() =>
+      waitForAttachedMcpCredential(
+        "alpha",
+        {
+          server: "github",
+          agent: "openclaw",
+          adapter: "mcporter",
+          url: "https://mcp.example.test/mcp",
+          env: ["GITHUB_TOKEN"],
+          providerName: "alpha-mcp-github-0123456789abcdef",
+          providerId: "11111111-2222-4333-8444-555555555555",
+          policyName: "mcp-bridge-github",
+          addedAt: "2026-06-01T00:00:00.000Z",
+        },
+        { refreshAfterObservedAbsence },
+      ),
+    ).toThrow("credential-free refresh failed");
+    expect(refreshAfterObservedAbsence).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not accept a stale revision after the absence refresh (#9764)", () => {
+    vi.stubEnv("NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS", "1");
+    const exec = vi
+      .spyOn(processRecovery, "executeSandboxExecCommand")
+      .mockReturnValueOnce({ status: 0, stdout: "absent", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "v11", stderr: "" });
+    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(1_000);
+    const refreshAfterObservedAbsence = vi.fn();
+
+    expect(() =>
+      waitForAttachedMcpCredential(
+        "alpha",
+        {
+          server: "github",
+          agent: "openclaw",
+          adapter: "mcporter",
+          url: "https://mcp.example.test/mcp",
+          env: ["GITHUB_TOKEN"],
+          providerName: "alpha-mcp-github-0123456789abcdef",
+          providerId: "11111111-2222-4333-8444-555555555555",
+          policyName: "mcp-bridge-github",
+          addedAt: "2026-06-01T00:00:00.000Z",
+        },
+        { previousRevision: "v11", refreshAfterObservedAbsence },
+      ),
+    ).toThrow(/did not synchronize the expected credential revision/);
+    expect(refreshAfterObservedAbsence).toHaveBeenCalledTimes(1);
+    expect(exec).toHaveBeenCalledTimes(2);
   });
 
   it("fails detach verification when the strict OpenShell exec is unavailable", () => {

--- a/test/mcp-add-crash-consistency.test.ts
+++ b/test/mcp-add-crash-consistency.test.ts
@@ -538,12 +538,16 @@ describe("MCP add crash consistency", () => {
       const first = spawnScript(home, script);
       const second = spawnScript(home, script);
       const results = await Promise.all([collectProcess(first), collectProcess(second)]);
+      const combinedOutput = results
+        .map((result) => `${result.stdout}\n${result.stderr}`)
+        .join("\n---\n");
 
       expect(
         results.map((result) => result.status).sort(),
-        results.map((result) => `${result.stdout}\n${result.stderr}`).join("\n---\n"),
+        combinedOutput,
       ).toEqual([0, 2]);
       expect(results.find((result) => result.status === 2)?.stderr).toContain("already exists");
+      expect(combinedOutput).not.toContain("host-only-secret");
       expect(fs.existsSync(path.join(home, "credential-observed-absent.marker"))).toBe(true);
       expect(fs.existsSync(path.join(home, "refresh-after-observed-absence.marker"))).toBe(true);
       expect(fs.existsSync(path.join(home, "provider.marker"))).toBe(true);

--- a/test/mcp-add-crash-consistency.test.ts
+++ b/test/mcp-add-crash-consistency.test.ts
@@ -17,6 +17,7 @@ type CrashBoundary =
   | "policy-drift"
   | "credential-collision"
   | "credential-command-race"
+  | "credential-projection-coalesced"
   | "registered-credential-collision"
   | "registered-late-collision"
   | "adapter"
@@ -39,6 +40,9 @@ includeSecret ? (process.env.FAKE_MCP_SECRET = "host-only-secret") : delete proc
 const fs = require("node:fs");
 const path = require("node:path");
 const crashAfter = ${JSON.stringify(crashAfter)};
+if (crashAfter === "credential-projection-coalesced") {
+  process.env.NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS = "2";
+}
 const marker = (name) => path.join(process.env.HOME, name + ".marker");
 const mark = (name) => fs.writeFileSync(marker(name), "yes\n", { mode: 0o600 });
 const marked = (name) => fs.existsSync(marker(name));
@@ -50,6 +54,8 @@ const foreignProviderId = "99999999-8888-4777-8666-555555555555";
 let providerGetCount = 0;
 let observedProviderName = null;
 let attachmentAttemptedThisProcess = false;
+let observedCredentialAbsentThisProcess = false;
+let credentialRefreshAfterAbsenceThisProcess = false;
 
 const registry = require("./src/lib/state/registry.js");
 const providerCommands = require("./src/lib/adapters/openshell/provider-command.js");
@@ -106,6 +112,14 @@ providerCommands.runOpenshellProviderCommand = (args) => {
       }
       setProviderVersion(providerVersion() + 1);
       if (isCredentialUpdate) mark("updated");
+      if (
+        crashAfter === "credential-projection-coalesced" &&
+        isCredentialFreeRefresh &&
+        observedCredentialAbsentThisProcess
+      ) {
+        credentialRefreshAfterAbsenceThisProcess = true;
+        mark("refresh-after-observed-absence");
+      }
     }
     mark("provider");
     if (crashAfter === "registered-late-collision") registry.addExtraProvider("foreign-registered");
@@ -179,6 +193,17 @@ processRecovery.executeSandboxExecCommand = (_sandbox, command) => {
     !marked("updated") &&
     !attachmentAttemptedThisProcess;
   isPreupdateObservation && mark("observation");
+  if (crashAfter === "credential-projection-coalesced" && isObservation) {
+    if (!credentialRefreshAfterAbsenceThisProcess) {
+      observedCredentialAbsentThisProcess = true;
+      mark("credential-observed-absent");
+    }
+    return {
+      status: 0,
+      stdout: credentialRefreshAfterAbsenceThisProcess ? "v" + providerVersion() : "absent",
+      stderr: "",
+    };
+  }
   return {
     status: crashAfter === "preupdate-observation-forbidden" && isPreupdateObservation ? 1 : 0,
     stdout: isObservation ? (marked("updated") ? "v" + providerVersion() : marked("provider") ? "v1" : "absent") : "",
@@ -506,6 +531,31 @@ function readBridge(home: string): Record<string, unknown> {
 }
 
 describe("MCP add crash consistency", () => {
+  it("commits one bridge and rejects one duplicate after delayed credential projection (#9764)", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-add-concurrent-projection-"));
+    try {
+      const script = buildAddProcessScript(home, "credential-projection-coalesced");
+      const first = spawnScript(home, script);
+      const second = spawnScript(home, script);
+      const results = await Promise.all([collectProcess(first), collectProcess(second)]);
+
+      expect(
+        results.map((result) => result.status).sort(),
+        results.map((result) => `${result.stdout}\n${result.stderr}`).join("\n---\n"),
+      ).toEqual([0, 2]);
+      expect(results.find((result) => result.status === 2)?.stderr).toContain("already exists");
+      expect(fs.existsSync(path.join(home, "credential-observed-absent.marker"))).toBe(true);
+      expect(fs.existsSync(path.join(home, "refresh-after-observed-absence.marker"))).toBe(true);
+      expect(fs.existsSync(path.join(home, "provider.marker"))).toBe(true);
+      expect(fs.existsSync(path.join(home, "attached.marker"))).toBe(true);
+      expect(fs.existsSync(path.join(home, "policy.marker"))).toBe(true);
+      expect(fs.existsSync(path.join(home, "adapter.marker"))).toBe(true);
+      expect(readBridge(home).addState).toBeUndefined();
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it("rejects a missing host credential before creating durable MCP state", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-add-missing-secret-"));
     try {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

OpenShell can observe the initial provider update before the credential-bound policy generation, so both serialized adds saw no projected placeholder and rolled back. The add flow now publishes one credential-free provider revision after a fresh OpenShell exec reports the placeholder absent, then requires a fresh, non-stale revision before it commits.

The prior deterministic tests did not model delayed credential projection. The new two-process regression verifies one committed bridge, one duplicate rejection, coherent final state, and no credential disclosure.

## Related Issue

Closes #9764

## Changes

- Add a deterministic two-process regression for delayed credential projection that verifies one committed bridge and one duplicate rejection.
- Move the add flow's credential-free provider republish behind the first bounded `absent` observation and run it at most once.
- Continue to fail closed for unavailable or malformed observations, absence after refresh, and unchanged revisions.
- Preserve the live MCP bridge concurrency assertion and final-state checks.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category review passed for commit `da0e2cc6` against `ce517dd3` with no findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/mcp-add-crash-consistency.test.ts src/lib/actions/sandbox/mcp-bridge-provider.test.ts`, 50 tests passed. The growth guard passed 32 tests. Three unrelated CLI files selected by `npm run test:changed` failed in the aggregate run, then passed 24 tests when run in isolation.
- [ ] Applicable broad gate passed — Not run. The change is focused on MCP credential readiness and its process-boundary regression; the targeted tests cover the changed contract.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## E2E root-cause evidence

Root cause: OpenShell did not project the expected placeholder revision after the managed MCP provider and policy changes, so both serialized adds rolled back.
Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/32378489657 (run 32378489657, attempt 1)
Failed jobs: `mcp-bridge (deepagents)` (https://github.com/NVIDIA/NemoClaw/actions/runs/32378489657/job/96456013232)
Signature: both concurrent `nemoclaw mcp add` processes exit nonzero after OpenShell does not project the expected placeholder revision
Scope: one root cause

Concurrent claim: draft PR #9768 contains an independent test-only reproduction for the same root cause. The repository comparator classified the implementations as independent and ranked this PR closest to ready, with a 16/16 correctness-and-quality score versus 12/16 for #9768. Neither PR was merged or closed.

The last confirmed pass was commit `7689b4a3831e4abc7a992c54d84c48ee60368dac`; the first confirmed failure was commit `66f69d4d6d1ea5936998fd221478245bb4ab2c8c`. Commit `8cddceec26c7b99bf2b499ffe2cb7329471bccfb` is an unproven temporal candidate because it updated OpenShell and MCP integration. It did not change the lifecycle lock, and earlier OpenClaw and Hermes runs had the same symptom.

Documentation writer review: PASS for commit `da0e2cc6` against `ce517dd3`. Documentation is unchanged because this fix restores the existing duplicate-add concurrency contract and does not change a documented command or workflow.

Security review: PASS for commit `da0e2cc6` against `ce517dd3`. The independent nine-category review found no findings.

---

Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP provider credential synchronization when credentials are temporarily unavailable.
  * Automatically retries credential detection after a refresh, helping prevent stale or delayed credential states.
  * Improved handling of delayed updates, malformed responses, and refresh failures.
  * Prevented stale credential revisions and inconsistent results during concurrent MCP additions.
* **Tests**
  * Expanded coverage for multiline credentials, refresh limits, delayed projections, duplicate requests, and secret protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->