### PR TITLE
fix(ci): bind Portable Podman to systemd cgroups

### DIFF
--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -184,8 +184,10 @@ jobs:
 
           uid="$(id -u)"
           receipt="${RUNNER_TEMP}/nemoclaw-portable-cpu-delegation.receipt"
+          containers_conf="/run/nemoclaw/portable-containers.conf"
           delegation_drop_in="/etc/systemd/system/user@.service.d/90-nemoclaw-cpu-delegation.conf"
           app_slice_drop_in="/etc/systemd/user/app.slice.d/90-nemoclaw-cpu-controller.conf"
+          podman_service_drop_in="/etc/systemd/user/podman.service.d/90-nemoclaw-cgroup-manager.conf"
           user_slice_drop_in="/etc/systemd/system/user-${uid}.slice.d/90-nemoclaw-cpu-controller.conf"
           : >"$receipt"
 
@@ -219,6 +221,14 @@ jobs:
             sudo chmod 0644 "$target"
           }
 
+          if test -e "$containers_conf" || test -L "$containers_conf"; then
+            printf 'Refusing existing Portable Podman configuration path: %s\n' "$containers_conf" >&2
+            exit 1
+          fi
+          printf 'file\tpodman-config\t%s\n' "$containers_conf" >>"$receipt"
+          printf '%s' $'[engine]\ncgroup_manager = "systemd"\n' >"$containers_conf"
+          chmod 0600 "$containers_conf"
+
           install_fixture_drop_in \
             user-slice \
             "$user_slice_drop_in" \
@@ -231,6 +241,10 @@ jobs:
             delegation \
             "$delegation_drop_in" \
             $'[Service]\nDelegate=cpu memory pids\n'
+          install_fixture_drop_in \
+            podman-service \
+            "$podman_service_drop_in" \
+            "[Service]"$'\n'"Environment=CONTAINERS_CONF=${containers_conf}"$'\n'
 
           if sudo systemctl is-active --quiet "user@${uid}.service"; then
             printf 'manager-active\t%s\n' "$uid" >>"$receipt"
@@ -246,10 +260,12 @@ jobs:
 
           export XDG_RUNTIME_DIR="$runtime_dir"
           export DBUS_SESSION_BUS_ADDRESS="unix:path=${runtime_dir}/bus"
+          export CONTAINERS_CONF="$containers_conf"
           export DOCKER_HOST="unix://${runtime_dir}/podman/podman.sock"
           {
             printf 'XDG_RUNTIME_DIR=%s\n' "$runtime_dir"
             printf 'DBUS_SESSION_BUS_ADDRESS=%s\n' "$DBUS_SESSION_BUS_ADDRESS"
+            printf 'CONTAINERS_CONF=%s\n' "$CONTAINERS_CONF"
             printf 'DOCKER_HOST=%s\n' "$DOCKER_HOST"
             printf 'E2E_PORTABLE_CPU_DELEGATION_RECEIPT=%s\n' "$receipt"
           } >>"$GITHUB_ENV"
@@ -265,7 +281,11 @@ jobs:
             process.stdout.write(result.detail + "\n");
           '
           cgroup_manager="$(podman info --format '{{.Host.CgroupManager}}')"
-          test "$cgroup_manager" = "systemd"
+          if [ "$cgroup_manager" != "systemd" ]; then
+            printf 'Portable Podman must use the systemd cgroup manager; observed: %s\n' \
+              "${cgroup_manager:-empty}" >&2
+            exit 1
+          fi
           podman --version
           docker --version
           docker --host "$DOCKER_HOST" info
@@ -340,8 +360,10 @@ jobs:
 
           uid="$(id -u)"
           receipt="${E2E_PORTABLE_CPU_DELEGATION_RECEIPT:-${RUNNER_TEMP}/nemoclaw-portable-cpu-delegation.receipt}"
