### PR TITLE
fix(ci): complete lifecycle release fixtures

### DIFF
--- a/test/onboard-custom-dockerfile.test.ts
+++ b/test/onboard-custom-dockerfile.test.ts
@@ -230,6 +230,7 @@ fs.statSync = (target, ...rest) => {
 runner.run = (command, opts = {}) => {
   const normalized = _n(command);
   commands.push({ command: normalized, env: opts.env || null });
+  if (normalized.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return normalized.includes("sandbox get") && normalized.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };

--- a/test/onboard-extra-provider-reconciliation.test.ts
+++ b/test/onboard-extra-provider-reconciliation.test.ts
@@ -61,6 +61,7 @@ registry.addExtraProvider("my-slack-bridge");
 runner.run = (command, opts = {}) => {
   const normalized = _n(command);
   commands.push({ command: normalized, env: opts.env || null });
+  if (normalized.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   if (normalized.includes("provider get -g nemoclaw tavily-search")) {
     const stderr = Buffer.from("Error: provider 'tavily-search' not found");
     return {

--- a/test/onboard-installer-restore-intent.test.ts
+++ b/test/onboard-installer-restore-intent.test.ts
@@ -64,6 +64,7 @@ let sandboxRecreated = false;
 runner.run = (command) => {
   const cmd = _n(command);
   events.push({ kind: "run", cmd });
+  if (cmd.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   if (cmd.includes("sandbox delete")) sandboxDeleted = true;
   return cmd.includes("sandbox get") && cmd.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }

--- a/test/onboard-reservation-recreate.test.ts
+++ b/test/onboard-reservation-recreate.test.ts
@@ -66,6 +66,7 @@ let sandboxRecreated = false;
 runner.run = (command) => {
   const cmd = _n(command);
   events.push({ kind: "run", cmd });
+  if (cmd.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   if (cmd.includes("sandbox delete")) sandboxDeleted = true;
   return cmd.includes("sandbox get") && cmd.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }

--- a/test/onboard-sandbox-build.test.ts
+++ b/test/onboard-sandbox-build.test.ts
@@ -58,6 +58,7 @@ const defaultCalls = [];
 runner.run = (command, opts = {}) => {
   const normalized = _n(command);
   commands.push({ command: normalized, env: opts.env || null });
+  if (normalized.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return normalized.includes("sandbox get") && normalized.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };
@@ -280,6 +281,7 @@ agentOnboard.createAgentSandbox = () => {
 runner.run = (command, opts = {}) => {
   const normalized = _n(command);
   commands.push({ command: normalized, env: opts.env || null });
+  if (normalized.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return normalized.includes("sandbox get hermes-sandbox") ? { status: 0, stdout: Buffer.from("Name: hermes-sandbox\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
 };
 runner.runFile = (file, args = [], opts = {}) => {
@@ -479,6 +481,7 @@ buildContext.stageOptimizedSandboxBuildContext = () => {
 runner.run = (command, opts = {}) => {
   const normalized = _n(command);
   commands.push({ command: normalized, env: opts.env || null });
+  if (normalized.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return normalized.includes("sandbox get") && normalized.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };
@@ -588,6 +591,7 @@ const commands = [];
 runner.run = (command, opts = {}) => {
   const normalized = _n(command);
   commands.push({ command: normalized, env: opts.env || null });
+  if (normalized.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return normalized.includes("sandbox get") && normalized.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };
@@ -689,6 +693,7 @@ const commands = [];
 runner.run = (command, opts = {}) => {
   const normalized = _n(command);
   commands.push({ command: normalized, env: opts.env || null });
+  if (normalized.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return normalized.includes("sandbox get") && normalized.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("Name: my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };

--- a/test/onboard-sandbox-recreation.test.ts
+++ b/test/onboard-sandbox-recreation.test.ts
@@ -47,6 +47,7 @@ runner.run = (command) => {
   if (_n(command).includes("sandbox delete")) {
     throw new Error("unexpected sandbox delete");
   }
+  if (_n(command).includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return { status: 0 };
 };
 runner.runCapture = (command) => {
@@ -141,6 +142,7 @@ runner.run = (command, opts = {}) => {
   const cmd = _n(command);
   _deleted = _deleted || cmd.includes("sandbox delete");
   commands.push({ command: cmd, env: opts.env || null });
+  if (cmd.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return cmd.includes("sandbox get") && cmd.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("my-assistant\nId: " + _sandboxId + "\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };
@@ -275,6 +277,7 @@ runner.run = (command) => {
   const cmd = _n(command);
   _deleted = _deleted || cmd.includes("sandbox delete");
   events.push({ kind: "run", cmd });
+  if (cmd.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return cmd.includes("sandbox get") && cmd.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };
@@ -429,6 +432,7 @@ runner.run = (command) => {
   const cmd = _n(command);
   _deleted = _deleted || cmd.includes("sandbox delete");
   events.push({ kind: "run", cmd });
+  if (cmd.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return cmd.includes("sandbox get") && cmd.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };
@@ -558,6 +562,7 @@ runner.run = (command) => {
   const cmd = _n(command);
   _deleted = _deleted || cmd.includes("sandbox delete");
   events.push({ kind: "run", cmd });
+  if (cmd.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   if (cmd.includes("sandbox delete")) sandboxDeleted = true;
   return cmd.includes("sandbox get") && cmd.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
@@ -708,6 +713,7 @@ runner.run = (command, opts = {}) => {
   const cmd = _n(command);
   _deleted = _deleted || cmd.includes("sandbox delete");
   commands.push({ command: cmd, env: opts.env || null });
+  if (cmd.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return cmd.includes("sandbox get") && cmd.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };
@@ -851,6 +857,7 @@ runner.run = (command, opts = {}) => {
     }
   }
   commands.push({ command: cmd, env: opts.env || null });
+  if (cmd.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return cmd.includes("sandbox get") && cmd.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };
@@ -987,6 +994,7 @@ runner.run = (command, opts = {}) => {
     }
   }
   commands.push({ command: cmd, env: opts.env || null });
+  if (cmd.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return cmd.includes("sandbox get") && cmd.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };
@@ -1119,6 +1127,7 @@ runner.run = (command, opts = {}) => {
   const cmd = _n(command);
   _deleted = _deleted || cmd.includes("sandbox delete");
   commands.push({ command: cmd, env: opts.env || null });
+  if (cmd.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   if (cmd.includes("sandbox delete")) sandboxDeleted = true;
   return cmd.includes("sandbox get") && cmd.includes("my-assistant")
     ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
@@ -1226,7 +1235,7 @@ const { createSandbox } = require(${onboardPath});
     assert.ok(result.stdout.includes("not ready"), "should mention sandbox is not ready");
   });
   it("registers a fresh create only after owner-scoped identity confirmation (#8942)", {
-    timeout: 20000,
+    timeout: 45000,
   }, async () => {
     const repoRoot = path.join(import.meta.dirname, "..");
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-create-ready-"));
@@ -1278,6 +1287,7 @@ runner.run = (command, opts = {}) => {
   const cmd = _n(command);
   _deleted = _deleted || cmd.includes("sandbox delete");
   commands.push({ command: cmd, env: opts.env || null });
+  if (cmd.includes("sandbox list")) return { status: 0, stdout: "No sandboxes found." };
   return cmd.includes("sandbox get") && cmd.includes("my-assistant") && sandboxCreated
     ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-fresh-create\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };
@@ -1393,7 +1403,7 @@ const { createSandbox } = require(${onboardPath});
         NEMOCLAW_NON_INTERACTIVE: "1",
         OPENSHELL_DRIVERS: "docker",
       },
-      timeout: 15000,
+      timeout: 30000,
     });
 
     assert.equal(result.status, 0, result.stderr);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Source-backed onboarding fixtures now return an explicit empty OpenShell sandbox list after teardown. This prevents lifecycle-release waits from holding CLI coverage shards 1, 2, 5, 7, and 12 until the 15-minute job timeout, while production continues to reject blank lifecycle receipts.

## Related Issue

Advances #6237.

## Changes

- Return `No sandboxes found.` from the affected successful sandbox teardown mocks.
- Increase one source-backed identity child-process timeout from 15 to 30 seconds and its test timeout from 20 to 45 seconds to remove a cold-loader boundary race.
- Preserve the production lifecycle-release contract and its fail-closed handling of blank output.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The diff is limited to integration-test mocks. The production lifecycle-release implementation is unchanged, and its unit suite verifies that an explicit empty list is accepted while blank output is rejected (25/25 passed).
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Documentation Writer Review

Independent documentation writer review result: no-docs-needed. On Codex Desktop, I reviewed the complete PR diff from base SHA `38a94ca9cdbe76fbf9cbd6c33135f20a14eefa85` to commit under review `64470ec34ae549a62521d4dea2fa4a69741a6a1f` under `AGENTS.md` blob `513518cdfca42e3a18fed71109e6d0eb60151d13`. The diff changes six integration-test files only. Source-backed onboarding mocks now return the explicit OpenShell lifecycle-release receipt `No sandboxes found.`, and two test-process timeout ceilings increase from 15 to 30 seconds and 20 to 45 seconds. The diff does not change production behavior, a supported surface, public documentation, user-visible text, code comments, or test titles. Production continues to reject a blank lifecycle receipt. The merged branch has the same stable patch ID as the previously reviewed patch. Before the merge, validation of that identical patch reported 35/35 affected integration tests, 25/25 production lifecycle unit tests, exact test-project membership, passing repository checks and normal pre-commit, commit-msg, and pre-push hooks, and a clean diff check. No `docs/**`, Fern, or owning repository guidance change is required.

<!-- docs-review-head-sha: 64470ec34ae549a62521d4dea2fa4a69741a6a1f -->
<!-- docs-review-agents-blob-sha: 513518cdfca42e3a18fed71109e6d0eb60151d13 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: All 35 affected integration tests passed across the final focused Vitest runs. `npx vitest run --project cli src/lib/onboard/docker-gpu-supervisor-reconnect.test.ts` passed 25/25.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to the narrow fixture repair. `npm run checks:repository` and `npm run test:projects:check` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
