### PR TITLE
fix(cli): validate dcode OpenRouter readiness

### DIFF
--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -853,9 +853,13 @@ describe("connectSandbox flow", () => {
     );
   });
 
-  it("probe-only reports final semantic validation failure as a runtime failure (#8942)", async () => {
+  it("probe-only names the failed final semantic check (#9834)", async () => {
     const harness = createConnectHarness({
-      readinessPublicationResult: { kind: "validation-failed", category: "health" },
+      readinessPublicationResult: {
+        kind: "validation-failed",
+        category: "health",
+        failedCheck: "inference request",
+      },
     });
 
     await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
@@ -864,7 +868,7 @@ describe("connectSandbox flow", () => {
 
     expect(harness.checkAndRecoverSpy).toHaveBeenCalled();
     expect(harness.errorSpy.mock.calls.flat().join("\n")).toContain(
-      "final launch-readiness validation failed due to health",
+      "final launch-readiness validation failed because the inference request failed",
     );
     expect(harness.errorSpy.mock.calls.flat().join("\n")).not.toContain(
       "complete probe and recovery succeeded",

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -1717,9 +1717,10 @@ async function prepareConnectSandboxWithinLifecycleFence(
       break;
     }
     if (publication.kind === "validation-failed") {
-      console.error(
-        `  Probe failed: final launch-readiness validation failed due to ${publication.category}.`,
-      );
+      const failedCheck = publication.failedCheck
+        ? ` because the ${publication.failedCheck} failed`
+        : ` due to ${publication.category}`;
+      console.error(`  Probe failed: final launch-readiness validation failed${failedCheck}.`);
       process.exit(1);
     }
     if (publication.kind === "evidence-failed") {

--- a/src/lib/actions/sandbox/inference-invocation-probe.test.ts
+++ b/src/lib/actions/sandbox/inference-invocation-probe.test.ts
@@ -91,7 +91,7 @@ describe("sandbox inference invocation probe", () => {
       "dcode-workspace",
       expect.any(String),
       expect.any(Number),
-      { gatewayName: "recorded-gateway" },
+      { gatewayName: "recorded-gateway", allowLocalDockerFallback: false },
     );
   });
 

--- a/src/lib/actions/sandbox/inference-invocation-probe.test.ts
+++ b/src/lib/actions/sandbox/inference-invocation-probe.test.ts
@@ -74,6 +74,27 @@ describe("sandbox inference invocation probe", () => {
     expect(probeSandboxInferenceInvocation(input, { execute })).toEqual({ ok: true });
   });
 
+  it("pins the invocation to the recorded owning gateway (#9834)", () => {
+    const execute = vi.fn(() => ({
+      status: 0,
+      stdout: '200\n{"choices":[{"message":{"content":"OK"}}]}',
+      stderr: "",
+    }));
+
+    expect(
+      probeSandboxInferenceInvocation(
+        { ...input, gatewayName: "recorded-gateway" },
+        { execute },
+      ),
+    ).toEqual({ ok: true });
+    expect(execute).toHaveBeenCalledWith(
+      "dcode-workspace",
+      expect.any(String),
+      expect.any(Number),
+      { gatewayName: "recorded-gateway" },
+    );
+  });
+
   it("accepts a served response body that serializes an empty tool call list (#9108)", () => {
     const body = JSON.stringify({
       object: "chat.completion",

--- a/src/lib/actions/sandbox/inference-invocation-probe.ts
+++ b/src/lib/actions/sandbox/inference-invocation-probe.ts
@@ -5,10 +5,15 @@ import { getSandboxInferenceConfig } from "../../inference/config";
 import { validateInferenceResponseBody } from "../../inference/health";
 import { MIN_PROBE_REPLY_TOKENS, resolveMaxTokensField } from "../../inference/max-tokens-field";
 import { shellQuote } from "../../runner";
-import { executeSandboxExecCommand, type SandboxCommandResult } from "./process-recovery";
+import {
+  executeSandboxExecCommand,
+  type SandboxCommandResult,
+  type SandboxExecCommandOptions,
+} from "./process-recovery";
 
 export type SandboxInferenceInvocationInput = {
   sandboxName: string;
+  gatewayName?: string;
   provider: string;
   model: string;
   preferredInferenceApi: string | null;
@@ -19,7 +24,12 @@ export type SandboxInferenceInvocationResult =
   | { ok: false; detail: string; httpStatus: number | null };
 
 export type SandboxInferenceInvocationDeps = {
-  execute?: (sandboxName: string, command: string, timeout?: number) => SandboxCommandResult | null;
+  execute?: (
+    sandboxName: string,
+    command: string,
+    timeout?: number,
+    options?: SandboxExecCommandOptions,
+  ) => SandboxCommandResult | null;
 };
 
 /**
@@ -109,6 +119,7 @@ export function probeSandboxInferenceInvocation(
     input.sandboxName,
     buildSandboxInferenceInvocationCommand(input),
     timeoutMs,
+    { gatewayName: input.gatewayName },
   );
   if (!result) {
     return {

--- a/src/lib/actions/sandbox/inference-invocation-probe.ts
+++ b/src/lib/actions/sandbox/inference-invocation-probe.ts
@@ -115,11 +115,14 @@ export function probeSandboxInferenceInvocation(
   timeoutMs: number = REBUILD_INFERENCE_INVOCATION_TIMEOUT_MS,
 ): SandboxInferenceInvocationResult {
   const execute = deps.execute ?? executeSandboxExecCommand;
+  const execOptions: SandboxExecCommandOptions = input.gatewayName
+    ? { gatewayName: input.gatewayName, allowLocalDockerFallback: false }
+    : {};
   const result = execute(
     input.sandboxName,
     buildSandboxInferenceInvocationCommand(input),
     timeoutMs,
-    { gatewayName: input.gatewayName },
+    execOptions,
   );
   if (!result) {
     return {

--- a/src/lib/actions/sandbox/launch-readiness-gateway-health.test.ts
+++ b/src/lib/actions/sandbox/launch-readiness-gateway-health.test.ts
@@ -89,6 +89,7 @@ describe("Deep Agents Code OpenRouter launch readiness", () => {
     ).resolves.toBeUndefined();
     expect(currentDeps.inferenceInvocationProbe).toHaveBeenCalledWith({
       sandboxName: SANDBOX,
+      gatewayName: GATEWAY,
       provider: "openrouter-api",
       model: MODEL,
       preferredInferenceApi: null,

--- a/src/lib/actions/sandbox/launch-readiness-gateway-health.test.ts
+++ b/src/lib/actions/sandbox/launch-readiness-gateway-health.test.ts
@@ -3,6 +3,13 @@
 
 import { describe, expect, it, vi } from "vitest";
 
+import { loadAgent } from "../../agent/defs";
+import type { SandboxEntry } from "../../state/registry";
+import {
+  LaunchReadinessObservationError,
+  requireLaunchSemanticHealth,
+  type LaunchReadinessHealthDeps,
+} from "./launch-readiness/health";
 import { isSandboxGatewayRunningForStatus } from "./process-recovery";
 
 describe("launch-readiness gateway health scope", () => {
@@ -32,5 +39,84 @@ describe("launch-readiness gateway health scope", () => {
       "nemoclaw-8091",
       "--",
     ]);
+  });
+});
+
+const SANDBOX = "alpha";
+const GATEWAY = "nemoclaw";
+const MODEL = "nvidia/nemotron-3-ultra-550b-a55b";
+const dcodeAgent = loadAgent("langchain-deepagents-code");
+
+function dcodeEntry(): SandboxEntry {
+  return {
+    name: SANDBOX,
+    agent: "langchain-deepagents-code",
+    provider: "openrouter-api",
+    model: MODEL,
+    preferredInferenceApi: null,
+  } as SandboxEntry;
+}
+
+function dcodeHealthDeps(
+  invocation: ReturnType<NonNullable<LaunchReadinessHealthDeps["inferenceInvocationProbe"]>>,
+): LaunchReadinessHealthDeps {
+  return {
+    smoke: vi.fn(() => ({ ok: true }) as const),
+    inferenceProbe: vi.fn(() => ({
+      healthy: true,
+      broken: false,
+      httpStatus: 404,
+      detail: "OK 404",
+    })),
+    inferenceInvocationProbe: vi.fn(() => invocation),
+  };
+}
+
+describe("Deep Agents Code OpenRouter launch readiness", () => {
+  it("accepts readiness after an inference request succeeds (#9834)", async () => {
+    const currentDeps = dcodeHealthDeps({ ok: true });
+
+    await expect(
+      requireLaunchSemanticHealth(
+        SANDBOX,
+        GATEWAY,
+        "langchain-deepagents-code",
+        dcodeEntry(),
+        dcodeAgent,
+        true,
+        currentDeps,
+      ),
+    ).resolves.toBeUndefined();
+    expect(currentDeps.inferenceInvocationProbe).toHaveBeenCalledWith({
+      sandboxName: SANDBOX,
+      provider: "openrouter-api",
+      model: MODEL,
+      preferredInferenceApi: null,
+    });
+  });
+
+  it("rejects readiness and names the inference request when invocation fails (#9834)", async () => {
+    const currentDeps = dcodeHealthDeps({
+      ok: false,
+      detail: "sandbox inference invocation probe returned HTTP 401",
+      httpStatus: 401,
+    });
+
+    await expect(
+      requireLaunchSemanticHealth(
+        SANDBOX,
+        GATEWAY,
+        "langchain-deepagents-code",
+        dcodeEntry(),
+        dcodeAgent,
+        true,
+        currentDeps,
+      ),
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<LaunchReadinessObservationError>>({
+        category: "health",
+        failedCheck: "inference request",
+      }),
+    );
   });
 });

--- a/src/lib/actions/sandbox/launch-readiness.ts
+++ b/src/lib/actions/sandbox/launch-readiness.ts
@@ -49,6 +49,7 @@ import {
 import {
   captureLaunchReadiness,
   LaunchReadinessEvidenceError,
+  type LaunchReadinessFailedCheck,
   type LaunchReadinessHealthDeps,
   LaunchReadinessObservationError as ObservationError,
   requireLaunchSemanticHealth,
@@ -131,6 +132,7 @@ export type LaunchReadinessPublicationResult =
   | {
       kind: "validation-failed";
       category: "identity" | "config" | "health" | "session";
+      failedCheck?: LaunchReadinessFailedCheck;
     }
   | { kind: "evidence-failed" };
 
@@ -834,13 +836,16 @@ function debugDecision(category: LaunchReadinessDecisionCategory): void {
   );
 }
 
-function publicationValidationCategory(
-  error: unknown,
-): LaunchReadinessPublicationValidationCategory | null {
+function publicationValidationCategory(error: unknown): {
+  category: LaunchReadinessPublicationValidationCategory;
+  failedCheck?: LaunchReadinessFailedCheck;
+} | null {
   if (!(error instanceof ObservationError)) return null;
-  return ["identity", "config", "health", "session"].includes(error.category)
-    ? (error.category as LaunchReadinessPublicationValidationCategory)
-    : null;
+  if (!["identity", "config", "health", "session"].includes(error.category)) return null;
+  return {
+    category: error.category as LaunchReadinessPublicationValidationCategory,
+    ...(error.failedCheck ? { failedCheck: error.failedCheck } : {}),
+  };
 }
 
 function fallback(
@@ -1214,9 +1219,9 @@ export async function publishLaunchReadiness(
         try {
           captured = await captureLaunchIdentity(sandboxName, gatewayName, gatewayPort, deps);
         } catch (error) {
-          const category = publicationValidationCategory(error);
-          return category
-            ? ({ kind: "validation-failed", category } as const)
+          const validation = publicationValidationCategory(error);
+          return validation
+            ? ({ kind: "validation-failed", ...validation } as const)
             : ({ kind: "evidence-failed" } as const);
         } finally {
           recordPerformanceStage("publication-validation", validationStartedAt);

--- a/src/lib/actions/sandbox/launch-readiness/health.ts
+++ b/src/lib/actions/sandbox/launch-readiness/health.ts
@@ -14,6 +14,7 @@ import {
   parseSandboxInferenceRouteProbeResult,
 } from "../connect-inference-route-probe";
 import { areSandboxLaunchForwardsHealthy } from "../forward-recovery";
+import { runSandboxInferenceInvocationProbe } from "../inference-route-health";
 import { isSandboxGatewayRunningForStatus } from "../process-recovery";
 
 export type LaunchReadinessObservationCategory =
@@ -28,6 +29,8 @@ export type LaunchReadinessObservationCategory =
 
 export type LaunchReadinessCaptureResult = ReturnType<typeof captureOpenshell>;
 
+export type LaunchReadinessFailedCheck = "inference request";
+
 export interface LaunchReadinessHealthDeps {
   listAgents?: typeof listAgents;
   loadAgent?: typeof loadAgent;
@@ -40,10 +43,14 @@ export interface LaunchReadinessHealthDeps {
     agent: InferenceRouteProbeAgent,
     gatewayName: string,
   ) => ReturnType<typeof parseSandboxInferenceRouteProbeResult>;
+  inferenceInvocationProbe?: typeof runSandboxInferenceInvocationProbe;
 }
 
 export class LaunchReadinessObservationError extends Error {
-  constructor(readonly category: LaunchReadinessObservationCategory) {
+  constructor(
+    readonly category: LaunchReadinessObservationCategory,
+    readonly failedCheck?: LaunchReadinessFailedCheck,
+  ) {
     super(category);
   }
 }
@@ -113,7 +120,7 @@ export async function requireLaunchSemanticHealth(
   sandboxName: string,
   gatewayName: string,
   agentName: string,
-  _entry: SandboxEntry,
+  entry: SandboxEntry,
   agent: AgentDefinition,
   inferenceConfigured: boolean,
   deps: LaunchReadinessHealthDeps,
@@ -149,8 +156,27 @@ export async function requireLaunchSemanticHealth(
   }
   if (inferenceConfigured) {
     const inference = (deps.inferenceProbe ?? probeInferenceRoute)(sandboxName, agent, gatewayName);
-    const usable = inference.healthy && inference.httpStatus >= 200 && inference.httpStatus < 300;
-    if (usable) return;
+    const strictRouteHealth =
+      inference.healthy && inference.httpStatus >= 200 && inference.httpStatus < 300;
+    if (strictRouteHealth) return;
+    const openRouterDcodeModelsRouteUnsupported =
+      agentName === "langchain-deepagents-code" &&
+      entry.provider === "openrouter-api" &&
+      inference.healthy &&
+      inference.httpStatus === 404;
+    if (openRouterDcodeModelsRouteUnsupported) {
+      const provider = normalizedString(entry.provider);
+      const model = normalizedString(entry.model);
+      if (!provider || !model) throw new LaunchReadinessEvidenceError();
+      const invocation = (deps.inferenceInvocationProbe ?? runSandboxInferenceInvocationProbe)({
+        sandboxName,
+        provider,
+        model,
+        preferredInferenceApi: normalizedString(entry.preferredInferenceApi),
+      });
+      if (invocation.ok) return;
+      throw new LaunchReadinessObservationError("health", "inference request");
+    }
     if (inference.broken || (inference.httpStatus >= 100 && inference.httpStatus < 600)) {
       throw new LaunchReadinessObservationError("health");
     }

--- a/src/lib/actions/sandbox/launch-readiness/health.ts
+++ b/src/lib/actions/sandbox/launch-readiness/health.ts
@@ -170,6 +170,7 @@ export async function requireLaunchSemanticHealth(
       if (!provider || !model) throw new LaunchReadinessEvidenceError();
       const invocation = (deps.inferenceInvocationProbe ?? runSandboxInferenceInvocationProbe)({
         sandboxName,
+        gatewayName,
         provider,
         model,
         preferredInferenceApi: normalizedString(entry.preferredInferenceApi),

--- a/src/lib/adapters/sandbox/command-transport.test.ts
+++ b/src/lib/adapters/sandbox/command-transport.test.ts
@@ -190,6 +190,22 @@ describe("sandbox command transport privileged execution lease", () => {
     ]);
   });
 
+  it("does not use local Docker fallback for gateway-pinned exec (#9834)", () => {
+    const deps = createDependencies({
+      extractSandboxExecCommandStdout: vi.fn(() => null),
+    });
+    mocks.spawnSync.mockReturnValue(spawnResult("untrusted-output", { status: 1 }));
+
+    expect(
+      executeSandboxExecCommandTransport(deps, "alpha", "id", 9000, {
+        gatewayName: "recorded-gateway",
+        allowLocalDockerFallback: false,
+      }),
+    ).toBeNull();
+    expect(deps.privilegedSandboxExecArgv).not.toHaveBeenCalled();
+    expect(deps.dockerSpawnSync).not.toHaveBeenCalled();
+  });
+
   it("holds one lease across OpenShell failure and the complete local fallback", () => {
     const events: string[] = [];
     let leaseHeld = false;

--- a/src/lib/adapters/sandbox/command-transport.test.ts
+++ b/src/lib/adapters/sandbox/command-transport.test.ts
@@ -167,6 +167,29 @@ describe("sandbox command transport privileged execution lease", () => {
     expect(mocks.spawnSync).not.toHaveBeenCalled();
   });
 
+  it("pins OpenShell exec to the requested gateway (#9834)", () => {
+    const deps = createDependencies();
+    mocks.spawnSync.mockReturnValue(spawnResult("ok"));
+
+    expect(
+      executeSandboxExecCommandTransport(deps, "alpha", "id", 9000, {
+        gatewayName: "recorded-gateway",
+      }),
+    ).toEqual({ status: 0, stdout: "ok", stderr: "" });
+    expect(mocks.spawnSync.mock.calls[0]?.[1]).toEqual([
+      "sandbox",
+      "exec",
+      "--name",
+      "alpha",
+      "-g",
+      "recorded-gateway",
+      "--",
+      "sh",
+      "-c",
+      "marked:id",
+    ]);
+  });
+
   it("holds one lease across OpenShell failure and the complete local fallback", () => {
     const events: string[] = [];
     let leaseHeld = false;

--- a/src/lib/adapters/sandbox/command-transport.ts
+++ b/src/lib/adapters/sandbox/command-transport.ts
@@ -13,6 +13,7 @@ export type SandboxCommandResult = {
 
 export type SandboxExecCommandOptions = {
   allowLocalDockerFallback?: boolean;
+  gatewayName?: string;
 };
 
 export type CommandTransportDependencies = {
@@ -165,9 +166,20 @@ export function executeSandboxExecCommandTransport(
       const markedCommand = deps.buildSandboxExecMarkedCommand(command);
       const effectiveTimeout = resolveSandboxExecTimeout(timeout);
       try {
+        const gatewayArgs = options.gatewayName ? ["-g", options.gatewayName] : [];
         const result = spawnSync(
           deps.getOpenshellBinary(),
-          ["sandbox", "exec", "--name", sandboxName, "--", "sh", "-c", markedCommand],
+          [
+            "sandbox",
+            "exec",
+            "--name",
+            sandboxName,
+            ...gatewayArgs,
+            "--",
+            "sh",
+            "-c",
+            markedCommand,
+          ],
           {
             cwd: deps.root,
             encoding: "utf-8",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Deep Agents Code launch readiness now validates OpenRouter with a bounded inference request when the adapter returns its expected HTTP 404 for `GET /v1/models`. The command now accepts a working managed inference route and names the inference request when final validation fails.

## Related Issue

Fixes #9834

## Changes

- Require a validated inference response before accepting the Deep Agents Code and `openrouter-api` HTTP 404 route result.
- Preserve the existing strict route checks for all other agents, providers, and HTTP results.
- Carry the failed inference-request check into the final `connect --probe-only` diagnostic.
- Extend the existing launch-readiness gateway-health and connect-flow tests with accepted and denied OpenRouter behavior.

The Deep Agents Code OpenRouter path is required by #9834. The adapter does not implement `GET /v1/models`, so a direct 2xx route check cannot validate this consumer. The gateway-health tests require a successful inference response and reject a failed request.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The issue-scoped maintainer review confirmed that the exception requires a validated inference response and preserves existing denied route results.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this PR does not change `scripts/prepare-dgx-station-host.sh`.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/actions/sandbox/launch-readiness-gateway-health.test.ts src/lib/actions/sandbox/launch-readiness.test.ts src/lib/actions/sandbox/connect-flow.test.ts` passed 109 tests; `npx vitest run --project integration test/growth-guardrails.test.ts` passed 32 tests; `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; focused source tests, the growth guard, and CLI type checking cover this issue-scoped path.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: J. Yaunches <jmyaunch@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launch-readiness validation now identifies the specific failed check.
  * Added inference request validation for Deep Agents Code using OpenRouter.
  * Healthy 404 routes are accepted when direct inference succeeds.
  * Inference checks use the configured gateway when provided.

* **Bug Fixes**
  * Improved validation errors with more relevant failure details.
  * Corrected gateway routing and prevented unintended local fallback during inference checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->