### PR TITLE
fix(onboard): inspect acknowledged Podman probe IDs

### DIFF
--- a/src/lib/onboard/runtime-provider/podman-host-local-inference.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference.test.ts
@@ -239,33 +239,55 @@ describe("Podman host-local inference lifecycle", () => {
     ).toBe(true);
   });
 
-  it.each([
-    ["malformed", "not-a-full-container-id", "must be a full immutable ID"],
-    ["a different full ID", `${"d".repeat(64)}\n`, "disagrees with exact name inspection"],
-  ] as const)(
-    "captures %s successful disposable-probe create acknowledgement and removes all residue",
-    (_label, acknowledgement, expectedFailure) => {
-      const harness = createPodmanHostLocalInferenceTestHarness();
-      harness.state.probeRunAcknowledgementText = acknowledgement;
-      const runtime = operationRuntime(harness);
+  it("uses a valid full container ID when probe name lookup would time out (#9211)", () => {
+    const harness = createPodmanHostLocalInferenceTestHarness();
+    harness.state.probePostCreateNameLookupTimeout = true;
+    expect(() =>
+      operationRuntime(harness).startManaged(harness.input, harness.writer),
+    ).not.toThrow();
+  });
 
-      expect(() => runtime.startManaged(harness.input, harness.writer)).toThrow(expectedFailure);
-      expect(
-        harness.failures.some(
-          ({ phase, message }) => phase === "ready" && message.includes(expectedFailure),
-        ),
-      ).toBe(true);
-      const evidenceIndex = harness.events.indexOf("evidence:ready");
-      const removeIndex = harness.events.findIndex((event) =>
-        event.includes(`podman:rm --force ${"c".repeat(64)}`),
-      );
-      expect(evidenceIndex).toBeGreaterThanOrEqual(0);
-      expect(removeIndex).toBeGreaterThan(evidenceIndex);
-      expect(harness.probe()).toBeNull();
-      expect(harness.container()).toBeNull();
-      expect(harness.written).toHaveLength(0);
-    },
-  );
+  it("captures a malformed disposable-probe create acknowledgement and removes all residue", () => {
+    const harness = createPodmanHostLocalInferenceTestHarness();
+    harness.state.probeRunAcknowledgementText = "not-a-full-container-id";
+    const runtime = operationRuntime(harness);
+
+    expect(() => runtime.startManaged(harness.input, harness.writer)).toThrow(
+      "must be a full immutable ID",
+    );
+    expect(
+      harness.failures.some(
+        ({ phase, message }) =>
+          phase === "ready" && message.includes("must be a full immutable ID"),
+      ),
+    ).toBe(true);
+    const evidenceIndex = harness.events.indexOf("evidence:ready");
+    const removeIndex = harness.events.findIndex((event) =>
+      event.includes(`podman:rm --force ${"c".repeat(64)}`),
+    );
+    expect(evidenceIndex).toBeGreaterThanOrEqual(0);
+    expect(removeIndex).toBeGreaterThan(evidenceIndex);
+    expect(harness.probe()).toBeNull();
+    expect(harness.container()).toBeNull();
+    expect(harness.written).toHaveLength(0);
+  });
+
+  it("retains a same-name probe when the acknowledged full container ID is absent", () => {
+    const harness = createPodmanHostLocalInferenceTestHarness();
+    harness.state.probeRunAcknowledgementText = `${"d".repeat(64)}\n`;
+    const runtime = operationRuntime(harness);
+
+    expect(() => runtime.startManaged(harness.input, harness.writer)).toThrow(
+      "probe identity is indeterminate after create",
+    );
+    expect(harness.probe()).toMatchObject({ id: "c".repeat(64), running: true });
+    expect(
+      harness.events.some((event) => event.includes(`podman:rm --force ${"c".repeat(64)}`)),
+    ).toBe(false);
+    expect(
+      harness.events.some((event) => event.includes(`podman:rm --force ${"d".repeat(64)}`)),
+    ).toBe(false);
+  });
 
   it("accepts a lost disposable-probe remove acknowledgement only after exact absence proof", () => {
     const harness = createPodmanHostLocalInferenceTestHarness();

--- a/src/lib/onboard/runtime-provider/podman-host-local-inference.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference.test.ts
@@ -262,32 +262,32 @@ describe("Podman host-local inference lifecycle", () => {
       ),
     ).toBe(true);
     const evidenceIndex = harness.events.indexOf("evidence:ready");
-    const removeIndex = harness.events.findIndex((event) =>
-      event.includes(`podman:rm --force ${"c".repeat(64)}`),
-    );
+    const removeIndex = harness.events.indexOf(`podman:rm --force ${"c".repeat(64)}`);
     expect(evidenceIndex).toBeGreaterThanOrEqual(0);
     expect(removeIndex).toBeGreaterThan(evidenceIndex);
     expect(harness.probe()).toBeNull();
     expect(harness.container()).toBeNull();
-    expect(harness.written).toHaveLength(0);
   });
 
