### PR TITLE
fix(e2e): use Brev exec for staging access

### DIFF
--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -186,6 +186,7 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     await completed;
 
     expect(fs.readdirSync(fixture.root).filter((file) => file.startsWith("issue-9880-remote."))).toEqual([]);
+    expect(fs.readdirSync(fixture.root).filter((file) => /^issue-9880\.[A-Za-z0-9]+$/u.test(file))).toEqual([]);
     expect(treeContainsLiteral(fixture.root, "nvapi-interrupt-test-secret")).toBe(false);
   }, 10_000);
 

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -10,6 +10,7 @@ import YAML from "yaml";
 import {
   cleanupIssue9880Fixtures,
   issue9880Fixture,
+  waitForIssue9880RemoteScript,
 } from "../../helpers/brev-launchable-issue-9880-fixture.ts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
 
@@ -165,6 +166,36 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     },
     10_000,
   );
+
+  it("removes the credential-bearing remote script after termination (#9880)", async () => {
+    const fixture = issue9880Fixture();
+    const child = fixture.start({
+      BREV_EXEC_TIMEOUT_SECONDS: "2",
+      FAKE_EXEC_SUCCEEDS: "1",
+      FAKE_SCENARIO_BLOCKS: "1",
+      NVIDIA_API_KEY: "nvapi-interrupt-test-secret",
+    });
+    const remoteFiles = await waitForIssue9880RemoteScript(fixture.root);
+    expect(remoteFiles, await new Promise<string>((resolve) => {
+      let output = "";
+      child.stdout?.on("data", (chunk) => { output += chunk.toString(); });
+      child.stderr?.on("data", (chunk) => { output += chunk.toString(); });
+      setTimeout(() => resolve(output), 20);
+    })).toHaveLength(1);
+
+    child.kill("SIGTERM");
+    await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+
+    expect(fs.readdirSync(fixture.root).filter((file) => file.startsWith("issue-9880-remote."))).toEqual([]);
+    const retainedSecret = fs
+      .readdirSync(fixture.root, { recursive: true })
+      .filter((entry): entry is string => typeof entry === "string")
+      .some((entry) => {
+        const file = path.join(fixture.root, entry);
+        return fs.statSync(file).isFile() && fs.readFileSync(file, "utf8").includes("nvapi-interrupt-test-secret");
+      });
+    expect(retainedSecret).toBe(false);
+  }, 10_000);
 
   it("caps poll sleep to the remaining Brev exec deadline (#9880)", () => {
     const fixture = issue9880Fixture();

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -8,6 +8,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import YAML from "yaml";
 
 import {
+  childCompletion,
+  childOutputAfterDelay,
   cleanupIssue9880Fixtures,
   issue9880Fixture,
   waitForIssue9880RemoteScript,
@@ -177,15 +179,11 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
       NVIDIA_API_KEY: "nvapi-interrupt-test-secret",
     });
     const remoteFiles = await waitForIssue9880RemoteScript(fixture.root);
-    expect(remoteFiles, await new Promise<string>((resolve) => {
-      let output = "";
-      child.stdout?.on("data", (chunk) => { output += chunk.toString(); });
-      child.stderr?.on("data", (chunk) => { output += chunk.toString(); });
-      setTimeout(() => resolve(output), 20);
-    })).toHaveLength(1);
+    expect(remoteFiles, await childOutputAfterDelay(child)).toHaveLength(1);
 
-    child.kill("SIGTERM");
-    await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+    const completed = childCompletion(child);
+    process.kill(-child.pid!, "SIGTERM");
+    await completed;
 
     expect(fs.readdirSync(fixture.root).filter((file) => file.startsWith("issue-9880-remote."))).toEqual([]);
     expect(treeContainsLiteral(fixture.root, "nvapi-interrupt-test-secret")).toBe(false);

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -123,8 +123,8 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     expect(script).toContain("for attempt in 1 2 3 4 5");
     expect(script).toContain("cleanup-owned-workspace");
     expect(script).toContain("cleanup could not inspect workspace inventory");
-    expect(script).toContain("workspace SSH readiness timed out");
-    expect(script).toContain('SSH access to $INSTANCE_NAME succeeded');
+    expect(script).toContain("workspace Brev exec readiness timed out");
+    expect(script).toContain('Brev exec access to $INSTANCE_NAME succeeded');
     expect(script).toContain('classification="timeout"');
     expect(script).toContain('brev delete "$INSTANCE_NAME"');
     expect(script).toContain('jq -e --arg run "$producer_run"');
@@ -135,8 +135,8 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
   });
 
   it.each([
-    ["BREV_SSH_TIMEOUT_SECONDS", "0"],
-    ["BREV_SSH_TIMEOUT_SECONDS", "1+1"],
+    ["BREV_EXEC_TIMEOUT_SECONDS", "0"],
+    ["BREV_EXEC_TIMEOUT_SECONDS", "1+1"],
     ["POLL_SECONDS", "0"],
     ["POLL_SECONDS", "$(touch forbidden)"],
   ])("rejects invalid %s before cloud operations (#9880)", (name, value) => {
@@ -149,38 +149,37 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     expect(fs.existsSync(fixture.state)).toBe(false);
   });
 
