### PR TITLE
feat(cli): report probe stage timing

### DIFF
--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -637,9 +637,9 @@ describe("connectSandbox flow", () => {
       ["sandbox", "connect", "alpha"],
       expect.any(Object),
     );
-    expect(harness.logSpy.mock.calls.flat().join("\n")).toContain(
-      "Probe complete: recovered OpenClaw gateway in 'alpha'.",
-    );
+    const output = harness.logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Probe complete: recovered OpenClaw gateway in 'alpha'.");
+    expect(output).toMatch(/Probe timing: .*lifecycleAction=skipped .*result=ready/);
   });
 
   it("probe-only accepts healthy launch evidence without duplicate recovery or publication (#8942)", async () => {
@@ -658,8 +658,10 @@ describe("connectSandbox flow", () => {
     expect(harness.checkAndRecoverSpy).not.toHaveBeenCalled();
     expect(harness.ensureLiveSandboxSpy).not.toHaveBeenCalled();
     expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();
-    expect(harness.logSpy.mock.calls.flat().join("\n")).toContain(
-      "Probe complete: launch readiness is healthy for 'alpha'.",
+    const output = harness.logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Probe complete: launch readiness is healthy for 'alpha'.");
+    expect(output).toMatch(
+      /Probe timing: .*lifecycleAction=reused forwardAction=skipped result=ready/,
     );
   });
 
@@ -715,6 +717,9 @@ describe("connectSandbox flow", () => {
     expect(harness.checkAndRecoverSpy).not.toHaveBeenCalled();
     expect(harness.errorSpy.mock.calls.flat().join("\n")).toContain(
       "complete probe and recovery did not run because prior launch-readiness evidence could not be fenced",
+    );
+    expect(harness.logSpy.mock.calls.flat().join("\n")).toMatch(
+      /Probe timing: .*result=failed failedStage=readiness/,
     );
   });
 

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -92,8 +92,10 @@ import {
 import { getSandboxTargetGatewayName } from "./gateway-target";
 import { printGatewayWedgeDiagnostics } from "./gateway-wedge-diagnostics";
 import {
+  createProbeTimingRecorder,
   inspectLaunchReadiness,
   portableOpenClawPairingIncompleteMessage,
+  type ProbeTimingRecorder,
   publicationFromDecision,
   publishLaunchReadiness,
   settlePortableOpenClawPairing,
@@ -302,26 +304,39 @@ async function settlePortablePairingOrExit(sandboxName: string): Promise<boolean
 
 async function runSandboxConnectProbe(
   sandboxName: string,
-  { hermesPortable = false }: { hermesPortable?: boolean } = {},
+  {
+    hermesPortable = false,
+    probeTiming,
+  }: { hermesPortable?: boolean; probeTiming?: ProbeTimingRecorder } = {},
 ): Promise<void> {
+  const measure = <T>(stage: "inference" | "pairing", operation: () => T): T =>
+    probeTiming ? probeTiming.measure(stage, operation) : operation();
+  const measureAsync = <T>(
+    stage: "inference" | "pairing",
+    operation: () => Promise<T>,
+  ): Promise<T> => (probeTiming ? probeTiming.measureAsync(stage, operation) : operation());
   const agent = agentRuntime.getSessionAgent(sandboxName);
   const agentName = agentRuntime.getAgentDisplayName(agent);
   if (hermesPortable) {
-    verifyHermesPortableInferenceRouteOrExit(sandboxName, agent);
+    measure("inference", () => verifyHermesPortableInferenceRouteOrExit(sandboxName, agent));
     console.log(
       `  Probe complete: ${agentName} passed receipt-owned authenticated health in '${sandboxName}'.`,
     );
     return;
   }
   if (agent && !agentRuntime.hasGatewayRuntime(agent)) {
-    const routeResult = await ensureSandboxInferenceRoute(sandboxName, agent, { quiet: true });
-    runTerminalAgentConnectProbe({
-      agent,
-      agentName,
-      capture: captureOpenshell,
-      ensureInferenceRoute: () => routeResult,
-      sandboxName,
-    });
+    const routeResult = await measureAsync("inference", () =>
+      ensureSandboxInferenceRoute(sandboxName, agent, { quiet: true }),
+    );
+    measure("inference", () =>
+      runTerminalAgentConnectProbe({
+        agent,
+        agentName,
+        capture: captureOpenshell,
+        ensureInferenceRoute: () => routeResult,
+        sandboxName,
+      }),
+    );
     return;
   }
 
@@ -331,23 +346,28 @@ async function runSandboxConnectProbe(
   let recoveryFailureLayer: GatewayRestartFailureLayer | null = null;
   const processCheck = checkAndRecoverSandboxProcesses(sandboxName, {
     quiet: true,
+    probeTiming,
     onRecoveryFailureLayer: (layer) => {
       recoveryFailureLayer = layer;
     },
   });
   if (!processCheck.checked) {
+    probeTiming?.markFailureStage("processes");
     console.error(
       `  Probe failed: could not inspect the ${agentName} gateway inside sandbox '${sandboxName}'.`,
     );
     process.exit(1);
   }
   if ("secretBoundaryRefused" in processCheck && processCheck.secretBoundaryRefused) {
+    probeTiming?.markFailureStage("processes");
     exitOnSecretBoundaryRefusal(sandboxName, agentName, processCheck, "Probe");
   }
   if ("mcpReconciliationRefused" in processCheck && processCheck.mcpReconciliationRefused) {
+    probeTiming?.markFailureStage("processes");
     exitOnMcpReconciliationRefusal(sandboxName, agentName, processCheck, "Probe");
   }
   if ("forwardRecoveryFailed" in processCheck && processCheck.forwardRecoveryFailed) {
+    probeTiming?.markFailureStage("forward");
     const detail =
       "forwardRecoveryFailureDetail" in processCheck
         ? String(processCheck.forwardRecoveryFailureDetail)
@@ -360,6 +380,7 @@ async function runSandboxConnectProbe(
     );
   }
   if ("recoveryFailureDetail" in processCheck && processCheck.recoveryFailureDetail) {
+    probeTiming?.markFailureStage("processes");
     exitOnGatewayRecoveryFailure(
       sandboxName,
       agentName,
@@ -369,12 +390,12 @@ async function runSandboxConnectProbe(
     );
   }
   if (processCheck.wasRunning) {
-    await ensureSandboxInferenceRouteOrExit(sandboxName, agent);
+    await measureAsync("inference", () => ensureSandboxInferenceRouteOrExit(sandboxName, agent));
     // Defense-in-depth scope-upgrade approval on the probe-only / `recover`
     // path (#4504): the gateway is up, so deterministically clear any pending
     // allowlisted CLI/webchat scope upgrade. Best-effort; never throws.
-    if (!(await settlePortablePairingOrExit(sandboxName))) {
-      runConnectAutoPairApprovalPass(sandboxName);
+    if (!(await measureAsync("pairing", () => settlePortablePairingOrExit(sandboxName)))) {
+      measure("pairing", () => runConnectAutoPairApprovalPass(sandboxName));
     }
     if (processCheck.forwardRecovered) {
       console.log(
@@ -386,10 +407,10 @@ async function runSandboxConnectProbe(
     return;
   }
   if (processCheck.recovered) {
-    await ensureSandboxInferenceRouteOrExit(sandboxName, agent);
+    await measureAsync("inference", () => ensureSandboxInferenceRouteOrExit(sandboxName, agent));
     // Same defense-in-depth approval after a recovery (#4504); best-effort.
-    if (!(await settlePortablePairingOrExit(sandboxName))) {
-      runConnectAutoPairApprovalPass(sandboxName);
+    if (!(await measureAsync("pairing", () => settlePortablePairingOrExit(sandboxName)))) {
+      measure("pairing", () => runConnectAutoPairApprovalPass(sandboxName));
     }
     const managedControlCompletion =
       "managedControlCompletion" in processCheck
@@ -402,10 +423,11 @@ async function runSandboxConnectProbe(
     }
     return;
   }
-  await ensureSandboxInferenceRouteOrExit(sandboxName, agent);
+  await measureAsync("inference", () => ensureSandboxInferenceRouteOrExit(sandboxName, agent));
   console.error(
     `  Probe failed: ${agentName} gateway is not running in '${sandboxName}' and automatic recovery failed.`,
   );
+  probeTiming?.markFailureStage("processes");
   if (printGatewayIntegrityRepairGuidance(sandboxName, recoveryFailureLayer)) {
     process.exit(1);
   }
@@ -1327,33 +1349,41 @@ async function runConnectEntryPreflight(
   sandboxName: string,
   {
     probeOnly,
+    probeTiming,
     withinLifecycleFence,
   }: {
     probeOnly: boolean;
+    probeTiming?: ProbeTimingRecorder;
     withinLifecycleFence?: (route: {
       readonly hermesPortable: boolean;
       readonly requalify: () => void;
     }) => Promise<void>;
   },
 ): Promise<void> {
+  const measure = <T>(stage: "authority" | "lifecycle" | "gateway", operation: () => T): T =>
+    probeTiming ? probeTiming.measure(stage, operation) : operation();
+  const measureAsync = <T>(stage: "gateway", operation: () => Promise<T>): Promise<T> =>
+    probeTiming ? probeTiming.measureAsync(stage, operation) : operation();
   await withConnectSandboxLifecycleLock(sandboxName, async () => {
     let hermesPortable = false;
     let requalify = () => undefined;
     try {
-      assertNoOpenShellGatewayEndpointOverride();
-      const authority = qualifyPortableAgentLifecycleAuthority(
-        sandboxName,
-        portableAgentLifecycleAuthorityDeps(),
+      measure("authority", assertNoOpenShellGatewayEndpointOverride);
+      const authority = measure("authority", () =>
+        qualifyPortableAgentLifecycleAuthority(sandboxName, portableAgentLifecycleAuthorityDeps()),
       );
       hermesPortable = authority.kind === "hermes";
       let hermesAuthority = hermesPortable
-        ? requireHermesPortableActiveLifecycleAuthority(
-            sandboxName,
-            undefined,
-            portableAgentLifecycleAuthorityDeps(),
+        ? measure("authority", () =>
+            requireHermesPortableActiveLifecycleAuthority(
+              sandboxName,
+              undefined,
+              portableAgentLifecycleAuthorityDeps(),
+            ),
           )
         : null;
-      const registered = hermesAuthority?.entry ?? registry.getSandbox(sandboxName);
+      const registered =
+        hermesAuthority?.entry ?? measure("authority", () => registry.getSandbox(sandboxName));
       if (registered?.pendingRouteReservation === true) {
         throw new Error(
           `Sandbox '${sandboxName}' is still being created by onboarding. Wait for onboarding to finish or remove the incomplete sandbox before connecting.`,
@@ -1363,56 +1393,84 @@ async function runConnectEntryPreflight(
         ? resolveSandboxGatewayName(registered)
         : getSandboxTargetGatewayName(sandboxName);
       if (registered && registry.getSandboxEntryInference(registered).kind === "configured") {
-        assertSandboxGatewayRouteCompatible(sandboxName, registered, gatewayName);
+        measure("authority", () =>
+          assertSandboxGatewayRouteCompatible(sandboxName, registered, gatewayName),
+        );
       }
-      const initialRecovery = recoverPortableDemoSandboxLifecycleForConnect(
-        sandboxName,
-        registered,
-        gatewayName,
+      const initialRecovery = measure("lifecycle", () =>
+        recoverPortableDemoSandboxLifecycleForConnect(sandboxName, registered, gatewayName),
+      );
+      probeTiming?.setLifecycleAction(
+        initialRecovery.kind === "recovered"
+          ? "recovered"
+          : initialRecovery.kind === "already-running"
+            ? "reused"
+            : "skipped",
       );
       if (hermesPortable && initialRecovery.kind === "not-installed") {
+        probeTiming?.setLifecycleAction("failed");
+        probeTiming?.markFailureStage("lifecycle");
         throw new Error("Hermes portable lifecycle authority disappeared during connect");
       }
       if (hermesAuthority) {
-        hermesAuthority = requireHermesPortableActiveLifecycleAuthority(
-          sandboxName,
-          hermesAuthority,
-          portableAgentLifecycleAuthorityDeps(),
+        const currentAuthority = hermesAuthority;
+        hermesAuthority = measure("authority", () =>
+          requireHermesPortableActiveLifecycleAuthority(
+            sandboxName,
+            currentAuthority,
+            portableAgentLifecycleAuthorityDeps(),
+          ),
         );
       }
       requalify = () => {
         if (!hermesAuthority) {
           if (
-            qualifyPortableAgentLifecycleAuthority(
-              sandboxName,
-              portableAgentLifecycleAuthorityDeps(),
-            ).kind === authority.kind
+            measure(
+              "authority",
+              () =>
+                qualifyPortableAgentLifecycleAuthority(
+                  sandboxName,
+                  portableAgentLifecycleAuthorityDeps(),
+                ).kind,
+            ) === authority.kind
           ) {
             return;
           }
           throw new Error("portable lifecycle receipt authority changed during connect");
         }
-        hermesAuthority = requireHermesPortableActiveLifecycleAuthority(
-          sandboxName,
-          hermesAuthority,
-          portableAgentLifecycleAuthorityDeps(),
+        const currentAuthority = hermesAuthority;
+        hermesAuthority = measure("authority", () =>
+          requireHermesPortableActiveLifecycleAuthority(
+            sandboxName,
+            currentAuthority,
+            portableAgentLifecycleAuthorityDeps(),
+          ),
         );
-        const currentGateway = resolveSandboxGatewayName(hermesAuthority.entry);
-        const recovery = recoverPortableDemoSandboxLifecycleForConnect(
-          sandboxName,
-          hermesAuthority.entry,
-          currentGateway,
+        const activeAuthority = hermesAuthority;
+        const currentGateway = resolveSandboxGatewayName(activeAuthority.entry);
+        const recovery = measure("lifecycle", () =>
+          recoverPortableDemoSandboxLifecycleForConnect(
+            sandboxName,
+            activeAuthority.entry,
+            currentGateway,
+          ),
         );
         if (recovery.kind === "not-installed") {
+          probeTiming?.setLifecycleAction("failed");
+          probeTiming?.markFailureStage("lifecycle");
           throw new Error("Hermes portable lifecycle authority disappeared during connect");
         }
-        hermesAuthority = requireHermesPortableActiveLifecycleAuthority(
-          sandboxName,
-          hermesAuthority,
-          portableAgentLifecycleAuthorityDeps(),
+        const recoveredAuthority = activeAuthority;
+        hermesAuthority = measure("authority", () =>
+          requireHermesPortableActiveLifecycleAuthority(
+            sandboxName,
+            recoveredAuthority,
+            portableAgentLifecycleAuthorityDeps(),
+          ),
         );
       };
     } catch (error) {
+      probeTiming?.markFailureStage("authority");
       console.error(`  Error: ${error instanceof Error ? error.message : String(error)}`);
       process.exit(1);
     }
@@ -1422,10 +1480,12 @@ async function runConnectEntryPreflight(
     // a stale NEMOCLAW_VLLM_MODEL.
     if (!probeOnly && !hermesPortable) preflightVllmModelEnvOrExit();
     if (!hermesPortable) {
-      const live = await ensureLiveSandboxOrExit(sandboxName, {
-        allowNonReadyPhase: true,
-        gatewayRecovery: probeOnly ? "observe" : "recover",
-      });
+      const live = await measureAsync("gateway", () =>
+        ensureLiveSandboxOrExit(sandboxName, {
+          allowNonReadyPhase: true,
+          gatewayRecovery: probeOnly ? "observe" : "recover",
+        }),
+      );
       const livePhase = parseSandboxPhase(live.output || "");
       if (
         livePhase &&
@@ -1434,6 +1494,7 @@ async function runConnectEntryPreflight(
         !isTerminalSandboxPhase(livePhase) &&
         isDockerRuntimeDown(sandboxName)
       ) {
+        probeTiming?.markFailureStage("gateway");
         failConnectReadinessDockerRuntimeDown(sandboxName);
       }
     }
@@ -1579,30 +1640,52 @@ export async function connectSandbox(
   sandboxName: string,
   options: SandboxConnectOptions = {},
 ): Promise<void> {
-  const started = await withConnectSandboxLifecycleLock(sandboxName, async () => {
-    const prepared = await prepareConnectSandboxWithinLifecycleFence(sandboxName, options);
-    if (!prepared) return null;
-    return {
-      completion: runConnectChildWithShieldsRelockNotice(
-        prepared.binary,
-        prepared.args,
-        {
-          hostCwd: ROOT,
-          stdin: true,
-          ...(prepared.hostEnv ? { hostEnv: prepared.hostEnv } : {}),
-        },
+  const probeTiming = options.probeOnly ? createProbeTimingRecorder() : undefined;
+  const finishOnExit = (code: number): void => {
+    probeTiming?.finishOnExit(
+      code === 0 ? "ready" : "failed",
+      probeTiming.activeStage() ?? undefined,
+    );
+  };
+  if (probeTiming) process.once("exit", finishOnExit);
+  try {
+    const started = await withConnectSandboxLifecycleLock(sandboxName, async () => {
+      const prepared = await prepareConnectSandboxWithinLifecycleFence(
         sandboxName,
-        prepared.watchShields,
-      ),
-    };
-  });
-  if (!started) return;
+        options,
+        probeTiming,
+      );
+      if (!prepared) return null;
+      return {
+        completion: runConnectChildWithShieldsRelockNotice(
+          prepared.binary,
+          prepared.args,
+          {
+            hostCwd: ROOT,
+            stdin: true,
+            ...(prepared.hostEnv ? { hostEnv: prepared.hostEnv } : {}),
+          },
+          sandboxName,
+          prepared.watchShields,
+        ),
+      };
+    });
+    if (!started) {
+      probeTiming?.finish("ready");
+      return;
+    }
 
-  // Start the selected child under the lifecycle lock, then release the lock
-  // before waiting for an interactive shell that can remain open indefinitely.
-  const result = await started.completion;
-  result.releaseSignals?.();
-  exitWithConnectSpawnResult(sandboxName, result);
+    // Start the selected child under the lifecycle lock, then release the lock
+    // before waiting for an interactive shell that can remain open indefinitely.
+    const result = await started.completion;
+    result.releaseSignals?.();
+    exitWithConnectSpawnResult(sandboxName, result);
+  } catch (error) {
+    probeTiming?.finish("failed", probeTiming.activeStage() ?? undefined);
+    throw error;
+  } finally {
+    if (probeTiming) process.off("exit", finishOnExit);
+  }
 }
 
 type PreparedConnectChild = {
@@ -1615,43 +1698,59 @@ type PreparedConnectChild = {
 async function prepareConnectSandboxWithinLifecycleFence(
   sandboxName: string,
   { probeOnly = false, requireLaunchReadinessPublication = true }: SandboxConnectOptions,
+  probeTiming?: ProbeTimingRecorder,
 ): Promise<PreparedConnectChild | null> {
   if (probeOnly) {
-    let readiness = await inspectLaunchReadiness(sandboxName);
+    let readiness = await probeTiming!.measureAsync("readiness", () =>
+      inspectLaunchReadiness(sandboxName),
+    );
     let publication: Awaited<ReturnType<typeof publishLaunchReadiness>>;
     while (true) {
       if (readiness.kind === "accepted") {
-        const authority = qualifyPortableAgentLifecycleAuthority(
-          sandboxName,
-          portableAgentLifecycleAuthorityDeps(),
-        );
-        if (authority.kind === "hermes") {
-          let activeAuthority = requireHermesPortableActiveLifecycleAuthority(
+        const acceptedReadiness = readiness;
+        const authority = probeTiming!.measure("authority", () =>
+          qualifyPortableAgentLifecycleAuthority(
             sandboxName,
-            undefined,
             portableAgentLifecycleAuthorityDeps(),
+          ),
+        );
+        probeTiming!.setLifecycleAction("reused");
+        if (authority.kind === "hermes") {
+          let activeAuthority = probeTiming!.measure("authority", () =>
+            requireHermesPortableActiveLifecycleAuthority(
+              sandboxName,
+              undefined,
+              portableAgentLifecycleAuthorityDeps(),
+            ),
           );
           const registered = activeAuthority.entry;
           const gatewayName = resolveSandboxGatewayName(registered);
-          const recovery = recoverPortableDemoSandboxLifecycleForConnect(
-            sandboxName,
-            registered,
-            gatewayName,
+          const recovery = probeTiming!.measure("lifecycle", () =>
+            recoverPortableDemoSandboxLifecycleForConnect(sandboxName, registered, gatewayName),
           );
           if (recovery.kind === "not-installed") {
+            probeTiming!.setLifecycleAction("failed");
+            probeTiming!.markFailureStage("lifecycle");
             throw new Error("Hermes portable lifecycle authority disappeared during probe");
           }
-          activeAuthority = requireHermesPortableActiveLifecycleAuthority(
-            sandboxName,
-            activeAuthority,
-            portableAgentLifecycleAuthorityDeps(),
+          probeTiming!.setLifecycleAction(recovery.kind === "recovered" ? "recovered" : "reused");
+          activeAuthority = probeTiming!.measure("authority", () =>
+            requireHermesPortableActiveLifecycleAuthority(
+              sandboxName,
+              activeAuthority,
+              portableAgentLifecycleAuthorityDeps(),
+            ),
           );
-          const verified = verifyHermesPortableInferenceRouteOrExit(
-            sandboxName,
-            readiness.agent,
-            activeAuthority,
+          const verified = probeTiming!.measure("inference", () =>
+            verifyHermesPortableInferenceRouteOrExit(
+              sandboxName,
+              acceptedReadiness.agent,
+              activeAuthority,
+            ),
           );
-          assertHermesPortableLifecycleForConnect(sandboxName, verified, gatewayName);
+          probeTiming!.measure("authority", () =>
+            assertHermesPortableLifecycleForConnect(sandboxName, verified, gatewayName),
+          );
         }
         console.log(`  Probe complete: launch readiness is healthy for '${sandboxName}'.`);
         return null;
@@ -1667,6 +1766,7 @@ async function prepareConnectSandboxWithinLifecycleFence(
         readiness.authorityUnsupported !== true &&
         readiness.recoveryBlocked
       ) {
+        probeTiming!.markFailureStage("readiness");
         console.error(
           "  Probe failed: complete probe and recovery did not run because prior launch-readiness evidence could not be fenced. Repair the current user's secure OS runtime authority and NemoClaw state permissions, then retry.",
         );
@@ -1676,38 +1776,52 @@ async function prepareConnectSandboxWithinLifecycleFence(
       const gated = await withLaunchReadinessMutationGate(publicationRequest, async () => {
         await runConnectEntryPreflight(sandboxName, {
           probeOnly: true,
+          probeTiming,
           withinLifecycleFence: async ({ hermesPortable, requalify }) => {
             // Restart a stopped container before the readiness wait. Without this step,
             // OpenShell keeps reporting the stopped sandbox until the wait expires (#8967).
-            if (!hermesPortable) startStoppedSandboxContainerForProbeRecovery(sandboxName);
-            waitForSandboxReadyOrExit(sandboxName, {
-              allowDockerRuntimeInspection: !hermesPortable,
-              captureSandboxList: hermesPortable
-                ? (args, captureOptions) =>
-                    captureHermesPortableOpenShell(sandboxName, args, captureOptions)
-                : undefined,
-              defaultTimeoutSec: SANDBOX_REPAIR_READY_TIMEOUT_SEC,
-              retryCommand: "connect --probe-only",
-            });
+            if (!hermesPortable) {
+              probeTiming!.measure("lifecycle", () =>
+                startStoppedSandboxContainerForProbeRecovery(sandboxName),
+              );
+            }
+            probeTiming!.measure("gateway", () =>
+              waitForSandboxReadyOrExit(sandboxName, {
+                allowDockerRuntimeInspection: !hermesPortable,
+                captureSandboxList: hermesPortable
+                  ? (args, captureOptions) =>
+                      captureHermesPortableOpenShell(sandboxName, args, captureOptions)
+                  : undefined,
+                defaultTimeoutSec: SANDBOX_REPAIR_READY_TIMEOUT_SEC,
+                retryCommand: "connect --probe-only",
+              }),
+            );
             // Re-pin and re-observe the owning gateway after a potentially long wait
             // before any in-sandbox process or host-forward mutation. The readiness
             // polls are already scoped to the owning gateway; this also catches
             // registry changes.
             if (!hermesPortable) {
-              await ensureLiveSandboxOrExit(sandboxName, { gatewayRecovery: "observe" });
+              await probeTiming!.measureAsync("gateway", () =>
+                ensureLiveSandboxOrExit(sandboxName, { gatewayRecovery: "observe" }),
+              );
             }
             requalify();
-            await runSandboxConnectProbe(sandboxName, { hermesPortable });
+            await runSandboxConnectProbe(sandboxName, { hermesPortable, probeTiming });
             requalify();
           },
         });
-        return publishLaunchReadiness(publicationRequest);
+        return probeTiming!.measureAsync("publication", () =>
+          publishLaunchReadiness(publicationRequest),
+        );
       });
       if (gated.kind === "changed") {
-        readiness = await inspectLaunchReadiness(sandboxName);
+        readiness = await probeTiming!.measureAsync("readiness", () =>
+          inspectLaunchReadiness(sandboxName),
+        );
         continue;
       }
       if (gated.kind === "unsafe") {
+        probeTiming!.markFailureStage("publication");
         console.error(
           "  Probe failed: complete probe and recovery did not run because the current launch-readiness epoch could not be safely revalidated. Repair the current user's secure OS runtime authority and NemoClaw state permissions, then retry.",
         );
@@ -1717,6 +1831,7 @@ async function prepareConnectSandboxWithinLifecycleFence(
       break;
     }
     if (publication.kind === "validation-failed") {
+      probeTiming!.markFailureStage("publication");
       const failedCheck = publication.failedCheck
         ? ` because the ${publication.failedCheck} failed`
         : ` due to ${publication.category}`;
@@ -1736,6 +1851,7 @@ async function prepareConnectSandboxWithinLifecycleFence(
         );
         return null;
       }
+      probeTiming!.markFailureStage("publication");
       console.error(
         "  Probe failed: complete probe and recovery succeeded, but final launch-readiness evidence could not be verified or published.",
       );

--- a/src/lib/actions/sandbox/launch-readiness.ts
+++ b/src/lib/actions/sandbox/launch-readiness.ts
@@ -63,6 +63,8 @@ import {
   type OpenClawPairingSettlementObservation,
 } from "./launch-readiness/openclaw-pairing-qualification";
 
+export { createProbeTimingRecorder, type ProbeTimingRecorder } from "./probe/timing";
+
 const LIVE_POLICY_MAX_BYTES = 2 * 1_024 * 1_024;
 const ALLOWED_OPENSHELL_DRIVERS = new Set(["docker", "kubernetes", "vm"]);
 

--- a/src/lib/actions/sandbox/probe/timing.test.ts
+++ b/src/lib/actions/sandbox/probe/timing.test.ts
@@ -61,6 +61,23 @@ describe("probe timing recorder", () => {
     expect(lines[0]).not.toContain("secret-token-value");
   });
 
+  it("emits one failed line when exit completion runs before normal completion", () => {
+    let clock = 0;
+    const lines: string[] = [];
+    const recorder = createProbeTimingRecorder({
+      now: () => clock,
+      write: (line) => lines.push(line),
+    });
+
+    clock = 7;
+    recorder.finishOnExit("failed", "forward");
+    recorder.finish("ready");
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("total=7ms");
+    expect(lines[0]).toContain("result=failed failedStage=forward");
+  });
+
   it("never changes the measured operation when its clock or writer fails", async () => {
     const writer = vi.fn(() => {
       throw new Error("writer failed");

--- a/src/lib/actions/sandbox/probe/timing.test.ts
+++ b/src/lib/actions/sandbox/probe/timing.test.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createProbeTimingRecorder } from "./timing";
+
+describe("probe timing recorder", () => {
+  it("emits one stable bounded success line with every stage and action", async () => {
+    let clock = 0;
+    const lines: string[] = [];
+    const recorder = createProbeTimingRecorder({
+      now: () => clock,
+      write: (line) => lines.push(line),
+    });
+
+    expect(
+      recorder.measure("readiness", () => {
+        clock = 5;
+        return "ready";
+      }),
+    ).toBe("ready");
+    await expect(
+      recorder.measureAsync("gateway", async () => {
+        clock = 17;
+        return "healthy";
+      }),
+    ).resolves.toBe("healthy");
+    recorder.setLifecycleAction("reused");
+    recorder.setForwardAction("restored");
+    clock = 20;
+    recorder.finish("ready");
+    recorder.finishOnExit("failed", "publication");
+
+    expect(lines).toEqual([
+      "  Probe timing: readiness=5ms authority=0ms lifecycle=0ms gateway=12ms processes=0ms forward=0ms inference=0ms pairing=0ms publication=0ms total=20ms lifecycleAction=reused forwardAction=restored result=ready",
+    ]);
+  });
+
+  it("records the first failing stage without leaking the thrown error", () => {
+    let clock = 0;
+    const lines: string[] = [];
+    const recorder = createProbeTimingRecorder({
+      now: () => clock,
+      write: (line) => lines.push(line),
+    });
+
+    expect(() =>
+      recorder.measure("forward", () => {
+        clock = 9;
+        throw new Error("secret-token-value");
+      }),
+    ).toThrow("secret-token-value");
+    recorder.markFailureStage("publication");
+    clock = 11;
+    recorder.finish("failed");
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("forward=9ms");
+    expect(lines[0]).toContain("result=failed failedStage=forward");
+    expect(lines[0]).not.toContain("secret-token-value");
+  });
+
+  it("never changes the measured operation when its clock or writer fails", async () => {
+    const writer = vi.fn(() => {
+      throw new Error("writer failed");
+    });
+    const recorder = createProbeTimingRecorder({
+      now: () => {
+        throw new Error("clock failed");
+      },
+      write: writer,
+    });
+
+    expect(recorder.measure("authority", () => 42)).toBe(42);
+    await expect(recorder.measureAsync("inference", async () => "ok")).resolves.toBe("ok");
+    expect(() => recorder.finish("ready")).not.toThrow();
+    expect(writer).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/actions/sandbox/probe/timing.ts
+++ b/src/lib/actions/sandbox/probe/timing.ts
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { writeSync } from "node:fs";
+
+export const PROBE_TIMING_STAGES = [
+  "readiness",
+  "authority",
+  "lifecycle",
+  "gateway",
+  "processes",
+  "forward",
+  "inference",
+  "pairing",
+  "publication",
+] as const;
+
+export type ProbeTimingStage = (typeof PROBE_TIMING_STAGES)[number];
+export type ProbeTimingResult = "ready" | "failed";
+export type ProbeLifecycleAction = "skipped" | "reused" | "recovered" | "failed";
+export type ProbeForwardAction = "skipped" | "verified" | "restored" | "failed";
+
+export type ProbeTimingRecorder = {
+  measure<T>(stage: ProbeTimingStage, operation: () => T): T;
+  measureAsync<T>(stage: ProbeTimingStage, operation: () => Promise<T>): Promise<T>;
+  setLifecycleAction(action: ProbeLifecycleAction): void;
+  setForwardAction(action: ProbeForwardAction): void;
+  markFailureStage(stage: ProbeTimingStage): void;
+  finish(result: ProbeTimingResult, failedStage?: ProbeTimingStage): void;
+  finishOnExit(result: ProbeTimingResult, failedStage?: ProbeTimingStage): void;
+  activeStage(): ProbeTimingStage | null;
+};
+
+type ProbeTimingDeps = {
+  now?: () => number;
+  write?: (line: string) => void;
+};
+
+function safeElapsed(startedAt: number | null, finishedAt: number | null): number {
+  if (startedAt === null || finishedAt === null) return 0;
+  return Math.max(0, Math.round(finishedAt - startedAt));
+}
+
+/**
+ * Record one bounded, credential-free timing line for `connect --probe-only`.
+ * Every diagnostic operation is fail-open so observability can never alter the
+ * probe result or hide its original failure.
+ */
+export function createProbeTimingRecorder(deps: ProbeTimingDeps = {}): ProbeTimingRecorder {
+  const now = deps.now ?? (() => performance.now());
+  const write = deps.write ?? ((line: string) => console.log(line));
+  const writeOnExit = deps.write ?? ((line: string) => writeSync(1, `${line}\n`));
+  const durations = new Map<ProbeTimingStage, number>();
+  const active: ProbeTimingStage[] = [];
+  let lifecycleAction: ProbeLifecycleAction = "skipped";
+  let forwardAction: ProbeForwardAction = "skipped";
+  let recordedFailureStage: ProbeTimingStage | null = null;
+  let finished = false;
+
+  const safeNow = (): number | null => {
+    try {
+      const value = now();
+      return Number.isFinite(value) ? value : null;
+    } catch {
+      return null;
+    }
+  };
+  const totalStartedAt = safeNow();
+
+  const record = <T>(stage: ProbeTimingStage, operation: () => T): T => {
+    const startedAt = safeNow();
+    active.push(stage);
+    try {
+      return operation();
+    } catch (error) {
+      recordedFailureStage ??= stage;
+      throw error;
+    } finally {
+      active.pop();
+      const elapsed = safeElapsed(startedAt, safeNow());
+      durations.set(stage, (durations.get(stage) ?? 0) + elapsed);
+    }
+  };
+
+  const recordAsync = async <T>(
+    stage: ProbeTimingStage,
+    operation: () => Promise<T>,
+  ): Promise<T> => {
+    const startedAt = safeNow();
+    active.push(stage);
+    try {
+      return await operation();
+    } catch (error) {
+      recordedFailureStage ??= stage;
+      throw error;
+    } finally {
+      active.pop();
+      const elapsed = safeElapsed(startedAt, safeNow());
+      durations.set(stage, (durations.get(stage) ?? 0) + elapsed);
+    }
+  };
+
+  const emit = (
+    result: ProbeTimingResult,
+    failedStage: ProbeTimingStage | undefined,
+    writeLine: (line: string) => void,
+  ): void => {
+    if (finished) return;
+    finished = true;
+    try {
+      const totalMs = safeElapsed(totalStartedAt, safeNow());
+      const stageFields = PROBE_TIMING_STAGES.map(
+        (stage) => `${stage}=${String(durations.get(stage) ?? 0)}ms`,
+      );
+      const failure =
+        result === "failed"
+          ? ` failedStage=${failedStage ?? recordedFailureStage ?? active[active.length - 1] ?? "unknown"}`
+          : "";
+      writeLine(
+        `  Probe timing: ${stageFields.join(" ")} total=${String(totalMs)}ms lifecycleAction=${lifecycleAction} forwardAction=${forwardAction} result=${result}${failure}`,
+      );
+    } catch {
+      // Timing output must never change the probe's status or error message.
+    }
+  };
+  const finish = (result: ProbeTimingResult, failedStage?: ProbeTimingStage): void =>
+    emit(result, failedStage, write);
+
+  return {
+    measure: record,
+    measureAsync: recordAsync,
+    setLifecycleAction(action: ProbeLifecycleAction): void {
+      lifecycleAction = action;
+    },
+    setForwardAction(action: ProbeForwardAction): void {
+      forwardAction = action;
+    },
+    markFailureStage(stage: ProbeTimingStage): void {
+      recordedFailureStage ??= stage;
+    },
+    finish,
+    finishOnExit(result: ProbeTimingResult, failedStage?: ProbeTimingStage): void {
+      emit(result, failedStage, writeOnExit);
+    },
+    activeStage: () => active[active.length - 1] ?? null,
+  };
+}

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -72,7 +72,6 @@ import {
   type ManagedSupervisorRelaunch,
   relaunchManagedSupervisorSession,
 } from "./supervisor-relaunch";
-
 export type { SandboxForwardHealth, SandboxForwardListEntry } from "./forward-health";
 export {
   classifyForwardHealthWithReachability,
@@ -90,6 +89,11 @@ export type {
 export { buildSandboxExecMarkedCommand } from "./sandbox-exec-output";
 
 export type { SandboxCommandResult, SandboxExecCommandOptions };
+
+type ProcessRecoveryProbeTiming = {
+  measure<T>(stage: "processes" | "forward", operation: () => T): T;
+  setForwardAction(action: "skipped" | "verified" | "restored" | "failed"): void;
+};
 
 function commandTransportDependencies(): CommandTransportDependencies {
   return {
@@ -1344,6 +1348,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     waitForRecreatedSandboxOpenShellReadyImpl = waitForRecreatedSandboxOpenShellReady,
     isWsl: isWslOverride,
     onRecoveryFailureLayer,
+    probeTiming,
   }: {
     quiet?: boolean;
     requestGatewaySupervisorAction?: typeof executeGatewaySupervisorAction;
@@ -1353,8 +1358,11 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     waitForRecreatedSandboxOpenShellReadyImpl?: typeof waitForRecreatedSandboxOpenShellReady;
     isWsl?: boolean;
     onRecoveryFailureLayer?: (layer: GatewayRestartFailureLayer | null, detail?: string) => void;
+    probeTiming?: ProcessRecoveryProbeTiming;
   } = {},
 ) {
+  const measure = <T>(stage: "processes" | "forward", operation: () => T): T =>
+    probeTiming ? probeTiming.measure(stage, operation) : operation();
   const recoveryAgent = agentRuntime.getSessionAgent(sandboxName);
   const recoveryDisplayName = recoveryAgentDisplayName(sandboxName, recoveryAgent);
   if (recoveryAgent && !agentRuntime.hasGatewayRuntime(recoveryAgent)) {
@@ -1366,7 +1374,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
       runtime: "terminal" as const,
     };
   }
-  const running = isSandboxGatewayRunningImpl(sandboxName);
+  const running = measure("processes", () => isSandboxGatewayRunningImpl(sandboxName));
   if (running === null) {
     return { checked: false, wasRunning: null, recovered: false, forwardRecovered: false };
   }
@@ -1394,22 +1402,28 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     // Gateway is alive but the host-side forward can still be dead or
     // owned by another sandbox. Probe and re-establish only when
     // necessary so the live-and-healthy path stays a no-op.
-    const forwardHealthy = isSandboxForwardHealthy(sandboxName, { isWsl: isWslOverride });
+    const forwardHealthy = measure("forward", () =>
+      isSandboxForwardHealthy(sandboxName, { isWsl: isWslOverride }),
+    );
     if (forwardHealthy === false) {
       if (!quiet) {
         console.log("");
         console.log(`  Dashboard port forward to '${sandboxName}' is missing or dead.`);
         console.log("  Re-establishing...");
       }
-      const forwardRecovered = ensureSandboxPortForward(sandboxName, { isWsl: isWslOverride });
-      const dashboardForwardRecovered = ensureHermesDashboardPortForwardIfEnabled(sandboxName);
-      const messagingForwardRecovered = recoverMessagingHostForward(sandboxName, { quiet });
-      const declaredForwardsRecovered = recoverDeclaredAgentForwardPorts(
-        sandboxName,
-        recoveryPort,
-        {
+      const forwardRecovered = measure("forward", () =>
+        ensureSandboxPortForward(sandboxName, { isWsl: isWslOverride }),
+      );
+      const dashboardForwardRecovered = measure("forward", () =>
+        ensureHermesDashboardPortForwardIfEnabled(sandboxName),
+      );
+      const messagingForwardRecovered = measure("forward", () =>
+        recoverMessagingHostForward(sandboxName, { quiet }),
+      );
+      const declaredForwardsRecovered = measure("forward", () =>
+        recoverDeclaredAgentForwardPorts(sandboxName, recoveryPort, {
           quiet,
-        },
+        }),
       );
       const auxiliaryResults = [
         { label: "the Hermes dashboard host forward", recovered: dashboardForwardRecovered },
@@ -1431,6 +1445,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
         }
       }
       if (!forwardRecovered) {
+        probeTiming?.setForwardAction("failed");
         return {
           checked: true,
           wasRunning: true,
@@ -1442,6 +1457,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
         };
       }
       if (auxiliaryFailureDetail !== null) {
+        probeTiming?.setForwardAction("failed");
         if (!quiet) console.error(`  ${auxiliaryFailureDetail}.`);
         return {
           checked: true,
@@ -1452,6 +1468,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
           forwardRecoveryFailureDetail: auxiliaryFailureDetail,
         };
       }
+      probeTiming?.setForwardAction("restored");
       return {
         checked: true,
         wasRunning: true,
@@ -1460,6 +1477,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
       };
     }
     if (forwardHealthy === "occupied") {
+      probeTiming?.setForwardAction("failed");
       if (!quiet) {
         console.log("");
         console.error(`  Dashboard port forward for '${sandboxName}' is owned by another sandbox.`);
@@ -1476,6 +1494,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
       };
     }
     if (forwardHealthy === null) {
+      probeTiming?.setForwardAction("failed");
       return {
         checked: true,
         wasRunning: true,
@@ -1486,11 +1505,15 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
           "the primary dashboard/API host forward could not be verified because OpenShell forward state was unavailable",
       };
     }
-    const dashboardForwardRecovered = ensureHermesDashboardPortForwardIfEnabled(sandboxName);
-    const messagingForwardRecovered = recoverMessagingHostForward(sandboxName, { quiet });
-    const declaredForwardsRecovered = recoverDeclaredAgentForwardPorts(sandboxName, recoveryPort, {
-      quiet,
-    });
+    const dashboardForwardRecovered = measure("forward", () =>
+      ensureHermesDashboardPortForwardIfEnabled(sandboxName),
+    );
+    const messagingForwardRecovered = measure("forward", () =>
+      recoverMessagingHostForward(sandboxName, { quiet }),
+    );
+    const declaredForwardsRecovered = measure("forward", () =>
+      recoverDeclaredAgentForwardPorts(sandboxName, recoveryPort, { quiet }),
+    );
     const auxiliaryResults = [
       { label: "the Hermes dashboard host forward", recovered: dashboardForwardRecovered },
       { label: "the messaging webhook host forward", recovered: messagingForwardRecovered },
@@ -1498,6 +1521,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     ];
     const auxiliaryFailureDetail = auxiliaryRecoveryFailureDetail(auxiliaryResults);
     if (auxiliaryFailureDetail !== null) {
+      probeTiming?.setForwardAction("failed");
       if (!quiet) console.error(`  ${auxiliaryFailureDetail}.`);
       return {
         checked: true,
@@ -1508,6 +1532,9 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
         forwardRecoveryFailureDetail: auxiliaryFailureDetail,
       };
     }
+    probeTiming?.setForwardAction(
+      anyAuxiliaryRecovered(auxiliaryResults) ? "restored" : "verified",
+    );
     return {
       checked: true,
       wasRunning: true,
@@ -1527,16 +1554,18 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
 
   let managedRecoveryFailureLayer: GatewayRestartFailureLayer | null = null;
   let managedRecoveryFailureDetail: string | null = null;
-  const recovery = recoverSandboxProcesses(sandboxName, {
-    quiet,
-    requestGatewaySupervisorAction,
-    requestPinnedGatewaySupervisorAction,
-    relaunchManagedSupervisorSessionImpl,
-    onFailureLayer: (layer, detail) => {
-      managedRecoveryFailureLayer = layer;
-      managedRecoveryFailureDetail = detail;
-    },
-  });
+  const recovery = measure("processes", () =>
+    recoverSandboxProcesses(sandboxName, {
+      quiet,
+      requestGatewaySupervisorAction,
+      requestPinnedGatewaySupervisorAction,
+      relaunchManagedSupervisorSessionImpl,
+      onFailureLayer: (layer, detail) => {
+        managedRecoveryFailureLayer = layer;
+        managedRecoveryFailureDetail = detail;
+      },
+    }),
+  );
   if (recovery !== null) {
     const withManagedControlCompletion = <T extends { recovered: true }>(
       result: T,
@@ -1583,18 +1612,20 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
     // recovered process can be alive before the OpenAI-compatible API is ready.
     let gatewayReady = false;
     try {
-      gatewayReady = waitForRecoveredSandboxGateway(sandboxName, {
-        quiet,
-        initialManagedHealthPassed: recovery.kind === "managed",
-        requireManagedProbe: recovery.kind === "relaunched",
-        timeoutSeconds: gatewayRecoveryTimeoutSeconds(recoveryAgent),
-        managedProbeImpl: relaunch
-          ? () => confirmRelaunchedManagedHealth?.(210000) ?? null
-          : (name) =>
-              confirmRecoveredSandboxGatewayManaged(name, {
-                requestGatewaySupervisorActionImpl: requestManagedProbe,
-              }),
-      });
+      gatewayReady = measure("processes", () =>
+        waitForRecoveredSandboxGateway(sandboxName, {
+          quiet,
+          initialManagedHealthPassed: recovery.kind === "managed",
+          requireManagedProbe: recovery.kind === "relaunched",
+          timeoutSeconds: gatewayRecoveryTimeoutSeconds(recoveryAgent),
+          managedProbeImpl: relaunch
+            ? () => confirmRelaunchedManagedHealth?.(210000) ?? null
+            : (name) =>
+                confirmRecoveredSandboxGatewayManaged(name, {
+                  requestGatewaySupervisorActionImpl: requestManagedProbe,
+                }),
+        }),
+      );
     } catch (error) {
       try {
         relaunch?.finalize(false);
@@ -1667,7 +1698,9 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
               : undefined,
           );
     };
-    const readinessFailureDetail = recoveryRequiresReadiness ? waitForRecoveryReadiness() : null;
+    const readinessFailureDetail = recoveryRequiresReadiness
+      ? measure("processes", waitForRecoveryReadiness)
+      : null;
     if (readinessFailureDetail) {
       const recoveryFailureDetail = relaunch
         ? recoveryDetailAfterRelaunchRollback(relaunch, readinessFailureDetail)
@@ -1681,26 +1714,30 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
       };
     }
     if (relaunch) {
-      const finalizationFailure = finalizeRelaunchedRecovery(sandboxName, relaunch, {
-        printRecoveryHints: () =>
-          printHostManagedGatewayRecoveryHints(
-            sandboxName,
-            recoveryAgent,
-            managedRecoveryFailureLayer,
-          ),
-        quiet,
-        requestManagedProbe,
-        waitForRecoveryReadiness,
-      });
+      const finalizationFailure = measure("processes", () =>
+        finalizeRelaunchedRecovery(sandboxName, relaunch, {
+          printRecoveryHints: () =>
+            printHostManagedGatewayRecoveryHints(
+              sandboxName,
+              recoveryAgent,
+              managedRecoveryFailureLayer,
+            ),
+          quiet,
+          requestManagedProbe,
+          waitForRecoveryReadiness,
+        }),
+      );
       if (finalizationFailure) return finalizationFailure;
     }
     const mcpRefusal = processRecoveryMcpReconciliationRefusal(sandboxName, false);
     if (mcpRefusal) return mcpRefusal;
-    const forwardRecovered = ensureSandboxPortForward(sandboxName, {
-      afterSuccess: confirmRelaunchedManagedHealthForForward ?? undefined,
-      beforeStart: confirmRelaunchedManagedHealthForForward ?? undefined,
-      isWsl: isWslOverride,
-    });
+    const forwardRecovered = measure("forward", () =>
+      ensureSandboxPortForward(sandboxName, {
+        afterSuccess: confirmRelaunchedManagedHealthForForward ?? undefined,
+        beforeStart: confirmRelaunchedManagedHealthForForward ?? undefined,
+        isWsl: isWslOverride,
+      }),
+    );
     if (!forwardRecovered && relaunchedManagedHealth.failure) {
       return {
         checked: true,
@@ -1713,11 +1750,15 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
             : `the managed supervisor health check for the pinned replacement container did not pass during the primary dashboard/API host forward check. Managed supervisor health check result: ${relaunchedManagedHealth.failure.layer}: ${relaunchedManagedHealth.failure.detail}`,
       };
     }
-    const dashboardForwardRecovered = ensureHermesDashboardPortForwardIfEnabled(sandboxName);
-    const messagingForwardRecovered = recoverMessagingHostForward(sandboxName, { quiet });
-    const declaredForwardsRecovered = recoverDeclaredAgentForwardPorts(sandboxName, recoveryPort, {
-      quiet,
-    });
+    const dashboardForwardRecovered = measure("forward", () =>
+      ensureHermesDashboardPortForwardIfEnabled(sandboxName),
+    );
+    const messagingForwardRecovered = measure("forward", () =>
+      recoverMessagingHostForward(sandboxName, { quiet }),
+    );
+    const declaredForwardsRecovered = measure("forward", () =>
+      recoverDeclaredAgentForwardPorts(sandboxName, recoveryPort, { quiet }),
+    );
     const auxiliaryResults = [
       { label: "the Hermes dashboard host forward", recovered: dashboardForwardRecovered },
       { label: "the messaging webhook host forward", recovered: messagingForwardRecovered },
@@ -1736,6 +1777,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
       }
     }
     if (!forwardRecovered) {
+      probeTiming?.setForwardAction("failed");
       return withManagedControlCompletion({
         checked: true,
         wasRunning: false,
@@ -1747,6 +1789,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
       });
     }
     if (auxiliaryFailureDetail !== null) {
+      probeTiming?.setForwardAction("failed");
       if (!quiet) console.error(`  ${auxiliaryFailureDetail}.`);
       return withManagedControlCompletion({
         checked: true,
@@ -1757,6 +1800,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
         forwardRecoveryFailureDetail: auxiliaryFailureDetail,
       });
     }
+    probeTiming?.setForwardAction("restored");
     return withManagedControlCompletion({
       checked: true,
       wasRunning: false,
@@ -1784,6 +1828,7 @@ export function checkAndRecoverSandboxProcesses(
     waitForRecreatedSandboxOpenShellReadyImpl?: typeof waitForRecreatedSandboxOpenShellReady;
     isWsl?: boolean;
     onRecoveryFailureLayer?: (layer: GatewayRestartFailureLayer | null, detail?: string) => void;
+    probeTiming?: ProcessRecoveryProbeTiming;
   } = {},
 ) {
   return withTimerBoundShieldsMutationLock(sandboxName, "gateway process recovery", () =>

--- a/src/lib/actions/sandbox/process-recovery.ts
+++ b/src/lib/actions/sandbox/process-recovery.ts
@@ -1739,6 +1739,7 @@ function checkAndRecoverSandboxProcessesWithoutHostLock(
       }),
     );
     if (!forwardRecovered && relaunchedManagedHealth.failure) {
+      probeTiming?.setForwardAction("failed");
       return {
         checked: true,
         wasRunning: false,

--- a/test/process-recovery-supervisor-relaunch.test.ts
+++ b/test/process-recovery-supervisor-relaunch.test.ts
@@ -1281,6 +1281,10 @@ describe("checkAndRecoverSandboxProcesses supervisor relaunch", () => {
     const runOpenshell = vi
       .spyOn(openshellRuntime, "runOpenshell")
       .mockReturnValue({ status: 0 } as never);
+    const probeTiming = {
+      measure: <T>(_stage: "processes" | "forward", operation: () => T): T => operation(),
+      setForwardAction: vi.fn(),
+    };
 
     const result = checkAndRecoverSandboxProcesses("drifted-box", {
       quiet: true,
@@ -1289,6 +1293,7 @@ describe("checkAndRecoverSandboxProcesses supervisor relaunch", () => {
       requestPinnedGatewaySupervisorAction,
       relaunchManagedSupervisorSessionImpl,
       waitForRecreatedSandboxOpenShellReadyImpl,
+      probeTiming,
     });
 
     expect(result).toMatchObject({
@@ -1310,6 +1315,8 @@ describe("checkAndRecoverSandboxProcesses supervisor relaunch", () => {
       "replacement-container-id",
     );
     expect(finalize).toHaveBeenCalledWith(true);
+    expect(probeTiming.setForwardAction).toHaveBeenCalledOnce();
+    expect(probeTiming.setForwardAction).toHaveBeenCalledWith("failed");
     expect(runOpenshell).toHaveBeenCalledOnce();
     expect(runOpenshell).toHaveBeenCalledWith(["forward", "stop", "18789", "drifted-box"], {
       ignoreError: true,

--- a/test/process-recovery.test.ts
+++ b/test/process-recovery.test.ts
@@ -16,6 +16,9 @@ const { checkAndRecoverSandboxProcesses: checkAndRecoverSandboxProcessesImpl } =
 const { ensureSandboxPortForwardForPort } = requireSource(
   "../src/lib/actions/sandbox/forward-recovery.ts",
 ) as typeof import("../src/lib/actions/sandbox/forward-recovery.js");
+const { createProbeTimingRecorder } = requireSource(
+  "../src/lib/actions/sandbox/probe/timing.ts",
+) as typeof import("../src/lib/actions/sandbox/probe/timing.js");
 
 function checkAndRecoverSandboxProcesses(
   sandboxName: string,
@@ -123,6 +126,8 @@ beta  127.0.0.1  18789  12345  dead`;
 beta  127.0.0.1  18789  12345  running`;
     let forwardStarted = false;
     let postStartListCalls = 0;
+    const timingLines: string[] = [];
+    const probeTiming = createProbeTimingRecorder({ write: (line) => timingLines.push(line) });
 
     vi.spyOn(childProcess, "spawnSync").mockImplementation(
       (_command: unknown, rawArgs: unknown) => {
@@ -166,7 +171,9 @@ beta  127.0.0.1  18789  12345  running`;
       });
 
     expect(
-      withFakeOpenshellBinary(() => checkAndRecoverSandboxProcesses("beta", { quiet: true })),
+      withFakeOpenshellBinary(() =>
+        checkAndRecoverSandboxProcesses("beta", { probeTiming, quiet: true }),
+      ),
     ).toEqual({
       checked: true,
       wasRunning: true,
@@ -183,6 +190,9 @@ beta  127.0.0.1  18789  12345  running`;
           Array.isArray(args) && args[0] === "forward" && args[1] === "stop" && args.length === 3,
       ),
     ).toBe(false);
+    probeTiming.finish("ready");
+    expect(timingLines[0]).toContain("forwardAction=restored");
+    expect(timingLines[0]).toContain("result=ready");
   });
 
   it.each([
@@ -311,6 +321,8 @@ beta  127.0.0.1  18789  12345  running`;
     const childProcess = requireSource("node:child_process");
     const dashboardForward = `SANDBOX  BIND  PORT  PID  STATUS
 beta  127.0.0.1  18789  12345  running`;
+    const timingLines: string[] = [];
+    const probeTiming = createProbeTimingRecorder({ write: (line) => timingLines.push(line) });
     const dashboardAndTeamsForwards = `${dashboardForward}
 beta  127.0.0.1  3978  12346  running`;
     let teamsForwardStarted = false;
@@ -349,7 +361,9 @@ beta  127.0.0.1  3978  12346  running`;
       });
 
     expect(
-      withFakeOpenshellBinary(() => checkAndRecoverSandboxProcesses("beta", { quiet: true })),
+      withFakeOpenshellBinary(() =>
+        checkAndRecoverSandboxProcesses("beta", { probeTiming, quiet: true }),
+      ),
     ).toEqual({
       checked: true,
       wasRunning: true,
@@ -365,6 +379,9 @@ beta  127.0.0.1  3978  12346  running`;
       ["forward", "start", "--background", "3978", "beta"],
       { ignoreError: true, stdio: "ignore" },
     );
+    probeTiming.finish("ready");
+    expect(timingLines[0]).toContain("forwardAction=restored");
+    expect(timingLines[0]).toContain("result=ready");
   });
 
   it("checkAndRecoverSandboxProcesses reports messaging webhook recovery failure without claiming forwardRecovered", () => {
@@ -375,6 +392,8 @@ beta  127.0.0.1  3978  12346  running`;
     const childProcess = requireSource("node:child_process");
     const dashboardForward = `SANDBOX  BIND  PORT  PID  STATUS
 beta  127.0.0.1  18789  12345  running`;
+    const timingLines: string[] = [];
+    const probeTiming = createProbeTimingRecorder({ write: (line) => timingLines.push(line) });
 
     vi.spyOn(childProcess, "spawnSync").mockReturnValue({
       status: 0,
@@ -405,7 +424,9 @@ beta  127.0.0.1  18789  12345  running`;
       });
 
     expect(
-      withFakeOpenshellBinary(() => checkAndRecoverSandboxProcesses("beta", { quiet: true })),
+      withFakeOpenshellBinary(() =>
+        checkAndRecoverSandboxProcesses("beta", { probeTiming, quiet: true }),
+      ),
     ).toEqual({
       checked: true,
       wasRunning: true,
@@ -419,6 +440,9 @@ beta  127.0.0.1  18789  12345  running`;
       ["forward", "start", "--background", "3978", "beta"],
       { ignoreError: true, stdio: "ignore" },
     );
+    probeTiming.finish("failed", "forward");
+    expect(timingLines[0]).toContain("forwardAction=failed");
+    expect(timingLines[0]).toContain("result=failed failedStage=forward");
   });
 
   it("waits for stopped Hermes recovery after managed OpenShell control succeeds", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`connect --probe-only` currently reports aggregate Portable Podman readiness and the final result, but it does not show which later readiness stage consumed the elapsed time. This change emits one credential-free stage-timing line on probe success or failure so operators can distinguish lifecycle recovery, port-forward restoration, inference, pairing, and publication latency without changing probe behavior.

## Related Issue

Related to #9200.

## Changes

- Add a fail-open probe timing recorder with fixed stage, action, result, and failure fields.
- Measure readiness, authority, lifecycle, gateway, process recovery, port forwarding, inference, pairing, and readiness publication.
- Report whether the lifecycle was reused or recovered and whether forwarding was verified, restored, or failed.
- Emit at most one bounded line on normal completion or process exit without including command output, paths, endpoint values, or errors.
- Preserve existing probe status, recovery attempts, timeouts, and interactive `connect` output.
- Cover successful timing, stage failures, diagnostic clock/writer failures, exit-before-normal-completion, and the managed-health forward-failure branch.

Review corrections:

- A failed primary forward attempt followed by a managed-health failure now records `forwardAction=failed` instead of `skipped`.
- The unfinished process-exit path now has a regression proving one failed line with the selected failure stage.

Live validation:

- Brev validation remains pending for one warm probe sample and one naturally occurring forward-restoration sample.
- This PR does not yet claim live timing evidence.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior -- justification:
- [ ] Tests not applicable -- justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded -- reviewer/approval link/justification: updated review is pending; the prior maintainer review confirmed fixed-field output avoids secret/path leakage, timing failures remain fail-open, and interactive connect behavior is unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer -- check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this change is limited to credential-free CLI probe diagnostics.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above -- command/result or justification: `npm exec -- vitest run src/lib/actions/sandbox/probe/timing.test.ts test/process-recovery-supervisor-relaunch.test.ts test/process-recovery.test.ts src/lib/actions/sandbox/connect-flow.test.ts` passed 123/123 tests; `npm run typecheck:cli` passed.
- [ ] Applicable broad gate passed -- `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes -- command/result: not applicable to this bounded diagnostic instrumentation; repository, architecture, growth, secret-scan, CLI typecheck, and changed-file hooks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added probe timing diagnostics for sandbox connection, recovery, readiness, inference, pairing, and forwarding stages.
  - Timing output reports stage durations, total duration, lifecycle actions, forward status, and failure stages.
  - Diagnostics support successful, failed, and early-exit scenarios.

- **Bug Fixes**
  - Timing diagnostics fail safely without disrupting sandbox operations, including when clocks or output handling encounter errors.

- **Tests**
  - Expanded coverage for timing output, recovery outcomes, failure tracking, and resilient diagnostic handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->