### PR TITLE
fix(docs): make publication restartable

### DIFF
--- a/test/post-merge-docs.test.ts
+++ b/test/post-merge-docs.test.ts
@@ -134,8 +134,15 @@ class FakeGitHub {
   readonly commitSha = "c".repeat(40);
   readonly existingSha = "b".repeat(40);
   readonly initialParent = "a".repeat(40);
+  readonly partialSha = "d".repeat(40);
   readonly commits = new Map<string, Record<string, unknown>>();
   afterWrite = (): void => undefined;
+  projectPullHead = (headSha: string): void => {
+    this.openPulls = this.openPulls.map((pull) => ({
+      ...pull,
+      head: { ...pull.head, sha: headSha },
+    }));
+  };
   constructor(readonly value: Fixture) {
     this.branch = `automation/post-merge-docs-${value.mainSha.slice(0, 12)}`;
     this.liveSha = value.mainSha;
@@ -183,11 +190,31 @@ class FakeGitHub {
         : this.pull(managedBody, this.existingSha, managedTitle),
     ];
   }
+  installPartiallyPublishedLegacy(tree = "f".repeat(40)) {
+    this.installActive("e".repeat(40), undefined, true);
+    this.commits.set(this.partialSha, {
+      author: { email: "41898282+github-actions[bot]@users.noreply.github.com" },
+      message: `docs: catch up after main\n\n${signOff}`,
+      parents: [{ sha: this.existingSha }, { sha: this.initialParent }],
+      sha: this.partialSha,
+      tree: { sha: tree },
+      verification: { verified: true },
+    });
+    this.branchRef = {
+      object: { sha: this.partialSha },
+      ref: `refs/heads/${this.branch}`,
+    };
+    this.openPulls = this.openPulls.map((pull) => ({
+      ...pull,
+      head: { ...pull.head, sha: this.partialSha },
+    }));
+  }
   readonly request = vi.fn<Request>(async (method, url, body) => {
     const key = `${method} ${url}`;
     switch (key) {
       case `GET /repos/${repository}/git/commits/${this.existingSha}`:
       case `GET /repos/${repository}/git/commits/${this.commitSha}`:
+      case `GET /repos/${repository}/git/commits/${this.partialSha}`:
         return this.commits.get(url.slice(url.lastIndexOf("/") + 1));
       case `GET /repos/${repository}/git/ref/heads/main`:
         return { object: { sha: this.liveSha } };
@@ -229,10 +256,7 @@ class FakeGitHub {
         expect(body).toEqual({ force: false, sha: this.commitSha });
         const ref = { object: { sha: this.commitSha }, ref: `refs/heads/${this.branch}` };
         this.branchRef = ref;
-        this.openPulls = this.openPulls.map((pull) => ({
-          ...pull,
-          head: { ...pull.head, sha: this.commitSha },
-        }));
+        this.projectPullHead(this.commitSha);
         this.afterWrite();
         return ref;
       }
@@ -477,6 +501,16 @@ describe("post-merge documentation publisher", () => {
     expect(requestCount(api, "PATCH", `/git/refs/heads/${api.branch}`)).toBe(1);
     expect(requestCount(api, "POST", "/pulls")).toBe(0);
   });
+  it("accepts a confirmed fast-forward before the PR head projection catches up", async () => {
+    const value = fixture();
+    const api = new FakeGitHub(value);
+    api.installActive();
+    api.projectPullHead = () => undefined;
+    await expect(publish(value, api)).rejects.toThrow("Documentation remains pending");
+    expect(api.branchRef?.object.sha).toBe(api.commitSha);
+    expect(api.openPulls[0]?.head.sha).toBe(api.existingSha);
+    expect(requestCount(api, "PATCH", `/git/refs/heads/${api.branch}`)).toBe(1);
+  });
   it("updates exact legacy metadata for the active managed PR", async () => {
     const value = fixture();
     const api = new FakeGitHub(value);
@@ -485,6 +519,44 @@ describe("post-merge documentation publisher", () => {
     expect(api.openPulls[0]?.title).toBe(managedTitle);
     expect(api.openPulls[0]?.body).toBe(managedBody);
     expect(requestCount(api, "PATCH", "/pulls/42")).toBe(1);
+  });
+  it("recovers legacy metadata after a previous fast-forward completed", async () => {
+    const value = fixture();
+    const api = new FakeGitHub(value);
+    api.installPartiallyPublishedLegacy(value.finalTree);
+    await expect(publish(value, api)).rejects.toThrow("Documentation remains pending");
+    expect(api.openPulls[0]?.title).toBe(managedTitle);
+    expect(api.openPulls[0]?.body).toBe(managedBody);
+    expect(api.branchRef?.object.sha).toBe(api.partialSha);
+    expect(requestCount(api, "PATCH", "/pulls/42")).toBe(1);
+    expect(requestCount(api, "PATCH", `/git/refs/heads/${api.branch}`)).toBe(0);
+  });
+  it("migrates recovered legacy metadata before the next fast-forward", async () => {
+    const value = fixture();
+    const api = new FakeGitHub(value);
+    api.installPartiallyPublishedLegacy();
+    await expect(publish(value, api)).rejects.toThrow("Documentation remains pending");
+    expect(api.commitBodies[0]).toMatchObject({
+      parents: [api.partialSha, value.mainSha],
+      tree: value.finalTree,
+    });
+    const metadataUpdate = api.request.mock.calls.findIndex(
+      ([method, url]) => method === "PATCH" && url.endsWith("/pulls/42"),
+    );
+    const refUpdate = api.request.mock.calls.findIndex(
+      ([method, url]) => method === "PATCH" && url.endsWith(`/git/refs/heads/${api.branch}`),
+    );
+    expect(metadataUpdate).toBeGreaterThan(-1);
+    expect(refUpdate).toBeGreaterThan(metadataUpdate);
+  });
+  it("rejects a partially published legacy PR without a verified legacy parent", async () => {
+    const value = fixture();
+    const api = new FakeGitHub(value);
+    api.installPartiallyPublishedLegacy();
+    const previous = api.commits.get(api.existingSha)!;
+    previous.author = { email: "maintainer@example.com" };
+    await expect(publish(value, api)).rejects.toThrow("not created by the workflow");
+    expect(writeCount(api)).toBe(0);
   });
   it("reconciles a lost legacy metadata update without retrying", async () => {
     const value = fixture();

--- a/test/post-merge-docs.test.ts
+++ b/test/post-merge-docs.test.ts
@@ -554,7 +554,7 @@ describe("post-merge documentation publisher", () => {
     const api = new FakeGitHub(value);
     api.installPartiallyPublishedLegacy();
     const previous = api.commits.get(api.existingSha)!;
-    previous.author = { email: "maintainer@example.com" };
+    previous.verification = { verified: false };
     await expect(publish(value, api)).rejects.toThrow("not created by the workflow");
     expect(writeCount(api)).toBe(0);
   });

--- a/tools/post-merge-docs/publish.mts
+++ b/tools/post-merge-docs/publish.mts
@@ -226,19 +226,6 @@ function samePull(left: Pull | undefined, right: Pull | undefined): boolean {
 function requireSamePull(expected: Pull | undefined, observed: Pull | undefined): void {
   if (!samePull(expected, observed)) fail("managed documentation PR changed during publication");
 }
-function requireAdvancedPull(previous: Pull, observed: Pull | undefined, commitSha: string): Pull {
-  if (
-    observed === undefined ||
-    observed.number !== previous.number ||
-    observed.body !== previous.body ||
-    observed.draft !== previous.draft ||
-    observed.head.ref !== previous.head.ref ||
-    observed.head.sha !== commitSha ||
-    observed.title !== previous.title
-  )
-    fail("managed documentation PR changed during publication");
-  return observed;
-}
 function pullTitle(target: string): string {
   return `docs: prepare ${target} documentation`;
 }
@@ -286,20 +273,33 @@ Updates documentation for merged changes through \`${mainSha}\`.
 
 ${SIGN_OFF}`;
 }
-function pullMetadataMode(
+async function legacyCoverageSha(
+  repository: string,
+  commit: Commit,
+  request: Request,
+): Promise<string | undefined> {
+  const firstParent = commit.parents?.[0]?.sha;
+  if (!firstParent) return undefined;
+  if (commit.parents?.length === 1) return firstParent;
+  if (commit.parents?.length !== 2) return undefined;
+  const previous = await managedCommit(repository, firstParent, request);
+  return previous.parents?.length === 1 ? previous.parents[0]?.sha : undefined;
+}
+async function pullMetadataMode(
   pull: Pull,
   commit: Commit,
+  repository: string,
   rangeStart: string,
   target: string,
-): "current" | "legacy" {
+  request: Request,
+): Promise<"current" | "legacy"> {
   if (pull.title === pullTitle(target) && pull.body === pullBody(rangeStart, target))
     return "current";
-  const firstParent = commit.parents?.[0]?.sha;
+  const coverageSha = await legacyCoverageSha(repository, commit, request);
   if (
-    commit.parents?.length === 1 &&
-    firstParent &&
+    coverageSha &&
     pull.title === "docs: catch up after merged changes" &&
-    pull.body === legacyPullBody(firstParent)
+    pull.body === legacyPullBody(coverageSha)
   )
     return "legacy";
   return fail("managed documentation PR metadata does not match the reviewed release target");
@@ -424,7 +424,7 @@ export async function publishDocumentation(input: {
   const { patch, rangeStartTag, targetReleaseTag: target } = approval;
   const body = pullBody(rangeStartTag, target);
   const title = pullTitle(target);
-  const active = await checkpoint(repository, mainSha, request);
+  let active = await checkpoint(repository, mainSha, request);
   const temporary = fs.mkdtempSync(path.join(tmpdir(), "nemoclaw-docs-publish-"));
   try {
     const destination = path.join(temporary, "repository");
@@ -435,19 +435,24 @@ export async function publishDocumentation(input: {
     const branch = active?.head.ref ?? `${PREFIX}${mainSha.slice(0, 12)}`;
     const refPath = `/repos/${repository}/git/ref/heads/${branch}`;
     const ref = (await request("GET", refPath)) as { object?: { sha?: string } } | null;
-    let metadataMode: "current" | "legacy" | undefined;
     if (active) {
       if (ref?.object?.sha !== active.head.sha)
         fail("managed documentation PR and branch point to different commits");
       const current = await managedCommit(repository, active.head.sha, request);
-      metadataMode = pullMetadataMode(active, current, rangeStartTag, target);
+      const metadataMode = await pullMetadataMode(
+        active,
+        current,
+        repository,
+        rangeStartTag,
+        target,
+        request,
+      );
+      if (metadataMode === "legacy") {
+        requireSamePull(active, await checkpoint(repository, mainSha, request));
+        active = await updatePullMetadata(active, repository, rangeStartTag, target, request);
+      }
       if (!prepared.changes.length || current.tree?.sha === prepared.finalTree) {
-        let pending = active;
-        if (metadataMode === "legacy") {
-          requireSamePull(active, await checkpoint(repository, mainSha, request));
-          pending = await updatePullMetadata(active, repository, rangeStartTag, target, request);
-        }
-        fail(`Documentation remains pending in ${pending.html_url}`);
+        fail(`Documentation remains pending in ${active.html_url}`);
       }
     } else if (ref !== null) {
       fail("an unmanaged documentation branch already exists for this main commit");
@@ -466,11 +471,7 @@ export async function publishDocumentation(input: {
 
     if (active) {
       await updateRef(repository, branch, commitSha, request);
-      let pull = requireAdvancedPull(active, (await managed(repository, request))[0], commitSha);
-      if (metadataMode === "legacy")
-        pull = await updatePullMetadata(pull, repository, rangeStartTag, target, request);
-      else checkedPull(pull, repository, branch, body, title);
-      fail(`Documentation remains pending in ${pull.html_url}`);
+      fail(`Documentation remains pending in ${active.html_url}`);
     }
 
     try {


### PR DESCRIPTION
## Summary

Make cumulative documentation publication restartable after GitHub accepts a branch fast-forward before the pull request API projects the new head. This repairs the partial state left on #9841 by normalizing its exact legacy metadata before the next branch update.

## Changes

- Treat the confirmed Git ref update as the authority for a completed fast-forward instead of requiring an immediate matching pull request head projection.
- Recognize only the exact verified-bot commit lineage produced when the earlier migration stopped after its first fast-forward.
- Migrate legacy pull request metadata before creating or publishing the next cumulative commit.
- Add regression coverage for delayed pull request projection, restart recovery, update ordering, and rejection of an unverified legacy parent.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: focused review confirmed that same-repository draft checks, exact metadata checkpoints, verified workflow-bot lineage, non-force ref updates, and credential boundaries remain unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run test/post-merge-docs.test.ts` (46 passed); `npm run test:changed` (passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Validation also passed `npm run typecheck:cli`, `npm run checks:repository`, and Oxfmt checks for both changed files.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved documentation publishing for legacy and partially published changes.
  - Added support for delayed pull-request updates and metadata recovery after completed fast-forwards.
  - Improved validation of documentation publication state, including safer handling of incomplete or unverified workflows.
  - Ensured pending pull requests are reported promptly after existing documentation branches advance.
  - Improved handling of documentation updates when publication metadata requires migration or recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->