### PR TITLE
fix(inference): validate llama.cpp candidate manifests

### DIFF
--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -546,13 +546,28 @@ jobs:
             exit 1
           fi
           reference="$IMAGE@$digest"
-          scripts/checks/validate-managed-base-index.sh \
-            "$reference" \
-            "${platform_digests[linux/amd64]}" \
-            "${platform_digests[linux/arm64]}"
           install -d -m 0700 "$RUNNER_TEMP/llama-cpp-candidate"
           docker buildx imagetools inspect "$reference" --raw \
             > "$RUNNER_TEMP/llama-cpp-candidate/candidate-index.json"
+          if ! jq -e \
+            --arg amd64 "${platform_digests[linux/amd64]}" \
+            --arg arm64 "${platform_digests[linux/arm64]}" '
+              (keys | sort) == ["manifests", "mediaType", "schemaVersion"]
+              and .schemaVersion == 2
+              and .mediaType == "application/vnd.oci.image.index.v1+json"
+              and (.manifests | type == "array" and length == 2)
+              and all(.manifests[];
+                (keys | sort) == ["digest", "mediaType", "platform", "size"]
+                and .mediaType == "application/vnd.oci.image.manifest.v1+json"
+                and (.size | type == "number" and . > 0 and floor == .)
+                and (.platform | keys | sort) == ["architecture", "os"]
+              )
+              and ([.manifests[] | select(.platform == {os:"linux", architecture:"amd64"} and .digest == $amd64)] | length) == 1
+              and ([.manifests[] | select(.platform == {os:"linux", architecture:"arm64"} and .digest == $arm64)] | length) == 1
+            ' "$RUNNER_TEMP/llama-cpp-candidate/candidate-index.json" >/dev/null; then
+            echo "ERROR: candidate index does not match the exact platform digests." >&2
+            exit 1
+          fi
           actual_digest="sha256:$(sha256sum "$RUNNER_TEMP/llama-cpp-candidate/candidate-index.json" | awk '{print $1}')"
           if [ "$actual_digest" != "$digest" ]; then
             echo "ERROR: candidate index bytes do not match its registry digest." >&2

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -155,6 +155,21 @@ fi
   }
 }
 
+function candidateIndexFilter(step: Step): string {
+  const source = required(step.run, "candidate assembly script is missing");
+  const match = /--arg arm64 [^\n]+ '\n(?<filter>[\s\S]*?)\n\s+' "\$RUNNER_TEMP\/llama-cpp-candidate\/candidate-index\.json"/u.exec(
+    source,
+  );
+  return required(match?.groups?.filter, "candidate index jq filter is missing");
+}
+
+function runCandidateIndexFilter(filter: string, candidate: unknown, amd64: string, arm64: string) {
+  return spawnSync("jq", ["-e", "--arg", "amd64", amd64, "--arg", "arm64", arm64, filter], {
+    encoding: "utf8",
+    input: JSON.stringify(candidate),
+  });
+}
+
 describe("llama.cpp image PR workflow", () => {
   const config = required(workflow.jobs?.config, "config job is missing");
   const build = required(workflow.jobs?.["pr-build"], "native PR build job is missing");
@@ -364,10 +379,48 @@ describe("llama.cpp image PR workflow", () => {
     expect(assembleStep.run).toContain(
       'docker buildx imagetools create --tag "$IMAGE:$CANDIDATE_TAG" "${sources[@]}"',
     );
-    expect(assembleStep.run).toContain("scripts/checks/validate-managed-base-index.sh");
+    expect(assembleStep.run).not.toContain("scripts/checks/validate-managed-base-index.sh");
     expect(assembleStep.run).toContain("candidate-index.json");
     expect(assembleStep.run).toContain("platform-digests.json");
     expect(assembleStep.run).not.toMatch(/latest|stable|release/iu);
+  });
+
+  it("accepts direct platform manifests and rejects descriptor drift (#8231)", () => {
+    const assemble = required(
+      workflow.jobs?.["assemble-candidate"],
+      "candidate assembly job is missing",
+    );
+    const assembleStep = namedStep(assemble, "Assemble candidate index and capture exact digest");
+    const descriptor = (architecture: string, digest: string) => ({
+      digest,
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      platform: { architecture, os: "linux" },
+      size: 4096,
+    });
+    const amd64 = `sha256:${"a".repeat(64)}`;
+    const arm64 = `sha256:${"b".repeat(64)}`;
+    const filter = candidateIndexFilter(assembleStep);
+    const candidate = (manifests: ReturnType<typeof descriptor>[]) => ({
+      manifests,
+      mediaType: "application/vnd.oci.image.index.v1+json",
+      schemaVersion: 2,
+    });
+
+    const accepted = runCandidateIndexFilter(
+      filter,
+      candidate([descriptor("amd64", amd64), descriptor("arm64", arm64)]),
+      amd64,
+      arm64,
+    );
+    expect(accepted.status, accepted.stderr).toBe(0);
+
+    const rejected = runCandidateIndexFilter(
+      filter,
+      candidate([descriptor("amd64", arm64), descriptor("arm64", amd64)]),
+      amd64,
+      arm64,
+    );
+    expect(rejected.status).toBe(1);
   });
 
   it("requires an anonymous exact-digest pull after publication and before candidate assembly (#8250)", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The llama.cpp publication workflow assembled the correct two-platform candidate, then applied the sandbox base-image validator to direct platform manifests. This change validates the candidate against the exact amd64 and arm64 manifest digests so publication can continue to scanning, signing, and receipt generation.

## Related Issue

Part of #8231.
Prerequisite for #9592.

## Changes

- Replace the sandbox base-image validator with the llama.cpp candidate's direct two-platform manifest contract.
- Add behavior coverage that accepts exact direct manifests and rejects swapped platform digests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed the main-only publication gate, exact digest binding, credential removal, anonymous pull ordering, partial-write state, and no-consumer-alias boundary. The change preserves fail-closed descriptor validation and does not change credential access or consumer selection.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this PR does not change `scripts/prepare-dgx-station-host.sh`.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — `npm run validate:pr` passed.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/llama-cpp-image-workflow.test.ts test/llama-cpp-image.test.ts test/llama-cpp-image-publication-evidence.test.ts test/llama-cpp-dgx-spark-qualification-plan.test.ts test/llama-cpp-dgx-spark-qualification-contract.test.ts` passed 91 tests in 5 files.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new doc pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of container image indexes before release.
  * Ensured indexes contain valid Linux amd64 and arm64 manifests with positive sizes and expected platform digests.
  * Prevented incorrectly swapped architecture-to-digest mappings from being accepted.

* **Tests**
  * Added coverage for valid multi-platform indexes and invalid digest mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->