### PR TITLE
fix(messaging): retain stopped channel provider bindings

### DIFF
--- a/src/lib/onboard/initial-policy-real-policy.test.ts
+++ b/src/lib/onboard/initial-policy-real-policy.test.ts
@@ -234,6 +234,16 @@ describe("initial sandbox policy real preset merge", () => {
     expect(discordBinaries).toContain("/opt/hermes/.venv/bin/python");
     expect(discordBinaries).not.toContain("/usr/bin/node");
 
+    const boundProviders =
+      policy.network_policies?.discord?.endpoints
+        ?.map((endpoint) => endpoint.credential_binding?.provider)
+        .filter(Boolean) ?? [];
+    expect(boundProviders).toEqual([
+      "hermes-channel-discord-bridge",
+      "hermes-channel-discord-bridge",
+      "hermes-channel-discord-bridge",
+    ]);
+
     const discordRules =
       policy.network_policies?.discord?.endpoints
         ?.find((endpoint) => endpoint.host === "discord.com")

--- a/src/lib/onboard/sandbox-create-intent.ts
+++ b/src/lib/onboard/sandbox-create-intent.ts
@@ -27,27 +27,6 @@ function filterMessagingProviderRequestsByEnabledChannel(
   return requests.filter(({ channel }) => !channel || !disabledChannelNames.has(channel));
 }
 
-function resolveTokenProviderChannelMap(
-  requests: readonly SandboxCreateMessagingProviderRequest[],
-): Map<string, string> {
-  const providerChannels = new Map<string, string>();
-  for (const { channel, name } of requests) {
-    if (channel) providerChannels.set(name, channel);
-  }
-  return providerChannels;
-}
-
-function filterMessagingProvidersByEnabledChannel(
-  providerNames: string[],
-  providerChannels: ReadonlyMap<string, string>,
-  disabledChannelNames: ReadonlySet<string>,
-): string[] {
-  return providerNames.filter((providerName) => {
-    const channel = providerChannels.get(providerName);
-    return !channel || !disabledChannelNames.has(channel);
-  });
-}
-
 function resolveActiveMessagingChannels({
   channels,
   disabledChannelNames,
@@ -157,7 +136,6 @@ export function resolveSandboxCreateIntent({
     messagingProviderRequests,
     disabledChannelNames,
   );
-  const providerChannels = resolveTokenProviderChannelMap(messagingProviderRequests);
   const activeMessagingChannels = resolveActiveMessagingChannels({
     channels,
     disabledChannelNames,
@@ -166,11 +144,11 @@ export function resolveSandboxCreateIntent({
     primaryMessagingCredentialEnvKeys,
     reusableMessagingChannels,
   });
-  const enabledReusableMessagingProviders = filterMessagingProvidersByEnabledChannel(
-    [...new Set(reusableMessagingProviders)],
-    providerChannels,
-    disabledChannelNames,
-  );
+  // A credential-bound policy can outlive an active channel while the channel is
+  // stopped, Shields is lowered, or a rebuild replays preserved policy state.
+  // Keep every exact reusable provider attached to the replacement sandbox; the
+  // disabled plan still suppresses channel startup, render, and runtime effects.
+  const enabledReusableMessagingProviders = [...new Set(reusableMessagingProviders)];
 
   const normalizedInferenceProvider = inferenceProvider?.trim() || null;
 

--- a/src/lib/onboard/sandbox-create-plan-materialization.ts
+++ b/src/lib/onboard/sandbox-create-plan-materialization.ts
@@ -192,27 +192,6 @@ export function validateSandboxCreateIntentBindings(
   });
 }
 
-function resolveProviderChannelMap(
-  requests: readonly SandboxCreateMessagingProviderRequest[],
-): Map<string, string> {
-  const providerChannels = new Map<string, string>();
-  for (const { channel, name } of requests) {
-    if (channel) providerChannels.set(name, channel);
-  }
-  return providerChannels;
-}
-
-function filterDisabledMessagingProviders(
-  providerNames: string[],
-  providerChannels: ReadonlyMap<string, string>,
-  disabledChannelNames: ReadonlySet<string>,
-): string[] {
-  return providerNames.filter((providerName) => {
-    const channel = providerChannels.get(providerName);
-    return !channel || !disabledChannelNames.has(channel);
-  });
-}
-
 /** Materialize policy, route metadata, resources, and providers from a secretless intent. */
 export function materializeSandboxCreatePlan({
   intent,
@@ -265,17 +244,17 @@ export function materializeSandboxCreatePlan({
   ];
 
   runProviderPreDeleteCleanup();
-  const providerChannels = resolveProviderChannelMap(intent.messagingProviderRequests);
-  const messagingProviders = filterDisabledMessagingProviders(
-    [
-      ...new Set([
-        ...upsertMessagingProviders(enabledMessagingTokenDefs, { replaceExisting: true }),
-        ...intent.reusableMessagingProviders,
-      ]),
-    ],
-    providerChannels,
-    new Set(intent.disabledChannelNames),
-  );
+  // Reusable providers hold gateway-side credential authority. Keep their exact
+  // attachment on the replacement even when the channel runtime is disabled:
+  // the initial policy can still carry a credential_binding during rebuild or
+  // Shields transitions, while enabledMessagingTokenDefs continues to suppress
+  // new provider creation for disabled channels.
+  const messagingProviders = [
+    ...new Set([
+      ...upsertMessagingProviders(enabledMessagingTokenDefs, { replaceExisting: true }),
+      ...intent.reusableMessagingProviders,
+    ]),
+  ];
   const createProviders = new Set<string>();
   if (intent.inferenceProvider) createProviders.add(intent.inferenceProvider);
   for (const provider of messagingProviders) createProviders.add(provider);

--- a/src/lib/onboard/sandbox-create-plan.test.ts
+++ b/src/lib/onboard/sandbox-create-plan.test.ts
@@ -23,6 +23,12 @@ const selectedSandboxGpuConfig: SandboxGpuCreateConfig = {
   sandboxGpuDevice: "nvidia.com/gpu=0",
 };
 
+const disabledSandboxGpuConfig: SandboxGpuCreateConfig = {
+  sandboxGpuEnabled: false,
+  sandboxGpuDevice: null,
+  hostGpuDetected: false,
+};
+
 afterEach(() => {
   vi.unstubAllEnvs();
 });
@@ -150,7 +156,7 @@ describe("resolveSandboxCreateIntent", () => {
     expect(JSON.stringify(requests)).not.toContain("telegram-super-secret");
   });
 
-  it("resolves deterministic serializable intent without execution artifacts", () => {
+  it("resolves serializable intent and keeps stopped-channel providers attached (#9773)", () => {
     const input = {
       basePolicyPath: "/repo/policy.yaml",
       sandboxName: "sandbox",
@@ -206,7 +212,10 @@ describe("resolveSandboxCreateIntent", () => {
       "sandbox-telegram-bridge",
       "sandbox-slack-bridge",
     ]);
-    expect(first.reusableMessagingProviders).toEqual(["sandbox-existing-discord"]);
+    expect(first.reusableMessagingProviders).toEqual([
+      "sandbox-existing-discord",
+      "sandbox-slack-bridge",
+    ]);
     expect(first.extraProviders).toEqual(["custom-provider"]);
     expect(first.staleExtraProviders).toEqual(["stale-provider"]);
     expect(first.resourceCreateArgs).toEqual(["--cpu", "4", "--memory", "16Gi"]);
@@ -235,6 +244,61 @@ describe("resolveSandboxCreateIntent", () => {
     });
     expect(JSON.parse(JSON.stringify(first))).toEqual(first);
     expect(JSON.stringify(first)).not.toContain("/tmp/");
+  });
+
+  it("attaches an exact reusable provider while its channel runtime is stopped (#9773)", () => {
+    const intent = resolveSandboxCreateIntent({
+      basePolicyPath: "/repo/hermes-policy.yaml",
+      sandboxName: "sandbox",
+      channels,
+      enabledChannels: ["discord"],
+      disabledChannelNames: new Set(["discord"]),
+      messagingProviderRequests: [
+        {
+          name: "sandbox-discord-bridge",
+          envKey: "DISCORD_BOT_TOKEN",
+          providerType: "discord-hermes-static-v1",
+          credentialConfigured: false,
+          channel: "discord",
+        },
+      ],
+      primaryMessagingCredentialEnvKeys: ["DISCORD_BOT_TOKEN"],
+      reusableMessagingChannels: [],
+      reusableMessagingProviders: ["sandbox-discord-bridge"],
+      extraProviders: [],
+      hermesToolGateways: [],
+      sandboxGpuConfig: disabledSandboxGpuConfig,
+      gpuCreateArgs: [],
+      gpuRoutePlan: "none",
+      sandboxGpuLogMessage: null,
+      agentName: "hermes",
+      policyTier: "balanced",
+    });
+    const upsertMessagingProviders = vi.fn(() => []);
+
+    const plan = materializeSandboxCreatePlan({
+      intent,
+      fromRef: "/tmp/Dockerfile",
+      messagingTokenDefs: [
+        {
+          name: "sandbox-discord-bridge",
+          envKey: "DISCORD_BOT_TOKEN",
+          token: null,
+          providerType: "discord-hermes-static-v1",
+        },
+      ],
+      runProviderPreDeleteCleanup: vi.fn(),
+      upsertMessagingProviders,
+      getHermesToolGatewayProviderName: vi.fn(),
+      prepareInitialSandboxCreatePolicy: vi.fn(() => ({
+        policyPath: "/tmp/policy.yaml",
+        appliedPresets: [],
+      })),
+    });
+
+    expect(upsertMessagingProviders).toHaveBeenCalledWith([], { replaceExisting: true });
+    expect(plan.messagingProviders).toEqual(["sandbox-discord-bridge"]);
+    expect(plan.createArgs).toContain("sandbox-discord-bridge");
   });
 
   it("keeps the real gateway provider while excluding direct host-local inference policy", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Hermes rebuild and channel lifecycle could recreate a sandbox without its exact Discord provider while the restored policy still referenced that provider. This change retains already validated reusable providers on the replacement sandbox, while stopped channels remain disabled and do not create providers, start runtimes, or widen egress.

## Related Issue

Fixes #9773

## Changes

- Preserve exact reusable messaging provider names in the secretless sandbox-create intent even when their channel is stopped.
- Keep those reusable providers in `sandbox create --provider` while continuing to filter disabled channel token definitions from provider creation.
- Add deterministic coverage proving a stopped Hermes Discord channel keeps the exact provider attachment and that the real Hermes policy materializes all three credential bindings to that provider.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Independent nine-category review found no blockers or warnings. Exact provider reuse still requires the existing gateway profile, type, and credential-key match; stopped channels remain excluded from runtime activation and policy preset selection.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/sandbox-create-plan.test.ts src/lib/onboard/initial-policy-real-policy.test.ts` passed 84 tests. `npm run build:cli` and `npm run typecheck:cli` passed. Repository checks passed after the build; the combined command timed out after its completed type check, and the repository check passed when run separately.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; this is a four-file provider attachment correction with focused owner tests and live PR E2E requested below.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## E2E root cause and required evidence

- Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/32641465070
- Stable signature: `credential_binding references provider '<sandbox>-discord-bridge', but that provider is not attached to the sandbox`
- Affected jobs: Hermes rebuild, stale-base rebuild, Shields posture change, channel stop/start, and Hermes open-egress networking.
- Required PR evidence: run those five scenarios against this exact commit and require all five to pass before the PR becomes ready.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
