### PR TITLE
fix(release): restore the LKG production image dispatch

### DIFF
--- a/.github/workflows/release-lkg-brev-image.yaml
+++ b/.github/workflows/release-lkg-brev-image.yaml
@@ -16,49 +16,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  attest-lkg-image-request:
-    if: ${{ github.repository == 'NVIDIA/NemoClaw' && github.event_name == 'push' && github.ref == 'refs/tags/lkg' && github.event.deleted == false && github.run_attempt == 1 }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      attestations: write
-      id-token: write
-    steps:
-      - name: Check out LKG target
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.sha }}
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Prepare LKG image request
-        env:
-          LKG_DELETED: ${{ github.event.deleted }}
-          LKG_REQUEST_PATH: nemoclaw-lkg-image-request.v1.json
-          LKG_SHA: ${{ github.sha }}
-        run: scripts/release-lkg-brev-image.sh prepare-request
-
-      - name: Upload LKG image request
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: nemoclaw-lkg-image-request-v1-${{ github.run_id }}-${{ github.run_attempt }}
-          path: nemoclaw-lkg-image-request.v1.json
-          if-no-files-found: error
-          retention-days: 30
-
-      - name: Attest LKG image request
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
-        with:
-          subject-path: nemoclaw-lkg-image-request.v1.json
-
   dispatch-production-image:
