### PR TITLE
test(e2e): reproduce OpenClaw CLI loop on staging

### DIFF
--- a/.github/workflows/issue-9880-staging-reproduction.yaml
+++ b/.github/workflows/issue-9880-staging-reproduction.yaml
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: E2E / Issue 9880 Staging Reproduction
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: issue-9880-staging-launchable
+  cancel-in-progress: false
+
+jobs:
+  reproduce:
+    if: ${{ github.repository == 'NVIDIA/NemoClaw' && github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 95
+    env:
+      INSTANCE_NAME: issue-9880-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Check out trusted reproduction lane
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: |
+            tools/e2e/brev-launchable-issue-9880.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Authorize maintainer dispatch
+        env:
+          ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ github.token }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          set -euo pipefail
+          for actor in "$ACTOR" "$TRIGGERING_ACTOR"; do
+            [[ "$actor" =~ ^[A-Za-z0-9-]{1,39}$ ]] || { echo "::error::invalid workflow actor"; exit 1; }
+            role="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${actor}/permission" --jq .role_name)"
+            case "$role" in maintain|admin) ;; *) echo "::error::maintain or admin permission is required"; exit 1 ;; esac
+          done
+
+      - id: prepare
+        name: Prepare Brev CLI and evidence directory
+        env:
+          BREV_API_KEY: ${{ secrets.BREV_API_KEY }}
+          BREV_CLI_SHA256: d4aa49db1716f10308a6587778a676a0c0076bd48a212d86a421ab9550bc8f32
+          HOME: ${{ runner.temp }}/issue-9880-home
+          BREV_CLI_VERSION: 0.6.334
+          BREV_ORG_ID: ${{ secrets.BREV_ORG_ID }}
+        run: |
+          set -euo pipefail
+          install -d -m 0700 "$HOME"
+          work_dir="$(mktemp -d "${RUNNER_TEMP}/issue-9880.XXXXXX")"
+          chmod 700 "$work_dir"
+          archive="${RUNNER_TEMP}/brev-cli.tar.gz"
+          curl -fsSL -o "$archive" "https://github.com/brevdev/brev-cli/releases/download/v${BREV_CLI_VERSION}/brev-cli_${BREV_CLI_VERSION}_linux_amd64.tar.gz"
+          printf '%s  %s\n' "$BREV_CLI_SHA256" "$archive" | sha256sum -c -
+          tar -xzf "$archive" -C "${RUNNER_TEMP}" brev
+          sudo install -m 0755 "${RUNNER_TEMP}/brev" /usr/local/bin/brev
+          brev login --api-key "$BREV_API_KEY" --org-id "$BREV_ORG_ID"
+          printf 'work_dir=%s\n' "$work_dir" >>"$GITHUB_OUTPUT"
+
+      - name: Reproduce issue 9880 on the staging Launchable
+        timeout-minutes: 65
+        env:
+          BREV_LAUNCHABLE_ID: ${{ vars.NEMOCLAW_STAGING_LAUNCHABLE_ID }}
+          GH_TOKEN: ${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          WORK_DIR: ${{ steps.prepare.outputs.work_dir }}
+        run: tools/e2e/brev-launchable-issue-9880.sh
+
+      - name: Verify workflow-owned workspace cleanup
+        if: ${{ always() && steps.prepare.outputs.work_dir != '' }}
+        timeout-minutes: 15
+        env:
+          BREV_DELETE_TIMEOUT_SECONDS: "720"
+          WORK_DIR: ${{ steps.prepare.outputs.work_dir }}
+        run: tools/e2e/brev-launchable-issue-9880.sh cleanup-owned-workspace
+
+      - name: Remove Brev credentials
+        if: always()
+        run: |
+          set -euo pipefail
+          rm -rf -- "$HOME"
+          test ! -e "$HOME"
+
+      - name: Upload issue 9880 evidence
+        if: ${{ always() && steps.prepare.outputs.work_dir != '' }}
+        uses: NVIDIA/NemoClaw/.github/actions/upload-e2e-artifacts@7768e15eb90d3ee2d33432f481dfe8747e4f6d57
+        with:
+          name: issue-9880-staging-reproduction-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ steps.prepare.outputs.work_dir }}/lane.log
+            ${{ steps.prepare.outputs.work_dir }}/issue-9880.json
+            ${{ steps.prepare.outputs.work_dir }}/issue-9880.log
+            ${{ steps.prepare.outputs.work_dir }}/cleanup.json

--- a/.github/workflows/issue-9880-staging-reproduction.yaml
+++ b/.github/workflows/issue-9880-staging-reproduction.yaml
@@ -69,6 +69,7 @@ jobs:
         env:
           BREV_LAUNCHABLE_ID: ${{ vars.NEMOCLAW_STAGING_LAUNCHABLE_ID }}
           GH_TOKEN: ${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}