-  it("retains a same-name probe when the acknowledged full container ID is absent", () => {
-    const harness = createPodmanHostLocalInferenceTestHarness();
-    harness.state.probeRunAcknowledgementText = `${"d".repeat(64)}\n`;
-    const runtime = operationRuntime(harness);
+  it.each([
+    ["after create", 1, "(?:wait|logs|rm --force)"],
+    ["during cleanup", 3, "rm --force"],
+  ] as const)(
+    "rejects a Podman inspect result whose container ID differs from the queried ID %s (#9211)",
+    (_stage, at, action) => {
+      const harness = createPodmanHostLocalInferenceTestHarness();
+      harness.state.probeInspectRuntimeIdMismatchAt = at;
+      const runtime = operationRuntime(harness);
+      const [acknowledgedId, inspectedId] = ["c".repeat(64), "d".repeat(64)];
 
-    expect(() => runtime.startManaged(harness.input, harness.writer)).toThrow(
-      "probe identity is indeterminate after create",
-    );
-    expect(harness.probe()).toMatchObject({ id: "c".repeat(64), running: true });
-    expect(
-      harness.events.some((event) => event.includes(`podman:rm --force ${"c".repeat(64)}`)),
-    ).toBe(false);
-    expect(
-      harness.events.some((event) => event.includes(`podman:rm --force ${"d".repeat(64)}`)),
-    ).toBe(false);
-  });
+      expect(() => runtime.startManaged(harness.input, harness.writer)).toThrow();
+      expect(harness.probe()).toMatchObject({ id: acknowledgedId });
+      expect(harness.events).toContain(`podman:container inspect ${acknowledgedId}`);
+      expect(harness.events.join("\n")).not.toMatch(
+        new RegExp(`podman:${action} (?:${acknowledgedId}|${inspectedId})`, "u"),
+      );
+    },
+  );
 
   it("accepts a lost disposable-probe remove acknowledgement only after exact absence proof", () => {
     const harness = createPodmanHostLocalInferenceTestHarness();

--- a/src/lib/onboard/runtime-provider/podman-host-local-inference.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference.test.ts
@@ -261,31 +261,24 @@ describe("Podman host-local inference lifecycle", () => {
           phase === "ready" && message.includes("must be a full immutable ID"),
       ),
     ).toBe(true);
-    const evidenceIndex = harness.events.indexOf("evidence:ready");
-    const removeIndex = harness.events.indexOf(`podman:rm --force ${"c".repeat(64)}`);
-    expect(evidenceIndex).toBeGreaterThanOrEqual(0);
-    expect(removeIndex).toBeGreaterThan(evidenceIndex);
+    expect(harness.failureProbeIds[0]).toBe("c".repeat(64));
     expect(harness.probe()).toBeNull();
     expect(harness.container()).toBeNull();
   });
 
   it.each([
-    ["after create", 1, "(?:wait|logs|rm --force)"],
-    ["during cleanup", 3, "rm --force"],
+    ["after create", 1, ["wait", "logs", "rm"], "probe identity is indeterminate after create"],
+    ["during cleanup", 3, ["rm"], "probe cleanup lost exact identity"],
   ] as const)(
     "rejects a Podman inspect result whose container ID differs from the queried ID %s (#9211)",
-    (_stage, at, action) => {
+    (_stage, at, forbiddenActions, expectedFailure) => {
       const harness = createPodmanHostLocalInferenceTestHarness();
       harness.state.probeInspectRuntimeIdMismatchAt = at;
+      harness.state.probeForbiddenActions = [...forbiddenActions];
       const runtime = operationRuntime(harness);
-      const [acknowledgedId, inspectedId] = ["c".repeat(64), "d".repeat(64)];
 
-      expect(() => runtime.startManaged(harness.input, harness.writer)).toThrow();
-      expect(harness.probe()).toMatchObject({ id: acknowledgedId });
-      expect(harness.events).toContain(`podman:container inspect ${acknowledgedId}`);
-      expect(harness.events.join("\n")).not.toMatch(
-        new RegExp(`podman:${action} (?:${acknowledgedId}|${inspectedId})`, "u"),
-      );
+      expect(() => runtime.startManaged(harness.input, harness.writer)).toThrow(expectedFailure);
+      expect(harness.probe()).toMatchObject({ id: "c".repeat(64) });
     },
   );
 

--- a/src/lib/onboard/runtime-provider/podman-host-local-inference.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference.ts
@@ -1849,14 +1849,25 @@ function executeExactProbe(
       `Podman inference probe create returned exit ${String(run.status)}: ${redactedCommandEvidence(redactor, run)}`,
     );
   }
