### PR TITLE
fix(exec): name the openclaw devices review path on a pending scope upgrade

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2267,6 +2267,39 @@ nemo-deepagents <name> policy add --from-file ./my-preset.yaml --yes
 Replace `<preset>` with a real preset name such as `github`, `pypi`, or `npm`.
 Run `$$nemoclaw <name> policy add` with no preset to list the available presets.
 
+<AgentOnly variant="openclaw">
+
+### An `openclaw` command inside the sandbox fails with `scope upgrade pending approval`
+
+The OpenClaw gateway refuses a command when the device asks for more scopes than are currently approved.
+The failure names the request id but not the command that clears it:
+
+```text
+gateway connect failed: GatewayClientRequestError: scope upgrade pending approval
+  (requestId: 4899d110-911f-4bc7-ac1a-85d76c7b366f)
+```
+
+When you run an `openclaw` command through `$$nemoclaw <name> exec -- ...` and it exits non-zero, NemoClaw asks the sandbox for pending device requests.
+If it finds one, it appends the remedy to stderr after the command's own output:
+
+```text
+$$nemoclaw: a device scope upgrade is waiting for approval inside sandbox 'my-assistant'.
+  The OpenClaw gateway refused the command until the requested scopes are approved.
+  Review pending requests: $$nemoclaw my-assistant exec -- openclaw devices list
+  Approve the request:     $$nemoclaw my-assistant exec -- openclaw devices approve 4899d110-911f-4bc7-ac1a-85d76c7b366f
+  Silence this hint:       export NEMOCLAW_NO_POLICY_HINT=1
+```
+
+Review the request before you approve it, then re-run the original command unchanged.
+
+The probe runs only for a failed `openclaw` command. A command that succeeds, a non-`openclaw` command, and a transport failure all print no hint.
+If the probe fails, no hint is added.
+If more than one request is pending, or the reported request id is unsafe to echo, the hint shows `<requestId>` and you name the request from `openclaw devices list`.
+An invalid sandbox name is shown as `<name>`.
+`NEMOCLAW_NO_POLICY_HINT` suppresses this hint on the same terms as the network-policy breadcrumb above.
+
+</AgentOnly>
+
 ### Sandbox creation reports a TLS certificate mismatch
 
 If sandbox creation reports a TLS or certificate mismatch, the OpenShell gateway certificate may have changed since the CLI last registered it.

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -2279,22 +2279,24 @@ gateway connect failed: GatewayClientRequestError: scope upgrade pending approva
   (requestId: 4899d110-911f-4bc7-ac1a-85d76c7b366f)
 ```
 
-When you run an `openclaw` command through `$$nemoclaw <name> exec -- ...` and it exits non-zero, NemoClaw asks the sandbox for pending device requests.
-If it finds one, it appends the remedy to stderr after the command's own output:
+When you run an `openclaw` command through `$$nemoclaw <name> exec -- ...` and it exits non-zero, NemoClaw asks the sandbox whether any device request is pending.
+If one is, it appends the review path to stderr after the command's own output:
 
 ```text
 $$nemoclaw: a device scope upgrade is waiting for approval inside sandbox 'my-assistant'.
   The OpenClaw gateway refused the command until the requested scopes are approved.
   Review pending requests: $$nemoclaw my-assistant exec -- openclaw devices list
