### PR TITLE
test(mcp): reproduce concurrent fixture registration replacement

### DIFF
--- a/test/mcp-add-crash-consistency.test.ts
+++ b/test/mcp-add-crash-consistency.test.ts
@@ -32,6 +32,7 @@ function buildAddProcessScript(
   home: string,
   crashAfter: CrashBoundary,
   includeSecret = true,
+  registrationGate = "",
 ): string {
   return String.raw`
 process.env.HOME = ${JSON.stringify(home)};
@@ -40,12 +41,21 @@ includeSecret ? (process.env.FAKE_MCP_SECRET = "host-only-secret") : delete proc
 const fs = require("node:fs");
 const path = require("node:path");
 const crashAfter = ${JSON.stringify(crashAfter)};
+const registrationGate = ${JSON.stringify(registrationGate)};
 if (crashAfter === "credential-projection-coalesced") {
   process.env.NEMOCLAW_MCP_PROVIDER_SYNC_TIMEOUT_SECONDS = "2";
 }
 const marker = (name) => path.join(process.env.HOME, name + ".marker");
 const mark = (name) => fs.writeFileSync(marker(name), "yes\n", { mode: 0o600 });
 const marked = (name) => fs.existsSync(marker(name));
+const waitForMarked = (name) => {
+  const deadline = Date.now() + 10_000;
+  const sleep = new Int32Array(new SharedArrayBuffer(4));
+  while (!marked(name)) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for " + name);
+    Atomics.wait(sleep, 0, 0, 10);
+  }
+};
 const providerVersion = () => Number.parseInt(marked("provider-version") ? fs.readFileSync(marker("provider-version"), "utf8") : "1", 10);
 const setProviderVersion = (version) => fs.writeFileSync(marker("provider-version"), String(version), { mode: 0o600 });
 const providerPresentAtStart = marked("provider");
@@ -240,7 +250,13 @@ processRecovery.executeSandboxCommand = (_sandbox, command) => {
   };
 };
 
-if (!registry.getSandbox("crash-test")) {
+const sandboxMissing = !registry.getSandbox("crash-test");
+if (registrationGate && sandboxMissing) {
+  mark(registrationGate + "-registration-ready");
+  waitForMarked("release-" + registrationGate + "-registration");
+}
+if (sandboxMissing) {
+  fs.appendFileSync(marker("sandbox-registration-log"), registrationGate + "\n", { mode: 0o600 });
   registry.registerSandbox({
     name: "crash-test",
     agent: "openclaw",
@@ -295,8 +311,18 @@ function collectProcess(child: ChildProcessWithoutNullStreams): Promise<{
   child.stdout.on("data", (chunk: string) => (stdout += chunk));
   child.stderr.on("data", (chunk: string) => (stderr += chunk));
   return new Promise((resolve, reject) => {
-    child.once("error", reject);
-    child.once("close", (status) => resolve({ status, stdout, stderr }));
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`Timed out waiting for child process ${child.pid ?? "unknown"}`));
+    }, 30_000);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (status) => {
+      clearTimeout(timer);
+      resolve({ status, stdout, stderr });
+    });
   });
 }
 
@@ -530,18 +556,47 @@ function readBridge(home: string): Record<string, unknown> {
   return parsed.sandboxes["crash-test"].mcp.bridges.fake;
 }
 
+function releaseRegistration(home: string, gate: string): void {
+  fs.writeFileSync(path.join(home, `release-${gate}-registration.marker`), "yes\n", {
+    mode: 0o600,
+  });
+}
+
 describe("MCP add crash consistency", () => {
   it("commits one bridge and rejects one duplicate after delayed credential projection (#9764)", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mcp-add-concurrent-projection-"));
+    let first: ChildProcessWithoutNullStreams | undefined;
+    let second: ChildProcessWithoutNullStreams | undefined;
     try {
-      const script = buildAddProcessScript(home, "credential-projection-coalesced");
-      const first = spawnScript(home, script);
-      const second = spawnScript(home, script);
-      const results = await Promise.all([collectProcess(first), collectProcess(second)]);
+      first = spawnScript(
+        home,
+        buildAddProcessScript(home, "credential-projection-coalesced", true, "winner"),
+      );
+      second = spawnScript(
+        home,
+        buildAddProcessScript(home, "credential-projection-coalesced", true, "late"),
+      );
+      await Promise.all([
+        waitForMarker(home, "winner-registration-ready"),
+        waitForMarker(home, "late-registration-ready"),
+      ]);
+
+      releaseRegistration(home, "winner");
+      const firstResult = await collectProcess(first);
+      expect(firstResult.status, `${firstResult.stdout}\n${firstResult.stderr}`).toBe(0);
+
+      releaseRegistration(home, "late");
+      const secondResult = await collectProcess(second);
+      const results = [firstResult, secondResult];
       const combinedOutput = results
         .map((result) => `${result.stdout}\n${result.stderr}`)
         .join("\n---\n");
 
+      const sandboxRegistrationCount = fs
+        .readFileSync(path.join(home, "sandbox-registration-log.marker"), "utf8")
+        .split("\n")
+        .filter(Boolean).length;
+      expect(sandboxRegistrationCount).toBe(1);
       expect(results.map((result) => result.status).sort(), combinedOutput).toEqual([0, 2]);
       expect(results.find((result) => result.status === 2)?.stderr).toContain("already exists");
       expect(combinedOutput).not.toContain("host-only-secret");
@@ -558,6 +613,10 @@ describe("MCP add crash consistency", () => {
       expect(fs.existsSync(path.join(home, "adapter.marker"))).toBe(true);
       expect(readBridge(home).addState).toBeUndefined();
     } finally {
+      releaseRegistration(home, "winner");
+      releaseRegistration(home, "late");
+      first?.kill("SIGKILL");
+      second?.kill("SIGKILL");
       fs.rmSync(home, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The concurrent MCP test lets both child processes conditionally register the same sandbox, so a late registration can replace state committed by the winning child. This fail-first draft records the fixture race with a bounded process schedule before moving registration to the parent fixture. The PR changes only the test fixture and does not claim the live MCP product correction in #9788.

## Related Issue

Related #9764.

## Changes

- Hold both child processes after they observe that the sandbox is absent.
- Release the winning child before the late child performs its stale registration.
- Require exactly one sandbox registration while retaining the duplicate-rejection, resource-marker, committed-bridge, and credential-redaction assertions.
- Bound each child collection at 30 seconds and each fixture gate at 10 seconds.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm exec -- vitest run --project integration test/mcp-add-crash-consistency.test.ts -t 'commits one bridge and rejects one duplicate after delayed credential projection'` reports one intended failure and 20 skipped tests: `sandboxRegistrationCount` expected 1 and received 2. The implementation commit will make this assertion pass.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Fail-first evidence

Commit `24de7b3ef3634056b861a0edce93d9157a56303f` schedules both children after the same absent-sandbox observation. The winning child completes before the late child resumes. The exact focused test then reports one failure because two registrations occurred instead of one; 20 sibling tests are skipped.

`npm run source-shape:check` reports zero source-shape cases and assertions. `npm run test-size:check` passes 32 tests. Normal pre-commit, commit-msg, and pre-push hooks pass.

Root key: `MCP test / concurrent fixture bootstrap / second conditional registerSandbox replaces winner state`.

---

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
