### PR TITLE
fix(e2e): bound staging SSH readiness operations

### DIFF
--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -150,8 +150,8 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
   });
 
   it.each([
-    ["brev refresh", /timeout [12]s brev refresh/u],
-    ["ssh", /timeout [12]s ssh .* issue-9880-test true/u],
+    ["brev refresh", /timeout --signal=KILL [12]s brev refresh/u],
+    ["ssh", /timeout --signal=KILL [12]s ssh .* issue-9880-test true/u],
   ])(
     "bounds a blocked %s operation by the SSH deadline (#9880)",
     (blockedCommand, boundedCall) => {
@@ -164,7 +164,7 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
       expect(result.status, `${result.stdout}\n${result.stderr}\n${fs.readFileSync(fixture.calls, "utf8")}`).not.toBe(0);
       const calls = fs.readFileSync(fixture.calls, "utf8");
       expect(`${result.stdout}\n${result.stderr}`, calls).toContain("workspace SSH readiness timed out");
-      expect(calls).toMatch(/timeout [12]s brev refresh/u);
+      expect(calls).toMatch(/timeout --signal=KILL [12]s brev refresh/u);
       expect(calls).toMatch(boundedCall);
     },
     10_000,
@@ -179,7 +179,8 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
 
     expect(result.status).not.toBe(0);
     const calls = fs.readFileSync(fixture.calls, "utf8");
-    const readiness = calls.slice(calls.indexOf("timeout 2s brev refresh"));
+    const readiness = calls.slice(calls.indexOf("timeout --signal=KILL 2s brev refresh"));
+    expect(readiness).toContain("timeout --signal=KILL 2s brev refresh");
     expect(readiness).toMatch(/sleep [12]/u);
     expect(readiness).not.toContain("sleep 9");
     expect(readiness).not.toContain("timeout 0s");

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -123,11 +123,6 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     expect(script).toContain("for attempt in 1 2 3 4 5");
     expect(script).toContain("cleanup-owned-workspace");
     expect(script).toContain("cleanup could not inspect workspace inventory");
-    expect(script).toContain("for name in BREV_SSH_TIMEOUT_SECONDS POLL_SECONDS");
-    expect(script).toContain('fail "$name must be a positive integer"');
-    expect(script).toContain("refresh_timeout=$((remaining < 60 ? remaining : 60))");
-    expect(script).toContain("ssh_timeout=$((remaining < 15 ? remaining : 15))");
-    expect(script).toContain("poll_seconds < remaining ? poll_seconds : remaining");
     expect(script).toContain("workspace SSH readiness timed out");
     expect(script).toContain('SSH access to $INSTANCE_NAME succeeded');
     expect(script).toContain('classification="timeout"');
@@ -187,5 +182,6 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     const readiness = calls.slice(calls.indexOf("timeout 2s brev refresh"));
     expect(readiness).toMatch(/sleep [12]/u);
     expect(readiness).not.toContain("sleep 9");
+    expect(readiness).not.toContain("timeout 0s");
   }, 10_000);
 });

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -117,6 +117,11 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     expect(script).toContain("for attempt in 1 2 3 4 5");
     expect(script).toContain("cleanup-owned-workspace");
     expect(script).toContain("cleanup could not inspect workspace inventory");
+    expect(script).toContain("for name in BREV_SSH_TIMEOUT_SECONDS POLL_SECONDS");
+    expect(script).toContain('fail "$name must be a positive integer"');
+    expect(script).toContain("refresh_timeout=$((remaining < 60 ? remaining : 60))");
+    expect(script).toContain("ssh_timeout=$((remaining < 15 ? remaining : 15))");
+    expect(script).toContain("poll_seconds < remaining ? poll_seconds : remaining");
     expect(script).toContain("workspace SSH readiness timed out");
     expect(script).toContain('SSH access to $INSTANCE_NAME succeeded');
     expect(script).toContain('classification="timeout"');

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -4,9 +4,13 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import YAML from "yaml";
 
+import {
+  cleanupIssue9880Fixtures,
+  issue9880Fixture,
+} from "../../helpers/brev-launchable-issue-9880-fixture.ts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
 
 type Step = {
@@ -35,6 +39,8 @@ const WORKFLOW_PATH = path.join(
   ".github/workflows/issue-9880-staging-reproduction.yaml",
 );
 const SCRIPT_PATH = path.join(REPO_ROOT, "tools/e2e/brev-launchable-issue-9880.sh");
+
+afterEach(() => cleanupIssue9880Fixtures());
 
 function workflow(): Workflow {
   return YAML.parse(fs.readFileSync(WORKFLOW_PATH, "utf8")) as Workflow;
@@ -132,4 +138,54 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     expect(script).not.toContain("--count");
     expect(script).not.toContain("KEEP_ALIVE");
   });
