### PR TITLE
fix(installer): preserve Station Express resume mode

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4139,8 +4139,8 @@ ensure_docker() {
             printf -v cmd '%s %q' "$cmd" "$arg"
           done
         fi
-        # Express mode derives the provider from its saved receipt. Do not let
-        # that derived value become explicit provider intent after re-entry.
+        # Fresh and resumed Express installs derive the provider internally. Do
+        # not let that value make the child classify it as explicit intent.
         if [ "${_STATION_INSTALL_MODE:-}" = "express" ]; then
           unset NEMOCLAW_PROVIDER
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4139,9 +4139,9 @@ ensure_docker() {
             printf -v cmd '%s %q' "$cmd" "$arg"
           done
         fi
-        # Station Express saves its mode before this re-exec. It reaches express
-        # mode only while NEMOCLAW_PROVIDER is unset, so remove the derived value
-        # and let the child restore the saved mode.
+        # Station Express saves its mode before this re-exec. The child treats an
+        # inherited provider as explicit intent, so remove the derived value and
+        # let the child restore the saved mode.
         if [ "${_STATION_INSTALL_MODE:-}" = "express" ]; then
           unset NEMOCLAW_PROVIDER
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4139,8 +4139,8 @@ ensure_docker() {
             printf -v cmd '%s %q' "$cmd" "$arg"
           done
         fi
-        # Station Express saves its mode before this re-exec. The child treats an
-        # inherited provider as explicit intent, so remove the derived value.
+        # Station Express selects or restores its mode before this re-exec. The
+        # child treats the derived provider as explicit intent, so remove it.
         # The child restores the saved mode and derives the provider again.
         if [ "${_STATION_INSTALL_MODE:-}" = "express" ]; then
           unset NEMOCLAW_PROVIDER

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4139,6 +4139,11 @@ ensure_docker() {
             printf -v cmd '%s %q' "$cmd" "$arg"
           done
         fi
+        # Express mode derives the provider from its saved receipt. Do not let
+        # that derived value become explicit provider intent after re-entry.
+        if [ "${_STATION_INSTALL_MODE:-}" = "express" ]; then
+          unset NEMOCLAW_PROVIDER
+        fi
         exec sg docker -c "$cmd"
       fi
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4140,8 +4140,8 @@ ensure_docker() {
           done
         fi
         # Station Express saves its mode before this re-exec. The child treats an
-        # inherited provider as explicit intent, so remove the derived value and
-        # let the child restore the saved mode.
+        # inherited provider as explicit intent, so remove the derived value.
+        # The child restores the saved mode and derives the provider again.
         if [ "${_STATION_INSTALL_MODE:-}" = "express" ]; then
           unset NEMOCLAW_PROVIDER
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4139,8 +4139,9 @@ ensure_docker() {
             printf -v cmd '%s %q' "$cmd" "$arg"
           done
         fi
-        # Fresh and resumed Express installs derive the provider internally. Do
-        # not let that value make the child classify it as explicit intent.
+        # Station Express saves its mode before this re-exec. It reaches express
+        # mode only while NEMOCLAW_PROVIDER is unset, so remove the derived value
+        # and let the child restore the saved mode.
         if [ "${_STATION_INSTALL_MODE:-}" = "express" ]; then
           unset NEMOCLAW_PROVIDER
         fi

--- a/test/install-docker-group-reexec.test.ts
+++ b/test/install-docker-group-reexec.test.ts
@@ -138,13 +138,17 @@ function runEnsureDocker(
     ? fs.readFileSync(sgProviderLog, "utf-8").trim()
     : null;
 
-  return {
-    status: result.status,
-    stdout: result.stdout,
-    stderr: result.stderr,
-    sgArgs,
-    sgProvider,
-  };
+  try {
+    return {
+      status: result.status,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      sgArgs,
+      sgProvider,
+    };
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
 }
 
 function runSourcedInstaller(body: string) {
@@ -232,9 +236,7 @@ describeLinux("install.sh ensure_docker — #4414 non-interactive self re-exec",
   });
 });
 
-// The harness supplies Linux behavior and a fake sg, so these process-boundary
-// cases run on every host.
-describe("install.sh ensure_docker — Station intent across self re-exec", () => {
+describeLinux("install.sh ensure_docker — Station intent across self re-exec", () => {
   it("unsets the derived provider before the Station Express Docker-group re-exec (#9900)", () => {
     const outcome = runEnsureDocker(
       {
@@ -344,11 +346,12 @@ maybe_offer_express_install
         "detect_express_platform() { printf 'DGX Station'; }",
         `station_installer_revision() { printf '${STATION_REVISION}'; }`,
         `station_express_resume_generation() { printf '${STATION_GENERATION}'; }`,
-        "NON_INTERACTIVE=1",
+        "NON_INTERACTIVE=''",
         "NEMOCLAW_NO_EXPRESS=''",
-        "_NEMOCLAW_INSTALLER_ARGS=(--non-interactive --yes-i-accept-third-party-software)",
+        "_NEMOCLAW_INSTALLER_ARGS=()",
         'NEMOCLAW_INSTALLER_STAGED="$0"',
         "maybe_offer_express_install",
+        '[[ "${NEMOCLAW_DOCKER_GROUP_REACTIVATED:-}" != "1" ]] && printf \'RESUME_COMMAND=%s\\n\' "$(station_express_resume_command)"',
         "phase=parent",
         '[[ "${NEMOCLAW_DOCKER_GROUP_REACTIVATED:-}" == "1" ]] && phase=child',
         'printf \'PHASE=%s MODE=%s PROVIDER=%s\\n\' "$phase" "$_STATION_INSTALL_MODE" "$NEMOCLAW_PROVIDER"',
@@ -379,6 +382,11 @@ maybe_offer_express_install
       const output = `${result.stdout}${result.stderr}`;
 
       expect(result.status, output).toBe(0);
+      const resumeCommand = output
+        .split("\n")
+        .find((line) => line.startsWith("RESUME_COMMAND="));
+      expect(resumeCommand).toContain("NEMOCLAW_AGENT=openclaw");
+      expect(resumeCommand).not.toContain("NEMOCLAW_PROVIDER");
       expect(output).toContain("PHASE=parent MODE=express PROVIDER=install-vllm");
       expect(output).toContain("PHASE=child MODE=express PROVIDER=install-vllm");
       expect(output).toContain("CHILD_CONTINUED");

--- a/test/install-docker-group-reexec.test.ts
+++ b/test/install-docker-group-reexec.test.ts
@@ -129,12 +129,18 @@ function runEnsureDocker(
         .readFileSync(sgLog, "utf-8")
         .split("\n")
         .filter((line) => line.length > 0)
-      : [];
+    : [];
   const sgProvider = fs.existsSync(sgProviderLog)
     ? fs.readFileSync(sgProviderLog, "utf-8").trim()
     : null;
 
-  return { status: result.status, stdout: result.stdout, stderr: result.stderr, sgArgs, sgProvider };
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    sgArgs,
+    sgProvider,
+  };
 }
 
 describeLinux("install.sh ensure_docker — #4414 non-interactive self re-exec", () => {

--- a/test/install-docker-group-reexec.test.ts
+++ b/test/install-docker-group-reexec.test.ts
@@ -7,9 +7,12 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 
 import { describe, expect, it } from "vitest";
+import { TEST_SYSTEM_PATH } from "./helpers/installer-sourced-env";
 
 const INSTALLER_PAYLOAD = path.join(import.meta.dirname, "..", "scripts", "install.sh");
 const INSTALLER_SOURCE = fs.readFileSync(INSTALLER_PAYLOAD, "utf-8");
+const STATION_REVISION = "a".repeat(40);
+const STATION_GENERATION = "0123456789abcdef0123456789abcdef";
 
 function extractShellFunctionBefore(name: string, nextName: string): string {
   const start = INSTALLER_SOURCE.indexOf(`${name}() {`);
@@ -205,18 +208,18 @@ describeLinux("install.sh ensure_docker — #4414 non-interactive self re-exec",
 });
 
 describe("install.sh ensure_docker — Station intent across self re-exec", () => {
-  it("does not reclassify derived Station Express provider state after re-exec (#9900)", () => {
+  it("removes the derived provider before Station Express enters sg (#9900)", () => {
     const outcome = runEnsureDocker(
       {
         NEMOCLAW_NON_INTERACTIVE: "1",
         NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
         NEMOCLAW_PROVIDER: "install-vllm",
-        NEMOCLAW_STATION_EXPRESS: "1",
         NEMOCLAW_TEST_STATION_INSTALL_MODE: "express",
       },
       ["--non-interactive", "--yes-i-accept-third-party-software"],
     );
 
+    expect(outcome.status, outcome.stderr).toBe(0);
     expect(outcome.sgArgs.length).toBeGreaterThan(0);
     expect(outcome.sgProvider).toBe("");
   });
@@ -232,7 +235,107 @@ describe("install.sh ensure_docker — Station intent across self re-exec", () =
       ["--non-interactive", "--yes-i-accept-third-party-software"],
     );
 
+    expect(outcome.status, outcome.stderr).toBe(0);
     expect(outcome.sgArgs.length).toBeGreaterThan(0);
     expect(outcome.sgProvider).toBe("install-vllm");
+  });
+
+  it("resumes the saved Station Express receipt after Docker-group re-exec (#9900)", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-station-docker-reexec-"));
+    const home = path.join(tmp, "home");
+    const fakeBin = path.join(tmp, "bin");
+    const stagedInstaller = path.join(tmp, "staged-install.sh");
+    const stateRoot = path.join(home, ".nemoclaw");
+    const gatewaysRoot = path.join(stateRoot, "gateways");
+    const stateDir = path.join(gatewaysRoot, "18081");
+    const receipt = path.join(stateDir, "station-express-resume");
+    const receiptContents =
+      `revision=${STATION_REVISION}\nmodel=nemotron-3-ultra-550b-a55b\n` +
+      `generation=${STATION_GENERATION}\nagent=openclaw\nsandbox=my-assistant\n` +
+      "policy_tier=balanced\ngateway_port=18081\ndashboard_port=18790\n" +
+      "vllm_port=18000\nmode=express\n";
+
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    fs.chmodSync(home, 0o700);
+    fs.chmodSync(stateRoot, 0o700);
+    fs.chmodSync(gatewaysRoot, 0o700);
+    fs.chmodSync(stateDir, 0o700);
+    fs.writeFileSync(receipt, receiptContents, { mode: 0o600 });
+    fs.writeFileSync(
+      path.join(fakeBin, "sg"),
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        '[[ "${1:-}" == "docker" ]] || exit 91',
+        '[[ "${2:-}" == "-c" ]] || exit 92',
+        'exec bash -c "$3"',
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      stagedInstaller,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'source "$INSTALLER_UNDER_TEST" >/dev/null',
+        "uname() { printf 'Linux\\n'; }",
+        "docker() { return 1; }",
+        "systemctl() { return 0; }",
+        "sudo() { return 0; }",
+        "id() {",
+        '  case "$1" in',
+        "    -u) printf '1000\\n' ;;",
+        "    -un) printf 'testuser\\n' ;;",
+        "    -nG) printf 'testuser sudo\\n' ;;",
+        "  esac",
+        "}",
+        "is_wsl_host() { return 1; }",
+        "verify_downloaded_script() { :; }",
+        "detect_express_platform() { printf 'DGX Station'; }",
+        `station_installer_revision() { printf '${STATION_REVISION}'; }`,
+        `station_express_resume_generation() { printf '${STATION_GENERATION}'; }`,
+        "NON_INTERACTIVE=1",
+        "NEMOCLAW_NO_EXPRESS=''",
+        "_NEMOCLAW_INSTALLER_ARGS=(--non-interactive --yes-i-accept-third-party-software)",
+        'NEMOCLAW_INSTALLER_STAGED="$0"',
+        "maybe_offer_express_install",
+        "phase=parent",
+        '[[ "${NEMOCLAW_DOCKER_GROUP_REACTIVATED:-}" == "1" ]] && phase=child',
+        'printf \'PHASE=%s MODE=%s PROVIDER=%s\\n\' "$phase" "$_STATION_INSTALL_MODE" "$NEMOCLAW_PROVIDER"',
+        '[[ "$phase" == "child" ]] && exit 0',
+        "ensure_docker",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    try {
+      const result = spawnSync("bash", [stagedInstaller], {
+        cwd: tmp,
+        encoding: "utf-8",
+        env: {
+          HOME: home,
+          PATH: `${fakeBin}:${TEST_SYSTEM_PATH}`,
+          INSTALLER_UNDER_TEST: INSTALLER_PAYLOAD,
+          NEMOCLAW_AGENT: "openclaw",
+          NEMOCLAW_SANDBOX_NAME: "my-assistant",
+          NEMOCLAW_POLICY_TIER: "balanced",
+          NEMOCLAW_GATEWAY_PORT: "18081",
+          NEMOCLAW_DASHBOARD_PORT: "18790",
+          NEMOCLAW_VLLM_PORT: "18000",
+        },
+        timeout: 15_000,
+        killSignal: "SIGKILL",
+      });
+      const output = `${result.stdout}${result.stderr}`;
+
+      expect(result.status, output).toBe(0);
+      expect(output).toContain("PHASE=parent MODE=express PROVIDER=install-vllm");
+      expect(output).toContain("PHASE=child MODE=express PROVIDER=install-vllm");
+      expect(output).not.toContain("refusing to resume it in provider mode");
+      expect(fs.readFileSync(receipt, "utf-8")).toBe(receiptContents);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/test/install-docker-group-reexec.test.ts
+++ b/test/install-docker-group-reexec.test.ts
@@ -280,7 +280,9 @@ describe("install.sh ensure_docker — Station intent across self re-exec", () =
         "set -euo pipefail",
         'source "$INSTALLER_UNDER_TEST" >/dev/null',
         "uname() { printf 'Linux\\n'; }",
-        "docker() { return 1; }",
+        "docker() {",
+        '  [[ "${NEMOCLAW_DOCKER_GROUP_REACTIVATED:-}" == "1" ]]',
+        "}",
         "systemctl() { return 0; }",
         "sudo() { return 0; }",
         "id() {",
@@ -303,8 +305,8 @@ describe("install.sh ensure_docker — Station intent across self re-exec", () =
         "phase=parent",
         '[[ "${NEMOCLAW_DOCKER_GROUP_REACTIVATED:-}" == "1" ]] && phase=child',
         'printf \'PHASE=%s MODE=%s PROVIDER=%s\\n\' "$phase" "$_STATION_INSTALL_MODE" "$NEMOCLAW_PROVIDER"',
-        '[[ "$phase" == "child" ]] && exit 0',
         "ensure_docker",
+        '[[ "$phase" == "child" ]] && printf "CHILD_CONTINUED\\n"',
       ].join("\n"),
       { mode: 0o755 },
     );
@@ -332,6 +334,7 @@ describe("install.sh ensure_docker — Station intent across self re-exec", () =
       expect(result.status, output).toBe(0);
       expect(output).toContain("PHASE=parent MODE=express PROVIDER=install-vllm");
       expect(output).toContain("PHASE=child MODE=express PROVIDER=install-vllm");
+      expect(output).toContain("CHILD_CONTINUED");
       expect(output).not.toContain("refusing to resume it in provider mode");
       expect(fs.readFileSync(receipt, "utf-8")).toBe(receiptContents);
     } finally {

--- a/test/install-docker-group-reexec.test.ts
+++ b/test/install-docker-group-reexec.test.ts
@@ -207,8 +207,10 @@ describeLinux("install.sh ensure_docker — #4414 non-interactive self re-exec",
   });
 });
 
+// The harness supplies Linux behavior and a fake sg, so these process-boundary
+// cases run on every host.
 describe("install.sh ensure_docker — Station intent across self re-exec", () => {
-  it("removes the derived provider before Station Express enters sg (#9900)", () => {
+  it("unsets the derived provider before the Station Express Docker-group re-exec (#9900)", () => {
     const outcome = runEnsureDocker(
       {
         NEMOCLAW_NON_INTERACTIVE: "1",
@@ -326,7 +328,7 @@ describe("install.sh ensure_docker — Station intent across self re-exec", () =
           NEMOCLAW_DASHBOARD_PORT: "18790",
           NEMOCLAW_VLLM_PORT: "18000",
         },
-        timeout: 15_000,
+        timeout: 10_000,
         killSignal: "SIGKILL",
       });
       const output = `${result.stdout}${result.stderr}`;

--- a/test/install-docker-group-reexec.test.ts
+++ b/test/install-docker-group-reexec.test.ts
@@ -28,6 +28,7 @@ type EnsureDockerOutcome = {
   stdout: string;
   stderr: string;
   sgArgs: string[];
+  sgProvider: string | null;
 };
 
 function runEnsureDocker(
@@ -36,6 +37,7 @@ function runEnsureDocker(
 ): EnsureDockerOutcome {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-install-docker-group-"));
   const sgLog = path.join(tmp, "sg-args.txt");
+  const sgProviderLog = path.join(tmp, "sg-provider.txt");
   const sgStub = path.join(tmp, "sg");
   const harnessDir = path.join(tmp, "scripts");
   const installHarness = path.join(harnessDir, "install.sh");
@@ -57,9 +59,11 @@ function runEnsureDocker(
   // Stub `sg`: record the args the installer asked us to execute, then exit 0.
   // Without this stub, `exec sg docker -c …` would replace the test process
   // with a real group switch — flaky and platform-dependent.
-  fs.writeFileSync(sgStub, `#!/usr/bin/env bash\nprintf '%s\\n' "$@" > "${sgLog}"\nexit 0\n`, {
-    mode: 0o755,
-  });
+  fs.writeFileSync(
+    sgStub,
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$@" > "${sgLog}"\nprintf '%s\\n' "$NEMOCLAW_PROVIDER" > "${sgProviderLog}"\nexit 0\n`,
+    { mode: 0o755 },
+  );
 
   // Backslashes must be escaped before quotes — otherwise a literal `\` in
   // an installer arg would slip through unescaped (CodeQL: incomplete string
@@ -108,6 +112,8 @@ function runEnsureDocker(
     verify_downloaded_script() { :; }
 
     _NEMOCLAW_INSTALLER_ARGS=(${argsArrayLiteral})
+    _STATION_INSTALL_MODE="$NEMOCLAW_TEST_STATION_INSTALL_MODE"
+    NEMOCLAW_INSTALLER_STAGED="${installHarness}"
     export PATH="${tmp}:$PATH"
 
     ensure_docker
@@ -115,7 +121,7 @@ function runEnsureDocker(
 
   const result = spawnSync("bash", ["-c", snippet], {
     encoding: "utf-8",
-    env: { ...process.env, ...env },
+    env: { ...process.env, NEMOCLAW_TEST_STATION_INSTALL_MODE: "", ...env },
   });
 
   const sgArgs = fs.existsSync(sgLog)
@@ -123,9 +129,12 @@ function runEnsureDocker(
         .readFileSync(sgLog, "utf-8")
         .split("\n")
         .filter((line) => line.length > 0)
-    : [];
+      : [];
+  const sgProvider = fs.existsSync(sgProviderLog)
+    ? fs.readFileSync(sgProviderLog, "utf-8").trim()
+    : null;
 
-  return { status: result.status, stdout: result.stdout, stderr: result.stderr, sgArgs };
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr, sgArgs, sgProvider };
 }
 
 describeLinux("install.sh ensure_docker — #4414 non-interactive self re-exec", () => {
@@ -186,5 +195,38 @@ describeLinux("install.sh ensure_docker — #4414 non-interactive self re-exec",
     expect(outcome.stdout).toContain(
       "Re-run: curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash",
     );
+  });
+});
+
+describe("install.sh ensure_docker — Station intent across self re-exec", () => {
+  it("does not reclassify derived Station Express provider state after re-exec (#9900)", () => {
+    const outcome = runEnsureDocker(
+      {
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+        NEMOCLAW_PROVIDER: "install-vllm",
+        NEMOCLAW_STATION_EXPRESS: "1",
+        NEMOCLAW_TEST_STATION_INSTALL_MODE: "express",
+      },
+      ["--non-interactive", "--yes-i-accept-third-party-software"],
+    );
+
+    expect(outcome.sgArgs.length).toBeGreaterThan(0);
+    expect(outcome.sgProvider).toBe("");
+  });
+
+  it("preserves an explicitly selected Station provider after re-exec", () => {
+    const outcome = runEnsureDocker(
+      {
+        NEMOCLAW_NON_INTERACTIVE: "1",
+        NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE: "1",
+        NEMOCLAW_PROVIDER: "install-vllm",
+        NEMOCLAW_TEST_STATION_INSTALL_MODE: "provider",
+      },
+      ["--non-interactive", "--yes-i-accept-third-party-software"],
+    );
+
+    expect(outcome.sgArgs.length).toBeGreaterThan(0);
+    expect(outcome.sgProvider).toBe("install-vllm");
   });
 });

--- a/test/install-docker-group-reexec.test.ts
+++ b/test/install-docker-group-reexec.test.ts
@@ -11,6 +11,7 @@ import { TEST_SYSTEM_PATH } from "./helpers/installer-sourced-env";
 
 const INSTALLER_PAYLOAD = path.join(import.meta.dirname, "..", "scripts", "install.sh");
 const INSTALLER_SOURCE = fs.readFileSync(INSTALLER_PAYLOAD, "utf-8");
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
 const STATION_REVISION = "a".repeat(40);
 const STATION_GENERATION = "0123456789abcdef0123456789abcdef";
 
@@ -146,6 +147,30 @@ function runEnsureDocker(
   };
 }
 
+function runSourcedInstaller(body: string) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-station-resume-mode-"));
+  try {
+    const result = spawnSync(
+      "bash",
+      ["--noprofile", "--norc", "-c", `source "$INSTALLER_UNDER_TEST" >/dev/null\n${body}`],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf-8",
+        env: {
+          HOME: home,
+          PATH: TEST_SYSTEM_PATH,
+          INSTALLER_UNDER_TEST: INSTALLER_PAYLOAD,
+        },
+        timeout: 10_000,
+        killSignal: "SIGKILL",
+      },
+    );
+    return { result, output: `${result.stdout}${result.stderr}` };
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
 describeLinux("install.sh ensure_docker — #4414 non-interactive self re-exec", () => {
   it("re-execs through 'sg docker' instead of exiting 0 when NEMOCLAW_NON_INTERACTIVE=1", () => {
     // Repro of #4414: on a clean Ubuntu VM, the non-interactive curl|bash
@@ -240,6 +265,26 @@ describe("install.sh ensure_docker — Station intent across self re-exec", () =
     expect(outcome.status, outcome.stderr).toBe(0);
     expect(outcome.sgArgs.length).toBeGreaterThan(0);
     expect(outcome.sgProvider).toBe("install-vllm");
+  });
+
+  it("rejects an explicit managed-vLLM provider against an Express receipt (#9900)", () => {
+    const { result, output } = runSourcedInstaller(`
+state_dir="$(ensure_nemoclaw_state_dir)"
+receipt="$state_dir/station-express-resume"
+printf 'revision=${STATION_REVISION}\\nmodel=nemotron-3-ultra-550b-a55b\\ngeneration=${STATION_GENERATION}\\nagent=openclaw\\nsandbox=my-assistant\\npolicy_tier=balanced\\ngateway_port=8080\\ndashboard_port=18789\\nvllm_port=8000\\nmode=express\\n' >"$receipt"
+chmod 0600 "$receipt"
+detect_express_platform() { printf 'DGX Station'; }
+station_installer_revision() { printf '${STATION_REVISION}'; }
+NON_INTERACTIVE=''
+NEMOCLAW_PROVIDER='install-vllm'
+NEMOCLAW_NO_EXPRESS=''
+maybe_offer_express_install
+`);
+
+    expect(result.status, output).not.toBe(0);
+    expect(output).toContain(
+      "resume state was accepted in express mode; refusing to resume it in provider mode",
+    );
   });
 
   it("resumes the saved Station Express receipt after Docker-group re-exec (#9900)", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Station Express derives `NEMOCLAW_PROVIDER=install-vllm` before Docker-group re-execution, and the child installer previously treated that inherited value as explicit provider intent. This change removes only the derived Express value at the re-execution boundary so the child restores the saved Express mode and derives the provider again.

## Related Issue

Fixes #9900

## Changes

- Remove the internally derived provider before a Station Express `sg docker` re-execution while preserving explicit provider selections.
- Add focused integration regression tests for the parent-to-child provider boundary, exact zero-flag resume command, saved receipt continuity, and explicit-provider mismatch guard.
- Keep the Station process tests Linux-gated and remove their temporary directories after each run.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent Claude and Codex review of commit `c77ab6b7f411e46f600aa37bbd9dbc90eecbebde` found no blocking findings. The change removes one internally derived environment value only for saved Station Express mode and preserves explicit provider intent.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/install-docker-group-reexec.test.ts` passed 4 Station cases with 3 legacy platform skips after the review host temporarily changed only the new block's `describeLinux` gate to `describe`. The committed Linux-gated suite will run in Linux CI. `npx vitest run --project installer-integration test/install-station-host-preparation.test.ts` passed 54 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused installer boundary repair.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: The reviewer compared commit `c77ab6b7f411e46f600aa37bbd9dbc90eecbebde` with base `cee1ecd5064444537f128f1fe03cf3d4ed92825b`. The change restores documented exact-resume behavior and does not change a user-facing command, configuration, or supported workflow. Existing DGX Station preparation and hosted installer exit-status documentation already describe this contract. The production comment and test titles have no writing-rule or documentation-style findings. The Station test bodies passed after the review host temporarily removed only their Linux gate; committed Linux CI remains authoritative. Final commit hooks and `git diff --check` passed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: c77ab6b7f411e46f600aa37bbd9dbc90eecbebde -->
<!-- docs-review-agents-blob-sha: 513518cdfca42e3a18fed71109e6d0eb60151d13 -->

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer recovery when Docker group permissions require a non-interactive restart.
  * Station Express installations now correctly restore saved settings and provider information.
  * Prevented incompatible installation receipts from being resumed.
  * Preserved provider settings when running in provider-specific installation mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->