### PR TITLE
fix(inference): accept catalog-selected vLLM model

### DIFF
--- a/src/lib/inference/vllm-fixed-catalog-install.test.ts
+++ b/src/lib/inference/vllm-fixed-catalog-install.test.ts
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HostLocalVllmSelectionResult } from "./serving/host-local-vllm-selection";
+import type { VllmProfile } from "./vllm";
+
+const mocks = vi.hoisted(() => ({
+  dockerCapture: vi.fn(),
+  dockerForceRm: vi.fn(),
+  dockerImageInspectFormat: vi.fn(),
+  dockerPullWithProgressWatchdog: vi.fn(),
+  dockerRunDetached: vi.fn(),
+  dockerSpawn: vi.fn(),
+  dockerStop: vi.fn(),
+  ensureDualStationVllmApiKey: vi.fn(() => "b".repeat(64)),
+  findUnwritableModelCachePath: vi.fn(),
+  getGpuIndicesByName: vi.fn<(_pattern: RegExp) => number[]>(() => []),
+  measureDirectorySizeBytes: vi.fn(),
+  persistHostLocalVllmRuntimeReceipt: vi.fn(),
+  probeDockerStorage: vi.fn(),
+  probeHostStorage: vi.fn(),
+  resolveHostLocalVllmSelection: vi.fn<() => HostLocalVllmSelectionResult>(() => ({
+    kind: "not-selected",
+  })),
+  runCapture: vi.fn(),
+  runCurlProbe: vi.fn(),
+  tryInstallManagedClusterManagedVllm: vi.fn(async () => ({
+    kind: "not-selected" as const,
+  })),
+}));
+
+vi.mock("../runner", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../runner")>()),
+  runCapture: mocks.runCapture,
+}));
+
+vi.mock("../adapters/docker", () => ({
+  dockerCapture: mocks.dockerCapture,
+  dockerForceRm: mocks.dockerForceRm,
+  dockerImageInspectFormat: mocks.dockerImageInspectFormat,
+  dockerPullWithProgressWatchdog: mocks.dockerPullWithProgressWatchdog,
+  dockerRunDetached: mocks.dockerRunDetached,
+  dockerSpawn: mocks.dockerSpawn,
+  dockerStop: mocks.dockerStop,
+}));
+
+vi.mock("../adapters/http/probe", () => ({
+  runCurlProbe: mocks.runCurlProbe,
+}));
+
+vi.mock("./nim", () => ({
+  getGpuIndicesByName: mocks.getGpuIndicesByName,
+}));
+
+vi.mock("./vllm-storage", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./vllm-storage")>();
+  return {
+    ...actual,
+    findUnwritableModelCachePath: mocks.findUnwritableModelCachePath,
+    measureDirectorySizeBytes: mocks.measureDirectorySizeBytes,
+    probeDockerStorage: mocks.probeDockerStorage,
+    probeHostStorage: mocks.probeHostStorage,
+  };
+});
+
+vi.mock("./serving/vllm-managed-support", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./serving/vllm-managed-support")>();
+  return {
+    ...actual,
+    ensureDualStationVllmApiKey: mocks.ensureDualStationVllmApiKey,
+    persistHostLocalVllmRuntimeReceipt: mocks.persistHostLocalVllmRuntimeReceipt,
+    resolveHostLocalVllmSelection: mocks.resolveHostLocalVllmSelection,
+    tryInstallManagedClusterManagedVllm: mocks.tryInstallManagedClusterManagedVllm,
+  };
+});
+
+import { detectVllmProfile, installVllm } from "./vllm";
+import {
+  applyVllmInstallProbeDefaults,
+  createVllmInstallSpies,
+  mockSuccessfulVllmInstall,
+  resetVllmInstallEnv,
+  type VllmInstallSpies,
+  vllmInstallTestReadiness,
+} from "./vllm-install.test-support";
+
+type SelectedHostLocalVllm = Extract<HostLocalVllmSelectionResult, { kind: "selected" }>;
+
+async function resolveMuseGlimmerSelection(profile: VllmProfile): Promise<SelectedHostLocalVllm> {
+  const readinessReports = vllmInstallTestReadiness(profile);
+  const actualSelection = await vi.importActual<
+    typeof import("./serving/host-local-vllm-selection")
+  >("./serving/host-local-vllm-selection");
+  const selection = actualSelection.resolveHostLocalVllmSelection(profile, process.env, {
+    automatic: true,
+    readinessReports,
+  });
+  expect(selection.kind).toBe("selected");
+  return selection as SelectedHostLocalVllm;
+}
+
+function mockSuccessfulAuthenticatedReadiness(servedModelId: string): void {
+  mocks.runCurlProbe
+    .mockReturnValueOnce({
+      ok: true,
+      httpStatus: 200,
+      curlStatus: 0,
+      body: "",
+      stderr: "",
+      message: "",
+    })
+    .mockReturnValueOnce({
+      ok: false,
+      httpStatus: 401,
+      curlStatus: 0,
+      body: "",
+      stderr: "",
+      message: "HTTP 401",
+    })
+    .mockReturnValueOnce({
+      ok: true,
+      httpStatus: 200,
+      curlStatus: 0,
+      body: JSON.stringify({ data: [{ id: servedModelId }] }),
+      stderr: "",
+      message: "",
+    });
+}
+
+describe("fixed catalog vLLM installs", () => {
+  let spies: VllmInstallSpies;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spies = createVllmInstallSpies();
+    resetVllmInstallEnv();
+    applyVllmInstallProbeDefaults(mocks);
+    mocks.ensureDualStationVllmApiKey.mockReturnValue("b".repeat(64));
+    mocks.getGpuIndicesByName.mockReturnValue([]);
+    mocks.resolveHostLocalVllmSelection.mockReturnValue({ kind: "not-selected" });
+    mocks.tryInstallManagedClusterManagedVllm.mockResolvedValue({ kind: "not-selected" });
+  });
+
+  afterEach(() => {
+    spies.restore();
+    process.env = { ...originalEnv };
+  });
+
+  it("installs a fixed catalog recipe selected by NEMOCLAW_VLLM_MODEL", async () => {
+    process.env.NEMOCLAW_VLLM_MODEL = "muse-glimmer-30b";
+    const profile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
+    const selection = await resolveMuseGlimmerSelection(profile);
+    const readinessReports = vllmInstallTestReadiness(profile);
+    mocks.resolveHostLocalVllmSelection.mockReturnValue(selection);
+    mockSuccessfulVllmInstall(mocks, selection.profile.containerName);
+    mockSuccessfulAuthenticatedReadiness(selection.model.servedModelId ?? selection.model.id);
+
+    const result = await installVllm(profile, {
+      hasImage: true,
+      nonInteractive: true,
+      promptFn: vi.fn(),
+      readinessReports,
+      resolveManagedBridgeHost: () => "172.18.0.1",
+    });
+
+    expect(spies.errSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("does not accept NEMOCLAW_VLLM_MODEL"),
+    );
+    expect(result).toEqual({ ok: true });
+    expect(mocks.dockerRunDetached).toHaveBeenCalledOnce();
+  });
+
+  it("still rejects extra serve arguments for a fixed catalog recipe", async () => {
+    process.env.NEMOCLAW_VLLM_MODEL = "muse-glimmer-30b";
+    const profile = detectVllmProfile({ platform: "spark", type: "nvidia" })!;
+    const selection = await resolveMuseGlimmerSelection(profile);
+    mocks.resolveHostLocalVllmSelection.mockReturnValue(selection);
+    process.env.NEMOCLAW_VLLM_EXTRA_ARGS_JSON = JSON.stringify(["--max-model-len", "4096"]);
+
+    const result = await installVllm(profile, {
+      hasImage: true,
+      nonInteractive: true,
+      promptFn: vi.fn(),
+      readinessReports: vllmInstallTestReadiness(profile),
+    });
+
+    expect(result).toEqual({ ok: false });
+    expect(spies.errSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "does not accept NEMOCLAW_VLLM_MODEL or NEMOCLAW_VLLM_EXTRA_ARGS_JSON",
+      ),
+    );
+    expect(mocks.runCapture).not.toHaveBeenCalled();
+    expect(mocks.dockerPullWithProgressWatchdog).not.toHaveBeenCalled();
+    expect(mocks.dockerRunDetached).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -1663,7 +1663,10 @@ async function runVllmInstall(
   const configuredPeer = String(process.env[NEMOCLAW_DGX_STATION_PEER_ENV] ?? "").trim();
   const fixedServeCommand = profile.defaultModel.fixedServeCommand === true;
   if (fixedServeCommand) {
-    if (explicitModel || String(process.env[VLLM_EXTRA_ARGS_ENV] ?? "").trim()) {
+    if (
+      (!hostLocalSelection && explicitModel) ||
+      String(process.env[VLLM_EXTRA_ARGS_ENV] ?? "").trim()
+    ) {
       console.error(
         `  vLLM install failed: this local model profile does not accept NEMOCLAW_VLLM_MODEL or ${VLLM_EXTRA_ARGS_ENV}.`,
       );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Restore the documented `NEMOCLAW_VLLM_MODEL=muse-glimmer-30b` onboarding path. A catalog-validated model selector can now enter its fixed vLLM recipe, while direct fixed-profile model overrides and all extra serve arguments remain rejected.

## Changes

- Allow `NEMOCLAW_VLLM_MODEL` through the fixed-profile guard only when the host-local catalog resolver already materialized the selected recipe.
- Add a regression test that resolves Muse Glimmer through the real catalog and completes the mocked authenticated vLLM lifecycle.
- Add a negative regression test proving `NEMOCLAW_VLLM_EXTRA_ARGS_JSON` still fails before Docker work.

The product root cause was the recursive install call: after catalog resolution materialized a fixed recipe, `runVllmInstall` reread the original selector and treated it as a new, unvalidated override. The detection gap was that model resolution and fixed-profile rejection had separate coverage, but no test carried a supported selector through both stages. The smallest prevention evidence is the paired positive and negative install tests: the catalog-selected model succeeds, while arbitrary serve arguments remain denied without side effects.

No documentation changes are needed because the v0.0.112 documentation already describes `muse-glimmer-30b` as a supported selector; this restores that behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Inference input validation was reviewed. Only a catalog-materialized selection bypasses the model-override rejection; extra serve arguments and direct fixed-profile overrides remain rejected before Docker work. Credential custody, image selection, and container lifecycle behavior are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run --project cli src/lib/inference/vllm-fixed-catalog-install.test.ts` (2 passed); full `vllm.test.ts` suite (73 passed); related vLLM suites (173 passed)
- [x] Applicable broad gate passed — `npm run test:changed` (32 growth checks and 291 affected tests passed), `npm run lint`, and `npm run typecheck:cli`
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional reproduction evidence: on the v0.0.112 tag, the focused positive scenario failed with `this local model profile does not accept NEMOCLAW_VLLM_MODEL or NEMOCLAW_VLLM_EXTRA_ARGS_JSON`, while its companion negative case passed. The same positive and negative scenarios pass with this change.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed local vLLM installation behavior when selecting a host-local model alongside an explicitly configured model.
  * Explicit model configuration now correctly selects and installs the matching fixed-catalog recipe.
  * Unsupported extra serving arguments continue to be rejected before installation begins.

* **Tests**
  * Added coverage for model selection, installation, dependency handling, and rejection of unsupported configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->