### PR TITLE
fix(portable): keep Podman proxy boolean attached

### DIFF
--- a/src/lib/onboard/runtime-provider/podman-host-local-inference.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference.test.ts
@@ -190,7 +190,7 @@ describe("Podman host-local inference lifecycle", () => {
       expect(run).toContain("--detach");
       expect(run).toContain("--read-only");
       expect(run).toContain("--ipc private");
-      expect(run).toContain("--http-proxy false");
+      expect(run).toContain("--http-proxy=false");
       expect(run).not.toContain(" --rm");
       expect(run).not.toContain("--publish");
       expect(run).not.toContain("--device");
@@ -526,7 +526,9 @@ describe("Podman host-local inference lifecycle", () => {
 
     expect(PROVIDER_FAILURE_SECRETS.every((secret) => !thrown.includes(secret))).toBe(true);
     const failureEvidence = harness.failures.map(({ message }) => message).join("\n");
-    expect(PROVIDER_FAILURE_SECRETS.every((secret) => !failureEvidence.includes(secret))).toBe(true);
+    expect(PROVIDER_FAILURE_SECRETS.every((secret) => !failureEvidence.includes(secret))).toBe(
+      true,
+    );
 
     expect(harness.routeAuthorityStore.load("ollama")).toBeNull();
     expect(harness.written).toHaveLength(0);
@@ -658,7 +660,9 @@ describe("Podman host-local inference lifecycle", () => {
 
     expect(PROVIDER_FAILURE_SECRETS.every((secret) => !thrown.includes(secret))).toBe(true);
     const failureEvidence = harness.failures.map(({ message }) => message).join("\n");
-    expect(PROVIDER_FAILURE_SECRETS.every((secret) => !failureEvidence.includes(secret))).toBe(true);
+    expect(PROVIDER_FAILURE_SECRETS.every((secret) => !failureEvidence.includes(secret))).toBe(
+      true,
+    );
 
     expect(harness.probe()).toBeNull();
   });
@@ -867,7 +871,7 @@ describe("Podman host-local inference lifecycle", () => {
       message: expect.stringContaining("transport closed after create"),
     });
     const runIndex = harness.events.findIndex((event) =>
-      event.startsWith("podman:run --http-proxy false --detach"),
+      event.startsWith("podman:run --http-proxy=false --detach"),
     );
     const evidenceIndex = harness.events.indexOf("evidence:start");
     const readyIndex = harness.events.findIndex((event) => event.includes("/v1/health/ready"));
@@ -1289,7 +1293,7 @@ describe("Podman host-local inference lifecycle", () => {
 
     const runEvents = harness.events.filter((event) => event.startsWith("podman:run "));
     expect(runEvents.length).toBeGreaterThan(2);
-    expect(runEvents.every((event) => event.startsWith("podman:run --http-proxy false "))).toBe(
+    expect(runEvents.every((event) => event.startsWith("podman:run --http-proxy=false "))).toBe(
       true,
     );
     expect(JSON.stringify(prepared.receipt)).not.toContain(proxySecret);

--- a/src/lib/onboard/runtime-provider/podman-inference-args.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-inference-args.test.ts
@@ -85,8 +85,7 @@ describe("Podman local inference command translation", () => {
       ),
     ).toEqual([
       "run",
-      "--http-proxy",
-      "false",
+      "--http-proxy=false",
       "--detach",
       "--pull",
       "never",
@@ -140,8 +139,7 @@ describe("Podman local inference command translation", () => {
       ),
     ).toEqual([
       "run",
-      "--http-proxy",
-      "false",
+      "--http-proxy=false",
       "--detach",
       "--pull",
       "never",
@@ -189,10 +187,16 @@ describe("Podman local inference command translation", () => {
 
     expect(translatePodmanLocalInferenceArgs(args, authority())).toEqual([
       "run",
-      "--http-proxy",
-      "false",
+      "--http-proxy=false",
       ...args.slice(1),
     ]);
+  });
+
+  it("keeps the Podman proxy boolean attached so false cannot become the image", () => {
+    const translated = translatePodmanLocalInferenceArgs(["run", IMAGE], authority());
+
+    expect(translated).toEqual(["run", "--http-proxy=false", IMAGE]);
+    expect(translated.slice(1, translated.indexOf(IMAGE))).not.toContain("false");
   });
 
   it("rejects auto-removal that would erase exact cleanup evidence", () => {

--- a/src/lib/onboard/runtime-provider/podman-inference-args.ts
+++ b/src/lib/onboard/runtime-provider/podman-inference-args.ts
@@ -369,7 +369,7 @@ export function translatePodmanLocalInferenceArgs(
     }
     allowedPublishAddresses.add(address);
   }
-  const translated = ["run", "--http-proxy", "false"];
+  const translated = ["run", "--http-proxy=false"];
   const seenOptions = new Set<string>(["--http-proxy"]);
   const seenLabels = new Set<string>();
   const requestedGpuDevices = new Set<string>();

--- a/test/helpers/podman-host-local-inference-test-harness.ts
+++ b/test/helpers/podman-host-local-inference-test-harness.ts
@@ -809,8 +809,7 @@ export function createPodmanHostLocalInferenceTestHarness(
         },
         createArguments: Object.freeze([
           "run",
-          "--http-proxy",
-          "false",
+          "--http-proxy=false",
           "--detach",
           "--pull",
           "never",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Pass Podman's proxy-disable boolean as `--http-proxy=false` so Podman 5.7 does not interpret a standalone `false` token as the container image during Portable host-local inference startup. The prior form stopped Hermes Portable onboarding before the sandbox was created.

## Related Issue

Relates to #9211

## Changes

- Emit the Podman `--http-proxy=false` boolean in one argument while preserving the existing proxy-disable and immutable-image authority checks.
- Update lifecycle fixtures and assertions to reconstruct the exact corrected launch arguments.
- Add a regression assertion that no standalone `false` token can appear before the image.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Focused nine-category review of `d3526943ed3c83ead60c51edd2a1acd3946433c9` passed with no findings. The change preserves proxy disablement, immutable image selection, credential denial, and existing runtime authority checks.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: focused Podman argument and lifecycle suites passed 120/120; `npm run typecheck:cli` passed; `NEMOCLAW_GROWTH_BASE_REF=upstream/main npm run test:changed` passed 2,184/2,184.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Documentation Writer Review

- Result: PASS — no documentation changes required.
- Evidence: An independent documentation writer reviewed the commit under review and confirmed that the pre-commit formatter changes do not alter behavior or test meaning.
- Agent surface: Internal Podman argument tokenization only; no public CLI flag, configuration, workflow, default, or user-facing text changed.

<!-- documentation-writer-review-head-sha: d3526943ed3c83ead60c51edd2a1acd3946433c9 -->
<!-- documentation-writer-review-agents-md-blob-sha: 513518cdfca42e3a18fed71109e6d0eb60151d13 -->

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Podman command generation to format the HTTP proxy option reliably as a single argument.
  * Prevented the proxy setting from being misinterpreted as another command value, improving local inference startup reliability.

* **Tests**
  * Updated and expanded coverage to verify the corrected Podman argument formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->