### PR TITLE
fix(mcp): republish credential after bound policy

### DIFF
--- a/src/lib/actions/sandbox/mcp-bridge-add-restart.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-add-restart.ts
@@ -443,13 +443,14 @@ async function addMcpBridgeUnlocked(
         : {}),
       refreshAfterObservedAbsence: () => {
         // OpenShell 0.0.106 can coalesce a no-field provider refresh without
-        // publishing the credential into fresh sandbox execs. The add still
-        // owns the host credential here, so republish it once after the bound
-        // policy is active. Crash recovery without the host value retains the
-        // credential-free refresh path.
+        // publishing the credential into fresh sandbox execs. When this
+        // process still has the host credential value, republish it once after
+        // the bound policy is active. Crash recovery without the host value
+        // retains the credential-free refresh path.
         const republished = upsertMcpProvider(entry.providerName ?? "", options.env, {
           allowExisting: true,
           expectedProviderId: entry.providerId,
+          requireExisting: true,
         });
         if (republished.action !== "updated") refreshMcpProviderEnvironment(entry);
       },

--- a/src/lib/actions/sandbox/mcp-bridge-add-restart.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-add-restart.ts
@@ -442,11 +442,18 @@ async function addMcpBridgeUnlocked(
           }
         : {}),
       refreshAfterObservedAbsence: () => {
-        // OpenShell 0.0.106 can coalesce a no-field provider refresh without
-        // publishing the credential into fresh sandbox execs. When this
-        // process still has the host credential value, republish it once after
-        // the bound policy is active. Crash recovery without the host value
-        // retains the credential-free refresh path.
+        // invalidState: OpenShell 0.0.106 can coalesce a no-field provider
+        // refresh without publishing the credential into fresh sandbox execs.
+        // sourceBoundary: OpenShell owns provider revision projection.
+        // whyNotSourceFix: NemoClaw can only observe absence after the bound
+        // policy is active, then republish when this process still has the host
+        // credential value. Hostless recovery retains the credential-free path.
+        // regressionTest: mcp-add-crash-consistency.test.ts covers republish
+        // and hostless recovery; mcp-provider-ownership.test.ts covers loss of
+        // the persisted provider identity before republish.
+        // removalCondition: remove the credential-bearing republish when the
+        // supported OpenShell version guarantees that a post-policy no-field
+        // refresh projects the bound credential into fresh sandbox execs.
         const republished = upsertMcpProvider(entry.providerName ?? "", options.env, {
           allowExisting: true,
           expectedProviderId: entry.providerId,

--- a/src/lib/actions/sandbox/mcp-bridge-add-restart.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-add-restart.ts
@@ -441,7 +441,18 @@ async function addMcpBridgeUnlocked(
             previousRevision: previousCredentialRevision,
           }
         : {}),
-      refreshAfterObservedAbsence: () => refreshMcpProviderEnvironment(entry),
+      refreshAfterObservedAbsence: () => {
+        // OpenShell 0.0.106 can coalesce a no-field provider refresh without
+        // publishing the credential into fresh sandbox execs. The add still
+        // owns the host credential here, so republish it once after the bound
+        // policy is active. Crash recovery without the host value retains the
+        // credential-free refresh path.
+        const republished = upsertMcpProvider(entry.providerName ?? "", options.env, {
+          allowExisting: true,
+          expectedProviderId: entry.providerId,
+        });
+        if (republished.action !== "updated") refreshMcpProviderEnvironment(entry);
+      },
     });
     // The adapter was proven absent above, so cleanup is safe even when a
     // command commits config and then fails during its runtime reload.

