### PR TITLE
feat(release): attest daily image requests

### DIFF
--- a/.github/workflows/release-daily-brev-image.yaml
+++ b/.github/workflows/release-daily-brev-image.yaml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release / Daily Brev Image
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-daily-brev-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  attest-daily-image-request:
+    if: ${{ github.repository == 'NVIDIA/NemoClaw' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.event.deleted == false && github.run_attempt == 1 }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out daily release target
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Prepare daily image request
+        env:
+          DAILY_IMAGE_DELETED: ${{ github.event.deleted }}
+          DAILY_IMAGE_REQUEST_PATH: nemoclaw-daily-image-request.v1.json
+          DAILY_IMAGE_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/release-daily-brev-image.sh prepare-request
+
+      - name: Upload daily image request
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nemoclaw-daily-image-request-v1-${{ github.run_id }}-${{ github.run_attempt }}
+          path: nemoclaw-daily-image-request.v1.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Attest daily image request
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: nemoclaw-daily-image-request.v1.json
+
+  dispatch-daily-image:
+    needs: attest-daily-image-request
+    if: ${{ success() && github.repository == 'NVIDIA/NemoClaw' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.event.deleted == false && github.run_attempt == 1 }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Check out daily release target
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Dispatch daily image build
+        env:
+          DAILY_IMAGE_DELETED: ${{ github.event.deleted }}
+          DAILY_IMAGE_SHA: ${{ github.sha }}
+          NEMOCLAW_IMAGE_DISPATCH_TOKEN: ${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}
+        run: scripts/release-daily-brev-image.sh dispatch-image

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -167,6 +167,11 @@
       "category": "security"
     },
     {
+      "file": "test/release-daily-brev-image.test.ts",
+      "test": "attests one daily request before the isolated dispatch job (#9799)",
+      "category": "security"
+    },
+    {
       "file": "test/release-lkg-brev-image.test.ts",
       "test": "attests one request before the isolated dispatch job (#9661)",
       "category": "security"

--- a/scripts/release-daily-brev-image.sh
+++ b/scripts/release-daily-brev-image.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+TARGET_REPOSITORY="brevdev/nemoclaw-image"
+TARGET_WORKFLOW="build-daily-image.yml"
+TARGET_REF="main"
+SOURCE_REPOSITORY="NVIDIA/NemoClaw"
+SOURCE_WORKFLOW=".github/workflows/release-daily-brev-image.yaml"
+SOURCE_EVENT="push"
+REQUEST_KIND="nemoclaw-daily-image-request"
+REQUEST_SCHEMA_VERSION="1"
+REQUEST_FILENAME="nemoclaw-daily-image-request.v1.json"
+SUMMARY_PATH="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+release_tag="unresolved"
+event_sha="unresolved"
+tag_object_sha="unresolved"
+dispatch_result="not attempted"
+downstream_run_id="unavailable"
+downstream_run_url=""
+
+fail() {
+  echo "release-daily-brev-image: $*" >&2
+  exit 1
+}
+
+write_summary() {
+  {
+    echo "## Daily Brev image dispatch"
+    echo
+    echo "- Release tag: \`$release_tag\`"
+    echo "- Event commit: \`$event_sha\`"
+    echo "- Source run: \`${GITHUB_RUN_ID:-unavailable}\` (attempt \`${GITHUB_RUN_ATTEMPT:-unavailable}\`)"
+    echo "- Target: \`$TARGET_REPOSITORY/.github/workflows/$TARGET_WORKFLOW@$TARGET_REF\`"
+    echo "- Dispatch result: \`$dispatch_result\`"
+    if [[ -n "$downstream_run_url" ]]; then
+      echo "- Downstream run: [$downstream_run_id]($downstream_run_url)"
+    else
+      echo "- Downstream run: \`$downstream_run_id\`"
+    fi
+    echo
+    echo "Follow the accepted downstream run to terminal success and verify its image publication."
+  } >>"$SUMMARY_PATH"
+}
+
+validate_source_context() {
+  [[ "${GITHUB_REPOSITORY:-}" == "$SOURCE_REPOSITORY" ]] \
+    || fail "GITHUB_REPOSITORY must be $SOURCE_REPOSITORY"
+  [[ "${GITHUB_EVENT_NAME:-}" == "$SOURCE_EVENT" ]] \
+    || fail "GITHUB_EVENT_NAME must be $SOURCE_EVENT"
+  [[ "${DAILY_IMAGE_DELETED:-}" == "false" ]] \
+    || fail "DAILY_IMAGE_DELETED must be false"
+  [[ "${GITHUB_REF:-}" =~ ^refs/tags/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] \
+    || fail "GITHUB_REF must identify an exact canonical vX.Y.Z release tag"
+
+  release_tag="${GITHUB_REF#refs/tags/}"
+  [[ "${GITHUB_WORKFLOW_REF:-}" == "$SOURCE_REPOSITORY/$SOURCE_WORKFLOW@$GITHUB_REF" ]] \
+    || fail "GITHUB_WORKFLOW_REF must identify $SOURCE_WORKFLOW at $GITHUB_REF"
+  [[ "${GITHUB_RUN_ID:-}" =~ ^[1-9][0-9]*$ ]] \
+    || fail "GITHUB_RUN_ID must be a positive decimal integer"
+  [[ "${GITHUB_RUN_ATTEMPT:-}" == "1" ]] \
+    || fail "GITHUB_RUN_ATTEMPT must be 1"
+  [[ "${GITHUB_SHA:-}" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "GITHUB_SHA must be a 40-character lowercase hexadecimal SHA"
+
+  [[ -n "${DAILY_IMAGE_SHA:-}" ]] \
+    || fail "DAILY_IMAGE_SHA is required"
+  [[ "$DAILY_IMAGE_SHA" == "$GITHUB_SHA" ]] \
+    || fail "DAILY_IMAGE_SHA must match GITHUB_SHA"
+  event_sha="$GITHUB_SHA"
+}
+
+github_api() {
+  env -u GH_DEBUG gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2026-03-10" \
+    "$@"
+}
+
+verify_release_tag() {
+  [[ -n "${GH_TOKEN:-}" ]] \
+    || fail "GH_TOKEN is required to verify the daily release tag"
+  command -v gh >/dev/null 2>&1 \
+    || fail "GitHub CLI is required to verify the daily release tag"
+
+  local ref_details
+  ref_details="$(
+    github_api \
+      "repos/$SOURCE_REPOSITORY/git/ref/tags/$release_tag" \
+      --jq '[.object.type, .object.sha] | @tsv'
+  )" || fail "Unable to resolve release tag $release_tag through the GitHub API"
+
+  local ref_object_type
+  IFS=$'\t' read -r ref_object_type tag_object_sha <<<"$ref_details"
+  [[ "$ref_object_type" == "tag" ]] \
+    || fail "Release tag $release_tag must be annotated"
+  [[ "$tag_object_sha" =~ ^[0-9a-f]{40}$ ]] \
+    || fail "Release tag $release_tag has an invalid tag-object SHA"
+
+  local verified="false"
+  local verification_reason="unknown"
+  local attempt
+  for attempt in {1..10}; do
+    local tag_details
+    tag_details="$(
+      github_api \
+        "repos/$SOURCE_REPOSITORY/git/tags/$tag_object_sha" \
+        --jq '[.tag, .object.type, .object.sha, .verification.verified, .verification.reason] | @tsv'
+    )" || fail "Unable to inspect release tag object $tag_object_sha through the GitHub API"
+
+    local object_tag
+    local object_type
+    local object_sha
+    IFS=$'\t' read -r object_tag object_type object_sha verified verification_reason <<<"$tag_details"
+    [[ "$object_tag" == "$release_tag" ]] \
+      || fail "Tag object $tag_object_sha names $object_tag, expected $release_tag"
+    [[ "$object_type" == "commit" ]] \
+      || fail "Release tag $release_tag must point directly to a commit"
+    [[ "$object_sha" == "$event_sha" ]] \
+      || fail "Release tag $release_tag must point to GITHUB_SHA"
+
+    if [[ "$verified" == "true" ]]; then
+      [[ "$verification_reason" == "valid" ]] \
+        || fail "Release tag $release_tag verification reason must be valid"
+      break
+    fi
+    if ((attempt < 10)); then
+      echo "release-daily-brev-image: waiting for GitHub tag verification ($attempt/10)"
+      sleep 3
+    fi
+  done
+  [[ "$verified" == "true" && "$verification_reason" == "valid" ]] \
+    || fail "Release tag $release_tag is not GitHub-Verified ($verification_reason)"
+
+  local compare_status
+  compare_status="$(
+    github_api \
+      "repos/$SOURCE_REPOSITORY/compare/$event_sha...main" \
+      --jq '.status'
+  )" || fail "Unable to compare release commit $event_sha with main through the GitHub API"
+  [[ "$compare_status" == "ahead" || "$compare_status" == "identical" ]] \
+    || fail "Release commit $event_sha must be reachable from main"
+}
+
+prepare_request() {
+  validate_source_context
+  verify_release_tag
+
+  local request_path="${DAILY_IMAGE_REQUEST_PATH:-}"
+  if [[ -z "$request_path" ]]; then
+    [[ -n "${RUNNER_TEMP:-}" ]] \
+      || fail "RUNNER_TEMP or DAILY_IMAGE_REQUEST_PATH is required to locate the daily image request"
+    request_path="$RUNNER_TEMP/nemoclaw-daily-image-request/$REQUEST_FILENAME"
+  fi
+  [[ -n "$request_path" && "${request_path##*/}" == "$REQUEST_FILENAME" ]] \
+    || fail "DAILY_IMAGE_REQUEST_PATH must end with $REQUEST_FILENAME"
+  [[ ! -e "$request_path" ]] || fail "Refusing to overwrite existing daily image request"
+
+  local created_at
+  created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  [[ "$created_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
+    || fail "Unable to create an RFC 3339 UTC timestamp"
+
+  local request_json
+  request_json="$(
+    jq -cn \
+      --argjson schema_version "$REQUEST_SCHEMA_VERSION" \
+      --arg kind "$REQUEST_KIND" \
+      --arg source_repository "$SOURCE_REPOSITORY" \
+      --arg source_workflow "$SOURCE_WORKFLOW" \
+      --arg event "$SOURCE_EVENT" \
+      --arg ref "$GITHUB_REF" \
+      --arg run_id "$GITHUB_RUN_ID" \
+      --arg event_sha "$event_sha" \
+      --arg release_tag "$release_tag" \
+      --arg tag_object_sha "$tag_object_sha" \
+      --arg target_repository "$TARGET_REPOSITORY" \
+      --arg target_workflow ".github/workflows/$TARGET_WORKFLOW" \
+      --arg created_at "$created_at" \
+      '{schemaVersion:$schema_version,kind:$kind,sourceRepository:$source_repository,sourceWorkflow:$source_workflow,event:$event,ref:$ref,runId:$run_id,runAttempt:1,eventSha:$event_sha,releaseTag:$release_tag,tagObjectSha:$tag_object_sha,targetRepository:$target_repository,targetWorkflow:$target_workflow,createdAt:$created_at}'
+  )" || fail "Unable to create the daily image request"
+
+  umask 077
+  local request_directory
+  request_directory="$(dirname -- "$request_path")"
+  mkdir -p "$request_directory"
+  printf '%s\n' "$request_json" >"$request_path"
+
+  local expected_bytes
+  expected_bytes=$((${#request_json} + 1))
+  local actual_bytes
+  actual_bytes="$(wc -c <"$request_path" | tr -d '[:space:]')"
+  if [[ "$(<"$request_path")" != "$request_json" || "$actual_bytes" != "$expected_bytes" ]]; then
+    fail "Daily image request bytes are not canonical compact JSON with one trailing LF"
+  fi
+  jq -e \
+    --arg ref "$GITHUB_REF" \
+    --arg run_id "$GITHUB_RUN_ID" \
+    --arg event_sha "$event_sha" \
+    --arg release_tag "$release_tag" \
+    --arg tag_object_sha "$tag_object_sha" \
+    --arg created_at "$created_at" \
+    'keys_unsorted == ["schemaVersion","kind","sourceRepository","sourceWorkflow","event","ref","runId","runAttempt","eventSha","releaseTag","tagObjectSha","targetRepository","targetWorkflow","createdAt"] and .schemaVersion == 1 and .kind == "nemoclaw-daily-image-request" and .sourceRepository == "NVIDIA/NemoClaw" and .sourceWorkflow == ".github/workflows/release-daily-brev-image.yaml" and .event == "push" and .ref == $ref and .runId == $run_id and .runAttempt == 1 and .eventSha == $event_sha and .releaseTag == $release_tag and .tagObjectSha == $tag_object_sha and .targetRepository == "brevdev/nemoclaw-image" and .targetWorkflow == ".github/workflows/build-daily-image.yml" and .createdAt == $created_at' \
+    "$request_path" >/dev/null || fail "Daily image request content failed local validation"
+  chmod 0400 "$request_path"
+  printf 'release-daily-brev-image: prepared %s for source run %s attempt %s\n' \
+    "$request_path" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT"
+}
+
+dispatch_image() {
+  validate_source_context
+
+  [[ -n "${NEMOCLAW_IMAGE_DISPATCH_TOKEN:-}" ]] \
+    || fail "NEMOCLAW_IMAGE_DISPATCH_TOKEN is required to dispatch $TARGET_REPOSITORY"
+  command -v gh >/dev/null 2>&1 \
+    || fail "GitHub CLI is required to dispatch $TARGET_REPOSITORY"
+
+  local payload
+  payload="$(printf '{\"ref\":\"%s\",\"return_run_details\":true,\"inputs\":{\"requester_workflow_run_id\":\"%s\",\"requester_workflow_run_attempt\":\"%s\"}}' "$TARGET_REF" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
+  local endpoint="repos/$TARGET_REPOSITORY/actions/workflows/$TARGET_WORKFLOW/dispatches"
+  local dispatch_details
+
+  dispatch_result="failed (dispatch may have been accepted)"
+  if ! dispatch_details="$(
+    printf '%s\n' "$payload" \
+      | env -u GH_DEBUG GH_TOKEN="$NEMOCLAW_IMAGE_DISPATCH_TOKEN" gh api \
+        --method POST \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2026-03-10" \
+        "$endpoint" \
+        --input - \
+        --jq '[.workflow_run_id, .html_url] | @tsv'
+  )"; then
+    echo "release-daily-brev-image: GitHub did not confirm the daily image dispatch; it may have been accepted and will not be retried" >&2
+    return 1
+  fi
+
+  IFS=$'\t' read -r downstream_run_id downstream_run_url <<<"$dispatch_details"
+  local expected_run_url="https://github.com/$TARGET_REPOSITORY/actions/runs/$downstream_run_id"
+  if [[ ! "$downstream_run_id" =~ ^[1-9][0-9]*$ || "$downstream_run_url" != "$expected_run_url" ]]; then
+    downstream_run_id="unavailable"
+    downstream_run_url=""
+    dispatch_result="accepted (remote run identity unavailable)"
+    echo "release-daily-brev-image: GitHub accepted the daily image dispatch but did not return valid run details; it will not be retried" >&2
+    return 1
+  fi
+
+  dispatch_result="accepted (HTTP 200)"
+  printf 'release-daily-brev-image: dispatched %s for %s (%s): %s\n' \
+    "$TARGET_WORKFLOW" "$release_tag" "$event_sha" "$downstream_run_url"
+}
+
+operation="${1:-dispatch-image}"
+case "$operation" in
+  prepare-request)
+    prepare_request
+    ;;
+  dispatch-image)
+    trap write_summary EXIT
+    if ! dispatch_image; then
+      fail "Daily image dispatch was not confirmed; see the workflow summary"
+    fi
+    ;;
+  *)
+    fail "Usage: ${0##*/} [prepare-request|dispatch-image]"
+    ;;
+esac

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -46,6 +46,11 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
   },
   {
     pattern:
+      /(?:^|\/)(?:\.github\/workflows\/release-daily-brev-image\.yaml|scripts\/release-daily-brev-image\.sh)$/,
+    testsToRun: runTests("test/release-daily-brev-image.test.ts"),
+  },
+  {
+    pattern:
       /(?:^|\/)(?:\.github\/workflows\/release-lkg-brev-image\.yaml|scripts\/release-lkg-brev-image\.sh)$/,
     testsToRun: runTests("test/release-lkg-brev-image.test.ts"),
   },

--- a/test/release-daily-brev-image.test.ts
+++ b/test/release-daily-brev-image.test.ts
@@ -1,0 +1,567 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readYaml } from "./helpers/e2e-workflow-contract";
+
+const repoRoot = path.join(import.meta.dirname, "..");
+const scriptPath = path.join(repoRoot, "scripts", "release-daily-brev-image.sh");
+const workflowPath = ".github/workflows/release-daily-brev-image.yaml";
+const releaseTag = "v0.0.113";
+const sourceRef = `refs/tags/${releaseTag}`;
+const sourceWorkflowRef = `NVIDIA/NemoClaw/${workflowPath}@${sourceRef}`;
+const eventSha = "a".repeat(40);
+const tagObjectSha = "b".repeat(40);
+const fixedCreatedAt = "2026-08-20T12:34:56Z";
+const sourceRunId = "32390000000";
+const tempRoots: string[] = [];
+
+type WorkflowStep = {
+  env?: Record<string, string>;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type WorkflowJob = {
+  if?: string;
+  needs?: string;
+  permissions?: Record<string, string>;
+  "runs-on"?: string;
+  steps?: WorkflowStep[];
+  "timeout-minutes"?: number;
+};
+
+type Workflow = {
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+  jobs: Record<string, WorkflowJob>;
+  on?: { push?: { tags?: string[] } };
+  permissions?: Record<string, string>;
+};
+
+type Fixture = {
+  binDir: string;
+  counterPath: string;
+  recordDir: string;
+  requestPath: string;
+  root: string;
+  summaryPath: string;
+};
+
+function createFixture(): Fixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-release-daily-brev-image-"));
+  tempRoots.push(root);
+  const binDir = path.join(root, "bin");
+  const recordDir = path.join(root, "gh-records");
+  const counterPath = path.join(root, "gh-counter.txt");
+  const requestPath = path.join(
+    root,
+    "runner-temp",
+    "nemoclaw-daily-image-request",
+    "nemoclaw-daily-image-request.v1.json",
+  );
+  const summaryPath = path.join(root, "summary.md");
+  fs.mkdirSync(binDir);
+  fs.mkdirSync(recordDir);
+
+  const fakeGh = path.join(binDir, "gh");
+  fs.writeFileSync(
+    fakeGh,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${GH_TOKEN:-}" != "\${EXPECTED_GH_TOKEN:-}" ]]; then
+  echo "unexpected GH_TOKEN" >&2
+  exit 2
+fi
+call=1
+if [[ -f "$GH_COUNTER_PATH" ]]; then
+  call=$(( $(<"$GH_COUNTER_PATH") + 1 ))
+fi
+printf '%s\n' "$call" >"$GH_COUNTER_PATH"
+printf '%s\n' "$@" >"$GH_RECORD_DIR/gh-args-$call.txt"
+endpoint=""
+for argument in "$@"; do
+  case "$argument" in
+    repos/*)
+      endpoint="$argument"
+      break
+      ;;
+  esac
+done
+printf '%s\n' "$endpoint" >"$GH_RECORD_DIR/gh-endpoint-$call.txt"
+if [[ " $* " == *" --input - "* ]]; then
+  cat >"$GH_RECORD_DIR/gh-input-$call.json"
+else
+  : >"$GH_RECORD_DIR/gh-input-$call.json"
+fi
+if [[ -n "\${GH_FAIL_ENDPOINT:-}" && "$endpoint" == "$GH_FAIL_ENDPOINT" ]]; then
+  echo "HTTP 403: request denied" >&2
+  exit 1
+fi
+case "$endpoint" in
+  repos/NVIDIA/NemoClaw/git/ref/tags/*)
+    printf '%s\t%s\n' "\${GH_REF_OBJECT_TYPE:-tag}" "\${GH_TAG_OBJECT_SHA:-${tagObjectSha}}"
+    ;;
+  repos/NVIDIA/NemoClaw/git/tags/*)
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+      "\${GH_OBJECT_TAG:-${releaseTag}}" \
+      "\${GH_OBJECT_TYPE:-commit}" \
+      "\${GH_OBJECT_SHA:-${eventSha}}" \
+      "\${GH_TAG_VERIFIED:-true}" \
+      "\${GH_VERIFICATION_REASON:-valid}"
+    ;;
+  repos/NVIDIA/NemoClaw/compare/*)
+    printf '%s\n' "\${GH_COMPARE_STATUS:-ahead}"
+    ;;
+  repos/brevdev/nemoclaw-image/actions/workflows/build-daily-image.yml/dispatches)
+    printf '%b\n' "\${GH_DISPATCH_OUTPUT:-987654321\\thttps://github.com/brevdev/nemoclaw-image/actions/runs/987654321}"
+    ;;
+  *)
+    echo "unexpected endpoint: $endpoint" >&2
+    exit 3
+    ;;
+esac
+`,
+    "utf8",
+  );
+  fs.chmodSync(fakeGh, 0o755);
+
+  const fakeDate = path.join(binDir, "date");
+  fs.writeFileSync(
+    fakeDate,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$#" == "2" && "$1" == "-u" && "$2" == "+%Y-%m-%dT%H:%M:%SZ" ]]; then
+  printf '%s\n' "${fixedCreatedAt}"
+else
+  /bin/date "$@"
+fi
+`,
+    "utf8",
+  );
+  fs.chmodSync(fakeDate, 0o755);
+
+  const fakeSleep = path.join(binDir, "sleep");
+  fs.writeFileSync(fakeSleep, "#!/usr/bin/env bash\nexit 0\n", "utf8");
+  fs.chmodSync(fakeSleep, 0o755);
+
+  return { binDir, counterPath, recordDir, requestPath, root, summaryPath };
+}
+
+function runScript(
+  fixture: Fixture,
+  operation: "prepare-request" | "dispatch-image",
+  extraEnv: NodeJS.ProcessEnv = {},
+): ReturnType<typeof spawnSync> {
+  const prepare = operation === "prepare-request";
+  return spawnSync("bash", [scriptPath, operation], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      DAILY_IMAGE_DELETED: "false",
+      DAILY_IMAGE_REQUEST_PATH: fixture.requestPath,
+      DAILY_IMAGE_SHA: eventSha,
+      EXPECTED_GH_TOKEN: prepare ? "test-read-token" : "test-dispatch-token",
+      GH_COUNTER_PATH: fixture.counterPath,
+      GH_RECORD_DIR: fixture.recordDir,
+      GH_TOKEN: prepare ? "test-read-token" : "",
+      GITHUB_EVENT_NAME: "push",
+      GITHUB_REF: sourceRef,
+      GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
+      GITHUB_RUN_ATTEMPT: "1",
+      GITHUB_RUN_ID: sourceRunId,
+      GITHUB_SHA: eventSha,
+      GITHUB_STEP_SUMMARY: fixture.summaryPath,
+      GITHUB_WORKFLOW_REF: sourceWorkflowRef,
+      NEMOCLAW_IMAGE_DISPATCH_TOKEN: "test-dispatch-token",
+      PATH: `${fixture.binDir}:${process.env.PATH ?? ""}`,
+      RUNNER_TEMP: path.join(fixture.root, "runner-temp"),
+      ...extraEnv,
+    },
+  });
+}
+
+function callCount(fixture: Fixture): number {
+  return fs.existsSync(fixture.counterPath)
+    ? Number.parseInt(fs.readFileSync(fixture.counterPath, "utf8"), 10)
+    : 0;
+}
+
+function callArgs(fixture: Fixture, call: number): string[] {
+  return fs
+    .readFileSync(path.join(fixture.recordDir, `gh-args-${call}.txt`), "utf8")
+    .trim()
+    .split("\n");
+}
+
+function callEndpoint(fixture: Fixture, call: number): string {
+  return fs.readFileSync(path.join(fixture.recordDir, `gh-endpoint-${call}.txt`), "utf8").trim();
+}
+
+function callInput(fixture: Fixture, call: number): string {
+  return fs.readFileSync(path.join(fixture.recordDir, `gh-input-${call}.json`), "utf8");
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe("Daily Brev image request workflow", () => {
+  // source-shape-contract: security -- The daily release caller must keep tag provenance, attestation permissions, action pins, job order, and its dispatch credential on reviewed workflow boundaries
+  it("attests one daily request before the isolated dispatch job (#9799)", () => {
+    const workflow = readYaml<Workflow>(workflowPath);
+
+    expect(workflow.on).toEqual({ push: { tags: ["v*.*.*"] } });
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(workflow.concurrency).toEqual({
+      group: "release-daily-brev-image-${{ github.ref }}",
+      "cancel-in-progress": false,
+    });
+    expect(Object.keys(workflow.jobs)).toEqual([
+      "attest-daily-image-request",
+      "dispatch-daily-image",
+    ]);
+
+    const attest = workflow.jobs["attest-daily-image-request"];
+    expect(attest.if).toContain("github.repository == 'NVIDIA/NemoClaw'");
+    expect(attest.if).toContain("github.event_name == 'push'");
+    expect(attest.if).toContain("startsWith(github.ref, 'refs/tags/v')");
+    expect(attest.if).toContain("github.event.deleted == false");
+    expect(attest.if).toContain("github.run_attempt == 1");
+    expect(attest.permissions).toEqual({
+      contents: "read",
+      attestations: "write",
+      "id-token": "write",
+    });
+    expect(attest["runs-on"]).toBe("ubuntu-latest");
+    expect(JSON.stringify(attest)).not.toContain("NEMOCLAW_IMAGE_DISPATCH_TOKEN");
+
+    const steps = attest.steps ?? [];
+    expect(steps.map((step) => step.name)).toEqual([
+      "Check out daily release target",
+      "Prepare daily image request",
+      "Upload daily image request",
+      "Attest daily image request",
+    ]);
+    expect(steps[0]).toMatchObject({
+      uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+      with: { ref: "${{ github.sha }}", "fetch-depth": 0, "persist-credentials": false },
+    });
+    expect(steps[1]).toEqual({
+      name: "Prepare daily image request",
+      env: {
+        DAILY_IMAGE_DELETED: "${{ github.event.deleted }}",
+        DAILY_IMAGE_REQUEST_PATH: "nemoclaw-daily-image-request.v1.json",
+        DAILY_IMAGE_SHA: "${{ github.sha }}",
+        GH_TOKEN: "${{ github.token }}",
+      },
+      run: "scripts/release-daily-brev-image.sh prepare-request",
+    });
+    expect(steps[2]).toEqual({
+      name: "Upload daily image request",
+      uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+      with: {
+        name: "nemoclaw-daily-image-request-v1-${{ github.run_id }}-${{ github.run_attempt }}",
+        path: "nemoclaw-daily-image-request.v1.json",
+        "if-no-files-found": "error",
+        "retention-days": 30,
+      },
+    });
+    expect(steps[3]).toEqual({
+      name: "Attest daily image request",
+      uses: "actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8",
+      with: { "subject-path": "nemoclaw-daily-image-request.v1.json" },
+    });
+
+    const dispatch = workflow.jobs["dispatch-daily-image"];
+    expect(dispatch.needs).toBe("attest-daily-image-request");
+    expect(dispatch.if).toContain("success()");
+    expect(dispatch.if).toContain("github.event.deleted == false");
+    expect(dispatch.if).toContain("github.run_attempt == 1");
+    expect(dispatch.permissions).toEqual({ contents: "read" });
+    expect(dispatch["runs-on"]).toBe("ubuntu-latest");
+    const dispatchSteps = dispatch.steps ?? [];
+    expect(dispatchSteps).toHaveLength(2);
+    expect(dispatchSteps[0]).toEqual({
+      name: "Check out daily release target",
+      uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+      with: {
+        ref: "${{ github.sha }}",
+        "fetch-depth": 1,
+        "persist-credentials": false,
+      },
+    });
+    expect(dispatchSteps[1]).toEqual({
+      name: "Dispatch daily image build",
+      env: {
+        DAILY_IMAGE_DELETED: "${{ github.event.deleted }}",
+        DAILY_IMAGE_SHA: "${{ github.sha }}",
+        NEMOCLAW_IMAGE_DISPATCH_TOKEN: "${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}",
+      },
+      run: "scripts/release-daily-brev-image.sh dispatch-image",
+    });
+    expect(JSON.stringify(dispatchSteps[0])).not.toContain("NEMOCLAW_IMAGE_DISPATCH_TOKEN");
+    expect(JSON.stringify(workflow).match(/\$\{\{ secrets\.[^}]+ \}\}/gu)).toEqual([
+      "${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}",
+    ]);
+    expect(JSON.stringify(workflow)).not.toContain("google-github-actions/auth");
+  });
+});
+
+describe("Daily Brev image request", () => {
+  it("writes the canonical verified-tag request bytes without credentials (#9799)", () => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture, "prepare-request");
+
+    expect(result.status).toBe(0);
+    expect(callCount(fixture)).toBe(3);
+    expect(callEndpoint(fixture, 1)).toBe(`repos/NVIDIA/NemoClaw/git/ref/tags/${releaseTag}`);
+    expect(callEndpoint(fixture, 2)).toBe(`repos/NVIDIA/NemoClaw/git/tags/${tagObjectSha}`);
+    expect(callEndpoint(fixture, 3)).toBe(`repos/NVIDIA/NemoClaw/compare/${eventSha}...main`);
+    expect(callInput(fixture, 1)).toBe("");
+    expect(callInput(fixture, 2)).toBe("");
+    expect(callInput(fixture, 3)).toBe("");
+
+    const expected = `${JSON.stringify({
+      schemaVersion: 1,
+      kind: "nemoclaw-daily-image-request",
+      sourceRepository: "NVIDIA/NemoClaw",
+      sourceWorkflow: workflowPath,
+      event: "push",
+      ref: sourceRef,
+      runId: sourceRunId,
+      runAttempt: 1,
+      eventSha,
+      releaseTag,
+      tagObjectSha,
+      targetRepository: "brevdev/nemoclaw-image",
+      targetWorkflow: ".github/workflows/build-daily-image.yml",
+      createdAt: fixedCreatedAt,
+    })}\n`;
+    const request = fs.readFileSync(fixture.requestPath, "utf8");
+    expect(request).toBe(expected);
+    expect(request.split("\n")).toHaveLength(2);
+    expect(fs.statSync(fixture.requestPath).mode & 0o777).toBe(0o400);
+    expect(fs.existsSync(fixture.summaryPath)).toBe(false);
+    expect(`${request}${result.stdout}${result.stderr}`).not.toContain("test-read-token");
+    expect(`${request}${result.stdout}${result.stderr}`).not.toContain("test-dispatch-token");
+  });
+
+  it.each([
+    ["another repository", { GITHUB_REPOSITORY: "example/NemoClaw" }, "GITHUB_REPOSITORY"],
+    ["a manual event", { GITHUB_EVENT_NAME: "workflow_dispatch" }, "GITHUB_EVENT_NAME"],
+    ["a deleted tag", { DAILY_IMAGE_DELETED: "true" }, "DAILY_IMAGE_DELETED"],
+    ["a branch", { GITHUB_REF: "refs/heads/main" }, "GITHUB_REF"],
+    ["a prerelease", { GITHUB_REF: "refs/tags/v0.0.113-rc.1" }, "GITHUB_REF"],
+    ["a leading-zero version", { GITHUB_REF: "refs/tags/v00.0.113" }, "GITHUB_REF"],
+    [
+      "another workflow ref",
+      { GITHUB_WORKFLOW_REF: `NVIDIA/NemoClaw/.github/workflows/other.yaml@${sourceRef}` },
+      "GITHUB_WORKFLOW_REF",
+    ],
+    ["a zero run ID", { GITHUB_RUN_ID: "0" }, "GITHUB_RUN_ID"],
+    ["a workflow rerun", { GITHUB_RUN_ATTEMPT: "2" }, "GITHUB_RUN_ATTEMPT"],
+    ["an uppercase event SHA", { GITHUB_SHA: "A".repeat(40) }, "GITHUB_SHA"],
+    ["a missing event SHA binding", { DAILY_IMAGE_SHA: "" }, "DAILY_IMAGE_SHA is required"],
+    ["another event SHA binding", { DAILY_IMAGE_SHA: "c".repeat(40) }, "must match GITHUB_SHA"],
+  ])("rejects %s before reading GitHub tag state (#9799)", (_name, environment, message) => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture, "prepare-request", environment);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(message);
+    expect(fs.existsSync(fixture.requestPath)).toBe(false);
+    expect(callCount(fixture)).toBe(0);
+  });
+
+  it("requires the job-scoped GitHub token before reading tag state (#9799)", () => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture, "prepare-request", { GH_TOKEN: "" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("GH_TOKEN is required to verify the daily release tag");
+    expect(callCount(fixture)).toBe(0);
+    expect(fs.existsSync(fixture.requestPath)).toBe(false);
+  });
+
+  it.each([
+    ["a lightweight tag", { GH_REF_OBJECT_TYPE: "commit" }, "must be annotated"],
+    ["an invalid tag-object SHA", { GH_TAG_OBJECT_SHA: "short" }, "invalid tag-object SHA"],
+    ["a renamed tag object", { GH_OBJECT_TAG: "v0.0.112" }, "names v0.0.112"],
+    ["an indirect tag", { GH_OBJECT_TYPE: "tag" }, "must point directly to a commit"],
+    ["another commit", { GH_OBJECT_SHA: "c".repeat(40) }, "must point to GITHUB_SHA"],
+    [
+      "a non-valid verification reason",
+      { GH_TAG_VERIFIED: "true", GH_VERIFICATION_REASON: "expired_key" },
+      "verification reason must be valid",
+    ],
+    ["an unverified tag", { GH_TAG_VERIFIED: "false" }, "is not GitHub-Verified"],
+    ["a commit outside main", { GH_COMPARE_STATUS: "diverged" }, "must be reachable from main"],
+  ])("rejects %s before creating a request (#9799)", (_name, environment, message) => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture, "prepare-request", environment);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(message);
+    expect(fs.existsSync(fixture.requestPath)).toBe(false);
+    expect(callCount(fixture)).toBeGreaterThan(0);
+  });
+
+  it("fails closed when GitHub cannot return the annotated tag object (#9799)", () => {
+    const fixture = createFixture();
+    const endpoint = `repos/NVIDIA/NemoClaw/git/tags/${tagObjectSha}`;
+
+    const result = runScript(fixture, "prepare-request", { GH_FAIL_ENDPOINT: endpoint });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Unable to inspect release tag object");
+    expect(callCount(fixture)).toBe(2);
+    expect(fs.existsSync(fixture.requestPath)).toBe(false);
+  });
+
+  it("requires a request location after validating the release tag (#9799)", () => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture, "prepare-request", {
+      DAILY_IMAGE_REQUEST_PATH: "",
+      RUNNER_TEMP: "",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "RUNNER_TEMP or DAILY_IMAGE_REQUEST_PATH is required to locate the daily image request",
+    );
+    expect(callCount(fixture)).toBe(3);
+  });
+
+  it("refuses to overwrite an existing request (#9799)", () => {
+    const fixture = createFixture();
+    fs.mkdirSync(path.dirname(fixture.requestPath), { recursive: true });
+    fs.writeFileSync(fixture.requestPath, "existing\n");
+
+    const result = runScript(fixture, "prepare-request");
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Refusing to overwrite existing daily image request");
+    expect(fs.readFileSync(fixture.requestPath, "utf8")).toBe("existing\n");
+  });
+});
+
+describe("Daily Brev image dispatch", () => {
+  it("dispatches only the attested source run identity without waiting downstream (#9799)", () => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture, "dispatch-image");
+
+    expect(result.status).toBe(0);
+    expect(callCount(fixture)).toBe(1);
+    expect(callEndpoint(fixture, 1)).toBe(
+      "repos/brevdev/nemoclaw-image/actions/workflows/build-daily-image.yml/dispatches",
+    );
+    expect(callArgs(fixture, 1)).toEqual([
+      "api",
+      "--method",
+      "POST",
+      "-H",
+      "Accept: application/vnd.github+json",
+      "-H",
+      "X-GitHub-Api-Version: 2026-03-10",
+      "repos/brevdev/nemoclaw-image/actions/workflows/build-daily-image.yml/dispatches",
+      "--input",
+      "-",
+      "--jq",
+      "[.workflow_run_id, .html_url] | @tsv",
+    ]);
+    expect(callInput(fixture, 1)).toBe(
+      `{"ref":"main","return_run_details":true,"inputs":{"requester_workflow_run_id":"${sourceRunId}","requester_workflow_run_attempt":"1"}}\n`,
+    );
+    const summary = fs.readFileSync(fixture.summaryPath, "utf8");
+    expect(summary).toContain(`Release tag: \`${releaseTag}\``);
+    expect(summary).toContain(`Event commit: \`${eventSha}\``);
+    expect(summary).toContain(`Source run: \`${sourceRunId}\` (attempt \`1\`)`);
+    expect(summary).toContain(
+      "Target: `brevdev/nemoclaw-image/.github/workflows/build-daily-image.yml@main`",
+    );
+    expect(summary).toContain("Dispatch result: `accepted (HTTP 200)`");
+    expect(summary).toContain(
+      "Downstream run: [987654321](https://github.com/brevdev/nemoclaw-image/actions/runs/987654321)",
+    );
+    expect(`${result.stdout}${result.stderr}${summary}`).not.toContain("test-dispatch-token");
+  });
+
+  it("fails before dispatch when the credential is absent (#9799)", () => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture, "dispatch-image", {
+      NEMOCLAW_IMAGE_DISPATCH_TOKEN: "",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("NEMOCLAW_IMAGE_DISPATCH_TOKEN is required");
+    expect(callCount(fixture)).toBe(0);
+    expect(fs.readFileSync(fixture.summaryPath, "utf8")).toContain(
+      "Dispatch result: `not attempted`",
+    );
+  });
+
+  it.each([
+    ["a deleted tag", { DAILY_IMAGE_DELETED: "true" }, "DAILY_IMAGE_DELETED"],
+    ["a manual event", { GITHUB_EVENT_NAME: "workflow_dispatch" }, "GITHUB_EVENT_NAME"],
+    ["a prerelease", { GITHUB_REF: "refs/tags/v0.0.113-rc.1" }, "GITHUB_REF"],
+    ["a workflow rerun", { GITHUB_RUN_ATTEMPT: "2" }, "GITHUB_RUN_ATTEMPT"],
+  ])("rejects %s before dispatch (#9799)", (_name, environment, message) => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture, "dispatch-image", environment);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(message);
+    expect(callCount(fixture)).toBe(0);
+    expect(fs.readFileSync(fixture.summaryPath, "utf8")).toContain(
+      "Dispatch result: `not attempted`",
+    );
+  });
+
+  it("does not retry an accepted dispatch with an invalid run identity (#9799)", () => {
+    const fixture = createFixture();
+
+    const result = runScript(fixture, "dispatch-image", { GH_DISPATCH_OUTPUT: "null\tnull" });
+
+    expect(result.status).not.toBe(0);
+    expect(callCount(fixture)).toBe(1);
+    expect(result.stderr).toContain("accepted the daily image dispatch");
+    expect(result.stderr).toContain("will not be retried");
+    const summary = fs.readFileSync(fixture.summaryPath, "utf8");
+    expect(summary).toContain("Dispatch result: `accepted (remote run identity unavailable)`");
+    expect(summary).toContain("Downstream run: `unavailable`");
+  });
+
+  it("does not retry an unconfirmed external write (#9799)", () => {
+    const fixture = createFixture();
+    const endpoint =
+      "repos/brevdev/nemoclaw-image/actions/workflows/build-daily-image.yml/dispatches";
+
+    const result = runScript(fixture, "dispatch-image", { GH_FAIL_ENDPOINT: endpoint });
+
+    expect(result.status).not.toBe(0);
+    expect(callCount(fixture)).toBe(1);
+    expect(result.stderr).toContain("dispatch; it may have been accepted");
+    expect(result.stderr).toContain("will not be retried");
+    expect(fs.readFileSync(fixture.summaryPath, "utf8")).toContain(
+      "Dispatch result: `failed (dispatch may have been accepted)`",
+    );
+  });
+});

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -41,6 +41,8 @@ const E2E_WORKFLOW_CONTRACTS = [
 ] as const;
 
 const OPAQUE_INPUTS = [
+  ".github/workflows/release-daily-brev-image.yaml",
+  "scripts/release-daily-brev-image.sh",
   ".github/workflows/release-lkg-brev-image.yaml",
   "scripts/release-lkg-brev-image.sh",
   "managed-inference/models/example.yaml",
@@ -89,6 +91,13 @@ function triggeredBy(relativePath: string): string[] {
 }
 
 describe("Vitest opaque-input watch triggers", () => {
+  it.each([
+    ".github/workflows/release-daily-brev-image.yaml",
+    "scripts/release-daily-brev-image.sh",
+  ])("maps each daily image caller input to its contract test [%s] (#9799)", (inputPath) => {
+    expect(triggeredBy(inputPath)).toEqual(["test/release-daily-brev-image.test.ts"]);
+  });
+
   it.each([".github/workflows/release-lkg-brev-image.yaml", "scripts/release-lkg-brev-image.sh"])(
     "maps each LKG image caller input to its contract test [%s] (#9661)",
     (inputPath) => {


### PR DESCRIPTION
## Summary

Daily signed `vX.Y.Z` release tags currently publish the normal release assets but do not request a Brev image in a dedicated Daily Tag family. This adds a separate least-privilege tag-push caller that attests the exact signed tag event and dispatches the fixed downstream Daily Image workflow.

The existing `lkg` to `nemoclaw-brev-cpu` production path is unchanged. This PR does not dispatch a workflow, build or publish an image, or change GCP state.

## Related Issue

Fixes #9799

Downstream contract: brevdev/nemoclaw-image#124

## Changes

- Add `Release / Daily Brev Image` for attempt-1, non-deletion, canonical semver tag pushes only.
- Verify the annotated tag object, GitHub verification result, direct commit target, event SHA, and protected-main reachability before creating a request.
- Upload and attest canonical request bytes that bind the dynamic release ref, release tag, tag-object SHA, peeled commit, source run, and fixed downstream workflow.
- Isolate attestation permissions from the existing cross-repository dispatch secret; pass only source run ID and attempt downstream and never wait for the downstream build.
- Add positive, negative, ambiguous-write, secret-redaction, workflow-boundary, source-shape, and opaque-input regression coverage.

The dedicated downstream workflow, project, family, protected environment, WIF publisher, evidence storage, source workflow ID pin, and release-tag creation restriction must be ready before this caller merges or is activated.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category review found no code-level vulnerability at `d67fc33e85dcddbc2c50ee2b1f7ccc94d1af4f9f`. It identified an activation blocker: restrict `refs/tags/v*` creation to the release principal before merge or activation. This PR remains draft while that and the listed downstream controls are provisioned.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused Vitest: 2 files, 83 tests passed; `actionlint`, ShellCheck, Bash syntax, repository shfmt, `npm run checks:repository`, and `npm run source-shape:check` passed
- [ ] Applicable broad gate passed — Not run. The new behavior is a deterministic workflow/script boundary; focused tests and normal hooks cover it without external writes.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated, secure process for preparing and dispatching daily Brev image builds from version tags.
  * Added validation for release context, verified tags, request integrity, and build results.
  * Added release summaries with dispatch details and safeguards against unsafe retries.

* **Tests**
  * Added comprehensive coverage for workflow security, validation, dispatch behavior, and failure handling.
  * Added automated test monitoring for related workflow and script changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->