+          containers_conf="/run/nemoclaw/portable-containers.conf"
           delegation_drop_in="/etc/systemd/system/user@.service.d/90-nemoclaw-cpu-delegation.conf"
           app_slice_drop_in="/etc/systemd/user/app.slice.d/90-nemoclaw-cpu-controller.conf"
+          podman_service_drop_in="/etc/systemd/user/podman.service.d/90-nemoclaw-cgroup-manager.conf"
           user_slice_drop_in="/etc/systemd/system/user-${uid}.slice.d/90-nemoclaw-cpu-controller.conf"
           disable_linger=0
           restore_manager=0
@@ -371,10 +393,18 @@ jobs:
               if [ "$kind" = "file" ]; then
                 case "$name:$target" in
                   "delegation:$delegation_drop_in")
-                    cleanup_fixture_drop_in "$target" $'[Service]\nDelegate=cpu memory pids' || cleanup_failed=1
+                    cleanup_fixture_drop_in "$target" $'[Service]\nDelegate=cpu memory pids\n' || cleanup_failed=1
                     ;;
                   "app-slice:$app_slice_drop_in"|"user-slice:$user_slice_drop_in")
-                    cleanup_fixture_drop_in "$target" $'[Slice]\nCPUWeight=100' || cleanup_failed=1
+                    cleanup_fixture_drop_in "$target" $'[Slice]\nCPUWeight=100\n' || cleanup_failed=1
+                    ;;
+                  "podman-service:$podman_service_drop_in")
+                    cleanup_fixture_drop_in \
+                      "$target" \
+                      "[Service]"$'\n'"Environment=CONTAINERS_CONF=${containers_conf}"$'\n' || cleanup_failed=1
+                    ;;
+                  "podman-config:$containers_conf")
+                    cleanup_fixture_drop_in "$target" $'[engine]\ncgroup_manager = "systemd"\n' || cleanup_failed=1
                     ;;
                   *)
                     printf 'Refusing unexpected Portable CPU-delegation receipt: %s:%s\n' "$name" "$target" >&2
@@ -387,7 +417,7 @@ jobs:
                 restore_manager=1
               elif [ "$kind" = "directory" ] && [ -z "${target:-}" ]; then
                 case "$name" in
-                  /etc/systemd/system/user@.service.d|/etc/systemd/user/app.slice.d|"/etc/systemd/system/user-${uid}.slice.d")
+                  /etc/systemd/system/user@.service.d|/etc/systemd/user/app.slice.d|/etc/systemd/user/podman.service.d|"/etc/systemd/system/user-${uid}.slice.d")
                     directories+=("$name")
                     ;;
                   *)

