### PR TITLE
fix(ci): pass Buildx target architecture explicitly

### DIFF
--- a/scripts/checks/build-protected-managed-images.sh
+++ b/scripts/checks/build-protected-managed-images.sh
@@ -396,6 +396,9 @@ build_agent() {
     --label "io.nvidia.nemoclaw.managed-image.capabilities=1"
     --label "io.nvidia.nemoclaw.managed-image.cohort=${cohort}"
     --build-arg "BASE_IMAGE=${base_reference}"
+    # Dockerfile defaults preserve direct Podman x86 builds. Pass the selected
+    # Buildx target explicitly so that default cannot override linux/arm64.
+    --build-arg "TARGETARCH=${platform#linux/}"
     --build-arg "NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1"
     --build-arg "NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root"
     "$source_root")

--- a/test/protected-managed-image-build-script.test.ts
+++ b/test/protected-managed-image-build-script.test.ts
@@ -329,10 +329,14 @@ describe("protected managed-image build-cache boundary", () => {
     const result = runBuild(REPO_ROOT, [], "linux/arm64");
 
     expect(result.status, result.stderr).toBe(0);
-    for (const invocation of recordedBuildInvocations()) {
-      expect(invocation).toContain("--platform linux/arm64");
-      expect(invocation).toContain("--build-arg TARGETARCH=arm64");
-    }
+    expect(recordedBuildInvocation("openclaw")).toContain("--platform linux/arm64");
+    expect(recordedBuildInvocation("openclaw")).toContain("--build-arg TARGETARCH=arm64");
+    expect(recordedBuildInvocation("hermes")).toContain("--platform linux/arm64");
+    expect(recordedBuildInvocation("hermes")).toContain("--build-arg TARGETARCH=arm64");
+    expect(recordedBuildInvocation("langchain-deepagents-code")).toContain("--platform linux/arm64");
+    expect(recordedBuildInvocation("langchain-deepagents-code")).toContain(
+      "--build-arg TARGETARCH=arm64",
+    );
   });
 
   it("builds every agent without optional cache arguments", () => {

--- a/test/protected-managed-image-build-script.test.ts
+++ b/test/protected-managed-image-build-script.test.ts
@@ -216,7 +216,11 @@ function recordedBuildInvocation(agent: string): string {
   return invocation!;
 }
 
-function runBuild(sourceRoot: string, extraArgs: readonly string[] = []) {
+function runBuild(
+  sourceRoot: string,
+  extraArgs: readonly string[] = [],
+  platform = "linux/amd64",
+) {
   const output = path.join(testRoot, "contracts.json");
   return spawnSync(
     "bash",
@@ -229,7 +233,7 @@ function runBuild(sourceRoot: string, extraArgs: readonly string[] = []) {
       "--cohort",
       "protected-1-1",
       "--platform",
-      "linux/amd64",
+      platform,
       "--openclaw-base",
       `ghcr.io/nvidia/nemoclaw/sandbox-base@sha256:${DIGEST}`,
       "--hermes-base",
@@ -319,6 +323,18 @@ describe("protected managed-image source-root boundary", () => {
 });
 
 describe("protected managed-image build-cache boundary", () => {
+  it("passes the selected Buildx architecture explicitly to every Dockerfile", () => {
+    stubBuildInvocation();
+
+    const result = runBuild(REPO_ROOT, [], "linux/arm64");
+
+    expect(result.status, result.stderr).toBe(0);
+    for (const invocation of recordedBuildInvocations()) {
+      expect(invocation).toContain("--platform linux/arm64");
+      expect(invocation).toContain("--build-arg TARGETARCH=arm64");
+    }
+  });
+
   it("builds every agent without optional cache arguments", () => {
     stubBuildInvocation();
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Protected Linux arm64 managed-image builds selected `--platform linux/arm64`, but the Hermes Dockerfile default still selected amd64. The build script now passes the selected target architecture to each Dockerfile, which prevents the managed-image bootstrap architecture check from failing.

The existing test fixed the platform to amd64 and did not inspect `TARGETARCH`, so it did not detect the arm64 failure.

## Changes

- Pass `TARGETARCH` from the validated build platform to every protected managed-image Docker build.
- Add a regression test that verifies the arm64 platform and build argument for OpenClaw, Hermes, and LangChain Deep Agents Code.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Pending maintainer review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm exec vitest run test/protected-managed-image-build-script.test.ts` — 27 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
