### PR TITLE
fix(inference): patch llama.cpp image dependencies

### DIFF
--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -44,6 +44,7 @@ jobs:
       cuda_runtime_image: ${{ steps.manifest.outputs.cuda_runtime_image }}
       image: ${{ steps.manifest.outputs.image }}
       matrix: ${{ steps.manifest.outputs.matrix }}
+      request_guard_go_version: ${{ steps.manifest.outputs.request_guard_go_version }}
       publication_allowed_ref: ${{ steps.manifest.outputs.publication_allowed_ref }}
       publication_anonymous_exact_digest_pull: ${{ steps.manifest.outputs.publication_anonymous_exact_digest_pull }}
       publication_candidate_tag_template: ${{ steps.manifest.outputs.publication_candidate_tag_template }}
@@ -117,6 +118,8 @@ jobs:
           LLAMA_CPP_ARCHIVE_SHA256: ${{ needs.config.outputs.source_archive_sha256 }}
           LLAMA_CPP_REVISION: ${{ needs.config.outputs.source_revision }}
           NEMOCLAW_REVISION: ${{ github.sha }}
+          REQUEST_GUARD_GO_ARCHIVE_SHA256: ${{ matrix.request_guard_go_archive_sha256 }}
+          REQUEST_GUARD_GO_VERSION: ${{ needs.config.outputs.request_guard_go_version }}
           RUNTIME_GID: ${{ needs.config.outputs.runtime_gid }}
           RUNTIME_UID: ${{ needs.config.outputs.runtime_uid }}
           TARGETPLATFORM: ${{ matrix.platform }}
@@ -133,6 +136,8 @@ jobs:
             --build-arg "LLAMA_CPP_ARCHIVE_SHA256=${LLAMA_CPP_ARCHIVE_SHA256}" \
             --build-arg "LLAMA_CPP_REVISION=${LLAMA_CPP_REVISION}" \
             --build-arg "NEMOCLAW_REVISION=${NEMOCLAW_REVISION}" \
+            --build-arg "REQUEST_GUARD_GO_ARCHIVE_SHA256=${REQUEST_GUARD_GO_ARCHIVE_SHA256}" \
+            --build-arg "REQUEST_GUARD_GO_VERSION=${REQUEST_GUARD_GO_VERSION}" \
             --build-arg "RUNTIME_GID=${RUNTIME_GID}" \
             --build-arg "RUNTIME_UID=${RUNTIME_UID}" \
             --build-arg "TARGETPLATFORM=${TARGETPLATFORM}"
@@ -157,6 +162,8 @@ jobs:
             LLAMA_CPP_ARCHIVE_SHA256=${{ needs.config.outputs.source_archive_sha256 }}
             LLAMA_CPP_REVISION=${{ needs.config.outputs.source_revision }}
             NEMOCLAW_REVISION=${{ github.sha }}
+            REQUEST_GUARD_GO_ARCHIVE_SHA256=${{ matrix.request_guard_go_archive_sha256 }}
+            REQUEST_GUARD_GO_VERSION=${{ needs.config.outputs.request_guard_go_version }}
             RUNTIME_GID=${{ needs.config.outputs.runtime_gid }}
             RUNTIME_UID=${{ needs.config.outputs.runtime_uid }}
             TARGETPLATFORM=${{ matrix.platform }}
@@ -173,6 +180,8 @@ jobs:
           CUDA_RUNTIME_IMAGE: ${{ needs.config.outputs.cuda_runtime_image }}
           IMAGE: nemoclaw-llama-cpp-pr:${{ matrix.arch }}-${{ github.sha }}
           PLATFORM: ${{ matrix.platform }}
+          REQUEST_GUARD_GO_ARCHIVE_SHA256: ${{ matrix.request_guard_go_archive_sha256 }}
+          REQUEST_GUARD_GO_VERSION: ${{ needs.config.outputs.request_guard_go_version }}
           RUNTIME_FORBIDDEN_PATHS: ${{ needs.config.outputs.runtime_forbidden_paths }}
           RUNTIME_GID: ${{ needs.config.outputs.runtime_gid }}
           RUNTIME_REQUIRED_PATHS: ${{ needs.config.outputs.runtime_required_paths }}
@@ -188,6 +197,8 @@ jobs:
             --arg dev "$CUDA_DEV_IMAGE" \
             --arg gid "$RUNTIME_GID" \
             --arg platform "$PLATFORM" \
+            --arg requestGuardGoArchive "$REQUEST_GUARD_GO_ARCHIVE_SHA256" \
+            --arg requestGuardGoVersion "$REQUEST_GUARD_GO_VERSION" \
             --arg revision "$GITHUB_SHA" \
             --arg runtime "$CUDA_RUNTIME_IMAGE" \
             --arg uid "$RUNTIME_UID" \
@@ -201,6 +212,8 @@ jobs:
               and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.platform"] == $platform
               and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.upstream.revision"] == $upstream
               and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.upstream.archive-sha256"] == $archive
