### PR TITLE
fix(images): pass managed target architecture

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -1890,9 +1890,12 @@ jobs:
           DOCKERFILE: ${{ matrix.dockerfile }}
         run: |
           set -euo pipefail
+          target_arch='${{ matrix.arch }}'
+          case "$target_arch" in amd64|arm64) ;; *) exit 1 ;; esac
           build_args=(
             -f "$DOCKERFILE"
             --build-arg "BASE_IMAGE=${BASE_IMAGE}"
+            --build-arg "TARGETARCH=${target_arch}"
             --build-arg "NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1"
             --build-arg "NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root"
           )
@@ -1922,6 +1925,7 @@ jobs:
             ${{ matrix.agent == 'langchain-deepagents-code' && format('com.nvidia.nemoclaw.base-resolution={0}', steps.base.outputs.resolution_label) || '' }}
           build-args: |
             BASE_IMAGE=${{ steps.base.outputs.ref }}
+            TARGETARCH=${{ matrix.arch }}
             NEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1
             NEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ matrix.image }}:buildcache-${{ matrix.artifact_platform }}

--- a/test/managed-image-publication-workflow.test.ts
+++ b/test/managed-image-publication-workflow.test.ts
@@ -956,6 +956,7 @@ fi
     expect(releaseIdentity.id).toBe("release");
     expect(releaseIdentity.run).toContain("git describe --tags --match 'v*' \"$GITHUB_SHA\"");
     expect(releaseIdentity.run).toContain("managed image release identity does not match");
+    expect(guard.run).toContain('--build-arg "TARGETARCH=${target_arch}"');
     expect(guard.run).toContain('scripts/check-production-build-args.sh "${build_args[@]}"');
     expect(build.uses).toBe("docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a");
     expect(build.with).toMatchObject({
@@ -963,7 +964,7 @@ fi
       file: "${{ matrix.dockerfile }}",
       platforms: "${{ matrix.platform }}",
       "build-args":
-        "BASE_IMAGE=${{ steps.base.outputs.ref }}\nNEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1\nNEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root\n",
+        "BASE_IMAGE=${{ steps.base.outputs.ref }}\nTARGETARCH=${{ matrix.arch }}\nNEMOCLAW_MANAGED_IMAGE_CAPABILITY_UNION=1\nNEMOCLAW_MANAGED_IMAGE_RUNTIME_USER=root\n",
       provenance: "mode=max",
       sbom: true,
     });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The managed-image publisher selected `linux/arm64` for Hermes but did not pass `TARGETARCH`, so Hermes's documented Podman fallback forced `amd64` and the native arm64 bootstrap ELF failed its architecture check. This change passes the trusted matrix architecture explicitly to both production argument validation and Buildx.

## Changes

- Pass validated `TARGETARCH=${{ matrix.arch }}` through the production managed-image guard.
- Pass the same architecture to the managed-image Buildx invocation.
- Protect the workflow contract with the existing publication test.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The exact architecture remains constrained to the trusted matrix `amd64|arm64`; the native ELF Machine assertion remains fail-closed. No credential boundary changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/managed-image-publication-workflow.test.ts` passed 34 tests; repository checks passed.
- [ ] Applicable broad gate passed — command/result: managed-image workflow will build both architectures on this PR.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Failure evidence

- Run: https://github.com/NVIDIA/NemoClaw/actions/runs/32665988248
- Failed job: Hermes arm64 managed image
- Stable signature: BuildKit rendered `target_arch="amd64"` on the arm64 runner; the fail-closed ELF Machine assertion rejected the resulting mismatch.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed image builds for both AMD64 and ARM64 architectures.
  - Ensured architecture-specific build settings are consistently validated and applied, helping produce more reliable images across supported platforms.

- **Tests**
  - Added coverage to verify architecture settings are included during production image publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->