### PR TITLE
feat(advisor): publish specialist job summaries

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -293,7 +293,11 @@ jobs:
       - name: Publish job summary
         if: always()
         run: |
-          SUMMARY_PATH="$GITHUB_WORKSPACE/artifacts/$PR_REVIEW_ADVISOR_ARTIFACT_DIR/pr-review-advisor-summary.md"
+          if [ -n "$PR_REVIEW_ADVISOR_INTEREST" ]; then
+            SUMMARY_PATH="$GITHUB_WORKSPACE/artifacts/$PR_REVIEW_ADVISOR_ARTIFACT_DIR/pr-review-$PR_REVIEW_ADVISOR_INTEREST-summary.md"
+          else
+            SUMMARY_PATH="$GITHUB_WORKSPACE/artifacts/$PR_REVIEW_ADVISOR_ARTIFACT_DIR/pr-review-advisor-summary.md"
+          fi
           if [ -f "$SUMMARY_PATH" ]; then
             cat "$SUMMARY_PATH" >> "$GITHUB_STEP_SUMMARY"
           else

--- a/test/pr-review-advisor-specialists.test.ts
+++ b/test/pr-review-advisor-specialists.test.ts
@@ -9,7 +9,10 @@ import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, onTestFinished, vi } from "vitest";
 
 import { TERMINOLOGY_TRACE_TOOL } from "../tools/pr-review-advisor/terminology.mts";
-import { runSpecialistAdvisor } from "../tools/pr-review-advisor/run-specialist.mts";
+import {
+  runSpecialistAdvisor,
+  writeSpecialistSummary,
+} from "../tools/pr-review-advisor/run-specialist.mts";
 import type { RunAdvisorResult, RunReadOnlyAdvisorOptions } from "../tools/advisors/session.mts";
 import {
   ADVISOR_INTERESTS,
@@ -107,6 +110,22 @@ describe("PR review advisor specialist prompts", () => {
     const toolNames = results.map(({ toolName }) => toolName);
     expect(turn.requiredToolNames).toEqual(toolNames);
     expect(turn.requireToolsBeforeText).toEqual(toolNames);
+  });
+
+  it("writes the completed specialist analysis as Markdown", () => {
+    const directory = fs.mkdtempSync(path.join(process.cwd(), ".tmp-specialist-summary-"));
+    onTestFinished(() => fs.rmSync(directory, { recursive: true, force: true }));
+    const artifact = writeSpecialistSummary(
+      directory,
+      "design-architecture",
+      "## Findings\n\nConcrete reduction.",
+    );
+
+    const expected = fs.readFileSync(artifact, "utf8");
+    expect(path.basename(artifact)).toBe("pr-review-design-architecture-summary.md");
+    expect(expected).toContain("PR Review Advisor — Design / Architecture specialist");
+    expect(expected).toContain("The primary advisor remains authoritative.");
+    expect(expected).toContain("Concrete reduction.");
   });
 
   it("passes terminology tracing only to the documentation specialist runner (#9968)", async () => {

--- a/tools/pr-review-advisor/run-specialist.mts
+++ b/tools/pr-review-advisor/run-specialist.mts
@@ -50,6 +50,24 @@ export function documentationSpecialistTools(
     : [];
 }
 
+export function renderSpecialistSummary(interest: AdvisorInterest, text: string): string {
+  const title = interest
+    .split("-")
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join(" / ");
+  return `# PR Review Advisor — ${title} specialist\n\n> Evidence for synthesis and human review. The primary advisor remains authoritative.\n\n${text.trim()}\n`;
+}
+
+export function writeSpecialistSummary(
+  outDir: string,
+  interest: AdvisorInterest,
+  text: string,
+): string {
+  const file = path.join(outDir, `pr-review-${interest}-summary.md`);
+  fs.writeFileSync(file, renderSpecialistSummary(interest, text));
+  return file;
+}
+
 export function runSpecialistAdvisor(
   interest: AdvisorInterest,
   refs: { baseRef: string; headRef: string },
@@ -132,6 +150,7 @@ async function main(): Promise<void> {
   );
   const errors = advisorRunErrors(run);
   if (errors.length > 0) throw new Error(errors.join("; "));
+  writeSpecialistSummary(outDir, interest, run.text);
   if (!run.sessionFile) throw new Error("Pi did not persist a specialist JSONL session");
   const sessionStat = fs.lstatSync(run.sessionFile);
   if (!sessionStat.isFile() || sessionStat.isSymbolicLink()) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Show each completed PR Review Advisor specialist analysis in its GitHub Actions job summary so PR creators can read the evidence without opening native Pi JSONL traces.

## Changes

- Write the specialist's completed assistant text unchanged to a Markdown artifact with an explicit advisory label.
- Select that specialist Markdown file in the shared workflow job-summary step while preserving the existing broad-advisor summary path.
- Cover the Markdown artifact output and keep the existing specialist tool-boundary tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: 
- Station profile/scenario: 
- Result: 
- Supporting evidence: 

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — Normal pre-commit, commit-msg, and pre-push hooks passed.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: npx vitest run --project integration test/pr-review-advisor-specialists.test.ts test/pr-review-advisor-openshell-workflow-boundary.test.ts (22 tests passed); npm run typecheck:cli; npm run checks:repository
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Focused integration tests, typecheck, repository checks, and normal hooks passed; broad npm run check was not run.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Specialist review results are now saved as Markdown summaries with interest-specific filenames.
  * Published review artifacts automatically use the relevant specialist summary when a review interest is selected.
  * Default summary behavior remains unchanged when no specialist interest is configured.

* **Bug Fixes**
  * Improved consistency between specialist review results and the summaries made available after advisor runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->