### PR TITLE
fix(inference): bootstrap llama.cpp package publication

### DIFF
--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -313,36 +313,9 @@ jobs:
           fi
           printf 'candidate_tag=%s\n' "$candidate_tag" >> "$GITHUB_OUTPUT"
 
-  publication-preflight:
-    name: Require public GHCR package
-    needs: [config, publication-gate]
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    permissions:
-      packages: read
-    steps:
-      - name: Verify public package visibility before registry writes
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          IMAGE: ${{ needs.config.outputs.publication_repository }}
-        run: |
-          set -euo pipefail
-          package_name="${IMAGE#ghcr.io/nvidia/}"
-          encoded_package_name="${package_name//\//%2F}"
-          package_api="/orgs/NVIDIA/packages/container/${encoded_package_name}"
-          if ! visibility="$(gh api "$package_api" --jq .visibility)"; then
-            echo "::error::GHCR package ${IMAGE} must exist with public visibility before publication. Bootstrap the package, set public visibility, then rerun this workflow."
-            exit 1
-          fi
-          if [ "$visibility" != "public" ]; then
-            echo "::error::GHCR package ${IMAGE} has ${visibility} visibility. Set public visibility, then rerun this workflow."
-            exit 1
-          fi
-
   publish-platform:
     name: Publish native llama.cpp digest (${{ matrix.arch }})
-    needs: [config, publication-gate, publication-preflight]
+    needs: [config, publication-gate]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     permissions:
@@ -449,6 +422,29 @@ jobs:
           fi
           install -d -m 0700 "$RUNNER_TEMP/llama-cpp-digests"
           touch "$RUNNER_TEMP/llama-cpp-digests/${ARCH}-${DIGEST#sha256:}"
