### PR TITLE
feat(tools): add E2E investigation catalog

### DIFF
--- a/.dsh/tools/README.md
+++ b/.dsh/tools/README.md
@@ -37,6 +37,10 @@ const range = await tools.git_tested_commit_range({
   recentSha: diff.recent.headSha,
 })
 
+if (!range.ancestor) {
+  throw new Error("The tested commit range diverges and cannot be correlated")
+}
+
 const failures = []
 for (const job of diff.newlyFailing) {
   const evidence = await tools.github_actions_failure_evidence({
@@ -56,11 +60,26 @@ const correlation = await tools.e2e_root_cause_correlator({
   failures,
   changedFiles: range.changedFiles,
 })
+
+const report = await tools.e2e_investigation_report({
+  repository: "NVIDIA/NemoClaw",
+  earlier: diff.earlier,
+  recent: diff.recent,
+  range: {
+    ancestor: range.ancestor,
+    commitsTruncated: range.commitsTruncated,
+    filesTruncated: range.filesTruncated,
+  },
+  commits: range.commits,
+  groups: correlation.groups,
+})
 ```
 
 Add `relevantPaths` to each failure before correlation when repository knowledge
 identifies the owning source paths. Without those paths, a no-overlap result has
 low confidence.
+The report marks the investigation as incomplete when the commit or changed-file list is truncated.
+Do not claim causal completeness or absence of path overlap from a truncated range.
 
 ## Trust boundaries
 

--- a/.dsh/tools/README.md
+++ b/.dsh/tools/README.md
@@ -1,0 +1,81 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# E2E Investigation Tools
+
+These project-scoped DSH tools separate evidence collection from causal analysis.
+Each directory contains the authoritative source-first `index.ts` definition that
+`dsh-tool-authoring` loads.
+
+## Pattern
+
+1. `github_actions_run_summary` normalizes one run and its jobs.
+2. `github_actions_run_diff` compares two runs by exact job name.
+3. `github_actions_failure_evidence` extracts bounded, redacted log signatures.
+4. `git_tested_commit_range` lists commits and files between tested revisions.
+5. `e2e_root_cause_correlator` groups shared signatures and checks relevant path overlap.
+6. `e2e_investigation_report` renders proven facts, supported hypotheses, missing evidence, and next steps.
+
+The first four tools collect deterministic evidence. The correlator provides a
+bounded first classification, not a final causal judgment. An agent must review
+the evidence before it adds `proven`, `hypothesis`, `notVerified`, and
+`nextSteps` fields to the report input.
+
+## Example sequence
+
+```ts
+const diff = await tools.github_actions_run_diff({
+  workdir: "/path/to/NemoClaw",
+  repository: "NVIDIA/NemoClaw",
+  earlierRunId: 32500184982,
+  recentRunId: 32523257489,
+})
+
+const range = await tools.git_tested_commit_range({
+  workdir: "/path/to/NemoClaw",
+  earlierSha: diff.earlier.headSha,
+  recentSha: diff.recent.headSha,
+})
+
+const failures = []
+for (const job of diff.newlyFailing) {
+  const evidence = await tools.github_actions_failure_evidence({
+    workdir: "/path/to/NemoClaw",
+    repository: "NVIDIA/NemoClaw",
+    runId: diff.recent.id,
+    jobId: job.recentJobId,
+  })
+  failures.push({
+    jobName: job.name,
+    jobId: job.recentJobId,
+    signatureLines: evidence.signatureLines,
+  })
+}
+
+const correlation = await tools.e2e_root_cause_correlator({
+  failures,
+  changedFiles: range.changedFiles,
+})
+```
+
+Add `relevantPaths` to each failure before correlation when repository knowledge
+identifies the owning source paths. Without those paths, a no-overlap result has
+low confidence.
+
+## Trust boundaries
+
+- The tools use authenticated `gh` and local `git`; they make no GitHub writes.
+- Job logs are untrusted input. The evidence tool returns bounded excerpts and
+  redacts common credential forms.
+- The tools do not download artifacts. Artifact collection needs a separate
+  design because it must create a mode-0700 temporary directory, validate exact
+  run identity, redact retained evidence, and verify directory removal.
+- Exact job-name comparison is intentional. A future stable target-identity
+  resolver must use repository-owned matrix metadata rather than fuzzy matching.
+
+## Activation
+
+The Web profile must include the `dsh-tool-authoring` bundle. Restart the DSH Web
+process after changing the profile so the server registers `tool_define`,
+`tool_list`, `tool_remove`, `tool_promote`, and the project tools. Starting a
+second Web server does not update the existing GUI.

--- a/.dsh/tools/e2e_investigation_report/index.ts
+++ b/.dsh/tools/e2e_investigation_report/index.ts
@@ -1,10 +1,11 @@
 /**
- * Render a concise Markdown report from a structured two-run E2E investigation.
+ * Render a bounded Markdown report from a structured two-run E2E investigation.
  */
 export default async function e2e_investigation_report(input: {
   repository: string;
   earlier: { id: Integer; headSha: string; url: string };
   recent: { id: Integer; headSha: string; url: string };
+  range: { ancestor: boolean; commitsTruncated: boolean; filesTruncated: boolean };
   commits: Array<{ sha: string; subject: string }>;
   groups: Array<{
     key: string;
@@ -19,40 +20,171 @@ export default async function e2e_investigation_report(input: {
     nextSteps?: string[];
   }>;
 }): Promise<{ markdown: string }> {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(input.repository))
+    throw new Error("repository must have owner/name form");
+  if (
+    !input.range ||
+    typeof input.range.ancestor !== "boolean" ||
+    typeof input.range.commitsTruncated !== "boolean" ||
+    typeof input.range.filesTruncated !== "boolean"
+  )
+    throw new Error("range must contain ancestry and truncation state");
+  if (!Array.isArray(input.commits) || input.commits.length > 1000)
+    throw new Error("commits must contain at most 1000 items");
+  if (!Array.isArray(input.groups) || input.groups.length > 100)
+    throw new Error("groups must contain at most 100 items");
+  let inputCharacters = input.repository.length;
+  const validateLine = (value: unknown, maximum: number, field: string) => {
+    if (typeof value !== "string" || value.length > maximum || /[\r\n]/u.test(value))
+      throw new Error(`${field} must be a bounded single-line string`);
+    inputCharacters += value.length;
+  };
+  const validateRun = (run: typeof input.earlier, field: string) => {
+    if (
+      !run ||
+      !Number.isSafeInteger(run.id) ||
+      run.id < 1 ||
+      typeof run.headSha !== "string" ||
+      !/^[a-f0-9]{40}(?:[a-f0-9]{24})?$/u.test(run.headSha) ||
+      typeof run.url !== "string" ||
+      run.url.length > 2000
+    )
+      throw new Error(`${field} must contain a bounded GitHub Actions run`);
+    let url: URL;
+    try {
+      url = new URL(run.url);
+    } catch {
+      throw new Error(`${field}.url must be a valid URL`);
+    }
+    if (
+      url.origin !== "https://github.com" ||
+      url.username ||
+      url.password ||
+      url.pathname !== `/${input.repository}/actions/runs/${run.id}` ||
+      url.search ||
+      url.hash ||
+      run.url !== `${url.origin}${url.pathname}`
+    )
+      throw new Error(`${field}.url must identify the supplied GitHub Actions run`);
+    inputCharacters += run.headSha.length + run.url.length;
+  };
+  validateRun(input.earlier, "earlier");
+  validateRun(input.recent, "recent");
+  for (const commit of input.commits) {
+    if (
+      !commit ||
+      typeof commit.sha !== "string" ||
+      !/^[a-f0-9]{40}(?:[a-f0-9]{24})?$/u.test(commit.sha)
+    )
+      throw new Error("commits must contain full hexadecimal commit SHAs");
+    validateLine(commit.subject, 1000, "commit subject");
+    inputCharacters += commit.sha.length;
+  }
+  for (const group of input.groups) {
+    if (!group || typeof group !== "object") throw new Error("groups must contain objects");
+    validateLine(group.key, 500, "group key");
+    validateLine(group.classification, 100, "group classification");
+    validateLine(group.confidence, 100, "group confidence");
+    if (!Array.isArray(group.jobs) || group.jobs.length > 100)
+      throw new Error("group jobs must contain at most 100 items");
+    if (!Array.isArray(group.matchedChangedFiles) || group.matchedChangedFiles.length > 2000)
+      throw new Error("matchedChangedFiles must contain at most 2000 items");
+    if (!Array.isArray(group.evidence) || group.evidence.length > 24)
+      throw new Error("group evidence must contain at most 24 items");
+    for (const job of group.jobs) {
+      if (!job || !Number.isSafeInteger(job.jobId) || job.jobId < 1)
+        throw new Error("group jobs must contain positive job IDs");
+      validateLine(job.jobName, 500, "job name");
+    }
+    for (const file of group.matchedChangedFiles) validateLine(file, 1000, "matched changed file");
+    for (const evidence of group.evidence) validateLine(evidence, 4000, "evidence line");
+    const sections: Array<[string, string[] | undefined]> = [
+      ["proven", group.proven],
+      ["hypothesis", group.hypothesis],
+      ["notVerified", group.notVerified],
+      ["nextSteps", group.nextSteps],
+    ];
+    for (const [field, items] of sections) {
+      if (items !== undefined && (!Array.isArray(items) || items.length > 100))
+        throw new Error(`${field} must contain at most 100 items`);
+      for (const item of items ?? []) validateLine(item, 2000, field);
+    }
+  }
+  if (inputCharacters > 400000) throw new Error("report input exceeds 400000 code units");
+  const markdownText = (value: string) =>
+    value
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replace(/([\\`*_{}\[\]()+#\-.!|~])/gu, "\\$1");
+  const inlineCode = (value: string) => {
+    const longest = Math.max(0, ...(value.match(/`+/gu) ?? []).map((item) => item.length));
+    const delimiter = "`".repeat(longest + 1);
+    const content = value.startsWith("`") || value.endsWith("`") ? ` ${value} ` : value;
+    return `${delimiter}${content}${delimiter}`;
+  };
   const lines: string[] = [];
   lines.push("# E2E Run Comparison", "");
-  lines.push(`Repository: \`${input.repository}\``);
+  lines.push(`Repository: ${inlineCode(input.repository)}`);
   lines.push(
-    `Earlier: [run ${input.earlier.id}](${input.earlier.url}) at \`${input.earlier.headSha}\``,
+    `Earlier: [run ${input.earlier.id}](${input.earlier.url}) at ${inlineCode(input.earlier.headSha)}`,
   );
   lines.push(
-    `Recent: [run ${input.recent.id}](${input.recent.url}) at \`${input.recent.headSha}\``,
+    `Recent: [run ${input.recent.id}](${input.recent.url}) at ${inlineCode(input.recent.headSha)}`,
   );
-  lines.push("", "## Commits between runs", "");
+  lines.push("", "## Investigation Status", "");
+  const limitations = [
+    ...(!input.range.ancestor
+      ? ["The earlier tested commit is not an ancestor of the recent tested commit."]
+      : []),
+    ...(input.range.commitsTruncated ? ["The commit list is truncated."] : []),
+    ...(input.range.filesTruncated ? ["The changed-file list is truncated."] : []),
+  ];
+  if (limitations.length === 0) lines.push("The tested commit range is complete.");
+  else lines.push("The investigation is incomplete.", ...limitations.map((item) => `- ${item}`));
+  lines.push("", "## Commits Between Runs", "");
   if (input.commits.length === 0) lines.push("No commits were found between the tested commits.");
   else
     for (const commit of input.commits)
-      lines.push(`- \`${commit.sha.slice(0, 12)}\` ${commit.subject}`);
-  lines.push("", "## Root-cause groups", "");
+      lines.push(`- ${inlineCode(commit.sha.slice(0, 12))} ${markdownText(commit.subject)}`);
+  lines.push("", "## Root-Cause Groups", "");
   for (const group of input.groups) {
-    lines.push(`### ${group.key}`, "");
-    lines.push(`- Classification: \`${group.classification}\``);
-    lines.push(`- Confidence: \`${group.confidence}\``);
-    lines.push(`- Jobs: ${group.jobs.map((job) => `${job.jobName} (${job.jobId})`).join(", ")}`);
+    lines.push(`### ${markdownText(group.key)}`, "");
+    lines.push(`- Classification: ${inlineCode(group.classification)}`);
+    lines.push(`- Confidence: ${inlineCode(group.confidence)}`);
     lines.push(
-      `- Changed files matched: ${group.matchedChangedFiles.length === 0 ? "none" : group.matchedChangedFiles.map((file) => `\`${file}\``).join(", ")}`,
+      `- Jobs: ${group.jobs.map((job) => `${markdownText(job.jobName)} (${job.jobId})`).join(", ")}`,
+    );
+    lines.push(
+      `- Changed files matched: ${group.matchedChangedFiles.length === 0 ? "none" : group.matchedChangedFiles.map(inlineCode).join(", ")}`,
     );
     if (group.proven?.length)
-      lines.push("", "**Proven**", ...group.proven.map((item) => `- ${item}`));
+      lines.push("", "**Proven**", ...group.proven.map((item) => `- ${markdownText(item)}`));
     if (group.hypothesis?.length)
-      lines.push("", "**Supported hypothesis**", ...group.hypothesis.map((item) => `- ${item}`));
+      lines.push(
+        "",
+        "**Supported hypothesis**",
+        ...group.hypothesis.map((item) => `- ${markdownText(item)}`),
+      );
     if (group.notVerified?.length)
-      lines.push("", "**Not yet verified**", ...group.notVerified.map((item) => `- ${item}`));
-    if (group.evidence.length)
-      lines.push("", "**Evidence excerpts**", "```text", ...group.evidence.slice(0, 12), "```");
+      lines.push(
+        "",
+        "**Not yet verified**",
+        ...group.notVerified.map((item) => `- ${markdownText(item)}`),
+      );
+    if (group.evidence.length) {
+      const longest = Math.max(
+        0,
+        ...group.evidence.flatMap((item) => (item.match(/`+/gu) ?? []).map((run) => run.length)),
+      );
+      const fence = "`".repeat(Math.max(3, longest + 1));
+      lines.push("", "**Evidence excerpts**", `${fence}text`, ...group.evidence, fence);
+    }
     if (group.nextSteps?.length)
-      lines.push("", "**Next steps**", ...group.nextSteps.map((item) => `- ${item}`));
+      lines.push("", "**Next steps**", ...group.nextSteps.map((item) => `- ${markdownText(item)}`));
     lines.push("");
   }
