### PR TITLE
fix(e2e): wait for staging workspace SSH

### DIFF
--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -117,7 +117,8 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     expect(script).toContain("for attempt in 1 2 3 4 5");
     expect(script).toContain("cleanup-owned-workspace");
     expect(script).toContain("cleanup could not inspect workspace inventory");
-    expect(script).toContain("Brev SSH configuration refresh failed");
+    expect(script).toContain("workspace SSH readiness timed out");
+    expect(script).toContain('SSH access to $INSTANCE_NAME succeeded');
     expect(script).toContain('classification="timeout"');
     expect(script).toContain('brev delete "$INSTANCE_NAME"');
     expect(script).toContain('jq -e --arg run "$producer_run"');

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -56,7 +56,9 @@ cleanup_owned_workspace() {
     fail "cleanup refused because the ownership receipt is invalid"
   fi
   existing="$(workspace || true)"
-  workspace_id="$(jq -r '.id // ""' <<<"${existing:-{}}")"
+  if [ -n "$existing" ]; then
+    workspace_id="$(jq -r '.id // ""' <<<"$existing")"
+  fi
   if [ -n "$existing" ]; then
     log "Deleting workflow-owned workspace $INSTANCE_NAME"
     timeout 60s brev delete "$INSTANCE_NAME" || true
@@ -166,7 +168,18 @@ jq -e '.status == "RUNNING" and (.shell_status // .shellStatus) == "READY" and
   || fail "workspace readiness timed out"
 workspace_id="$(jq -r '.id // ""' <<<"$ready")"
 log "Workspace $INSTANCE_NAME ($workspace_id) is ready"
-timeout 60s brev refresh >/dev/null || fail "Brev SSH configuration refresh failed"
+ssh_deadline=$((SECONDS + ${BREV_SSH_TIMEOUT_SECONDS:-900}))
+ssh_ready=0
+while [ "$SECONDS" -lt "$ssh_deadline" ]; do
+  timeout 60s brev refresh >/dev/null 2>&1 || true
+  if timeout 15s ssh "${SSH_OPTIONS[@]}" "$INSTANCE_NAME" true >/dev/null 2>&1; then
+    ssh_ready=1
+    break
+  fi
+  sleep "${POLL_SECONDS:-15}"
+done
+[ "$ssh_ready" -eq 1 ] || fail "workspace SSH readiness timed out"
+log "SSH access to $INSTANCE_NAME succeeded"
 
 # The remote shell expands the single-quoted command.
 # shellcheck disable=SC2016


### PR DESCRIPTION
## Summary

Waits for the Brev SSH alias to become usable after the staging workspace reports ready, and fixes cleanup evidence parsing when the workspace inventory is empty.

## Related Issue

Refs #9880

## Verification

- Focused E2E-support contract: 3 tests passed
- ShellCheck and commit hooks passed

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH readiness checks by retrying connection attempts within a defined timeout.
  * Added clearer reporting for SSH readiness timeouts and successful access.
  * Prevented cleanup errors when no workspace record is available.
* **Tests**
  * Updated end-to-end coverage to validate SSH timeout and successful connection outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->