### PR TITLE
fix(e2e): compare staging producer run as text

### DIFF
--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -120,6 +120,7 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     expect(script).toContain("Brev SSH configuration refresh failed");
     expect(script).toContain('classification="timeout"');
     expect(script).toContain('brev delete "$INSTANCE_NAME"');
+    expect(script).toContain('jq -e --arg run "$producer_run"');
     expect(script).toContain("standing Launchable runtime identity does not match");
     expect(script).toContain("NEMOCLAW_REDACTION_SECRET");
     expect(script).not.toContain("--count");

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -128,7 +128,7 @@ producer_run="$(jq -er '[.workflow_runs[] | select(.display_title | startswith("
 gh run download "$producer_run" --repo brevdev/nemoclaw-image \
   --name "nemoclaw-image-handoff-v1-${producer_run}-1" --dir "$handoff_dir"
 manifest="$handoff_dir/nemoclaw-image-manifest.v1.json"
-jq -e --argjson run "$producer_run" '
+jq -e --arg run "$producer_run" '
   .schemaVersion == 1 and .kind == "nemoclaw-exact-image-manifest" and
   .imageRepository == "brevdev/nemoclaw-image" and
   .producerWorkflow == ".github/workflows/build-launchable-e2e-image.yml" and


### PR DESCRIPTION
## Summary

Fixes the issue #9880 staging reproduction lane's handoff validation by comparing the manifest's string run ID as text instead of passing it to jq as JSON.

## Related Issue

Refs #9880

## Verification

- Focused E2E-support contract: 3 tests passed
- ShellCheck and commit hooks passed

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest validation for producer run identifiers.
  * Ensured validation handles run identifiers consistently as strings, preventing parsing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->