### PR TITLE
test(e2e): project stock evidence predicate counts

### DIFF
--- a/test/e2e/live/common-egress-agent-helpers.ts
+++ b/test/e2e/live/common-egress-agent-helpers.ts
@@ -96,6 +96,19 @@ export interface PersonalStockToolEvidenceArtifact {
   qualifyingWebFetchResults: number;
   webFetchCalls: number;
   webFetchExecutions: number;
+  webFetchResultCounts: {
+    asOfMatches: number;
+    directFetch: number;
+    httpSuccess: number;
+    maxCharsWithinLimit: number;
+    paired: number;
+    priceMatches: number;
+    publicHttpsTarget: number;
+    resultSuccess: number;
+    sourceUrlMatches: number;
+    symbolMatches: number;
+    total: number;
+  };
   webFetchResultsWithinMaxChars: number;
 }
 
@@ -845,6 +858,23 @@ export function projectPersonalStockToolEvidenceArtifact(
   evidence: OpenClawToolEvidence,
 ): PersonalStockToolEvidenceArtifact {
   const assessment = assessPersonalStockToolEvidence(evidence);
+  const webFetchResultCounts = {
+    asOfMatches: evidence.webFetchResults.filter(({ asOfMatches }) => asOfMatches).length,
+    directFetch: evidence.webFetchResults.filter(({ directFetch }) => directFetch).length,
+    httpSuccess: evidence.webFetchResults.filter(({ httpSuccess }) => httpSuccess).length,
+    maxCharsWithinLimit: evidence.webFetchResults.filter(
+      ({ maxCharsWithinLimit }) => maxCharsWithinLimit,
+    ).length,
+    paired: evidence.webFetchResults.filter(({ paired }) => paired).length,
+    priceMatches: evidence.webFetchResults.filter(({ priceMatches }) => priceMatches).length,
+    publicHttpsTarget: evidence.webFetchResults.filter(({ target }) => isPublicHttpsTarget(target))
+      .length,
+    resultSuccess: evidence.webFetchResults.filter(({ resultSuccess }) => resultSuccess).length,
+    sourceUrlMatches: evidence.webFetchResults.filter(({ sourceUrlMatches }) => sourceUrlMatches)
+      .length,
+    symbolMatches: evidence.webFetchResults.filter(({ symbolMatches }) => symbolMatches).length,
+    total: evidence.webFetchResults.length,
+  };
   return {
     schemaVersion: 1,
     controlTargetViolations: evidence.controlTargetViolations,
@@ -859,9 +889,8 @@ export function projectPersonalStockToolEvidenceArtifact(
     qualifyingWebFetchResults: assessment.qualifyingWebFetchResults,
     webFetchCalls: assessment.webFetchCalls,
     webFetchExecutions: assessment.webFetchExecutions,
-    webFetchResultsWithinMaxChars: evidence.webFetchResults.filter(
-      ({ maxCharsWithinLimit }) => maxCharsWithinLimit,
-    ).length,
+    webFetchResultCounts,
+    webFetchResultsWithinMaxChars: webFetchResultCounts.maxCharsWithinLimit,
   };
 }
 
@@ -994,7 +1023,8 @@ export async function validateOpenClawAgentAttemptEvidence(
     }
     await options.recordToolEvidence(toolEvidence);
     if (!options.toolEvidenceValidator(toolEvidence)) {
-      const assessment = assessPersonalStockToolEvidence(toolEvidence);
+      const assessment = projectPersonalStockToolEvidenceArtifact(toolEvidence);
+      const counts = assessment.webFetchResultCounts;
       const diagnostic = [
         `errors=${toolEvidence.errors.length}`,
         `finalStatuses=${toolEvidence.finalStatuses.length}`,
@@ -1004,8 +1034,19 @@ export async function validateOpenClawAgentAttemptEvidence(
         `webFetchCalls=${assessment.webFetchCalls}`,
         `webFetchExecutions=${assessment.webFetchExecutions}`,
         `qualifying=${assessment.qualifyingWebFetchResults}`,
-        `forbiddenTools=${assessment.forbiddenToolNames.length}`,
-        `forbiddenProviders=${assessment.forbiddenProviderMentions.length}`,
+        `webFetchResults=${counts.total}`,
+        `asOfMatches=${counts.asOfMatches}`,
+        `directFetch=${counts.directFetch}`,
+        `httpSuccess=${counts.httpSuccess}`,
+        `maxCharsWithinLimit=${counts.maxCharsWithinLimit}`,
+        `paired=${counts.paired}`,
+        `priceMatches=${counts.priceMatches}`,
+        `publicHttpsTarget=${counts.publicHttpsTarget}`,
+        `resultSuccess=${counts.resultSuccess}`,
+        `sourceUrlMatches=${counts.sourceUrlMatches}`,
+        `symbolMatches=${counts.symbolMatches}`,
+        `forbiddenTools=${assessment.forbiddenToolCount}`,
+        `forbiddenProviders=${assessment.forbiddenProviderMentionCount}`,
       ].join("; ");
       return {
         attempt: { passed: false, failureClass: "deterministic" },

--- a/test/e2e/support/common-egress-agent-helpers.test.ts
+++ b/test/e2e/support/common-egress-agent-helpers.test.ts
@@ -28,6 +28,8 @@ import {
   runOpenClawAgentAssertionRetry,
   type NvdaPersonalStockReply,
   type OpenClawAgentAttemptEvidenceOptions,
+  type OpenClawToolEvidence,
+  type PersonalStockToolEvidenceArtifact,
   validateOpenClawAgentAttemptEvidence,
 } from "../live/common-egress-agent-helpers.ts";
 
@@ -244,6 +246,38 @@ function stockAttemptValidationOptions(
     toolEvidenceValidator: (candidate) => assessPersonalStockToolEvidence(candidate).matches,
     ...overrides,
   };
+}
+
+async function expectAggregateStockFailure(
+  evidence: OpenClawToolEvidence,
+  countName: keyof PersonalStockToolEvidenceArtifact["webFetchResultCounts"],
+): Promise<void> {
+  const artifact = projectPersonalStockToolEvidenceArtifact(evidence);
+  const result = await validateOpenClawAgentAttemptEvidence(
+    stockAttemptValidationOptions({
+      reduceToolEvidence: vi.fn().mockResolvedValue({
+        exitCode: 0,
+        stdout: `__NEMOCLAW_TOOL_EVIDENCE__=${JSON.stringify(evidence)}\n`,
+      }),
+      toolEvidenceValidator: () => false,
+    }),
+  );
+
+  expect(artifact.webFetchResultCounts).toMatchObject({ total: 1, [countName]: 0 });
+  expect(artifact.qualifyingWebFetchResults).toBe(0);
+  expect(result.failure).toContain(`${countName}=0`);
+  for (const sensitiveValue of [
+    STOCK_SOURCE_URL,
+    String(STOCK_REPLY.price),
+    STOCK_REPLY.as_of,
+    stockPayload().text as string,
+    evidence.expectedStockFingerprint!,
+    "must-not-remain",
+    "web_fetch",
+  ]) {
+    expect(JSON.stringify(artifact)).not.toContain(sensitiveValue);
+    expect(result.failure).not.toContain(sensitiveValue);
+  }
 }
 
 describe("common-egress agent parsing and classification helpers", () => {
@@ -580,6 +614,19 @@ describe("common-egress agent parsing and classification helpers", () => {
       forbiddenToolCount: 1,
       matches: false,
       publicHttpsTargets: [{ hostname: "query1.finance.yahoo.com", protocol: "https:" }],
+      webFetchResultCounts: {
+        asOfMatches: 1,
+        directFetch: 0,
+        httpSuccess: 1,
+        maxCharsWithinLimit: 1,
+        paired: 1,
+        priceMatches: 1,
+        publicHttpsTarget: 1,
+        resultSuccess: 1,
+        sourceUrlMatches: 1,
+        symbolMatches: 1,
+        total: 1,
+      },
     });
     expect(serialized).not.toContain(providerSentinel);
     expect(serialized).not.toContain(toolSentinel);
@@ -599,6 +646,43 @@ describe("common-egress agent parsing and classification helpers", () => {
     expect(result.failure).toContain("forbiddenTools=1; forbiddenProviders=1");
     expect(result.failure).not.toContain(providerSentinel);
     expect(result.failure).not.toContain(toolSentinel);
+  });
+
+  it.each([
+    { predicate: "asOfMatches", countName: "asOfMatches" },
+    { predicate: "directFetch", countName: "directFetch" },
+    { predicate: "httpSuccess", countName: "httpSuccess" },
+    { predicate: "maxCharsWithinLimit", countName: "maxCharsWithinLimit" },
+    { predicate: "paired", countName: "paired" },
+    { predicate: "priceMatches", countName: "priceMatches" },
+    { predicate: "resultSuccess", countName: "resultSuccess" },
+    { predicate: "sourceUrlMatches", countName: "sourceUrlMatches" },
+    { predicate: "symbolMatches", countName: "symbolMatches" },
+  ] as const)(
+    "projects a zero $countName count when only $predicate is false",
+    async ({ predicate, countName }) => {
+      const evidence = reduceOpenClawToolEvidence(
+        stockSessionJsonLines(),
+        stockTrajectory(),
+        STOCK_REPLY,
+      );
+      const candidate = structuredClone(evidence) as OpenClawToolEvidence;
+      candidate.webFetchResults[0]![predicate] = false;
+
+      await expectAggregateStockFailure(candidate, countName);
+    },
+  );
+
+  it("projects a zero public-target count for a non-public result target", async () => {
+    const evidence = reduceOpenClawToolEvidence(
+      stockSessionJsonLines(),
+      stockTrajectory(),
+      STOCK_REPLY,
+    );
+    const candidate = structuredClone(evidence);
+    candidate.webFetchResults[0]!.target = { hostname: "127.0.0.1", protocol: "https:" };
+
+    await expectAggregateStockFailure(candidate, "publicHttpsTarget");
   });
 
   it("validates and records a successful Personal stock-fetch attempt", async () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Personal stock failures now report how many reduced results pass each existing qualification predicate. The uploaded artifact and terminal diagnostic remain aggregate-only. This change does not alter qualification behavior or fix the observed quote mismatch.

## Changes

- Add count-only projection for every existing stock-result qualification predicate.
- Include those aggregate counts in the deterministic trajectory-mismatch diagnostic.
- Independently falsify each predicate and verify that artifacts and diagnostics exclude the full URL, response text, quote values, date values, fingerprint, provider and tool names, and credential material.

## E2E Root Cause

- Diagnostic root-cause key: `OpenClaw Personal stock fetch / failure evidence projection / predicate-level qualification counts are unavailable`
- Source: automatic E2E run [32623009512](https://github.com/NVIDIA/NemoClaw/actions/runs/32623009512), attempt 1, commit `ede33e2e4312b0db58103bbfb6ec89e598416577`
- Failed job: [OpenClaw Personal stock fetch](https://github.com/NVIDIA/NemoClaw/actions/runs/32623009512/job/97156591641), job `97156591641`
- Detection gap: the reduced evidence reported zero qualifying results but did not identify which existing predicate rejected them.
- Boundary: the behavioral root remains unresolved. A later automatic run that naturally reaches this target can use these counts for exact classification. This PR does not dispatch or retry live E2E.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The scoped review confirms that the projection derives only counts from existing booleans and that focused tests reject raw URL, response, quote, date, fingerprint, provider, tool, and credential values. The normal secret scan passed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `pass`
- Evidence: The reviewer found no remaining writing or data-safety issues. No public documentation or owning E2E guidance change is required because this is an additive internal evidence schema.
- Agent: Codex subagent `/root/documentation_writer_review` — independent documentation writer review
<!-- docs-review-head-sha: c5c34c3baf709b01d7093388ee7b21ac5849238e -->
<!-- docs-review-agents-blob-sha: 6b16b3280189af75653adf6f9bbe1d3444b618e5 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — bundled Node.js v24.19.0 ran `node node_modules/vitest/vitest.mjs run --project e2e-support test/e2e/support/common-egress-agent-helpers.test.ts`: 1 file and 56 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — Not applicable to this two-file evidence-projection change; the focused support test and normal hooks cover the changed boundary.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation coverage for web-fetch evidence, including aggregate result counts and individual success criteria.
  * Added checks for failed conditions and non-public targets.
  * Improved diagnostic validation to ensure sensitive stock data is not exposed while still reporting relevant aggregate counts.
* **Refactor**
  * Updated evidence reporting to provide clearer, criterion-level web-fetch result summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->