### PR TITLE
fix(sandbox): warn about active SSH sessions on pre-confirmed destroy

### DIFF
--- a/src/lib/actions/sandbox/destroy-confirmation.test.ts
+++ b/src/lib/actions/sandbox/destroy-confirmation.test.ts
@@ -28,7 +28,7 @@ describe("destroy confirmation", () => {
     await expect(confirmSandboxDestroy("test-sb", { yes: true })).resolves.toBe(true);
 
     const output = log.mock.calls.flat().join("\n");
-    expect(output).toContain("Active SSH session detected (1 connection)");
+    expect(output).toContain("Active SSH session detected (1 connection, PID 4242)");
     expect(output).toContain("terminate the active session with a Broken pipe error");
     expect(prompt).not.toHaveBeenCalled();
   });
@@ -40,7 +40,7 @@ describe("destroy confirmation", () => {
     await expect(confirmSandboxDestroy("test-sb", { force: true })).resolves.toBe(true);
 
     const output = log.mock.calls.flat().join("\n");
-    expect(output).toContain("Active SSH sessions detected (2 connections)");
+    expect(output).toContain("Active SSH sessions detected (2 connections, PIDs 4242, 4243)");
     expect(output).toContain("terminate all active sessions with a Broken pipe error");
   });
 
@@ -65,7 +65,7 @@ describe("destroy confirmation", () => {
     await expect(confirmSandboxDestroy("test-sb", {})).resolves.toBe(false);
 
     const output = log.mock.calls.flat().join("\n");
-    expect(output).toContain("Active SSH session detected (1 connection)");
+    expect(output).toContain("Active SSH session detected (1 connection, PID 4242)");
     expect(output.indexOf("Active SSH session detected")).toBeLessThan(
       output.indexOf("This cannot be undone."),
     );

--- a/src/lib/actions/sandbox/destroy-confirmation.test.ts
+++ b/src/lib/actions/sandbox/destroy-confirmation.test.ts
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as openshellResolve from "../../adapters/openshell/resolve";
+import * as credentialStore from "../../credentials/store";
+import * as sandboxSession from "../../state/sandbox-session";
+import { confirmSandboxDestroy } from "./destroy-confirmation";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function stubActiveSessions(pids: number[]): void {
+  vi.spyOn(openshellResolve, "resolveOpenshell").mockReturnValue("/usr/bin/openshell");
+  vi.spyOn(sandboxSession, "getActiveSandboxSessions").mockReturnValue({
+    detected: true,
+    sessions: pids.map((pid) => ({ sandboxName: "test-sb", pid, sshHost: "test-sb.default" })),
+  });
+}
+
+describe("destroy confirmation", () => {
+  it("warns about active sessions when --yes skips the prompt (#9855)", async () => {
+    stubActiveSessions([4242]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const prompt = vi.spyOn(credentialStore, "prompt");
+
+    await expect(confirmSandboxDestroy("test-sb", { yes: true })).resolves.toBe(true);
+
+    const output = log.mock.calls.flat().join("\n");
+    expect(output).toContain("Active SSH session detected (1 connection)");
+    expect(output).toContain("terminate the active session with a Broken pipe error");
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it("warns about active sessions when --force skips the prompt (#9855)", async () => {
+    stubActiveSessions([4242, 4243]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await expect(confirmSandboxDestroy("test-sb", { force: true })).resolves.toBe(true);
+
+    const output = log.mock.calls.flat().join("\n");
+    expect(output).toContain("Active SSH sessions detected (2 connections)");
+    expect(output).toContain("terminate all active sessions with a Broken pipe error");
+  });
+
+  it("stays silent on a pre-confirmed destroy with no active sessions (#9855)", async () => {
+    vi.spyOn(openshellResolve, "resolveOpenshell").mockReturnValue("/usr/bin/openshell");
+    vi.spyOn(sandboxSession, "getActiveSandboxSessions").mockReturnValue({
+      detected: true,
+      sessions: [],
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await expect(confirmSandboxDestroy("test-sb", { yes: true })).resolves.toBe(true);
+
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("prints the active-session warning before the interactive prompt", async () => {
+    stubActiveSessions([4242]);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(credentialStore, "prompt").mockResolvedValue("n");
+
+    await expect(confirmSandboxDestroy("test-sb", {})).resolves.toBe(false);
+
+    const output = log.mock.calls.flat().join("\n");
+    expect(output).toContain("Active SSH session detected (1 connection)");
+    expect(output.indexOf("Active SSH session detected")).toBeLessThan(
+      output.indexOf("This cannot be undone."),
+    );
+  });
+
+  it("treats an unavailable session detector as zero active sessions", async () => {
+    vi.spyOn(openshellResolve, "resolveOpenshell").mockReturnValue(null);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await expect(confirmSandboxDestroy("test-sb", { yes: true })).resolves.toBe(true);
+
+    expect(log.mock.calls.flat().join("\n")).not.toContain("Active SSH");
+  });
+});

--- a/src/lib/actions/sandbox/destroy-confirmation.ts
+++ b/src/lib/actions/sandbox/destroy-confirmation.ts
@@ -9,27 +9,34 @@ import { assertHermesPortableCommandUnavailable } from "../../onboard/experiment
 import {
   createSystemDeps as createSessionDeps,
   getActiveSandboxSessions,
+  type SandboxSession,
 } from "../../state/sandbox-session";
 
-function countActiveSandboxSessions(sandboxName: string): number {
+function findActiveSandboxSessions(sandboxName: string): SandboxSession[] {
   const opsBin = resolveOpenshell();
-  if (!opsBin) return 0;
+  if (!opsBin) return [];
   try {
     const result = getActiveSandboxSessions(sandboxName, createSessionDeps(opsBin));
-    return result.detected ? result.sessions.length : 0;
+    return result.detected ? result.sessions : [];
   } catch {
-    return 0;
+    return [];
   }
 }
 
-function printActiveSessionWarning(activeSessionCount: number): void {
-  if (activeSessionCount < 1) return;
-  const plural = activeSessionCount > 1 ? "sessions" : "session";
+function printActiveSessionWarning(sessions: SandboxSession[]): void {
+  if (sessions.length < 1) return;
+  const plural = sessions.length > 1 ? "sessions" : "session";
+  // #9855 asked for the detected PIDs, not just a count, so the operator can
+  // identify whose session is about to break before they confirm the destroy.
+  const pids =
+    sessions.length === 1
+      ? `PID ${sessions[0]?.pid}`
+      : `PIDs ${sessions.map((session) => session.pid).join(", ")}`;
   console.log(
-    `  ${YW}⚠  Active SSH ${plural} detected (${activeSessionCount} connection${activeSessionCount > 1 ? "s" : ""})${R}`,
+    `  ${YW}⚠  Active SSH ${plural} detected (${sessions.length} connection${sessions.length > 1 ? "s" : ""}, ${pids})${R}`,
   );
   console.log(
-    `  Destroying will terminate ${activeSessionCount === 1 ? "the" : "all"} active ${plural} with a Broken pipe error.`,
+    `  Destroying will terminate ${sessions.length === 1 ? "the" : "all"} active ${plural} with a Broken pipe error.`,
   );
 }
 
@@ -41,18 +48,18 @@ export async function confirmSandboxDestroy(
   sandboxName: string,
   options: DestroySandboxOptions,
 ): Promise<boolean> {
-  const activeSessionCount = countActiveSandboxSessions(sandboxName);
+  const activeSessions = findActiveSandboxSessions(sandboxName);
   // #9855: --yes/--force waives the confirmation prompt, not the notice that
   // this destroy is about to break somebody else's live SSH session. Without
   // this the operator sees no warning and the connected terminal just gets a
   // Broken pipe.
   if (options.yes === true || options.force === true) {
-    printActiveSessionWarning(activeSessionCount);
+    printActiveSessionWarning(activeSessions);
     return true;
   }
 
   console.log(`  ${YW}Destroy sandbox '${sandboxName}'?${R}`);
-  printActiveSessionWarning(activeSessionCount);
+  printActiveSessionWarning(activeSessions);
   console.log("  This will permanently delete the sandbox and all workspace files inside it.");
   console.log("  This cannot be undone.");
   const answer = await askPrompt("  Type 'yes' to confirm, or press Enter to cancel [y/N]: ");

--- a/src/lib/actions/sandbox/destroy-confirmation.ts
+++ b/src/lib/actions/sandbox/destroy-confirmation.ts
@@ -22,6 +22,17 @@ function countActiveSandboxSessions(sandboxName: string): number {
   }
 }
 
+function printActiveSessionWarning(activeSessionCount: number): void {
+  if (activeSessionCount < 1) return;
+  const plural = activeSessionCount > 1 ? "sessions" : "session";
+  console.log(
+    `  ${YW}⚠  Active SSH ${plural} detected (${activeSessionCount} connection${activeSessionCount > 1 ? "s" : ""})${R}`,
+  );
+  console.log(
+    `  Destroying will terminate ${activeSessionCount === 1 ? "the" : "all"} active ${plural} with a Broken pipe error.`,
+  );
+}
+
 export function assertSandboxDestroyCommandAvailable(sandboxName: string): void {
   assertHermesPortableCommandUnavailable(sandboxName, "sandbox:destroy");
 }
@@ -30,21 +41,18 @@ export async function confirmSandboxDestroy(
   sandboxName: string,
   options: DestroySandboxOptions,
 ): Promise<boolean> {
-  // Preserve the existing best-effort session probe even for pre-confirmed
-  // destroys; callers historically performed it before checking --yes/--force.
   const activeSessionCount = countActiveSandboxSessions(sandboxName);
-  if (options.yes === true || options.force === true) return true;
+  // #9855: --yes/--force waives the confirmation prompt, not the notice that
+  // this destroy is about to break somebody else's live SSH session. Without
+  // this the operator sees no warning and the connected terminal just gets a
+  // Broken pipe.
+  if (options.yes === true || options.force === true) {
+    printActiveSessionWarning(activeSessionCount);
+    return true;
+  }
 
   console.log(`  ${YW}Destroy sandbox '${sandboxName}'?${R}`);
-  if (activeSessionCount > 0) {
-    const plural = activeSessionCount > 1 ? "sessions" : "session";
-    console.log(
-      `  ${YW}⚠  Active SSH ${plural} detected (${activeSessionCount} connection${activeSessionCount > 1 ? "s" : ""})${R}`,
-    );
-    console.log(
-      `  Destroying will terminate ${activeSessionCount === 1 ? "the" : "all"} active ${plural} with a Broken pipe error.`,
-    );
-  }
+  printActiveSessionWarning(activeSessionCount);
   console.log("  This will permanently delete the sandbox and all workspace files inside it.");
   console.log("  This cannot be undone.");
   const answer = await askPrompt("  Type 'yes' to confirm, or press Enter to cancel [y/N]: ");


### PR DESCRIPTION
## Summary

`nemoclaw <sandbox> destroy --yes` terminated a live SSH session without printing any notice. `confirmSandboxDestroy()` probed for active sessions and then returned early on `--yes`/`--force`, so the probe result was discarded and the warning branch was unreachable. The operator saw a silent destroy while the connected terminal died with a Broken pipe. `--yes` and `--force` now waive the confirmation prompt only; the active-session warning prints on the pre-confirmed path as well.

## Related Issue

Closes #9855

## Changes

- `src/lib/actions/sandbox/destroy-confirmation.ts`: moved the active-session warning into `printActiveSessionWarning()` and called it on the `--yes`/`--force` branch before returning `true`. The interactive path prints the same text in the same position as before.
- `src/lib/actions/sandbox/destroy-confirmation.ts`: the warning now lists the detected PIDs, which the issue's Expected Result asks for. The session records already carried `pid` and the previous count discarded them. Rendering follows the existing repository idiom for a process list in `readiness/gateway-production.ts:569` (`PID 4242` for one, `PIDs 4242, 4243` for several).
- `src/lib/actions/sandbox/destroy-confirmation.test.ts`: new tests for the pre-confirmed warning, the singular and plural PID forms, the silent no-session case, warning order on the interactive path, and the unavailable-detector fallback.

Before and after, with one session connected:

```text
- (no output)
+   ⚠  Active SSH session detected (1 connection, PID 4242)
+   Destroying will terminate the active session with a Broken pipe error.
```

No new configuration, fallback, or compatibility path.

Scope note: `confirmSandboxRebuildIfNeeded()` in `rebuild-preflight-confirmation.ts` returns on `skipConfirm` before its own active-session block, which is the same shape. That path is not part of this issue's repro, so it is left unchanged here rather than widening the diff.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: requested from maintainers; the change is a console notice on the destroy confirmation path and does not alter destroy behavior, ordering, or return values.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/actions/sandbox/destroy-confirmation.test.ts` — 5 passed, including the singular `PID 4242` and plural `PIDs 4242, 4243` renderings. The two `#9855` warning tests fail on `main` before the fix and pass after it; the other three pass either way as regression guards. `npm run typecheck:cli`, `npm run checks:repository`, oxlint, and oxfmt are clean.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not applicable; the change is confined to one CLI action file and its co-located test.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Test platform

I did not test on DGX Spark. Verification ran on x86_64 Linux through the unit tests above. The reported device is DGX Spark aarch64 and I have no access to that hardware.

The defect itself is platform-independent. The early `return true` on `--yes`/`--force` preceded the warning on every platform, and this change touches only that control flow; nothing on the path branches on architecture or device.

One reviewer-relevant caveat: the warning prints only when host session detection reports a session. `findActiveSandboxSessions` fails open and reports no sessions when the probe cannot run, so a detection gap would still produce a silent destroy. That detection path is separate from the confirmation defect reported here and is not changed by this PR. QA rerunning the issue's steps on DGX Spark is the cleanest confirmation.

---

Signed-off-by: Dongni Yang <dongniy@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added warnings when active SSH sessions are detected before sandbox destruction.
  - Warnings now include the connection count and process IDs of active sessions.
  - Warnings appear consistently for interactive, `--yes`, and `--force` destruction modes.
  - Warning text reflects whether one or multiple sessions are active.

- **Bug Fixes**
  - Improved handling when session information is unavailable, treating it as no active sessions.
  - Silent behavior is preserved when pre-confirmed destruction has no active sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->