+          HOME: ${{ runner.temp }}/issue-9880-home
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           WORK_DIR: ${{ steps.prepare.outputs.work_dir }}
         run: tools/e2e/brev-launchable-issue-9880.sh
@@ -78,11 +79,14 @@ jobs:
         timeout-minutes: 15
         env:
           BREV_DELETE_TIMEOUT_SECONDS: "720"
+          HOME: ${{ runner.temp }}/issue-9880-home
           WORK_DIR: ${{ steps.prepare.outputs.work_dir }}
         run: tools/e2e/brev-launchable-issue-9880.sh cleanup-owned-workspace
 
       - name: Remove Brev credentials
         if: always()
+        env:
+          HOME: ${{ runner.temp }}/issue-9880-home
         run: |
           set -euo pipefail
           rm -rf -- "$HOME"

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -47,6 +47,21 @@
       "category": "compatibility"
     },
     {
+      "file": "test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts",
+      "test": "keeps the manual workflow read-only and non-cancelling (#9880)",
+      "category": "security"
+    },
+    {
+      "file": "test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts",
+      "test": "exposes credentials only to their owning steps and removes Brev state (#9880)",
+      "category": "security"
+    },
+    {
+      "file": "test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts",
+      "test": "runs one bounded prompt and always verifies workspace cleanup (#9880)",
+      "category": "security"
+    },
+    {
       "file": "test/e2e/support/larger-runner-routing-workflow-boundary.test.ts",
       "test": "keeps every candidate on standard runners when $name (#7145)",
       "category": "security"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -207,7 +207,12 @@ and exact-staging Launchable job own its product coverage:
 | `gpu` | Unified E2E | `gpu-e2e` runs on the dedicated GPU runner. |
 | `all` | Retired | The selector only duplicated `credential-sanitization` and `telegram-injection`. |
 
-The retired nightly caller no longer runs.
+The retired nightly caller no longer runs. The explicit
+`E2E / Issue 9880 Staging Reproduction` workflow is a temporary issue-specific
+exception: it deploys the standing staging Launchable, runs five bounded fresh
+OpenClaw CLI sessions against the baked image, uploads redacted evidence, and
+confirms that the workflow-owned workspace is absent. It does not restore source
+copying, source installation, the legacy suite selector, or scheduled Brev coverage.
 Each push to `main` selects E2E work from the changed files.
 Manual GPU validation must use `gpu-e2e`.
 It must not provision a generic Brev VM.

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -114,6 +114,8 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     expect(script).toContain("meta/llama-3.3-70b-instruct");
     expect(script).toContain("for attempt in 1 2 3 4 5");
     expect(script).toContain("cleanup-owned-workspace");
+    expect(script).toContain("Brev SSH configuration refresh failed");
+    expect(script).toContain('classification="timeout"');
     expect(script).toContain('brev delete "$INSTANCE_NAME"');
     expect(script).toContain("standing Launchable runtime identity does not match");
     expect(script).toContain("NEMOCLAW_REDACTION_SECRET");

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -84,6 +84,8 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
       }),
     );
     expect(prepare.env).not.toHaveProperty("NVIDIA_INFERENCE_API_KEY");
+    const privateHome = prepare.env?.HOME;
+    expect(privateHome).toBe("${{ runner.temp }}/issue-9880-home");
     expect(reproduce.env).toEqual(
       expect.objectContaining({
         BREV_LAUNCHABLE_ID: "${{ vars.NEMOCLAW_STAGING_LAUNCHABLE_ID }}",
@@ -92,9 +94,12 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
       }),
     );
     expect(reproduce.env).not.toHaveProperty("BREV_API_KEY");
+    expect(reproduce.env?.HOME).toBe(privateHome);
     expect(cleanup.if).toContain("always()");
+    expect(cleanup.env?.HOME).toBe(privateHome);
     expect(cleanup.run).toContain("cleanup-owned-workspace");
     expect(removeCredentials.if).toBe("always()");
+    expect(removeCredentials.env?.HOME).toBe(privateHome);
     expect(removeCredentials.run).toContain('rm -rf -- "$HOME"');
   });
 

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -116,6 +116,7 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     expect(script).toContain("meta/llama-3.3-70b-instruct");
     expect(script).toContain("for attempt in 1 2 3 4 5");
     expect(script).toContain("cleanup-owned-workspace");
+    expect(script).toContain("cleanup could not inspect workspace inventory");
     expect(script).toContain("Brev SSH configuration refresh failed");
     expect(script).toContain('classification="timeout"');
     expect(script).toContain('brev delete "$INSTANCE_NAME"');

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -95,9 +95,11 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     );
     expect(reproduce.env).not.toHaveProperty("BREV_API_KEY");
     expect(reproduce.env?.HOME).toBe(privateHome);
