### PR TITLE
fix(release): continue post-tag follow-through

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -215,7 +215,7 @@ Classify the effects that each workflow owns:
 - For `Release / Latest Tag`, verify that `latest` identifies the release tag. Verify label
   carry-forward and released-label deletion.
 - For `Docs / Publish Public`, require the `publish` job to succeed.
-- For `Images / Base Images`, require `Promote complete multi-platform managed image cohort` to
+- For `Images / Base Images`, require `Publish complete managed images` to
   succeed. Report Pi candidate failures separately; they do not determine production promotion.
 
 A failed post-tag workflow does not change tag success. Report the failing job and recovery path.

--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nemoclaw-maintainer-cut-release-tag
-description: Cuts one signed NemoClaw semver tag after required candidate checks and the maintainer's E2E decision. Use when preparing or publishing a vX.Y.Z release tag.
+description: Cuts one signed NemoClaw semver tag after required candidate checks and the maintainer's E2E decision, then follows the tag-triggered release work and drafts the Announcement. Use when preparing or publishing a vX.Y.Z release tag.
 user_invocable: true
 ---
 
@@ -18,8 +18,9 @@ Treat these as separate states:
 - **Tag can be cut:** all required documentation and image checks pass.
   The release brief records the maintainer's general E2E decision and contains no unresolved prompts.
 - **Tag cut:** the remote signed tag exists and peels to the planned candidate.
-- **Post-tag work:** `latest`, release labels, public documentation, release images, `lkg`, and the Announcement
-  continue outside this skill. Do not wait for them here; some share a downstream workflow.
+- **Post-tag follow-through:** after reporting the tag as cut, continue the same task. Monitor
+  `latest`, release labels, public documentation, and release images. Draft the Announcement and
+  report `lkg` state.
 
 ## Hard Rules
 
@@ -37,6 +38,10 @@ Treat these as separate states:
   signed tag annotation; do not maintain another exception record.
 - Ask the maintainer to paste the plan's full confirmation phrase before cutting.
 - Push only the planned semver tag. Never push or move `latest` or `lkg` here.
+- Report the tag as cut immediately after remote readback. This report is a progress checkpoint, not
+  the final response.
+- Continue the same task through post-tag follow-through. Do not make a post-tag result a tag gate.
+- Ask before a workflow rerun. Never create a GitHub Discussion.
 - Never move, delete, or replace an existing remote semver tag unless the maintainer starts a
   protected-tag remediation.
 - Follow the [release-train policy](../nemoclaw-maintainer-policies/references/release-train.md) and
@@ -53,6 +58,7 @@ Release tag:
 - [ ] 3. Show E2E context and record the maintainer's decision
 - [ ] 4. Finish and review the Markdown release brief
 - [ ] 5. Confirm, cut, and read back the signed tag
+- [ ] 6. Follow tag-triggered work and draft the Announcement
 ```
 
 ### 1. Generate the Plan and Brief Template
@@ -163,7 +169,7 @@ Do not put secrets in the brief. Show the complete rendered file to the maintain
 exact public Markdown becomes the signed tag annotation, make any correction in the file before
 asking for confirmation.
 
-### 5. Confirm, Cut, and Return
+### 5. Confirm, Cut, and Report the Tag
 
 Ask the maintainer to paste the plan's exact phrase:
 
@@ -188,13 +194,47 @@ npm run release:cut -- \
 ```
 
 Require the script's remote readback to show that the signed annotated tag exists and peels to the
-planned candidate. Return immediately with the tag, candidate, plan path, brief path, and readback.
+planned candidate. Report the tag, candidate, plan path, brief path, and readback. Then continue the
+same task.
 
