### PR TITLE
ci(e2e): delegate portable BuildKit cgroups

### DIFF
--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -351,7 +351,6 @@ jobs:
           cleanup_fixture_drop_in() {
             local target="$1"
             local expected="$2"
-            local actual
             if ! sudo test -e "$target" && ! sudo test -L "$target"; then
               return 0
             fi
@@ -359,8 +358,7 @@ jobs:
               printf 'Refusing unexpected Portable CPU-delegation fixture path: %s\n' "$target" >&2
               return 1
             fi
-            actual="$(sudo cat -- "$target")"
-            if [ "$actual" != "$expected" ]; then
+            if ! printf '%s' "$expected" | sudo cmp -s -- "$target" -; then
               printf 'Refusing changed Portable CPU-delegation fixture file: %s\n' "$target" >&2
               return 1
             fi

--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -182,19 +182,120 @@ jobs:
             sudo usermod --add-subgids 100000-165535 "$USER"
           fi
 
-          shim_dir="${RUNNER_TEMP}/nemoclaw-portable-bin"
-          install -d -m 700 "$shim_dir"
-          install -m 700 test/e2e/fixtures/portable-profile-systemctl-shim.sh "$shim_dir/systemctl"
+          uid="$(id -u)"
+          receipt="${RUNNER_TEMP}/nemoclaw-portable-cpu-delegation.receipt"
+          delegation_drop_in="/etc/systemd/system/user@.service.d/90-nemoclaw-cpu-delegation.conf"
+          app_slice_drop_in="/etc/systemd/user/app.slice.d/90-nemoclaw-cpu-controller.conf"
+          user_slice_drop_in="/etc/systemd/system/user-${uid}.slice.d/90-nemoclaw-cpu-controller.conf"
+          : >"$receipt"
 
-          export PATH="$shim_dir:$PATH"
+          install_fixture_drop_in() {
+            local receipt_name="$1"
+            local target="$2"
+            local content="$3"
+            local target_dir
+            target_dir="$(dirname "$target")"
+            if sudo test -e "$target" || sudo test -L "$target"; then
+              printf 'Refusing existing Portable CPU-delegation fixture path: %s\n' "$target" >&2
+              return 1
+            fi
+            if sudo test -L "$target_dir" || \
+              { sudo test -e "$target_dir" && ! sudo test -d "$target_dir"; }; then
+              printf 'Refusing unexpected Portable CPU-delegation fixture directory: %s\n' "$target_dir" >&2
+              return 1
+            fi
+            if sudo test -d "$target_dir"; then
+              if [ "$(sudo stat -Lc '%U:%G %a' -- "$target_dir")" != "root:root 755" ]; then
+                printf 'Refusing Portable CPU-delegation fixture directory owner or mode: %s\n' "$target_dir" >&2
+                return 1
+              fi
+            else
+              printf 'directory\t%s\n' "$target_dir" >>"$receipt"
+              sudo install -d -m 0755 -o root -g root "$target_dir"
+            fi
+            printf 'file\t%s\t%s\n' "$receipt_name" "$target" >>"$receipt"
+            printf '%s' "$content" | sudo tee "$target" >/dev/null
+            sudo chown root:root "$target"
+            sudo chmod 0644 "$target"
+          }
+
+          install_fixture_drop_in \
+            user-slice \
+            "$user_slice_drop_in" \
+            $'[Slice]\nCPUWeight=100\n'
+          install_fixture_drop_in \
+            app-slice \
+            "$app_slice_drop_in" \
+            $'[Slice]\nCPUWeight=100\n'
+          install_fixture_drop_in \
+            delegation \
+            "$delegation_drop_in" \
+            $'[Service]\nDelegate=cpu memory pids\n'
+
+          if sudo systemctl is-active --quiet "user@${uid}.service"; then
+            printf 'manager-active\t%s\n' "$uid" >>"$receipt"
+          fi
+          if [ "$(loginctl show-user "$USER" --property=Linger --value 2>/dev/null || true)" != "yes" ]; then
+            printf 'linger\t%s\n' "$USER" >>"$receipt"
+            sudo loginctl enable-linger "$USER"
+          fi
+
+          sudo systemctl stop "user@${uid}.service"
+          sudo systemctl daemon-reload
+          sudo systemctl start "user@${uid}.service"
+
           export XDG_RUNTIME_DIR="$runtime_dir"
-          printf '%s\n' "$shim_dir" >>"$GITHUB_PATH"
-          printf 'XDG_RUNTIME_DIR=%s\n' "$runtime_dir" >>"$GITHUB_ENV"
-          printf 'DOCKER_HOST=unix://%s/podman/podman.sock\n' "$runtime_dir" >>"$GITHUB_ENV"
-          systemctl --user start podman.socket
+          export DBUS_SESSION_BUS_ADDRESS="unix:path=${runtime_dir}/bus"
+          export DOCKER_HOST="unix://${runtime_dir}/podman/podman.sock"
+          {
+            printf 'XDG_RUNTIME_DIR=%s\n' "$runtime_dir"
+            printf 'DBUS_SESSION_BUS_ADDRESS=%s\n' "$DBUS_SESSION_BUS_ADDRESS"
+            printf 'DOCKER_HOST=%s\n' "$DOCKER_HOST"
+            printf 'E2E_PORTABLE_CPU_DELEGATION_RECEIPT=%s\n' "$receipt"
+          } >>"$GITHUB_ENV"
+
+          /usr/bin/systemctl --user start podman.socket
+          /usr/bin/systemctl --user is-active --quiet podman.socket
+          node --experimental-strip-types --no-warnings --input-type=module --eval '
+            const { inspectPortableCpuDelegation } = await import(
+              "./src/lib/onboard/experimental/portable-cpu-delegation-preflight.ts"
+            );
+            const result = inspectPortableCpuDelegation();
+            if (!result.ok) throw new Error(result.detail);
+            process.stdout.write(result.detail + "\n");
+          '
+          cgroup_manager="$(podman info --format '{{.Host.CgroupManager}}')"
+          test "$cgroup_manager" = "systemd"
           podman --version
           docker --version
-          docker --host "unix://$runtime_dir/podman/podman.sock" info
+          docker --host "$DOCKER_HOST" info
+
+      - name: Prove nested BuildKit on the portable Podman socket
+        shell: bash
+        run: |
+          set -euo pipefail
+          builder_name="nemoclaw-portable-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          build_context="$(mktemp -d "${RUNNER_TEMP}/nemoclaw-portable-buildx.XXXXXX")"
+          build_output="$(mktemp -d "${RUNNER_TEMP}/nemoclaw-portable-buildx-output.XXXXXX")"
+          {
+            printf 'E2E_PORTABLE_BUILDX_BUILDER=%s\n' "$builder_name"
+            printf 'E2E_PORTABLE_BUILDX_CONTEXT=%s\n' "$build_context"
+            printf 'E2E_PORTABLE_BUILDX_OUTPUT=%s\n' "$build_output"
+          } >>"$GITHUB_ENV"
+          printf 'FROM scratch\nCOPY proof.txt /proof.txt\n' >"$build_context/Dockerfile"
+          printf 'portable-buildkit-cgroup-proof\n' >"$build_context/proof.txt"
+
+          docker buildx create \
+            --name "$builder_name" \
+            --driver docker-container \
+            "$DOCKER_HOST"
+          docker buildx inspect "$builder_name" --bootstrap
+          docker buildx build \
+            --builder "$builder_name" \
+            --progress=plain \
+            --output "type=local,dest=$build_output" \
+            "$build_context"
+          grep -Fx 'portable-buildkit-cgroup-proof' "$build_output/proof.txt"
 
       - name: Exercise a portable launch through chat and permission restoration
         env:
@@ -218,9 +319,97 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          builder_name="${E2E_PORTABLE_BUILDX_BUILDER:-}"
+          if [[ "$builder_name" =~ ^nemoclaw-portable-[0-9]+-[0-9]+$ ]]; then
+            docker buildx rm "$builder_name" || true
+          fi
+          for temporary in \
+            "${E2E_PORTABLE_BUILDX_CONTEXT:-}" \
+            "${E2E_PORTABLE_BUILDX_OUTPUT:-}"
+          do
+            if [[ "$temporary" == "${RUNNER_TEMP}/nemoclaw-portable-buildx."* ]] || \
+              [[ "$temporary" == "${RUNNER_TEMP}/nemoclaw-portable-buildx-output."* ]]; then
+              rm -rf -- "$temporary"
+            fi
+          done
+
           rm -f -- /run/nemoclaw/portable-inference.json /run/nemoclaw/.portable-inference.json.tmp
+          /usr/bin/systemctl --user stop nemoclaw-openshell-gateway.service || true
+          /usr/bin/systemctl --user stop podman.socket podman.service || true
           podman system reset --force || true
-          runtime_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
-          node --experimental-strip-types --no-warnings --input-type=module \
-            --eval 'import { cleanupPortableProfileSystemctlFixture } from "./test/e2e/fixtures/portable-profile-systemctl.ts"; await cleanupPortableProfileSystemctlFixture(process.argv[1]);' \
-            "$runtime_dir"
+
+          uid="$(id -u)"
+          receipt="${E2E_PORTABLE_CPU_DELEGATION_RECEIPT:-${RUNNER_TEMP}/nemoclaw-portable-cpu-delegation.receipt}"
+          delegation_drop_in="/etc/systemd/system/user@.service.d/90-nemoclaw-cpu-delegation.conf"
+          app_slice_drop_in="/etc/systemd/user/app.slice.d/90-nemoclaw-cpu-controller.conf"
+          user_slice_drop_in="/etc/systemd/system/user-${uid}.slice.d/90-nemoclaw-cpu-controller.conf"
+          disable_linger=0
+          restore_manager=0
+          directories=()
+          sudo systemctl stop "user@${uid}.service" || true
+
+          cleanup_fixture_drop_in() {
+            local target="$1"
+            local expected="$2"
+            local actual
+            if ! sudo test -e "$target" && ! sudo test -L "$target"; then
+              return 0
+            fi
+            if sudo test -L "$target" || ! sudo test -f "$target"; then
+              printf 'Refusing unexpected Portable CPU-delegation fixture path: %s\n' "$target" >&2
+              return 1
+            fi
+            actual="$(sudo cat -- "$target")"
+            if [ "$actual" != "$expected" ]; then
+              printf 'Refusing changed Portable CPU-delegation fixture file: %s\n' "$target" >&2
+              return 1
+            fi
+            sudo rm -f -- "$target"
+          }
+
+          if [ -f "$receipt" ]; then
+            while IFS=$'\t' read -r kind name target; do
+              if [ "$kind" = "file" ]; then
+                case "$name:$target" in
+                  "delegation:$delegation_drop_in")
+                    cleanup_fixture_drop_in "$target" $'[Service]\nDelegate=cpu memory pids'
+                    ;;
+                  "app-slice:$app_slice_drop_in"|"user-slice:$user_slice_drop_in")
+                    cleanup_fixture_drop_in "$target" $'[Slice]\nCPUWeight=100'
+                    ;;
+                  *)
+                    printf 'Refusing unexpected Portable CPU-delegation receipt: %s:%s\n' "$name" "$target" >&2
+                    exit 1
+                    ;;
+                esac
+              elif [ "$kind" = "linger" ] && [ "$name" = "$USER" ] && [ -z "${target:-}" ]; then
+                disable_linger=1
+              elif [ "$kind" = "manager-active" ] && [ "$name" = "$uid" ] && [ -z "${target:-}" ]; then
+                restore_manager=1
+              elif [ "$kind" = "directory" ] && [ -z "${target:-}" ]; then
+                case "$name" in
+                  /etc/systemd/system/user@.service.d|/etc/systemd/user/app.slice.d|"/etc/systemd/system/user-${uid}.slice.d")
+                    directories+=("$name")
+                    ;;
+                  *)
+                    printf 'Refusing unexpected Portable CPU-delegation directory receipt: %s\n' "$name" >&2
+                    exit 1
+                    ;;
+                esac
+              else
+                printf 'Refusing malformed Portable CPU-delegation receipt.\n' >&2
+                exit 1
+              fi
+            done <"$receipt"
+          fi
+          sudo systemctl daemon-reload
+          for directory in "${directories[@]}"; do
+            sudo rmdir -- "$directory" || true
+          done
+          if [ "$restore_manager" = "1" ]; then
+            sudo systemctl start "user@${uid}.service"
+          fi
+          if [ "$disable_linger" = "1" ]; then
+            sudo loginctl disable-linger "$USER"
+          fi
+          rm -f -- "$receipt"

