### PR TITLE
fix(docs): transfer ready catch-up PRs to maintainers

### DIFF
--- a/.github/workflows/post-merge-docs.yaml
+++ b/.github/workflows/post-merge-docs.yaml
@@ -32,7 +32,7 @@ jobs:
           owner="$(
             gh api --paginate "repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" |
               jq --slurp -r '
-                [.[][] | select((.head.ref | startswith("automation/post-merge-docs-")) and .head.repo.full_name == "NVIDIA/NemoClaw")] |
+                [.[][] | select((.head.ref | test("^automation/post-merge-docs-[0-9a-f]{12}$")) and .head.repo.full_name == "NVIDIA/NemoClaw")] |
                 if length > 1 then "invalid"
                 elif length == 0 or .[0].draft == true then "automation"
                 elif .[0].draft == false then "maintainer"
@@ -109,9 +109,12 @@ jobs:
       - name: Validate the documentation candidate
         working-directory: author/repo
         run: |
+          before_status="$(git status --porcelain=v1 --untracked-files=all)"
+          before_diff="$(git diff --no-ext-diff --binary HEAD | sha256sum)"
           npm ci --ignore-scripts --no-audit --no-fund
           npm run docs
-          git diff --exit-code
+          [[ "$(git status --porcelain=v1 --untracked-files=all)" == "$before_status" ]]
+          [[ "$(git diff --no-ext-diff --binary HEAD | sha256sum)" == "$before_diff" ]]
 
       - id: review
         name: Independently review the candidate

--- a/.github/workflows/post-merge-docs.yaml
+++ b/.github/workflows/post-merge-docs.yaml
@@ -17,25 +17,40 @@ concurrency:
 
 jobs:
   gate:
-    name: Validate the managed documentation PR count
+    name: Select documentation PR ownership
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: read
+    outputs:
+      automate: ${{ steps.scan.outputs.automate }}
     steps:
-      - env:
+      - id: scan
+        env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          count="$(
+          owner="$(
             gh api --paginate "repos/$GITHUB_REPOSITORY/pulls?state=open&base=main&per_page=100" |
-              jq --slurp '[.[][] | select((.head.ref | startswith("automation/post-merge-docs-")) and .head.repo.full_name == "NVIDIA/NemoClaw")] | length'
+              jq --slurp -r '
+                [.[][] | select((.head.ref | startswith("automation/post-merge-docs-")) and .head.repo.full_name == "NVIDIA/NemoClaw")] |
+                if length > 1 then "invalid"
+                elif length == 0 or .[0].draft == true then "automation"
+                elif .[0].draft == false then "maintainer"
+                else "invalid"
+                end
+              '
           )"
-          [[ "$count" =~ ^[0-9]+$ && "$count" -le 1 ]]
+          [[ "$owner" == "automation" || "$owner" == "maintainer" ]]
+          if [[ "$owner" == "automation" ]]; then
+            echo "automate=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "automate=false" >> "$GITHUB_OUTPUT"
+          fi
 
   author:
     name: Author and review documentation catch-up
     needs: gate
