### PR TITLE
fix(advisor): complete synthesis trace reads

### DIFF
--- a/test/pr-review-advisor-specialist-sessions.test.ts
+++ b/test/pr-review-advisor-specialist-sessions.test.ts
@@ -8,6 +8,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { advisorTurnFlowErrors, resolveAdvisorTurnTools } from "../tools/advisors/session.mts";
+import {
+  requiredReadPreparationErrors,
+  requiredReadPreparationPrompt,
+} from "../tools/advisors/turn-protocol.mts";
 import { buildSynthesisTurn } from "../tools/pr-review-advisor/synthesis-turn.mts";
 import { ADVISOR_INTERESTS } from "../tools/pr-review-advisor/specialists.mts";
 import {
@@ -116,6 +120,30 @@ describe("specialist Pi session inputs", () => {
       { type: "tool_start" as const, toolName },
       { type: "tool_end" as const, toolName, isError: false },
     ];
+
+    const preparationTurn = { ...turn, requiredReadPaths: [paths[0]!] };
+    expect(requiredReadPreparationPrompt(preparationTurn)).toContain(
+      `Required files:\n- ${paths[0]}`,
+    );
+    expect(requiredReadPreparationPrompt(preparationTurn)).not.toContain(paths[1]!);
+    expect(
+      requiredReadPreparationErrors("synthesize", [complete[0]!], {
+        ...tools,
+        requiredReadPaths: [paths[0]!],
+      }),
+    ).toEqual([]);
+    expect(
+      requiredReadPreparationErrors("synthesize", [receipt, complete[0]!], {
+        ...tools,
+        requiredReadPaths: [paths[0]!],
+      }),
+    ).toContain("synthesize required-read preparation emitted text");
+    expect(
+      requiredReadPreparationErrors("synthesize", [...toolCall("grep"), complete[0]!], {
+        ...tools,
+        requiredReadPaths: [paths[0]!],
+      }),
+    ).toContain("synthesize required-read preparation called grep");
 
     expect(advisorTurnFlowErrors("synthesize", [...complete, receipt], tools)).toEqual([]);
     expect(

--- a/test/pr-review-advisor-specialist-sessions.test.ts
+++ b/test/pr-review-advisor-specialist-sessions.test.ts
@@ -144,6 +144,12 @@ describe("specialist Pi session inputs", () => {
         requiredReadPaths: [paths[0]!],
       }),
     ).toContain("synthesize required-read preparation called grep");
+    expect(
+      requiredReadPreparationErrors("synthesize", [complete[1]!, complete[0]!], {
+        ...tools,
+        requiredReadPaths: [paths[0]!],
+      }),
+    ).toContain(`synthesize required-read preparation read unexpected path: ${paths[1]}`);
 
     expect(advisorTurnFlowErrors("synthesize", [...complete, receipt], tools)).toEqual([]);
     expect(

--- a/tools/advisors/session.mts
+++ b/tools/advisors/session.mts
@@ -35,6 +35,8 @@ import {
   normalizedToolNames,
   promptWithRequiredContextTools,
   READ_ONLY_TOOLS,
+  requiredReadPreparationErrors,
+  requiredReadPreparationPrompt,
   repairableAtomicTerminalToolName,
   repairableTerminalSubmitToolName,
   resolveAdvisorTurnTools,
@@ -580,6 +582,28 @@ export async function runReadOnlyAdvisor(
             await Promise.race([session.prompt(prompt), timeoutPromise]);
             await Promise.race([agentEndPromise, timeoutPromise]);
           };
+          if ((tools.requiredReadPaths?.length ?? 0) > 0) {
+            contextTools.deactivate();
+            session.setActiveToolsByName(["read"]);
+            currentTurnFlow = [];
+            raw.append(`\n[${options.logPrefix}] required_read_preparation_start ${turn.name}\n`);
+            for (const requiredPath of tools.requiredReadPaths!) {
+              const preparationTurn = { ...turn, requiredReadPaths: [requiredPath] };
+              const eventOffset = currentTurnFlow.length;
+              await promptAndWait(requiredReadPreparationPrompt(preparationTurn));
+              const preparationErrors = requiredReadPreparationErrors(
+                turn.name,
+                currentTurnFlow.slice(eventOffset),
+                { ...tools, requiredReadPaths: [requiredPath] },
+              );
+              if (preparationErrors.length > 0) throw new Error(preparationErrors.join("; "));
+            }
+            const preparationFlow = currentTurnFlow;
+            raw.append(`[${options.logPrefix}] required_read_preparation_end ${turn.name} ok\n`);
+            contextTools.activateTurn(turn);
+            session.setActiveToolsByName([READ_ONLY_TOOLS, tools.activeToolNames].flat());
+            currentTurnFlow = preparationFlow;
+          }
           await promptAndWait(promptWithRequiredContextTools(turn.prompt, contextToolNames));
           const originalFlow = currentTurnFlow;
           const repairToolName = repairableAtomicTerminalToolName(

--- a/tools/advisors/turn-protocol.mts
+++ b/tools/advisors/turn-protocol.mts
@@ -310,6 +310,32 @@ function atomicTerminalToolErrors(
   return errors;
 }
 
+export function requiredReadPreparationPrompt(turn: AdvisorPromptTurn): string {
+  const paths = [...new Set(turn.requiredReadPaths ?? [])];
+  return `Prepare ${turn.name} by reading every required file with ordinary \`read\` calls. Read each file contiguously from line 1 through EOF. If a read is truncated, continue at the next unread line until that file reaches EOF. Emit only \`read\` calls and no text. Do not use any other tool.\n\nRequired files:\n${paths.map((requiredPath) => `- ${requiredPath}`).join("\n")}`;
+}
+
+export function requiredReadPreparationErrors(
+  turnName: string,
+  events: AdvisorTurnFlowEvent[],
+  tools: AdvisorTurnTools,
+): string[] {
+  const errors = advisorTurnFlowErrors(turnName, events, {
+    ...tools,
+    requireAssistantText: false,
+  });
+  if (events.some((event) => event.type === "text" && event.text.trim())) {
+    errors.push(`${turnName} required-read preparation emitted text`);
+  }
+  const unexpected = events.find(
+    (event) => event.type !== "text" && event.type !== "read" && event.toolName !== "read",
+  );
+  if (unexpected && unexpected.type !== "text" && unexpected.type !== "read") {
+    errors.push(`${turnName} required-read preparation called ${unexpected.toolName}`);
+  }
+  return [...new Set(errors)];
+}
+
 export function advisorTurnFlowErrors(
   turnName: string,
   events: AdvisorTurnFlowEvent[],

--- a/tools/advisors/turn-protocol.mts
+++ b/tools/advisors/turn-protocol.mts
@@ -327,11 +327,14 @@ export function requiredReadPreparationErrors(
   if (events.some((event) => event.type === "text" && event.text.trim())) {
     errors.push(`${turnName} required-read preparation emitted text`);
   }
-  const unexpected = events.find(
-    (event) => event.type !== "text" && event.type !== "read" && event.toolName !== "read",
-  );
-  if (unexpected && unexpected.type !== "text" && unexpected.type !== "read") {
-    errors.push(`${turnName} required-read preparation called ${unexpected.toolName}`);
+  const requiredPaths = new Set(tools.requiredReadPaths ?? []);
+  for (const event of events) {
+    if (event.type === "read" && !requiredPaths.has(event.path)) {
+      errors.push(`${turnName} required-read preparation read unexpected path: ${event.path}`);
+    }
+    if (event.type !== "text" && event.type !== "read" && event.toolName !== "read") {
+      errors.push(`${turnName} required-read preparation called ${event.toolName}`);
+    }
   }
   return [...new Set(errors)];
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Force the shadow synthesis advisor to complete every native specialist trace read before analysis after post-#9970 live sampling showed prompt-only enforcement still allowed premature output.

## Changes

- Run a read-only preparation phase with only Pi's ordinary read tool active.
- Prepare one native JSONL trace at a time and require contiguous line-1-through-EOF coverage.
- Carry validated read observations into synthesis and reject preparation text or other tools.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: 
- Station profile/scenario: 
- Result: 
- Supporting evidence: 

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — Normal pre-commit, commit-msg, and pre-push hooks passed.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 37 focused integration tests passed; CLI build and type-check, repository checks, Oxlint, formatting, diff, and normal hooks passed.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: npm run build:cli; npm run typecheck:cli; focused integration tests; npm run checks:repository
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Advisor sessions now ensure all required files are fully read before continuing.
  * Preparation is limited to necessary file-reading activity, improving consistency and focus.
  * Sessions reject incomplete preparation attempts, including unexpected text or unsupported actions.
  * Clear errors are reported when required files cannot be read successfully.
* **Tests**
  * Added coverage for successful preparation, scoped file access, and invalid preparation attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->