--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -345,6 +345,7 @@ jobs:
           user_slice_drop_in="/etc/systemd/system/user-${uid}.slice.d/90-nemoclaw-cpu-controller.conf"
           disable_linger=0
           restore_manager=0
+          cleanup_failed=0
           directories=()
           sudo systemctl stop "user@${uid}.service" || true
 
@@ -370,14 +371,14 @@ jobs:
               if [ "$kind" = "file" ]; then
                 case "$name:$target" in
                   "delegation:$delegation_drop_in")
-                    cleanup_fixture_drop_in "$target" $'[Service]\nDelegate=cpu memory pids'
+                    cleanup_fixture_drop_in "$target" $'[Service]\nDelegate=cpu memory pids' || cleanup_failed=1
                     ;;
                   "app-slice:$app_slice_drop_in"|"user-slice:$user_slice_drop_in")
-                    cleanup_fixture_drop_in "$target" $'[Slice]\nCPUWeight=100'
+                    cleanup_fixture_drop_in "$target" $'[Slice]\nCPUWeight=100' || cleanup_failed=1
                     ;;
                   *)
                     printf 'Refusing unexpected Portable CPU-delegation receipt: %s:%s\n' "$name" "$target" >&2
-                    exit 1
+                    cleanup_failed=1
                     ;;
                 esac
               elif [ "$kind" = "linger" ] && [ "$name" = "$USER" ] && [ -z "${target:-}" ]; then