+
+      - name: Remove GHCR publication credentials
+        if: always()
+        shell: bash
+        run: docker logout ghcr.io
+
+      - name: Verify anonymous exact platform pull
+        shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ${{ needs.config.outputs.publication_repository }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          reference="${IMAGE}@${DIGEST}"
+          anonymous_config="$(mktemp -d "$RUNNER_TEMP/llama-cpp-anonymous-XXXXXX")"
+          chmod 0700 "$anonymous_config"
+          trap 'rm -rf -- "$anonymous_config"' EXIT
+          if ! env -u DOCKER_AUTH_CONFIG DOCKER_CONFIG="$anonymous_config" \
+            docker pull --platform "$PLATFORM" "$reference"; then
+            echo "::error::Anonymous exact-digest pull failed for ${reference}. The GHCR package ${IMAGE} must be public before candidate assembly."
+            exit 1
+          fi
 
       - name: Upload platform digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -3,6 +3,7 @@
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -11,6 +12,7 @@ import YAML from "yaml";
 type Step = {
   env?: Record<string, unknown>;
   id?: string;
+  if?: string;
   name?: string;
   run?: string;
   uses?: string;
@@ -103,6 +105,54 @@ function jobPermissionValues(workflowValue: Workflow): string[] {
   return Object.values(workflowValue.jobs ?? {}).flatMap((job) =>
     permissionValues(job.permissions),
   );
+}
+
+function runAnonymousPull(step: Step, result: "denied" | "success") {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "llama-cpp-anonymous-pull-"));
+  const fakeBin = path.join(temporaryRoot, "bin");
+  const invocationLog = path.join(temporaryRoot, "docker-invocation");
+  const configLog = path.join(temporaryRoot, "docker-config");
+  fs.mkdirSync(fakeBin);
+  fs.writeFileSync(
+    path.join(fakeBin, "docker"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$INVOCATION_LOG"
+printf '%s\n' "$DOCKER_CONFIG" > "$CONFIG_LOG"
+[ -z "\${DOCKER_AUTH_CONFIG+x}" ] || exit 91
+if [ "$RESULT" = "denied" ]; then
+  exit 37
+fi
+`,
+    { mode: 0o755 },
+  );
+
+  try {
+    const command = required(step.run, "anonymous pull script is missing");
+    const commandResult = spawnSync("bash", ["--noprofile", "--norc", "-c", command], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CONFIG_LOG: configLog,
+        DIGEST: `sha256:${"a".repeat(64)}`,
+        DOCKER_AUTH_CONFIG: "must-not-reach-docker",
+        IMAGE: "ghcr.io/nvidia/nemoclaw/llama-cpp-server",
+        INVOCATION_LOG: invocationLog,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        PLATFORM: "linux/arm64",
+        RESULT: result,
+        RUNNER_TEMP: temporaryRoot,
+      },
+    });
+    const anonymousConfig = fs.readFileSync(configLog, "utf8").trim();
+    return {
+      ...commandResult,
+      anonymousConfigWasRemoved: !fs.existsSync(anonymousConfig),
+      invocation: fs.readFileSync(invocationLog, "utf8").trim(),
+    };
+  } finally {
+    fs.rmSync(temporaryRoot, { force: true, recursive: true });
+  }
 }
 
 describe("llama.cpp image PR workflow", () => {
@@ -222,13 +272,13 @@ describe("llama.cpp image PR workflow", () => {
 
   it("gates digest-first native publication on an enabled main-only declarative contract (#8250)", () => {
     const gate = required(workflow.jobs?.["publication-gate"], "publication gate is missing");
-    const preflight = required(
-      workflow.jobs?.["publication-preflight"],
-      "publication preflight is missing",
-    );
     const publish = required(workflow.jobs?.["publish-platform"], "platform publisher is missing");
     const publishGuard = namedStep(publish, "Validate trusted image build args");
     const publishBuild = namedStep(publish, "Publish exact platform digest");
+    const exportDigest = namedStep(publish, "Export validated platform digest");
+    const logout = namedStep(publish, "Remove GHCR publication credentials");
+    const anonymousPull = namedStep(publish, "Verify anonymous exact platform pull");
+    const uploadDigest = namedStep(publish, "Upload platform digest");
     const assemble = required(
       workflow.jobs?.["assemble-candidate"],
       "candidate assembly job is missing",
@@ -274,12 +324,8 @@ describe("llama.cpp image PR workflow", () => {
       clientTimeoutMilliseconds: 251,
     };
     expect(runPublicationQualificationFilter(filter, driftedBounds).status).not.toBe(0);
-    expect(preflight.needs).toEqual(["config", "publication-gate"]);
-    expect(preflight.permissions).toEqual({ packages: "read" });
-    expect(
-      namedStep(preflight, "Verify public package visibility before registry writes").run,
-    ).toContain("must exist with public visibility before publication");
-    expect(publish.needs).toEqual(["config", "publication-gate", "publication-preflight"]);
+    expect(workflow.jobs?.["publication-preflight"]).toBeUndefined();
+    expect(publish.needs).toEqual(["config", "publication-gate"]);
     expect(publish.permissions).toEqual({
       contents: "read",
       packages: "write",
@@ -300,6 +346,20 @@ describe("llama.cpp image PR workflow", () => {
     expect(publish.steps?.indexOf(publishGuard)).toBeLessThan(
       publish.steps?.indexOf(publishBuild) ?? Number.POSITIVE_INFINITY,
     );
+    expect(logout.if).toBe("always()");
+    expect(logout.run).toBe("docker logout ghcr.io");
+    expect(publish.steps?.indexOf(publishBuild)).toBeLessThan(
+      publish.steps?.indexOf(exportDigest) ?? Number.POSITIVE_INFINITY,
+    );
+    expect(publish.steps?.indexOf(exportDigest)).toBeLessThan(
+      publish.steps?.indexOf(logout) ?? Number.POSITIVE_INFINITY,
+    );
+    expect(publish.steps?.indexOf(logout)).toBeLessThan(
+      publish.steps?.indexOf(anonymousPull) ?? Number.POSITIVE_INFINITY,
+    );
+    expect(publish.steps?.indexOf(anonymousPull)).toBeLessThan(
+      publish.steps?.indexOf(uploadDigest) ?? Number.POSITIVE_INFINITY,
+    );
     expect(assemble.needs).toEqual(["config", "publication-gate", "publish-platform"]);
     expect(assembleStep.run).toContain(
       'docker buildx imagetools create --tag "$IMAGE:$CANDIDATE_TAG" "${sources[@]}"',
@@ -308,6 +368,25 @@ describe("llama.cpp image PR workflow", () => {
     expect(assembleStep.run).toContain("candidate-index.json");
     expect(assembleStep.run).toContain("platform-digests.json");
     expect(assembleStep.run).not.toMatch(/latest|stable|release/iu);
+  });
+
+  it("requires an anonymous exact-digest pull after publication and before candidate assembly (#8250)", () => {
+    const publish = required(workflow.jobs?.["publish-platform"], "platform publisher is missing");
+    const anonymousPull = namedStep(publish, "Verify anonymous exact platform pull");
+
+    const accepted = runAnonymousPull(anonymousPull, "success");
+    expect(accepted.status, accepted.stderr).toBe(0);
+    expect(accepted.invocation).toBe(
+      `pull --platform linux/arm64 ghcr.io/nvidia/nemoclaw/llama-cpp-server@sha256:${"a".repeat(64)}`,
+    );
+    expect(accepted.anonymousConfigWasRemoved).toBe(true);
+
+    const rejected = runAnonymousPull(anonymousPull, "denied");
+    expect(rejected.status).toBe(1);
+    expect(rejected.stdout + rejected.stderr).toContain(
+      "The GHCR package ghcr.io/nvidia/nemoclaw/llama-cpp-server must be public before candidate assembly.",
+    );
+    expect(rejected.anonymousConfigWasRemoved).toBe(true);
   });
 
   it("scans, attests, verifies, and creates a receipt for the exact candidate without a consumer alias (#8250)", () => {


### PR DESCRIPTION
## Summary

Managed llama.cpp publication currently fails before the first registry write when the GHCR package does not exist. This change publishes each exact platform digest first, removes publication credentials, and requires an anonymous exact-digest pull before candidate assembly.

## Changes

- Remove the public-package preflight while retaining the main-only declarative publication gate before registry writes.
- Remove GHCR publication credentials after each digest push and verify public access with a credential-free Docker configuration.
- Block digest artifact upload and candidate assembly when the anonymous exact-digest pull fails.
- Add regression coverage for publication order, credential isolation, success, failure, and temporary-state cleanup.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Local security review verified credential removal, credential-free public access, failure propagation, and temporary-state cleanup.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/llama-cpp-image-workflow.test.ts test/llama-cpp-image.test.ts test/llama-cpp-image-publication-evidence.test.ts test/llama-cpp-dgx-spark-qualification-plan.test.ts test/llama-cpp-dgx-spark-qualification-contract.test.ts` passed 90 tests in 5 files.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image publication validation by verifying that each published platform image can be pulled anonymously using its exact digest.
  * Publication now stops if public visibility or digest-based access verification fails.

* **Tests**
  * Added coverage for credential isolation, anonymous digest pulls, publication ordering, and failure handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->