### PR TITLE
fix(onboard): observe pending OpenClaw scope upgrade

### DIFF
--- a/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.test.ts
+++ b/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.test.ts
@@ -291,7 +291,7 @@ describe("OpenClaw launch-readiness pairing qualification", () => {
       expect(() => observeSettlement()).toThrow("OpenClaw pairing qualification is unavailable");
     });
 
-    it("allows unrelated pending requests but rejects same-device pending state during ordinary onboarding (#9844)", () => {
+    it("rejects unrelated or same-device pending requests during ordinary onboarding (#9844)", () => {
       writeJson(path.join(stateDirectory, "devices", "pending.json"), {
         unrelated: {
           requestId: "unrelated",
@@ -302,10 +302,9 @@ describe("OpenClaw launch-readiness pairing qualification", () => {
         },
       });
 
-      expect(observeOrdinarySettlement()).toEqual({
-        state: "settled",
-        deviceIdentitySha256: expect.stringMatching(/^[a-f0-9]{64}$/),
-      });
+      expect(() => observeOrdinarySettlement()).toThrow(
+        "OpenClaw pairing qualification is unavailable",
+      );
       expect(() => observeSettlement()).toThrow(
         "OpenClaw pairing qualification is unavailable",
       );
@@ -362,14 +361,10 @@ describe("OpenClaw launch-readiness pairing qualification", () => {
         },
         second: {
           requestId: "second",
-          deviceId,
-          publicKey,
-          clientId: "cli",
-          clientMode: "cli",
-          role: "operator",
-          roles: ["operator"],
-          scopes: ["operator.write"],
-          isRepair: true,
+          deviceId: "b".repeat(64),
+          publicKey: "unrelated-public-key",
+          clientId: "unknown-client",
+          scopes: ["operator.admin"],
         },
       });
       expect(() => observeOrdinarySettlement()).toThrow(

--- a/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.test.ts
+++ b/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.test.ts
@@ -324,6 +324,59 @@ describe("OpenClaw launch-readiness pairing qualification", () => {
       );
     });
 
+    it("observes pairing-only state while one canonical scope upgrade awaits approval (#9817)", () => {
+      writePairingOnlyState();
+      writeJson(path.join(stateDirectory, "devices", "pending.json"), {
+        "canonical-cli-write": {
+          requestId: "canonical-cli-write",
+          deviceId,
+          publicKey,
+          clientId: "cli",
+          clientMode: "cli",
+          role: "operator",
+          roles: ["operator"],
+          scopes: ["operator.write"],
+          isRepair: true,
+        },
+      });
+
+      expect(observeOrdinarySettlement()).toEqual({
+        state: "pairing-only",
+        deviceIdentitySha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      });
+      expect(() => observeSettlement()).toThrow(
+        "OpenClaw pairing qualification is unavailable",
+      );
+
+      writeJson(path.join(stateDirectory, "devices", "pending.json"), {
+        first: {
+          requestId: "first",
+          deviceId,
+          publicKey,
+          clientId: "cli",
+          clientMode: "cli",
+          role: "operator",
+          roles: ["operator"],
+          scopes: ["operator.write"],
+          isRepair: true,
+        },
+        second: {
+          requestId: "second",
+          deviceId,
+          publicKey,
+          clientId: "cli",
+          clientMode: "cli",
+          role: "operator",
+          roles: ["operator"],
+          scopes: ["operator.write"],
+          isRepair: true,
+        },
+      });
+      expect(() => observeOrdinarySettlement()).toThrow(
+        "OpenClaw pairing qualification is unavailable",
+      );
+    });
+
     it("qualifies the persisted result of the complete canonical approval transition (#9023)", () => {
       const approvalPolicy = readAutoPairApprovalPolicyModule();
       expect(approvalPolicy).toBeTruthy();

--- a/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.ts
+++ b/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.ts
@@ -478,6 +478,7 @@ try:
 
     if STRICT_SETTLEMENT and pending:
         reject()
+    ordinary_local_write_pending_ids = []
     for request_id, request in pending.items():
         if (
             not isinstance(request_id, str)
@@ -487,8 +488,36 @@ try:
         ):
             reject()
         if ORDINARY_SETTLEMENT:
-            if request.get('deviceId') == device_id or request.get('publicKey') == device_public_key:
-                sys.exit(2)
+            # The startup watcher can publish the canonical write transition
+            # before finalization observes the pairing-only device. Admit only
+            # that exact intermediate state so the owning controller can reach
+            # its one approval pass. Its final observation still requires the
+            # settled scopes and no same-device pending request.
+            matches_device = request.get('deviceId') == device_id
+            matches_public_key = request.get('publicKey') == device_public_key
+            if matches_device or matches_public_key:
+                decision = approval_request_decision(request)
+                request_scopes = request.get('scopes')
+                valid_write_scopes = (
+                    exact_string_set(request_scopes, ['operator.write'])
+                    or exact_string_set(request_scopes, REQUEST_SCOPES)
+                )
+                if (
+                    not matches_device
+                    or not matches_public_key
+                    or request.get('clientId') != 'cli'
+                    or request.get('clientMode') != 'cli'
+                    or request.get('role') != 'operator'
+                    or not exact_string_set(request.get('roles'), REQUIRED_ROLES)
+                    or 'requestedScopes' in request
+                    or 'publicKeyPem' in request
+                    or type(request.get('isRepair')) is not bool
+                    or not valid_write_scopes
+                    or not isinstance(decision, dict)
+                    or decision.get('allowed') is not True
+                ):
+                    reject()
+                ordinary_local_write_pending_ids.append(request_id)
             continue
         decision = approval_request_decision(request)
         if decision.get('reason') == 'malformed-scopes':
@@ -516,6 +545,9 @@ try:
         and exact_string_set(paired_operator.get('scopes'), PAIRING_ONLY_SCOPES)
         and exact_string_set(auth_operator.get('scopes'), PAIRING_ONLY_SCOPES)
     )
+    if ORDINARY_SETTLEMENT and ordinary_local_write_pending_ids:
+        if len(ordinary_local_write_pending_ids) != 1 or not pairing_only:
+            reject()
     if not settled and not pairing_only:
         reject()
 

--- a/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.ts
+++ b/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.ts
@@ -478,7 +478,6 @@ try:
 
     if STRICT_SETTLEMENT and pending:
         reject()
-    ordinary_local_write_pending_ids = []
     for request_id, request in pending.items():
         if (
             not isinstance(request_id, str)
@@ -493,31 +492,27 @@ try:
             # that exact intermediate state so the owning controller can reach
             # its one approval pass. Its final observation still requires the
             # settled scopes and no same-device pending request.
-            matches_device = request.get('deviceId') == device_id
-            matches_public_key = request.get('publicKey') == device_public_key
-            if matches_device or matches_public_key:
-                decision = approval_request_decision(request)
-                request_scopes = request.get('scopes')
-                valid_write_scopes = (
-                    exact_string_set(request_scopes, ['operator.write'])
-                    or exact_string_set(request_scopes, REQUEST_SCOPES)
-                )
-                if (
-                    not matches_device
-                    or not matches_public_key
-                    or request.get('clientId') != 'cli'
-                    or request.get('clientMode') != 'cli'
-                    or request.get('role') != 'operator'
-                    or not exact_string_set(request.get('roles'), REQUIRED_ROLES)
-                    or 'requestedScopes' in request
-                    or 'publicKeyPem' in request
-                    or type(request.get('isRepair')) is not bool
-                    or not valid_write_scopes
-                    or not isinstance(decision, dict)
-                    or decision.get('allowed') is not True
-                ):
-                    reject()
-                ordinary_local_write_pending_ids.append(request_id)
+            decision = approval_request_decision(request)
+            request_scopes = request.get('scopes')
+            valid_write_scopes = (
+                exact_string_set(request_scopes, ['operator.write'])
+                or exact_string_set(request_scopes, REQUEST_SCOPES)
+            )
+            if (
+                request.get('deviceId') != device_id
+                or request.get('publicKey') != device_public_key
+                or request.get('clientId') != 'cli'
+                or request.get('clientMode') != 'cli'
+                or request.get('role') != 'operator'
+                or not exact_string_set(request.get('roles'), REQUIRED_ROLES)
+                or 'requestedScopes' in request
+                or 'publicKeyPem' in request
+                or type(request.get('isRepair')) is not bool
+                or not valid_write_scopes
+                or not isinstance(decision, dict)
+                or decision.get('allowed') is not True
+            ):
+                reject()
             continue
         decision = approval_request_decision(request)
         if decision.get('reason') == 'malformed-scopes':
@@ -545,9 +540,8 @@ try:
         and exact_string_set(paired_operator.get('scopes'), PAIRING_ONLY_SCOPES)
         and exact_string_set(auth_operator.get('scopes'), PAIRING_ONLY_SCOPES)
     )
-    if ORDINARY_SETTLEMENT and ordinary_local_write_pending_ids:
-        if len(ordinary_local_write_pending_ids) != 1 or not pairing_only:
-            reject()
+    if ORDINARY_SETTLEMENT and pending and (len(pending) != 1 or not pairing_only):
+        reject()
     if not settled and not pairing_only:
         reject()
 

--- a/test/helpers/openclaw-real-device-self-approval-proof.ts
+++ b/test/helpers/openclaw-real-device-self-approval-proof.ts
@@ -14,6 +14,10 @@ import {
   readAutoPairApprovalPolicyModule,
 } from "../../src/lib/actions/sandbox/auto-pair-approval";
 import {
+  buildOpenClawPairingObservationScript,
+  parseOpenClawPairingSettlementObservation,
+} from "../../src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification";
+import {
   CONNECT_AUTO_PAIR_APPROVE_TIMEOUT_S,
   CONNECT_AUTO_PAIR_LIST_TIMEOUT_S,
   CONNECT_AUTO_PAIR_MAX_APPROVALS,
@@ -1151,7 +1155,7 @@ async function runLiveStoredDeviceAuthSelfApprovalProof(options: ProofOptions): 
   requireLiveProof(fs.existsSync(openclawEntry), "reviewed OpenClaw CLI entrypoint missing");
 
   const liveRoot = path.join(options.tmp, "device-approval-live-stored-auth");
-  const stateDir = path.join(liveRoot, "state");
+  const stateDirPath = path.join(liveRoot, "state");
   const primaryStateDir = path.join(liveRoot, "primary-state");
   const homeDir = path.join(liveRoot, "home");
   const proofBin = path.join(liveRoot, "bin");
@@ -1162,7 +1166,8 @@ async function runLiveStoredDeviceAuthSelfApprovalProof(options: ProofOptions): 
   const proofStoredAuthGuard = path.join(proofBin, "deny-primary-device-auth.cjs");
   const configPath = path.join(liveRoot, "openclaw.json");
   const gatewayLog = path.join(liveRoot, "gateway.log");
-  fs.mkdirSync(stateDir, { recursive: true });
+  fs.mkdirSync(stateDirPath, { recursive: true });
+  const stateDir = fs.realpathSync(stateDirPath);
   fs.mkdirSync(homeDir, { recursive: true });
   fs.mkdirSync(proofBin, { recursive: true });
   fs.writeFileSync(
@@ -1237,6 +1242,22 @@ fs.statSync = function nemoclawProofStatSync(candidate, ...args) {
   );
   const approvalPolicy = readAutoPairApprovalPolicyModule();
   requireLiveProof(approvalPolicy, "restored-clone approval policy module missing");
+  const observeOrdinaryPairing = () => {
+    const observation = spawnSync("sh", ["-s"], {
+      encoding: "utf8",
+      env,
+      input: buildOpenClawPairingObservationScript(
+        Buffer.from(approvalPolicy, "utf8").toString("base64"),
+        stateDir,
+        "ordinary-settlement",
+      ),
+      timeout: Math.min(options.timeoutMs, 60_000),
+    });
+    requireSuccess(observation, "observe real ordinary pairing settlement");
+    const parsed = parseOpenClawPairingSettlementObservation(observation.stdout ?? "");
+    requireLiveProof(parsed, "real ordinary pairing settlement returned no observation");
+    return parsed;
+  };
   const pairedTokenApprovalScript = buildAutoPairApprovalScript(
     Buffer.from(approvalPolicy, "utf8").toString("base64"),
     {
@@ -1570,6 +1591,12 @@ fs.statSync = function nemoclawProofStatSync(candidate, ...args) {
       String(identity.deviceId),
       "pending pairing settlement list",
     );
+    proofPhase = "ordinary-settlement-observation-before-approval";
+    const pairingOnlyObservation = observeOrdinaryPairing();
+    requireLiveProof(
+      pairingOnlyObservation.state === "pairing-only",
+      "ordinary settlement did not observe pairing-only state before canonical approval",
+    );
     const pendingBeforeOrdinaryApproval = fs.readFileSync(pendingPath, "utf8");
     const pairedBeforeOrdinaryApproval = fs.readFileSync(pairedPath, "utf8");
     const authBeforeOrdinaryApproval = fs.readFileSync(deviceAuthPath, "utf8");
@@ -1628,6 +1655,13 @@ fs.statSync = function nemoclawProofStatSync(candidate, ...args) {
       ordinaryAuthOperator.scopes,
       ["operator.pairing", "operator.read", "operator.write"],
       "ordinary stored-device approval auth scopes",
+    );
+    proofPhase = "ordinary-settlement-observation-after-approval";
+    const settledObservation = observeOrdinaryPairing();
+    requireLiveProof(
+      settledObservation.state === "settled" &&
+        settledObservation.deviceIdentitySha256 === pairingOnlyObservation.deviceIdentitySha256,
+      "ordinary settlement did not preserve the canonical device through scope approval",
     );
     proofPhase = "ordinary-stored-device-approval-output";
     const ordinaryApprovalOutput = `${String(ordinaryApproval.stdout ?? "")}\n${String(ordinaryApproval.stderr ?? "")}`;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Fresh default-profile OpenClaw onboarding can observe its canonical CLI device's legitimate write-scope transition before the first device-state read. Treat that one exact transition as pairing-only state so the existing bounded controller reaches its single approval pass; completion still requires the matching canonical device, baseline scopes, and no same-device pending request.

## Related Issue

Fixes #9817

## Changes

- Recognize one validated same-device local CLI write-scope transition during ordinary pairing observation.
- Reject multiple transitions, noncanonical identities or scopes, and any settled state that still has a pending request; keep Portable's strict no-pending observation unchanged.
- Extend the pinned OpenClaw 2026.7.1 runtime proof to observe the real transition before approval and the persisted settled state after approval.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The transition must match the canonical device ID and public key, CLI client identity, operator role, exact local write-scope request, and approval policy. Credential validation, descriptor-pinned reads, settled-state scope requirements, secret-free diagnostics, and Portable's strict no-pending rule remain unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 93 focused pairing/controller tests passed; the pinned OpenClaw 2026.7.1 runtime harness passed 6/6; `npm run typecheck:cli`, `npm run checks:repository`, and the 32-test growth guardrail passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; the change is limited to one observer transition and its existing pinned-runtime proof, which the focused suites exercise.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved device pairing qualification during approval workflows.
  * Valid same-device pairing requests can now proceed through the intermediate `pairing-only` state and settle successfully.
  * Device identity is preserved and verified throughout the pairing process.

* **Bug Fixes**
  * Invalid, unrelated, ambiguous, or multiple simultaneous pairing requests are now rejected.
  * Strict settlement continues to prevent incomplete pairing states from being treated as fully settled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->