@@ -391,23 +392,27 @@ jobs:
                     ;;
                   *)
                     printf 'Refusing unexpected Portable CPU-delegation directory receipt: %s\n' "$name" >&2
-                    exit 1
+                    cleanup_failed=1
                     ;;
                 esac
               else
                 printf 'Refusing malformed Portable CPU-delegation receipt.\n' >&2
-                exit 1
+                cleanup_failed=1
               fi
             done <"$receipt"
           fi
-          sudo systemctl daemon-reload
+          sudo systemctl daemon-reload || cleanup_failed=1
           for directory in "${directories[@]}"; do
             sudo rmdir -- "$directory" || true
           done
           if [ "$restore_manager" = "1" ]; then
-            sudo systemctl start "user@${uid}.service"
+            sudo systemctl start "user@${uid}.service" || cleanup_failed=1
           fi
           if [ "$disable_linger" = "1" ]; then
-            sudo loginctl disable-linger "$USER"
+            sudo loginctl disable-linger "$USER" || cleanup_failed=1
           fi
-          rm -f -- "$receipt"
+          rm -f -- "$receipt" || cleanup_failed=1
+          if [ "$cleanup_failed" = "1" ]; then
+            printf 'Portable CPU-delegation cleanup detected invalid fixture state or a cleanup command failed.\n' >&2
+            exit 1
+          fi

