### PR TITLE
fix(sandbox): retain llama.cpp cleanup authority

### DIFF
--- a/docs/inference/set-up-llama-cpp.mdx
+++ b/docs/inference/set-up-llama-cpp.mdx
@@ -308,6 +308,9 @@ docker context show
 printf 'DOCKER_CONFIG=%s\n' "${DOCKER_CONFIG:-<unset>}"
 printf 'DOCKER_CONTEXT=%s\n' "${DOCKER_CONTEXT:-<unset>}"
 printf 'DOCKER_HOST=%s\n' "${DOCKER_HOST:-<unset>}"
+printf 'DOCKER_TLS=%s\n' "${DOCKER_TLS:-<unset>}"
+printf 'DOCKER_TLS_VERIFY=%s\n' "${DOCKER_TLS_VERIFY:-<unset>}"
+printf 'DOCKER_CERT_PATH=%s\n' "${DOCKER_CERT_PATH:-<unset>}"
 ```
 
 Compare this output with the shell or automation that ran onboarding.
@@ -334,6 +337,10 @@ Restore the configuration and selection used during onboarding with the matching
   unset DOCKER_CONTEXT
   export DOCKER_HOST="<onboarding-docker-host>"
   ```
+
+For either selection path, restore `DOCKER_TLS`, `DOCKER_TLS_VERIFY`, and `DOCKER_CERT_PATH` to their onboarding state.
+Unset each TLS variable that was unset or empty during onboarding.
+These variables are part of the endpoint-selection tuple for both Docker contexts and `DOCKER_HOST`.
 
 After restoring the recorded Docker configuration and selector, run `docker info`.
 Confirm that it reports the Docker daemon used during onboarding.

--- a/docs/inference/set-up-llama-cpp.mdx
+++ b/docs/inference/set-up-llama-cpp.mdx
@@ -299,7 +299,7 @@ Although the setup steps above target DGX Spark, this removal and recovery behav
 NemoClaw qualifies the Docker operation authority recorded during managed llama.cpp onboarding.
 It completes this qualification before it requests sandbox deletion or reconciles an already-absent sandbox.
 This authority includes Docker endpoint selection and identity, Docker executable identity, and command environment.
-When cleanup relies on private managed llama.cpp state, NemoClaw proves Docker availability and the exact container and network before any OpenShell command.
+When cleanup relies on private managed llama.cpp state, NemoClaw proves Docker availability and the exact container and network before OpenShell sandbox deletion.
 It retains the identity of that private lifecycle state across sandbox deletion and rejects cleanup if the identity changes.
 If any pre-delete proof fails, NemoClaw reports the error and stops the destroy operation.
 If `$$nemoclaw list` no longer shows the sandbox, `destroy` can still reconcile leftover managed llama.cpp state that names it when the command uses the original `NEMOCLAW_GATEWAY_PORT`.

--- a/docs/inference/set-up-llama-cpp.mdx
+++ b/docs/inference/set-up-llama-cpp.mdx
@@ -296,9 +296,10 @@ $$nemoclaw my-assistant destroy
 ```
 
 Although the setup steps above target DGX Spark, this removal and recovery behavior also applies to other experimental managed llama.cpp profiles on Linux.
-Before sandbox deletion, NemoClaw qualifies the Docker operation authority recorded during managed llama.cpp onboarding.
+NemoClaw qualifies the Docker operation authority recorded during managed llama.cpp onboarding.
+It completes this qualification before it requests sandbox deletion or reconciles an already-absent sandbox.
 This authority includes Docker endpoint selection and identity, Docker executable identity, and command environment.
-If qualification fails, NemoClaw leaves the sandbox in place and reports the Docker operation authority error.
+If qualification fails, NemoClaw reports the Docker operation authority error and stops the destroy operation.
 
 If the reported Docker operation authority mismatch involves endpoint selection, inspect the current Docker configuration and selectors:
 
@@ -336,9 +337,11 @@ Restore the configuration and selection used during onboarding with the matching
 
 After restoring the recorded Docker configuration and selector, run `docker info`.
 Confirm that it reports the Docker daemon used during onboarding.
-Other Docker operation authority mismatches can involve Docker executable identity or command environment.
-Restore the reported Docker executable or command environment to the value used during onboarding.
 Rerun the earlier `destroy` command.
+
+NemoClaw stores opaque authority identity and binding data, not the original Docker executable or command environment values.
+For any other authority mismatch, do not guess Docker selector values.
+Retry the earlier `destroy` command from the same shell or automation environment that ran onboarding.
 After OpenShell confirms sandbox deletion, the command removes the exact managed llama.cpp container, internal network, API key, and gateway-scoped ownership state.
 It preserves `~/.cache/huggingface/` because other applications can use that cache.
 If exact cleanup fails, NemoClaw preserves the sandbox registry entry and ownership state for a retry.

--- a/docs/inference/set-up-llama-cpp.mdx
+++ b/docs/inference/set-up-llama-cpp.mdx
@@ -302,7 +302,7 @@ This authority includes Docker endpoint selection and identity, Docker executabl
 When cleanup relies on private managed llama.cpp state, NemoClaw proves Docker availability and the exact container and network before any OpenShell command.
 It retains the identity of that private lifecycle state across sandbox deletion and rejects cleanup if the identity changes.
 If any pre-delete proof fails, NemoClaw reports the error and stops the destroy operation.
-If `$$nemoclaw list` no longer shows the sandbox, `destroy` can still reconcile leftover managed llama.cpp state that names it.
+If `$$nemoclaw list` no longer shows the sandbox, `destroy` can still reconcile leftover managed llama.cpp state that names it when the command uses the original `NEMOCLAW_GATEWAY_PORT`.
 
 If the reported Docker operation authority mismatch involves endpoint selection, inspect the current Docker configuration and selectors:
 

--- a/docs/inference/set-up-llama-cpp.mdx
+++ b/docs/inference/set-up-llama-cpp.mdx
@@ -302,7 +302,6 @@ This authority includes Docker endpoint selection and identity, Docker executabl
 When cleanup relies on private managed llama.cpp state, NemoClaw proves Docker availability and the exact container and network before OpenShell sandbox deletion.
 It retains the identity of that private lifecycle state across sandbox deletion and rejects cleanup if the identity changes.
 If any pre-delete proof fails, NemoClaw reports the error and stops the destroy operation.
-If `$$nemoclaw list` no longer shows the sandbox, `destroy` can still reconcile leftover managed llama.cpp state that names it when the command uses the original `NEMOCLAW_GATEWAY_PORT`.
 
 If the reported Docker operation authority mismatch involves endpoint selection, inspect the current Docker configuration and selectors:
 

--- a/docs/inference/set-up-llama-cpp.mdx
+++ b/docs/inference/set-up-llama-cpp.mdx
@@ -295,6 +295,50 @@ Run:
 $$nemoclaw my-assistant destroy
 ```
 
+Although the setup steps above target DGX Spark, this removal and recovery behavior also applies to other experimental managed llama.cpp profiles on Linux.
+Before sandbox deletion, NemoClaw qualifies the Docker operation authority recorded during managed llama.cpp onboarding.
+This authority includes Docker endpoint selection and identity, Docker executable identity, and command environment.
+If qualification fails, NemoClaw leaves the sandbox in place and reports the Docker operation authority error.
+
+If the reported Docker operation authority mismatch involves endpoint selection, inspect the current Docker configuration and selectors:
+
+```bash
+docker context show
+printf 'DOCKER_CONFIG=%s\n' "${DOCKER_CONFIG:-<unset>}"
+printf 'DOCKER_CONTEXT=%s\n' "${DOCKER_CONTEXT:-<unset>}"
+printf 'DOCKER_HOST=%s\n' "${DOCKER_HOST:-<unset>}"
+```
+
+Compare this output with the shell or automation that ran onboarding.
+Restore the configuration and selection used during onboarding with the matching path:
+
+- If onboarding used a custom `DOCKER_CONFIG` directory, restore it first:
+
+  ```bash
+  export DOCKER_CONFIG="<onboarding-docker-config>"
+  ```
+
+  If onboarding used Docker's default configuration directory, unset `DOCKER_CONFIG`.
+
+- If onboarding used `DOCKER_CONTEXT` or Docker's persisted current context, select the original context explicitly:
+
+  ```bash
+  unset DOCKER_HOST
+  export DOCKER_CONTEXT="<onboarding-context>"
+  ```
+
+- If onboarding used `DOCKER_HOST`, restore that selection:
+
+  ```bash
+  unset DOCKER_CONTEXT
+  export DOCKER_HOST="<onboarding-docker-host>"
+  ```
+
+After restoring the recorded Docker configuration and selector, run `docker info`.
+Confirm that it reports the Docker daemon used during onboarding.
+Other Docker operation authority mismatches can involve Docker executable identity or command environment.
+Restore the reported Docker executable or command environment to the value used during onboarding.
+Rerun the earlier `destroy` command.
 After OpenShell confirms sandbox deletion, the command removes the exact managed llama.cpp container, internal network, API key, and gateway-scoped ownership state.
 It preserves `~/.cache/huggingface/` because other applications can use that cache.
 If exact cleanup fails, NemoClaw preserves the sandbox registry entry and ownership state for a retry.

--- a/docs/inference/set-up-llama-cpp.mdx
+++ b/docs/inference/set-up-llama-cpp.mdx
@@ -299,7 +299,10 @@ Although the setup steps above target DGX Spark, this removal and recovery behav
 NemoClaw qualifies the Docker operation authority recorded during managed llama.cpp onboarding.
 It completes this qualification before it requests sandbox deletion or reconciles an already-absent sandbox.
 This authority includes Docker endpoint selection and identity, Docker executable identity, and command environment.
-If qualification fails, NemoClaw reports the Docker operation authority error and stops the destroy operation.
+When cleanup relies on private managed llama.cpp state, NemoClaw proves Docker availability and the exact container and network before any OpenShell command.
+It retains the identity of that private lifecycle state across sandbox deletion and rejects cleanup if the identity changes.
+If any pre-delete proof fails, NemoClaw reports the error and stops the destroy operation.
+If `$$nemoclaw list` no longer shows the sandbox, `destroy` can still reconcile leftover managed llama.cpp state that names it.
 
 If the reported Docker operation authority mismatch involves endpoint selection, inspect the current Docker configuration and selectors:
 
@@ -351,7 +354,15 @@ For any other authority mismatch, do not guess Docker selector values.
 Retry the earlier `destroy` command from the same shell or automation environment that ran onboarding.
 After OpenShell confirms sandbox deletion, the command removes the exact managed llama.cpp container, internal network, API key, and gateway-scoped ownership state.
 It preserves `~/.cache/huggingface/` because other applications can use that cache.
-If exact cleanup fails, NemoClaw preserves the sandbox registry entry and ownership state for a retry.
+If exact cleanup fails, NemoClaw preserves the ownership state and any existing sandbox registry entry for a retry.
+
+After `destroy` succeeds, run:
+
+```bash
+$$nemoclaw list
+```
+
+Confirm that `my-assistant` no longer appears.
 
 For full NemoClaw removal, run `$$nemoclaw uninstall`.
 Full uninstall applies the same exact-ownership checks and preserves the shared Hugging Face cache by default.

