### PR TITLE
fix(advisor): restore shadow synthesis evidence

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -310,12 +310,13 @@ jobs:
           retention-days: 14
 
       - name: Upload native specialist session
+        id: upload-specialist-session
         if: ${{ always() && matrix.advisor.interest != '' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.advisor.artifact_name }}
           path: artifacts/${{ matrix.advisor.artifact_dir }}/pr-review-${{ matrix.advisor.interest }}-session.jsonl
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 14
 
       - name: Verify advisor analysis outcome
@@ -326,6 +327,8 @@ jobs:
           CONFIGURE_OUTCOME: ${{ steps.configure-openshell.outcome }}
           DOWNLOAD_OUTCOME: ${{ steps.download-analysis.outcome }}
           UNAVAILABLE_OUTCOME: ${{ steps.unavailable-analysis.outcome }}
+          ADVISOR_INTEREST: ${{ matrix.advisor.interest }}
+          SPECIALIST_UPLOAD_OUTCOME: ${{ steps.upload-specialist-session.outcome }}
         run: |
           if [ "$CONFIGURE_OUTCOME" != "success" ]; then
             if [ "$UNAVAILABLE_OUTCOME" != "success" ]; then
@@ -346,6 +349,13 @@ jobs:
             echo "::error::PR review advisor artifacts were not downloaded: outcome=$DOWNLOAD_OUTCOME"
             exit 1
           fi
+          if [ -n "$ADVISOR_INTEREST" ]; then
+            if [ "$SPECIALIST_UPLOAD_OUTCOME" != "success" ]; then
+              echo "::error::PR review advisor native specialist session was not uploaded: outcome=$SPECIALIST_UPLOAD_OUTCOME"
+              exit 1
+            fi
+            exit 0
+          fi
 
   review-specialists:
     name: PR review specialist (${{ matrix.advisor.label }})
@@ -363,11 +373,11 @@ jobs:
       fail-fast: false
       matrix:
         advisor:
-          - { interest: behavior, label: Behavior, model: azure/openai/gpt-5.6-terra, sandbox_name: pr-advisor-sp-behavior, artifact_dir: pr-review-specialist-behavior, artifact_name: pr-review-specialist-behavior }
-          - { interest: trust, label: Trust, model: azure/openai/gpt-5.6-terra, sandbox_name: pr-advisor-sp-trust, artifact_dir: pr-review-specialist-trust, artifact_name: pr-review-specialist-trust }
-          - { interest: design-architecture, label: Design / Architecture, model: azure/openai/gpt-5.6-terra, sandbox_name: pr-advisor-sp-design, artifact_dir: pr-review-specialist-design-architecture, artifact_name: pr-review-specialist-design-architecture }
-          - { interest: operations, label: Operations, model: azure/openai/gpt-5.6-terra, sandbox_name: pr-advisor-sp-operations, artifact_dir: pr-review-specialist-operations, artifact_name: pr-review-specialist-operations }
-          - { interest: documentation, label: Documentation, model: azure/openai/gpt-5.6-terra, sandbox_name: pr-advisor-sp-docs, artifact_dir: pr-review-specialist-documentation, artifact_name: pr-review-specialist-documentation }
+          - { interest: behavior, label: Behavior, model: azure/openai/gpt-5.6-terra, sandbox_name: pr-adv-sp-beh, artifact_dir: pr-review-specialist-behavior, artifact_name: pr-review-specialist-behavior }
+          - { interest: trust, label: Trust, model: azure/openai/gpt-5.6-terra, sandbox_name: pr-adv-sp-trust, artifact_dir: pr-review-specialist-trust, artifact_name: pr-review-specialist-trust }
+          - { interest: design-architecture, label: Design / Architecture, model: azure/openai/gpt-5.6-terra, sandbox_name: pr-adv-sp-design, artifact_dir: pr-review-specialist-design-architecture, artifact_name: pr-review-specialist-design-architecture }
+          - { interest: operations, label: Operations, model: azure/openai/gpt-5.6-terra, sandbox_name: pr-adv-sp-ops, artifact_dir: pr-review-specialist-operations, artifact_name: pr-review-specialist-operations }
+          - { interest: documentation, label: Documentation, model: azure/openai/gpt-5.6-terra, sandbox_name: pr-adv-sp-docs, artifact_dir: pr-review-specialist-documentation, artifact_name: pr-review-specialist-documentation }
     env:
       PI_SDK_VERSION: "0.80.6"
       TYPEBOX_VERSION: "1.1.38"
@@ -412,7 +422,7 @@ jobs:
     strategy:
       matrix:
         advisor:
