### PR TITLE
fix(inference): restore Station large-model selection

### DIFF
--- a/managed-inference/recipes/vllm.deepseek-v4-flash.station-arm64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.deepseek-v4-flash.station-arm64-single.v1.yaml
@@ -17,7 +17,7 @@ spec:
     imageDownloadSizeBytes: 9603085145
     imageUnpackedSizeBytes: 27658526720
     minimumComputeCapability: 100
-    minimumGpuMemoryBytes: 352381000000
+    # Station qualification validates the supported GB300 runtime. The model repository size is not an HBM minimum.
     pullTimeoutSeconds: 43200
     architecture: arm64
     networkMode: bridge

--- a/managed-inference/recipes/vllm.nemotron-3-ultra-550b-a55b-nvfp4.station-arm64-single.v1.yaml
+++ b/managed-inference/recipes/vllm.nemotron-3-ultra-550b-a55b-nvfp4.station-arm64-single.v1.yaml
@@ -16,7 +16,7 @@ spec:
     image: vllm/vllm-openai@sha256:0fec7ec5f3e6bc168e54899935fb0557da908a4832a1dbc88e2debcf2f889416
     imageDownloadSizeBytes: 10670087425
     minimumComputeCapability: 100
-    minimumGpuMemoryBytes: 352381245521
+    # Station qualification validates the supported GB300 runtime. The model repository size is not an HBM minimum.
     pullTimeoutSeconds: 43200
     architecture: arm64
     networkMode: bridge

--- a/src/lib/inference/serving/resolver.test.ts
+++ b/src/lib/inference/serving/resolver.test.ts
@@ -50,6 +50,16 @@ const LINUX_VLLM_PROFILES = [
     minimumGpuMemoryBytes: 96_000_000_000,
   },
 ] as const;