-Report any already-known `latest`, release-label, public-documentation, release-image, `lkg`, and Announcement
-state, and mark the rest pending or unknown. Do not poll. These states are separate from tag
-completion, but `latest` and label carry-forward share the release workflow. The tag-triggered image
-workflow performs a release rebuild and publication; it can fail after the tag is cut and can be
-retried without moving the semver tag. Do not call it promotion-only.
+### 6. Follow Tag-Triggered Work and Draft the Announcement
+
+Start these operations together:
+
+1. Load `nemoclaw-maintainer-release-notes`. Draft `release-note-draft.md` from the plan's immutable
+   range. Open the completed draft in the requested editor. Never create the Discussion.
+2. Find the tag-push runs for these workflow files:
+   - `.github/workflows/release-latest-tag.yaml`
+   - `.github/workflows/docs-publish-public.yaml`
+   - `.github/workflows/base-image.yaml`
+3. Bind each run by workflow path, `event=push`, release tag, and planned candidate. Retain its run
+   ID and attempt. Monitor the three runs concurrently until they reach terminal results.
+
+Classify the effects that each workflow owns:
+
+- For `Release / Latest Tag`, verify that `latest` identifies the release tag. Verify label
+  carry-forward and released-label deletion.
+- For `Docs / Publish Public`, require the `publish` job to succeed.
+- For `Images / Base Images`, require `Promote complete multi-platform managed image cohort` to
+  succeed. Report Pi candidate failures separately; they do not determine production promotion.
+
+A failed post-tag workflow does not change tag success. Report the failing job and recovery path.
+Ask before a rerun. Bind and monitor the new attempt. The managed-image workflow supports failed-job
+reruns that reuse successful producer artifacts from the same run.
+
+After image classification, read the peeled `lkg` commit. This skill never moves `lkg`. If
+production promotion succeeded and `lkg` differs, show the current and proposed releases and ask for
+separate maintainer authorization. If the maintainer moves `lkg`, monitor
+`.github/workflows/release-lkg-brev-image.yaml` and its returned downstream production-image run.
+
+Send the final response only after:
+
+- all three automatic workflows are terminal and their effects are classified;
+- the Announcement draft exists; and
+- `lkg` already identifies the release, is ineligible because production promotion failed, awaits
+  an explicit maintainer decision, or its authorized downstream production run is classified.
+
+Keep the semver tag immutable.
 
 ## Recovery
 

--- a/.agents/skills/nemoclaw-maintainer-evening/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-evening/SKILL.md
@@ -10,7 +10,7 @@ user_invocable: true
 # NemoClaw Maintainer Evening
 
 Close the day with one release candidate, one cumulative documentation change, and a clear handoff.
-Tagging is optional. Do not turn post-tag automation into part of the tag wait.
+Tagging is optional. Report tag creation first, then let the tag skill finish post-tag follow-through.
 
 See [PR-REVIEW-PRIORITIES.md](../nemoclaw-maintainer-day/PR-REVIEW-PRIORITIES.md) for the daily
 cadence and the [release-train policy](../nemoclaw-maintainer-policies/references/release-train.md)
@@ -84,25 +84,21 @@ Load `nemoclaw-maintainer-cut-release-tag` and pass the exact version. That skil
 Do not run a full E2E suite automatically. Do not ask for confirmation until the release brief is
 complete and the maintainer has reviewed it.
 
-## 5. Return the Handoff
+## 5. Complete the Handoff
 
-After tag readback, return immediately with:
+After tag readback, report:
 
 - tag and candidate commit;
 - plan and release-brief paths;
 - documentation and image evidence URLs;
-- E2E decision and exception reason, if any; and
-- current state of `latest`, release labels, public documentation, release images, `lkg`, and the Announcement.
+- E2E decision and exception reason, if any.
 
-Those states continue outside tag cutting; some share a workflow or depend on another post-tag
-state. A tag-triggered release-image rebuild can fail and be retried without changing the semver
-tag. Draft the public Announcement later with
-`nemoclaw-maintainer-release-notes`; do not delay tag completion for it.
+Then let `nemoclaw-maintainer-cut-release-tag` monitor the automatic post-tag workflows, draft the
+Announcement, and report `lkg` state. A post-tag failure does not change tag success.
 
 ## Hard Rules
 
 - Never cut a tag without the maintainer's exact confirmation phrase.
 - Never bypass the release entry, approved-empty Pi result, or applicable GHCR evidence.
 - Never make a different candidate stale merely because `main` advanced or a later documentation PR opened.
-- Never wait for `latest`, label retirement, public documentation, release images, `lkg`, or the Announcement
-  before reporting the tag as cut.
+- Never delay the tag-cut report for post-tag work. Continue the same task after that report.