+
+  it.each([
+    ["BREV_SSH_TIMEOUT_SECONDS", "0"],
+    ["BREV_SSH_TIMEOUT_SECONDS", "1+1"],
+    ["POLL_SECONDS", "0"],
+    ["POLL_SECONDS", "$(touch forbidden)"],
+  ])("rejects invalid %s before cloud operations (#9880)", (name, value) => {
+    const fixture = issue9880Fixture();
+    const result = fixture.run({ [name]: value });
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(`${name} must be a positive integer`);
+    expect(fs.existsSync(fixture.calls)).toBe(false);
+    expect(fs.existsSync(fixture.state)).toBe(false);
+  });
+
+  it.each([
+    ["brev refresh", /timeout [12]s brev refresh/u],
+    ["ssh", /timeout [12]s ssh .* issue-9880-test true/u],
+  ])(
+    "bounds a blocked %s operation by the SSH deadline (#9880)",
+    (blockedCommand, boundedCall) => {
+      const fixture = issue9880Fixture();
+      const result = fixture.run({
+        BREV_SSH_TIMEOUT_SECONDS: "2",
+        FAKE_BLOCK_COMMAND: blockedCommand,
+      });
+
+      expect(result.status, `${result.stdout}\n${result.stderr}\n${fs.readFileSync(fixture.calls, "utf8")}`).not.toBe(0);
+      const calls = fs.readFileSync(fixture.calls, "utf8");
+      expect(`${result.stdout}\n${result.stderr}`, calls).toContain("workspace SSH readiness timed out");
+      expect(calls).toMatch(/timeout [12]s brev refresh/u);
+      expect(calls).toMatch(boundedCall);
+    },
+    10_000,
+  );
+
+  it("caps poll sleep to the remaining SSH deadline (#9880)", () => {
+    const fixture = issue9880Fixture();
+    const result = fixture.run({
+      BREV_SSH_TIMEOUT_SECONDS: "2",
+      POLL_SECONDS: "9",
+    });
+
+    expect(result.status).not.toBe(0);
+    const calls = fs.readFileSync(fixture.calls, "utf8");
+    const readiness = calls.slice(calls.indexOf("timeout 2s brev refresh"));
+    expect(readiness).toMatch(/sleep [12]/u);
+    expect(readiness).not.toContain("sleep 9");
+  }, 10_000);
 });