--- a/test/e2e/support/portable-profile-cgroup-cleanup-workflow.test.ts
+++ b/test/e2e/support/portable-profile-cgroup-cleanup-workflow.test.ts
@@ -26,6 +26,8 @@ it("restores the portable user manager and linger state after refusing a changed
   const root = fs.mkdtempSync("/tmp/portable-cpu-delegation-restoration-");
   const bin = path.join(root, "bin");
   const changed = path.join(root, "changed.conf");
+  const podmanConfig = path.join(root, "portable-containers.conf");
+  const podmanService = path.join(root, "podman-service.conf");
   const receipt = path.join(root, "receipt");
   const commandLog = path.join(root, "commands.log");
   const expected = "[Service]\nDelegate=cpu memory pids\n";
@@ -40,10 +42,17 @@ it("restores the portable user manager and linger state after refusing a changed
     '#!/usr/bin/env bash\nprintf "loginctl\\t%s\\n" "$*" >>"$FAKE_CLEANUP_LOG"\n',
   );
   fs.writeFileSync(changed, `${expected}unexpected\n`);
+  fs.writeFileSync(podmanConfig, '[engine]\ncgroup_manager = "systemd"\n');
+  fs.writeFileSync(podmanService, `[Service]\nEnvironment=CONTAINERS_CONF=${podmanConfig}\n`);
   fs.writeFileSync(
     receipt,
-    [`file\tdelegation\t${changed}`, "manager-active\t501\t", "linger\tfixture-user\t"].join("\n") +
-      "\n",
+    [
+      `file\tpodman-config\t${podmanConfig}`,
+      `file\tpodman-service\t${podmanService}`,
+      `file\tdelegation\t${changed}`,
+      "manager-active\t501\t",
+      "linger\tfixture-user\t",
+    ].join("\n") + "\n",
   );
 
   const cleanupRun = portableCleanupRun();
@@ -56,6 +65,14 @@ it("restores the portable user manager and linger state after refusing a changed
     .replace(
       'delegation_drop_in="/etc/systemd/system/user@.service.d/90-nemoclaw-cpu-delegation.conf"',
       `delegation_drop_in=${JSON.stringify(changed)}`,
+    )
+    .replace(
+      'containers_conf="/run/nemoclaw/portable-containers.conf"',
+      `containers_conf=${JSON.stringify(podmanConfig)}`,
+    )
+    .replace(
+      'podman_service_drop_in="/etc/systemd/user/podman.service.d/90-nemoclaw-cgroup-manager.conf"',
+      `podman_service_drop_in=${JSON.stringify(podmanService)}`,
     );
 
   try {
@@ -83,6 +100,8 @@ it("restores the portable user manager and linger state after refusing a changed
       "loginctl\tdisable-linger fixture-user",
     ]);
     expect(fs.readFileSync(changed, "utf8")).toBe(`${expected}unexpected\n`);
+    expect(fs.existsSync(podmanConfig)).toBe(false);
+    expect(fs.existsSync(podmanService)).toBe(false);
     expect(fs.existsSync(receipt)).toBe(false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/test/e2e/support/portable-profile-systemctl-shim.test.ts
+++ b/test/e2e/support/portable-profile-systemctl-shim.test.ts
@@ -84,6 +84,12 @@ const fs = require("node:fs");
 const net = require("node:net");
 const args = process.argv.slice(2);
 if (args[0] === "info") {
+  if (args.includes("{{.Host.CgroupManager}}")) {
+    const source = fs.readFileSync(process.env.CONTAINERS_CONF, "utf8");
+    const configured = source.match(/^cgroup_manager = "([^"]+)"$/m)?.[1] ?? "";
+    process.stdout.write((process.env.FAKE_PODMAN_CGROUP_MANAGER ?? configured) + "\\n");
+    process.exit(0);
+  }
   process.stdout.write(process.env.FAKE_PODMAN_SOCKET + "\\n");
   process.exit(0);
 }
@@ -471,15 +477,6 @@ function portableLaunchStep(name: string): WorkflowStep {
   );
   expect(step).toBeDefined();
   return step!;
-}
-
-function portableLaunchShellFunction(stepName: string, functionName: string): string {
-  const run = portableLaunchStep(stepName).run ?? "";
-  const start = run.indexOf(`${functionName}() {\n`);
-  expect(start).toBeGreaterThanOrEqual(0);
-  const end = run.slice(start).search(/^\}\n/mu);
-  expect(end).toBeGreaterThanOrEqual(0);
-  return run.slice(start, start + end + 2);
 }
 
 describe("portable profile systemctl fixture", () => {
@@ -1399,8 +1396,6 @@ describe("portable profile systemctl fixture", () => {
     expect(provision).toContain('sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" /run/nemoclaw');
     expect(provision).toContain('containers_conf="/run/nemoclaw/portable-containers.conf"');
     expect(provision).toContain("podman.service.d/90-nemoclaw-cgroup-manager.conf");
-    expect(provision).toContain('cgroup_manager = "systemd"');
-    expect(provision).toContain("Environment=CONTAINERS_CONF=${containers_conf}");
     expect(provision).toContain("user@.service.d/90-nemoclaw-cpu-delegation.conf");
     expect(provision).toContain("/etc/systemd/user/app.slice.d/90-nemoclaw-cpu-controller.conf");
     expect(provision).toContain("user-${uid}.slice.d/90-nemoclaw-cpu-controller.conf");
@@ -1411,8 +1406,6 @@ describe("portable profile systemctl fixture", () => {
     expect(provision).toContain('sudo systemctl start "user@${uid}.service"');
     expect(provision).toContain("/usr/bin/systemctl --user start podman.socket");
     expect(provision).toContain("inspectPortableCpuDelegation");
-    expect(provision).toContain('if [ "$cgroup_manager" != "systemd" ]; then');
-    expect(provision).toContain("Portable Podman must use the systemd cgroup manager");
     const podmanConfigIndex = provision.indexOf('cgroup_manager = "systemd"');
     expect(podmanConfigIndex).toBeGreaterThanOrEqual(0);
     expect(podmanConfigIndex).toBeLessThan(
@@ -1437,8 +1430,6 @@ describe("portable profile systemctl fixture", () => {
     expect(cleanupRun).toContain('docker buildx rm "$builder_name"');
     expect(cleanupRun).toContain("Delegate=cpu memory pids\\n'");
     expect(cleanupRun).toContain("CPUWeight=100\\n'");
-    expect(cleanupRun).toContain('"podman-service:$podman_service_drop_in"');
-    expect(cleanupRun).toContain('"podman-config:$containers_conf"');
     expect(cleanupRun).toContain("sudo systemctl daemon-reload");
     expect(cleanupRun.indexOf('docker buildx rm "$builder_name"')).toBeLessThan(
       cleanupRun.indexOf("podman system reset"),
@@ -1448,49 +1439,62 @@ describe("portable profile systemctl fixture", () => {
     );
   });
 
-  it("removes only byte-identical CPU-delegation drop-ins with terminal newlines", () => {
-    const root = fs.mkdtempSync("/tmp/portable-cpu-delegation-cleanup-");
-    const bin = path.join(root, "bin");
-    const exact = path.join(root, "exact.conf");
-    const changed = path.join(root, "changed.conf");
-    const expected = "[Service]\nDelegate=cpu memory pids\n";
-    fs.mkdirSync(bin, { mode: 0o700 });
-    writeExecutable(path.join(bin, "sudo"), '#!/usr/bin/env bash\nexec "$@"\n');
-    fs.writeFileSync(exact, expected);
-    fs.writeFileSync(changed, `${expected}unexpected\n`);
-    const cleanupFunction = portableLaunchShellFunction(
-      "Clean up portable runtime",
-      "cleanup_fixture_drop_in",
-    );
-    const runCleanup = (target: string) =>
-      spawnSync(
+  it("creates the Portable Podman configuration and rejects a non-systemd cgroup manager", async () => {
+    const scope = createFixture();
+    const provision = portableLaunchStep("Provision restricted rootless Linux runtime").run ?? "";
+    const configStart = provision.indexOf('if test -e "$containers_conf"');
+    const configEnd = provision.indexOf("\n\ninstall_fixture_drop_in", configStart);
+    const managerStart = provision.indexOf('cgroup_manager="$(podman info');
+    const managerEnd = provision.indexOf("\npodman --version", managerStart);
+    expect([configStart, configEnd, managerStart, managerEnd]).not.toContain(-1);
+    const containersConf = path.join(scope.directory, "portable-containers.conf");
+    const receipt = path.join(scope.directory, "receipt");
+    try {
+      const configure = spawnSync(
         "bash",
         [
           "-c",
-          `${cleanupFunction}\ncleanup_fixture_drop_in \"$1\" \"$2\"`,
-          "cleanup",
-          target,
-          expected,
+          `set -euo pipefail\ncontainers_conf="$1"\nreceipt="$2"\n${provision.slice(configStart, configEnd)}`,
+          "configure-podman",
+          containersConf,
+          receipt,
         ],
-        {
+        { encoding: "utf8", env: scope.env },
+      );
+      expect(configure.status, configure.stderr).toBe(0);
+      expect(fs.readFileSync(containersConf, "utf8")).toBe(
+        '[engine]\ncgroup_manager = "systemd"\n',
+      );
+      expect(fs.statSync(containersConf).mode & 0o777).toBe(0o600);
+      expect(fs.readFileSync(receipt, "utf8")).toBe(`file\tpodman-config\t${containersConf}\n`);
+      expect(
+        systemctl(scope, [
+          "--user",
+          "set-environment",
+          "NETAVARK_FW=iptables",
+          `CONTAINERS_CONF=${containersConf}`,
+        ]).status,
+      ).toBe(0);
+      expect(systemctl(scope, ["--user", "start", "podman.socket"]).status).toBe(0);
+      expect(await activateThroughSocket(scope.socketPath)).toBe("ready");
+      const managerCheck = provision.slice(managerStart, managerEnd);
+      const runManagerCheck = (manager?: string) =>
+        spawnSync("bash", ["-c", `set -euo pipefail\n${managerCheck}`], {
           encoding: "utf8",
-          env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` },
-        },
+          env: {
+            ...scope.env,
+            CONTAINERS_CONF: containersConf,
+            FAKE_PODMAN_CGROUP_MANAGER: manager,
+          },
+        });
+      expect(runManagerCheck().status).toBe(0);
+      const rejected = runManagerCheck("cgroupfs");
+      expect(rejected.status).not.toBe(0);
+      expect(rejected.stderr).toContain(
+        "Portable Podman must use the systemd cgroup manager; observed: cgroupfs",
       );
-
-    try {
-      const exactCleanup = runCleanup(exact);
-      expect(exactCleanup.status, exactCleanup.stderr).toBe(0);
-      expect(fs.existsSync(exact)).toBe(false);
-
-      const changedCleanup = runCleanup(changed);
-      expect(changedCleanup.status).not.toBe(0);
-      expect(changedCleanup.stderr).toContain(
-        "Refusing changed Portable CPU-delegation fixture file",
-      );
-      expect(fs.readFileSync(changed, "utf8")).toBe(`${expected}unexpected\n`);
     } finally {
-      fs.rmSync(root, { recursive: true, force: true });
+      await cleanFixture(scope);
     }
   });
 });

--- a/test/e2e/support/portable-profile-systemctl-shim.test.ts
+++ b/test/e2e/support/portable-profile-systemctl-shim.test.ts
@@ -1397,13 +1397,13 @@ describe("portable profile systemctl fixture", () => {
     const provision = portableLaunchStep("Provision restricted rootless Linux runtime").run ?? "";
     expect(provision).not.toContain("portable-profile-systemctl-shim.sh");
     expect(provision).toContain('sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" /run/nemoclaw');
-    expect(provision).toContain(
-      "/etc/systemd/system/user@.service.d/90-nemoclaw-cpu-delegation.conf",
-    );
+    expect(provision).toContain('containers_conf="/run/nemoclaw/portable-containers.conf"');
+    expect(provision).toContain("podman.service.d/90-nemoclaw-cgroup-manager.conf");
+    expect(provision).toContain('cgroup_manager = "systemd"');
+    expect(provision).toContain("Environment=CONTAINERS_CONF=${containers_conf}");
+    expect(provision).toContain("user@.service.d/90-nemoclaw-cpu-delegation.conf");
     expect(provision).toContain("/etc/systemd/user/app.slice.d/90-nemoclaw-cpu-controller.conf");
-    expect(provision).toContain(
-      "/etc/systemd/system/user-${uid}.slice.d/90-nemoclaw-cpu-controller.conf",
-    );
+    expect(provision).toContain("user-${uid}.slice.d/90-nemoclaw-cpu-controller.conf");
     expect(provision).toContain("Delegate=cpu memory pids");
     expect(provision.match(/CPUWeight=100/gu)).toHaveLength(2);
     expect(provision).toContain('sudo systemctl stop "user@${uid}.service"');
@@ -1411,7 +1411,13 @@ describe("portable profile systemctl fixture", () => {
     expect(provision).toContain('sudo systemctl start "user@${uid}.service"');
     expect(provision).toContain("/usr/bin/systemctl --user start podman.socket");
     expect(provision).toContain("inspectPortableCpuDelegation");
-    expect(provision).toContain('test "$cgroup_manager" = "systemd"');
+    expect(provision).toContain('if [ "$cgroup_manager" != "systemd" ]; then');
+    expect(provision).toContain("Portable Podman must use the systemd cgroup manager");
+    const podmanConfigIndex = provision.indexOf('cgroup_manager = "systemd"');
+    expect(podmanConfigIndex).toBeGreaterThanOrEqual(0);
+    expect(podmanConfigIndex).toBeLessThan(
+      provision.indexOf('sudo systemctl start "user@${uid}.service"'),
+    );
     const runtimeExportIndex = provision.indexOf("XDG_RUNTIME_DIR=%s");
     expect(runtimeExportIndex).toBeGreaterThanOrEqual(0);
     expect(runtimeExportIndex).toBeLessThan(
@@ -1429,7 +1435,10 @@ describe("portable profile systemctl fixture", () => {
     const cleanupRun = cleanup.run ?? "";
     expect(cleanup.if).toBe("always()");
     expect(cleanupRun).toContain('docker buildx rm "$builder_name"');
-    expect(cleanupRun).toContain("cleanup_fixture_drop_in");
+    expect(cleanupRun).toContain("Delegate=cpu memory pids\\n'");
+    expect(cleanupRun).toContain("CPUWeight=100\\n'");
+    expect(cleanupRun).toContain('"podman-service:$podman_service_drop_in"');
+    expect(cleanupRun).toContain('"podman-config:$containers_conf"');
     expect(cleanupRun).toContain("sudo systemctl daemon-reload");
     expect(cleanupRun.indexOf('docker buildx rm "$builder_name"')).toBeLessThan(
       cleanupRun.indexOf("podman system reset"),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Portable launch now gives the real current-user Podman service a temporary `containers.conf` that selects systemd cgroups before the socket starts. Cleanup now compares every owned fixture file with its terminal newline, so unchanged drop-ins are removed.

## Changes

- Configure the Portable Podman CLI and user-systemd service with the same temporary `containers.conf`.
- Fail before nested BuildKit with an observed-value diagnostic unless Podman reports `CgroupManager=systemd`.
- Preserve terminal newlines in cleanup comparisons for the CPU drop-ins and the new Podman fixture files.
- Extend the Portable workflow contract test for configuration order, diagnostics, and cleanup ownership.

E2E root cause: Portable profile workflow / #9910 runner fixture preparation and cleanup / Podman did not use systemd cgroups and cleanup omitted expected terminal newlines

Source runs:
- https://github.com/NVIDIA/NemoClaw/actions/runs/32513473217 (run 32513473217, attempt 1)
- https://github.com/NVIDIA/NemoClaw/actions/runs/32514862303 (run 32514862303, attempt 1)

Failed jobs:
- `portable-launch` (96869704060): https://github.com/NVIDIA/NemoClaw/actions/runs/32513473217/job/96869704060
- `portable-launch` (96874108302): https://github.com/NVIDIA/NemoClaw/actions/runs/32514862303/job/96874108302

Signature: CPU-delegation preflight passed, Podman reported a cgroup manager other than `systemd`, and cleanup rejected unchanged newline-terminated drop-ins.

Scope: one #9910 Portable runner-fixture containment cause. Product ABI fail-closed behavior is unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/portable-profile-systemctl-shim.test.ts test/e2e/support/portable-profile-cgroup-cleanup-workflow.test.ts` passed 38/38; four Portable Bash blocks passed `bash -n`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portable launch reliability by ensuring Podman uses the systemd cgroup manager.
  * Added clearer validation errors when the required cgroup configuration is unavailable.
  * Enhanced cleanup to reliably remove temporary configuration and service artifacts, including handling unexpected changes safely.
* **Tests**
  * Expanded end-to-end coverage for cgroup configuration, service startup ordering, temporary fixture permissions, and cleanup verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->