-  let runtimeId: string | null;
-  try {
-    runtimeId = lookupContainerId(engine, spec.name);
-  } catch (error) {
-    captureFailure(error);
-    throw new PodmanInferenceIndeterminateCleanupError(
-      "Podman inference probe identity lookup failed after create.",
-    );
+  let runtimeId: string | null = null;
+  let acknowledgementFailure: Error | null = null;
+  if (run.status === 0 && !run.error) {
+    try {
+      runtimeId = exactContainerId(run.stdout.trim());
+    } catch (error) {
+      acknowledgementFailure =
+        error instanceof Error ? error : new Error(errorEvidence(redactor, error));
+    }
+  }
+  if (runtimeId === null) {
+    try {
+      runtimeId = lookupContainerId(engine, spec.name);
+    } catch (error) {
+      captureFailure(error);
+      throw new PodmanInferenceIndeterminateCleanupError(
+        "Podman inference probe identity lookup failed after create.",
+      );
+    }
   }
   if (runtimeId === null) {
     throw new Error(
@@ -1872,32 +1883,16 @@ function executeExactProbe(
       "Podman inference probe identity is indeterminate after create.",
     );
   }
-  if (run.status === 0 && !run.error) {
-    let acknowledgementFailure: Error | null = null;
+  if (acknowledgementFailure !== null) {
+    captureFailure(acknowledgementFailure);
+    cleanupExactProbe(engine, container, spec, phase, onFailureEvidence, redactor);
     try {
-      const reportedId = exactContainerId(run.stdout.trim());
-      if (reportedId !== container.runtimeId) {
-        throw new Error(
-          "Podman inference probe create identity disagrees with exact name inspection.",
-        );
-      }
+      assertAuthority();
     } catch (error) {
-      acknowledgementFailure =
-        error instanceof Error ? error : new Error(errorEvidence(redactor, error));
-      captureFailure(acknowledgementFailure);
+      captureFailure(error);
+      throw new PodmanInferenceCapturedFailureError(errorEvidence(redactor, error));
     }
-    if (acknowledgementFailure !== null) {
-      cleanupExactProbe(engine, container, spec, phase, onFailureEvidence, redactor);
-      try {
-        assertAuthority();
-      } catch (error) {
-        captureFailure(error);
-        throw new PodmanInferenceCapturedFailureError(errorEvidence(redactor, error));
-      }
-      throw new PodmanInferenceCapturedFailureError(
-        errorEvidence(redactor, acknowledgementFailure),
-      );
-    }
+    throw new PodmanInferenceCapturedFailureError(errorEvidence(redactor, acknowledgementFailure));
   }
 
   let failure: Error | null = null;

--- a/src/lib/onboard/runtime-provider/podman-host-local-inference.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference.ts
@@ -1718,7 +1718,16 @@ function probeLabels(spec: ProbeSpec): Readonly<Record<string, string>> {
   });
 }
 
-function requireProbeIdentity(container: ProbeContainer, spec: ProbeSpec): ProbeContainer {
+function requireProbeIdentity(
+  container: ProbeContainer,
+  spec: ProbeSpec,
+  expectedRuntimeId: string,
+): ProbeContainer {
+  if (container.runtimeId !== expectedRuntimeId) {
+    throw new Error(
+      "Podman inference probe inspect returned a container ID other than the queried full container ID.",
+    );
+  }
   const expectedLabels = probeLabels(spec);
   const actualControlledLabels = Object.fromEntries(
     Object.entries(container.labels).filter(([key]) =>
@@ -1758,7 +1767,11 @@ function cleanupExactProbe(
 ): void {
   let current: ProbeContainer;
   try {
-    current = requireProbeIdentity(inspectProbeContainer(engine, container.runtimeId), spec);
+    current = requireProbeIdentity(
+      inspectProbeContainer(engine, container.runtimeId),
+      spec,
+      container.runtimeId,
+    );
   } catch (error) {
     emitProviderFailure(
       phase,
@@ -1827,7 +1840,7 @@ function executeExactProbe(
   }
   if (existingId !== null) {
     try {
-      requireProbeIdentity(inspectProbeContainer(engine, existingId), spec);
+      requireProbeIdentity(inspectProbeContainer(engine, existingId), spec, existingId);
     } catch (error) {
       captureFailure(error);
       throw new PodmanInferenceIndeterminateCleanupError(
@@ -1876,7 +1889,7 @@ function executeExactProbe(
   }
   let container: ProbeContainer;
   try {
-    container = requireProbeIdentity(inspectProbeContainer(engine, runtimeId), spec);
+    container = requireProbeIdentity(inspectProbeContainer(engine, runtimeId), spec, runtimeId);
   } catch (error) {
     captureFailure(error);
     throw new PodmanInferenceIndeterminateCleanupError(
@@ -1903,7 +1916,11 @@ function executeExactProbe(
     );
     captureFailure(failure);
     try {
-      container = requireProbeIdentity(inspectProbeContainer(engine, container.runtimeId), spec);
+      container = requireProbeIdentity(
+        inspectProbeContainer(engine, container.runtimeId),
+        spec,
+        container.runtimeId,
+      );
       if (container.running) {
         const stop = engine.capture(
           ["stop", "--time", String(STOP_GRACE_SECONDS), container.runtimeId],
@@ -1914,7 +1931,11 @@ function executeExactProbe(
             `Podman inference probe stop returned exit ${String(stop.status)}: ${redactedCommandEvidence(redactor, stop)}`,
           );
         }
-        container = requireProbeIdentity(inspectProbeContainer(engine, container.runtimeId), spec);
+        container = requireProbeIdentity(
+          inspectProbeContainer(engine, container.runtimeId),
+          spec,
+          container.runtimeId,
+        );
         if (container.running || !AT_REST_STATES.has(container.status)) {
           throw new Error("probe stop did not prove an exact at-rest state");
         }
@@ -1932,7 +1953,11 @@ function executeExactProbe(
       captureFailure(failure);
     }
     try {
-      container = requireProbeIdentity(inspectProbeContainer(engine, container.runtimeId), spec);
+      container = requireProbeIdentity(
+        inspectProbeContainer(engine, container.runtimeId),
+        spec,
+        container.runtimeId,
+      );
       if (
         container.running ||
         !AT_REST_STATES.has(container.status) ||

--- a/test/helpers/podman-host-local-inference-test-harness.ts
+++ b/test/helpers/podman-host-local-inference-test-harness.ts
@@ -90,6 +90,7 @@ export interface PodmanHostLocalInferenceHarness {
   readonly env: NodeJS.ProcessEnv;
   readonly events: string[];
   readonly failures: PodmanInferenceFailureEvidence[];
+  readonly failureProbeIds: Array<string | null>;
   readonly input: HostLocalManagedInferenceInput;
   readonly operationAcceleration: HostLocalOllamaAccelerationAuthority;
   readonly routeAuthorityStore: HostLocalInferenceRouteAuthorityStore;
@@ -120,6 +121,7 @@ export interface PodmanHostLocalInferenceHarness {
     probeRunAcknowledgementText: string | null;
     probePostCreateNameLookupTimeout: boolean;
     probeInspectRuntimeIdMismatchAt: number | null;
+    probeForbiddenActions: Array<"logs" | "rm" | "wait">;
     probeWaitFailure: boolean;
     probeRemoveLostAcknowledgement: boolean;
     probeRemoveLeavesContainer: boolean;
@@ -360,6 +362,7 @@ export function createPodmanHostLocalInferenceTestHarness(
   const probeImageRef = options.probeImageRef ?? `registry.test/curl@sha256:${PROBE_DIGEST}`;
   const events: string[] = [];
   const failures: PodmanInferenceFailureEvidence[] = [];
+  const failureProbeIds: Array<string | null> = [];
   const written: string[] = [];
   const state = {
     cdiDevices: [...(options.cdiDevices ?? [`nvidia.com/gpu=${GPU_UUID}`])],
@@ -395,6 +398,7 @@ export function createPodmanHostLocalInferenceTestHarness(
     probeRunAcknowledgementText: null as string | null,
     probePostCreateNameLookupTimeout: false,
     probeInspectRuntimeIdMismatchAt: null as number | null,
+    probeForbiddenActions: [] as Array<"logs" | "rm" | "wait">,
     probeWaitFailure: false,
     probeRemoveLostAcknowledgement: false,
     probeRemoveLeavesContainer: false,
@@ -464,6 +468,16 @@ export function createPodmanHostLocalInferenceTestHarness(
     authorityId: options.authorityId ?? "test:podman-inference",
     endpointAuthorityId: options.authorityId ?? "test:podman-inference",
     capture: (args) => {
+      const probeAction =
+        args[0] === "logs" || args[0] === "rm" || args[0] === "wait" ? args[0] : null;
+      const probeActionId = probeAction === "rm" ? args[2] : args[1];
+      if (
+        probeAction !== null &&
+        state.probeForbiddenActions.includes(probeAction) &&
+        (probeActionId === PROBE_CONTAINER_ID || probeActionId === REUSED_PROBE_CONTAINER_ID)
+      ) {
+        throw new Error(`test forbids probe action '${probeAction}'`);
+      }
       events.push(`podman:${args.join(" ")}`);
       if (args[0] === "version") {
         return result(0, JSON.stringify({ Server: { Version: "6.0.1" } }));
@@ -723,6 +737,7 @@ export function createPodmanHostLocalInferenceTestHarness(
     env,
     events,
     failures,
+    failureProbeIds,
     input,
     operationAcceleration,
     routeAuthorityStore,
@@ -730,6 +745,7 @@ export function createPodmanHostLocalInferenceTestHarness(
     written,
     state,
     onFailureEvidence: (evidence) => {
+      failureProbeIds.push(currentProbe?.id ?? null);
       events.push(`evidence:${evidence.phase}`);
       failures.push(evidence);
     },

--- a/test/helpers/podman-host-local-inference-test-harness.ts
+++ b/test/helpers/podman-host-local-inference-test-harness.ts
@@ -118,6 +118,7 @@ export interface PodmanHostLocalInferenceHarness {
     runSemanticMismatchText: string | null;
     probeRunLostAcknowledgement: boolean;
     probeRunAcknowledgementText: string | null;
+    probePostCreateNameLookupTimeout: boolean;
     probeWaitFailure: boolean;
     probeRemoveLostAcknowledgement: boolean;
     probeRemoveLeavesContainer: boolean;
@@ -391,6 +392,7 @@ export function createPodmanHostLocalInferenceTestHarness(
     runSemanticMismatchText: null as string | null,
     probeRunLostAcknowledgement: false,
     probeRunAcknowledgementText: null as string | null,
+    probePostCreateNameLookupTimeout: false,
     probeWaitFailure: false,
     probeRemoveLostAcknowledgement: false,
     probeRemoveLeavesContainer: false,
@@ -512,6 +514,13 @@ export function createPodmanHostLocalInferenceTestHarness(
         const candidate = [currentContainer, currentProbe].find(
           (container) => container?.name === expectedName,
         );
+        if (
+          state.probePostCreateNameLookupTimeout &&
+          candidate === currentProbe &&
+          currentProbe !== null
+        ) {
+          return result(1, "", "spawnSync /usr/local/bin/podman ETIMEDOUT", new Error("ETIMEDOUT"));
+        }
         if (!candidate) return result();
         return result(0, `${candidate.id}\t${candidate.name}\n`);
       }

--- a/test/helpers/podman-host-local-inference-test-harness.ts
+++ b/test/helpers/podman-host-local-inference-test-harness.ts
@@ -119,6 +119,7 @@ export interface PodmanHostLocalInferenceHarness {
     probeRunLostAcknowledgement: boolean;
     probeRunAcknowledgementText: string | null;
     probePostCreateNameLookupTimeout: boolean;
+    probeInspectRuntimeIdMismatchAt: number | null;
     probeWaitFailure: boolean;
     probeRemoveLostAcknowledgement: boolean;
     probeRemoveLeavesContainer: boolean;
@@ -393,6 +394,7 @@ export function createPodmanHostLocalInferenceTestHarness(
     probeRunLostAcknowledgement: false,
     probeRunAcknowledgementText: null as string | null,
     probePostCreateNameLookupTimeout: false,
+    probeInspectRuntimeIdMismatchAt: null as number | null,
     probeWaitFailure: false,
     probeRemoveLostAcknowledgement: false,
     probeRemoveLeavesContainer: false,
@@ -408,6 +410,7 @@ export function createPodmanHostLocalInferenceTestHarness(
   };
   let currentContainer: TestContainer | null = null;
   let currentProbe: TestProbeContainer | null = null;
+  let probeInspectCount = 0;
   let networkEngineAuthoritySha256 = "";
   let persistedAuthority: PersistedEngineAuthority | null = null;
   let routeAuthority: HostLocalInferenceRouteAuthority | null = null;
@@ -526,7 +529,14 @@ export function createPodmanHostLocalInferenceTestHarness(
       }
       if (args[0] === "container" && args[1] === "inspect") {
         if (currentContainer?.id === args[2]) return result(0, inspectPayload(currentContainer));
-        if (currentProbe?.id === args[2]) return result(0, probeInspectPayload(currentProbe));
+        if (currentProbe?.id === args[2]) {
+          probeInspectCount += 1;
+          const inspectedProbe =
+            state.probeInspectRuntimeIdMismatchAt === probeInspectCount
+              ? { ...currentProbe, id: REUSED_PROBE_CONTAINER_ID }
+              : currentProbe;
+          return result(0, probeInspectPayload(inspectedProbe));
+        }
         return result(125, "", "no such container");
       }
       if (args[0] === "container" && args[1] === "exists") {


### PR DESCRIPTION
## Summary

A successful Podman probe create now uses its full container ID acknowledgement as the immediate immutable inspection target. Previously, every successful create performed a redundant name lookup, so a bounded `podman ps` timeout could abort onboarding even when `podman run --detach` returned a valid full ID. Every probe inspection now also requires the payload ID to equal the queried full ID before wait, logs, or cleanup actions.

## Related Issue

Related to #9211

## Changes

- Inspect a successful probe create by its acknowledged full container ID.
- Retain bounded name lookup for non-successful, lost, or malformed create acknowledgements so residue remains fail-closed.
- Require query-to-payload full-ID equality at every probe inspection and reinspection boundary, including cleanup.
- Add deterministic regressions for a post-create name lookup timeout, malformed acknowledgement cleanup, and mismatched inspect IDs after create and during cleanup.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security review returned PASS for exact head `7306a0250d5bff160fa17346b22d64d52a33f8ed`, base `fac4e6d6783e8909aabf4a9d94f5fa809fea3ec1`, and diff SHA-256 `c8ae813ddd390a1d3eb0c841b98e3bcd923dae6146aab181874acc7ba8d3ec11`; no findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Exact-head review returned PASS for `7306a0250d5bff160fa17346b22d64d52a33f8ed` against `fac4e6d6783e8909aabf4a9d94f5fa809fea3ec1`, diff SHA-256 `c8ae813ddd390a1d3eb0c841b98e3bcd923dae6146aab181874acc7ba8d3ec11`. This internal fail-closed identity correction restores documented Portable onboarding behavior without changing commands, configuration, schemas, or supported workflows.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 7306a0250d5bff160fa17346b22d64d52a33f8ed -->
<!-- docs-review-agents-blob-sha: 513518cdfca42e3a18fed71109e6d0eb60151d13 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `4` focused files / `125` tests; affected selection `142` files / `2168` tests; CLI type-check and `32` growth guardrails passed.
- [ ] Applicable broad gate passed — not applicable; this is a narrow runtime-provider correction covered by the affected-test selection.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local inference startup when container name lookup times out but a valid container ID is available.
  * Strengthened container identity checks throughout probe creation, inspection, cleanup, and rollback.
  * Added safer handling for malformed or mismatched container identifiers, including cleanup of leftover probe containers.
  * Improved failure reporting with clearer stage-specific errors.

* **Tests**
  * Expanded coverage for timeout, malformed acknowledgement, identity mismatch, forbidden actions, and cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