-  it.each([
-    ["brev refresh", /timeout --signal=KILL [12]s brev refresh/u],
-    ["ssh", /timeout --signal=KILL [12]s ssh .* issue-9880-test true/u],
-  ])(
-    "bounds a blocked %s operation by the SSH deadline (#9880)",
+  it.each([["brev exec", /timeout --signal=KILL [12]s brev exec issue-9880-test true/u]])(
+    "bounds a blocked %s operation by the Brev exec deadline (#9880)",
     (blockedCommand, boundedCall) => {
       const fixture = issue9880Fixture();
       const result = fixture.run({
-        BREV_SSH_TIMEOUT_SECONDS: "2",
+        BREV_EXEC_TIMEOUT_SECONDS: "2",
         FAKE_BLOCK_COMMAND: blockedCommand,
       });
 
       expect(result.status, `${result.stdout}\n${result.stderr}\n${fs.readFileSync(fixture.calls, "utf8")}`).not.toBe(0);
       const calls = fs.readFileSync(fixture.calls, "utf8");
-      expect(`${result.stdout}\n${result.stderr}`, calls).toContain("workspace SSH readiness timed out");
-      expect(calls).toMatch(/timeout --signal=KILL [12]s brev refresh/u);
+      expect(`${result.stdout}\n${result.stderr}`, calls).toContain("workspace Brev exec readiness timed out");
       expect(calls).toMatch(boundedCall);
     },
     10_000,
   );
 
-  it("caps poll sleep to the remaining SSH deadline (#9880)", () => {
+  it("caps poll sleep to the remaining Brev exec deadline (#9880)", () => {
     const fixture = issue9880Fixture();
     const result = fixture.run({
-      BREV_SSH_TIMEOUT_SECONDS: "2",
+      BREV_EXEC_TIMEOUT_SECONDS: "2",
       POLL_SECONDS: "9",
+      FAKE_EXEC_SUCCEEDS: "0",
     });
 
     expect(result.status).not.toBe(0);
     const calls = fs.readFileSync(fixture.calls, "utf8");
-    const readiness = calls.slice(calls.indexOf("timeout --signal=KILL 2s brev refresh"));
-    expect(readiness).toContain("timeout --signal=KILL 2s brev refresh");
+    const readinessStart = calls.search(/timeout --signal=KILL [12]s brev exec/u);
+    expect(readinessStart, calls).toBeGreaterThanOrEqual(0);
+    const readiness = calls.slice(readinessStart);
+    expect(readiness).toMatch(/timeout --signal=KILL [12]s brev exec issue-9880-test true/u);
     expect(readiness).toMatch(/sleep [12]/u);
     expect(readiness).not.toContain("sleep 9");
     expect(readiness).not.toContain("timeout 0s");

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -42,7 +42,10 @@ const WORKFLOW_PATH = path.join(
   REPO_ROOT,
   ".github/workflows/issue-9880-staging-reproduction.yaml",
 );
-const SCRIPT_PATH = path.join(REPO_ROOT, "tools/e2e/brev-launchable-issue-9880.sh");
+const SCRIPT_PATH = path.join(
+  REPO_ROOT,
+  "tools/e2e/brev-launchable-issue-9880.sh",
+);
 
 afterEach(() => cleanupIssue9880Fixtures());
 
@@ -51,7 +54,9 @@ function workflow(): Workflow {
 }
 
 function step(value: Workflow, name: string): Step {
-  const found = value.jobs?.reproduce?.steps?.find((entry) => entry.name === name);
+  const found = value.jobs?.reproduce?.steps?.find(
+    (entry) => entry.name === name,
+  );
   expect(found).toBeDefined();
   return found!;
 }
@@ -77,7 +82,10 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     const checkout = step(value, "Check out trusted reproduction lane");
     const authorize = step(value, "Authorize maintainer dispatch");
     const prepare = step(value, "Prepare Brev CLI and evidence directory");
-    const reproduce = step(value, "Reproduce issue 9880 on the staging Launchable");
+    const reproduce = step(
+      value,
+      "Reproduce issue 9880 on the staging Launchable",
+    );
     const cleanup = step(value, "Verify workflow-owned workspace cleanup");
     const removeCredentials = step(value, "Remove Brev credentials");
 
@@ -105,7 +113,9 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     );
     expect(reproduce.env).not.toHaveProperty("BREV_API_KEY");
     expect(reproduce.env?.HOME).toBe(privateHome);
-    expect(cleanup.if).toBe("${{ always() && steps.prepare.outputs.work_dir != '' }}");
+    expect(cleanup.if).toBe(
+      "${{ always() && steps.prepare.outputs.work_dir != '' }}",
+    );
     expect(cleanup.env?.HOME).toBe(privateHome);
     expect(cleanup.run).toMatch(
       /^tools\/e2e\/brev-launchable-issue-9880[.]sh cleanup-owned-workspace$/,
@@ -119,21 +129,35 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
   it("runs one bounded prompt and always verifies workspace cleanup (#9880)", () => {
     const script = fs.readFileSync(SCRIPT_PATH, "utf8");
 
-    expect(script).toContain('brev create "$INSTANCE_NAME" --launchable "$BREV_LAUNCHABLE_ID"');
+    expect(script).toContain(
+      'brev create "$INSTANCE_NAME" --launchable "$BREV_LAUNCHABLE_ID"',
+    );
     expect(script).toContain("timeout --signal=TERM --kill-after=10s 90s");
-    expect(script).toContain("List 10 REST API endpoints for a blog service, one per line");
-    expect(script).toContain("openclaw agent --agent main --json --thinking off");
+    expect(script).toContain(
+      "List 10 REST API endpoints for a blog service, one per line",
+    );
+    expect(script).toContain(
+      "openclaw agent --agent main --json --thinking off",
+    );
     expect(script).toContain("meta/llama-3.3-70b-instruct");
     expect(script).toContain("for attempt in 1 2 3 4 5");
     expect(script).toContain("cleanup-owned-workspace");
     expect(script).toContain("cleanup could not inspect workspace inventory");
     expect(script).toContain("workspace Brev exec readiness timed out");
-    expect(script).toContain('Brev exec access to $INSTANCE_NAME succeeded');
+    expect(script).toContain("Brev exec access to $INSTANCE_NAME succeeded");
     expect(script).toContain('classification="timeout"');
     expect(script).toContain('brev delete "$INSTANCE_NAME"');
     expect(script).toContain('jq -e --arg run "$producer_run"');
-    expect(script).toContain("standing Launchable runtime identity does not match");
+    expect(script).toContain(
+      "standing Launchable runtime identity does not match",
+    );
     expect(script).toContain("NEMOCLAW_REDACTION_SECRET");
+    expect(script.indexOf("trap cleanup_scenario_files EXIT")).toBeLessThan(
+      script.indexOf('remote_script="$(mktemp'),
+    );
+    expect(script.indexOf('redact_file "$raw_log"')).toBeLessThan(
+      script.indexOf("trap - EXIT INT TERM"),
+    );
     expect(script).not.toContain("--count");
     expect(script).not.toContain("KEEP_ALIVE");
   });
@@ -148,12 +172,19 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     const result = fixture.run({ [name]: value });
 
     expect(result.status).not.toBe(0);
-    expect(`${result.stdout}\n${result.stderr}`).toContain(`${name} must be a positive integer`);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      `${name} must be a positive integer`,
+    );
     expect(fs.existsSync(fixture.calls)).toBe(false);
     expect(fs.existsSync(fixture.state)).toBe(false);
   });
 
-  it.each([["brev exec", /timeout --signal=KILL [12]s brev exec issue-9880-test true/u]])(
+  it.each([
+    [
+      "brev exec",
+      /timeout --signal=KILL [12]s brev exec issue-9880-test true/u,
+    ],
+  ])(
     "bounds a blocked %s operation by the Brev exec deadline (#9880)",
     (blockedCommand, boundedCall) => {
       const fixture = issue9880Fixture();
@@ -162,9 +193,14 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
         FAKE_BLOCK_COMMAND: blockedCommand,
       });
 
-      expect(result.status, `${result.stdout}\n${result.stderr}\n${fs.readFileSync(fixture.calls, "utf8")}`).not.toBe(0);
+      expect(
+        result.status,
+        `${result.stdout}\n${result.stderr}\n${fs.readFileSync(fixture.calls, "utf8")}`,
+      ).not.toBe(0);
       const calls = fs.readFileSync(fixture.calls, "utf8");
-      expect(`${result.stdout}\n${result.stderr}`, calls).toContain("workspace Brev exec readiness timed out");
+      expect(`${result.stdout}\n${result.stderr}`, calls).toContain(
+        "workspace Brev exec readiness timed out",
+      );
       expect(calls).toMatch(boundedCall);
     },
     10_000,
@@ -185,10 +221,87 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     process.kill(-child.pid!, "SIGTERM");
     await completed;
 
-    expect(fs.readdirSync(fixture.root).filter((file) => file.startsWith("issue-9880-remote."))).toEqual([]);
-    expect(fs.readdirSync(fixture.root).filter((file) => /^issue-9880\.[A-Za-z0-9]+$/u.test(file))).toEqual([]);
-    expect(treeContainsLiteral(fixture.root, "nvapi-interrupt-test-secret")).toBe(false);
+    expect(
+      fs
+        .readdirSync(fixture.root)
+        .filter((file) => file.startsWith("issue-9880-remote.")),
+    ).toEqual([]);
+    expect(
+      fs
+        .readdirSync(fixture.root)
+        .filter((file) => /^issue-9880\.[A-Za-z0-9]+$/u.test(file)),
+    ).toEqual([]);
+    expect(
+      treeContainsLiteral(fixture.root, "nvapi-interrupt-test-secret"),
+    ).toBe(false);
   }, 10_000);
