### PR TITLE
fix(scripts): pin curl protocol in release-pin update scripts

### DIFF
--- a/scripts/update-docker-pin.sh
+++ b/scripts/update-docker-pin.sh
@@ -33,7 +33,7 @@ resolve_latest_digest() {
   local token digest
 
   # Step 1: get an auth token for the Docker Hub library repo
-  token=$(curl -fsSL --retry 3 --retry-delay 1 --retry-all-errors \
+  token=$(curl -fsSL --proto '=https' --proto-redir '=https' --retry 3 --retry-delay 1 --retry-all-errors \
     --connect-timeout 10 --max-time 30 \
     "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/${IMAGE}:pull" \
     | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
@@ -44,7 +44,7 @@ resolve_latest_digest() {
   fi
 
   # Step 2: fetch the tag headers and use Docker-Content-Digest for the index.
-  digest=$(curl -fsSIL --retry 3 --retry-delay 1 --retry-all-errors \
+  digest=$(curl -fsSIL --proto '=https' --proto-redir '=https' --retry 3 --retry-delay 1 --retry-all-errors \
     --connect-timeout 10 --max-time 30 \
     -H "Authorization: Bearer ${token}" \
     -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json" \

--- a/scripts/update-hermes-agent.sh
+++ b/scripts/update-hermes-agent.sh
@@ -98,7 +98,7 @@ gh_api() {
   local url="$1"
   local -a auth=()
   [[ -n "${GITHUB_TOKEN:-}" ]] && auth=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
-  curl -fsSL --retry 3 --retry-delay 1 --retry-all-errors \
+  curl -fsSL --proto '=https' --proto-redir '=https' --retry 3 --retry-delay 1 --retry-all-errors \
     --connect-timeout 10 --max-time 60 \
     -H "Accept: application/vnd.github+json" "${auth[@]}" "$url"
 }
@@ -327,7 +327,7 @@ trap 'rm -rf "$WORKDIR_TMP"' EXIT
 TARBALL="${WORKDIR_TMP}/hermes-${TAG}.tar.gz"
 TARBALL_URL="https://github.com/${GITHUB_REPO}/archive/refs/tags/${TAG}.tar.gz"
 echo "Downloading ${TARBALL_URL}"
-curl -fsSL --retry 3 --retry-delay 1 --retry-all-errors \
+curl -fsSL --proto '=https' --proto-redir '=https' --retry 3 --retry-delay 1 --retry-all-errors \
   --connect-timeout 10 --max-time 300 \
   -o "$TARBALL" "$TARBALL_URL"
 

--- a/test/release-pin-script-curl-proto-pin.test.ts
+++ b/test/release-pin-script-curl-proto-pin.test.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.join(import.meta.dirname, "..");
+const DOCKER_PIN_SCRIPT = path.join(REPO_ROOT, "scripts", "update-docker-pin.sh");
+const FAKE_DIGEST = `sha256:${"a".repeat(64)}`;
+
+function writeExecutable(file: string, body: string) {
+  fs.writeFileSync(file, body, { mode: 0o755 });
+}
+
+describe("release-pin update scripts pin curl to HTTPS (#9979)", () => {
+  it("passes --proto/--proto-redir on every curl call update-docker-pin.sh makes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-docker-pin-"));
+    const fixtureScript = path.join(tmp, "scripts", "update-docker-pin.sh");
+    const fakeBin = path.join(tmp, "bin");
+    const curlLog = path.join(tmp, "curl-argv.log");
+    fs.mkdirSync(path.dirname(fixtureScript), { recursive: true });
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.copyFileSync(DOCKER_PIN_SCRIPT, fixtureScript);
+    fs.chmodSync(fixtureScript, 0o755);
+    fs.writeFileSync(
+      path.join(tmp, "Dockerfile"),
+      `FROM node:22-trixie-slim@sha256:${"0".repeat(64)}\n`,
+    );
+    writeExecutable(
+      path.join(fakeBin, "curl"),
+      [
+        "#!/usr/bin/env bash",
+        'printf \'%s\\n\' "$*" >> "$FAKE_CURL_LOG"',
+        'if [[ "$*" == *auth.docker.io* ]]; then',
+        '  echo \'{"token":"faketoken"}\'',
+        'elif [[ "$*" == *registry-1.docker.io* ]]; then',
+        "  printf 'HTTP/1.1 200 OK\\r\\nDocker-Content-Digest: %s\\r\\n\\r\\n' ",
+        `    ${JSON.stringify(FAKE_DIGEST)}`,
+        "fi",
+      ].join("\n"),
+    );
+
+    const result = spawnSync("bash", [fixtureScript, "--check"], {
+      env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH}`, FAKE_CURL_LOG: curlLog },
+      encoding: "utf-8",
+    });
+
+    const curlArgv = fs.readFileSync(curlLog, "utf-8").trim();
+    const curlCallCount = curlArgv.split("\n").length;
+    const pinnedCallCount = curlArgv.split("--proto =https --proto-redir =https").length - 1;
+    expect(curlArgv, result.stdout + result.stderr).not.toBe("");
+    expect(pinnedCallCount).toBe(curlCallCount);
+  });
+});

--- a/test/update-hermes-agent-script.test.ts
+++ b/test/update-hermes-agent-script.test.ts
@@ -147,50 +147,78 @@ fi
 
   it("pins the latest-release GitHub API lookup to HTTPS when --tag is omitted (#9979)", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-update-latest-"));
-    const repo = path.join(tmp, "repo");
-    const script = path.join(repo, "scripts", "update-hermes-agent.sh");
-    const fakeBin = path.join(tmp, "bin");
-    const curlLog = path.join(tmp, "curl-argv.log");
-    fs.mkdirSync(path.dirname(script), { recursive: true });
-    fs.mkdirSync(path.join(repo, "agents", "hermes"), { recursive: true });
-    fs.mkdirSync(fakeBin, { recursive: true });
-    fs.copyFileSync(SCRIPT, script);
-    fs.chmodSync(script, 0o755);
-    fs.copyFileSync(HERMES_BASE_DOCKERFILE, path.join(repo, "agents", "hermes", "Dockerfile.base"));
-    fs.copyFileSync(HERMES_MANIFEST, path.join(repo, "agents", "hermes", "manifest.yaml"));
-    writeExecutable(
-      path.join(fakeBin, "curl"),
-      `#!/usr/bin/env bash
+    try {
+      const repo = path.join(tmp, "repo");
+      const script = path.join(repo, "scripts", "update-hermes-agent.sh");
+      const fakeBin = path.join(tmp, "bin");
+      const curlLog = path.join(tmp, "curl-argv.log");
+      fs.mkdirSync(path.dirname(script), { recursive: true });
+      fs.mkdirSync(path.join(repo, "agents", "hermes"), { recursive: true });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.copyFileSync(SCRIPT, script);
+      fs.chmodSync(script, 0o755);
+      fs.copyFileSync(
+        HERMES_BASE_DOCKERFILE,
+        path.join(repo, "agents", "hermes", "Dockerfile.base"),
+      );
+      fs.copyFileSync(HERMES_MANIFEST, path.join(repo, "agents", "hermes", "manifest.yaml"));
+      writeExecutable(
+        path.join(fakeBin, "curl"),
+        `#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\\n' "$*" >> "$FAKE_CURL_LOG"
+# Redact any bearer token before it ever touches disk, so a real
+# credential can never end up in a test log even transiently.
+printf '%s\\n' "$*" | sed -E 's/(Authorization: ?Bearer )[^ ]+/\\1[REDACTED]/' >> "$FAKE_CURL_LOG"
 if [[ "$*" == *api.github.com* ]]; then
   printf '{"tag_name":"v2026.6.5"}'
 fi
 `,
-    );
+      );
 
-    const run = spawnSync("bash", [script, "--check"], {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        PATH: `${fakeBin}:${process.env.PATH}`,
-        HOME: path.join(tmp, "home"),
-        FAKE_CURL_LOG: curlLog,
-        NEMOCLAW_SOURCE_ROOT: undefined,
-      },
-      timeout: 10_000,
-    });
+      const run = spawnSync("bash", [script, "--check"], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH}`,
+          HOME: path.join(tmp, "home"),
+          FAKE_CURL_LOG: curlLog,
+          // A deliberately fake, obviously-not-a-secret value: proves the
+          // auth path is exercised without ever risking a real token,
+          // even if one happens to be set in the host environment.
+          GITHUB_TOKEN: "test-not-a-real-token",
+          NEMOCLAW_SOURCE_ROOT: undefined,
+        },
+        timeout: 10_000,
+      });
 
-    // gh_api() is only reached when --tag is omitted; #9979 pins its request
-    // (which can carry an Authorization: Bearer GITHUB_TOKEN header) to HTTPS.
-    const curlArgv = fs.readFileSync(curlLog, "utf8").trim();
-    const curlCallCount = curlArgv.split("\n").length;
-    const pinnedCallCount = curlArgv.split("--proto =https --proto-redir =https").length - 1;
-    expect(curlArgv, `${run.stdout}\n${run.stderr}`).not.toBe("");
-    expect(curlArgv).toContain("api.github.com/repos/NousResearch/hermes-agent/releases/latest");
-    expect(pinnedCallCount).toBe(curlCallCount);
+      // --check exits 0 (pins current) or 1 (pins stale); either is a
+      // completed run. Anything else means the fixture itself broke.
+      expect([0, 1], `${run.stdout}\n${run.stderr}`).toContain(run.status);
+      expect(run.stdout).toMatch(/^(OK|STALE): Dockerfile\.base pins Hermes/m);
 
-    fs.rmSync(tmp, { recursive: true, force: true });
+      // gh_api() is only reached when --tag is omitted; #9979 pins its
+      // request (which can carry an Authorization: Bearer GITHUB_TOKEN
+      // header) to HTTPS. Validate every logged invocation independently,
+      // not just an aggregate count, so one covered and one uncovered call
+      // cannot offset each other.
+      const curlCalls = fs
+        .readFileSync(curlLog, "utf8")
+        .split("\n")
+        .filter((line) => line.length > 0);
+      expect(curlCalls.length).toBeGreaterThan(0);
+      expect(
+        curlCalls.every(
+          (call) => call.includes("--proto =https") && call.includes("--proto-redir =https"),
+        ),
+      ).toBe(true);
+      expect(curlCalls.some((call) => call.includes("[REDACTED]"))).toBe(true);
+      expect(curlCalls.join("\n")).not.toContain("test-not-a-real-token");
+      expect(curlCalls.join("\n")).toContain(
+        "api.github.com/repos/NousResearch/hermes-agent/releases/latest",
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it("keeps installed-copy scanning opt-in unless rebuild needs it", () => {

--- a/test/update-hermes-agent-script.test.ts
+++ b/test/update-hermes-agent-script.test.ts
@@ -71,10 +71,12 @@ describe("scripts/update-hermes-agent.sh", () => {
     fs.chmodSync(script, 0o755);
     fs.copyFileSync(HERMES_BASE_DOCKERFILE, path.join(repo, "agents", "hermes", "Dockerfile.base"));
     fs.copyFileSync(HERMES_MANIFEST, path.join(repo, "agents", "hermes", "manifest.yaml"));
+    const curlLog = path.join(tmp, "curl-argv.log");
     writeExecutable(
       path.join(fakeBin, "curl"),
       `#!/usr/bin/env bash
 set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_CURL_LOG"
 output=""
 previous=""
 for arg in "$@"; do
@@ -122,6 +124,7 @@ fi
           HERMES_BASE_REF: baseRef,
           FAKE_DOCKER_LOG: dockerLog,
           FAKE_NEMOHERMES_LOG: nemohermesLog,
+          FAKE_CURL_LOG: curlLog,
           NEMOCLAW_SOURCE_ROOT: undefined,
         },
         timeout: 10_000,
@@ -131,6 +134,12 @@ fi
       expect(fs.readFileSync(dockerLog, "utf8")).toContain(`tag ${baseRef} ${pinnedRef}`);
       expect(fs.readFileSync(nemohermesLog, "utf8")).toContain(`${pinnedRef}|hermes rebuild`);
       expect(run.stdout).toContain("OK: sandbox reports Hermes Agent v0.19.0");
+      // #9979: the curl fetch must fail closed on a protocol-downgrade redirect.
+      const curlArgv = fs.readFileSync(curlLog, "utf8").trim();
+      const curlCallCount = curlArgv.split("\n").length;
+      const pinnedCallCount = curlArgv.split("--proto =https --proto-redir =https").length - 1;
+      expect(curlArgv).not.toBe("");
+      expect(pinnedCallCount).toBe(curlCallCount);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/update-hermes-agent-script.test.ts
+++ b/test/update-hermes-agent-script.test.ts
@@ -145,6 +145,54 @@ fi
     }
   });
 
+  it("pins the latest-release GitHub API lookup to HTTPS when --tag is omitted (#9979)", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-update-latest-"));
+    const repo = path.join(tmp, "repo");
+    const script = path.join(repo, "scripts", "update-hermes-agent.sh");
+    const fakeBin = path.join(tmp, "bin");
+    const curlLog = path.join(tmp, "curl-argv.log");
+    fs.mkdirSync(path.dirname(script), { recursive: true });
+    fs.mkdirSync(path.join(repo, "agents", "hermes"), { recursive: true });
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.copyFileSync(SCRIPT, script);
+    fs.chmodSync(script, 0o755);
+    fs.copyFileSync(HERMES_BASE_DOCKERFILE, path.join(repo, "agents", "hermes", "Dockerfile.base"));
+    fs.copyFileSync(HERMES_MANIFEST, path.join(repo, "agents", "hermes", "manifest.yaml"));
+    writeExecutable(
+      path.join(fakeBin, "curl"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_CURL_LOG"
+if [[ "$*" == *api.github.com* ]]; then
+  printf '{"tag_name":"v2026.6.5"}'
+fi
+`,
+    );
+
+    const run = spawnSync("bash", [script, "--check"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        HOME: path.join(tmp, "home"),
+        FAKE_CURL_LOG: curlLog,
+        NEMOCLAW_SOURCE_ROOT: undefined,
+      },
+      timeout: 10_000,
+    });
+
+    // gh_api() is only reached when --tag is omitted; #9979 pins its request
+    // (which can carry an Authorization: Bearer GITHUB_TOKEN header) to HTTPS.
+    const curlArgv = fs.readFileSync(curlLog, "utf8").trim();
+    const curlCallCount = curlArgv.split("\n").length;
+    const pinnedCallCount = curlArgv.split("--proto =https --proto-redir =https").length - 1;
+    expect(curlArgv, `${run.stdout}\n${run.stderr}`).not.toBe("");
+    expect(curlArgv).toContain("api.github.com/repos/NousResearch/hermes-agent/releases/latest");
+    expect(pinnedCallCount).toBe(curlCallCount);
+
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
   it("keeps installed-copy scanning opt-in unless rebuild needs it", () => {
     const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-update-home-"));
     const installedDockerfile = path.join(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
`scripts/update-docker-pin.sh` and `scripts/update-hermes-agent.sh` fetch data over `curl -fsSL`/`-fsSIL` (both follow redirects) without pinning the transfer protocol, then write a value derived from that fetch directly as the new trusted pin, with no independent corroboration. `update-docker-pin.sh` writes the fetched `Docker-Content-Digest` straight into `Dockerfile`'s `node:22-trixie-slim` pin; `update-hermes-agent.sh`'s `gh_api()` also sends `Authorization: Bearer ${GITHUB_TOKEN}` on a redirect-following request, and curl only strips `Authorization` on a cross-host redirect, so a same-host downgrade would still carry the token in plaintext. This adds `--proto '=https' --proto-redir '=https'` to all four curl calls, the same hardening already applied in #9703, #9861, and #9977, so a protocol-downgrade redirect during a maintainer's pin-update run can no longer poison the recorded pin or leak `GITHUB_TOKEN`.

## Related Issue
Fixes #9979

## Changes
- `scripts/update-docker-pin.sh`: pinned both curl calls (auth-token fetch, manifest-digest fetch).
- `scripts/update-hermes-agent.sh`: pinned both curl calls (`gh_api()`, release tarball fetch).
- `test/release-pin-script-curl-proto-pin.test.ts` (new): runs `update-docker-pin.sh` against a stubbed curl in an isolated fixture tree and asserts every captured invocation carries both proto flags.
- `test/update-hermes-agent-script.test.ts`: extended the existing full-fixture `--rebuild` test (which already exercises the tarball curl call end to end) with the same assertion, instead of adding a second test/fixture for the same behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit: n/a — `scripts/prepare-dgx-station-host.sh` is not touched by this change
- Station profile/scenario: n/a
- Result: n/a
- Supporting evidence: n/a

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run test/release-pin-script-curl-proto-pin.test.ts test/update-hermes-agent-script.test.ts --project integration`: 7/7 passed; also confirmed the new assertions fail without the fix (reverted the source change locally, reran, saw the expected failure, then restored the fix)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aditya Jain <adityaj0714@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened automated update and authentication requests to allow only HTTPS connections, including redirects.
  - Helps prevent protocol-downgrade redirects during downloads and release lookups.
  - Preserved existing retry, timeout, authentication, and error-handling behavior.

- **Tests**
  - Added coverage verifying HTTPS-only request and redirect behavior across update scripts.
  - Improved testing for token-authenticated requests and credential redaction in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->