### PR TITLE
fix(state): preserve live unverifiable registry locks

### DIFF
--- a/src/lib/state/registry-lock.test.ts
+++ b/src/lib/state/registry-lock.test.ts
@@ -249,6 +249,25 @@ describe("process-bound registry locking", () => {
     expect(fs.existsSync(test.lockDir)).toBe(true);
   });
 
+  it("keeps a live owner when the host cannot read process identity (#9746)", () => {
+    const test = fixture("nemoclaw-unverifiable-host-lock-");
+    writeOrdinaryGeneration(test, 4242);
+    markStale(test.lockDir);
+    const wait = vi.fn();
+
+    expect(() =>
+      withRegistryLockAt(test.registryFile, () => undefined, {
+        isProcessAlive: () => true,
+        maxRetries: 1,
+        now: () => Number.MAX_SAFE_INTEGER,
+        readProcessIdentity: () => null,
+        wait,
+      }),
+    ).toThrow(/after 1 retries/);
+    expect(wait).toHaveBeenCalledOnce();
+    expect(fs.existsSync(test.lockDir)).toBe(true);
+  });
+
   it("keeps ordinary non-Linux acquisition and release behavior", () => {
     const test = fixture("nemoclaw-ordinary-no-proc-");
     vi.spyOn(process, "getuid").mockImplementation(() => undefined as never);

--- a/src/lib/state/registry/lock.ts
+++ b/src/lib/state/registry/lock.ts
@@ -109,7 +109,7 @@ export function classifyExistingLock(options: { ownerAlive: boolean; ownerPid: n
 }
 
 function status(pid: number, alive: boolean, record: string | null, read: (pid: number) => string | null): RegistryOwnerStatus {
-  if (record === null) return "ordinary";
+  if (record === null) return alive && read(pid) === null ? "unverifiable" : "ordinary";
   if (!alive) return "recycled";
   const current = read(pid);
   return current === null ? "unverifiable" : record === `${String(pid)} ${current}` ? "original" : "recycled";


### PR DESCRIPTION
## Summary

Registry locks now preserve a live owner when the host cannot inspect its process identity. This prevents stale-age recovery on macOS and other non-`/proc` hosts from stealing a lock that is still actively held.

## Related Issue

Fixes #9746

## Changes

- Classify a live, sidecar-less owner with unreadable process identity as `unverifiable`.
- Fail closed by waiting instead of stale-breaking that live owner's lock.
- Add a regression that ages the lock beyond the stale threshold and proves it remains owned.
- Preserve dead-owner recovery, exact Linux identity handling, and ordinary non-Linux acquisition and release.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — [concurrency and security review](https://github.com/NVIDIA/NemoClaw/issues/9746#issuecomment-5357287355); the fence fails closed and does not change secrets, inputs, authentication, dependencies, logging, cryptography, or configuration.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Security Review

- Secrets and credentials: pass; no credential path changes.
- Input validation: pass; no new external input is accepted.
- Authentication and authorization: pass; lock ownership becomes stricter.
- Dependencies: pass; no dependency changes.
- Error handling and logging: pass; existing bounded retry failure remains intact.
- Cryptography and data protection: pass; no cryptographic behavior changes.
- Configuration and security headers: pass; no deployed configuration changes.
- Security testing: pass; the regression covers a live owner beyond the stale threshold.
- System security: pass; ambiguous live ownership fails closed. A reused live PID can delay recovery on a host without identity inspection, which is safer than deleting a potentially live lock.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli --maxWorkers=1 src/lib/state/registry-lock.test.ts` passed 27/27 tests.
- [ ] Applicable broad gate passed — not applicable to this narrow two-file lock-classification fix; `npm run typecheck` and `npm run lint -- --no-cache` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of locks held by live processes when process identity cannot be verified.
  * Prevented stale lock cleanup in unverifiable cases, preserving lock integrity.
  * Added bounded retry behavior before lock acquisition fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->