### PR TITLE
fix(advisor): write specialist diff to runtime

### DIFF
--- a/test/pr-review-advisor-specialists.test.ts
+++ b/test/pr-review-advisor-specialists.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { TERMINOLOGY_TRACE_TOOL } from "../tools/pr-review-advisor/terminology.mts";
 import {
   runSpecialistAdvisor,
+  writeSpecialistDiff,
   writeSpecialistSummary,
 } from "../tools/pr-review-advisor/run-specialist.mts";
 import type { RunAdvisorResult, RunReadOnlyAdvisorOptions } from "../tools/advisors/session.mts";
@@ -46,6 +47,16 @@ const context: InvestigateTurnContext = {
 };
 
 describe("PR review advisor specialist prompts", () => {
+  it("writes diff evidence under the writable specialist runtime directory", () => {
+    const configDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-specialist-config-"));
+    onTestFinished(() => fs.rmSync(configDir, { recursive: true, force: true }));
+
+    const file = writeSpecialistDiff(configDir, "diff evidence");
+
+    expect(file).toBe(path.join(configDir, "context", "diff.patch"));
+    expect(fs.readFileSync(file, "utf8")).toBe("diff evidence");
+  });
+
   it("parses exactly the five supported interests (#9949)", () => {
     expect(ADVISOR_INTERESTS).toEqual([
       "behavior",

--- a/test/pr-review-advisor-specialists.test.ts
+++ b/test/pr-review-advisor-specialists.test.ts
@@ -47,14 +47,33 @@ const context: InvestigateTurnContext = {
 };
 
 describe("PR review advisor specialist prompts", () => {
-  it("writes diff evidence under the writable specialist runtime directory", () => {
+  it("writes diff evidence to a new owner-only runtime path", () => {
     const configDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-specialist-config-"));
     onTestFinished(() => fs.rmSync(configDir, { recursive: true, force: true }));
+    const directory = path.join(configDir, "context");
+    const expected = path.join(directory, "diff.patch");
 
     const file = writeSpecialistDiff(configDir, "diff evidence");
 
-    expect(file).toBe(path.join(configDir, "context", "diff.patch"));
+    expect(file).toBe(expected);
     expect(fs.readFileSync(file, "utf8")).toBe("diff evidence");
+    expect(fs.statSync(directory).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it("tightens an existing specialist diff path", () => {
+    const configDir = fs.mkdtempSync(path.join(process.cwd(), ".tmp-specialist-config-"));
+    onTestFinished(() => fs.rmSync(configDir, { recursive: true, force: true }));
+    const directory = path.join(configDir, "context");
+    const expected = path.join(directory, "diff.patch");
+    fs.mkdirSync(directory, { mode: 0o755 });
+    fs.writeFileSync(expected, "stale", { mode: 0o644 });
+
+    writeSpecialistDiff(configDir, "diff evidence");
+
+    expect(fs.readFileSync(expected, "utf8")).toBe("diff evidence");
+    expect(fs.statSync(directory).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(expected).mode & 0o777).toBe(0o600);
   });
 
   it("parses exactly the five supported interests (#9949)", () => {

--- a/tools/pr-review-advisor/run-specialist.mts
+++ b/tools/pr-review-advisor/run-specialist.mts
@@ -68,6 +68,14 @@ export function writeSpecialistSummary(
   return file;
 }
 
+export function writeSpecialistDiff(configDir: string, diff: string): string {
+  const directory = path.join(configDir, "context");
+  fs.mkdirSync(directory, { recursive: true });
+  const file = path.join(directory, "diff.patch");
+  fs.writeFileSync(file, diff);
+  return file;
+}
+
 export function runSpecialistAdvisor(
   interest: AdvisorInterest,
   refs: { baseRef: string; headRef: string },
@@ -106,10 +114,7 @@ async function main(): Promise<void> {
   delete process.env.GH_TOKEN;
   delete process.env.GITHUB_TOKEN;
 
-  const diffDirectory = path.join(process.cwd(), ".pr-review-advisor-context");
-  fs.mkdirSync(diffDirectory, { recursive: true });
-  const diffPath = path.join(diffDirectory, "diff.patch");
-  fs.writeFileSync(diffPath, diff);
+  const diffPath = writeSpecialistDiff(configDir, diff);
 
   const turn = buildSpecialistInvestigateTurn(interest, {
     metadata: JSON.stringify({ version: 1, baseRef, headRef, headSha, changedFiles }, null, 2),

--- a/tools/pr-review-advisor/run-specialist.mts
+++ b/tools/pr-review-advisor/run-specialist.mts
@@ -70,9 +70,11 @@ export function writeSpecialistSummary(
 
 export function writeSpecialistDiff(configDir: string, diff: string): string {
   const directory = path.join(configDir, "context");
-  fs.mkdirSync(directory, { recursive: true });
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
   const file = path.join(directory, "diff.patch");
-  fs.writeFileSync(file, diff);
+  fs.writeFileSync(file, diff, { mode: 0o600 });
+  fs.chmodSync(file, 0o600);
   return file;
 }
 


### PR DESCRIPTION
## Summary

Restore PR Review Advisor specialist execution after the authoritative synthesis rollout. Specialists now write diff evidence under their writable runtime configuration directory instead of the read-only PR worktree.

## Changes

- Write specialist diff evidence under the existing writable Pi runtime directory.
- Add regression coverage for the exact runtime path and file contents.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a Signed-off-by line and every commit appears as Verified in GitHub
- [x] Normal pre-commit, commit-msg, and pre-push hooks passed, or npm run validate:pr passed after refreshing origin/main when hooks were skipped or unavailable — normal hooks passed for b12e66ffad26b4a496f45b768e203a48bc424edd.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — CLI typecheck; 47 focused advisor tests; repository checks.
- [ ] Applicable broad gate passed — npm test for broad runtime/test-harness changes; npm run check for repo-wide validation/coverage changes — not run; change is isolated to specialist diff placement.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] npm run docs builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Specialist review diff evidence is now stored in the configured runtime directory.
  * Diff content is preserved consistently in the expected context file.
  * Context directories and files use restricted owner-only permissions.
  * Existing context paths are tightened to the appropriate permissions.
  * Temporary test files are cleaned up after validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->