-    needs: attest-lkg-image-request
-    if: ${{ success() && github.repository == 'NVIDIA/NemoClaw' && github.event_name == 'push' && github.ref == 'refs/tags/lkg' && github.event.deleted == false && github.run_attempt == 1 }}
+    if: ${{ github.repository == 'NVIDIA/NemoClaw' && github.event.deleted == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: read
     steps:
       - name: Check out LKG target
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -67,9 +28,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Dispatch production and LKG-only image builds
+      - name: Dispatch production image build
         env:
-          LKG_DELETED: ${{ github.event.deleted }}
           LKG_SHA: ${{ github.sha }}
           NEMOCLAW_IMAGE_DISPATCH_TOKEN: ${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}
-        run: scripts/release-lkg-brev-image.sh dispatch-images
+        run: scripts/release-lkg-brev-image.sh

--- a/.github/workflows/release-lkg-brev-image.yaml
+++ b/.github/workflows/release-lkg-brev-image.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   dispatch-production-image:
-    if: ${{ github.repository == 'NVIDIA/NemoClaw' && github.event.deleted == false }}
+    if: ${{ github.repository == 'NVIDIA/NemoClaw' && github.event.deleted == false && github.run_attempt == 1 }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -162,6 +162,11 @@
       "category": "security"
     },
     {
+      "file": "test/release-lkg-brev-image.test.ts",
+      "test": "keeps the LKG credential on the production-only dispatch step (#9798)",
+      "category": "security"
+    },
+    {
       "file": "test/repro-4538-raw-doctor-perms.test.ts",
       "test": "emitted openclaw() guard restores the contract AND preserves a nonzero exit",
       "category": "security"

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -162,11 +162,6 @@
       "category": "security"
     },
     {
-      "file": "test/release-lkg-brev-image.test.ts",
-      "test": "attests one request before the isolated dispatch job (#9661)",
-      "category": "security"
-    },
-    {
       "file": "test/repro-4538-raw-doctor-perms.test.ts",
       "test": "emitted openclaw() guard restores the contract AND preserves a nonzero exit",
       "category": "security"

--- a/scripts/release-lkg-brev-image.sh
+++ b/scripts/release-lkg-brev-image.sh
@@ -5,59 +5,31 @@
 set -euo pipefail
 
 TARGET_REPOSITORY="brevdev/nemoclaw-image"
-PRODUCTION_WORKFLOW="build-scheduled.yml"
-LKG_WORKFLOW="build-lkg-image.yml"
+TARGET_WORKFLOW="build-scheduled.yml"
 TARGET_REF="main"
-SOURCE_REPOSITORY="NVIDIA/NemoClaw"
-SOURCE_WORKFLOW=".github/workflows/release-lkg-brev-image.yaml"
-SOURCE_EVENT="push"
-SOURCE_REF="refs/tags/lkg"
-REQUEST_KIND="nemoclaw-lkg-image-request"
-REQUEST_SCHEMA_VERSION="1"
-REQUEST_FILENAME="nemoclaw-lkg-image-request.v1.json"
 SUMMARY_PATH="${GITHUB_STEP_SUMMARY:-/dev/null}"
 
 lkg_commit="unresolved"
 release_tag="none"
-production_dispatch_result="not attempted"
-production_run_id="unavailable"
-production_run_url=""
-lkg_dispatch_result="not attempted"
-lkg_run_id="unavailable"
-lkg_run_url=""
-last_dispatch_result="not attempted"
-last_run_id="unavailable"
-last_run_url=""
+dispatch_result="not attempted"
+downstream_run_id="unavailable"
+downstream_run_url=""
 
 write_summary() {
   {
-    echo "## LKG Brev image dispatches"
+    echo "## LKG production image dispatch"
     echo
     echo "- LKG commit: \`$lkg_commit\`"
     echo "- Release tag: \`$release_tag\`"
-    echo "- Source run: \`${GITHUB_RUN_ID:-unavailable}\` (attempt \`${GITHUB_RUN_ATTEMPT:-unavailable}\`)"
-    echo
-    echo "### Production image"
-    echo
-    echo "- Target: \`$TARGET_REPOSITORY/.github/workflows/$PRODUCTION_WORKFLOW@$TARGET_REF\`"
-    echo "- Dispatch result: \`$production_dispatch_result\`"
-    if [[ -n "$production_run_url" ]]; then
-      echo "- Downstream run: [$production_run_id]($production_run_url)"
+    echo "- Target: \`$TARGET_REPOSITORY/.github/workflows/$TARGET_WORKFLOW@$TARGET_REF\`"
+    echo "- Dispatch result: \`$dispatch_result\`"
+    if [[ -n "$downstream_run_url" ]]; then
+      echo "- Downstream run: [$downstream_run_id]($downstream_run_url)"
+      echo
+      echo "Follow the downstream run to terminal success and verify production image promotion."
     else
-      echo "- Downstream run: \`$production_run_id\`"
+      echo "- Downstream run: \`$downstream_run_id\`"
     fi
-    echo
-    echo "### LKG-only image"
-    echo
-    echo "- Target: \`$TARGET_REPOSITORY/.github/workflows/$LKG_WORKFLOW@$TARGET_REF\`"
-    echo "- Dispatch result: \`$lkg_dispatch_result\`"
-    if [[ -n "$lkg_run_url" ]]; then
-      echo "- Downstream run: [$lkg_run_id]($lkg_run_url)"
-    else
-      echo "- Downstream run: \`$lkg_run_id\`"
-    fi
-    echo
-    echo "Follow each accepted downstream run to terminal success and verify its image publication."
   } >>"$SUMMARY_PATH"
 }
 
@@ -66,220 +38,73 @@ fail() {
   exit 1
 }
 
-skip_deleted_lkg() {
-  if [[ "${LKG_DELETED:-false}" != "true" ]]; then
-    return 1
-  fi
+trap write_summary EXIT
 
-  production_dispatch_result="skipped (lkg deleted)"
-  lkg_dispatch_result="skipped (lkg deleted)"
+if [[ "${LKG_DELETED:-false}" == "true" ]]; then
+  dispatch_result="skipped (lkg deleted)"
   echo "release-lkg-brev-image: skipping deleted lkg tag"
-  return 0
-}
+  exit 0
+fi
 
-validate_source_context() {
-  [[ "${GITHUB_REPOSITORY:-}" == "$SOURCE_REPOSITORY" ]] \
-    || fail "GITHUB_REPOSITORY must be $SOURCE_REPOSITORY"
-  [[ "${GITHUB_EVENT_NAME:-}" == "$SOURCE_EVENT" ]] \
-    || fail "GITHUB_EVENT_NAME must be $SOURCE_EVENT"
-  [[ "${GITHUB_REF:-}" == "$SOURCE_REF" ]] \
-    || fail "GITHUB_REF must be $SOURCE_REF"
-  [[ "${GITHUB_WORKFLOW_REF:-}" == "$SOURCE_REPOSITORY/$SOURCE_WORKFLOW@$SOURCE_REF" ]] \
-    || fail "GITHUB_WORKFLOW_REF must identify $SOURCE_WORKFLOW at $SOURCE_REF"
-  [[ "${GITHUB_RUN_ID:-}" =~ ^[1-9][0-9]*$ ]] \
-    || fail "GITHUB_RUN_ID must be a positive decimal integer"
-  [[ "${GITHUB_RUN_ATTEMPT:-}" == "1" ]] \
-    || fail "GITHUB_RUN_ATTEMPT must be 1"
-  [[ "${GITHUB_SHA:-}" =~ ^[0-9a-f]{40}$ ]] \
-    || fail "GITHUB_SHA must be a 40-character lowercase hexadecimal SHA"
-}
+LKG_SHA="${LKG_SHA:?LKG_SHA is required}"
+if [[ ! "$LKG_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  fail "LKG_SHA must be a full commit or tag-object SHA"
+fi
 
-resolve_release() {
-  LKG_SHA="${LKG_SHA:?LKG_SHA is required}"
-  if [[ ! "$LKG_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-    fail "LKG_SHA must be a full commit or tag-object SHA"
-  fi
-  if [[ "$LKG_SHA" != "$GITHUB_SHA" ]]; then
-    fail "LKG_SHA must match GITHUB_SHA"
-  fi
+lkg_commit="$(git rev-parse --verify "${LKG_SHA}^{commit}" 2>/dev/null)" \
+  || fail "Unable to peel LKG target $LKG_SHA to a commit"
 
-  lkg_commit="$(git rev-parse --verify "${LKG_SHA}^{commit}" 2>/dev/null)" \
-    || fail "Unable to peel LKG target $LKG_SHA to a commit"
-  if [[ "$lkg_commit" != "$GITHUB_SHA" ]]; then
-    fail "LKG_SHA must identify the LKG commit directly"
-  fi
+release_tag="$({
+  git tag --points-at "$lkg_commit" --list 'v*' \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sort -V \
+    | tail -1
+} || true)"
 
-  release_tag="$({
-    git tag --points-at "$lkg_commit" --list 'v*' \
-      | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-      | sort -V \
-      | tail -1
-  } || true)"
+if [[ -z "$release_tag" ]]; then
+  release_tag="none"
+  fail "LKG target $lkg_commit has no exact vX.Y.Z release tag"
+fi
 
-  if [[ -z "$release_tag" ]]; then
-    release_tag="none"
-    fail "LKG target $lkg_commit has no exact vX.Y.Z release tag"
-  fi
+release_commit="$(git rev-parse --verify "refs/tags/${release_tag}^{commit}")"
+if [[ "$release_commit" != "$lkg_commit" ]]; then
+  fail "Release tag $release_tag does not peel to LKG target $lkg_commit"
+fi
 
-  release_commit="$(git rev-parse --verify "refs/tags/${release_tag}^{commit}")"
-  if [[ "$release_commit" != "$lkg_commit" ]]; then
-    fail "Release tag $release_tag does not peel to LKG target $lkg_commit"
-  fi
-}
+if [[ -z "${NEMOCLAW_IMAGE_DISPATCH_TOKEN:-}" ]]; then
+  fail "NEMOCLAW_IMAGE_DISPATCH_TOKEN is required to dispatch $TARGET_REPOSITORY"
+fi
 
-prepare_request() {
-  validate_source_context
-  resolve_release
+if ! command -v gh >/dev/null 2>&1; then
+  fail "GitHub CLI is required to dispatch $TARGET_REPOSITORY"
+fi
 
-  local request_path="${LKG_REQUEST_PATH:-}"
-  if [[ -z "$request_path" ]]; then
-    [[ -n "${RUNNER_TEMP:-}" ]] \
-      || fail "RUNNER_TEMP or LKG_REQUEST_PATH is required to locate the LKG image request"
-    request_path="$RUNNER_TEMP/nemoclaw-lkg-image-request/$REQUEST_FILENAME"
-  fi
-  [[ -n "$request_path" && "${request_path##*/}" == "$REQUEST_FILENAME" ]] \
-    || fail "LKG_REQUEST_PATH must end with $REQUEST_FILENAME"
-  [[ ! -e "$request_path" ]] || fail "Refusing to overwrite existing LKG image request"
+payload="$(printf '{"ref":"%s","inputs":{"nemoclaw_ref":"%s"},"return_run_details":true}' "$TARGET_REF" "$release_tag")"
+endpoint="repos/$TARGET_REPOSITORY/actions/workflows/$TARGET_WORKFLOW/dispatches"
 
-  local created_at
-  created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  [[ "$created_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
-    || fail "Unable to create an RFC 3339 UTC timestamp"
+if ! dispatch_details="$(
+  printf '%s\n' "$payload" \
+    | env -u GH_DEBUG GH_TOKEN="$NEMOCLAW_IMAGE_DISPATCH_TOKEN" gh api \
+      --method POST \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2026-03-10" \
+      "$endpoint" \
+      --input - \
+      --jq '[.workflow_run_id, .html_url] | @tsv'
+)"; then
+  dispatch_result="rejected"
+  fail "GitHub rejected the production image dispatch to $TARGET_REPOSITORY/$TARGET_WORKFLOW"
+fi
 
-  local request_json
-  request_json="$(
-    jq -cn \
-      --argjson schema_version "$REQUEST_SCHEMA_VERSION" \
-      --arg kind "$REQUEST_KIND" \
-      --arg source_repository "$SOURCE_REPOSITORY" \
-      --arg source_workflow "$SOURCE_WORKFLOW" \
-      --arg event "$SOURCE_EVENT" \
-      --arg ref "$SOURCE_REF" \
-      --arg run_id "$GITHUB_RUN_ID" \
-      --arg event_sha "$GITHUB_SHA" \
-      --arg target_repository "$TARGET_REPOSITORY" \
-      --arg target_workflow ".github/workflows/$LKG_WORKFLOW" \
-      --arg created_at "$created_at" \
-      '{schemaVersion:$schema_version,kind:$kind,sourceRepository:$source_repository,sourceWorkflow:$source_workflow,event:$event,ref:$ref,runId:$run_id,runAttempt:1,eventSha:$event_sha,targetRepository:$target_repository,targetWorkflow:$target_workflow,createdAt:$created_at}'
-  )" || fail "Unable to create the LKG image request"
+IFS=$'\t' read -r downstream_run_id downstream_run_url <<<"$dispatch_details"
+expected_run_url="https://github.com/$TARGET_REPOSITORY/actions/runs/$downstream_run_id"
+if [[ ! "$downstream_run_id" =~ ^[0-9]+$ || "$downstream_run_url" != "$expected_run_url" ]]; then
+  downstream_run_id="unavailable"
+  downstream_run_url=""
+  dispatch_result="rejected (invalid run details)"
+  fail "GitHub accepted the dispatch but did not return valid downstream run details"
+fi
 
-  umask 077
-  local request_directory
-  request_directory="$(dirname -- "$request_path")"
-  mkdir -p "$request_directory"
-  printf '%s\n' "$request_json" >"$request_path"
-  local expected_bytes
-  expected_bytes=$((${#request_json} + 1))
-  local actual_bytes
-  actual_bytes="$(wc -c <"$request_path" | tr -d '[:space:]')"
-  if [[ "$(<"$request_path")" != "$request_json" || "$actual_bytes" != "$expected_bytes" ]]; then
-    fail "LKG image request bytes are not canonical compact JSON with one trailing LF"
-  fi
-  jq -e \
-    --arg run_id "$GITHUB_RUN_ID" \
-    --arg event_sha "$GITHUB_SHA" \
-    --arg created_at "$created_at" \
-    'keys_unsorted == ["schemaVersion","kind","sourceRepository","sourceWorkflow","event","ref","runId","runAttempt","eventSha","targetRepository","targetWorkflow","createdAt"] and .schemaVersion == 1 and .kind == "nemoclaw-lkg-image-request" and .sourceRepository == "NVIDIA/NemoClaw" and .sourceWorkflow == ".github/workflows/release-lkg-brev-image.yaml" and .event == "push" and .ref == "refs/tags/lkg" and .runId == $run_id and .runAttempt == 1 and .eventSha == $event_sha and .targetRepository == "brevdev/nemoclaw-image" and .targetWorkflow == ".github/workflows/build-lkg-image.yml" and .createdAt == $created_at' \
-    "$request_path" >/dev/null || fail "LKG image request content failed local validation"
-  chmod 0400 "$request_path"
-  printf 'release-lkg-brev-image: prepared %s for source run %s attempt %s\n' \
-    "$request_path" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"
-}
-
-dispatch_workflow() {
-  local workflow="$1"
-  local payload="$2"
-  local label="$3"
-  local endpoint="repos/$TARGET_REPOSITORY/actions/workflows/$workflow/dispatches"
-  local dispatch_details
-
-  last_dispatch_result="failed (dispatch may have been accepted)"
-  last_run_id="unavailable"
-  last_run_url=""
-
-  if ! dispatch_details="$(
-    printf '%s\n' "$payload" \
-      | env -u GH_DEBUG GH_TOKEN="$NEMOCLAW_IMAGE_DISPATCH_TOKEN" gh api \
-        --method POST \
-        -H "Accept: application/vnd.github+json" \
-        -H "X-GitHub-Api-Version: 2026-03-10" \
-        "$endpoint" \
-        --input - \
-        --jq '[.workflow_run_id, .html_url] | @tsv'
-  )"; then
-    echo "release-lkg-brev-image: GitHub did not confirm the $label dispatch; it may have been accepted and will not be retried" >&2
-    return 1
-  fi
-
-  IFS=$'\t' read -r last_run_id last_run_url <<<"$dispatch_details"
-  local expected_run_url="https://github.com/$TARGET_REPOSITORY/actions/runs/$last_run_id"
-  if [[ ! "$last_run_id" =~ ^[1-9][0-9]*$ || "$last_run_url" != "$expected_run_url" ]]; then
-    last_run_id="unavailable"
-    last_run_url=""
-    last_dispatch_result="accepted (remote run identity unavailable)"
-    echo "release-lkg-brev-image: GitHub accepted the $label dispatch but did not return valid run details; it will not be retried" >&2
-    return 1
-  fi
-
-  last_dispatch_result="accepted (HTTP 200)"
-  printf 'release-lkg-brev-image: dispatched %s for %s (%s): %s\n' \
-    "$workflow" "$release_tag" "$lkg_commit" "$last_run_url"
-  return 0
-}
-
-dispatch_images() {
-  validate_source_context
-  resolve_release
-
-  if [[ -z "${NEMOCLAW_IMAGE_DISPATCH_TOKEN:-}" ]]; then
-    fail "NEMOCLAW_IMAGE_DISPATCH_TOKEN is required to dispatch $TARGET_REPOSITORY"
-  fi
-
-  if ! command -v gh >/dev/null 2>&1; then
-    fail "GitHub CLI is required to dispatch $TARGET_REPOSITORY"
-  fi
-
-  local production_payload
-  production_payload="$(printf '{\"ref\":\"%s\",\"inputs\":{\"nemoclaw_ref\":\"%s\"},\"return_run_details\":true}' "$TARGET_REF" "$release_tag")"
-  local lkg_payload
-  lkg_payload="$(printf '{\"ref\":\"%s\",\"return_run_details\":true,\"inputs\":{\"requester_workflow_run_id\":\"%s\",\"requester_workflow_run_attempt\":\"%s\"}}' "$TARGET_REF" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
-
-  local failed=0
-  if ! dispatch_workflow "$PRODUCTION_WORKFLOW" "$production_payload" "production image"; then
-    failed=1
-  fi
-  production_dispatch_result="$last_dispatch_result"
-  production_run_id="$last_run_id"
-  production_run_url="$last_run_url"
-
-  if ! dispatch_workflow "$LKG_WORKFLOW" "$lkg_payload" "LKG-only image"; then
-    failed=1
-  fi
-  lkg_dispatch_result="$last_dispatch_result"
-  lkg_run_id="$last_run_id"
-  lkg_run_url="$last_run_url"
-
-  if ((failed != 0)); then
-    fail "One or more image dispatches were not confirmed; see the workflow summary"
-  fi
-}
-
-operation="${1:-dispatch-images}"
-case "$operation" in
-  prepare-request)
-    if skip_deleted_lkg; then
-      exit 0
-    fi
-    prepare_request
-    ;;
-  dispatch-images)
-    trap write_summary EXIT
-    if skip_deleted_lkg; then
-      exit 0
-    fi
-    dispatch_images
-    ;;
-  *)
-    fail "Usage: ${0##*/} [prepare-request|dispatch-images]"
-    ;;
-esac
+dispatch_result="accepted (HTTP 200)"
+printf 'release-lkg-brev-image: dispatched %s for %s (%s): %s\n' \
+  "$TARGET_WORKFLOW" "$release_tag" "$lkg_commit" "$downstream_run_url"

--- a/scripts/release-lkg-brev-image.sh
+++ b/scripts/release-lkg-brev-image.sh
@@ -82,9 +82,10 @@ fi
 payload="$(printf '{"ref":"%s","inputs":{"nemoclaw_ref":"%s"},"return_run_details":true}' "$TARGET_REF" "$release_tag")"
 endpoint="repos/$TARGET_REPOSITORY/actions/workflows/$TARGET_WORKFLOW/dispatches"
 
+unset GH_DEBUG
 if ! dispatch_details="$(
   printf '%s\n' "$payload" \
-    | env -u GH_DEBUG GH_TOKEN="$NEMOCLAW_IMAGE_DISPATCH_TOKEN" gh api \
+    | GH_TOKEN="$NEMOCLAW_IMAGE_DISPATCH_TOKEN" gh api \
       --method POST \
       -H "Accept: application/vnd.github+json" \
       -H "X-GitHub-Api-Version: 2026-03-10" \

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -41,6 +41,11 @@ function runTests(...tests: string[]): () => string[] {
 
 export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
   {
+    pattern:
+      /(?:^|\/)(?:\.github\/workflows\/release-lkg-brev-image\.yaml|scripts\/release-lkg-brev-image\.sh)$/,
+    testsToRun: runTests("test/release-lkg-brev-image.test.ts"),
+  },
+  {
     pattern: /(?:^|\/)managed-inference\/(?:models|presets|recipes|schemas)\/[^/]+\.(?:json|yaml)$/,
     testsToRun: runTests(
       "src/lib/inference/serving/catalog.test.ts",

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -41,11 +41,6 @@ function runTests(...tests: string[]): () => string[] {
 
 export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
   {
-    pattern:
-      /(?:^|\/)(?:\.github\/workflows\/release-lkg-brev-image\.yaml|scripts\/release-lkg-brev-image\.sh)$/,
-    testsToRun: runTests("test/release-lkg-brev-image.test.ts"),
-  },
-  {
     pattern: /(?:^|\/)managed-inference\/(?:models|presets|recipes|schemas)\/[^/]+\.(?:json|yaml)$/,
     testsToRun: runTests(
       "src/lib/inference/serving/catalog.test.ts",

--- a/test/release-lkg-brev-image.test.ts
+++ b/test/release-lkg-brev-image.test.ts
@@ -146,7 +146,7 @@ afterEach(() => {
 });
 
 describe("LKG production image workflow", () => {
-  // source-shape-contract: security -- The LKG caller must keep its production-only trigger, permissions, action pins, and dispatch credential on reviewed workflow boundaries
+  // source-shape-contract: security -- The LKG caller must keep its production-only trigger, permissions, action pins, and dispatch credential on reviewed workflow and process boundaries
   it("keeps the LKG credential on the production-only dispatch step (#9798)", () => {
     const workflow = readYaml<Workflow>(".github/workflows/release-lkg-brev-image.yaml");
 
@@ -189,6 +189,11 @@ describe("LKG production image workflow", () => {
     expect(serialized).not.toContain("id-token");
     expect(serialized).not.toContain("build-lkg-image.yml");
     expect(serialized).not.toContain("build-daily-image.yml");
+
+    const scriptSource = fs.readFileSync(scriptPath, "utf8");
+    expect(scriptSource).toContain("\nunset GH_DEBUG\n");
+    expect(scriptSource).toContain('GH_TOKEN="$NEMOCLAW_IMAGE_DISPATCH_TOKEN" gh api');
+    expect(scriptSource).not.toMatch(/\benv[^\n]*GH_TOKEN=/u);
   });
 });
 

--- a/test/release-lkg-brev-image.test.ts
+++ b/test/release-lkg-brev-image.test.ts
@@ -26,6 +26,8 @@ type Workflow = {
     string,
     {
       if?: string;
+      permissions?: Record<string, string>;
+      "runs-on"?: string;
       steps?: WorkflowStep[];
       "timeout-minutes"?: number;
     }
@@ -141,6 +143,53 @@ afterEach(() => {
   for (const root of tempRoots.splice(0)) {
     fs.rmSync(root, { force: true, recursive: true });
   }
+});
+
+describe("LKG production image workflow", () => {
+  // source-shape-contract: security -- The LKG caller must keep its production-only trigger, permissions, action pins, and dispatch credential on reviewed workflow boundaries
+  it("keeps the LKG credential on the production-only dispatch step (#9798)", () => {
+    const workflow = readYaml<Workflow>(".github/workflows/release-lkg-brev-image.yaml");
+
+    expect(workflow.on).toEqual({ push: { tags: ["lkg"] } });
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(Object.keys(workflow.jobs)).toEqual(["dispatch-production-image"]);
+
+    const dispatch = workflow.jobs["dispatch-production-image"];
+    expect(dispatch.if).toBe(
+      "${{ github.repository == 'NVIDIA/NemoClaw' && github.event.deleted == false }}",
+    );
+    expect(dispatch.permissions).toBeUndefined();
+    expect(dispatch["runs-on"]).toBe("ubuntu-latest");
+    expect(dispatch["timeout-minutes"]).toBe(5);
+    expect(dispatch.steps).toEqual([
+      {
+        name: "Check out LKG target",
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        with: {
+          ref: "${{ github.sha }}",
+          "fetch-depth": 0,
+          "persist-credentials": false,
+        },
+      },
+      {
+        name: "Dispatch production image build",
+        env: {
+          LKG_SHA: "${{ github.sha }}",
+          NEMOCLAW_IMAGE_DISPATCH_TOKEN: "${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}",
+        },
+        run: "scripts/release-lkg-brev-image.sh",
+      },
+    ]);
+
+    const serialized = JSON.stringify(workflow);
+    expect(serialized.match(/\$\{\{ secrets\.[^}]+ \}\}/gu)).toEqual([
+      "${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}",
+    ]);
+    expect(serialized).not.toContain("attestations");
+    expect(serialized).not.toContain("id-token");
+    expect(serialized).not.toContain("build-lkg-image.yml");
+    expect(serialized).not.toContain("build-daily-image.yml");
+  });
 });
 
 describe("LKG production image dispatch", () => {

--- a/test/release-lkg-brev-image.test.ts
+++ b/test/release-lkg-brev-image.test.ts
@@ -156,7 +156,7 @@ describe("LKG production image workflow", () => {
 
     const dispatch = workflow.jobs["dispatch-production-image"];
     expect(dispatch.if).toBe(
-      "${{ github.repository == 'NVIDIA/NemoClaw' && github.event.deleted == false }}",
+      "${{ github.repository == 'NVIDIA/NemoClaw' && github.event.deleted == false && github.run_attempt == 1 }}",
     );
     expect(dispatch.permissions).toBeUndefined();
     expect(dispatch["runs-on"]).toBe("ubuntu-latest");

--- a/test/release-lkg-brev-image.test.ts
+++ b/test/release-lkg-brev-image.test.ts
@@ -11,10 +11,6 @@ import { readYaml } from "./helpers/e2e-workflow-contract";
 
 const repoRoot = path.join(import.meta.dirname, "..");
 const scriptPath = path.join(repoRoot, "scripts", "release-lkg-brev-image.sh");
-const workflowPath = ".github/workflows/release-lkg-brev-image.yaml";
-const sourceWorkflowRef = `NVIDIA/NemoClaw/${workflowPath}@refs/tags/lkg`;
-const fixedCreatedAt = "2026-08-19T12:34:56Z";
-const sourceRunId = "32290000000";
 const tempRoots: string[] = [];
 
 type WorkflowStep = {
@@ -25,27 +21,28 @@ type WorkflowStep = {
   with?: Record<string, unknown>;
 };
 
-type WorkflowJob = {
-  if?: string;
-  needs?: string;
-  permissions?: Record<string, string>;
-  "runs-on"?: string;
-  steps?: WorkflowStep[];
-  "timeout-minutes"?: number;
-};
-
 type Workflow = {
-  jobs: Record<string, WorkflowJob>;
-  on?: { push?: { tags?: string[] } };
+  jobs: Record<
+    string,
+    {
+      if?: string;
+      steps?: WorkflowStep[];
+      "timeout-minutes"?: number;
+    }
+  >;
+  on?: {
+    push?: {
+      tags?: string[];
+    };
+  };
   permissions?: Record<string, string>;
 };
 
 type Fixture = {
+  argsPath: string;
   binDir: string;
   commit: string;
-  counterPath: string;
-  recordDir: string;
-  requestPath: string;
+  inputPath: string;
   root: string;
   summaryPath: string;
   work: string;
@@ -61,11 +58,9 @@ function git(cwd: string, args: string[]): string {
       GIT_AUTHOR_EMAIL: "lkg-dispatch@example.com",
       GIT_COMMITTER_NAME: "LKG Dispatch Test",
       GIT_COMMITTER_EMAIL: "lkg-dispatch@example.com",
-      GIT_CONFIG_COUNT: "2",
+      GIT_CONFIG_COUNT: "1",
       GIT_CONFIG_KEY_0: "tag.gpgSign",
       GIT_CONFIG_VALUE_0: "false",
-      GIT_CONFIG_KEY_1: "commit.gpgSign",
-      GIT_CONFIG_VALUE_1: "false",
     },
   }).trim();
 }
@@ -75,18 +70,11 @@ function createFixture(): Fixture {
   tempRoots.push(root);
   const work = path.join(root, "work");
   const binDir = path.join(root, "bin");
-  const recordDir = path.join(root, "gh-records");
-  const counterPath = path.join(root, "gh-counter.txt");
-  const requestPath = path.join(
-    root,
-    "runner-temp",
-    "nemoclaw-lkg-image-request",
-    "nemoclaw-lkg-image-request.v1.json",
-  );
+  const argsPath = path.join(root, "gh-args.txt");
+  const inputPath = path.join(root, "gh-input.json");
   const summaryPath = path.join(root, "summary.md");
   fs.mkdirSync(work);
   fs.mkdirSync(binDir);
-  fs.mkdirSync(recordDir);
   git(work, ["init"]);
   fs.writeFileSync(path.join(work, "file.txt"), "initial\n");
   git(work, ["add", "file.txt"]);
@@ -102,51 +90,23 @@ if [[ "\${GH_TOKEN:-}" != "\${EXPECTED_GH_TOKEN:-}" ]]; then
   echo "unexpected GH_TOKEN" >&2
   exit 2
 fi
-call=1
-if [[ -f "$GH_COUNTER_PATH" ]]; then
-  call=$(( $(<"$GH_COUNTER_PATH") + 1 ))
-fi
-printf '%s\n' "$call" >"$GH_COUNTER_PATH"
-printf '%s\n' "$@" >"$GH_RECORD_DIR/gh-args-$call.txt"
-cat >"$GH_RECORD_DIR/gh-input-$call.json"
-exit_name="GH_EXIT_CODE_$call"
-exit_code="\${!exit_name:-0}"
-if [[ "$exit_code" != "0" ]]; then
+printf '%s\n' "$@" >"$GH_ARGS_PATH"
+cat >"$GH_INPUT_PATH"
+if [[ "\${GH_EXIT_CODE:-0}" != "0" ]]; then
   echo "HTTP 403: dispatch denied" >&2
-  exit "$exit_code"
+  exit "$GH_EXIT_CODE"
 fi
-output_name="GH_OUTPUT_$call"
-printf '%s\n' "\${!output_name}"
+if [[ -n "\${GH_OUTPUT+x}" ]]; then
+  printf '%s\n' "$GH_OUTPUT"
+else
+  printf '123456789\thttps://github.com/brevdev/nemoclaw-image/actions/runs/123456789\n'
+fi
 `,
     "utf8",
   );
   fs.chmodSync(fakeGh, 0o755);
 
-  const fakeDate = path.join(binDir, "date");
-  fs.writeFileSync(
-    fakeDate,
-    `#!/usr/bin/env bash
-set -euo pipefail
-if [[ "$#" == "2" && "$1" == "-u" && "$2" == "+%Y-%m-%dT%H:%M:%SZ" ]]; then
-  printf '%s\n' "${fixedCreatedAt}"
-else
-  /bin/date "$@"
-fi
-`,
-    "utf8",
-  );
-  fs.chmodSync(fakeDate, 0o755);
-
-  return {
-    binDir,
-    commit,
-    counterPath,
-    recordDir,
-    requestPath,
-    root,
-    summaryPath,
-    work,
-  };
+  return { argsPath, binDir, commit, inputPath, root, summaryPath, work };
 }
 
 function tag(fixture: Fixture, name: string, annotated = true): void {
@@ -156,74 +116,25 @@ function tag(fixture: Fixture, name: string, annotated = true): void {
   git(fixture.work, args);
 }
 
-function runScript(
+function runDispatch(
   fixture: Fixture,
-  operation: "prepare-request" | "dispatch-images",
   extraEnv: NodeJS.ProcessEnv = {},
 ): ReturnType<typeof spawnSync> {
-  return spawnSync("bash", [scriptPath, operation], {
+  return spawnSync("bash", [scriptPath], {
     cwd: fixture.work,
     encoding: "utf8",
     env: {
       ...process.env,
       EXPECTED_GH_TOKEN: "test-dispatch-token",
-      GH_COUNTER_PATH: fixture.counterPath,
-      GH_EXIT_CODE_1: "0",
-      GH_EXIT_CODE_2: "0",
-      GH_OUTPUT_1: "123456789\thttps://github.com/brevdev/nemoclaw-image/actions/runs/123456789",
-      GH_OUTPUT_2: "987654321\thttps://github.com/brevdev/nemoclaw-image/actions/runs/987654321",
-      GH_RECORD_DIR: fixture.recordDir,
-      GITHUB_EVENT_NAME: "push",
-      GITHUB_REF: "refs/tags/lkg",
-      GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
-      GITHUB_RUN_ATTEMPT: "1",
-      GITHUB_RUN_ID: sourceRunId,
-      GITHUB_SHA: fixture.commit,
+      GH_ARGS_PATH: fixture.argsPath,
+      GH_INPUT_PATH: fixture.inputPath,
       GITHUB_STEP_SUMMARY: fixture.summaryPath,
-      GITHUB_WORKFLOW_REF: sourceWorkflowRef,
-      LKG_DELETED: "false",
-      LKG_REQUEST_PATH: fixture.requestPath,
       LKG_SHA: fixture.commit,
       NEMOCLAW_IMAGE_DISPATCH_TOKEN: "test-dispatch-token",
       PATH: `${fixture.binDir}:${process.env.PATH ?? ""}`,
-      RUNNER_TEMP: path.join(fixture.root, "runner-temp"),
       ...extraEnv,
     },
   });
-}
-
-function callCount(fixture: Fixture): number {
-  return fs.existsSync(fixture.counterPath)
-    ? Number.parseInt(fs.readFileSync(fixture.counterPath, "utf8"), 10)
-    : 0;
-}
-
-function callArgs(fixture: Fixture, call: number): string[] {
-  return fs
-    .readFileSync(path.join(fixture.recordDir, `gh-args-${call}.txt`), "utf8")
-    .trim()
-    .split("\n");
-}
-
-function callInput(fixture: Fixture, call: number): string {
-  return fs.readFileSync(path.join(fixture.recordDir, `gh-input-${call}.json`), "utf8");
-}
-
-function expectedArgs(workflow: string): string[] {
-  return [
-    "api",
-    "--method",
-    "POST",
-    "-H",
-    "Accept: application/vnd.github+json",
-    "-H",
-    "X-GitHub-Api-Version: 2026-03-10",
-    `repos/brevdev/nemoclaw-image/actions/workflows/${workflow}/dispatches`,
-    "--input",
-    "-",
-    "--jq",
-    "[.workflow_run_id, .html_url] | @tsv",
-  ];
 }
 
 afterEach(() => {
@@ -232,250 +143,76 @@ afterEach(() => {
   }
 });
 
-describe("LKG Brev image request workflow", () => {
-  // source-shape-contract: security -- The LKG caller must keep event provenance, attestation permissions, action pins, operation order, and its dispatch credential on reviewed workflow boundaries
-  it("attests one request before the isolated dispatch job (#9661)", () => {
-    const workflow = readYaml<Workflow>(workflowPath);
-
-    expect(workflow.on).toEqual({ push: { tags: ["lkg"] } });
-    expect(workflow.permissions).toEqual({ contents: "read" });
-    expect(Object.keys(workflow.jobs)).toEqual([
-      "attest-lkg-image-request",
-      "dispatch-production-image",
-    ]);
-
-    const attest = workflow.jobs["attest-lkg-image-request"];
-    expect(attest.if).toContain("github.repository == 'NVIDIA/NemoClaw'");
-    expect(attest.if).toContain("github.event_name == 'push'");
-    expect(attest.if).toContain("github.ref == 'refs/tags/lkg'");
-    expect(attest.if).toContain("github.event.deleted == false");
-    expect(attest.if).toContain("github.run_attempt == 1");
-    expect(attest.permissions).toEqual({
-      contents: "read",
-      attestations: "write",
-      "id-token": "write",
-    });
-    expect(attest["runs-on"]).toBe("ubuntu-latest");
-    expect(JSON.stringify(attest)).not.toContain("NEMOCLAW_IMAGE_DISPATCH_TOKEN");
-
-    const steps = attest.steps ?? [];
-    expect(steps.map((step) => step.name)).toEqual([
-      "Check out LKG target",
-      "Prepare LKG image request",
-      "Upload LKG image request",
-      "Attest LKG image request",
-    ]);
-    expect(steps[0]).toMatchObject({
-      uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
-      with: { ref: "${{ github.sha }}", "fetch-depth": 0, "persist-credentials": false },
-    });
-    expect(steps[1]).toMatchObject({
-      run: "scripts/release-lkg-brev-image.sh prepare-request",
-      env: {
-        LKG_REQUEST_PATH: "nemoclaw-lkg-image-request.v1.json",
-        LKG_SHA: "${{ github.sha }}",
-      },
-    });
-    expect(steps[2]).toEqual({
-      name: "Upload LKG image request",
-      uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
-      with: {
-        name: "nemoclaw-lkg-image-request-v1-${{ github.run_id }}-${{ github.run_attempt }}",
-        path: "nemoclaw-lkg-image-request.v1.json",
-        "if-no-files-found": "error",
-        "retention-days": 30,
-      },
-    });
-    expect(steps[3]).toEqual({
-      name: "Attest LKG image request",
-      uses: "actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8",
-      with: {
-        "subject-path": "nemoclaw-lkg-image-request.v1.json",
-      },
-    });
-
-    const dispatch = workflow.jobs["dispatch-production-image"];
-    expect(dispatch.needs).toBe("attest-lkg-image-request");
-    expect(dispatch.if).toContain("success()");
-    expect(dispatch.if).toContain("github.run_attempt == 1");
-    expect(dispatch.permissions).toEqual({ contents: "read" });
-    expect(dispatch["runs-on"]).toBe("ubuntu-latest");
-    const dispatchSteps = dispatch.steps ?? [];
-    expect(dispatchSteps.at(-1)).toMatchObject({
-      run: "scripts/release-lkg-brev-image.sh dispatch-images",
-      env: {
-        NEMOCLAW_IMAGE_DISPATCH_TOKEN: "${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}",
-      },
-    });
-    expect(JSON.stringify(dispatchSteps.slice(0, -1))).not.toContain(
-      "NEMOCLAW_IMAGE_DISPATCH_TOKEN",
-    );
-    expect(JSON.stringify(workflow).match(/\$\{\{ secrets\.[^}]+ \}\}/gu)).toEqual([
-      "${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}",
-    ]);
-  });
-});
-
-describe("LKG Brev image request", () => {
-  it("writes the canonical request bytes without credentials (#9661)", () => {
+describe("LKG production image dispatch", () => {
+  it("dispatches the highest exact release tag to the production workflow (#6772)", () => {
     const fixture = createFixture();
-    tag(fixture, "lkg", false);
-    tag(fixture, "v0.0.109");
-
-    const result = runScript(fixture, "prepare-request");
-
-    expect(result.status).toBe(0);
-    const expected = `${JSON.stringify({
-      schemaVersion: 1,
-      kind: "nemoclaw-lkg-image-request",
-      sourceRepository: "NVIDIA/NemoClaw",
-      sourceWorkflow: workflowPath,
-      event: "push",
-      ref: "refs/tags/lkg",
-      runId: sourceRunId,
-      runAttempt: 1,
-      eventSha: fixture.commit,
-      targetRepository: "brevdev/nemoclaw-image",
-      targetWorkflow: ".github/workflows/build-lkg-image.yml",
-      createdAt: fixedCreatedAt,
-    })}\n`;
-    const request = fs.readFileSync(fixture.requestPath, "utf8");
-    expect(request).toBe(expected);
-    expect(request.split("\n")).toHaveLength(2);
-    expect(fs.statSync(fixture.requestPath).mode & 0o777).toBe(0o400);
-    expect(callCount(fixture)).toBe(0);
-    expect(fs.existsSync(fixture.summaryPath)).toBe(false);
-    expect(`${request}${result.stdout}${result.stderr}`).not.toContain("test-dispatch-token");
-  });
-
-  it.each([
-    ["another repository", { GITHUB_REPOSITORY: "example/NemoClaw" }, "GITHUB_REPOSITORY"],
-    ["another event", { GITHUB_EVENT_NAME: "workflow_dispatch" }, "GITHUB_EVENT_NAME"],
-    ["another ref", { GITHUB_REF: "refs/heads/lkg" }, "GITHUB_REF"],
-    [
-      "another workflow ref",
-      { GITHUB_WORKFLOW_REF: "NVIDIA/NemoClaw/.github/workflows/other.yaml@refs/tags/lkg" },
-      "GITHUB_WORKFLOW_REF",
-    ],
-    ["a zero run ID", { GITHUB_RUN_ID: "0" }, "GITHUB_RUN_ID"],
-    ["a workflow rerun", { GITHUB_RUN_ATTEMPT: "2" }, "GITHUB_RUN_ATTEMPT"],
-    ["an uppercase event SHA", { GITHUB_SHA: "A".repeat(40) }, "GITHUB_SHA"],
-  ])("rejects %s before creating a request (#9661)", (_name, environment, message) => {
-    const fixture = createFixture();
-    tag(fixture, "v0.0.109");
-
-    const result = runScript(fixture, "prepare-request", environment);
-
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain(message);
-    expect(fs.existsSync(fixture.requestPath)).toBe(false);
-    expect(callCount(fixture)).toBe(0);
-  });
-
-  it("rejects an indirect LKG tag object before creating a request (#9661)", () => {
-    const fixture = createFixture();
-    tag(fixture, "v0.0.109");
     tag(fixture, "lkg");
-    const lkgObject = git(fixture.work, ["rev-parse", "refs/tags/lkg"]);
-
-    const result = runScript(fixture, "prepare-request", {
-      GITHUB_SHA: lkgObject,
-      LKG_SHA: lkgObject,
-    });
-
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("LKG_SHA must identify the LKG commit directly");
-    expect(fs.existsSync(fixture.requestPath)).toBe(false);
-  });
-
-  it("fails before creating a request when LKG has no exact release (#9661)", () => {
-    const fixture = createFixture();
-    tag(fixture, "v0.0.109-rc.1");
-
-    const result = runScript(fixture, "prepare-request");
-
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain(`LKG target ${fixture.commit} has no exact vX.Y.Z release tag`);
-    expect(fs.existsSync(fixture.requestPath)).toBe(false);
-    expect(callCount(fixture)).toBe(0);
-  });
-
-  it("requires a request location before creating the request (#9661)", () => {
-    const fixture = createFixture();
-    tag(fixture, "v0.0.109");
-
-    const result = runScript(fixture, "prepare-request", {
-      LKG_REQUEST_PATH: "",
-      RUNNER_TEMP: "",
-    });
-
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain(
-      "RUNNER_TEMP or LKG_REQUEST_PATH is required to locate the LKG image request",
-    );
-    expect(fs.existsSync(fixture.requestPath)).toBe(false);
-    expect(callCount(fixture)).toBe(0);
-  });
-
-  it("refuses to overwrite an existing request (#9661)", () => {
-    const fixture = createFixture();
-    tag(fixture, "v0.0.109");
-    fs.mkdirSync(path.dirname(fixture.requestPath), { recursive: true });
-    fs.writeFileSync(fixture.requestPath, "existing\n");
-
-    const result = runScript(fixture, "prepare-request");
-
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("Refusing to overwrite existing LKG image request");
-    expect(fs.readFileSync(fixture.requestPath, "utf8")).toBe("existing\n");
-  });
-});
-
-describe("LKG Brev image dispatches", () => {
-  it("preserves production and adds the run-identity-only LKG dispatch (#9661)", () => {
-    const fixture = createFixture();
     tag(fixture, "v0.0.9");
     tag(fixture, "v0.0.10");
     tag(fixture, "v0.0.11-rc.1");
+    const lkgObject = git(fixture.work, ["rev-parse", "refs/tags/lkg"]);
 
-    const result = runScript(fixture, "dispatch-images");
+    const result = runDispatch(fixture, { LKG_SHA: lkgObject });
 
     expect(result.status).toBe(0);
-    expect(callCount(fixture)).toBe(2);
-    expect(callArgs(fixture, 1)).toEqual(expectedArgs("build-scheduled.yml"));
-    expect(callInput(fixture, 1)).toBe(
-      '{"ref":"main","inputs":{"nemoclaw_ref":"v0.0.10"},"return_run_details":true}\n',
-    );
-    expect(callArgs(fixture, 2)).toEqual(expectedArgs("build-lkg-image.yml"));
-    expect(callInput(fixture, 2)).toBe(
-      `{"ref":"main","return_run_details":true,"inputs":{"requester_workflow_run_id":"${sourceRunId}","requester_workflow_run_attempt":"1"}}\n`,
-    );
-
+    expect(fs.readFileSync(fixture.argsPath, "utf8").trim().split("\n")).toEqual([
+      "api",
+      "--method",
+      "POST",
+      "-H",
+      "Accept: application/vnd.github+json",
+      "-H",
+      "X-GitHub-Api-Version: 2026-03-10",
+      "repos/brevdev/nemoclaw-image/actions/workflows/build-scheduled.yml/dispatches",
+      "--input",
+      "-",
+      "--jq",
+      "[.workflow_run_id, .html_url] | @tsv",
+    ]);
+    expect(JSON.parse(fs.readFileSync(fixture.inputPath, "utf8"))).toEqual({
+      ref: "main",
+      inputs: { nemoclaw_ref: "v0.0.10" },
+      return_run_details: true,
+    });
     const summary = fs.readFileSync(fixture.summaryPath, "utf8");
     expect(summary).toContain(`LKG commit: \`${fixture.commit}\``);
     expect(summary).toContain("Release tag: `v0.0.10`");
-    expect(summary).toContain(`Source run: \`${sourceRunId}\` (attempt \`1\`)`);
     expect(summary).toContain(
       "Target: `brevdev/nemoclaw-image/.github/workflows/build-scheduled.yml@main`",
     );
+    expect(summary).toContain("Dispatch result: `accepted (HTTP 200)`");
     expect(summary).toContain(
       "Downstream run: [123456789](https://github.com/brevdev/nemoclaw-image/actions/runs/123456789)",
     );
     expect(summary).toContain(
-      "Target: `brevdev/nemoclaw-image/.github/workflows/build-lkg-image.yml@main`",
+      "Follow the downstream run to terminal success and verify production image promotion.",
     );
-    expect(summary).toContain(
-      "Downstream run: [987654321](https://github.com/brevdev/nemoclaw-image/actions/runs/987654321)",
+    expect(result.stdout).toContain(
+      "https://github.com/brevdev/nemoclaw-image/actions/runs/123456789",
     );
-    expect(summary.match(/Dispatch result: `accepted \(HTTP 200\)`/gu)).toHaveLength(2);
     expect(`${result.stdout}${result.stderr}${summary}`).not.toContain("test-dispatch-token");
   });
 
-  it("skips both dispatches when the LKG tag is deleted (#9661)", () => {
+  it("fails before dispatch when LKG has no exact release tag (#6772)", () => {
+    const fixture = createFixture();
+    tag(fixture, "latest", false);
+    tag(fixture, "v0.0.1-rc.1");
+
+    const result = runDispatch(fixture);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(`LKG target ${fixture.commit} has no exact vX.Y.Z release tag`);
+    expect(fs.existsSync(fixture.argsPath)).toBe(false);
+    const summary = fs.readFileSync(fixture.summaryPath, "utf8");
+    expect(summary).toContain(`LKG commit: \`${fixture.commit}\``);
+    expect(summary).toContain("Release tag: `none`");
+    expect(summary).toContain("Dispatch result: `not attempted`");
+  });
+
+  it("skips dispatch when the LKG tag is deleted (#6772)", () => {
     const fixture = createFixture();
 
-    const result = runScript(fixture, "dispatch-images", {
-      GITHUB_SHA: "",
+    const result = runDispatch(fixture, {
       LKG_DELETED: "true",
       LKG_SHA: "",
       NEMOCLAW_IMAGE_DISPATCH_TOKEN: "",
@@ -483,107 +220,68 @@ describe("LKG Brev image dispatches", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("skipping deleted lkg tag");
-    expect(callCount(fixture)).toBe(0);
-    const summary = fs.readFileSync(fixture.summaryPath, "utf8");
-    expect(summary.match(/Dispatch result: `skipped \(lkg deleted\)`/gu)).toHaveLength(2);
+    expect(fs.existsSync(fixture.argsPath)).toBe(false);
+    expect(fs.readFileSync(fixture.summaryPath, "utf8")).toContain(
+      "Dispatch result: `skipped (lkg deleted)`",
+    );
   });
 
-  it("fails before either dispatch when the credential is absent (#9661)", () => {
+  it("reports a missing dispatch token without invoking GitHub (#6772)", () => {
     const fixture = createFixture();
-    tag(fixture, "v0.0.109");
+    tag(fixture, "v0.0.1");
 
-    const result = runScript(fixture, "dispatch-images", {
-      NEMOCLAW_IMAGE_DISPATCH_TOKEN: "",
-    });
+    const result = runDispatch(fixture, { NEMOCLAW_IMAGE_DISPATCH_TOKEN: "" });
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("NEMOCLAW_IMAGE_DISPATCH_TOKEN is required");
-    expect(callCount(fixture)).toBe(0);
-    const summary = fs.readFileSync(fixture.summaryPath, "utf8");
-    expect(summary.match(/Dispatch result: `not attempted`/gu)).toHaveLength(2);
+    expect(fs.existsSync(fixture.argsPath)).toBe(false);
+    expect(fs.readFileSync(fixture.summaryPath, "utf8")).toContain("Release tag: `v0.0.1`");
   });
 
-  it("rejects a workflow rerun before either dispatch (#9661)", () => {
+  it("fails without changing LKG when GitHub rejects the dispatch (#6772)", () => {
     const fixture = createFixture();
-    tag(fixture, "v0.0.109");
+    tag(fixture, "v0.0.1");
 
-    const result = runScript(fixture, "dispatch-images", { GITHUB_RUN_ATTEMPT: "2" });
+    const result = runDispatch(fixture, { GH_EXIT_CODE: "1" });
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("GITHUB_RUN_ATTEMPT must be 1");
-    expect(callCount(fixture)).toBe(0);
-    const summary = fs.readFileSync(fixture.summaryPath, "utf8");
-    expect(summary.match(/Dispatch result: `not attempted`/gu)).toHaveLength(2);
+    expect(result.stderr).toContain("HTTP 403: dispatch denied");
+    expect(result.stderr).toContain("GitHub rejected the production image dispatch");
+    expect(git(fixture.work, ["rev-parse", "HEAD"])).toBe(fixture.commit);
+    expect(fs.readFileSync(fixture.summaryPath, "utf8")).toContain("Dispatch result: `rejected`");
   });
 
-  it("records the LKG run when production returns invalid run details (#9661)", () => {
+  it("fails when GitHub omits valid downstream run details (#6772)", () => {
     const fixture = createFixture();
-    tag(fixture, "v0.0.109");
+    tag(fixture, "v0.0.1");
 
-    const result = runScript(fixture, "dispatch-images", { GH_OUTPUT_1: "null\tnull" });
+    const result = runDispatch(fixture, { GH_OUTPUT: "null\tnull" });
 
     expect(result.status).not.toBe(0);
-    expect(callCount(fixture)).toBe(2);
     expect(result.stderr).toContain(
-      "GitHub accepted the production image dispatch but did not return valid run details",
+      "GitHub accepted the dispatch but did not return valid downstream run details",
     );
-    expect(result.stderr).toContain("will not be retried");
     const summary = fs.readFileSync(fixture.summaryPath, "utf8");
-    expect(summary).toContain("Dispatch result: `accepted (remote run identity unavailable)`");
-    expect(summary).toContain(
-      "Downstream run: [987654321](https://github.com/brevdev/nemoclaw-image/actions/runs/987654321)",
-    );
+    expect(summary).toContain("Dispatch result: `rejected (invalid run details)`");
+    expect(summary).toContain("Downstream run: `unavailable`");
+    expect(summary).not.toContain("actions/runs/");
   });
 
-  it("attempts the LKG dispatch after an unconfirmed production write (#9661)", () => {
+  it("rejects a downstream run URL that does not match its numeric ID (#6772)", () => {
     const fixture = createFixture();
-    tag(fixture, "v0.0.109");
+    tag(fixture, "v0.0.1");
 
-    const result = runScript(fixture, "dispatch-images", { GH_EXIT_CODE_1: "1" });
-
-    expect(result.status).not.toBe(0);
-    expect(callCount(fixture)).toBe(2);
-    expect(result.stderr).toContain("production image dispatch; it may have been accepted");
-    expect(callArgs(fixture, 2)).toEqual(expectedArgs("build-lkg-image.yml"));
-    const summary = fs.readFileSync(fixture.summaryPath, "utf8");
-    expect(summary).toContain("Dispatch result: `failed (dispatch may have been accepted)`");
-    expect(summary).toContain(
-      "Downstream run: [987654321](https://github.com/brevdev/nemoclaw-image/actions/runs/987654321)",
-    );
-  });
-
-  it("preserves the production run when the LKG dispatch is unconfirmed (#9661)", () => {
-    const fixture = createFixture();
-    tag(fixture, "v0.0.109");
-
-    const result = runScript(fixture, "dispatch-images", { GH_EXIT_CODE_2: "1" });
-
-    expect(result.status).not.toBe(0);
-    expect(callCount(fixture)).toBe(2);
-    expect(result.stderr).toContain("LKG-only image dispatch; it may have been accepted");
-    const summary = fs.readFileSync(fixture.summaryPath, "utf8");
-    expect(summary).toContain(
-      "Downstream run: [123456789](https://github.com/brevdev/nemoclaw-image/actions/runs/123456789)",
-    );
-    expect(summary).toContain("Dispatch result: `failed (dispatch may have been accepted)`");
-  });
-
-  it("rejects a returned run URL that does not match its numeric ID (#9661)", () => {
-    const fixture = createFixture();
-    tag(fixture, "v0.0.109");
-
-    const result = runScript(fixture, "dispatch-images", {
-      GH_OUTPUT_2: "987654321\thttps://github.com/brevdev/nemoclaw-image/actions/runs/123456789",
+    const result = runDispatch(fixture, {
+      GH_OUTPUT: "123456789\thttps://github.com/brevdev/nemoclaw-image/actions/runs/987654321",
     });
 
     expect(result.status).not.toBe(0);
-    expect(callCount(fixture)).toBe(2);
     expect(result.stderr).toContain(
-      "GitHub accepted the LKG-only image dispatch but did not return valid run details",
+      "GitHub accepted the dispatch but did not return valid downstream run details",
     );
     const summary = fs.readFileSync(fixture.summaryPath, "utf8");
-    expect(summary).toContain("Dispatch result: `accepted (remote run identity unavailable)`");
+    expect(summary).toContain("Dispatch result: `rejected (invalid run details)`");
     expect(summary).toContain("Downstream run: `unavailable`");
-    expect(summary).not.toContain("actions/runs/987654321");
+    expect(summary).not.toContain("actions/runs/");
   });
 });

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -41,8 +41,6 @@ const E2E_WORKFLOW_CONTRACTS = [
 ] as const;
 
 const OPAQUE_INPUTS = [
-  ".github/workflows/release-lkg-brev-image.yaml",
-  "scripts/release-lkg-brev-image.sh",
   "managed-inference/models/example.yaml",
   "managed-inference/recipes/vllm.example.managed-cluster.v1.yaml",
   "Dockerfile",
@@ -89,13 +87,6 @@ function triggeredBy(relativePath: string): string[] {
 }
 
 describe("Vitest opaque-input watch triggers", () => {
-  it.each([".github/workflows/release-lkg-brev-image.yaml", "scripts/release-lkg-brev-image.sh"])(
-    "maps each LKG image caller input to its contract test [%s] (#9661)",
-    (inputPath) => {
-      expect(triggeredBy(inputPath)).toEqual(["test/release-lkg-brev-image.test.ts"]);
-    },
-  );
-
   it.each([
     ".github/actions/docker-auth-setup/action.yaml",
     ".github/actions/docker-auth-cleanup/action.yaml",

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -41,6 +41,8 @@ const E2E_WORKFLOW_CONTRACTS = [
 ] as const;
 
 const OPAQUE_INPUTS = [
+  ".github/workflows/release-lkg-brev-image.yaml",
+  "scripts/release-lkg-brev-image.sh",
   "managed-inference/models/example.yaml",
   "managed-inference/recipes/vllm.example.managed-cluster.v1.yaml",
   "Dockerfile",
@@ -87,6 +89,13 @@ function triggeredBy(relativePath: string): string[] {
 }
 
 describe("Vitest opaque-input watch triggers", () => {
+  it.each([".github/workflows/release-lkg-brev-image.yaml", "scripts/release-lkg-brev-image.sh"])(
+    "maps each LKG image caller input to its contract test [%s] (#9798)",
+    (inputPath) => {
+      expect(triggeredBy(inputPath)).toEqual(["test/release-lkg-brev-image.test.ts"]);
+    },
+  );
+
   it.each([
     ".github/actions/docker-auth-setup/action.yaml",
     ".github/actions/docker-auth-cleanup/action.yaml",


### PR DESCRIPTION
## Summary

PR #9663 added a second LKG-only Brev image request after the intended source event was misunderstood. This restores the preexisting behavior: moving `lkg` dispatches only the exact semver release to the existing Brev production-image workflow.

No workflow was dispatched and no image, family, or GCP state was changed by this PR.

## Related Issue

Fixes #9798

## Changes

- Remove the unintended LKG request artifact, attestation job, and second downstream dispatch.
- Restore the fixed `build-scheduled.yml@main` production dispatch and its existing run-identity reporting.
- Restore the LKG contract tests, source-shape budget, and opaque-input mappings to the production-only behavior while preserving later unrelated watch-trigger entries.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security review passed with no findings at `378511b6d195523204159432412a05f23672757e`. Current head `1b041adc5e7a146a8926ea9471aadcc525deeab8` adds only the reviewed CodeRabbit token-transport hardening. The initial test-evidence warning and automated rerun-dispatch finding were also fixed by follow-up commits.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused Vitest: 2 files, 50 tests passed; `actionlint`, ShellCheck, Bash syntax, shfmt, and `npm run checks:repository` passed
- [ ] Applicable broad gate passed — Not run. This restores one existing workflow/script contract; focused tests and normal hooks cover the changed behavior.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
