### PR TITLE
fix(sandbox): revalidate Portable destroy identity

### DIFF
--- a/src/lib/actions/sandbox/destroy-execution.ts
+++ b/src/lib/actions/sandbox/destroy-execution.ts
@@ -3,7 +3,11 @@
 
 import { R, YW } from "../../cli/terminal-style";
 import { getSandboxDeleteOutcome } from "../../domain/sandbox/destroy";
-import { removePortableDemoSandboxLifecycleReceipt } from "../../onboard/experimental/portable-demo-lifecycle";
+import {
+  type PreparedPortableDemoSandboxDestroyAuthority,
+  preparePortableDemoSandboxDestroyAuthority,
+  removePortableDemoSandboxLifecycleReceipt,
+} from "../../onboard/experimental/portable-demo-lifecycle";
 import {
   CURRENT_RUNTIME_PROVIDER_BUNDLES,
   type RuntimeProviderBundle,
@@ -50,6 +54,8 @@ export function retirePortableLifecycleAuthority(sandboxName: string): void {
   removePortableDemoSandboxLifecycleReceipt(sandboxName);
 }
 
+export { preparePortableDemoSandboxDestroyAuthority };
+
 type SandboxDestroyExecutionInput = {
   cleanupShieldsArtifacts: (sandboxName: string) => void;
   force: boolean;
@@ -63,6 +69,7 @@ type SandboxDestroyExecutionInput = {
   // `null` records confirmed absence; an object records the one managed
   // container observed by the pre-destroy guard.
   expectedContainerIdentity?: SandboxNameLabeledContainer | null;
+  portableContainerAuthority?: PreparedPortableDemoSandboxDestroyAuthority;
   stopInferenceResources: () => void;
   runtimeProviders?: RuntimeProviderBundleRegistry;
   deps?: {
@@ -91,6 +98,7 @@ export type SandboxDestroyExecutionResult =
       hostLocalInferenceOwnershipRequiresGateway: boolean;
       mcpOwnershipRequiresGateway: boolean;
       mcpRecoveryFailure?: string;
+      portableLifecycleOwnershipRequiresGateway?: boolean;
       shieldsRelockRequiresGateway: boolean;
       hostLocalInferenceCleanupFailure?: string;
       deleteConfirmed?: boolean;
@@ -281,6 +289,7 @@ export async function executeSandboxDestroy({
   sandboxConfirmedAbsent,
   sandboxName,
   expectedContainerIdentity,
+  portableContainerAuthority,
   stopInferenceResources,
   runtimeProviders = CURRENT_RUNTIME_PROVIDER_BUNDLES,
   deps = {},
@@ -292,6 +301,14 @@ export async function executeSandboxDestroy({
       | { status: "ambiguous"; detail: string }
       | { status: "probe-failed"; detail: string };
     const inspectIdentityContinuity = (): IdentityContinuity => {
+      if (portableContainerAuthority) {
+        try {
+          portableContainerAuthority.revalidate();
+          return { status: "match" };
+        } catch (error) {
+          return { status: "probe-failed", detail: redactDestroyError(error) };
+        }
+      }
       if (expectedContainerIdentity === undefined) return { status: "match" };
       const verdict = classifyDestroyContainerIdentity(
         sandboxName,
@@ -495,6 +512,7 @@ export async function executeSandboxDestroy({
       force &&
       !hasMcpOwnership &&
       !hasHostLocalInferenceOwnership &&
+      portableContainerAuthority === undefined &&
       !hardened.hardeningFailed;
 
     if (deleteResult.status !== 0 && !alreadyGone && !forcedLocalCleanup) {
@@ -510,13 +528,19 @@ export async function executeSandboxDestroy({
           gatewayUnreachable && hasHostLocalInferenceOwnership,
         mcpOwnershipRequiresGateway: gatewayUnreachable && hasMcpOwnership,
         mcpRecoveryFailure,
+        portableLifecycleOwnershipRequiresGateway:
+          gatewayUnreachable && portableContainerAuthority !== undefined,
         shieldsRelockRequiresGateway: gatewayUnreachable && hardened.hardeningFailed,
       };
     }
 
-    if (!forcedLocalCleanup && expectedContainerIdentity) {
+    if (!forcedLocalCleanup && (portableContainerAuthority || expectedContainerIdentity)) {
       try {
-        removeExactDestroyContainerIdentity(sandboxName, expectedContainerIdentity, console.log);
+        if (portableContainerAuthority) {
+          portableContainerAuthority.verifyAbsent();
+        } else if (expectedContainerIdentity) {
+          removeExactDestroyContainerIdentity(sandboxName, expectedContainerIdentity, console.log);
+        }
       } catch (error) {
         const detail = redactDestroyError(error);
         return {

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -119,19 +119,28 @@ describe("destroySandbox flow", () => {
     );
   });
 
-  it("fails closed on invalid schema-4 Portable receipt authority before Docker preflight (#9189)", async () => {
+  it("redacts credentials from an invalid schema-4 Portable receipt refusal and releases the lifecycle lock before retry (#9189)", async () => {
     const harness = createDestroyHarness({
-      portableDestroyPrepareError: "portable receipt is invalid",
+      portableDestroyPrepareError: "portable receipt API_KEY=opaque-portable-secret is invalid",
     });
 
-    await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow(
-      "portable receipt is invalid",
-    );
+    const refusal = await harness.destroySandbox("alpha", { yes: true }).catch((error) => error);
 
+    expect(String(refusal)).toContain("API_KEY=<REDACTED>");
+    expect(String(refusal)).not.toContain("opaque-portable-secret");
+    expect(exitSpy).not.toHaveBeenCalled();
     expect(harness.dockerRunSpy).not.toHaveBeenCalled();
     expect(harness.runOpenshellSpy).not.toHaveBeenCalled();
     expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
     expect(harness.retirePortableLifecycleReceiptSpy).not.toHaveBeenCalled();
+
+    harness.preparePortableDestroyAuthoritySpy.mockReturnValue(null);
+    await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
+    expect(harness.preparePortableDestroyAuthoritySpy).toHaveBeenCalledTimes(2);
+    expect(harness.runOpenshellSpy).toHaveBeenCalledWith(
+      ["sandbox", "delete", "alpha"],
+      expect.any(Object),
+    );
   });
 
   it("preserves the sandbox registry record and Portable receipt when Podman absence is unproven (#9189)", async () => {

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -99,6 +99,72 @@ describe("destroySandbox flow", () => {
     expect(harness.retirePortableLifecycleReceiptSpy).not.toHaveBeenCalled();
   });
 
+  it("revalidates schema-4 Portable identity at every destroy checkpoint without Docker preflight (#9189)", async () => {
+    const harness = createDestroyHarness({
+      dockerRunResult: { status: 0, stdout: `${"f".repeat(64)}\t\tforeign\t` },
+      portableDestroyAuthority: true,
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
+
+    expect(harness.preparePortableDestroyAuthoritySpy).toHaveBeenCalledOnce();
+    expect(harness.portableDestroyRevalidateSpy).toHaveBeenCalledTimes(6);
+    expect(harness.portableDestroyVerifyAbsentSpy).toHaveBeenCalledOnce();
+    expect(harness.dockerRunSpy).not.toHaveBeenCalled();
+    expect(harness.portableDestroyVerifyAbsentSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.removeSandboxSpy.mock.invocationCallOrder[0],
+    );
+    expect(harness.removeSandboxSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.retirePortableLifecycleReceiptSpy.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("fails closed on invalid schema-4 Portable receipt authority before Docker preflight (#9189)", async () => {
+    const harness = createDestroyHarness({
+      portableDestroyPrepareError: "portable receipt is invalid",
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow(
+      "portable receipt is invalid",
+    );
+
+    expect(harness.dockerRunSpy).not.toHaveBeenCalled();
+    expect(harness.runOpenshellSpy).not.toHaveBeenCalled();
+    expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
+    expect(harness.retirePortableLifecycleReceiptSpy).not.toHaveBeenCalled();
+  });
+
+  it("preserves the sandbox registry record and Portable receipt when Podman absence is unproven (#9189)", async () => {
+    const harness = createDestroyHarness({
+      portableDestroyAuthority: true,
+      portableDestroyVerifyAbsentError: "recorded Podman container remains",
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow("process.exit(1)");
+
+    expect(harness.events).toContain("delete");
+    expect(harness.portableDestroyVerifyAbsentSpy).toHaveBeenCalledOnce();
+    expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
+    expect(harness.retirePortableLifecycleReceiptSpy).not.toHaveBeenCalled();
+  });
+
+  it("refuses forced local cleanup while schema-4 Portable authority is retained (#9189)", async () => {
+    const harness = createDestroyHarness({
+      deleteStatus: 1,
+      deleteOutput: "error trying to connect: connection refused",
+      portableDestroyAuthority: true,
+    });
+
+    await expect(harness.destroySandbox("alpha", { force: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    const errorOutput = harness.errorSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(errorOutput).toContain("--force cannot discard this ownership state");
+    expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
+    expect(harness.retirePortableLifecycleReceiptSpy).not.toHaveBeenCalled();
+  });
+
   it(
     "removes the owned managed Hermes state volume after confirmed sandbox deletion",
     { timeout: 30_000 },

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -481,16 +481,23 @@ async function destroySandboxUnlocked(
   const normalized = normalizeDestroySandboxOptions(options);
   if (!(await confirmSandboxDestroy(sandboxName, normalized))) return;
   const destroySession = onboardSession.loadSession();
-  const portableContainerAuthority = preparePortableDemoSandboxDestroyAuthority(sandboxName, () => {
-    const current = registry.getSandbox(sandboxName);
-    return current
-      ? {
-          agent: current.agent,
-          lifecycleGeneration: current.lifecycleGeneration,
-          openshellDriver: current.openshellDriver,
-        }
-      : null;
-  });
+  let portableContainerAuthority: ReturnType<typeof preparePortableDemoSandboxDestroyAuthority>;
+  try {
+    portableContainerAuthority = preparePortableDemoSandboxDestroyAuthority(sandboxName, () => {
+      const current = registry.getSandbox(sandboxName);
+      return current
+        ? {
+            agent: current.agent,
+            lifecycleGeneration: current.lifecycleGeneration,
+            openshellDriver: current.openshellDriver,
+          }
+        : null;
+    });
+  } catch (error) {
+    throw new Error(
+      `Refusing to destroy sandbox '${sandboxName}': NemoClaw could not validate Portable lifecycle authority before the Docker preflight: ${redactDestroyError(error)}. NemoClaw removed no sandbox resources.`,
+    );
+  }
 
   const inspectContainerIdentity = () =>
     assertUnambiguousDestroyContainerIdentity(sandboxName, {

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -46,6 +46,7 @@ import {
 } from "./destroy-confirmation";
 import {
   executeSandboxDestroy,
+  preparePortableDemoSandboxDestroyAuthority,
   redactDestroyError,
   retirePortableLifecycleAuthority,
 } from "./destroy-execution";
@@ -480,6 +481,16 @@ async function destroySandboxUnlocked(
   const normalized = normalizeDestroySandboxOptions(options);
   if (!(await confirmSandboxDestroy(sandboxName, normalized))) return;
   const destroySession = onboardSession.loadSession();
+  const portableContainerAuthority = preparePortableDemoSandboxDestroyAuthority(sandboxName, () => {
+    const current = registry.getSandbox(sandboxName);
+    return current
+      ? {
+          agent: current.agent,
+          lifecycleGeneration: current.lifecycleGeneration,
+          openshellDriver: current.openshellDriver,
+        }
+      : null;
+  });
 
   const inspectContainerIdentity = () =>
     assertUnambiguousDestroyContainerIdentity(sandboxName, {
@@ -489,7 +500,7 @@ async function destroySandboxUnlocked(
       ),
       redact: redactDestroyError,
     });
-  const initialIdentity = inspectContainerIdentity();
+  const initialIdentity = portableContainerAuthority ? null : inspectContainerIdentity();
   if (initialIdentity === false) {
     process.exit(1);
   }
@@ -497,17 +508,28 @@ async function destroySandboxUnlocked(
   const { cleanupGatewayName, runOpenshell, sandbox, sandboxConfirmedAbsent } =
     prepareSandboxDestroy(sandboxName);
   // Recheck identity after read-only preflight and before local mutation.
-  const preMutationIdentity = inspectContainerIdentity();
-  if (
-    preMutationIdentity === false ||
-    !isSameDestroyContainerIdentityProof(initialIdentity, preMutationIdentity)
-  ) {
-    if (preMutationIdentity !== false) {
+  if (portableContainerAuthority) {
+    try {
+      portableContainerAuthority.revalidate();
+    } catch (error) {
       console.error(
-        `  Refusing to destroy sandbox '${sandboxName}': Container identity changed during preflight. No sandbox resources were removed.`,
+        `  Refusing to destroy sandbox '${sandboxName}': NemoClaw could not revalidate Portable container identity during preflight: ${redactDestroyError(error)}. NemoClaw removed no sandbox resources.`,
       );
+      process.exit(1);
     }
-    process.exit(1);
+  } else {
+    const preMutationIdentity = inspectContainerIdentity();
+    if (
+      preMutationIdentity === false ||
+      !isSameDestroyContainerIdentityProof(initialIdentity!, preMutationIdentity)
+    ) {
+      if (preMutationIdentity !== false) {
+        console.error(
+          `  Refusing to destroy sandbox '${sandboxName}': Container identity changed during preflight. No sandbox resources were removed.`,
+        );
+      }
+      process.exit(1);
+    }
   }
   const priorHttpsPinRouteId = parseHttpsPinRouteId(sandbox?.endpointUrl);
   const destructiveResult = await executeSandboxDestroy({
@@ -519,7 +541,8 @@ async function destroySandboxUnlocked(
     sandbox,
     sandboxConfirmedAbsent,
     sandboxName,
-    expectedContainerIdentity: initialIdentity.identity,
+    expectedContainerIdentity: initialIdentity?.identity,
+    ...(portableContainerAuthority ? { portableContainerAuthority } : {}),
     stopInferenceResources: () => stopSandboxInferenceResources(sandboxName, sandbox),
   });
   if (!destructiveResult.ok) {
@@ -564,6 +587,13 @@ async function destroySandboxUnlocked(
         );
         console.error(
           `  Start the gateway (run '${CLI_NAME} ${sandboxName} status'), then retry destroy; --force cannot safely discard MCP ownership.`,
+        );
+      } else if (destructiveResult.portableLifecycleOwnershipRequiresGateway) {
+        console.error(
+          `  The OpenShell gateway is unreachable. NemoClaw preserved the sandbox registry record and schema-4 Portable receipt because OpenShell sandbox deletion and absence of the exact Podman container are unconfirmed.`,
+        );
+        console.error(
+          `  Start the gateway by running '${CLI_NAME} ${sandboxName} status'. Retry destroy. --force cannot discard this ownership state until NemoClaw confirms both results.`,
         );
       } else {
         console.error(

--- a/src/lib/onboard/experimental/portable-demo-lifecycle-authority.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle-authority.test.ts
@@ -10,7 +10,9 @@ import type { PodmanSocketAuthorityDeps } from "../../adapters/podman";
 import type { CheckpointPortableRuntimeAuthority } from "../../state/onboard-checkpoint-types";
 import {
   installPortableDemoSandboxLifecycle,
+  type PortableDemoLifecycleDeps,
   portableDemoLifecycleInternals,
+  preparePortableDemoSandboxDestroyAuthority,
 } from "./portable-demo-lifecycle";
 
 const CONTAINER_ID = "a".repeat(64);
@@ -45,40 +47,56 @@ function temporaryStateDir(): string {
 }
 
 function createPodman() {
+  let containerId = CONTAINER_ID;
+  let managedLabel = "true";
+  let present = true;
   const podman = vi.fn((args: readonly string[], _env?: NodeJS.ProcessEnv) => {
     const command = args[0] === "--url" ? args.slice(2) : args;
     switch (command[0]) {
       case "version":
         return { status: 0, stdout: JSON.stringify({ Server: { Version: "5.6.1" } }) };
       case "ps":
-        return { status: 0, stdout: `${CONTAINER_ID}\n` };
+        return { status: 0, stdout: present ? `${CONTAINER_ID}\n` : "" };
       case "inspect":
-        return {
-          status: 0,
-          stdout: JSON.stringify([
-            {
-              Id: CONTAINER_ID,
-              Name: `openshell-default--alpha-${SANDBOX_ID}`,
-              Config: {
-                Labels: {
-                  "openshell.managed": "true",
-                  "openshell.ai/sandbox-id": SANDBOX_ID,
-                  "openshell.ai/sandbox-name": "alpha",
-                  "openshell.ai/sandbox-namespace": "",
-                  "openshell.ai/sandbox-workspace": "default",
+        return present
+          ? {
+              status: 0,
+              stdout: JSON.stringify([
+                {
+                  Id: containerId,
+                  Name: `openshell-default--alpha-${SANDBOX_ID}`,
+                  Config: {
+                    Labels: {
+                      "openshell.managed": managedLabel,
+                      "openshell.ai/sandbox-id": SANDBOX_ID,
+                      "openshell.ai/sandbox-name": "alpha",
+                      "openshell.ai/sandbox-namespace": "",
+                      "openshell.ai/sandbox-workspace": "default",
+                    },
+                  },
+                  State: { Running: true },
                 },
-              },
-              State: { Running: true },
-            },
-          ]),
-        };
+              ]),
+            }
+          : { status: 125, stderr: `Error: no such container ${CONTAINER_ID}` };
       case "update":
         return { status: 0 };
       default:
         throw new Error(`Unexpected Podman command: ${args.join(" ")}`);
     }
   });
-  return { podman };
+  return {
+    podman,
+    setContainerId(value: string) {
+      containerId = value;
+    },
+    setManagedLabel(value: string) {
+      managedLabel = value;
+    },
+    setPresent(value: boolean) {
+      present = value;
+    },
+  };
 }
 
 function socketAuthorityDeps(socketInode: () => bigint = () => 9001n): PodmanSocketAuthorityDeps {
@@ -116,6 +134,42 @@ function lifecycleDeps(authorityDeps: PodmanSocketAuthorityDeps) {
   };
 }
 
+function installReceipt(stateDir: string, runtime: ReturnType<typeof createPodman>): void {
+  installPortableDemoSandboxLifecycle(
+    "alpha",
+    STARTUP_ARGV,
+    { NEMOCLAW_EXPERIMENTAL_PROFILE: "portable" },
+    {
+      podman: runtime.podman,
+      stateDir,
+      ...lifecycleDeps(socketAuthorityDeps()),
+    },
+  );
+  runtime.podman.mockClear();
+}
+
+function prepareDestroyAuthority(
+  stateDir: string,
+  runtime: ReturnType<typeof createPodman>,
+  readContext: () => {
+    agent: string;
+    lifecycleGeneration: string;
+    openshellDriver: string;
+  } = () => ({
+    agent: "openclaw",
+    lifecycleGeneration: CONTAINER_ID,
+    openshellDriver: "docker",
+  }),
+  overrides: Partial<PortableDemoLifecycleDeps> = {},
+) {
+  return preparePortableDemoSandboxDestroyAuthority("alpha", readContext, {
+    podman: runtime.podman,
+    stateDir,
+    ...lifecycleDeps(socketAuthorityDeps()),
+    ...overrides,
+  });
+}
+
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
     fs.rmSync(directory, { force: true, recursive: true });
@@ -123,6 +177,65 @@ afterEach(() => {
 });
 
 describe("portable demo lifecycle authority", () => {
+  it("revalidates schema-4 Portable destroy authority without removing its Podman container (#9189)", () => {
+    const stateDir = temporaryStateDir();
+    const runtime = createPodman();
+    installReceipt(stateDir, runtime);
+    const authority = prepareDestroyAuthority(stateDir, runtime);
+
+    expect(authority).not.toBeNull();
+    expect(() => authority?.revalidate()).not.toThrow();
+    runtime.setPresent(false);
+    expect(() => authority?.verifyAbsent()).not.toThrow();
+    expect(
+      runtime.podman.mock.calls.some(([args]) => {
+        const command = args[0] === "--url" ? args.slice(2) : args;
+        return command[0] === "rm";
+      }),
+    ).toBe(false);
+  });
+
+  it("refuses a changed registry lifecycle generation during Portable destroy (#9189)", () => {
+    const stateDir = temporaryStateDir();
+    const runtime = createPodman();
+    installReceipt(stateDir, runtime);
+    let lifecycleGeneration = CONTAINER_ID;
+    const authority = prepareDestroyAuthority(stateDir, runtime, () => ({
+      agent: "openclaw",
+      lifecycleGeneration,
+      openshellDriver: "docker",
+    }));
+    lifecycleGeneration = "replacement-generation";
+
+    expect(() => authority?.revalidate()).toThrow("does not match the OpenClaw sandbox registry");
+  });
+
+  it("refuses a changed Podman container ID or required label during Portable destroy (#9189)", () => {
+    const stateDir = temporaryStateDir();
+    const runtime = createPodman();
+    installReceipt(stateDir, runtime);
+    const authority = prepareDestroyAuthority(stateDir, runtime);
+
+    runtime.setContainerId("b".repeat(64));
+    expect(() => authority?.revalidate()).toThrow("OpenShell identity does not match");
+    runtime.setContainerId(CONTAINER_ID);
+    runtime.setManagedLabel("false");
+    expect(() => authority?.revalidate()).toThrow("OpenShell identity does not match");
+  });
+
+  it("refuses a changed current-user Podman socket inode during Portable destroy (#9189)", () => {
+    const stateDir = temporaryStateDir();
+    const runtime = createPodman();
+    installReceipt(stateDir, runtime);
+    let inode = 9001n;
+    const authority = prepareDestroyAuthority(stateDir, runtime, undefined, {
+      podmanSocketAuthorityDeps: socketAuthorityDeps(() => inode),
+    });
+    inode = 9002n;
+
+    expect(() => authority?.revalidate()).toThrow("changed after it was qualified");
+  });
+
   it("records the exact OpenShell container and applies the unless-stopped restart policy (#8441)", () => {
     const stateDir = temporaryStateDir();
     const { podman } = createPodman();

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.ts
@@ -106,7 +106,13 @@ export interface PortablePodmanLifecycleTransport {
 export interface PreparedPortableDemoSandboxRemoval {
   readonly present: boolean;
   readonly receipt: PortableDemoLifecycleReceiptRecord;
+  revalidate(): void;
   removeAndVerify(): void;
+  verifyAbsent(): void;
+}
+
+export interface PreparedPortableDemoSandboxDestroyAuthority {
+  revalidate(): void;
   verifyAbsent(): void;
 }
 
@@ -167,6 +173,11 @@ export interface PortableDemoLifecycleContext {
   openshellDriver?: string | null;
   provider?: string | null;
 }
+
+export type PortableDemoDestroyContext = Pick<
+  PortableDemoLifecycleContext,
+  "agent" | "lifecycleGeneration" | "openshellDriver"
+>;
 
 function defaultPodmanCapture(env: NodeJS.ProcessEnv): ContainerEngineCommandCapture {
   return (_executable, args, timeoutMs) => {
@@ -691,35 +702,40 @@ export function preparePortableDemoSandboxRemoval(
   transport: PortablePodmanLifecycleTransport,
   stateDir = defaultStateDir(process.env),
 ): PreparedPortableDemoSandboxRemoval {
-  const loaded = loadReceipt(receiptRecord.sandboxName, stateDir);
-  if (!loaded || !isDeepStrictEqual(currentReceipt(loaded), receiptRecord)) {
-    throw new Error(
-      `Portable demo lifecycle receipt changed for sandbox '${receiptRecord.sandboxName}'`,
+  const assertReceiptAndAuthority = (): PortableDemoLifecycleReceipt => {
+    const current = loadReceipt(receiptRecord.sandboxName, stateDir);
+    if (!current || !isDeepStrictEqual(currentReceipt(current), receiptRecord)) {
+      throw new Error(
+        `Portable demo lifecycle receipt changed for sandbox '${receiptRecord.sandboxName}'`,
+      );
+    }
+    requireCurrentRegistryGeneration(current, receiptRecord.registryGeneration);
+    transport.assertRuntimeAuthority();
+    return current;
+  };
+  const inspectPresence = (): boolean => {
+    const loaded = assertReceiptAndAuthority();
+    const matches = matchingPortableSandboxContainerIds(
+      receiptRecord.sandboxName,
+      transport.podman,
     );
-  }
-  requireCurrentRegistryGeneration(loaded, receiptRecord.registryGeneration);
-  transport.assertRuntimeAuthority();
-  const matches = matchingPortableSandboxContainerIds(receiptRecord.sandboxName, transport.podman);
-  if (matches.length > 1 || (matches.length === 1 && matches[0] !== receiptRecord.containerId)) {
-    throw new Error(
-      `Portable demo lifecycle found a replaced or ambiguous container for sandbox '${receiptRecord.sandboxName}'`,
-    );
-  }
-  const initial = transport.podman(["inspect", receiptRecord.containerId]);
-  let present = true;
-  if (isMissingPodmanContainer(initial)) {
-    present = false;
-    if (matches.length !== 0) {
+    if (matches.length > 1 || (matches.length === 1 && matches[0] !== receiptRecord.containerId)) {
+      throw new Error(
+        `Portable demo lifecycle found a replaced or ambiguous container for sandbox '${receiptRecord.sandboxName}'`,
+      );
+    }
+    const result = transport.podman(["inspect", receiptRecord.containerId]);
+    if (isMissingPodmanContainer(result)) {
+      if (matches.length === 0) return false;
       throw new Error(
         `Portable demo lifecycle found a replacement container for sandbox '${receiptRecord.sandboxName}'`,
       );
     }
-  } else {
     const inspection = inspectPodmanContainer(
       receiptRecord.containerId,
       receiptRecord.sandboxName,
       transport.podman,
-      initial,
+      result,
     );
     requireReceiptOwnedInspection(loaded, inspection);
     if (matches.length !== 1) {
@@ -727,16 +743,16 @@ export function preparePortableDemoSandboxRemoval(
         `Portable demo lifecycle could not prove the label index for sandbox '${receiptRecord.sandboxName}'`,
       );
     }
-  }
-
-  const assertReceiptAndAuthority = (): void => {
-    const current = loadReceipt(receiptRecord.sandboxName, stateDir);
-    if (!current || !isDeepStrictEqual(currentReceipt(current), receiptRecord)) {
+    transport.assertRuntimeAuthority();
+    return true;
+  };
+  const present = inspectPresence();
+  const revalidate = (): void => {
+    if (inspectPresence() !== present) {
       throw new Error(
-        `Portable demo lifecycle receipt changed for sandbox '${receiptRecord.sandboxName}'`,
+        `Portable demo lifecycle container presence changed for sandbox '${receiptRecord.sandboxName}'`,
       );
     }
-    transport.assertRuntimeAuthority();
   };
   const verifyAbsent = (): void => {
     assertReceiptAndAuthority();
@@ -766,12 +782,60 @@ export function preparePortableDemoSandboxRemoval(
   return {
     present,
     receipt: receiptRecord,
+    revalidate,
     removeAndVerify: () => {
       assertReceiptAndAuthority();
       if (present) transport.podman(["rm", "--force", receiptRecord.containerId]);
       verifyAbsent();
     },
     verifyAbsent,
+  };
+}
+
+function requirePortableDemoDestroyContext(
+  sandboxName: string,
+  receipt: PortableDemoLifecycleReceiptRecord,
+  context: PortableDemoDestroyContext | null,
+): void {
+  if (
+    context?.agent !== "openclaw" ||
+    context.openshellDriver !== "docker" ||
+    context.lifecycleGeneration !== receipt.registryGeneration
+  ) {
+    throw new Error(
+      `Portable demo lifecycle receipt does not match the OpenClaw sandbox registry record for '${sandboxName}'`,
+    );
+  }
+}
+
+/** Revalidate schema-4 receipt and Podman identity without granting Podman removal authority. */
+export function preparePortableDemoSandboxDestroyAuthority(
+  sandboxName: string,
+  readContext: () => PortableDemoDestroyContext | null,
+  deps: PortableDemoLifecycleDeps = {},
+): PreparedPortableDemoSandboxDestroyAuthority | null {
+  const commandEnv = deps.env ?? process.env;
+  const stateDir = deps.stateDir ?? defaultStateDir(commandEnv);
+  const receipt = loadReceipt(sandboxName, stateDir);
+  if (!receipt) return null;
+  const receiptRecord = currentReceipt(receipt);
+  if ((deps.platform ?? process.platform) !== "linux") {
+    throw new Error("Portable demo lifecycle receipt is only valid on Linux");
+  }
+  requirePortableDemoDestroyContext(sandboxName, receiptRecord, readContext());
+  const transport = qualifiedPodmanAuthority(receipt, commandEnv, deps);
+  const prepared = preparePortableDemoSandboxRemoval(receiptRecord, transport, stateDir);
+  const assertRegistryAuthority = (): void =>
+    requirePortableDemoDestroyContext(sandboxName, receiptRecord, readContext());
+  return {
+    revalidate: () => {
+      assertRegistryAuthority();
+      prepared.revalidate();
+    },
+    verifyAbsent: () => {
+      assertRegistryAuthority();
+      prepared.verifyAbsent();
+    },
   };
 }
 

--- a/test/helpers/destroy-flow-test-harness.ts
+++ b/test/helpers/destroy-flow-test-harness.ts
@@ -33,10 +33,13 @@ export type DestroyHarness = {
   logSpy: MockInstance;
   prepareMcpBridgesForAbsentSandboxDestroySpy: MockInstance;
   prepareMcpBridgesForDestroySpy: MockInstance;
+  preparePortableDestroyAuthoritySpy: MockInstance;
   promptSpy: MockInstance;
   removeManagedHermesStateVolumeSpy: MockInstance;
   removeSandboxSpy: MockInstance;
   retirePortableLifecycleReceiptSpy: MockInstance;
+  portableDestroyRevalidateSpy: MockInstance;
+  portableDestroyVerifyAbsentSpy: MockInstance;
   revokeHttpsPinRuntimeAdapterRouteSpy: MockInstance;
   restoreMcpBridgesAfterDestroyAbortSpy: MockInstance;
   runOpenshellSpy: MockInstance;
@@ -81,6 +84,9 @@ type DestroyHarnessOptions = {
   mcpServers?: string[];
   openshellDriver?: string;
   portableCommandError?: string;
+  portableDestroyAuthority?: boolean;
+  portableDestroyPrepareError?: string;
+  portableDestroyVerifyAbsentError?: string;
   prepareMcpBridgeError?: string;
   promptResponses?: string[];
   provider?: string;
@@ -198,11 +204,36 @@ export function createDestroyHarness(options: DestroyHarnessOptions = {}): Destr
   const portableAgentLifecycle = requireDist(
     "../../onboard/experimental/portable-agent-lifecycle.js",
   );
+  const portableDemoLifecycle = requireDist(
+    "../../onboard/experimental/portable-demo-lifecycle.js",
+  );
 
   const assertHermesPortableCommandUnavailableSpy = vi
     .spyOn(portableAgentLifecycle, "assertHermesPortableCommandUnavailable")
     .mockImplementation(() => {
       if (options.portableCommandError) throw new Error(options.portableCommandError);
+    });
+  const portableDestroyRevalidateSpy = vi.fn(() => {
+    events.push("portable-revalidate");
+  });
+  const portableDestroyVerifyAbsentSpy = vi.fn(() => {
+    events.push("portable-absent");
+    if (options.portableDestroyVerifyAbsentError) {
+      throw new Error(options.portableDestroyVerifyAbsentError);
+    }
+  });
+  const preparePortableDestroyAuthoritySpy = vi
+    .spyOn(portableDemoLifecycle, "preparePortableDemoSandboxDestroyAuthority")
+    .mockImplementation(() => {
+      if (options.portableDestroyPrepareError) {
+        throw new Error(options.portableDestroyPrepareError);
+      }
+      return options.portableDestroyAuthority
+        ? {
+            revalidate: portableDestroyRevalidateSpy,
+            verifyAbsent: portableDestroyVerifyAbsentSpy,
+          }
+        : null;
     });
 
   vi.spyOn(resolve, "resolveOpenshell").mockReturnValue("/usr/bin/openshell");
@@ -522,6 +553,9 @@ export function createDestroyHarness(options: DestroyHarnessOptions = {}): Destr
     logSpy,
     prepareMcpBridgesForAbsentSandboxDestroySpy,
     prepareMcpBridgesForDestroySpy,
+    preparePortableDestroyAuthoritySpy,
+    portableDestroyRevalidateSpy,
+    portableDestroyVerifyAbsentSpy,
     promptSpy,
     removeManagedHermesStateVolumeSpy,
     removeSandboxSpy,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Portable OpenClaw startup records a receipt-owned Podman container that does not carry Docker's `openshell.ai/managed-by` label, so destroy rejected its own container before OpenShell could remove the sandbox. Select the existing schema-4 Portable receipt before the Docker guard, revalidate its exact Podman identity throughout destroy, and retain local ownership until OpenShell deletion and exact container absence are both confirmed.

## Related Issue

Fixes #9189

Tracked by #9200

## Changes

- Select schema-4 Portable OpenClaw receipt authority before the generic Docker foreign-container guard.
- Revalidate the current-user Podman socket, registry lifecycle generation, full container ID, and required Portable labels at every destroy checkpoint.
- Require absence of the exact Podman container before sandbox registry and receipt retirement; preserve state when absence is unproven or the gateway is unreachable.
- Preserve foreign Docker refusal, invalid-receipt refusal, and schema-5 Hermes rejection. OpenShell remains the only deletion path; this change adds no Podman removal fallback or production Podman support.
- Add a narrow destroy authority consumed only by sandbox destroy. The existing uninstall authority includes removal capability, so reusing it would grant behavior outside this requirement. `destroy-flow.test.ts` and `portable-demo-lifecycle-authority.test.ts` protect the non-mutating contract and its negative cases.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category security review passed with no findings. It confirmed strict schema-4 and current-user Podman authority, fail-closed drift handling, no new removal capability, and exact absence before local retirement.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/actions/sandbox/destroy-flow.test.ts src/lib/actions/uninstall/portable-runtime-cleanup.test.ts src/lib/onboard/experimental/portable-demo-lifecycle.test.ts src/lib/onboard/experimental/portable-demo-lifecycle-authority.test.ts` passed 4 files and 182 tests; `npx vitest run --project integration test/growth-guardrails.test.ts` passed 32 tests; `npm run typecheck:cli`, `npm run checks:repository`, and `git diff --check upstream/main...HEAD` passed.
- [ ] Applicable broad gate passed — Not applicable to this focused destroy correction and its deterministic test helpers; the affected behavior suites and repository gates passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Independent Reviews

- Security: PASS, no findings across all nine categories.
- Documentation writing: PASS, no blocking or advisory findings.
- Documentation disposition: No public documentation change. This restores the accepted experimental schema-4 behavior without changing command syntax, configuration, production Podman support, or supported product scope.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portable demo sandbox deletion by rechecking ownership, identity, and lifecycle state before cleanup.
  * Prevented local cleanup when remote deletion cannot be confirmed.
  * Preserved sandbox records and receipts until remote deletion and container absence are verified.
  * Added clearer errors when gateway access is required.
  * Prevented destructive actions for invalid lifecycle receipts and enabled safe retry after temporary locks.
* **Tests**
  * Expanded coverage for identity changes, registry updates, unavailable services, container changes, and successful retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->