-  Approve the request:     $$nemoclaw my-assistant exec -- openclaw devices approve 4899d110-911f-4bc7-ac1a-85d76c7b366f
+  Approve the one you recognize, after checking its device and requested scopes:
+                           $$nemoclaw my-assistant exec -- openclaw devices approve <requestId>
   Silence this hint:       export NEMOCLAW_NO_POLICY_HINT=1
 ```
 
-Review the request before you approve it, then re-run the original command unchanged.
+Read `openclaw devices list`, confirm the requesting device and the requested scopes, approve that request by id, then re-run the original command unchanged.
+
+The hint never names a request id. NemoClaw cannot tell which pending request belongs to the failed command, so naming one would present an unrelated request — for example a different device asking for `operator.admin` — as this command's remedy. You make that decision from `devices list`.
 
 The probe runs only for a failed `openclaw` command. A command that succeeds, a non-`openclaw` command, and a transport failure all print no hint.
-If the probe fails, no hint is added.
-If more than one request is pending, or the reported request id is unsafe to echo, the hint shows `<requestId>` and you name the request from `openclaw devices list`.
+If the probe fails, or nothing is pending, no hint is added.
 An invalid sandbox name is shown as `<name>`.
 `NEMOCLAW_NO_POLICY_HINT` suppresses this hint on the same terms as the network-policy breadcrumb above.
 

--- a/src/lib/actions/sandbox/exec-policy-hint-emission.ts
+++ b/src/lib/actions/sandbox/exec-policy-hint-emission.ts
@@ -9,7 +9,13 @@ import {
   getLogsProbeTimeoutMs,
 } from "../../domain/sandbox/logs";
 import { findRecentPolicyDenial, type PolicyDenialMatch } from "./exec-policy-hint-detection";
-import { buildPolicyDenialExecHint, shouldProbePolicyDenial } from "./exec-policy-hint-rendering";
+import {
+  buildPolicyDenialExecHint,
+  buildScopeUpgradeExecHint,
+  findPendingScopeUpgradeRequestId,
+  shouldProbePolicyDenial,
+  shouldProbeScopeUpgrade,
+} from "./exec-policy-hint-rendering";
 
 /** Number of recent log lines to scan for a denial event. */
 export const POLICY_HINT_TAIL_LINES = 200;
@@ -23,8 +29,11 @@ export const POLICY_HINT_MAX_RUNTIME_TIMEOUT_MS = 1_000;
 export type PolicyDenialLogProbe = (sandboxName: string, gatewayName?: string) => string;
 export type PolicyDenialAuditEnabler = (sandboxName: string, gatewayName?: string) => void;
 
+export type PendingDeviceProbe = (sandboxName: string, gatewayName?: string) => string;
+
 export type PolicyDenialHintDeps = {
   probeLogs?: PolicyDenialLogProbe;
+  probePendingDevices?: PendingDeviceProbe;
   enableAudit?: PolicyDenialAuditEnabler;
   env?: NodeJS.ProcessEnv;
   writeStderr?: (line: string) => void;
@@ -71,6 +80,65 @@ function defaultProbeLogs(sandboxName: string, gatewayName?: string): string {
     throw result.error ?? new Error(`failed to read audit logs (exit ${result.status})`);
   }
   return String(result.output ?? "");
+}
+
+function defaultProbePendingDevices(sandboxName: string, gatewayName?: string): string {
+  // Built inline rather than through buildOpenshellExecArgs so this optional
+  // probe does not create an emission -> exec import cycle.
+  const argv = ["sandbox", "exec", "--name", sandboxName];
+  if (gatewayName) argv.push("-g", gatewayName);
+  argv.push("--no-tty", "--", "openclaw", "devices", "list", "--json");
+  const result = captureOpenshell(argv, {
+    ignoreError: true,
+    includeStderr: false,
+    timeout: runtimeTimeoutMs(),
+  });
+  if (result.error || result.status !== 0) {
+    throw result.error ?? new Error(`failed to list pending devices (exit ${result.status})`);
+  }
+  return String(result.output ?? "");
+}
+
+/**
+ * Emit the scope-upgrade remedy after a failed in-sandbox OpenClaw command.
+ * #5324 added `openclaw devices approve`; this names it at the point of failure
+ * so the operator does not have to already know the command. Every dependency
+ * is best-effort and never replaces the command's output or exit code.
+ */
+export async function maybeEmitScopeUpgradeHint(
+  cliName: string,
+  sandboxName: string,
+  commandCode: number,
+  hadInvocationError: boolean,
+  command: readonly string[],
+  deps: PolicyDenialHintDeps = {},
+  gatewayName?: string,
+): Promise<string | null> {
+  const env = deps.env ?? process.env;
+  if (!shouldProbeScopeUpgrade(commandCode, hadInvocationError, command, env)) return null;
+
+  let devicesOutput: string;
+  try {
+    devicesOutput = (deps.probePendingDevices ?? defaultProbePendingDevices)(
+      sandboxName,
+      gatewayName,
+    );
+  } catch {
+    // Deliberately silent: a failed optional probe must not append host
+    // diagnostics to the child's error output.
+    return null;
+  }
+
+  const requestId = findPendingScopeUpgradeRequestId(devicesOutput);
+  if (!requestId) return null;
+
+  try {
+    const hint = buildScopeUpgradeExecHint(cliName, sandboxName, requestId);
+    (deps.writeStderr ?? ((line: string) => console.error(line)))(hint);
+    return hint;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/lib/actions/sandbox/exec-policy-hint-emission.ts
+++ b/src/lib/actions/sandbox/exec-policy-hint-emission.ts
@@ -12,7 +12,7 @@ import { findRecentPolicyDenial, type PolicyDenialMatch } from "./exec-policy-hi
 import {
   buildPolicyDenialExecHint,
   buildScopeUpgradeExecHint,
-  findPendingScopeUpgradeRequestId,
+  hasPendingDeviceRequest,
   shouldProbePolicyDenial,
   shouldProbeScopeUpgrade,
 } from "./exec-policy-hint-rendering";
@@ -104,6 +104,12 @@ function defaultProbePendingDevices(sandboxName: string, gatewayName?: string): 
  * #5324 added `openclaw devices approve`; this names it at the point of failure
  * so the operator does not have to already know the command. Every dependency
  * is best-effort and never replaces the command's output or exit code.
+ *
+ * The probe is a presence check. NemoClaw cannot correlate a pending request
+ * with the failed command, the expected device, or an acceptable scope set, so
+ * no field of the payload reaches the hint and the approve line keeps its
+ * literal placeholder. Naming an id here would present an unrelated pending
+ * `operator.admin` request as this command's remedy.
  */
 export async function maybeEmitScopeUpgradeHint(
   cliName: string,
@@ -129,11 +135,10 @@ export async function maybeEmitScopeUpgradeHint(
     return null;
   }
 
-  const requestId = findPendingScopeUpgradeRequestId(devicesOutput);
-  if (!requestId) return null;
+  if (!hasPendingDeviceRequest(devicesOutput)) return null;
 
   try {
-    const hint = buildScopeUpgradeExecHint(cliName, sandboxName, requestId);
+    const hint = buildScopeUpgradeExecHint(cliName, sandboxName);
     (deps.writeStderr ?? ((line: string) => console.error(line)))(hint);
     return hint;
   } catch {

--- a/src/lib/actions/sandbox/exec-policy-hint-integration.ts
+++ b/src/lib/actions/sandbox/exec-policy-hint-integration.ts
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { maybeEmitPolicyDenialHint, type PolicyDenialHintDeps } from "./exec-policy-hint";
+import {
+  maybeEmitPolicyDenialHint,
+  maybeEmitScopeUpgradeHint,
+  type PolicyDenialHintDeps,
+} from "./exec-policy-hint";
 
 export type ExecPolicyHintDeps = PolicyDenialHintDeps & {
   now?: () => number;
@@ -20,6 +24,7 @@ type ExecPolicyDenialHintCompletion = {
 export function preparePolicyHint(
   cliName: string,
   sandboxName: string,
+  command: readonly string[],
   deps: ExecPolicyHintDeps = {},
   gatewayName?: string,
 ): (completion: ExecPolicyDenialHintCompletion) => Promise<void> {
@@ -32,6 +37,15 @@ export function preparePolicyHint(
       completion.commandCode,
       Boolean(completion.invocationError),
       commandStartedAtMs,
+      hintDeps,
+      gatewayName,
+    );
+    await maybeEmitScopeUpgradeHint(
+      cliName,
+      sandboxName,
+      completion.commandCode,
+      Boolean(completion.invocationError),
+      command,
       hintDeps,
       gatewayName,
     );

--- a/src/lib/actions/sandbox/exec-policy-hint-rendering.test.ts
+++ b/src/lib/actions/sandbox/exec-policy-hint-rendering.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildPolicyDenialExecHint,
   buildScopeUpgradeExecHint,
-  findPendingScopeUpgradeRequestId,
+  hasPendingDeviceRequest,
   POLICY_HINT_SUPPRESS_ENV,
   SCOPE_UPGRADE_REQUEST_PLACEHOLDER,
   shouldProbeScopeUpgrade,
@@ -62,7 +62,7 @@ describe("buildPolicyDenialExecHint (#5978)", () => {
     const hint = buildPolicyDenialExecHint("nemoclaw", unsafe, "example.com:443");
     expect(hint).toContain("nemoclaw <name> logs --tail 50");
     expect(hint).toContain("nemoclaw <name> policy add <preset>");
-    expect(buildScopeUpgradeExecHint("nemoclaw", unsafe, REQUEST_ID)).toContain(
+    expect(buildScopeUpgradeExecHint("nemoclaw", unsafe)).toContain(
       "nemoclaw <name> exec -- openclaw devices list",
     );
     expect(hint).not.toContain(unsafe);
@@ -71,51 +71,45 @@ describe("buildPolicyDenialExecHint (#5978)", () => {
 });
 
 describe("buildScopeUpgradeExecHint (#9744)", () => {
-  const hint = buildScopeUpgradeExecHint("nemoclaw", "my-assistant", REQUEST_ID);
+  const hint = buildScopeUpgradeExecHint("nemoclaw", "my-assistant");
 
   it.each([
     ["the sandbox name", "waiting for approval inside sandbox 'my-assistant'"],
     ["the devices-list review breadcrumb", "nemoclaw my-assistant exec -- openclaw devices list"],
     [
-      "the devices-approve remedy with the request id",
-      `nemoclaw my-assistant exec -- openclaw devices approve ${REQUEST_ID}`,
+      "the devices-approve remedy with the literal placeholder",
+      `nemoclaw my-assistant exec -- openclaw devices approve ${SCOPE_UPGRADE_REQUEST_PLACEHOLDER}`,
     ],
+    ["the review-before-approve instruction", "Approve the one you recognize"],
     ["the opt-out env", POLICY_HINT_SUPPRESS_ENV],
   ])("names %s", (_label, expected) => {
     expect(hint).toContain(expected);
   });
+
+  it("never resolves the placeholder to a concrete request id", () => {
+    expect(hint).not.toContain(REQUEST_ID);
+    expect(buildScopeUpgradeExecHint("nemoclaw", "my-assistant")).toBe(hint);
+  });
 });
 
-describe("findPendingScopeUpgradeRequestId (#9744)", () => {
+describe("hasPendingDeviceRequest (#9744)", () => {
   it.each([
-    ["one pending request", JSON.stringify({ pending: [{ requestId: REQUEST_ID }] }), REQUEST_ID],
-    ["no pending requests", JSON.stringify({ pending: [] }), null],
-    ["no pending key", JSON.stringify({ paired: [{ requestId: REQUEST_ID }] }), null],
-    ["a non-array pending value", JSON.stringify({ pending: { requestId: REQUEST_ID } }), null],
-    ["unparseable table output", "Pending (1)\nRequest  Device", null],
-    ["a non-object payload", JSON.stringify([{ requestId: REQUEST_ID }]), null],
+    ["one pending request", JSON.stringify({ pending: [{ requestId: REQUEST_ID }] }), true],
     [
-      "two pending requests",
-      JSON.stringify({ pending: [{ requestId: REQUEST_ID }, { requestId: "other-id" }] }),
-      SCOPE_UPGRADE_REQUEST_PLACEHOLDER,
+      "an unrelated admin-scope pending request",
+      JSON.stringify({
+        pending: [{ requestId: REQUEST_ID, device: "other", scopes: ["operator.admin"] }],
+      }),
+      true,
     ],
-    [
-      "a pending request with no id",
-      JSON.stringify({ pending: [{ device: "819086ffdb" }] }),
-      SCOPE_UPGRADE_REQUEST_PLACEHOLDER,
-    ],
-    [
-      "a pending request whose id carries shell metacharacters",
-      JSON.stringify({ pending: [{ requestId: "id; rm -rf /" }] }),
-      SCOPE_UPGRADE_REQUEST_PLACEHOLDER,
-    ],
-    [
-      "a pending request whose id is over-length",
-      JSON.stringify({ pending: [{ requestId: "a".repeat(129) }] }),
-      SCOPE_UPGRADE_REQUEST_PLACEHOLDER,
-    ],
-  ])("returns the expected id for %s", (_label, output, expected) => {
-    expect(findPendingScopeUpgradeRequestId(output)).toBe(expected);
+    ["several pending requests", JSON.stringify({ pending: [{}, {}] }), true],
+    ["no pending requests", JSON.stringify({ pending: [] }), false],
+    ["no pending key", JSON.stringify({ paired: [{ requestId: REQUEST_ID }] }), false],
+    ["a non-array pending value", JSON.stringify({ pending: { requestId: REQUEST_ID } }), false],
+    ["unparseable table output", "Pending (1)\nRequest  Device", false],
+    ["a non-object payload", JSON.stringify([{ requestId: REQUEST_ID }]), false],
+  ])("reports the expected presence for %s", (_label, output, expected) => {
+    expect(hasPendingDeviceRequest(output)).toBe(expected);
   });
 });
 

--- a/src/lib/actions/sandbox/exec-policy-hint-rendering.test.ts
+++ b/src/lib/actions/sandbox/exec-policy-hint-rendering.test.ts
@@ -2,7 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { buildPolicyDenialExecHint, POLICY_HINT_SUPPRESS_ENV } from "./exec-policy-hint";
+import {
+  buildPolicyDenialExecHint,
+  buildScopeUpgradeExecHint,
+  findPendingScopeUpgradeRequestId,
+  POLICY_HINT_SUPPRESS_ENV,
+  SCOPE_UPGRADE_REQUEST_PLACEHOLDER,
+  shouldProbeScopeUpgrade,
+} from "./exec-policy-hint";
+
+const REQUEST_ID = "4899d110-911f-4bc7-ac1a-85d76c7b366f";
 
 describe("buildPolicyDenialExecHint (#5978)", () => {
   const hint = buildPolicyDenialExecHint("nemoclaw", "oc-fresh", "example.com:443");
@@ -53,7 +62,80 @@ describe("buildPolicyDenialExecHint (#5978)", () => {
     const hint = buildPolicyDenialExecHint("nemoclaw", unsafe, "example.com:443");
     expect(hint).toContain("nemoclaw <name> logs --tail 50");
     expect(hint).toContain("nemoclaw <name> policy add <preset>");
+    expect(buildScopeUpgradeExecHint("nemoclaw", unsafe, REQUEST_ID)).toContain(
+      "nemoclaw <name> exec -- openclaw devices list",
+    );
     expect(hint).not.toContain(unsafe);
     expect(hint).not.toContain("");
+  });
+});
+
+describe("buildScopeUpgradeExecHint (#9744)", () => {
+  const hint = buildScopeUpgradeExecHint("nemoclaw", "my-assistant", REQUEST_ID);
+
+  it.each([
+    ["the sandbox name", "waiting for approval inside sandbox 'my-assistant'"],
+    ["the devices-list review breadcrumb", "nemoclaw my-assistant exec -- openclaw devices list"],
+    [
+      "the devices-approve remedy with the request id",
+      `nemoclaw my-assistant exec -- openclaw devices approve ${REQUEST_ID}`,
+    ],
+    ["the opt-out env", POLICY_HINT_SUPPRESS_ENV],
+  ])("names %s", (_label, expected) => {
+    expect(hint).toContain(expected);
+  });
+});
+
+describe("findPendingScopeUpgradeRequestId (#9744)", () => {
+  it.each([
+    ["one pending request", JSON.stringify({ pending: [{ requestId: REQUEST_ID }] }), REQUEST_ID],
+    ["no pending requests", JSON.stringify({ pending: [] }), null],
+    ["no pending key", JSON.stringify({ paired: [{ requestId: REQUEST_ID }] }), null],
+    ["a non-array pending value", JSON.stringify({ pending: { requestId: REQUEST_ID } }), null],
+    ["unparseable table output", "Pending (1)\nRequest  Device", null],
+    ["a non-object payload", JSON.stringify([{ requestId: REQUEST_ID }]), null],
+    [
+      "two pending requests",
+      JSON.stringify({ pending: [{ requestId: REQUEST_ID }, { requestId: "other-id" }] }),
+      SCOPE_UPGRADE_REQUEST_PLACEHOLDER,
+    ],
+    [
+      "a pending request with no id",
+      JSON.stringify({ pending: [{ device: "819086ffdb" }] }),
+      SCOPE_UPGRADE_REQUEST_PLACEHOLDER,
+    ],
+    [
+      "a pending request whose id carries shell metacharacters",
+      JSON.stringify({ pending: [{ requestId: "id; rm -rf /" }] }),
+      SCOPE_UPGRADE_REQUEST_PLACEHOLDER,
+    ],
+    [
+      "a pending request whose id is over-length",
+      JSON.stringify({ pending: [{ requestId: "a".repeat(129) }] }),
+      SCOPE_UPGRADE_REQUEST_PLACEHOLDER,
+    ],
+  ])("returns the expected id for %s", (_label, output, expected) => {
+    expect(findPendingScopeUpgradeRequestId(output)).toBe(expected);
+  });
+});
+
+describe("shouldProbeScopeUpgrade (#9744)", () => {
+  it.each([
+    ["a failed openclaw command", 1, false, ["openclaw", "cron", "add"], {}, true],
+    ["an absolute openclaw path", 1, false, ["/usr/bin/openclaw", "agent"], {}, true],
+    ["a successful openclaw command", 0, false, ["openclaw", "cron", "add"], {}, false],
+    ["a failed non-openclaw command", 1, false, ["curl", "example.com"], {}, false],
+    ["an empty command", 1, false, [], {}, false],
+    ["a transport invocation error", 1, true, ["openclaw", "cron", "add"], {}, false],
+    [
+      "a suppressed hint",
+      1,
+      false,
+      ["openclaw", "cron", "add"],
+      { [POLICY_HINT_SUPPRESS_ENV]: "1" },
+      false,
+    ],
+  ])("decides %s", (_label, code, invocationError, command, env, expected) => {
+    expect(shouldProbeScopeUpgrade(code, invocationError, command, env)).toBe(expected);
   });
 });

--- a/src/lib/actions/sandbox/exec-policy-hint-rendering.ts
+++ b/src/lib/actions/sandbox/exec-policy-hint-rendering.ts
@@ -43,14 +43,15 @@ export function shouldProbePolicyDenial(
   return !suppress || suppress === "0" || suppress === "false";
 }
 
-/** Placeholder used when the pending request cannot be named exactly. */
+/**
+ * Literal placeholder for the request the operator must choose. NemoClaw cannot
+ * correlate a pending request with the failed command, the expected device, or
+ * an acceptable scope set, so it never resolves this to a concrete id: naming
+ * one would present an unrelated `operator.admin` request as this command's
+ * remedy and turn the operator into a confused deputy. The operator reads the
+ * id from `devices list` and decides.
+ */
 export const SCOPE_UPGRADE_REQUEST_PLACEHOLDER = "<requestId>";
-
-// Matches the request-id shape OpenClaw publishes in pending.json and echoes in
-// the failure text. Kept permissive on charset but strictly bounded so a hostile
-// devices-list payload cannot smuggle shell metacharacters into the printed
-// remedy line.
-const REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 
 /** Whether the exec'd command was OpenClaw itself, the only scope-gated case. */
 export function execCommandTargetsOpenClaw(command: readonly string[]): boolean {
@@ -75,42 +76,35 @@ export function shouldProbeScopeUpgrade(
 }
 
 /**
- * Extract the single pending request id from `openclaw devices list --json`.
- * Returns the placeholder when a pending request exists but cannot be named
- * unambiguously, and null when nothing is pending.
+ * Whether `openclaw devices list --json` reports at least one pending request.
+ * This is a presence check only. No field of the payload is read, so nothing
+ * from the sandbox reaches the rendered hint.
  */
-export function findPendingScopeUpgradeRequestId(devicesListOutput: string): string | null {
+export function hasPendingDeviceRequest(devicesListOutput: string): boolean {
   let parsed: unknown;
   try {
     parsed = JSON.parse(devicesListOutput);
   } catch {
-    return null;
+    return false;
   }
-  if (typeof parsed !== "object" || parsed === null) return null;
+  if (typeof parsed !== "object" || parsed === null) return false;
   const pending = (parsed as { pending?: unknown }).pending;
-  if (!Array.isArray(pending) || pending.length === 0) return null;
-  if (pending.length > 1) return SCOPE_UPGRADE_REQUEST_PLACEHOLDER;
-  const entry = pending[0];
-  if (typeof entry !== "object" || entry === null) return SCOPE_UPGRADE_REQUEST_PLACEHOLDER;
-  const requestId = (entry as { requestId?: unknown }).requestId;
-  if (typeof requestId !== "string" || !REQUEST_ID_PATTERN.test(requestId)) {
-    return SCOPE_UPGRADE_REQUEST_PLACEHOLDER;
-  }
-  return requestId;
+  return Array.isArray(pending) && pending.length > 0;
 }
 
-/** Render the remedy stanza for a gateway scope upgrade waiting on approval. */
-export function buildScopeUpgradeExecHint(
-  cliName: string,
-  rawSandboxName: string,
-  requestId: string,
-): string {
+/**
+ * Render the review stanza for a gateway scope upgrade waiting on approval.
+ * The approve line carries the literal placeholder, never a resolved id; see
+ * SCOPE_UPGRADE_REQUEST_PLACEHOLDER.
+ */
+export function buildScopeUpgradeExecHint(cliName: string, rawSandboxName: string): string {
   const sandboxName = displaySandboxName(rawSandboxName);
   return [
     `${cliName}: a device scope upgrade is waiting for approval inside sandbox '${sandboxName}'.`,
     "  The OpenClaw gateway refused the command until the requested scopes are approved.",
     `  Review pending requests: ${cliName} ${sandboxName} exec -- openclaw devices list`,
-    `  Approve the request:     ${cliName} ${sandboxName} exec -- openclaw devices approve ${requestId}`,
+    `  Approve the one you recognize, after checking its device and requested scopes:`,
+    `                           ${cliName} ${sandboxName} exec -- openclaw devices approve ${SCOPE_UPGRADE_REQUEST_PLACEHOLDER}`,
     `  Silence this hint:       export ${POLICY_HINT_SUPPRESS_ENV}=1`,
   ].join("\n");
 }

--- a/src/lib/actions/sandbox/exec-policy-hint-rendering.ts
+++ b/src/lib/actions/sandbox/exec-policy-hint-rendering.ts
@@ -42,3 +42,75 @@ export function shouldProbePolicyDenial(
   const suppress = env[POLICY_HINT_SUPPRESS_ENV]?.toLowerCase();
   return !suppress || suppress === "0" || suppress === "false";
 }
+
+/** Placeholder used when the pending request cannot be named exactly. */
+export const SCOPE_UPGRADE_REQUEST_PLACEHOLDER = "<requestId>";
+
+// Matches the request-id shape OpenClaw publishes in pending.json and echoes in
+// the failure text. Kept permissive on charset but strictly bounded so a hostile
+// devices-list payload cannot smuggle shell metacharacters into the printed
+// remedy line.
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+/** Whether the exec'd command was OpenClaw itself, the only scope-gated case. */
+export function execCommandTargetsOpenClaw(command: readonly string[]): boolean {
+  const executable = command[0];
+  if (!executable) return false;
+  return executable.split("/").pop() === "openclaw";
+}
+
+/**
+ * Whether a pending-scope-upgrade probe is warranted after an exec. Reuses the
+ * denial gate and adds the OpenClaw-command prefilter so ordinary in-sandbox
+ * command failures cost no extra round trip.
+ */
+export function shouldProbeScopeUpgrade(
+  commandCode: number,
+  hadInvocationError: boolean,
+  command: readonly string[],
+  env: NodeJS.ProcessEnv,
+): boolean {
+  if (!execCommandTargetsOpenClaw(command)) return false;
+  return shouldProbePolicyDenial(commandCode, hadInvocationError, env);
+}
+
+/**
+ * Extract the single pending request id from `openclaw devices list --json`.
+ * Returns the placeholder when a pending request exists but cannot be named
+ * unambiguously, and null when nothing is pending.
+ */
+export function findPendingScopeUpgradeRequestId(devicesListOutput: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(devicesListOutput);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const pending = (parsed as { pending?: unknown }).pending;
+  if (!Array.isArray(pending) || pending.length === 0) return null;
+  if (pending.length > 1) return SCOPE_UPGRADE_REQUEST_PLACEHOLDER;
+  const entry = pending[0];
+  if (typeof entry !== "object" || entry === null) return SCOPE_UPGRADE_REQUEST_PLACEHOLDER;
+  const requestId = (entry as { requestId?: unknown }).requestId;
+  if (typeof requestId !== "string" || !REQUEST_ID_PATTERN.test(requestId)) {
+    return SCOPE_UPGRADE_REQUEST_PLACEHOLDER;
+  }
+  return requestId;
+}
+
+/** Render the remedy stanza for a gateway scope upgrade waiting on approval. */
+export function buildScopeUpgradeExecHint(
+  cliName: string,
+  rawSandboxName: string,
+  requestId: string,
+): string {
+  const sandboxName = displaySandboxName(rawSandboxName);
+  return [
+    `${cliName}: a device scope upgrade is waiting for approval inside sandbox '${sandboxName}'.`,
+    "  The OpenClaw gateway refused the command until the requested scopes are approved.",
+    `  Review pending requests: ${cliName} ${sandboxName} exec -- openclaw devices list`,
+    `  Approve the request:     ${cliName} ${sandboxName} exec -- openclaw devices approve ${requestId}`,
+    `  Silence this hint:       export ${POLICY_HINT_SUPPRESS_ENV}=1`,
+  ].join("\n");
+}

--- a/src/lib/actions/sandbox/exec-policy-hint-runtime.test.ts
+++ b/src/lib/actions/sandbox/exec-policy-hint-runtime.test.ts
@@ -9,6 +9,7 @@ vi.mock("../../adapters/openshell/runtime", () => ({ captureOpenshell }));
 
 import {
   maybeEmitPolicyDenialHint,
+  maybeEmitScopeUpgradeHint,
   POLICY_HINT_MAX_RUNTIME_TIMEOUT_MS,
   POLICY_HINT_TAIL_LINES,
 } from "./exec-policy-hint";
@@ -104,5 +105,66 @@ describe("policy-denial hint runtime adapter integration (#5978)", () => {
     expect(hint).toBeNull();
     expect(captureOpenshell).toHaveBeenCalledTimes(2);
     expect(sleep).not.toHaveBeenCalled();
+  });
+});
+
+describe("scope-upgrade hint runtime adapter integration (#9744)", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("reads pending devices through one bounded read-only OpenShell exec", async () => {
+    captureOpenshell.mockReturnValueOnce({
+      output: JSON.stringify({ pending: [{ requestId: "req-1" }] }),
+      status: 0,
+    });
+    const stderr: string[] = [];
+
+    const hint = await maybeEmitScopeUpgradeHint(
+      "nemoclaw",
+      "oc-fresh",
+      1,
+      false,
+      ["openclaw", "cron", "add"],
+      { env: {}, writeStderr: (line: string) => stderr.push(line) },
+      "nemoclaw-8091",
+    );
+
+    expect(captureOpenshell).toHaveBeenCalledTimes(1);
+    expect(captureOpenshell.mock.calls[0]?.[0]).toEqual([
+      "sandbox",
+      "exec",
+      "--name",
+      "oc-fresh",
+      "-g",
+      "nemoclaw-8091",
+      "--no-tty",
+      "--",
+      "openclaw",
+      "devices",
+      "list",
+      "--json",
+    ]);
+    expect(captureOpenshell.mock.calls[0]?.[1]?.timeout).toBeLessThanOrEqual(
+      POLICY_HINT_MAX_RUNTIME_TIMEOUT_MS,
+    );
+    expect(stderr).toEqual([hint]);
+  });
+
+  it("stays silent when the pending-devices probe exits non-zero", async () => {
+    captureOpenshell.mockReturnValueOnce({ output: "", status: 1 });
+    const stderr: string[] = [];
+
+    const hint = await maybeEmitScopeUpgradeHint(
+      "nemoclaw",
+      "oc-fresh",
+      1,
+      false,
+      ["openclaw", "cron", "add"],
+      { env: {}, writeStderr: (line: string) => stderr.push(line) },
+    );
+
+    expect(hint).toBeNull();
+    expect(stderr).toEqual([]);
   });
 });

--- a/src/lib/actions/sandbox/exec-policy-hint.test.ts
+++ b/src/lib/actions/sandbox/exec-policy-hint.test.ts
@@ -237,11 +237,21 @@ describe("maybeEmitPolicyDenialHint (#5978)", () => {
 
 describe("maybeEmitScopeUpgradeHint (#9744)", () => {
   const OPENCLAW_CRON_ADD = ["openclaw", "cron", "add"];
-  const PENDING_JSON = JSON.stringify({
-    pending: [{ requestId: "4899d110-911f-4bc7-ac1a-85d76c7b366f" }],
+  const PENDING_REQUEST_ID = "4899d110-911f-4bc7-ac1a-85d76c7b366f";
+  const PENDING_JSON = JSON.stringify({ pending: [{ requestId: PENDING_REQUEST_ID }] });
+  // An upgrade the failed command did not ask for: a different device asking for
+  // operator.admin. NemoClaw cannot correlate it, so it must never be named.
+  const UNRELATED_ADMIN_PENDING_JSON = JSON.stringify({
+    pending: [
+      {
+        requestId: "c0ffee00-dead-4beef-b0bb-000000000001",
+        device: "unrelated-device-fingerprint",
+        scopes: ["operator.admin"],
+      },
+    ],
   });
 
-  const harness = () => {
+  const harness = (devicesJson: string = PENDING_JSON) => {
     const lines: string[] = [];
     let probeCalls = 0;
     return {
@@ -252,13 +262,13 @@ describe("maybeEmitScopeUpgradeHint (#9744)", () => {
         writeStderr: (line: string) => lines.push(line),
         probePendingDevices: () => {
           probeCalls += 1;
-          return PENDING_JSON;
+          return devicesJson;
         },
       },
     };
   };
 
-  it("names devices approve with the pending request id after a failed openclaw command", async () => {
+  it("names the devices-list review command after a failed openclaw command", async () => {
     const h = harness();
     const hint = await maybeEmitScopeUpgradeHint(
       "nemoclaw",
@@ -268,30 +278,64 @@ describe("maybeEmitScopeUpgradeHint (#9744)", () => {
       OPENCLAW_CRON_ADD,
       h.base,
     );
-    expect(hint).toContain(
-      "nemoclaw my-assistant exec -- openclaw devices approve 4899d110-911f-4bc7-ac1a-85d76c7b366f",
-    );
+    expect(hint).toContain("nemoclaw my-assistant exec -- openclaw devices list");
     expect(h.lines).toEqual([hint]);
   });
+
+  it.each([
+    ["a sole uncorrelated pending request", PENDING_JSON, PENDING_REQUEST_ID],
+    [
+      "an unrelated admin-scope pending request",
+      UNRELATED_ADMIN_PENDING_JSON,
+      "c0ffee00-dead-4beef-b0bb-000000000001",
+    ],
+  ])(
+    "keeps the approve placeholder and never names the request id for %s",
+    async (_label, devicesJson, leakedId) => {
+      const h = harness(devicesJson);
+      const hint = await maybeEmitScopeUpgradeHint(
+        "nemoclaw",
+        "my-assistant",
+        1,
+        false,
+        OPENCLAW_CRON_ADD,
+        h.base,
+      );
+      expect(hint).toContain(
+        "nemoclaw my-assistant exec -- openclaw devices approve <requestId>",
+      );
+      expect(hint).not.toContain(leakedId);
+      expect(hint).not.toContain("operator.admin");
+      expect(hint).not.toContain("unrelated-device-fingerprint");
+    },
+  );
 
   it.each([
     ["a successful command", 0, false, OPENCLAW_CRON_ADD, {}],
     ["a non-openclaw command", 1, false, ["curl", "example.com"], {}],
     ["a transport invocation error", 1, true, OPENCLAW_CRON_ADD, {}],
     ["a suppressed hint", 1, false, OPENCLAW_CRON_ADD, { [POLICY_HINT_SUPPRESS_ENV]: "1" }],
-  ])("stays silent and skips the probe for %s", async (_label, code, invocationError, command, env) => {
-    const h = harness();
-    const hint = await maybeEmitScopeUpgradeHint("nemoclaw", "my-assistant", code, invocationError, command, {
-      ...h.base,
-      env: env as NodeJS.ProcessEnv,
-    });
-    expect(hint).toBeNull();
-    expect(h.lines).toEqual([]);
-    expect(h.probeCount()).toBe(0);
-  });
+  ])(
+    "stays silent and skips the probe for %s",
+    async (_label, code, invocationError, command, env) => {
+      const h = harness();
+      const hint = await maybeEmitScopeUpgradeHint(
+        "nemoclaw",
+        "my-assistant",
+        code,
+        invocationError,
+        command,
+        { ...h.base, env: env as NodeJS.ProcessEnv },
+      );
+      expect(hint).toBeNull();
+      expect(h.lines).toEqual([]);
+      expect(h.probeCount()).toBe(0);
+    },
+  );
 
   it.each([
     ["nothing is pending", () => JSON.stringify({ pending: [] })],
+    ["only paired devices are reported", () => JSON.stringify({ paired: [{ scopes: ["a"] }] })],
     [
       "the probe fails",
       () => {

--- a/src/lib/actions/sandbox/exec-policy-hint.test.ts
+++ b/src/lib/actions/sandbox/exec-policy-hint.test.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { maybeEmitPolicyDenialHint, POLICY_HINT_SUPPRESS_ENV } from "./exec-policy-hint";
+import {
+  maybeEmitPolicyDenialHint,
+  maybeEmitScopeUpgradeHint,
+  POLICY_HINT_SUPPRESS_ENV,
+} from "./exec-policy-hint";
 
 const DENIED_CURL_LINE =
   "[1783046573.602] [sandbox] [OCSF ] [ocsf] NET:OPEN [MED] DENIED /usr/bin/curl(1245) -> example.com:443 [policy:- engine:opa] [reason:endpoint example.com:443 is not allowed by any policy]";
@@ -228,5 +232,83 @@ describe("maybeEmitPolicyDenialHint (#5978)", () => {
     expect(calls).toBe(3);
     expect(h.enableCount()).toBe(1);
     expect(h.lines).toHaveLength(0);
+  });
+});
+
+describe("maybeEmitScopeUpgradeHint (#9744)", () => {
+  const OPENCLAW_CRON_ADD = ["openclaw", "cron", "add"];
+  const PENDING_JSON = JSON.stringify({
+    pending: [{ requestId: "4899d110-911f-4bc7-ac1a-85d76c7b366f" }],
+  });
+
+  const harness = () => {
+    const lines: string[] = [];
+    let probeCalls = 0;
+    return {
+      lines,
+      probeCount: () => probeCalls,
+      base: {
+        env: {} as NodeJS.ProcessEnv,
+        writeStderr: (line: string) => lines.push(line),
+        probePendingDevices: () => {
+          probeCalls += 1;
+          return PENDING_JSON;
+        },
+      },
+    };
+  };
+
+  it("names devices approve with the pending request id after a failed openclaw command", async () => {
+    const h = harness();
+    const hint = await maybeEmitScopeUpgradeHint(
+      "nemoclaw",
+      "my-assistant",
+      1,
+      false,
+      OPENCLAW_CRON_ADD,
+      h.base,
+    );
+    expect(hint).toContain(
+      "nemoclaw my-assistant exec -- openclaw devices approve 4899d110-911f-4bc7-ac1a-85d76c7b366f",
+    );
+    expect(h.lines).toEqual([hint]);
+  });
+
+  it.each([
+    ["a successful command", 0, false, OPENCLAW_CRON_ADD, {}],
+    ["a non-openclaw command", 1, false, ["curl", "example.com"], {}],
+    ["a transport invocation error", 1, true, OPENCLAW_CRON_ADD, {}],
+    ["a suppressed hint", 1, false, OPENCLAW_CRON_ADD, { [POLICY_HINT_SUPPRESS_ENV]: "1" }],
+  ])("stays silent and skips the probe for %s", async (_label, code, invocationError, command, env) => {
+    const h = harness();
+    const hint = await maybeEmitScopeUpgradeHint("nemoclaw", "my-assistant", code, invocationError, command, {
+      ...h.base,
+      env: env as NodeJS.ProcessEnv,
+    });
+    expect(hint).toBeNull();
+    expect(h.lines).toEqual([]);
+    expect(h.probeCount()).toBe(0);
+  });
+
+  it.each([
+    ["nothing is pending", () => JSON.stringify({ pending: [] })],
+    [
+      "the probe fails",
+      () => {
+        throw new Error("exec failed");
+      },
+    ],
+  ])("stays silent when %s", async (_label, probePendingDevices) => {
+    const h = harness();
+    const hint = await maybeEmitScopeUpgradeHint(
+      "nemoclaw",
+      "my-assistant",
+      1,
+      false,
+      OPENCLAW_CRON_ADD,
+      { ...h.base, probePendingDevices },
+    );
+    expect(hint).toBeNull();
+    expect(h.lines).toEqual([]);
   });
 });

--- a/src/lib/actions/sandbox/exec.test.ts
+++ b/src/lib/actions/sandbox/exec.test.ts
@@ -480,3 +480,96 @@ describe("execSandbox policy-denial hint wiring (#5978)", () => {
     expect(stderr).toHaveLength(0);
   });
 });
+
+describe("execSandbox scope-upgrade hint wiring (#9744)", () => {
+  const cleanupSkipped: SandboxExecCleanupDeps = {
+    getSandbox: () => null,
+    inspectMutableConfigPerms: vi.fn(() => {
+      throw new Error("cleanup should be skipped for an unregistered sandbox");
+    }) as unknown as SandboxExecCleanupDeps["inspectMutableConfigPerms"],
+    repairMutableConfigPerms: vi.fn(() => {
+      throw new Error("cleanup should be skipped for an unregistered sandbox");
+    }) as unknown as SandboxExecCleanupDeps["repairMutableConfigPerms"],
+  };
+
+  const UNRELATED_ADMIN_PENDING = JSON.stringify({
+    pending: [
+      {
+        requestId: "c0ffee00-dead-4beef-b0bb-000000000001",
+        device: "unrelated-device-fingerprint",
+        scopes: ["operator.admin"],
+      },
+    ],
+  });
+
+  const runOpenClawExec = async (status: number, devicesJson: string) => {
+    const stderr: string[] = [];
+    const probePendingDevices = vi.fn(() => devicesJson);
+    let exitCode = Number.NaN;
+    const exit = ((code?: number) => {
+      exitCode = code ?? 0;
+      throw new Error("__exec_exit__");
+    }) as (code: number) => never;
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await execSandbox(
+      "wire-sbx",
+      ["openclaw", "cron", "add"],
+      {},
+      {
+        resolveBinary: () => "openshell",
+        selectGateway: () => ({ outcome: "unregistered", gatewayName: null }),
+        run: async () => ({ status }),
+        cleanupDeps: cleanupSkipped,
+        exit,
+        policyHint: {
+          now: () => 0,
+          env: {},
+          probeLogs: () => "",
+          enableAudit: () => {},
+          sleep: async () => {},
+          attempts: 1,
+          probePendingDevices,
+          writeStderr: (line) => stderr.push(line),
+        },
+      },
+    ).catch(() => {});
+    errSpy.mockRestore();
+    return { exitCode, probePendingDevices, stderr: stderr.join("\n") };
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("names the review command and preserves the exit code when a request is pending", async () => {
+    const { exitCode, stderr } = await runOpenClawExec(1, UNRELATED_ADMIN_PENDING);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("nemoclaw wire-sbx exec -- openclaw devices list");
+  });
+
+  it.each([
+    ["the uncorrelated request id", "c0ffee00-dead-4beef-b0bb-000000000001"],
+    ["the requested scopes", "operator.admin"],
+    ["the requesting device", "unrelated-device-fingerprint"],
+  ])("never presents %s as this command's remedy", async (_label, leaked) => {
+    const { stderr } = await runOpenClawExec(1, UNRELATED_ADMIN_PENDING);
+    expect(stderr).toContain("openclaw devices approve <requestId>");
+    expect(stderr).not.toContain(leaked);
+  });
+
+  it("skips the probe entirely when the openclaw command succeeds", async () => {
+    const { exitCode, probePendingDevices, stderr } = await runOpenClawExec(
+      0,
+      UNRELATED_ADMIN_PENDING,
+    );
+    expect(exitCode).toBe(0);
+    expect(probePendingDevices).not.toHaveBeenCalled();
+    expect(stderr).toBe("");
+  });
+
+  it("stays silent when the failure leaves no pending request", async () => {
+    const { exitCode, stderr } = await runOpenClawExec(1, JSON.stringify({ pending: [] }));
+    expect(exitCode).toBe(1);
+    expect(stderr).toBe("");
+  });
+});

--- a/src/lib/actions/sandbox/exec.ts
+++ b/src/lib/actions/sandbox/exec.ts
@@ -481,6 +481,7 @@ export async function execSandbox(
   const emitPolicyDenialHint = preparePolicyHint(
     CLI_NAME,
     sandboxName,
+    command,
     deps.policyHint,
     gatewayName,
   );


### PR DESCRIPTION
## Summary

A failed in-sandbox `openclaw` command reported a queued gateway scope upgrade but never named the commands that clear it, so the operator had to already know `openclaw devices list` and `openclaw devices approve`. NemoClaw now checks for a pending device request after such a failure and appends a review stanza to stderr, matching the existing network-policy denial breadcrumb.

The hint never names a request id. NemoClaw cannot establish that a pending request belongs to the failed command, the expected device, or an acceptable scope set, so it points at `devices list` and leaves the approve line at its literal `<requestId>` placeholder. The operator makes that decision.

## Related Issue

Closes #9744

## Changes

- `src/lib/actions/sandbox/exec-policy-hint-rendering.ts`: add `execCommandTargetsOpenClaw`, `shouldProbeScopeUpgrade`, `hasPendingDeviceRequest`, and `buildScopeUpgradeExecHint`. `hasPendingDeviceRequest` is a presence check — it reads no field of the payload, so nothing from the sandbox reaches the rendered text. The sandbox name reuses the existing `<name>` placeholder rule.
- `src/lib/actions/sandbox/exec-policy-hint-emission.ts`: add `maybeEmitScopeUpgradeHint`, which runs a single bounded read-only `openclaw devices list --json` probe inside the sandbox and prints the stanza. Every dependency is best-effort; a failed probe prints nothing and never changes the command's output or exit code.
- `src/lib/actions/sandbox/exec-policy-hint-integration.ts` and `exec.ts`: emit the new hint from the existing post-exec observability boundary, so `exec.ts` gains no new import.
- `docs/reference/troubleshooting.mdx`: document the failure signature, the emitted stanza, and its gates.

The probe is gated on a nonzero exit **and** the exec'd command being `openclaw`, so an ordinary in-sandbox command failure costs no extra round trip. No new file, env var, or configuration surface is added: `NEMOCLAW_NO_POLICY_HINT` suppresses the new hint on the same terms as the existing one. The functions were folded into the existing `exec-policy-hint-*` modules because `src/lib/actions/sandbox` is at its 183-file root budget.

New behavior text:

```text
nemoclaw: a device scope upgrade is waiting for approval inside sandbox 'my-assistant'.
  The OpenClaw gateway refused the command until the requested scopes are approved.
  Review pending requests: nemoclaw my-assistant exec -- openclaw devices list
  Approve the one you recognize, after checking its device and requested scopes:
                           nemoclaw my-assistant exec -- openclaw devices approve <requestId>
  Silence this hint:       export NEMOCLAW_NO_POLICY_HINT=1
```

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: reviewed by @cv, whose confused-deputy finding on the concrete approval hint is addressed in c940fdc. The change is additive stderr guidance on the sandbox exec path. It does not read, write, or approve any device request, and no field of the devices-list payload reaches the output. The sandbox name is pattern-bounded before it is printed. Negative emitter and `execSandbox` integration tests cover an unrelated `operator.admin` pending request.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/actions/sandbox/exec` — 11 files, 225 tests passed; `npx vitest run --project cli src/lib/actions/sandbox/exec-policy-hint` — 5 files, 141 tests passed; `npx vitest run --project integration test/repro-5978-policy-denial-hint.test.ts` — 31 passed, 1 skipped; `npm run typecheck:cli` and `npm run checks:repository` clean.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Dongni Yang <dongniy@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for failed OpenClaw commands that may require scope approval.
  * Prompts operators to review pending device requests and requested scopes before approval.
  * Uses a generic `<requestId>` placeholder without exposing request details.

* **Bug Fixes**
  * Suppresses hints when no request is pending, probing fails, or the command is unrelated.
  * Preserves the original command result and exit status.

* **Tests**
  * Expanded coverage for pending-request detection, hint rendering, filtering, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->