+const STATION_LARGE_MODEL_PROFILES = [
+  {
+    presetId: "vllm.dgx-station-gb300.single.deepseek-v4-flash",
+    model: "deepseek-v4-flash",
+  },
+  {
+    presetId: "vllm.dgx-station-gb300.single.nemotron-3-ultra-550b-a55b-nvfp4",
+    model: "nemotron-3-ultra-550b-a55b",
+  },
+] as const;
 
 function shippedCatalog(): CompiledManagedInferenceCatalog {
   return structuredClone(loadManagedInferenceCatalog());
@@ -333,6 +343,42 @@ function catalogWithSecondProfile(options: {
 }
 
 describe("managed inference resolver", () => {
+  it.each(STATION_LARGE_MODEL_PROFILES)(
+    "selects the supported single-Station $model profile at physical GB300 HBM capacity (#9850)",
+    ({ presetId, model }) => {
+      const catalog = shippedCatalog();
+      const preset = catalog.presets.find(({ metadata }) => metadata.id === presetId);
+      expect(preset).toBeDefined();
+      const base = readinessReport({}, preset!);
+      const physicalGb300MemoryBytes = 269_172_604_928;
+      const report = {
+        ...base,
+        observations: base.observations.map((observation) =>
+          observation.id === "host.gpu.memory_total_bytes" ||
+          observation.id === "host.gpu.memory_per_device_bytes"
+            ? { ...observation, value: physicalGb300MemoryBytes }
+            : observation,
+        ),
+      } as SystemReadinessReport;
+
+      expect(
+        resolveManagedInferenceServing(
+          {
+            readinessReports: [{ nodeId: "station", report }],
+            topologyQualifications: [],
+            intent: { provider: "vllm", vllmModel: model },
+            now: NOW,
+          },
+          catalog,
+        ),
+      ).toMatchObject({
+        outcome: "selected",
+        selection: "explicit",
+        preset: { metadata: { id: presetId } },
+      });
+    },
+  );
+
   it.each(LINUX_VLLM_PROFILES)(
     "selects the shipped Linux amd64 profile for direct model $model (#9673)",
     ({ presetId, recipeId, model }) => {
@@ -342,9 +388,7 @@ describe("managed inference resolver", () => {
 
       const result = resolveManagedInferenceServing(
         {
-          readinessReports: [
-            { nodeId: "linux-host", report: readinessReport({}, preset!) },
-          ],
+          readinessReports: [{ nodeId: "linux-host", report: readinessReport({}, preset!) }],
           topologyQualifications: [],
           intent: { provider: "vllm", vllmModel: model },
           now: NOW,

--- a/src/lib/inference/vllm-models.test.ts
+++ b/src/lib/inference/vllm-models.test.ts
@@ -5,10 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import { vllmProbePolicyForModel } from "./openai-probe-models";
 import { loadManagedInferenceCatalog } from "./serving/catalog-loader";
-import type {
-  HostLocalInferenceServingRecipe,
-  ServingModelPreparation,
-} from "./serving/types";
+import type { HostLocalInferenceServingRecipe, ServingModelPreparation } from "./serving/types";
 import { detectVllmProfile, resolveVllmModelRuntime } from "./vllm";
 import {
   assertGatedModelAccess,
@@ -280,9 +277,9 @@ describe("vllm model registry", () => {
       ]),
       dockerRunArgsMode: "replace",
       minComputeCapability: 100,
-      minGpuMemoryBytes: 352_381_245_521,
       pullTimeoutSec: 43_200,
     });
+    expect(ultra!.runtime?.minGpuMemoryBytes).toBeUndefined();
 
     const cmd = buildVllmServeCommand(ultra!);
     expect(cmd).toContain("export VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY=1");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Qualified single-DGX-Station profiles no longer compare Hugging Face repository download bytes with GPU HBM. This restores the supported Nemotron Ultra and DeepSeek V4 Flash selections on a physical GB300 while preserving the existing memory gates for generic Linux and Spark profiles.

## Related Issue

Fixes #9850

## Changes

- Remove the invalid GPU-memory floor from the two hardware-qualified single-Station large-model recipes.
- Verify both profiles resolve at the GPU-memory capacity reported by a physical DGX Station GB300.
- Keep the model download sizes for storage preflight and retain all non-Station GPU-memory requirements.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [review](https://github.com/NVIDIA/NemoClaw/pull/9852#pullrequestreview-4989813971) confirms the metadata-only boundary; [maintainer scope acceptance](https://github.com/NVIDIA/NemoClaw/issues/9850#issuecomment-5365644805) defines the preserved contracts.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [x] Tested on DGX Station
- Tested commit: `3d28b0d76702c332cb0e1ab932106a785f4d509b`
- Station profile/scenario: physical single DGX Station GB300, true-default Station Express, OpenClaw with `nvidia/nemotron-3-ultra-550b-a55b`
- Result: Recipe selection and startup passed. Managed vLLM reached API readiness, the OpenClaw sandbox reached `Ready`, route checks matched, direct inference and OpenClaw smoke passed, no OOM or restart occurred, and ECC remained 0 corrected / 0 uncorrected. Resolver regression tests cover both changed recipes at `269172604928` bytes. The physical run verifies the shared HBM-floor correction and the Nemotron Ultra runtime path; the only DeepSeek recipe change removes the same HBM floor.
- Supporting evidence: [physical hardware evidence](https://github.com/NVIDIA/NemoClaw/pull/9852#issuecomment-5365657754)

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm run test:changed` passed 32 integration tests and 139 CLI tests; `npx vitest run --project integration test/managed-inference-catalog-compiler.test.ts` passed 18 tests
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The fix restores already-documented DGX Station model selection without changing commands, configuration, supported workflows, or user-facing claims.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 3d28b0d76702c332cb0e1ab932106a785f4d509b -->
<!-- docs-review-agents-blob-sha: 513518cdfca42e3a18fed71109e6d0eb60151d13 -->

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DeepSeek V4 Flash and Nemotron 3 Ultra on Station GB300 large-model profiles.
  * Models can now be selected based on the platform’s physical HBM capacity without requiring repository size as a minimum memory threshold.

* **Tests**
  * Added coverage confirming correct profile selection and runtime behavior for both models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
