### PR TITLE
test(e2e): supply vLLM storage GPU telemetry

### DIFF
--- a/test/vllm-docker-storage.test.ts
+++ b/test/vllm-docker-storage.test.ts
@@ -240,9 +240,9 @@ realDockerTest(
       fs.writeFileSync(
         path.join(fakeBinDir, "nvidia-smi"),
         `#!/bin/sh
-case "$*" in
-  *--query-gpu=compute_cap*) printf '9.0\\n' ;;
-  *--query-gpu=index,uuid,memory.total,memory.free*)
+case "$#:$1:$2" in
+  2:--query-gpu=compute_cap:--format=csv,noheader,nounits) printf '9.0\\n' ;;
+  2:--query-gpu=index,uuid,memory.total,memory.free:--format=csv,noheader,nounits)
     printf '0, GPU-storage-proof, 131072, 131072\\n'
     ;;
   *) exit 64 ;;

--- a/test/vllm-docker-storage.test.ts
+++ b/test/vllm-docker-storage.test.ts
@@ -237,9 +237,19 @@ realDockerTest(
       fs.mkdirSync(blockedHome);
       fs.writeFileSync(path.join(blockedHome, ".cache"), "not a directory\n");
       fs.writeFileSync(statfsLogPath, "");
-      fs.writeFileSync(path.join(fakeBinDir, "nvidia-smi"), "#!/bin/sh\nexit 0\n", {
-        mode: 0o755,
-      });
+      fs.writeFileSync(
+        path.join(fakeBinDir, "nvidia-smi"),
+        `#!/bin/sh
+case "$*" in
+  *--query-gpu=compute_cap*) printf '9.0\\n' ;;
+  *--query-gpu=index,uuid,memory.total,memory.free*)
+    printf '0, GPU-storage-proof, 131072, 131072\\n'
+    ;;
+  *) exit 64 ;;
+esac
+`,
+        { mode: 0o755 },
+      );
       fs.writeFileSync(path.join(fakeBinDir, "curl"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
       fs.writeFileSync(
         path.join(fakeBinDir, "docker"),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Docker-backed managed-vLLM storage E2E fixture now reports valid deterministic GPU compute and memory telemetry. The test reaches its intended Docker storage and Hugging Face cache boundary instead of stopping at the GPU-memory preflight added by #9932.

## Related Issue

Related to #7039

## Changes

- Replace the empty `nvidia-smi` fixture with fixed responses for the exact compute-capability and per-device memory queries used by managed vLLM.
- Reject any unexpected `nvidia-smi` query so the fixture remains limited to the storage scenario.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run test/e2e/support/e2e-semantic-phase-check.test.ts --project e2e-support` passed 21 tests. The Docker-backed `vllm-docker-storage` test is intentionally skipped without its native Linux Docker selector and will run through targeted PR E2E.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this one-fixture correction.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved GPU detection test coverage for compute capability and memory queries.
  * Added validation for exact request formats and argument counts, including consistent rejection of unsupported requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->