### PR TITLE
perf(advisor): trim specialist workflow overhead

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -51,7 +51,7 @@ concurrency:
 
 jobs:
   review:
-    name: PR review advisor (${{ matrix.advisor.label }})
+    name: Advisor / ${{ matrix.advisor.label }}
     if: ${{ github.repository == 'NVIDIA/NemoClaw' && (github.event_name != 'pull_request_target' || github.event.action != 'edited' || github.event.changes.base != null) }}
     permissions:
       actions: read
@@ -66,16 +66,14 @@ jobs:
       fail-fast: false
       matrix:
         advisor:
-          - id: gpt-5.6-terra
-            interest: ""
+          - interest: ""
             label: GPT-5.6 Terra
             model: azure/openai/gpt-5.6-terra
             sandbox_name: pr-advisor-gpt
             artifact_dir: pr-review-advisor
             artifact_name: pr-review-advisor
             publish_comment: true
-          - id: nemotron-ultra
-            interest: ""
+          - interest: ""
             label: Nemotron 3 Ultra
             model: nvidia/nvidia/nemotron-3-ultra
             sandbox_name: pr-advisor-nem
@@ -150,6 +148,8 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: advisor/package-lock.json
 
       # pull_request_target content is fetched manually so no PR-controlled
       # action, hook, submodule, LFS filter, or package setup can run. The base
@@ -358,7 +358,7 @@ jobs:
           fi
 
   review-specialists:
-    name: PR review specialist (${{ matrix.advisor.label }})
+    name: Specialist / ${{ matrix.advisor.label }}
     if: ${{ github.repository == 'NVIDIA/NemoClaw' && (github.event_name != 'pull_request_target' || github.event.action != 'edited' || github.event.changes.base != null) }}
     permissions:
       actions: read
@@ -407,7 +407,7 @@ jobs:
     steps: *advisor-analysis-steps
 
   review-synthesis-shadow:
-    name: PR review synthesis candidate
+    name: Synthesis
     needs: review-specialists
     if: ${{ always() && needs.review-specialists.result != 'cancelled' && github.repository == 'NVIDIA/NemoClaw' && (github.event_name != 'pull_request_target' || github.event.action != 'edited' || github.event.changes.base != null) }}
     permissions:
@@ -452,7 +452,7 @@ jobs:
     steps: *advisor-analysis-steps
 
   publish:
-    name: Publish PR review advisor
+    name: Publish advisor
     needs: review
     if: ${{ always() && github.event_name == 'pull_request_target' && (github.event.action != 'edited' || github.event.changes.base != null) && needs.review.result != 'cancelled' }}
     # Publication is best-effort and must never hide the primary analysis

--- a/tools/advisors/session.mts
+++ b/tools/advisors/session.mts
@@ -115,7 +115,7 @@ export type RunReadOnlyAdvisorOptions = {
   promptTurns: AdvisorPromptTurn[];
   systemPrompt: string;
   configDir: string;
-  htmlExportPath: string;
+  htmlExportPath?: string;
   timeoutMs: number;
   heartbeatMs: number;
   maxCaptureBytes: number;
@@ -817,14 +817,16 @@ export async function runReadOnlyAdvisor(
     unsubscribe();
     clearInterval(heartbeat);
     if (timeout) clearTimeout(timeout);
-    try {
-      const exportedPath = await session.exportToHtml(options.htmlExportPath);
-      raw.append(`\n[${options.logPrefix}] exported_session_html=${exportedPath}\n`);
-      options.logProgress(`Exported advisor session HTML: ${exportedPath}`);
-    } catch (error: unknown) {
-      const reason = error instanceof Error ? error.message : String(error);
-      raw.append(`\n[${options.logPrefix}] failed_to_export_session_html=${reason}\n`);
-      options.logProgress(`Failed to export advisor session HTML: ${reason}`);
+    if (options.htmlExportPath) {
+      try {
+        const exportedPath = await session.exportToHtml(options.htmlExportPath);
+        raw.append(`\n[${options.logPrefix}] exported_session_html=${exportedPath}\n`);
+        options.logProgress(`Exported advisor session HTML: ${exportedPath}`);
+      } catch (error: unknown) {
+        const reason = error instanceof Error ? error.message : String(error);
+        raw.append(`\n[${options.logPrefix}] failed_to_export_session_html=${reason}\n`);
+        options.logProgress(`Failed to export advisor session HTML: ${reason}`);
+      }
     }
     session.dispose();
   }

--- a/tools/pr-review-advisor/run-specialist.mts
+++ b/tools/pr-review-advisor/run-specialist.mts
@@ -112,7 +112,6 @@ async function main(): Promise<void> {
       promptTurns: [turn],
       systemPrompt: buildSystemPrompt(readParsedTrustedSecurityRubric()),
       configDir,
-      htmlExportPath: path.join(outDir, `pr-review-${interest}-session.html`),
       timeoutMs: parsePositiveInt(process.env.PR_REVIEW_ADVISOR_TIMEOUT_MS, 900000),
       heartbeatMs: parsePositiveInt(process.env.PR_REVIEW_ADVISOR_HEARTBEAT_MS, 60000),
       maxCaptureBytes: parsePositiveInt(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Make PR Review Advisor runs easier to scan and avoid repeated work that does not feed synthesis.

## Changes

- Shorten advisor, specialist, synthesis, and publisher check names.
- Cache trusted npm downloads across the read-only analysis lanes.
- Stop rendering specialist HTML files because synthesis consumes native Pi JSONL sessions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: The existing workflow-boundary, security-boundary, specialist, and session-runner tests cover these paths.
- [ ] Tests not applicable — justification: The existing workflow-boundary, security-boundary, specialist, and session-runner tests cover these paths.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Workflow-boundary, OpenShell-boundary, and security-boundary integration tests passed; analysis remains read-only and separate from the publisher.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: 
- Station profile/scenario: 
- Result: 
- Supporting evidence: 

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — Normal pre-commit, commit-msg, and pre-push hooks passed.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 175 focused integration tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; focused workflow and advisor validation covered the change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - HTML session reports are now generated only when an export location is provided.
  - Advisor runs continue to report export failures through progress updates without interrupting other session output.
  - Specialist review sessions continue to preserve JSONL records consistently.
  - Review workflow labels and setup have been streamlined for clearer processing and improved caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->