### PR TITLE
fix(e2e): validate OpenClaw channel state

### DIFF
--- a/test/e2e/live/channels-stop-start-config-state.ts
+++ b/test/e2e/live/channels-stop-start-config-state.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// The live probe emits only these booleans. The settings fields exclude
+// `enabled`, so artifacts do not contain credential-bearing configuration.
+export interface OpenClawChannelConfigState {
+  channelPresent: boolean;
+  channelEnabled: boolean;
+  channelDisabled: boolean;
+  channelHasSettings: boolean;
+  pluginPresent: boolean;
+  pluginEnabled: boolean;
+  pluginDisabled: boolean;
+  pluginHasSettings: boolean;
+}
+
+export function openClawChannelIsActive(state: OpenClawChannelConfigState): boolean {
+  return (
+    state.channelPresent &&
+    state.channelEnabled &&
+    !state.channelDisabled &&
+    state.pluginPresent &&
+    state.pluginEnabled &&
+    !state.pluginDisabled
+  );
+}
+
+export function openClawChannelIsInert(state: OpenClawChannelConfigState): boolean {
+  const channelIsInert =
+    !state.channelPresent || (state.channelDisabled && !state.channelHasSettings);
+  const pluginIsInert = !state.pluginPresent || (state.pluginDisabled && !state.pluginHasSettings);
+
+  return !state.channelEnabled && !state.pluginEnabled && channelIsInert && pluginIsInert;
+}

