### PR TITLE
fix: include completed second-opinion findings

### DIFF
--- a/test/pr-review-advisor-rendering.test.ts
+++ b/test/pr-review-advisor-rendering.test.ts
@@ -4,7 +4,7 @@
 import Ajv2020 from "ajv/dist/2020.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderSummary } from "../tools/pr-review-advisor/render-result.mts";
-import { buildComment } from "../tools/pr-review-advisor/comment.mts";
+import { buildComment, normalizeAdvisorLaneReport } from "../tools/pr-review-advisor/comment.mts";
 import {
   loadAdvisorSchema,
   metadata,
@@ -124,6 +124,43 @@ describe("PR review advisor", () => {
     expect(comment).toContain("#### `PRA-20` Blocker — Blocker 20");
     expect(comment).not.toContain("`PRA-21`");
     expect(comment).not.toContain("### Recommended refactoring");
+  });
+
+  it("keeps completed second-opinion warnings visible when the primary lane is skipped", () => {
+    const headSha = "abc123def456";
+    const secondOpinionResult = validResult({
+      headSha,
+      findings: [
+        {
+          severity: "warning",
+          category: "correctness",
+          file: "src/lib/example.ts",
+          line: 12,
+          title: "Check the alternate path",
+          description: "The second opinion found a concrete non-blocking concern.",
+          recommendation: "Review or justify the alternate path before merge.",
+        },
+      ],
+    });
+    const comment = buildComment({
+      summary: "unused",
+      result: validResult({ headSha, findings: [] }),
+      lanes: {
+        primary: { status: "skipped", partial: false },
+        secondOpinion: normalizeAdvisorLaneReport(
+          secondOpinionResult,
+          secondOpinionResult,
+          headSha,
+        ),
+      },
+    });
+
+    expect(comment).toContain("**Findings:** 0 blockers · 1 warning · 0 suggestions");
+    expect(comment).toContain("**Next action:** Review the warnings below.");
+    expect(comment).toContain("#### `PRA-1` Warning — Check the alternate path");
+    expect(comment).toContain(
+      "**Nemotron 3 Ultra (second opinion):** Completed · high confidence · 0 blockers · 1 warning · 0 suggestions",
+    );
   });
 
   it("keeps warning-only reviews non-blocking without synthetic test tasks", () => {

--- a/tools/pr-review-advisor/comment.mts
+++ b/tools/pr-review-advisor/comment.mts
@@ -158,6 +158,7 @@ export type AdvisorLaneReport = {
   counts?: FindingCounts;
   confidence?: "low" | "medium" | "high";
   fingerprints?: LaneFingerprints;
+  result?: ReviewAdvisorResult;
   e2e?: LaneE2eRecommendations;
   terminology?: TrustedLaneTerminologyDecision[];
 };
@@ -377,7 +378,7 @@ export function normalizeAdvisorLaneReport(
     };
   }
   if (analysisResult.version !== 1 || !structure) return unavailableLaneReport();
-  return { status: "completed", partial: false, ...structure };
+  return { status: "completed", partial: false, result: finalResult as ReviewAdvisorResult, ...structure };
 }
 
 export function buildComment({
@@ -397,7 +398,8 @@ export function buildComment({
   metadata?: CommentMetadata;
   lanes?: AdvisorLaneReports;
 }): string {
-  const findingRecords = collectFindingRecords(result);
+  const effectiveResult = resultWithCompletedSecondOpinionFindings(result, lanes);
+  const findingRecords = collectFindingRecords(effectiveResult);
   const blockerCount = findingRecords.filter(
     (record) => record.finding.severity === "blocker",
   ).length;
@@ -407,23 +409,23 @@ export function buildComment({
   const suggestionCount = findingRecords.filter(
     (record) => record.finding.severity === "suggestion",
   ).length;
-  const reviewHistory = buildSecondarySummary(result);
+  const reviewHistory = buildSecondarySummary(effectiveResult);
   const informational =
-    result?.summary?.recommendation === "info_only" && result.summary.oneLine
-      ? `**Status:** ${escapeCommentText(result.summary.oneLine)}\n`
+    effectiveResult?.summary?.recommendation === "info_only" && effectiveResult.summary.oneLine
+      ? `**Status:** ${escapeCommentText(effectiveResult.summary.oneLine)}\n`
       : "";
   const findingsDetails = renderFindingsDetails(findingRecords);
-  const terminologyDetails = renderTerminologyDetails(result);
-  const e2eDetails = renderE2eDetails(result);
+  const terminologyDetails = renderTerminologyDetails(effectiveResult);
+  const e2eDetails = renderE2eDetails(effectiveResult);
   const laneDetails = renderAdvisorLanes(lanes);
   const details = runUrl ? `\n[Workflow run details](${runUrl})` : "";
-  const hiddenMetadata = renderHiddenMetadata(result, metadata);
+  const hiddenMetadata = renderHiddenMetadata(effectiveResult, metadata);
   const posture = reviewPosture(
-    result?.summary?.recommendation,
-    result?.summary?.confidence,
+    effectiveResult?.summary?.recommendation,
+    effectiveResult?.summary?.confidence,
     blockerCount,
   );
-  const headline = reviewHeadline(result?.summary?.recommendation, blockerCount);
+  const headline = reviewHeadline(effectiveResult?.summary?.recommendation, blockerCount);
   const heading = validateSingleLineCommentField(title || COMMENT_TITLE, "title");
   const renderedMarker = validateCommentMarker(marker || MARKER);
   const prefix = `${renderedMarker}\n${hiddenMetadata}`;
@@ -821,6 +823,30 @@ function collectFindingRecords(result?: ReviewAdvisorResult): FindingRecord[] {
     id: `PRA-${index + 1}`,
     finding,
   }));
+}
+
+function resultWithCompletedSecondOpinionFindings(
+  result?: ReviewAdvisorResult,
+  lanes?: AdvisorLaneReports,
+): ReviewAdvisorResult | undefined {
+  const secondOpinionFindingRecords =
+    lanes?.primary.status !== "completed" &&
+    lanes?.secondOpinion.status === "completed" &&
+    !lanes.secondOpinion.partial
+      ? collectFindingRecords(lanes.secondOpinion.result)
+      : [];
+  if (secondOpinionFindingRecords.length === 0) return result;
+  const primaryFingerprints = new Set(
+    collectFindingRecords(result).map((record) => stableJson(record.finding)),
+  );
+  const secondOpinionOnly = secondOpinionFindingRecords
+    .filter((record) => !primaryFingerprints.has(stableJson(record.finding)))
+    .map((record) => record.finding);
+  if (secondOpinionOnly.length === 0) return result;
+  return {
+    ...result,
+    findings: [...(result?.findings || []), ...secondOpinionOnly],
+  };
 }
 
 function trustedLaneStructure(


### PR DESCRIPTION
## Summary
The PR Review Advisor comment now folds completed second-opinion findings into the canonical aggregate when the primary lane did not complete. This keeps the headline finding count and next action from reporting no follow-up while the available model lane contains warnings.

## Related Issue
Fixes #9995

## Changes
- Preserve the validated final result on normalized model-lane reports.
- Build the public comment from an effective result that includes completed second-opinion-only findings when the primary lane is skipped, failed, or unavailable.
- Add a regression test for a skipped primary lane with a completed second-opinion warning.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [ ] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/pr-review-advisor-rendering.test.ts test/pr-review-advisor-comment-cli.test.ts` (22 tests passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Glenn-Agent <glenn_agent@163.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Second-opinion review findings now remain visible when the primary review lane is skipped.
  - Review summaries accurately reflect merged findings, counts, warnings, recommended next actions, and review status.
  - Headline and guidance content now consistently reflect available review results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->