--- a/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
@@ -121,18 +121,27 @@ Pass that exact Markdown to `release:cut` with `--message-file`. It becomes the 
 message and is the release evidence record. Do not create a separate exception file.
 
 Require the full confirmation phrase from the plan. After the script reads the remote tag back and
-confirms that it peels to the candidate, report the tag as cut and return.
+confirms that it peels to the candidate, report the tag as cut. Then continue the same task.
 
 ## Post-Tag States
 
-Moving `latest`, carrying labels forward, publishing public documentation, rebuilding and publishing release
-images, promoting `lkg`, and publishing the Announcement do not extend tag cutting. Some share a
-workflow or depend on another post-tag state. Report only already-known results and mark the rest
-pending or unknown; do not poll before returning the tag result.
+The tag event starts `Release / Latest Tag`, `Docs / Publish Public`, and `Images / Base Images`.
+Monitor the exact tag and candidate runs concurrently. Draft the Announcement while they run.
+
+Report the tag as cut before this follow-through. Post-tag results never change tag success. Verify
+the owned effects instead of relying only on workflow conclusions:
+
+- `latest` and release-label carry-forward;
+- the public documentation `publish` job; and
+- the production managed-image promotion job, with Pi candidate results reported separately.
+
+Read `lkg` after production image classification. Never move `lkg` automatically. When production
+promotion succeeds, ask for separate maintainer authorization. After an authorized move, monitor
+`Release / LKG Brev Image` and its returned downstream production-image run.
 
 Tag-triggered image publication performs a release rebuild and can fail after the tag exists. Repair
-and rerun that workflow independently. Do not describe it as promotion-only and do not move the
-semver tag.
+and rerun that workflow independently. Ask before a rerun. Do not describe it as promotion-only and
+do not move the semver tag.
 
 ## Carry Forward
 

--- a/.agents/skills/nemoclaw-maintainer-release-notes/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-release-notes/SKILL.md
@@ -163,7 +163,8 @@ Create a Markdown draft outside the checkout root so the repo stays clean, for e
 
 The Markdown body is the source the maintainer can paste into GitHub Discussions.
 
-Stop here. The maintainer creates the GitHub Discussion and shares the announcement link.
+Return the draft path to the calling release workflow. The maintainer creates the GitHub Discussion
+and shares the Announcement link.
 
 ## Output
 

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -278,6 +278,11 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     pattern: /(?:^|\/)ci\/platform-vitest-macos-requirements\.lock$/,
     testsToRun: runTests("test/platform-vitest-main-workflow.test.ts"),
   },