--- a/src/lib/actions/sandbox/mcp-bridge-provider-mutation.ts
+++ b/src/lib/actions/sandbox/mcp-bridge-provider-mutation.ts
@@ -127,6 +127,7 @@ export function upsertMcpProvider(
   options: {
     allowExisting: boolean;
     expectedProviderId?: string;
+    requireExisting?: boolean;
     prepareMutation?: (action: "create" | "update") => void;
   },
 ): {
@@ -151,6 +152,11 @@ export function upsertMcpProvider(
   if (inspection.exists === null) {
     throw new McpBridgeError(
       inspection.error ?? `Could not inspect OpenShell provider '${providerName}'.`,
+    );
+  }
+  if (inspection.exists === false && options.requireExisting) {
+    throw new McpBridgeError(
+      `OpenShell provider '${providerName}' disappeared before credential republish. Refusing to create a replacement with a different identity.`,
     );
   }
   if (inspection.exists && !options.allowExisting) {

--- a/test/mcp-add-crash-consistency.test.ts
+++ b/test/mcp-add-crash-consistency.test.ts
@@ -55,7 +55,7 @@ let providerGetCount = 0;
 let observedProviderName = null;
 let attachmentAttemptedThisProcess = false;
 let observedCredentialAbsentThisProcess = false;
-let credentialRefreshAfterAbsenceCountThisProcess = 0;
+let credentialRepublishAfterAbsenceCountThisProcess = 0;
 
 const registry = require("./src/lib/state/registry.js");
 const providerCommands = require("./src/lib/adapters/openshell/provider-command.js");
@@ -114,11 +114,12 @@ providerCommands.runOpenshellProviderCommand = (args) => {
       if (isCredentialUpdate) mark("updated");
       if (
         crashAfter === "credential-projection-coalesced" &&
-        isCredentialFreeRefresh &&
+        isCredentialUpdate &&
+        marked("bound-policy") &&
         observedCredentialAbsentThisProcess
       ) {
-        credentialRefreshAfterAbsenceCountThisProcess += 1;
-        fs.appendFileSync(marker("refresh-after-observed-absence"), "refresh\n", { mode: 0o600 });
+        credentialRepublishAfterAbsenceCountThisProcess += 1;
+        fs.appendFileSync(marker("republish-after-observed-absence"), "republish\n", { mode: 0o600 });
       }
     }
     mark("provider");
@@ -175,6 +176,7 @@ policies.applyPresetContent = () => {
   if (crashAfter === "policy-failure") return false;
   fs.appendFileSync(marker("policy-apply-log"), "apply\n", { mode: 0o600 });
   mark("policy");
+  if (marked("attached")) mark("bound-policy");
   if (crashAfter === "policy") process.exit(86);
   return true;
 };
@@ -194,13 +196,13 @@ processRecovery.executeSandboxExecCommand = (_sandbox, command) => {
     !attachmentAttemptedThisProcess;
   isPreupdateObservation && mark("observation");
   if (crashAfter === "credential-projection-coalesced" && isObservation) {
-    if (credentialRefreshAfterAbsenceCountThisProcess === 0) {
+    if (credentialRepublishAfterAbsenceCountThisProcess === 0) {
       observedCredentialAbsentThisProcess = true;
       mark("credential-observed-absent");
     }
     return {
       status: 0,
-      stdout: credentialRefreshAfterAbsenceCountThisProcess > 0 ? "v" + providerVersion() : "absent",
+      stdout: credentialRepublishAfterAbsenceCountThisProcess > 0 ? "v" + providerVersion() : "absent",
       stderr: "",
     };
   }
@@ -546,12 +548,12 @@ describe("MCP add crash consistency", () => {
       expect(results.find((result) => result.status === 2)?.stderr).toContain("already exists");
       expect(combinedOutput).not.toContain("host-only-secret");
       expect(fs.existsSync(path.join(home, "credential-observed-absent.marker"))).toBe(true);
-      expect(fs.existsSync(path.join(home, "refresh-after-observed-absence.marker"))).toBe(true);
-      const credentialRefreshCount = fs
-        .readFileSync(path.join(home, "refresh-after-observed-absence.marker"), "utf8")
+      expect(fs.existsSync(path.join(home, "republish-after-observed-absence.marker"))).toBe(true);
+      const credentialRepublishCount = fs
+        .readFileSync(path.join(home, "republish-after-observed-absence.marker"), "utf8")
         .split("\n")
         .filter(Boolean).length;
-      expect(credentialRefreshCount).toBe(1);
+      expect(credentialRepublishCount).toBe(1);
       expect(fs.existsSync(path.join(home, "provider.marker"))).toBe(true);
       expect(fs.existsSync(path.join(home, "attached.marker"))).toBe(true);
       expect(fs.existsSync(path.join(home, "policy.marker"))).toBe(true);

--- a/test/mcp-add-crash-consistency.test.ts
+++ b/test/mcp-add-crash-consistency.test.ts
@@ -18,6 +18,7 @@ type CrashBoundary =
   | "credential-collision"
   | "credential-command-race"
   | "credential-projection-coalesced"
+  | "credential-projection-delayed-hostless"
   | "registered-credential-collision"
   | "registered-late-collision"
   | "adapter"
@@ -40,7 +41,10 @@ includeSecret ? (process.env.FAKE_MCP_SECRET = "host-only-secret") : delete proc
 const fs = require("node:fs");
 const path = require("node:path");
 const crashAfter = ${JSON.stringify(crashAfter)};
-if (crashAfter === "credential-projection-coalesced") {
+if (
+  crashAfter === "credential-projection-coalesced" ||
+  crashAfter === "credential-projection-delayed-hostless"
+) {
   process.env.NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS = "2";
 }
 const marker = (name) => path.join(process.env.HOME, name + ".marker");
@@ -56,6 +60,7 @@ let observedProviderName = null;
 let attachmentAttemptedThisProcess = false;
 let observedCredentialAbsentThisProcess = false;
 let credentialRepublishAfterAbsenceCountThisProcess = 0;
+let credentialFreeRefreshAfterAbsenceCountThisProcess = 0;
 
 const registry = require("./src/lib/state/registry.js");
 const providerCommands = require("./src/lib/adapters/openshell/provider-command.js");
@@ -120,6 +125,14 @@ providerCommands.runOpenshellProviderCommand = (args) => {
       ) {
         credentialRepublishAfterAbsenceCountThisProcess += 1;
         fs.appendFileSync(marker("republish-after-observed-absence"), "republish\n", { mode: 0o600 });
+      }
+      if (
+        crashAfter === "credential-projection-delayed-hostless" &&
+        isCredentialFreeRefresh &&
+        observedCredentialAbsentThisProcess
+      ) {
+        credentialFreeRefreshAfterAbsenceCountThisProcess += 1;
+        fs.appendFileSync(marker("refresh-after-observed-absence"), "refresh\n", { mode: 0o600 });
       }
     }
     mark("provider");
@@ -203,6 +216,17 @@ processRecovery.executeSandboxExecCommand = (_sandbox, command) => {
     return {
       status: 0,
       stdout: credentialRepublishAfterAbsenceCountThisProcess > 0 ? "v" + providerVersion() : "absent",
+      stderr: "",
+    };
+  }
+  if (crashAfter === "credential-projection-delayed-hostless" && isObservation) {
+    if (credentialFreeRefreshAfterAbsenceCountThisProcess === 0) {
+      observedCredentialAbsentThisProcess = true;
+      mark("credential-observed-absent");
+    }
+    return {
+      status: 0,
+      stdout: credentialFreeRefreshAfterAbsenceCountThisProcess > 0 ? "v" + providerVersion() : "absent",
       stderr: "",
     };
   }
@@ -559,6 +583,31 @@ describe("MCP add crash consistency", () => {
       expect(fs.existsSync(path.join(home, "policy.marker"))).toBe(true);
       expect(fs.existsSync(path.join(home, "adapter.marker"))).toBe(true);
       expect(readBridge(home).addState).toBeUndefined();
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("uses one credential-free refresh when hostless recovery observes absence (#9764)", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-add-hostless-projection-"));
+    try {
+      const interrupted = runAddProcess(home, "adapter");
+      expect(interrupted.status, `${interrupted.stdout}\n${interrupted.stderr}`).toBe(86);
+
+      const resumed = runAddProcess(home, "credential-projection-delayed-hostless", false);
+      expect(resumed.status, `${resumed.stdout}\n${resumed.stderr}`).toBe(0);
+      expect(`${resumed.stdout}\n${resumed.stderr}`).not.toContain("host-only-secret");
+      expect(fs.existsSync(path.join(home, "credential-observed-absent.marker"))).toBe(true);
+      const credentialFreeRefreshCount = fs
+        .readFileSync(path.join(home, "refresh-after-observed-absence.marker"), "utf8")
+        .split("\n")
+        .filter(Boolean).length;
+      expect(credentialFreeRefreshCount).toBe(1);
+      expect(readBridge(home).addState).toBeUndefined();
+      expect(fs.existsSync(path.join(home, "provider.marker"))).toBe(true);
+      expect(fs.existsSync(path.join(home, "attached.marker"))).toBe(true);
+      expect(fs.existsSync(path.join(home, "policy.marker"))).toBe(true);
+      expect(fs.existsSync(path.join(home, "adapter.marker"))).toBe(true);
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }

--- a/test/mcp-provider-ownership.test.ts
+++ b/test/mcp-provider-ownership.test.ts
@@ -497,6 +497,52 @@ process.stdout.write(JSON.stringify({ message, resourceVersion, calls }));
     expect(JSON.stringify(payload.calls)).not.toContain("host-only-secret");
   });
 
+  it("does not recreate a missing provider during credential republish", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-provider-republish-missing-"));
+    const script = String.raw`
+process.env.HOME = ${JSON.stringify(home)};
+process.env.EXPECTED_TOKEN = "host-only-secret";
+const providerCommands = require("./src/lib/adapters/openshell/provider-command.js");
+const calls = [];
+providerCommands.runOpenshellProviderCommand = (args) => {
+  calls.push(args.join(" "));
+  if (args[0] === "provider" && args[1] === "get") {
+    return { status: 1, stdout: "", stderr: "NotFound: provider" };
+  }
+  throw new Error("unexpected call: " + args.join(" "));
+};
+const providerActions = require("./src/lib/actions/sandbox/mcp-bridge-provider.js");
+let message = "";
+try {
+  providerActions.upsertMcpProvider(
+    "alpha-mcp-fake",
+    [{ name: "EXPECTED_TOKEN" }],
+    {
+      allowExisting: true,
+      expectedProviderId: "11111111-2222-4333-8444-555555555555",
+      requireExisting: true,
+    },
+  );
+} catch (error) {
+  message = error.message;
+}
+process.stdout.write(JSON.stringify({ message, calls }));
+`;
+    const result = spawnSync(process.execPath, ["-e", script], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: { ...process.env, HOME: home },
+    });
+    fs.rmSync(home, { recursive: true, force: true });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    const payload = JSON.parse(result.stdout) as { message: string; calls: string[] };
+    expect(payload.message).toContain("disappeared before credential republish");
+    expect(payload.message).toContain("Refusing to create a replacement");
+    expect(payload.calls).toEqual(["provider get alpha-mcp-fake"]);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain("host-only-secret");
+  });
+
   it("never detaches or deletes a non-matching provider in force mode", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-provider-owner-"));
     const script = `


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

OpenShell 0.0.106 can keep an attached MCP credential absent from fresh sandbox execs after a no-field provider refresh. This change republishes the credential once after the bound policy is active, so one concurrent add commits and the duplicate rejects against that winner.

## Related Issue

Follow-up to #9769, #9764, and the merged test coverage in #9772. This failure blocked the exact MCP E2E checks on #9766. Draft #9768 contains an independent fail-first reproduction; no code was transferred from it.

## Changes

- Reuse the existing credential-bearing provider update after a fresh exec observes the credential absent and the bound policy is active.
- Require the persisted provider to exist and match its immutable identity before republish; never create a replacement in this recovery path.
- Retain the credential-free refresh for crash recovery when the host credential is not available.
- Model OpenShell 0.0.106 no-field refresh coalescing at the process boundary and require exactly one credential republish across two serialized adds, plus one credential-free refresh for hostless recovery.
- Preserve one winner, one duplicate rejection, coherent provider, policy, adapter, and registry state, and credential redaction.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior. Justification:
- [ ] Tests not applicable. Justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded. Reviewer, approval link, or justification: Independent nine-category security review passed with no findings for commit `a228268af` against base `46e10df22`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer. Check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable. `npm run validate:pr` passed on executable head `a3917b343` against `origin/main` at `46e10df22`; the comment-only `a228268af` follow-up passed normal commit hooks.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above. Fail-first produced two synchronization failures and statuses `[2, 2]`; after the fix, `npx vitest run test/mcp-add-crash-consistency.test.ts test/mcp-provider-ownership.test.ts src/lib/actions/sandbox/mcp-bridge-provider.test.ts` passed 59 tests, and `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed. Not run. The direct process-boundary and provider suites plus full repository PR validation cover this focused four-file change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Escaped-defect evidence

Exact MCP E2E run 32401056850 failed both OpenClaw discovery passes at `test/e2e/live/mcp-bridge.test.ts:277`. Each pass observed zero successful concurrent adds because both commands rolled back after OpenShell did not synchronize `FAKE_MCP_SECRET` into fresh sandbox execs. The tightened deterministic fixture reproduced the same `[2, 2]` no-winner result before the production change.

Documentation writer review: PASS with result `no-docs-needed` for commit `a228268afbf6473408504e1c353b4feff49a4413` against base `46e10df221853bca151281faf10ae7417505439f`. This restores the existing `mcp add` contract and changes no public command, flag, default, configuration, schema, output contract, agent behavior, or operator step. Agent: Codex Desktop. `AGENTS.md` blob SHA: `513518cdfca42e3a18fed71109e6d0eb60151d13`. Changed documentation paths: none.

Security review: PASS with no findings for commit `a228268afbf6473408504e1c353b4feff49a4413` against base `46e10df221853bca151281faf10ae7417505439f`. Credential-bearing republish is bounded, update-only, and requires the persisted immutable provider identity. Missing and mismatched providers fail before credential mutation; hostless recovery retains the credential-free path; output remains redacted.

---

Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential recovery when provider connections are interrupted or resumed without a host.
  * Prevented credential refresh operations from recreating missing providers under a new identity.
  * Ensured recovery performs only one appropriate operation during concurrent or delayed resume scenarios.
  * Continued protecting credential values during failed provider recovery.

* **Tests**
  * Added coverage for crash recovery, hostless resumes, concurrent operations, and provider ownership safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->