### PR TITLE
fix(ci): pin Portable launch Podman runtime

### DIFF
--- a/.github/workflows/portable-profile-e2e.yaml
+++ b/.github/workflows/portable-profile-e2e.yaml
@@ -144,7 +144,7 @@ jobs:
 
   portable-launch:
     if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 75
     env:
       E2E_JOB: "1"
@@ -157,6 +157,7 @@ jobs:
       NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1"
       NEMOCLAW_EXPERIMENTAL_PROFILE: portable
       NEMOCLAW_SANDBOX_NAME: portable-launch
+      PODMAN_APT_VERSION: "5.7.0+ds2-3build1"
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -171,7 +172,29 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install --yes fuse-overlayfs passt podman slirp4netns uidmap
+          sudo apt-get install --yes \
+            apparmor \
+            fuse-overlayfs \
+            passt \
+            slirp4netns \
+            uidmap \
+            "podman=$PODMAN_APT_VERSION"
+          uid="$(id -u)"
+          receipt="${RUNNER_TEMP}/nemoclaw-portable-cpu-delegation.receipt"
+          : >"$receipt"
+          if sudo systemctl is-active --quiet "user@${uid}.service"; then
+            printf 'manager-active\t%s\n' "$uid" >>"$receipt"
+          fi
+          package_version="$(dpkg-query --show --showformat='${Version}' podman)"
+          runtime_path="$(readlink -f "$(command -v podman)")"
+          runtime_version="$(podman --version)"
+          if [ "$package_version" != "$PODMAN_APT_VERSION" ] || \
+            [ "$runtime_path" != "/usr/bin/podman" ] || \
+            [ "$runtime_version" != "podman version 5.7.0" ]; then
+            printf 'Portable Podman runtime identity mismatch: package version=%s; executable path=%s; client version=%s\n' \
+              "${package_version:-empty}" "${runtime_path:-empty}" "${runtime_version:-empty}" >&2
+            exit 1
+          fi
           runtime_dir="/run/user/$(id -u)"
           sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" "$runtime_dir"
           sudo install -d -m 700 -o "$(id -u)" -g "$(id -g)" /run/nemoclaw
@@ -182,15 +205,11 @@ jobs:
             sudo usermod --add-subgids 100000-165535 "$USER"
           fi
 
-          uid="$(id -u)"
-          receipt="${RUNNER_TEMP}/nemoclaw-portable-cpu-delegation.receipt"
           containers_conf="/run/nemoclaw/portable-containers.conf"
           delegation_drop_in="/etc/systemd/system/user@.service.d/90-nemoclaw-cpu-delegation.conf"
           app_slice_drop_in="/etc/systemd/user/app.slice.d/90-nemoclaw-cpu-controller.conf"
           podman_service_drop_in="/etc/systemd/user/podman.service.d/90-nemoclaw-cgroup-manager.conf"
           user_slice_drop_in="/etc/systemd/system/user-${uid}.slice.d/90-nemoclaw-cpu-controller.conf"
-          : >"$receipt"
-
           install_fixture_drop_in() {
             local receipt_name="$1"
             local target="$2"
@@ -246,9 +265,6 @@ jobs:
             "$podman_service_drop_in" \
             "[Service]"$'\n'"Environment=CONTAINERS_CONF=${containers_conf}"$'\n'
 
-          if sudo systemctl is-active --quiet "user@${uid}.service"; then
-            printf 'manager-active\t%s\n' "$uid" >>"$receipt"
-          fi
           if [ "$(loginctl show-user "$USER" --property=Linger --value 2>/dev/null || true)" != "yes" ]; then
             printf 'linger\t%s\n' "$USER" >>"$receipt"
             sudo loginctl enable-linger "$USER"
@@ -289,6 +305,28 @@ jobs:
           podman --version
           docker --version
           docker --host "$DOCKER_HOST" info
+          service_version="$(docker --host "$DOCKER_HOST" version --format '{{.Server.Version}}')"
+          if [ "$service_version" != "5.7.0" ]; then
+            printf 'Portable Podman service version mismatch: expected 5.7.0; observed: %s\n' \
+              "${service_version:-empty}" >&2
+            exit 1
+          fi
+
+      - name: Apply Ubuntu pasta signal policy correction
+        shell: bash
+        run: |
+          set -euo pipefail
+          pasta_profile="/etc/apparmor.d/usr.bin.pasta"
+          signal_rule='^[[:space:]]*signal[[:space:]]+\(receive\)[[:space:]]+peer=podman,[[:space:]]*$'
+          test -f "$pasta_profile"
+          test "$(grep -Fc 'include <abstractions/pasta>' "$pasta_profile")" -eq 1
+          if ! grep -Eq "$signal_rule" "$pasta_profile"; then
+            sudo sed -i \
+              '/^[[:space:]]*include <abstractions\/pasta>[[:space:]]*$/a\  signal (receive) peer=podman,' \
+              "$pasta_profile"
+          fi
+          test "$(grep -Ec "$signal_rule" "$pasta_profile")" -eq 1
+          sudo apparmor_parser -r "$pasta_profile"
 
       - name: Prove nested BuildKit on the portable Podman socket
         shell: bash

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -68,6 +68,11 @@
     },
     {
       "file": "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",
+      "test": "pins the Portable launch runtime and rejects runtime identity drift (#9006)",
+      "category": "compatibility"
+    },
+    {
+      "file": "test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts",
       "test": "selects exact-commit rootless evidence for Portable recovery changes (#9707)",
       "category": "security"
     },