+  {
+    pattern:
+      /(?:^|\/)\.agents\/skills\/(?:nemoclaw-maintainer-cut-release-tag\/SKILL\.md|nemoclaw-maintainer-evening\/SKILL\.md|nemoclaw-maintainer-release-notes\/SKILL\.md|nemoclaw-maintainer-policies\/references\/release-train\.md)$/,
+    testsToRun: runTests("test/release-post-tag-follow-through.test.ts"),
+  },
 ];
 export function resolveVitestWatchTests(file: string): string[] {
   const normalized = file.replaceAll("\\", "/");

--- a/test/release-post-tag-follow-through.test.ts
+++ b/test/release-post-tag-follow-through.test.ts
@@ -15,6 +15,7 @@ const releaseNotes = read(".agents/skills/nemoclaw-maintainer-release-notes/SKIL
 const releaseTrain = read(
   ".agents/skills/nemoclaw-maintainer-policies/references/release-train.md",
 );
+const compactCutTag = cutTag.replace(/\s+/gu, " ");
 
 describe("release post-tag follow-through", () => {
   it("continues the same task after remote tag readback", () => {
@@ -42,6 +43,16 @@ describe("release post-tag follow-through", () => {
     expect(cutTag).toContain("release-note-draft.md");
     expect(releaseNotes).toContain("Return the draft path to the calling release workflow");
     expect(cutTag).toContain("Never create a GitHub Discussion");
+  });
+
+  it("requires every owned effect before the final response", () => {
+    expect(compactCutTag).toContain("verify that `latest` identifies the release tag");
+    expect(compactCutTag).toContain("Verify label carry-forward and released-label deletion");
+    expect(compactCutTag).toContain("require the `publish` job to succeed");
+    expect(compactCutTag).toContain(
+      "all three automatic workflows are terminal and their effects are classified",
+    );
+    expect(compactCutTag).toContain("`lkg` already identifies the release");
   });
 
   it("classifies production images and leaves lkg under maintainer control", () => {

--- a/test/release-post-tag-follow-through.test.ts
+++ b/test/release-post-tag-follow-through.test.ts
@@ -56,7 +56,7 @@ describe("release post-tag follow-through", () => {
   });
 
   it("classifies production images and leaves lkg under maintainer control", () => {
-    expect(cutTag).toContain("Promote complete multi-platform managed image cohort");
+    expect(cutTag).toContain("Publish complete managed images");
     expect(cutTag).toContain("Report Pi candidate failures separately");
     expect(cutTag).toMatch(/supports failed-job\s+reruns/u);
     expect(cutTag).toContain("This skill never moves `lkg`");

--- a/test/release-post-tag-follow-through.test.ts
+++ b/test/release-post-tag-follow-through.test.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+function read(path: string): string {
+  return fs.readFileSync(path, "utf8");
+}
+
+const cutTag = read(".agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md");
+const evening = read(".agents/skills/nemoclaw-maintainer-evening/SKILL.md");
+const releaseNotes = read(".agents/skills/nemoclaw-maintainer-release-notes/SKILL.md");
+const releaseTrain = read(
+  ".agents/skills/nemoclaw-maintainer-policies/references/release-train.md",
+);
+
+describe("release post-tag follow-through", () => {
+  it("continues the same task after remote tag readback", () => {
+    const postReadback = cutTag.slice(cutTag.indexOf("### 5."));
+
+    expect(cutTag).toContain("progress checkpoint, not\n  the final response");
+    expect(cutTag).toContain("Continue the same task through post-tag follow-through");
+    expect(evening).toContain("Continue the same task after that report");
+    expect(releaseTrain).toContain("Then continue the same task");
+    expect(postReadback).not.toContain("Return immediately");
+    expect(postReadback).not.toContain("Do not poll");
+  });
+
+  it.each([
+    ".github/workflows/release-latest-tag.yaml",
+    ".github/workflows/docs-publish-public.yaml",
+    ".github/workflows/base-image.yaml",
+  ])("monitors the tag workflow %s", (workflow) => {
+    expect(cutTag).toContain(workflow);
+  });
+
+  it("drafts the Announcement during post-tag monitoring", () => {
+    expect(cutTag).toContain("Monitor the three runs concurrently");
+    expect(cutTag).toContain("`nemoclaw-maintainer-release-notes`");
+    expect(cutTag).toContain("release-note-draft.md");
+    expect(releaseNotes).toContain("Return the draft path to the calling release workflow");
+    expect(cutTag).toContain("Never create a GitHub Discussion");
+  });
+
+  it("classifies production images and leaves lkg under maintainer control", () => {
+    expect(cutTag).toContain("Promote complete multi-platform managed image cohort");
+    expect(cutTag).toContain("Report Pi candidate failures separately");
+    expect(cutTag).toContain("supports failed-job\nreruns");
+    expect(cutTag).toContain("This skill never moves `lkg`");
+    expect(cutTag).toContain("returned downstream production-image run");
+    expect(releaseTrain).toContain("Never move `lkg` automatically");
+    expect(cutTag).not.toMatch(/git push[^\n]*lkg/u);
+  });
+});

--- a/test/release-post-tag-follow-through.test.ts
+++ b/test/release-post-tag-follow-through.test.ts
@@ -47,7 +47,7 @@ describe("release post-tag follow-through", () => {
   it("classifies production images and leaves lkg under maintainer control", () => {
     expect(cutTag).toContain("Promote complete multi-platform managed image cohort");
     expect(cutTag).toContain("Report Pi candidate failures separately");
-    expect(cutTag).toContain("supports failed-job\nreruns");
+    expect(cutTag).toMatch(/supports failed-job\s+reruns/u);
     expect(cutTag).toContain("This skill never moves `lkg`");
     expect(cutTag).toContain("returned downstream production-image run");
     expect(releaseTrain).toContain("Never move `lkg` automatically");

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -85,6 +85,7 @@ const OPAQUE_INPUTS = [
   ".github/workflows/platform-vitest-main.yaml",
   "tools/wsl/ci-helper.ps1",
   "ci/platform-vitest-macos-requirements.lock",
+  ".agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md",
 ] as const;
 
 function triggeredBy(relativePath: string): string[] {
@@ -266,6 +267,12 @@ describe("Vitest opaque-input watch triggers", () => {
     expect(triggeredBy("ci/platform-vitest-macos-requirements.lock")).toEqual([
       "test/platform-vitest-main-workflow.test.ts",
     ]);
+    expect(triggeredBy(".agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md")).toEqual([
+      "test/release-post-tag-follow-through.test.ts",
+    ]);
+    expect(
+      triggeredBy(".agents/skills/nemoclaw-maintainer-policies/references/release-train.md"),
+    ).toEqual(["test/release-post-tag-follow-through.test.ts"]);
   });
 
   it.each(Array.from(vitestWatchTriggerPatterns, (value) => [value]))(

--- a/test/vitest-watch-triggers.test.ts
+++ b/test/vitest-watch-triggers.test.ts
@@ -86,6 +86,9 @@ const OPAQUE_INPUTS = [
   "tools/wsl/ci-helper.ps1",
   "ci/platform-vitest-macos-requirements.lock",
   ".agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md",
+  ".agents/skills/nemoclaw-maintainer-evening/SKILL.md",
+  ".agents/skills/nemoclaw-maintainer-release-notes/SKILL.md",
+  ".agents/skills/nemoclaw-maintainer-policies/references/release-train.md",
 ] as const;
 
 function triggeredBy(relativePath: string): string[] {
@@ -268,6 +271,12 @@ describe("Vitest opaque-input watch triggers", () => {
       "test/platform-vitest-main-workflow.test.ts",
     ]);
     expect(triggeredBy(".agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md")).toEqual([
+      "test/release-post-tag-follow-through.test.ts",
+    ]);
+    expect(triggeredBy(".agents/skills/nemoclaw-maintainer-evening/SKILL.md")).toEqual([
+      "test/release-post-tag-follow-through.test.ts",
+    ]);
+    expect(triggeredBy(".agents/skills/nemoclaw-maintainer-release-notes/SKILL.md")).toEqual([
       "test/release-post-tag-follow-through.test.ts",
     ]);
     expect(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

After a signed tag is read back, the release task now reports that checkpoint and continues through the existing post-tag work. The task monitors the automatic workflows, drafts the Announcement, and reports the separate `lkg` decision without changing tag success or write ownership.

## Changes

- Continue the same task through `latest` and label updates, public documentation, and production image classification.
- Draft the Announcement while the automatic workflows run. Keep Discussion publication and `lkg` movement under maintainer control.
- Follow the current managed-image failed-job rerun contract and the current single downstream `lkg` image dispatch.
- Add a focused skill contract test and map the changed skill files to that test.
- Leave pre-tag evidence, E2E decisions, and workflow implementations unchanged. The cumulative documentation work in #9762 can land independently.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending repository review. This PR changes release instructions and tests, not workflow or release-script code. It preserves separate approval for reruns and `lkg` writes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — the post-tag, skill-frontmatter, and watch-trigger suites passed 3 files and 105 tests; the current `lkg` dispatch suite passed 8 tests; the growth guardrail passed 32 tests; `npm run typecheck:cli` passed after rebuilding local generated artifacts.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run. The focused contract tests and normal hooks cover this instruction-only change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved post-tag release follow-through and workflow monitoring procedures.
  - Clarified announcement drafting, documentation updates, image publication checks, and controlled promotion of the latest known-good release.
  - Documented approval requirements for image repairs and reruns.
  - Clarified how announcement drafts and discussion links are shared.

- **Tests**
  - Added coverage for post-release monitoring, announcement drafting, image classification, promotion controls, and flexible failed-job matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->