### PR TITLE
fix(inference): isolate receipt platform pulls

### DIFF
--- a/.github/workflows/llama-cpp-image.yaml
+++ b/.github/workflows/llama-cpp-image.yaml
@@ -450,6 +450,7 @@ jobs:
       - name: Verify anonymous exact platform pull
         shell: bash
         env:
+          ARCH: ${{ matrix.arch }}
           DIGEST: ${{ steps.build.outputs.digest }}
           IMAGE: ${{ needs.config.outputs.publication_repository }}
           PLATFORM: ${{ matrix.platform }}
@@ -464,6 +465,28 @@ jobs:
             echo "::error::Anonymous exact-digest pull failed for ${reference}. The GHCR package ${IMAGE} must be public before candidate assembly."
             exit 1
           fi
+          image_id="$(docker image inspect --format '{{.Id}}' "$reference")"
+          if [[ ! "$image_id" =~ ^sha256:[0-9a-f]{64}$ ]] \
+            || [ "$(docker image inspect --format '{{.Id}}' "$image_id")" != "$image_id" ]; then
+            echo "ERROR: anonymous $PLATFORM pull did not resolve to one immutable local image ID." >&2
+            exit 1
+          fi
+          install -d -m 0700 "$RUNNER_TEMP/llama-cpp-anonymous-pulls"
+          jq -cnS \
+            --arg imageId "$image_id" \
+            --arg platform "$PLATFORM" \
+            --arg platformDigest "$DIGEST" \
+            --arg reference "$reference" \
+            '{imageId:$imageId,platform:$platform,platformDigest:$platformDigest,reference:$reference}' \
+            > "$RUNNER_TEMP/llama-cpp-anonymous-pulls/anonymous-pull-${ARCH}.json"
+
+      - name: Upload anonymous pull evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: llama-cpp-anonymous-pull-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/llama-cpp-anonymous-pulls/anonymous-pull-${{ matrix.arch }}.json
+          if-no-files-found: error
+          retention-days: ${{ fromJSON(needs.config.outputs.publication_receipt_retention_days) }}
 
       - name: Upload platform digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -736,6 +759,13 @@ jobs:
           path: ${{ runner.temp }}/llama-cpp-evidence
           merge-multiple: true
 
+      - name: Download anonymous pull evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: llama-cpp-anonymous-pull-${{ github.run_id }}-${{ github.run_attempt }}-*
+          path: ${{ runner.temp }}/llama-cpp-evidence
+          merge-multiple: true
+
       - name: Download SPDX SBOMs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -800,6 +830,8 @@ jobs:
             --reference "$REFERENCE" \
             --candidate-index "$evidence/candidate-index.json" \
             --platform-digests "$evidence/platform-digests.json" \
+            --anonymous-pull-amd64 "$evidence/anonymous-pull-amd64.json" \
+            --anonymous-pull-arm64 "$evidence/anonymous-pull-arm64.json" \
             --sbom-amd64 "$evidence/llama-cpp-sbom-amd64.spdx.json" \
             --sbom-arm64 "$evidence/llama-cpp-sbom-arm64.spdx.json" \
             --sbom-verification "$evidence/sbom-verification.json" \

--- a/scripts/checks/verify-llama-cpp-image-publication-evidence.sh
+++ b/scripts/checks/verify-llama-cpp-image-publication-evidence.sh
@@ -170,7 +170,11 @@ if [ -L "$output" ] || { [ -e "$output" ] && [ ! -f "$output" ]; }; then
 fi
 
 temporary_root="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/llama-cpp-publication-evidence-XXXXXX")"
+pulled_reference=''
 cleanup() {
+  if [ -n "$pulled_reference" ]; then
+    docker image rm "$pulled_reference" >/dev/null 2>&1 || true
+  fi
   rm -rf "$temporary_root"
 }
 trap cleanup EXIT
@@ -243,6 +247,7 @@ for arch in amd64 arm64; do
     echo "ERROR: anonymous exact-digest pull failed for $platform." >&2
     exit 1
   fi
+  pulled_reference="$reference"
   image_id="$(docker image inspect --format '{{.Id}}' "$reference")"
   if [[ ! "$image_id" =~ ^sha256:[0-9a-f]{64}$ ]] \
     || [ "$(docker image inspect --format '{{.Id}}' "$image_id")" != "$image_id" ]; then