--- a/test/helpers/brev-launchable-issue-9880-fixture.ts
+++ b/test/helpers/brev-launchable-issue-9880-fixture.ts
@@ -38,9 +38,11 @@ export function issue9880Fixture(): {
     path.join(bin, "timeout"),
     String.raw`#!/usr/bin/env bash
 set -euo pipefail
+signal=""
+if [ "${"$"}{1:-}" = --signal=KILL ]; then signal="--signal=KILL "; shift; fi
 duration="$1"
 shift
-printf 'timeout %s %s\n' "$duration" "$*" >> "$FAKE_CALLS"
+printf 'timeout %s%s %s\n' "$signal" "$duration" "$*" >> "$FAKE_CALLS"
 if [ "${"$"}{FAKE_BLOCK_COMMAND:-}" = "brev refresh" ] && [ "${"$"}{1:-} ${"$"}{2:-}" = "brev refresh" ]; then
   /bin/sleep "${"$"}{duration%s}"
   exit 124

--- a/test/helpers/brev-launchable-issue-9880-fixture.ts
+++ b/test/helpers/brev-launchable-issue-9880-fixture.ts
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
+const SCRIPT = path.join(REPO_ROOT, "tools/e2e/brev-launchable-issue-9880.sh");
+const roots: string[] = [];
+
+function executable(file: string, source: string): void {
+  fs.writeFileSync(file, source, { mode: 0o755 });
+}
+
+export function cleanupIssue9880Fixtures(): void {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+}
+
+export function issue9880Fixture(): {
+  calls: string;
+  env: NodeJS.ProcessEnv;
+  run: (overrides?: NodeJS.ProcessEnv, args?: string[]) => ReturnType<typeof spawnSync>;
+  state: string;
+  workDir: string;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-issue-9880-"));
+  roots.push(root);
+  const bin = path.join(root, "bin");
+  const calls = path.join(root, "calls.log");
+  const state = path.join(root, "workspace.json");
+  const workDir = path.join(root, "evidence");
+  fs.mkdirSync(bin);
+  fs.mkdirSync(workDir);
+
+  executable(
+    path.join(bin, "timeout"),
+    String.raw`#!/usr/bin/env bash
+set -euo pipefail
+duration="$1"
+shift
+printf 'timeout %s %s\n' "$duration" "$*" >> "$FAKE_CALLS"
+if [ "${"$"}{FAKE_BLOCK_COMMAND:-}" = "brev refresh" ] && [ "${"$"}{1:-} ${"$"}{2:-}" = "brev refresh" ]; then
+  /bin/sleep "${"$"}{duration%s}"
+  exit 124
+fi
+if [ "${"$"}{FAKE_BLOCK_COMMAND:-}" = ssh ] && [ "${"$"}{1:-}" = ssh ]; then
+  /bin/sleep "${"$"}{duration%s}"
+  exit 124
+fi
+exec "$@"
+`,
+  );
+  executable(
+    path.join(bin, "sleep"),
+    String.raw`#!/usr/bin/env bash
+printf 'sleep %s\n' "$1" >> "$FAKE_CALLS"
+/bin/sleep "$1"
+`,
+  );
+  executable(
+    path.join(bin, "ssh"),
+    String.raw`#!/usr/bin/env bash
+printf 'ssh %s\n' "$*" >> "$FAKE_CALLS"
+exit 34
+`,
+  );
+  executable(
+    path.join(bin, "brev"),
+    String.raw`#!/usr/bin/env bash
+set -euo pipefail
+printf 'brev %s\n' "$*" >> "$FAKE_CALLS"
+case "${"$"}{1:-}" in
+  ls)
+    if [ -f "$FAKE_STATE" ]; then
+      printf '{"workspaces":['; cat "$FAKE_STATE"; printf ']}\n'
+    else
+      printf '{"workspaces":[]}\n'
+    fi ;;
+  create)
+    printf '%s\n' '{"name":"issue-9880-test","id":"ws-1","status":"RUNNING","shell_status":"READY","build_status":"COMPLETED"}' > "$FAKE_STATE" ;;
+  refresh) exit 0 ;;
+  delete) rm -f "$FAKE_STATE" ;;
+  *) exit 2 ;;
+esac
+`,
+  );
+  executable(
+    path.join(bin, "gh"),
+    String.raw`#!/usr/bin/env bash
+set -euo pipefail
+printf 'gh %s\n' "$*" >> "$FAKE_CALLS"
+if [ "${"$"}{1:-}" = api ]; then
+  printf '%s\n' '{"workflow_runs":[{"id":123,"display_title":"Build Launchable E2E image for NemoClaw test","created_at":"2026-08-23T00:00:00Z"}]}'
+elif [ "${"$"}{1:-} ${"$"}{2:-}" = 'run download' ]; then
+  directory=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = --dir ]; then shift; directory="$1"; fi
+    shift
+  done
+  mkdir -p "$directory"
+  printf '%s\n' '{"schemaVersion":1,"kind":"nemoclaw-exact-image-manifest","imageRepository":"brevdev/nemoclaw-image","producerWorkflow":".github/workflows/build-launchable-e2e-image.yml","workflowRunId":"123","workflowRunAttempt":1,"status":"READY","channel":"staging","variant":"cpu","observedFamily":"nemoclaw-brev-staging-cpu","project":"brevdevprod","imageName":"nemoclaw-test-image","nemoclawSha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","imageRepositorySha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}' > "$directory/nemoclaw-image-manifest.v1.json"
+else
+  exit 2
+fi
+`,
+  );
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH ?? ""}`,
+    BREV_LAUNCHABLE_ID: "env-staging123",
+    FAKE_BLOCK_COMMAND: "",
+    FAKE_CALLS: calls,
+    FAKE_STATE: state,
+    GH_TOKEN: "github-test-token",
+    INSTANCE_NAME: "issue-9880-test",
+    NVIDIA_API_KEY: "nvapi-test-value",
+    POLL_SECONDS: "1",
+    RUNNER_TEMP: root,
+    WORK_DIR: workDir,
+  };
+
+  return {
+    calls,
+    env,
+    state,
+    workDir,
+    run: (overrides = {}, args = []) =>
+      spawnSync("bash", [SCRIPT, ...args], {
+        encoding: "utf8",
+        env: { ...env, ...overrides },
+        timeout: 20_000,
+      }),
+  };
+}

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -122,6 +122,10 @@ require NVIDIA_API_KEY
 command -v gh >/dev/null 2>&1 || fail "gh is required"
 command -v ssh >/dev/null 2>&1 || fail "ssh is required"
 [[ "$BREV_LAUNCHABLE_ID" =~ ^env-[A-Za-z0-9]+$ ]] || fail "BREV_LAUNCHABLE_ID is invalid"
