### PR TITLE
fix(onboard): align Hermes Portable OpenShell version

### DIFF
--- a/src/lib/adapters/openshell/resolve-shared.ts
+++ b/src/lib/adapters/openshell/resolve-shared.ts
@@ -11,7 +11,7 @@ import {
 } from "../podman/executable-authority";
 import { resolveOpenshell } from "./resolve";
 
-export const HERMES_PORTABLE_OPENSHELL_VERSION = "0.0.101" as const;
+export const HERMES_PORTABLE_OPENSHELL_VERSION = "0.0.106" as const;
 const VERSION_TIMEOUT_MS = 5_000;
 const VERSION_MAX_BUFFER_BYTES = 16 * 1024;
 const SEMVER_PATTERN = /(?:^|[^0-9.])([0-9]+\.[0-9]+\.[0-9]+)(?![0-9.])/u;

--- a/src/lib/adapters/openshell/resolve.test.ts
+++ b/src/lib/adapters/openshell/resolve.test.ts
@@ -46,7 +46,7 @@ function executableAuthorityHarness() {
     resolve: (env) => env.NEMOCLAW_OPENSHELL_BIN ?? AUTHORITY_BINARY,
     runVersion: () => ({
       status: 0,
-      stdout: "openshell 0.0.101\n",
+      stdout: "openshell 0.0.106\n",
       stderr: "",
     }),
   };