+
+  it("removes the raw log when redaction fails (#9880)", () => {
+    const fixture = issue9880Fixture();
+    fs.mkdirSync(path.join(fixture.workDir, "issue-9880.log"));
+    const result = fixture.run({
+      FAKE_EXEC_SUCCEEDS: "1",
+      FAKE_SCENARIO_SUCCEEDS: "1",
+      NVIDIA_API_KEY: "nvapi-redaction-failure-secret",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain("IsADirectoryError");
+    const calls = fs.readFileSync(fixture.calls, "utf8");
+    expect(calls).toContain("brev exec issue-9880-test true");
+    expect(calls).toMatch(/brev exec issue-9880-test @.*issue-9880-remote[.]/u);
+    expect(
+      fs
+        .readdirSync(fixture.root)
+        .filter((file) => file.startsWith("issue-9880-remote.")),
+    ).toEqual([]);
+    expect(
+      fs
+        .readdirSync(fixture.root)
+        .filter((file) => /^issue-9880\.[A-Za-z0-9]+$/u.test(file)),
+    ).toEqual([]);
+    expect(
+      treeContainsLiteral(fixture.root, "nvapi-redaction-failure-secret"),
+    ).toBe(false);
+  });
+
+  it("removes the raw log when remote script setup fails (#9880)", () => {
+    const fixture = issue9880Fixture();
+    const result = fixture.run({
+      FAKE_EXEC_SUCCEEDS: "1",
+      FAKE_REMOTE_MKTEMP_FAILS: "1",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      "Verified standing Launchable runtime identity before credential exposure",
+    );
+    expect(
+      fs
+        .readdirSync(fixture.root)
+        .filter((file) => file.startsWith("issue-9880-remote.")),
+    ).toEqual([]);
+    expect(
+      fs
+        .readdirSync(fixture.root)
+        .filter((file) => /^issue-9880\.[A-Za-z0-9]+$/u.test(file)),
+    ).toEqual([]);
+  });
+
+  it("fails closed when a regular artifact cannot be read (#9880)", () => {
+    const fixture = issue9880Fixture();
+    const unreadable = path.join(fixture.root, "unreadable-artifact");
+    fs.writeFileSync(unreadable, "nvapi-unreadable-secret");
+    fs.chmodSync(unreadable, 0o000);
+
+    try {
+      expect(() =>
+        treeContainsLiteral(fixture.root, "nvapi-unreadable-secret"),
+      ).toThrow();
+    } finally {
+      fs.chmodSync(unreadable, 0o600);
+    }
+  });
 
   it("caps poll sleep to the remaining Brev exec deadline (#9880)", () => {
     const fixture = issue9880Fixture();
@@ -200,10 +313,14 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
 
     expect(result.status).not.toBe(0);
     const calls = fs.readFileSync(fixture.calls, "utf8");
-    const readinessStart = calls.search(/timeout --signal=KILL [12]s brev exec/u);
+    const readinessStart = calls.search(
+      /timeout --signal=KILL [12]s brev exec/u,
+    );
     expect(readinessStart, calls).toBeGreaterThanOrEqual(0);
     const readiness = calls.slice(readinessStart);
-    expect(readiness).toMatch(/timeout --signal=KILL [12]s brev exec issue-9880-test true/u);
+    expect(readiness).toMatch(
+      /timeout --signal=KILL [12]s brev exec issue-9880-test true/u,
+    );
     expect(readiness).toMatch(/sleep [12]/u);
     expect(readiness).not.toContain("sleep 9");
     expect(readiness).not.toContain("timeout 0s");

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -12,6 +12,7 @@ import {
   issue9880Fixture,
   waitForIssue9880RemoteScript,
 } from "../../helpers/brev-launchable-issue-9880-fixture.ts";
+import { treeContainsLiteral } from "../../helpers/secret-scan.ts";
 import { REPO_ROOT } from "../fixtures/paths.ts";
 
 type Step = {
@@ -187,14 +188,7 @@ describe("the staging Launchable reproduces the bounded OpenClaw CLI scenario", 
     await new Promise<void>((resolve) => child.once("exit", () => resolve()));
 
     expect(fs.readdirSync(fixture.root).filter((file) => file.startsWith("issue-9880-remote."))).toEqual([]);
-    const retainedSecret = fs
-      .readdirSync(fixture.root, { recursive: true })
-      .filter((entry): entry is string => typeof entry === "string")
-      .some((entry) => {
-        const file = path.join(fixture.root, entry);
-        return fs.statSync(file).isFile() && fs.readFileSync(file, "utf8").includes("nvapi-interrupt-test-secret");
-      });
-    expect(retainedSecret).toBe(false);
+    expect(treeContainsLiteral(fixture.root, "nvapi-interrupt-test-secret")).toBe(false);
   }, 10_000);
 
   it("caps poll sleep to the remaining Brev exec deadline (#9880)", () => {

--- a/test/helpers/brev-launchable-issue-9880-fixture.ts
+++ b/test/helpers/brev-launchable-issue-9880-fixture.ts
@@ -14,13 +14,17 @@ function executable(file: string, source: string): void {
   fs.writeFileSync(file, source, { mode: 0o755 });
 }
 
-export function childCompletion(child: ReturnType<typeof spawn>): Promise<void> {
+export function childCompletion(
+  child: ReturnType<typeof spawn>,
+): Promise<void> {
   return child.exitCode !== null || child.signalCode !== null
     ? Promise.resolve()
     : new Promise((resolve) => child.once("exit", () => resolve()));
 }
 
-export async function childOutputAfterDelay(child: ReturnType<typeof spawn>): Promise<string> {
+export async function childOutputAfterDelay(
+  child: ReturnType<typeof spawn>,
+): Promise<string> {
   let output = "";
   child.stdout?.on("data", (chunk) => {
     output += chunk.toString();
@@ -32,9 +36,13 @@ export async function childOutputAfterDelay(child: ReturnType<typeof spawn>): Pr
   return output;
 }
 
-export async function waitForIssue9880RemoteScript(root: string): Promise<string[]> {
+export async function waitForIssue9880RemoteScript(
+  root: string,
+): Promise<string[]> {
   for (let attempt = 0; attempt < 250; attempt += 1) {
-    const files = fs.readdirSync(root).filter((file) => file.startsWith("issue-9880-remote."));
+    const files = fs
+      .readdirSync(root)
+      .filter((file) => file.startsWith("issue-9880-remote."));
     if (files.length > 0) return files;
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
@@ -42,14 +50,21 @@ export async function waitForIssue9880RemoteScript(root: string): Promise<string
 }
 
 export function cleanupIssue9880Fixtures(): void {
-  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+  for (const root of roots.splice(0))
+    fs.rmSync(root, { recursive: true, force: true });
 }
 
 export function issue9880Fixture(): {
   calls: string;
   env: NodeJS.ProcessEnv;
-  run: (overrides?: NodeJS.ProcessEnv, args?: string[]) => ReturnType<typeof spawnSync>;
-  start: (overrides?: NodeJS.ProcessEnv, args?: string[]) => ReturnType<typeof spawn>;
+  run: (
+    overrides?: NodeJS.ProcessEnv,
+    args?: string[],
+  ) => ReturnType<typeof spawnSync>;
+  start: (
+    overrides?: NodeJS.ProcessEnv,
+    args?: string[],
+  ) => ReturnType<typeof spawn>;
   root: string;
   state: string;
   workDir: string;
@@ -89,6 +104,16 @@ printf 'sleep %s\n' "$1" >> "$FAKE_CALLS"
 `,
   );
   executable(
+    path.join(bin, "mktemp"),
+    String.raw`#!/usr/bin/env bash
+set -euo pipefail
+if [ "${"$"}{FAKE_REMOTE_MKTEMP_FAILS:-0}" = 1 ] && [[ "${"$"}*" == *issue-9880-remote.* ]]; then
+  exit 70
+fi
+exec /usr/bin/mktemp "${"$"}@"
+`,
+  );
+  executable(
     path.join(bin, "brev"),
     String.raw`#!/usr/bin/env bash
 set -euo pipefail
@@ -104,11 +129,22 @@ case "${"$"}{1:-}" in
     printf '%s\n' '{"name":"issue-9880-test","id":"ws-1","status":"RUNNING","shell_status":"READY","build_status":"COMPLETED"}' > "$FAKE_STATE" ;;
   refresh) exit 0 ;;
   exec)
+    [ "$#" -eq 3 ] || exit 34
+    [ "${"$"}{2:-}" = "$INSTANCE_NAME" ] || exit 34
     if [ "${"$"}{3:-}" = true ] && [ "${"$"}{FAKE_EXEC_SUCCEEDS:-0}" = 1 ]; then exit 0; fi
-    if [[ "${"$"}{3:-}" == @* ]] && [ "${"$"}{FAKE_SCENARIO_BLOCKS:-0}" = 1 ]; then
-      printf '%s\n' "${"$"}{NVIDIA_API_KEY:-}" >&2
-      /bin/sleep 30
-      exit 0
+    if [[ "${"$"}{3:-}" == @* ]]; then
+      remote_script="${"$"}{3#@}"
+      [[ "$remote_script" == "$RUNNER_TEMP"/issue-9880-remote.* ]] || exit 34
+      [ -f "$remote_script" ] || exit 34
+      if [ "${"$"}{FAKE_SCENARIO_BLOCKS:-0}" = 1 ]; then
+        printf '%s\n' "${"$"}{NVIDIA_API_KEY:-}" >&2
+        /bin/sleep 30
+        exit 0
+      fi
+      if [ "${"$"}{FAKE_SCENARIO_SUCCEEDS:-0}" = 1 ]; then
+        printf '%s\n' "${"$"}{NVIDIA_API_KEY:-}" >&2
+        exit 0
+      fi
     fi
     if [[ "${"$"}{3:-}" == "set -euo pipefail"* ]]; then
       printf '%s\n' '{"sourceRepository":"NVIDIA/NemoClaw","sourcePath":"/opt/nemoclaw-image/NemoClaw","provisionSha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","imageRepositorySha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","repoSha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","bootImage":"projects/brevdevprod/global/images/nemoclaw-test-image","repoClean":true,"runtimeOverrides":false}'
@@ -147,6 +183,8 @@ fi
     BREV_LAUNCHABLE_ID: "env-staging123",
     FAKE_BLOCK_COMMAND: "",
     FAKE_EXEC_SUCCEEDS: "0",
+    FAKE_REMOTE_MKTEMP_FAILS: "0",
+    FAKE_SCENARIO_SUCCEEDS: "0",
     FAKE_CALLS: calls,
     FAKE_STATE: state,
     GH_TOKEN: "github-test-token",

--- a/test/helpers/brev-launchable-issue-9880-fixture.ts
+++ b/test/helpers/brev-launchable-issue-9880-fixture.ts
@@ -14,6 +14,24 @@ function executable(file: string, source: string): void {
   fs.writeFileSync(file, source, { mode: 0o755 });
 }
 
+export function childCompletion(child: ReturnType<typeof spawn>): Promise<void> {
+  return child.exitCode !== null || child.signalCode !== null
+    ? Promise.resolve()
+    : new Promise((resolve) => child.once("exit", () => resolve()));
+}
+
+export async function childOutputAfterDelay(child: ReturnType<typeof spawn>): Promise<string> {
+  let output = "";
+  child.stdout?.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  child.stderr?.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  return output;
+}
+
 export async function waitForIssue9880RemoteScript(root: string): Promise<string[]> {
   for (let attempt = 0; attempt < 250; attempt += 1) {
     const files = fs.readdirSync(root).filter((file) => file.startsWith("issue-9880-remote."));
@@ -50,10 +68,12 @@ export function issue9880Fixture(): {
     String.raw`#!/usr/bin/env bash
 set -euo pipefail
 signal=""
-if [ "${"$"}{1:-}" = --signal=KILL ]; then signal="--signal=KILL "; shift; fi
+kill_after=""
+if [[ "${"$"}{1:-}" == --signal=* ]]; then signal="${"$"}{1} "; shift; fi
+if [[ "${"$"}{1:-}" == --kill-after=* ]]; then kill_after="${"$"}{1} "; shift; fi
 duration="$1"
 shift
-printf 'timeout %s%s %s\n' "$signal" "$duration" "$*" >> "$FAKE_CALLS"
+printf 'timeout %s%s%s %s\n' "$signal" "$kill_after" "$duration" "$*" >> "$FAKE_CALLS"
 if [ "${"$"}{FAKE_BLOCK_COMMAND:-}" = "brev exec" ] && [ "${"$"}{1:-} ${"$"}{2:-}" = "brev exec" ]; then
   /bin/sleep "${"$"}{duration%s}"
   exit 124
@@ -150,6 +170,7 @@ fi
       }),
     start: (overrides = {}, args = []) =>
       spawn("bash", [SCRIPT, ...args], {
+        detached: true,
         env: { ...env, ...overrides },
         stdio: ["ignore", "pipe", "pipe"],
       }),

--- a/test/helpers/brev-launchable-issue-9880-fixture.ts
+++ b/test/helpers/brev-launchable-issue-9880-fixture.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -14,6 +14,15 @@ function executable(file: string, source: string): void {
   fs.writeFileSync(file, source, { mode: 0o755 });
 }
 
+export async function waitForIssue9880RemoteScript(root: string): Promise<string[]> {
+  for (let attempt = 0; attempt < 250; attempt += 1) {
+    const files = fs.readdirSync(root).filter((file) => file.startsWith("issue-9880-remote."));
+    if (files.length > 0) return files;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return [];
+}
+
 export function cleanupIssue9880Fixtures(): void {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 }
@@ -22,6 +31,8 @@ export function issue9880Fixture(): {
   calls: string;
   env: NodeJS.ProcessEnv;
   run: (overrides?: NodeJS.ProcessEnv, args?: string[]) => ReturnType<typeof spawnSync>;
+  start: (overrides?: NodeJS.ProcessEnv, args?: string[]) => ReturnType<typeof spawn>;
+  root: string;
   state: string;
   workDir: string;
 } {
@@ -47,10 +58,6 @@ if [ "${"$"}{FAKE_BLOCK_COMMAND:-}" = "brev exec" ] && [ "${"$"}{1:-} ${"$"}{2:-
   /bin/sleep "${"$"}{duration%s}"
   exit 124
 fi
-if [ "${"$"}{FAKE_BLOCK_COMMAND:-}" = ssh ] && [ "${"$"}{1:-}" = ssh ]; then
-  /bin/sleep "${"$"}{duration%s}"
-  exit 124
-fi
 exec "$@"
 `,
   );
@@ -59,13 +66,6 @@ exec "$@"
     String.raw`#!/usr/bin/env bash
 printf 'sleep %s\n' "$1" >> "$FAKE_CALLS"
 /bin/sleep "$1"
-`,
-  );
-  executable(
-    path.join(bin, "ssh"),
-    String.raw`#!/usr/bin/env bash
-printf 'ssh %s\n' "$*" >> "$FAKE_CALLS"
-exit 34
 `,
   );
   executable(
@@ -84,7 +84,15 @@ case "${"$"}{1:-}" in
     printf '%s\n' '{"name":"issue-9880-test","id":"ws-1","status":"RUNNING","shell_status":"READY","build_status":"COMPLETED"}' > "$FAKE_STATE" ;;
   refresh) exit 0 ;;
   exec)
-    if [ "${"$"}{FAKE_EXEC_SUCCEEDS:-0}" = 1 ]; then exit 0; fi
+    if [ "${"$"}{3:-}" = true ] && [ "${"$"}{FAKE_EXEC_SUCCEEDS:-0}" = 1 ]; then exit 0; fi
+    if [[ "${"$"}{3:-}" == @* ]] && [ "${"$"}{FAKE_SCENARIO_BLOCKS:-0}" = 1 ]; then
+      /bin/sleep 30
+      exit 0
+    fi
+    if [[ "${"$"}{3:-}" == "set -euo pipefail"* ]]; then
+      printf '%s\n' '{"sourceRepository":"NVIDIA/NemoClaw","sourcePath":"/opt/nemoclaw-image/NemoClaw","provisionSha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","imageRepositorySha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","repoSha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","bootImage":"projects/brevdevprod/global/images/nemoclaw-test-image","repoClean":true,"runtimeOverrides":false}'
+      exit 0
+    fi
     exit 34 ;;
   delete) rm -f "$FAKE_STATE" ;;
   *) exit 2 ;;
@@ -117,6 +125,7 @@ fi
     PATH: `${bin}:${process.env.PATH ?? ""}`,
     BREV_LAUNCHABLE_ID: "env-staging123",
     FAKE_BLOCK_COMMAND: "",
+    FAKE_EXEC_SUCCEEDS: "0",
     FAKE_CALLS: calls,
     FAKE_STATE: state,
     GH_TOKEN: "github-test-token",
@@ -130,6 +139,7 @@ fi
   return {
     calls,
     env,
+    root,
     state,
     workDir,
     run: (overrides = {}, args = []) =>
@@ -137,6 +147,11 @@ fi
         encoding: "utf8",
         env: { ...env, ...overrides },
         timeout: 20_000,
+      }),
+    start: (overrides = {}, args = []) =>
+      spawn("bash", [SCRIPT, ...args], {
+        env: { ...env, ...overrides },
+        stdio: ["ignore", "pipe", "pipe"],
       }),
   };
 }

--- a/test/helpers/brev-launchable-issue-9880-fixture.ts
+++ b/test/helpers/brev-launchable-issue-9880-fixture.ts
@@ -43,7 +43,7 @@ if [ "${"$"}{1:-}" = --signal=KILL ]; then signal="--signal=KILL "; shift; fi
 duration="$1"
 shift
 printf 'timeout %s%s %s\n' "$signal" "$duration" "$*" >> "$FAKE_CALLS"
-if [ "${"$"}{FAKE_BLOCK_COMMAND:-}" = "brev refresh" ] && [ "${"$"}{1:-} ${"$"}{2:-}" = "brev refresh" ]; then
+if [ "${"$"}{FAKE_BLOCK_COMMAND:-}" = "brev exec" ] && [ "${"$"}{1:-} ${"$"}{2:-}" = "brev exec" ]; then
   /bin/sleep "${"$"}{duration%s}"
   exit 124
 fi
@@ -83,6 +83,9 @@ case "${"$"}{1:-}" in
   create)
     printf '%s\n' '{"name":"issue-9880-test","id":"ws-1","status":"RUNNING","shell_status":"READY","build_status":"COMPLETED"}' > "$FAKE_STATE" ;;
   refresh) exit 0 ;;
+  exec)
+    if [ "${"$"}{FAKE_EXEC_SUCCEEDS:-0}" = 1 ]; then exit 0; fi
+    exit 34 ;;
   delete) rm -f "$FAKE_STATE" ;;
   *) exit 2 ;;
 esac

--- a/test/helpers/brev-launchable-issue-9880-fixture.ts
+++ b/test/helpers/brev-launchable-issue-9880-fixture.ts
@@ -106,6 +106,7 @@ case "${"$"}{1:-}" in
   exec)
     if [ "${"$"}{3:-}" = true ] && [ "${"$"}{FAKE_EXEC_SUCCEEDS:-0}" = 1 ]; then exit 0; fi
     if [[ "${"$"}{3:-}" == @* ]] && [ "${"$"}{FAKE_SCENARIO_BLOCKS:-0}" = 1 ]; then
+      printf '%s\n' "${"$"}{NVIDIA_API_KEY:-}" >&2
       /bin/sleep 30
       exit 0
     fi

--- a/test/helpers/secret-scan.ts
+++ b/test/helpers/secret-scan.ts
@@ -16,8 +16,9 @@ function fileContainsLiteral(file: string, literal: string): boolean {
   try {
     handle = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
     return fs.fstatSync(handle).isFile() && fs.readFileSync(handle, "utf8").includes(literal);
-  } catch {
-    return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ELOOP") return false;
+    throw error;
   } finally {
     if (handle !== undefined) fs.closeSync(handle);
   }

--- a/test/helpers/secret-scan.ts
+++ b/test/helpers/secret-scan.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+export function treeContainsLiteral(root: string, literal: string): boolean {
+  return fs
+    .readdirSync(root, { recursive: true })
+    .filter((entry): entry is string => typeof entry === "string")
+    .some((entry) => fileContainsLiteral(path.join(root, entry), literal));
+}
+
+function fileContainsLiteral(file: string, literal: string): boolean {
+  let handle: number | undefined;
+  try {
+    handle = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    return fs.fstatSync(handle).isFile() && fs.readFileSync(handle, "utf8").includes(literal);
+  } catch {
+    return false;
+  } finally {
+    if (handle !== undefined) fs.closeSync(handle);
+  }
+}

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -217,7 +217,9 @@ raw_log="$(mktemp "${RUNNER_TEMP:-/tmp}/issue-9880.XXXXXX")"
 remote_script="$(mktemp "${RUNNER_TEMP:-/tmp}/issue-9880-remote.XXXXXX")"
 chmod 600 "$raw_log" "$remote_script"
 cleanup_remote_script() { rm -f -- "$remote_script"; }
-trap cleanup_remote_script EXIT INT TERM
+trap cleanup_remote_script EXIT
+trap 'cleanup_remote_script; exit 130' INT
+trap 'cleanup_remote_script; exit 143' TERM
 {
   printf 'export NVIDIA_INFERENCE_API_KEY=%q\n' "$NVIDIA_API_KEY"
   cat <<'REMOTE'

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -216,10 +216,10 @@ log "Verified standing Launchable runtime identity before credential exposure"
 raw_log="$(mktemp "${RUNNER_TEMP:-/tmp}/issue-9880.XXXXXX")"
 remote_script="$(mktemp "${RUNNER_TEMP:-/tmp}/issue-9880-remote.XXXXXX")"
 chmod 600 "$raw_log" "$remote_script"
-cleanup_remote_script() { rm -f -- "$remote_script"; }
-trap cleanup_remote_script EXIT
-trap 'cleanup_remote_script; exit 130' INT
-trap 'cleanup_remote_script; exit 143' TERM
+cleanup_scenario_files() { rm -f -- "$remote_script" "$raw_log"; }
+trap cleanup_scenario_files EXIT
+trap 'cleanup_scenario_files; exit 130' INT
+trap 'cleanup_scenario_files; exit 143' TERM
 {
   printf 'export NVIDIA_INFERENCE_API_KEY=%q\n' "$NVIDIA_API_KEY"
   cat <<'REMOTE'
@@ -300,7 +300,7 @@ set +e
 timeout --signal=TERM --kill-after=10s 900s brev exec "$INSTANCE_NAME" "@$remote_script" >"$raw_log" 2>&1
 scenario_status=$?
 set -e
-cleanup_remote_script
+rm -f -- "$remote_script"
 trap - EXIT INT TERM
 remote_script=""
 redact_file "$raw_log" "$WORK_DIR/issue-9880.log"

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -214,12 +214,19 @@ jq -e --arg expectedBootImage "$expected_boot_image" --arg expectedSha "$expecte
 log "Verified standing Launchable runtime identity before credential exposure"
 
 raw_log="$(mktemp "${RUNNER_TEMP:-/tmp}/issue-9880.XXXXXX")"
-remote_script="$(mktemp "${RUNNER_TEMP:-/tmp}/issue-9880-remote.XXXXXX")"
-chmod 600 "$raw_log" "$remote_script"
-cleanup_scenario_files() { rm -f -- "$remote_script" "$raw_log"; }
+remote_script=""
+cleanup_scenario_files() {
+  local cleanup_status=0
+  [ -z "${remote_script:-}" ] || rm -f -- "$remote_script" || cleanup_status=$?
+  [ -z "${raw_log:-}" ] || rm -f -- "$raw_log" || cleanup_status=$?
+  return "$cleanup_status"
+}
 trap cleanup_scenario_files EXIT
 trap 'cleanup_scenario_files; exit 130' INT
 trap 'cleanup_scenario_files; exit 143' TERM
+chmod 600 "$raw_log"
+remote_script="$(mktemp "${RUNNER_TEMP:-/tmp}/issue-9880-remote.XXXXXX")"
+chmod 600 "$remote_script"
 {
   printf 'export NVIDIA_INFERENCE_API_KEY=%q\n' "$NVIDIA_API_KEY"
   cat <<'REMOTE'
@@ -301,9 +308,10 @@ timeout --signal=TERM --kill-after=10s 900s brev exec "$INSTANCE_NAME" "@$remote
 scenario_status=$?
 set -e
 rm -f -- "$remote_script"
-trap - EXIT INT TERM
 remote_script=""
 redact_file "$raw_log" "$WORK_DIR/issue-9880.log"
+raw_log=""
+trap - EXIT INT TERM
 
 classification="completed"
 if [ "$scenario_status" -eq 86 ]; then

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -119,7 +119,6 @@ require BREV_LAUNCHABLE_ID
 require GH_TOKEN
 require NVIDIA_API_KEY
 command -v gh >/dev/null 2>&1 || fail "gh is required"
-command -v ssh >/dev/null 2>&1 || fail "ssh is required"
 [[ "$BREV_LAUNCHABLE_ID" =~ ^env-[A-Za-z0-9]+$ ]] || fail "BREV_LAUNCHABLE_ID is invalid"
 for name in BREV_EXEC_TIMEOUT_SECONDS POLL_SECONDS; do
   value="${!name:-}"
@@ -217,6 +216,8 @@ log "Verified standing Launchable runtime identity before credential exposure"
 raw_log="$(mktemp "${RUNNER_TEMP:-/tmp}/issue-9880.XXXXXX")"
 remote_script="$(mktemp "${RUNNER_TEMP:-/tmp}/issue-9880-remote.XXXXXX")"
 chmod 600 "$raw_log" "$remote_script"
+cleanup_remote_script() { rm -f -- "$remote_script"; }
+trap cleanup_remote_script EXIT INT TERM
 {
   printf 'export NVIDIA_INFERENCE_API_KEY=%q\n' "$NVIDIA_API_KEY"
   cat <<'REMOTE'
@@ -297,7 +298,9 @@ set +e
 timeout --signal=TERM --kill-after=10s 900s brev exec "$INSTANCE_NAME" "@$remote_script" >"$raw_log" 2>&1
 scenario_status=$?
 set -e
-rm -f -- "$remote_script"
+cleanup_remote_script
+trap - EXIT INT TERM
+remote_script=""
 redact_file "$raw_log" "$WORK_DIR/issue-9880.log"
 
 classification="completed"

--- a/tools/e2e/brev-launchable-issue-9880.sh
+++ b/tools/e2e/brev-launchable-issue-9880.sh
@@ -5,7 +5,6 @@
 set -euo pipefail
 
 OWNER_FILE="${WORK_DIR}.workspace-owner"
-SSH_OPTIONS=(-T -o BatchMode=yes -o ConnectTimeout=10 -o ConnectionAttempts=1 -o LogLevel=ERROR)
 log() { printf '%s\n' "$*" | tee -a "$WORK_DIR/lane.log"; }
 fail() {
   log "FAILED: $*" >&2
@@ -122,7 +121,7 @@ require NVIDIA_API_KEY
 command -v gh >/dev/null 2>&1 || fail "gh is required"
 command -v ssh >/dev/null 2>&1 || fail "ssh is required"
 [[ "$BREV_LAUNCHABLE_ID" =~ ^env-[A-Za-z0-9]+$ ]] || fail "BREV_LAUNCHABLE_ID is invalid"
-for name in BREV_SSH_TIMEOUT_SECONDS POLL_SECONDS; do
+for name in BREV_EXEC_TIMEOUT_SECONDS POLL_SECONDS; do
   value="${!name:-}"
   [ -z "$value" ] || [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "$name must be a positive integer"
 done
@@ -172,27 +171,23 @@ jq -e '.status == "RUNNING" and (.shell_status // .shellStatus) == "READY" and
   || fail "workspace readiness timed out"
 workspace_id="$(jq -r '.id // ""' <<<"$ready")"
 log "Workspace $INSTANCE_NAME ($workspace_id) is ready"
-ssh_deadline=$((SECONDS + ${BREV_SSH_TIMEOUT_SECONDS:-900}))
-ssh_ready=0
-while [ "$SECONDS" -lt "$ssh_deadline" ]; do
-  remaining=$((ssh_deadline - SECONDS))
+exec_deadline=$((SECONDS + ${BREV_EXEC_TIMEOUT_SECONDS:-900}))
+exec_ready=0
+while [ "$SECONDS" -lt "$exec_deadline" ]; do
+  remaining=$((exec_deadline - SECONDS))
   [ "$remaining" -gt 0 ] || break
-  refresh_timeout=$((remaining < 60 ? remaining : 60))
-  timeout --signal=KILL "${refresh_timeout}s" brev refresh >/dev/null 2>&1 || true
-  remaining=$((ssh_deadline - SECONDS))
-  [ "$remaining" -gt 0 ] || break
-  ssh_timeout=$((remaining < 15 ? remaining : 15))
-  if timeout --signal=KILL "${ssh_timeout}s" ssh "${SSH_OPTIONS[@]}" "$INSTANCE_NAME" true >/dev/null 2>&1; then
-    ssh_ready=1
+  exec_timeout=$((remaining < 30 ? remaining : 30))
+  if timeout --signal=KILL "${exec_timeout}s" brev exec "$INSTANCE_NAME" true >/dev/null 2>&1; then
+    exec_ready=1
     break
   fi
-  remaining=$((ssh_deadline - SECONDS))
+  remaining=$((exec_deadline - SECONDS))
   [ "$remaining" -gt 0 ] || break
   poll_seconds="${POLL_SECONDS:-15}"
   sleep "$((poll_seconds < remaining ? poll_seconds : remaining))"
 done
-[ "$ssh_ready" -eq 1 ] || fail "workspace SSH readiness timed out"
-log "SSH access to $INSTANCE_NAME succeeded"
+[ "$exec_ready" -eq 1 ] || fail "workspace Brev exec readiness timed out"
+log "Brev exec access to $INSTANCE_NAME succeeded"
 
 # The remote shell expands the single-quoted command.
 # shellcheck disable=SC2016
@@ -220,8 +215,8 @@ jq -e --arg expectedBootImage "$expected_boot_image" --arg expectedSha "$expecte
 log "Verified standing Launchable runtime identity before credential exposure"
 
 raw_log="$(mktemp "${RUNNER_TEMP:-/tmp}/issue-9880.XXXXXX")"
-chmod 600 "$raw_log"
-set +e
+remote_script="$(mktemp "${RUNNER_TEMP:-/tmp}/issue-9880-remote.XXXXXX")"
+chmod 600 "$raw_log" "$remote_script"
 {
   printf 'export NVIDIA_INFERENCE_API_KEY=%q\n' "$NVIDIA_API_KEY"
   cat <<'REMOTE'
@@ -297,9 +292,12 @@ PY
 done
 if [ "$reproduced" -eq 1 ]; then exit 86; fi
 REMOTE
-} | ssh "${SSH_OPTIONS[@]}" "$INSTANCE_NAME" 'bash -s' >"$raw_log" 2>&1
+} >"$remote_script"
+set +e
+timeout --signal=TERM --kill-after=10s 900s brev exec "$INSTANCE_NAME" "@$remote_script" >"$raw_log" 2>&1
 scenario_status=$?
 set -e
+rm -f -- "$remote_script"
 redact_file "$raw_log" "$WORK_DIR/issue-9880.log"
 
 classification="completed"


### PR DESCRIPTION
## Summary

Uses the supported Brev exec access path after workspace readiness instead of relying on a direct SSH alias that may not be published on CI runners. Sends the bounded issue scenario as a private local script and keeps the existing identity, redaction, timeout, and cleanup boundaries.

## Related Issue

Refs #9880

## Verification

- Focused E2E-support contract: 13 tests passed
- Full PR validation (`npm run validate:pr`) passed

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated staging workflows to validate `brev exec` readiness instead of SSH access.
  * Added bounded timeout handling and capped polling intervals for remote execution.
  * Improved validation for execution timeout settings and blocked-operation scenarios.
  * Ensured temporary scripts and logs containing credentials are removed after completion or interruption.
  * Expanded secret-retention checks to cover remote scripts and temporary credential files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
