### PR TITLE
fix(onboard): extend Podman inference validation timeout

### DIFF
--- a/docs/inference/configure-inference-timeouts.mdx
+++ b/docs/inference/configure-inference-timeouts.mdx
@@ -19,7 +19,7 @@ Use the error location to select the correct setting.
 | Setting | Applies to | Default |
 |---|---|---|
 | `NEMOCLAW_AGENT_TIMEOUT` | OpenClaw per-request inference | `600` seconds |
-| `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` | Ollama, vLLM, NIM, and compatible-endpoint validation during onboarding | `180` seconds |
+| `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` | Ollama, vLLM, NIM, and compatible-endpoint onboarding validation paths that read this setting | `180` seconds |
 | `NEMOCLAW_SANDBOX_READY_TIMEOUT` | Image build, gateway upload, and in-sandbox boot after creation | `180` seconds |
 | `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` | OpenShell command re-registration after policy application, plus gateway health and re-registration during managed OpenClaw or Hermes recovery | `30`, `90`, or `120` seconds, depending on the recovery phase |
 
@@ -30,13 +30,6 @@ The readiness timeout does not govern inference requests or provider validation.
 `NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS` accepts finite, nonnegative seconds and preserves fractional values.
 A valid value overrides the internal budget for the current recovery phase.
 An unset, blank, invalid, or negative value uses 30 seconds for OpenClaw gateway health, 90 seconds for Hermes gateway health, and 120 seconds for recreated-sandbox OpenShell registration when the recovery path does not supply another budget.
-
-<AgentOnly variant="openclaw,hermes">
-
-Portable onboarding gives its receipt-owned Podman inference validation request 120 seconds.
-`NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` does not change this fixed deadline.
-
-</AgentOnly>
 
 ## Increase the OpenClaw Request Timeout
 
@@ -81,8 +74,15 @@ Deep Agents does not consume the OpenClaw-only `NEMOCLAW_AGENT_TIMEOUT` setting.
 
 ## Increase the Local Validation Timeout
 
-Raise `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` when the inference-server validation probe needs more than 180 seconds.
+For validation paths that read `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT`, raise it when the inference-server validation request needs more than 180 seconds.
 Large prompts, cold local model loads, and slower hardware can require a larger budget.