--- a/test/e2e/live/channels-stop-start-config-state.ts
+++ b/test/e2e/live/channels-stop-start-config-state.ts
@@ -33,15 +33,8 @@ export function openClawChannelIsActive(state: OpenClawChannelConfigState): bool
 export function openClawChannelIsInert(state: OpenClawChannelConfigState): boolean {
   const channelIsInert =
     !state.channelPresent || (state.channelDisabled && !state.channelHasSettings);
-  const pluginIsInert = !state.pluginPresent || (state.pluginDisabled && !state.pluginHasSettings);
 
-  return (
-    !state.channelEnabled &&
-    !state.channelHasEnabledAccount &&
-    !state.pluginEnabled &&
-    channelIsInert &&
-    pluginIsInert
-  );
+  return !state.channelEnabled && !state.channelHasEnabledAccount && channelIsInert;
 }
 
 export function openClawChannelStateProbeScript(

--- a/test/e2e/live/channels-stop-start-config-state.ts
+++ b/test/e2e/live/channels-stop-start-config-state.ts
@@ -5,8 +5,10 @@
 // `enabled`, so artifacts do not contain credential-bearing configuration.
 export interface OpenClawChannelConfigState {
   channelPresent: boolean;
+  channelActivationUsesAccounts: boolean;
   channelEnabled: boolean;
   channelDisabled: boolean;
+  channelHasEnabledAccount: boolean;
   channelHasSettings: boolean;
   pluginPresent: boolean;
   pluginEnabled: boolean;
@@ -15,9 +17,12 @@ export interface OpenClawChannelConfigState {
 }
 
 export function openClawChannelIsActive(state: OpenClawChannelConfigState): boolean {
+  const channelIsEnabled = state.channelActivationUsesAccounts
+    ? state.channelHasEnabledAccount
+    : state.channelEnabled;
   return (
     state.channelPresent &&
-    state.channelEnabled &&
+    channelIsEnabled &&
     !state.channelDisabled &&
     state.pluginPresent &&
     state.pluginEnabled &&
@@ -30,5 +35,46 @@ export function openClawChannelIsInert(state: OpenClawChannelConfigState): boole
     !state.channelPresent || (state.channelDisabled && !state.channelHasSettings);
   const pluginIsInert = !state.pluginPresent || (state.pluginDisabled && !state.pluginHasSettings);
 
-  return !state.channelEnabled && !state.pluginEnabled && channelIsInert && pluginIsInert;
+  return (
+    !state.channelEnabled &&
+    !state.channelHasEnabledAccount &&
+    !state.pluginEnabled &&
+    channelIsInert &&
+    pluginIsInert
+  );
+}
+
+export function openClawChannelStateProbeScript(
+  channel: string,
+  configPath = "/sandbox/.openclaw/openclaw.json",
+): string {
+  const key = channel === "wechat" ? "openclaw-weixin" : channel === "teams" ? "msteams" : channel;
+  return `
+import json
+key = ${JSON.stringify(key)}
+channel_uses_accounts = ${channel === "wechat" ? "True" : "False"}
+cfg = json.load(open(${JSON.stringify(configPath)}))
+channels = cfg.get('channels', {})
+plugins = cfg.get('plugins', {}).get('entries', {})
+channel_present = key in channels
+plugin_present = key in plugins
+channel = channels.get(key)
+plugin = plugins.get(key)
+channel_obj = channel if isinstance(channel, dict) else None
+plugin_obj = plugin if isinstance(plugin, dict) else None
+accounts = channel_obj.get('accounts') if channel_obj is not None else None
+account_values = accounts.values() if isinstance(accounts, dict) else []
+print(json.dumps({
+  'channelPresent': channel_present,
+  'channelActivationUsesAccounts': channel_uses_accounts,
+  'channelEnabled': channel_obj is not None and channel_obj.get('enabled') is True,
+  'channelDisabled': channel_obj is not None and channel_obj.get('enabled') is False,
+  'channelHasEnabledAccount': any(isinstance(account, dict) and account.get('enabled') is True for account in account_values),
+  'channelHasSettings': channel_present and (channel_obj is None or any(field != 'enabled' for field in channel_obj)),
+  'pluginPresent': plugin_present,
+  'pluginEnabled': plugin_obj is not None and plugin_obj.get('enabled') is True,
+  'pluginDisabled': plugin_obj is not None and plugin_obj.get('enabled') is False,
+  'pluginHasSettings': plugin_present and (plugin_obj is None or any(field != 'enabled' for field in plugin_obj)),
+}, separators=(',', ':')))
+`.trim();
 }

--- a/test/e2e/live/channels-stop-start-helpers.ts
+++ b/test/e2e/live/channels-stop-start-helpers.ts
@@ -6,6 +6,11 @@ import os from "node:os";
 import path from "node:path";
 
 import { expect } from "../fixtures/e2e-test.ts";
+import {
+  type OpenClawChannelConfigState,
+  openClawChannelIsActive,
+  openClawChannelIsInert,
+} from "./channels-stop-start-config-state.ts";
 import { startChannelsStopStartProgress } from "./channels-stop-start-progress.ts";
 import { assertChannelsStopStartSandboxName } from "./channels-stop-start-safety.ts";
 import {
@@ -60,6 +65,7 @@ const CHANNELS_WITHOUT_CREDENTIAL_BINDING: Record<string, string> = {
 export const LIVE_TIMEOUT_MS = 80 * 60_000;
 
 type ChannelState = "active" | "disabled";
+type AgentConfigState = "active" | "inert";
 type JsonRecord = Record<string, unknown>;
 type Phase6Tokens = {
   telegram: string;
@@ -309,26 +315,49 @@ function openClawChannelKey(channel: string): string {
   return channel;
 }
 
-async function agentConfigContains(
+async function readOpenClawChannelState(
   sandbox: import("../fixtures/clients/sandbox.ts").SandboxClient,
   channel: string,
+  context: string,
+  redactions: string[],
+): Promise<OpenClawChannelConfigState> {
+  const script = `
+import json
+key = ${JSON.stringify(openClawChannelKey(channel))}
+cfg = json.load(open('/sandbox/.openclaw/openclaw.json'))
+channels = cfg.get('channels', {})
+plugins = cfg.get('plugins', {}).get('entries', {})
+channel_present = key in channels
+plugin_present = key in plugins
+channel = channels.get(key)
+plugin = plugins.get(key)
+channel_obj = channel if isinstance(channel, dict) else None
+plugin_obj = plugin if isinstance(plugin, dict) else None
+print(json.dumps({
+  'channelPresent': channel_present,
+  'channelEnabled': channel_obj is not None and channel_obj.get('enabled') is True,
+  'channelDisabled': channel_obj is not None and channel_obj.get('enabled') is False,
+  'channelHasSettings': channel_present and (channel_obj is None or any(field != 'enabled' for field in channel_obj)),
+  'pluginPresent': plugin_present,
+  'pluginEnabled': plugin_obj is not None and plugin_obj.get('enabled') is True,
+  'pluginDisabled': plugin_obj is not None and plugin_obj.get('enabled') is False,
+  'pluginHasSettings': plugin_present and (plugin_obj is None or any(field != 'enabled' for field in plugin_obj)),
+}, separators=(',', ':')))
+`.trim();
+  const result = await sandboxSh(sandbox, SANDBOX_NAME, `python3 -c ${shellQuote(script)}`, {
+    artifactName: `config-channel-${AGENT}-${channel}-${context}`,
+    redactionValues: redactions,
+  });
+  expectExitZero(result, `read OpenClaw channel ${channel} ${context}`);
+  return JSON.parse(result.stdout.trim()) as OpenClawChannelConfigState;
+}
+
+async function hermesChannelIsActive(
+  sandbox: import("../fixtures/clients/sandbox.ts").SandboxClient,
+  channel: string,
+  context: string,
   redactions: string[],
 ): Promise<boolean> {
-  if (AGENT === "openclaw") {
-    const result = await sandboxSh(
-      sandbox,
-      SANDBOX_NAME,
-      `python3 -c ${shellQuote(
-        `import json; channel=${JSON.stringify(
-          openClawChannelKey(channel),
-        )}; cfg=json.load(open('/sandbox/.openclaw/openclaw.json')); print('yes' if channel in cfg.get('channels', {}) else 'no')`,
-      )}`,
-      { artifactName: `config-channel-${AGENT}-${channel}`, redactionValues: redactions },
-    );
-    expectExitZero(result, `read OpenClaw channel ${channel}`);
-    return result.stdout.trim() === "yes";
-  }
-
   const probes: Record<string, string> = {
     telegram:
       'grep -Eq "^TELEGRAM_BOT_TOKEN=openshell:resolve:env:TELEGRAM_BOT_TOKEN$" /sandbox/.hermes/.env',
@@ -349,20 +378,35 @@ async function agentConfigContains(
     sandbox,
     SANDBOX_NAME,
     `if [ -r /sandbox/.hermes/.env ] && ${probes[channel]}; then echo yes; else echo no; fi`,
-    { artifactName: `config-channel-${AGENT}-${channel}`, redactionValues: redactions },
+    {
+      artifactName: `config-channel-${AGENT}-${channel}-${context}`,
+      redactionValues: redactions,
+    },
   );
-  expectExitZero(result, `read Hermes channel ${channel}`);
+  expectExitZero(result, `read Hermes channel ${channel} ${context}`);
   return result.stdout.trim() === "yes";
 }
 
 async function expectAgentConfig(
   sandbox: import("../fixtures/clients/sandbox.ts").SandboxClient,
-  expected: "present" | "absent",
+  expected: AgentConfigState,
+  context: string,
   redactions: string[],
 ): Promise<void> {
   for (const channel of CHANNELS) {
-    const present = await agentConfigContains(sandbox, channel, redactions);
-    expect(present, `${AGENT}/${channel} config ${expected}`).toBe(expected === "present");
+    if (AGENT === "openclaw") {
+      const state = await readOpenClawChannelState(sandbox, channel, context, redactions);
+      const matches =
+        expected === "active" ? openClawChannelIsActive(state) : openClawChannelIsInert(state);
+      expect(
+        matches,
+        `${AGENT}/${channel} config ${expected}; state=${JSON.stringify(state)}`,
+      ).toBe(true);
+      continue;
+    }
+
+    const active = await hermesChannelIsActive(sandbox, channel, context, redactions);
+    expect(active, `${AGENT}/${channel} config ${expected}`).toBe(expected === "active");
   }
 }
 
@@ -481,18 +525,19 @@ async function policyPresetState(
   env: NodeJS.ProcessEnv,
   redactions: string[],
   channel: string,
+  context: string,
 ): Promise<ReturnType<typeof parsePolicyPresetState>> {
   const result = await host.command(
     "node",
     [process.env.NEMOCLAW_CLI_BIN ?? "bin/nemoclaw.js", SANDBOX_NAME, "policy-list"],
     {
-      artifactName: `policy-list-${channel}-${AGENT}`,
+      artifactName: `policy-list-${channel}-${AGENT}-${context}`,
       env,
       redactionValues: redactions,
       timeoutMs: 60_000,
     },
   );
-  expectExitZero(result, `policy-list ${channel}`);
+  expectExitZero(result, `policy-list ${channel} ${context}`);
   return parsePolicyPresetState(resultText(result), channel);
 }
 
@@ -613,11 +658,11 @@ export async function runChannelsStopStartTarget({
   progress.phase("validate active channel integrations");
   expectChannelInputs(env);
   for (const channel of CHANNELS) expectPlanChannelState(channel, "active");
-  await expectAgentConfig(sandbox, "present", redactions);
+  await expectAgentConfig(sandbox, "active", "baseline", redactions);
   await expectProvidersExist(host, env, redactions, "baseline");
   for (const channel of CHANNELS) {
     expect(
-      await policyPresetState(host, env, redactions, channel),
+      await policyPresetState(host, env, redactions, channel, "baseline"),
       `${channel} policy active`,
     ).toBe("active");
   }
@@ -635,12 +680,12 @@ export async function runChannelsStopStartTarget({
   );
   expectExitZero(stopRebuild, "rebuild after stopping all channels");
   expectChannelInputs(env);
-  await expectAgentConfig(sandbox, "absent", redactions);
+  await expectAgentConfig(sandbox, "inert", "after-stop", redactions);
   await expectProvidersExist(host, env, redactions, "after-stop");
   for (const channel of CHANNELS) expectPlanChannelState(channel, "disabled");
   for (const channel of CHANNELS) {
     expect(
-      await policyPresetState(host, env, redactions, channel),
+      await policyPresetState(host, env, redactions, channel, "after-stop"),
       `${channel} policy inactive after stop+rebuild`,
     ).toBe("inactive");
   }
@@ -658,12 +703,12 @@ export async function runChannelsStopStartTarget({
   );
   expectExitZero(startRebuild, "rebuild after starting all channels");
   expectChannelInputs(env);
-  await expectAgentConfig(sandbox, "present", redactions);
+  await expectAgentConfig(sandbox, "active", "after-start", redactions);
   await expectProvidersExist(host, env, redactions, "after-start");
   for (const channel of CHANNELS) expectPlanChannelState(channel, "active");
   for (const channel of CHANNELS) {
     expect(
-      await policyPresetState(host, env, redactions, channel),
+      await policyPresetState(host, env, redactions, channel, "after-start"),
       `${channel} policy active after start+rebuild`,
     ).toBe("active");
   }

--- a/test/e2e/live/channels-stop-start-helpers.ts
+++ b/test/e2e/live/channels-stop-start-helpers.ts
@@ -10,6 +10,7 @@ import {
   type OpenClawChannelConfigState,
   openClawChannelIsActive,
   openClawChannelIsInert,
+  openClawChannelStateProbeScript,
 } from "./channels-stop-start-config-state.ts";
 import { startChannelsStopStartProgress } from "./channels-stop-start-progress.ts";
 import { assertChannelsStopStartSandboxName } from "./channels-stop-start-safety.ts";
@@ -309,41 +310,13 @@ function expectChannelInputs(env: NodeJS.ProcessEnv): void {
   }
 }
 
-function openClawChannelKey(channel: string): string {
-  if (channel === "wechat") return "openclaw-weixin";
-  if (channel === "teams") return "msteams";
-  return channel;
-}
-
 async function readOpenClawChannelState(
   sandbox: import("../fixtures/clients/sandbox.ts").SandboxClient,
   channel: string,
   context: string,
   redactions: string[],
 ): Promise<OpenClawChannelConfigState> {
-  const script = `
-import json
-key = ${JSON.stringify(openClawChannelKey(channel))}
-cfg = json.load(open('/sandbox/.openclaw/openclaw.json'))
-channels = cfg.get('channels', {})
-plugins = cfg.get('plugins', {}).get('entries', {})
-channel_present = key in channels
-plugin_present = key in plugins
-channel = channels.get(key)
-plugin = plugins.get(key)
-channel_obj = channel if isinstance(channel, dict) else None
-plugin_obj = plugin if isinstance(plugin, dict) else None
-print(json.dumps({
-  'channelPresent': channel_present,
-  'channelEnabled': channel_obj is not None and channel_obj.get('enabled') is True,
-  'channelDisabled': channel_obj is not None and channel_obj.get('enabled') is False,
-  'channelHasSettings': channel_present and (channel_obj is None or any(field != 'enabled' for field in channel_obj)),
-  'pluginPresent': plugin_present,
-  'pluginEnabled': plugin_obj is not None and plugin_obj.get('enabled') is True,
-  'pluginDisabled': plugin_obj is not None and plugin_obj.get('enabled') is False,
-  'pluginHasSettings': plugin_present and (plugin_obj is None or any(field != 'enabled' for field in plugin_obj)),
-}, separators=(',', ':')))
-`.trim();
+  const script = openClawChannelStateProbeScript(channel);
   const result = await sandboxSh(sandbox, SANDBOX_NAME, `python3 -c ${shellQuote(script)}`, {
     artifactName: `config-channel-${AGENT}-${channel}-${context}`,
     redactionValues: redactions,

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -601,6 +601,7 @@
     {
       "live": "test/e2e/live/channels-stop-start.test.ts",
       "fast": [
+        "test/e2e/support/channels-stop-start-config-state.test.ts",
         "test/e2e/support/channels-stop-start-googlechat-entry.test.ts",
         "test/e2e/support/e2e-progress-fixture.test.ts",
         "test/e2e/support/e2e-progress-outcome.test.ts",

--- a/test/e2e/support/channels-stop-start-config-state.test.ts
+++ b/test/e2e/support/channels-stop-start-config-state.test.ts
@@ -67,6 +67,17 @@ describe("channels stop/start OpenClaw configuration state", () => {
     expect(openClawChannelIsActive(state)).toBe(false);
   });
 
+  it("treats an enabled plugin without channel configuration as inert (#9820)", () => {
+    const state = {
+      ...ABSENT,
+      pluginPresent: true,
+      pluginEnabled: true,
+    };
+
+    expect(openClawChannelIsActive(state)).toBe(false);
+    expect(openClawChannelIsInert(state)).toBe(true);
+  });
+
   it("treats an enabled channel and plugin as active (#9820)", () => {
     const state = {
       ...MANAGED_IMAGE_DISABLED,
@@ -116,36 +127,25 @@ describe("channels stop/start OpenClaw configuration state", () => {
     },
   );
 
-  it.each([
-    ["channel", { channelEnabled: true, channelDisabled: false }],
-    ["plugin", { pluginEnabled: true, pluginDisabled: false }],
-  ])("rejects one-sided %s activation as active or inert (#9820)", (_case, overrides) => {
+  it("rejects channel activation without an enabled plugin as active or inert (#9820)", () => {
+    const overrides = { channelEnabled: true, channelDisabled: false };
     const state = { ...MANAGED_IMAGE_DISABLED, ...overrides };
 
     expect(openClawChannelIsActive(state)).toBe(false);
     expect(openClawChannelIsInert(state)).toBe(false);
   });
 
-  it.each([
-    ["channel", { channelHasSettings: true }],
-    ["plugin", { pluginHasSettings: true }],
-  ])("rejects disabled %s settings as inert (#9820)", (_case, overrides) => {
-    const state = { ...MANAGED_IMAGE_DISABLED, ...overrides };
+  it("rejects disabled channel settings as inert (#9820)", () => {
+    const state = { ...MANAGED_IMAGE_DISABLED, channelHasSettings: true };
 
     expect(openClawChannelIsActive(state)).toBe(false);
     expect(openClawChannelIsInert(state)).toBe(false);
   });
 
-  it.each([
-    ["channel", { channelDisabled: false }],
-    ["plugin", { pluginDisabled: false }],
-  ])(
-    "rejects a present %s entry without an explicit state as inert (#9820)",
-    (_case, overrides) => {
-      const state = { ...MANAGED_IMAGE_DISABLED, ...overrides };
+  it("rejects a present channel entry without an explicit state as inert (#9820)", () => {
+    const state = { ...MANAGED_IMAGE_DISABLED, channelDisabled: false };
 
-      expect(openClawChannelIsActive(state)).toBe(false);
-      expect(openClawChannelIsInert(state)).toBe(false);
-    },
-  );
+    expect(openClawChannelIsActive(state)).toBe(false);
+    expect(openClawChannelIsInert(state)).toBe(false);
+  });
 });

--- a/test/e2e/support/channels-stop-start-config-state.test.ts
+++ b/test/e2e/support/channels-stop-start-config-state.test.ts
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  type OpenClawChannelConfigState,
+  openClawChannelIsActive,
+  openClawChannelIsInert,
+} from "../live/channels-stop-start-config-state.ts";
+
+const ABSENT: OpenClawChannelConfigState = {
+  channelPresent: false,
+  channelEnabled: false,
+  channelDisabled: false,
+  channelHasSettings: false,
+  pluginPresent: false,
+  pluginEnabled: false,
+  pluginDisabled: false,
+  pluginHasSettings: false,
+};
+
+const MANAGED_IMAGE_DISABLED: OpenClawChannelConfigState = {
+  ...ABSENT,
+  channelPresent: true,
+  channelDisabled: true,
+  pluginPresent: true,
+  pluginDisabled: true,
+};
+
+describe("channels stop/start OpenClaw configuration state", () => {
+  it.each([
+    ["missing entries", ABSENT],
+    ["managed-image disabled entries", MANAGED_IMAGE_DISABLED],
+  ])("treats %s as inert (#9820)", (_case, state) => {
+    expect(openClawChannelIsInert(state)).toBe(true);
+    expect(openClawChannelIsActive(state)).toBe(false);
+  });
+
+  it("treats an enabled channel and plugin as active (#9820)", () => {
+    const state = {
+      ...MANAGED_IMAGE_DISABLED,
+      channelEnabled: true,
+      channelDisabled: false,
+      channelHasSettings: true,
+      pluginEnabled: true,
+      pluginDisabled: false,
+    };
+
+    expect(openClawChannelIsActive(state)).toBe(true);
+    expect(openClawChannelIsInert(state)).toBe(false);
+  });
+
+  it.each([
+    ["channel", { channelEnabled: true, channelDisabled: false }],
+    ["plugin", { pluginEnabled: true, pluginDisabled: false }],
+  ])("rejects one-sided %s activation as active or inert (#9820)", (_case, overrides) => {
+    const state = { ...MANAGED_IMAGE_DISABLED, ...overrides };
+
+    expect(openClawChannelIsActive(state)).toBe(false);
+    expect(openClawChannelIsInert(state)).toBe(false);
+  });
+
+  it.each([
+    ["channel", { channelHasSettings: true }],
+    ["plugin", { pluginHasSettings: true }],
+  ])("rejects disabled %s settings as inert (#9820)", (_case, overrides) => {
+    const state = { ...MANAGED_IMAGE_DISABLED, ...overrides };
+
+    expect(openClawChannelIsActive(state)).toBe(false);
+    expect(openClawChannelIsInert(state)).toBe(false);
+  });
+
+  it.each([
+    ["channel", { channelDisabled: false }],
+    ["plugin", { pluginDisabled: false }],
+  ])(
+    "rejects a present %s entry without an explicit state as inert (#9820)",
+    (_case, overrides) => {
+      const state = { ...MANAGED_IMAGE_DISABLED, ...overrides };
+
+      expect(openClawChannelIsActive(state)).toBe(false);
+      expect(openClawChannelIsInert(state)).toBe(false);
+    },
+  );
+});

--- a/test/e2e/support/channels-stop-start-config-state.test.ts
+++ b/test/e2e/support/channels-stop-start-config-state.test.ts
@@ -1,18 +1,26 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
 import { describe, expect, it } from "vitest";
 
 import {
   type OpenClawChannelConfigState,
   openClawChannelIsActive,
   openClawChannelIsInert,
+  openClawChannelStateProbeScript,
 } from "../live/channels-stop-start-config-state.ts";
 
 const ABSENT: OpenClawChannelConfigState = {
   channelPresent: false,
+  channelActivationUsesAccounts: false,
   channelEnabled: false,
   channelDisabled: false,
+  channelHasEnabledAccount: false,
   channelHasSettings: false,
   pluginPresent: false,
   pluginEnabled: false,
@@ -27,6 +35,28 @@ const MANAGED_IMAGE_DISABLED: OpenClawChannelConfigState = {
   pluginPresent: true,
   pluginDisabled: true,
 };
+
+function parseRenderedOpenClawState(
+  channel: string,
+  config: Record<string, unknown>,
+): OpenClawChannelConfigState {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-channel-state-"));
+  const configPath = path.join(fixtureDir, "openclaw.json");
+  try {
+    fs.writeFileSync(configPath, JSON.stringify(config));
+    const result = spawnSync(
+      "python3",
+      ["-c", openClawChannelStateProbeScript(channel, configPath)],
+      {
+        encoding: "utf8",
+      },
+    );
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    return JSON.parse(result.stdout) as OpenClawChannelConfigState;
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  }
+}
 
 describe("channels stop/start OpenClaw configuration state", () => {
   it.each([
@@ -50,6 +80,41 @@ describe("channels stop/start OpenClaw configuration state", () => {
     expect(openClawChannelIsActive(state)).toBe(true);
     expect(openClawChannelIsInert(state)).toBe(false);
   });
+
+  it("parses an enabled WeChat account and plugin as active (#9820)", () => {
+    const state = parseRenderedOpenClawState("wechat", {
+      channels: {
+        "openclaw-weixin": { accounts: { "wechat-account": { enabled: true } } },
+      },
+      plugins: { entries: { "openclaw-weixin": { enabled: true } } },
+    });
+
+    expect(state.channelActivationUsesAccounts).toBe(true);
+    expect(state.channelEnabled).toBe(false);
+    expect(state.channelHasEnabledAccount).toBe(true);
+    expect(openClawChannelIsActive(state)).toBe(true);
+    expect(openClawChannelIsInert(state)).toBe(false);
+  });
+
+  it.each([
+    [false, true],
+    [true, false],
+  ])(
+    "rejects one-sided WeChat account/plugin activation (%s/%s) (#9820)",
+    (accountEnabled, pluginEnabled) => {
+      const state = parseRenderedOpenClawState("wechat", {
+        channels: {
+          "openclaw-weixin": {
+            accounts: { "wechat-account": { enabled: accountEnabled } },
+          },
+        },
+        plugins: { entries: { "openclaw-weixin": { enabled: pluginEnabled } } },
+      });
+
+      expect(openClawChannelIsActive(state)).toBe(false);
+      expect(openClawChannelIsInert(state)).toBe(false);
+    },
+  );
 
   it.each([
     ["channel", { channelEnabled: true, channelDisabled: false }],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The channels stop/start E2E test now evaluates OpenClaw channel and plugin state instead of treating key presence as active configuration. Managed-image entries with `enabled: false` pass stopped-state verification, while partial activation and retained settings fail.

## Related Issue

Fixes #9820

## Changes

- Add a credential-free OpenClaw configuration-state classifier for the live probe and fast regression test. The pure helper lets pull request tests cover the state contract without exposing channel configuration in artifacts.
- Preserve separate baseline, post-stop, and post-start artifacts for agent configuration and network policy state.
- Register the regression test as fast evidence for the channels stop/start live E2E test.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The probe emits only state booleans. It does not emit channel setting names, channel setting values, or credentials. Existing artifact redaction remains active.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/channels-stop-start-config-state.test.ts test/e2e/support/channels-add-remove-helpers.test.ts` passed 14 tests; `npx vitest run --project integration test/generate-openclaw-config-plugin-entries.test.ts` passed 6 tests; `npm run test:e2e-phases:check` validated 131 tests across 86 files.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for channel stop/start configuration states.
  * Added validation for active, inert, incomplete, disabled, and missing configurations.
  * Added account-based activation checks, including valid and invalid paired-account scenarios.
  * Improved lifecycle verification after stopping and restarting channels.
  * Added clearer diagnostics and test artifacts for configuration-state failures.
  * Added fast-test coverage for channel configuration-state probing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->