### PR TITLE
fix(docs): retain independent review reports

### DIFF
--- a/test/post-merge-docs.test.ts
+++ b/test/post-merge-docs.test.ts
@@ -745,9 +745,19 @@ describe("post-merge documentation runner", () => {
     expect(fs.existsSync(path.join(input.root, "artifact/review.json"))).toBe(false);
     expect(state.deleted).toBe(true);
   });
+  it("retains an independent review report at the size limit", () => {
+    const input = runnerFixture("review");
+    const report = "x".repeat(65_536);
+    const { state, tools } = runnerTools(input, undefined, "rejected", report);
+    expect(() => executePostMergeDocs(input.env, tools)).toThrow("did not approve");
+    expect(fs.readFileSync(path.join(input.root, "artifact/review-report.txt"), "utf8")).toBe(
+      report,
+    );
+    expect(state.deleted).toBe(true);
+  });
   it("rejects an oversized independent review report and deletes the sandbox", () => {
     const input = runnerFixture("review");
-    const { state, tools } = runnerTools(input, undefined, "rejected", "x".repeat(1_025));
+    const { state, tools } = runnerTools(input, undefined, "rejected", "x".repeat(65_537));
     expect(() => executePostMergeDocs(input.env, tools)).toThrow("bounded regular file");
     expect(state.deleted).toBe(true);
   });

--- a/tools/post-merge-docs/run.mts
+++ b/tools/post-merge-docs/run.mts
@@ -27,6 +27,7 @@ import { allowedDocumentationPath, nextPatchReleaseTag, readBoundedFile } from "
 const PATCH_FILE = "docs.patch";
 const REVIEW_REPORT_FILE = "review-report.txt";
 const MAX_PATCH_BYTES = 5_242_880;
+const MAX_REVIEW_REPORT_BYTES = 65_536;
 const MAX_FILE_BYTES = 1_048_576;
 const SHA = /^[0-9a-f]{40}$/u;
 const AGENT_FLAGS =
@@ -294,11 +295,10 @@ function download(env: NodeJS.ProcessEnv, name: string, tools: OpenShellTools): 
     },
     tools,
   );
-  return readBoundedFile(
-    path.join(directory, name),
-    name === PATCH_FILE ? MAX_PATCH_BYTES : 1_024,
-    true,
-  );
+  let maximum = 1_024;
+  if (name === PATCH_FILE) maximum = MAX_PATCH_BYTES;
+  if (name === REVIEW_REPORT_FILE) maximum = MAX_REVIEW_REPORT_BYTES;
+  return readBoundedFile(path.join(directory, name), maximum, true);
 }
 
 function exportArtifact(env: NodeJS.ProcessEnv, tools: OpenShellTools): void {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Documentation reviewer reports shared the 1 KiB decision-file limit, so valid rejection reports could be discarded before artifact upload. This change gives the report a 64 KiB limit while the decision file keeps its existing limit.

## Changes

- Apply a 64 KiB limit to `review-report.txt` while preserving the regular-file, no-follow, and exact-read checks.
- Retain the 1 KiB limit for `decision.json` and the existing 5 MiB patch limit.
- Accept a report at the exact limit and reject the next byte in focused regression tests. The previous test treated 1,025 bytes as oversized and did not represent reviewer output.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Focused review of the model-output and artifact boundary. The report remains untrusted and must pass the existing no-follow, regular-file, size, and stable-read checks before upload.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run test/post-merge-docs.test.ts --testTimeout=30000` (54 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a 64 KiB size limit for downloaded review reports.
  - Review reports at the limit are retained, while larger reports are rejected and cleaned up.
  - Preserved existing download limits for patches and other artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->