### PR TITLE
fix(inference): bind receipt to published SBOM files

### DIFF
--- a/.github/workflows/llama-cpp-image-attest.yaml
+++ b/.github/workflows/llama-cpp-image-attest.yaml
@@ -123,9 +123,16 @@ jobs:
           format: ${{ needs.validate-inputs.outputs.sbom_format }}
           artifact-name: llama-cpp-sbom-amd64-${{ needs.validate-inputs.outputs.candidate_tag }}
           output-file: llama-cpp-sbom-amd64.spdx.json
-          upload-artifact: true
-          upload-artifact-retention: ${{ needs.validate-inputs.outputs.retention_days }}
+          upload-artifact: false
           upload-release-assets: false
+
+      - name: Upload amd64 SPDX SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: llama-cpp-sbom-amd64-${{ needs.validate-inputs.outputs.candidate_tag }}
+          path: llama-cpp-sbom-amd64.spdx.json
+          if-no-files-found: error
+          retention-days: ${{ needs.validate-inputs.outputs.retention_days }}
 
       - name: Generate arm64 SPDX SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
@@ -136,9 +143,16 @@ jobs:
           format: ${{ needs.validate-inputs.outputs.sbom_format }}
           artifact-name: llama-cpp-sbom-arm64-${{ needs.validate-inputs.outputs.candidate_tag }}
           output-file: llama-cpp-sbom-arm64.spdx.json
-          upload-artifact: true
-          upload-artifact-retention: ${{ needs.validate-inputs.outputs.retention_days }}
+          upload-artifact: false
           upload-release-assets: false
+
+      - name: Upload arm64 SPDX SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: llama-cpp-sbom-arm64-${{ needs.validate-inputs.outputs.candidate_tag }}
+          path: llama-cpp-sbom-arm64.spdx.json
+          if-no-files-found: error
+          retention-days: ${{ needs.validate-inputs.outputs.retention_days }}
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -786,6 +786,7 @@ jobs:
       - name: Verify publication evidence and create receipt
         shell: bash
         env:
+          CANDIDATE_TAG: ${{ needs.assemble-candidate.outputs.candidate_tag }}
           CERTIFICATE_IDENTITY: ${{ needs.config.outputs.publication_signature_identity }}
           CERTIFICATE_OIDC_ISSUER: ${{ needs.config.outputs.publication_signature_issuer }}
           CUDA_DEVELOPMENT_BASE: ${{ needs.config.outputs.cuda_dev_image }}
@@ -800,8 +801,8 @@ jobs:
             --reference "$REFERENCE" \
             --candidate-index "$evidence/candidate-index.json" \
             --platform-digests "$evidence/platform-digests.json" \
-            --sbom-amd64 "$evidence/llama-cpp-sbom-amd64.spdx.json" \
-            --sbom-arm64 "$evidence/llama-cpp-sbom-arm64.spdx.json" \
+            --sbom-amd64 "$evidence/llama-cpp-sbom-amd64-$CANDIDATE_TAG" \
+            --sbom-arm64 "$evidence/llama-cpp-sbom-arm64-$CANDIDATE_TAG" \
             --sbom-verification "$evidence/sbom-verification.json" \
             --provenance-verification "$evidence/provenance-verification.json" \
             --signature-verification "$evidence/signature-verification.json" \

--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -786,7 +786,6 @@ jobs:
       - name: Verify publication evidence and create receipt
         shell: bash
         env:
-          CANDIDATE_TAG: ${{ needs.assemble-candidate.outputs.candidate_tag }}
           CERTIFICATE_IDENTITY: ${{ needs.config.outputs.publication_signature_identity }}
           CERTIFICATE_OIDC_ISSUER: ${{ needs.config.outputs.publication_signature_issuer }}
           CUDA_DEVELOPMENT_BASE: ${{ needs.config.outputs.cuda_dev_image }}
@@ -801,8 +800,8 @@ jobs:
             --reference "$REFERENCE" \
             --candidate-index "$evidence/candidate-index.json" \
             --platform-digests "$evidence/platform-digests.json" \