+for name in BREV_SSH_TIMEOUT_SECONDS POLL_SECONDS; do
+  value="${!name:-}"
+  [ -z "$value" ] || [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "$name must be a positive integer"
+done
 [[ "$NVIDIA_API_KEY" == nvapi-* ]] || fail "NVIDIA_API_KEY must be a public NVIDIA Endpoints key"
 write_cleanup_evidence NOT_OWNED
 handoff_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/issue-9880-handoff.XXXXXX")"
@@ -171,12 +175,20 @@ log "Workspace $INSTANCE_NAME ($workspace_id) is ready"
 ssh_deadline=$((SECONDS + ${BREV_SSH_TIMEOUT_SECONDS:-900}))
 ssh_ready=0
 while [ "$SECONDS" -lt "$ssh_deadline" ]; do
-  timeout 60s brev refresh >/dev/null 2>&1 || true
-  if timeout 15s ssh "${SSH_OPTIONS[@]}" "$INSTANCE_NAME" true >/dev/null 2>&1; then
+  remaining=$((ssh_deadline - SECONDS))
+  refresh_timeout=$((remaining < 60 ? remaining : 60))
+  timeout "${refresh_timeout}s" brev refresh >/dev/null 2>&1 || true
+  remaining=$((ssh_deadline - SECONDS))
+  [ "$remaining" -gt 0 ] || break
+  ssh_timeout=$((remaining < 15 ? remaining : 15))
+  if timeout "${ssh_timeout}s" ssh "${SSH_OPTIONS[@]}" "$INSTANCE_NAME" true >/dev/null 2>&1; then
     ssh_ready=1
     break
   fi
-  sleep "${POLL_SECONDS:-15}"
+  remaining=$((ssh_deadline - SECONDS))
+  [ "$remaining" -gt 0 ] || break
+  poll_seconds="${POLL_SECONDS:-15}"
+  sleep "$((poll_seconds < remaining ? poll_seconds : remaining))"
 done
 [ "$ssh_ready" -eq 1 ] || fail "workspace SSH readiness timed out"
 log "SSH access to $INSTANCE_NAME succeeded"

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -176,6 +176,7 @@ ssh_deadline=$((SECONDS + ${BREV_SSH_TIMEOUT_SECONDS:-900}))
 ssh_ready=0
 while [ "$SECONDS" -lt "$ssh_deadline" ]; do
   remaining=$((ssh_deadline - SECONDS))
+  [ "$remaining" -gt 0 ] || break
   refresh_timeout=$((remaining < 60 ? remaining : 60))
   timeout "${refresh_timeout}s" brev refresh >/dev/null 2>&1 || true
   remaining=$((ssh_deadline - SECONDS))

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -178,11 +178,11 @@ while [ "$SECONDS" -lt "$ssh_deadline" ]; do
   remaining=$((ssh_deadline - SECONDS))
   [ "$remaining" -gt 0 ] || break
   refresh_timeout=$((remaining < 60 ? remaining : 60))
-  timeout "${refresh_timeout}s" brev refresh >/dev/null 2>&1 || true
+  timeout --signal=KILL "${refresh_timeout}s" brev refresh >/dev/null 2>&1 || true
   remaining=$((ssh_deadline - SECONDS))
   [ "$remaining" -gt 0 ] || break
   ssh_timeout=$((remaining < 15 ? remaining : 15))
-  if timeout "${ssh_timeout}s" ssh "${SSH_OPTIONS[@]}" "$INSTANCE_NAME" true >/dev/null 2>&1; then
+  if timeout --signal=KILL "${ssh_timeout}s" ssh "${SSH_OPTIONS[@]}" "$INSTANCE_NAME" true >/dev/null 2>&1; then
     ssh_ready=1
     break
   fi


### PR DESCRIPTION
## Summary

Bounds every Brev refresh, SSH probe, and poll sleep by the remaining staging SSH readiness deadline. Validates the timeout environment values before starting the credential-bearing lifecycle.

## Related Issue

Refs #9880

## Verification

- Focused E2E-support contract: 3 tests passed
- ShellCheck and commit hooks passed

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging readiness checks by validating timeout and polling settings.
  * Prevented refresh, SSH, and polling operations from exceeding configured deadlines.
  * Ensured timed-out operations terminate reliably.
  * Prevented unnecessary cloud operations when configuration or readiness checks fail.
  * Improved reliability when services are slow to become available or settings are invalid.
* **Tests**
  * Added coverage for timeout validation, bounded operations, polling behavior, forced termination, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->