-    if: ${{ github.repository == 'NVIDIA/NemoClaw' }}
+    if: ${{ github.repository == 'NVIDIA/NemoClaw' && needs.gate.outputs.automate == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 70
     permissions:
@@ -91,7 +106,15 @@ jobs:
           SANDBOX_NAME: docs-main-author
         run: node --experimental-strip-types --no-warnings "$TRUSTED_CHECKOUT/tools/post-merge-docs/run.mts" execute
 
-      - name: Independently review the candidate
+      - name: Validate the documentation candidate
+        working-directory: author/repo
+        run: |
+          npm ci --ignore-scripts --no-audit --no-fund
+          npm run docs
+          git diff --exit-code
+
+      - id: review
+        name: Independently review the candidate
         env:
           POST_MERGE_DOCS_ARTIFACT_DIR: ${{ github.workspace }}/approved
           POST_MERGE_DOCS_CANDIDATE_DIR: ${{ github.workspace }}/candidate
@@ -99,6 +122,15 @@ jobs:
           POST_MERGE_DOCS_WORKDIR: ${{ github.workspace }}/review
           SANDBOX_NAME: docs-main-review
         run: node --experimental-strip-types --no-warnings "$TRUSTED_CHECKOUT/tools/post-merge-docs/run.mts" execute
+
+      - name: Upload the independent review report
+        if: ${{ failure() && steps.review.outcome == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: ignore
+          name: post-merge-docs-review-rejection
+          path: ${{ github.workspace }}/approved/review-report.txt
+          retention-days: 3
 
       - id: upload
         name: Upload the approved patch

--- a/test/post-merge-docs.test.ts
+++ b/test/post-merge-docs.test.ts
@@ -781,6 +781,15 @@ describe("post-merge documentation workflow boundary", () => {
     (candidate) =>
       (candidate.jobs.gate.steps.find((step: Record<string, any>) => step.id === "scan").run =
         "echo automate=true"),
+    (candidate) => {
+      const scan = candidate.jobs.gate.steps.find(
+        (step: Record<string, any>) => step.id === "scan",
+      );
+      scan.run = scan.run.replace(
+        'test("^automation/post-merge-docs-[0-9a-f]{12}$")',
+        'startswith("automation/post-merge-docs-")',
+      );
+    },
     (candidate) =>
       (candidate.jobs.author.if =
         "${{ github.repository == 'NVIDIA/NemoClaw' && needs.gate.outputs.pending != 'true' }}"),
@@ -792,6 +801,10 @@ describe("post-merge documentation workflow boundary", () => {
       (candidate.jobs.author.steps.find(
         (step: Record<string, any>) => step.name === "Upload the independent review report",
       ).with.path = "${{ github.workspace }}/candidate/docs.patch"),
+    (candidate) =>
+      (candidate.jobs.author.steps.find(
+        (step: Record<string, any>) => step.name === "Upload the independent review report",
+      ).with["retention-days"] = 30),
     (candidate) => (candidate.jobs.publish.permissions.issues = "write"),
     (candidate) => (candidate.jobs.gate.secrets = "inherit"),
     (candidate) =>

--- a/test/post-merge-docs.test.ts
+++ b/test/post-merge-docs.test.ts
@@ -34,18 +34,20 @@ The workflow selects \`v1.0.1\` by incrementing the patch component of \`v1.0.0\
 
 - Each push to \`main\` that changes a path outside the allowed documentation paths starts a cumulative authoring and independent review run.
 - An approved patch creates a verified merge commit and fast-forwards this branch.
-- The workflow never force-pushes. It stops if a person changes the branch or PR metadata.
-- Keep this PR open as a draft while code PRs merge for \`v1.0.1\`.
+- Keep this PR as a draft while code PRs merge for \`v1.0.1\`. The workflow owns the draft branch.
+- Mark this PR ready for review only at release cutoff. Ready status transfers branch ownership to maintainers, and later workflow runs leave the PR unchanged.
+- The workflow never force-pushes. While the PR is a draft, it stops if a person changes the branch or PR metadata.
 
 ## Release cutoff
 
 1. Stop merging code PRs intended for \`v1.0.1\`.
-2. Add the dated \`## v1.0.1\` changelog entry and final documentation to this PR.
-3. Run \`npm run docs\` and complete the final review.
-4. Merge this PR. Its docs-only merge does not start another catch-up run.
-5. Ask the tag session to show this PR's coverage point, later commits and PRs, checks, reviews, and any open managed docs PR.
-6. Decide whether to proceed, create or update a docs PR for the uncovered range, or stop.
-7. Cut \`v1.0.1\` only after you choose to proceed with the displayed documentation coverage.
+2. Mark this PR ready for review to transfer branch ownership to maintainers.
+3. Add the dated \`## v1.0.1\` changelog entry and final documentation to this PR.
+4. Run \`npm run docs\` and complete the final review.
+5. Merge this PR. Its docs-only merge does not start another catch-up run.
+6. Ask the tag session to show this PR's coverage point, later commits and PRs, checks, reviews, and any open managed docs PR.
+7. Decide whether to proceed, create or update a docs PR for the uncovered range, or stop.
+8. Cut \`v1.0.1\` only after you choose to proceed with the displayed documentation coverage.
 
 ## Verification
 
@@ -340,7 +342,8 @@ function runnerFixture(phase: "author" | "review", startTag = rangeStartTag) {
 function runnerTools(
   input: ReturnType<typeof runnerFixture>,
   failure?: RunnerStage,
-  decision = "approved",
+  decision: "approved" | "rejected" = "approved",
+  reviewReport = "The candidate omits one user-visible change.\n",
 ) {
   const { env, root } = input;
   const sandbox = path.join(root, "sandbox");
@@ -360,11 +363,17 @@ function runnerTools(
       state.agentArgs = args;
       const agents = {
         author: () => fs.writeFileSync(path.join(sandbox, "docs/guide.mdx"), "authored\n"),
-        review: () =>
+        review: () => {
+          const reports = {
+            approved: () => undefined,
+            rejected: () => fs.writeFileSync(path.join(output, "review-report.txt"), reviewReport),
+          };
           fs.writeFileSync(
             path.join(output, "decision.json"),
             JSON.stringify({ outcome: decision }),
-          ),
+          );
+          reports[decision]();
+        },
       };
       agents[env.POST_MERGE_DOCS_PHASE]();
     },
@@ -424,6 +433,9 @@ describe("post-merge documentation publisher", () => {
     );
     expect(api.openPulls[0]?.body).toMatch(
       /`v1[.]0[.]0`[\s\S]*never force-pushes[\s\S]*`npm run docs`[\s\S]*`v1[.]0[.]1`/u,
+    );
+    expect(api.openPulls[0]?.body).toContain(
+      "Ready status transfers branch ownership to maintainers",
     );
   });
   it("creates no writes for an approved empty patch without an active PR", async () => {
@@ -727,6 +739,16 @@ describe("post-merge documentation runner", () => {
     const input = runnerFixture("review");
     const { state, tools } = runnerTools(input, undefined, "rejected");
     expect(() => executePostMergeDocs(input.env, tools)).toThrow("did not approve");
+    expect(fs.readFileSync(path.join(input.root, "artifact/review-report.txt"), "utf8")).toBe(
+      "The candidate omits one user-visible change.\n",
+    );
+    expect(fs.existsSync(path.join(input.root, "artifact/review.json"))).toBe(false);
+    expect(state.deleted).toBe(true);
+  });
+  it("rejects an oversized independent review report and deletes the sandbox", () => {
+    const input = runnerFixture("review");
+    const { state, tools } = runnerTools(input, undefined, "rejected", "x".repeat(1_025));
+    expect(() => executePostMergeDocs(input.env, tools)).toThrow("bounded regular file");
     expect(state.deleted).toBe(true);
   });
   it.each<RunnerStage>(["create", "agent", "export", "download"])(
@@ -755,9 +777,21 @@ describe("post-merge documentation workflow boundary", () => {
 
   it.each<(candidate: Record<string, any>) => void>([
     (candidate) => (candidate.jobs.author.permissions = { contents: "write" }),
+    (candidate) => (candidate.jobs.gate.outputs.automate = "false"),
+    (candidate) =>
+      (candidate.jobs.gate.steps.find((step: Record<string, any>) => step.id === "scan").run =
+        "echo automate=true"),
     (candidate) =>
       (candidate.jobs.author.if =
         "${{ github.repository == 'NVIDIA/NemoClaw' && needs.gate.outputs.pending != 'true' }}"),
+    (candidate) =>
+      (candidate.jobs.author.steps.find(
+        (step: Record<string, any>) => step.name === "Validate the documentation candidate",
+      ).run = "npm run docs"),
+    (candidate) =>
+      (candidate.jobs.author.steps.find(
+        (step: Record<string, any>) => step.name === "Upload the independent review report",
+      ).with.path = "${{ github.workspace }}/candidate/docs.patch"),
     (candidate) => (candidate.jobs.publish.permissions.issues = "write"),
     (candidate) => (candidate.jobs.gate.secrets = "inherit"),
     (candidate) =>
@@ -769,7 +803,7 @@ describe("post-merge documentation workflow boundary", () => {
         OPENAI_API_KEY: "${{ secrets.POST_MERGE_DOCS_API_KEY }}",
       }),
     (candidate) => (candidate.on.push["paths-ignore"] = ["docs/**"]),
-  ])("rejects credential and permission boundary mutation %#", (mutate) => {
+  ])("rejects workflow boundary mutation %#", (mutate) => {
     const candidate = structuredClone(workflow);
     mutate(candidate);
     expect(validatePostMergeDocsWorkflowBoundary(candidate)).not.toEqual([]);

--- a/tools/post-merge-docs/contract.mts
+++ b/tools/post-merge-docs/contract.mts
@@ -22,10 +22,23 @@ export function validatePostMergeDocsWorkflowBoundary(value: unknown): string[] 
   const gate = object(jobs.gate) ?? {};
   const author = object(jobs.author) ?? {};
   const publish = object(jobs.publish) ?? {};
+  const gateSteps = Array.isArray(gate.steps) ? gate.steps : [];
+  const scanSteps = gateSteps.filter((step) => object(step)?.id === "scan");
+  const scan = object(scanSteps[0]) ?? {};
+  const authorSteps = Array.isArray(author.steps) ? author.steps : [];
   const configureSteps = (Array.isArray(author.steps) ? author.steps : []).filter(
     (step) => object(step)?.name === "Configure isolated inference",
   );
   const configure = object(configureSteps[0]) ?? {};
+  const validationSteps = authorSteps.filter(
+    (step) => object(step)?.name === "Validate the documentation candidate",
+  );
+  const validation = object(validationSteps[0]) ?? {};
+  const reviewSteps = authorSteps.filter((step) => object(step)?.id === "review");
+  const rejectionSteps = authorSteps.filter(
+    (step) => object(step)?.name === "Upload the independent review report",
+  );
+  const rejection = object(rejectionSteps[0]) ?? {};
   const modelSecret = "${{ secrets.POST_MERGE_DOCS_API_KEY }}";
   const references = strings(workflow).filter((text) => /\$\{\{[^}]*\bsecrets\b/u.test(text));
   const valid =
@@ -34,7 +47,14 @@ export function validatePostMergeDocsWorkflowBoundary(value: unknown): string[] 
     Object.keys(jobs).sort().join(",") === "author,gate,publish" &&
     Object.values(jobs).every((job) => !Object.hasOwn(object(job) ?? {}, "secrets")) &&
     isDeepStrictEqual(gate.permissions, { "pull-requests": "read" }) &&
-    author.if === "${{ github.repository == 'NVIDIA/NemoClaw' }}" &&
+    isDeepStrictEqual(gate.outputs, { automate: "${{ steps.scan.outputs.automate }}" }) &&
+    scanSteps.length === 1 &&
+    typeof scan.run === "string" &&
+    scan.run.includes('elif length == 0 or .[0].draft == true then "automation"') &&
+    scan.run.includes('elif .[0].draft == false then "maintainer"') &&
+    scan.run.includes('echo "automate=false" >> "$GITHUB_OUTPUT"') &&
+    author.if ===
+      "${{ github.repository == 'NVIDIA/NemoClaw' && needs.gate.outputs.automate == 'true' }}" &&
     isDeepStrictEqual(author.permissions, { contents: "read" }) &&
     isDeepStrictEqual(publish.permissions, {
       actions: "read",
@@ -47,6 +67,15 @@ export function validatePostMergeDocsWorkflowBoundary(value: unknown): string[] 
     isDeepStrictEqual(configure.env, { OPENAI_API_KEY: modelSecret }) &&
     configure.run ===
       'node --experimental-strip-types --no-warnings "$TRUSTED_CHECKOUT/tools/post-merge-docs/run.mts" configure' &&
+    validationSteps.length === 1 &&
+    validation["working-directory"] === "author/repo" &&
+    validation.run ===
+      "npm ci --ignore-scripts --no-audit --no-fund\nnpm run docs\ngit diff --exit-code\n" &&
+    reviewSteps.length === 1 &&
+    rejectionSteps.length === 1 &&
+    rejection.if === "${{ failure() && steps.review.outcome == 'failure' }}" &&
+    object(rejection.with)?.path === "${{ github.workspace }}/approved/review-report.txt" &&
+    object(rejection.with)?.["if-no-files-found"] === "ignore" &&
     !strings(publish).some((text) => /(?:POST_MERGE_DOCS|OPENAI)_API_KEY/u.test(text));
   return valid ? [] : ["workflow must separate the model credential from repository writes"];
 }

--- a/tools/post-merge-docs/contract.mts
+++ b/tools/post-merge-docs/contract.mts
@@ -50,6 +50,7 @@ export function validatePostMergeDocsWorkflowBoundary(value: unknown): string[] 
     isDeepStrictEqual(gate.outputs, { automate: "${{ steps.scan.outputs.automate }}" }) &&
     scanSteps.length === 1 &&
     typeof scan.run === "string" &&
+    scan.run.includes('test("^automation/post-merge-docs-[0-9a-f]{12}$")') &&
     scan.run.includes('elif length == 0 or .[0].draft == true then "automation"') &&
     scan.run.includes('elif .[0].draft == false then "maintainer"') &&
     scan.run.includes('echo "automate=false" >> "$GITHUB_OUTPUT"') &&
@@ -70,12 +71,18 @@ export function validatePostMergeDocsWorkflowBoundary(value: unknown): string[] 
     validationSteps.length === 1 &&
     validation["working-directory"] === "author/repo" &&
     validation.run ===
-      "npm ci --ignore-scripts --no-audit --no-fund\nnpm run docs\ngit diff --exit-code\n" &&
+      'before_status="$(git status --porcelain=v1 --untracked-files=all)"\n' +
+        'before_diff="$(git diff --no-ext-diff --binary HEAD | sha256sum)"\n' +
+        "npm ci --ignore-scripts --no-audit --no-fund\n" +
+        "npm run docs\n" +
+        '[[ "$(git status --porcelain=v1 --untracked-files=all)" == "$before_status" ]]\n' +
+        '[[ "$(git diff --no-ext-diff --binary HEAD | sha256sum)" == "$before_diff" ]]\n' &&
     reviewSteps.length === 1 &&
     rejectionSteps.length === 1 &&
     rejection.if === "${{ failure() && steps.review.outcome == 'failure' }}" &&
     object(rejection.with)?.path === "${{ github.workspace }}/approved/review-report.txt" &&
     object(rejection.with)?.["if-no-files-found"] === "ignore" &&
+    object(rejection.with)?.["retention-days"] === 3 &&
     !strings(publish).some((text) => /(?:POST_MERGE_DOCS|OPENAI)_API_KEY/u.test(text));
   return valid ? [] : ["workflow must separate the model credential from repository writes"];
 }

--- a/tools/post-merge-docs/publish.mts
+++ b/tools/post-merge-docs/publish.mts
@@ -240,18 +240,20 @@ The workflow selects \`${target}\` by incrementing the patch component of \`${ra
 
 - Each push to \`main\` that changes a path outside the allowed documentation paths starts a cumulative authoring and independent review run.
 - An approved patch creates a verified merge commit and fast-forwards this branch.
-- The workflow never force-pushes. It stops if a person changes the branch or PR metadata.
-- Keep this PR open as a draft while code PRs merge for \`${target}\`.
+- Keep this PR as a draft while code PRs merge for \`${target}\`. The workflow owns the draft branch.
+- Mark this PR ready for review only at release cutoff. Ready status transfers branch ownership to maintainers, and later workflow runs leave the PR unchanged.
+- The workflow never force-pushes. While the PR is a draft, it stops if a person changes the branch or PR metadata.
 
 ## Release cutoff
 
 1. Stop merging code PRs intended for \`${target}\`.
-2. Add the dated \`## ${target}\` changelog entry and final documentation to this PR.
-3. Run \`npm run docs\` and complete the final review.
-4. Merge this PR. Its docs-only merge does not start another catch-up run.
-5. Ask the tag session to show this PR's coverage point, later commits and PRs, checks, reviews, and any open managed docs PR.
-6. Decide whether to proceed, create or update a docs PR for the uncovered range, or stop.
-7. Cut \`${target}\` only after you choose to proceed with the displayed documentation coverage.
+2. Mark this PR ready for review to transfer branch ownership to maintainers.
+3. Add the dated \`## ${target}\` changelog entry and final documentation to this PR.
+4. Run \`npm run docs\` and complete the final review.
+5. Merge this PR. Its docs-only merge does not start another catch-up run.
+6. Ask the tag session to show this PR's coverage point, later commits and PRs, checks, reviews, and any open managed docs PR.
+7. Decide whether to proceed, create or update a docs PR for the uncovered range, or stop.
+8. Cut \`${target}\` only after you choose to proceed with the displayed documentation coverage.
 
 ## Verification
 

--- a/tools/post-merge-docs/run.mts
+++ b/tools/post-merge-docs/run.mts
@@ -25,6 +25,7 @@ import {
 import { allowedDocumentationPath, nextPatchReleaseTag, readBoundedFile } from "./contract.mts";
 
 const PATCH_FILE = "docs.patch";
+const REVIEW_REPORT_FILE = "review-report.txt";
 const MAX_PATCH_BYTES = 5_242_880;
 const MAX_FILE_BYTES = 1_048_576;
 const SHA = /^[0-9a-f]{40}$/u;
@@ -145,6 +146,7 @@ function prompt(env: NodeJS.ProcessEnv, current: Phase): string {
       "Inspect the committed range and staged candidate. Do not edit the repository.",
       "Approve only if it completely and accurately covers user-visible changes, follows DORI and writing rules, and makes no unsupported claim.",
       "An empty patch is valid only when no documentation update is needed.",
+      `If you reject the candidate, write a concise evidence-backed report to /sandbox/output/${REVIEW_REPORT_FILE}.`,
       'Write exactly {"outcome":"approved"} or {"outcome":"rejected"} to /sandbox/output/decision.json.',
     ].join("\n");
   }
@@ -326,7 +328,11 @@ function exportArtifact(env: NodeJS.ProcessEnv, tools: OpenShellTools): void {
     );
     return;
   }
-  if (download(env, "decision.json", tools).toString("utf8").trim() !== '{"outcome":"approved"}') {
+  const decision = download(env, "decision.json", tools).toString("utf8").trim();
+  if (decision !== '{"outcome":"approved"}') {
+    if (decision === '{"outcome":"rejected"}') {
+      write(path.join(artifact, REVIEW_REPORT_FILE), download(env, REVIEW_REPORT_FILE, tools));
+    }
     fail("Independent documentation review did not approve the candidate");
   }
   const patch = readBoundedFile(patchPath(env), MAX_PATCH_BYTES, true);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Draft managed documentation PRs remain owned by the post-merge workflow. Marking a managed PR ready for review now transfers branch ownership to maintainers, so later catch-up runs leave it unchanged while final release edits are made.

The workflow also validates each exact authored candidate before independent review and retains a bounded report when that review rejects the candidate.

## Changes

- Classify zero or one draft managed PR as workflow-owned, one ready-for-review managed PR as maintainer-owned, and multiple managed PRs as an invalid state.
- Run the full documentation validation on the exact authored candidate and reject any uncommitted generated changes before independent review.
- Retain a bounded independent-review report when the reviewer rejects a candidate.
- Update the managed PR instructions to describe the draft-to-maintainer ownership handoff.
- Extend the workflow, reviewer, and publisher contract tests for the new ownership and rejection paths.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (GitHub workflow credentials and publication boundary)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: focused credential and publication boundary review; secret isolation, exact-patch approval, same-PR checkpoints, bot draft lineage, and non-force updates remain enforced by `test/post-merge-docs.test.ts`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run test/post-merge-docs.test.ts` (51 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Documentation automation now validates generated documentation and repository changes before creating or updating a pull request.
  - Rejected documentation reviews can include an evidence-based report for follow-up.
  - Review reports are preserved when available, including after automated approval failures.

- **Documentation**
  - Updated instructions clarify draft ownership, review readiness, and release-cutoff steps.

- **Bug Fixes**
  - Strengthened safeguards prevent documentation automation from proceeding when validation or workflow requirements are not met.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->