@@ -253,6 +258,11 @@ for arch in amd64 arm64; do
     --arg imageId "$image_id" \
     --arg platform "$platform" \
     '{platform:$platform,imageId:$imageId}' >>"$anonymous_pull_summary"
+  if ! docker image rm "$reference" >/dev/null; then
+    echo "ERROR: anonymous $platform pull could not be removed after verification." >&2
+    exit 1
+  fi
+  pulled_reference=''
 done
 
 for sbom in "$sbom_amd64" "$sbom_arm64"; do

--- a/scripts/checks/verify-llama-cpp-image-publication-evidence.sh
+++ b/scripts/checks/verify-llama-cpp-image-publication-evidence.sh
@@ -5,13 +5,15 @@
 set -euo pipefail
 
 usage() {
-  printf '%s\n' "Usage: $0 --reference IMAGE@DIGEST --candidate-index PATH --platform-digests PATH --sbom-amd64 PATH --sbom-arm64 PATH --sbom-verification PATH --provenance-verification PATH --signature-verification PATH --scan-amd64 PATH --scan-arm64 PATH --repository OWNER/REPOSITORY --revision GIT_SHA --source-revision GIT_SHA --source-archive-sha256 DIGEST --cuda-development-base IMAGE@DIGEST --cuda-runtime-base IMAGE@DIGEST --run-id ID --run-attempt ATTEMPT --certificate-identity IDENTITY --certificate-oidc-issuer ISSUER --output PATH" >&2
+  printf '%s\n' "Usage: $0 --reference IMAGE@DIGEST --candidate-index PATH --platform-digests PATH --anonymous-pull-amd64 PATH --anonymous-pull-arm64 PATH --sbom-amd64 PATH --sbom-arm64 PATH --sbom-verification PATH --provenance-verification PATH --signature-verification PATH --scan-amd64 PATH --scan-arm64 PATH --repository OWNER/REPOSITORY --revision GIT_SHA --source-revision GIT_SHA --source-archive-sha256 DIGEST --cuda-development-base IMAGE@DIGEST --cuda-runtime-base IMAGE@DIGEST --run-id ID --run-attempt ATTEMPT --certificate-identity IDENTITY --certificate-oidc-issuer ISSUER --output PATH" >&2
   exit 64
 }
 
 reference=""
 candidate_index=""
 platform_digests=""
+anonymous_pull_amd64=""
+anonymous_pull_arm64=""
 sbom_amd64=""
 sbom_arm64=""
 sbom_verification=""
@@ -43,6 +45,14 @@ while [ "$#" -gt 0 ]; do
       ;;
     --platform-digests)
       platform_digests="${2:-}"
+      shift 2
+      ;;
+    --anonymous-pull-amd64)
+      anonymous_pull_amd64="${2:-}"
+      shift 2
+      ;;
+    --anonymous-pull-arm64)
+      anonymous_pull_arm64="${2:-}"
       shift 2
       ;;
     --sbom-amd64)
@@ -145,6 +155,8 @@ fi
 for evidence_file in \
   "$candidate_index" \
   "$platform_digests" \
+  "$anonymous_pull_amd64" \
+  "$anonymous_pull_arm64" \
   "$sbom_amd64" \
   "$sbom_arm64" \
   "$sbom_verification" \
@@ -170,11 +182,7 @@ if [ -L "$output" ] || { [ -e "$output" ] && [ ! -f "$output" ]; }; then
 fi
 
 temporary_root="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/llama-cpp-publication-evidence-XXXXXX")"
-pulled_reference=''
 cleanup() {
-  if [ -n "$pulled_reference" ]; then
-    docker image rm "$pulled_reference" >/dev/null 2>&1 || true
-  fi
   rm -rf "$temporary_root"
 }
 trap cleanup EXIT
@@ -238,31 +246,33 @@ if ! cmp -s "$candidate_index" "$anonymous_index"; then
   exit 1
 fi
 
-anonymous_pull_summary="$temporary_root/anonymous-pull-summary.jsonl"
-: >"$anonymous_pull_summary"
+anonymous_pull_summary="$temporary_root/anonymous-pull-summary.json"
+printf '[]\n' >"$anonymous_pull_summary"
 for arch in amd64 arm64; do
   platform="linux/$arch"
