### PR TITLE
fix(shields): retire timer authority after lifecycle gates

### DIFF
--- a/src/lib/shields/timer.test.ts
+++ b/src/lib/shields/timer.test.ts
@@ -672,7 +672,7 @@ describe("shields timer authorization", () => {
     expect(fs.existsSync(`${mutationLockPath}.containment`)).toBe(false);
   });
 
-  it("restores and updates state when marker matches current timer invocation", async () => {
+  it("retires successful timer authority only after lifecycle gates are released (#9750)", async () => {
     const timer = await import("./timer");
     const stateDir = path.join(tmpHome, ".nemoclaw", "state");
     fs.mkdirSync(stateDir, { recursive: true });
@@ -707,6 +707,15 @@ describe("shields timer authorization", () => {
 
     const lockPath = path.join(stateDir, `shields-transition-lock-${sandboxName}.json`);
     const deadlinePath = `${sandboxMutationLockPath}.deadline`;
+    let lifecycleGatePresentAtMarkerCleanup: boolean | null = null;
+    const renameSync = fs.renameSync;
+    const renameSpy = vi.spyOn(fs, "renameSync").mockImplementation((oldPath, newPath) => {
+      if (oldPath === markerPath) {
+        lifecycleGatePresentAtMarkerCleanup =
+          fs.existsSync(sandboxMutationLockPath) || fs.existsSync(deadlinePath);
+      }
+      renameSync(oldPath, newPath);
+    });
     shieldsIndexMock.applyShieldsPolicySnapshot.mockImplementationOnce(() => {
       expect(fs.existsSync(sandboxMutationLockPath)).toBe(true);
       expect(fs.existsSync(deadlinePath)).toBe(true);
@@ -721,7 +730,13 @@ describe("shields timer authorization", () => {
       };
     });
 
-    const exitCode = await invokeTimerAndCaptureExit(timer.runRestoreTimer, args);
+    const exitCode = await (async () => {
+      try {
+        return await invokeTimerAndCaptureExit(timer.runRestoreTimer, args);
+      } finally {
+        renameSpy.mockRestore();
+      }
+    })();
     const stateFile = path.join(stateDir, `shields-${sandboxName}.json`);
     const updatedState = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
 
@@ -732,6 +747,7 @@ describe("shields timer authorization", () => {
     expect(fs.existsSync(markerPath)).toBe(false);
     expect(fs.existsSync(sandboxMutationLockPath)).toBe(false);
     expect(fs.existsSync(deadlinePath)).toBe(false);
+    expect(lifecycleGatePresentAtMarkerCleanup).toBe(false);
     expect(shieldsIndexMock.completeAutoRestoreTransition).toHaveBeenCalledWith(
       sandboxName,
       PROCESS_TOKEN,

--- a/src/lib/shields/timer.test.ts
+++ b/src/lib/shields/timer.test.ts
@@ -707,13 +707,13 @@ describe("shields timer authorization", () => {
 
     const lockPath = path.join(stateDir, `shields-transition-lock-${sandboxName}.json`);
     const deadlinePath = `${sandboxMutationLockPath}.deadline`;
-    let lifecycleGatePresentAtMarkerCleanup: boolean | null = null;
+    const lifecycleGateStatesAtMarkerCleanup: boolean[] = [];
     const renameSync = fs.renameSync;
     const renameSpy = vi.spyOn(fs, "renameSync").mockImplementation((oldPath, newPath) => {
-      if (oldPath === markerPath) {
-        lifecycleGatePresentAtMarkerCleanup =
-          fs.existsSync(sandboxMutationLockPath) || fs.existsSync(deadlinePath);
-      }
+      oldPath === markerPath &&
+        lifecycleGateStatesAtMarkerCleanup.push(
+          fs.existsSync(sandboxMutationLockPath) || fs.existsSync(deadlinePath),
+        );
       renameSync(oldPath, newPath);
     });
     shieldsIndexMock.applyShieldsPolicySnapshot.mockImplementationOnce(() => {
@@ -747,7 +747,7 @@ describe("shields timer authorization", () => {
     expect(fs.existsSync(markerPath)).toBe(false);
     expect(fs.existsSync(sandboxMutationLockPath)).toBe(false);
     expect(fs.existsSync(deadlinePath)).toBe(false);
-    expect(lifecycleGatePresentAtMarkerCleanup).toBe(false);
+    expect(lifecycleGateStatesAtMarkerCleanup).toEqual([false]);
     expect(shieldsIndexMock.completeAutoRestoreTransition).toHaveBeenCalledWith(
       sandboxName,
       PROCESS_TOKEN,

--- a/src/lib/shields/timer.ts
+++ b/src/lib/shields/timer.ts
@@ -303,6 +303,7 @@ async function runRestoreTimerWithBudget(
   let exitCode = 0;
   let retryScheduled = false;
   let terminalContainment = false;
+  let restoreCompleted = false;
   let managedMcpWarning: string | undefined;
   const scheduleRetry = (): boolean => {
     if (!markerMatchesCurrentTimer(args)) return false;
@@ -531,7 +532,7 @@ async function runRestoreTimerWithBudget(
               scheduled_restore_at: args.restoreAtIso,
               ...(managedMcpWarning ? { warning: managedMcpWarning } : {}),
             });
-            cleanupOwnedTimerMarker(args);
+            restoreCompleted = true;
             exitCode = 0;
             return "complete";
           }
@@ -630,6 +631,11 @@ async function runRestoreTimerWithBudget(
             policy_snapshot: args.snapshotPath,
             error: `${reason}${ownerPid ? ` Contained owner PID: ${String(ownerPid)}.` : ""}`,
           });
+        },
+        onReleased: () => {
+          // Retire timer authority only after both exact lifecycle generations
+          // are gone, without yielding another event-loop turn in between.
+          if (restoreCompleted) cleanupOwnedTimerMarker(args);
         },
       },
     );

--- a/src/lib/state/mcp-lifecycle-lock-acquisition.test.ts
+++ b/src/lib/state/mcp-lifecycle-lock-acquisition.test.ts
@@ -663,6 +663,25 @@ describe("MCP lifecycle lock acquisition", () => {
     expect(fs.existsSync(deadlinePath)).toBe(false);
   });
 
+  it("runs deadline release completion only after exact gates are absent (#9750)", async () => {
+    const processToken = "8".repeat(32);
+    const lockPath = getMcpLifecycleLockPath(SANDBOX_NAME, stateDir);
+    const deadlinePath = `${lockPath}.deadline`;
+    writeTimerMarker(processToken);
+    const onReleased = vi.fn(() => {
+      expect(fs.existsSync(lockPath)).toBe(false);
+      expect(fs.existsSync(deadlinePath)).toBe(false);
+    });
+
+    await expect(
+      withMcpLifecycleDeadlineFence(SANDBOX_NAME, processToken, () => "complete", {
+        ...options(),
+        onReleased,
+      }),
+    ).resolves.toBe("complete");
+    expect(onReleased).toHaveBeenCalledOnce();
+  });
+
   it("contains a stale async main generation that records a rotated Shields timer token", async () => {
     const ownerToken = "3".repeat(32);
     const currentToken = "4".repeat(32);

--- a/src/lib/state/mcp-lifecycle-lock-acquisition.ts
+++ b/src/lib/state/mcp-lifecycle-lock-acquisition.ts
@@ -58,6 +58,8 @@ export interface McpLifecycleDeadlineFenceOptions extends McpLifecycleLockOption
   onSetupFailure?: (error: unknown) => Promise<void> | void;
   /** Return operator guidance instead of waiting when durable containment already exists. */
   throwOnCommittedContainment?: boolean;
+  /** Run synchronously after this fence's exact main and deadline generations are released. */
+  onReleased?: () => void;
 }
 
 export interface McpLifecycleDeadlineFenceSyncOptions extends McpLifecycleLockOptions {
@@ -1581,6 +1583,7 @@ export async function withMcpLifecycleDeadlineFence<T>(
     if (!retainOwnedGate) {
       if (mainToken) await safelyReleaseMcpLifecycleLock(lockPath, mainToken);
       await safelyReleaseMcpLifecycleLock(fence.lockPath, fence.token);
+      options.onReleased?.();
     }
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Successful shields auto-restore now retires its exact timer authority only after the lifecycle main and deadline gates are released. This prevents a normal timer exit from leaving stale gates that indefinitely block snapshot operations.

## Related Issue

Fixes #9750

## Changes

- Move successful timer-marker cleanup to a synchronous post-release callback after both exact lifecycle gate generations are released.
- Add the `onReleased` lifecycle-fence callback because only the fence helper owns both release operations; the lifecycle-lock regression test protects this ordering.
- Update the timer flow test to prove marker cleanup observes no lifecycle gate, while existing retry and containment tests continue to protect fail-closed outcomes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category review passed with no findings at `0bcf321a50715d533daa4e280cd6ea03985aa72a`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx --no-install vitest run --project cli src/lib/shields/timer.test.ts src/lib/state/mcp-lifecycle-lock-acquisition.test.ts -t 'retires successful timer authority only after lifecycle gates are released|runs deadline release completion only after exact gates are absent'` passed 2/2; `npx --no-install vitest run --project integration test/mcp-lifecycle-lock.test.ts` passed 44/44 on the host.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Documentation Writer Review

- Result: `docs-not-needed`
- Evidence: `docs/manage-sandboxes/runtime-controls.mdx:136-166` and `docs/reference/commands.mdx:1668-1688` already document lifecycle-gate retention during restoration, failure containment, and recovery. This fix restores that behavior after successful timed Shields auto-restore.
- Agent surface: Codex Desktop

<!-- documentation-writer-review-head: 0bcf321a50715d533daa4e280cd6ea03985aa72a -->
<!-- documentation-writer-review-agents-blob: 513518cdfca42e3a18fed71109e6d0eb60151d13 -->

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic policy restoration sequencing to ensure cleanup occurs only after lifecycle safeguards are fully released.
  * Strengthened lifecycle deadline handling so release callbacks run after all related protections are removed.

* **Tests**
  * Added coverage validating restoration cleanup and lifecycle release ordering under asynchronous conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->