### PR TITLE
fix(inference): admit N1x preview readiness

### DIFF
--- a/src/lib/inference/serving/resolver.test.ts
+++ b/src/lib/inference/serving/resolver.test.ts
@@ -292,6 +292,37 @@ function deferredN1xReadinessReport(
   };
 }
 
+function deferredN1xWithRemediableStorageReport(
+  extraFindings: SystemReadinessReport["findings"] = [],
+): SystemReadinessReport {
+  const report = deferredN1xReadinessReport([
+    {
+      id: "host.docker.storage_incompatible",
+      severity: "blocking",
+      summary: "The Docker storage configuration requires lifecycle remediation.",
+      capabilityIds: ["host.docker.storage_compatible"],
+    },
+    ...extraFindings,
+  ]);
+  return {
+    ...report,
+    capabilities: [
+      ...report.capabilities.map((capability) =>
+        capability.id === "host.docker.storage_compatible"
+          ? { ...capability, state: "absent" as const }
+          : capability.id === "host.docker.storage_remediation_available"
+            ? { ...capability, state: "present" as const }
+            : capability,
+      ),
+      ...(report.capabilities.some(
+        ({ id }) => id === "host.docker.storage_remediation_available",
+      )
+        ? []
+        : [{ id: "host.docker.storage_remediation_available", state: "present" as const }]),
+    ],
+  };
+}
+
 function topology(
   overrides: Partial<ManagedInferenceTopologyQualification<ManagedClusterTopologyOutput>> = {},
 ): ManagedInferenceTopologyQualification<ManagedClusterTopologyOutput> {
@@ -1170,6 +1201,22 @@ describe("managed inference resolver", () => {
     });
   });
 