+              and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.request-guard.go.version"] == $requestGuardGoVersion
+              and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.request-guard.go.archive-sha256"] == $requestGuardGoArchive
               and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.cuda.development-base"] == $dev
               and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.cuda.runtime-base"] == $runtime
               and .[0].Config.Labels["io.nvidia.nemoclaw.inference-server.cuda.architectures"] == $architectures
@@ -352,6 +365,8 @@ jobs:
           LLAMA_CPP_ARCHIVE_SHA256: ${{ needs.config.outputs.source_archive_sha256 }}
           LLAMA_CPP_REVISION: ${{ needs.config.outputs.source_revision }}
           NEMOCLAW_REVISION: ${{ github.sha }}
+          REQUEST_GUARD_GO_ARCHIVE_SHA256: ${{ matrix.request_guard_go_archive_sha256 }}
+          REQUEST_GUARD_GO_VERSION: ${{ needs.config.outputs.request_guard_go_version }}
           RUNTIME_GID: ${{ needs.config.outputs.runtime_gid }}
           RUNTIME_UID: ${{ needs.config.outputs.runtime_uid }}
           TARGETPLATFORM: ${{ matrix.platform }}
@@ -368,6 +383,8 @@ jobs:
             --build-arg "LLAMA_CPP_ARCHIVE_SHA256=${LLAMA_CPP_ARCHIVE_SHA256}" \
             --build-arg "LLAMA_CPP_REVISION=${LLAMA_CPP_REVISION}" \
             --build-arg "NEMOCLAW_REVISION=${NEMOCLAW_REVISION}" \
+            --build-arg "REQUEST_GUARD_GO_ARCHIVE_SHA256=${REQUEST_GUARD_GO_ARCHIVE_SHA256}" \
+            --build-arg "REQUEST_GUARD_GO_VERSION=${REQUEST_GUARD_GO_VERSION}" \
             --build-arg "RUNTIME_GID=${RUNTIME_GID}" \
             --build-arg "RUNTIME_UID=${RUNTIME_UID}" \
             --build-arg "TARGETPLATFORM=${TARGETPLATFORM}"
@@ -391,6 +408,8 @@ jobs:
             LLAMA_CPP_ARCHIVE_SHA256=${{ needs.config.outputs.source_archive_sha256 }}
             LLAMA_CPP_REVISION=${{ needs.config.outputs.source_revision }}
             NEMOCLAW_REVISION=${{ github.sha }}
+            REQUEST_GUARD_GO_ARCHIVE_SHA256=${{ matrix.request_guard_go_archive_sha256 }}
+            REQUEST_GUARD_GO_VERSION=${{ needs.config.outputs.request_guard_go_version }}
             RUNTIME_GID=${{ needs.config.outputs.runtime_gid }}
             RUNTIME_UID=${{ needs.config.outputs.runtime_uid }}
             TARGETPLATFORM=${{ matrix.platform }}

--- a/managed-inference/images/llama-cpp/Dockerfile
+++ b/managed-inference/images/llama-cpp/Dockerfile
@@ -13,6 +13,9 @@ ARG GGML_BACKEND_DIR
 ARG C_COMPILER
 ARG CXX_COMPILER
 ARG CUDA_HOST_CXX_COMPILER
+ARG REQUEST_GUARD_GO_ARCHIVE_SHA256
+ARG REQUEST_GUARD_GO_VERSION
+ARG TARGETARCH
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -22,7 +25,10 @@ RUN test -n "${LLAMA_CPP_REVISION}" \
     && test -n "${GGML_BACKEND_DIR}" \
     && test -n "${C_COMPILER}" \
     && test -n "${CXX_COMPILER}" \
-    && test -n "${CUDA_HOST_CXX_COMPILER}"
+    && test -n "${CUDA_HOST_CXX_COMPILER}" \
+    && test -n "${REQUEST_GUARD_GO_ARCHIVE_SHA256}" \
+    && test -n "${REQUEST_GUARD_GO_VERSION}" \
+    && { [ "${TARGETARCH}" = "amd64" ] || [ "${TARGETARCH}" = "arm64" ]; }
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -32,14 +38,26 @@ RUN apt-get update \
       curl=8.5.0-2ubuntu10.12 \
       g++-14=14.2.0-4ubuntu2~24.04.1 \
       gcc-14=14.2.0-4ubuntu2~24.04.1 \