--- a/src/lib/actions/sandbox/destroy-execution.ts
+++ b/src/lib/actions/sandbox/destroy-execution.ts
@@ -573,7 +573,6 @@ export async function executeSandboxDestroy({
           current,
           hostLocalInferenceAuthority,
           listSandboxes!().sandboxes,
-          deps.hostLocalInferenceLifecycleOptions,
         );
         commonLlamaCppAuthorityRetired =
           hostLocalInferenceAuthority.receipt.service === "llama-cpp";

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -109,7 +109,7 @@ describe("destroySandbox flow", () => {
       const harness = createDestroyHarness({
         provider: "llama-cpp-local",
         hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
-        preparedManagedLlamaCppRuntimeCleanup: { cleanup },
+        preparedManagedLlamaCppRuntimeCleanup: { abort: vi.fn(), cleanup },
         onPrepareManagedLlamaCppRuntimeCleanup: () => trace.push("prepare"),
       });
       harness.runOpenshellSpy.mockImplementation((args: unknown) => {
@@ -139,64 +139,72 @@ describe("destroySandbox flow", () => {
     },
   );
 
-  it("runs the real retained llama.cpp cleanup capability after sandbox deletion (#9888)", async () => {
-    const homeDir = fs.realpathSync(
-      fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-destroy-cleanup-")),
-    );
-    try {
-      const qualified = engineHarness({ authorityId: "docker:qualified" });
-      const drifted = engineHarness({ authorityId: "docker:drifted" });
-      createManagedState(homeDir, qualified.engine, {
-        gatewayPort: 19080,
-        sandboxName: "alpha",
-      });
-      let crossedDeleteBoundary = false;
-      const createEngine = vi
-        .spyOn(dockerLlamaCppOperation, "createManagedLlamaCppEngine")
-        .mockImplementation(() => (crossedDeleteBoundary ? drifted.engine : qualified.engine));
-      const prepared = prepareManagedLlamaCppRuntimeCleanupForSandbox("alpha", {
-        gatewayPort: 19080,
-        homeDir,
-      });
-      const harness = createDestroyHarness({
-        provider: "llama-cpp-local",
-        hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
-        preparedManagedLlamaCppRuntimeCleanup: prepared,
-      });
-      harness.runOpenshellSpy.mockImplementation((args: unknown) => {
-        const argv = Array.isArray(args) ? args : [];
-        switch (`${String(argv[0])}:${String(argv[1])}`) {
-          case "sandbox:delete":
-            crossedDeleteBoundary = true;
-            return { status: 0, stdout: "", stderr: "" };
-          case "sandbox:list":
-            return {
-              status: 0,
-              stdout: '[{"name":"alpha","phase":"Ready"}]',
-              stderr: "",
-            };
-          default:
-            return { status: 0, stdout: "", stderr: "" };
-        }
-      });
-
-      await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
-
-      expect(createEngine).toHaveBeenCalledOnce();
-      expect(qualified.capture).toHaveBeenCalledWith(
-        ["rm", "--force", RUNTIME_ID],
-        expect.any(Number),
+  it.each([
+    ["--yes", false],
+    ["--yes --force", true],
+  ] as const)(
+    "runs the real retained llama.cpp cleanup capability after sandbox deletion with %s (#9888)",
+    async (_flags, force) => {
+      const homeDir = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-destroy-cleanup-")),
       );
-      expect(qualified.capture).toHaveBeenCalledWith(
-        ["network", "rm", NETWORK_ID],
-        expect.any(Number),
-      );
-      expect(drifted.capture).not.toHaveBeenCalled();
-      expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
-    } finally {
-      fs.rmSync(homeDir, { force: true, recursive: true });
-    }
-  });
+      try {
+        const qualified = engineHarness({ authorityId: "docker:qualified" });
+        const drifted = engineHarness({ authorityId: "docker:drifted" });
+        createManagedState(homeDir, qualified.engine, {
+          gatewayPort: 19080,
+          sandboxName: "alpha",
+        });
+        let crossedDeleteBoundary = false;
+        const createEngine = vi
+          .spyOn(dockerLlamaCppOperation, "createManagedLlamaCppEngine")
+          .mockImplementation(() => (crossedDeleteBoundary ? drifted.engine : qualified.engine));
+        const prepared = prepareManagedLlamaCppRuntimeCleanupForSandbox("alpha", {
+          gatewayPort: 19080,
+          homeDir,
+        });
+        const harness = createDestroyHarness({
+          provider: "llama-cpp-local",
+          hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
+          preparedManagedLlamaCppRuntimeCleanup: prepared,
+        });
+        harness.runOpenshellSpy.mockImplementation((args: unknown) => {
+          const argv = Array.isArray(args) ? args : [];
+          switch (`${String(argv[0])}:${String(argv[1])}`) {
+            case "sandbox:delete":
+              crossedDeleteBoundary = true;
+              return { status: 0, stdout: "", stderr: "" };
+            case "sandbox:list":
+              return {
+                status: 0,
+                stdout: '[{"name":"alpha","phase":"Ready"}]',
+                stderr: "",
+              };
+            default:
+              return { status: 0, stdout: "", stderr: "" };
+          }
+        });
+
+        await expect(
+          harness.destroySandbox("alpha", { yes: true, force }),
+        ).resolves.toBeUndefined();
+
+        expect(createEngine).toHaveBeenCalledOnce();
+        expect(qualified.capture).toHaveBeenCalledWith(
+          ["rm", "--force", RUNTIME_ID],
+          expect.any(Number),
+        );
+        expect(qualified.capture).toHaveBeenCalledWith(
+          ["network", "rm", NETWORK_ID],
+          expect.any(Number),
+        );
+        expect(drifted.capture).not.toHaveBeenCalled();
+        expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
+      } finally {
+        fs.rmSync(homeDir, { force: true, recursive: true });
+      }
+    },
+  );
 
   it("does not let legacy llama.cpp state block an unrelated provider destroy (#9888)", async () => {
     const harness = createDestroyHarness({
@@ -246,6 +254,7 @@ describe("destroySandbox flow", () => {
       provider: "llama-cpp-local",
       hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
       preparedManagedLlamaCppRuntimeCleanup: {
+        abort: vi.fn(),
         cleanup: () => ({
           ok: false,
           reason: "qualified cleanup failed",
@@ -264,16 +273,18 @@ describe("destroySandbox flow", () => {
   });
 
   it("does not run prepared managed llama.cpp cleanup when OpenShell deletion fails (#9888)", async () => {
+    const abort = vi.fn();
     const cleanup = vi.fn(() => ({ ok: true as const, removed: [], preserved: [] }));
     const harness = createDestroyHarness({
       deleteStatus: 7,
       provider: "llama-cpp-local",
       hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
-      preparedManagedLlamaCppRuntimeCleanup: { cleanup },
+      preparedManagedLlamaCppRuntimeCleanup: { abort, cleanup },
     });
 
     await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow("process.exit(7)");
 
+    expect(abort).toHaveBeenCalledOnce();
     expect(cleanup).not.toHaveBeenCalled();
     expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
   });
@@ -284,7 +295,7 @@ describe("destroySandbox flow", () => {
       sandboxPresent: false,
       provider: "llama-cpp-local",
       hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
-      preparedManagedLlamaCppRuntimeCleanup: { cleanup },
+      preparedManagedLlamaCppRuntimeCleanup: { abort: vi.fn(), cleanup },
     });
 
     await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
@@ -300,7 +311,7 @@ describe("destroySandbox flow", () => {
     const harness = createDestroyHarness({
       registryEntryPresent: false,
       sandboxPresent: false,
-      preparedManagedLlamaCppRuntimeCleanup: { cleanup },
+      preparedManagedLlamaCppRuntimeCleanup: { abort: vi.fn(), cleanup },
     });
 
     await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -25,6 +25,8 @@ import {
   resetDestroyModuleCache,
   traceDestroyBoundaryCalls,
 } from "../../../../test/helpers/destroy-flow-test-harness";
+import { serializedLlamaCppHostLocalInferenceReceipt } from "../../../../test/helpers/host-local-inference-receipt";
+import { createSandboxHostLocalInferenceProvenance } from "../../state/registry/host-local-inference";
 import type { SandboxWorkloadReceipt } from "../../state/registry";
 
 const managedHermesWorkload = {
@@ -79,6 +81,160 @@ describe("destroySandbox flow", () => {
     expect(harness.removeSandboxSpy.mock.invocationCallOrder[0]).toBeLessThan(
       harness.retirePortableLifecycleReceiptSpy.mock.invocationCallOrder[0],
     );
+  });
+
+  it.each([
+    ["--yes", false],
+    ["--yes --force", true],
+  ] as const)(
+    "keeps managed llama.cpp cleanup authority across the sandbox delete boundary with %s (#9888)",
+    async (_flags, force) => {
+      const trace: string[] = [];
+      const cleanup = vi.fn(() => {
+        trace.push("cleanup");
+        return { ok: true as const, removed: [], preserved: [] };
+      });
+      const harness = createDestroyHarness({
+        provider: "llama-cpp-local",
+        hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
+        preparedManagedLlamaCppRuntimeCleanup: { cleanup },
+        onPrepareManagedLlamaCppRuntimeCleanup: () => trace.push("prepare"),
+      });
+      harness.runOpenshellSpy.mockImplementation((args: unknown) => {
+        const argv = Array.isArray(args) ? args : [];
+        switch (`${String(argv[0])}:${String(argv[1])}`) {
+          case "sandbox:delete":
+            trace.push("delete");
+            return { status: 0, stdout: "", stderr: "" };
+          case "sandbox:list":
+            return { status: 0, stdout: '[{"name":"alpha","phase":"Ready"}]', stderr: "" };
+          default:
+            return { status: 0, stdout: "", stderr: "" };
+        }
+      });
+
+      await expect(harness.destroySandbox("alpha", { yes: true, force })).resolves.toBeUndefined();
+
+      expect(harness.prepareManagedLlamaCppRuntimeCleanupSpy).toHaveBeenCalledWith("alpha", {
+        gatewayPort: 19080,
+      });
+      expect(cleanup).toHaveBeenCalledOnce();
+      expect(trace).toEqual(["prepare", "delete", "cleanup"]);
+      expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
+      expect(harness.retirePortableLifecycleReceiptSpy).toHaveBeenCalledWith("alpha");
+      expect(exitSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["--yes", false],
+    ["--yes --force", true],
+  ] as const)(
+    "refuses sandbox deletion when managed llama.cpp cleanup authority cannot be qualified with %s (#9888)",
+    async (_flags, force) => {
+      const harness = createDestroyHarness({
+        provider: "llama-cpp-local",
+        hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
+        onPrepareManagedLlamaCppRuntimeCleanup: () => {
+          throw new Error("qualified container endpoint does not match persisted authority");
+        },
+      });
+
+      await expect(harness.destroySandbox("alpha", { yes: true, force })).rejects.toThrow(
+        "process.exit(1)",
+      );
+
+      expect(
+        harness.runOpenshellSpy.mock.calls.map(([args]) => (args as string[]).slice(0, 2)),
+      ).not.toContainEqual(["sandbox", "delete"]);
+      expect(harness.errorSpy.mock.calls.map(([message]) => String(message)).join("\n")).toContain(
+        "The sandbox was not deleted. Fix the reported authority and retry destroy.",
+      );
+      expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves the registry when prepared managed llama.cpp cleanup fails after deletion (#9888)", async () => {
+    const harness = createDestroyHarness({
+      provider: "llama-cpp-local",
+      hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
+      preparedManagedLlamaCppRuntimeCleanup: {
+        cleanup: () => ({
+          ok: false,
+          reason: "qualified cleanup failed",
+          removed: [],
+          preserved: ["managed llama.cpp runtime"],
+        }),
+      },
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow("process.exit(1)");
+
+    expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
+    expect(harness.errorSpy.mock.calls.map(([message]) => String(message)).join("\n")).toContain(
+      "qualified cleanup failed",
+    );
+  });
+
+  it("does not run prepared managed llama.cpp cleanup when OpenShell deletion fails (#9888)", async () => {
+    const cleanup = vi.fn(() => ({ ok: true as const, removed: [], preserved: [] }));
+    const harness = createDestroyHarness({
+      deleteStatus: 7,
+      provider: "llama-cpp-local",
+      hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
+      preparedManagedLlamaCppRuntimeCleanup: { cleanup },
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow("process.exit(7)");
+
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
+  });
+
+  it("reconciles prepared managed llama.cpp cleanup after OpenShell already deleted the sandbox (#9888)", async () => {
+    const cleanup = vi.fn(() => ({ ok: true as const, removed: [], preserved: [] }));
+    const harness = createDestroyHarness({
+      sandboxPresent: false,
+      provider: "llama-cpp-local",
+      hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
+      preparedManagedLlamaCppRuntimeCleanup: { cleanup },
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
+    expect(harness.retirePortableLifecycleReceiptSpy).toHaveBeenCalledWith("alpha");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("completes destroy through common cleanup for provenance-tracked llama.cpp (#9888)", async () => {
+    const receipt = serializedLlamaCppHostLocalInferenceReceipt();
+    const harness = createDestroyHarness({
+      provider: "llama-cpp-local",
+      hostLocalInferenceReceipt: receipt,
+      hostLocalInferenceProvenance: createSandboxHostLocalInferenceProvenance("alpha", receipt),
+      executeSandboxDestroyResult: {
+        ok: true,
+        alreadyGone: false,
+        deleteOutput: "",
+        deleteResult: { status: 0, stdout: "", stderr: "" },
+        detachOutcome: { detached: [], failures: [] },
+        forcedLocalCleanup: false,
+        commonLlamaCppAuthorityRetired: true,
+      },
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
+
+    expect(harness.prepareManagedLlamaCppRuntimeCleanupSpy).not.toHaveBeenCalled();
+    expect(harness.executeSandboxDestroySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandbox: expect.objectContaining({ hostLocalInferenceProvenance: expect.any(Object) }),
+      }),
+    );
+    expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it("rejects schema-5 inside the destroy lifecycle fence before Docker or OpenShell (#9203)", async () => {

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -243,7 +243,7 @@ describe("destroySandbox flow", () => {
         harness.runOpenshellSpy.mock.calls.map(([args]) => (args as string[]).slice(0, 2)),
       ).not.toContainEqual(["sandbox", "delete"]);
       expect(harness.errorSpy.mock.calls.map(([message]) => String(message)).join("\n")).toContain(
-        "The sandbox was not deleted. Fix the reported authority and retry destroy.",
+        "The sandbox was not deleted. Resolve the reported cleanup preflight failure and retry destroy.",
       );
       expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
     },
@@ -283,6 +283,49 @@ describe("destroySandbox flow", () => {
     });
 
     await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow("process.exit(7)");
+
+    expect(abort).toHaveBeenCalledOnce();
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
+  });
+
+  it("releases prepared managed llama.cpp cleanup when destroy execution throws (#9888)", async () => {
+    const abort = vi.fn();
+    const cleanup = vi.fn(() => ({ ok: true as const, removed: [], preserved: [] }));
+    const harness = createDestroyHarness({
+      provider: "llama-cpp-local",
+      hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
+      preparedManagedLlamaCppRuntimeCleanup: { abort, cleanup },
+    });
+    harness.executeSandboxDestroySpy.mockRejectedValueOnce(
+      new Error("injected destroy execution failure"),
+    );
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow(
+      "injected destroy execution failure",
+    );
+
+    expect(abort).toHaveBeenCalledOnce();
+    expect(cleanup).not.toHaveBeenCalled();
+    expect(harness.removeSandboxSpy).not.toHaveBeenCalled();
+  });
+
+  it("releases prepared managed llama.cpp cleanup when service cleanup throws (#9888)", async () => {
+    const abort = vi.fn();
+    const cleanup = vi.fn(() => ({ ok: true as const, removed: [], preserved: [] }));
+    const harness = createDestroyHarness({
+      provider: "llama-cpp-local",
+      hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
+      preparedManagedLlamaCppRuntimeCleanup: { abort, cleanup },
+      registeredSandboxCount: 1,
+    });
+    harness.stopAllSpy.mockImplementationOnce(() => {
+      throw new Error("injected service cleanup failure");
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).rejects.toThrow(
+      "injected service cleanup failure",
+    );
 
     expect(abort).toHaveBeenCalledOnce();
     expect(cleanup).not.toHaveBeenCalled();

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -126,6 +126,21 @@ describe("destroySandbox flow", () => {
     },
   );
 
+  it("does not let legacy llama.cpp state block an unrelated provider destroy (#9888)", async () => {
+    const harness = createDestroyHarness({
+      provider: "nvidia-prod",
+      onPrepareManagedLlamaCppRuntimeCleanup: () => {
+        throw new Error("foreign managed llama.cpp state is corrupt");
+      },
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
+
+    expect(harness.prepareManagedLlamaCppRuntimeCleanupSpy).not.toHaveBeenCalled();
+    expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["--yes", false],
     ["--yes --force", true],

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -107,6 +107,7 @@ describe("destroySandbox flow", () => {
             trace.push("delete");
             return { status: 0, stdout: "", stderr: "" };
           case "sandbox:list":
+            trace.push("list");
             return { status: 0, stdout: '[{"name":"alpha","phase":"Ready"}]', stderr: "" };
           default:
             return { status: 0, stdout: "", stderr: "" };
@@ -119,7 +120,7 @@ describe("destroySandbox flow", () => {
         gatewayPort: 19080,
       });
       expect(cleanup).toHaveBeenCalledOnce();
-      expect(trace).toEqual(["prepare", "delete", "cleanup"]);
+      expect(trace).toEqual(["prepare", "list", "delete", "cleanup"]);
       expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
       expect(harness.retirePortableLifecycleReceiptSpy).toHaveBeenCalledWith("alpha");
       expect(exitSpy).not.toHaveBeenCalled();
@@ -220,6 +221,21 @@ describe("destroySandbox flow", () => {
     expect(cleanup).toHaveBeenCalledOnce();
     expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
     expect(harness.retirePortableLifecycleReceiptSpy).toHaveBeenCalledWith("alpha");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("prepares leftover managed llama.cpp cleanup when the registry row is already absent (#9888)", async () => {
+    const cleanup = vi.fn(() => ({ ok: true as const, removed: [], preserved: [] }));
+    const harness = createDestroyHarness({
+      registryEntryPresent: false,
+      sandboxPresent: false,
+      preparedManagedLlamaCppRuntimeCleanup: { cleanup },
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
+
+    expect(harness.prepareManagedLlamaCppRuntimeCleanupSpy).toHaveBeenCalledWith("alpha", {});
+    expect(cleanup).toHaveBeenCalledOnce();
     expect(exitSpy).not.toHaveBeenCalled();
   });
 

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
 import {
@@ -28,6 +32,14 @@ import {
 import { serializedLlamaCppHostLocalInferenceReceipt } from "../../../../test/helpers/host-local-inference-receipt";
 import { createSandboxHostLocalInferenceProvenance } from "../../state/registry/host-local-inference";
 import type { SandboxWorkloadReceipt } from "../../state/registry";
+import * as dockerLlamaCppOperation from "../../onboard/runtime-provider/docker-llama-cpp-operation";
+import { prepareManagedLlamaCppRuntimeCleanupForSandbox } from "../../inference/local-model-profile/cleanup";
+import {
+  createManagedState,
+  engineHarness,
+  NETWORK_ID,
+  RUNTIME_ID,
+} from "../../inference/local-model-profile/cleanup.test-support";
 
 const managedHermesWorkload = {
   schemaVersion: 1,
@@ -126,6 +138,65 @@ describe("destroySandbox flow", () => {
       expect(exitSpy).not.toHaveBeenCalled();
     },
   );
+
+  it("runs the real retained llama.cpp cleanup capability after sandbox deletion (#9888)", async () => {
+    const homeDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-destroy-cleanup-")),
+    );
+    try {
+      const qualified = engineHarness({ authorityId: "docker:qualified" });
+      const drifted = engineHarness({ authorityId: "docker:drifted" });
+      createManagedState(homeDir, qualified.engine, {
+        gatewayPort: 19080,
+        sandboxName: "alpha",
+      });
+      let crossedDeleteBoundary = false;
+      const createEngine = vi
+        .spyOn(dockerLlamaCppOperation, "createManagedLlamaCppEngine")
+        .mockImplementation(() => (crossedDeleteBoundary ? drifted.engine : qualified.engine));
+      const prepared = prepareManagedLlamaCppRuntimeCleanupForSandbox("alpha", {
+        gatewayPort: 19080,
+        homeDir,
+      });
+      const harness = createDestroyHarness({
+        provider: "llama-cpp-local",
+        hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
+        preparedManagedLlamaCppRuntimeCleanup: prepared,
+      });
+      harness.runOpenshellSpy.mockImplementation((args: unknown) => {
+        const argv = Array.isArray(args) ? args : [];
+        switch (`${String(argv[0])}:${String(argv[1])}`) {
+          case "sandbox:delete":
+            crossedDeleteBoundary = true;
+            return { status: 0, stdout: "", stderr: "" };
+          case "sandbox:list":
+            return {
+              status: 0,
+              stdout: '[{"name":"alpha","phase":"Ready"}]',
+              stderr: "",
+            };
+          default:
+            return { status: 0, stdout: "", stderr: "" };
+        }
+      });
+
+      await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
+
+      expect(createEngine).toHaveBeenCalledOnce();
+      expect(qualified.capture).toHaveBeenCalledWith(
+        ["rm", "--force", RUNTIME_ID],
+        expect.any(Number),
+      );
+      expect(qualified.capture).toHaveBeenCalledWith(
+        ["network", "rm", NETWORK_ID],
+        expect.any(Number),
+      );
+      expect(drifted.capture).not.toHaveBeenCalled();
+      expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
+    } finally {
+      fs.rmSync(homeDir, { force: true, recursive: true });
+    }
+  });
 
   it("does not let legacy llama.cpp state block an unrelated provider destroy (#9888)", async () => {
     const harness = createDestroyHarness({
@@ -236,6 +307,21 @@ describe("destroySandbox flow", () => {
 
     expect(harness.prepareManagedLlamaCppRuntimeCleanupSpy).toHaveBeenCalledWith("alpha", {});
     expect(cleanup).toHaveBeenCalledOnce();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not discover unprepared llama.cpp state after sandbox deletion (#9888)", async () => {
+    const harness = createDestroyHarness({
+      provider: "llama-cpp-local",
+      hostLocalInferenceReceipt: serializedLlamaCppHostLocalInferenceReceipt(),
+      preparedManagedLlamaCppRuntimeCleanup: null,
+    });
+
+    await expect(harness.destroySandbox("alpha", { yes: true })).resolves.toBeUndefined();
+
+    expect(harness.prepareManagedLlamaCppRuntimeCleanupSpy).toHaveBeenCalledOnce();
+    expect(harness.cleanupManagedLlamaCppRuntimeForSandboxSpy).not.toHaveBeenCalled();
+    expect(harness.removeSandboxSpy).toHaveBeenCalledWith("alpha");
     expect(exitSpy).not.toHaveBeenCalled();
   });
 

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -518,21 +518,26 @@ async function destroySandboxUnlocked(
       console.error(
         `  Refusing to destroy sandbox '${sandboxName}': Managed llama.cpp cleanup preflight failed: ${redactDestroyError(error)}`,
       );
-      console.error(`  The sandbox was not deleted. Fix the reported authority and retry destroy.`);
+      console.error(
+        `  The sandbox was not deleted. Resolve the reported cleanup preflight failure and retry destroy.`,
+      );
       process.exit(1);
     }
   }
+  const abortPreparedCleanupOnError = <T>(operation: () => T): T => {
+    try {
+      return operation();
+    } catch (error) {
+      preparedManagedLlamaCppCleanup?.abort();
+      throw error;
+    }
+  };
   let destroyPreflight: ReturnType<typeof prepareSandboxDestroy>;
-  try {
-    destroyPreflight = prepareSandboxDestroy(sandboxName);
-  } catch (error) {
-    preparedManagedLlamaCppCleanup?.abort();
-    throw error;
-  }
+  destroyPreflight = abortPreparedCleanupOnError(() => prepareSandboxDestroy(sandboxName));
   const { cleanupGatewayName, runOpenshell, sandbox, sandboxConfirmedAbsent } = destroyPreflight;
   // Recheck identity after pre-delete qualification and recoverable journal
   // publication reconciliation, before any sandbox runtime mutation.
-  const preMutationIdentity = inspectContainerIdentity();
+  const preMutationIdentity = abortPreparedCleanupOnError(inspectContainerIdentity);
   if (
     preMutationIdentity === false ||
     !isSameDestroyContainerIdentityProof(initialIdentity, preMutationIdentity)
@@ -545,19 +550,27 @@ async function destroySandboxUnlocked(
     preparedManagedLlamaCppCleanup?.abort();
     process.exit(1);
   }
-  const priorHttpsPinRouteId = parseHttpsPinRouteId(sandbox?.endpointUrl);
-  const destructiveResult = await executeSandboxDestroy({
-    cleanupShieldsArtifacts: cleanupShieldsDestroyArtifacts,
-    force: normalized.force === true,
-    getSandbox: registry.getSandbox,
-    listSandboxes: registry.listSandboxes,
-    runOpenshell,
-    sandbox,
-    sandboxConfirmedAbsent,
-    sandboxName,
-    expectedContainerIdentity: initialIdentity.identity,
-    stopInferenceResources: () => stopSandboxInferenceResources(sandboxName, sandbox),
-  });
+  const priorHttpsPinRouteId = abortPreparedCleanupOnError(() =>
+    parseHttpsPinRouteId(sandbox?.endpointUrl),
+  );
+  let destructiveResult: Awaited<ReturnType<typeof executeSandboxDestroy>>;
+  try {
+    destructiveResult = await executeSandboxDestroy({
+      cleanupShieldsArtifacts: cleanupShieldsDestroyArtifacts,
+      force: normalized.force === true,
+      getSandbox: registry.getSandbox,
+      listSandboxes: registry.listSandboxes,
+      runOpenshell,
+      sandbox,
+      sandboxConfirmedAbsent,
+      sandboxName,
+      expectedContainerIdentity: initialIdentity.identity,
+      stopInferenceResources: () => stopSandboxInferenceResources(sandboxName, sandbox),
+    });
+  } catch (error) {
+    preparedManagedLlamaCppCleanup?.abort();
+    throw error;
+  }
   if (!destructiveResult.ok) {
     if (destructiveResult.hostLocalInferenceCleanupFailure) {
       console.error(
@@ -660,12 +673,14 @@ async function destroySandboxUnlocked(
     preparedManagedLlamaCppCleanup?.abort();
   }
   if (deleteSucceededOrAlreadyGone && sandbox) {
-    const stateVolumeCleanup = removeManagedHermesStateVolume({
-      agentName: sandbox.agent,
-      runtimeProviderId: normalizeRuntimeProviderIdentity(sandbox.openshellDriver),
-      sandboxName,
-      workloadKind: sandbox.workload?.kind ?? "",
-    });
+    const stateVolumeCleanup = abortPreparedCleanupOnError(() =>
+      removeManagedHermesStateVolume({
+        agentName: sandbox.agent,
+        runtimeProviderId: normalizeRuntimeProviderIdentity(sandbox.openshellDriver),
+        sandboxName,
+        workloadKind: sandbox.workload?.kind ?? "",
+      }),
+    );
     if (stateVolumeCleanup.status === "failed") {
       console.error(
         `  Sandbox '${sandboxName}' is gone, but its managed Hermes state volume '${stateVolumeCleanup.volumeName}' could not be removed: ${redactDestroyError(stateVolumeCleanup.detail)}`,
@@ -682,14 +697,15 @@ async function destroySandboxUnlocked(
       console.log(`  Removed managed Hermes state volume for '${sandboxName}'.`);
     }
   }
-  const shouldStopHostServices = shouldStopHostServicesAfterDestroy({
-    deleteSucceededOrAlreadyGone,
-    registeredSandboxCount: registry.listSandboxes().sandboxes.length,
-    sandboxStillRegistered: !!registry.getSandbox(sandboxName),
-  });
-
-  cleanupSandboxServices(sandboxName, {
-    stopHostServices: shouldStopHostServices,
+  abortPreparedCleanupOnError(() => {
+    const shouldStopHostServices = shouldStopHostServicesAfterDestroy({
+      deleteSucceededOrAlreadyGone,
+      registeredSandboxCount: registry.listSandboxes().sandboxes.length,
+      sandboxStillRegistered: !!registry.getSandbox(sandboxName),
+    });
+    cleanupSandboxServices(sandboxName, {
+      stopHostServices: shouldStopHostServices,
+    });
   });
   if (deleteSucceededOrAlreadyGone && commonLlamaCppAuthorityRetired === true) {
     preparedManagedLlamaCppCleanup?.abort();

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -497,18 +497,25 @@ async function destroySandboxUnlocked(
     process.exit(1);
   }
 
-  const { cleanupGatewayName, runOpenshell, sandbox, sandboxConfirmedAbsent } =
-    prepareSandboxDestroy(sandboxName);
+  const registeredSandbox = registry.getSandbox(sandboxName);
   let preparedManagedLlamaCppCleanup: ReturnType<
     typeof prepareManagedLlamaCppRuntimeCleanupForSandbox
   > = null;
-  if (sandbox?.provider === "llama-cpp-local" && !sandbox.hostLocalInferenceProvenance) {
+  if (
+    !registeredSandbox ||
+    (registeredSandbox.provider === "llama-cpp-local" &&
+      !registeredSandbox.hostLocalInferenceProvenance)
+  ) {
     try {
       // Fresh Docker qualification reads ambient DOCKER_CONTEXT, DOCKER_HOST,
-      // or Docker's persisted currentContext. Pin that selection before the
-      // OpenShell delete boundary so legacy cleanup cannot switch daemons.
+      // or Docker's persisted currentContext. Pin that selection before any
+      // OpenShell subprocess and the delete boundary so legacy cleanup cannot
+      // switch daemons. A missing registry row still permits exact owner-state
+      // recovery for a prior partial destroy.
       preparedManagedLlamaCppCleanup = prepareManagedLlamaCppRuntimeCleanupForSandbox(sandboxName, {
-        ...(typeof sandbox?.gatewayPort === "number" ? { gatewayPort: sandbox.gatewayPort } : {}),
+        ...(typeof registeredSandbox?.gatewayPort === "number"
+          ? { gatewayPort: registeredSandbox.gatewayPort }
+          : {}),
       });
     } catch (error) {
       console.error(
@@ -518,7 +525,10 @@ async function destroySandboxUnlocked(
       process.exit(1);
     }
   }
-  // Recheck identity after read-only preflight and before local mutation.
+  const { cleanupGatewayName, runOpenshell, sandbox, sandboxConfirmedAbsent } =
+    prepareSandboxDestroy(sandboxName);
+  // Recheck identity after pre-delete qualification and recoverable journal
+  // publication reconciliation, before any sandbox runtime mutation.
   const preMutationIdentity = inspectContainerIdentity();
   if (
     preMutationIdentity === false ||
@@ -526,7 +536,7 @@ async function destroySandboxUnlocked(
   ) {
     if (preMutationIdentity !== false) {
       console.error(
-        `  Refusing to destroy sandbox '${sandboxName}': Container identity changed during preflight. No sandbox resources were removed.`,
+        `  Refusing to destroy sandbox '${sandboxName}': Container identity changed during preflight. No sandbox runtime resources were removed.`,
       );
     }
     process.exit(1);

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -21,10 +21,7 @@ import {
   parseHttpsPinRouteId,
   revokeHttpsPinRuntimeAdapterRoute,
 } from "../../inference/https-pin-runtime-adapter";
-import {
-  cleanupManagedLlamaCppRuntimeForSandbox,
-  prepareManagedLlamaCppRuntimeCleanupForSandbox,
-} from "../../inference/local-model-profile/cleanup";
+import { prepareManagedLlamaCppRuntimeCleanupForSandbox } from "../../inference/local-model-profile/cleanup";
 import {
   CURRENT_RUNTIME_PROVIDER_BUNDLES,
   normalizeRuntimeProviderIdentity,
@@ -683,12 +680,11 @@ async function destroySandboxUnlocked(
     stopHostServices: shouldStopHostServices,
   });
   if (deleteSucceededOrAlreadyGone && commonLlamaCppAuthorityRetired !== true) {
-    const managedLlamaCppCleanup =
-      preparedManagedLlamaCppCleanup?.cleanup() ??
-      cleanupManagedLlamaCppRuntimeForSandbox(sandboxName, {
-        ...(typeof sandbox?.gatewayPort === "number" ? { gatewayPort: sandbox.gatewayPort } : {}),
-      });
-    if (!managedLlamaCppCleanup.ok) {
+    // A null pre-delete result proves that no matching legacy owner state was
+    // present. Never discover and qualify newly appeared state only after the
+    // sandbox boundary; a later destroy retry must preflight that state first.
+    const managedLlamaCppCleanup = preparedManagedLlamaCppCleanup?.cleanup();
+    if (managedLlamaCppCleanup && !managedLlamaCppCleanup.ok) {
       console.error(
         `  Managed llama.cpp cleanup failed for '${sandboxName}': ${managedLlamaCppCleanup.reason}`,
       );

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -508,8 +508,8 @@ async function destroySandboxUnlocked(
   ) {
     try {
       // Fresh Docker qualification reads ambient DOCKER_CONTEXT, DOCKER_HOST,
-      // or Docker's persisted currentContext. Pin that selection before any
-      // OpenShell subprocess and the delete boundary so legacy cleanup cannot
+      // or Docker's persisted currentContext. Pin that selection before
+      // OpenShell sandbox deletion so legacy cleanup cannot
       // switch daemons. A missing registry row still permits exact owner-state
       // recovery for a prior partial destroy.
       preparedManagedLlamaCppCleanup = prepareManagedLlamaCppRuntimeCleanupForSandbox(sandboxName, {

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -522,8 +522,14 @@ async function destroySandboxUnlocked(
       process.exit(1);
     }
   }
-  const { cleanupGatewayName, runOpenshell, sandbox, sandboxConfirmedAbsent } =
-    prepareSandboxDestroy(sandboxName);
+  let destroyPreflight: ReturnType<typeof prepareSandboxDestroy>;
+  try {
+    destroyPreflight = prepareSandboxDestroy(sandboxName);
+  } catch (error) {
+    preparedManagedLlamaCppCleanup?.abort();
+    throw error;
+  }
+  const { cleanupGatewayName, runOpenshell, sandbox, sandboxConfirmedAbsent } = destroyPreflight;
   // Recheck identity after pre-delete qualification and recoverable journal
   // publication reconciliation, before any sandbox runtime mutation.
   const preMutationIdentity = inspectContainerIdentity();
@@ -536,6 +542,7 @@ async function destroySandboxUnlocked(
         `  Refusing to destroy sandbox '${sandboxName}': Container identity changed during preflight. No sandbox runtime resources were removed.`,
       );
     }
+    preparedManagedLlamaCppCleanup?.abort();
     process.exit(1);
   }
   const priorHttpsPinRouteId = parseHttpsPinRouteId(sandbox?.endpointUrl);
@@ -603,6 +610,7 @@ async function destroySandboxUnlocked(
         );
       }
     }
+    preparedManagedLlamaCppCleanup?.abort();
     process.exit(destructiveResult.exitCode);
   }
   const {
@@ -648,6 +656,9 @@ async function destroySandboxUnlocked(
   // forcedLocalCleanup — so a forced cleanup of the last registered sandbox does
   // not shut down services for a sandbox we never confirmed deleted (#6046).
   const deleteSucceededOrAlreadyGone = deleteResult.status === 0 || alreadyGone;
+  if (!deleteSucceededOrAlreadyGone) {
+    preparedManagedLlamaCppCleanup?.abort();
+  }
   if (deleteSucceededOrAlreadyGone && sandbox) {
     const stateVolumeCleanup = removeManagedHermesStateVolume({
       agentName: sandbox.agent,
@@ -660,6 +671,7 @@ async function destroySandboxUnlocked(
         `  Sandbox '${sandboxName}' is gone, but its managed Hermes state volume '${stateVolumeCleanup.volumeName}' could not be removed: ${redactDestroyError(stateVolumeCleanup.detail)}`,
       );
       console.error("  The sandbox registry entry was preserved so exact cleanup can be retried.");
+      preparedManagedLlamaCppCleanup?.abort();
       process.exit(1);
     }
     if (stateVolumeCleanup.status === "not-owned") {
@@ -679,7 +691,9 @@ async function destroySandboxUnlocked(
   cleanupSandboxServices(sandboxName, {
     stopHostServices: shouldStopHostServices,
   });
-  if (deleteSucceededOrAlreadyGone && commonLlamaCppAuthorityRetired !== true) {
+  if (deleteSucceededOrAlreadyGone && commonLlamaCppAuthorityRetired === true) {
+    preparedManagedLlamaCppCleanup?.abort();
+  } else if (deleteSucceededOrAlreadyGone) {
     // A null pre-delete result proves that no matching legacy owner state was
     // present. Never discover and qualify newly appeared state only after the
     // sandbox boundary; a later destroy retry must preflight that state first.

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -503,6 +503,20 @@ async function destroySandboxUnlocked(
     (registeredSandbox.provider === "llama-cpp-local" &&
       !registeredSandbox.hostLocalInferenceProvenance)
   ) {
+    /**
+     * SOURCE_OF_TRUTH
+     * Invalid state: the sandbox registry row is absent after a partial destroy,
+     * but private managed llama.cpp owner state still requires exact cleanup.
+     * Source boundary: destroy qualifies that private owner, journal, and Docker
+     * operation before crossing the OpenShell sandbox-delete boundary.
+     * Source-fix constraint: destroy cannot reconstruct the missing registry row
+     * or safely select a Docker daemon after deletion, so it may use only the
+     * retained private authority and must fail closed when qualification fails.
+     * Regression proof: destroy-flow.test.ts proves registry-absent preparation
+     * and completion without post-delete authority discovery.
+     * Removal condition: remove this recovery path when sandbox registry
+     * retirement and private managed-runtime retirement are one durable action.
+     */
     try {
       // Fresh Docker qualification reads ambient DOCKER_CONTEXT, DOCKER_HOST,
       // or Docker's persisted currentContext. Pin that selection before

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -502,7 +502,7 @@ async function destroySandboxUnlocked(
   let preparedManagedLlamaCppCleanup: ReturnType<
     typeof prepareManagedLlamaCppRuntimeCleanupForSandbox
   > = null;
-  if (!sandbox?.hostLocalInferenceProvenance) {
+  if (sandbox?.provider === "llama-cpp-local" && !sandbox.hostLocalInferenceProvenance) {
     try {
       // Fresh Docker qualification reads ambient DOCKER_CONTEXT, DOCKER_HOST,
       // or Docker's persisted currentContext. Pin that selection before the

--- a/src/lib/actions/sandbox/destroy.ts
+++ b/src/lib/actions/sandbox/destroy.ts
@@ -21,7 +21,10 @@ import {
   parseHttpsPinRouteId,
   revokeHttpsPinRuntimeAdapterRoute,
 } from "../../inference/https-pin-runtime-adapter";
-import { cleanupManagedLlamaCppRuntimeForSandbox } from "../../inference/local-model-profile/cleanup";
+import {
+  cleanupManagedLlamaCppRuntimeForSandbox,
+  prepareManagedLlamaCppRuntimeCleanupForSandbox,
+} from "../../inference/local-model-profile/cleanup";
 import {
   CURRENT_RUNTIME_PROVIDER_BUNDLES,
   normalizeRuntimeProviderIdentity,
@@ -496,6 +499,25 @@ async function destroySandboxUnlocked(
 
   const { cleanupGatewayName, runOpenshell, sandbox, sandboxConfirmedAbsent } =
     prepareSandboxDestroy(sandboxName);
+  let preparedManagedLlamaCppCleanup: ReturnType<
+    typeof prepareManagedLlamaCppRuntimeCleanupForSandbox
+  > = null;
+  if (!sandbox?.hostLocalInferenceProvenance) {
+    try {
+      // Fresh Docker qualification reads ambient DOCKER_CONTEXT, DOCKER_HOST,
+      // or Docker's persisted currentContext. Pin that selection before the
+      // OpenShell delete boundary so legacy cleanup cannot switch daemons.
+      preparedManagedLlamaCppCleanup = prepareManagedLlamaCppRuntimeCleanupForSandbox(sandboxName, {
+        ...(typeof sandbox?.gatewayPort === "number" ? { gatewayPort: sandbox.gatewayPort } : {}),
+      });
+    } catch (error) {
+      console.error(
+        `  Refusing to destroy sandbox '${sandboxName}': Managed llama.cpp cleanup preflight failed: ${redactDestroyError(error)}`,
+      );
+      console.error(`  The sandbox was not deleted. Fix the reported authority and retry destroy.`);
+      process.exit(1);
+    }
+  }
   // Recheck identity after read-only preflight and before local mutation.
   const preMutationIdentity = inspectContainerIdentity();
   if (
@@ -651,9 +673,11 @@ async function destroySandboxUnlocked(
     stopHostServices: shouldStopHostServices,
   });
   if (deleteSucceededOrAlreadyGone && commonLlamaCppAuthorityRetired !== true) {
-    const managedLlamaCppCleanup = cleanupManagedLlamaCppRuntimeForSandbox(sandboxName, {
-      ...(typeof sandbox?.gatewayPort === "number" ? { gatewayPort: sandbox.gatewayPort } : {}),
-    });
+    const managedLlamaCppCleanup =
+      preparedManagedLlamaCppCleanup?.cleanup() ??
+      cleanupManagedLlamaCppRuntimeForSandbox(sandboxName, {
+        ...(typeof sandbox?.gatewayPort === "number" ? { gatewayPort: sandbox.gatewayPort } : {}),
+      });
     if (!managedLlamaCppCleanup.ok) {
       console.error(
         `  Managed llama.cpp cleanup failed for '${sandboxName}': ${managedLlamaCppCleanup.reason}`,

--- a/src/lib/actions/uninstall/hermes-portable-uninstall.ts
+++ b/src/lib/actions/uninstall/hermes-portable-uninstall.ts
@@ -412,10 +412,7 @@ function loadAuthority(
       inferencePeers,
     );
     if (!admittedAbsence.inference || sharing.disposition === "shared") {
-      assertPreparedHostLocalInferenceRuntimePresent(runtime.bundle, inferenceRow, inference, {
-        environment: input.env,
-        homeDir: input.homeDir,
-      });
+      assertPreparedHostLocalInferenceRuntimePresent(runtime.bundle, inferenceRow, inference);
     }
     const provider = prepareHermesPortableOllamaProviderRetirement({
       directory: runtime.inferenceStateDir,
@@ -515,7 +512,6 @@ export function runHermesPortableUninstall(
             target.runtime.bundle,
             target.inferenceRow,
             target.inference,
-            { environment: input.env, homeDir: input.homeDir },
           );
           continue;
         }
@@ -524,7 +520,6 @@ export function runHermesPortableUninstall(
           target.inferenceRow,
           target.inference,
           target.inferencePeers,
-          { environment: input.env, homeDir: input.homeDir },
         );
         if (result.status === "shared" || result.status === "retained") {
           throw new Error("Hermes Portable inference retirement changed custody");
@@ -543,7 +538,6 @@ export function runHermesPortableUninstall(
             target.runtime.bundle,
             target.inferenceRow,
             target.inference,
-            { environment: input.env, homeDir: input.homeDir },
           );
         }
       }

--- a/src/lib/inference/local-model-profile/cleanup.test-support.ts
+++ b/src/lib/inference/local-model-profile/cleanup.test-support.ts
@@ -40,6 +40,7 @@ function commandResult(status: number, stdout = "", stderr = ""): ContainerEngin
 
 interface EngineHarnessOptions {
   authorityId?: string;
+  containerForeign?: boolean;
   containerPresent?: boolean;
   networkPresent?: boolean;
   daemonInspectFailure?: boolean;
@@ -64,14 +65,16 @@ export function engineHarness(options: EngineHarnessOptions = {}): {
             Id: RUNTIME_ID,
             Name: `/${MANAGED_LLAMA_CPP_CONTAINER_NAME}`,
             Config: {
-              Labels: {
-                [MANAGED_LLAMA_CPP_OWNER_LABEL]: MANAGED_LLAMA_CPP_OWNER_VALUE,
-                "io.nvidia.nemoclaw.host-local-inference.managed": "true",
-                "io.nvidia.nemoclaw.host-local-inference.provider": "docker",
-                "io.nvidia.nemoclaw.host-local-inference.service": "llama-cpp",
-                "io.nvidia.nemoclaw.host-local-inference.spec-sha256": SPEC_SHA256,
-                "io.nvidia.nemoclaw.host-local-inference.transaction-sha256": TRANSACTION_ID,
-              },
+              Labels: options.containerForeign
+                ? {}
+                : {
+                    [MANAGED_LLAMA_CPP_OWNER_LABEL]: MANAGED_LLAMA_CPP_OWNER_VALUE,
+                    "io.nvidia.nemoclaw.host-local-inference.managed": "true",
+                    "io.nvidia.nemoclaw.host-local-inference.provider": "docker",
+                    "io.nvidia.nemoclaw.host-local-inference.service": "llama-cpp",
+                    "io.nvidia.nemoclaw.host-local-inference.spec-sha256": SPEC_SHA256,
+                    "io.nvidia.nemoclaw.host-local-inference.transaction-sha256": TRANSACTION_ID,
+                  },
             },
           },
         ]),

--- a/src/lib/inference/local-model-profile/cleanup.test-support.ts
+++ b/src/lib/inference/local-model-profile/cleanup.test-support.ts
@@ -134,13 +134,14 @@ export function createManagedState(
     phase?: HostLocalCreateJournalPhase;
     gatewayPort?: number;
     createIntentUnixMs?: number;
+    sandboxName?: string;
   } = {},
 ): void {
   const phase = options.phase ?? "finalized";
   const paths = managedLlamaCppStatePaths(homeDir, options.gatewayPort);
   reserveManagedLlamaCppOwner(paths, {
     schemaVersion: 1,
-    sandboxName: "spark-agent",
+    sandboxName: options.sandboxName ?? "spark-agent",
     catalogDigest: `sha256:${"5".repeat(64)}`,
     presetDigest: `sha256:${"6".repeat(64)}`,
     recipeDigest: `sha256:${"7".repeat(64)}`,

--- a/src/lib/inference/local-model-profile/cleanup.test.ts
+++ b/src/lib/inference/local-model-profile/cleanup.test.ts
@@ -791,6 +791,75 @@ describe("host-local model cleanup", () => {
     expect(fs.existsSync(managedLlamaCppStatePaths(homeDir).stateDir)).toBe(true);
   });
 
+  it("refuses an unavailable engine before preparing interrupted cleanup (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine, { phase: "started" });
+    harness.capture.mockClear();
+    harness.capture.mockReturnValue({ status: 1, stdout: "", stderr: "daemon unavailable" });
+
+    expect(() =>
+      prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+        homeDir,
+        engine: harness.engine,
+      }),
+    ).toThrow("engine availability check");
+    expect(harness.capture).toHaveBeenCalledWith(["info"], expect.any(Number));
+    expect(harness.capture).not.toHaveBeenCalledWith(
+      ["rm", "--force", RUNTIME_ID],
+      expect.any(Number),
+    );
+    expect(fs.existsSync(managedLlamaCppStatePaths(homeDir).stateDir)).toBe(true);
+  });
+
+  it("refuses a foreign container before preparing interrupted cleanup (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness({ containerForeign: true });
+    createManagedState(homeDir, harness.engine, { phase: "started" });
+    harness.capture.mockClear();
+
+    expect(() =>
+      prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+        homeDir,
+        engine: harness.engine,
+      }),
+    ).toThrow("container does not match its exact journal");
+    expect(harness.capture).not.toHaveBeenCalledWith(
+      ["rm", "--force", RUNTIME_ID],
+      expect.any(Number),
+    );
+    expect(fs.existsSync(managedLlamaCppStatePaths(homeDir).stateDir)).toBe(true);
+  });
+
+  it("refuses private owner drift after cleanup preparation (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine);
+    const paths = managedLlamaCppStatePaths(homeDir);
+    const prepared = prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+      homeDir,
+      engine: harness.engine,
+    });
+    const owner = fs.readFileSync(paths.ownerPath, "utf8");
+    const parsedOwner = JSON.parse(owner) as Record<string, unknown>;
+    fs.writeFileSync(
+      paths.ownerPath,
+      `${JSON.stringify({ ...parsedOwner, catalogDigest: `sha256:${"0".repeat(64)}` })}\n`,
+      { mode: 0o600 },
+    );
+    harness.capture.mockClear();
+
+    expect(prepared?.cleanup()).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("private authority changed after cleanup preparation"),
+    });
+    expect(harness.capture).not.toHaveBeenCalledWith(
+      ["rm", "--force", RUNTIME_ID],
+      expect.any(Number),
+    );
+    expect(fs.existsSync(paths.stateDir)).toBe(true);
+  });
+
   it("rejects receipt and journal disagreement during pre-delete qualification (#9888)", () => {
     const homeDir = temporaryHome();
     const harness = engineHarness();
@@ -814,6 +883,34 @@ describe("host-local model cleanup", () => {
     ).toThrow("receipt does not match gateway lifecycle authority");
     expect(harness.capture).not.toHaveBeenCalled();
     expect(fs.existsSync(paths.stateDir)).toBe(true);
+  });
+
+  it("reports an incompatible journal before a missing finalized receipt (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine);
+    const paths = managedLlamaCppStatePaths(homeDir);
+    fs.unlinkSync(paths.receiptPath);
+    const journalDirectory = path.join(paths.stateDir, HOST_LOCAL_CREATE_JOURNAL_DIRECTORY);
+    const [entry] = fs.readdirSync(journalDirectory);
+    const journalPath = path.join(journalDirectory, entry!);
+    const record = JSON.parse(fs.readFileSync(journalPath, "utf8")) as Record<string, unknown>;
+    fs.writeFileSync(
+      journalPath,
+      `${JSON.stringify({ ...record, containerName: "foreign-container" })}\n`,
+      { mode: 0o600 },
+    );
+
+    expect(
+      cleanupManagedLlamaCppRuntimeForSandbox("spark-agent", {
+        homeDir,
+        engine: harness.engine,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("lifecycle journal is incompatible"),
+    });
+    expect(harness.capture).not.toHaveBeenCalled();
   });
 
   it("retains the selected engine for an interrupted journal without a receipt (#9888)", () => {

--- a/src/lib/inference/local-model-profile/cleanup.test.ts
+++ b/src/lib/inference/local-model-profile/cleanup.test.ts
@@ -759,6 +759,37 @@ describe("host-local model cleanup", () => {
     expect(fs.existsSync(managedLlamaCppStatePaths(homeDir).stateDir)).toBe(false);
   });
 
+  it("fails closed when the qualified engine becomes unavailable after preparation (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    const privateBridge = privateBridgeFixture();
+    createManagedState(homeDir, harness.engine);
+
+    const prepared = prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+      homeDir,
+      engine: harness.engine,
+      privateBridge,
+    });
+    harness.capture.mockClear();
+    harness.capture.mockReturnValue({
+      status: 1,
+      stdout: "",
+      stderr: "daemon unavailable",
+    });
+
+    expect(prepared).not.toBeNull();
+    expect(prepared!.cleanup()).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("engine availability check"),
+    });
+    expect(harness.capture).toHaveBeenCalledWith(["info"], expect.any(Number));
+    expect(harness.capture).not.toHaveBeenCalledWith(
+      ["rm", "--force", RUNTIME_ID],
+      expect.any(Number),
+    );
+    expect(fs.existsSync(managedLlamaCppStatePaths(homeDir).stateDir)).toBe(true);
+  });
+
   it("retains the selected engine for an interrupted journal without a receipt (#9888)", () => {
     const homeDir = temporaryHome();
     const qualified = engineHarness({ authorityId: "docker:qualified" });

--- a/src/lib/inference/local-model-profile/cleanup.test.ts
+++ b/src/lib/inference/local-model-profile/cleanup.test.ts
@@ -9,14 +9,16 @@ import { afterEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
 import * as dockerLlamaCppOperation from "../../onboard/runtime-provider/docker-llama-cpp-operation";
 import { privateBridgeFixture } from "../../onboard/runtime-provider/docker-llama-cpp-private-bridge.test-support";
-import { createHostLocalCreateJournalStore } from "../../onboard/runtime-provider/host-local-create-journal";
+import {
+  createHostLocalCreateJournalStore,
+  HOST_LOCAL_CREATE_JOURNAL_DIRECTORY,
+} from "../../onboard/runtime-provider/host-local-create-journal";
 import { serializeHostLocalInferenceReceipt } from "../../onboard/runtime-provider/host-local-inference";
 import {
   loadManagedLlamaCppReceipt,
   managedLlamaCppStatePaths,
   reserveManagedLlamaCppOwner,
 } from "../llama-cpp/managed-state";
-import { HOST_LOCAL_CREATE_JOURNAL_DIRECTORY } from "../../onboard/runtime-provider/host-local-create-journal";
 import { PERSISTED_ENGINE_AUTHORITY_DIRECTORY } from "../../onboard/runtime-provider/persisted-engine-authority";
 import { runtimeAuthFingerprint } from "../serving/runtime-auth-fingerprint";
 import {
@@ -858,6 +860,28 @@ describe("host-local model cleanup", () => {
       expect.any(Number),
     );
     expect(fs.existsSync(paths.stateDir)).toBe(true);
+  });
+
+  it("refuses missing private state after cleanup preparation (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine);
+    const paths = managedLlamaCppStatePaths(homeDir);
+    const prepared = prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+      homeDir,
+      engine: harness.engine,
+    });
+    fs.rmSync(paths.stateDir, { recursive: true });
+    harness.capture.mockClear();
+
+    expect(prepared?.cleanup()).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("private authority changed after cleanup preparation"),
+    });
+    expect(harness.capture).not.toHaveBeenCalledWith(
+      ["rm", "--force", RUNTIME_ID],
+      expect.any(Number),
+    );
   });
 
   it("rejects receipt and journal disagreement during pre-delete qualification (#9888)", () => {

--- a/src/lib/inference/local-model-profile/cleanup.test.ts
+++ b/src/lib/inference/local-model-profile/cleanup.test.ts
@@ -665,6 +665,44 @@ describe("host-local model cleanup", () => {
     }
   });
 
+  it("does not prepare sandbox deletion against a live lifecycle execution lease (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine, { phase: "started" });
+    const store = createHostLocalCreateJournalStore(managedLlamaCppStatePaths(homeDir).stateDir);
+    const lease = store.acquireExecution(TRANSACTION_ID);
+    try {
+      expect(() =>
+        prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+          homeDir,
+          engine: harness.engine,
+        }),
+      ).toThrow("live process");
+      expect(harness.capture).not.toHaveBeenCalled();
+    } finally {
+      store.releaseExecution(lease);
+    }
+  });
+
+  it("retains cleanup execution ownership until sandbox deletion is aborted (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine, { phase: "started" });
+    const prepared = prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+      homeDir,
+      engine: harness.engine,
+    });
+    const contender = createHostLocalCreateJournalStore(
+      managedLlamaCppStatePaths(homeDir).stateDir,
+    );
+
+    expect(() => contender.acquireExecution(TRANSACTION_ID)).toThrow("live process");
+    prepared?.abort();
+    const replacement = contender.acquireExecution(TRANSACTION_ID);
+    contender.assertExecution(replacement);
+    contender.releaseExecution(replacement);
+  });
+
   it("re-inspects after removal and retains authority when the container remains", () => {
     const homeDir = temporaryHome();
     const harness = engineHarness({ removalLeavesContainer: true });

--- a/src/lib/inference/local-model-profile/cleanup.test.ts
+++ b/src/lib/inference/local-model-profile/cleanup.test.ts
@@ -862,6 +862,53 @@ describe("host-local model cleanup", () => {
     expect(fs.existsSync(paths.stateDir)).toBe(true);
   });
 
+  it("refuses API-key replacement after cleanup preparation (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine);
+    const paths = managedLlamaCppStatePaths(homeDir);
+    const prepared = prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+      homeDir,
+      engine: harness.engine,
+    });
+    fs.writeFileSync(paths.apiKeyPath, `${"f".repeat(64)}\n`, { mode: 0o600 });
+    harness.capture.mockClear();
+
+    expect(prepared?.cleanup()).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("private authority changed after cleanup preparation"),
+    });
+    expect(fs.existsSync(paths.apiKeyPath)).toBe(true);
+    expect(harness.capture).not.toHaveBeenCalledWith(
+      ["rm", "--force", RUNTIME_ID],
+      expect.any(Number),
+    );
+  });
+
+  it("refuses a new private-state entry after cleanup preparation (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine);
+    const paths = managedLlamaCppStatePaths(homeDir);
+    const prepared = prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+      homeDir,
+      engine: harness.engine,
+    });
+    const concurrentState = path.join(paths.stateDir, "concurrent-state.json");
+    fs.writeFileSync(concurrentState, "{}\n", { mode: 0o600 });
+    harness.capture.mockClear();
+
+    expect(prepared?.cleanup()).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("private authority changed after cleanup preparation"),
+    });
+    expect(fs.existsSync(concurrentState)).toBe(true);
+    expect(harness.capture).not.toHaveBeenCalledWith(
+      ["rm", "--force", RUNTIME_ID],
+      expect.any(Number),
+    );
+  });
+
   it("refuses missing private state after cleanup preparation (#9888)", () => {
     const homeDir = temporaryHome();
     const harness = engineHarness();

--- a/src/lib/inference/local-model-profile/cleanup.test.ts
+++ b/src/lib/inference/local-model-profile/cleanup.test.ts
@@ -909,6 +909,33 @@ describe("host-local model cleanup", () => {
     expect(fs.existsSync(paths.stateDir)).toBe(true);
   });
 
+  it("refuses mixed lifecycle journals during cleanup preparation (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine, { phase: "started" });
+    const paths = managedLlamaCppStatePaths(homeDir);
+    const journalStore = createHostLocalCreateJournalStore(paths.stateDir);
+    const [journal] = journalStore.list();
+    journalStore.create({
+      ...journal!,
+      transactionId: "8".repeat(64),
+      phase: "prepared",
+      service: "ollama",
+      runtimeId: null,
+      createIntentUnixMs: null,
+    });
+    harness.capture.mockClear();
+
+    expect(() =>
+      prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+        homeDir,
+        engine: harness.engine,
+      }),
+    ).toThrow("more than one lifecycle journal");
+    expect(harness.capture).not.toHaveBeenCalled();
+    expect(fs.existsSync(paths.stateDir)).toBe(true);
+  });
+
   it("reports an incompatible journal before a missing finalized receipt (#9888)", () => {
     const homeDir = temporaryHome();
     const harness = engineHarness();

--- a/src/lib/inference/local-model-profile/cleanup.test.ts
+++ b/src/lib/inference/local-model-profile/cleanup.test.ts
@@ -5,11 +5,18 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
+import * as dockerLlamaCppOperation from "../../onboard/runtime-provider/docker-llama-cpp-operation";
 import { privateBridgeFixture } from "../../onboard/runtime-provider/docker-llama-cpp-private-bridge.test-support";
 import { createHostLocalCreateJournalStore } from "../../onboard/runtime-provider/host-local-create-journal";
-import { loadManagedLlamaCppReceipt, managedLlamaCppStatePaths } from "../llama-cpp/managed-state";
+import {
+  loadManagedLlamaCppReceipt,
+  managedLlamaCppStatePaths,
+  reserveManagedLlamaCppOwner,
+} from "../llama-cpp/managed-state";
+import { HOST_LOCAL_CREATE_JOURNAL_DIRECTORY } from "../../onboard/runtime-provider/host-local-create-journal";
+import { PERSISTED_ENGINE_AUTHORITY_DIRECTORY } from "../../onboard/runtime-provider/persisted-engine-authority";
 import { runtimeAuthFingerprint } from "../serving/runtime-auth-fingerprint";
 import {
   HOST_LOCAL_VLLM_AUTH_LABEL,
@@ -30,6 +37,7 @@ import {
   cleanupManagedLlamaCppRuntimeForSandbox,
   finalizeManagedLlamaCppLifecycleCleanup,
   prepareManagedLlamaCppLifecycleCleanup,
+  prepareManagedLlamaCppRuntimeCleanupForSandbox,
   resolveManagedLlamaCppCleanupTarget,
 } from "./cleanup";
 import {
@@ -42,8 +50,11 @@ import {
 } from "./cleanup.test-support";
 
 const temporaryDirectories: string[] = [];
+let createManagedLlamaCppEngineSpy: MockInstance | undefined;
 
 afterEach(() => {
+  createManagedLlamaCppEngineSpy?.mockRestore();
+  createManagedLlamaCppEngineSpy = undefined;
   for (const directory of temporaryDirectories.splice(0)) {
     fs.rmSync(directory, { force: true, recursive: true });
   }
@@ -538,27 +549,24 @@ describe("host-local model cleanup", () => {
     expect(fs.lstatSync(paths.stateDir).isSymbolicLink()).toBe(true);
   });
 
-  it.each([
-    "network-creating",
-    "creating",
-    "created",
-    "started",
-    "receipt-prepared",
-  ] as const)("rolls back an unfinished %s create journal before deleting state", (phase) => {
-    const homeDir = temporaryHome();
-    const harness = engineHarness({ containerPresent: phase !== "network-creating" });
-    createManagedState(homeDir, harness.engine, { phase });
-    const privateBridge = privateBridgeFixture();
+  it.each(["network-creating", "creating", "created", "started", "receipt-prepared"] as const)(
+    "rolls back an unfinished %s create journal before deleting state",
+    (phase) => {
+      const homeDir = temporaryHome();
+      const harness = engineHarness({ containerPresent: phase !== "network-creating" });
+      createManagedState(homeDir, harness.engine, { phase });
+      const privateBridge = privateBridgeFixture();
 
-    const result = cleanupLocalModelRuntimes({
-      homeDir,
-      engine: harness.engine,
-      privateBridge,
-    });
+      const result = cleanupLocalModelRuntimes({
+        homeDir,
+        engine: harness.engine,
+        privateBridge,
+      });
 
-    expect(result).toMatchObject({ ok: true });
-    expect(fs.existsSync(managedLlamaCppStatePaths(homeDir).stateDir)).toBe(false);
-  });
+      expect(result).toMatchObject({ ok: true });
+      expect(fs.existsSync(managedLlamaCppStatePaths(homeDir).stateDir)).toBe(false);
+    },
+  );
 
   it("fails closed on a fresh uncertain create that has no exact container yet", () => {
     const homeDir = temporaryHome();
@@ -716,6 +724,104 @@ describe("host-local model cleanup", () => {
       harness.capture.mock.invocationCallOrder[containerRemovalCall]!,
     );
     expect(fs.existsSync(managedLlamaCppStatePaths(homeDir, gatewayPort).stateDir)).toBe(false);
+  });
+
+  it("retains the qualified engine across delayed sandbox cleanup (#9888)", () => {
+    const homeDir = temporaryHome();
+    const qualified = engineHarness({ authorityId: "docker:qualified" });
+    const drifted = engineHarness({ authorityId: "docker:drifted" });
+    const privateBridge = privateBridgeFixture();
+    createManagedState(homeDir, qualified.engine);
+    let crossedDeleteBoundary = false;
+    const createEngine = (createManagedLlamaCppEngineSpy = vi
+      .spyOn(dockerLlamaCppOperation, "createManagedLlamaCppEngine")
+      .mockImplementation(() => (crossedDeleteBoundary ? drifted.engine : qualified.engine)));
+
+    const prepared = prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+      homeDir,
+      privateBridge,
+    });
+    crossedDeleteBoundary = true;
+
+    expect(prepared).not.toBeNull();
+    expect(prepared!.cleanup()).toMatchObject({ ok: true });
+    expect(createEngine).toHaveBeenCalledOnce();
+    expect(privateBridge.stopTransaction).toHaveBeenCalledWith(TRANSACTION_ID);
+    expect(qualified.capture).toHaveBeenCalledWith(
+      ["rm", "--force", RUNTIME_ID],
+      expect.any(Number),
+    );
+    expect(qualified.capture).toHaveBeenCalledWith(
+      ["network", "rm", NETWORK_ID],
+      expect.any(Number),
+    );
+    expect(drifted.capture).not.toHaveBeenCalled();
+    expect(fs.existsSync(managedLlamaCppStatePaths(homeDir).stateDir)).toBe(false);
+  });
+
+  it("retains the selected engine for an interrupted journal without a receipt (#9888)", () => {
+    const homeDir = temporaryHome();
+    const qualified = engineHarness({ authorityId: "docker:qualified" });
+    const drifted = engineHarness({ authorityId: "docker:drifted" });
+    createManagedState(homeDir, qualified.engine, { phase: "started" });
+    let crossedDeleteBoundary = false;
+    createManagedLlamaCppEngineSpy = vi
+      .spyOn(dockerLlamaCppOperation, "createManagedLlamaCppEngine")
+      .mockImplementation(() => (crossedDeleteBoundary ? drifted.engine : qualified.engine));
+
+    const prepared = prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", { homeDir });
+    crossedDeleteBoundary = true;
+
+    expect(prepared?.cleanup()).toMatchObject({ ok: true });
+    expect(qualified.capture).toHaveBeenCalledWith(
+      ["rm", "--force", RUNTIME_ID],
+      expect.any(Number),
+    );
+    expect(drifted.capture).not.toHaveBeenCalled();
+    expect(fs.existsSync(managedLlamaCppStatePaths(homeDir).stateDir)).toBe(false);
+  });
+
+  it("refuses a drifted engine before deleting an interrupted journal owner (#9888)", () => {
+    const homeDir = temporaryHome();
+    const qualified = engineHarness({ authorityId: "docker:qualified" });
+    const drifted = engineHarness({ authorityId: "docker:drifted" });
+    createManagedState(homeDir, qualified.engine, { phase: "started" });
+    createManagedLlamaCppEngineSpy = vi
+      .spyOn(dockerLlamaCppOperation, "createManagedLlamaCppEngine")
+      .mockReturnValue(drifted.engine);
+
+    expect(() =>
+      prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", { homeDir }),
+    ).toThrow("Qualified container endpoint does not match persisted authority.");
+    expect(drifted.capture).not.toHaveBeenCalled();
+    expect(fs.existsSync(managedLlamaCppStatePaths(homeDir).stateDir)).toBe(true);
+  });
+
+  it("does not create journal or authority directories during owner-only preflight (#9888)", () => {
+    const homeDir = temporaryHome();
+    const paths = managedLlamaCppStatePaths(homeDir);
+    reserveManagedLlamaCppOwner(paths, {
+      schemaVersion: 1,
+      sandboxName: "spark-agent",
+      catalogDigest: `sha256:${"5".repeat(64)}`,
+      presetDigest: `sha256:${"6".repeat(64)}`,
+      recipeDigest: `sha256:${"7".repeat(64)}`,
+      recipeId: "llama-cpp.nemotron.spark.v1",
+    });
+    const harness = engineHarness();
+
+    expect(() =>
+      prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+        homeDir,
+        engine: harness.engine,
+      }),
+    ).toThrow("authority directory is missing");
+    expect(fs.existsSync(path.join(paths.stateDir, HOST_LOCAL_CREATE_JOURNAL_DIRECTORY))).toBe(
+      false,
+    );
+    expect(fs.existsSync(path.join(paths.stateDir, PERSISTED_ENGINE_AUTHORITY_DIRECTORY))).toBe(
+      false,
+    );
   });
 
   it("stops the managed llama.cpp bridge before removing the container it forwards to (#9598)", () => {

--- a/src/lib/inference/local-model-profile/cleanup.test.ts
+++ b/src/lib/inference/local-model-profile/cleanup.test.ts
@@ -703,6 +703,36 @@ describe("host-local model cleanup", () => {
     contender.releaseExecution(replacement);
   });
 
+  it("retains cleanup execution ownership through final private-state removal (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine);
+    const paths = managedLlamaCppStatePaths(homeDir);
+    const prepared = prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+      homeDir,
+      engine: harness.engine,
+    });
+    const contender = createHostLocalCreateJournalStore(paths.stateDir);
+    const remove = fs.rmSync.bind(fs);
+    let contentionError: unknown;
+    let unexpectedLease: unknown;
+    vi.spyOn(fs, "rmSync").mockImplementationOnce(((target, options) => {
+      try {
+        unexpectedLease = contender.acquireExecution("9".repeat(64));
+      } catch (error) {
+        contentionError = error;
+      }
+      return remove(target, options);
+    }) as typeof fs.rmSync);
+
+    expect(prepared?.cleanup()).toMatchObject({ ok: true });
+    expect(contentionError).toEqual(
+      expect.objectContaining({ message: expect.stringContaining("live process") }),
+    );
+    expect(unexpectedLease).toBeUndefined();
+    expect(fs.existsSync(paths.stateDir)).toBe(false);
+  });
+
   it("re-inspects after removal and retains authority when the container remains", () => {
     const homeDir = temporaryHome();
     const harness = engineHarness({ removalLeavesContainer: true });

--- a/src/lib/inference/local-model-profile/cleanup.test.ts
+++ b/src/lib/inference/local-model-profile/cleanup.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it, type MockInstance, vi } from "vitest";
 import * as dockerLlamaCppOperation from "../../onboard/runtime-provider/docker-llama-cpp-operation";
 import { privateBridgeFixture } from "../../onboard/runtime-provider/docker-llama-cpp-private-bridge.test-support";
 import { createHostLocalCreateJournalStore } from "../../onboard/runtime-provider/host-local-create-journal";
+import { serializeHostLocalInferenceReceipt } from "../../onboard/runtime-provider/host-local-inference";
 import {
   loadManagedLlamaCppReceipt,
   managedLlamaCppStatePaths,
@@ -788,6 +789,31 @@ describe("host-local model cleanup", () => {
       expect.any(Number),
     );
     expect(fs.existsSync(managedLlamaCppStatePaths(homeDir).stateDir)).toBe(true);
+  });
+
+  it("rejects receipt and journal disagreement during pre-delete qualification (#9888)", () => {
+    const homeDir = temporaryHome();
+    const harness = engineHarness();
+    createManagedState(homeDir, harness.engine);
+    const paths = managedLlamaCppStatePaths(homeDir);
+    const receipt = loadManagedLlamaCppReceipt(paths)!;
+    fs.writeFileSync(
+      paths.receiptPath,
+      serializeHostLocalInferenceReceipt({
+        ...receipt,
+        endpoint: { ...receipt.endpoint, networkName: "foreign-network" },
+      }),
+      { mode: 0o600 },
+    );
+
+    expect(() =>
+      prepareManagedLlamaCppRuntimeCleanupForSandbox("spark-agent", {
+        homeDir,
+        engine: harness.engine,
+      }),
+    ).toThrow("receipt does not match gateway lifecycle authority");
+    expect(harness.capture).not.toHaveBeenCalled();
+    expect(fs.existsSync(paths.stateDir)).toBe(true);
   });
 
   it("retains the selected engine for an interrupted journal without a receipt (#9888)", () => {

--- a/src/lib/inference/local-model-profile/cleanup.ts
+++ b/src/lib/inference/local-model-profile/cleanup.ts
@@ -397,6 +397,28 @@ function requireManagedLlamaJournal(
   }
 }
 
+function requireManagedLlamaReceiptJournalAgreement(
+  receipt: HostLocalInferenceReceipt,
+  journal: HostLocalCreateJournalRecord,
+  ownerRecipeId: string,
+): void {
+  requireManagedLlamaJournal(journal, ownerRecipeId);
+  if (
+    receipt.service !== "llama-cpp" ||
+    receipt.runtime.kind !== "container" ||
+    receipt.runtime.name !== MANAGED_LLAMA_CPP_CONTAINER_NAME ||
+    receipt.endpoint.networkName !== MANAGED_LLAMA_CPP_NETWORK_NAME ||
+    receipt.runtime.model?.recipeId !== ownerRecipeId ||
+    receipt.runtime.model.generation !== journal.transactionId ||
+    receipt.runtime.runtimeId !== journal.runtimeId ||
+    receipt.runtime.specSha256 !== journal.specSha256 ||
+    JSON.stringify(receipt.engineAuthority) !== JSON.stringify(journal.engineAuthority) ||
+    (journal.phase !== "receipt-prepared" && journal.phase !== "finalized")
+  ) {
+    throw new Error("managed llama.cpp receipt does not match gateway lifecycle authority");
+  }
+}
+
 function requireQualifiedEngine(
   authority: HostLocalCreateJournalRecord["engineAuthority"],
   engine: ContainerEngine,
@@ -531,24 +553,12 @@ function cleanupLlamaCpp(
     throw new Error("managed llama.cpp has more than one lifecycle journal");
   }
   const journal = journals[0]!;
-  requireManagedLlamaJournal(journal, owner.recipeId);
   if (receipt !== null) {
-    if (
-      receipt.service !== "llama-cpp" ||
-      receipt.runtime.kind !== "container" ||
-      receipt.runtime.name !== MANAGED_LLAMA_CPP_CONTAINER_NAME ||
-      receipt.endpoint.networkName !== MANAGED_LLAMA_CPP_NETWORK_NAME ||
-      receipt.runtime.model?.recipeId !== owner.recipeId ||
-      receipt.runtime.model.generation !== journal.transactionId ||
-      receipt.runtime.runtimeId !== journal.runtimeId ||
-      receipt.runtime.specSha256 !== journal.specSha256 ||
-      JSON.stringify(receipt.engineAuthority) !== JSON.stringify(journal.engineAuthority) ||
-      (journal.phase !== "receipt-prepared" && journal.phase !== "finalized")
-    ) {
-      throw new Error("managed llama.cpp receipt does not match gateway lifecycle authority");
-    }
+    requireManagedLlamaReceiptJournalAgreement(receipt, journal, owner.recipeId);
   } else if (journal.phase === "finalized") {
     throw new Error("managed llama.cpp finalized receipt is missing");
+  } else {
+    requireManagedLlamaJournal(journal, owner.recipeId);
   }
 
   const lease = journalStore.acquireExecution(journal.transactionId);
@@ -676,19 +686,24 @@ export function prepareManagedLlamaCppRuntimeCleanupForSandbox(
   if (!owner || owner.sandboxName !== sandboxName) return null;
   const engine = options.engine ?? createManagedLlamaCppEngine(options.env ?? process.env);
   const receipt = loadManagedLlamaCppReceipt(paths);
+  const journals = readHostLocalCreateJournalRecords(paths.stateDir).filter(
+    ({ providerId, service }) => providerId === "docker" && service === "llama-cpp",
+  );
+  if (journals.length > 1) {
+    throw new Error("managed llama.cpp has more than one lifecycle journal");
+  }
   if (receipt !== null) {
+    const journal = journals[0];
+    if (!journal) {
+      throw new Error("managed llama.cpp receipt exists without lifecycle authority");
+    }
+    requireManagedLlamaReceiptJournalAgreement(receipt, journal, owner.recipeId);
     prepareManagedLlamaCppLifecycleCleanup(owner.sandboxName, receipt, {
       ...options,
       homeDir,
       engine,
     });
   } else {
-    const journals = readHostLocalCreateJournalRecords(paths.stateDir).filter(
-      ({ providerId, service }) => providerId === "docker" && service === "llama-cpp",
-    );
-    if (journals.length > 1) {
-      throw new Error("managed llama.cpp has more than one lifecycle journal");
-    }
     const authority =
       journals[0]?.engineAuthority ??
       openFilePersistedEngineAuthorityStore(paths.stateDir).load("host-local-inference");

--- a/src/lib/inference/local-model-profile/cleanup.ts
+++ b/src/lib/inference/local-model-profile/cleanup.ts
@@ -17,10 +17,12 @@ import {
 } from "../../onboard/runtime-provider/docker-llama-cpp-private-bridge";
 import {
   createHostLocalCreateJournalStore,
+  readHostLocalCreateJournalRecords,
   type HostLocalCreateJournalRecord,
 } from "../../onboard/runtime-provider/host-local-create-journal";
 import {
   createFilePersistedEngineAuthorityStore,
+  openFilePersistedEngineAuthorityStore,
   requirePersistedEngineAuthority,
 } from "../../onboard/runtime-provider/persisted-engine-authority";
 import {
@@ -643,6 +645,67 @@ export interface ManagedLlamaCppSandboxCleanupOptions {
 
 export interface ManagedLlamaCppLifecycleCleanupOptions extends ManagedLlamaCppSandboxCleanupOptions {
   readonly privateBridge?: DockerLlamaCppPrivateBridgeController;
+}
+
+export interface PreparedManagedLlamaCppRuntimeCleanup {
+  readonly cleanup: () => LocalModelRuntimeCleanupResult;
+}
+
+/**
+ * Qualify legacy sandbox-scoped cleanup before deletion. Docker qualification
+ * reads ambient DOCKER_CONTEXT, DOCKER_HOST, or persisted currentContext, so
+ * the returned capability retains that exact selection across the OpenShell
+ * delete boundary and revalidates its endpoint and private ownership at use.
+ */
+export function prepareManagedLlamaCppRuntimeCleanupForSandbox(
+  sandboxName: string,
+  options: ManagedLlamaCppSandboxCleanupOptions = {},
+): PreparedManagedLlamaCppRuntimeCleanup | null {
+  const homeDir = canonicalCleanupHomeDir(options.homeDir ?? os.homedir());
+  const paths = managedLlamaCppStatePaths(homeDir, options.gatewayPort);
+  if (!statePathExists(paths.stateDir)) return null;
+  const currentUserId =
+    options.deps?.currentUserId === undefined
+      ? typeof process.getuid === "function"
+        ? process.getuid()
+        : null
+      : options.deps.currentUserId;
+  requirePrivateManagedState(paths, currentUserId);
+  if (!fs.existsSync(paths.ownerPath)) return null;
+  const owner = loadManagedLlamaCppOwner(paths);
+  if (!owner || owner.sandboxName !== sandboxName) return null;
+  const engine = options.engine ?? createManagedLlamaCppEngine(options.env ?? process.env);
+  const receipt = loadManagedLlamaCppReceipt(paths);
+  if (receipt !== null) {
+    prepareManagedLlamaCppLifecycleCleanup(owner.sandboxName, receipt, {
+      ...options,
+      homeDir,
+      engine,
+    });
+  } else {
+    const journals = readHostLocalCreateJournalRecords(paths.stateDir).filter(
+      ({ providerId, service }) => providerId === "docker" && service === "llama-cpp",
+    );
+    if (journals.length > 1) {
+      throw new Error("managed llama.cpp has more than one lifecycle journal");
+    }
+    const authority =
+      journals[0]?.engineAuthority ??
+      openFilePersistedEngineAuthorityStore(paths.stateDir).load("host-local-inference");
+    if (authority === null) {
+      throw new Error("managed llama.cpp engine authority is missing while ownership remains");
+    }
+    if (journals[0]) requireManagedLlamaJournal(journals[0], owner.recipeId);
+    requireQualifiedEngine(authority, engine);
+  }
+  return Object.freeze({
+    cleanup: () =>
+      cleanupManagedLlamaCppRuntimeForSandbox(sandboxName, {
+        ...options,
+        homeDir,
+        engine,
+      }),
+  });
 }
 
 function requireManagedLlamaCppLifecycleCleanupReceipt(

--- a/src/lib/inference/local-model-profile/cleanup.ts
+++ b/src/lib/inference/local-model-profile/cleanup.ts
@@ -427,20 +427,27 @@ function managedLlamaCppPrivateAuthoritySha256(paths: ManagedLlamaCppStatePaths)
   const owner = loadManagedLlamaCppOwner(paths);
   const receipt = loadManagedLlamaCppReceipt(paths);
   const journals = reconcileAndReadHostLocalCreateJournalRecords(paths.stateDir);
-  const authorityDirectory = path.join(paths.stateDir, PERSISTED_ENGINE_AUTHORITY_DIRECTORY);
-  const authority = statePathExists(authorityDirectory)
-    ? openFilePersistedEngineAuthorityStore(paths.stateDir).load("host-local-inference")
-    : null;
+  const authority = serializedManagedLlamaCppPersistedAuthority(paths);
   return createHash("sha256")
     .update(
       JSON.stringify({
         owner,
         receipt: receipt === null ? null : serializeHostLocalInferenceReceipt(receipt),
         journals: journals.map(serializeHostLocalCreateJournalRecord),
-        authority: authority === null ? null : serializePersistedEngineAuthority(authority),
+        authority,
       }),
     )
     .digest("hex");
+}
+
+function serializedManagedLlamaCppPersistedAuthority(
+  paths: ManagedLlamaCppStatePaths,
+): string | null {
+  const authorityDirectory = path.join(paths.stateDir, PERSISTED_ENGINE_AUTHORITY_DIRECTORY);
+  const authority = statePathExists(authorityDirectory)
+    ? openFilePersistedEngineAuthorityStore(paths.stateDir).load("host-local-inference")
+    : null;
+  return authority === null ? null : serializePersistedEngineAuthority(authority);
 }
 
 function requireManagedLlamaCppPrivateAuthority(
@@ -602,10 +609,18 @@ function cleanupLlamaCpp(
   requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
 
   const receipt = loadManagedLlamaCppReceipt(paths);
+  const persistedAuthority = serializedManagedLlamaCppPersistedAuthority(paths);
   const journalStore = createHostLocalCreateJournalStore(paths.stateDir);
-  const journals = journalStore
-    .list()
-    .filter(({ providerId, service }) => providerId === "docker" && service === "llama-cpp");
+  const journalRecords = journalStore.list();
+  const journals = journalRecords.filter(
+    ({ providerId, service }) => providerId === "docker" && service === "llama-cpp",
+  );
+  if (journalRecords.length > 1) {
+    throw new Error("managed llama.cpp has more than one lifecycle journal");
+  }
+  if (journalRecords.length !== journals.length) {
+    throw new Error("managed llama.cpp has an incompatible lifecycle journal");
+  }
   if (journals.length === 0) {
     if (receipt !== null) {
       throw new Error("managed llama.cpp receipt exists without lifecycle authority");
@@ -645,9 +660,6 @@ function cleanupLlamaCpp(
     fs.rmSync(paths.stateDir, { recursive: true });
     removed.push(`state:${paths.stateDir}`);
     return true;
-  }
-  if (journals.length > 1) {
-    throw new Error("managed llama.cpp has more than one lifecycle journal");
   }
   const journal = journals[0]!;
   if (receipt !== null) {
@@ -713,6 +725,7 @@ function cleanupLlamaCpp(
       : finalReceipt === null ||
         serializeHostLocalInferenceReceipt(finalReceipt) !==
           serializeHostLocalInferenceReceipt(receipt)) ||
+    serializedManagedLlamaCppPersistedAuthority(paths) !== persistedAuthority ||
     journalStore.list().length !== 0
   ) {
     throw new Error("managed llama.cpp state changed during exact cleanup");
@@ -768,8 +781,11 @@ export function prepareManagedLlamaCppRuntimeCleanupForSandbox(
   const journals = journalRecords.filter(
     ({ providerId, service }) => providerId === "docker" && service === "llama-cpp",
   );
-  if (journals.length > 1) {
+  if (journalRecords.length > 1) {
     throw new Error("managed llama.cpp has more than one lifecycle journal");
+  }
+  if (journalRecords.length !== journals.length) {
+    throw new Error("managed llama.cpp has an incompatible lifecycle journal");
   }
   if (receipt !== null) {
     const journal = journals[0];

--- a/src/lib/inference/local-model-profile/cleanup.ts
+++ b/src/lib/inference/local-model-profile/cleanup.ts
@@ -21,7 +21,9 @@ import {
   HOST_LOCAL_CREATE_JOURNAL_DIRECTORY,
   reconcileAndReadHostLocalCreateJournalRecords,
   serializeHostLocalCreateJournalRecord,
+  type HostLocalCreateJournalExecutionLease,
   type HostLocalCreateJournalRecord,
+  type HostLocalCreateJournalStore,
 } from "../../onboard/runtime-provider/host-local-create-journal";
 import {
   createFilePersistedEngineAuthorityStore,
@@ -438,6 +440,42 @@ interface ManagedLlamaCppPrivateAuthority {
   readonly staticStateSha256: string;
 }
 
+interface ManagedLlamaCppExecutionOwnership {
+  readonly lease: HostLocalCreateJournalExecutionLease;
+  readonly assert: () => void;
+  readonly release: () => void;
+}
+
+function acquireManagedLlamaCppExecutionOwnership(
+  store: HostLocalCreateJournalStore,
+  transactionId: string,
+  stateDir: string,
+): ManagedLlamaCppExecutionOwnership {
+  const lease = store.acquireExecution(transactionId);
+  const leasePath = path.join(
+    stateDir,
+    HOST_LOCAL_CREATE_JOURNAL_DIRECTORY,
+    ".execution-lease.json",
+  );
+  let held = true;
+  return Object.freeze({
+    lease,
+    assert: () => {
+      if (!held) throw new Error("managed llama.cpp execution ownership was already released");
+      store.assertExecution(lease);
+    },
+    release: () => {
+      if (!held) return;
+      if (!statePathExists(leasePath)) {
+        held = false;
+        return;
+      }
+      store.releaseExecution(lease);
+      held = false;
+    },
+  });
+}
+
 interface ManagedLlamaCppPrivateStateEntry {
   readonly path: string;
   readonly kind: "directory" | "file";
@@ -741,6 +779,7 @@ function cleanupLlamaCpp(
     engine?: ContainerEngine;
     privateBridge?: DockerLlamaCppPrivateBridgeController;
     expectedPrivateAuthority?: ManagedLlamaCppPrivateAuthority;
+    executionOwnership?: ManagedLlamaCppExecutionOwnership;
   } = {},
 ): boolean {
   const paths = managedLlamaCppStatePaths(homeDir, options.gatewayPort);
@@ -831,9 +870,14 @@ function cleanupLlamaCpp(
     }
   }
 
-  const lease = journalStore.acquireExecution(journal.transactionId);
+  const executionOwnership =
+    options.executionOwnership ??
+    acquireManagedLlamaCppExecutionOwnership(journalStore, journal.transactionId, paths.stateDir);
+  if (executionOwnership.lease.transactionId !== journal.transactionId) {
+    throw new Error("managed llama.cpp execution ownership changed after cleanup preparation");
+  }
   try {
-    journalStore.assertExecution(lease);
+    executionOwnership.assert();
     requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthority);
     const privateBridge =
       options.privateBridge ??
@@ -842,17 +886,17 @@ function cleanupLlamaCpp(
       privateBridge.stopTransaction(journal.transactionId);
       privateBridge.assertStopped(journal.transactionId);
     }
-    journalStore.assertExecution(lease);
+    executionOwnership.assert();
     const engine = options.engine ?? createManagedLlamaCppEngine(options.env ?? process.env);
     requireQualifiedEngine(receipt?.engineAuthority ?? journal.engineAuthority, engine);
     requireEngineSuccess(
       "engine availability check",
       engine.capture(["info"], DOCKER_INSPECT_TIMEOUT_MS),
     );
-    journalStore.assertExecution(lease);
+    executionOwnership.assert();
     requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthority);
     removeExactContainerForJournal(engine, journal, removed);
-    journalStore.assertExecution(lease);
+    executionOwnership.assert();
     requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthority);
     let network = inspectExactNetworkForJournal(engine, journal);
     if (network.kind === "owned") {
@@ -868,12 +912,12 @@ function cleanupLlamaCpp(
     if (network.kind !== "absent") {
       throw new Error("managed llama.cpp network removal was not proven exact and absent");
     }
-    journalStore.assertExecution(lease);
+    executionOwnership.assert();
     requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthority);
     journalStore.retire(journal.transactionId);
-    journalStore.assertExecution(lease);
+    executionOwnership.assert();
   } finally {
-    journalStore.releaseExecution(lease);
+    executionOwnership.release();
   }
 
   requirePrivateManagedState(paths, deps.currentUserId);
@@ -910,7 +954,25 @@ export interface ManagedLlamaCppLifecycleCleanupOptions extends ManagedLlamaCppS
 }
 
 export interface PreparedManagedLlamaCppRuntimeCleanup {
+  readonly abort: () => void;
   readonly cleanup: () => LocalModelRuntimeCleanupResult;
+}
+
+function managedLlamaCppJournalRecords(paths: ManagedLlamaCppStatePaths): {
+  readonly records: readonly HostLocalCreateJournalRecord[];
+  readonly journals: readonly HostLocalCreateJournalRecord[];
+} {
+  const records = reconcileAndReadHostLocalCreateJournalRecords(paths.stateDir);
+  const journals = records.filter(
+    ({ providerId, service }) => providerId === "docker" && service === "llama-cpp",
+  );
+  if (records.length > 1) {
+    throw new Error("managed llama.cpp has more than one lifecycle journal");
+  }
+  if (records.length !== journals.length) {
+    throw new Error("managed llama.cpp has an incompatible lifecycle journal");
+  }
+  return { records, journals };
 }
 
 /**
@@ -936,81 +998,113 @@ export function prepareManagedLlamaCppRuntimeCleanupForSandbox(
   if (!fs.existsSync(paths.ownerPath)) return null;
   const owner = loadManagedLlamaCppOwner(paths);
   if (!owner || owner.sandboxName !== sandboxName) return null;
-  // Pin the complete private-state baseline before proving any external
-  // resource. Recheck it after proof so a concurrent lifecycle replacement
-  // cannot become the accepted post-proof baseline.
-  const expectedPrivateAuthority = managedLlamaCppPrivateAuthority(paths);
-  const engine = options.engine ?? createManagedLlamaCppEngine(options.env ?? process.env);
-  const receipt = loadManagedLlamaCppReceipt(paths);
-  const journalRecords = reconcileAndReadHostLocalCreateJournalRecords(paths.stateDir);
-  const journals = journalRecords.filter(
-    ({ providerId, service }) => providerId === "docker" && service === "llama-cpp",
-  );
-  if (journalRecords.length > 1) {
-    throw new Error("managed llama.cpp has more than one lifecycle journal");
-  }
-  if (journalRecords.length !== journals.length) {
-    throw new Error("managed llama.cpp has an incompatible lifecycle journal");
-  }
-  if (receipt !== null) {
-    const journal = journals[0];
-    if (!journal) {
-      throw new Error("managed llama.cpp receipt exists without lifecycle authority");
+  const initial = managedLlamaCppJournalRecords(paths);
+  const journalStore = createHostLocalCreateJournalStore(paths.stateDir);
+  const executionOwnership = initial.journals[0]
+    ? acquireManagedLlamaCppExecutionOwnership(
+        journalStore,
+        initial.journals[0].transactionId,
+        paths.stateDir,
+      )
+    : undefined;
+  try {
+    // Pin private state while holding lifecycle execution ownership, then
+    // recheck it after external proof so the capability owns one generation.
+    const expectedPrivateAuthority = managedLlamaCppPrivateAuthority(paths);
+    const engine = options.engine ?? createManagedLlamaCppEngine(options.env ?? process.env);
+    const receipt = loadManagedLlamaCppReceipt(paths);
+    const { journals } = managedLlamaCppJournalRecords(paths);
+    if (
+      executionOwnership &&
+      journals[0]?.transactionId !== executionOwnership.lease.transactionId
+    ) {
+      throw new Error("managed llama.cpp lifecycle journal changed during cleanup preparation");
     }
-    requireManagedLlamaReceiptJournalAgreement(receipt, journal, owner.recipeId);
-    prepareManagedLlamaCppLifecycleCleanup(owner.sandboxName, receipt, {
-      ...options,
-      homeDir,
-      engine,
-    });
-  } else {
-    const authority =
-      journals[0]?.engineAuthority ??
-      openFilePersistedEngineAuthorityStore(paths.stateDir).load("host-local-inference");
-    if (authority === null) {
-      throw new Error("managed llama.cpp engine authority is missing while ownership remains");
-    }
-    if (journals[0]) {
-      requireManagedLlamaJournal(journals[0], owner.recipeId);
-      if (journals[0].phase === "finalized") {
-        throw new Error("managed llama.cpp finalized receipt is missing");
+    if (receipt !== null) {
+      const journal = journals[0];
+      if (!journal) {
+        throw new Error("managed llama.cpp receipt exists without lifecycle authority");
       }
-    }
-    requireQualifiedEngine(authority, engine);
-    requireEngineSuccess(
-      "engine availability check",
-      engine.capture(["info"], DOCKER_INSPECT_TIMEOUT_MS),
-    );
-    if (journals[0]) {
-      inspectExactContainerForJournal(engine, journals[0]);
-      inspectExactNetworkForJournal(engine, journals[0]);
-    } else {
-      const container = inspectOwnedLlamaResource(
+      requireManagedLlamaReceiptJournalAgreement(receipt, journal, owner.recipeId);
+      prepareManagedLlamaCppLifecycleCleanup(owner.sandboxName, receipt, {
+        ...options,
+        homeDir,
         engine,
-        "container",
-        MANAGED_LLAMA_CPP_CONTAINER_NAME,
+      });
+    } else {
+      const authority =
+        journals[0]?.engineAuthority ??
+        openFilePersistedEngineAuthorityStore(paths.stateDir).load("host-local-inference");
+      if (authority === null) {
+        throw new Error("managed llama.cpp engine authority is missing while ownership remains");
+      }
+      if (journals[0]) {
+        requireManagedLlamaJournal(journals[0], owner.recipeId);
+        if (journals[0].phase === "finalized") {
+          throw new Error("managed llama.cpp finalized receipt is missing");
+        }
+      }
+      requireQualifiedEngine(authority, engine);
+      requireEngineSuccess(
+        "engine availability check",
+        engine.capture(["info"], DOCKER_INSPECT_TIMEOUT_MS),
       );
-      const network = inspectOwnedLlamaResource(engine, "network", MANAGED_LLAMA_CPP_NETWORK_NAME);
-      if (container.kind !== "absent" || network.kind !== "absent") {
-        throw new Error(
-          "managed llama.cpp pre-start cleanup cannot prove its fixed runtime names absent",
+      if (journals[0]) {
+        inspectExactContainerForJournal(engine, journals[0]);
+        inspectExactNetworkForJournal(engine, journals[0]);
+      } else {
+        const container = inspectOwnedLlamaResource(
+          engine,
+          "container",
+          MANAGED_LLAMA_CPP_CONTAINER_NAME,
         );
+        const network = inspectOwnedLlamaResource(
+          engine,
+          "network",
+          MANAGED_LLAMA_CPP_NETWORK_NAME,
+        );
+        if (container.kind !== "absent" || network.kind !== "absent") {
+          throw new Error(
+            "managed llama.cpp pre-start cleanup cannot prove its fixed runtime names absent",
+          );
+        }
       }
     }
+    requireManagedLlamaCppPrivateAuthority(paths, expectedPrivateAuthority);
+    executionOwnership?.assert();
+    let settled = false;
+    return Object.freeze({
+      abort: () => {
+        if (settled) return;
+        executionOwnership?.release();
+        settled = true;
+      },
+      cleanup: () => {
+        if (settled) {
+          return {
+            ok: false,
+            reason: "managed llama.cpp cleanup capability was already settled",
+            removed: [],
+            preserved: [],
+          };
+        }
+        settled = true;
+        try {
+          return cleanupManagedLlamaCppRuntimeForSandboxInternal(
+            sandboxName,
+            { ...options, homeDir, engine },
+            expectedPrivateAuthority,
+            executionOwnership,
+          );
+        } finally {
+          executionOwnership?.release();
+        }
+      },
+    });
+  } catch (error) {
+    executionOwnership?.release();
+    throw error;
   }
-  requireManagedLlamaCppPrivateAuthority(paths, expectedPrivateAuthority);
-  return Object.freeze({
-    cleanup: () =>
-      cleanupManagedLlamaCppRuntimeForSandboxInternal(
-        sandboxName,
-        {
-          ...options,
-          homeDir,
-          engine,
-        },
-        expectedPrivateAuthority,
-      ),
-  });
 }
 
 function requireManagedLlamaCppLifecycleCleanupReceipt(
@@ -1258,6 +1352,7 @@ function cleanupManagedLlamaCppRuntimeForSandboxInternal(
   sandboxName: string,
   options: ManagedLlamaCppSandboxCleanupOptions = {},
   expectedPrivateAuthority?: ManagedLlamaCppPrivateAuthority,
+  executionOwnership?: ManagedLlamaCppExecutionOwnership,
 ): LocalModelRuntimeCleanupResult {
   const deps: CleanupDeps = {
     capture: options.deps?.capture ?? dockerCapture,
@@ -1302,6 +1397,7 @@ function cleanupManagedLlamaCppRuntimeForSandboxInternal(
       engine: options.engine,
       privateBridge: options.privateBridge,
       expectedPrivateAuthority,
+      executionOwnership,
     });
     preserveSharedHuggingFaceCache(homeDir, preserved);
     return { ok: true, removed, preserved };

--- a/src/lib/inference/local-model-profile/cleanup.ts
+++ b/src/lib/inference/local-model-profile/cleanup.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -17,13 +18,16 @@ import {
 } from "../../onboard/runtime-provider/docker-llama-cpp-private-bridge";
 import {
   createHostLocalCreateJournalStore,
-  readHostLocalCreateJournalRecords,
+  reconcileAndReadHostLocalCreateJournalRecords,
+  serializeHostLocalCreateJournalRecord,
   type HostLocalCreateJournalRecord,
 } from "../../onboard/runtime-provider/host-local-create-journal";
 import {
   createFilePersistedEngineAuthorityStore,
   openFilePersistedEngineAuthorityStore,
+  PERSISTED_ENGINE_AUTHORITY_DIRECTORY,
   requirePersistedEngineAuthority,
+  serializePersistedEngineAuthority,
 } from "../../onboard/runtime-provider/persisted-engine-authority";
 import {
   MANAGED_LLAMA_CPP_CONTAINER_NAME,
@@ -419,6 +423,38 @@ function requireManagedLlamaReceiptJournalAgreement(
   }
 }
 
+function managedLlamaCppPrivateAuthoritySha256(paths: ManagedLlamaCppStatePaths): string {
+  const owner = loadManagedLlamaCppOwner(paths);
+  const receipt = loadManagedLlamaCppReceipt(paths);
+  const journals = reconcileAndReadHostLocalCreateJournalRecords(paths.stateDir);
+  const authorityDirectory = path.join(paths.stateDir, PERSISTED_ENGINE_AUTHORITY_DIRECTORY);
+  const authority = statePathExists(authorityDirectory)
+    ? openFilePersistedEngineAuthorityStore(paths.stateDir).load("host-local-inference")
+    : null;
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        owner,
+        receipt: receipt === null ? null : serializeHostLocalInferenceReceipt(receipt),
+        journals: journals.map(serializeHostLocalCreateJournalRecord),
+        authority: authority === null ? null : serializePersistedEngineAuthority(authority),
+      }),
+    )
+    .digest("hex");
+}
+
+function requireManagedLlamaCppPrivateAuthority(
+  paths: ManagedLlamaCppStatePaths,
+  expectedSha256: string | undefined,
+): void {
+  if (
+    expectedSha256 !== undefined &&
+    managedLlamaCppPrivateAuthoritySha256(paths) !== expectedSha256
+  ) {
+    throw new Error("managed llama.cpp private authority changed after cleanup preparation");
+  }
+}
+
 function requireQualifiedEngine(
   authority: HostLocalCreateJournalRecord["engineAuthority"],
   engine: ContainerEngine,
@@ -426,11 +462,10 @@ function requireQualifiedEngine(
   requirePersistedEngineAuthority(authority, "docker", engine, dockerLlamaCppBindingSha256(engine));
 }
 
-function removeExactContainerForJournal(
+function inspectExactContainerForJournal(
   engine: ContainerEngine,
   journal: HostLocalCreateJournalRecord,
-  removed: string[],
-): void {
+): InspectedResource {
   const expectedLabels = {
     [LLAMA_MANAGED_LABEL]: "true",
     [LLAMA_PROVIDER_LABEL]: "docker",
@@ -448,10 +483,10 @@ function removeExactContainerForJournal(
     if (unexpected.kind !== "absent") {
       throw new Error("managed llama.cpp pre-container journal unexpectedly has a container");
     }
-    return;
+    return unexpected;
   }
   const target = journal.runtimeId ?? journal.containerName;
-  let inspected = inspectOwnedLlamaResource(
+  const inspected = inspectOwnedLlamaResource(
     engine,
     "container",
     target,
@@ -473,16 +508,60 @@ function removeExactContainerForJournal(
     if (journal.runtimeId !== null && inspected.id !== journal.runtimeId) {
       throw new Error("managed llama.cpp container identity changed from its exact journal");
     }
+  }
+  return inspected;
+}
+
+function removeExactContainerForJournal(
+  engine: ContainerEngine,
+  journal: HostLocalCreateJournalRecord,
+  removed: string[],
+): void {
+  const inspected = inspectExactContainerForJournal(engine, journal);
+  if (inspected.kind === "owned") {
     requireEngineSuccess(
       "container removal",
       engine.capture(["rm", "--force", inspected.id], DOCKER_MUTATION_TIMEOUT_MS),
     );
     removed.push(`container:${inspected.id}`);
   }
-  inspected = inspectOwnedLlamaResource(engine, "container", journal.containerName, expectedLabels);
-  if (inspected.kind !== "absent") {
+  const after = inspectOwnedLlamaResource(engine, "container", journal.containerName, {
+    [LLAMA_MANAGED_LABEL]: "true",
+    [LLAMA_PROVIDER_LABEL]: "docker",
+    [LLAMA_SERVICE_LABEL]: "llama-cpp",
+    [LLAMA_SPEC_LABEL]: journal.specSha256,
+    [LLAMA_TRANSACTION_LABEL]: journal.transactionId,
+  });
+  if (after.kind !== "absent") {
     throw new Error("managed llama.cpp container removal was not proven exact and absent");
   }
+}
+
+function inspectExactNetworkForJournal(
+  engine: ContainerEngine,
+  journal: HostLocalCreateJournalRecord,
+): InspectedResource {
+  const network = inspectOwnedLlamaResource(engine, "network", MANAGED_LLAMA_CPP_NETWORK_NAME, {
+    [LLAMA_NETWORK_TRANSACTION_LABEL]: journal.transactionId,
+  });
+  if (
+    journal.phase === "network-creating" &&
+    network.kind === "absent" &&
+    (journal.createIntentUnixMs === null ||
+      Date.now() - journal.createIntentUnixMs < UNCERTAIN_CREATE_ABSENCE_GRACE_MS)
+  ) {
+    throw new Error(
+      "managed llama.cpp uncertain network create remains inside its absence grace period",
+    );
+  }
+  if (
+    network.kind === "foreign" ||
+    (network.kind === "owned" && journal.networkId !== null && network.id !== journal.networkId) ||
+    (journal.phase !== "network-creating" && journal.networkId === null)
+  ) {
+    throw new Error("managed llama.cpp network does not match its exact journal");
+  }
+  return network;
 }
 
 function cleanupLlamaCpp(
@@ -495,15 +574,32 @@ function cleanupLlamaCpp(
     env?: NodeJS.ProcessEnv;
     engine?: ContainerEngine;
     privateBridge?: DockerLlamaCppPrivateBridgeController;
+    expectedPrivateAuthoritySha256?: string;
   } = {},
 ): boolean {
   const paths = managedLlamaCppStatePaths(homeDir, options.gatewayPort);
-  if (!statePathExists(paths.stateDir)) return false;
+  if (!statePathExists(paths.stateDir)) {
+    if (options.expectedPrivateAuthoritySha256 !== undefined) {
+      throw new Error("managed llama.cpp private authority changed after cleanup preparation");
+    }
+    return false;
+  }
   requirePrivateManagedState(paths, deps.currentUserId);
-  if (!fs.existsSync(paths.ownerPath)) return false;
+  if (!fs.existsSync(paths.ownerPath)) {
+    if (options.expectedPrivateAuthoritySha256 !== undefined) {
+      throw new Error("managed llama.cpp private authority changed after cleanup preparation");
+    }
+    return false;
+  }
   const owner = loadManagedLlamaCppOwner(paths);
   if (!owner) throw new Error("managed llama.cpp owner state is missing");
-  if (options.sandboxName !== undefined && owner.sandboxName !== options.sandboxName) return false;
+  if (options.sandboxName !== undefined && owner.sandboxName !== options.sandboxName) {
+    if (options.expectedPrivateAuthoritySha256 !== undefined) {
+      throw new Error("managed llama.cpp private authority changed after cleanup preparation");
+    }
+    return false;
+  }
+  requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
 
   const receipt = loadManagedLlamaCppReceipt(paths);
   const journalStore = createHostLocalCreateJournalStore(paths.stateDir);
@@ -545,6 +641,7 @@ function cleanupLlamaCpp(
     ) {
       throw new Error("managed llama.cpp state changed during pre-start cleanup");
     }
+    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
     fs.rmSync(paths.stateDir, { recursive: true });
     removed.push(`state:${paths.stateDir}`);
     return true;
@@ -555,15 +652,17 @@ function cleanupLlamaCpp(
   const journal = journals[0]!;
   if (receipt !== null) {
     requireManagedLlamaReceiptJournalAgreement(receipt, journal, owner.recipeId);
-  } else if (journal.phase === "finalized") {
-    throw new Error("managed llama.cpp finalized receipt is missing");
   } else {
     requireManagedLlamaJournal(journal, owner.recipeId);
+    if (journal.phase === "finalized") {
+      throw new Error("managed llama.cpp finalized receipt is missing");
+    }
   }
 
   const lease = journalStore.acquireExecution(journal.transactionId);
   try {
     journalStore.assertExecution(lease);
+    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
     const privateBridge =
       options.privateBridge ??
       (process.platform === "linux" ? createDockerLlamaCppPrivateBridgeController() : undefined);
@@ -579,36 +678,11 @@ function cleanupLlamaCpp(
       engine.capture(["info"], DOCKER_INSPECT_TIMEOUT_MS),
     );
     journalStore.assertExecution(lease);
+    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
     removeExactContainerForJournal(engine, journal, removed);
     journalStore.assertExecution(lease);
-    const expectedNetworkLabels = {
-      [LLAMA_NETWORK_TRANSACTION_LABEL]: journal.transactionId,
-    };
-    let network = inspectOwnedLlamaResource(
-      engine,
-      "network",
-      MANAGED_LLAMA_CPP_NETWORK_NAME,
-      expectedNetworkLabels,
-    );
-    if (
-      journal.phase === "network-creating" &&
-      network.kind === "absent" &&
-      (journal.createIntentUnixMs === null ||
-        Date.now() - journal.createIntentUnixMs < UNCERTAIN_CREATE_ABSENCE_GRACE_MS)
-    ) {
-      throw new Error(
-        "managed llama.cpp uncertain network create remains inside its absence grace period",
-      );
-    }
-    if (
-      network.kind === "foreign" ||
-      (network.kind === "owned" &&
-        journal.networkId !== null &&
-        network.id !== journal.networkId) ||
-      (journal.phase !== "network-creating" && journal.networkId === null)
-    ) {
-      throw new Error("managed llama.cpp network does not match its exact journal");
-    }
+    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
+    let network = inspectExactNetworkForJournal(engine, journal);
     if (network.kind === "owned") {
       requireEngineSuccess(
         "network removal",
@@ -616,16 +690,14 @@ function cleanupLlamaCpp(
       );
       removed.push(`network:${network.id}`);
     }
-    network = inspectOwnedLlamaResource(
-      engine,
-      "network",
-      MANAGED_LLAMA_CPP_NETWORK_NAME,
-      expectedNetworkLabels,
-    );
+    network = inspectOwnedLlamaResource(engine, "network", MANAGED_LLAMA_CPP_NETWORK_NAME, {
+      [LLAMA_NETWORK_TRANSACTION_LABEL]: journal.transactionId,
+    });
     if (network.kind !== "absent") {
       throw new Error("managed llama.cpp network removal was not proven exact and absent");
     }
     journalStore.assertExecution(lease);
+    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
     journalStore.retire(journal.transactionId);
     journalStore.assertExecution(lease);
   } finally {
@@ -633,8 +705,14 @@ function cleanupLlamaCpp(
   }
 
   requirePrivateManagedState(paths, deps.currentUserId);
+  const finalReceipt = loadManagedLlamaCppReceipt(paths);
   if (
     JSON.stringify(loadManagedLlamaCppOwner(paths)) !== JSON.stringify(owner) ||
+    (receipt === null
+      ? finalReceipt !== null
+      : finalReceipt === null ||
+        serializeHostLocalInferenceReceipt(finalReceipt) !==
+          serializeHostLocalInferenceReceipt(receipt)) ||
     journalStore.list().length !== 0
   ) {
     throw new Error("managed llama.cpp state changed during exact cleanup");
@@ -686,7 +764,8 @@ export function prepareManagedLlamaCppRuntimeCleanupForSandbox(
   if (!owner || owner.sandboxName !== sandboxName) return null;
   const engine = options.engine ?? createManagedLlamaCppEngine(options.env ?? process.env);
   const receipt = loadManagedLlamaCppReceipt(paths);
-  const journals = readHostLocalCreateJournalRecords(paths.stateDir).filter(
+  const journalRecords = reconcileAndReadHostLocalCreateJournalRecords(paths.stateDir);
+  const journals = journalRecords.filter(
     ({ providerId, service }) => providerId === "docker" && service === "llama-cpp",
   );
   if (journals.length > 1) {
@@ -710,16 +789,46 @@ export function prepareManagedLlamaCppRuntimeCleanupForSandbox(
     if (authority === null) {
       throw new Error("managed llama.cpp engine authority is missing while ownership remains");
     }
-    if (journals[0]) requireManagedLlamaJournal(journals[0], owner.recipeId);
+    if (journals[0]) {
+      requireManagedLlamaJournal(journals[0], owner.recipeId);
+      if (journals[0].phase === "finalized") {
+        throw new Error("managed llama.cpp finalized receipt is missing");
+      }
+    }
     requireQualifiedEngine(authority, engine);
+    requireEngineSuccess(
+      "engine availability check",
+      engine.capture(["info"], DOCKER_INSPECT_TIMEOUT_MS),
+    );
+    if (journals[0]) {
+      inspectExactContainerForJournal(engine, journals[0]);
+      inspectExactNetworkForJournal(engine, journals[0]);
+    } else {
+      const container = inspectOwnedLlamaResource(
+        engine,
+        "container",
+        MANAGED_LLAMA_CPP_CONTAINER_NAME,
+      );
+      const network = inspectOwnedLlamaResource(engine, "network", MANAGED_LLAMA_CPP_NETWORK_NAME);
+      if (container.kind !== "absent" || network.kind !== "absent") {
+        throw new Error(
+          "managed llama.cpp pre-start cleanup cannot prove its fixed runtime names absent",
+        );
+      }
+    }
   }
+  const expectedPrivateAuthoritySha256 = managedLlamaCppPrivateAuthoritySha256(paths);
   return Object.freeze({
     cleanup: () =>
-      cleanupManagedLlamaCppRuntimeForSandbox(sandboxName, {
-        ...options,
-        homeDir,
-        engine,
-      }),
+      cleanupManagedLlamaCppRuntimeForSandboxInternal(
+        sandboxName,
+        {
+          ...options,
+          homeDir,
+          engine,
+        },
+        expectedPrivateAuthoritySha256,
+      ),
   });
 }
 
@@ -964,10 +1073,10 @@ export function resolveManagedLlamaCppCleanupTarget(
   return Object.freeze({ gatewayPort, sandboxName: owner.sandboxName, stateDir: paths.stateDir });
 }
 
-/** Retire the exact gateway-owned runtime only when the named sandbox owns it. */
-export function cleanupManagedLlamaCppRuntimeForSandbox(
+function cleanupManagedLlamaCppRuntimeForSandboxInternal(
   sandboxName: string,
   options: ManagedLlamaCppSandboxCleanupOptions = {},
+  expectedPrivateAuthoritySha256?: string,
 ): LocalModelRuntimeCleanupResult {
   const deps: CleanupDeps = {
     capture: options.deps?.capture ?? dockerCapture,
@@ -985,23 +1094,47 @@ export function cleanupManagedLlamaCppRuntimeForSandbox(
   try {
     const homeDir = canonicalCleanupHomeDir(options.homeDir ?? os.homedir());
     const paths = managedLlamaCppStatePaths(homeDir, options.gatewayPort);
-    if (!statePathExists(paths.stateDir)) return { ok: true, removed, preserved };
+    if (!statePathExists(paths.stateDir)) {
+      if (expectedPrivateAuthoritySha256 !== undefined) {
+        throw new Error("managed llama.cpp private authority changed after cleanup preparation");
+      }
+      return { ok: true, removed, preserved };
+    }
     requirePrivateManagedState(paths, deps.currentUserId);
-    if (!fs.existsSync(paths.ownerPath)) return { ok: true, removed, preserved };
+    if (!fs.existsSync(paths.ownerPath)) {
+      if (expectedPrivateAuthoritySha256 !== undefined) {
+        throw new Error("managed llama.cpp private authority changed after cleanup preparation");
+      }
+      return { ok: true, removed, preserved };
+    }
     const owner = loadManagedLlamaCppOwner(paths);
-    if (!owner || owner.sandboxName !== sandboxName) return { ok: true, removed, preserved };
+    if (!owner || owner.sandboxName !== sandboxName) {
+      if (expectedPrivateAuthoritySha256 !== undefined) {
+        throw new Error("managed llama.cpp private authority changed after cleanup preparation");
+      }
+      return { ok: true, removed, preserved };
+    }
     cleanupLlamaCpp(homeDir, deps, removed, {
       gatewayPort: options.gatewayPort,
       sandboxName,
       env: options.env,
       engine: options.engine,
       privateBridge: options.privateBridge,
+      expectedPrivateAuthoritySha256,
     });
     preserveSharedHuggingFaceCache(homeDir, preserved);
     return { ok: true, removed, preserved };
   } catch (error) {
     return { ok: false, reason: (error as Error).message, removed, preserved };
   }
+}
+
+/** Retire the exact gateway-owned runtime only when the named sandbox owns it. */
+export function cleanupManagedLlamaCppRuntimeForSandbox(
+  sandboxName: string,
+  options: ManagedLlamaCppSandboxCleanupOptions = {},
+): LocalModelRuntimeCleanupResult {
+  return cleanupManagedLlamaCppRuntimeForSandboxInternal(sandboxName, options);
 }
 
 /** Remove only exact owned host-local runtime resources before uninstall deletes state. */

--- a/src/lib/inference/local-model-profile/cleanup.ts
+++ b/src/lib/inference/local-model-profile/cleanup.ts
@@ -916,28 +916,27 @@ function cleanupLlamaCpp(
     requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthority);
     journalStore.retire(journal.transactionId);
     executionOwnership.assert();
+    requirePrivateManagedState(paths, deps.currentUserId);
+    const finalReceipt = loadManagedLlamaCppReceipt(paths);
+    if (
+      JSON.stringify(loadManagedLlamaCppOwner(paths)) !== JSON.stringify(owner) ||
+      (receipt === null
+        ? finalReceipt !== null
+        : finalReceipt === null ||
+          serializeHostLocalInferenceReceipt(finalReceipt) !==
+            serializeHostLocalInferenceReceipt(receipt)) ||
+      serializedManagedLlamaCppPersistedAuthority(paths) !== persistedAuthority ||
+      journalStore.list().length !== 0
+    ) {
+      throw new Error("managed llama.cpp state changed during exact cleanup");
+    }
+    requireManagedLlamaCppStaticState(paths, options.expectedPrivateAuthority);
+    fs.rmSync(paths.stateDir, { recursive: true });
+    removed.push(`state:${paths.stateDir}`);
+    return true;
   } finally {
     executionOwnership.release();
   }
-
-  requirePrivateManagedState(paths, deps.currentUserId);
-  const finalReceipt = loadManagedLlamaCppReceipt(paths);
-  if (
-    JSON.stringify(loadManagedLlamaCppOwner(paths)) !== JSON.stringify(owner) ||
-    (receipt === null
-      ? finalReceipt !== null
-      : finalReceipt === null ||
-        serializeHostLocalInferenceReceipt(finalReceipt) !==
-          serializeHostLocalInferenceReceipt(receipt)) ||
-    serializedManagedLlamaCppPersistedAuthority(paths) !== persistedAuthority ||
-    journalStore.list().length !== 0
-  ) {
-    throw new Error("managed llama.cpp state changed during exact cleanup");
-  }
-  requireManagedLlamaCppStaticState(paths, options.expectedPrivateAuthority);
-  fs.rmSync(paths.stateDir, { recursive: true });
-  removed.push(`state:${paths.stateDir}`);
-  return true;
 }
 
 export interface ManagedLlamaCppSandboxCleanupOptions {

--- a/src/lib/inference/local-model-profile/cleanup.ts
+++ b/src/lib/inference/local-model-profile/cleanup.ts
@@ -18,6 +18,7 @@ import {
 } from "../../onboard/runtime-provider/docker-llama-cpp-private-bridge";
 import {
   createHostLocalCreateJournalStore,
+  HOST_LOCAL_CREATE_JOURNAL_DIRECTORY,
   reconcileAndReadHostLocalCreateJournalRecords,
   serializeHostLocalCreateJournalRecord,
   type HostLocalCreateJournalRecord,
@@ -38,6 +39,9 @@ import {
 import {
   loadManagedLlamaCppOwner,
   loadManagedLlamaCppReceipt,
+  MANAGED_LLAMA_CPP_API_KEY_FILE,
+  MANAGED_LLAMA_CPP_OWNER_FILE,
+  MANAGED_LLAMA_CPP_RECEIPT_FILE,
   type ManagedLlamaCppStatePaths,
   managedLlamaCppStatePaths,
 } from "../llama-cpp/managed-state";
@@ -71,6 +75,12 @@ const LLAMA_TRANSACTION_LABEL = "io.nvidia.nemoclaw.host-local-inference.transac
 const LLAMA_NETWORK_TRANSACTION_LABEL =
   "io.nvidia.nemoclaw.host-local-inference.network-transaction-sha256";
 const HUGGING_FACE_CREDENTIAL_ENTRIES = new Set(["stored_tokens", "token"]);
+const MANAGED_LLAMA_CPP_PRIVATE_FILE_MAX_BYTES = 64 * 1024;
+const HOST_LOCAL_CREATE_JOURNAL_RECORD_FILE = /^[a-f0-9]{64}\.json$/u;
+const HOST_LOCAL_CREATE_JOURNAL_TRANSIENT_FILES = new Set([
+  ".execution-lease.json",
+  ".execution-recovery.json",
+]);
 
 interface CleanupDeps {
   capture: typeof dockerCapture;
@@ -423,21 +433,156 @@ function requireManagedLlamaReceiptJournalAgreement(
   }
 }
 
-function managedLlamaCppPrivateAuthoritySha256(paths: ManagedLlamaCppStatePaths): string {
+interface ManagedLlamaCppPrivateAuthority {
+  readonly sha256: string;
+  readonly staticStateSha256: string;
+}
+
+interface ManagedLlamaCppPrivateStateEntry {
+  readonly path: string;
+  readonly kind: "directory" | "file";
+  readonly mode: number;
+  readonly uid: number;
+  readonly contentSha256?: string;
+}
+
+function readManagedLlamaCppPrivateFileEntry(
+  target: string,
+  relativePath: string,
+): ManagedLlamaCppPrivateStateEntry {
+  const noFollow = fs.constants.O_NOFOLLOW;
+  if (typeof noFollow !== "number") {
+    throw new Error("managed llama.cpp private state requires no-follow file reads");
+  }
+  const descriptor = fs.openSync(
+    target,
+    fs.constants.O_RDONLY | noFollow | (fs.constants.O_NONBLOCK ?? 0),
+  );
+  try {
+    const before = fs.fstatSync(descriptor);
+    if (
+      !before.isFile() ||
+      before.nlink !== 1 ||
+      (typeof process.getuid === "function" && before.uid !== process.getuid()) ||
+      (before.mode & 0o077) !== 0 ||
+      before.size > MANAGED_LLAMA_CPP_PRIVATE_FILE_MAX_BYTES
+    ) {
+      throw new Error("managed llama.cpp private state contains an unsafe file");
+    }
+    const content = fs.readFileSync(descriptor);
+    const after = fs.fstatSync(descriptor);
+    if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.mode !== after.mode ||
+      before.nlink !== after.nlink ||
+      before.uid !== after.uid ||
+      before.size !== after.size ||
+      before.mtimeMs !== after.mtimeMs
+    ) {
+      throw new Error("managed llama.cpp private state changed while it was read");
+    }
+    return Object.freeze({
+      path: relativePath,
+      kind: "file" as const,
+      mode: before.mode & 0o777,
+      uid: before.uid,
+      contentSha256: createHash("sha256").update(content).digest("hex"),
+    });
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function readManagedLlamaCppPrivateDirectoryEntry(
+  target: string,
+  relativePath: string,
+): ManagedLlamaCppPrivateStateEntry {
+  const status = fs.lstatSync(target);
+  if (
+    !status.isDirectory() ||
+    status.isSymbolicLink() ||
+    (typeof process.getuid === "function" && status.uid !== process.getuid()) ||
+    (status.mode & 0o077) !== 0
+  ) {
+    throw new Error("managed llama.cpp private state contains an unsafe directory");
+  }
+  return Object.freeze({
+    path: relativePath,
+    kind: "directory" as const,
+    mode: status.mode & 0o777,
+    uid: status.uid,
+  });
+}
+
+function managedLlamaCppStaticStateSha256(paths: ManagedLlamaCppStatePaths): string {
+  const entries: ManagedLlamaCppPrivateStateEntry[] = [];
+  const rootFiles = new Set<string>([
+    MANAGED_LLAMA_CPP_API_KEY_FILE,
+    MANAGED_LLAMA_CPP_OWNER_FILE,
+    MANAGED_LLAMA_CPP_RECEIPT_FILE,
+  ]);
+  const rootDirectories = new Set<string>([
+    HOST_LOCAL_CREATE_JOURNAL_DIRECTORY,
+    PERSISTED_ENGINE_AUTHORITY_DIRECTORY,
+  ]);
+  for (const name of fs.readdirSync(paths.stateDir).sort()) {
+    const target = path.join(paths.stateDir, name);
+    if (rootFiles.has(name)) {
+      entries.push(readManagedLlamaCppPrivateFileEntry(target, name));
+      continue;
+    }
+    if (!rootDirectories.has(name)) {
+      throw new Error(`managed llama.cpp private state contains unexpected entry '${name}'`);
+    }
+    entries.push(readManagedLlamaCppPrivateDirectoryEntry(target, name));
+    for (const child of fs.readdirSync(target).sort()) {
+      const relativePath = `${name}/${child}`;
+      const childTarget = path.join(target, child);
+      if (name === HOST_LOCAL_CREATE_JOURNAL_DIRECTORY) {
+        if (
+          HOST_LOCAL_CREATE_JOURNAL_RECORD_FILE.test(child) ||
+          HOST_LOCAL_CREATE_JOURNAL_TRANSIENT_FILES.has(child)
+        ) {
+          const childStatus = fs.lstatSync(childTarget);
+          if (!childStatus.isFile() || childStatus.isSymbolicLink()) {
+            throw new Error("managed llama.cpp lifecycle authority contains an unsafe entry");
+          }
+          continue;
+        }
+        throw new Error(
+          `managed llama.cpp lifecycle authority contains unexpected entry '${child}'`,
+        );
+      }
+      if (child !== "host-local-inference.json") {
+        throw new Error(`managed llama.cpp engine authority contains unexpected entry '${child}'`);
+      }
+      entries.push(readManagedLlamaCppPrivateFileEntry(childTarget, relativePath));
+    }
+  }
+  return createHash("sha256").update(JSON.stringify(entries)).digest("hex");
+}
+
+function managedLlamaCppPrivateAuthority(
+  paths: ManagedLlamaCppStatePaths,
+): ManagedLlamaCppPrivateAuthority {
   const owner = loadManagedLlamaCppOwner(paths);
   const receipt = loadManagedLlamaCppReceipt(paths);
   const journals = reconcileAndReadHostLocalCreateJournalRecords(paths.stateDir);
   const authority = serializedManagedLlamaCppPersistedAuthority(paths);
-  return createHash("sha256")
+  const staticStateSha256 = managedLlamaCppStaticStateSha256(paths);
+  const sha256 = createHash("sha256")
     .update(
       JSON.stringify({
         owner,
         receipt: receipt === null ? null : serializeHostLocalInferenceReceipt(receipt),
         journals: journals.map(serializeHostLocalCreateJournalRecord),
         authority,
+        staticStateSha256,
       }),
     )
     .digest("hex");
+  return Object.freeze({ sha256, staticStateSha256 });
 }
 
 function serializedManagedLlamaCppPersistedAuthority(
@@ -452,14 +597,28 @@ function serializedManagedLlamaCppPersistedAuthority(
 
 function requireManagedLlamaCppPrivateAuthority(
   paths: ManagedLlamaCppStatePaths,
-  expectedSha256: string | undefined,
+  expected: ManagedLlamaCppPrivateAuthority | undefined,
 ): void {
-  if (
-    expectedSha256 !== undefined &&
-    managedLlamaCppPrivateAuthoritySha256(paths) !== expectedSha256
-  ) {
-    throw new Error("managed llama.cpp private authority changed after cleanup preparation");
+  if (expected === undefined) return;
+  try {
+    if (managedLlamaCppPrivateAuthority(paths).sha256 === expected.sha256) return;
+  } catch {
+    // A malformed, missing, or newly introduced entry is authority drift too.
   }
+  throw new Error("managed llama.cpp private authority changed after cleanup preparation");
+}
+
+function requireManagedLlamaCppStaticState(
+  paths: ManagedLlamaCppStatePaths,
+  expected: ManagedLlamaCppPrivateAuthority | undefined,
+): void {
+  if (expected === undefined) return;
+  try {
+    if (managedLlamaCppStaticStateSha256(paths) === expected.staticStateSha256) return;
+  } catch {
+    // Preserve the same fail-closed boundary for malformed or unexpected entries.
+  }
+  throw new Error("managed llama.cpp private authority changed after cleanup preparation");
 }
 
 function requireQualifiedEngine(
@@ -581,19 +740,19 @@ function cleanupLlamaCpp(
     env?: NodeJS.ProcessEnv;
     engine?: ContainerEngine;
     privateBridge?: DockerLlamaCppPrivateBridgeController;
-    expectedPrivateAuthoritySha256?: string;
+    expectedPrivateAuthority?: ManagedLlamaCppPrivateAuthority;
   } = {},
 ): boolean {
   const paths = managedLlamaCppStatePaths(homeDir, options.gatewayPort);
   if (!statePathExists(paths.stateDir)) {
-    if (options.expectedPrivateAuthoritySha256 !== undefined) {
+    if (options.expectedPrivateAuthority !== undefined) {
       throw new Error("managed llama.cpp private authority changed after cleanup preparation");
     }
     return false;
   }
   requirePrivateManagedState(paths, deps.currentUserId);
   if (!fs.existsSync(paths.ownerPath)) {
-    if (options.expectedPrivateAuthoritySha256 !== undefined) {
+    if (options.expectedPrivateAuthority !== undefined) {
       throw new Error("managed llama.cpp private authority changed after cleanup preparation");
     }
     return false;
@@ -601,12 +760,12 @@ function cleanupLlamaCpp(
   const owner = loadManagedLlamaCppOwner(paths);
   if (!owner) throw new Error("managed llama.cpp owner state is missing");
   if (options.sandboxName !== undefined && owner.sandboxName !== options.sandboxName) {
-    if (options.expectedPrivateAuthoritySha256 !== undefined) {
+    if (options.expectedPrivateAuthority !== undefined) {
       throw new Error("managed llama.cpp private authority changed after cleanup preparation");
     }
     return false;
   }
-  requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
+  requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthority);
 
   const receipt = loadManagedLlamaCppReceipt(paths);
   const persistedAuthority = serializedManagedLlamaCppPersistedAuthority(paths);
@@ -656,7 +815,8 @@ function cleanupLlamaCpp(
     ) {
       throw new Error("managed llama.cpp state changed during pre-start cleanup");
     }
-    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
+    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthority);
+    requireManagedLlamaCppStaticState(paths, options.expectedPrivateAuthority);
     fs.rmSync(paths.stateDir, { recursive: true });
     removed.push(`state:${paths.stateDir}`);
     return true;
@@ -674,7 +834,7 @@ function cleanupLlamaCpp(
   const lease = journalStore.acquireExecution(journal.transactionId);
   try {
     journalStore.assertExecution(lease);
-    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
+    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthority);
     const privateBridge =
       options.privateBridge ??
       (process.platform === "linux" ? createDockerLlamaCppPrivateBridgeController() : undefined);
@@ -690,10 +850,10 @@ function cleanupLlamaCpp(
       engine.capture(["info"], DOCKER_INSPECT_TIMEOUT_MS),
     );
     journalStore.assertExecution(lease);
-    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
+    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthority);
     removeExactContainerForJournal(engine, journal, removed);
     journalStore.assertExecution(lease);
-    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
+    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthority);
     let network = inspectExactNetworkForJournal(engine, journal);
     if (network.kind === "owned") {
       requireEngineSuccess(
@@ -709,7 +869,7 @@ function cleanupLlamaCpp(
       throw new Error("managed llama.cpp network removal was not proven exact and absent");
     }
     journalStore.assertExecution(lease);
-    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthoritySha256);
+    requireManagedLlamaCppPrivateAuthority(paths, options.expectedPrivateAuthority);
     journalStore.retire(journal.transactionId);
     journalStore.assertExecution(lease);
   } finally {
@@ -730,6 +890,7 @@ function cleanupLlamaCpp(
   ) {
     throw new Error("managed llama.cpp state changed during exact cleanup");
   }
+  requireManagedLlamaCppStaticState(paths, options.expectedPrivateAuthority);
   fs.rmSync(paths.stateDir, { recursive: true });
   removed.push(`state:${paths.stateDir}`);
   return true;
@@ -775,6 +936,10 @@ export function prepareManagedLlamaCppRuntimeCleanupForSandbox(
   if (!fs.existsSync(paths.ownerPath)) return null;
   const owner = loadManagedLlamaCppOwner(paths);
   if (!owner || owner.sandboxName !== sandboxName) return null;
+  // Pin the complete private-state baseline before proving any external
+  // resource. Recheck it after proof so a concurrent lifecycle replacement
+  // cannot become the accepted post-proof baseline.
+  const expectedPrivateAuthority = managedLlamaCppPrivateAuthority(paths);
   const engine = options.engine ?? createManagedLlamaCppEngine(options.env ?? process.env);
   const receipt = loadManagedLlamaCppReceipt(paths);
   const journalRecords = reconcileAndReadHostLocalCreateJournalRecords(paths.stateDir);
@@ -833,7 +998,7 @@ export function prepareManagedLlamaCppRuntimeCleanupForSandbox(
       }
     }
   }
-  const expectedPrivateAuthoritySha256 = managedLlamaCppPrivateAuthoritySha256(paths);
+  requireManagedLlamaCppPrivateAuthority(paths, expectedPrivateAuthority);
   return Object.freeze({
     cleanup: () =>
       cleanupManagedLlamaCppRuntimeForSandboxInternal(
@@ -843,7 +1008,7 @@ export function prepareManagedLlamaCppRuntimeCleanupForSandbox(
           homeDir,
           engine,
         },
-        expectedPrivateAuthoritySha256,
+        expectedPrivateAuthority,
       ),
   });
 }
@@ -1092,7 +1257,7 @@ export function resolveManagedLlamaCppCleanupTarget(
 function cleanupManagedLlamaCppRuntimeForSandboxInternal(
   sandboxName: string,
   options: ManagedLlamaCppSandboxCleanupOptions = {},
-  expectedPrivateAuthoritySha256?: string,
+  expectedPrivateAuthority?: ManagedLlamaCppPrivateAuthority,
 ): LocalModelRuntimeCleanupResult {
   const deps: CleanupDeps = {
     capture: options.deps?.capture ?? dockerCapture,
@@ -1111,21 +1276,21 @@ function cleanupManagedLlamaCppRuntimeForSandboxInternal(
     const homeDir = canonicalCleanupHomeDir(options.homeDir ?? os.homedir());
     const paths = managedLlamaCppStatePaths(homeDir, options.gatewayPort);
     if (!statePathExists(paths.stateDir)) {
-      if (expectedPrivateAuthoritySha256 !== undefined) {
+      if (expectedPrivateAuthority !== undefined) {
         throw new Error("managed llama.cpp private authority changed after cleanup preparation");
       }
       return { ok: true, removed, preserved };
     }
     requirePrivateManagedState(paths, deps.currentUserId);
     if (!fs.existsSync(paths.ownerPath)) {
-      if (expectedPrivateAuthoritySha256 !== undefined) {
+      if (expectedPrivateAuthority !== undefined) {
         throw new Error("managed llama.cpp private authority changed after cleanup preparation");
       }
       return { ok: true, removed, preserved };
     }
     const owner = loadManagedLlamaCppOwner(paths);
     if (!owner || owner.sandboxName !== sandboxName) {
-      if (expectedPrivateAuthoritySha256 !== undefined) {
+      if (expectedPrivateAuthority !== undefined) {
         throw new Error("managed llama.cpp private authority changed after cleanup preparation");
       }
       return { ok: true, removed, preserved };
@@ -1136,7 +1301,7 @@ function cleanupManagedLlamaCppRuntimeForSandboxInternal(
       env: options.env,
       engine: options.engine,
       privateBridge: options.privateBridge,
-      expectedPrivateAuthoritySha256,
+      expectedPrivateAuthority,
     });
     preserveSharedHuggingFaceCache(homeDir, preserved);
     return { ok: true, removed, preserved };

--- a/src/lib/onboard/runtime-provider/host-local-create-journal.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-create-journal.test.ts
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createHostLocalCreateJournalStore,
   HOST_LOCAL_CREATE_JOURNAL_DIRECTORY,
-  readHostLocalCreateJournalRecords,
+  reconcileAndReadHostLocalCreateJournalRecords,
   type HostLocalCreateJournalRecord,
   serializeHostLocalCreateJournalRecord,
 } from "./host-local-create-journal";
@@ -101,7 +101,7 @@ function executionPath(name: ".execution-lease.json" | ".execution-recovery.json
 
 describe("existing journal reads", () => {
   it("does not create an absent journal directory", () => {
-    expect(readHostLocalCreateJournalRecords(stateDirectory)).toEqual([]);
+    expect(reconcileAndReadHostLocalCreateJournalRecords(stateDirectory)).toEqual([]);
     expect(fs.existsSync(path.dirname(journalPath()))).toBe(false);
   });
 
@@ -114,7 +114,7 @@ describe("existing journal reads", () => {
     );
     fs.linkSync(journalPath(), orphan);
 
-    expect(readHostLocalCreateJournalRecords(stateDirectory)).toEqual([prepared()]);
+    expect(reconcileAndReadHostLocalCreateJournalRecords(stateDirectory)).toEqual([prepared()]);
     expect(fs.existsSync(orphan)).toBe(false);
   });
 });

--- a/src/lib/onboard/runtime-provider/host-local-create-journal.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-create-journal.test.ts
@@ -99,13 +99,13 @@ function executionPath(name: ".execution-lease.json" | ".execution-recovery.json
   return path.join(stateDirectory, HOST_LOCAL_CREATE_JOURNAL_DIRECTORY, name);
 }
 
-describe("non-mutating journal reads", () => {
+describe("existing journal reads", () => {
   it("does not create an absent journal directory", () => {
     expect(readHostLocalCreateJournalRecords(stateDirectory)).toEqual([]);
     expect(fs.existsSync(path.dirname(journalPath()))).toBe(false);
   });
 
-  it("rejects an exclusive-publish orphan without repairing it", () => {
+  it("repairs a recoverable exclusive-publish orphan", () => {
     const store = createHostLocalCreateJournalStore(stateDirectory);
     store.create(prepared());
     const orphan = path.join(
@@ -114,10 +114,8 @@ describe("non-mutating journal reads", () => {
     );
     fs.linkSync(journalPath(), orphan);
 
-    expect(() => readHostLocalCreateJournalRecords(stateDirectory)).toThrow(
-      "journal file authority is invalid",
-    );
-    expect(fs.existsSync(orphan)).toBe(true);
+    expect(readHostLocalCreateJournalRecords(stateDirectory)).toEqual([prepared()]);
+    expect(fs.existsSync(orphan)).toBe(false);
   });
 });
 

--- a/src/lib/onboard/runtime-provider/host-local-create-journal.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-create-journal.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createHostLocalCreateJournalStore,
   HOST_LOCAL_CREATE_JOURNAL_DIRECTORY,
+  readHostLocalCreateJournalRecords,
   type HostLocalCreateJournalRecord,
   serializeHostLocalCreateJournalRecord,
 } from "./host-local-create-journal";
@@ -97,6 +98,28 @@ function journalPath(): string {
 function executionPath(name: ".execution-lease.json" | ".execution-recovery.json"): string {
   return path.join(stateDirectory, HOST_LOCAL_CREATE_JOURNAL_DIRECTORY, name);
 }
+
+describe("non-mutating journal reads", () => {
+  it("does not create an absent journal directory", () => {
+    expect(readHostLocalCreateJournalRecords(stateDirectory)).toEqual([]);
+    expect(fs.existsSync(path.dirname(journalPath()))).toBe(false);
+  });
+
+  it("rejects an exclusive-publish orphan without repairing it", () => {
+    const store = createHostLocalCreateJournalStore(stateDirectory);
+    store.create(prepared());
+    const orphan = path.join(
+      path.dirname(journalPath()),
+      `.${path.basename(journalPath())}.${OWNER_ONE}.tmp`,
+    );
+    fs.linkSync(journalPath(), orphan);
+
+    expect(() => readHostLocalCreateJournalRecords(stateDirectory)).toThrow(
+      "journal file authority is invalid",
+    );
+    expect(fs.existsSync(orphan)).toBe(true);
+  });
+});
 
 function executionSource(transactionId: string, ownerId: string, ownerPid: number): string {
   return `${JSON.stringify({ schemaVersion: 1, transactionId, ownerId, ownerPid })}\n`;

--- a/src/lib/onboard/runtime-provider/host-local-create-journal.ts
+++ b/src/lib/onboard/runtime-provider/host-local-create-journal.ts
@@ -308,10 +308,17 @@ function fsyncDirectory(directory: string): void {
   }
 }
 
-function requireDirectory(root: string): void {
+function requireDirectory(root: string, createIfMissing = true): boolean {
   const existed = fs.existsSync(root);
-  fs.mkdirSync(root, { recursive: true, mode: DIRECTORY_MODE });
-  const status = fs.lstatSync(root);
+  if (!existed && !createIfMissing) return false;
+  if (createIfMissing) fs.mkdirSync(root, { recursive: true, mode: DIRECTORY_MODE });
+  let status: fs.Stats;
+  try {
+    status = fs.lstatSync(root);
+  } catch (error) {
+    if (!createIfMissing && (error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
   if (
     !status.isDirectory() ||
     status.isSymbolicLink() ||
@@ -322,6 +329,7 @@ function requireDirectory(root: string): void {
     fail("journal directory must be a private current-user-owned directory");
   }
   if (!existed) fsyncDirectory(path.dirname(root));
+  return true;
 }
 
 function recordPath(root: string, transactionId: string): string {
@@ -391,7 +399,7 @@ function reconcileExclusivePublishOrphan(
   return reconciled;
 }
 
-function readPrivateFile(target: string): string | null {
+function readPrivateFile(target: string, recoverPublishOrphan = true): string | null {
   if (typeof fs.constants.O_NOFOLLOW !== "number") fail("O_NOFOLLOW is unavailable");
   const nonblock = typeof fs.constants.O_NONBLOCK === "number" ? fs.constants.O_NONBLOCK : 0;
   let descriptor: number;
@@ -402,11 +410,10 @@ function readPrivateFile(target: string): string | null {
     throw error;
   }
   try {
-    const before = reconcileExclusivePublishOrphan(
-      target,
-      descriptor,
-      fs.fstatSync(descriptor, { bigint: true }),
-    );
+    const initial = fs.fstatSync(descriptor, { bigint: true });
+    const before = recoverPublishOrphan
+      ? reconcileExclusivePublishOrphan(target, descriptor, initial)
+      : initial;
     if (
       !before.isFile() ||
       before.uid !== BigInt(currentUid()) ||
@@ -436,8 +443,11 @@ function readPrivateFile(target: string): string | null {
   }
 }
 
-function readRecord(target: string): HostLocalCreateJournalRecord | null {
-  const source = readPrivateFile(target);
+function readRecord(
+  target: string,
+  recoverPublishOrphan = true,
+): HostLocalCreateJournalRecord | null {
+  const source = readPrivateFile(target, recoverPublishOrphan);
   if (source === null) return null;
   let parsed: unknown;
   try {
@@ -750,4 +760,22 @@ export function createHostLocalCreateJournalStore(
     },
   };
   return Object.freeze(store);
+}
+
+/** Read existing journal records without creating or repairing filesystem state. */
+export function readHostLocalCreateJournalRecords(
+  stateDirectory: string,
+): readonly HostLocalCreateJournalRecord[] {
+  const root = path.join(stateDirectory, HOST_LOCAL_CREATE_JOURNAL_DIRECTORY);
+  if (!requireDirectory(root, false)) return Object.freeze([]);
+  return Object.freeze(
+    fs
+      .readdirSync(root)
+      .filter((entry) => SHA256.test(entry.replace(/\.json$/u, "")) && entry.endsWith(".json"))
+      .sort()
+      .flatMap((entry) => {
+        const record = readRecord(path.join(root, entry), false);
+        return record === null ? [] : [record];
+      }),
+  );
 }

--- a/src/lib/onboard/runtime-provider/host-local-create-journal.ts
+++ b/src/lib/onboard/runtime-provider/host-local-create-journal.ts
@@ -462,6 +462,23 @@ function readRecord(
   return record;
 }
 
+function listRecords(
+  root: string,
+  options: { readonly createDirectory: boolean; readonly recoverPublishOrphans: boolean },
+): readonly HostLocalCreateJournalRecord[] {
+  if (!requireDirectory(root, options.createDirectory)) return Object.freeze([]);
+  return Object.freeze(
+    fs
+      .readdirSync(root)
+      .filter((entry) => SHA256.test(entry.replace(/\.json$/u, "")) && entry.endsWith(".json"))
+      .sort()
+      .flatMap((entry) => {
+        const record = readRecord(path.join(root, entry), options.recoverPublishOrphans);
+        return record === null ? [] : [record];
+      }),
+  );
+}
+
 function readExecutionLease(target: string): HostLocalCreateJournalExecutionLease | null {
   const source = readPrivateFile(target);
   if (source === null) return null;
@@ -607,17 +624,7 @@ export function createHostLocalCreateJournalStore(
   const store: HostLocalCreateJournalStore = {
     load,
     list() {
-      requireDirectory(root);
-      return Object.freeze(
-        fs
-          .readdirSync(root)
-          .filter((entry) => SHA256.test(entry.replace(/\.json$/u, "")) && entry.endsWith(".json"))
-          .sort()
-          .flatMap((entry) => {
-            const record = readRecord(path.join(root, entry));
-            return record === null ? [] : [record];
-          }),
-      );
+      return listRecords(root, { createDirectory: true, recoverPublishOrphans: true });
     },
     create(record) {
       requireDirectory(root);
@@ -762,20 +769,10 @@ export function createHostLocalCreateJournalStore(
   return Object.freeze(store);
 }
 
-/** Read existing journal records without creating or repairing filesystem state. */
+/** Read existing journal records without creating state; repair an interrupted exclusive publish. */
 export function readHostLocalCreateJournalRecords(
   stateDirectory: string,
 ): readonly HostLocalCreateJournalRecord[] {
   const root = path.join(stateDirectory, HOST_LOCAL_CREATE_JOURNAL_DIRECTORY);
-  if (!requireDirectory(root, false)) return Object.freeze([]);
-  return Object.freeze(
-    fs
-      .readdirSync(root)
-      .filter((entry) => SHA256.test(entry.replace(/\.json$/u, "")) && entry.endsWith(".json"))
-      .sort()
-      .flatMap((entry) => {
-        const record = readRecord(path.join(root, entry), false);
-        return record === null ? [] : [record];
-      }),
-  );
+  return listRecords(root, { createDirectory: false, recoverPublishOrphans: true });
 }

--- a/src/lib/onboard/runtime-provider/host-local-create-journal.ts
+++ b/src/lib/onboard/runtime-provider/host-local-create-journal.ts
@@ -769,8 +769,8 @@ export function createHostLocalCreateJournalStore(
   return Object.freeze(store);
 }
 
-/** Read existing journal records without creating state; repair an interrupted exclusive publish. */
-export function readHostLocalCreateJournalRecords(
+/** Reconcile an interrupted exclusive publish and read records without creating a directory. */
+export function reconcileAndReadHostLocalCreateJournalRecords(
   stateDirectory: string,
 ): readonly HostLocalCreateJournalRecord[] {
   const root = path.join(stateDirectory, HOST_LOCAL_CREATE_JOURNAL_DIRECTORY);

--- a/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.test.ts
@@ -241,6 +241,7 @@ function provider(
     bundle,
     createOperation,
     destroy,
+    operation,
     operationInputs,
     prepareDestroy,
     preserveForRebuild,
@@ -398,6 +399,45 @@ describe("host-local inference lifecycle authority", () => {
       ).status,
     ).toBe("shared");
     expect(runtimeProvider.destroy).not.toHaveBeenCalled();
+  });
+
+  it("reuses the pre-delete llama.cpp operation for provenance-tracked retirement (#9888)", () => {
+    const qualified = provider();
+    const drifted = provider({ authorityId: `drifted:${"9".repeat(64)}` });
+    qualified.createOperation
+      .mockImplementationOnce(() => qualified.operation)
+      .mockImplementation(() => drifted.operation);
+    const entry = explicitLlamaSandbox();
+    const createLlamaCppAdapter = vi.fn((options) => {
+      const selected = options.operation === qualified.operation ? qualified : drifted;
+      return {
+        gatewayPort: options.gatewayPort ?? 8080,
+        runtimeOwnerSandboxName: options.runtimeOwnerSandboxName,
+        model: "llama-cpp-model",
+        operation: options.operation!,
+        receipt: options.expectedReceipt,
+        runtime: selected.runtime,
+        prepareStartup: vi.fn(),
+      };
+    });
+    const lifecycleOptions = { createLlamaCppAdapter };
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(qualified.bundle, entry, lifecycleOptions),
+    );
+
+    expect(
+      retirePreparedHostLocalInferenceAuthority(
+        qualified.bundle,
+        entry,
+        prepared,
+        [entry],
+        lifecycleOptions,
+      ).status,
+    ).toBe("removed");
+    expect(qualified.createOperation).toHaveBeenCalledOnce();
+    expect(qualified.assertAuthority).toHaveBeenCalledTimes(2);
+    expect(qualified.destroy).toHaveBeenCalledOnce();
+    expect(drifted.destroy).not.toHaveBeenCalled();
   });
 
   it("rejects a llama.cpp peer on a different gateway before retirement", () => {

--- a/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.test.ts
@@ -438,6 +438,35 @@ describe("host-local inference lifecycle authority", () => {
     expect(drifted.destroy).not.toHaveBeenCalled();
   });
 
+  it("refuses provenance-tracked retirement when prepared authority drifts (#9888)", () => {
+    const qualified = provider();
+    qualified.assertAuthority
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error("prepared authority drifted");
+      });
+    const entry = explicitLlamaSandbox();
+    const createLlamaCppAdapter = vi.fn((options) => ({
+      gatewayPort: options.gatewayPort ?? 8080,
+      runtimeOwnerSandboxName: options.runtimeOwnerSandboxName,
+      model: "llama-cpp-model",
+      operation: options.operation!,
+      receipt: options.expectedReceipt,
+      runtime: qualified.runtime,
+      prepareStartup: vi.fn(),
+    }));
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(qualified.bundle, entry, {
+        createLlamaCppAdapter,
+      }),
+    );
+
+    expect(() =>
+      retirePreparedHostLocalInferenceAuthority(qualified.bundle, entry, prepared, [entry]),
+    ).toThrow("prepared authority drifted");
+    expect(qualified.destroy).not.toHaveBeenCalled();
+  });
+
   it("rejects a llama.cpp peer on a different gateway before retirement", () => {
     const runtimeProvider = provider();
     const alpha = explicitLlamaSandbox("alpha");

--- a/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.test.ts
@@ -395,7 +395,6 @@ describe("host-local inference lifecycle authority", () => {
         alpha,
         prepared,
         [beta, alpha],
-        lifecycleOptions,
       ).status,
     ).toBe("shared");
     expect(runtimeProvider.destroy).not.toHaveBeenCalled();
@@ -431,7 +430,6 @@ describe("host-local inference lifecycle authority", () => {
         entry,
         prepared,
         [entry],
-        lifecycleOptions,
       ).status,
     ).toBe("removed");
     expect(qualified.createOperation).toHaveBeenCalledOnce();
@@ -468,7 +466,6 @@ describe("host-local inference lifecycle authority", () => {
         alpha,
         prepared,
         [alpha, beta],
-        lifecycleOptions,
       ),
     ).toThrow(/conflicting gateway, route, or provenance authority/);
     expect(runtimeProvider.destroy).not.toHaveBeenCalled();
@@ -505,7 +502,6 @@ describe("host-local inference lifecycle authority", () => {
         alpha,
         prepared,
         [alpha, beta],
-        lifecycleOptions,
       ),
     ).toThrow(/conflicting gateway, route, or provenance authority/);
     expect(runtimeProvider.destroy).not.toHaveBeenCalled();
@@ -542,7 +538,6 @@ describe("host-local inference lifecycle authority", () => {
         alpha,
         prepared,
         [alpha, beta],
-        lifecycleOptions,
       ),
     ).toThrow(/conflicting gateway, route, or provenance authority/);
     expect(runtimeProvider.destroy).not.toHaveBeenCalled();

--- a/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.test.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.test.ts
@@ -390,12 +390,10 @@ describe("host-local inference lifecycle authority", () => {
     );
 
     expect(
-      retirePreparedHostLocalInferenceAuthority(
-        runtimeProvider.bundle,
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, alpha, prepared, [
+        beta,
         alpha,
-        prepared,
-        [beta, alpha],
-      ).status,
+      ]).status,
     ).toBe("shared");
     expect(runtimeProvider.destroy).not.toHaveBeenCalled();
   });
@@ -425,17 +423,27 @@ describe("host-local inference lifecycle authority", () => {
     );
 
     expect(
-      retirePreparedHostLocalInferenceAuthority(
-        qualified.bundle,
-        entry,
-        prepared,
-        [entry],
-      ).status,
+      retirePreparedHostLocalInferenceAuthority(qualified.bundle, entry, prepared, [entry]).status,
     ).toBe("removed");
     expect(qualified.createOperation).toHaveBeenCalledOnce();
     expect(qualified.assertAuthority).toHaveBeenCalledTimes(2);
     expect(qualified.destroy).toHaveBeenCalledOnce();
     expect(drifted.destroy).not.toHaveBeenCalled();
+  });
+
+  it.each(SERVICES)("reuses the pre-delete %s operation during retirement (#9888)", (service) => {
+    const runtimeProvider = provider();
+    const entry = sandbox("alpha", receipt(service));
+    const prepared = requiredPrepared(
+      prepareSandboxHostLocalInferenceDestroyAuthority(runtimeProvider.bundle, entry),
+    );
+
+    expect(
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, entry, prepared, [entry])
+        .status,
+    ).toBe(service === "ollama" ? "retained" : "removed");
+    expect(runtimeProvider.createOperation).toHaveBeenCalledOnce();
+    expect(runtimeProvider.assertAuthority).toHaveBeenCalledTimes(2);
   });
 
   it("refuses provenance-tracked retirement when prepared authority drifts (#9888)", () => {
@@ -490,12 +498,10 @@ describe("host-local inference lifecycle authority", () => {
     );
 
     expect(() =>
-      retirePreparedHostLocalInferenceAuthority(
-        runtimeProvider.bundle,
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, alpha, prepared, [
         alpha,
-        prepared,
-        [alpha, beta],
-      ),
+        beta,
+      ]),
     ).toThrow(/conflicting gateway, route, or provenance authority/);
     expect(runtimeProvider.destroy).not.toHaveBeenCalled();
   });
@@ -526,12 +532,10 @@ describe("host-local inference lifecycle authority", () => {
     );
 
     expect(() =>
-      retirePreparedHostLocalInferenceAuthority(
-        runtimeProvider.bundle,
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, alpha, prepared, [
         alpha,
-        prepared,
-        [alpha, beta],
-      ),
+        beta,
+      ]),
     ).toThrow(/conflicting gateway, route, or provenance authority/);
     expect(runtimeProvider.destroy).not.toHaveBeenCalled();
   });
@@ -562,12 +566,10 @@ describe("host-local inference lifecycle authority", () => {
     );
 
     expect(() =>
-      retirePreparedHostLocalInferenceAuthority(
-        runtimeProvider.bundle,
+      retirePreparedHostLocalInferenceAuthority(runtimeProvider.bundle, alpha, prepared, [
         alpha,
-        prepared,
-        [alpha, beta],
-      ),
+        beta,
+      ]),
     ).toThrow(/conflicting gateway, route, or provenance authority/);
     expect(runtimeProvider.destroy).not.toHaveBeenCalled();
   });

--- a/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.ts
@@ -434,7 +434,6 @@ export function assertPreparedHostLocalInferenceRuntimePresent(
   provider: RuntimeProviderBundle,
   sandbox: HostLocalInferenceLifecycleSandbox,
   prepared: PreparedHostLocalInferenceAuthority,
-  _options: HostLocalInferenceLifecycleOptions = {},
 ): void {
   const { receipt, runtime } = currentHostLocalInferenceRuntime(provider, sandbox, prepared);
   runtime.inspectManaged(receipt);
@@ -574,7 +573,6 @@ export function retirePreparedHostLocalInferenceAuthority(
   sandbox: HostLocalInferenceLifecycleSandbox,
   prepared: PreparedHostLocalInferenceAuthority,
   peers: readonly HostLocalInferenceLifecycleSandbox[],
-  _options: HostLocalInferenceLifecycleOptions = {},
 ): HostLocalInferenceRetirementResult {
   const runtime = confirmHostLocalInferenceDestroyAuthority(provider, sandbox, prepared);
   if (sharedPeerStatus(provider, sandbox, prepared, peers) === "shared") {

--- a/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.ts
@@ -68,6 +68,10 @@ export interface PreparedHostLocalInferenceAuthority {
   readonly sandboxAuthority: HostLocalInferenceSandboxAuthority;
   /** Stable compare-and-swap identity for the complete outer registry binding. */
   readonly sandboxAuthoritySha256: string;
+  /** In-memory capability pinned before a destructive sandbox boundary. */
+  readonly destroyRuntime?: HostLocalInferenceRuntime;
+  /** Revalidates the pinned provider operation immediately before destructive use. */
+  readonly assertDestroyRuntimeAuthority?: () => void;
 }
 
 export type HostLocalInferenceRetirementResult =
@@ -210,7 +214,10 @@ function requireRuntime(
   receipt: ManagedHostLocalInferenceReceipt,
   sandbox: HostLocalInferenceLifecycleSandbox,
   options: HostLocalInferenceLifecycleOptions,
-): HostLocalInferenceRuntime {
+): {
+  readonly runtime: HostLocalInferenceRuntime;
+  readonly assertAuthority: () => void;
+} {
   const acceleration =
     receipt.runtime.kind === "host" ? receipt.runtime.acceleration : "nvidia-gpu";
   const operation = requireRuntimeProviderHostLocalInferenceOperation(provider, receipt.service, {
@@ -246,7 +253,7 @@ function requireRuntime(
     if (adapter.model !== sandbox.model) {
       fail("sandbox model differs from reconstructed llama.cpp authority");
     }
-    return adapter.runtime;
+    return Object.freeze({ runtime: adapter.runtime, assertAuthority: operation.assertAuthority });
   }
   const runtime = operation.managedRuntime;
   if (
@@ -260,7 +267,7 @@ function requireRuntime(
   ) {
     fail("provider returned an incomplete managed inference lifecycle");
   }
-  return runtime;
+  return Object.freeze({ runtime, assertAuthority: operation.assertAuthority });
 }
 
 function requireExactReceipt(
@@ -282,7 +289,8 @@ function prepare(
   const receipt = parseManagedReceipt(serialized, sandbox);
   if (!receipt) return null;
   const sandboxAuthority = captureSandboxAuthority(provider, sandbox, serialized, receipt);
-  const runtime = requireRuntime(provider, receipt, sandbox, options);
+  const required = requireRuntime(provider, receipt, sandbox, options);
+  const { runtime } = required;
   const reproved =
     mode === "destroy" ? runtime.prepareDestroy(receipt) : runtime.preserveForRebuild(receipt);
   requireExactReceipt(
@@ -300,6 +308,12 @@ function prepare(
     mode,
     sandboxAuthority,
     sandboxAuthoritySha256: sandboxAuthoritySha256(sandboxAuthority),
+    ...(mode === "destroy"
+      ? {
+          destroyRuntime: runtime,
+          assertDestroyRuntimeAuthority: required.assertAuthority,
+        }
+      : {}),
   });
 }
 
@@ -375,7 +389,7 @@ export function confirmHostLocalInferenceAuthority(
   requireCurrentSandboxAuthority(provider, sandbox, prepared, "preserve");
   const receipt = parseManagedReceipt(prepared.serializedReceipt, sandbox);
   if (!receipt) fail("prepared receipt no longer has a managed lifecycle");
-  const runtime = requireRuntime(provider, receipt, sandbox, options);
+  const { runtime } = requireRuntime(provider, receipt, sandbox, options);
   requireExactReceipt(
     prepared.serializedReceipt,
     runtime.preserveForRebuild(receipt),
@@ -395,7 +409,10 @@ function currentHostLocalInferenceRuntime(
   requireCurrentSandboxAuthority(provider, sandbox, prepared, "destroy");
   const receipt = parseManagedReceipt(prepared.serializedReceipt, sandbox);
   if (!receipt) fail("prepared receipt no longer has a managed lifecycle");
-  const runtime = requireRuntime(provider, receipt, sandbox, options);
+  const runtime = prepared.destroyRuntime;
+  const assertAuthority = prepared.assertDestroyRuntimeAuthority;
+  if (!runtime || !assertAuthority) fail("prepared destroy runtime capability is missing");
+  assertAuthority();
   return { receipt, runtime };
 }
 

--- a/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.ts
+++ b/src/lib/onboard/runtime-provider/host-local-inference-lifecycle.ts
@@ -401,7 +401,6 @@ function currentHostLocalInferenceRuntime(
   provider: RuntimeProviderBundle,
   sandbox: HostLocalInferenceLifecycleSandbox,
   prepared: PreparedHostLocalInferenceAuthority,
-  options: HostLocalInferenceLifecycleOptions,
 ): {
   readonly receipt: ManagedHostLocalInferenceReceipt;
   readonly runtime: HostLocalInferenceRuntime;
@@ -420,14 +419,8 @@ function confirmHostLocalInferenceDestroyAuthority(
   provider: RuntimeProviderBundle,
   sandbox: HostLocalInferenceLifecycleSandbox,
   prepared: PreparedHostLocalInferenceAuthority,
-  options: HostLocalInferenceLifecycleOptions,
 ): HostLocalInferenceRuntime {
-  const { receipt, runtime } = currentHostLocalInferenceRuntime(
-    provider,
-    sandbox,
-    prepared,
-    options,
-  );
+  const { receipt, runtime } = currentHostLocalInferenceRuntime(provider, sandbox, prepared);
   requireExactReceipt(
     prepared.serializedReceipt,
     runtime.prepareDestroy(receipt),
@@ -441,14 +434,9 @@ export function assertPreparedHostLocalInferenceRuntimePresent(
   provider: RuntimeProviderBundle,
   sandbox: HostLocalInferenceLifecycleSandbox,
   prepared: PreparedHostLocalInferenceAuthority,
-  options: HostLocalInferenceLifecycleOptions = {},
+  _options: HostLocalInferenceLifecycleOptions = {},
 ): void {
-  const { receipt, runtime } = currentHostLocalInferenceRuntime(
-    provider,
-    sandbox,
-    prepared,
-    options,
-  );
+  const { receipt, runtime } = currentHostLocalInferenceRuntime(provider, sandbox, prepared);
   runtime.inspectManaged(receipt);
 }
 
@@ -586,9 +574,9 @@ export function retirePreparedHostLocalInferenceAuthority(
   sandbox: HostLocalInferenceLifecycleSandbox,
   prepared: PreparedHostLocalInferenceAuthority,
   peers: readonly HostLocalInferenceLifecycleSandbox[],
-  options: HostLocalInferenceLifecycleOptions = {},
+  _options: HostLocalInferenceLifecycleOptions = {},
 ): HostLocalInferenceRetirementResult {
-  const runtime = confirmHostLocalInferenceDestroyAuthority(provider, sandbox, prepared, options);
+  const runtime = confirmHostLocalInferenceDestroyAuthority(provider, sandbox, prepared);
   if (sharedPeerStatus(provider, sandbox, prepared, peers) === "shared") {
     return Object.freeze({ status: "shared" as const, receipt: prepared.receipt });
   }

--- a/test/e2e/live/llama-cpp-generic-gpu.test.ts
+++ b/test/e2e/live/llama-cpp-generic-gpu.test.ts
@@ -455,6 +455,13 @@ test("installs managed llama.cpp on a generic Linux NVIDIA GPU and routes a real
     timeoutMs: 180_000,
   });
   expect(destroy.exitCode, resultText(destroy)).toBe(0);
+  const listAfterDestroy = await host.command("node", [CLI_ENTRYPOINT, "list"], {
+    artifactName: "list-after-managed-llama-cpp-destroy",
+    env: env(),
+    timeoutMs: 30_000,
+  });
+  expect(listAfterDestroy.exitCode, resultText(listAfterDestroy)).toBe(0);
+  expect(listAfterDestroy.stdout).not.toContain(SANDBOX_NAME);
   const runtimeAbsent = await host.command(
     "docker",
     ["container", "inspect", MANAGED_LLAMA_CPP_CONTAINER_NAME],

--- a/test/e2e/live/llama-cpp-generic-gpu.test.ts
+++ b/test/e2e/live/llama-cpp-generic-gpu.test.ts
@@ -19,6 +19,7 @@ import {
 import { isLlamaCppServingRecipe } from "../../../src/lib/inference/serving/adapter-registry.ts";
 import { managedInferenceDigest } from "../../../src/lib/inference/serving/catalog-integrity.ts";
 import { loadManagedInferenceCatalog } from "../../../src/lib/inference/serving/catalog-loader.ts";
+import { createDockerLlamaCppPrivateBridgeController } from "../../../src/lib/onboard/runtime-provider/docker-llama-cpp-private-bridge.ts";
 import { buildAvailabilityProbeEnv } from "../fixtures/availability-env.ts";
 import { resultText } from "../fixtures/clients/index.ts";
 import { trustedSandboxShellScript, validateSandboxName } from "../fixtures/clients/sandbox.ts";
@@ -63,436 +64,455 @@ function loadGenericGpuSetting() {
   return { modelFile, preset, recipe };
 }
 
-test("installs managed llama.cpp on a generic Linux NVIDIA GPU and routes a real agent turn (#8144)", {
-  timeout: TIMEOUT_MS,
-  meta: {
-    e2ePhases: [
-      "validate exact source and generic NVIDIA GPU host",
-      "run the declarative managed llama.cpp installer",
-      "verify exact runtime identity and full GPU offload",
-      "verify authenticated host and sandbox inference",
-      "verify OpenClaw agent inference and owned cleanup",
-    ],
+test(
+  "installs managed llama.cpp on a generic Linux NVIDIA GPU and routes a real agent turn (#8144)",
+  {
+    timeout: TIMEOUT_MS,
+    meta: {
+      e2ePhases: [
+        "validate exact source and generic NVIDIA GPU host",
+        "run the declarative managed llama.cpp installer",
+        "verify exact runtime identity and full GPU offload",
+        "verify authenticated host and sandbox inference",
+        "verify OpenClaw agent inference and owned cleanup",
+      ],
+    },
   },
-}, async ({ artifacts, cleanup, host, progress, sandbox }) => {
-  await artifacts.target.declare({
-    id: "llama-cpp-generic-gpu",
-    boundary:
-      "Linux amd64 host + Docker Engine + one NVIDIA GPU + install.sh managed llama.cpp + OpenShell sandbox route",
-    configurationAuthority:
-      "The repository-owned serving recipe and hardware preset supply every model, image, runtime, and serving value.",
-    credentialBoundary:
-      "The generated llama.cpp API key remains in owner-only host state and enters commands only through redacted process input.",
-  });
+  async ({ artifacts, cleanup, host, progress, sandbox }) => {
+    await artifacts.target.declare({
+      id: "llama-cpp-generic-gpu",
+      boundary:
+        "Linux amd64 host + Docker Engine + one NVIDIA GPU + install.sh managed llama.cpp + OpenShell sandbox route",
+      configurationAuthority:
+        "The repository-owned serving recipe and hardware preset supply every model, image, runtime, and serving value.",
+      credentialBoundary:
+        "The generated llama.cpp API key remains in owner-only host state and enters commands only through redacted process input.",
+    });
 
-  const cleanupEnv = env();
-  cleanup.trackGateway(host, "nemoclaw", {
-    artifactName: "cleanup-gateway",
-    env: cleanupEnv,
-    timeoutMs: 60_000,
-  });
-  cleanup.trackDisposable(`delete OpenShell sandbox ${SANDBOX_NAME}`, () =>
-    sandbox.cleanupSandbox(SANDBOX_NAME, {
-      artifactName: "cleanup-openshell-sandbox",
+    const cleanupEnv = env();
+    cleanup.trackGateway(host, "nemoclaw", {
+      artifactName: "cleanup-gateway",
       env: cleanupEnv,
       timeoutMs: 60_000,
-    }),
-  );
-  cleanup.trackSandbox(host, SANDBOX_NAME, {
-    artifactName: "cleanup-nemoclaw-sandbox",
-    env: cleanupEnv,
-    timeoutMs: 180_000,
-  });
-
-  progress.phase("validate exact source and generic NVIDIA GPU host");
-  const qualificationHeadSha = process.env.NEMOCLAW_LLAMA_CPP_QUALIFICATION_HEAD_SHA;
-  expect(qualificationHeadSha, "workflow must bind the exact candidate commit").toMatch(
-    /^[a-f0-9]{40}$/u,
-  );
-  const candidateSha = await host.command("git", ["rev-parse", "HEAD"], {
-    artifactName: "candidate-commit",
-    cwd: REPO_ROOT,
-    env: buildAvailabilityProbeEnv(),
-    timeoutMs: 30_000,
-  });
-  expect(candidateSha.exitCode, resultText(candidateSha)).toBe(0);
-  expect(candidateSha.stdout.trim()).toBe(qualificationHeadSha);
-
-  const architecture = await host.command("uname", ["-m"], {
-    artifactName: "host-architecture",
-    env: buildAvailabilityProbeEnv(),
-    timeoutMs: 30_000,
-  });
-  expect(architecture.exitCode, resultText(architecture)).toBe(0);
-  expect(architecture.stdout.trim()).toBe("x86_64");
-  const docker = await host.command("docker", ["info", "--format", "{{json .}}"], {
-    artifactName: "docker-info",
-    env: buildAvailabilityProbeEnv(),
-    timeoutMs: 30_000,
-  });
-  expect(docker.exitCode, resultText(docker)).toBe(0);
-  expect(resultText(docker)).not.toMatch(/docker desktop/i);
-  const nvidia = await host.command(
-    "nvidia-smi",
-    ["--query-gpu=name,driver_version,memory.total", "--format=csv,noheader,nounits"],
-    {
-      artifactName: "nvidia-smi",
-      env: buildAvailabilityProbeEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  expect(nvidia.exitCode, resultText(nvidia)).toBe(0);
-  expect(nvidia.stdout.trim()).toMatch(/^NVIDIA .+,[ ]*[0-9.]+,[ ]*[1-9][0-9]*$/u);
-
-  const { modelFile, preset, recipe } = loadGenericGpuSetting();
-
-  progress.phase("run the declarative managed llama.cpp installer");
-  const install = await host.command("bash", ["install.sh", "--non-interactive"], {
-    artifactName: "install-managed-llama-cpp",
-    cwd: REPO_ROOT,
-    env: env(),
-    timeoutMs: 75 * 60_000,
-  });
-  expect(install.exitCode, resultText(install)).toBe(0);
-  await artifacts.writeText("install-managed-llama-cpp.log", resultText(install));
-
-  progress.phase("verify exact runtime identity and full GPU offload");
-  const paths = managedLlamaCppStatePaths(os.homedir());
-  const modelCacheEntry = path.join(
-    os.homedir(),
-    ".cache",
-    "huggingface",
-    "hub",
-    `models--${recipe.spec.model.id.replaceAll("/", "--")}`,
-    "snapshots",
-    recipe.spec.model.revision,
-    modelFile.path,
-  );
-  const owner = loadManagedLlamaCppOwner(paths);
-  const receipt = loadManagedLlamaCppReceipt(paths);
-  expect(owner).not.toBeNull();
-  expect(receipt).not.toBeNull();
-  expect(fs.existsSync(modelCacheEntry), "verified GGUF cache entry is missing").toBe(true);
-  expect(owner).toMatchObject({
-    sandboxName: SANDBOX_NAME,
-    recipeId: RECIPE_ID,
-    presetDigest: managedInferenceDigest(preset),
-    recipeDigest: managedInferenceDigest(recipe),
-  });
-  expect(receipt).toMatchObject({
-    providerId: "docker",
-    service: "llama-cpp",
-    endpoint: {
-      host: "host.openshell.internal",
-      networkName: MANAGED_LLAMA_CPP_NETWORK_NAME,
-      port: recipe.spec.serve.port,
-    },
-    runtime: {
-      kind: "container",
-      name: MANAGED_LLAMA_CPP_CONTAINER_NAME,
-      imageRef: recipe.spec.runtime.image,
-      model: {
-        digest: modelFile.digest,
-        recipeId: RECIPE_ID,
-        sizeBytes: modelFile.sizeBytes,
-      },
-    },
-  });
-
-  const inspect = await host.command(
-    "docker",
-    ["container", "inspect", MANAGED_LLAMA_CPP_CONTAINER_NAME],
-    {
-      artifactName: "managed-llama-cpp-container-inspect",
-      env: buildAvailabilityProbeEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  expect(inspect.exitCode, resultText(inspect)).toBe(0);
-  const inspectedRuntime = JSON.parse(inspect.stdout) as Array<{
-    Config?: { Cmd?: unknown; Image?: unknown };
-    HostConfig?: { PortBindings?: Record<string, unknown> };
-    NetworkSettings?: { Ports?: Record<string, unknown> };
-    State?: { Pid?: unknown; Running?: unknown };
-  }>;
-  expect(inspectedRuntime).toHaveLength(1);
-  const runtime = inspectedRuntime[0];
-  expect(runtime?.State?.Running).toBe(true);
-  expect(runtime?.State?.Pid).toEqual(expect.any(Number));
-  expect(runtime?.Config?.Image).toBe(recipe.spec.runtime.image);
-  const containerPid = runtime?.State?.Pid as number;
-  expect(containerPid).toBeGreaterThan(0);
-  expect(runtime?.Config?.Cmd).toEqual(expect.any(Array));
-  const command = runtime?.Config?.Cmd as string[];
-  const gpuLayersIndex = command.indexOf("--gpu-layers");
-  expect(gpuLayersIndex).toBeGreaterThanOrEqual(0);
-  expect(command[gpuLayersIndex + 1]).toBe("all");
-  expect(inspectedRuntime[0]?.HostConfig?.PortBindings).toEqual({});
-  expect(
-    Object.values(inspectedRuntime[0]?.NetworkSettings?.Ports ?? {}).every(
-      (value) => value === null,
-    ),
-  ).toBe(true);
-  const logs = await host.command(
-    "docker",
-    ["logs", "--tail", "20000", MANAGED_LLAMA_CPP_CONTAINER_NAME],
-    {
-      artifactName: "managed-llama-cpp-container-logs",
-      env: buildAvailabilityProbeEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  expect(logs.exitCode, resultText(logs)).toBe(0);
-  const startupLog = resultText(logs);
-  expect(Buffer.byteLength(startupLog)).toBeGreaterThan(0);
-  expect(Buffer.byteLength(startupLog)).toBeLessThanOrEqual(16 * 1024 * 1024);
-  expect(startupLog).not.toMatch(
-    /no usable GPU|gpu-layers[^\n]*ignored|compiled without[^\n]*GPU|CPU fallback|fallback to CPU|falling back to CPU/iu,
-  );
-  expect(startupLog).toContain("llama_server: model loaded");
-  expect(startupLog).toContain(
-    `llama_server: listening on http://0.0.0.0:${recipe.spec.serve.port}`,
-  );
-  const computeApps = await host.command(
-    "nvidia-smi",
-    ["--query-compute-apps=pid,process_name,used_gpu_memory", "--format=csv,noheader,nounits"],
-    {
-      artifactName: "managed-llama-cpp-nvidia-compute-apps",
-      env: buildAvailabilityProbeEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  expect(computeApps.exitCode, resultText(computeApps)).toBe(0);
-  const llamaGpuProcess = computeApps.stdout
-    .trim()
-    .split("\n")
-    .map((line) => line.split(",").map((value) => value.trim()))
-    .find(
-      ([pid, processName]) => Number(pid) === containerPid && /llama-server$/u.test(processName),
-    );
-  expect(llamaGpuProcess, resultText(computeApps)).toBeDefined();
-  const usedGpuMemoryMiB = Number(llamaGpuProcess?.[2]);
-  const minimumFullOffloadMemoryMiB = Math.floor((modelFile.sizeBytes / 1024 ** 2) * 0.75);
-  expect(usedGpuMemoryMiB).toBeGreaterThanOrEqual(minimumFullOffloadMemoryMiB);
-  const status = await host.command("node", [CLI_ENTRYPOINT, SANDBOX_NAME, "status"], {
-    artifactName: "managed-llama-cpp-status",
-    env: env(),
-    timeoutMs: 120_000,
-  });
-  expect(status.exitCode, resultText(status)).toBe(0);
-  expect(resultText(status)).toContain("Managed llama.cpp: running");
-  expect(resultText(status)).toContain(RECIPE_ID);
-  const doctor = await host.command("node", [CLI_ENTRYPOINT, SANDBOX_NAME, "doctor"], {
-    artifactName: "managed-llama-cpp-doctor",
-    env: env(),
-    timeoutMs: 120_000,
-  });
-  expect(doctor.exitCode, resultText(doctor)).toBe(0);
-
-  progress.phase("verify authenticated host and sandbox inference");
-  const apiKey = loadManagedLlamaCppApiKey(paths);
-  expect(apiKey, "managed llama.cpp API key is missing").toMatch(/^[a-f0-9]{64}$/u);
-  artifacts.addRedactionValues([apiKey!]);
-  const unauthorized = await host.command(
-    "curl",
-    [
-      "-sS",
-      "-o",
-      "/dev/null",
-      "-w",
-      "%{http_code}",
-      `http://127.0.0.1:${String(recipe.spec.serve.port)}/props`,
-    ],
-    {
-      artifactName: "llama-cpp-unauthorized",
-      env: env(),
-      timeoutMs: 30_000,
-    },
-  );
-  expect(unauthorized.exitCode, resultText(unauthorized)).toBe(0);
-  expect(unauthorized.stdout).toBe("401");
-
-  const health = await host.command(
-    "curl",
-    [
-      "-fsS",
-      "-H",
-      `Authorization: Bearer ${apiKey!}`,
-      `http://127.0.0.1:${String(recipe.spec.serve.port)}/health`,
-    ],
-    {
-      artifactName: "llama-cpp-health",
-      env: env(),
-      redactionValues: [apiKey!],
-      timeoutMs: 30_000,
-    },
-  );
-  expect(health.exitCode, resultText(health)).toBe(0);
-  expect(health.stdout).toMatch(/ok/i);
-
-  const models = await host.command(
-    "curl",
-    [
-      "-fsS",
-      "-H",
-      `Authorization: Bearer ${apiKey!}`,
-      `http://127.0.0.1:${String(recipe.spec.serve.port)}/v1/models`,
-    ],
-    {
-      artifactName: "llama-cpp-models",
-      env: env(),
-      redactionValues: [apiKey!],
-      timeoutMs: 30_000,
-    },
-  );
-  expect(models.exitCode, resultText(models)).toBe(0);
-  expect(models.stdout).toContain(recipe.spec.model.servedName);
-
-  const hostChat = await host.command(
-    "curl",
-    [
-      "-fsS",
-      "-H",
-      `Authorization: Bearer ${apiKey!}`,
-      "-H",
-      "Content-Type: application/json",
-      `http://127.0.0.1:${String(recipe.spec.serve.port)}/v1/chat/completions`,
-      "--data",
-      JSON.stringify({
-        model: recipe.spec.model.servedName,
-        messages: [{ role: "user", content: "Reply with exactly one word: PONG" }],
-        max_tokens: 32,
+    });
+    cleanup.trackDisposable(`delete OpenShell sandbox ${SANDBOX_NAME}`, () =>
+      sandbox.cleanupSandbox(SANDBOX_NAME, {
+        artifactName: "cleanup-openshell-sandbox",
+        env: cleanupEnv,
+        timeoutMs: 60_000,
       }),
-    ],
-    {
-      artifactName: "llama-cpp-host-chat",
-      env: env(),
-      redactionValues: [apiKey!],
-      timeoutMs: 5 * 60_000,
-    },
-  );
-  expect(hostChat.exitCode, resultText(hostChat)).toBe(0);
-  expect(chatContent(hostChat.stdout)).toMatch(/pong/i);
+    );
+    cleanup.trackSandbox(host, SANDBOX_NAME, {
+      artifactName: "cleanup-nemoclaw-sandbox",
+      env: cleanupEnv,
+      timeoutMs: 180_000,
+    });
 
-  const sandboxChat = await sandbox.execShell(
-    SANDBOX_NAME,
-    trustedSandboxShellScript(
-      `curl -fsS --max-time 300 https://inference.local/v1/chat/completions -H 'Content-Type: application/json' --data '${JSON.stringify(
-        {
+    progress.phase("validate exact source and generic NVIDIA GPU host");
+    const qualificationHeadSha = process.env.NEMOCLAW_LLAMA_CPP_QUALIFICATION_HEAD_SHA;
+    expect(qualificationHeadSha, "workflow must bind the exact candidate commit").toMatch(
+      /^[a-f0-9]{40}$/u,
+    );
+    const candidateSha = await host.command("git", ["rev-parse", "HEAD"], {
+      artifactName: "candidate-commit",
+      cwd: REPO_ROOT,
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: 30_000,
+    });
+    expect(candidateSha.exitCode, resultText(candidateSha)).toBe(0);
+    expect(candidateSha.stdout.trim()).toBe(qualificationHeadSha);
+
+    const architecture = await host.command("uname", ["-m"], {
+      artifactName: "host-architecture",
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: 30_000,
+    });
+    expect(architecture.exitCode, resultText(architecture)).toBe(0);
+    expect(architecture.stdout.trim()).toBe("x86_64");
+    const docker = await host.command("docker", ["info", "--format", "{{json .}}"], {
+      artifactName: "docker-info",
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: 30_000,
+    });
+    expect(docker.exitCode, resultText(docker)).toBe(0);
+    expect(resultText(docker)).not.toMatch(/docker desktop/i);
+    const nvidia = await host.command(
+      "nvidia-smi",
+      ["--query-gpu=name,driver_version,memory.total", "--format=csv,noheader,nounits"],
+      {
+        artifactName: "nvidia-smi",
+        env: buildAvailabilityProbeEnv(),
+        timeoutMs: 30_000,
+      },
+    );
+    expect(nvidia.exitCode, resultText(nvidia)).toBe(0);
+    expect(nvidia.stdout.trim()).toMatch(/^NVIDIA .+,[ ]*[0-9.]+,[ ]*[1-9][0-9]*$/u);
+
+    const { modelFile, preset, recipe } = loadGenericGpuSetting();
+
+    progress.phase("run the declarative managed llama.cpp installer");
+    const install = await host.command("bash", ["install.sh", "--non-interactive"], {
+      artifactName: "install-managed-llama-cpp",
+      cwd: REPO_ROOT,
+      env: env(),
+      timeoutMs: 75 * 60_000,
+    });
+    expect(install.exitCode, resultText(install)).toBe(0);
+    await artifacts.writeText("install-managed-llama-cpp.log", resultText(install));
+
+    progress.phase("verify exact runtime identity and full GPU offload");
+    const paths = managedLlamaCppStatePaths(os.homedir());
+    const modelCacheEntry = path.join(
+      os.homedir(),
+      ".cache",
+      "huggingface",
+      "hub",
+      `models--${recipe.spec.model.id.replaceAll("/", "--")}`,
+      "snapshots",
+      recipe.spec.model.revision,
+      modelFile.path,
+    );
+    const owner = loadManagedLlamaCppOwner(paths);
+    const receipt = loadManagedLlamaCppReceipt(paths);
+    expect(owner).not.toBeNull();
+    expect(receipt).not.toBeNull();
+    expect(fs.existsSync(modelCacheEntry), "verified GGUF cache entry is missing").toBe(true);
+    expect(owner).toMatchObject({
+      sandboxName: SANDBOX_NAME,
+      recipeId: RECIPE_ID,
+      presetDigest: managedInferenceDigest(preset),
+      recipeDigest: managedInferenceDigest(recipe),
+    });
+    expect(receipt).toMatchObject({
+      providerId: "docker",
+      service: "llama-cpp",
+      endpoint: {
+        host: "host.openshell.internal",
+        networkName: MANAGED_LLAMA_CPP_NETWORK_NAME,
+        port: recipe.spec.serve.port,
+      },
+      runtime: {
+        kind: "container",
+        name: MANAGED_LLAMA_CPP_CONTAINER_NAME,
+        imageRef: recipe.spec.runtime.image,
+        model: {
+          digest: modelFile.digest,
+          recipeId: RECIPE_ID,
+          sizeBytes: modelFile.sizeBytes,
+        },
+      },
+    });
+    assert(
+      receipt?.runtime.kind === "container" &&
+        "model" in receipt.runtime &&
+        receipt.runtime.model !== undefined,
+      "managed llama.cpp receipt runtime is incomplete",
+    );
+    const transactionId = receipt.runtime.model.generation;
+
+    const inspect = await host.command(
+      "docker",
+      ["container", "inspect", MANAGED_LLAMA_CPP_CONTAINER_NAME],
+      {
+        artifactName: "managed-llama-cpp-container-inspect",
+        env: buildAvailabilityProbeEnv(),
+        timeoutMs: 30_000,
+      },
+    );
+    expect(inspect.exitCode, resultText(inspect)).toBe(0);
+    const inspectedRuntime = JSON.parse(inspect.stdout) as Array<{
+      Config?: { Cmd?: unknown; Image?: unknown };
+      HostConfig?: { PortBindings?: Record<string, unknown> };
+      NetworkSettings?: { Ports?: Record<string, unknown> };
+      State?: { Pid?: unknown; Running?: unknown };
+    }>;
+    expect(inspectedRuntime).toHaveLength(1);
+    const runtime = inspectedRuntime[0];
+    expect(runtime?.State?.Running).toBe(true);
+    expect(runtime?.State?.Pid).toEqual(expect.any(Number));
+    expect(runtime?.Config?.Image).toBe(recipe.spec.runtime.image);
+    const containerPid = runtime?.State?.Pid as number;
+    expect(containerPid).toBeGreaterThan(0);
+    expect(runtime?.Config?.Cmd).toEqual(expect.any(Array));
+    const command = runtime?.Config?.Cmd as string[];
+    const gpuLayersIndex = command.indexOf("--gpu-layers");
+    expect(gpuLayersIndex).toBeGreaterThanOrEqual(0);
+    expect(command[gpuLayersIndex + 1]).toBe("all");
+    expect(inspectedRuntime[0]?.HostConfig?.PortBindings).toEqual({});
+    expect(
+      Object.values(inspectedRuntime[0]?.NetworkSettings?.Ports ?? {}).every(
+        (value) => value === null,
+      ),
+    ).toBe(true);
+    const logs = await host.command(
+      "docker",
+      ["logs", "--tail", "20000", MANAGED_LLAMA_CPP_CONTAINER_NAME],
+      {
+        artifactName: "managed-llama-cpp-container-logs",
+        env: buildAvailabilityProbeEnv(),
+        timeoutMs: 30_000,
+      },
+    );
+    expect(logs.exitCode, resultText(logs)).toBe(0);
+    const startupLog = resultText(logs);
+    expect(Buffer.byteLength(startupLog)).toBeGreaterThan(0);
+    expect(Buffer.byteLength(startupLog)).toBeLessThanOrEqual(16 * 1024 * 1024);
+    expect(startupLog).not.toMatch(
+      /no usable GPU|gpu-layers[^\n]*ignored|compiled without[^\n]*GPU|CPU fallback|fallback to CPU|falling back to CPU/iu,
+    );
+    expect(startupLog).toContain("llama_server: model loaded");
+    expect(startupLog).toContain(
+      `llama_server: listening on http://0.0.0.0:${recipe.spec.serve.port}`,
+    );
+    const computeApps = await host.command(
+      "nvidia-smi",
+      ["--query-compute-apps=pid,process_name,used_gpu_memory", "--format=csv,noheader,nounits"],
+      {
+        artifactName: "managed-llama-cpp-nvidia-compute-apps",
+        env: buildAvailabilityProbeEnv(),
+        timeoutMs: 30_000,
+      },
+    );
+    expect(computeApps.exitCode, resultText(computeApps)).toBe(0);
+    const llamaGpuProcess = computeApps.stdout
+      .trim()
+      .split("\n")
+      .map((line) => line.split(",").map((value) => value.trim()))
+      .find(
+        ([pid, processName]) => Number(pid) === containerPid && /llama-server$/u.test(processName),
+      );
+    expect(llamaGpuProcess, resultText(computeApps)).toBeDefined();
+    const usedGpuMemoryMiB = Number(llamaGpuProcess?.[2]);
+    const minimumFullOffloadMemoryMiB = Math.floor((modelFile.sizeBytes / 1024 ** 2) * 0.75);
+    expect(usedGpuMemoryMiB).toBeGreaterThanOrEqual(minimumFullOffloadMemoryMiB);
+    const status = await host.command("node", [CLI_ENTRYPOINT, SANDBOX_NAME, "status"], {
+      artifactName: "managed-llama-cpp-status",
+      env: env(),
+      timeoutMs: 120_000,
+    });
+    expect(status.exitCode, resultText(status)).toBe(0);
+    expect(resultText(status)).toContain("Managed llama.cpp: running");
+    expect(resultText(status)).toContain(RECIPE_ID);
+    const doctor = await host.command("node", [CLI_ENTRYPOINT, SANDBOX_NAME, "doctor"], {
+      artifactName: "managed-llama-cpp-doctor",
+      env: env(),
+      timeoutMs: 120_000,
+    });
+    expect(doctor.exitCode, resultText(doctor)).toBe(0);
+
+    progress.phase("verify authenticated host and sandbox inference");
+    const apiKey = loadManagedLlamaCppApiKey(paths);
+    expect(apiKey, "managed llama.cpp API key is missing").toMatch(/^[a-f0-9]{64}$/u);
+    artifacts.addRedactionValues([apiKey!]);
+    const unauthorized = await host.command(
+      "curl",
+      [
+        "-sS",
+        "-o",
+        "/dev/null",
+        "-w",
+        "%{http_code}",
+        `http://127.0.0.1:${String(recipe.spec.serve.port)}/props`,
+      ],
+      {
+        artifactName: "llama-cpp-unauthorized",
+        env: env(),
+        timeoutMs: 30_000,
+      },
+    );
+    expect(unauthorized.exitCode, resultText(unauthorized)).toBe(0);
+    expect(unauthorized.stdout).toBe("401");
+
+    const health = await host.command(
+      "curl",
+      [
+        "-fsS",
+        "-H",
+        `Authorization: Bearer ${apiKey!}`,
+        `http://127.0.0.1:${String(recipe.spec.serve.port)}/health`,
+      ],
+      {
+        artifactName: "llama-cpp-health",
+        env: env(),
+        redactionValues: [apiKey!],
+        timeoutMs: 30_000,
+      },
+    );
+    expect(health.exitCode, resultText(health)).toBe(0);
+    expect(health.stdout).toMatch(/ok/i);
+
+    const models = await host.command(
+      "curl",
+      [
+        "-fsS",
+        "-H",
+        `Authorization: Bearer ${apiKey!}`,
+        `http://127.0.0.1:${String(recipe.spec.serve.port)}/v1/models`,
+      ],
+      {
+        artifactName: "llama-cpp-models",
+        env: env(),
+        redactionValues: [apiKey!],
+        timeoutMs: 30_000,
+      },
+    );
+    expect(models.exitCode, resultText(models)).toBe(0);
+    expect(models.stdout).toContain(recipe.spec.model.servedName);
+
+    const hostChat = await host.command(
+      "curl",
+      [
+        "-fsS",
+        "-H",
+        `Authorization: Bearer ${apiKey!}`,
+        "-H",
+        "Content-Type: application/json",
+        `http://127.0.0.1:${String(recipe.spec.serve.port)}/v1/chat/completions`,
+        "--data",
+        JSON.stringify({
           model: recipe.spec.model.servedName,
           messages: [{ role: "user", content: "Reply with exactly one word: PONG" }],
           max_tokens: 32,
-        },
-      )}'`,
-    ),
-    { artifactName: "sandbox-inference-local-chat", env: env(), timeoutMs: 6 * 60_000 },
-  );
-  expect(sandboxChat.exitCode, resultText(sandboxChat)).toBe(0);
-  expect(chatContent(sandboxChat.stdout)).toMatch(/pong/i);
+        }),
+      ],
+      {
+        artifactName: "llama-cpp-host-chat",
+        env: env(),
+        redactionValues: [apiKey!],
+        timeoutMs: 5 * 60_000,
+      },
+    );
+    expect(hostChat.exitCode, resultText(hostChat)).toBe(0);
+    expect(chatContent(hostChat.stdout)).toMatch(/pong/i);
 
-  progress.phase("verify OpenClaw agent inference and owned cleanup");
-  const agent = await host.nemoclaw(
-    [
+    const sandboxChat = await sandbox.execShell(
       SANDBOX_NAME,
-      "agent",
-      "--agent",
-      "main",
-      "--json",
-      "--session-id",
-      `e2e-llama-cpp-generic-gpu-${Date.now()}-${process.pid}`,
-      "-m",
-      "Reply with exactly one word: PONG",
-    ],
-    {
-      artifactName: "openclaw-agent-through-managed-llama-cpp",
+      trustedSandboxShellScript(
+        `curl -fsS --max-time 300 https://inference.local/v1/chat/completions -H 'Content-Type: application/json' --data '${JSON.stringify(
+          {
+            model: recipe.spec.model.servedName,
+            messages: [{ role: "user", content: "Reply with exactly one word: PONG" }],
+            max_tokens: 32,
+          },
+        )}'`,
+      ),
+      { artifactName: "sandbox-inference-local-chat", env: env(), timeoutMs: 6 * 60_000 },
+    );
+    expect(sandboxChat.exitCode, resultText(sandboxChat)).toBe(0);
+    expect(chatContent(sandboxChat.stdout)).toMatch(/pong/i);
+
+    progress.phase("verify OpenClaw agent inference and owned cleanup");
+    const agent = await host.nemoclaw(
+      [
+        SANDBOX_NAME,
+        "agent",
+        "--agent",
+        "main",
+        "--json",
+        "--session-id",
+        `e2e-llama-cpp-generic-gpu-${Date.now()}-${process.pid}`,
+        "-m",
+        "Reply with exactly one word: PONG",
+      ],
+      {
+        artifactName: "openclaw-agent-through-managed-llama-cpp",
+        env: env(),
+        timeoutMs: 12 * 60_000,
+      },
+    );
+    expect(agent.exitCode, resultText(agent)).toBe(0);
+    assertAgentExecutionSucceeded(agent.stdout, "inference", recipe.spec.model.servedName);
+
+    const readySandbox = await sandbox.openshell(["sandbox", "get", SANDBOX_NAME], {
+      artifactName: "openshell-sandbox-ready-after-agent",
+      env: buildAvailabilityProbeEnv(),
+      timeoutMs: 30_000,
+    });
+    expect(readySandbox.exitCode, resultText(readySandbox)).toBe(0);
+    expect(hasExactReadyPhase(readySandbox.stdout)).toBe(true);
+
+    await artifacts.writeJson("qualification-evidence.json", {
+      candidateSha: qualificationHeadSha,
+      preset: { id: PRESET_ID, digest: owner!.presetDigest },
+      recipe: { id: RECIPE_ID, digest: owner!.recipeDigest },
+      model: {
+        id: recipe.spec.model.id,
+        digest: modelFile.digest,
+        servedName: recipe.spec.model.servedName,
+      },
+      runtime: { image: recipe.spec.runtime.image, provider: receipt!.providerId },
+      gpu: {
+        host: nvidia.stdout.trim(),
+        computeProcess: computeApps.stdout.trim(),
+        requestedLayers: command[gpuLayersIndex + 1],
+        usedMemoryMiB: usedGpuMemoryMiB,
+        minimumFullOffloadMemoryMiB,
+      },
+      probes: {
+        unauthorizedStatus: 401,
+        health: "passed",
+        models: "passed",
+        status: "passed",
+        doctor: "passed",
+        hostChat: "passed",
+        sandboxChat: "passed",
+        openClawAgent: "passed",
+      },
+    });
+
+    const destroy = await host.command("node", [CLI_ENTRYPOINT, SANDBOX_NAME, "destroy", "--yes"], {
+      artifactName: "destroy-managed-llama-cpp-sandbox",
       env: env(),
-      timeoutMs: 12 * 60_000,
-    },
-  );
-  expect(agent.exitCode, resultText(agent)).toBe(0);
-  assertAgentExecutionSucceeded(agent.stdout, "inference", recipe.spec.model.servedName);
+      timeoutMs: 180_000,
+    });
+    expect(destroy.exitCode, resultText(destroy)).toBe(0);
+    expect(() =>
+      createDockerLlamaCppPrivateBridgeController().assertStopped(transactionId),
+    ).not.toThrow();
+    const listAfterDestroy = await host.command("node", [CLI_ENTRYPOINT, "list", "--json"], {
+      artifactName: "list-after-managed-llama-cpp-destroy",
+      env: env(),
+      timeoutMs: 30_000,
+    });
+    expect(listAfterDestroy.exitCode, resultText(listAfterDestroy)).toBe(0);
+    const inventory = JSON.parse(listAfterDestroy.stdout) as {
+      sandboxes: Array<{ name: string }>;
+    };
+    expect(inventory.sandboxes.map(({ name }) => name)).not.toContain(SANDBOX_NAME);
+    const runtimeAbsent = await host.command(
+      "docker",
+      ["container", "inspect", MANAGED_LLAMA_CPP_CONTAINER_NAME],
+      {
+        artifactName: "managed-llama-cpp-container-absent",
+        env: buildAvailabilityProbeEnv(),
+        timeoutMs: 30_000,
+      },
+    );
+    expect(runtimeAbsent.exitCode).toBe(1);
+    const networkAbsent = await host.command(
+      "docker",
+      ["network", "inspect", MANAGED_LLAMA_CPP_NETWORK_NAME],
+      {
+        artifactName: "managed-llama-cpp-network-absent",
+        env: buildAvailabilityProbeEnv(),
+        timeoutMs: 30_000,
+      },
+    );
+    expect(networkAbsent.exitCode).toBe(1);
+    expect(fs.existsSync(paths.stateDir), "destroy must remove managed llama.cpp state").toBe(
+      false,
+    );
+    expect(
+      fs.existsSync(modelCacheEntry),
+      "destroy must preserve the shared Hugging Face cache entry",
+    ).toBe(true);
 
-  const readySandbox = await sandbox.openshell(["sandbox", "get", SANDBOX_NAME], {
-    artifactName: "openshell-sandbox-ready-after-agent",
-    env: buildAvailabilityProbeEnv(),
-    timeoutMs: 30_000,
-  });
-  expect(readySandbox.exitCode, resultText(readySandbox)).toBe(0);
-  expect(hasExactReadyPhase(readySandbox.stdout)).toBe(true);
-
-  await artifacts.writeJson("qualification-evidence.json", {
-    candidateSha: qualificationHeadSha,
-    preset: { id: PRESET_ID, digest: owner!.presetDigest },
-    recipe: { id: RECIPE_ID, digest: owner!.recipeDigest },
-    model: {
-      id: recipe.spec.model.id,
-      digest: modelFile.digest,
-      servedName: recipe.spec.model.servedName,
-    },
-    runtime: { image: recipe.spec.runtime.image, provider: receipt!.providerId },
-    gpu: {
-      host: nvidia.stdout.trim(),
-      computeProcess: computeApps.stdout.trim(),
-      requestedLayers: command[gpuLayersIndex + 1],
-      usedMemoryMiB: usedGpuMemoryMiB,
-      minimumFullOffloadMemoryMiB,
-    },
-    probes: {
-      unauthorizedStatus: 401,
-      health: "passed",
-      models: "passed",
+    await artifacts.target.complete({
+      id: "llama-cpp-generic-gpu",
       status: "passed",
-      doctor: "passed",
-      hostChat: "passed",
-      sandboxChat: "passed",
-      openClawAgent: "passed",
-    },
-  });
-
-  const destroy = await host.command("node", [CLI_ENTRYPOINT, SANDBOX_NAME, "destroy", "--yes"], {
-    artifactName: "destroy-managed-llama-cpp-sandbox",
-    env: env(),
-    timeoutMs: 180_000,
-  });
-  expect(destroy.exitCode, resultText(destroy)).toBe(0);
-  const listAfterDestroy = await host.command("node", [CLI_ENTRYPOINT, "list"], {
-    artifactName: "list-after-managed-llama-cpp-destroy",
-    env: env(),
-    timeoutMs: 30_000,
-  });
-  expect(listAfterDestroy.exitCode, resultText(listAfterDestroy)).toBe(0);
-  expect(listAfterDestroy.stdout).not.toContain(SANDBOX_NAME);
-  const runtimeAbsent = await host.command(
-    "docker",
-    ["container", "inspect", MANAGED_LLAMA_CPP_CONTAINER_NAME],
-    {
-      artifactName: "managed-llama-cpp-container-absent",
-      env: buildAvailabilityProbeEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  expect(runtimeAbsent.exitCode).toBe(1);
-  const networkAbsent = await host.command(
-    "docker",
-    ["network", "inspect", MANAGED_LLAMA_CPP_NETWORK_NAME],
-    {
-      artifactName: "managed-llama-cpp-network-absent",
-      env: buildAvailabilityProbeEnv(),
-      timeoutMs: 30_000,
-    },
-  );
-  expect(networkAbsent.exitCode).toBe(1);
-  expect(fs.existsSync(paths.stateDir), "destroy must remove managed llama.cpp state").toBe(false);
-  expect(
-    fs.existsSync(modelCacheEntry),
-    "destroy must preserve the shared Hugging Face cache entry",
-  ).toBe(true);
-
-  await artifacts.target.complete({
-    id: "llama-cpp-generic-gpu",
-    status: "passed",
-    candidateSha: qualificationHeadSha,
-    fullGpuOffload: true,
-    model: recipe.spec.model.servedName,
-  });
-});
+      candidateSha: qualificationHeadSha,
+      fullGpuOffload: true,
+      model: recipe.spec.model.servedName,
+    });
+  },
+);

--- a/test/e2e/live/llama-cpp-generic-gpu.test.ts
+++ b/test/e2e/live/llama-cpp-generic-gpu.test.ts
@@ -65,7 +65,7 @@ function loadGenericGpuSetting() {
 }
 
 test(
-  "installs managed llama.cpp on a generic Linux NVIDIA GPU and routes a real agent turn (#8144)",
+  "installs managed llama.cpp, routes a real agent turn, and destroys its runtime (#8144, #9888)",
   {
     timeout: TIMEOUT_MS,
     meta: {

--- a/test/e2e/live/llama-cpp-generic-gpu.test.ts
+++ b/test/e2e/live/llama-cpp-generic-gpu.test.ts
@@ -460,9 +460,15 @@ test(
       },
     });
 
+    const destroyEnv = env();
+    delete destroyEnv.NEMOCLAW_ACCEPT_THIRD_PARTY_SOFTWARE;
+    delete destroyEnv.NEMOCLAW_LLAMACPP_RECIPE;
+    delete destroyEnv.NEMOCLAW_NON_INTERACTIVE;
+    delete destroyEnv.NEMOCLAW_PROVIDER;
+    delete destroyEnv.NEMOCLAW_RECREATE_SANDBOX;
     const destroy = await host.command("node", [CLI_ENTRYPOINT, SANDBOX_NAME, "destroy", "--yes"], {
       artifactName: "destroy-managed-llama-cpp-sandbox",
-      env: env(),
+      env: destroyEnv,
       timeoutMs: 180_000,
     });
     expect(destroy.exitCode, resultText(destroy)).toBe(0);
@@ -471,7 +477,7 @@ test(
     ).not.toThrow();
     const listAfterDestroy = await host.command("node", [CLI_ENTRYPOINT, "list", "--json"], {
       artifactName: "list-after-managed-llama-cpp-destroy",
-      env: env(),
+      env: destroyEnv,
       timeoutMs: 30_000,
     });
     expect(listAfterDestroy.exitCode, resultText(listAfterDestroy)).toBe(0);

--- a/test/helpers/destroy-flow-test-harness.ts
+++ b/test/helpers/destroy-flow-test-harness.ts
@@ -37,6 +37,7 @@ export type DestroyHarness = {
   prepareMcpBridgesForAbsentSandboxDestroySpy: MockInstance;
   prepareMcpBridgesForDestroySpy: MockInstance;
   prepareManagedLlamaCppRuntimeCleanupSpy: MockInstance;
+  cleanupManagedLlamaCppRuntimeForSandboxSpy: MockInstance;
   promptSpy: MockInstance;
   removeManagedHermesStateVolumeSpy: MockInstance;
   removeSandboxSpy: MockInstance;
@@ -221,6 +222,9 @@ export function createDestroyHarness(options: DestroyHarnessOptions = {}): Destr
       options.onPrepareManagedLlamaCppRuntimeCleanup?.();
       return options.preparedManagedLlamaCppRuntimeCleanup ?? null;
     });
+  const cleanupManagedLlamaCppRuntimeForSandboxSpy = vi
+    .spyOn(localModelProfileCleanup, "cleanupManagedLlamaCppRuntimeForSandbox")
+    .mockReturnValue({ ok: true, removed: [], preserved: [] });
 
   const assertHermesPortableCommandUnavailableSpy = vi
     .spyOn(portableAgentLifecycle, "assertHermesPortableCommandUnavailable")
@@ -557,6 +561,7 @@ export function createDestroyHarness(options: DestroyHarnessOptions = {}): Destr
     prepareMcpBridgesForAbsentSandboxDestroySpy,
     prepareMcpBridgesForDestroySpy,
     prepareManagedLlamaCppRuntimeCleanupSpy,
+    cleanupManagedLlamaCppRuntimeForSandboxSpy,
     promptSpy,
     removeManagedHermesStateVolumeSpy,
     removeSandboxSpy,

--- a/test/helpers/destroy-flow-test-harness.ts
+++ b/test/helpers/destroy-flow-test-harness.ts
@@ -93,6 +93,7 @@ type DestroyHarnessOptions = {
   prepareMcpBridgeError?: string;
   promptResponses?: string[];
   provider?: string;
+  registryEntryPresent?: boolean;
   registeredSandboxCount?: number;
   replaceSessionAfterRegistryRemoval?: boolean;
   removeSandboxResult?: boolean;
@@ -236,36 +237,40 @@ export function createDestroyHarness(options: DestroyHarnessOptions = {}): Destr
     detected: true,
     sessions: [{ pid: 1 }],
   });
-  vi.spyOn(registry, "getSandbox").mockReturnValue({
-    ...sandboxEntry,
-    imageTag: options.imageTag === undefined ? sandboxEntry.imageTag : options.imageTag,
-    agent: options.agent ?? sandboxEntry.agent,
-    ...(options.provider ? { provider: options.provider } : {}),
-    ...(options.openshellDriver ? { openshellDriver: options.openshellDriver } : {}),
-    ...(options.endpointUrl ? { endpointUrl: options.endpointUrl } : {}),
-    ...(options.hostLocalInferenceReceipt !== undefined
-      ? { hostLocalInferenceReceipt: options.hostLocalInferenceReceipt }
-      : {}),
-    ...(options.hostLocalInferenceProvenance
-      ? { hostLocalInferenceProvenance: options.hostLocalInferenceProvenance }
-      : {}),
-    ...(options.workload ? { workload: options.workload } : {}),
-    ...(options.mcpServers?.length
-      ? {
-          mcp: {
-            bridges: Object.fromEntries(
-              options.mcpServers.map((server) => [
-                server,
-                {
-                  server,
-                  ...(options.mcpAddState ? { addState: options.mcpAddState } : {}),
+  vi.spyOn(registry, "getSandbox").mockReturnValue(
+    options.registryEntryPresent === false
+      ? null
+      : {
+          ...sandboxEntry,
+          imageTag: options.imageTag === undefined ? sandboxEntry.imageTag : options.imageTag,
+          agent: options.agent ?? sandboxEntry.agent,
+          ...(options.provider ? { provider: options.provider } : {}),
+          ...(options.openshellDriver ? { openshellDriver: options.openshellDriver } : {}),
+          ...(options.endpointUrl ? { endpointUrl: options.endpointUrl } : {}),
+          ...(options.hostLocalInferenceReceipt !== undefined
+            ? { hostLocalInferenceReceipt: options.hostLocalInferenceReceipt }
+            : {}),
+          ...(options.hostLocalInferenceProvenance
+            ? { hostLocalInferenceProvenance: options.hostLocalInferenceProvenance }
+            : {}),
+          ...(options.workload ? { workload: options.workload } : {}),
+          ...(options.mcpServers?.length
+            ? {
+                mcp: {
+                  bridges: Object.fromEntries(
+                    options.mcpServers.map((server) => [
+                      server,
+                      {
+                        server,
+                        ...(options.mcpAddState ? { addState: options.mcpAddState } : {}),
+                      },
+                    ]),
+                  ),
                 },
-              ]),
-            ),
-          },
-        }
-      : {}),
-  });
+              }
+            : {}),
+        },
+  );
   let registeredSandboxCount = options.registeredSandboxCount ?? 0;
   vi.spyOn(registry, "listSandboxes").mockImplementation(() => ({
     sandboxes: Array.from({ length: registeredSandboxCount }, (_, index) => ({

--- a/test/helpers/destroy-flow-test-harness.ts
+++ b/test/helpers/destroy-flow-test-harness.ts
@@ -4,9 +4,11 @@
 import { createRequire } from "node:module";
 
 import { expect, type MockInstance, vi } from "vitest";
+import type { SandboxDestroyExecutionResult } from "../../src/lib/actions/sandbox/destroy-execution";
+import type { PreparedManagedLlamaCppRuntimeCleanup } from "../../src/lib/inference/local-model-profile/cleanup";
 import type { ManagedHermesStateVolumeCleanupResult } from "../../src/lib/onboard/managed-workload/hermes-state-volume";
 import type { Session } from "../../src/lib/state/onboard-session";
-import type { SandboxWorkloadReceipt } from "../../src/lib/state/registry";
+import type { SandboxEntry, SandboxWorkloadReceipt } from "../../src/lib/state/registry";
 
 type DestroySandbox = (typeof import("../../src/lib/actions/sandbox/destroy"))["destroySandbox"];
 
@@ -25,6 +27,7 @@ export type DestroyHarness = {
   dockerRunSpy: MockInstance;
   errorSpy: MockInstance;
   events: string[];
+  executeSandboxDestroySpy: MockInstance;
   finalizeMcpBridgesAfterSandboxDeleteSpy: MockInstance;
   gatewayPinsAtMcpPrepare: Array<string | undefined>;
   gatewayPinsAtSandboxList: Array<string | undefined>;
@@ -33,6 +36,7 @@ export type DestroyHarness = {
   logSpy: MockInstance;
   prepareMcpBridgesForAbsentSandboxDestroySpy: MockInstance;
   prepareMcpBridgesForDestroySpy: MockInstance;
+  prepareManagedLlamaCppRuntimeCleanupSpy: MockInstance;
   promptSpy: MockInstance;
   removeManagedHermesStateVolumeSpy: MockInstance;
   removeSandboxSpy: MockInstance;
@@ -72,11 +76,16 @@ type DestroyHarnessOptions = {
   onDockerRun?: (call: number) => void;
   detachedProviders?: string[];
   endpointUrl?: string;
+  executeSandboxDestroyResult?: SandboxDestroyExecutionResult;
   finalizeMcpBridgeError?: string;
   finalizeMcpError?: string;
   imageTag?: string | null;
+  hostLocalInferenceReceipt?: string | null;
+  hostLocalInferenceProvenance?: SandboxEntry["hostLocalInferenceProvenance"];
   liveListOutput?: string;
   managedHermesStateVolumeCleanupResult?: ManagedHermesStateVolumeCleanupResult;
+  onPrepareManagedLlamaCppRuntimeCleanup?: () => void;
+  preparedManagedLlamaCppRuntimeCleanup?: PreparedManagedLlamaCppRuntimeCleanup | null;
   mcpAddState?: "prepared";
   mcpServers?: string[];
   openshellDriver?: string;
@@ -198,6 +207,19 @@ export function createDestroyHarness(options: DestroyHarnessOptions = {}): Destr
   const portableAgentLifecycle = requireDist(
     "../../onboard/experimental/portable-agent-lifecycle.js",
   );
+  const localModelProfileCleanup = requireDist("../../inference/local-model-profile/cleanup.js");
+
+  const executeSandboxDestroySpy = vi.spyOn(destroyExecution, "executeSandboxDestroy");
+  if (options.executeSandboxDestroyResult) {
+    executeSandboxDestroySpy.mockResolvedValue(options.executeSandboxDestroyResult);
+  }
+
+  const prepareManagedLlamaCppRuntimeCleanupSpy = vi
+    .spyOn(localModelProfileCleanup, "prepareManagedLlamaCppRuntimeCleanupForSandbox")
+    .mockImplementation(() => {
+      options.onPrepareManagedLlamaCppRuntimeCleanup?.();
+      return options.preparedManagedLlamaCppRuntimeCleanup ?? null;
+    });
 
   const assertHermesPortableCommandUnavailableSpy = vi
     .spyOn(portableAgentLifecycle, "assertHermesPortableCommandUnavailable")
@@ -221,6 +243,12 @@ export function createDestroyHarness(options: DestroyHarnessOptions = {}): Destr
     ...(options.provider ? { provider: options.provider } : {}),
     ...(options.openshellDriver ? { openshellDriver: options.openshellDriver } : {}),
     ...(options.endpointUrl ? { endpointUrl: options.endpointUrl } : {}),
+    ...(options.hostLocalInferenceReceipt !== undefined
+      ? { hostLocalInferenceReceipt: options.hostLocalInferenceReceipt }
+      : {}),
+    ...(options.hostLocalInferenceProvenance
+      ? { hostLocalInferenceProvenance: options.hostLocalInferenceProvenance }
+      : {}),
     ...(options.workload ? { workload: options.workload } : {}),
     ...(options.mcpServers?.length
       ? {
@@ -514,6 +542,7 @@ export function createDestroyHarness(options: DestroyHarnessOptions = {}): Destr
     destroySandbox: requireDist(destroyModulePath).destroySandbox,
     errorSpy,
     events,
+    executeSandboxDestroySpy,
     finalizeMcpBridgesAfterSandboxDeleteSpy,
     gatewayPinsAtMcpPrepare,
     gatewayPinsAtSandboxList,
@@ -522,6 +551,7 @@ export function createDestroyHarness(options: DestroyHarnessOptions = {}): Destr
     logSpy,
     prepareMcpBridgesForAbsentSandboxDestroySpy,
     prepareMcpBridgesForDestroySpy,
+    prepareManagedLlamaCppRuntimeCleanupSpy,
     promptSpy,
     removeManagedHermesStateVolumeSpy,
     removeSandboxSpy,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Pin managed llama.cpp's qualified Docker operation, exclusive lifecycle execution lease, and exact private state before the OpenShell sandbox-delete boundary, then reuse them during cleanup. Destroy now avoids false authority drift on provenance-tracked and legacy sandboxes while failing before deletion when Docker, resource ownership, persisted authority, or lifecycle exclusivity cannot be proved.

## Related Issue

Fixes #9888

## Changes

- Retain the exact common-lifecycle runtime and authority guard from destroy preparation through provenance-tracked retirement.
- Prepare legacy managed llama.cpp cleanup before OpenShell sandbox deletion and reuse the same qualified engine afterward.
- Read legacy create journals and persisted engine authority without creating directories during preflight, while reconciling a recoverable interrupted exclusive publication.
- Require private receipt/journal agreement, Docker availability, and exact container/network ownership before sandbox deletion.
- Bind cleanup to an allowlisted snapshot of every recursively removed private entry, including the API key, owner, receipt, journals, and persisted authority; reject any drift after deletion.
- Hold exclusive lifecycle execution ownership from cleanup preparation through sandbox deletion; release it on every abort path and reject a concurrent live lifecycle operation before deletion.
- Abort the retained cleanup lease when destroy execution or post-delete service cleanup throws so a retry is never blocked by the failed attempt.
- Capture the private-state baseline before external resource proof, recheck it afterward, and never qualify newly appeared state only after sandbox deletion.
- Reject mixed or multiple lifecycle journals before deletion and recheck persisted authority before removing private state.
- Add regression coverage for destructive ordering, live lifecycle leases, interrupted state, cleanup retry, private-state drift, foreign resources, post-destroy listing, and unrelated-provider isolation.
- Document Docker selector recovery, pre-delete proofs, failure preservation, and post-destroy verification.

The two cleanup mechanisms serve the repository's two existing lifecycle consumers: provenance-tracked sandboxes use the common host-local inference coordinator, while `llama-cpp-local` rows with unmarked schema-v1 receipts retain the legacy local-model-profile path. Hermes and snapshot lifecycle signatures are unchanged. A post-delete-only change is insufficient because Docker selection can already have changed at that boundary.

Uninstall remains intentionally out of scope and is tracked separately by #9575, matching the issue family's command-specific split.

Intentional failure-ordering change: when owner state exists but persisted Docker authority does not, `destroy` now refuses before OpenShell sandbox deletion instead of deleting the sandbox and failing local cleanup afterward.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The exact-head private grogu+Codex gate ran on normal push; the independent documentation-writer review passed. Maintainer review is still requested.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 186 focused tests passed on the final code head across the changed destroy, cleanup, journal, and managed host-local inference lifecycle suites; the prior broader focused pass covered 235 tests.
- [ ] Applicable broad gate passed — `npm test` was attempted, but the local host lacks the Docker executable plus installer, PTY, and system prerequisites required by unrelated integration lanes. The 186 changed-path tests, CLI build, `npm run checks:repository`, type check, and semantic E2E phase passed. The hardware-backed x86_64 `llama-cpp-generic-gpu` live target was extended but was not executed locally; aarch64 and live `--force` remain unexecuted evidence dimensions.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — Completed with zero errors and two pre-existing Fern warnings.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `docs-updated`
- Evidence: Independently reviewed the complete PR diff from base `79714f1040f74b1a333b1cb1c759a4ff2bd64efa` through commit `330c31b443a8faccacb4fdd86a99c43ba9caee5f` under `AGENTS.md` blob `513518cdfca42e3a18fed71109e6d0eb60151d13`. The llama.cpp documentation remains accurate for retained managed Docker cleanup authority and the preserved schema-4 Portable Podman authority. The fast-forward from the previously reviewed `6f79bd5a7859b7f259fe5b57e8905364b54d619f` added only the PR Review Advisor workflow and tooling files; it did not alter the PR documentation or lifecycle implementation. At the exact reviewed commit, `npm run docs` passed with 68 guarded routes, 0 errors, and 2 pre-existing warnings, and `git diff --check` was clean. Validation of the unchanged lifecycle patch at `6f79bd5a7859b7f259fe5b57e8905364b54d619f` included a successful CLI build, 80/80 focused destroy and Portable authority tests, and successful normal pre-commit and commit-msg hooks.
- Agent: Codex Desktop
- Nonblocking note: `docs/inference/set-up-llama-cpp.mdx` line 347 can later say “After restoring the Docker configuration and selector used during onboarding…” because NemoClaw does not retain the original values. No edit is required for this refresh.
<!-- docs-review-head-sha: 330c31b443a8faccacb4fdd86a99c43ba9caee5f -->
<!-- docs-review-agents-blob-sha: 513518cdfca42e3a18fed71109e6d0eb60151d13 -->

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed llama.cpp sandbox removal by validating Docker and runtime authority before deletion.
  - Prevents sandbox deletion when the configured runtime no longer matches the recorded environment.
  - Reuses validated cleanup settings after deletion to avoid removing the wrong runtime.
  - Improved handling of already-removed sandboxes and interrupted cleanup operations.

- **Documentation**
  - Added troubleshooting guidance for Docker endpoint, context, host, executable, and environment configuration issues.
  - Explains how to restore the recorded Docker authority and retry sandbox removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