-            --sbom-amd64 "$evidence/llama-cpp-sbom-amd64-$CANDIDATE_TAG" \
-            --sbom-arm64 "$evidence/llama-cpp-sbom-arm64-$CANDIDATE_TAG" \
+            --sbom-amd64 "$evidence/llama-cpp-sbom-amd64.spdx.json" \
+            --sbom-arm64 "$evidence/llama-cpp-sbom-arm64.spdx.json" \
             --sbom-verification "$evidence/sbom-verification.json" \
             --provenance-verification "$evidence/provenance-verification.json" \
             --signature-verification "$evidence/signature-verification.json" \

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -465,6 +465,7 @@ describe("llama.cpp image PR workflow", () => {
     const attest = required(workflow.jobs?.["attest-candidate"], "attestation job is missing");
     const verify = required(workflow.jobs?.["verify-candidate"], "verification job is missing");
     const scanStep = namedStep(scan, "Scan exact platform digest");
+    const downloadSboms = namedStep(verify, "Download SPDX SBOMs");
     const crypto = namedStep(verify, "Verify cryptographic evidence");
     const receipt = namedStep(verify, "Verify publication evidence and create receipt");
 
@@ -504,7 +505,21 @@ describe("llama.cpp image PR workflow", () => {
     expect(crypto.run).toContain("--signer-workflow");
     expect(crypto.run).toContain('--source-ref "$EXPECTED_REF"');
     expect(crypto.run).toContain('--source-digest "$EXPECTED_REVISION"');
+    expect(downloadSboms.with).toEqual({
+      pattern: "llama-cpp-sbom-*-${{ needs.assemble-candidate.outputs.candidate_tag }}",
+      path: "${{ runner.temp }}/llama-cpp-evidence",
+      "merge-multiple": true,
+    });
+    expect(receipt.env?.CANDIDATE_TAG).toBe(
+      "${{ needs.assemble-candidate.outputs.candidate_tag }}",
+    );
     expect(receipt.run).toContain("scripts/checks/verify-llama-cpp-image-publication-evidence.sh");
+    expect(receipt.run).toContain(
+      '--sbom-amd64 "$evidence/llama-cpp-sbom-amd64-$CANDIDATE_TAG"',
+    );
+    expect(receipt.run).toContain(
+      '--sbom-arm64 "$evidence/llama-cpp-sbom-arm64-$CANDIDATE_TAG"',
+    );
     const publicationJobs = [
       "publish-platform",
       "assemble-candidate",
@@ -575,6 +590,10 @@ describe("llama.cpp image PR workflow", () => {
     expect(sbomSteps.map((step) => step.uses)).toEqual([
       "anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610",
       "anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610",
+    ]);
+    expect(sbomSteps.map((step) => step.with?.["artifact-name"])).toEqual([
+      "llama-cpp-sbom-amd64-${{ needs.validate-inputs.outputs.candidate_tag }}",
+      "llama-cpp-sbom-arm64-${{ needs.validate-inputs.outputs.candidate_tag }}",
     ]);
     expect(namedStep(attest, "Attest SLSA build provenance").uses).toBe(
       "actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8",

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -510,15 +510,12 @@ describe("llama.cpp image PR workflow", () => {
       path: "${{ runner.temp }}/llama-cpp-evidence",
       "merge-multiple": true,
     });
-    expect(receipt.env?.CANDIDATE_TAG).toBe(
-      "${{ needs.assemble-candidate.outputs.candidate_tag }}",
-    );
     expect(receipt.run).toContain("scripts/checks/verify-llama-cpp-image-publication-evidence.sh");
     expect(receipt.run).toContain(
-      '--sbom-amd64 "$evidence/llama-cpp-sbom-amd64-$CANDIDATE_TAG"',
+      '--sbom-amd64 "$evidence/llama-cpp-sbom-amd64.spdx.json"',
     );
     expect(receipt.run).toContain(
-      '--sbom-arm64 "$evidence/llama-cpp-sbom-arm64-$CANDIDATE_TAG"',
+      '--sbom-arm64 "$evidence/llama-cpp-sbom-arm64.spdx.json"',
     );
     const publicationJobs = [
       "publish-platform",
@@ -595,6 +592,23 @@ describe("llama.cpp image PR workflow", () => {
       "llama-cpp-sbom-amd64-${{ needs.validate-inputs.outputs.candidate_tag }}",
       "llama-cpp-sbom-arm64-${{ needs.validate-inputs.outputs.candidate_tag }}",
     ]);
+    expect(sbomSteps.map((step) => step.with?.["output-file"])).toEqual([
+      "llama-cpp-sbom-amd64.spdx.json",
+      "llama-cpp-sbom-arm64.spdx.json",
+    ]);
+    expect(sbomSteps.map((step) => step.with?.["upload-artifact"])).toEqual([false, false]);
+    for (const arch of ["amd64", "arm64"]) {
+      const uploadSbom = namedStep(attest, `Upload ${arch} SPDX SBOM`);
+      expect(uploadSbom.uses).toBe(
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+      );
+      expect(uploadSbom.with).toEqual({
+        name: `llama-cpp-sbom-${arch}-\${{ needs.validate-inputs.outputs.candidate_tag }}`,
+        path: `llama-cpp-sbom-${arch}.spdx.json`,
+        "if-no-files-found": "error",
+        "retention-days": "${{ needs.validate-inputs.outputs.retention_days }}",
+      });
+    }
     expect(namedStep(attest, "Attest SLSA build provenance").uses).toBe(
       "actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8",
     );

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -597,18 +597,26 @@ describe("llama.cpp image PR workflow", () => {
       "llama-cpp-sbom-arm64.spdx.json",
     ]);
     expect(sbomSteps.map((step) => step.with?.["upload-artifact"])).toEqual([false, false]);
-    for (const arch of ["amd64", "arm64"]) {
-      const uploadSbom = namedStep(attest, `Upload ${arch} SPDX SBOM`);
-      expect(uploadSbom.uses).toBe(
-        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
-      );
-      expect(uploadSbom.with).toEqual({
-        name: `llama-cpp-sbom-${arch}-\${{ needs.validate-inputs.outputs.candidate_tag }}`,
-        path: `llama-cpp-sbom-${arch}.spdx.json`,
-        "if-no-files-found": "error",
-        "retention-days": "${{ needs.validate-inputs.outputs.retention_days }}",
-      });
-    }
+    const uploadAmd64Sbom = namedStep(attest, "Upload amd64 SPDX SBOM");
+    const uploadArm64Sbom = namedStep(attest, "Upload arm64 SPDX SBOM");
+    expect(uploadAmd64Sbom.uses).toBe(
+      "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    );
+    expect(uploadAmd64Sbom.with).toEqual({
+      name: "llama-cpp-sbom-amd64-${{ needs.validate-inputs.outputs.candidate_tag }}",
+      path: "llama-cpp-sbom-amd64.spdx.json",
+      "if-no-files-found": "error",
+      "retention-days": "${{ needs.validate-inputs.outputs.retention_days }}",
+    });
+    expect(uploadArm64Sbom.uses).toBe(
+      "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    );
+    expect(uploadArm64Sbom.with).toEqual({
+      name: "llama-cpp-sbom-arm64-${{ needs.validate-inputs.outputs.candidate_tag }}",
+      path: "llama-cpp-sbom-arm64.spdx.json",
+      "if-no-files-found": "error",
+      "retention-days": "${{ needs.validate-inputs.outputs.retention_days }}",
+    });
     expect(namedStep(attest, "Attest SLSA build provenance").uses).toBe(
       "actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8",
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The trusted llama.cpp image publication generated and attested both platform SBOMs, but the receipt job looked for different filenames after artifact download. This change gives each candidate-specific artifact a fixed platform SBOM payload filename and binds receipt verification to those filenames.

## Related Issue

Part of #8231. Prerequisite for #9592.

## Changes

- Disable the Anchore action's implicit artifact upload while preserving its fixed local output files.
- Upload each fixed platform SBOM file under a candidate-specific artifact name.
- Bind the producer artifact names and payloads, download pattern, and receipt inputs in the workflow contract test.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/llama-cpp-image-workflow.test.ts test/llama-cpp-image-publication-evidence.test.ts --project integration` passed 20 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved software bill of materials (SBOM) handling for amd64 and arm64 builds.
  * SBOM files now use consistent architecture-specific names for downloads and verification.
  * Attestation uploads now use explicit artifact files, candidate-tagged names, configurable retention, and required-file validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->