### PR TITLE
test(mcp): count concurrent credential refreshes

### DIFF
--- a/test/mcp-add-crash-consistency.test.ts
+++ b/test/mcp-add-crash-consistency.test.ts
@@ -55,7 +55,7 @@ let providerGetCount = 0;
 let observedProviderName = null;
 let attachmentAttemptedThisProcess = false;
 let observedCredentialAbsentThisProcess = false;
-let credentialRefreshAfterAbsenceThisProcess = false;
+let credentialRefreshAfterAbsenceCountThisProcess = 0;
 
 const registry = require("./src/lib/state/registry.js");
 const providerCommands = require("./src/lib/adapters/openshell/provider-command.js");
@@ -117,8 +117,8 @@ providerCommands.runOpenshellProviderCommand = (args) => {
         isCredentialFreeRefresh &&
         observedCredentialAbsentThisProcess
       ) {
-        credentialRefreshAfterAbsenceThisProcess = true;
-        mark("refresh-after-observed-absence");
+        credentialRefreshAfterAbsenceCountThisProcess += 1;
+        fs.appendFileSync(marker("refresh-after-observed-absence"), "refresh\n", { mode: 0o600 });
       }
     }
     mark("provider");
@@ -194,13 +194,13 @@ processRecovery.executeSandboxExecCommand = (_sandbox, command) => {
     !attachmentAttemptedThisProcess;
   isPreupdateObservation && mark("observation");
   if (crashAfter === "credential-projection-coalesced" && isObservation) {
-    if (!credentialRefreshAfterAbsenceThisProcess) {
+    if (credentialRefreshAfterAbsenceCountThisProcess === 0) {
       observedCredentialAbsentThisProcess = true;
       mark("credential-observed-absent");
     }
     return {
       status: 0,
-      stdout: credentialRefreshAfterAbsenceThisProcess ? "v" + providerVersion() : "absent",
+      stdout: credentialRefreshAfterAbsenceCountThisProcess > 0 ? "v" + providerVersion() : "absent",
       stderr: "",
     };
   }
@@ -542,14 +542,16 @@ describe("MCP add crash consistency", () => {
         .map((result) => `${result.stdout}\n${result.stderr}`)
         .join("\n---\n");
 
-      expect(
-        results.map((result) => result.status).sort(),
-        combinedOutput,
-      ).toEqual([0, 2]);
+      expect(results.map((result) => result.status).sort(), combinedOutput).toEqual([0, 2]);
       expect(results.find((result) => result.status === 2)?.stderr).toContain("already exists");
       expect(combinedOutput).not.toContain("host-only-secret");
       expect(fs.existsSync(path.join(home, "credential-observed-absent.marker"))).toBe(true);
       expect(fs.existsSync(path.join(home, "refresh-after-observed-absence.marker"))).toBe(true);
+      const credentialRefreshCount = fs
+        .readFileSync(path.join(home, "refresh-after-observed-absence.marker"), "utf8")
+        .split("\n")
+        .filter(Boolean).length;
+      expect(credentialRefreshCount).toBe(1);
       expect(fs.existsSync(path.join(home, "provider.marker"))).toBe(true);
       expect(fs.existsSync(path.join(home, "attached.marker"))).toBe(true);
       expect(fs.existsSync(path.join(home, "policy.marker"))).toBe(true);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

PR #9769 fixed delayed MCP credential projection, but its two-process regression recorded refresh occurrence with an overwrite-only marker. That evidence could not distinguish one refresh from repeated refreshes across the competing processes.

This follow-up records every matching credential-free refresh and requires exactly one after both child processes finish. Production behavior is unchanged.

## Related Issue

Follow-up to #9769. Related to #9764.

## Changes

- Replace the delayed-projection fixture's Boolean refresh marker with an append-only count.
- Require exactly one credential-free refresh across both add processes while preserving duplicate rejection, coherent final state, and credential-redaction assertions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security review passed with no findings for commit `98cbb890c` against base `429aa0586`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — `npm run validate:pr` passed against `origin/main` at `429aa0586`.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/mcp-add-crash-consistency.test.ts`, 21 tests passed; `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — Not run. This is a one-file deterministic test-only follow-up; the targeted suite and full `validate:pr` fallback cover the changed contract.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Escaped-defect evidence

The CodeRabbit review on #9769 identified that the shared regression marker proved only that a refresh occurred. Repeated refreshes overwrote the same marker and could pass unnoticed. Commit `98cbb890c` changes the marker to append one fixed, non-sensitive line per refresh and asserts a final count of exactly one after both child processes close.

Documentation writer review: PASS for commit `98cbb890c880a5c0fdb0453f5cb582041c86ee11` against base `429aa058698505e898323562aaf5f42396655e96`. This test-only follow-up strengthens the regression evidence for merged PR #9769 and changes no public command, configuration, workflow, or supported behavior. No public documentation change or docs build is required.

Security review: PASS with no findings for commit `98cbb890c880a5c0fdb0453f5cb582041c86ee11` against base `429aa058698505e898323562aaf5f42396655e96`. The shared marker contains only the fixed text `refresh`, uses mode `0600`, and the existing credential-redaction assertion remains intact. Production authorization and credential handling are unchanged.

---

Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved credential refresh tracking for more consistent behavior during concurrent operations.
  - Credential observations now reliably reflect the refreshed provider version after a successful refresh.
  - Prevented duplicate refresh handling and improved consistency when credentials become available again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->