### PR TITLE
feat(inference): select managed vLLM GPU

### DIFF
--- a/ci/env-var-doc-allowlist.json
+++ b/ci/env-var-doc-allowlist.json
@@ -94,5 +94,9 @@
   {
     "name": "NEMOCLAW_MANAGED_HERMES_HASH_B64",
     "reason": "Internal one-shot transport from the privileged managed-startup runtime or root image applicator to the sandbox-owned Hermes compatibility-hash writer. The value is a bounded base64-encoded hash receipt that only the private internal writer consumes; NemoClaw synthesizes it and users must not set it."
+  },
+  {
+    "name": "NEMOCLAW_VLLM_GPU_DEVICE",
+    "reason": "Internal command-scoped handoff for the public --vllm-gpu-device flag. NemoClaw validates, persists, scopes, and restores it; users should set the CLI flag instead."
   }
 ]

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -280,7 +280,7 @@ The wizard creates an OpenShell gateway, registers inference providers, builds t
 Use this command for new installs and for recreating a sandbox after changes to policy or configuration.
 
 ```bash
-$$nemoclaw onboard [--profile <name>] [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--gpu | --no-gpu] [--from <Dockerfile>] [--name <sandbox>] [--host-mount <host:/sandbox/path>] [--sandbox-gpu | --no-sandbox-gpu] [--sandbox-gpu-device <device>] [--agent <name>] [--agents <agents.yaml>] [--tool-disclosure <progressive|direct>] [--observability | --no-observability] [--control-ui-port <N>] [--events=jsonl] [--yes | -y] [--no-ollama-autostart] [--yes-i-accept-third-party-software]
+$$nemoclaw onboard [--profile <name>] [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--gpu | --no-gpu] [--from <Dockerfile>] [--name <sandbox>] [--host-mount <host:/sandbox/path>] [--sandbox-gpu | --no-sandbox-gpu] [--sandbox-gpu-device <device>] [--vllm-gpu-device <index-or-uuid>] [--agent <name>] [--agents <agents.yaml>] [--tool-disclosure <progressive|direct>] [--observability | --no-observability] [--control-ui-port <N>] [--events=jsonl] [--yes | -y] [--no-ollama-autostart] [--yes-i-accept-third-party-software]
 ```
 
 <AgentOnly variant="hermes">
@@ -1056,6 +1056,9 @@ Use `--gpu` to require GPU passthrough and fail fast if an NVIDIA GPU is not det
 Use `--sandbox-gpu` or `--no-sandbox-gpu` to control only direct NVIDIA GPU access inside the sandbox.
 Use `--sandbox-gpu --sandbox-gpu-device <device>` to select an NVIDIA GPU by index (`0`), GPU UUID (`GPU-...`), or full CDI device name (`nvidia.com/gpu=0`).
 NemoClaw preserves the selection on resume.
+Use `--vllm-gpu-device <index-or-uuid>` to select the host GPU for the vLLM container that NemoClaw installs and manages.
+This selection is separate from sandbox GPU access, and NemoClaw also preserves it on resume.
+The selected GPU must satisfy the model's memory and compute-capability requirements.
 For native Docker and Podman creation, NemoClaw passes the normalized CDI name through OpenShell driver config; compatibility routes use the equivalent container-runtime selector.
 Device selection requires explicit sandbox GPU enablement.
 On ordinary native Linux Docker-driver hosts, NemoClaw uses native OpenShell GPU injection by default and never broadens confinement automatically.
@@ -4319,7 +4322,7 @@ The `$$nemoclaw setup` command is deprecated.
 Use `$$nemoclaw onboard` instead.
 </Warning>
 
-This command remains as a compatibility alias to `$$nemoclaw onboard` and accepts the same flags: `--profile <name>`, `--non-interactive`, `--resume`, `--fresh`, `--recreate-sandbox`, `--gpu` / `--no-gpu`, `--from`, `--name`, `--host-mount`, `--sandbox-gpu` / `--no-sandbox-gpu`, `--sandbox-gpu-device`, `--agent`, `--agents <agents.yaml>`, `--tool-disclosure <progressive|direct>`, `--observability` / `--no-observability`, `--control-ui-port`, `--yes` / `-y`, `--no-ollama-autostart`, `--yes-i-accept-third-party-software`.
+This command remains as a compatibility alias to `$$nemoclaw onboard` and accepts the same flags: `--profile <name>`, `--non-interactive`, `--resume`, `--fresh`, `--recreate-sandbox`, `--gpu` / `--no-gpu`, `--from`, `--name`, `--host-mount`, `--sandbox-gpu` / `--no-sandbox-gpu`, `--sandbox-gpu-device`, `--vllm-gpu-device`, `--agent`, `--agents <agents.yaml>`, `--tool-disclosure <progressive|direct>`, `--observability` / `--no-observability`, `--control-ui-port`, `--yes` / `-y`, `--no-ollama-autostart`, `--yes-i-accept-third-party-software`.
 
 ```bash
 $$nemoclaw setup
@@ -4332,7 +4335,7 @@ The `$$nemoclaw setup-spark` command is deprecated.
 Use the standard installer and run `$$nemoclaw onboard` instead, because current OpenShell releases handle the older DGX Spark cgroup behavior.
 </Warning>
 
-This command remains as a compatibility alias to `$$nemoclaw onboard` and accepts the same flags: `--profile <name>`, `--non-interactive`, `--resume`, `--fresh`, `--recreate-sandbox`, `--gpu` / `--no-gpu`, `--from`, `--name`, `--host-mount`, `--sandbox-gpu` / `--no-sandbox-gpu`, `--sandbox-gpu-device`, `--agent`, `--agents <agents.yaml>`, `--tool-disclosure <progressive|direct>`, `--observability` / `--no-observability`, `--control-ui-port`, `--yes` / `-y`, `--no-ollama-autostart`, `--yes-i-accept-third-party-software`.
+This command remains as a compatibility alias to `$$nemoclaw onboard` and accepts the same flags: `--profile <name>`, `--non-interactive`, `--resume`, `--fresh`, `--recreate-sandbox`, `--gpu` / `--no-gpu`, `--from`, `--name`, `--host-mount`, `--sandbox-gpu` / `--no-sandbox-gpu`, `--sandbox-gpu-device`, `--vllm-gpu-device`, `--agent`, `--agents <agents.yaml>`, `--tool-disclosure <progressive|direct>`, `--observability` / `--no-observability`, `--control-ui-port`, `--yes` / `-y`, `--no-ollama-autostart`, `--yes-i-accept-third-party-software`.
 
 ```bash
 $$nemoclaw setup-spark

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -76,6 +76,21 @@ describe("onboard oclif command", () => {
     );
   });
 