+  it("selects the N1x managed-vLLM preset when Docker storage is remediable (#9902)", () => {
+    expect(
+      resolveManagedInferenceServing({
+        readinessReports: [
+          { nodeId: "n1x-host", report: deferredN1xWithRemediableStorageReport() },
+        ],
+        topologyQualifications: [],
+        intent: { provider: "vllm" },
+        now: NOW,
+      }),
+    ).toMatchObject({
+      outcome: "selected",
+      preset: { metadata: { id: N1X_VLLM_PRESET_ID } },
+    });
+  });
+
   it.each([
     {
       condition: "managed-vLLM intent is absent",
@@ -1185,6 +1232,18 @@ describe("managed inference resolver", () => {
       condition: "another blocking finding remains",
       intent: { provider: "vllm" },
       report: deferredN1xReadinessReport([
+        {
+          id: "host.gpu.container_toolkit_missing",
+          severity: "blocking",
+          summary: "NVIDIA Container Toolkit is missing.",
+          capabilityIds: ["host.gpu.container_toolkit_available"],
+        },
+      ]),
+    },
+    {
+      condition: "another blocking finding remains with remediable storage",
+      intent: { provider: "vllm" },
+      report: deferredN1xWithRemediableStorageReport([
         {
           id: "host.gpu.container_toolkit_missing",
           severity: "blocking",

--- a/src/lib/inference/serving/resolver.test.ts
+++ b/src/lib/inference/serving/resolver.test.ts
@@ -36,6 +36,7 @@ import type {
 
 const NOW = new Date("2026-08-02T18:00:00.000Z");
 const SOURCE_REVISION = "a".repeat(40);
+const N1X_VLLM_PRESET_ID = "vllm.n1x.single.qwen3-6-35b-a3b-nvfp4";
 const LINUX_VLLM_PROFILES = [
   {
     presetId: "vllm.linux-amd64-nvidia.single.muse-glimmer-30b-nvfp4-w4a4",
@@ -251,6 +252,38 @@ function storageRemediableReadinessReport(
         severity: "blocking",
         summary: "The Docker storage configuration requires lifecycle remediation.",
         capabilityIds: ["host.docker.storage_compatible"],
+      },
+      ...extraFindings,
+    ],
+    status: "incompatible",
+    exitCode: 2,
+  };
+}
+
+function deferredN1xReadinessReport(
+  extraFindings: SystemReadinessReport["findings"] = [],
+  n1xState: "present" | "absent" = "present",
+): SystemReadinessReport {
+  const catalog = shippedCatalog();
+  const preset = catalog.presets.find(({ metadata }) => metadata.id === N1X_VLLM_PRESET_ID);
+  expect(preset).toBeDefined();
+  const report = readinessReport({}, preset!);
+  return {
+    ...report,
+    capabilities: [
+      ...report.capabilities.map((capability) =>
+        capability.id === "host.platform.n1x"
+          ? { ...capability, state: n1xState }
+          : capability,
+      ),
+      { id: "host.platform.supported", state: "absent" as const },
+    ],
+    findings: [
+      {
+        id: "host.platform.n1x_validation_pending",
+        severity: "blocking",
+        summary: "N1x platform validation is pending a physical NemoClaw Express E2E run.",
+        capabilityIds: ["host.platform.n1x", "host.platform.supported"],
       },
       ...extraFindings,
     ],
@@ -1121,6 +1154,54 @@ describe("managed inference resolver", () => {
     );
 
     expect(result).toMatchObject({ outcome: "selected", selection: "explicit" });
+  });
+
+  it("selects the N1x managed-vLLM preset with explicit Deferred preview intent (#9902)", () => {
+    expect(
+      resolveManagedInferenceServing({
+        readinessReports: [{ nodeId: "n1x-host", report: deferredN1xReadinessReport() }],
+        topologyQualifications: [],
+        intent: { provider: "vllm" },
+        now: NOW,
+      }),
+    ).toMatchObject({
+      outcome: "selected",
+      preset: { metadata: { id: N1X_VLLM_PRESET_ID } },
+    });
+  });
+
+  it.each([
+    {
+      condition: "managed-vLLM intent is absent",
+      intent: undefined,
+      report: deferredN1xReadinessReport(),
+    },
+    {
+      condition: "N1x identity is absent",
+      intent: { provider: "vllm" },
+      report: deferredN1xReadinessReport([], "absent"),
+    },
+    {
+      condition: "another blocking finding remains",
+      intent: { provider: "vllm" },
+      report: deferredN1xReadinessReport([
+        {
+          id: "host.gpu.container_toolkit_missing",
+          severity: "blocking",
+          summary: "NVIDIA Container Toolkit is missing.",
+          capabilityIds: ["host.gpu.container_toolkit_available"],
+        },
+      ]),
+    },
+  ])("rejects Deferred N1x readiness when $condition (#9902)", ({ intent, report }) => {
+    expect(
+      resolveManagedInferenceServing({
+        readinessReports: [{ nodeId: "n1x-host", report }],
+        topologyQualifications: [],
+        intent,
+        now: NOW,
+      }),
+    ).toMatchObject({ outcome: "rejected", code: "invalid-readiness" });
   });
 
   it("rejects remediation when another blocking finding remains (#8246)", () => {

--- a/src/lib/inference/serving/resolver.ts
+++ b/src/lib/inference/serving/resolver.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { checkSystemReadinessSchemaVersion } from "../../readiness/compatibility.js";
+import {
+  evaluateOnboardReadinessAdmission,
+  ONBOARD_READINESS_FINDING_IDS,
+} from "../../readiness/onboard-admission.js";
 import { getSystemReadinessReferenceErrors } from "../../readiness/references.js";
 import {
   hasRemediableStorageConflict,
@@ -86,10 +90,21 @@ function recipeMatchesModelIntent(
   );
 }
 
+function hasManagedVllmIntent(
+  intent: ManagedInferenceSelectionIntent,
+  catalog: CompiledManagedInferenceCatalog,
+): boolean {
+  if (intent.provider === "vllm" || hasText(intent.vllmModel)) return true;
+  if (!hasText(intent.preset)) return false;
+  const presets = catalog.presets.filter(({ metadata }) => metadata.id === intent.preset);
+  return presets.length === 1 && presets[0]!.spec.plan.backend === "vllm";
+}
+
 function readinessError(
   source: ManagedInferenceReadinessSource,
   nowMs: number,
   maxAgeMs: number,
+  allowDeferredN1xManagedVllm: boolean,
 ): string | undefined {
   const { nodeId, report } = source;
   if (!hasText(nodeId)) return "readiness node ID is empty";
@@ -110,12 +125,27 @@ function readinessError(
   const referenceErrors = getSystemReadinessReferenceErrors(report);
   if (referenceErrors.length > 0) return `${nodeId}: ${referenceErrors[0]}`;
   const remediableStorage = hasRemediableStorageConflict(report);
-  if ((report.status !== "supported" || report.exitCode !== 0) && !remediableStorage) {
+  const n1xAdmission = allowDeferredN1xManagedVllm
+    ? evaluateOnboardReadinessAdmission(report, {
+        explicitlyOptedOutGpuPassthrough: false,
+        allowUnsupportedRuntime: false,
+        allowStorageRemediation: false,
+        allowDeferredN1xManagedVllm: true,
+      })
+    : undefined;
+  const deferredN1xManagedVllm =
+    report.status === "incompatible" &&
+    report.exitCode === 2 &&
+    n1xAdmission?.admitted === true &&
+    n1xAdmission.waivedFindingIds.length === 1 &&
+    n1xAdmission.waivedFindingIds[0] === ONBOARD_READINESS_FINDING_IDS.n1xValidationPending;
+  const admittedReadinessException = remediableStorage || deferredN1xManagedVllm;
+  if ((report.status !== "supported" || report.exitCode !== 0) && !admittedReadinessException) {
     return `${nodeId}: readiness status is ${report.status}`;
   }
   if (
     report.findings.some(({ severity }) => severity === "fatal" || severity === "blocking") &&
-    !remediableStorage
+    !admittedReadinessException
   ) {
     return `${nodeId}: readiness report contains a blocking finding`;
   }
@@ -126,13 +156,14 @@ function readinessReportsError(
   sources: readonly ManagedInferenceReadinessSource[],
   nowMs: number,
   maxAgeMs: number,
+  allowDeferredN1xManagedVllm: boolean,
 ): string | undefined {
   const nodeIds = sources.map(({ nodeId }) => nodeId);
   if (new Set(nodeIds).size !== nodeIds.length) {
     return "readiness reports contain duplicate node IDs";
   }
   for (const source of sources) {
-    const error = readinessError(source, nowMs, maxAgeMs);
+    const error = readinessError(source, nowMs, maxAgeMs, allowDeferredN1xManagedVllm);
     if (error) return error;
   }
   return undefined;
@@ -556,7 +587,12 @@ export function resolveManagedInferenceServing<TOutput>(
       message: "Readiness freshness policy is invalid.",
     };
   }
-  const reportsError = readinessReportsError(input.readinessReports, nowMs, maxAgeMs);
+  const reportsError = readinessReportsError(
+    input.readinessReports,
+    nowMs,
+    maxAgeMs,
+    hasManagedVllmIntent(intent, catalog),
+  );
   if (reportsError) {
     return {
       outcome: "rejected",

--- a/src/lib/inference/serving/resolver.ts
+++ b/src/lib/inference/serving/resolver.ts
@@ -11,6 +11,7 @@ import {
   hasRemediableStorageConflict,
   STORAGE_COMPATIBLE_CAPABILITY,
 } from "../../readiness/storage-remediation.js";
+import type { SystemReadinessReport } from "../../readiness/types.js";
 import {
   getManagedInferenceMaterializerDescriptor,
   getManagedInferenceRecipeRegistrationError,
@@ -100,6 +101,41 @@ function hasManagedVllmIntent(
   return presets.length === 1 && presets[0]!.spec.plan.backend === "vllm";
 }
 
+function hasRemediableStorageFinding(report: SystemReadinessReport): boolean {
+  const storageFindings = report.findings.filter(
+    ({ id, severity }) =>
+      id === ONBOARD_READINESS_FINDING_IDS.storageIncompatible && severity === "blocking",
+  );
+  return (
+    storageFindings.length === 1 &&
+    hasRemediableStorageConflict({ ...report, findings: storageFindings })
+  );
+}
+
+function hasAdmittedReadinessException(
+  report: SystemReadinessReport,
+  allowDeferredN1xManagedVllm: boolean,
+): boolean {
+  if (report.status !== "incompatible" || report.exitCode !== 2) return false;
+  const remediableStorage = hasRemediableStorageFinding(report);
+  const admission = evaluateOnboardReadinessAdmission(report, {
+    explicitlyOptedOutGpuPassthrough: false,
+    allowUnsupportedRuntime: false,
+    allowStorageRemediation: remediableStorage,
+    allowDeferredN1xManagedVllm,
+  });
+  if (!admission.admitted || admission.waivedFindingIds.length === 0) return false;
+  const waivedFindingIds = new Set(admission.waivedFindingIds);
+  if (waivedFindingIds.size !== admission.waivedFindingIds.length) return false;
+  const allowedFindingIds = new Set<string>([
+    ONBOARD_READINESS_FINDING_IDS.storageIncompatible,
+    ...(allowDeferredN1xManagedVllm
+      ? [ONBOARD_READINESS_FINDING_IDS.n1xValidationPending]
+      : []),
+  ]);
+  return admission.waivedFindingIds.every((id) => allowedFindingIds.has(id));
+}
+
 function readinessError(
   source: ManagedInferenceReadinessSource,
   nowMs: number,
@@ -124,22 +160,10 @@ function readinessError(
   }
   const referenceErrors = getSystemReadinessReferenceErrors(report);
   if (referenceErrors.length > 0) return `${nodeId}: ${referenceErrors[0]}`;
-  const remediableStorage = hasRemediableStorageConflict(report);
-  const n1xAdmission = allowDeferredN1xManagedVllm
-    ? evaluateOnboardReadinessAdmission(report, {
-        explicitlyOptedOutGpuPassthrough: false,
-        allowUnsupportedRuntime: false,
-        allowStorageRemediation: false,
-        allowDeferredN1xManagedVllm: true,
-      })
-    : undefined;
-  const deferredN1xManagedVllm =
-    report.status === "incompatible" &&
-    report.exitCode === 2 &&
-    n1xAdmission?.admitted === true &&
-    n1xAdmission.waivedFindingIds.length === 1 &&
-    n1xAdmission.waivedFindingIds[0] === ONBOARD_READINESS_FINDING_IDS.n1xValidationPending;
-  const admittedReadinessException = remediableStorage || deferredN1xManagedVllm;
+  const admittedReadinessException = hasAdmittedReadinessException(
+    report,
+    allowDeferredN1xManagedVllm,
+  );
   if ((report.status !== "supported" || report.exitCode !== 0) && !admittedReadinessException) {
     return `${nodeId}: readiness status is ${report.status}`;
   }
@@ -273,7 +297,7 @@ function readinessRequirementMatches(
       requirement.kind === "capability" &&
       requirement.id === STORAGE_COMPATIBLE_CAPABILITY &&
       requirement.state === "present" &&
-      hasRemediableStorageConflict(report)
+      hasRemediableStorageFinding(report)
     );
   });
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

N1x preview onboarding can now resolve the managed vLLM preset when its deferred physical-validation blocker appears alone or with a remediable Docker storage blocker. Other readiness failures and non-vLLM requests remain rejected.

## Related Issue

Fixes #9902

## Changes

- Reuse the existing onboarding readiness admission when resolving a managed vLLM request, after the standard readiness report validation completes.
- Compose the accepted N1x preview waiver with structurally verified Docker storage remediation, matching the live N1x report without admitting unrelated blockers. The N1x scope is defined in https://github.com/NVIDIA/NemoClaw/issues/8574#issuecomment-5267304469.
- Add preset-based tests for each admitted state, their live two-blocker composition, and rejection when vLLM intent, N1x identity, or the allowed-blocker invariant is missing.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Local review confirmed that standard schema, mutation, producer, freshness, source revision, and reference checks still run first; unified admission accepts only the exact managed-vLLM N1x blocker and structurally verified storage remediation, individually or together, with negative tests for broader admission.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/inference/serving/resolver.test.ts` (57 passed); `npm run test:changed` (32 growth-guard tests and 614 changed-source tests passed); `npm run build:cli`; `npm run typecheck:cli`; `npx oxlint src/lib/inference/serving/resolver.ts src/lib/inference/serving/resolver.test.ts`; `npm run test:titles:check`; and `git diff --check` all passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing managed vLLM deployments using the N1X preset while platform validation is pending.
  * Readiness checks can accept this deferred-validation scenario when only permitted findings are present.

* **Bug Fixes**
  * Restricted storage remediation to a single blocking storage incompatibility.
  * Invalid readiness is reported when required intent or N1X identity is missing, or when additional blocking findings remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->