--- a/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
+++ b/test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 
 import { describe, expect, it } from "vitest";
@@ -85,6 +86,119 @@ describe("portable profile rootless runtime workflow", () => {
     expect(liveTest).toContain("DOCKER_NETWORK_IPAM_INSPECT_FORMAT");
     expect(liveTest).toContain("parseDockerNetworkIpamEntries(");
     expect(liveTest).not.toContain("{{range .Subnets}}");
+  });
+
+  // source-shape-contract: compatibility -- portable-launch must reject package, executable, client, or service version drift before nested BuildKit starts
+  it("pins the Portable launch runtime and rejects runtime identity drift (#9006)", () => {
+    const workflow = readYaml<Workflow>(".github/workflows/portable-profile-e2e.yaml");
+    const job = workflow.jobs["portable-launch"];
+    const steps = job?.steps ?? [];
+    const provisionIndex = steps.findIndex(
+      (step) => step.name === "Provision restricted rootless Linux runtime",
+    );
+    const policyIndex = steps.findIndex(
+      (step) => step.name === "Apply Ubuntu pasta signal policy correction",
+    );
+    const buildkitIndex = steps.findIndex(
+      (step) => step.name === "Prove nested BuildKit on the portable Podman socket",
+    );
+    const provision = steps[provisionIndex]?.run ?? "";
+    const policy = steps[policyIndex]?.run ?? "";
+    const receiptStart = provision.indexOf('receipt="${RUNNER_TEMP}/');
+    const identityStart = provision.indexOf('package_version="$(dpkg-query');
+    const identityEnd = provision.indexOf('\nruntime_dir="', identityStart);
+    const identityCheck = provision.slice(identityStart, identityEnd);
+    const serviceIdentityStart = provision.indexOf('service_version="$(docker --host');
+    const serviceIdentityCheck = provision.slice(serviceIdentityStart);
+    const accepted = {
+      packageVersion: "5.7.0+ds2-3build1",
+      runtimePath: "/usr/bin/podman",
+      runtimeVersion: "podman version 5.7.0",
+    };
+    const runIdentityCheck = (identity: typeof accepted) =>
+      spawnSync(
+        "bash",
+        [
+          "-c",
+          `set -euo pipefail
+dpkg-query() { printf '%s' "$FAKE_PACKAGE_VERSION"; }
+podman() { printf '%s\\n' "$FAKE_RUNTIME_VERSION"; }
+readlink() { printf '%s\\n' "$FAKE_RUNTIME_PATH"; }
+${identityCheck}`,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            FAKE_PACKAGE_VERSION: identity.packageVersion,
+            FAKE_RUNTIME_PATH: identity.runtimePath,
+            FAKE_RUNTIME_VERSION: identity.runtimeVersion,
+            PATH: process.env.PATH ?? "",
+            PODMAN_APT_VERSION: accepted.packageVersion,
+          },
+          killSignal: "SIGKILL",
+          timeout: 5_000,
+        },
+      );
+    const runServiceIdentityCheck = (serviceVersion: string) =>
+      spawnSync(
+        "bash",
+        [
+          "-c",
+          `set -euo pipefail
+docker() { printf '%s\\n' "$FAKE_SERVICE_VERSION"; }
+${serviceIdentityCheck}`,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            DOCKER_HOST: "unix:///test/podman.sock",
+            FAKE_SERVICE_VERSION: serviceVersion,
+            PATH: process.env.PATH ?? "",
+          },
+          killSignal: "SIGKILL",
+          timeout: 5_000,
+        },
+      );
+
+    expect(job?.["runs-on"]).toBe("ubuntu-26.04");
+    expect(job?.env?.PODMAN_APT_VERSION).toBe(accepted.packageVersion);
+    expect([
+      provisionIndex,
+      policyIndex,
+      buildkitIndex,
+      receiptStart,
+      identityStart,
+      identityEnd,
+      serviceIdentityStart,
+    ]).not.toContain(-1);
+    expect(policyIndex).toBeGreaterThan(provisionIndex);
+    expect(buildkitIndex).toBeGreaterThan(policyIndex);
+    expect(receiptStart).toBeLessThan(identityStart);
+    expect(provision).toContain("apparmor");
+    expect(provision).toContain('"podman=$PODMAN_APT_VERSION"');
+    expect(provision).toContain('runtime_path="$(readlink -f "$(command -v podman)")"');
+    expect(provision).toContain('service_version="$(docker --host "$DOCKER_HOST" version');
+    expect(provision).toContain("Portable Podman service version mismatch:");
+    expect(policy).toContain("/etc/apparmor.d/usr.bin.pasta");
+    expect(policy).toContain("signal (receive) peer=podman,");
+    expect(policy).toContain('apparmor_parser -r "$pasta_profile"');
+    expect(runIdentityCheck(accepted).status).toBe(0);
+    expect(runServiceIdentityCheck("5.7.0").status).toBe(0);
+
+    [
+      { ...accepted, packageVersion: "4.9.3+ds1-1ubuntu0.2" },
+      { ...accepted, runtimePath: "/usr/local/bin/podman" },
+      { ...accepted, runtimeVersion: "podman version 5.8.4" },
+    ].forEach((identity) => {
+      const rejected = runIdentityCheck(identity);
+      expect(rejected.status).not.toBe(0);
+      expect(rejected.stderr).toContain("Portable Podman runtime identity mismatch:");
+    });
+    const rejectedService = runServiceIdentityCheck("5.8.4");
+    expect(rejectedService.status).not.toBe(0);
+    expect(rejectedService.stderr).toContain(
+      "Portable Podman service version mismatch: expected 5.7.0; observed: 5.8.4",
+    );
   });
 
   // source-shape-contract: security -- topology changes must select an exact-commit rootless proof, and the live receipt must distinguish ordinary full-ID removal from the netavark-rejected retired state


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`portable-launch` now uses the accepted Ubuntu 26.04 and Podman 5.7 runtime contract, including pasta and AppArmor. This replaces the `ubuntu-latest` toolchain that failed in run 32529030784. The fixture checks runtime identity before NemoClaw runs and retains the systemd cgroup delegation and nested Buildx proof.