+  it("forwards the managed vLLM GPU device independently of sandbox GPU flags", async () => {
+    await OnboardCliCommand.run(
+      ["--non-interactive", "--vllm-gpu-device", "GPU-69adb14e-820e-bfb4-0993-171e73f68504"],
+      rootDir,
+    );
+
+    expect(runOnboardAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "non-interactive": true,
+        "vllm-gpu-device": "GPU-69adb14e-820e-bfb4-0993-171e73f68504",
+      }),
+      mocks.onboardRuntimeDeps,
+    );
+  });
+
   it("forwards --no-gpu to the onboard action", async () => {
     await OnboardCliCommand.run(["--non-interactive", "--no-gpu"], rootDir);
 

--- a/src/lib/actions/onboard.ts
+++ b/src/lib/actions/onboard.ts
@@ -6,7 +6,7 @@ import type { GooglechatTunnelRuntimeDeps } from "../messaging/channels/googlech
 import { type OnboardCommandOptions, runOnboardCommand } from "../onboard/command";
 import { type OnboardFlags, readAgentRegistryNames } from "../onboard/command-support";
 import { resolveOnboardResumeIntent } from "../onboard/session-bootstrap";
-import { loadServingProfileResumeSession } from "../onboard/sandbox-registration";
+import { loadOnboardCommandResumeSession } from "../onboard/sandbox-registration";
 import type { OnboardOptions } from "../onboard/types";
 
 export interface OnboardActionRuntimeDeps {
@@ -32,7 +32,7 @@ function buildOnboardCommandDeps(flags: OnboardFlags, runtimeDeps: OnboardAction
     runOnboard: (options: OnboardCommandOptions) => runOnboard(options, runtimeDeps),
     listAgents: () => [...readAgentRegistryNames()],
     loadServingCatalog,
-    loadSession: loadServingProfileResumeSession,
+    loadSession: loadOnboardCommandResumeSession,
     resolveResumeIntent: resolveOnboardResumeIntent,
     log: console.log,
     error: console.error,

--- a/src/lib/inference/vllm-compute-capability.test.ts
+++ b/src/lib/inference/vllm-compute-capability.test.ts
@@ -68,6 +68,7 @@ import {
   readGpuComputeCapabilities,
   readGpuMemoryDevices,
   resolveVllmModelRuntime,
+  selectVllmGpuDevice,
   type VllmProfile,
 } from "./vllm";
 import {
@@ -80,6 +81,7 @@ import {
   withVllmInstallTestReadiness,
 } from "./vllm-install.test-support";
 import { VLLM_MODELS } from "./vllm-models";
+import { NEMOCLAW_VLLM_GPU_DEVICE_ENV } from "./vllm-models";
 
 const READY_MODELS_RESPONSE = '{"data":[]}';
 
@@ -213,6 +215,16 @@ describe("managed vLLM GPU compute capability preflight", () => {
     expect(computeCapabilityPreflight(model!, [121, 90])).toEqual({ ok: true });
   });
 
+  it("queries compute capability for the selected GPU UUID", () => {
+    mockHostCommands({ computeCap: "9.0\n" });
+
+    expect(readGpuComputeCapabilities("GPU-69adb14e-820e-bfb4-0993-171e73f68504")).toEqual([90]);
+    expect(mocks.runCapture).toHaveBeenCalledWith(
+      expect.arrayContaining(["--id=GPU-69adb14e-820e-bfb4-0993-171e73f68504"]),
+      expect.any(Object),
+    );
+  });
+
   it("prints a capability on the scale vLLM reports (#8307)", () => {
     expect(formatComputeCapability(80)).toBe("8.0");
     expect(formatComputeCapability(89)).toBe("8.9");
@@ -278,6 +290,31 @@ describe("managed vLLM GPU memory preflight", () => {
     expect(errors).toContain("49.2 GiB of 95.6 GiB is free");
     expect(errors).toContain("free at least 22.5 GiB");
     expect(errors).toContain("then resume onboarding");
+  });
+
+  it("launches managed vLLM on the selected UUID and checks that GPU's free memory", async () => {
+    const profile = { ...detectVllmProfile({ type: "nvidia" })!, architecture: "x64" as const };
+    const uuid = "GPU-69adb14e-820e-bfb4-0993-171e73f68504";
+    process.env.NEMOCLAW_VLLM_MODEL = "qwen3.6-27b";
+    process.env[NEMOCLAW_VLLM_GPU_DEVICE_ENV] = uuid;
+    mockHostCommands({
+      computeCap: "9.0\n9.0\n",
+      gpuMemory:
+        `0, GPU-00000000-0000-0000-0000-000000000000, 97887, 1000\n` + `1, ${uuid}, 97887, 90000\n`,
+    });
+    mockDockerDaemon(profile.containerName);
+
+    const result = await installVllm(profile, {
+      hasImage: false,
+      nonInteractive: true,
+      promptFn: vi.fn(),
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(mocks.tryInstallManagedClusterManagedVllm).not.toHaveBeenCalled();
+    expect(mocks.dockerRunDetached.mock.calls[0]?.[0]).toEqual(
+      expect.arrayContaining(["--gpus", `device=${uuid}`]),
+    );
   });
 
   it.each(["--gpu-memory-utilization", "--gpu_memory_utilization"])(
@@ -386,6 +423,33 @@ describe("managed vLLM GPU memory preflight", () => {
 
     expect(profile.gpuMemoryUtilization).toBe(0.75);
     expect(gpuMemoryPreflight(model, profile, devices)).toEqual({ ok: true });
+  });
+
+  it("checks memory on the UUID selected for managed vLLM", () => {
+    const detected = detectVllmProfile({ type: "nvidia" })!;
+    const model = VLLM_MODELS.find((entry) => entry.envValue === "muse-glimmer-30b")!;
+    const resolved = resolveVllmModelRuntime(detected, model, "x64");
+    const profile = selectVllmGpuDevice(
+      resolved.profile,
+      "GPU-69adb14e-820e-bfb4-0993-171e73f68504",
+    );
+
+    expect(
+      gpuMemoryPreflight(model, profile, [
+        {
+          index: 0,
+          uuid: "GPU-00000000-0000-0000-0000-000000000000",
+          totalBytes: 96n,
+          freeBytes: 1n,
+        },
+        {
+          index: 1,
+          uuid: "GPU-69adb14e-820e-bfb4-0993-171e73f68504",
+          totalBytes: 96n,
+          freeBytes: 80n,
+        },
+      ]),
+    ).toEqual({ ok: true });
   });
 
   it("fails closed when Docker's selected GPU is absent from telemetry", () => {

--- a/src/lib/inference/vllm-models.ts
+++ b/src/lib/inference/vllm-models.ts
@@ -49,6 +49,33 @@ import type {
 export type VllmPlatform = "spark" | "station" | "n1x" | "linux";
 export const STATION_PAIR_OPTIONAL_ORCHESTRATION = "vllm.station-pair-optional/v1";
 export const DUAL_STATION_VLLM_GPU_MEMORY_UTILIZATION = 0.9;
+export const NEMOCLAW_VLLM_GPU_DEVICE_ENV = "NEMOCLAW_VLLM_GPU_DEVICE" as const;
+
+const GPU_INDEX_PATTERN = /^\d+$/;
+const GPU_UUID_PATTERN = /^GPU-[A-Fa-f0-9]{8}(?:-[A-Fa-f0-9]{4}){3}-[A-Fa-f0-9]{12}$/;
+
+export function normalizeVllmGpuDevice(value: string): string {
+  const candidate = value.trim();
+  if (GPU_INDEX_PATTERN.test(candidate)) {
+    const index = Number(candidate);
+    if (Number.isSafeInteger(index)) return String(index);
+  }
+  if (GPU_UUID_PATTERN.test(candidate)) {
+    return `GPU-${candidate.slice("GPU-".length).toLowerCase()}`;
+  }
+  throw new Error(
+    "vLLM GPU device must be a non-negative GPU index or full GPU UUID reported by nvidia-smi",
+  );
+}
+
+export function parseVllmGpuDevice(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  try {
+    return normalizeVllmGpuDevice(value);
+  } catch {
+    return null;
+  }
+}
 
 export interface VllmServingCatalogIdentity {
   readonly catalogDigest: string;

--- a/src/lib/inference/vllm.ts
+++ b/src/lib/inference/vllm.ts
@@ -62,6 +62,8 @@ import {
   defaultVllmModelForPlatform,
   defaultVllmRuntimeForPlatform,
   STATION_PAIR_OPTIONAL_ORCHESTRATION,
+  NEMOCLAW_VLLM_GPU_DEVICE_ENV,
+  normalizeVllmGpuDevice,
   parseVllmExtraServeArgs,
   resolveVllmGpuMemoryUtilization,
   VLLM_EXTRA_ARGS_ENV,
@@ -254,6 +256,27 @@ function vllmDockerRunFlags(gpuFlag = "all"): string[] {
   ];
 }
 
+function replaceVllmGpuRequest(flags: readonly string[], device: string): string[] {
+  const gpuIndex = flags.indexOf("--gpus");
+  if (gpuIndex < 0 || gpuIndex === flags.length - 1 || flags.indexOf("--gpus", gpuIndex + 1) >= 0) {
+    throw new Error("managed vLLM profile must contain exactly one Docker --gpus request");
+  }
+  const selected = [...flags];
+  selected[gpuIndex + 1] = `device=${device}`;
+  return selected;
+}
+
+export function selectVllmGpuDevice(profile: VllmProfile, device: string): VllmProfile {
+  const normalized = normalizeVllmGpuDevice(device);
+  return {
+    ...profile,
+    dockerRunFlags: replaceVllmGpuRequest(profile.dockerRunFlags, normalized),
+    buildDockerRunFlags: profile.buildDockerRunFlags
+      ? () => replaceVllmGpuRequest(profile.buildDockerRunFlags!(), normalized)
+      : undefined,
+  };
+}
+
 function printHfDownloadAuthentication(nonInteractive: boolean): void {
   const authentication = hfDownloadAuthentication();
   if (authentication.authenticated) {
@@ -415,10 +438,15 @@ function dockerPrereqsOk(): { ok: boolean; reason?: string } {
   return { ok: true };
 }
 
-export function readGpuComputeCapabilities(): number[] {
-  const out = captureNvidiaSmi(["--query-gpu=compute_cap", "--format=csv,noheader,nounits"], {
-    runCaptureImpl: runCapture,
-  });
+export function readGpuComputeCapabilities(device?: string): number[] {
+  const out = captureNvidiaSmi(
+    [
+      ...(device ? [`--id=${device}`] : []),
+      "--query-gpu=compute_cap",
+      "--format=csv,noheader,nounits",
+    ],
+    { runCaptureImpl: runCapture },
+  );
   if (!out) return [];
   const capabilities: number[] = [];
   for (const line of out.split("\n")) {
@@ -429,6 +457,13 @@ export function readGpuComputeCapabilities(): number[] {
     capabilities.push(Number(match[1]) * 10 + Number(match[2]));
   }
   return capabilities;
+}
+
+function readProfileGpuComputeCapabilities(profile: VllmProfile): number[] {
+  const request = profileGpuRequest(profile);
+  if (!request?.startsWith("device=")) return readGpuComputeCapabilities();
+  const device = request.slice("device=".length).split(",")[0]?.trim();
+  return readGpuComputeCapabilities(device || undefined);
 }
 
 export function formatComputeCapability(capability: number): string {
@@ -523,7 +558,10 @@ function selectedGpuMemoryDevice(
   const selector = request.slice("device=".length).split(",")[0]?.trim();
   if (!selector) return null;
   return (
-    devices.find((device) => String(device.index) === selector || device.uuid === selector) ?? null
+    devices.find(
+      (device) =>
+        String(device.index) === selector || device.uuid.toLowerCase() === selector.toLowerCase(),
+    ) ?? null
   );
 }
 
@@ -1795,6 +1833,69 @@ function resolveVllmInstallSelectionEnv(
   };
 }
 
+type VllmInstallRequestEnv =
+  | {
+      readonly ok: true;
+      readonly env: NodeJS.ProcessEnv;
+      readonly explicitModel: string;
+      readonly requestedGpuDevice: string | null;
+      readonly configuredPeer: string;
+      readonly configuredManagedClusterPeers: string;
+    }
+  | { readonly ok: false; readonly error: string };
+
+function resolveVllmInstallRequestEnv(
+  modelIntent: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): VllmInstallRequestEnv {
+  const selection = resolveVllmInstallSelectionEnv(modelIntent, env);
+  if (!selection.ok) {
+    return {
+      ok: false,
+      error: "the resumed model conflicts with NEMOCLAW_VLLM_MODEL.",
+    };
+  }
+  const rawGpuDevice = String(env[NEMOCLAW_VLLM_GPU_DEVICE_ENV] ?? "").trim();
+  let requestedGpuDevice: string | null = null;
+  try {
+    requestedGpuDevice = rawGpuDevice ? normalizeVllmGpuDevice(rawGpuDevice) : null;
+  } catch (error) {
+    return { ok: false, error: `${(error as Error).message}.` };
+  }
+  const configuredPeer = String(env[NEMOCLAW_DGX_STATION_PEER_ENV] ?? "").trim();
+  const configuredManagedClusterPeers = String(
+    env[NEMOCLAW_MANAGED_CLUSTER_PEERS_ENV] ?? "",
+  ).trim();
+  if (requestedGpuDevice && (configuredPeer || configuredManagedClusterPeers)) {
+    return {
+      ok: false,
+      error:
+        "--vllm-gpu-device selects one host GPU and cannot be combined with managed multi-node inference.",
+    };
+  }
+  return {
+    ...selection,
+    requestedGpuDevice,
+    configuredPeer,
+    configuredManagedClusterPeers,
+  };
+}
+
+function shouldTryManagedClusterInstall(
+  hostLocalSelection: MaterializedHostLocalVllmSelection | undefined,
+  fixedServeCommand: boolean,
+  requestedGpuDevice: string | null,
+): boolean {
+  return !hostLocalSelection && !fixedServeCommand && !requestedGpuDevice;
+}
+
+function applyRequestedVllmGpuDevice(
+  profile: VllmProfile,
+  requestedGpuDevice: string | null,
+): VllmProfile {
+  return requestedGpuDevice ? selectVllmGpuDevice(profile, requestedGpuDevice) : profile;
+}
+
 /**
  * Name the process holding the serving port so the operator can act, matching
  * how the Ollama auth proxy reports its own port conflict.
@@ -1863,13 +1964,18 @@ async function runVllmInstall(
   opts: InstallVllmOptions,
   hostLocalSelection?: MaterializedHostLocalVllmSelection,
 ): Promise<{ ok: boolean }> {
-  const selection = resolveVllmInstallSelectionEnv(opts.modelIntent);
+  const selection = resolveVllmInstallRequestEnv(opts.modelIntent);
   if (!selection.ok) {
-    console.error("  vLLM install failed: the resumed model conflicts with NEMOCLAW_VLLM_MODEL.");
+    console.error(`  vLLM install failed: ${selection.error}`);
     return { ok: false };
   }
-  const { env: selectionEnv, explicitModel } = selection;
-  const configuredPeer = String(process.env[NEMOCLAW_DGX_STATION_PEER_ENV] ?? "").trim();
+  const {
+    env: selectionEnv,
+    explicitModel,
+    requestedGpuDevice,
+    configuredPeer,
+    configuredManagedClusterPeers,
+  } = selection;
   const fixedServeCommand = profile.defaultModel.fixedServeCommand === true;
   if (fixedServeCommand) {
     if (
@@ -1881,9 +1987,6 @@ async function runVllmInstall(
       );
       return { ok: false };
     }
-    const configuredManagedClusterPeers = String(
-      process.env[NEMOCLAW_MANAGED_CLUSTER_PEERS_ENV] ?? "",
-    ).trim();
     const configuredServingPreset = String(process.env[NEMOCLAW_SERVING_PRESET_ENV] ?? "").trim();
     if (configuredManagedClusterPeers) {
       console.error(
@@ -1898,7 +2001,7 @@ async function runVllmInstall(
       return { ok: false };
     }
   }
-  if (!hostLocalSelection && !fixedServeCommand) {
+  if (shouldTryManagedClusterInstall(hostLocalSelection, fixedServeCommand, requestedGpuDevice)) {
     const managedCluster = await tryInstallManagedClusterManagedVllm(
       {
         env: selectionEnv,
@@ -2134,6 +2237,8 @@ async function runVllmInstall(
     return { ok: false };
   }
 
+  runtimeProfile = applyRequestedVllmGpuDevice(runtimeProfile, requestedGpuDevice);
+
   // Reject a held serving port before anything durable happens. In
   // particular, managed bearer auth persists a host credential below and
   // beforeInstall publishes the selected model to onboarding state. Running
@@ -2214,7 +2319,7 @@ async function runVllmInstall(
 
   const capability = computeCapabilityPreflight(
     model,
-    readGpuComputeCapabilities(),
+    readProfileGpuComputeCapabilities(runtimeProfile),
     runtimeProfile.minComputeCapability,
   );
   if (!capability.ok) {

--- a/src/lib/inference/vllm/gpu-device.test.ts
+++ b/src/lib/inference/vllm/gpu-device.test.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { buildVllmRunArgs, detectVllmProfile, selectVllmGpuDevice } from "../vllm";
+import { normalizeVllmGpuDevice } from "../vllm-models";
+
+describe("managed vLLM GPU selection", () => {
+  it.each([
+    ["an index", "2"],
+    ["a UUID", "GPU-69adb14e-820e-bfb4-0993-171e73f68504"],
+  ])("uses %s as the exact Docker GPU request", (_kind, device) => {
+    const profile = detectVllmProfile({ platform: "linux", type: "nvidia" })!;
+    const selected = selectVllmGpuDevice(profile, device);
+    const args = buildVllmRunArgs(
+      selected,
+      selected.defaultModel,
+      selected.buildDockerRunFlags?.() ?? selected.dockerRunFlags,
+    );
+
+    expect(args.slice(args.indexOf("--gpus"), args.indexOf("--gpus") + 2)).toEqual([
+      "--gpus",
+      `device=${device}`,
+    ]);
+  });
+
+  it.each(["-1", "GPU-deadbeef", "nvidia.com/gpu=0", "0,1"])(
+    "rejects unsupported selector %s",
+    (device) => {
+      expect(() => normalizeVllmGpuDevice(device)).toThrow(
+        "non-negative GPU index or full GPU UUID",
+      );
+    },
+  );
+});

--- a/src/lib/onboard/command-support.ts
+++ b/src/lib/onboard/command-support.ts
@@ -47,7 +47,7 @@ function agentFlagDescription(): string {
 }
 
 export const onboardUsage = [
-  `onboard [--profile <name>] [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--gpu | --no-gpu] [--from <Dockerfile>] [--name <sandbox>] [--host-mount <host:/sandbox/path>] [--sandbox-gpu | --no-sandbox-gpu] [--sandbox-gpu-device <device>] [--agent <name>] [--agents <agents.yaml>] [--tool-disclosure <progressive|direct>] [--observability | --no-observability] [--control-ui-port <N>] [--events=jsonl] [--yes | -y] [--no-ollama-autostart] [${NOTICE_ACCEPT_FLAG}]`,
+  `onboard [--profile <name>] [--non-interactive] [--resume | --fresh] [--recreate-sandbox] [--gpu | --no-gpu] [--from <Dockerfile>] [--name <sandbox>] [--host-mount <host:/sandbox/path>] [--sandbox-gpu | --no-sandbox-gpu] [--sandbox-gpu-device <device>] [--vllm-gpu-device <index-or-uuid>] [--agent <name>] [--agents <agents.yaml>] [--tool-disclosure <progressive|direct>] [--observability | --no-observability] [--control-ui-port <N>] [--events=jsonl] [--yes | -y] [--no-ollama-autostart] [${NOTICE_ACCEPT_FLAG}]`,
 ];
 
 export const onboardExamples = [
@@ -78,6 +78,7 @@ export type OnboardFlags = {
   "sandbox-gpu"?: boolean;
   "no-sandbox-gpu"?: boolean;
   "sandbox-gpu-device"?: string;
+  "vllm-gpu-device"?: string;
   agent?: string;
   agents?: string;
   "tool-disclosure"?: ToolDisclosure;
@@ -135,6 +136,9 @@ export function buildOnboardFlags(options: { includeEvents?: boolean } = {}): Re
     "sandbox-gpu-device": Flags.string({
       description: "NVIDIA GPU index, UUID, or CDI device name; requires --sandbox-gpu",
       dependsOn: ["sandbox-gpu"],
+    }),
+    "vllm-gpu-device": Flags.string({
+      description: "GPU index or UUID for the host-side vLLM container managed by NemoClaw",
     }),
     agent: Flags.string({ description: agentFlagDescription() }),
     agents: Flags.string({

--- a/src/lib/onboard/command.test.ts
+++ b/src/lib/onboard/command.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { getCredential } from "../credentials/store";
 import { loadServingCatalog } from "../inference/serving/catalog-loader";
 import { servingProfileProvenance } from "../inference/serving/profile-provenance";
+import { NEMOCLAW_VLLM_GPU_DEVICE_ENV } from "../inference/vllm-models";
 import { resolveOnboardOptions, runOnboardCommand, servingProfileProviderKey } from "./command";
 import type { OnboardFlags } from "./command-support";
 import { PortableInferenceDescriptorError } from "./experimental/portable-inference-descriptor";
@@ -200,6 +201,44 @@ describe("onboard command options", () => {
     expect(errors.join("\n")).toContain("legacy onboarding session");
   });
 
+  it("normalizes a vLLM GPU index or UUID and reuses the recorded device on resume", () => {
+    expect(resolve({ "vllm-gpu-device": "002" }).vllmGpuDevice).toBe("2");
+    const uuid = "GPU-69ADB14E-820E-BFB4-0993-171E73F68504";
+    const normalizedUuid = "GPU-69adb14e-820e-bfb4-0993-171e73f68504";
+    expect(resolve({ "vllm-gpu-device": uuid }).vllmGpuDevice).toBe(normalizedUuid);
+    expect(
+      resolve({ resume: true }, { loadSession: () => ({ vllmGpuDevice: normalizedUuid }) })
+        .vllmGpuDevice,
+    ).toBe(normalizedUuid);
+  });
+
+  it.each([
+    {
+      caseName: "a CDI device name",
+      flags: { "vllm-gpu-device": "nvidia.com/gpu=0" } as OnboardFlags,
+      session: null,
+    },
+    {
+      caseName: "a device added to a legacy resume",
+      flags: { resume: true, "vllm-gpu-device": "1" } as OnboardFlags,
+      session: {},
+    },
+    {
+      caseName: "a device changed during resume",
+      flags: { resume: true, "vllm-gpu-device": "1" } as OnboardFlags,
+      session: { vllmGpuDevice: "0" },
+    },
+  ])("rejects $caseName", ({ flags, session }) => {
+    const errors: string[] = [];
+    expect(() =>
+      resolve(flags, {
+        ...(session ? { loadSession: () => session } : {}),
+        error: (message = "") => errors.push(message),
+      }),
+    ).toThrow("exit:1");
+    expect(errors.join("\n")).toMatch(/vllm-gpu-device|resumed GPU device/);
+  });
+
   it("maps typed oclif flags to onboarding options", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-onboard-options-"));
     const dockerfilePath = path.join(tmpDir, "Custom.Dockerfile");
@@ -219,6 +258,7 @@ describe("onboard command options", () => {
           name: "second-assistant",
           "sandbox-gpu": true,
           "sandbox-gpu-device": "nvidia.com/gpu=0",
+          "vllm-gpu-device": "2",
           agent: "dcode",
           "tool-disclosure": "direct",
           observability: true,
@@ -228,7 +268,10 @@ describe("onboard command options", () => {
           "no-ollama-autostart": true,
           "yes-i-accept-third-party-software": true,
         },
-        { listAgents: () => ["openclaw", "hermes", "langchain-deepagents-code"] },
+        {
+          listAgents: () => ["openclaw", "hermes", "langchain-deepagents-code"],
+          loadSession: () => ({ vllmGpuDevice: "2" }),
+        },
       ),
     ).toEqual({
       tempManagedRuntime: true,
@@ -241,6 +284,7 @@ describe("onboard command options", () => {
       sandboxName: "second-assistant",
       sandboxGpu: "enable",
       sandboxGpuDevice: "nvidia.com/gpu=0",
+      vllmGpuDevice: "2",
       acceptThirdPartySoftware: true,
       agent: "langchain-deepagents-code",
       agentsManifest: null,
@@ -272,6 +316,7 @@ describe("onboard command options", () => {
       sandboxName: null,
       sandboxGpu: null,
       sandboxGpuDevice: null,
+      vllmGpuDevice: null,
       acceptThirdPartySoftware: false,
       agent: null,
       agentsManifest: null,
@@ -536,6 +581,22 @@ describe("onboard command options", () => {
     expect(runOnboard).toHaveBeenCalledWith(expect.objectContaining({ resume: true }));
   });
 
+  it("scopes the selected vLLM GPU device to one onboarding run", async () => {
+    const env: NodeJS.ProcessEnv = { [NEMOCLAW_VLLM_GPU_DEVICE_ENV]: "9" };
+    let observed: string | undefined;
+    await runOnboardCommand({
+      flags: { "vllm-gpu-device": "2" },
+      env,
+      runOnboard: async (options) => {
+        observed = env[NEMOCLAW_VLLM_GPU_DEVICE_ENV];
+        expect(options.vllmGpuDevice).toBe("2");
+      },
+    });
+
+    expect(observed).toBe("2");
+    expect(env[NEMOCLAW_VLLM_GPU_DEVICE_ENV]).toBe("9");
+  });
+
   it("re-resolves once after onboard reports a pre-read race (#9035)", async () => {
     const snapshots = ["first", "second"].map((fingerprint) => ({
       effectiveResume: true,
@@ -693,9 +754,7 @@ describe("onboard command options", () => {
   ])(
     "restores every scoped command value before a handled-error exit when the provider is $providerState (#9035)",
     async ({ previousProvider }) => {
-      const tmpDir = fs.mkdtempSync(
-        path.join(os.tmpdir(), "nemoclaw-handled-error-environment-"),
-      );
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-handled-error-environment-"));
       const manifestPath = path.join(tmpDir, "agents.yaml");
       fs.writeFileSync(manifestPath, "agents: []\n");
       const env: NodeJS.ProcessEnv = {

--- a/src/lib/onboard/command.ts
+++ b/src/lib/onboard/command.ts
@@ -18,7 +18,11 @@ import {
   servingProfileProvenance,
 } from "../inference/serving/profile-provenance";
 import type { CompiledServingCatalog, ServingProfileProvenance } from "../inference/serving/types";
-import { VLLM_EXTRA_ARGS_ENV } from "../inference/vllm-models";
+import {
+  NEMOCLAW_VLLM_GPU_DEVICE_ENV,
+  normalizeVllmGpuDevice,
+  VLLM_EXTRA_ARGS_ENV,
+} from "../inference/vllm-models";
 import {
   resolveToolDisclosureRequest,
   TOOL_DISCLOSURE_ENV,
@@ -70,6 +74,7 @@ export interface OnboardCommandOptions {
   hostMounts?: import("../state/registry/types").SandboxHostMount[];
   sandboxGpu: "enable" | "disable" | null;
   sandboxGpuDevice: string | null;
+  vllmGpuDevice: string | null;
   acceptThirdPartySoftware: boolean;
   agent: string | null;
   agentsManifest: string | null;
@@ -96,7 +101,10 @@ export interface ResolveOnboardOptionsDeps {
   listAgents?: () => string[];
   listServingProfiles?: () => ServingProfileListEntry[];
   loadServingCatalog?: () => CompiledServingCatalog;
-  loadSession?: () => { servingProfileProvenance?: ServingProfileProvenance | null } | null;
+  loadSession?: () => {
+    servingProfileProvenance?: ServingProfileProvenance | null;
+    vllmGpuDevice?: string | null;
+  } | null;
   error?: (message?: string) => void;
   exit?: (code: number) => never;
   resumeIntent?: ResolvedOnboardResumeIntent;
@@ -188,6 +196,37 @@ function resolveSandboxGpu(flags: OnboardFlags): "enable" | "disable" | null {
   if (flags["sandbox-gpu"]) return "enable";
   if (flags["no-sandbox-gpu"]) return "disable";
   return null;
+}
+
+function resolveVllmGpuDevice(
+  requested: string | undefined,
+  resume: boolean,
+  deps: ResolveOnboardOptionsDeps,
+): string | null {
+  let normalized: string | null = null;
+  if (requested !== undefined) {
+    try {
+      normalized = normalizeVllmGpuDevice(requested);
+    } catch (error) {
+      fail(deps, `  Invalid --vllm-gpu-device: ${(error as Error).message}.`);
+    }
+  }
+  if (!resume) return normalized;
+
+  const recorded = deps.loadSession?.()?.vllmGpuDevice ?? null;
+  if (!recorded) {
+    if (normalized) {
+      fail(
+        deps,
+        "  --vllm-gpu-device cannot be added while resuming a legacy onboarding session; start fresh instead.",
+      );
+    }
+    return null;
+  }
+  if (normalized && normalized !== recorded) {
+    fail(deps, `  --vllm-gpu-device ${normalized} does not match resumed GPU device ${recorded}.`);
+  }
+  return recorded;
 }
 
 function resolveHostMounts(
@@ -412,6 +451,7 @@ export function resolveOnboardOptions(
   const resume = deps.resumeIntent?.effectiveResume ?? flags.resume === true;
   const agent = resolveAgent(flags.agent, deps);
   const servingProfileProvenance = resolveServingProfileLifecycle(flags, deps, resume);
+  const vllmGpuDevice = resolveVllmGpuDevice(flags["vllm-gpu-device"], resume, deps);
   validateObservabilityAgent(flags.observability, agent, deps);
   let toolDisclosure: ToolDisclosure | null;
   try {
@@ -437,6 +477,7 @@ export function resolveOnboardOptions(
     ...(hostMounts.length > 0 ? { hostMounts } : {}),
     sandboxGpu: resolveSandboxGpu(flags),
     sandboxGpuDevice: flags["sandbox-gpu-device"] ?? null,
+    vllmGpuDevice,
     acceptThirdPartySoftware:
       flags[NOTICE_ACCEPT_FLAG_NAME] === true || String(deps.env[NOTICE_ACCEPT_ENV] || "") === "1",
     agent,
@@ -589,6 +630,7 @@ type OnboardCommandAttemptResult = "complete" | "retry" | number;
 interface OnboardCommandEnvironmentSnapshot {
   agentsManifest: string | undefined;
   toolDisclosure: string | undefined;
+  vllmGpuDevice: string | undefined;
   ollamaAutostart: { present: boolean; value: string | undefined };
 }
 
@@ -638,6 +680,8 @@ function restoreOnboardCommandEnvironment(
   restoreServingProfileEnvironment();
   if (snapshot.toolDisclosure === undefined) delete env[TOOL_DISCLOSURE_ENV];
   else env[TOOL_DISCLOSURE_ENV] = snapshot.toolDisclosure;
+  if (snapshot.vllmGpuDevice === undefined) delete env[NEMOCLAW_VLLM_GPU_DEVICE_ENV];
+  else env[NEMOCLAW_VLLM_GPU_DEVICE_ENV] = snapshot.vllmGpuDevice;
   if (snapshot.ollamaAutostart.present) {
     env.NEMOCLAW_OLLAMA_NO_AUTOSTART = snapshot.ollamaAutostart.value ?? "";
   } else {
@@ -656,6 +700,7 @@ async function runOnboardCommandAttempt(
   const environmentSnapshot: OnboardCommandEnvironmentSnapshot = {
     agentsManifest: env.NEMOCLAW_EXTRA_AGENTS_JSON,
     toolDisclosure: env[TOOL_DISCLOSURE_ENV],
+    vllmGpuDevice: env[NEMOCLAW_VLLM_GPU_DEVICE_ENV],
     ollamaAutostart: {
       present: Object.prototype.hasOwnProperty.call(env, "NEMOCLAW_OLLAMA_NO_AUTOSTART"),
       value: env.NEMOCLAW_OLLAMA_NO_AUTOSTART,
@@ -668,6 +713,8 @@ async function runOnboardCommandAttempt(
     restoreServingProfileEnvironment = applyServingProfileEnvironment(options, env);
     const toolDisclosure = toolDisclosureEnvironmentOverride(options, deps.flags);
     if (toolDisclosure) env[TOOL_DISCLOSURE_ENV] = toolDisclosure;
+    if (options.vllmGpuDevice) env[NEMOCLAW_VLLM_GPU_DEVICE_ENV] = options.vllmGpuDevice;
+    else delete env[NEMOCLAW_VLLM_GPU_DEVICE_ENV];
     if (options.noOllamaAutostart && !options.experimentalProfile) {
       env.NEMOCLAW_OLLAMA_NO_AUTOSTART = "1";
     }

--- a/src/lib/onboard/sandbox-registration.ts
+++ b/src/lib/onboard/sandbox-registration.ts
@@ -311,12 +311,18 @@ export function buildCreatedSandboxRegistryEntry(
   };
 }
 
-/** Load only the immutable profile identity needed by command-level resume validation. */
-export function loadServingProfileResumeSession(): {
+/** Load the immutable choices needed by command-level resume validation. */
+export function loadOnboardCommandResumeSession(): {
   servingProfileProvenance: onboardSession.Session["servingProfileProvenance"];
+  vllmGpuDevice: onboardSession.Session["vllmGpuDevice"];
 } | null {
   const session = onboardSession.loadSession();
-  return session ? { servingProfileProvenance: session.servingProfileProvenance } : null;
+  return session
+    ? {
+        servingProfileProvenance: session.servingProfileProvenance,
+        vllmGpuDevice: session.vllmGpuDevice,
+      }
+    : null;
 }
 
 export function registerCreatedSandbox(input: CreatedSandboxRegistrationInput): SandboxEntry {

--- a/src/lib/onboard/session-bootstrap.test.ts
+++ b/src/lib/onboard/session-bootstrap.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { decisionSelected, decisionUnset } from "../state/onboard-checkpoint-decision";
+import { NEMOCLAW_VLLM_GPU_DEVICE_ENV } from "../inference/vllm-models";
 import {
   CHECKPOINT_SCHEMA_VERSION,
   type CheckpointLoadResult,
@@ -217,6 +218,24 @@ describe("prepareOnboardSession", () => {
     expect(result.session?.servingProfileProvenance).toEqual(SERVING_PROFILE_PROVENANCE);
   });
 
+  it("checkpoints the managed vLLM GPU device before fresh onboarding effects", async () => {
+    vi.stubEnv(NEMOCLAW_VLLM_GPU_DEVICE_ENV, "GPU-69adb14e-820e-bfb4-0993-171e73f68504");
+    const { deps } = createDeps();
+    const result = await prepareOnboardSession(
+      {
+        resume: false,
+        fresh: false,
+        requestedFromDockerfile: null,
+        requestedSandboxName: "gpu-test",
+        cannotPrompt: true,
+        nonInteractive: true,
+      },
+      deps,
+    );
+
+    expect(result.session?.vllmGpuDevice).toBe("GPU-69adb14e-820e-bfb4-0993-171e73f68504");
+  });
+
   it("checkpoints Station Express choices before managed vLLM setup", async () => {
     const { deps } = createDeps();
     const stationExpress = {
@@ -403,34 +422,34 @@ describe("prepareOnboardSession", () => {
   it.each([
     { recorded: true, requested: false },
     { recorded: false, requested: true },
-  ])("records an explicit observability request while resuming", async ({
-    recorded,
-    requested,
-  }) => {
-    const { deps } = createDeps(
-      createSession({
-        sandboxName: "demo",
-        observabilityEnabled: recorded,
-        status: "failed",
-      }),
-    );
+  ])(
+    "records an explicit observability request while resuming",
+    async ({ recorded, requested }) => {
+      const { deps } = createDeps(
+        createSession({
+          sandboxName: "demo",
+          observabilityEnabled: recorded,
+          status: "failed",
+        }),
+      );
 
-    const result = await prepareOnboardSession(
-      {
-        resume: true,
-        fresh: false,
-        requestedFromDockerfile: null,
-        requestedSandboxName: null,
-        cannotPrompt: false,
-        nonInteractive: false,
-        requestedObservabilityEnabled: requested,
-      },
-      deps,
-    );
+      const result = await prepareOnboardSession(
+        {
+          resume: true,
+          fresh: false,
+          requestedFromDockerfile: null,
+          requestedSandboxName: null,
+          cannotPrompt: false,
+          nonInteractive: false,
+          requestedObservabilityEnabled: requested,
+        },
+        deps,
+      );
 
-    expect(result.session?.observabilityEnabled).toBe(requested);
-    expect(result.session?.observabilityRequestedExplicitly).toBe(true);
-  });
+      expect(result.session?.observabilityEnabled).toBe(requested);
+      expect(result.session?.observabilityRequestedExplicitly).toBe(true);
+    },
+  );
 
   it("records and reports resume conflicts before exiting", async () => {
     const conflict: ResumeConfigConflict = {
@@ -718,9 +737,10 @@ describe("prepareOnboardSession", () => {
     };
     session.checkpoint = checkpoint;
     const { deps } = createDeps(session, {
-      resolveResumeCheckpoint: vi.fn(
-        (): CheckpointLoadResult => ({ status: "loaded", checkpoint }),
-      ),
+      resolveResumeCheckpoint: vi.fn((): CheckpointLoadResult => ({
+        status: "loaded",
+        checkpoint,
+      })),
     });
 
     const result = await prepareOnboardSession(

--- a/src/lib/onboard/session-bootstrap.ts
+++ b/src/lib/onboard/session-bootstrap.ts
@@ -4,6 +4,7 @@
 import path from "node:path";
 
 import type { ServingProfileProvenance } from "../inference/serving/types";
+import { NEMOCLAW_VLLM_GPU_DEVICE_ENV, parseVllmGpuDevice } from "../inference/vllm-models";
 import { PERSONAL_POLICY_TIER_NAME } from "../policy/tiers";
 import { redact, redactFull, redactSensitiveText } from "../security/redact";
 import { isDecisionSelected } from "../state/onboard-checkpoint-decision";
@@ -610,6 +611,7 @@ function prepareFreshSession(
     observabilityRequestedExplicitly: typeof input.requestedObservabilityEnabled === "boolean",
     stationExpressIntent: input.stationExpressIntent ?? null,
     servingProfileProvenance: input.servingProfileProvenance ?? null,
+    vllmGpuDevice: parseVllmGpuDevice(process.env[NEMOCLAW_VLLM_GPU_DEVICE_ENV]),
     metadata: {
       gatewayName: "nemoclaw",
       fromDockerfile: fromDockerfile || null,

--- a/src/lib/onboard/setup-nim-flow-vllm-gpu-device.test.ts
+++ b/src/lib/onboard/setup-nim-flow-vllm-gpu-device.test.ts
@@ -4,7 +4,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { NEMOCLAW_VLLM_GPU_DEVICE_ENV } from "../inference/vllm-models";
-import { makeDeps } from "./__test-helpers__/setup-nim-flow";
+import { makeDeps, makeHostState } from "./__test-helpers__/setup-nim-flow";
+import type { SetupNimFlowDeps } from "./setup-nim-flow";
 import { createSetupNim } from "./setup-nim-flow";
 
 afterEach(() => {
@@ -31,5 +32,63 @@ describe("managed vLLM GPU provider selection", () => {
     expect(abortNonInteractive).toHaveBeenCalledWith(
       expect.stringContaining("selected provider is 'build'"),
     );
+  });
+
+  it("rejects an existing local vLLM selected during fresh onboarding", async () => {
+    vi.stubEnv(NEMOCLAW_VLLM_GPU_DEVICE_ENV, "2");
+    const abortNonInteractive = vi.fn((message: string): never => {
+      throw new Error(message);
+    });
+    const handleVllmSelection = vi.fn<SetupNimFlowDeps["handleVllmSelection"]>();
+    const setupNim = createSetupNim(
+      makeDeps({
+        isNonInteractive: () => true,
+        getNonInteractiveProvider: () => "vllm",
+        detectInferenceProviderHostState: () =>
+          makeHostState({
+            vllmRunning: true,
+            vllmEntries: [{ key: "vllm", label: "Local vLLM - running" }],
+          }),
+        abortNonInteractive,
+        handleVllmSelection,
+      }),
+    );
+
+    await expect(setupNim(null)).rejects.toThrow(
+      "applies only when NemoClaw installs managed vLLM",
+    );
+    expect(abortNonInteractive).toHaveBeenCalledWith(
+      expect.stringContaining("selected provider is 'vllm'"),
+    );
+    expect(handleVllmSelection).not.toHaveBeenCalled();
+  });
+
+  it("allows the persisted device when resuming its managed vLLM provider", async () => {
+    vi.stubEnv(NEMOCLAW_VLLM_GPU_DEVICE_ENV, "2");
+    const handleVllmSelection = vi.fn<SetupNimFlowDeps["handleVllmSelection"]>(async (state) => {
+      state.model = "resumed-model";
+      state.provider = "vllm-local";
+      return "selected";
+    });
+    const setupNim = createSetupNim(
+      makeDeps({
+        isNonInteractive: () => true,
+        detectInferenceProviderHostState: () =>
+          makeHostState({
+            vllmRunning: true,
+            vllmEntries: [{ key: "vllm", label: "Local vLLM - running" }],
+          }),
+        readRecordedProvider: () => "vllm-local",
+        readRecordedNimContainer: () => null,
+        readRecordedModel: () => "resumed-model",
+        handleVllmSelection,
+      }),
+    );
+
+    await expect(setupNim(null, "existing-sandbox")).resolves.toMatchObject({
+      model: "resumed-model",
+      provider: "vllm-local",
+    });
+    expect(handleVllmSelection).toHaveBeenCalledOnce();
   });
 });

--- a/src/lib/onboard/setup-nim-flow-vllm-gpu-device.test.ts
+++ b/src/lib/onboard/setup-nim-flow-vllm-gpu-device.test.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NEMOCLAW_VLLM_GPU_DEVICE_ENV } from "../inference/vllm-models";
+import { makeDeps } from "./__test-helpers__/setup-nim-flow";
+import { createSetupNim } from "./setup-nim-flow";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("managed vLLM GPU provider selection", () => {
+  it("rejects the GPU device when non-interactive onboarding selects another provider", async () => {
+    vi.stubEnv(NEMOCLAW_VLLM_GPU_DEVICE_ENV, "2");
+    const abortNonInteractive = vi.fn((message: string): never => {
+      throw new Error(message);
+    });
+    const setupNim = createSetupNim(
+      makeDeps({
+        isNonInteractive: () => true,
+        getNonInteractiveProvider: () => "build",
+        abortNonInteractive,
+      }),
+    );
+
+    await expect(setupNim(null, null, null, false)).rejects.toThrow(
+      "applies only when NemoClaw installs managed vLLM",
+    );
+    expect(abortNonInteractive).toHaveBeenCalledWith(
+      expect.stringContaining("selected provider is 'build'"),
+    );
+  });
+});

--- a/src/lib/onboard/setup-nim-flow.ts
+++ b/src/lib/onboard/setup-nim-flow.ts
@@ -254,14 +254,14 @@ function requireSelectedProvider(
 
 function assertVllmGpuProviderSelection(
   selected: ProviderMenuChoice,
-  recoverProvider: boolean,
+  recoveredFromSandbox: boolean,
   deps: Pick<
     SetupNimFlowDeps,
     "abortNonInteractive" | "error" | "exitProcess" | "isNonInteractive"
   >,
 ): void {
   const requestedDevice = String(process.env.NEMOCLAW_VLLM_GPU_DEVICE ?? "").trim();
-  const resumedManagedVllm = recoverProvider && selected.key === "vllm";
+  const resumedManagedVllm = recoveredFromSandbox && selected.key === "vllm";
   if (!requestedDevice || selected.key === "install-vllm" || resumedManagedVllm) return;
 
   const message =
@@ -945,7 +945,7 @@ export function createSetupNim(
         }
 
         selected = requireSelectedProvider(selected, deps);
-        assertVllmGpuProviderSelection(selected, recoverProvider, deps);
+        assertVllmGpuProviderSelection(selected, recoveredFromSandbox, deps);
         if (selected.key !== "hermesProvider") {
           hermesAuthMethod = null;
           hermesToolGateways = [];

--- a/src/lib/onboard/setup-nim-flow.ts
+++ b/src/lib/onboard/setup-nim-flow.ts
@@ -225,9 +225,7 @@ export interface SetupNimFlowDeps {
   resolveRequestedServingProfileModel?(
     env?: NodeJS.ProcessEnv,
   ): RequestedServingProfileModel | null;
-  selectVllmModelFromEnv?(
-    env?: NodeJS.ProcessEnv,
-  ): { id: string; servedModelId?: string } | null;
+  selectVllmModelFromEnv?(env?: NodeJS.ProcessEnv): { id: string; servedModelId?: string } | null;
   handleRoutedSelection(state: SetupNimSelectionState): Promise<SetupNimSelectionResult>;
   coerceAgentInferenceApi(
     agent: AgentDefinition | null,
@@ -252,6 +250,26 @@ function requireSelectedProvider(
     deps.exitProcess(1);
   }
   return selected;
+}
+
+function assertVllmGpuProviderSelection(
+  selected: ProviderMenuChoice,
+  recoverProvider: boolean,
+  deps: Pick<
+    SetupNimFlowDeps,
+    "abortNonInteractive" | "error" | "exitProcess" | "isNonInteractive"
+  >,
+): void {
+  const requestedDevice = String(process.env.NEMOCLAW_VLLM_GPU_DEVICE ?? "").trim();
+  const resumedManagedVllm = recoverProvider && selected.key === "vllm";
+  if (!requestedDevice || selected.key === "install-vllm" || resumedManagedVllm) return;
+
+  const message =
+    `--vllm-gpu-device applies only when NemoClaw installs managed vLLM; ` +
+    `the selected provider is '${selected.key}'.`;
+  deps.error(`  ${message}`);
+  if (deps.isNonInteractive()) deps.abortNonInteractive(message);
+  deps.exitProcess(1);
 }
 
 function handleSelectedOllama(
@@ -927,6 +945,7 @@ export function createSetupNim(
         }
 
         selected = requireSelectedProvider(selected, deps);
+        assertVllmGpuProviderSelection(selected, recoverProvider, deps);
         if (selected.key !== "hermesProvider") {
           hermesAuthMethod = null;
           hermesToolGateways = [];

--- a/src/lib/onboard/types.ts
+++ b/src/lib/onboard/types.ts
@@ -150,6 +150,8 @@ export type OnboardOptions = {
   hostMounts?: readonly import("../state/registry/types").SandboxHostMount[];
   sandboxGpu?: "enable" | "disable" | null;
   sandboxGpuDevice?: string | null;
+  /** GPU exposed to the host-side vLLM container managed by NemoClaw. */
+  vllmGpuDevice?: string | null;
   acceptThirdPartySoftware?: boolean;
   agent?: string | null;
   toolDisclosure?: import("../tool-disclosure").ToolDisclosure | null;

--- a/src/lib/state/onboard-session-vllm-resume.test.ts
+++ b/src/lib/state/onboard-session-vllm-resume.test.ts
@@ -64,6 +64,22 @@ describe("managed vLLM resume checkpoint persistence", () => {
     expect(session.normalizeSession(malformed as never)).toBeNull();
   });
 
+  it("persists a vLLM GPU UUID and keeps sessions without the new field compatible", () => {
+    const uuid = "GPU-69adb14e-820e-bfb4-0993-171e73f68504";
+    session.saveSession(session.createSession({ vllmGpuDevice: uuid }));
+
+    expect(requireLoadedSession().vllmGpuDevice).toBe(uuid);
+    expect(session.summarizeForDebug()?.vllmGpuDevice).toBe(uuid);
+
+    const legacy = session.createSession() as unknown as Record<string, unknown>;
+    delete legacy.vllmGpuDevice;
+    expect(session.normalizeSession(legacy as never)?.vllmGpuDevice).toBeNull();
+
+    const malformed = session.createSession() as unknown as Record<string, unknown>;
+    malformed.vllmGpuDevice = "nvidia.com/gpu=0";
+    expect(session.normalizeSession(malformed as never)).toBeNull();
+  });
+
   it("refuses to checkpoint outside provider selection", () => {
     session.saveSession(session.createSession());
     expect(() => session.checkpointVllmInstallModel("example/model")).toThrow(

--- a/src/lib/state/onboard-session.ts
+++ b/src/lib/state/onboard-session.ts
@@ -207,6 +207,8 @@ export interface Session {
   model: string | null;
   /** Secret-free model intent retained only while a managed vLLM install is unfinished. */
   vllmInstallModel: string | null;
+  /** GPU exposed to the host-side managed vLLM container for this onboarding attempt. */
+  vllmGpuDevice: string | null;
   /** Exact secret-free serving recipe identity selected before runtime side effects. */
   servingProfileProvenance: ServingProfileProvenance | null;
   /** Secret-free installer choices needed to retry an interrupted DGX Station Express run. */
@@ -334,6 +336,7 @@ export interface DebugSessionSummary {
   provider: string | null;
   model: string | null;
   vllmInstallModel: string | null;
+  vllmGpuDevice: string | null;
   servingProfileProvenance: ServingProfileProvenance | null;
   endpointUrl: string | null;
   credentialEnv: string | null;
@@ -392,6 +395,18 @@ function parseVllmInstallModel(value: unknown): string | null {
   const model = value.trim();
   return model.length > 0 && model.length <= 512 && SAFE_VLLM_INSTALL_MODEL.test(model)
     ? model
+    : null;
+}
+
+function parseVllmGpuDevice(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const candidate = value.trim();
+  if (/^\d+$/.test(candidate)) {
+    const index = Number(candidate);
+    if (Number.isSafeInteger(index)) return String(index);
+  }
+  return /^GPU-[A-Fa-f0-9]{8}(?:-[A-Fa-f0-9]{4}){3}-[A-Fa-f0-9]{12}$/.test(candidate)
+    ? `GPU-${candidate.slice("GPU-".length).toLowerCase()}`
     : null;
 }
 
@@ -749,6 +764,7 @@ export function createSession(overrides: Partial<Session> = {}): Session {
     provider: overrides.provider ?? null,
     model: overrides.model ?? null,
     vllmInstallModel: parseVllmInstallModel(overrides.vllmInstallModel),
+    vllmGpuDevice: parseVllmGpuDevice(overrides.vllmGpuDevice),
     servingProfileProvenance: parseServingProfileProvenance(overrides.servingProfileProvenance),
     stationExpressIntent: parseStationExpressResumeIntent(overrides.stationExpressIntent),
     stationExpressReceiptRetirement: isValidStationExpressReceiptGeneration(
@@ -818,6 +834,10 @@ export function normalizeSession(data: Session | SessionJsonValue | undefined): 
   if (hasOwn(data, "vllmInstallModel") && data.vllmInstallModel !== null && !vllmInstallModel) {
     return null;
   }
+  const vllmGpuDevice = parseVllmGpuDevice(data.vllmGpuDevice);
+  if (hasOwn(data, "vllmGpuDevice") && data.vllmGpuDevice !== null && !vllmGpuDevice) {
+    return null;
+  }
   const compatibleEndpointReasoningEffort = normalizeReasoningEffort(
     data.compatibleEndpointReasoningEffort,
   );
@@ -858,6 +878,7 @@ export function normalizeSession(data: Session | SessionJsonValue | undefined): 
     provider: readString(data.provider),
     model: readString(data.model),
     vllmInstallModel,
+    vllmGpuDevice,
     servingProfileProvenance,
     stationExpressIntent,
     stationExpressReceiptRetirement,
@@ -1847,6 +1868,7 @@ export function summarizeForDebug(
     provider: session.provider,
     model: session.model,
     vllmInstallModel: session.vllmInstallModel,
+    vllmGpuDevice: session.vllmGpuDevice,
     servingProfileProvenance: session.servingProfileProvenance,
     endpointUrl: redactUrl(session.endpointUrl),
     credentialEnv: session.credentialEnv,


### PR DESCRIPTION
## Summary

Managed vLLM currently uses GPU 0 even when another host GPU has enough free memory. This adds `nemoclaw onboard --vllm-gpu-device <index-or-uuid>` and preserves that host GPU choice when onboarding resumes. Sandbox GPU exposure remains independently controlled by `--sandbox-gpu-device`.

## Changes

- Validate and canonicalize a non-negative GPU index or full GPU UUID reported by `nvidia-smi`.
- Apply the selection to the managed vLLM Docker `--gpus device=...` request and to GPU-specific memory and compute-capability preflights.
- Persist the selection before onboarding effects and replay it on resume; reject attempts to change it during resume.
- Reject the option for non-vLLM providers and managed multi-node inference so it cannot be silently ignored.
- Document the flag for onboarding and its deprecated command aliases.
- Use a scoped internal environment handoff because the onboarding entry point is architecture-budget constrained; the public consumer remains the CLI flag, and tests protect scoping and restoration.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior - justification:
- [ ] Tests not applicable - justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded - reviewer/approval link/justification: Maintainer review requested on this PR.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer - check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above - `npx vitest run --project cli ...`: 9 files, 244 tests passed
- [x] Applicable broad gate passed - `npm run validate:pr` passed; repository architecture, lint, growth, env-var, and CLI TypeScript gates passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional functional evidence: on an NVIDIA GB10 host, Docker exposed the same selected GPU using both `--gpus device=0` and `--gpus device=GPU-69adb14e-820e-bfb4-0993-171e73f68504`.

CLI/reference parity verification: `bash test/e2e/e2e-cloud-experimental/check-docs.sh --only-cli` passed.

---
Signed-off-by: prekshivyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `--vllm-gpu-device` onboarding option to select a managed vLLM GPU by index or NVIDIA UUID.
  * GPU selection is independent of sandbox GPU access and persists when onboarding is resumed.
  * Added validation for invalid, conflicting, or incompatible GPU selections.
* **Documentation**
  * Updated command reference documentation and setup aliases with the new option and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->