### PR TITLE
fix(messaging): stabilize detailed channel status JSON

### DIFF
--- a/src/lib/actions/sandbox/channel-status.test.ts
+++ b/src/lib/actions/sandbox/channel-status.test.ts
@@ -385,6 +385,7 @@ describe("showSandboxChannelStatus (whatsapp)", () => {
     expect(result && "report" in result && result.report.verdict).toBe("info");
     const dump = out_lines.join("\n");
     expect(dump).toMatch(/registered but currently paused/);
+    expect(dump).toMatch(/Verdict:.*info/);
     // The paused fallback must not claim it is the summary view nor tell the
     // operator to rerun the --channel command they are already running (#6887).
     const runtime =

--- a/src/lib/actions/sandbox/channel-status.test.ts
+++ b/src/lib/actions/sandbox/channel-status.test.ts
@@ -382,23 +382,22 @@ describe("showSandboxChannelStatus (whatsapp)", () => {
     deps.execSandbox = execSpy as unknown as typeof deps.execSandbox;
     const result = await showSandboxChannelStatus("alpha", { deps, channel: "whatsapp" });
     expect(execSpy).not.toHaveBeenCalled();
-    expect(result && "verdict" in result && result.verdict).toBe("info");
+    expect(result && "report" in result && result.report.verdict).toBe("info");
     const dump = out_lines.join("\n");
     expect(dump).toMatch(/registered but currently paused/);
     // The paused fallback must not claim it is the summary view nor tell the
     // operator to rerun the --channel command they are already running (#6887).
     const runtime =
-      result && "signals" in result
-        ? result.signals.find((s) => s.label === "Runtime health")
+      result && "report" in result
+        ? result.report.signals.find((s) => s.label === "Runtime health")
         : undefined;
     expect(runtime?.detail).toBe("not checked — whatsapp is currently paused");
     expect(runtime?.hint).toBeUndefined();
   });
 
   it("labels a paused telegram channel as paused rather than summary view under --channel (#6887)", async () => {
-    // A probe-capable channel that is paused lands on the basic report even
-    // under an explicit --channel request, since the probe is gated on
-    // !channelIsPaused. The Runtime health signal must reflect the paused state.
+    // A probe-capable channel that is paused skips the live probe but keeps the
+    // detailed envelope. The Runtime health signal must reflect the paused state.
     const execSpy = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
     const { deps } = makeDeps({
       exec: () => ({ status: 0, stdout: "", stderr: "" }),
@@ -412,11 +411,26 @@ describe("showSandboxChannelStatus (whatsapp)", () => {
       .join("\n");
     expect(probeCommands).not.toMatch(/gateway\.log|pgrep/);
     const runtime =
-      result && "signals" in result
-        ? result.signals.find((s) => s.label === "Runtime health")
+      result && "report" in result
+        ? result.report.signals.find((s) => s.label === "Runtime health")
         : undefined;
     expect(runtime?.detail).toBe("not checked — telegram is currently paused");
     expect(runtime?.hint).toBeUndefined();
+    expect(result).toEqual({
+      schemaVersion: 1,
+      sandbox: "alpha",
+      channel: "telegram",
+      report: {
+        schemaVersion: 1,
+        agent: "openclaw",
+        channel: "telegram",
+        verdict: "info",
+        probedAt: "2026-05-28T04:00:00.000Z",
+        signals: expect.any(Array),
+        hints: expect.any(Array),
+      },
+    });
+    expect(result && (await import("./channel-status")).exitCodeFor(result)).toBe(0);
   });
 });
 

--- a/src/lib/actions/sandbox/channel-status.ts
+++ b/src/lib/actions/sandbox/channel-status.ts
@@ -84,20 +84,22 @@ export type ChannelStatusOptions = {
   deps?: StatusDeps;
 };
 
-type ChannelStatusSingleReport =
-  | {
-      schemaVersion: 1;
-      sandbox: string;
-      channel: string;
-      report: ChannelHealthReport;
-    }
-  | {
-      schemaVersion: 1;
-      sandbox: string;
-      channel: string;
-      verdict: "info";
-      signals: DiagnosticSignal[];
-    };
+type ChannelStatusDetailedReport = {
+  schemaVersion: 1;
+  sandbox: string;
+  channel: string;
+  report: ChannelHealthReport;
+};
+
+type ChannelStatusBasicReport = {
+  schemaVersion: 1;
+  sandbox: string;
+  channel: string;
+  verdict: "info";
+  signals: DiagnosticSignal[];
+};
+
+type ChannelStatusSingleReport = ChannelStatusDetailedReport | ChannelStatusBasicReport;
 
 type ChannelStatusSnapshotReport =
   | ChannelStatusSingleReport
@@ -279,6 +281,7 @@ export function exitCodeFor(report: ChannelStatusReport): number {
   if ("report" in report) {
     switch (report.report.verdict) {
       case "healthy":
+      case "info":
       case "unknown":
         return 0;
       default:
@@ -295,7 +298,7 @@ function buildBasicChannelReport(
   deps: Required<StatusDeps>,
   diagnostic: MessagingChannelDiagnosticSpec,
   options: { readonly includeDeepDiagnostics?: boolean; readonly channelPaused?: boolean } = {},
-): ChannelStatusSingleReport {
+): ChannelStatusBasicReport {
   const entry = deps.getSandbox(sandboxName);
   const enabled = registry.getConfiguredMessagingChannelsFromEntry(entry).includes(channelName);
   const disabled = registry.getDisabledMessagingChannelsFromEntry(entry).includes(channelName);
@@ -372,7 +375,7 @@ function buildBasicChannelReport(
 function buildUnknownConfiguredChannelReport(
   sandboxName: string,
   channelName: string,
-): ChannelStatusSingleReport {
+): ChannelStatusBasicReport {
   return {
     schemaVersion: 1,
     sandbox: sandboxName,
@@ -494,9 +497,29 @@ function collectChannelReport(
         )
       : undefined;
   if (!healthReport) {
-    return buildBasicChannelReport(sandboxName, channelName, agent, collectionDeps, diagnostic, {
-      channelPaused: channelIsPaused,
-    });
+    const basicReport = buildBasicChannelReport(
+      sandboxName,
+      channelName,
+      agent,
+      collectionDeps,
+      diagnostic,
+      { channelPaused: channelIsPaused },
+    );
+    if (!hasHealthHook) return basicReport;
+    return {
+      schemaVersion: 1,
+      sandbox: sandboxName,
+      channel: channelName,
+      report: {
+        schemaVersion: 1,
+        agent: agent.name,
+        channel: channelName,
+        verdict: basicReport.verdict,
+        probedAt: collectionDeps.now().toISOString(),
+        signals: basicReport.signals,
+        hints: basicReport.signals.flatMap((signal) => (signal.hint ? [signal.hint] : [])),
+      },
+    };
   }
   const configSignals = buildConfigStatusSignals(
     sandboxName,

--- a/src/lib/actions/sandbox/channel-status.ts
+++ b/src/lib/actions/sandbox/channel-status.ts
@@ -259,6 +259,8 @@ function renderSingleChannelSignals(
         ? G
         : report.report.verdict === "idle" || report.report.verdict === "unpaired"
           ? YW
+          : report.report.verdict === "info"
+            ? D
           : RD;
     deps.out(`  Verdict: ${verdictColor}${report.report.verdict}${R}`);
     for (const hint of report.report.hints) {

--- a/test/cli/channel-status-json.test.ts
+++ b/test/cli/channel-status-json.test.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+import { expect } from "vitest";
+
+import { test as it } from "../helpers/owned-test-resources";
+import { makeMessagingPlan } from "../helpers/messaging-plan-fixtures";
+import { runWithEnv, writeSandboxRegistry } from "./helpers";
+
+it("keeps the detailed JSON envelope when paused Telegram skips its live probe (#10015)", ({
+  testHome,
+}) => {
+  const { home, bin } = testHome;
+  const sandboxName = "my-assistant";
+  const openshell = path.join(bin, "openshell");
+  const calls = path.join(home, "openshell.calls");
+  fs.mkdirSync(bin, { recursive: true });
+  writeSandboxRegistry(home, sandboxName, {
+    agent: "openclaw",
+    policies: ["telegram"],
+    messaging: {
+      schemaVersion: 1,
+      plan: makeMessagingPlan({
+        sandboxName,
+        channels: ["telegram"],
+        disabledChannels: ["telegram"],
+      }),
+    },
+  });
+  fs.writeFileSync(
+    openshell,
+    [
+      "#!/usr/bin/env bash",
+      `printf '%s\\n' "$*" >> ${JSON.stringify(calls)}`,
+      'if [ "$1" = "sandbox" ] && [ "$2" = "exec" ]; then',
+      `  printf '%s\\n' ${JSON.stringify(
+        JSON.stringify({
+          channels: {
+            telegram: {
+              enabled: true,
+              groupPolicy: "allowlist",
+              groups: { "*": { requireMention: true } },
+            },
+          },
+        }),
+      )}`,
+      "  exit 0",
+      "fi",
+      "exit 1",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+
+  const result = runWithEnv(
+    `${sandboxName} channels status --channel telegram --json`,
+    testHome.environment({ NEMOCLAW_OPENSHELL_BIN: openshell }),
+  );
+
+  expect(result.code).toBe(0);
+  const status = JSON.parse(result.out) as Record<string, unknown>;
+  expect(Object.keys(status).sort()).toEqual(["channel", "report", "sandbox", "schemaVersion"]);
+  const report = status.report as Record<string, unknown>;
+  expect(Object.keys(report).sort()).toEqual([
+    "agent",
+    "channel",
+    "hints",
+    "probedAt",
+    "schemaVersion",
+    "signals",
+    "verdict",
+  ]);
+  expect(report).toMatchObject({
+    schemaVersion: 1,
+    agent: "openclaw",
+    channel: "telegram",
+    verdict: "info",
+    hints: expect.any(Array),
+  });
+  expect(report.probedAt).toEqual(expect.any(String));
+  expect(report.signals).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        label: "Channel registration",
+        severity: "warn",
+        detail: "telegram registered but currently paused",
+      }),
+      expect.objectContaining({
+        label: "Runtime health",
+        severity: "info",
+        detail: "not checked — telegram is currently paused",
+      }),
+    ]),
+  );
+  const invoked = fs.existsSync(calls) ? fs.readFileSync(calls, "utf8") : "";
+  expect(invoked).not.toMatch(/gateway\.log|pgrep/);
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Keep the schema-version-1 detailed channel-status JSON envelope stable when a probe-capable channel is paused. Previously, the same OpenClaw Telegram command returned a nested `report` while active and flat `verdict` and `signals` fields while paused; paused detailed status now remains nested, keeps its bounded informational result, skips the live probe, and exits 0.

## Related Issue

Fixes #10015

## Changes

- Wrap the existing basic signals in a `ChannelHealthReport` only when a detailed request targets a channel with an applicable health hook and that hook produces no live report.
- Preserve the existing flat summary and no-health-hook responses.
- Treat the informational nested fallback as a successful status result.
- Add focused paused-channel coverage and a real CLI process regression for `nemoclaw my-assistant channels status --channel telegram --json`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [PASS review](https://github.com/NVIDIA/NemoClaw/pull/10021#issuecomment-5387585985)
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every published commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 3 focused source files / 29 tests; 1 real-process integration file / 1 test; CLI typecheck passed
- [ ] Applicable broad gate passed — not applicable; this is a narrow status-response repair, and `npm run validate:pr` passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel status reporting for paused WhatsApp and Telegram channels.
  * Ensured informational status results complete successfully.
  * Added consistent report metadata and exit codes for paused channels.
  * Preserved basic diagnostics when detailed health information is unavailable.

* **Tests**
  * Added coverage for paused-channel JSON status output.
  * Verified that status checks avoid unnecessary live gateway and process probes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->