## Related Issue

Related to #9006 and #9208.

## Changes

- Pin `portable-launch` to Ubuntu 26.04 and Podman `5.7.0+ds2-3build1`.
- Apply the accepted pasta AppArmor signal rule before nested Buildx starts.
- Reject drift in the Podman package version, executable path, client version, or service version with explicit diagnostics.
- Add an `e2e-support` contract that executes each identity guard and verifies that each mismatch stops the workflow.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent nine-category review passed on diff SHA-256 `5803f3d0c27b0085a4db8ab2b7718c56a283d7aac944dd949faf3298e8a162c6`; no findings
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/portable-profile-rootless-runtime-workflow.test.ts test/e2e/support/portable-profile-cgroup-cleanup-workflow.test.ts` (4 passed); full `portable-profile-systemctl-shim.test.ts` (37 passed)
- [ ] Applicable broad gate passed — Not applicable to this main-only workflow fixture. `npm run checks:repository`, source-shape, growth, YAML, actionlint, formatting, and diff checks passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Independent writing review: PASS. `DOCS_NOT_NEEDED` because this changes only a main-only CI fixture and its regression contract.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for portable, rootless runtime workflows.
  - Added validation to detect mismatched runtime packages, executable paths, versions, and service APIs.
  - Added checks for provisioning order and required security-policy configuration.

- **Chores**
  - Updated the portable runtime test environment with a newer Ubuntu runner and pinned Podman version.
  - Improved setup diagnostics and verification to make portable runtime checks more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->