-      golang-go=2:1.22~2build1 \
       libcurl4-openssl-dev=8.5.0-2ubuntu10.12 \
       libssl-dev=3.0.13-0ubuntu3.12 \
     && rm -rf /var/lib/apt/lists/*
 
 ENV CC=${C_COMPILER} \
     CXX=${CXX_COMPILER} \
-    CUDAHOSTCXX=${CUDA_HOST_CXX_COMPILER}
+    CUDAHOSTCXX=${CUDA_HOST_CXX_COMPILER} \
+    GOTOOLCHAIN=local \
+    PATH=/usr/local/go/bin:${PATH}
+
+RUN go_archive="/tmp/go${REQUEST_GUARD_GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
+    && curl --fail --location --proto '=https' --tlsv1.2 --retry 5 \
+      --output "$go_archive" \
+      "https://go.dev/dl/go${REQUEST_GUARD_GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
+    && printf '%s  %s\n' "${REQUEST_GUARD_GO_ARCHIVE_SHA256#sha256:}" "$go_archive" \
+      | sha256sum --check --strict \
+    && test ! -e /usr/local/go \
+    && tar --extract --gzip --file "$go_archive" --directory /usr/local \
+    && rm "$go_archive" \
+    && test "$(go env GOVERSION)" = "go${REQUEST_GUARD_GO_VERSION}"
 
 WORKDIR /src/llama.cpp
 
@@ -91,12 +109,10 @@ RUN go test ./... \
       -ldflags='-s -w -buildid=' \
       -o /opt/llama.cpp/bin/nemoclaw-llama-cpp-request-guard . \
     && mkdir -p /opt/llama.cpp/licenses/go \
-    && set -- /usr/share/doc/golang-[0-9]*-go/copyright \
-    && test "$#" -eq 1 \
-    && cp "$1" /opt/llama.cpp/licenses/go/copyright \
+    && cp /usr/local/go/LICENSE /opt/llama.cpp/licenses/go/LICENSE \
     && chmod 0555 /opt/llama.cpp/bin/nemoclaw-llama-cpp-request-guard \
     && chmod 0555 /opt/llama.cpp/licenses/go \
-    && chmod 0444 /opt/llama.cpp/licenses/go/copyright
+    && chmod 0444 /opt/llama.cpp/licenses/go/LICENSE
 
 FROM ${CUDA_RUNTIME_IMAGE} AS runtime
 
@@ -106,6 +122,8 @@ ARG CUDA_ARCHITECTURES
 ARG LLAMA_CPP_REVISION
 ARG LLAMA_CPP_ARCHIVE_SHA256
 ARG NEMOCLAW_REVISION
+ARG REQUEST_GUARD_GO_ARCHIVE_SHA256
+ARG REQUEST_GUARD_GO_VERSION
 ARG TARGETPLATFORM
 ARG RUNTIME_UID
 ARG RUNTIME_GID
@@ -116,6 +134,8 @@ RUN test -n "${CUDA_DEV_IMAGE}" \
     && test -n "${LLAMA_CPP_REVISION}" \
     && test -n "${LLAMA_CPP_ARCHIVE_SHA256}" \
     && test -n "${NEMOCLAW_REVISION}" \
+    && test -n "${REQUEST_GUARD_GO_ARCHIVE_SHA256}" \
+    && test -n "${REQUEST_GUARD_GO_VERSION}" \
     && test -n "${TARGETPLATFORM}" \
     && test -n "${RUNTIME_UID}" \
     && test -n "${RUNTIME_GID}"
@@ -125,6 +145,7 @@ RUN apt-get update \
       ca-certificates=20260601~24.04.1 \
       libcurl4t64=8.5.0-2ubuntu10.12 \
       libgomp1=14.2.0-4ubuntu2~24.04.1 \
+      libssl3t64=3.0.13-0ubuntu3.12 \
     && groupadd --gid "${RUNTIME_GID}" nemoclaw-llama \
     && useradd --uid "${RUNTIME_UID}" --gid "${RUNTIME_GID}" \
       --home-dir /nonexistent --no-create-home --shell /usr/sbin/nologin nemoclaw-llama \
@@ -159,6 +180,8 @@ LABEL org.opencontainers.image.source="https://github.com/NVIDIA/NemoClaw" \
       io.nvidia.nemoclaw.inference-server.upstream.repository="https://github.com/ggml-org/llama.cpp" \
       io.nvidia.nemoclaw.inference-server.upstream.revision="${LLAMA_CPP_REVISION}" \
       io.nvidia.nemoclaw.inference-server.upstream.archive-sha256="${LLAMA_CPP_ARCHIVE_SHA256}" \
+      io.nvidia.nemoclaw.inference-server.request-guard.go.version="${REQUEST_GUARD_GO_VERSION}" \
+      io.nvidia.nemoclaw.inference-server.request-guard.go.archive-sha256="${REQUEST_GUARD_GO_ARCHIVE_SHA256}" \
       io.nvidia.nemoclaw.inference-server.cuda.development-base="${CUDA_DEV_IMAGE}" \
       io.nvidia.nemoclaw.inference-server.cuda.runtime-base="${CUDA_RUNTIME_IMAGE}" \
       io.nvidia.nemoclaw.inference-server.cuda.architectures="${CUDA_ARCHITECTURES}"

--- a/managed-inference/images/llama-cpp/image.yaml
+++ b/managed-inference/images/llama-cpp/image.yaml
@@ -112,6 +112,11 @@ spec:
       c: gcc-14
       cxx: g++-14
       cudaHostCxx: g++-14
+    requestGuardToolchain:
+      version: 1.26.6
+      archives:
+        amd64: sha256:708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89
+        arm64: sha256:d0507e9e9d7fe012aae570108cbd76c15de879e17130ab8cb90d4d7445cb1f2e
     packages:
       build-essential: 12.10ubuntu1
       ca-certificates: 20260601~24.04.1
@@ -119,7 +124,6 @@ spec:
       curl: 8.5.0-2ubuntu10.12
       g++-14: 14.2.0-4ubuntu2~24.04.1
       gcc-14: 14.2.0-4ubuntu2~24.04.1
-      golang-go: 2:1.22~2build1
       libcurl4-openssl-dev: 8.5.0-2ubuntu10.12
       libssl-dev: 3.0.13-0ubuntu3.12
     cmake:
@@ -148,7 +152,7 @@ spec:
       - /opt/llama.cpp/lib/libggml-cuda.so
       - /usr/local/bin/llama-server
       - /usr/local/bin/nemoclaw-llama-cpp-request-guard
-      - /usr/local/share/licenses/go/copyright
+      - /usr/local/share/licenses/go/LICENSE
       - /usr/local/share/licenses/llama.cpp/AUTHORS
       - /usr/local/share/licenses/llama.cpp/LICENSE
     forbiddenPaths:
@@ -165,5 +169,6 @@ spec:
       ca-certificates: 20260601~24.04.1
       libcurl4t64: 8.5.0-2ubuntu10.12
       libgomp1: 14.2.0-4ubuntu2~24.04.1
+      libssl3t64: 3.0.13-0ubuntu3.12
     writablePaths:
       - /tmp

--- a/scripts/checks/export-llama-cpp-image-config.mts
+++ b/scripts/checks/export-llama-cpp-image-config.mts
@@ -28,6 +28,10 @@ type ServerImageManifest = {
       cmake?: unknown;
       compiler?: unknown;
       packages?: unknown;
+      requestGuardToolchain?: {
+        archives?: { amd64?: unknown; arm64?: unknown };
+        version?: unknown;
+      };
       target?: unknown;
     };
     cuda?: { developmentBase?: unknown; runtimeBase?: unknown };
@@ -326,8 +330,18 @@ export function loadLlamaCppImageConfig(
     "cmake",
     "compiler",
     "packages",
+    "requestGuardToolchain",
     "target",
   ]);
+  assertExactKeys(manifest.spec?.build?.requestGuardToolchain, "request guard toolchain", [
+    "archives",
+    "version",
+  ]);
+  assertExactKeys(
+    manifest.spec?.build?.requestGuardToolchain?.archives,
+    "request guard toolchain archives",
+    ["amd64", "arm64"],
+  );
   assertExactKeys(manifest.spec?.cuda, "cuda", ["developmentBase", "runtimeBase"]);
   assertExactKeys(manifest.spec?.runtime, "runtime", [
     "entrypoint",
@@ -631,7 +645,6 @@ export function loadLlamaCppImageConfig(
     curl: "8.5.0-2ubuntu10.12",
     "g++-14": "14.2.0-4ubuntu2~24.04.1",
     "gcc-14": "14.2.0-4ubuntu2~24.04.1",
-    "golang-go": "2:1.22~2build1",
     "libcurl4-openssl-dev": "8.5.0-2ubuntu10.12",
     "libssl-dev": "3.0.13-0ubuntu3.12",
   };
@@ -644,12 +657,13 @@ export function loadLlamaCppImageConfig(
     "ca-certificates": "20260601~24.04.1",
     libcurl4t64: "8.5.0-2ubuntu10.12",
     libgomp1: "14.2.0-4ubuntu2~24.04.1",
+    libssl3t64: "3.0.13-0ubuntu3.12",
   };
   const expectedRequiredPaths = [
     "/opt/llama.cpp/lib/libggml-cuda.so",
     "/usr/local/bin/llama-server",
     "/usr/local/bin/nemoclaw-llama-cpp-request-guard",
-    "/usr/local/share/licenses/go/copyright",
+    "/usr/local/share/licenses/go/LICENSE",
     "/usr/local/share/licenses/llama.cpp/AUTHORS",
     "/usr/local/share/licenses/llama.cpp/LICENSE",
   ];
@@ -665,6 +679,25 @@ export function loadLlamaCppImageConfig(
     "/usr/bin/sh",
   ];
   const cmake = spec?.build?.cmake;
+  const requestGuardToolchain = spec?.build?.requestGuardToolchain;
+  const requestGuardToolchainArchives = requestGuardToolchain?.archives;
+  const requestGuardGoVersion = requiredString(
+    requestGuardToolchain?.version,
+    "request guard Go version",
+    /^1\.26\.6$/u,
+  );
+  const requestGuardGoArchives = {
+    amd64: requiredString(
+      requestGuardToolchainArchives?.amd64,
+      "amd64 request guard Go archive SHA-256",
+      /^sha256:708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89$/u,
+    ),
+    arm64: requiredString(
+      requestGuardToolchainArchives?.arm64,
+      "arm64 request guard Go archive SHA-256",
+      /^sha256:d0507e9e9d7fe012aae570108cbd76c15de879e17130ab8cb90d4d7445cb1f2e$/u,
+    ),
+  };
   if (
     spec?.source?.repository !== "https://github.com/ggml-org/llama.cpp" ||
     spec?.build?.target !== "llama-server" ||
@@ -698,10 +731,12 @@ export function loadLlamaCppImageConfig(
       `CUDA architectures for ${platform}`,
       /^[0-9]+[a-z]?(?:-real)?(?:;[0-9]+[a-z]?(?:-real)?)*$/u,
     );
+    const arch = platform.slice("linux/".length) as "amd64" | "arm64";
     return {
-      arch: platform.slice("linux/".length),
+      arch,
       cuda_architectures: cudaArchitectures,
       platform,
+      request_guard_go_archive_sha256: requestGuardGoArchives[arch],
       runner: expectedRunner,
     };
   });
@@ -793,6 +828,7 @@ export function loadLlamaCppImageConfig(
       /^ghcr\.io\/nvidia\/nemoclaw\/llama-cpp-server$/u,
     ),
     matrix: JSON.stringify({ include }),
+    request_guard_go_version: requestGuardGoVersion,
     publication_allowed_ref: requiredString(
       publication.allowedRef,
       "publication allowed ref",

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -157,9 +157,10 @@ fi
 
 function candidateIndexFilter(step: Step): string {
   const source = required(step.run, "candidate assembly script is missing");
-  const match = /--arg arm64 [^\n]+ '\n(?<filter>[\s\S]*?)\n\s+' "\$RUNNER_TEMP\/llama-cpp-candidate\/candidate-index\.json"/u.exec(
-    source,
-  );
+  const match =
+    /--arg arm64 [^\n]+ '\n(?<filter>[\s\S]*?)\n\s+' "\$RUNNER_TEMP\/llama-cpp-candidate\/candidate-index\.json"/u.exec(
+      source,
+    );
   return required(match?.groups?.filter, "candidate index jq filter is missing");
 }
 
@@ -221,6 +222,7 @@ describe("llama.cpp image PR workflow", () => {
       cuda_runtime_image: "${{ steps.manifest.outputs.cuda_runtime_image }}",
       image: "${{ steps.manifest.outputs.image }}",
       matrix: "${{ steps.manifest.outputs.matrix }}",
+      request_guard_go_version: "${{ steps.manifest.outputs.request_guard_go_version }}",
       runtime_forbidden_paths: "${{ steps.manifest.outputs.runtime_forbidden_paths }}",
       runtime_gid: "${{ steps.manifest.outputs.runtime_gid }}",
       runtime_required_paths: "${{ steps.manifest.outputs.runtime_required_paths }}",
@@ -228,27 +230,31 @@ describe("llama.cpp image PR workflow", () => {
       source_archive_sha256: "${{ steps.manifest.outputs.source_archive_sha256 }}",
       source_revision: "${{ steps.manifest.outputs.source_revision }}",
     });
-    expect([
-          "publication_allowed_ref",
-          "publication_anonymous_exact_digest_pull",
-          "publication_candidate_tag_template",
-          "publication_enabled",
-          "publication_platforms",
-          "publication_provenance_predicate_type",
-          "publication_qualification",
-          "publication_receipt_retention_days",
-          "publication_receipt_schema_version",
-          "publication_repository",
-          "publication_sbom_format",
-          "publication_signature_identity",
-          "publication_signature_issuer",
-          "publication_signature_mode",
-          "publication_signature_transparency_log",
-          "publication_trigger",
-          "publication_vulnerability_only_fixed",
-          "publication_vulnerability_scanner",
-          "publication_vulnerability_severity_cutoff",
-        ].every((output) => Object.is(config.outputs?.[output], `\${{ steps.manifest.outputs.${output} }}`))).toBe(true);
+    expect(
+      [
+        "publication_allowed_ref",
+        "publication_anonymous_exact_digest_pull",
+        "publication_candidate_tag_template",
+        "publication_enabled",
+        "publication_platforms",
+        "publication_provenance_predicate_type",
+        "publication_qualification",
+        "publication_receipt_retention_days",
+        "publication_receipt_schema_version",
+        "publication_repository",
+        "publication_sbom_format",
+        "publication_signature_identity",
+        "publication_signature_issuer",
+        "publication_signature_mode",
+        "publication_signature_transparency_log",
+        "publication_trigger",
+        "publication_vulnerability_only_fixed",
+        "publication_vulnerability_scanner",
+        "publication_vulnerability_severity_cutoff",
+      ].every((output) =>
+        Object.is(config.outputs?.[output], `\${{ steps.manifest.outputs.${output} }}`),
+      ),
+    ).toBe(true);
     expect(namedStep(config, "Compile image manifest").run).toBe(
       "node --experimental-strip-types --no-warnings scripts/checks/export-llama-cpp-image-config.mts",
     );
@@ -257,19 +263,31 @@ describe("llama.cpp image PR workflow", () => {
     expect(build.strategy?.matrix).toBe("${{ fromJSON(needs.config.outputs.matrix) }}");
 
     const args = String(buildStep.with?.["build-args"] ?? "");
-    expect([
-          "backend_directory",
-          "compiler_c",
-          "compiler_cuda_host_cxx",
-          "compiler_cxx",
-          "cuda_dev_image",
-          "cuda_runtime_image",
-          "runtime_gid",
-          "runtime_uid",
-          "source_archive_sha256",
-          "source_revision",
-        ].every((output) => args.includes(`needs.config.outputs.${output}`))).toBe(true);
+    expect(
+      [
+        "backend_directory",
+        "compiler_c",
+        "compiler_cuda_host_cxx",
+        "compiler_cxx",
+        "cuda_dev_image",
+        "cuda_runtime_image",
+        "request_guard_go_version",
+        "runtime_gid",
+        "runtime_uid",
+        "source_archive_sha256",
+        "source_revision",
+      ].every((output) => args.includes(`needs.config.outputs.${output}`)),
+    ).toBe(true);
     expect(args).toContain("CUDA_ARCHITECTURES=${{ matrix.cuda_architectures }}");
+    expect(args).toContain(
+      "REQUEST_GUARD_GO_ARCHIVE_SHA256=${{ matrix.request_guard_go_archive_sha256 }}",
+    );
+    expect(validate.run).toContain(
+      'Labels["io.nvidia.nemoclaw.inference-server.request-guard.go.version"] == $requestGuardGoVersion',
+    );
+    expect(validate.run).toContain(
+      'Labels["io.nvidia.nemoclaw.inference-server.request-guard.go.archive-sha256"] == $requestGuardGoArchive',
+    );
     expect(args).toContain("TARGETPLATFORM=${{ matrix.platform }}");
     expect(args).not.toMatch(/sha256:[0-9a-f]{64}/u);
     expect(args).not.toMatch(/[0-9a-f]{40}/u);
@@ -304,15 +322,9 @@ describe("llama.cpp image PR workflow", () => {
     expect(gate.if).toContain("inputs.publish == true");
     expect(gate.permissions).toEqual({});
     const gateStep = namedStep(gate, "Enforce declarative publication boundary");
-    expect(gateStep.run).toContain(
-      'PUBLICATION_ENABLED" != "true"',
-    );
-    expect(gateStep.run).toContain(
-      'GITHUB_REPOSITORY" != "NVIDIA/NemoClaw"',
-    );
-    expect(gateStep.run).toContain(
-      'GITHUB_REF" != "$ALLOWED_REF"',
-    );
+    expect(gateStep.run).toContain('PUBLICATION_ENABLED" != "true"');
+    expect(gateStep.run).toContain('GITHUB_REPOSITORY" != "NVIDIA/NemoClaw"');
+    expect(gateStep.run).toContain('GITHUB_REF" != "$ALLOWED_REF"');
     expect(gateStep.run).toContain(
       `and .probes == ${JSON.stringify(
         required(
@@ -353,6 +365,12 @@ describe("llama.cpp image PR workflow", () => {
     expect(publishBuild.with?.provenance).toBe(false);
     expect(publishBuild.with?.sbom).toBe(false);
     const publishArgs = String(publishBuild.with?.["build-args"] ?? "");
+    expect(publishArgs).toContain(
+      "REQUEST_GUARD_GO_ARCHIVE_SHA256=${{ matrix.request_guard_go_archive_sha256 }}",
+    );
+    expect(publishArgs).toContain(
+      "REQUEST_GUARD_GO_VERSION=${{ needs.config.outputs.request_guard_go_version }}",
+    );
     const publishArgNames = [...publishArgs.matchAll(/^([A-Z0-9_]+)=/gmu)].map((match) => match[1]);
     const guardedArgNames = [
       ...(publishGuard.run ?? "").matchAll(/--build-arg "([A-Z0-9_]+)=/gu),
@@ -567,9 +585,10 @@ describe("llama.cpp image PR workflow", () => {
     expect(JSON.stringify(attestationWorkflow)).not.toContain("secrets.");
     (attest.steps ?? [])
       .map((step) => step.uses)
-      .filter((uses): uses is string => uses !== undefined).forEach((action) => {
-      expect(action).toMatch(fullShaAction);
-    });
+      .filter((uses): uses is string => uses !== undefined)
+      .forEach((action) => {
+        expect(action).toMatch(fullShaAction);
+      });
   });
 
   it("pins actions and validates the native non-root read-only image (#8231)", () => {

--- a/test/llama-cpp-image.test.ts
+++ b/test/llama-cpp-image.test.ts
@@ -41,6 +41,10 @@ type ImageManifest = {
       cmake?: Record<string, boolean>;
       compiler?: { c?: string; cudaHostCxx?: string; cxx?: string };
       packages?: Record<string, string>;
+      requestGuardToolchain?: {
+        archives?: { amd64?: string; arm64?: string };
+        version?: string;
+      };
       target?: string;
     };
     cuda?: { developmentBase?: string; runtimeBase?: string };
@@ -197,7 +201,7 @@ describe("declarative llama.cpp server image", () => {
             "/opt/llama.cpp/lib/libggml-cuda.so",
             "/usr/local/bin/llama-server",
             "/usr/local/bin/nemoclaw-llama-cpp-request-guard",
-            "/usr/local/share/licenses/go/copyright",
+            "/usr/local/share/licenses/go/LICENSE",
             "/usr/local/share/licenses/llama.cpp/LICENSE",
           ]),
           writablePaths: ["/tmp"],
@@ -214,6 +218,13 @@ describe("declarative llama.cpp server image", () => {
     );
     expect(manifest.spec?.runtime?.uid).toBeGreaterThan(0);
     expect(manifest.spec?.runtime?.gid).toBeGreaterThan(0);
+    expect(manifest.spec?.build?.requestGuardToolchain).toEqual({
+      archives: {
+        amd64: "sha256:708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89",
+        arm64: "sha256:d0507e9e9d7fe012aae570108cbd76c15de879e17130ab8cb90d4d7445cb1f2e",
+      },
+      version: "1.26.6",
+    });
   });
 
   it("declares native amd64 and DGX Spark arm64 compilation explicitly (#8231)", () => {
@@ -340,6 +351,7 @@ describe("declarative llama.cpp server image", () => {
         manifest.spec?.publication?.evidence?.vulnerability?.scanner,
       publication_vulnerability_severity_cutoff:
         manifest.spec?.publication?.evidence?.vulnerability?.severityCutoff,
+      request_guard_go_version: manifest.spec?.build?.requestGuardToolchain?.version,
       runtime_forbidden_paths: JSON.stringify(manifest.spec?.runtime?.forbiddenPaths),
       runtime_gid: String(manifest.spec?.runtime?.gid),
       runtime_required_paths: JSON.stringify(manifest.spec?.runtime?.requiredPaths),
@@ -348,12 +360,17 @@ describe("declarative llama.cpp server image", () => {
       source_revision: manifest.spec?.source?.revision,
     });
     expect(JSON.parse(output.matrix ?? "null")).toEqual({
-      include: manifest.spec?.platforms?.map(({ cudaArchitectures, platform, runner }) => ({
-        arch: platform?.slice("linux/".length),
-        cuda_architectures: cudaArchitectures,
-        platform,
-        runner,
-      })),
+      include: manifest.spec?.platforms?.map(({ cudaArchitectures, platform, runner }) => {
+        const arch = platform?.slice("linux/".length) as "amd64" | "arm64";
+        return {
+          arch,
+          cuda_architectures: cudaArchitectures,
+          platform,
+          request_guard_go_archive_sha256:
+            manifest.spec?.build?.requestGuardToolchain?.archives?.[arch],
+          runner,
+        };
+      }),
     });
     expect(JSON.parse(output.publication_qualification ?? "null")).toEqual(
       manifest.spec?.publication?.qualification,
@@ -374,6 +391,17 @@ describe("declarative llama.cpp server image", () => {
       manifestSource.replace(
         "sha256:ef2203909e80b8b976cfc672f7e2ae2b00bc0e25c404ee86d89e10a3802f1c52",
         "sha256:invalid",
+      ),
+    ],
+    [
+      "an unreviewed request guard Go version",
+      manifestSource.replace("version: 1.26.6", "version: 1.26.5"),
+    ],
+    [
+      "a substituted request guard Go archive",
+      manifestSource.replace(
+        "sha256:708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89",
+        `sha256:${"0".repeat(64)}`,
       ),
     ],
     [
@@ -534,10 +562,7 @@ describe("declarative llama.cpp server image", () => {
   });
 
   it.each([
-    [
-      "an unexpected publication field",
-      addUnexpectedPublicationField(manifestSource),
-    ],
+    ["an unexpected publication field", addUnexpectedPublicationField(manifestSource)],
     ["automatic publication", manifestSource.replace("workflow_dispatch", "push")],
     ["an untrusted ref", manifestSource.replace("refs/heads/main", "refs/heads/release")],
     [
@@ -694,17 +719,32 @@ describe("declarative llama.cpp server image", () => {
     expect(dockerfile).toContain("--target llama-server");
     expect(dockerfile).toContain('-DGGML_BACKEND_DIR="${GGML_BACKEND_DIR}"');
     expect(dockerfile).toContain('test -f "${GGML_BACKEND_DIR}/libggml-cuda.so"');
-    expect(Object.entries({
-          ...manifest.spec?.build?.packages,
-          ...manifest.spec?.runtime?.packages,
-        }).every(([packageName, version]) => dockerfile.includes(`${packageName}=${version}`))).toBe(true);
+    expect(
+      Object.entries({
+        ...manifest.spec?.build?.packages,
+        ...manifest.spec?.runtime?.packages,
+      }).every(([packageName, version]) => dockerfile.includes(`${packageName}=${version}`)),
+    ).toBe(true);
     expect(dockerfile).toContain("USER ${RUNTIME_UID}:${RUNTIME_GID}");
     expect(dockerfile).toContain('SHELL ["/bin/bash", "-o", "pipefail", "-c"]');
     expect(dockerfile).toContain('ENTRYPOINT ["/usr/local/bin/llama-server"]');
     expect(dockerfile).toContain("go test ./...");
     expect(dockerfile).toContain("CGO_ENABLED=0 go build");
-    expect(dockerfile).toContain("set -- /usr/share/doc/golang-[0-9]*-go/copyright");
-    expect(dockerfile).toContain('cp "$1" /opt/llama.cpp/licenses/go/copyright');
+    expect(dockerfile).toContain("GOTOOLCHAIN=local");
+    expect(dockerfile).toContain(
+      '"https://go.dev/dl/go${REQUEST_GUARD_GO_VERSION}.linux-${TARGETARCH}.tar.gz"',
+    );
+    expect(dockerfile).toContain('"${REQUEST_GUARD_GO_ARCHIVE_SHA256#sha256:}" "$go_archive"');
+    expect(dockerfile).toContain('test "$(go env GOVERSION)" = "go${REQUEST_GUARD_GO_VERSION}"');
+    expect(dockerfile).toContain("test ! -e /usr/local/go");
+    expect(dockerfile).toContain("cp /usr/local/go/LICENSE /opt/llama.cpp/licenses/go/LICENSE");
+    expect(dockerfile).toContain(
+      'io.nvidia.nemoclaw.inference-server.request-guard.go.version="${REQUEST_GUARD_GO_VERSION}"',
+    );
+    expect(dockerfile).toContain(
+      'io.nvidia.nemoclaw.inference-server.request-guard.go.archive-sha256="${REQUEST_GUARD_GO_ARCHIVE_SHA256}"',
+    );
+    expect(dockerfile).not.toContain("golang-go=");
     expect(dockerfile).toContain(
       "COPY --from=build --chmod=0555 /opt/llama.cpp/bin/nemoclaw-llama-cpp-request-guard /usr/local/bin/nemoclaw-llama-cpp-request-guard",
     );
@@ -714,9 +754,13 @@ describe("declarative llama.cpp server image", () => {
     expect(dockerfile).toContain("ENV CC=${C_COMPILER}");
     expect(dockerfile).toContain("CXX=${CXX_COMPILER}");
     expect(dockerfile).toContain("CUDAHOSTCXX=${CUDA_HOST_CXX_COMPILER}");
-    expect((manifest.spec?.runtime?.forbiddenPaths?.filter(
+    expect(
+      (
+        manifest.spec?.runtime?.forbiddenPaths?.filter(
           (forbiddenPath) => forbiddenPath !== "/opt/llama.cpp/ui",
-        ) ?? []).every((shellPath) => dockerfile.includes(shellPath))).toBe(true);
+        ) ?? []
+      ).every((shellPath) => dockerfile.includes(shellPath)),
+    ).toBe(true);
     expect(dockerfile).toContain("sha256sum --check --strict");
     expect(dockerfile).toContain("cp LICENSE AUTHORS");
     expect(dockerfile).toContain("find /opt/llama.cpp/licenses -type d -exec chmod 0555");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Patch the managed llama.cpp image dependencies that failed the trusted publication scan after candidate assembly. The image now builds the request guard with an exact, checksummed Go 1.26.6 toolchain and installs the fixed Ubuntu OpenSSL runtime packages, while preserving the fail-closed High/Critical vulnerability policy.

## Related Issue

Part of #8231; prerequisite for #9592.

## Changes

- Declare the exact Go 1.26.6 version and official per-architecture archive SHA-256 values in the owned image manifest. The image build and publication workflow consume this binding because the Ubuntu 24.04 `golang-go` package provides vulnerable Go 1.22.2; manifest and workflow tests reject a substituted version, checksum, or missing build argument.
- Download and verify the selected Go archive before building the request guard with `GOTOOLCHAIN=local`, record its identity in image labels, and install its upstream license. The checksum binding prevents a mutable toolchain fetch from changing the built binary.
- Upgrade `libssl3t64` and `openssl` in the runtime image to `3.0.13-0ubuntu3.12`, which removes the fixed High findings reported by the trusted publication scan.
- Propagate and validate the toolchain identity in both pull-request and trusted publication builds.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/llama-cpp-image-workflow.test.ts test/llama-cpp-image.test.ts test/llama-cpp-image-publication-evidence.test.ts test/llama-cpp-dgx-spark-qualification-plan.test.ts test/llama-cpp-dgx-spark-qualification-contract.test.ts` (93 passed); full arm64 image build passed; Grype 0.110.0 with `--only-fixed --fail-on high` found zero High/Critical findings
- [ ] Applicable broad gate passed — `npm run check` for repo-wide validation/coverage changes — structural/manual checks passed through the coverage phase; unrelated coverage suites failed because `/tmp/package.json` changed temporary scripts to ESM and the checkout lacked the plugin `json5` package
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Container images now use pinned, architecture-specific Go toolchains with checksum and version verification for more consistent builds.
  - Image metadata now records validated toolchain information.
  - Runtime images include the required SSL library for improved compatibility.
  - Build configuration validation now rejects unsupported versions, architectures, or invalid archive checksums.

- **Tests**
  - Expanded automated coverage for image builds, publication workflows, metadata, and configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->