-  if ! DOCKER_CONFIG="$temporary_root/docker-config" \
-    docker pull --platform "$platform" "$reference"; then
-    echo "ERROR: anonymous exact-digest pull failed for $platform." >&2
-    exit 1
+  expected="$(jq -er --arg platform "$platform" '.[$platform]' "$platform_digests")"
+  if [ "$arch" = "amd64" ]; then
+    anonymous_pull="$anonymous_pull_amd64"
+  else
+    anonymous_pull="$anonymous_pull_arm64"
   fi
-  pulled_reference="$reference"
-  image_id="$(docker image inspect --format '{{.Id}}' "$reference")"
-  if [[ ! "$image_id" =~ ^sha256:[0-9a-f]{64}$ ]] \
-    || [ "$(docker image inspect --format '{{.Id}}' "$image_id")" != "$image_id" ]; then
-    echo "ERROR: anonymous $platform pull did not resolve to one immutable local image ID." >&2
-    exit 1
-  fi
-  jq -cn \
-    --arg imageId "$image_id" \
+  if ! jq -e \
+    --arg digest "$expected" \
     --arg platform "$platform" \
-    '{platform:$platform,imageId:$imageId}' >>"$anonymous_pull_summary"
-  if ! docker image rm "$reference" >/dev/null; then
-    echo "ERROR: anonymous $platform pull could not be removed after verification." >&2
+    --arg reference "$image@$expected" '
+      (keys | sort) == ["imageId", "platform", "platformDigest", "reference"]
+      and .platform == $platform
+      and .platformDigest == $digest
+      and .reference == $reference
+      and (.imageId | type == "string" and test("^sha256:[0-9a-f]{64}$"))
+    ' "$anonymous_pull" >/dev/null; then
+    echo "ERROR: isolated anonymous pull evidence does not match $platform." >&2
     exit 1
   fi
-  pulled_reference=''
+  jq -cS --slurpfile pull "$anonymous_pull" \
+    '. + [{platform:$pull[0].platform,imageId:$pull[0].imageId}]' \
+    "$anonymous_pull_summary" >"$anonymous_pull_summary.next"
+  mv "$anonymous_pull_summary.next" "$anonymous_pull_summary"
 done
 
 for sbom in "$sbom_amd64" "$sbom_arm64"; do
@@ -438,7 +448,7 @@ jq -nS \
         exactDigest:true,
         reference:$reference,
         indexSha256:$digest,
-        platforms:$anonymousPlatforms
+        platforms:$anonymousPlatforms[0]
       }
     }
   }' >"$temporary_output"

--- a/test/llama-cpp-image-publication-evidence.test.ts
+++ b/test/llama-cpp-image-publication-evidence.test.ts
@@ -32,9 +32,8 @@ const certificateOidcIssuer = "https://token.actions.githubusercontent.com";
 const sha256 = (value: string) => `sha256:${createHash("sha256").update(value).digest("hex")}`;
 
 type FixtureOptions = {
-  anonymousCleanupFailure?: "amd64" | "arm64";
+  anonymousEvidenceMismatch?: "amd64" | "arm64";
   anonymousMismatch?: boolean;
-  anonymousPullFailure?: "amd64" | "arm64";
   duplicateSbom?: boolean;
   identicalSbomDocuments?: boolean;
   indexArm64Digest?: string;
@@ -85,6 +84,13 @@ function runEvidence(options: FixtureOptions = {}) {
   });
   const candidateDigest = sha256(candidate);
   const reference = `${image}@${candidateDigest}`;