-          - { interest: "", label: Shadow synthesis, model: azure/openai/gpt-5.6-terra, sandbox_name: pr-advisor-synthesis, artifact_dir: pr-review-advisor-shadow-synthesis, artifact_name: pr-review-advisor-shadow-synthesis }
+          - { interest: "", label: Shadow synthesis, model: azure/openai/gpt-5.6-terra, sandbox_name: pr-adv-synthesis, artifact_dir: pr-review-advisor-shadow-synthesis, artifact_name: pr-review-advisor-shadow-synthesis }
     env:
       PI_SDK_VERSION: "0.80.6"
       TYPEBOX_VERSION: "1.1.38"

--- a/test/pr-review-advisor-openshell-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-openshell-workflow-boundary.test.ts
@@ -113,6 +113,30 @@ describe("PR review advisor OpenShell workflow boundary", () => {
     );
   });
 
+  it.each([
+    [
+      "missing",
+      (workflow: Record<string, any>) => {
+        delete workflow.jobs["review-synthesis-shadow"].strategy.matrix.advisor;
+      },
+    ],
+    [
+      "non-array",
+      (workflow: Record<string, any>) => {
+        workflow.jobs["review-synthesis-shadow"].strategy.matrix.advisor = {};
+      },
+    ],
+    [
+      "empty",
+      (workflow: Record<string, any>) => {
+        workflow.jobs["review-synthesis-shadow"].strategy.matrix.advisor = [];
+      },
+    ],
+  ])("rejects a %s synthesis advisor matrix (#9968)", (_case, mutate) => {
+    const errors = validateMutation((source) => mutateWorkflowSource(source, mutate));
+    expect(errors).toContain("synthesis matrix must declare a non-empty advisor array");
+  });
+
   it("requires specialist success to include the native session upload (#9968)", () => {
     const errors = validateMutation((source) =>
       mutateWorkflowSource(source, (workflow) => {

--- a/test/pr-review-advisor-openshell-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-openshell-workflow-boundary.test.ts
@@ -79,9 +79,60 @@ describe("PR review advisor OpenShell workflow boundary", () => {
         "review job env.OPENSHELL_GATEWAY_ENDPOINT must be http://127.0.0.1:8080",
         "review job env.PI_IMAGE must be ghcr.io/nvidia/openshell-community/sandboxes/pi@sha256:00d0c5e9e733f94f6db3eaa2ab70d4fd75bcc4aace6b13a54535cbf2dd20dfcd",
         "review job env.SANDBOX_NAME must be ${{ matrix.advisor.sandbox_name }}",
-        "advisor matrix entry 1 sandbox_name must satisfy the OpenShell 0.0.99 sandbox-name contract",
+        "advisor matrix entry 1 sandbox_name must satisfy the OpenShell sandbox-name contract (max 19 characters)",
         "advisor matrix entry 1 artifact_dir must be a simple directory name",
         "Prepare isolated analysis workspace must use the fixed pr-workdir upload directory",
+      ]),
+    );
+  });
+
+  it("rejects overlong and duplicate specialist and synthesis sandbox names (#9968)", () => {
+    const overlong = validateMutation((source) =>
+      mutateWorkflowSource(source, (workflow) => {
+        workflow.jobs["review-specialists"].strategy.matrix.advisor[0].sandbox_name =
+          "pr-advisor-sp-behavior";
+        workflow.jobs["review-synthesis-shadow"].strategy.matrix.advisor[0].sandbox_name =
+          "pr-advisor-synthesis";
+      }),
+    );
+    expect(overlong).toEqual(
+      expect.arrayContaining([
+        "specialist matrix entry 1 sandbox_name must satisfy the OpenShell sandbox-name contract (max 19 characters)",
+        "synthesis matrix entry 1 sandbox_name must satisfy the OpenShell sandbox-name contract (max 19 characters)",
+      ]),
+    );
+
+    const duplicate = validateMutation((source) =>
+      mutateWorkflowSource(source, (workflow) => {
+        workflow.jobs["review-synthesis-shadow"].strategy.matrix.advisor[0].sandbox_name =
+          workflow.jobs["review-specialists"].strategy.matrix.advisor[0].sandbox_name;
+      }),
+    );
+    expect(duplicate).toContain(
+      "advisor, specialist, and synthesis sandbox_name values must be unique",
+    );
+  });
+
+  it("requires specialist success to include the native session upload (#9968)", () => {
+    const errors = validateMutation((source) =>
+      mutateWorkflowSource(source, (workflow) => {
+        const steps = workflow.jobs["review-specialists"].steps;
+        const upload = steps.find(
+          (step: { name?: string }) => step.name === "Upload native specialist session",
+        );
+        upload.id = "detached-upload";
+        upload.with["if-no-files-found"] = "warn";
+        const outcome = steps.find(
+          (step: { name?: string }) => step.name === "Verify advisor analysis outcome",
+        );
+        outcome.env.SPECIALIST_UPLOAD_OUTCOME = "success";
+      }),
+    );
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        "Upload native specialist session id must be upload-specialist-session",
+        "step 'Upload native specialist session' expected with.if-no-files-found=error",
+        "specialist outcome must use the native session upload outcome",
       ]),
     );
   });