-    expect(cleanup.if).toContain("always()");
+    expect(cleanup.if).toBe("${{ always() && steps.prepare.outputs.work_dir != '' }}");
     expect(cleanup.env?.HOME).toBe(privateHome);
-    expect(cleanup.run).toContain("cleanup-owned-workspace");
+    expect(cleanup.run).toMatch(
+      /^tools\/e2e\/brev-launchable-issue-9880[.]sh cleanup-owned-workspace$/,
+    );
     expect(removeCredentials.if).toBe("always()");
     expect(removeCredentials.env?.HOME).toBe(privateHome);
     expect(removeCredentials.run).toContain('rm -rf -- "$HOME"');

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+import { REPO_ROOT } from "../fixtures/paths.ts";
+
+type Step = {
+  name?: string;
+  if?: string;
+  run?: string;
+  env?: Record<string, string>;
+  with?: Record<string, unknown>;
+};
+
+type Workflow = {
+  permissions?: Record<string, string>;
+  concurrency?: Record<string, unknown>;
+  jobs?: Record<
+    string,
+    {
+      if?: string;
+      permissions?: Record<string, string>;
+      steps?: Step[];
+    }
+  >;
+};
+
+const WORKFLOW_PATH = path.join(
+  REPO_ROOT,
+  ".github/workflows/issue-9880-staging-reproduction.yaml",
+);
+const SCRIPT_PATH = path.join(REPO_ROOT, "tools/e2e/brev-launchable-issue-9880.sh");
+
+function workflow(): Workflow {
+  return YAML.parse(fs.readFileSync(WORKFLOW_PATH, "utf8")) as Workflow;
+}
+
+function step(value: Workflow, name: string): Step {
+  const found = value.jobs?.reproduce?.steps?.find((entry) => entry.name === name);
+  expect(found).toBeDefined();
+  return found!;
+}
+
+describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", () => {
+  // source-shape-contract: security -- The temporary credential-bearing Launchable lane must remain manual, trusted-main-only, read-only, and non-cancelling.
+  it("keeps the manual workflow read-only and non-cancelling (#9880)", () => {
+    const value = workflow();
+
+    expect(value.permissions).toEqual({ contents: "read" });
+    expect(value.concurrency).toEqual({
+      group: "issue-9880-staging-launchable",
+      "cancel-in-progress": false,
+    });
+    expect(value.jobs?.reproduce?.if).toContain("workflow_dispatch");
+    expect(value.jobs?.reproduce?.if).toContain("refs/heads/main");
+    expect(value.jobs?.reproduce?.if).toContain("NVIDIA/NemoClaw");
+  });
+
+  // source-shape-contract: security -- Step-scoped credentials, trusted workflow checkout, maintainer authorization, and independent cleanup prevent PR code or failed execution from retaining cloud access.
+  it("exposes credentials only to their owning steps and removes Brev state (#9880)", () => {
+    const value = workflow();
+    const checkout = step(value, "Check out trusted reproduction lane");
+    const authorize = step(value, "Authorize maintainer dispatch");
+    const prepare = step(value, "Prepare Brev CLI and evidence directory");
+    const reproduce = step(value, "Reproduce issue 9880 on the staging Launchable");
+    const cleanup = step(value, "Verify workflow-owned workspace cleanup");
+    const removeCredentials = step(value, "Remove Brev credentials");
+
+    expect(checkout.env).toBeUndefined();
+    expect(checkout.with?.ref).toBe("${{ github.workflow_sha }}");
+    expect(String(checkout.with?.["sparse-checkout"])).toContain(
+      "tools/e2e/brev-launchable-issue-9880.sh",
+    );
+    expect(authorize.run).toContain("maintain|admin");
+    expect(prepare.env).toEqual(
+      expect.objectContaining({
+        BREV_API_KEY: "${{ secrets.BREV_API_KEY }}",
+        BREV_ORG_ID: "${{ secrets.BREV_ORG_ID }}",
+      }),
+    );
+    expect(prepare.env).not.toHaveProperty("NVIDIA_INFERENCE_API_KEY");
+    expect(reproduce.env).toEqual(
+      expect.objectContaining({
+        BREV_LAUNCHABLE_ID: "${{ vars.NEMOCLAW_STAGING_LAUNCHABLE_ID }}",
+        GH_TOKEN: "${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}",
+        NVIDIA_API_KEY: "${{ secrets.NVIDIA_API_KEY }}",
+      }),
+    );
+    expect(reproduce.env).not.toHaveProperty("BREV_API_KEY");
+    expect(cleanup.if).toContain("always()");
+    expect(cleanup.run).toContain("cleanup-owned-workspace");
+    expect(removeCredentials.if).toBe("always()");
+    expect(removeCredentials.run).toContain('rm -rf -- "$HOME"');
+  });
+
+  // source-shape-contract: security -- The shipped trusted script must bind staging identity before credential exposure, bound every turn, redact evidence, and retain exact-name cleanup.
+  it("runs one bounded prompt and always verifies workspace cleanup (#9880)", () => {
+    const script = fs.readFileSync(SCRIPT_PATH, "utf8");
+
+    expect(script).toContain('brev create "$INSTANCE_NAME" --launchable "$BREV_LAUNCHABLE_ID"');
+    expect(script).toContain("timeout --signal=TERM --kill-after=10s 90s");
+    expect(script).toContain("List 10 REST API endpoints for a blog service, one per line");
+    expect(script).toContain("openclaw agent --agent main --json --thinking off");
+    expect(script).toContain("meta/llama-3.3-70b-instruct");
+    expect(script).toContain("for attempt in 1 2 3 4 5");
+    expect(script).toContain("cleanup-owned-workspace");
+    expect(script).toContain('brev delete "$INSTANCE_NAME"');
+    expect(script).toContain("standing Launchable runtime identity does not match");
+    expect(script).toContain("NEMOCLAW_REDACTION_SECRET");
+    expect(script).not.toContain("--count");
+    expect(script).not.toContain("KEEP_ALIVE");
+  });
+});

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+OWNER_FILE="${WORK_DIR}.workspace-owner"
+SSH_OPTIONS=(-T -o BatchMode=yes -o ConnectTimeout=10 -o ConnectionAttempts=1 -o LogLevel=ERROR)
+log() { printf '%s\n' "$*" | tee -a "$WORK_DIR/lane.log"; }
+fail() {
+  log "FAILED: $*" >&2
+  exit 1
+}
+require() {
+  local name="$1"
+  [ -n "${!name:-}" ] || fail "$name is required"
+}
+
+workspace_rows() {
+  timeout 30s brev ls --json | jq -c '
+    if type == "array" then .
+    elif type == "object" and has("workspaces") and .workspaces == null then []
+    elif type == "object" and (.workspaces | type) == "array" then .workspaces
+    else error("unexpected brev ls --json shape") end'
+}
+workspace() {
+  workspace_rows | jq -c --arg name "$INSTANCE_NAME" '
+    map(select(((.name // .workspaceName // .instanceName // "") | tostring) == $name))
+    | if length == 0 then empty elif length == 1 then .[0]
+      else error("workspace name is ambiguous") end'
+}
+write_cleanup_evidence() {
+  local status="$1" workspace_id="${2:-}"
+  jq -n --arg workspaceName "$INSTANCE_NAME" --arg workspaceId "$workspace_id" \
+    --arg status "$status" --arg checkedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{schemaVersion:1,workspaceName:$workspaceName,workspaceId:$workspaceId,status:$status,checkedAt:$checkedAt}' \
+    >"$WORK_DIR/cleanup.json"
+}
+cleanup_owned_workspace() {
+  local existing="" workspace_id="" absent=0
+  if ! jq -e --arg name "$INSTANCE_NAME" '.workspaceName == $name and .owned == true' \
+    "$OWNER_FILE" >/dev/null 2>&1; then
+    write_cleanup_evidence NOT_OWNED
+    fail "cleanup refused because the ownership receipt is absent or invalid"
+  fi
+  existing="$(workspace || true)"
+  workspace_id="$(jq -r '.id // ""' <<<"${existing:-{}}")"
+  if [ -n "$existing" ]; then
+    log "Deleting workflow-owned workspace $INSTANCE_NAME"
+    timeout 60s brev delete "$INSTANCE_NAME" || true
+  fi
+  local deadline=$((SECONDS + ${BREV_DELETE_TIMEOUT_SECONDS:-600}))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if existing="$(workspace)"; then
+      if [ -z "$existing" ]; then
+        absent=$((absent + 1))
+        if [ "$absent" -ge 2 ]; then
+          write_cleanup_evidence ABSENT "$workspace_id"
+          rm -f -- "$OWNER_FILE"
+          return
+        fi
+      else
+        absent=0
+      fi
+    else
+      absent=0
+    fi
+    timeout 30s brev refresh >/dev/null 2>&1 || true
+    sleep "${POLL_SECONDS:-15}"
+  done
+  write_cleanup_evidence UNKNOWN "$workspace_id"
+  fail "cleanup could not confirm workspace absence"
+}
+redact_file() {
+  local source="$1" target="$2"
+  NEMOCLAW_REDACTION_SECRET="$NVIDIA_API_KEY" python3 - "$source" "$target" <<'PY'
+import os
+import re
+import sys
+from pathlib import Path
+source, target = sys.argv[1:]
+text = Path(source).read_text(encoding="utf-8", errors="replace")
+secret = os.environ["NEMOCLAW_REDACTION_SECRET"]
+if secret:
+    text = text.replace(secret, "[REDACTED]")
+text = re.sub(r"(?i)(?:nvapi-|sk-)[A-Za-z0-9_./+=-]{8,}", "[REDACTED]", text)
+Path(target).write_text(text[-65536:], encoding="utf-8")
+Path(source).unlink(missing_ok=True)
+PY
+}
+
+for name in WORK_DIR INSTANCE_NAME; do require "$name"; done
+for tool in brev jq python3 timeout; do command -v "$tool" >/dev/null 2>&1 || fail "$tool is required"; done
+[[ "$INSTANCE_NAME" =~ ^[a-z][a-z0-9-]{0,62}$ ]] || fail "INSTANCE_NAME is invalid"
+mkdir -p "$WORK_DIR"
+chmod 700 "$WORK_DIR"
+touch "$WORK_DIR/lane.log"
+if [ "${1:-}" = cleanup-owned-workspace ] && [ "$#" -eq 1 ]; then
+  cleanup_owned_workspace
+  exit 0
+elif [ "$#" -ne 0 ]; then
+  fail "only cleanup-owned-workspace is accepted as an argument"
+fi
+
+require BREV_LAUNCHABLE_ID
+require GH_TOKEN
+require NVIDIA_API_KEY
+command -v gh >/dev/null 2>&1 || fail "gh is required"
+command -v ssh >/dev/null 2>&1 || fail "ssh is required"
+[[ "$BREV_LAUNCHABLE_ID" =~ ^env-[A-Za-z0-9]+$ ]] || fail "BREV_LAUNCHABLE_ID is invalid"
+[[ "$NVIDIA_API_KEY" == nvapi-* ]] || fail "NVIDIA_API_KEY must be a public NVIDIA Endpoints key"
+write_cleanup_evidence NOT_OWNED
+handoff_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/issue-9880-handoff.XXXXXX")"
+latest_runs="$(gh api 'repos/brevdev/nemoclaw-image/actions/workflows/build-launchable-e2e-image.yml/runs?branch=main&event=workflow_dispatch&status=success&per_page=20')"
+producer_run="$(jq -er '[.workflow_runs[] | select(.display_title | startswith("Build Launchable E2E image for NemoClaw "))] | sort_by(.created_at) | last | .id' <<<"$latest_runs")"
+gh run download "$producer_run" --repo brevdev/nemoclaw-image \
+  --name "nemoclaw-image-handoff-v1-${producer_run}-1" --dir "$handoff_dir"
+manifest="$handoff_dir/nemoclaw-image-manifest.v1.json"
+jq -e --argjson run "$producer_run" '
+  .schemaVersion == 1 and .kind == "nemoclaw-exact-image-manifest" and
+  .imageRepository == "brevdev/nemoclaw-image" and
+  .producerWorkflow == ".github/workflows/build-launchable-e2e-image.yml" and
+  .workflowRunId == $run and .workflowRunAttempt == 1 and .status == "READY" and
+  .channel == "staging" and .variant == "cpu" and
+  .observedFamily == "nemoclaw-brev-staging-cpu" and
+  (.project | type == "string" and length > 0) and
+  (.imageName | type == "string" and length > 0) and
+  (.nemoclawSha | test("^[0-9a-f]{40}$")) and
+  (.imageRepositorySha | test("^[0-9a-f]{40}$"))' "$manifest" >/dev/null \
+  || fail "latest staging image handoff is invalid"
+expected_boot_image="projects/$(jq -er .project "$manifest")/global/images/$(jq -er .imageName "$manifest")"
+expected_nemoclaw_sha="$(jq -er .nemoclawSha "$manifest")"
+expected_image_repository_sha="$(jq -er .imageRepositorySha "$manifest")"
+rm -rf -- "$handoff_dir"
+log "Bound latest successful staging image producer run $producer_run"
+[ -z "$(workspace || true)" ] || fail "workspace name already exists"
+jq -n --arg workspaceName "$INSTANCE_NAME" '{workspaceName:$workspaceName,owned:true}' >"$OWNER_FILE"
+chmod 600 "$OWNER_FILE"
+log "Deploying the current standing staging Launchable"
+timeout 900s brev create "$INSTANCE_NAME" --launchable "$BREV_LAUNCHABLE_ID" --detached --timeout 900
+
+deadline=$((SECONDS + ${BREV_READY_TIMEOUT_SECONDS:-1200}))
+ready=""
+while [ "$SECONDS" -lt "$deadline" ]; do
+  ready="$(workspace || true)"
+  if jq -e '.status == "RUNNING" and (.shell_status // .shellStatus) == "READY" and
+    (.build_status // .buildStatus) == "COMPLETED"' <<<"${ready:-null}" >/dev/null; then break; fi
+  state="$(jq -r '(.status // "") + ":" + (.build_status // .buildStatus // "")' <<<"${ready:-null}")"
+  [[ "$state" =~ FAILURE|FAILED|ERROR|CREATE_FAILED ]] && fail "workspace entered $state"
+  sleep "${POLL_SECONDS:-15}"
+done
+jq -e '.status == "RUNNING" and (.shell_status // .shellStatus) == "READY" and
+  (.build_status // .buildStatus) == "COMPLETED"' <<<"${ready:-null}" >/dev/null \
+  || fail "workspace readiness timed out"
+workspace_id="$(jq -r '.id // ""' <<<"$ready")"
+log "Workspace $INSTANCE_NAME ($workspace_id) is ready"
+
+# The remote shell expands the single-quoted command.
+# shellcheck disable=SC2016
+identity="$(timeout 300s brev exec "$INSTANCE_NAME" 'set -euo pipefail
+  source_path=$(sudo -n jq -er .sourcePath /etc/nemoclaw/provision.json)
+  source_repository=$(sudo -n jq -er .sourceRepository /etc/nemoclaw/provision.json)
+  provision_sha=$(sudo -n jq -er .gitSha /etc/nemoclaw/provision.json)
+  image_repository_sha=$(sudo -n jq -er .imageRepositorySha /etc/nemoclaw/provision.json)
+  repo_sha=$(git -C "$source_path" rev-parse HEAD)
+  test -z "$(git -C "$source_path" status --porcelain --untracked-files=normal)"
+  sudo -n test ! -e /etc/nemoclaw/runtime-overrides.json
+  boot_image=$(curl -fsS --max-time 10 -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/image)
+  jq -cn --arg sourceRepository "$source_repository" --arg sourcePath "$source_path" \
+    --arg provisionSha "$provision_sha" --arg imageRepositorySha "$image_repository_sha" \
+    --arg repoSha "$repo_sha" --arg bootImage "$boot_image" \
+    "{sourceRepository:\$sourceRepository,sourcePath:\$sourcePath,provisionSha:\$provisionSha,imageRepositorySha:\$imageRepositorySha,repoSha:\$repoSha,bootImage:\$bootImage,repoClean:true,runtimeOverrides:false}"' | tail -n 1)"
+jq -e --arg expectedBootImage "$expected_boot_image" --arg expectedSha "$expected_nemoclaw_sha" \
+  --arg expectedImageRepositorySha "$expected_image_repository_sha" '
+  .sourceRepository == "NVIDIA/NemoClaw" and
+  .sourcePath == "/opt/nemoclaw-image/NemoClaw" and
+  .provisionSha == $expectedSha and .repoSha == $expectedSha and
+  .imageRepositorySha == $expectedImageRepositorySha and .bootImage == $expectedBootImage and
+  .repoClean == true and .runtimeOverrides == false' <<<"$identity" >/dev/null \
+  || fail "standing Launchable runtime identity does not match the latest staging handoff"
+log "Verified standing Launchable runtime identity before credential exposure"
+
+raw_log="$(mktemp "${RUNNER_TEMP:-/tmp}/issue-9880.XXXXXX")"
+chmod 600 "$raw_log"
+set +e
+{
+  printf 'export NVIDIA_INFERENCE_API_KEY=%q\n' "$NVIDIA_API_KEY"
+  cat <<'REMOTE'
+set -euo pipefail
+export NEMOCLAW_MODEL=meta/llama-3.3-70b-instruct
+export NEMOCLAW_PROVIDER=build
+export NEMOCLAW_AGENT=openclaw
+brev-quickstart issue-9880
+nemoclaw issue-9880 exec -- node -e '
+const fs = require("fs");
+const cfg = JSON.parse(fs.readFileSync("/sandbox/.openclaw/openclaw.json", "utf8"));
+const model = cfg?.agents?.defaults?.model?.primary;
+if (model !== "inference/meta/llama-3.3-70b-instruct") {
+  console.error(`unexpected managed model: ${String(model)}`);
+  process.exit(1);
+}
+'
+prompt='List 10 REST API endpoints for a blog service, one per line'
+reproduced=0
+for attempt in 1 2 3 4 5; do
+  session_id="e2e-issue-9880-$(date +%s)-$$-$attempt"
+  output="$(mktemp)"
+  set +e
+  timeout --signal=TERM --kill-after=10s 90s nemoclaw issue-9880 exec -- \
+    openclaw agent --agent main --json --thinking off --session-id "$session_id" -m "$prompt" \
+    >"$output" 2>&1
+  status=$?
+  set -e
+  classification="$(python3 - "$output" "$status" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+path, status_text = sys.argv[1:]
+status = int(status_text)
+text = Path(path).read_text(encoding="utf-8", errors="replace")
+if status == 124:
+    print("inconclusive-timeout")
+    raise SystemExit
+tool_invocations = len(re.findall(r"(?i)(invoking tool|tool[_ -]?call|tool_use)", text))
+tool_refusals = len(re.findall(r"(?i)(tool call refused|does not exist|unknown tool|tool not found)", text))
+if tool_invocations >= 2 and tool_refusals >= 2:
+    print("reproduced-tool-loop")
+    raise SystemExit
+strings = []
+try:
+    root = json.loads(text)
+except json.JSONDecodeError:
+    strings.append(text)
+else:
+    def visit(value):
+        if isinstance(value, str): strings.append(value)
+        elif isinstance(value, list):
+            for item in value: visit(item)
+        elif isinstance(value, dict):
+            for item in value.values(): visit(item)
+    visit(root)
+lines = "\n".join(strings).splitlines()
+endpoints = {line.strip() for line in lines if re.match(r"^\s*(?:\d+[.)]\s*)?(?:GET|POST|PUT|PATCH|DELETE)\s+/\S+", line)}
+print(
+    "completed"
+    if status == 0 and len(endpoints) >= 10 and tool_invocations == 0 and tool_refusals == 0
+    else "unexpected"
+)
+PY
+)"
+  printf 'NEMOCLAW_ISSUE_9880_ATTEMPT=%s STATUS=%s CLASSIFICATION=%s\n' "$attempt" "$status" "$classification"
+  tail -c 4096 "$output"
+  rm -f "$output"
+  if [[ "$classification" == reproduced-* ]]; then reproduced=1; break; fi
+  [ "$classification" = completed ] || exit 2
+done
+if [ "$reproduced" -eq 1 ]; then exit 86; fi
+REMOTE
+} | ssh "${SSH_OPTIONS[@]}" "$INSTANCE_NAME" 'bash -s' >"$raw_log" 2>&1
+scenario_status=$?
+set -e
+redact_file "$raw_log" "$WORK_DIR/issue-9880.log"
+
+classification="completed"
+if [ "$scenario_status" -eq 86 ]; then
+  classification="reproduced"
+elif [ "$scenario_status" -ne 0 ]; then classification="setup-or-unexpected-failure"; fi
+jq -n --arg launchableId "$BREV_LAUNCHABLE_ID" --arg workspaceName "$INSTANCE_NAME" \
+  --arg workspaceId "$workspace_id" --arg classification "$classification" \
+  --arg producerRun "$producer_run" --argjson scenarioStatus "$scenario_status" \
+  --argjson identity "$identity" \
+  '{schemaVersion:1,kind:"nemoclaw-issue-9880-staging-reproduction-v1",launchableId:$launchableId,producerRunId:$producerRun,workspace:{name:$workspaceName,id:$workspaceId},runtimeIdentity:$identity,prompt:"List 10 REST API endpoints for a blog service, one per line",model:"meta/llama-3.3-70b-instruct",attemptLimit:5,turnTimeoutSeconds:90,classification:$classification,scenarioStatus:$scenarioStatus}' \
+  >"$WORK_DIR/issue-9880.json"
+case "$classification" in
+  reproduced) fail "issue #9880 reproduced on the standing staging Launchable" ;;
+  completed) log "Five fresh CLI sessions completed without reproducing issue #9880" ;;
+  *) fail "issue #9880 scenario failed before a conclusive result" ;;
+esac

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -39,7 +39,10 @@ write_cleanup_evidence() {
 cleanup_owned_workspace() {
   local existing="" workspace_id="" absent=0
   if [ ! -e "$OWNER_FILE" ]; then
-    existing="$(workspace || true)"
+    if ! existing="$(workspace)"; then
+      write_cleanup_evidence UNKNOWN
+      fail "cleanup could not inspect workspace inventory without an ownership receipt"
+    fi
     if [ -z "$existing" ]; then
       write_cleanup_evidence ABSENT
       return

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -38,10 +38,19 @@ write_cleanup_evidence() {
 }
 cleanup_owned_workspace() {
   local existing="" workspace_id="" absent=0
+  if [ ! -e "$OWNER_FILE" ]; then
+    existing="$(workspace || true)"
+    if [ -z "$existing" ]; then
+      write_cleanup_evidence ABSENT
+      return
+    fi
+    write_cleanup_evidence NOT_OWNED "$(jq -r '.id // ""' <<<"$existing")"
+    fail "cleanup refused because a matching workspace exists without an ownership receipt"
+  fi
   if ! jq -e --arg name "$INSTANCE_NAME" '.workspaceName == $name and .owned == true' \
     "$OWNER_FILE" >/dev/null 2>&1; then
     write_cleanup_evidence NOT_OWNED
-    fail "cleanup refused because the ownership receipt is absent or invalid"
+    fail "cleanup refused because the ownership receipt is invalid"
   fi
   existing="$(workspace || true)"
   workspace_id="$(jq -r '.id // ""' <<<"${existing:-{}}")"
@@ -154,6 +163,7 @@ jq -e '.status == "RUNNING" and (.shell_status // .shellStatus) == "READY" and
   || fail "workspace readiness timed out"
 workspace_id="$(jq -r '.id // ""' <<<"$ready")"
 log "Workspace $INSTANCE_NAME ($workspace_id) is ready"
+timeout 60s brev refresh >/dev/null || fail "Brev SSH configuration refresh failed"
 
 # The remote shell expands the single-quoted command.
 # shellcheck disable=SC2016
@@ -253,6 +263,7 @@ PY
   tail -c 4096 "$output"
   rm -f "$output"
   if [[ "$classification" == reproduced-* ]]; then reproduced=1; break; fi
+  [ "$classification" != inconclusive-timeout ] || exit 87
   [ "$classification" = completed ] || exit 2
 done
 if [ "$reproduced" -eq 1 ]; then exit 86; fi
@@ -265,6 +276,8 @@ redact_file "$raw_log" "$WORK_DIR/issue-9880.log"
 classification="completed"
 if [ "$scenario_status" -eq 86 ]; then
   classification="reproduced"
+elif [ "$scenario_status" -eq 87 ]; then
+  classification="timeout"
 elif [ "$scenario_status" -ne 0 ]; then classification="setup-or-unexpected-failure"; fi
 jq -n --arg launchableId "$BREV_LAUNCHABLE_ID" --arg workspaceName "$INSTANCE_NAME" \
   --arg workspaceId "$workspace_id" --arg classification "$classification" \
@@ -275,5 +288,6 @@ jq -n --arg launchableId "$BREV_LAUNCHABLE_ID" --arg workspaceName "$INSTANCE_NA
 case "$classification" in
   reproduced) fail "issue #9880 reproduced on the standing staging Launchable" ;;
   completed) log "Five fresh CLI sessions completed without reproducing issue #9880" ;;
+  timeout) fail "issue #9880 trial timed out without issue-specific loop evidence" ;;
   *) fail "issue #9880 scenario failed before a conclusive result" ;;
 esac


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds a temporary, manually dispatched staging Launchable lane that reproduces issue #9880 against the current exact staging image. The lane binds the latest successful staging handoff before credential exposure, runs five bounded fresh OpenClaw CLI sessions with the issue model and prompt, publishes redacted evidence, and verifies removal of its Brev workspace.

## Related Issue

Refs #9880

## Changes

- Add `E2E / Issue 9880 Staging Reproduction`, restricted to trusted `main` workflow code and maintain/admin dispatchers.
- Deploy the standing staging Launchable with the pinned Brev CLI, verify its concrete image and clean baked runtime against the latest successful producer handoff, and only then expose the public NVIDIA inference credential.
- Onboard `meta/llama-3.3-70b-instruct`, verify the managed model reference, and run five fresh 90-second CLI trials with issue-specific result classification.
- Upload bounded redacted logs and structured identity/result evidence, then confirm the workflow-owned workspace is absent in an independent always-run cleanup step.
- Record the temporary exception beside the retired generic Brev source-install lane. This does not restore source copying, source installation, legacy selectors, or scheduled Brev coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent agent review completed before publication; trusted dispatch, staging identity binding, step-scoped credentials, redaction, bounded execution, and independent cleanup were reviewed and hardened.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts --silent=false --reporter=default` — 3 tests passed; `actionlint`, `bash -n`, and ShellCheck passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered staging reproduction workflow with trusted access controls.
  * Added controlled execution across up to five fresh CLI sessions with staging identity verification.
  * Added structured, redacted evidence collection and secure workspace and credential cleanup.
  * Added clear outcome classification for reproduced, completed, timed-out, and unexpected results.

* **Documentation**
  * Documented workflow usage, evidence handling, cleanup verification, and retired legacy coverage.

* **Tests**
  * Added end-to-end validation for permissions, credential handling, execution limits, timeout behavior, cleanup, and evidence redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->