+  const anonymousPull = (arch: "amd64" | "arm64", digest: string, imageId: string) => ({
+    imageId,
+    platform: `linux/${arch}`,
+    platformDigest:
+      options.anonymousEvidenceMismatch === arch ? `sha256:${"0".repeat(64)}` : digest,
+    reference: `${image}@${digest}`,
+  });
   const amd64Sbom = spdx("amd64");
   const arm64Sbom = options.identicalSbomDocuments ? amd64Sbom : spdx("arm64");
   const sbomStatement = (predicate: ReturnType<typeof spdx>) => ({
@@ -170,6 +176,12 @@ function runEvidence(options: FixtureOptions = {}) {
       "linux/amd64": amd64Digest,
       "linux/arm64": arm64Digest,
     }),
+    "anonymous-pull-amd64.json": JSON.stringify(
+      anonymousPull("amd64", amd64Digest, `sha256:${"3".repeat(64)}`),
+    ),
+    "anonymous-pull-arm64.json": JSON.stringify(
+      anonymousPull("arm64", arm64Digest, `sha256:${"4".repeat(64)}`),
+    ),
     "sbom-amd64.json": JSON.stringify(amd64Sbom),
     "sbom-arm64.json": JSON.stringify(arm64Sbom),
     "sbom-verification.json": JSON.stringify(sbomVerification),
@@ -185,32 +197,9 @@ function runEvidence(options: FixtureOptions = {}) {
     path.join(bin, "docker"),
     `#!/usr/bin/env bash
 set -euo pipefail
+printf '%s\n' "$*" >> "$FIXTURE_ROOT/docker-invocations"
 if [ "$*" = "buildx imagetools inspect ${reference} --raw" ]; then
   cp "$FIXTURE_ROOT/evidence/anonymous-index.json" /dev/stdout
-elif [ "$1" = "pull" ] && [ "$2" = "--platform" ]; then
-  platform="$3"
-  if [ "$platform" = "linux/${options.anonymousPullFailure ?? "none"}" ]; then
-    exit 91
-  fi
-  if [ -e "$FIXTURE_ROOT/last-pulled-platform" ]; then
-    printf 'cannot overwrite digest\n' >&2
-    exit 93
-  fi
-  printf '%s\n' "$platform" > "$FIXTURE_ROOT/last-pulled-platform"
-elif [ "$*" = "image inspect --format {{.Id}} ${reference}" ]; then
-  case "$(cat "$FIXTURE_ROOT/last-pulled-platform")" in
-    linux/amd64) printf 'sha256:%s\n' '${"3".repeat(64)}' ;;
-    linux/arm64) printf 'sha256:%s\n' '${"4".repeat(64)}' ;;
-    *) exit 92 ;;
-  esac
-elif [ "$1" = "image" ] && [ "$2" = "inspect" ] \
-  && [ "$3" = "--format" ] && [[ "$5" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-  printf '%s\n' "$5"
-elif [ "$*" = "image rm ${reference}" ]; then
-  if [ "$(cat "$FIXTURE_ROOT/last-pulled-platform")" = "linux/${options.anonymousCleanupFailure ?? "none"}" ]; then
-    exit 94
-  fi
-  rm "$FIXTURE_ROOT/last-pulled-platform"
 else
   printf 'unexpected docker invocation: %s\n' "$*" >&2
   exit 90
@@ -218,6 +207,8 @@ fi
 `,
     { mode: 0o755 },
   );
+  const sharedDaemonReference = path.join(root, "pre-existing-daemon-reference");
+  fs.writeFileSync(sharedDaemonReference, "owned-by-another-process\n");
 
   const result = spawnSync(
     "bash",
@@ -229,6 +220,10 @@ fi
       path.join(evidence, "candidate-index.json"),
       "--platform-digests",
       path.join(evidence, "platform-digests.json"),
+      "--anonymous-pull-amd64",
+      path.join(evidence, "anonymous-pull-amd64.json"),
+      "--anonymous-pull-arm64",
+      path.join(evidence, "anonymous-pull-arm64.json"),
       "--sbom-amd64",
       path.join(evidence, "sbom-amd64.json"),
       "--sbom-arm64",
@@ -279,17 +274,31 @@ fi
   const receipt = fs.existsSync(receiptPath)
     ? (JSON.parse(fs.readFileSync(receiptPath, "utf8")) as Record<string, unknown>)
     : null;
-  const localImageWasRemoved = !fs.existsSync(path.join(root, "last-pulled-platform"));
+  const dockerInvocationPath = path.join(root, "docker-invocations");
+  const dockerInvocations = fs.existsSync(dockerInvocationPath)
+    ? fs.readFileSync(dockerInvocationPath, "utf8").trim()
+    : "";
+  const sharedDaemonReferenceWasPreserved =
+    fs.readFileSync(sharedDaemonReference, "utf8") === "owned-by-another-process\n";
   fs.rmSync(root, { recursive: true, force: true });
-  return { candidateDigest, localImageWasRemoved, receipt, result };
+  return {
+    candidateDigest,
+    dockerInvocations,
+    receipt,
+    result,
+    sharedDaemonReferenceWasPreserved,
+  };
 }
 
 describe("llama.cpp image publication evidence verifier", () => {
-  it("binds the exact index, platforms, supply-chain evidence, scans, and anonymous pull (#8250)", () => {
+  it("binds isolated anonymous pulls without touching shared Docker image state (#8250)", () => {
     const fixture = runEvidence();
 
     expect(fixture.result.status, fixture.result.stderr).toBe(0);
-    expect(fixture.localImageWasRemoved).toBe(true);
+    expect(fixture.dockerInvocations).toBe(
+      `buildx imagetools inspect ${image}@${fixture.candidateDigest} --raw`,
+    );
+    expect(fixture.sharedDaemonReferenceWasPreserved).toBe(true);
     expect(fixture.receipt).toMatchObject({
       schemaVersion: 1,
       image: {
@@ -338,8 +347,7 @@ describe("llama.cpp image publication evidence verifier", () => {
   it.each([
     ["substituted platform descriptor", { indexArm64Digest: `sha256:${"f".repeat(64)}` }],
     ["anonymous bytes mismatch", { anonymousMismatch: true }],
-    ["anonymous arm64 pull failure", { anonymousPullFailure: "arm64" as const }],
-    ["anonymous amd64 cleanup failure", { anonymousCleanupFailure: "amd64" as const }],
+    ["anonymous arm64 pull evidence mismatch", { anonymousEvidenceMismatch: "arm64" as const }],
     ["duplicate SBOM predicate", { duplicateSbom: true }],
     ["identical platform SBOM documents", { identicalSbomDocuments: true }],
     ["SBOM subject mismatch", { sbomDigest: "0".repeat(64) }],

--- a/test/llama-cpp-image-publication-evidence.test.ts
+++ b/test/llama-cpp-image-publication-evidence.test.ts
@@ -32,6 +32,7 @@ const certificateOidcIssuer = "https://token.actions.githubusercontent.com";
 const sha256 = (value: string) => `sha256:${createHash("sha256").update(value).digest("hex")}`;
 
 type FixtureOptions = {
+  anonymousCleanupFailure?: "amd64" | "arm64";
   anonymousMismatch?: boolean;
   anonymousPullFailure?: "amd64" | "arm64";
   duplicateSbom?: boolean;
@@ -191,6 +192,10 @@ elif [ "$1" = "pull" ] && [ "$2" = "--platform" ]; then
   if [ "$platform" = "linux/${options.anonymousPullFailure ?? "none"}" ]; then
     exit 91
   fi
+  if [ -e "$FIXTURE_ROOT/last-pulled-platform" ]; then
+    printf 'cannot overwrite digest\n' >&2
+    exit 93
+  fi
   printf '%s\n' "$platform" > "$FIXTURE_ROOT/last-pulled-platform"
 elif [ "$*" = "image inspect --format {{.Id}} ${reference}" ]; then
   case "$(cat "$FIXTURE_ROOT/last-pulled-platform")" in
@@ -201,6 +206,11 @@ elif [ "$*" = "image inspect --format {{.Id}} ${reference}" ]; then
 elif [ "$1" = "image" ] && [ "$2" = "inspect" ] \
   && [ "$3" = "--format" ] && [[ "$5" =~ ^sha256:[0-9a-f]{64}$ ]]; then
   printf '%s\n' "$5"
+elif [ "$*" = "image rm ${reference}" ]; then
+  if [ "$(cat "$FIXTURE_ROOT/last-pulled-platform")" = "linux/${options.anonymousCleanupFailure ?? "none"}" ]; then
+    exit 94
+  fi
+  rm "$FIXTURE_ROOT/last-pulled-platform"
 else
   printf 'unexpected docker invocation: %s\n' "$*" >&2
   exit 90
@@ -269,8 +279,9 @@ fi
   const receipt = fs.existsSync(receiptPath)
     ? (JSON.parse(fs.readFileSync(receiptPath, "utf8")) as Record<string, unknown>)
     : null;
+  const localImageWasRemoved = !fs.existsSync(path.join(root, "last-pulled-platform"));
   fs.rmSync(root, { recursive: true, force: true });
-  return { candidateDigest, receipt, result };
+  return { candidateDigest, localImageWasRemoved, receipt, result };
 }
 
 describe("llama.cpp image publication evidence verifier", () => {
@@ -278,6 +289,7 @@ describe("llama.cpp image publication evidence verifier", () => {
     const fixture = runEvidence();
 
     expect(fixture.result.status, fixture.result.stderr).toBe(0);
+    expect(fixture.localImageWasRemoved).toBe(true);
     expect(fixture.receipt).toMatchObject({
       schemaVersion: 1,
       image: {
@@ -327,6 +339,7 @@ describe("llama.cpp image publication evidence verifier", () => {
     ["substituted platform descriptor", { indexArm64Digest: `sha256:${"f".repeat(64)}` }],
     ["anonymous bytes mismatch", { anonymousMismatch: true }],
     ["anonymous arm64 pull failure", { anonymousPullFailure: "arm64" as const }],
+    ["anonymous amd64 cleanup failure", { anonymousCleanupFailure: "amd64" as const }],
     ["duplicate SBOM predicate", { duplicateSbom: true }],
     ["identical platform SBOM documents", { identicalSbomDocuments: true }],
     ["SBOM subject mismatch", { sbomDigest: "0".repeat(64) }],

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -553,18 +553,10 @@ describe("llama.cpp image PR workflow", () => {
       "merge-multiple": true,
     });
     expect(receipt.run).toContain("scripts/checks/verify-llama-cpp-image-publication-evidence.sh");
-    expect(receipt.run).toContain(
-      '--sbom-amd64 "$evidence/llama-cpp-sbom-amd64.spdx.json"',
-    );
-    expect(receipt.run).toContain(
-      '--sbom-arm64 "$evidence/llama-cpp-sbom-arm64.spdx.json"',
-    );
-    expect(receipt.run).toContain(
-      '--anonymous-pull-amd64 "$evidence/anonymous-pull-amd64.json"',
-    );
-    expect(receipt.run).toContain(
-      '--anonymous-pull-arm64 "$evidence/anonymous-pull-arm64.json"',
-    );
+    expect(receipt.run).toContain('--sbom-amd64 "$evidence/llama-cpp-sbom-amd64.spdx.json"');
+    expect(receipt.run).toContain('--sbom-arm64 "$evidence/llama-cpp-sbom-arm64.spdx.json"');
+    expect(receipt.run).toContain('--anonymous-pull-amd64 "$evidence/anonymous-pull-amd64.json"');
+    expect(receipt.run).toContain('--anonymous-pull-arm64 "$evidence/anonymous-pull-arm64.json"');
     const publicationJobs = [
       "publish-platform",
       "assemble-candidate",

--- a/test/llama-cpp-image-workflow.test.ts
+++ b/test/llama-cpp-image-workflow.test.ts
@@ -110,18 +110,27 @@ function jobPermissionValues(workflowValue: Workflow): string[] {
 function runAnonymousPull(step: Step, result: "denied" | "success") {
   const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "llama-cpp-anonymous-pull-"));
   const fakeBin = path.join(temporaryRoot, "bin");
-  const invocationLog = path.join(temporaryRoot, "docker-invocation");
+  const invocationLog = path.join(temporaryRoot, "docker-invocations");
   const configLog = path.join(temporaryRoot, "docker-config");
   fs.mkdirSync(fakeBin);
   fs.writeFileSync(
     path.join(fakeBin, "docker"),
     `#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\n' "$*" > "$INVOCATION_LOG"
-printf '%s\n' "$DOCKER_CONFIG" > "$CONFIG_LOG"
-[ -z "\${DOCKER_AUTH_CONFIG+x}" ] || exit 91
-if [ "$RESULT" = "denied" ]; then
-  exit 37
+printf '%s\n' "$*" >> "$INVOCATION_LOG"
+if [ "$1" = "pull" ]; then
+  printf '%s\n' "$DOCKER_CONFIG" > "$CONFIG_LOG"
+  [ -z "\${DOCKER_AUTH_CONFIG+x}" ] || exit 91
+  if [ "$RESULT" = "denied" ]; then
+    exit 37
+  fi
+  exit 0
+elif [ "$*" = "image inspect --format {{.Id}} ghcr.io/nvidia/nemoclaw/llama-cpp-server@sha256:${"a".repeat(64)}" ]; then
+  printf 'sha256:%s\n' '${"b".repeat(64)}'
+elif [ "$*" = "image inspect --format {{.Id}} sha256:${"b".repeat(64)}" ]; then
+  printf 'sha256:%s\n' '${"b".repeat(64)}'
+else
+  exit 92
 fi
 `,
     { mode: 0o755 },
@@ -133,6 +142,7 @@ fi
       encoding: "utf8",
       env: {
         ...process.env,
+        ARCH: "arm64",
         CONFIG_LOG: configLog,
         DIGEST: `sha256:${"a".repeat(64)}`,
         DOCKER_AUTH_CONFIG: "must-not-reach-docker",
@@ -145,10 +155,18 @@ fi
       },
     });
     const anonymousConfig = fs.readFileSync(configLog, "utf8").trim();
+    const evidencePath = path.join(
+      temporaryRoot,
+      "llama-cpp-anonymous-pulls",
+      "anonymous-pull-arm64.json",
+    );
     return {
       ...commandResult,
       anonymousConfigWasRemoved: !fs.existsSync(anonymousConfig),
-      invocation: fs.readFileSync(invocationLog, "utf8").trim(),
+      evidence: fs.existsSync(evidencePath)
+        ? (JSON.parse(fs.readFileSync(evidencePath, "utf8")) as Record<string, unknown>)
+        : null,
+      invocations: fs.readFileSync(invocationLog, "utf8").trim().split("\n"),
     };
   } finally {
     fs.rmSync(temporaryRoot, { force: true, recursive: true });
@@ -311,6 +329,7 @@ describe("llama.cpp image PR workflow", () => {
     const exportDigest = namedStep(publish, "Export validated platform digest");
     const logout = namedStep(publish, "Remove GHCR publication credentials");
     const anonymousPull = namedStep(publish, "Verify anonymous exact platform pull");
+    const uploadAnonymousPull = namedStep(publish, "Upload anonymous pull evidence");
     const uploadDigest = namedStep(publish, "Upload platform digest");
     const assemble = required(
       workflow.jobs?.["assemble-candidate"],
@@ -357,6 +376,7 @@ describe("llama.cpp image PR workflow", () => {
       contents: "read",
       packages: "write",
     });
+    expect(publish["runs-on"]).toBe("${{ matrix.runner }}");
     expect(publish.strategy?.matrix).toBe("${{ fromJSON(needs.config.outputs.matrix) }}");
     expect(publishBuild.with?.outputs).toBe(
       "type=image,name=${{ needs.config.outputs.publication_repository }},push-by-digest=true,name-canonical=true,push=true",
@@ -391,8 +411,16 @@ describe("llama.cpp image PR workflow", () => {
       publish.steps?.indexOf(anonymousPull) ?? Number.POSITIVE_INFINITY,
     );
     expect(publish.steps?.indexOf(anonymousPull)).toBeLessThan(
+      publish.steps?.indexOf(uploadAnonymousPull) ?? Number.POSITIVE_INFINITY,
+    );
+    expect(publish.steps?.indexOf(uploadAnonymousPull)).toBeLessThan(
       publish.steps?.indexOf(uploadDigest) ?? Number.POSITIVE_INFINITY,
     );
+    expect(uploadAnonymousPull.with).toMatchObject({
+      name: "llama-cpp-anonymous-pull-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}",
+      path: "${{ runner.temp }}/llama-cpp-anonymous-pulls/anonymous-pull-${{ matrix.arch }}.json",
+      "if-no-files-found": "error",
+    });
     expect(assemble.needs).toEqual(["config", "publication-gate", "publish-platform"]);
     expect(assembleStep.run).toContain(
       'docker buildx imagetools create --tag "$IMAGE:$CANDIDATE_TAG" "${sources[@]}"',
@@ -447,9 +475,17 @@ describe("llama.cpp image PR workflow", () => {
 
     const accepted = runAnonymousPull(anonymousPull, "success");
     expect(accepted.status, accepted.stderr).toBe(0);
-    expect(accepted.invocation).toBe(
+    expect(accepted.invocations).toEqual([
       `pull --platform linux/arm64 ghcr.io/nvidia/nemoclaw/llama-cpp-server@sha256:${"a".repeat(64)}`,
-    );
+      `image inspect --format {{.Id}} ghcr.io/nvidia/nemoclaw/llama-cpp-server@sha256:${"a".repeat(64)}`,
+      `image inspect --format {{.Id}} sha256:${"b".repeat(64)}`,
+    ]);
+    expect(accepted.evidence).toEqual({
+      imageId: `sha256:${"b".repeat(64)}`,
+      platform: "linux/arm64",
+      platformDigest: `sha256:${"a".repeat(64)}`,
+      reference: `ghcr.io/nvidia/nemoclaw/llama-cpp-server@sha256:${"a".repeat(64)}`,
+    });
     expect(accepted.anonymousConfigWasRemoved).toBe(true);
 
     const rejected = runAnonymousPull(anonymousPull, "denied");
@@ -468,6 +504,7 @@ describe("llama.cpp image PR workflow", () => {
     const downloadSboms = namedStep(verify, "Download SPDX SBOMs");
     const crypto = namedStep(verify, "Verify cryptographic evidence");
     const receipt = namedStep(verify, "Verify publication evidence and create receipt");
+    const downloadAnonymousPull = namedStep(verify, "Download anonymous pull evidence");
 
     expect(scan.needs).toEqual(["config", "publication-gate", "assemble-candidate"]);
     expect(scanStep.uses).toBe("anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2");
@@ -510,12 +547,23 @@ describe("llama.cpp image PR workflow", () => {
       path: "${{ runner.temp }}/llama-cpp-evidence",
       "merge-multiple": true,
     });
+    expect(downloadAnonymousPull.with).toEqual({
+      pattern: "llama-cpp-anonymous-pull-${{ github.run_id }}-${{ github.run_attempt }}-*",
+      path: "${{ runner.temp }}/llama-cpp-evidence",
+      "merge-multiple": true,
+    });
     expect(receipt.run).toContain("scripts/checks/verify-llama-cpp-image-publication-evidence.sh");
     expect(receipt.run).toContain(
       '--sbom-amd64 "$evidence/llama-cpp-sbom-amd64.spdx.json"',
     );
     expect(receipt.run).toContain(
       '--sbom-arm64 "$evidence/llama-cpp-sbom-arm64.spdx.json"',
+    );
+    expect(receipt.run).toContain(
+      '--anonymous-pull-amd64 "$evidence/anonymous-pull-amd64.json"',
+    );
+    expect(receipt.run).toContain(
+      '--anonymous-pull-arm64 "$evidence/anonymous-pull-arm64.json"',
     );
     const publicationJobs = [
       "publish-platform",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The publication receipt verifier pulled both candidate platforms through one shared Docker daemon at the same multi-architecture digest, so Docker retained the amd64 reference and rejected the arm64 pull with `cannot overwrite digest`. This change records full anonymous-pull evidence in each isolated architecture publisher job and makes the final verifier validate those artifacts without reading or mutating shared Docker image state.

## Related Issue

Part of #8231. Prerequisite for #9592.

## Changes

- Record the exact platform digest, reference, and immutable image ID after each isolated architecture job completes its anonymous pull.
- Download and fail-closed validate both architecture evidence artifacts before binding them into the canonical receipt.
- Restrict the final verifier to stateless anonymous index inspection and prove it performs no Docker pull, image-inspection, or image-removal operations against shared daemon state.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Self-reviewed the anonymous registry boundary, immutable reference and image-ID bindings, architecture-job isolation, artifact download boundary, shared-daemon non-mutation, and fail-closed receipt behavior. This also addresses Carlos's review at https://github.com/NVIDIA/NemoClaw/pull/9857#pullrequestreview-4989963600.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run test/llama-cpp-image-publication-evidence.test.ts test/llama-cpp-image-workflow.test.ts --project integration` (20 passed); `npm run test:changed` (32 growth guardrails passed; no affected CLI, plugin, or E2E-support tests).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image publication checks now collect anonymous, platform-specific pull evidence for amd64 and arm64 images.
  * Verification confirms each image’s platform, digest, reference, and immutable image ID before publication.
  * Verification receipts now include the collected pull evidence.

* **Bug Fixes**
  * Improved publication validation by avoiding changes to shared Docker state during evidence verification.

* **Tests**
  * Expanded coverage for multi-platform evidence collection, artifact handling, and validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->