### PR TITLE
fix(install): pin curl protocol for install.sh's own fetches

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4062,7 +4062,7 @@ ensure_docker() {
     info "The next step uses sudo to install Docker system-wide via the official convenience script. You may be prompted for your password."
     local docker_tmp
     docker_tmp="$(mktemp)"
-    if ! curl -fsSL https://get.docker.com -o "$docker_tmp"; then
+    if ! curl -fsSL --proto '=https' --proto-redir '=https' https://get.docker.com -o "$docker_tmp"; then
       rm -f "$docker_tmp"
       error "Failed to download the Docker convenience script from https://get.docker.com"
     fi
@@ -6182,7 +6182,7 @@ if [[ "${BASH_SOURCE[0]:-}" == "$0" ]] || { [[ -z "${BASH_SOURCE[0]:-}" ]] && { 
   if [[ -z "${BASH_SOURCE[0]:-}" ]] && [[ -z "${NEMOCLAW_INSTALLER_STAGED:-}" ]]; then
     _installer_url="${NEMOCLAW_INSTALLER_URL:-https://www.nvidia.com/nemoclaw.sh}"
     if _staged="$(mktemp /tmp/nemoclaw-installer-XXXXXX 2>/dev/null)" \
-      && curl -fsSL "$_installer_url" -o "$_staged" 2>/dev/null \
+      && curl -fsSL --proto '=https' --proto-redir '=https' "$_installer_url" -o "$_staged" 2>/dev/null \
       && [[ -s "$_staged" ]] \
       && head -1 "$_staged" | grep -qE '^#!.*(sh|bash)' \
       && bash -n "$_staged" 2>/dev/null; then

--- a/test/install-curl-proto-pin.test.ts
+++ b/test/install-curl-proto-pin.test.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import { INSTALLER_PAYLOAD } from "./helpers/installer-sourced-env";
+
+describe("installer curl fetch protocol pinning (#9977)", () => {
+  const script = fs.readFileSync(INSTALLER_PAYLOAD, "utf-8");
+
+  it("pins the Docker convenience-script fetch to HTTPS", () => {
+    expect(script).toContain(
+      "curl -fsSL --proto '=https' --proto-redir '=https' https://get.docker.com -o \"$docker_tmp\"",
+    );
+  });
+
+  it("pins the installer self re-stage fetch to HTTPS", () => {
+    expect(script).toContain(
+      "curl -fsSL --proto '=https' --proto-redir '=https' \"$_installer_url\" -o \"$_staged\"",
+    );
+  });
+});

--- a/test/install-stage-from-stdin.test.ts
+++ b/test/install-stage-from-stdin.test.ts
@@ -74,7 +74,7 @@ function runEntryGuardInFixture(tmp: string, opts: EntryGuardOptions): StagingOu
     if [[ -z "$_test_bash_source" ]] && [[ -z "\${NEMOCLAW_INSTALLER_STAGED:-}" ]]; then
       _installer_url="\${NEMOCLAW_INSTALLER_URL:-https://www.nvidia.com/nemoclaw.sh}"
       if _staged="$(mktemp /tmp/nemoclaw-installer-XXXXXX 2>/dev/null)" \\
-         && curl -fsSL "$_installer_url" -o "$_staged" 2>/dev/null \\
+         && curl -fsSL --proto '=https' --proto-redir '=https' "$_installer_url" -o "$_staged" 2>/dev/null \\
          && [[ -s "$_staged" ]] \\
          && head -1 "$_staged" | grep -qE '^#!.*(sh|bash)' \\
          && bash -n "$_staged" 2>/dev/null; then


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
`scripts/install.sh` — the script that `curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash` actually runs — downloads and executes two remote scripts without pinning the transfer protocol: the Docker convenience script (`get.docker.com`, run as root via `sudo sh`) and its own re-staged installer body (the `curl | bash` entry-guard re-exec path). Neither fetch has a cryptographic integrity check backing it, so a redirect to a non-HTTPS location could substitute bytes that never arrived over TLS. This adds `--proto '=https' --proto-redir '=https'` to both curl calls, the same hardening `src/lib/onboard/install-ollama-linux.ts` and (after #9861) `src/lib/actions/update.ts` already apply, so each fetch now fails closed on a downgrade redirect.

## Related Issue
Fixes #9977

## Changes
- `scripts/install.sh`: added `--proto '=https' --proto-redir '=https'` to the `get.docker.com` fetch in `ensure_docker` and to the installer self re-stage fetch in the `curl | bash` entry guard.
- `test/install-stage-from-stdin.test.ts`: updated the inlined copy of the entry-guard staging block (kept in sync per its own comment) to match the pinned fetch.
- `test/install-curl-proto-pin.test.ts` (new): asserts both fixed fetches in `scripts/install.sh` carry the proto-pinning flags.

The third curl-then-execute fetch in `install.sh` (the nvm installer, `scripts/install.sh:2170`) is unaffected — it already pins and verifies a SHA-256 before execution, so a substituted payload is caught regardless of transport, and no change was needed there.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit: n/a — `scripts/prepare-dgx-station-host.sh` is not touched by this change
- Station profile/scenario: n/a
- Result: n/a
- Supporting evidence: n/a

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/install-curl-proto-pin.test.ts test/install-stage-from-stdin.test.ts --project integration`: 8/8 passed; `npx vitest run test/install-preflight-docker-bootstrap.test.ts --project installer-integration`: 4/4 passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aditya Jain <adityaj0714@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Installer downloads now require HTTPS for both direct requests and redirects.
  * Improved protection for Docker and staged installer downloads against insecure connections.

* **Tests**
  * Added coverage to verify HTTPS enforcement across installer download flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->