--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -403,7 +403,7 @@ jobs:
           fi
           sudo systemctl daemon-reload || cleanup_failed=1
           for directory in "${directories[@]}"; do
-            sudo rmdir -- "$directory" || true
+            sudo rmdir -- "$directory" || cleanup_failed=1
           done
           if [ "$restore_manager" = "1" ]; then
             sudo systemctl start "user@${uid}.service" || cleanup_failed=1

--- a/test/e2e/support/portable-profile-cgroup-cleanup-workflow.test.ts
+++ b/test/e2e/support/portable-profile-cgroup-cleanup-workflow.test.ts
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { expect, it } from "vitest";
+
+import { readYaml, type Workflow } from "../../helpers/e2e-workflow-contract.ts";
+
+function writeExecutable(filePath: string, source: string): void {
+  fs.writeFileSync(filePath, source, { encoding: "utf8", mode: 0o700 });
+}
+
+function portableCleanupRun(): string {
+  const workflow = readYaml<Workflow>(".github/workflows/portable-profile-e2e.yaml");
+  const cleanup = workflow.jobs["portable-launch"]?.steps?.find(
+    (step) => step.name === "Clean up portable runtime",
+  );
+  expect(cleanup).toBeDefined();
+  return cleanup?.run ?? "";
+}
+
+it("restores the portable user manager and linger state after refusing a changed drop-in", () => {
+  const root = fs.mkdtempSync("/tmp/portable-cpu-delegation-restoration-");
+  const bin = path.join(root, "bin");
+  const changed = path.join(root, "changed.conf");
+  const receipt = path.join(root, "receipt");
+  const commandLog = path.join(root, "commands.log");
+  const expected = "[Service]\nDelegate=cpu memory pids\n";
+  fs.mkdirSync(bin, { mode: 0o700 });
+  writeExecutable(path.join(bin, "sudo"), '#!/usr/bin/env bash\nexec "$@"\n');
+  writeExecutable(
+    path.join(bin, "systemctl"),
+    '#!/usr/bin/env bash\nprintf "systemctl\\t%s\\n" "$*" >>"$FAKE_CLEANUP_LOG"\n',
+  );
+  writeExecutable(
+    path.join(bin, "loginctl"),
+    '#!/usr/bin/env bash\nprintf "loginctl\\t%s\\n" "$*" >>"$FAKE_CLEANUP_LOG"\n',
+  );
+  fs.writeFileSync(changed, `${expected}unexpected\n`);
+  fs.writeFileSync(
+    receipt,
+    [`file\tdelegation\t${changed}`, "manager-active\t501\t", "linger\tfixture-user\t"].join("\n") +
+      "\n",
+  );
+
+  const cleanupRun = portableCleanupRun();
+  const fixtureStart = cleanupRun.indexOf('uid="$(id -u)"');
+  expect(fixtureStart).toBeGreaterThanOrEqual(0);
+  const cleanupFixture = cleanupRun
+    .slice(fixtureStart)
+    .replace('uid="$(id -u)"', 'uid="501"')
+    .replace(
+      'delegation_drop_in="/etc/systemd/system/user@.service.d/90-nemoclaw-cpu-delegation.conf"',
+      `delegation_drop_in=${JSON.stringify(changed)}`,
+    );
+
+  try {
+    const result = spawnSync("bash", ["-c", `set -eo pipefail\n${cleanupFixture}`], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        E2E_PORTABLE_CPU_DELEGATION_RECEIPT: receipt,
+        FAKE_CLEANUP_LOG: commandLog,
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        USER: "fixture-user",
+      },
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Refusing changed Portable CPU-delegation fixture file");
+    expect(result.stderr).toContain(
+      "Portable CPU-delegation cleanup detected invalid fixture state or a cleanup command failed",
+    );
+    expect(fs.readFileSync(commandLog, "utf8").trim().split("\n")).toEqual([
+      "systemctl\tstop user@501.service",
+      "systemctl\tdaemon-reload",
+      "systemctl\tstart user@501.service",
+      "loginctl\tdisable-linger fixture-user",
+    ]);
+    expect(fs.readFileSync(changed, "utf8")).toBe(`${expected}unexpected\n`);
+    expect(fs.existsSync(receipt)).toBe(false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/e2e/support/portable-profile-cgroup-cleanup-workflow.test.ts
+++ b/test/e2e/support/portable-profile-cgroup-cleanup-workflow.test.ts
@@ -47,6 +47,7 @@ it("restores the portable user manager and linger state after refusing a changed
   );
 
   const cleanupRun = portableCleanupRun();
+  expect(cleanupRun).toContain('sudo rmdir -- "$directory" || cleanup_failed=1');
   const fixtureStart = cleanupRun.indexOf('uid="$(id -u)"');
   expect(fixtureStart).toBeGreaterThanOrEqual(0);
   const cleanupFixture = cleanupRun
@@ -67,6 +68,8 @@ it("restores the portable user manager and linger state after refusing a changed
         PATH: `${bin}:${process.env.PATH ?? ""}`,
         USER: "fixture-user",
       },
+      killSignal: "SIGKILL",
+      timeout: 15_000,
     });
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("Refusing changed Portable CPU-delegation fixture file");

--- a/test/e2e/support/portable-profile-systemctl-shim.test.ts
+++ b/test/e2e/support/portable-profile-systemctl-shim.test.ts
@@ -1381,29 +1381,48 @@ describe("portable profile systemctl fixture", () => {
     }
   });
 
-  it("binds portable-launch setup and always-run cleanup to the shared systemctl fixture (#9006)", () => {
+  it("binds portable-launch to delegated systemd Podman and disposable BuildKit", () => {
     const provision = portableLaunchStep("Provision restricted rootless Linux runtime").run ?? "";
+    expect(provision).not.toContain("portable-profile-systemctl-shim.sh");
+    expect(provision).toContain('sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" /run/nemoclaw');
     expect(provision).toContain(
-      'install -m 700 test/e2e/fixtures/portable-profile-systemctl-shim.sh "$shim_dir/systemctl"',
+      "/etc/systemd/system/user@.service.d/90-nemoclaw-cpu-delegation.conf",
     );
+    expect(provision).toContain("/etc/systemd/user/app.slice.d/90-nemoclaw-cpu-controller.conf");
     expect(provision).toContain(
-      'sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" /run/nemoclaw',
+      "/etc/systemd/system/user-${uid}.slice.d/90-nemoclaw-cpu-controller.conf",
     );
-    expect(provision).toContain("systemctl --user start podman.socket");
+    expect(provision).toContain("Delegate=cpu memory pids");
+    expect(provision.match(/CPUWeight=100/gu)).toHaveLength(2);
+    expect(provision).toContain('sudo systemctl stop "user@${uid}.service"');
+    expect(provision).toContain("sudo systemctl daemon-reload");
+    expect(provision).toContain('sudo systemctl start "user@${uid}.service"');
+    expect(provision).toContain("/usr/bin/systemctl --user start podman.socket");
+    expect(provision).toContain("inspectPortableCpuDelegation");
+    expect(provision).toContain('test "$cgroup_manager" = "systemd"');
     const runtimeExportIndex = provision.indexOf("XDG_RUNTIME_DIR=%s");
     expect(runtimeExportIndex).toBeGreaterThanOrEqual(0);
     expect(runtimeExportIndex).toBeLessThan(
-      provision.indexOf("systemctl --user start podman.socket"),
+      provision.indexOf("/usr/bin/systemctl --user start podman.socket"),
     );
 
+    const buildkit = portableLaunchStep("Prove nested BuildKit on the portable Podman socket");
+    expect(buildkit.run).toContain("docker buildx create");
+    expect(buildkit.run).toContain("--driver docker-container");
+    expect(buildkit.run).toContain('"$DOCKER_HOST"');
+    expect(buildkit.run).toContain('docker buildx inspect "$builder_name" --bootstrap');
+    expect(buildkit.run).toContain("docker buildx build");
+
     const cleanup = portableLaunchStep("Clean up portable runtime");
+    const cleanupRun = cleanup.run ?? "";
     expect(cleanup.if).toBe("always()");
-    expect(cleanup.run).toContain('runtime_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"');
-    expect(cleanup.run).toContain(
-      'import { cleanupPortableProfileSystemctlFixture } from "./test/e2e/fixtures/portable-profile-systemctl.ts"; await cleanupPortableProfileSystemctlFixture(process.argv[1]);',
+    expect(cleanupRun).toContain('docker buildx rm "$builder_name"');
+    expect(cleanupRun).toContain("cleanup_fixture_drop_in");
+    expect(cleanupRun).toContain("sudo systemctl daemon-reload");
+    expect(cleanupRun.indexOf('docker buildx rm "$builder_name"')).toBeLessThan(
+      cleanupRun.indexOf("podman system reset"),
     );
-    expect(cleanup.run).toContain('"$runtime_dir"');
-    expect(cleanup.run).toContain(
+    expect(cleanupRun).toContain(
       "rm -f -- /run/nemoclaw/portable-inference.json /run/nemoclaw/.portable-inference.json.tmp",
     );
   });

--- a/test/e2e/support/portable-profile-systemctl-shim.test.ts
+++ b/test/e2e/support/portable-profile-systemctl-shim.test.ts
@@ -372,11 +372,14 @@ async function waitForGatewayCommands(
   scope: FixtureScope,
   expectedKinds: string[],
 ): Promise<Record<string, unknown>[]> {
-  return vi.waitFor(() => {
-    const commands = readGatewayCommands(scope);
-    expect(commands.map((command) => command.kind)).toEqual(expectedKinds);
-    return commands;
-  }, { timeout: 5_000 });
+  return vi.waitFor(
+    () => {
+      const commands = readGatewayCommands(scope);
+      expect(commands.map((command) => command.kind)).toEqual(expectedKinds);
+      return commands;
+    },
+    { timeout: 5_000 },
+  );
 }
 
 function pidIsActive(pid: number): boolean {
@@ -468,6 +471,15 @@ function portableLaunchStep(name: string): WorkflowStep {
   );
   expect(step).toBeDefined();
   return step!;
+}
+
+function portableLaunchShellFunction(stepName: string, functionName: string): string {
+  const run = portableLaunchStep(stepName).run ?? "";
+  const start = run.indexOf(`${functionName}() {\n`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = run.slice(start).search(/^\}\n/mu);
+  expect(end).toBeGreaterThanOrEqual(0);
+  return run.slice(start, start + end + 2);
 }
 
 describe("portable profile systemctl fixture", () => {
@@ -1425,5 +1437,51 @@ describe("portable profile systemctl fixture", () => {
     expect(cleanupRun).toContain(
       "rm -f -- /run/nemoclaw/portable-inference.json /run/nemoclaw/.portable-inference.json.tmp",
     );
+  });
+
+  it("removes only byte-identical CPU-delegation drop-ins with terminal newlines", () => {
+    const root = fs.mkdtempSync("/tmp/portable-cpu-delegation-cleanup-");
+    const bin = path.join(root, "bin");
+    const exact = path.join(root, "exact.conf");
+    const changed = path.join(root, "changed.conf");
+    const expected = "[Service]\nDelegate=cpu memory pids\n";
+    fs.mkdirSync(bin, { mode: 0o700 });
+    writeExecutable(path.join(bin, "sudo"), '#!/usr/bin/env bash\nexec "$@"\n');
+    fs.writeFileSync(exact, expected);
+    fs.writeFileSync(changed, `${expected}unexpected\n`);
+    const cleanupFunction = portableLaunchShellFunction(
+      "Clean up portable runtime",
+      "cleanup_fixture_drop_in",
+    );
+    const runCleanup = (target: string) =>
+      spawnSync(
+        "bash",
+        [
+          "-c",
+          `${cleanupFunction}\ncleanup_fixture_drop_in \"$1\" \"$2\"`,
+          "cleanup",
+          target,
+          expected,
+        ],
+        {
+          encoding: "utf8",
+          env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` },
+        },
+      );
+
+    try {
+      const exactCleanup = runCleanup(exact);
+      expect(exactCleanup.status, exactCleanup.stderr).toBe(0);
+      expect(fs.existsSync(exact)).toBe(false);
+
+      const changedCleanup = runCleanup(changed);
+      expect(changedCleanup.status).not.toBe(0);
+      expect(changedCleanup.stderr).toContain(
+        "Refusing changed Portable CPU-delegation fixture file",
+      );
+      expect(fs.readFileSync(changed, "utf8")).toBe(`${expected}unexpected\n`);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Portable launch used a process shim for `systemctl`, so its rootless Podman API ran without the systemd CPU delegation required by nested BuildKit. This change prepares the accepted current-user delegation fixture, proves a nested `docker-container` Buildx build through the exact Podman socket before onboarding, and restores runner state during `always()` cleanup.

## Changes

- Apply the three accepted #9188/#9197 systemd CPU settings to the hosted current user with receipt-bound ownership checks and restoration of the prior user-manager and linger state.
- Start `podman.socket` through current-user systemd and require the existing four-boundary Portable CPU preflight plus Podman `CgroupManager=systemd`.
- Bootstrap and build a disposable scratch context with the `docker-container` Buildx driver through the exact `DOCKER_HOST`, then remove the builder and fixture-owned resources during `always()` cleanup.
- Update the Portable workflow contract to reject the former shim path and require the delegation, Buildx, and cleanup boundaries, including restoration after a refused fixture cleanup.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Fixture-only boundary follows the accepted #9188/#9197 delegation settings; the exact workflow contract, actionlint with ShellCheck, and repository checks pass. Product ABI resolution, CPU limits, credentials, and supported runtime behavior are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Independent review of all three changed files, repeated after every cleanup review correction, found no public documentation or changelog impact because this is a main-only CI fixture and its workflow-contract tests. All changed explanatory text was reviewed with no findings.
- Agent: Codex Desktop
<!-- docs-review-head-sha: a1a7c3a4bbf22ff4865a0a0ee98606d3d8bbb3f8 -->
<!-- docs-review-agents-blob-sha: 513518cdfca42e3a18fed71109e6d0eb60151d13 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/portable-profile-systemctl-shim.test.ts test/e2e/support/portable-profile-cgroup-cleanup-workflow.test.ts` (38 passed); all embedded Portable Bash blocks passed `bash -n`; `npm run checks:repository`, `npm run source-shape:check`, formatting, and CLI type-check passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded portable-launch end-to-end coverage for CPU delegation, container-based image builds, service startup, and cgroup validation.
  * Added verification for nested image builds, including successful creation, use, and cleanup.
  * Confirmed cleanup preserves modified configuration files while removing only matching temporary fixtures.
  * Added checks for cleanup ordering, diagnostics, and restoration of service state.

* **Chores**
  * Improved tracking and restoration of temporary system resources.
  * Replaced the previous service-management workaround with a more reliable system configuration approach.
  * Improved cleanup reporting so all steps complete before failures are summarized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->