### PR TITLE
fix(onboard): isolate broken WSL Docker credentials

### DIFF
--- a/src/lib/adapters/docker/credential-store.ts
+++ b/src/lib/adapters/docker/credential-store.ts
@@ -4,7 +4,7 @@
 import os from "node:os";
 import path from "node:path";
 
-import { DOCKER_DESKTOP_CREDENTIAL_STORE_NAMES } from "./docker-host";
+import { DOCKER_DESKTOP_CREDENTIAL_STORE_NAMES } from "../../domain/docker-host";
 
 type ReadFile = (filePath: string, encoding: BufferEncoding) => string;
 type RunCapture = (

--- a/src/lib/domain/docker-credential-store.ts
+++ b/src/lib/domain/docker-credential-store.ts
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import os from "node:os";
+import path from "node:path";
+
+import { DOCKER_DESKTOP_CREDENTIAL_STORE_NAMES } from "./docker-host";
+
+type ReadFile = (filePath: string, encoding: BufferEncoding) => string;
+type RunCapture = (
+  command: readonly string[],
+  options?: { ignoreError?: boolean; timeout?: number },
+) => string | null;
+
+export interface DockerCredentialStoreConfig {
+  readonly credsStore?: string;
+  readonly configPath?: string;
+}
+
+/**
+ * Read the global credential-helper name from the active Docker client config.
+ * Missing, unreadable, and malformed configs intentionally declare no helper.
+ */
+export function readDockerCredentialStore(
+  env: NodeJS.ProcessEnv,
+  readFile: ReadFile,
+): DockerCredentialStoreConfig {
+  try {
+    // os.homedir() can throw in HOME-less containers. Treat that like a
+    // missing config so host inspection and generated-image builds fail safe.
+    const configDirectory = env.DOCKER_CONFIG || path.join(os.homedir(), ".docker");
+    const configPath = env.DOCKER_CONFIG ? "$DOCKER_CONFIG/config.json" : "~/.docker/config.json";
+    const parsed: { credsStore?: unknown } = JSON.parse(
+      readFile(path.join(configDirectory, "config.json"), "utf-8"),
+    );
+    return typeof parsed.credsStore === "string" && parsed.credsStore !== ""
+      ? { credsStore: parsed.credsStore, configPath }
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+// Windows interop can stall. Bound the read-only probe so a hung helper cannot
+// hang preflight, readiness collection, or a generated sandbox-image build.
+const DOCKER_CREDENTIAL_HELPER_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * True when an exact Docker Desktop credential helper answers a read-only
+ * `list` call with parseable JSON. The allowlist prevents Docker config from
+ * selecting an arbitrary executable at this trust boundary.
+ */
+export function dockerDesktopCredentialHelperResponds(
+  credsStore: string,
+  runCapture: RunCapture,
+): boolean {
+  if (!DOCKER_DESKTOP_CREDENTIAL_STORE_NAMES.has(credsStore)) return false;
+  try {
+    const output = runCapture([`docker-credential-${credsStore}`, "list"], {
+      ignoreError: true,
+      timeout: DOCKER_CREDENTIAL_HELPER_PROBE_TIMEOUT_MS,
+    });
+    JSON.parse(String(output || ""));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/onboard/preflight.ts
+++ b/src/lib/onboard/preflight.ts
@@ -19,6 +19,10 @@ import { ADVISORY_CHECKS } from "../advisories/registry";
 import { runAdvisories } from "../advisories/runner";
 import { DASHBOARD_PORT } from "../core/ports";
 import {
+  dockerDesktopCredentialHelperResponds,
+  readDockerCredentialStore,
+} from "../domain/docker-credential-store";
+import {
   DOCKER_DESKTOP_CREDENTIAL_STORE_NAMES,
   isDockerDaemonReachable,
   isSupportedGatewayDockerHost,
@@ -467,61 +471,6 @@ function isHeadlessLikely(env: NodeJS.ProcessEnv): boolean {
   return !env.DISPLAY && !env.WAYLAND_DISPLAY && !env.TERM_PROGRAM;
 }
 
-/**
- * Read the `credsStore` credential-helper name from the Docker client config
- * (`$DOCKER_CONFIG/config.json`, default `~/.docker/config.json`). A missing,
- * unreadable, or malformed config declares no credential store (#9457).
- */
-function readDockerCredsStore(
-  env: NodeJS.ProcessEnv,
-  readFileImpl: (filePath: string, encoding: BufferEncoding) => string,
-): { credsStore?: string; configPath?: string } {
-  try {
-    // os.homedir() can throw on HOME-less containers; degrade like a missing
-    // config instead of failing the host assessment.
-    const configDir = env.DOCKER_CONFIG || path.join(os.homedir(), ".docker");
-    const configPath = env.DOCKER_CONFIG
-      ? "$DOCKER_CONFIG/config.json"
-      : "~/.docker/config.json";
-    const parsed: { credsStore?: unknown } = JSON.parse(
-      readFileImpl(path.join(configDir, "config.json"), "utf-8"),
-    );
-    return typeof parsed.credsStore === "string" && parsed.credsStore !== ""
-      ? { credsStore: parsed.credsStore, configPath }
-      : {};
-  } catch {
-    return {};
-  }
-}
-
-// Windows interop can stall; bound the probe so a hung helper cannot hang
-// preflight or a readiness collection.
-const DOCKER_CREDENTIAL_HELPER_PROBE_TIMEOUT_MS = 10_000;
-
-/**
- * True when the configured Docker Desktop credential helper answers a
- * read-only `list` call with parseable JSON from this session. In WSL the
- * helper runs on the Windows side through interop, so session markers
- * (DISPLAY, SSH variables) cannot see whether a usable Windows logon session
- * exists — probe the helper instead (#9457). Probed only for the exact Docker
- * Desktop helper names, so no configurable string selects the executable.
- */
-function dockerCredentialHelperResponds(
-  credsStore: string,
-  runCaptureImpl: RunCaptureFn,
-): boolean {
-  try {
-    const output = runCaptureImpl([`docker-credential-${credsStore}`, "list"], {
-      ignoreError: true,
-      timeout: DOCKER_CREDENTIAL_HELPER_PROBE_TIMEOUT_MS,
-    });
-    JSON.parse(String(output || ""));
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 // lspci line shape: "<slot> <class label>: <vendor> <device> ...".
 // The slot token contains colons (e.g. "01:00.0"), so anchor on the class
 // label that follows it and ends at the first ": ".
@@ -664,7 +613,7 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
     runtime = "docker";
   }
   const isWslHost = detectWsl({ platform, env, release, procVersion });
-  const dockerCredentialStore = readDockerCredsStore(env, readFileImpl);
+  const dockerCredentialStore = readDockerCredentialStore(env, readFileImpl);
   const dockerCredsStore = dockerCredentialStore.credsStore;
   // Session markers cannot see the Windows side of WSL interop, so probe the
   // helper there; the advisory check consumes this instead of DISPLAY/SSH
@@ -673,7 +622,7 @@ export function assessHost(opts: AssessHostOpts = {}): HostAssessment {
     isWslHost &&
     dockerCredsStore !== undefined &&
     DOCKER_DESKTOP_CREDENTIAL_STORE_NAMES.has(dockerCredsStore)
-      ? !dockerCredentialHelperResponds(dockerCredsStore, runCaptureImpl)
+      ? !dockerDesktopCredentialHelperResponds(dockerCredsStore, runCaptureImpl)
       : undefined;
   const dockerCgroupVersion = dockerReachable
     ? parseDockerCgroupVersion(dockerInfoOutput)

--- a/src/lib/onboard/preflight.ts
+++ b/src/lib/onboard/preflight.ts
@@ -15,13 +15,13 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 
-import { ADVISORY_CHECKS } from "../advisories/registry";
-import { runAdvisories } from "../advisories/runner";
-import { DASHBOARD_PORT } from "../core/ports";
 import {
   dockerDesktopCredentialHelperResponds,
   readDockerCredentialStore,
-} from "../domain/docker-credential-store";
+} from "../adapters/docker/credential-store";
+import { ADVISORY_CHECKS } from "../advisories/registry";
+import { runAdvisories } from "../advisories/runner";
+import { DASHBOARD_PORT } from "../core/ports";
 import {
   DOCKER_DESKTOP_CREDENTIAL_STORE_NAMES,
   isDockerDaemonReachable,

--- a/src/lib/onboard/sandbox-prebuild.test.ts
+++ b/src/lib/onboard/sandbox-prebuild.test.ts
@@ -370,6 +370,127 @@ describe("sandbox BuildKit prebuild", () => {
     });
   });
 
+  it("isolates a generated BuildKit build from an unavailable WSL Docker Desktop helper (#9748)", async () => {
+    const { buildCtx, createArgs } = createBuildContext();
+    const dockerConfig = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-wsl-docker-config-"));
+    temporaryDirectories.push(dockerConfig);
+    const originalConfig = JSON.stringify({
+      auths: { "registry.example.com": { auth: "must-remain-private" } },
+      credsStore: "desktop.exe",
+    });
+    fs.writeFileSync(path.join(dockerConfig, "config.json"), originalConfig);
+    const credentialHelperResponds = vi.fn(() => false);
+    const log = vi.fn();
+    let isolatedConfig = "";
+    const buildImage = vi.fn(async (_args, options) => {
+      isolatedConfig = String(options.env.DOCKER_CONFIG);
+      expect(isolatedConfig).toContain("nemoclaw-wsl-buildkit-docker-config-");
+      expect(isolatedConfig).not.toBe(dockerConfig);
+      expect(fs.statSync(isolatedConfig).mode & 0o777).toBe(0o700);
+      expect(
+        JSON.parse(fs.readFileSync(path.join(isolatedConfig, "config.json"), "utf-8")),
+      ).toEqual({ auths: {} });
+      expect(fs.statSync(path.join(isolatedConfig, "config.json")).mode & 0o777).toBe(0o600);
+      return 0;
+    });
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        env: {
+          DOCKER_CONFIG: dockerConfig,
+          NEMOCLAW_SANDBOX_PREBUILD: "1",
+          WSL_DISTRO_NAME: "Ubuntu",
+        },
+        buildImage,
+        credentialHelperResponds,
+        isWslHost: true,
+        inspectImageId: () => IMAGE_ID,
+        log,
+      }),
+    ).resolves.toMatchObject({ imageRef: "nemoclaw-sandbox-local:alpha-1234567890" });
+
+    expect(credentialHelperResponds).toHaveBeenCalledOnce();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("isolated credential-free config"));
+    expect(fs.existsSync(isolatedConfig)).toBe(false);
+    expect(fs.readFileSync(path.join(dockerConfig, "config.json"), "utf-8")).toBe(originalConfig);
+  });
+
+  it("removes the isolated WSL Docker config after a failed required build (#9748)", async () => {
+    const { buildCtx, createArgs } = createBuildContext();
+    const dockerConfig = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-wsl-docker-config-"));
+    temporaryDirectories.push(dockerConfig);
+    fs.writeFileSync(
+      path.join(dockerConfig, "config.json"),
+      JSON.stringify({ credsStore: "desktop.exe" }),
+    );
+    let isolatedConfig = "";
+    const buildImage = vi.fn(async (_args, options) => {
+      isolatedConfig = String(options.env.DOCKER_CONFIG);
+      expect(fs.existsSync(isolatedConfig)).toBe(true);
+      return 1;
+    });
+
+    await expect(
+      prebuildSandboxImageIfEligible({
+        buildCtx,
+        buildId: BUILD_ID,
+        origin: "generated",
+        createArgs,
+        sandboxName: "alpha",
+        dockerDriverGateway: true,
+        requiresLocalBuildKit: true,
+        env: { DOCKER_CONFIG: dockerConfig, WSL_DISTRO_NAME: "Ubuntu" },
+        buildImage,
+        credentialHelperResponds: () => false,
+        isWslHost: true,
+        log: () => {},
+      }),
+    ).rejects.toThrow("Local BuildKit build failed (exit 1)");
+
+    expect(fs.existsSync(isolatedConfig)).toBe(false);
+  });
+
+  it("preserves the active WSL Docker config when its Desktop helper responds (#9748)", async () => {
+    const { buildCtx, createArgs } = createBuildContext();
+    const dockerConfig = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-wsl-docker-config-"));
+    temporaryDirectories.push(dockerConfig);
+    fs.writeFileSync(
+      path.join(dockerConfig, "config.json"),
+      JSON.stringify({ credsStore: "desktop.exe" }),
+    );
+    const buildImage = vi.fn(async (_args, options) => {
+      expect(options.env.DOCKER_CONFIG).toBe(dockerConfig);
+      return 0;
+    });
+
+    await prebuildSandboxImageIfEligible({
+      buildCtx,
+      buildId: BUILD_ID,
+      origin: "generated",
+      createArgs,
+      sandboxName: "alpha",
+      dockerDriverGateway: true,
+      env: {
+        DOCKER_CONFIG: dockerConfig,
+        NEMOCLAW_SANDBOX_PREBUILD: "1",
+        WSL_DISTRO_NAME: "Ubuntu",
+      },
+      buildImage,
+      credentialHelperResponds: () => true,
+      isWslHost: true,
+      inspectImageId: () => IMAGE_ID,
+      log: () => {},
+    });
+
+    expect(fs.existsSync(dockerConfig)).toBe(true);
+  });
+
   it("publishes portable-profile builds to the managed loopback registry", async () => {
     const { buildCtx, createArgs } = createBuildContext();
     const buildImage = vi.fn(async () => 0);

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -13,6 +13,12 @@ import {
   LOCAL_SANDBOX_IMAGE_REPO,
   PORTABLE_LOCAL_SANDBOX_IMAGE_REPO,
 } from "../domain/sandbox/image-tag";
+import {
+  dockerDesktopCredentialHelperResponds,
+  readDockerCredentialStore,
+} from "../domain/docker-credential-store";
+import { DOCKER_DESKTOP_CREDENTIAL_STORE_NAMES } from "../domain/docker-host";
+import { isWsl } from "../platform";
 import {
   SANDBOX_BUILD_CONTEXT_PREFIX,
   type SandboxBuildContextOrigin,
@@ -51,6 +57,8 @@ export interface SandboxPrebuildInput {
     options: { env: NodeJS.ProcessEnv; stdio: "inherit" },
   ) => Promise<number | null>;
   inspectImageId?: (imageRef: string) => string;
+  credentialHelperResponds?: (credsStore: string) => boolean;
+  isWslHost?: boolean;
   log?: (message: string) => void;
 }
 
@@ -66,8 +74,10 @@ interface TrustedStagedBuildContext {
   dockerfile: string;
 }
 
-function createCredentialFreeDockerConfig(): string {
-  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-docker-config-"));
+function createCredentialFreeDockerConfig(purpose: "portable" | "wsl-buildkit"): string {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), `nemoclaw-${purpose}-docker-config-`),
+  );
   fs.chmodSync(directory, 0o700);
   fs.writeFileSync(path.join(directory, "config.json"), '{"auths":{}}\n', {
     encoding: "utf-8",
@@ -135,10 +145,12 @@ function resolveTrustedStagedBuildContext(buildCtx: string): TrustedStagedBuildC
 }
 
 /** Restrict the host Docker build to environment values used by Docker itself. */
-export function dockerBuildSubprocessEnv(): Record<string, string> {
+export function dockerBuildSubprocessEnv(
+  sourceEnv: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
   const env = buildSubprocessEnv();
   for (const key of DOCKER_ENV_NAMES) {
-    const value = process.env[key];
+    const value = sourceEnv[key];
     if (value !== undefined) env[key] = value;
   }
   for (const key of Object.keys(env)) {
@@ -154,6 +166,38 @@ export function dockerBuildSubprocessEnv(): Record<string, string> {
     }
   }
   return env;
+}
+
+function requiresCredentialFreeWslBuildConfig(
+  env: NodeJS.ProcessEnv,
+  helperResponds: (credsStore: string) => boolean,
+  isWslHost?: boolean,
+): boolean {
+  if (!isWsl({ env, isWsl: isWslHost })) return false;
+  const { credsStore } = readDockerCredentialStore(env, fs.readFileSync);
+  return (
+    credsStore !== undefined &&
+    DOCKER_DESKTOP_CREDENTIAL_STORE_NAMES.has(credsStore) &&
+    !helperResponds(credsStore)
+  );
+}
+
+function dockerDesktopCredentialHelperRespondsFromBuild(
+  credsStore: string,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  return dockerDesktopCredentialHelperResponds(credsStore, (command, options) => {
+    const [executable, ...args] = command;
+    if (!executable) return null;
+    const result = spawnSync(executable, args, {
+      encoding: "utf-8",
+      env: dockerBuildSubprocessEnv(env),
+      shell: false,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: options?.timeout,
+    });
+    return result.error || result.status !== 0 ? null : result.stdout;
+  });
 }
 
 export function resolveSandboxPrebuildEnabled(
@@ -268,14 +312,29 @@ export async function prebuildSandboxImageIfEligible(
   log(`  Building sandbox image with ${builderName} (skips the slower in-gateway builder)...`);
 
   let status: number | null;
+  let credentialFreeWslConfig: string | null = null;
   try {
+    const buildEnv: NodeJS.ProcessEnv = {
+      ...dockerBuildSubprocessEnv(env),
+      ...(portable ? {} : { DOCKER_BUILDKIT: "1" }),
+    };
+    const helperResponds =
+      input.credentialHelperResponds ??
+      ((credsStore: string) => dockerDesktopCredentialHelperRespondsFromBuild(credsStore, env));
+    if (
+      !portable &&
+      requiresCredentialFreeWslBuildConfig(env, helperResponds, input.isWslHost)
+    ) {
+      credentialFreeWslConfig = createCredentialFreeDockerConfig("wsl-buildkit");
+      buildEnv.DOCKER_CONFIG = credentialFreeWslConfig;
+      log(
+        "  Docker Desktop credential helper is unavailable in this WSL session; using an isolated credential-free config for the generated sandbox image build.",
+      );
+    }
     status = await buildImage(
       ["build", "-t", imageRef, "-f", trustedContext.dockerfile, trustedContext.buildCtx],
       {
-        env: {
-          ...dockerBuildSubprocessEnv(),
-          ...(portable ? {} : { DOCKER_BUILDKIT: "1" }),
-        },
+        env: buildEnv,
         stdio: "inherit",
       },
     );
@@ -288,6 +347,10 @@ export async function prebuildSandboxImageIfEligible(
       `  Local ${builderName} build could not start (${detail}); using the gateway builder instead.`,
     );
     return { createArgs, imageRef: null, imageId: null };
+  } finally {
+    if (credentialFreeWslConfig !== null) {
+      fs.rmSync(credentialFreeWslConfig, { recursive: true, force: true });
+    }
   }
 
   if (status !== 0) {
@@ -303,11 +366,11 @@ export async function prebuildSandboxImageIfEligible(
     const publishImage = input.publishImage ?? buildImage;
     log("  Publishing sandbox image to the managed local registry...");
     let publishStatus: number | null;
-    const credentialFreeDockerConfig = createCredentialFreeDockerConfig();
+    const credentialFreeDockerConfig = createCredentialFreeDockerConfig("portable");
     try {
       publishStatus = await publishImage(["push", imageRef], {
         env: {
-          ...dockerBuildSubprocessEnv(),
+          ...dockerBuildSubprocessEnv(env),
           DOCKER_CONFIG: credentialFreeDockerConfig,
           REGISTRY_AUTH_FILE: path.join(credentialFreeDockerConfig, "config.json"),
         },

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -7,16 +7,16 @@ import os from "node:os";
 import path from "node:path";
 
 import { dockerImageInspectFormat } from "../adapters/docker";
+import {
+  dockerDesktopCredentialHelperResponds,
+  readDockerCredentialStore,
+} from "../adapters/docker/credential-store";
 import { dockerSpawn } from "../adapters/docker/exec";
 import { redirectInheritedChildStdoutToStderr } from "../cli/stdout-guard";
 import {
   LOCAL_SANDBOX_IMAGE_REPO,
   PORTABLE_LOCAL_SANDBOX_IMAGE_REPO,
 } from "../domain/sandbox/image-tag";
-import {
-  dockerDesktopCredentialHelperResponds,
-  readDockerCredentialStore,
-} from "../domain/docker-credential-store";
 import { DOCKER_DESKTOP_CREDENTIAL_STORE_NAMES } from "../domain/docker-host";
 import { isWsl } from "../platform";
 import {


### PR DESCRIPTION
## Summary

Generated sandbox-image builds on WSL now recover when Docker Desktop's configured credential helper cannot respond. NemoClaw uses a temporary credential-free Docker configuration only for that generated BuildKit operation, leaving the user's Docker configuration and all custom or private-image build paths unchanged.

## Related Issue

Fixes #9748

## Changes

- Extract Docker credential-store parsing and probing into a shared domain helper.
- Accept only the exact Docker Desktop helper names `desktop` and `desktop.exe` for the WSL recovery path.
- Probe the helper read-only with a bounded timeout before deciding whether recovery is required.
- Create a mode `0700` temporary Docker config containing a mode `0600` credential-free `config.json` for the generated sandbox-image BuildKit invocation.
- Remove the temporary configuration in `finally` after successful or failed builds.
- Keep custom Dockerfiles, gateway builds, private registries, and responsive helpers on the original Docker configuration.
- Add success, failure-cleanup, and responsive-helper regression coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — detailed review below; credential isolation is narrowed to a generated credential-free build and fails closed for custom or private-image paths.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Security Review

- Secrets and credentials: pass; helper output stays in memory and is not logged, and unusable credentials are excluded only from the credential-free generated build.
- Input validation: pass; executable selection is restricted to `desktop` and `desktop.exe` and uses argv without a shell.
- Authentication and authorization: pass; private and custom build boundaries keep the original Docker credentials.
- Dependencies: pass; no dependency changes.
- Error handling and logging: pass; build failures are preserved and temporary configuration is removed in `finally`.
- Cryptography and data protection: pass; no cryptographic behavior changes.
- Configuration and security headers: pass; temporary directory and file modes are `0700` and `0600`.
- Security testing: pass; tests cover broken-helper recovery, responsive-helper preservation, original-config integrity, and cleanup after failure.
- System security: pass; the state transition is limited to WSL, an exact Docker Desktop helper, and NemoClaw's generated sandbox-image build.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — focused preflight and sandbox-prebuild suites passed 55/55 tests.
- [ ] Applicable broad gate passed — not applicable to this bounded preflight/build recovery; `npm run typecheck` and `npm run lint -- --no-cache` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker credential handling for WSL-based local builds.
  * Builds now avoid unavailable Docker Desktop credential helpers by using a temporary, credential-free configuration.
  * Temporary configuration files are securely permissioned, cleaned up after builds, and do not alter existing Docker settings.
  * Portable image publishing uses isolated temporary credential-free configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->