@@ -184,7 +184,7 @@ describe("lib/resolve-openshell", () => {
 describe("Hermes portable OpenShell executable authority", () => {
   const childEnv = { HOME: "/home/test", PATH: "/opt/nemoclaw/bin" };
 
-  it("captures and reuses the exact canonical OpenShell 0.0.101 generation (#9203)", () => {
+  it("captures and reuses the exact canonical OpenShell 0.0.106 generation (#9211)", () => {
     const harness = executableAuthorityHarness();
     const authority = captureHermesPortableOpenShellExecutableAuthority(
       AUTHORITY_BINARY,
@@ -193,7 +193,7 @@ describe("Hermes portable OpenShell executable authority", () => {
       harness.deps,
     );
 
-    expect(authority.version).toBe("0.0.101");
+    expect(authority.version).toBe("0.0.106");
     expect(authority.executable.executablePath).toBe(AUTHORITY_BINARY);
     expect(
       assertHermesPortableOpenShellExecutableAuthority(
@@ -280,7 +280,7 @@ describe("Hermes portable OpenShell executable authority", () => {
     ).toThrow("executable generation changed after reservation");
   });
 
-  it("rejects version mismatch before authority is captured or reused (#9203)", () => {
+  it("rejects OpenShell 0.0.101 before authority capture or reuse (#9211)", () => {
     const harness = executableAuthorityHarness();
     expect(() =>
       captureHermesPortableOpenShellExecutableAuthority(
@@ -289,10 +289,10 @@ describe("Hermes portable OpenShell executable authority", () => {
         childEnv,
         {
           ...harness.deps,
-          runVersion: () => ({ status: 0, stdout: "openshell 0.0.102\n", stderr: "" }),
+          runVersion: () => ({ status: 0, stdout: "openshell 0.0.101\n", stderr: "" }),
         },
       ),
-    ).toThrow("requires OpenShell 0.0.101");
+    ).toThrow("requires OpenShell 0.0.106");
 
     const reuseHarness = executableAuthorityHarness();
     const authority = captureHermesPortableOpenShellExecutableAuthority(
@@ -308,9 +308,9 @@ describe("Hermes portable OpenShell executable authority", () => {
         childEnv,
         {
           ...reuseHarness.deps,
-          runVersion: () => ({ status: 0, stdout: "openshell 0.0.102\n", stderr: "" }),
+          runVersion: () => ({ status: 0, stdout: "openshell 0.0.101\n", stderr: "" }),
         },
       ),
-    ).toThrow("requires OpenShell 0.0.101");
+    ).toThrow("requires OpenShell 0.0.106");
   });
 });

--- a/src/lib/onboard/created-sandbox-finalization.test.ts
+++ b/src/lib/onboard/created-sandbox-finalization.test.ts
@@ -950,7 +950,7 @@ describe("created sandbox completion actions", () => {
               sandboxGpuDevice: null,
               sandboxGpuProof: null,
               openshellDriver: "docker",
-              openshellVersion: "0.0.101",
+              openshellVersion: "0.0.106",
             },
             agent: null,
             agentVersionKnown: true,

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
@@ -71,7 +71,7 @@ function directoryChain(directory: string): string[] {
 
 function openshellExecutableAuthority(): HermesPortableOpenShellExecutableAuthority {
   return {
-    version: "0.0.101",
+    version: "0.0.106",
     executable: {
       executablePath: "/usr/bin/openshell",
       device: "1",
@@ -296,7 +296,7 @@ function lifecycleDeps(receipt: HermesPortableConfiguredReceipt, initiallyRunnin
           gatewayName: GATEWAY,
           lifecycleGeneration: GENERATION,
           lifecycleLiveIdentityFingerprint: liveIdentityFingerprint,
-          openshellVersion: "0.0.101",
+          openshellVersion: "0.0.106",
         }) as SandboxEntry,
       captureOpenShell,
       assertOpenShellExecutableAuthority: vi.fn(() => "/usr/bin/openshell"),

--- a/src/lib/onboard/experimental/hermes-portable-onboarding.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-onboarding.test.ts
@@ -823,11 +823,14 @@ describe("Hermes portable onboarding transaction", () => {
       gatewayName: "nemoclaw",
       lifecycleGeneration: "generation-1",
       openshellDriver: "docker",
-      openshellVersion: "0.0.101",
+      openshellVersion: "0.0.106",
     };
 
     expect(classifyHermesPortableRegistry(receipt, null)).toEqual({ kind: "missing" });
     expect(classifyHermesPortableRegistry(receipt, matching)).toMatchObject({ kind: "matching" });
+    expect(
+      classifyHermesPortableRegistry(receipt, { ...matching, openshellVersion: "0.0.101" }),
+    ).toMatchObject({ kind: "conflict" });
     expect(
       classifyHermesPortableRegistry(receipt, { ...matching, lifecycleGeneration: "other" }),
     ).toMatchObject({ kind: "conflict" });

--- a/src/lib/onboard/experimental/hermes-portable-policy-authority.ts
+++ b/src/lib/onboard/experimental/hermes-portable-policy-authority.ts
@@ -141,7 +141,7 @@ function capturePolicy(
 }
 
 /**
- * Prove the current 0.0.101 Hermes matrix's empty provider projection.
+ * Prove the current 0.0.106 Hermes matrix's empty provider projection.
  * Both reads are explicitly gateway and sandbox scoped. A non-empty full/base
  * delta is unsupported until OpenShell exposes an authoritative projection.
  */

--- a/src/lib/onboard/experimental/hermes-portable-receipt.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-receipt.test.ts
@@ -148,7 +148,7 @@ function socketAuthority(): PodmanSocketAuthority {
 
 function openshellExecutableAuthority(): HermesPortableOpenShellExecutableAuthority {
   return {
-    version: "0.0.101",
+    version: "0.0.106",
     executable: {
       executablePath: "/usr/bin/openshell",
       device: "1",
@@ -397,6 +397,21 @@ describe("Hermes portable receipt authority", () => {
     const directory = hermesPortableReceiptDirectory(SANDBOX, stateDir);
 
     expect(() => publish(wrongVersion as never)).toThrow("invalid Podman executable authority");
+    expect(fs.existsSync(path.join(directory, "pending.json"))).toBe(false);
+  });
+
+  it("rejects an OpenShell 0.0.101 receipt before writing a stage (#9211)", () => {
+    const receipt = pending();
+    const staleVersion = {
+      ...receipt,
+      openshellExecutableAuthority: {
+        ...receipt.openshellExecutableAuthority,
+        version: "0.0.101",
+      },
+    };
+    const directory = hermesPortableReceiptDirectory(SANDBOX, stateDir);
+
+    expect(() => publish(staleVersion as never)).toThrow("invalid OpenShell executable authority");
     expect(fs.existsSync(path.join(directory, "pending.json"))).toBe(false);
   });
 

--- a/src/lib/onboard/sandbox-create/orchestration.ts
+++ b/src/lib/onboard/sandbox-create/orchestration.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SandboxCreateOrchestrationRuntime } from "../../onboard";
+import { HERMES_PORTABLE_OPENSHELL_VERSION } from "../../adapters/openshell/resolve-shared";
 import type { AgentDefinition } from "../../agent/defs";
 import type { WebSearchConfig } from "../../inference/web-search";
 import type { BackupResult } from "../../state/sandbox";
@@ -1054,7 +1055,7 @@ export function createSandboxWithBaseImageResolution(runtime: SandboxCreateOrche
     const sandboxRuntimeFields = agentCreateInput.hermesPortableLifecycle
       ? sandboxRegistryMetadata.getHermesPortableSandboxRuntimeRegistryFields(
           effectiveSandboxGpuConfig,
-          "0.0.101",
+          HERMES_PORTABLE_OPENSHELL_VERSION,
         )
       : getSandboxRuntimeRegistryFields(effectiveSandboxGpuConfig);
     const createdSandboxCompletion = createOnboardCreatedSandboxCompletion(

--- a/src/lib/onboard/sandbox-registry-metadata.ts
+++ b/src/lib/onboard/sandbox-registry-metadata.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { AgentDefinition } from "../agent/defs";
+import type { HERMES_PORTABLE_OPENSHELL_VERSION } from "../adapters/openshell/resolve-shared";
 import type { SandboxEntry } from "../state/registry";
 import * as registry from "../state/registry";
 import { getSandboxAgentRegistryFields } from "./sandbox-agent";
@@ -42,7 +43,7 @@ export interface SandboxRegistryMetadataHelpers {
 /** Build schema-5 runtime fields without ambient driver or OpenShell discovery. */
 export function getHermesPortableSandboxRuntimeRegistryFields(
   config: SandboxGpuConfig,
-  openshellVersion: "0.0.101",
+  openshellVersion: typeof HERMES_PORTABLE_OPENSHELL_VERSION,
 ): ReturnType<SandboxRegistryMetadataHelpers["getSandboxRuntimeRegistryFields"]> {
   return {
     gpuEnabled: config.sandboxGpuEnabled,

--- a/test/helpers/hermes-portable-onboarding-fixture.ts
+++ b/test/helpers/hermes-portable-onboarding-fixture.ts
@@ -104,7 +104,7 @@ export function unexpectedHermesPortablePodmanArgs(args: readonly string[]): nev
 
 export function hermesPortableTestOpenShellAuthority(): HermesPortableOpenShellExecutableAuthority {
   return {
-    version: "0.0.101",
+    version: "0.0.106",
     executable: {
       executablePath: "/usr/bin/openshell",
       device: "1",

--- a/test/onboard-openshell-version.test.ts
+++ b/test/onboard-openshell-version.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { HERMES_PORTABLE_OPENSHELL_VERSION } from "../src/lib/adapters/openshell/resolve-shared";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
@@ -146,7 +147,7 @@ describe("OpenShell version helpers", () => {
     }
   });
 
-  it("shipped blueprint.yaml exposes parseable min/max OpenShell versions", () => {
+  it("keeps Hermes Portable aligned with both shipped OpenShell bounds (#9211)", () => {
     const min = getBlueprintMinOpenshellVersion(repoRoot);
     const max = getBlueprintMaxOpenshellVersion(repoRoot);
     expect(min).not.toBe(null);
@@ -154,6 +155,8 @@ describe("OpenShell version helpers", () => {
     expect(/^[0-9]+\.[0-9]+\.[0-9]+/.test(min || "")).toBe(true);
     expect(/^[0-9]+\.[0-9]+\.[0-9]+/.test(max || "")).toBe(true);
     expect(versionGte(max, min)).toBe(true);
+    expect(HERMES_PORTABLE_OPENSHELL_VERSION).toBe(min);
+    expect(HERMES_PORTABLE_OPENSHELL_VERSION).toBe(max);
   });
 
   it("reads max_openshell_version from blueprint.yaml", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hermes Portable required OpenShell `0.0.101`, but the shipped blueprint requires exactly `0.0.106`. This PR aligns the executable authority and registry metadata with `0.0.106`. It rejects `0.0.101` before authority capture or reuse, receipt publication, or registry reuse.

## Related Issue

Related to #9211.

## Changes

- Change the exact Hermes Portable OpenShell authority and matrix fixtures to `0.0.106`.
- Derive Hermes Portable sandbox registry metadata from the shared exact-version authority.
- Add regression tests that bind the authority to both blueprint bounds and reject `0.0.101` during executable capture, reuse, receipt publication, and registry classification.
- Preserve the existing fail-closed checks for executable path, inode, digest, receipt, registry, and lifecycle authority. This PR adds no fallback or receipt migration.
- Record an independent documentation writer review result of `no-docs-needed`; public documentation has no current Hermes Portable `0.0.101` compatibility claim.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Codex Desktop security review returned PASS with no findings for commit `b81c91fedcc2753b6da304e349a36747d7e0048f`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
  - `node_modules/.bin/vitest run --project cli src/lib/adapters/openshell/resolve.test.ts src/lib/onboard/created-sandbox-finalization.test.ts src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts src/lib/onboard/experimental/hermes-portable-onboarding.test.ts src/lib/onboard/experimental/hermes-portable-receipt.test.ts`: 5 files and 128 tests passed.
  - `node_modules/.bin/vitest run --project integration test/onboard-openshell-version.test.ts`: 29 tests passed.
  - `node_modules/.bin/vitest run --project installer-integration test/install-hermes-portable-active.test.ts`: 3 tests passed.
  - `npm run test:changed`: 355 files passed; 5,162 tests passed and 2 skipped.
  - `npm run build:cli`, `npm run typecheck:cli`, and `npm run checks:repository` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

The recorded evidence comes from deterministic local tests, checks, and independent reviews. This PR does not claim Brev evidence or live E2E qualification.

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Hermes Portable OpenShell runtime to version 0.0.106.
  * Sandbox metadata and onboarding flows now consistently use the updated runtime version.

* **Bug Fixes**
  * Older OpenShell versions are now rejected when authority, receipt, or registry data is stale.

* **Tests**
  * Expanded coverage to verify version compatibility, rejection behavior, and runtime metadata consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->