-  return { markdown: lines.join("\n") };
+  const markdown = lines.join("\n");
+  if (markdown.length > 400000) throw new Error("report output exceeds 400000 code units");
+  return { markdown };
 }

--- a/.dsh/tools/e2e_investigation_report/index.ts
+++ b/.dsh/tools/e2e_investigation_report/index.ts
@@ -1,0 +1,58 @@
+/**
+ * Render a concise Markdown report from a structured two-run E2E investigation.
+ */
+export default async function e2e_investigation_report(input: {
+  repository: string;
+  earlier: { id: Integer; headSha: string; url: string };
+  recent: { id: Integer; headSha: string; url: string };
+  commits: Array<{ sha: string; subject: string }>;
+  groups: Array<{
+    key: string;
+    jobs: Array<{ jobName: string; jobId: Integer }>;
+    classification: string;
+    matchedChangedFiles: string[];
+    evidence: string[];
+    confidence: string;
+    proven?: string[];
+    hypothesis?: string[];
+    notVerified?: string[];
+    nextSteps?: string[];
+  }>;
+}): Promise<{ markdown: string }> {
+  const lines: string[] = [];
+  lines.push("# E2E Run Comparison", "");
+  lines.push(`Repository: \`${input.repository}\``);
+  lines.push(
+    `Earlier: [run ${input.earlier.id}](${input.earlier.url}) at \`${input.earlier.headSha}\``,
+  );
+  lines.push(
+    `Recent: [run ${input.recent.id}](${input.recent.url}) at \`${input.recent.headSha}\``,
+  );
+  lines.push("", "## Commits between runs", "");
+  if (input.commits.length === 0) lines.push("No commits were found between the tested commits.");
+  else
+    for (const commit of input.commits)
+      lines.push(`- \`${commit.sha.slice(0, 12)}\` ${commit.subject}`);
+  lines.push("", "## Root-cause groups", "");
+  for (const group of input.groups) {
+    lines.push(`### ${group.key}`, "");
+    lines.push(`- Classification: \`${group.classification}\``);
+    lines.push(`- Confidence: \`${group.confidence}\``);
+    lines.push(`- Jobs: ${group.jobs.map((job) => `${job.jobName} (${job.jobId})`).join(", ")}`);
+    lines.push(
+      `- Changed files matched: ${group.matchedChangedFiles.length === 0 ? "none" : group.matchedChangedFiles.map((file) => `\`${file}\``).join(", ")}`,
+    );
+    if (group.proven?.length)
+      lines.push("", "**Proven**", ...group.proven.map((item) => `- ${item}`));
+    if (group.hypothesis?.length)
+      lines.push("", "**Supported hypothesis**", ...group.hypothesis.map((item) => `- ${item}`));
+    if (group.notVerified?.length)
+      lines.push("", "**Not yet verified**", ...group.notVerified.map((item) => `- ${item}`));
+    if (group.evidence.length)
+      lines.push("", "**Evidence excerpts**", "```text", ...group.evidence.slice(0, 12), "```");
+    if (group.nextSteps?.length)
+      lines.push("", "**Next steps**", ...group.nextSteps.map((item) => `- ${item}`));
+    lines.push("");
+  }
+  return { markdown: lines.join("\n") };
+}

--- a/.dsh/tools/e2e_root_cause_correlator/index.ts
+++ b/.dsh/tools/e2e_root_cause_correlator/index.ts
@@ -1,0 +1,83 @@
+/**
+ * Group E2E failures by stable signature and correlate them with changed files.
+ */
+export default async function e2e_root_cause_correlator(input: {
+  failures: Array<{
+    jobName: string;
+    jobId: Integer;
+    signatureLines: string[];
+    relevantPaths?: string[];
+  }>;
+  changedFiles: string[];
+}): Promise<{
+  groups: Array<{
+    key: string;
+    jobs: Array<{ jobName: string; jobId: Integer }>;
+    classification:
+      | "source-change-candidate"
+      | "no-relevant-source-change"
+      | "external-or-transient-candidate";
+    matchedChangedFiles: string[];
+    evidence: string[];
+    confidence: "high" | "medium" | "low";
+  }>;
+}> {
+  const signatureKey = (lines: string[]) => {
+    const text = lines.join(" ").toLowerCase();
+    if (text.includes("failedstage=publication") || text.includes("launch-readiness evidence"))
+      return "launch-readiness/publication/evidence-failed";
+    if (text.includes("sandbox_phase=deleting") || text.includes("sandbox in deleting"))
+      return "openshell/lifecycle/sandbox-deleting";
+    if (
+      text.includes("reviewed npm audit") ||
+      text.includes("unaccepted at or above high") ||
+      text.includes("advisory")
+    )
+      return "dependency-audit/unaccepted-advisory";
+    if (text.includes("timed out") || text.includes("timeout"))
+      return "runtime/timeout/unclassified";
+    const first =
+      lines.find((line) => /error|failed|failure/i.test(line)) ?? "unclassified failure";
+    return first
+      .replace(/\x1b\[[0-9;]*m/g, "")
+      .replace(/[a-f0-9]{40}/gi, "<sha>")
+      .replace(/\d+/g, "<n>")
+      .slice(0, 120)
+      .toLowerCase();
+  };
+  const byKey = new Map<string, any[]>();
+  for (const failure of input.failures) {
+    const key = signatureKey(failure.signatureLines);
+    const group = byKey.get(key) ?? [];
+    group.push(failure);
+    byKey.set(key, group);
+  }
+  const groups: any[] = [];
+  for (const [key, failures] of byKey) {
+    const relevant = new Set<string>();
+    for (const failure of failures)
+      for (const path of failure.relevantPaths ?? []) relevant.add(path);
+    const matched = input.changedFiles.filter((file) =>
+      [...relevant].some(
+        (path) => file === path || file.startsWith(`${path}/`) || path.startsWith(`${file}/`),
+      ),
+    );
+    const externalSignature = key.includes("dependency-audit") || key.includes("sandbox-deleting");
+    const classification =
+      matched.length > 0
+        ? "source-change-candidate"
+        : externalSignature
+          ? "external-or-transient-candidate"
+          : "no-relevant-source-change";
+    groups.push({
+      key,
+      jobs: failures.map((failure) => ({ jobName: failure.jobName, jobId: failure.jobId })),
+      classification,
+      matchedChangedFiles: matched,
+      evidence: failures.flatMap((failure) => failure.signatureLines.slice(0, 8)).slice(0, 24),
+      confidence:
+        matched.length > 0 || failures.length > 1 ? "high" : relevant.size > 0 ? "medium" : "low",
+    });
+  }
+  return { groups };
+}

--- a/.dsh/tools/e2e_root_cause_correlator/index.ts
+++ b/.dsh/tools/e2e_root_cause_correlator/index.ts
@@ -22,6 +22,54 @@ export default async function e2e_root_cause_correlator(input: {
     confidence: "high" | "medium" | "low";
   }>;
 }> {
+  if (!Array.isArray(input.failures) || input.failures.length > 100)
+    throw new Error("failures must contain at most 100 items");
+  if (!Array.isArray(input.changedFiles) || input.changedFiles.length > 2000)
+    throw new Error("changedFiles must contain at most 2000 items");
+  let inputCharacters = 0;
+  let relevantPathCount = 0;
+  for (const file of input.changedFiles) {
+    if (typeof file !== "string" || file.length === 0 || file.length > 1000 || /[\r\n]/u.test(file))
+      throw new Error("changedFiles must contain bounded single-line paths");
+    inputCharacters += file.length;
+  }
+  for (const failure of input.failures) {
+    if (
+      !failure ||
+      typeof failure.jobName !== "string" ||
+      failure.jobName.length === 0 ||
+      failure.jobName.length > 500 ||
+      /[\r\n]/u.test(failure.jobName) ||
+      !Number.isSafeInteger(failure.jobId) ||
+      failure.jobId < 1
+    )
+      throw new Error("failures must contain bounded job identities");
+    if (!Array.isArray(failure.signatureLines) || failure.signatureLines.length > 300)
+      throw new Error("signatureLines must contain at most 300 items");
+    if (failure.relevantPaths !== undefined && !Array.isArray(failure.relevantPaths))
+      throw new Error("relevantPaths must be an array");
+    const relevantPaths = failure.relevantPaths ?? [];
+    if (relevantPaths.length > 100) throw new Error("relevantPaths must contain at most 100 items");
+    relevantPathCount += relevantPaths.length;
+    inputCharacters += failure.jobName.length;
+    for (const line of failure.signatureLines) {
+      if (typeof line !== "string" || line.length > 4000 || /[\r\n]/u.test(line))
+        throw new Error("signatureLines must contain bounded single-line strings");
+      inputCharacters += line.length;
+    }
+    for (const path of relevantPaths) {
+      if (
+        typeof path !== "string" ||
+        path.length === 0 ||
+        path.length > 1000 ||
+        /[\r\n]/u.test(path)
+      )
+        throw new Error("relevantPaths must contain bounded single-line paths");
+      inputCharacters += path.length;
+    }
+  }
+  if (relevantPathCount > 2000) throw new Error("relevantPaths exceed the total item bound");
+  if (inputCharacters > 400000) throw new Error("correlation input exceeds 400000 code units");
   const signatureKey = (lines: string[]) => {
     const text = lines.join(" ").toLowerCase();
     if (text.includes("failedstage=publication") || text.includes("launch-readiness evidence"))
@@ -57,8 +105,9 @@ export default async function e2e_root_cause_correlator(input: {
     const relevant = new Set<string>();
     for (const failure of failures)
       for (const path of failure.relevantPaths ?? []) relevant.add(path);
+    const relevantPaths = [...relevant];
     const matched = input.changedFiles.filter((file) =>
-      [...relevant].some(
+      relevantPaths.some(
         (path) => file === path || file.startsWith(`${path}/`) || path.startsWith(`${file}/`),
       ),
     );
@@ -79,5 +128,8 @@ export default async function e2e_root_cause_correlator(input: {
         matched.length > 0 || failures.length > 1 ? "high" : relevant.size > 0 ? "medium" : "low",
     });
   }
-  return { groups };
+  const output = { groups };
+  if (JSON.stringify(output).length > 400000)
+    throw new Error("correlation output exceeds 400000 code units");
+  return output;
 }

--- a/.dsh/tools/git_tested_commit_range/index.ts
+++ b/.dsh/tools/git_tested_commit_range/index.ts
@@ -31,7 +31,7 @@ export default async function git_tested_commit_range(input: {
       "printf '%s\\n' __COMMITS__",
       `git log --format='%H%x09%s' --reverse --max-count=${maximumCommits + 1} '${input.earlierSha}..${input.recentSha}'`,
       "printf '%s\\n' __FILES__",
-      `git diff --name-only --diff-filter=ACDMRTUXB '${input.earlierSha}..${input.recentSha}' | head -n ${maximumFiles + 1}`,
+      `git diff --name-only --diff-filter=ACDMRTUXB '${input.earlierSha}..${input.recentSha}' | sed -n '1,${maximumFiles + 1}p'`,
     ].join("; "),
     workdir: input.workdir,
     description: "Summarize tested Git commit range",

--- a/.dsh/tools/git_tested_commit_range/index.ts
+++ b/.dsh/tools/git_tested_commit_range/index.ts
@@ -1,0 +1,74 @@
+/**
+ * Summarize bounded commits and changed files between two tested Git commits in one checkout.
+ */
+export default async function git_tested_commit_range(input: {
+  workdir: string;
+  earlierSha: string;
+  recentSha: string;
+  maximumCommits?: Integer;
+  maximumFiles?: Integer;
+}): Promise<{
+  earlierSha: string;
+  recentSha: string;
+  ancestor: boolean;
+  commits: Array<{ sha: string; subject: string }>;
+  changedFiles: string[];
+  commitsTruncated: boolean;
+  filesTruncated: boolean;
+}> {
+  const validSha = (value: string) => /^(?:[a-f0-9]{40}|[a-f0-9]{64})$/u.test(value);
+  if (!validSha(input.earlierSha) || !validSha(input.recentSha))
+    throw new Error("commit references must be full hexadecimal Git object IDs");
+  const maximumCommits = Math.max(1, Math.min(input.maximumCommits ?? 200, 1000));
+  const maximumFiles = Math.max(1, Math.min(input.maximumFiles ?? 500, 2000));
+  const result = await tools.bash({
+    command: [
+      "set -euo pipefail",
+      `git cat-file -e '${input.earlierSha}^{commit}'`,
+      `git cat-file -e '${input.recentSha}^{commit}'`,
+      "printf '%s\\n' __ANCESTOR__",
+      `if git merge-base --is-ancestor '${input.earlierSha}' '${input.recentSha}'; then echo yes; else echo no; fi`,
+      "printf '%s\\n' __COMMITS__",
+      `git log --format='%H%x09%s' --reverse --max-count=${maximumCommits + 1} '${input.earlierSha}..${input.recentSha}'`,
+      "printf '%s\\n' __FILES__",
+      `git diff --name-only --diff-filter=ACDMRTUXB '${input.earlierSha}..${input.recentSha}' | head -n ${maximumFiles + 1}`,
+    ].join("; "),
+    workdir: input.workdir,
+    description: "Summarize tested Git commit range",
+    timeoutMs: 120000,
+  });
+  if (result.kind !== "foreground")
+    throw new Error("Git range inspection did not return in the foreground");
+  if (
+    result.exitCode !== 0 ||
+    result.timedOut ||
+    result.aborted ||
+    result.signal !== null ||
+    result.sandbox?.denied
+  )
+    throw new Error("Git range inspection failed");
+  if (result.stdout.truncated || result.stderr.truncated)
+    throw new Error("Git range inspection exceeded bounded process output");
+  const lines = result.stdout.text.split("\n");
+  const ancestorIndex = lines.indexOf("__ANCESTOR__");
+  const commitsIndex = lines.indexOf("__COMMITS__");
+  const filesIndex = lines.indexOf("__FILES__");
+  if (ancestorIndex < 0 || commitsIndex < 0 || filesIndex < 0)
+    throw new Error("Git range output is incomplete");
+  const commitLines = lines.slice(commitsIndex + 1, filesIndex).filter(Boolean);
+  const fileLines = lines.slice(filesIndex + 1).filter(Boolean);
+  const commits = commitLines.slice(0, maximumCommits).map((line) => {
+    const separator = line.indexOf("\t");
+    if (separator < 1) throw new Error("Git range returned an invalid commit record");
+    return { sha: line.slice(0, separator), subject: line.slice(separator + 1) };
+  });
+  return {
+    earlierSha: input.earlierSha,
+    recentSha: input.recentSha,
+    ancestor: lines[ancestorIndex + 1] === "yes",
+    commits,
+    changedFiles: fileLines.slice(0, maximumFiles),
+    commitsTruncated: commitLines.length > maximumCommits,
+    filesTruncated: fileLines.length > maximumFiles,
+  };
+}

--- a/.dsh/tools/github_actions_failure_evidence/index.ts
+++ b/.dsh/tools/github_actions_failure_evidence/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Extract bounded, redacted failure evidence from one GitHub Actions job log.
+ */
+export default async function github_actions_failure_evidence(input: {
+  workdir: string;
+  repository: string;
+  runId: Integer;
+  jobId: Integer;
+  contextLines?: Integer;
+  maximumLines?: Integer;
+}): Promise<{
+  runId: Integer;
+  jobId: Integer;
+  signatureLines: string[];
+  matchedLines: Integer;
+  truncated: boolean;
+  truncationReasons: string[];
+}> {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(input.repository))
+    throw new Error("repository must have owner/name form");
+  if (!Number.isSafeInteger(input.runId) || input.runId < 1)
+    throw new Error("runId must be a positive integer");
+  if (!Number.isSafeInteger(input.jobId) || input.jobId < 1)
+    throw new Error("jobId must be a positive integer");
+  const contextLines = Math.max(0, Math.min(input.contextLines ?? 2, 10));
+  const maximumLines = Math.max(1, Math.min(input.maximumLines ?? 120, 300));
+  const evidence = await tools.inspect_gh_job_log({
+    workdir: input.workdir,
+    jobId: input.jobId,
+    repo: input.repository,
+    pattern:
+      "##\\[error\\]|\\b(?:AssertionError|Error:|ERROR:|failed|failure|timed out|timeout|Deleting|failedStage=)\\b",
+    contextLines,
+    maxLines: maximumLines,
+    clipMode: "head",
+  });
+  if (evidence.code !== 0)
+    throw new Error("GitHub Actions job log inspection failed: " + evidence.stderr);
+  return {
+    runId: input.runId,
+    jobId: input.jobId,
+    signatureLines: evidence.stdout.split("\n").filter((line) => line.length > 0),
+    matchedLines: evidence.matchedLines,
+    truncated: evidence.truncated,
+    truncationReasons: evidence.truncationReasons,
+  };
+}

--- a/.dsh/tools/github_actions_failure_evidence/index.ts
+++ b/.dsh/tools/github_actions_failure_evidence/index.ts
@@ -24,6 +24,13 @@ export default async function github_actions_failure_evidence(input: {
     throw new Error("jobId must be a positive integer");
   const contextLines = Math.max(0, Math.min(input.contextLines ?? 2, 10));
   const maximumLines = Math.max(1, Math.min(input.maximumLines ?? 120, 300));
+  const summary = await tools.github_actions_run_summary({
+    workdir: input.workdir,
+    repository: input.repository,
+    runId: input.runId,
+  });
+  if (summary.run.id !== input.runId || !summary.jobs.some((job) => job.id === input.jobId))
+    throw new Error("jobId does not belong to runId");
   const evidence = await tools.inspect_gh_job_log({
     workdir: input.workdir,
     jobId: input.jobId,

--- a/.dsh/tools/github_actions_run_diff/index.ts
+++ b/.dsh/tools/github_actions_run_diff/index.ts
@@ -1,0 +1,96 @@
+/**
+ * Compare two GitHub Actions runs by exact job name and conclusion.
+ */
+export default async function github_actions_run_diff(input: {
+  workdir: string;
+  repository: string;
+  earlierRunId: Integer;
+  recentRunId: Integer;
+}): Promise<{
+  earlier: { id: Integer; headSha: string; url: string };
+  recent: { id: Integer; headSha: string; url: string };
+  newlyFailing: Array<{
+    name: string;
+    earlierConclusion: string | null;
+    recentConclusion: string | null;
+    recentJobId: Integer;
+    url: string;
+  }>;
+  newlyPassing: Array<{
+    name: string;
+    earlierConclusion: string | null;
+    recentConclusion: string | null;
+    recentJobId: Integer;
+    url: string;
+  }>;
+  persistentFailures: Array<{ name: string; recentJobId: Integer; url: string }>;
+  added: Array<{ name: string; conclusion: string | null; recentJobId: Integer; url: string }>;
+  removed: Array<{ name: string; conclusion: string | null; earlierJobId: Integer; url: string }>;
+}> {
+  const earlier = await tools.github_actions_run_summary({
+    workdir: input.workdir,
+    repository: input.repository,
+    runId: input.earlierRunId,
+  });
+  const recent = await tools.github_actions_run_summary({
+    workdir: input.workdir,
+    repository: input.repository,
+    runId: input.recentRunId,
+  });
+  const earlierByName = new Map(earlier.jobs.map((job) => [job.name, job]));
+  const recentByName = new Map(recent.jobs.map((job) => [job.name, job]));
+  const isFailure = (value: string | null) =>
+    value === "failure" ||
+    value === "cancelled" ||
+    value === "timed_out" ||
+    value === "action_required";
+  const isPassing = (value: string | null) =>
+    value === "success" || value === "neutral" || value === "skipped";
+  const newlyFailing = [];
+  const newlyPassing = [];
+  const persistentFailures = [];
+  const added = [];
+  const removed = [];
+  for (const job of recent.jobs) {
+    const prior = earlierByName.get(job.name);
+    if (!prior) {
+      added.push({ name: job.name, conclusion: job.conclusion, recentJobId: job.id, url: job.url });
+    } else if (!isFailure(prior.conclusion) && isFailure(job.conclusion)) {
+      newlyFailing.push({
+        name: job.name,
+        earlierConclusion: prior.conclusion,
+        recentConclusion: job.conclusion,
+        recentJobId: job.id,
+        url: job.url,
+      });
+    } else if (isFailure(prior.conclusion) && isPassing(job.conclusion)) {
+      newlyPassing.push({
+        name: job.name,
+        earlierConclusion: prior.conclusion,
+        recentConclusion: job.conclusion,
+        recentJobId: job.id,
+        url: job.url,
+      });
+    } else if (isFailure(prior.conclusion) && isFailure(job.conclusion)) {
+      persistentFailures.push({ name: job.name, recentJobId: job.id, url: job.url });
+    }
+  }
+  for (const job of earlier.jobs) {
+    if (!recentByName.has(job.name))
+      removed.push({
+        name: job.name,
+        conclusion: job.conclusion,
+        earlierJobId: job.id,
+        url: job.url,
+      });
+  }
+  return {
+    earlier: { id: earlier.run.id, headSha: earlier.run.headSha, url: earlier.run.url },
+    recent: { id: recent.run.id, headSha: recent.run.headSha, url: recent.run.url },
+    newlyFailing,
+    newlyPassing,
+    persistentFailures,
+    added,
+    removed,
+  };
+}

--- a/.dsh/tools/github_actions_run_summary/index.ts
+++ b/.dsh/tools/github_actions_run_summary/index.ts
@@ -1,0 +1,81 @@
+/**
+ * Read one GitHub Actions run and return bounded, normalized run and job metadata.
+ */
+export default async function github_actions_run_summary(input: {
+  workdir: string;
+  repository: string;
+  runId: Integer;
+}): Promise<{
+  run: {
+    id: Integer;
+    attempt: Integer;
+    workflowName: string;
+    event: string;
+    status: string;
+    conclusion: string | null;
+    headSha: string;
+    createdAt: string;
+    updatedAt: string;
+    url: string;
+  };
+  jobs: Array<{
+    id: Integer;
+    name: string;
+    status: string;
+    conclusion: string | null;
+    startedAt: string;
+    completedAt: string;
+    url: string;
+    failedStep: string | null;
+  }>;
+}> {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(input.repository))
+    throw new Error("repository must have owner/name form");
+  if (!Number.isSafeInteger(input.runId) || input.runId < 1)
+    throw new Error("runId must be a positive integer");
+  const result = await tools.run_github_cli({
+    workdir: input.workdir,
+    args: [
+      "run",
+      "view",
+      String(input.runId),
+      "--repo",
+      input.repository,
+      "--json",
+      "databaseId,attempt,workflowName,event,status,conclusion,headSha,createdAt,updatedAt,url,jobs",
+    ],
+    timeoutMs: 120000,
+  });
+  const value = JSON.parse(result.stdout);
+  if (!Array.isArray(value.jobs) || value.jobs.length > 1000)
+    throw new Error("GitHub Actions run returned an invalid or oversized job list");
+  const jobs = value.jobs.map((job) => {
+    if (!Array.isArray(job.steps) || job.steps.length > 1000)
+      throw new Error("GitHub Actions run returned an invalid or oversized step list");
+    return {
+      id: job.databaseId,
+      name: job.name,
+      status: job.status,
+      conclusion: job.conclusion ?? null,
+      startedAt: job.startedAt ?? "",
+      completedAt: job.completedAt ?? "",
+      url: job.url,
+      failedStep: job.steps.find((step) => step.conclusion === "failure")?.name ?? null,
+    };
+  });
+  return {
+    run: {
+      id: value.databaseId,
+      attempt: value.attempt,
+      workflowName: value.workflowName,
+      event: value.event,
+      status: value.status,
+      conclusion: value.conclusion ?? null,
+      headSha: value.headSha,
+      createdAt: value.createdAt,
+      updatedAt: value.updatedAt,
+      url: value.url,
+    },
+    jobs,
+  };
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add six project-authored DSH tools that compare GitHub Actions E2E runs, collect bounded failure evidence, correlate failures with tested commit changes, and render an investigation report. The catalog keeps the evidence collection and shared orchestration in NemoClaw alongside the existing internal DSH automation.

## Changes

- Add bounded summaries and exact job-name diffs for GitHub Actions runs.
- Add redacted failure-log evidence collection through the existing audited GitHub and diagnostic tools.
- Add tested-commit range inspection, deterministic root-cause grouping, and Markdown report rendering.
- Document the shared investigation sequence and its trust boundaries.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the existing project tool catalog uses repository hooks and source-first contract validation rather than a separate catalog test framework.
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run format:check`, `npm run checks:repository`, and source-first contract validation passed for all six tools.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tools to summarize and compare CI runs, identify newly failing or persistent jobs, and inspect failure evidence.
  * Added E2E investigation capabilities that group related failures, correlate them with changed files, assess likely causes, and generate validated Markdown reports.
  * Added bounded Git commit-range inspection with ancestry, commit, changed-file, and truncation details.

* **Documentation**
  * Added guidance for using the E2E investigation tools, including workflows, examples, evidence handling, limitations, and trust boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->