### PR TITLE
fix(test): realpath fixture temp dir for llama.cpp private bridge credential test

### DIFF
--- a/src/lib/onboard/runtime-provider/docker-llama-cpp-private-bridge.test.ts
+++ b/src/lib/onboard/runtime-provider/docker-llama-cpp-private-bridge.test.ts
@@ -95,7 +95,13 @@ function privateCredentialFile(
   readonly directory: string;
   readonly file: string;
 } {
-  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-llama-bridge-key-"));
+  // defaultOpenApiKeyDescriptor() rejects a credential path that differs from
+  // its own realpath (anti symlink-swap check). os.tmpdir() resolves through
+  // a symlinked ancestor on macOS (/var -> /private/var), so realpath the
+  // created directory before building fixture paths on top of it.
+  const directory = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-llama-bridge-key-")),
+  );
   const file = path.join(directory, "api-key");
   fs.writeFileSync(file, "a".repeat(size), { mode });
   fs.chmodSync(file, mode);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
`defaultOpenApiKeyDescriptor()` in `docker-llama-cpp-private-bridge.ts` rejects an API-key path whose `fs.realpathSync()` differs from the path itself, as an anti symlink-swap check. The private-bridge credential test built its fixture directory directly on `os.tmpdir()`, which resolves through a symlinked ancestor on macOS (`/var` -> `/private/var`), so the 64- and 65-byte valid-credential test cases failed on macOS even though the underlying code and the credential file were both correct. This realpaths the fixture's temp directory before building paths on top of it, so the test exercises the real code path instead of tripping on a macOS-only ancestor symlink.

## Related Issue
Fixes #10009

## Changes
- `src/lib/onboard/runtime-provider/docker-llama-cpp-private-bridge.test.ts`: realpath the `mkdtempSync()` result in `privateCredentialFile()`'s directory helper before joining fixture file paths under it.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: this fixes the existing `it.each([64, 65])` credential-size test cases in `docker-llama-cpp-private-bridge.test.ts`; no new behavior is added, so no new test is needed.
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/onboard/runtime-provider/docker-llama-cpp-private-bridge.test.ts` — 16 passed (16), 0 failed (2 of the 16 failed on macOS before this change)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aditya Jain <adityaj0714@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential file path resolution to consistently use canonical temporary-directory paths.
  * Fixed path matching in relevant setup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