--- a/test/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-workflow-boundary.test.ts
@@ -627,6 +627,31 @@ describe("PR review advisor workflow boundary", () => {
     );
   });
 
+  it.skipIf(!CAN_RUN_BASH)(
+    "accepts a successful specialist native session without broad result artifacts (#9968)",
+    () => {
+      const result = spawnSync(
+        "/bin/bash",
+        ["-c", workflowStepScript("review-specialists", "Verify advisor analysis outcome")],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            ADVISOR_INTEREST: "behavior",
+            ANALYSIS_OUTCOME: "success",
+            ANALYSIS_REQUESTED: "1",
+            CONFIGURE_OUTCOME: "success",
+            DOWNLOAD_OUTCOME: "success",
+            SPECIALIST_UPLOAD_OUTCOME: "success",
+            UNAVAILABLE_OUTCOME: "skipped",
+          },
+        },
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+    },
+  );
+
   it("requires all specialist models to match the unique publishing review model", () => {
     const errors = validateMutation((source) =>
       mutateWorkflowSource(source, (workflow) => {

--- a/tools/pr-review-advisor/README.md
+++ b/tools/pr-review-advisor/README.md
@@ -158,8 +158,9 @@ The parallel Nemotron Ultra lane writes the same filenames under
 
 The specialist shadow runs five focused, read-only Pi sessions for Behavior, Trust, Design /
 Architecture, Operations, and Documentation. Each cell uses the primary model and uploads Pi's
-unchanged native JSONL session. Specialists have ordinary repository read tools and cannot record or
-submit the canonical review.
+unchanged native JSONL session. A specialist succeeds when its Pi turn completes and that native session
+is uploaded; it does not produce or validate the broad advisor result schema. Specialists have ordinary
+repository read tools and cannot record or submit the canonical review.
 
 The shadow synthesis job places the available traces beside the read-only repository inside OpenShell.
 It reads them with the ordinary Pi filesystem tools, treats their model-authored content as advisory and

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -451,7 +451,11 @@ function checkSandboxNames(
   const sandboxNames: string[] = [];
   for (const { name, job } of jobs) {
     const advisor = asRecord(asRecord(job.strategy).matrix).advisor;
-    const entries = Array.isArray(advisor) ? advisor.map(asRecord) : [];
+    if (!Array.isArray(advisor) || advisor.length === 0) {
+      errors.push(`${name} matrix must declare a non-empty advisor array`);
+      continue;
+    }
+    const entries = advisor.map(asRecord);
     for (const [index, entry] of entries.entries()) {
       const sandboxName = stringValue(entry.sandbox_name);
       sandboxNames.push(sandboxName);

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -444,6 +444,32 @@ function checkPrivilegeDomains(
   }
 }
 
+function checkSandboxNames(
+  errors: string[],
+  jobs: Array<{ name: string; job: WorkflowRecord }>,
+): void {
+  const sandboxNames: string[] = [];
+  for (const { name, job } of jobs) {
+    const advisor = asRecord(asRecord(job.strategy).matrix).advisor;
+    const entries = Array.isArray(advisor) ? advisor.map(asRecord) : [];
+    for (const [index, entry] of entries.entries()) {
+      const sandboxName = stringValue(entry.sandbox_name);
+      sandboxNames.push(sandboxName);
+      if (
+        sandboxName.length > OPENSHELL_SANDBOX_NAME_MAX_LENGTH ||
+        !OPENSHELL_SANDBOX_NAME_PATTERN.test(sandboxName)
+      ) {
+        errors.push(
+          `${name} matrix entry ${index + 1} sandbox_name must satisfy the OpenShell sandbox-name contract (max 19 characters)`,
+        );
+      }
+    }
+  }
+  if (new Set(sandboxNames).size !== sandboxNames.length) {
+    errors.push("advisor, specialist, and synthesis sandbox_name values must be unique");
+  }
+}
+
 function checkAnalysisJob(errors: string[], reviewJob: WorkflowRecord): void {
   if (stringValue(reviewJob["runs-on"]) !== "ubuntu-24.04") {
     errors.push("review job must pin the Ubuntu runner used by runtime package versions");
@@ -481,15 +507,6 @@ function checkAnalysisJob(errors: string[], reviewJob: WorkflowRecord): void {
   for (const [index, entry] of entries.entries()) {
     if (!/^[a-z0-9][a-z0-9-]*$/u.test(stringValue(entry.artifact_dir))) {
       errors.push(`advisor matrix entry ${index + 1} artifact_dir must be a simple directory name`);
-    }
-    const sandboxName = stringValue(entry.sandbox_name);
-    if (
-      sandboxName.length > OPENSHELL_SANDBOX_NAME_MAX_LENGTH ||
-      !OPENSHELL_SANDBOX_NAME_PATTERN.test(sandboxName)
-    ) {
-      errors.push(
-        `advisor matrix entry ${index + 1} sandbox_name must satisfy the OpenShell 0.0.99 sandbox-name contract`,
-      );
     }
   }
 
@@ -1326,6 +1343,9 @@ function checkShadowTopology(
   checkShadowAnalysisTrustBoundary(errors, "review-specialists", specialistJob, specialistSteps);
   checkShadowAnalysisTrustBoundary(errors, "review-synthesis-shadow", synthesisJob, synthesisSteps);
   const upload = requireStep(errors, specialistSteps, "Upload native specialist session");
+  if (stringValue(upload?.id) !== "upload-specialist-session") {
+    errors.push("Upload native specialist session id must be upload-specialist-session");
+  }
   requireWith(errors, upload, "name", "${{ matrix.advisor.artifact_name }}");
   requireWith(
     errors,
@@ -1333,6 +1353,20 @@ function checkShadowTopology(
     "path",
     "artifacts/${{ matrix.advisor.artifact_dir }}/pr-review-${{ matrix.advisor.interest }}-session.jsonl",
   );
+  requireWith(errors, upload, "if-no-files-found", "error");
+  const specialistOutcome = requireStep(errors, specialistSteps, "Verify advisor analysis outcome");
+  const specialistOutcomeEnv = asRecord(specialistOutcome?.env);
+  if (specialistOutcomeEnv.ADVISOR_INTEREST !== "${{ matrix.advisor.interest }}") {
+    errors.push("specialist outcome must use the matrix interest");
+  }
+  if (
+    specialistOutcomeEnv.SPECIALIST_UPLOAD_OUTCOME !==
+    "${{ steps.upload-specialist-session.outcome }}"
+  ) {
+    errors.push("specialist outcome must use the native session upload outcome");
+  }
+  requireRunContains(errors, specialistOutcome, 'if [ -n "$ADVISOR_INTEREST" ]');
+  requireRunContains(errors, specialistOutcome, 'if [ "$SPECIALIST_UPLOAD_OUTCOME" != "success" ]');
   const download = requireStep(errors, synthesisSteps, "Download specialist session artifacts");
   requireWith(errors, download, "pattern", "pr-review-specialist-*");
   requireWith(errors, download, "path", "pr-workdir/.pr-review-advisor-sessions");
@@ -1377,6 +1411,11 @@ export function validatePrReviewAdvisorWorkflowBoundary(
   if (Object.keys(synthesisJob).length === 0) errors.push("workflow must declare shadow synthesis");
   if (Object.keys(publishJob).length === 0) errors.push("workflow must declare the publish job");
   checkPrivilegeDomains(errors, workflow, reviewJob, publishJob);
+  checkSandboxNames(errors, [
+    { name: "advisor", job: reviewJob },
+    { name: "specialist", job: specialistJob },
+    { name: "synthesis", job: synthesisJob },
+  ]);
   checkAnalysisJob(errors, reviewJob);
   checkShadowTopology(errors, reviewJob, specialistJob, synthesisJob);
   checkPublishJob(errors, publishJob);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Restore usable specialist shadow evidence by giving every OpenShell sandbox a valid unique name and judging specialist completion by native Pi session delivery.

## Related Issue

Closes #9968

## Changes

- Replace specialist and synthesis sandbox names with unique values that satisfy OpenShell's 19-character limit.
- Validate sandbox syntax, length, and uniqueness across primary, specialist, and synthesis lanes.
- Make specialist jobs pass only after successful Pi analysis, sandbox artifact download, and native JSONL session upload, without applying the broad advisor result contract.
- Add mutation and execution coverage for invalid names, duplicate names, missing uploads, and native-session-based success.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Workflow-boundary mutation tests cover invalid and duplicate sandbox names, missing native uploads, permissions, credential placement, artifact paths, and synthesis dependencies. No credential or publisher boundary changed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — All normal hooks passed.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Focused integration tests passed: 4 files, 94 tests. Repository checks, Oxfmt, diff checks, and NUL checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; this is a focused workflow reliability repair covered by targeted workflow tests and repository hooks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Specialist analysis sessions now require successful completion and upload of native session records.
  - Sandbox names are validated for proper formatting and uniqueness across advisor, specialist, and synthesis activities.
  - Specialist outcomes are verified through native session results rather than broad result artifacts.

- **Documentation**
  - Updated workflow guidance for specialist session requirements and validation behavior.

- **Tests**
  - Expanded coverage for upload failures, outcome verification, duplicate or overlong names, malformed matrices, and successful workflow execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->