+
+<AgentOnly variant="openclaw,hermes">
+
+Portable onboarding uses a fixed 120-second deadline for its receipt-owned Podman inference validation request.
+`NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` does not change this deadline.
+
+</AgentOnly>
 
 ```bash
 export NEMOCLAW_LOCAL_INFERENCE_TIMEOUT=300

--- a/docs/inference/configure-inference-timeouts.mdx
+++ b/docs/inference/configure-inference-timeouts.mdx
@@ -31,6 +31,13 @@ The readiness timeout does not govern inference requests or provider validation.
 A valid value overrides the internal budget for the current recovery phase.
 An unset, blank, invalid, or negative value uses 30 seconds for OpenClaw gateway health, 90 seconds for Hermes gateway health, and 120 seconds for recreated-sandbox OpenShell registration when the recovery path does not supply another budget.
 
+<AgentOnly variant="openclaw,hermes">
+
+Portable onboarding gives its receipt-owned Podman inference validation request 120 seconds.
+`NEMOCLAW_LOCAL_INFERENCE_TIMEOUT` does not change this fixed deadline.
+
+</AgentOnly>
+
 ## Increase the OpenClaw Request Timeout
 
 <AgentOnly variant="openclaw">

--- a/src/lib/onboard/runtime-provider/podman-host-local-inference-timeout.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference-timeout.test.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { createPodmanHostLocalInferenceTestHarness } from "../../../../test/helpers/podman-host-local-inference-test-harness";
+import {
+  createPodmanHostLocalInferenceOperation,
+  PODMAN_INFERENCE_PROBE_MANAGED_LABEL,
+} from "./podman-host-local-inference";
+
+describe("Podman host-local inference timeout boundaries", () => {
+  it("uses separate bounded timeouts for the readiness check and inference validation request (#9211)", () => {
+    const harness = createPodmanHostLocalInferenceTestHarness();
+    const operation = createPodmanHostLocalInferenceOperation({
+      engine: harness.engine,
+      env: harness.env,
+      acceleration: harness.operationAcceleration,
+      authorityStore: harness.authorityStore,
+      routeAuthorityStore: harness.routeAuthorityStore,
+      onFailureEvidence: harness.onFailureEvidence,
+      redactSensitive: harness.redactSensitive,
+    });
+    const runtime =
+      operation.managedRuntime ??
+      (() => {
+        throw new Error("test operation lacks managed runtime");
+      })();
+
+    runtime.startManaged(harness.input, harness.writer);
+
+    const probeRuns = harness.events.filter(
+      (event) =>
+        event.startsWith("podman:run ") &&
+        event.includes(`${PODMAN_INFERENCE_PROBE_MANAGED_LABEL}=true`),
+    );
+    const readyRun = probeRuns.find((event) => event.includes("/v1/health/ready"));
+    const inferenceRun = probeRuns.find((event) => event.includes("/v1/chat/completions"));
+    expect(readyRun).toContain("--retry-max-time 220");
+    expect(readyRun).toContain("--max-time 20");
+    expect(inferenceRun).toContain("--max-time 120");
+    expect(inferenceRun).not.toContain("--retry-max-time");
+    expect(harness.state.probeWaitTimeouts).toEqual([240_000, 150_000]);
+  });
+});

--- a/src/lib/onboard/runtime-provider/podman-host-local-inference-timeout.test.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference-timeout.test.ts
@@ -9,23 +9,26 @@ import {
   PODMAN_INFERENCE_PROBE_MANAGED_LABEL,
 } from "./podman-host-local-inference";
 
+function operationAndRuntime(
+  harness: ReturnType<typeof createPodmanHostLocalInferenceTestHarness>,
+) {
+  const operation = createPodmanHostLocalInferenceOperation({
+    engine: harness.engine,
+    env: harness.env,
+    acceleration: harness.operationAcceleration,
+    authorityStore: harness.authorityStore,
+    routeAuthorityStore: harness.routeAuthorityStore,
+    onFailureEvidence: harness.onFailureEvidence,
+    redactSensitive: harness.redactSensitive,
+  });
+  const runtime = operation.managedRuntime!;
+  return { operation, runtime };
+}
+
 describe("Podman host-local inference timeout boundaries", () => {
   it("uses separate bounded timeouts for the readiness check and inference validation request (#9211)", () => {
     const harness = createPodmanHostLocalInferenceTestHarness();
-    const operation = createPodmanHostLocalInferenceOperation({
-      engine: harness.engine,
-      env: harness.env,
-      acceleration: harness.operationAcceleration,
-      authorityStore: harness.authorityStore,
-      routeAuthorityStore: harness.routeAuthorityStore,
-      onFailureEvidence: harness.onFailureEvidence,
-      redactSensitive: harness.redactSensitive,
-    });
-    const runtime =
-      operation.managedRuntime ??
-      (() => {
-        throw new Error("test operation lacks managed runtime");
-      })();
+    const { runtime } = operationAndRuntime(harness);
 
     runtime.startManaged(harness.input, harness.writer);
 
@@ -41,5 +44,49 @@ describe("Podman host-local inference timeout boundaries", () => {
     expect(inferenceRun).toContain("--max-time 120");
     expect(inferenceRun).not.toContain("--retry-max-time");
     expect(harness.state.probeWaitTimeouts).toEqual([240_000, 150_000]);
+  });
+
+  it("removes an exact at-rest 20-second inference probe before recovery starts its replacement (#9211)", () => {
+    const harness = createPodmanHostLocalInferenceTestHarness();
+    const { operation, runtime } = operationAndRuntime(harness);
+    harness.seedManaged("stopped", false, operation.bindingSha256);
+    harness.state.retainLegacyInferenceProbe = true;
+    harness.events.length = 0;
+
+    const prepared = runtime.recoverManaged!(harness.input, harness.writer);
+
+    const legacyRemoval = harness.events.indexOf(`podman:rm ${"c".repeat(64)}`);
+    const replacementRun = harness.events.findIndex(
+      (event) => event.startsWith("podman:run ") && event.includes("/v1/chat/completions"),
+    );
+    expect(legacyRemoval).toBeGreaterThanOrEqual(0);
+    expect(replacementRun).toBeGreaterThan(legacyRemoval);
+    expect(harness.events[replacementRun]).toContain("--max-time 120");
+    expect(harness.probe()).toBeNull();
+    expect(prepared.rollback()).toMatchObject({ status: "restored", priorState: "stopped" });
+  });
+
+  it("does not remove a running probe that has the legacy inference identity (#9211)", () => {
+    const harness = createPodmanHostLocalInferenceTestHarness();
+    const { operation, runtime } = operationAndRuntime(harness);
+    harness.seedManaged("stopped", false, operation.bindingSha256);
+    harness.state.retainLegacyInferenceProbe = true;
+    harness.state.legacyInferenceProbeRunning = true;
+    harness.events.length = 0;
+
+    expect(() => runtime.recoverManaged?.(harness.input, harness.writer)).toThrow(
+      "retained legacy probe is not in an exact at-rest state",
+    );
+    const retained = harness.probe();
+    const legacyLookup = harness.events.findIndex((event) =>
+      event.includes(`name=^${String(retained?.name)}$`),
+    );
+    expect(legacyLookup).toBeGreaterThanOrEqual(0);
+    expect(
+      harness.events
+        .slice(legacyLookup + 1)
+        .some((event) => event.startsWith("podman:rm ") && event.endsWith("c".repeat(64))),
+    ).toBe(false);
+    expect(retained).toMatchObject({ running: true, status: "running" });
   });
 });

--- a/src/lib/onboard/runtime-provider/podman-host-local-inference.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference.ts
@@ -255,6 +255,11 @@ interface ProbeSpec {
   readonly launchArguments: readonly string[];
 }
 
+interface ProbeSpecSet {
+  readonly current: ProbeSpec;
+  readonly legacy: ProbeSpec;
+}
+
 interface OllamaModelPlacementAuthority {
   readonly modelDigest: string;
 }
@@ -1632,81 +1637,109 @@ function createProbeSpec(
   parent: ProbeParentAuthority,
   request: readonly string[],
   authority: PodmanInferenceAuthorityReceipt,
-): ProbeSpec {
+): ProbeSpecSet {
   const curlMaxTimeSeconds =
     phase === "inference" ? INFERENCE_PROBE_CURL_MAX_TIME_SECONDS : PROBE_CURL_MAX_TIME_SECONDS;
   const normalizedImage = normalizeHostLocalInferenceImageRef(probeImageRef);
+  const normalizedRequest = normalizedArguments(request, "Podman inference probe request");
+  const transactionId = exactText(
+    parent.transactionId,
+    SHA256,
+    "Podman inference probe transaction",
+  );
+  const receiptTargetSha256 = exactText(
+    parent.receiptTargetSha256,
+    SHA256,
+    "Podman inference probe receipt target",
+  );
+  const parentAuthoritySha256 = exactText(
+    parent.parentAuthoritySha256,
+    SHA256,
+    "Podman inference probe parent authority",
+  );
+  const legacyCanonical = Object.freeze({
+    providerId: PROVIDER_ID,
+    service,
+    phase,
+    endpoint,
+    probeImageRef: normalizedImage,
+    transactionId,
+    receiptTargetSha256,
+    parentAuthoritySha256,
+    request: normalizedRequest,
+  });
   const canonical = Object.freeze({
     providerId: PROVIDER_ID,
     service,
     phase,
     endpoint,
     probeImageRef: normalizedImage,
-    transactionId: exactText(parent.transactionId, SHA256, "Podman inference probe transaction"),
-    receiptTargetSha256: exactText(
-      parent.receiptTargetSha256,
-      SHA256,
-      "Podman inference probe receipt target",
-    ),
-    parentAuthoritySha256: exactText(
-      parent.parentAuthoritySha256,
-      SHA256,
-      "Podman inference probe parent authority",
-    ),
-    request: normalizedArguments(request, "Podman inference probe request"),
+    transactionId,
+    receiptTargetSha256,
+    parentAuthoritySha256,
+    curlMaxTimeSeconds,
+    request: normalizedRequest,
   });
-  const specSha256 = digest(canonical);
-  const name = `nemoclaw-inference-probe-${phase}-${specSha256.slice(0, 16)}`;
-  const source = Object.freeze([
-    "run",
-    "--detach",
-    "--pull=never",
-    "--name",
-    name,
-    "--label",
-    `${PODMAN_INFERENCE_PROBE_MANAGED_LABEL}=true`,
-    "--label",
-    `${PODMAN_INFERENCE_PROVIDER_LABEL}=${PROVIDER_ID}`,
-    "--label",
-    `${PODMAN_INFERENCE_SERVICE_LABEL}=${service}`,
-    "--label",
-    `${PODMAN_INFERENCE_AUTHORITY_LABEL}=${canonical.parentAuthoritySha256}`,
-    "--label",
-    `${PODMAN_INFERENCE_TRANSACTION_LABEL}=${canonical.transactionId}`,
-    "--label",
-    `${PODMAN_INFERENCE_RECEIPT_TARGET_LABEL}=${canonical.receiptTargetSha256}`,
-    "--label",
-    `${PODMAN_INFERENCE_PROBE_PHASE_LABEL}=${phase}`,
-    "--label",
-    `${PODMAN_INFERENCE_PROBE_SPEC_LABEL}=${specSha256}`,
-    "--network",
-    endpoint.networkName,
-    "--read-only",
-    "--ipc",
-    "private",
-    normalizedImage,
-    "--fail-with-body",
-    "--silent",
-    "--show-error",
-    "--connect-timeout",
-    "3",
-    "--max-time",
-    String(curlMaxTimeSeconds),
-    ...canonical.request,
-  ]);
-  const launchArguments = translatePodmanLocalInferenceArgs(source, authority);
+  const buildSpec = (
+    identity: typeof canonical | typeof legacyCanonical,
+    maxTimeSeconds: number,
+  ): ProbeSpec => {
+    const specSha256 = digest(identity);
+    const name = `nemoclaw-inference-probe-${phase}-${specSha256.slice(0, 16)}`;
+    const source = Object.freeze([
+      "run",
+      "--detach",
+      "--pull=never",
+      "--name",
+      name,
+      "--label",
+      `${PODMAN_INFERENCE_PROBE_MANAGED_LABEL}=true`,
+      "--label",
+      `${PODMAN_INFERENCE_PROVIDER_LABEL}=${PROVIDER_ID}`,
+      "--label",
+      `${PODMAN_INFERENCE_SERVICE_LABEL}=${service}`,
+      "--label",
+      `${PODMAN_INFERENCE_AUTHORITY_LABEL}=${identity.parentAuthoritySha256}`,
+      "--label",
+      `${PODMAN_INFERENCE_TRANSACTION_LABEL}=${identity.transactionId}`,
+      "--label",
+      `${PODMAN_INFERENCE_RECEIPT_TARGET_LABEL}=${identity.receiptTargetSha256}`,
+      "--label",
+      `${PODMAN_INFERENCE_PROBE_PHASE_LABEL}=${phase}`,
+      "--label",
+      `${PODMAN_INFERENCE_PROBE_SPEC_LABEL}=${specSha256}`,
+      "--network",
+      endpoint.networkName,
+      "--read-only",
+      "--ipc",
+      "private",
+      normalizedImage,
+      "--fail-with-body",
+      "--silent",
+      "--show-error",
+      "--connect-timeout",
+      "3",
+      "--max-time",
+      String(maxTimeSeconds),
+      ...identity.request,
+    ]);
+    return Object.freeze({
+      service,
+      phase,
+      endpoint,
+      probeImageRef: normalizedImage,
+      transactionId: identity.transactionId,
+      receiptTargetSha256: identity.receiptTargetSha256,
+      parentAuthoritySha256: identity.parentAuthoritySha256,
+      request: identity.request,
+      name,
+      specSha256,
+      launchArguments: translatePodmanLocalInferenceArgs(source, authority),
+    });
+  };
   return Object.freeze({
-    service,
-    phase,
-    endpoint,
-    probeImageRef: normalizedImage,
-    transactionId: canonical.transactionId,
-    receiptTargetSha256: canonical.receiptTargetSha256,
-    parentAuthoritySha256: canonical.parentAuthoritySha256,
-    request: canonical.request,
-    name,
-    specSha256,
-    launchArguments,
+    current: buildSpec(canonical, curlMaxTimeSeconds),
+    legacy: buildSpec(legacyCanonical, PROBE_CURL_MAX_TIME_SECONDS),
   });
 }
 
@@ -1764,11 +1797,12 @@ function requireProbeIdentity(
 
 function cleanupExactProbe(
   engine: ContainerEngine,
-  container: ProbeContainer,
+  container: Pick<ProbeContainer, "runtimeId">,
   spec: ProbeSpec,
   phase: PodmanInferenceFailureEvidence["phase"],
   onFailureEvidence: (evidence: PodmanInferenceFailureEvidence) => void,
   redactor: PodmanInferenceRedactor,
+  mode: "owned" | "retained-legacy" = "owned",
 ): void {
   let current: ProbeContainer;
   try {
@@ -1777,6 +1811,9 @@ function cleanupExactProbe(
       spec,
       container.runtimeId,
     );
+    if (mode === "retained-legacy" && (current.running || !AT_REST_STATES.has(current.status))) {
+      throw new Error("retained legacy probe is not in an exact at-rest state");
+    }
   } catch (error) {
     emitProviderFailure(
       phase,
@@ -1788,7 +1825,10 @@ function cleanupExactProbe(
       `Podman inference probe cleanup lost exact identity: ${errorEvidence(redactor, error)}`,
     );
   }
-  const removal = engine.capture(["rm", "--force", current.runtimeId], MUTATION_TIMEOUT_MS);
+  const removal = engine.capture(
+    mode === "owned" ? ["rm", "--force", current.runtimeId] : ["rm", current.runtimeId],
+    MUTATION_TIMEOUT_MS,
+  );
   if (removal.status !== 0 || removal.error) {
     emitProviderFailure(
       phase,
@@ -1824,16 +1864,38 @@ function executeExactProbe(
   engine: ContainerEngine,
   authority: PodmanInferenceAuthorityReceipt,
   assertAuthority: () => void,
-  spec: ProbeSpec,
+  specs: ProbeSpecSet,
   timeoutMs: number,
   validateOutput: (output: string) => void,
   onFailureEvidence: (evidence: PodmanInferenceFailureEvidence) => void,
   redactor: PodmanInferenceRedactor,
 ): string {
+  const spec = specs.current;
   const phase = spec.phase;
   const captureFailure = (error: unknown) =>
     emitProviderFailure(phase, errorEvidence(redactor, error), onFailureEvidence, redactor);
   assertAuthority();
+  let legacyId: string | null;
+  try {
+    legacyId = lookupContainerId(engine, specs.legacy.name);
+  } catch (error) {
+    captureFailure(error);
+    throw new PodmanInferenceIndeterminateCleanupError(
+      "Podman inference legacy probe name lookup is indeterminate.",
+    );
+  }
+  if (legacyId !== null) {
+    cleanupExactProbe(
+      engine,
+      { runtimeId: legacyId },
+      specs.legacy,
+      phase,
+      onFailureEvidence,
+      redactor,
+      "retained-legacy",
+    );
+    assertAuthority();
+  }
   let existingId: string | null;
   try {
     existingId = lookupContainerId(engine, spec.name);

--- a/src/lib/onboard/runtime-provider/podman-host-local-inference.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference.ts
@@ -1657,6 +1657,8 @@ function createProbeSpec(
     SHA256,
     "Podman inference probe parent authority",
   );
+  // Temporary compatibility for retained probes from pre-fix PR #9906 qualification runs.
+  // Remove when no preserved qualification host can resume a pre-timeout probe.
   const legacyCanonical = Object.freeze({
     providerId: PROVIDER_ID,
     service,
@@ -1680,10 +1682,9 @@ function createProbeSpec(
     curlMaxTimeSeconds,
     request: normalizedRequest,
   });
-  const buildSpec = (
-    identity: typeof canonical | typeof legacyCanonical,
-    maxTimeSeconds: number,
-  ): ProbeSpec => {
+  const buildSpec = (identity: typeof canonical | typeof legacyCanonical): ProbeSpec => {
+    const maxTimeSeconds =
+      "curlMaxTimeSeconds" in identity ? identity.curlMaxTimeSeconds : PROBE_CURL_MAX_TIME_SECONDS;
     const specSha256 = digest(identity);
     const name = `nemoclaw-inference-probe-${phase}-${specSha256.slice(0, 16)}`;
     const source = Object.freeze([
@@ -1738,8 +1739,8 @@ function createProbeSpec(
     });
   };
   return Object.freeze({
-    current: buildSpec(canonical, curlMaxTimeSeconds),
-    legacy: buildSpec(legacyCanonical, PROBE_CURL_MAX_TIME_SECONDS),
+    current: buildSpec(canonical),
+    legacy: buildSpec(legacyCanonical),
   });
 }
 

--- a/src/lib/onboard/runtime-provider/podman-host-local-inference.ts
+++ b/src/lib/onboard/runtime-provider/podman-host-local-inference.ts
@@ -93,7 +93,10 @@ const RESERVED_NETWORK_NAMES = new Set([
 ]);
 const AT_REST_STATES = new Set(["configured", "created", "dead", "exited", "stopped"]);
 const PROBE_TIMEOUT_MS = 30_000;
+const INFERENCE_PROBE_TIMEOUT_MS = 150_000;
 const READY_PROBE_TIMEOUT_MS = 240_000;
+const PROBE_CURL_MAX_TIME_SECONDS = 20;
+const INFERENCE_PROBE_CURL_MAX_TIME_SECONDS = 120;
 const MUTATION_TIMEOUT_MS = 60_000;
 const OLLAMA_MODEL_PULL_TIMEOUT_MS = 30 * 60_000;
 const STOP_GRACE_SECONDS = 30;
@@ -1630,6 +1633,8 @@ function createProbeSpec(
   request: readonly string[],
   authority: PodmanInferenceAuthorityReceipt,
 ): ProbeSpec {
+  const curlMaxTimeSeconds =
+    phase === "inference" ? INFERENCE_PROBE_CURL_MAX_TIME_SECONDS : PROBE_CURL_MAX_TIME_SECONDS;
   const normalizedImage = normalizeHostLocalInferenceImageRef(probeImageRef);
   const canonical = Object.freeze({
     providerId: PROVIDER_ID,
@@ -1686,7 +1691,7 @@ function createProbeSpec(
     "--connect-timeout",
     "3",
     "--max-time",
-    "20",
+    String(curlMaxTimeSeconds),
     ...canonical.request,
   ]);
   const launchArguments = translatePodmanLocalInferenceArgs(source, authority);
@@ -2301,7 +2306,7 @@ function probeOpenAiInference(
     authorityReceipt,
     assertAuthority,
     probe,
-    PROBE_TIMEOUT_MS,
+    INFERENCE_PROBE_TIMEOUT_MS,
     (output) => {
       const response = parseJsonResponse(output, `${service} inference proof`);
       if (response.model !== model) {

--- a/test/helpers/podman-host-local-inference-test-harness.ts
+++ b/test/helpers/podman-host-local-inference-test-harness.ts
@@ -24,6 +24,8 @@ import {
   PODMAN_INFERENCE_NETWORK_PROVIDER_LABEL,
   PODMAN_INFERENCE_PRIOR_STATE_LABEL,
   PODMAN_INFERENCE_PROBE_MANAGED_LABEL,
+  PODMAN_INFERENCE_PROBE_PHASE_LABEL,
+  PODMAN_INFERENCE_PROBE_SPEC_LABEL,
   PODMAN_INFERENCE_PROVIDER_LABEL,
   PODMAN_INFERENCE_RECEIPT_TARGET_LABEL,
   PODMAN_INFERENCE_SERVICE_LABEL,
@@ -123,6 +125,8 @@ export interface PodmanHostLocalInferenceHarness {
     probeInspectRuntimeIdMismatchAt: number | null;
     probeForbiddenActions: Array<"logs" | "rm" | "wait">;
     probeWaitTimeouts: number[];
+    retainLegacyInferenceProbe: boolean;
+    legacyInferenceProbeRunning: boolean;
     probeWaitFailure: boolean;
     probeRemoveLostAcknowledgement: boolean;
     probeRemoveLeavesContainer: boolean;
@@ -346,6 +350,28 @@ function digest(value: object): string {
   return createHash("sha256").update(JSON.stringify(value), "utf8").digest("hex");
 }
 
+function networkAuthoritySha256(engineAuthoritySha256: string): string {
+  return digest({
+    id: NETWORK_ID,
+    name: NETWORK_NAME,
+    driver: "bridge",
+    internal: false,
+    ipv6Enabled: false,
+    dnsEnabled: true,
+    networkInterface: "podman42",
+    subnet: { subnet: NETWORK_SUBNET, gateway: NETWORK_GATEWAY_IP },
+    labels: Object.fromEntries(
+      [
+        [PODMAN_INFERENCE_NETWORK_ENGINE_AUTHORITY_LABEL, engineAuthoritySha256],
+        [PODMAN_INFERENCE_NETWORK_MANAGED_LABEL, "true"],
+        [PODMAN_INFERENCE_NETWORK_PROVIDER_LABEL, "podman"],
+      ].sort(([left], [right]) => left.localeCompare(right)),
+    ),
+    ipamOptions: { driver: "host-local" },
+    options: {},
+  });
+}
+
 function discoveredDevicesAuthority(state: {
   readonly cdiDevices: readonly string[];
   readonly omitDiscoveredDevices: boolean;
@@ -401,6 +427,8 @@ export function createPodmanHostLocalInferenceTestHarness(
     probeInspectRuntimeIdMismatchAt: null as number | null,
     probeForbiddenActions: [] as Array<"logs" | "rm" | "wait">,
     probeWaitTimeouts: [] as number[],
+    retainLegacyInferenceProbe: false,
+    legacyInferenceProbeRunning: false,
     probeWaitFailure: false,
     probeRemoveLostAcknowledgement: false,
     probeRemoveLeavesContainer: false,
@@ -420,6 +448,7 @@ export function createPodmanHostLocalInferenceTestHarness(
   let networkEngineAuthoritySha256 = "";
   let persistedAuthority: PersistedEngineAuthority | null = null;
   let routeAuthority: HostLocalInferenceRouteAuthority | null = null;
+  let retainedLegacyInferenceProbeForName = (_name: string): TestProbeContainer | null => null;
 
   const authorityStore: PersistedEngineAuthorityStore = {
     load: () => persistedAuthority,
@@ -472,7 +501,7 @@ export function createPodmanHostLocalInferenceTestHarness(
     capture: (args, timeoutMs) => {
       const probeAction =
         args[0] === "logs" || args[0] === "rm" || args[0] === "wait" ? args[0] : null;
-      const probeActionId = probeAction === "rm" ? args[2] : args[1];
+      const probeActionId = probeAction === "rm" ? args.at(-1) : args[1];
       if (
         probeAction !== null &&
         state.probeForbiddenActions.includes(probeAction) &&
@@ -530,9 +559,17 @@ export function createPodmanHostLocalInferenceTestHarness(
           "name=^".length,
           -1,
         );
-        const candidate = [currentContainer, currentProbe].find(
+        let candidate = [currentContainer, currentProbe].find(
           (container) => container?.name === expectedName,
         );
+        if (!candidate && state.retainLegacyInferenceProbe) {
+          const retained = retainedLegacyInferenceProbeForName(expectedName);
+          if (retained !== null) {
+            currentProbe = retained;
+            state.retainLegacyInferenceProbe = false;
+            candidate = retained;
+          }
+        }
         if (
           state.probePostCreateNameLookupTimeout &&
           candidate === currentProbe &&
@@ -734,6 +771,106 @@ export function createPodmanHostLocalInferenceTestHarness(
     requireToolCalling: true,
     environment: secretNames,
   };
+  retainedLegacyInferenceProbeForName = (expectedName) => {
+    if (currentContainer === null) return null;
+    const parentAuthoritySha256 = currentContainer.labels[PODMAN_INFERENCE_AUTHORITY_LABEL];
+    if (!parentAuthoritySha256) {
+      throw new Error("test managed runtime lacks probe parent authority");
+    }
+    const endpoint = Object.freeze({
+      host: "host.openshell.internal" as const,
+      port: input.hostPort,
+      networkName: input.networkName,
+      networkId: input.networkId,
+      networkGatewayIp: input.networkGatewayIp,
+      networkAuthoritySha256: networkAuthoritySha256(networkEngineAuthoritySha256),
+    });
+    const body = JSON.stringify({
+      model: input.model,
+      messages: [{ role: "user", content: "Use the probe tool when it is available." }],
+      max_tokens: 512,
+      stream: false,
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "nemoclaw_probe",
+            description: "Return one host-local inference proof.",
+            parameters: { type: "object", properties: {}, additionalProperties: false },
+          },
+        },
+      ],
+      tool_choice: "required",
+    });
+    const request = Object.freeze([
+      "--header",
+      "Content-Type: application/json",
+      "--data-binary",
+      body,
+      `http://${input.networkGatewayIp}:${String(input.hostPort)}/v1/chat/completions`,
+    ]);
+    const specSha256 = digest({
+      providerId: "podman",
+      service: input.service,
+      phase: "inference",
+      endpoint,
+      probeImageRef: input.probeImageRef,
+      transactionId: writer.transactionId,
+      receiptTargetSha256: writer.targetSha256,
+      parentAuthoritySha256,
+      request,
+    });
+    const name = `nemoclaw-inference-probe-inference-${specSha256.slice(0, 16)}`;
+    if (name !== expectedName) return null;
+    const labels = {
+      [PODMAN_INFERENCE_PROBE_MANAGED_LABEL]: "true",
+      [PODMAN_INFERENCE_PROVIDER_LABEL]: "podman",
+      [PODMAN_INFERENCE_SERVICE_LABEL]: input.service,
+      [PODMAN_INFERENCE_AUTHORITY_LABEL]: parentAuthoritySha256,
+      [PODMAN_INFERENCE_TRANSACTION_LABEL]: writer.transactionId,
+      [PODMAN_INFERENCE_RECEIPT_TARGET_LABEL]: writer.targetSha256,
+      [PODMAN_INFERENCE_PROBE_PHASE_LABEL]: "inference",
+      [PODMAN_INFERENCE_PROBE_SPEC_LABEL]: specSha256,
+    };
+    const running = state.legacyInferenceProbeRunning;
+    return {
+      id: PROBE_CONTAINER_ID,
+      name,
+      imageRef: input.probeImageRef,
+      labels,
+      createArguments: Object.freeze([
+        "run",
+        "--http-proxy=false",
+        "--detach",
+        "--pull",
+        "never",
+        "--name",
+        name,
+        ...Object.entries(labels).flatMap(([key, value]) => ["--label", `${key}=${value}`]),
+        "--network",
+        input.networkName,
+        "--read-only",
+        "--ipc",
+        "private",
+        input.probeImageRef,
+        "--fail-with-body",
+        "--silent",
+        "--show-error",
+        "--connect-timeout",
+        "3",
+        "--max-time",
+        "20",
+        ...request,
+      ]),
+      running,
+      status: running ? "running" : "exited",
+      exitCode: running ? 0 : 28,
+      logsStdout: "",
+      logsStderr: running
+        ? ""
+        : "curl: (28) Operation timed out after 20002 milliseconds with 0 bytes received",
+    };
+  };
   return {
     authorityStore,
     engine,
@@ -769,25 +906,7 @@ export function createPodmanHostLocalInferenceTestHarness(
         networkName: input.networkName,
         networkId: input.networkId,
         networkGatewayIp: input.networkGatewayIp,
-        networkAuthoritySha256: digest({
-          id: NETWORK_ID,
-          name: NETWORK_NAME,
-          driver: "bridge",
-          internal: false,
-          ipv6Enabled: false,
-          dnsEnabled: true,
-          networkInterface: "podman42",
-          subnet: { subnet: NETWORK_SUBNET, gateway: NETWORK_GATEWAY_IP },
-          labels: Object.fromEntries(
-            [
-              [PODMAN_INFERENCE_NETWORK_ENGINE_AUTHORITY_LABEL, networkEngineAuthoritySha256],
-              [PODMAN_INFERENCE_NETWORK_MANAGED_LABEL, "true"],
-              [PODMAN_INFERENCE_NETWORK_PROVIDER_LABEL, "podman"],
-            ].sort(([left], [right]) => left.localeCompare(right)),
-          ),
-          ipamOptions: { driver: "host-local" },
-          options: {},
-        }),
+        networkAuthoritySha256: networkAuthoritySha256(networkEngineAuthoritySha256),
       });
       const canonical = {
         service: input.service,

--- a/test/helpers/podman-host-local-inference-test-harness.ts
+++ b/test/helpers/podman-host-local-inference-test-harness.ts
@@ -122,6 +122,7 @@ export interface PodmanHostLocalInferenceHarness {
     probePostCreateNameLookupTimeout: boolean;
     probeInspectRuntimeIdMismatchAt: number | null;
     probeForbiddenActions: Array<"logs" | "rm" | "wait">;
+    probeWaitTimeouts: number[];
     probeWaitFailure: boolean;
     probeRemoveLostAcknowledgement: boolean;
     probeRemoveLeavesContainer: boolean;
@@ -399,6 +400,7 @@ export function createPodmanHostLocalInferenceTestHarness(
     probePostCreateNameLookupTimeout: false,
     probeInspectRuntimeIdMismatchAt: null as number | null,
     probeForbiddenActions: [] as Array<"logs" | "rm" | "wait">,
+    probeWaitTimeouts: [] as number[],
     probeWaitFailure: false,
     probeRemoveLostAcknowledgement: false,
     probeRemoveLeavesContainer: false,
@@ -467,7 +469,7 @@ export function createPodmanHostLocalInferenceTestHarness(
     displayName: "Podman",
     authorityId: options.authorityId ?? "test:podman-inference",
     endpointAuthorityId: options.authorityId ?? "test:podman-inference",
-    capture: (args) => {
+    capture: (args, timeoutMs) => {
       const probeAction =
         args[0] === "logs" || args[0] === "rm" || args[0] === "wait" ? args[0] : null;
       const probeActionId = probeAction === "rm" ? args[2] : args[1];
@@ -606,6 +608,7 @@ export function createPodmanHostLocalInferenceTestHarness(
           : result(0, state.runAcknowledgementText ?? `${CONTAINER_ID}\n`);
       }
       if (args[0] === "wait") {
+        state.probeWaitTimeouts.push(timeoutMs ?? 0);
         if (!currentProbe || currentProbe.id !== args[1]) return result(125, "", "missing probe");
         return completeProbeWait(currentProbe, currentContainer, state);
       }


### PR DESCRIPTION
## Summary

Portable Podman inference validation stopped after 20 seconds, even when a cold local model needed more time to return its first completion.
This change gives only the inference validation request a 120-second curl deadline and a 150-second outer wait while preserving the existing readiness, GPU, exact-ID, and cleanup boundaries.

## Related Issue

Related to #9211.

## Changes

- Apply the larger bounded deadline only to the real inference validation request.
- Bind the curl deadline into the canonical probe identity and derive launch behavior from that identity.
- Safely remove an exact, at-rest probe from the prior 20-second identity before retrying; fail closed for a running or mismatched legacy probe.
- Keep readiness and GPU probe deadlines unchanged.
- Add regression coverage for timeout boundaries and retained prior-timeout recovery.
- Document the fixed Portable Podman validation-request deadline for OpenClaw and Hermes, including its exclusion from `NEMOCLAW_LOCAL_INFERENCE_TIMEOUT`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security review passed through `52dff220807df302cd94d919c2b78f39f5d0a985`; no findings.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `128/128` focused provider tests passed for the recovery change; the final identity-derived refinement passed its `3/3` focused timeout tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional validation: `32/32` growth guardrails, CLI typecheck, repository checks through the normal pre-commit hook, `npm run docs`, and `git diff --check` passed. The prior PR head also passed `2,169/2,169` changed tests and `npm run validate:pr`.

## Documentation Writer Review

- Result: PASS. An independent documentation writer reviewed the completed PR change through commit `52dff220807df302cd94d919c2b78f39f5d0a985`; no findings remain.
- Commit under review: `52dff220807df302cd94d919c2b78f39f5d0a985`
- Agent surface: OpenClaw and Hermes Portable onboarding; the Deep Agents generated page was reviewed for the intentional exclusion and is unaffected by the final production-only refinement.
- Evidence: `npm run docs` passed. Generated OpenClaw and Hermes pages contain the fixed 120-second deadline and environment-variable exclusion; Deep Agents omits the Portable note. The final one-file refinement matches the reviewed candidate (`f398b4732f0a37a392f0c3b268d03e989349edf0acbcd0a39072352d9fcfc6f4`), states the bounded PR #9906 compatibility reason and retirement condition, and passed focused timeout tests `3/3`, CLI typecheck, and `git diff --check`.

<!-- documentation-writer-review-head: 52dff220807df302cd94d919c2b78f39f5d0a985 -->
<!-- documentation-writer-review-agents-blob: 513518cdfca42e3a18fed71109e6d0eb60151d13 -->

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of local inference validation with longer probe and request timeouts.
  - Automatically removes inactive legacy inference probes before creating replacements.
  - Preserves running legacy probes and reports an error instead of removing them.
  - Maintained existing timeout behavior for unrelated runtime checks.

- **Documentation**
  - Clarified which validation paths use the local inference timeout setting.
  - Documented the fixed deadline for portable onboarding validation.

- **Tests**
  - Added coverage for legacy probe recovery, running-probe protection, and timeout boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
