### PR TITLE
fix(e2e): stage Portable hosted inference descriptor

### DIFF
--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -174,6 +174,7 @@ jobs:
           sudo apt-get install --yes fuse-overlayfs passt podman slirp4netns uidmap
           runtime_dir="/run/user/$(id -u)"
           sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" "$runtime_dir"
+          sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" /run/nemoclaw
           if ! grep -q "^${USER}:" /etc/subuid; then
             sudo usermod --add-subuids 100000-165535 "$USER"
           fi
@@ -216,6 +217,8 @@ jobs:
         if: always()
         shell: bash
         run: |
+          set -euo pipefail
+          rm -f -- /run/nemoclaw/portable-inference.json /run/nemoclaw/.portable-inference.json.tmp
           podman system reset --force || true
           runtime_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
           node --experimental-strip-types --no-warnings --input-type=module \

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1303,7 +1303,15 @@ Treat it as passing evidence only when the `E2E` workflow concludes with `succes
 A changed PR source repository, candidate commit SHA, or base commit SHA invalidates the evidence and requires a new manual run.
 
 The platform-evidence workflow runs on configured pushes to `main` and supports manual dispatch for branch diagnosis.
-The experimental portable-profile workflow runs on `main` when one of its configured paths changes.
+The experimental portable-profile workflow can run for pull requests, matching `main` pushes, and manual dispatch.
+Its `portable-launch` job runs only when `github.ref` is `refs/heads/main`.
+The `portable-launch` job's exercise step exposes the long-lived repository `NVIDIA_INFERENCE_API_KEY` to the checked-out source through its environment.
+The hosted-inference fixture copies that key into `/run/nemoclaw/portable-inference.json`, a mode-`0600` file beneath the current-user-owned mode-`0700` `/run/nemoclaw` directory.
+Code running as the current user can read that descriptor until the production loader consumes it or cleanup removes it.
+The descriptor has a one-hour admission window; that window does not expire or revoke the API key.
+The production loader consumes and unlinks the descriptor before provider selection.
+The always-run workflow cleanup removes `/run/nemoclaw/portable-inference.json` and `/run/nemoclaw/.portable-inference.json.tmp` and fails if it cannot remove either path.
+Runner teardown is the fallback that discards the ephemeral runner filesystem; only issuer rotation or revocation removes later API-key access.
 The Podman CPU proof runs only for matching pull request changes.
 The sandbox-image workflow accepts manual and reusable workflow calls for image build and test evidence.
 

--- a/test/e2e/fixtures/hosted-inference.ts
+++ b/test/e2e/fixtures/hosted-inference.ts
@@ -1,6 +1,15 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  PORTABLE_INFERENCE_DESCRIPTOR_PATH,
+  type PortableInferenceDescriptor,
+} from "../../../src/lib/onboard/experimental/portable-inference-descriptor.ts";
+import { createPrivateRegularFile } from "../../../tools/e2e/private-file.mts";
+
 export const HOSTED_INFERENCE_SECRET = "NVIDIA_INFERENCE_API_KEY";
 export const HOSTED_INFERENCE_CREDENTIAL_ENV = "COMPATIBLE_API_KEY";
 export const HOSTED_INFERENCE_MODELS_PROBE_SECRET_ENV = HOSTED_INFERENCE_SECRET;
@@ -8,6 +17,8 @@ export const HOSTED_INFERENCE_PROVIDER = "custom";
 export const HOSTED_INFERENCE_PROVIDER_NAME = "compatible-endpoint";
 export const DEFAULT_HOSTED_INFERENCE_BASE_URL = "https://inference-api.nvidia.com/v1";
 export const DEFAULT_HOSTED_INFERENCE_MODEL = "nvidia/nvidia/nemotron-3-ultra";
+
+const PORTABLE_DESCRIPTOR_VALIDITY_MS = 60 * 60_000;
 
 export interface HostedInferenceSecrets {
   required(name: string): string;
@@ -33,6 +44,118 @@ export interface HostedInferenceModelsProbe {
   args: string[];
   command: "bash";
   env: NodeJS.ProcessEnv;
+}
+
+function currentEffectiveUid(): number {
+  const uid = process.geteuid?.() ?? process.getuid?.();
+  if (uid === undefined) {
+    throw new Error("Portable hosted inference staging cannot verify the current user.");
+  }
+  return uid;
+}
+
+function assertPrivateDescriptorDirectory(directory: string, uid: number): void {
+  const metadata = fs.lstatSync(directory);
+  if (
+    metadata.isSymbolicLink() ||
+    !metadata.isDirectory() ||
+    metadata.uid !== uid ||
+    (metadata.mode & 0o077) !== 0
+  ) {
+    throw new Error(
+      `Portable hosted inference staging requires a private current-user directory at ${directory}.`,
+    );
+  }
+}
+
+function removeExactDescriptor(filePath: string, expected: fs.Stats): void {
+  let current: fs.Stats;
+  try {
+    current = fs.lstatSync(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  if (
+    current.isSymbolicLink() ||
+    !current.isFile() ||
+    current.dev !== expected.dev ||
+    current.ino !== expected.ino
+  ) {
+    throw new Error(`Portable hosted inference descriptor at ${filePath} changed before cleanup.`);
+  }
+  fs.unlinkSync(filePath);
+}
+
+export function stagePortableHostedInferenceDescriptor(
+  config: HostedInferenceConfig,
+  options: { readonly filePath?: string; readonly now?: () => number } = {},
+): { readonly filePath: string; dispose(): void } {
+  const filePath = options.filePath ?? PORTABLE_INFERENCE_DESCRIPTOR_PATH;
+  const directory = path.dirname(filePath);
+  const uid = currentEffectiveUid();
+  assertPrivateDescriptorDirectory(directory, uid);
+  if (typeof fs.constants.O_NOFOLLOW !== "number") {
+    throw new Error("Portable hosted inference staging requires O_NOFOLLOW.");
+  }
+
+  const descriptor: PortableInferenceDescriptor = {
+    schemaVersion: 1,
+    apiKey: config.apiKey,
+    baseUrl: config.endpointUrl,
+    model: config.model,
+    expiresAt: new Date(
+      (options.now ?? Date.now)() + PORTABLE_DESCRIPTOR_VALIDITY_MS,
+    ).toISOString(),
+  };
+  const temporary = path.join(directory, `.${path.basename(filePath)}.tmp`);
+  let published: fs.Stats | null = null;
+  try {
+    createPrivateRegularFile(temporary, `${JSON.stringify(descriptor)}\n`);
+    const staged = fs.lstatSync(temporary);
+    if (staged.uid !== uid || (staged.mode & 0o777) !== 0o600) {
+      throw new Error(
+        "Portable hosted inference staging did not create a current-user-owned mode-0600 file.",
+      );
+    }
+    try {
+      fs.linkSync(temporary, filePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        throw new Error(
+          `Portable hosted inference descriptor already exists at ${filePath}; refusing to replace it.`,
+        );
+      }
+      throw error;
+    }
+    published = staged;
+    fs.unlinkSync(temporary);
+
+    const final = fs.lstatSync(filePath);
+    if (
+      final.isSymbolicLink() ||
+      !final.isFile() ||
+      final.uid !== uid ||
+      (final.mode & 0o777) !== 0o600 ||
+      final.nlink !== 1 ||
+      final.dev !== staged.dev ||
+      final.ino !== staged.ino
+    ) {
+      throw new Error(
+        "Portable hosted inference staging did not publish the staged current-user-owned mode-0600 single-link regular file.",
+      );
+    }
+    published = final;
+    return {
+      filePath,
+      dispose: () => removeExactDescriptor(filePath, final),
+    };
+  } catch (error) {
+    if (published) removeExactDescriptor(filePath, published);
+    throw error;
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
 }
 
 export function buildHostedInferenceModelsProbe(

--- a/test/e2e/fixtures/hosted-inference.ts
+++ b/test/e2e/fixtures/hosted-inference.ts
@@ -87,6 +87,16 @@ function removeExactDescriptor(filePath: string, expected: fs.Stats): void {
   fs.unlinkSync(filePath);
 }
 
+function removeOwnedDescriptorAfterFailure(filePath: string, expected: fs.Stats | null): void {
+  if (!expected) return;
+  try {
+    removeExactDescriptor(filePath, expected);
+  } catch {
+    // Preserve the staging failure. The workflow's always-run cleanup still
+    // owns exact-path removal and reports a cleanup failure separately.
+  }
+}
+
 export function stagePortableHostedInferenceDescriptor(
   config: HostedInferenceConfig,
   options: { readonly filePath?: string; readonly now?: () => number } = {},
@@ -109,10 +119,12 @@ export function stagePortableHostedInferenceDescriptor(
     ).toISOString(),
   };
   const temporary = path.join(directory, `.${path.basename(filePath)}.tmp`);
+  let stagedTemporary: fs.Stats | null = null;
   let published: fs.Stats | null = null;
   try {
     createPrivateRegularFile(temporary, `${JSON.stringify(descriptor)}\n`);
     const staged = fs.lstatSync(temporary);
+    stagedTemporary = staged;
     if (staged.uid !== uid || (staged.mode & 0o777) !== 0o600) {
       throw new Error(
         "Portable hosted inference staging did not create a current-user-owned mode-0600 file.",
@@ -130,6 +142,7 @@ export function stagePortableHostedInferenceDescriptor(
     }
     published = staged;
     fs.unlinkSync(temporary);
+    stagedTemporary = null;
 
     const final = fs.lstatSync(filePath);
     if (
@@ -145,16 +158,14 @@ export function stagePortableHostedInferenceDescriptor(
         "Portable hosted inference staging did not publish the staged current-user-owned mode-0600 single-link regular file.",
       );
     }
-    published = final;
     return {
       filePath,
       dispose: () => removeExactDescriptor(filePath, final),
     };
   } catch (error) {
-    if (published) removeExactDescriptor(filePath, published);
+    removeOwnedDescriptorAfterFailure(filePath, published);
+    removeOwnedDescriptorAfterFailure(temporary, stagedTemporary);
     throw error;
-  } finally {
-    fs.rmSync(temporary, { force: true });
   }
 }
 

--- a/test/e2e/live/full-e2e.test.ts
+++ b/test/e2e/live/full-e2e.test.ts
@@ -19,6 +19,7 @@ import { expect, test } from "../fixtures/e2e-test.ts";
 import {
   buildHostedInferenceModelsProbe,
   requireHostedInferenceConfig,
+  stagePortableHostedInferenceDescriptor,
 } from "../fixtures/hosted-inference.ts";
 import {
   type ColdOnboardPerformanceBudget,
@@ -377,6 +378,15 @@ test("full e2e: install, onboard, inference, cli operations, and cleanup", {
   },
 }, async ({ artifacts, cleanup: cleanupRegistry, host, progress, sandbox, secrets, skip }) => {
   const hosted = requireHostedInferenceConfig(secrets);
+  const portableHostedDescriptor =
+    PORTABLE_PROFILE && !USE_PREINSTALLED_LAUNCHABLE
+      ? stagePortableHostedInferenceDescriptor(hosted)
+      : null;
+  portableHostedDescriptor &&
+    cleanupRegistry.trackDisposable(
+      "remove unconsumed Portable hosted inference descriptor",
+      portableHostedDescriptor.dispose,
+    );
   const coldOnboardBudget = USE_PREINSTALLED_LAUNCHABLE ? null : readFullE2eColdPathBudget();
   const redactionValues = [hosted.apiKey];
   await artifacts.target.declare({

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -125,6 +125,7 @@
     {
       "live": "test/e2e/live/full-e2e.test.ts",
       "fast": [
+        "test/e2e/support/hosted-inference.test.ts",
         "test/e2e/support/full-e2e-inference-probe.test.ts",
         "test/e2e/support/launch-agent-turn.test.ts",
         "test/e2e/support/onboard-performance.test.ts",

--- a/test/e2e/support/hosted-inference.test.ts
+++ b/test/e2e/support/hosted-inference.test.ts
@@ -5,14 +5,20 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+import { setupBedrockRuntimeInference } from "../../../src/lib/onboard/bedrock-runtime.ts";
+import { loadPortableInferenceDescriptor } from "../../../src/lib/onboard/experimental/portable-inference-descriptor.ts";
+import { setupOpenRouterRuntimeInference } from "../../../src/lib/onboard/openrouter-runtime.ts";
+import { resolveRequestedProviderSelection } from "../../../src/lib/onboard/provider-selection.ts";
+import { createPortableOnboardEnvironmentScope } from "../../../src/lib/onboard/session-bootstrap.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { ProviderClient, trustedProviderEndpoint } from "../fixtures/clients/provider.ts";
 import { startFakeOpenAiCompatibleServer } from "../fixtures/fake-openai-compatible.ts";
 import {
   buildHostedInferenceModelsProbe,
   requireHostedInferenceConfig,
+  stagePortableHostedInferenceDescriptor,
 } from "../fixtures/hosted-inference.ts";
 import { startTestProgress } from "../fixtures/progress.ts";
 import type {
@@ -192,6 +198,137 @@ describe("hosted inference E2E config", () => {
 
     expect(cfg.apiKey).toBe("sk-compatible-key");
     expect(cfg.credentialEnv).toBe("COMPATIBLE_API_KEY");
+  });
+
+  it("stages the Portable NVIDIA inference descriptor before provider selection or network activity (#9200)", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-hosted-"));
+    const filePath = path.join(directory, "portable-inference.json");
+    const now = Date.parse("2026-08-20T16:00:00Z");
+    const resolverCalls: string[] = [];
+    const config = requireHostedInferenceConfig(
+      secrets({ NVIDIA_INFERENCE_API_KEY: "portable-hosted-key" }),
+      {
+        NEMOCLAW_ENDPOINT_URL: "https://inference.example.test/v1",
+        NEMOCLAW_MODEL: "nvidia/provider-model",
+      },
+    );
+
+    try {
+      const staged = stagePortableHostedInferenceDescriptor(config, {
+        filePath,
+        now: () => now,
+      });
+      const metadata = fs.lstatSync(filePath);
+      expect(resolverCalls).toEqual([]);
+      expect(metadata.isFile()).toBe(true);
+      expect(metadata.isSymbolicLink()).toBe(false);
+      expect(metadata.mode & 0o777).toBe(0o600);
+      expect(metadata.nlink).toBe(1);
+      expect(JSON.parse(fs.readFileSync(filePath, "utf8"))).toMatchObject({
+        schemaVersion: 1,
+        baseUrl: config.endpointUrl,
+        model: config.model,
+      });
+
+      const conflicting = { ...config, model: "ollama/model" };
+      expect(() =>
+        stagePortableHostedInferenceDescriptor(conflicting, {
+          filePath,
+          now: () => now,
+        }),
+      ).toThrow(/already exists.*refusing to replace/u);
+      expect(JSON.parse(fs.readFileSync(filePath, "utf8"))).toMatchObject({
+        baseUrl: config.endpointUrl,
+        model: config.model,
+      });
+      expect(fs.existsSync(path.join(directory, ".portable-inference.json.tmp"))).toBe(false);
+
+      const descriptor = await loadPortableInferenceDescriptor({
+        filePath,
+        now: () => now,
+        resolveEndpointHost: async (hostname) => {
+          resolverCalls.push(hostname);
+          return [{ address: "93.184.216.34", family: 4 }];
+        },
+      });
+      expect(resolverCalls).toEqual(["inference.example.test"]);
+      expect(descriptor).not.toBeNull();
+
+      const selectorEnv: NodeJS.ProcessEnv = {
+        NEMOCLAW_PROVIDER: "install-ollama",
+        NEMOCLAW_MODEL: "nvidia/provider-model",
+      };
+      const environmentScope = createPortableOnboardEnvironmentScope(selectorEnv, {
+        schemaVersion: descriptor!.schemaVersion,
+        baseUrl: descriptor!.baseUrl,
+        model: descriptor!.model,
+        expiresAt: descriptor!.expiresAt,
+      });
+      const selection = resolveRequestedProviderSelection({
+        options: [
+          { key: "custom", label: "Compatible endpoint" },
+          { key: "install-ollama", label: "Install Ollama" },
+        ],
+        requestedProvider: selectorEnv.NEMOCLAW_PROVIDER ?? null,
+        sandboxName: "portable-launch",
+        remoteProviderConfig: {},
+        isWsl: false,
+        isWindowsHostOllama: false,
+        windowsHostOllamaSupported: false,
+        hermesProviderAvailable: false,
+        ollamaRunning: false,
+        readRecordedProvider: () => null,
+        readRecordedNimContainer: () => null,
+        readRecordedModel: () => null,
+      });
+
+      expect(selectorEnv.NEMOCLAW_PROVIDER).toBe("custom");
+      expect(selectorEnv.NEMOCLAW_MODEL).toBe(config.model);
+      expect(selectorEnv.NEMOCLAW_ENDPOINT_URL).toBe(config.endpointUrl);
+      expect(selection.kind).toBe("selected");
+      expect(selection.kind === "selected" ? selection.selected.key : null).toBe("custom");
+
+      const unexpectedRuntimeCall = (): never => {
+        throw new Error("Portable NVIDIA hosted inference entered a local-adapter lifecycle.");
+      };
+      const bedrockAdapter = vi.fn(async () => unexpectedRuntimeCall());
+      const openrouterAdapter = vi.fn(async () => unexpectedRuntimeCall());
+      const commonRuntimeOptions = {
+        sandboxName: "portable-launch",
+        provider: config.providerName,
+        model: config.model,
+        credentialEnv: config.credentialEnv,
+        isNonInteractive: () => true,
+        runOpenshell: unexpectedRuntimeCall,
+        upsertProvider: unexpectedRuntimeCall,
+        verifyInferenceRoute: unexpectedRuntimeCall,
+        verifyOnboardInferenceSmoke: unexpectedRuntimeCall,
+        exitProcess: unexpectedRuntimeCall,
+        error: unexpectedRuntimeCall,
+        log: unexpectedRuntimeCall,
+      };
+      expect(
+        await setupBedrockRuntimeInference({
+          ...commonRuntimeOptions,
+          endpointUrl: config.endpointUrl,
+          ensureAdapter: bedrockAdapter,
+        }),
+      ).toEqual({ handled: false });
+      expect(
+        await setupOpenRouterRuntimeInference({
+          ...commonRuntimeOptions,
+          credentialValue: config.apiKey,
+          ensureAdapter: openrouterAdapter,
+        }),
+      ).toEqual({ handled: false });
+      expect(bedrockAdapter).not.toHaveBeenCalled();
+      expect(openrouterAdapter).not.toHaveBeenCalled();
+      expect(fs.existsSync(filePath)).toBe(false);
+      expect(() => staged.dispose()).not.toThrow();
+      environmentScope.restore();
+    } finally {
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
   });
 
   it("passes hosted authorization to curl on stdin without exposing the key in arguments", () => {

--- a/test/e2e/support/hosted-inference.test.ts
+++ b/test/e2e/support/hosted-inference.test.ts
@@ -5,7 +5,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { loadPortableInferenceDescriptor } from "../../../src/lib/onboard/experimental/portable-inference-descriptor.ts";
 import { resolveRequestedProviderSelection } from "../../../src/lib/onboard/provider-selection.ts";
@@ -255,7 +255,6 @@ describe("hosted inference E2E config", () => {
         model: config.model,
       });
       const temporaryPath = path.join(directory, ".portable-inference.json.tmp");
-      expect(fs.existsSync(temporaryPath)).toBe(false);
       fs.writeFileSync(temporaryPath, "foreign temporary marker", {
         encoding: "utf8",
         flag: "wx",
@@ -330,6 +329,45 @@ describe("hosted inference E2E config", () => {
       expect(() => staged.dispose()).not.toThrow();
       environmentScope.restore();
     } finally {
+      fs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("preserves the staging failure when owned-file rollback also fails (#9200)", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-hosted-"));
+    const filePath = path.join(directory, "portable-inference.json");
+    const temporaryPath = path.join(directory, ".portable-inference.json.tmp");
+    const config = requireHostedInferenceConfig(
+      secrets({ NVIDIA_INFERENCE_API_KEY: "portable-hosted-key" }),
+      {
+        NEMOCLAW_ENDPOINT_URL: "https://inference.example.test/v1",
+        NEMOCLAW_MODEL: "nvidia/provider-model",
+      },
+    );
+    const realUnlinkSync = fs.unlinkSync.bind(fs);
+    const unlinkSync = vi
+      .spyOn(fs, "unlinkSync")
+      .mockImplementationOnce((target) => {
+        expect(target).toBe(temporaryPath);
+        realUnlinkSync(target);
+        throw new Error("original staging failure");
+      })
+      .mockImplementationOnce((target) => {
+        expect(target).toBe(filePath);
+        throw new Error("rollback cleanup failure");
+      });
+
+    try {
+      expect(() =>
+        stagePortableHostedInferenceDescriptor(config, {
+          filePath,
+          now: () => Date.parse("2026-08-20T16:00:00Z"),
+        }),
+      ).toThrow("original staging failure");
+      expect(fs.existsSync(filePath)).toBe(true);
+      expect(unlinkSync).toHaveBeenCalledTimes(2);
+    } finally {
+      unlinkSync.mockRestore();
       fs.rmSync(directory, { force: true, recursive: true });
     }
   });

--- a/test/e2e/support/hosted-inference.test.ts
+++ b/test/e2e/support/hosted-inference.test.ts
@@ -5,11 +5,9 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { setupBedrockRuntimeInference } from "../../../src/lib/onboard/bedrock-runtime.ts";
 import { loadPortableInferenceDescriptor } from "../../../src/lib/onboard/experimental/portable-inference-descriptor.ts";
-import { setupOpenRouterRuntimeInference } from "../../../src/lib/onboard/openrouter-runtime.ts";
 import { resolveRequestedProviderSelection } from "../../../src/lib/onboard/provider-selection.ts";
 import { createPortableOnboardEnvironmentScope } from "../../../src/lib/onboard/session-bootstrap.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
@@ -35,6 +33,20 @@ const COMPAT_HELPER = path.join(
   "lib",
   "ci-compatible-inference.sh",
 );
+
+function readPrivateFileSnapshot(filePath: string): { contents: string; metadata: fs.Stats } {
+  const descriptor = fs.openSync(
+    filePath,
+    fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK,
+  );
+  try {
+    const metadata = fs.fstatSync(descriptor);
+    const contents = fs.readFileSync(descriptor, "utf8");
+    return { contents, metadata };
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
 
 function secrets(values: Record<string, string | undefined>) {
   return {
@@ -218,13 +230,14 @@ describe("hosted inference E2E config", () => {
         filePath,
         now: () => now,
       });
-      const metadata = fs.lstatSync(filePath);
+      const stagedSnapshot = readPrivateFileSnapshot(filePath);
+      const metadata = stagedSnapshot.metadata;
       expect(resolverCalls).toEqual([]);
       expect(metadata.isFile()).toBe(true);
       expect(metadata.isSymbolicLink()).toBe(false);
       expect(metadata.mode & 0o777).toBe(0o600);
       expect(metadata.nlink).toBe(1);
-      expect(JSON.parse(fs.readFileSync(filePath, "utf8"))).toMatchObject({
+      expect(JSON.parse(stagedSnapshot.contents)).toMatchObject({
         schemaVersion: 1,
         baseUrl: config.endpointUrl,
         model: config.model,
@@ -237,11 +250,25 @@ describe("hosted inference E2E config", () => {
           now: () => now,
         }),
       ).toThrow(/already exists.*refusing to replace/u);
-      expect(JSON.parse(fs.readFileSync(filePath, "utf8"))).toMatchObject({
+      expect(JSON.parse(readPrivateFileSnapshot(filePath).contents)).toMatchObject({
         baseUrl: config.endpointUrl,
         model: config.model,
       });
-      expect(fs.existsSync(path.join(directory, ".portable-inference.json.tmp"))).toBe(false);
+      const temporaryPath = path.join(directory, ".portable-inference.json.tmp");
+      expect(fs.existsSync(temporaryPath)).toBe(false);
+      fs.writeFileSync(temporaryPath, "foreign temporary marker", {
+        encoding: "utf8",
+        flag: "wx",
+        mode: 0o600,
+      });
+      expect(() =>
+        stagePortableHostedInferenceDescriptor(conflicting, {
+          filePath,
+          now: () => now,
+        }),
+      ).toThrow(/EEXIST/u);
+      expect(readPrivateFileSnapshot(temporaryPath).contents).toBe("foreign temporary marker");
+      fs.unlinkSync(temporaryPath);
 
       const descriptor = await loadPortableInferenceDescriptor({
         filePath,
@@ -267,6 +294,8 @@ describe("hosted inference E2E config", () => {
       const selection = resolveRequestedProviderSelection({
         options: [
           { key: "custom", label: "Compatible endpoint" },
+          { key: "anthropicCompatible", label: "Anthropic-compatible endpoint" },
+          { key: "openrouter", label: "OpenRouter" },
           { key: "install-ollama", label: "Install Ollama" },
         ],
         requestedProvider: selectorEnv.NEMOCLAW_PROVIDER ?? null,
@@ -287,42 +316,16 @@ describe("hosted inference E2E config", () => {
       expect(selectorEnv.NEMOCLAW_ENDPOINT_URL).toBe(config.endpointUrl);
       expect(selection.kind).toBe("selected");
       expect(selection.kind === "selected" ? selection.selected.key : null).toBe("custom");
-
-      const unexpectedRuntimeCall = (): never => {
-        throw new Error("Portable NVIDIA hosted inference entered a local-adapter lifecycle.");
-      };
-      const bedrockAdapter = vi.fn(async () => unexpectedRuntimeCall());
-      const openrouterAdapter = vi.fn(async () => unexpectedRuntimeCall());
-      const commonRuntimeOptions = {
-        sandboxName: "portable-launch",
-        provider: config.providerName,
-        model: config.model,
-        credentialEnv: config.credentialEnv,
-        isNonInteractive: () => true,
-        runOpenshell: unexpectedRuntimeCall,
-        upsertProvider: unexpectedRuntimeCall,
-        verifyInferenceRoute: unexpectedRuntimeCall,
-        verifyOnboardInferenceSmoke: unexpectedRuntimeCall,
-        exitProcess: unexpectedRuntimeCall,
-        error: unexpectedRuntimeCall,
-        log: unexpectedRuntimeCall,
-      };
-      expect(
-        await setupBedrockRuntimeInference({
-          ...commonRuntimeOptions,
-          endpointUrl: config.endpointUrl,
-          ensureAdapter: bedrockAdapter,
-        }),
-      ).toEqual({ handled: false });
-      expect(
-        await setupOpenRouterRuntimeInference({
-          ...commonRuntimeOptions,
-          credentialValue: config.apiKey,
-          ensureAdapter: openrouterAdapter,
-        }),
-      ).toEqual({ handled: false });
-      expect(bedrockAdapter).not.toHaveBeenCalled();
-      expect(openrouterAdapter).not.toHaveBeenCalled();
+      expect(config.providerName).toBe("compatible-endpoint");
+      expect(config.providerName).not.toBe("compatible-anthropic-endpoint");
+      expect(config.providerName).not.toBe("openrouter-api");
+      expect(selection.kind === "selected" ? selection.selected.key : null).not.toBe(
+        "anthropicCompatible",
+      );
+      expect(selection.kind === "selected" ? selection.selected.key : null).not.toBe("openrouter");
+      expect(selection.kind === "selected" ? selection.selected.key : null).not.toBe(
+        "install-ollama",
+      );
       expect(fs.existsSync(filePath)).toBe(false);
       expect(() => staged.dispose()).not.toThrow();
       environmentScope.restore();
@@ -414,7 +417,6 @@ printf '{"data":[]}'
       "https://inference-api.nvidia.com/v1",
     ]);
   });
-
 
   it("uses a lightweight compatible reachability probe without API or auth requests", () => {
     const { result, calls } = runHostedProbe({

--- a/test/e2e/support/portable-profile-systemctl-shim.test.ts
+++ b/test/e2e/support/portable-profile-systemctl-shim.test.ts
@@ -1386,6 +1386,9 @@ describe("portable profile systemctl fixture", () => {
     expect(provision).toContain(
       'install -m 700 test/e2e/fixtures/portable-profile-systemctl-shim.sh "$shim_dir/systemctl"',
     );
+    expect(provision).toContain(
+      'sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" /run/nemoclaw',
+    );
     expect(provision).toContain("systemctl --user start podman.socket");
     const runtimeExportIndex = provision.indexOf("XDG_RUNTIME_DIR=%s");
     expect(runtimeExportIndex).toBeGreaterThanOrEqual(0);
@@ -1400,5 +1403,8 @@ describe("portable profile systemctl fixture", () => {
       'import { cleanupPortableProfileSystemctlFixture } from "./test/e2e/fixtures/portable-profile-systemctl.ts"; await cleanupPortableProfileSystemctlFixture(process.argv[1]);',
     );
     expect(cleanup.run).toContain('"$runtime_dir"');
+    expect(cleanup.run).toContain(
+      "rm -f -- /run/nemoclaw/portable-inference.json /run/nemoclaw/.portable-inference.json.tmp",
+    );
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The automatic Portable profile workflow exports hosted NVIDIA inference inputs but did not stage the descriptor that noninteractive onboarding reads. Onboarding therefore kept the ambient `install-ollama` provider and treated the hosted NVIDIA model as an Ollama registry path. This change securely stages and cleans up the descriptor before onboarding, so the hosted model and compatible endpoint share one authority.

## Related Issue

Related to #9200 and #9208.

## Changes

- Stage the Portable inference descriptor as a current-user-owned mode-`0600` file beneath the mode-`0700` `/run/nemoclaw` directory before the first awaited fixture operation.
- Refuse conflicting descriptor replacement, consume and unlink the descriptor before provider selection, and always clean up the exact final and temporary paths.
- Prove that the staged NVIDIA descriptor overrides ambient `install-ollama` with `custom`, preserves the provider-specific model, and does not enter Ollama, Bedrock, OpenRouter, or unauthenticated loopback-proxy paths.
- Add the owning E2E credential-boundary guidance and map the deterministic support test to the live full-E2E path.

E2E root cause:

- Workflow: `E2E / Portable Profile`
- Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/32446954903 (attempt 1)
- Failed job: `portable-launch` 96668212745; `rootless-linux` 96668212876 passed
- Signature: `NEMOCLAW_E2E_USE_HOSTED_INFERENCE=1` → `install-ollama` → `nvidia/nvidia/nemotron-3-ultra` → `https://nvidia/v2/...` → DNS lookup failure for host `nvidia`
- Artifact: 9434427845, SHA-256 `cf690ba7caa70f6b45c530e1250ea0a25f9e7e752a2ead63599c7758f9bd8408`
- Scope: one fixture-composition root cause; artifact upload and unrelated transport failures are excluded

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent exact-base security review passed with no findings; the review covered descriptor publication, credential lifetime, cleanup, provider authority, SSRF boundaries, and merged #9836 composition.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 66 E2E-support assertions passed across hosted inference, Portable systemctl, rootless workflow, and timeout contracts; 34 Portable environment-scope assertions passed; 64 mock-parity and project-routing assertions passed; protected-loopback and recovery composition passed under supported Node 24 (22 CLI assertions and 80 integration assertions, with 2 expected skips).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable to this fixture-only correction; `npm run checks:repository`, CLI type checking, project-membership, source-shape, and E2E phase checks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Local `npm run test:changed` also reached 680 passing assertions and 8 skips. Its two Darwin-only failures are the unchanged Linux-only user-service fixture tracked outside this candidate; the owning file is byte-identical to the base.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure portable hosted-inference setup using temporary, protected credential descriptors.
  * Added validation for descriptor ownership, permissions, expiration, provider selection, and safe cleanup.

* **Bug Fixes**
  * Improved portable runtime setup and cleanup, including removal of temporary inference state.
  * Enhanced handling of temporary-file conflicts and cleanup failures.

* **Documentation**
  * Clarified portable workflow triggers, credential handling, expiration, cleanup, and teardown limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->