### PR TITLE
feat(release): support historical candidates

### DIFF
--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/SKILL.md
@@ -27,7 +27,10 @@ Treat these as separate states:
 
 - Use the exact requested version. Generate the plan with `--version vX.Y.Z`; never infer a bump.
 - Tag only the candidate captured in the plan.
-- Require the release entry. It cannot be waived.
+- By default, plan `origin/main` without an exception. For urgent QA qualification, a maintainer may
+  select an exact historical ancestor with `--candidate <full-sha> --exception <reason>`.
+- Require the release entry for a current-main plan. A historical plan records its explicit
+  release-entry exception in the signed release brief.
 - Treat documentation coverage as maintainer context, not a tag gate. Show the exact coverage point,
   later commits and PRs, review and check state, changed paths, and open managed docs PRs.
 - Record the maintainer's documentation decision in the signed release brief.
@@ -66,11 +69,22 @@ Release tag:
 
 ### 1. Generate the Plan and Brief Template
 
-Run:
+Run the default current-main plan:
 
 ```bash
 npm run release:plan -- --version vX.Y.Z
 ```
+
+For an accepted urgent QA qualification, run:
+
+```bash
+npm run release:plan -- --version vX.Y.Z \
+  --candidate <full-lowercase-40-sha> \
+  --exception "<plain-language reason>"
+```
+
+Do not pass `--exception` without a historical candidate. Do not select current `origin/main` with an
+exception.
 
 The script writes `../nemoclaw-release-vX.Y.Z/plan.json`. Show the maintainer:
 
@@ -84,7 +98,8 @@ After later reads of remote state, keep this candidate when all of these remain 
 
 - the candidate is still an ancestor of `origin/main`;
 - the previous release tag still peels to the commit recorded in the plan;
-- the candidate's release entry remains valid; and
+- the candidate's release entry remains valid, or the historical plan retains its explicit
+  release-entry exception; and
 - the candidate's own required evidence remains valid.
 
 New commits on `main` do not invalidate that plan. A managed documentation PR or branch for a later
@@ -155,14 +170,15 @@ and no requested run remains unresolved. Otherwise, ask for and record one conci
 reason. The reason must say what differs or remains unresolved and why the maintainer is proceeding.
 Selecting “Proceed with the status as shown” is the decision, not the reason. Stop and ask the
 maintainer why before continuing when a reason is required.
-This exception applies only to E2E. It never replaces the release entry, documentation coverage
-decision, or required image evidence.
+This exception applies only to E2E. It never replaces the current-main release entry, a historical
+plan's release-entry exception, the documentation coverage decision, or required image evidence.
 
 ### 4. Finish and Review the Release Brief
 
 Replace every `TODO_RELEASE_BRIEF` prompt in that Markdown file with:
 
-- the complete canonical release entry and its repository path;
+- the complete canonical release entry and its repository path for a current-main plan, or the
+  plan-bound historical release-entry exception;
 - the latest included cumulative docs PR, coverage commit, later commits and PRs, changed-path
   result, review and check state, open managed docs PRs, and maintainer decision;
 - exact-candidate E2E workflow, attempt, and successful `base-image-publication` job URL;
@@ -244,8 +260,9 @@ Keep the semver tag immutable.
 
 ## Recovery
 
-- Missing release entry: finish the candidate's documentation work and generate a new plan for the
-  resulting commit. Do not bypass the release entry.
+- Missing release entry in a current-main plan: finish the candidate's documentation work and
+  generate a new plan for the resulting commit. A historical plan uses only its plan-bound explicit
+  exception.
 - Documentation coverage shows a gap, failed checks, unapproved changes, unsupported paths, or an
   open managed docs PR: show that state. Let the maintainer proceed, create or update a docs PR, or
   stop. If documentation work changes the candidate, generate a new plan.

--- a/.agents/skills/nemoclaw-maintainer-cut-release-tag/references/candidate-evidence.md
+++ b/.agents/skills/nemoclaw-maintainer-cut-release-tag/references/candidate-evidence.md
@@ -9,8 +9,8 @@ the general E2E decision. Keep the shell only until its evidence is copied into 
 
 ```bash
 set -euo pipefail
-PLAN_PATH='../nemoclaw-release-vX.Y.Z/plan.json'
-EVIDENCE_DIR="$(mktemp -d)"
+PLAN_PATH="${PLAN_PATH:-../nemoclaw-release-vX.Y.Z/plan.json}"
+EVIDENCE_DIR="${EVIDENCE_DIR:-$(mktemp -d)}"
 chmod 700 "$EVIDENCE_DIR"
 trap 'rm -rf "$EVIDENCE_DIR"' EXIT
 
@@ -36,26 +36,47 @@ PLAN_FIELDS="$EVIDENCE_DIR/plan-fields.txt"
 run_or_stop "release plan read" jq -er '
   if
     (keys | sort) == [
-      "nextTag", "originMainCommit", "originMainHeadline",
-      "previousTag", "previousTagCommit", "previousTagObject"
+      "candidateCommit", "candidateSelection", "historicalCandidateException",
+      "nextTag", "originMainCommit",
+      "originMainHeadline", "previousTag", "previousTagCommit", "previousTagObject"
     ] and
     (.nextTag | test("^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$")) and
+    (.candidateCommit | test("^[0-9a-f]{40}$")) and
     (.originMainCommit | test("^[0-9a-f]{40}$")) and
-    (.previousTagCommit | test("^[0-9a-f]{40}$"))
-  then [.nextTag, .originMainCommit, .previousTagCommit] | @tsv
+    (.previousTagCommit | test("^[0-9a-f]{40}$")) and
+    (
+      (.candidateSelection == "current-main" and
+       .candidateCommit == .originMainCommit and
+       .historicalCandidateException == "None") or
+      (.candidateSelection == "historical" and
+       .candidateCommit != .originMainCommit and
+       (.historicalCandidateException | test("[^[:space:]]")))
+    )
+  then [
+    .nextTag, .candidateCommit, .previousTagCommit,
+    .candidateSelection, .historicalCandidateException
+  ] | @tsv
   else error("release plan is invalid")
   end
 ' "$PLAN_PATH" >"$PLAN_FIELDS"
-IFS=$'\t' read -r VERSION CANDIDATE_SHA PREVIOUS_TAG_SHA <"$PLAN_FIELDS"
+IFS=$'\t' read -r VERSION CANDIDATE_SHA PREVIOUS_TAG_SHA \
+  CANDIDATE_SELECTION HISTORICAL_CANDIDATE_EXCEPTION <"$PLAN_FIELDS"
 DOCS_PREFIX='automation/post-merge-docs-'
 ```
 
 ## Release Entry and Documentation Coverage
 
-Find exactly one target heading at the candidate. Save only that H2 section, ending before the next
-H2, for the release brief.
+For a current-main plan, find exactly one target heading at the candidate. Save only that H2 section,
+ending before the next H2, for the release brief. For a historical plan, record the plan's explicit
+release-entry exception instead. Do not use the historical exception for a current-main plan.
 
 ```bash
+if [[ "$CANDIDATE_SELECTION" == 'historical' ]]; then
+  ENTRY_FILE="$EVIDENCE_DIR/release-entry.md"
+  ENTRY_PATH='Historical candidate exception'
+  printf '%s\n' \
+    "Release entry exception: $HISTORICAL_CANDIDATE_EXCEPTION" >"$ENTRY_FILE"
+else
 ENTRY_MATCHES="$EVIDENCE_DIR/release-entry-matches.txt"
 VERSION_PATTERN="${VERSION//./[.]}"
 run_or_stop "release-entry search" git grep -n -E "^## ${VERSION_PATTERN}$" \
@@ -79,6 +100,7 @@ run_or_stop "release-entry detail validation" awk '
   /^-[[:space:]]/ { detailed = 1 }
   END { exit(detailed ? 0 : 1) }
 ' "$ENTRY_FILE"
+fi
 ```
 
 Read documentation coverage from Git history and GitHub PR state. Do not require another
@@ -241,7 +263,8 @@ Record all of this evidence in the release brief:
 - whether the docs PR changed only allowed documentation paths;
 - the docs PR review decision and complete check state;
 - every open managed docs PR; and
-- the canonical release entry and path.
+- the canonical release entry and path for a current-main plan; or
+- the plan-bound release-entry exception for a historical plan.
 
 Then offer exactly these choices:
 

--- a/.agents/skills/nemoclaw-maintainer-day/scripts/handoff-summary.ts
+++ b/.agents/skills/nemoclaw-maintainer-day/scripts/handoff-summary.ts
@@ -21,6 +21,8 @@ export interface HandoffInput {
   previousTagCommit: string;
   targetVersion: string;
   candidateCommit: string;
+  candidateSelection: "current-main" | "historical";
+  historicalCandidateException: string;
 }
 
 export interface HandoffOutput extends HandoffInput {
@@ -79,6 +81,17 @@ function validateInput(input: HandoffInput): void {
   }
   if (!SHA.test(input.candidateCommit)) {
     throw new Error("candidate commit must be a lowercase 40-character Git SHA");
+  }
+  if (input.candidateSelection === "current-main") {
+    if (input.historicalCandidateException !== "None") {
+      throw new Error("current-main input must not contain a historical candidate exception");
+    }
+  } else if (
+    input.candidateSelection !== "historical" ||
+    !/\S/u.test(input.historicalCandidateException) ||
+    /[\u0000-\u001f\u007f]/u.test(input.historicalCandidateException)
+  ) {
+    throw new Error("historical input must contain a single-line exception reason");
   }
 }
 
@@ -168,6 +181,10 @@ export function renderHandoffMarkdown(summary: HandoffOutput): string {
     "",
     `- Previous release: ${code(summary.previousTag)} at ${code(summary.previousTagCommit)}`,
     `- Candidate: ${code(summary.candidateCommit)}`,
+    `- Candidate selection: ${summary.candidateSelection}`,
+    ...(summary.candidateSelection === "historical"
+      ? [`- Historical candidate exception: ${text(summary.historicalCandidateException)}`]
+      : []),
     `- Commits: ${summary.commitCount}`,
     `- Risky files detected: ${summary.riskyFileCount}`,
     "",
@@ -239,6 +256,9 @@ function readPlan(planPath: string): HandoffInput {
     unknown
   >;
   const expectedKeys = [
+    "candidateCommit",
+    "candidateSelection",
+    "historicalCandidateException",
     "nextTag",
     "originMainCommit",
     "originMainHeadline",
@@ -247,16 +267,36 @@ function readPlan(planPath: string): HandoffInput {
     "previousTagObject",
   ];
   if (JSON.stringify(Object.keys(value).sort()) !== JSON.stringify(expectedKeys)) {
-    throw new Error("release plan must contain exactly the six supported fields");
+    throw new Error("release plan must contain exactly the nine supported fields");
   }
   if (typeof value.originMainHeadline !== "string" || !value.originMainHeadline) {
     throw new Error("release plan headline must be a nonempty string");
   }
-  const input = {
+  if (
+    value.candidateSelection !== "current-main" &&
+    value.candidateSelection !== "historical"
+  ) {
+    throw new Error("release plan candidate selection is invalid");
+  }
+  if (
+    value.candidateSelection === "current-main" &&
+    value.candidateCommit !== value.originMainCommit
+  ) {
+    throw new Error("current-main plan candidate must equal originMainCommit");
+  }
+  if (
+    value.candidateSelection === "historical" &&
+    value.candidateCommit === value.originMainCommit
+  ) {
+    throw new Error("historical plan candidate must differ from originMainCommit");
+  }
+  const input: HandoffInput = {
     previousTag: String(value.previousTag),
     previousTagCommit: String(value.previousTagCommit),
     targetVersion: String(value.nextTag),
-    candidateCommit: String(value.originMainCommit),
+    candidateCommit: String(value.candidateCommit),
+    candidateSelection: value.candidateSelection,
+    historicalCandidateException: String(value.historicalCandidateException),
   };
   validateInput(input);
   return input;

--- a/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
+++ b/.agents/skills/nemoclaw-maintainer-policies/references/release-train.md
@@ -52,8 +52,10 @@ Before tag confirmation, show the maintainer:
 - the canonical release entry and path.
 
 The maintainer must choose to proceed, create or update a docs PR for the uncovered range, or stop.
-Record a proceed decision in the signed release brief. The release entry cannot be waived. Do not
-create a separate documentation receipt or exception record.
+Record a proceed decision in the signed release brief. A current-main plan requires the release
+entry. An accepted urgent QA qualification may use an exact historical ancestor and must bind its
+explicit release-entry exception into the signed release brief. Do not create a separate exception
+record.
 
 ## Cutoff
 
@@ -65,8 +67,9 @@ At cutoff:
 2. Confirm each is intended for the release.
 3. List open PRs and issues still carrying the target label as post-tag stragglers.
 4. Complete [Release-Prep Docs](#release-prep-docs) for the intended release range.
-5. Generate the immutable release plan with the exact `--version vX.Y.Z` to capture the candidate
-   commit.
+5. Generate the immutable release plan with the exact `--version vX.Y.Z` to capture `origin/main`.
+   For accepted urgent QA qualification, select an exact historical ancestor with `--candidate` and
+   bind a nonblank `--exception` reason.
 6. Show the candidate's documentation coverage and required image evidence. If the maintainer
    requests documentation work, complete [Release-Prep Docs](#release-prep-docs), merge that PR,
    generate a new plan, and show the evidence for the new candidate.

--- a/scripts/release-cut-tag.sh
+++ b/scripts/release-cut-tag.sh
@@ -143,7 +143,7 @@ require_brief_line_once() {
   local expected="$1"
   local label="$2"
   local count
-  count="$(awk -v expected="$expected" '$0 == expected { count++ } END { print count + 0 }' "$brief_snapshot")" \
+  count="$(grep -Fxc -- "$expected" "$brief_snapshot" || true)" \
     || fail "Could not validate release brief $label"
   [[ "$count" == "1" ]] || fail "Release brief must contain exactly one $label"
 }
@@ -153,7 +153,14 @@ printf -v expected_base_candidate -- "- Base-image candidate: \`%s\`" "$target"
 require_brief_line_once "$expected_docs_decision" "documentation proceed decision"
 require_brief_line_once "$expected_base_candidate" "plan-bound base-image candidate"
 if [[ "$candidate_selection" == "historical" ]]; then
-  printf -v expected_historical_exception -- "- Historical candidate exception: %s" "$historical_exception"
+  # JavaScript owns $1 in the replacement string.
+  # shellcheck disable=SC2016
+  escaped_historical_exception="$(
+    node -e 'process.stdout.write(process.argv[1].replace(/([\\`*_[\]<>#])/g, "\\$1"))' \
+      "$historical_exception"
+  )" || fail "Could not escape the historical candidate exception"
+  printf -v expected_historical_exception -- \
+    "- Historical candidate exception: %s" "$escaped_historical_exception"
   require_brief_line_once "$expected_historical_exception" "plan-bound historical candidate exception"
 else
   if grep -q '^\- Historical candidate exception:' "$brief_snapshot"; then

--- a/scripts/release-cut-tag.sh
+++ b/scripts/release-cut-tag.sh
@@ -66,13 +66,16 @@ cp -- "$MESSAGE_FILE" "$brief_snapshot" || fail "Could not snapshot the release 
 repo_root="$(cd -- "$(git rev-parse --show-toplevel)" && pwd -P)"
 cd "$repo_root"
 
-IFS=$'\t' read -r previous_tag planned_previous_object planned_previous_commit tag target < <(
+IFS=$'\t' read -r previous_tag planned_previous_object planned_previous_commit tag target candidate_selection historical_exception < <(
   node -e '
     const fs = require("node:fs");
     const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
     const semver = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
     const sha = /^[0-9a-f]{40}$/;
     const expectedKeys = [
+      "candidateCommit",
+      "candidateSelection",
+      "historicalCandidateException",
       "nextTag",
       "originMainCommit",
       "originMainHeadline",
@@ -82,28 +85,41 @@ IFS=$'\t' read -r previous_tag planned_previous_object planned_previous_commit t
     ];
     const actualKeys = Object.keys(data).sort();
     if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
-      throw new Error("release plan must contain exactly the six supported fields");
+      throw new Error("release plan must contain exactly the nine supported fields");
     }
     if (!semver.test(data.previousTag)) throw new Error("previousTag must be semver");
-    if (!sha.test(data.previousTagCommit)) {
-      throw new Error("previousTagCommit must be a full SHA");
-    }
-    if (!sha.test(data.previousTagObject)) {
-      throw new Error("previousTagObject must be a full SHA");
-    }
+    if (!sha.test(data.previousTagCommit)) throw new Error("previousTagCommit must be a full SHA");
+    if (!sha.test(data.previousTagObject)) throw new Error("previousTagObject must be a full SHA");
     if (!semver.test(data.nextTag)) throw new Error("nextTag must be semver");
-    if (!sha.test(data.originMainCommit)) {
-      throw new Error("originMainCommit must be a full SHA");
-    }
+    if (!sha.test(data.originMainCommit)) throw new Error("originMainCommit must be a full SHA");
+    if (!sha.test(data.candidateCommit)) throw new Error("candidateCommit must be a full SHA");
     if (typeof data.originMainHeadline !== "string" || data.originMainHeadline.length === 0) {
       throw new Error("originMainHeadline must be a nonempty string");
+    }
+    if (data.candidateSelection === "current-main") {
+      if (data.candidateCommit !== data.originMainCommit || data.historicalCandidateException !== "None") {
+        throw new Error("current-main plan must select originMainCommit without an exception");
+      }
+    } else if (data.candidateSelection === "historical") {
+      if (data.candidateCommit === data.originMainCommit) {
+        throw new Error("historical plan must select a commit before originMainCommit");
+      }
+      if (typeof data.historicalCandidateException !== "string" ||
+          !/\S/u.test(data.historicalCandidateException) ||
+          /[\u0000-\u001f\u007f]/u.test(data.historicalCandidateException)) {
+        throw new Error("historical plan must contain a single-line exception reason");
+      }
+    } else {
+      throw new Error("candidateSelection must be current-main or historical");
     }
     process.stdout.write([
       data.previousTag,
       data.previousTagObject,
       data.previousTagCommit,
       data.nextTag,
-      data.originMainCommit,
+      data.candidateCommit,
+      data.candidateSelection,
+      data.historicalCandidateException,
     ].join("\t") + "\n");
   ' "$PLAN_PATH"
 ) || fail "Could not read release plan"
@@ -136,6 +152,14 @@ expected_docs_decision="- Maintainer decision: Proceed with the candidate as sho
 printf -v expected_base_candidate -- "- Base-image candidate: \`%s\`" "$target"
 require_brief_line_once "$expected_docs_decision" "documentation proceed decision"
 require_brief_line_once "$expected_base_candidate" "plan-bound base-image candidate"
+if [[ "$candidate_selection" == "historical" ]]; then
+  printf -v expected_historical_exception -- "- Historical candidate exception: %s" "$historical_exception"
+  require_brief_line_once "$expected_historical_exception" "plan-bound historical candidate exception"
+else
+  if grep -q '^\- Historical candidate exception:' "$brief_snapshot"; then
+    fail "Current-main release brief must not contain a historical candidate exception"
+  fi
+fi
 if grep -Eq -- "TODO_RELEASE_BRIEF|Complete before confirmation" "$brief_snapshot"; then
   fail "Release brief still contains unresolved prompts"
 fi
@@ -269,6 +293,12 @@ IFS=$'\t' read -r current_previous_tag previous_object previous_commit <<<"$high
   || fail "Remote $previous_tag changed from $planned_previous_commit to $previous_commit; stop for protected-tag remediation"
 
 git cat-file -e "${target}^{commit}" || fail "Candidate commit does not exist: $target"
+refreshed_origin_main="$(git rev-parse origin/main)" \
+  || fail "Could not resolve refreshed origin/main"
+if [[ "$candidate_selection" == "historical" ]]; then
+  [[ "$target" != "$refreshed_origin_main" ]] \
+    || fail "Historical candidate now identifies origin/main; generate a current-main plan without an exception"
+fi
 git merge-base --is-ancestor "$target" origin/main \
   || fail "Candidate commit is not reachable from origin/main: $target"
 git cat-file -e "${previous_commit}^{commit}" \

--- a/scripts/release-plan.mts
+++ b/scripts/release-plan.mts
@@ -8,10 +8,13 @@ import process from "node:process";
 import { isCanonicalNemoClawRemote, isLocalReleaseFixtureRemote } from "./release/remote.mts";
 
 const SEMVER_TAG = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const FULL_SHA = /^[0-9a-f]{40}$/;
 
 type Options = {
   version: string;
   output?: string;
+  candidate?: string;
+  exception?: string;
 };
 
 type ReleasePlan = {
@@ -21,6 +24,9 @@ type ReleasePlan = {
   nextTag: string;
   originMainCommit: string;
   originMainHeadline: string;
+  candidateCommit: string;
+  candidateSelection: "current-main" | "historical";
+  historicalCandidateException: string;
 };
 
 function run(command: string, args: string[]): string {
@@ -39,23 +45,42 @@ function run(command: string, args: string[]): string {
   }
 }
 
+function readValue(argv: string[], index: number, option: string): string {
+  const value = argv[index + 1] ?? "";
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${option} requires ${option === "--output" ? "a path" : "a value"}`);
+  }
+  return value;
+}
+
 function parseArgs(argv: string[]): Options {
   let version = "";
   let output: string | undefined;
+  let candidate: string | undefined;
+  let exception: string | undefined;
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--version") {
-      version = argv[++index] ?? "";
+      version = readValue(argv, index, "--version");
+      index += 1;
     } else if (arg.startsWith("--version=")) {
       version = arg.slice("--version=".length);
     } else if (arg === "--output") {
-      output = argv[++index];
-      if (!output || output.startsWith("--")) {
-        throw new Error("--output requires a path");
-      }
+      output = readValue(argv, index, "--output");
+      index += 1;
     } else if (arg.startsWith("--output=")) {
       output = arg.slice("--output=".length);
-      if (!output) throw new Error("--output requires a path");
+      if (!output) throw new Error("--output requires a value");
+    } else if (arg === "--candidate") {
+      candidate = readValue(argv, index, "--candidate");
+      index += 1;
+    } else if (arg.startsWith("--candidate=")) {
+      candidate = arg.slice("--candidate=".length);
+    } else if (arg === "--exception") {
+      exception = readValue(argv, index, "--exception");
+      index += 1;
+    } else if (arg.startsWith("--exception=")) {
+      exception = arg.slice("--exception=".length);
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
@@ -66,12 +91,24 @@ function parseArgs(argv: string[]): Options {
   if (!SEMVER_TAG.test(version)) {
     throw new Error("--version must be an exact vX.Y.Z tag");
   }
-  return { version, output };
+  if (candidate !== undefined && !FULL_SHA.test(candidate)) {
+    throw new Error("--candidate must be a full lowercase 40-character Git SHA");
+  }
+  if (candidate !== undefined && !exception?.trim()) {
+    throw new Error("--exception requires a nonblank plain-language reason with --candidate");
+  }
+  if (exception !== undefined && /[\u0000-\u001f\u007f]/u.test(exception)) {
+    throw new Error("--exception must be a single-line plain-language reason");
+  }
+  if (candidate === undefined && exception !== undefined) {
+    throw new Error("--exception is only valid with a historical --candidate");
+  }
+  return { version, output, candidate, exception: exception?.trim() };
 }
 
 function printHelp(): void {
   console.log(
-    "Usage: tsx scripts/release-plan.mts --version vX.Y.Z [--output PATH]\n\nCaptures an exact release version and candidate commit from origin/main.",
+    "Usage: tsx scripts/release-plan.mts --version vX.Y.Z [--output PATH] [--candidate FULL_SHA --exception REASON]\n\nCaptures origin/main by default. A historical candidate requires an explicit exception reason.",
   );
 }
 
@@ -166,6 +203,27 @@ function main(): void {
 
   const originMainCommit = run("git", ["rev-parse", "origin/main"]).trim();
   const originMainHeadline = run("git", ["log", "--oneline", "-1", "origin/main"]).trim();
+  const candidateCommit = options.candidate
+    ? run("git", ["rev-parse", "--verify", `${options.candidate}^{commit}`]).trim()
+    : originMainCommit;
+  if (options.candidate && candidateCommit !== options.candidate) {
+    throw new Error(`Candidate does not resolve to the exact commit ${options.candidate}`);
+  }
+  if (options.candidate && candidateCommit === originMainCommit) {
+    throw new Error("--candidate identifies current origin/main; omit --candidate and --exception");
+  }
+  try {
+    run("git", ["merge-base", "--is-ancestor", previousTagCommit, candidateCommit]);
+  } catch {
+    throw new Error(`Candidate commit ${candidateCommit} does not follow previous release ${previousTag}`);
+  }
+  try {
+    run("git", ["merge-base", "--is-ancestor", candidateCommit, originMainCommit]);
+  } catch {
+    throw new Error(`Candidate commit is not reachable from origin/main: ${candidateCommit}`);
+  }
+  const candidateHeadline = run("git", ["log", "--oneline", "-1", candidateCommit]).trim();
+  const candidateSelection = options.candidate ? "historical" : "current-main";
   const output = path.resolve(
     options.output ?? path.join(repoRoot, "..", `nemoclaw-release-${options.version}`, "plan.json"),
   );
@@ -176,6 +234,9 @@ function main(): void {
     nextTag: options.version,
     originMainCommit,
     originMainHeadline,
+    candidateCommit,
+    candidateSelection,
+    historicalCandidateException: options.exception ?? "None",
   };
 
   mkdirSync(path.dirname(output), { recursive: true });
@@ -195,9 +256,11 @@ function main(): void {
   console.log(`Previous tag object: ${previousTagObject}`);
   console.log(`Previous tag commit: ${previousTagCommit}`);
   console.log(`Next tag: ${options.version}`);
-  console.log(`Candidate commit: ${originMainHeadline}`);
+  console.log(`Candidate commit: ${candidateHeadline}`);
+  console.log(`Candidate selection: ${candidateSelection}`);
+  if (options.exception) console.log(`Historical candidate exception: ${options.exception}`);
   console.log("Confirmation phrase:");
-  console.log(`CONFIRM RELEASE ${options.version} ${originMainCommit}`);
+  console.log(`CONFIRM RELEASE ${options.version} ${candidateCommit}`);
 }
 
 main();

--- a/test/handoff-summary.test.ts
+++ b/test/handoff-summary.test.ts
@@ -70,6 +70,8 @@ describe("release handoff summary", () => {
         previousTagCommit: previous,
         targetVersion: "v1.2.3",
         candidateCommit: candidate,
+        candidateSelection: "current-main",
+        historicalCandidateException: "None",
       },
       command,
     );
@@ -79,6 +81,8 @@ describe("release handoff summary", () => {
       previousTagCommit: previous,
       targetVersion: "v1.2.3",
       candidateCommit: candidate,
+      candidateSelection: "current-main",
+      historicalCandidateException: "None",
       commitCount: 2,
       riskyFileCount: 5,
       riskyAreas: [
@@ -132,6 +136,9 @@ describe("release handoff summary CLI", () => {
     fs.writeFileSync(
       plan,
       JSON.stringify({
+        candidateCommit: candidate,
+        candidateSelection: "current-main",
+        historicalCandidateException: "None",
         nextTag: "v1.2.3",
         originMainCommit: candidate,
         originMainHeadline: "test: release candidate",

--- a/test/helpers/historical-release-fixture.ts
+++ b/test/helpers/historical-release-fixture.ts
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const repositoryRoot = path.join(import.meta.dirname, "../..");
+export const planScriptPath = path.join(repositoryRoot, "scripts", "release-plan.mts");
+const cutScriptPath = path.join(repositoryRoot, "scripts", "release-cut-tag.sh");
+const temporaryRoots: string[] = [];
+
+export type HistoricalReleaseFixture = {
+  firstCommit: string;
+  remote: string;
+  root: string;
+  work: string;
+};
+
+function environment(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (!key.startsWith("GIT_") && key !== "NODE_OPTIONS" && value !== undefined) env[key] = value;
+  }
+  return {
+    ...env,
+    GIT_AUTHOR_EMAIL: "release-test@example.com",
+    GIT_AUTHOR_NAME: "Release Test",
+    GIT_COMMITTER_EMAIL: "release-test@example.com",
+    GIT_COMMITTER_NAME: "Release Test",
+    GIT_CONFIG_COUNT: "2",
+    GIT_CONFIG_KEY_0: "tag.gpgSign",
+    GIT_CONFIG_KEY_1: "commit.gpgSign",
+    GIT_CONFIG_VALUE_0: "false",
+    GIT_CONFIG_VALUE_1: "false",
+    ...extra,
+  };
+}
+
+export function run(
+  cwd: string,
+  args: string[],
+  extraEnv: NodeJS.ProcessEnv = {},
+): ReturnType<typeof spawnSync> {
+  return spawnSync(args[0], args.slice(1), { cwd, encoding: "utf8", env: environment(extraEnv) });
+}
+
+export function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8", env: environment() }).trim();
+}
+
+export function createFixture(): HistoricalReleaseFixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-historical-release-"));
+  temporaryRoots.push(root);
+  const remote = path.join(root, "remote.git");
+  const work = path.join(root, "work");
+  const signingKey = path.join(root, "release-signing-key");
+  git(root, "init", "--bare", remote);
+  execFileSync(
+    "ssh-keygen",
+    ["-q", "-t", "ed25519", "-N", "", "-C", "release-test@example.com", "-f", signingKey],
+    { cwd: root, env: environment() },
+  );
+  fs.mkdirSync(work);
+  git(work, "init");
+  git(work, "config", "user.name", "Release Test");
+  git(work, "config", "user.email", "release-test@example.com");
+  git(work, "config", "gpg.format", "ssh");
+  git(work, "config", "user.signingkey", signingKey);
+  fs.writeFileSync(path.join(work, "file.txt"), "initial\n");
+  git(work, "add", "file.txt");
+  git(work, "commit", "-m", "initial");
+  git(work, "branch", "-M", "main");
+  git(work, "remote", "add", "origin", remote);
+  git(work, "push", "-u", "origin", "main");
+  return { firstCommit: git(work, "rev-parse", "HEAD"), remote, root, work };
+}
+
+export function cleanupFixtures(): void {
+  for (const root of temporaryRoots.splice(0)) fs.rmSync(root, { force: true, recursive: true });
+}
+
+export function commit(fixture: HistoricalReleaseFixture, message: string): string {
+  fs.appendFileSync(path.join(fixture.work, "file.txt"), `${message}\n`);
+  git(fixture.work, "add", "file.txt");
+  git(fixture.work, "commit", "-m", message);
+  git(fixture.work, "push", "origin", "main");
+  return git(fixture.work, "rev-parse", "HEAD");
+}
+
+export function pushTag(fixture: HistoricalReleaseFixture, tag: string, target: string): void {
+  git(fixture.work, "-c", "tag.gpgSign=false", "tag", "-a", tag, target, "-m", tag);
+  git(fixture.work, "push", "origin", `refs/tags/${tag}`);
+}
+
+export function planArguments(candidate: string, exception?: string, output?: string): string[] {
+  const args = [
+    "node",
+    "--experimental-strip-types",
+    "--no-warnings",
+    planScriptPath,
+    "--version",
+    "v0.0.2",
+    "--candidate",
+    candidate,
+  ];
+  if (exception !== undefined) args.push("--exception", exception);
+  if (output !== undefined) args.push("--output", output);
+  return args;
+}
+
+export function createHistoricalPlan(
+  fixture: HistoricalReleaseFixture,
+  candidate: string,
+  exception: string,
+): { path: string; plan: Record<string, string> } {
+  const planPath = path.join(fixture.root, "release", "plan.json");
+  const result = run(fixture.work, planArguments(candidate, exception, planPath), {
+    NEMOCLAW_RELEASE_ALLOW_NON_CANONICAL: "1",
+  });
+  if (result.status !== 0) throw new Error(String(result.stderr));
+  return {
+    path: planPath,
+    plan: JSON.parse(fs.readFileSync(planPath, "utf8")) as Record<string, string>,
+  };
+}
+
+export function releaseBrief(plan: Record<string, string>): string {
+  return [
+    `# NemoClaw ${plan.nextTag} release brief`,
+    "",
+    `- Candidate: \`${plan.candidateCommit}\``,
+    `- Historical candidate exception: ${plan.historicalCandidateException}`,
+    "",
+    "## Canonical release entry",
+    "",
+    `Release entry exception: ${plan.historicalCandidateException}`,
+    "",
+    "## Documentation coverage",
+    "",
+    "- Latest included cumulative docs PR: None.",
+    "- Final PR commit and merge commit: None.",
+    `- Final automated refresh coverage commit: \`${plan.previousTagCommit}\``,
+    "- Later commits and merged PRs: Recorded.",
+    "- Changed paths: Recorded.",
+    "- Review and checks: Recorded.",
+    "- Open managed docs PRs: None.",
+    "- Maintainer decision: Proceed with the candidate as shown.",
+    "",
+    "## Base and managed image evidence",
+    "",
+    `- Base-image candidate: \`${plan.candidateCommit}\``,
+    "- Evidence: successful publication aggregate.",
+    "",
+    "## General E2E decision",
+    "",
+    "- Decision: proceed.",
+    "",
+    "Exceptions: None",
+    "",
+  ].join("\n");
+}
+
+export function writeBrief(fixture: HistoricalReleaseFixture, content: string): string {
+  const messageFile = path.join(fixture.root, "release-brief.md");
+  fs.writeFileSync(messageFile, content);
+  return messageFile;
+}
+
+export function cutHistoricalPlan(
+  fixture: HistoricalReleaseFixture,
+  planPath: string,
+  plan: Record<string, string>,
+  messageFile: string,
+): ReturnType<typeof spawnSync> {
+  return run(
+    fixture.work,
+    [
+      "bash",
+      cutScriptPath,
+      "--plan",
+      planPath,
+      "--message-file",
+      messageFile,
+      "--confirm",
+      `CONFIRM RELEASE ${plan.nextTag} ${plan.candidateCommit}`,
+    ],
+    { NEMOCLAW_RELEASE_ALLOW_NON_CANONICAL: "1" },
+  );
+}
+
+export function remoteCommit(fixture: HistoricalReleaseFixture, ref: string): string {
+  return git(fixture.root, "--git-dir", fixture.remote, "rev-parse", `${ref}^{}`);
+}
+
+export function remoteTagText(fixture: HistoricalReleaseFixture, ref: string): string {
+  const object = git(fixture.root, "--git-dir", fixture.remote, "rev-parse", ref);
+  return git(fixture.root, "--git-dir", fixture.remote, "cat-file", "-p", object);
+}

--- a/test/helpers/historical-release-fixture.ts
+++ b/test/helpers/historical-release-fixture.ts
@@ -126,12 +126,16 @@ export function createHistoricalPlan(
   };
 }
 
+function markdownText(value: string): string {
+  return value.replace(/([\\`*_[\]<>#])/g, "\\$1");
+}
+
 export function releaseBrief(plan: Record<string, string>): string {
   return [
     `# NemoClaw ${plan.nextTag} release brief`,
     "",
     `- Candidate: \`${plan.candidateCommit}\``,
-    `- Historical candidate exception: ${plan.historicalCandidateException}`,
+    `- Historical candidate exception: ${markdownText(plan.historicalCandidateException)}`,
     "",
     "## Canonical release entry",
     "",

--- a/test/historical-release-candidate.test.ts
+++ b/test/historical-release-candidate.test.ts
@@ -27,7 +27,7 @@ import {
 } from "./helpers/historical-release-fixture";
 
 const fixtureEnvironment = { NEMOCLAW_RELEASE_ALLOW_NON_CANONICAL: "1" };
-const exception = "Urgent QA qualification requires the preceding main commit.";
+const exception = "Urgent QA qualification for issue `#123` requires the preceding main commit.";
 
 afterEach(cleanupFixtures);
 
@@ -58,7 +58,9 @@ describe("historical release candidate", () => {
     );
 
     expect(markdown).toContain("- Candidate selection: historical");
-    expect(markdown).toContain(`- Historical candidate exception: ${exception}`);
+    expect(markdown).toContain(
+      "- Historical candidate exception: Urgent QA qualification for issue \\`\\#123\\` requires the preceding main commit.",
+    );
   });
 
   it("plans an ancestor and binds its exception into the signed brief", () => {
@@ -85,7 +87,7 @@ describe("historical release candidate", () => {
     });
     expect(remoteCommit(fixture, "refs/tags/v0.0.2")).toBe(candidate);
     expect(remoteTagText(fixture, "refs/tags/v0.0.2")).toContain(
-      `- Historical candidate exception: ${exception}`,
+      "- Historical candidate exception: Urgent QA qualification for issue \\`\\#123\\` requires the preceding main commit.",
     );
   });
 

--- a/test/historical-release-candidate.test.ts
+++ b/test/historical-release-candidate.test.ts
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildHandoffSummary,
+  renderHandoffMarkdown,
+} from "../.agents/skills/nemoclaw-maintainer-day/scripts/handoff-summary";
+import {
+  cleanupFixtures,
+  commit,
+  createFixture,
+  createHistoricalPlan,
+  cutHistoricalPlan,
+  git,
+  planArguments,
+  pushTag,
+  releaseBrief,
+  remoteCommit,
+  remoteTagText,
+  run,
+  writeBrief,
+} from "./helpers/historical-release-fixture";
+
+const fixtureEnvironment = { NEMOCLAW_RELEASE_ALLOW_NON_CANONICAL: "1" };
+const exception = "Urgent QA qualification requires the preceding main commit.";
+
+afterEach(cleanupFixtures);
+
+describe("historical release candidate", () => {
+  it("renders the plan-bound exception in the handoff summary", () => {
+    const previous = "1".repeat(40);
+    const candidate = "2".repeat(40);
+    const results = new Map([
+      [`rev-parse ${candidate}^{commit}`, candidate],
+      [`merge-base ${previous} ${candidate}`, previous],
+      [`rev-list --count ${previous}..${candidate}`, "1"],
+      [`diff --name-only ${previous}..${candidate}`, ""],
+    ]);
+    const command = (_command: string, args: string[]): string => results.get(args.join(" "))!;
+
+    const markdown = renderHandoffMarkdown(
+      buildHandoffSummary(
+        {
+          previousTag: "v1.2.2",
+          previousTagCommit: previous,
+          targetVersion: "v1.2.3",
+          candidateCommit: candidate,
+          candidateSelection: "historical",
+          historicalCandidateException: exception,
+        },
+        command,
+      ),
+    );
+
+    expect(markdown).toContain("- Candidate selection: historical");
+    expect(markdown).toContain(`- Historical candidate exception: ${exception}`);
+  });
+
+  it("plans an ancestor and binds its exception into the signed brief", () => {
+    const fixture = createFixture();
+    pushTag(fixture, "v0.0.1", fixture.firstCommit);
+    const candidate = commit(fixture, "historical release candidate");
+    const currentMain = commit(fixture, "planned release commit");
+    const historical = createHistoricalPlan(fixture, candidate, exception);
+    const brief = releaseBrief(historical.plan);
+
+    const result = cutHistoricalPlan(
+      fixture,
+      historical.path,
+      historical.plan,
+      writeBrief(fixture, brief),
+    );
+
+    expect(result.status, String(result.stderr)).toBe(0);
+    expect(historical.plan).toMatchObject({
+      candidateCommit: candidate,
+      candidateSelection: "historical",
+      historicalCandidateException: exception,
+      originMainCommit: currentMain,
+    });
+    expect(remoteCommit(fixture, "refs/tags/v0.0.2")).toBe(candidate);
+    expect(remoteTagText(fixture, "refs/tags/v0.0.2")).toContain(
+      `- Historical candidate exception: ${exception}`,
+    );
+  });
+
+  it("requires a historical exception", () => {
+    const fixture = createFixture();
+    pushTag(fixture, "v0.0.1", fixture.firstCommit);
+    const candidate = commit(fixture, "historical release candidate");
+    commit(fixture, "planned release commit");
+
+    const result = run(fixture.work, planArguments(candidate), fixtureEnvironment);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("--exception requires a nonblank plain-language reason");
+  });
+
+  it("rejects an exception for current origin/main", () => {
+    const fixture = createFixture();
+    pushTag(fixture, "v0.0.1", fixture.firstCommit);
+    const currentMain = commit(fixture, "planned release commit");
+
+    const result = run(fixture.work, planArguments(currentMain, "Not needed."), fixtureEnvironment);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("omit --candidate and --exception");
+  });
+
+  it("rejects a candidate that is not reachable from origin/main", () => {
+    const fixture = createFixture();
+    pushTag(fixture, "v0.0.1", fixture.firstCommit);
+    commit(fixture, "planned release commit");
+    const tree = git(fixture.work, "rev-parse", "HEAD^{tree}");
+    const unreachable = git(
+      fixture.work,
+      "commit-tree",
+      tree,
+      "-p",
+      fixture.firstCommit,
+      "-m",
+      "unreachable candidate",
+    );
+
+    const result = run(
+      fixture.work,
+      planArguments(unreachable, "Urgent QA qualification requires this commit."),
+      fixtureEnvironment,
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      `Candidate commit is not reachable from origin/main: ${unreachable}`,
+    );
+  });
+
+  it("rejects a candidate before the previous release", () => {
+    const fixture = createFixture();
+    const candidate = fixture.firstCommit;
+    const previousRelease = commit(fixture, "previous release commit");
+    pushTag(fixture, "v0.0.1", previousRelease);
+    commit(fixture, "planned release commit");
+    const planPath = path.join(fixture.root, "release", "plan.json");
+
+    const result = run(
+      fixture.work,
+      planArguments(candidate, "Urgent QA qualification requires this commit.", planPath),
+      fixtureEnvironment,
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      `Candidate commit ${candidate} does not follow previous release v0.0.1`,
+    );
+    expect(fs.existsSync(planPath)).toBe(false);
+  });
+
+  it("rejects a brief whose historical exception differs from the plan", () => {
+    const fixture = createFixture();
+    pushTag(fixture, "v0.0.1", fixture.firstCommit);
+    const candidate = commit(fixture, "historical release candidate");
+    commit(fixture, "planned release commit");
+    const historical = createHistoricalPlan(fixture, candidate, exception);
+    const brief = releaseBrief(historical.plan).replace(
+      /^- Historical candidate exception:.*$/mu,
+      "- Historical candidate exception: A different reason.",
+    );
+
+    const result = cutHistoricalPlan(
+      fixture,
+      historical.path,
+      historical.plan,
+      writeBrief(fixture, brief),
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("plan-bound historical candidate exception");
+    expect(
+      run(fixture.work, ["git", "show-ref", "--verify", "--quiet", "refs/tags/v0.0.2"]).status,
+    ).not.toBe(0);
+  });
+});

--- a/test/release-candidate-evidence.test.ts
+++ b/test/release-candidate-evidence.test.ts
@@ -41,6 +41,7 @@ function bashBlockContaining(source: string, marker: string): string {
   );
 }
 
+const planReadBlock = bashBlockContaining(evidence, 'PLAN_FIELDS="$EVIDENCE_DIR/plan-fields.txt"');
 const releaseEntryBlock = bashBlockUnder(evidence, "## Release Entry and Documentation Coverage");
 const docsPrSelectionBlock = bashBlockContaining(evidence, 'SELECTED_DOCS_PR="$EVIDENCE_DIR');
 const docsPrReadBlock = bashBlockContaining(evidence, 'DOCS_PR_COMMITS="$EVIDENCE_DIR');
@@ -103,7 +104,9 @@ function runReleaseEntry(
     env: {
       ...process.env,
       CANDIDATE_SHA: input.candidate,
+      CANDIDATE_SELECTION: "current-main",
       EVIDENCE_DIR: input.evidenceDir,
+      HISTORICAL_CANDIDATE_EXCEPTION: "None",
       VERSION: version,
     },
   });
@@ -227,6 +230,49 @@ describe("release candidate evidence commands", () => {
     expect(evidence).toContain("- Maintainer decision: Proceed with the candidate as shown.");
     expect(evidence).not.toContain("approved-empty");
     expect(evidence).not.toContain("Final Documentation Recheck");
+  });
+
+  it("accepts the historical plan schema and records its release-entry exception", () => {
+    const input = fixture({ "docs/changelog/2026-08-17.mdx": "# Releases\n" });
+    const previous = input.candidate;
+    git(input.root, "commit", "--allow-empty", "-m", "test: historical candidate");
+    const candidate = git(input.root, "rev-parse", "HEAD");
+    git(input.root, "commit", "--allow-empty", "-m", "test: current main");
+    const originMain = git(input.root, "rev-parse", "HEAD");
+    const reason = "Urgent QA qualification requires the preceding main commit.";
+    const planPath = path.join(input.root, "plan.json");
+    fs.writeFileSync(
+      planPath,
+      JSON.stringify({
+        candidateCommit: candidate,
+        candidateSelection: "historical",
+        historicalCandidateException: reason,
+        nextTag: "v1.2.3",
+        originMainCommit: originMain,
+        originMainHeadline: "main",
+        previousTag: "v1.2.2",
+        previousTagCommit: previous,
+        previousTagObject: previous,
+      }),
+    );
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `${shellHelpers}\nPLAN_PATH="$PLAN_PATH"\n${planReadBlock}\ntrap - EXIT\n${releaseEntryBlock}`,
+      ],
+      {
+        cwd: input.root,
+        encoding: "utf8",
+        env: { ...process.env, EVIDENCE_DIR: input.evidenceDir, PLAN_PATH: planPath },
+      },
+    );
+
+    expect(result.status, String(result.stderr)).toBe(0);
+    expect(fs.readFileSync(path.join(input.evidenceDir, "release-entry.md"), "utf8").trim()).toBe(
+      `Release entry exception: ${reason}`,
+    );
   });
 
   it("extracts only the exact release H2 section from a multi-entry changelog", () => {

--- a/test/release-latest-tag.test.ts
+++ b/test/release-latest-tag.test.ts
@@ -213,14 +213,8 @@ function createPlan(
   const result = runScript(
     fixture.work,
     [
-      "node",
-      "--experimental-strip-types",
-      "--no-warnings",
-      planScriptPath,
-      "--version",
-      version,
-      "--output",
-      planPath,
+      "node", "--experimental-strip-types", "--no-warnings", planScriptPath,
+      "--version", version, "--output", planPath,
     ],
     { NEMOCLAW_RELEASE_ALLOW_NON_CANONICAL: "1" },
   );
@@ -233,28 +227,31 @@ function createPlan(
     previousTagCommit: remoteCommit(fixture, "refs/tags/v0.0.1"),
     nextTag: version,
     originMainCommit: releaseCommit,
+    candidateCommit: releaseCommit, candidateSelection: "current-main",
+    historicalCandidateException: "None",
   });
   expect(plan.originMainHeadline).toMatch(/^[0-9a-f]+ planned release commit$/u);
   expect(Object.keys(plan).sort()).toEqual([
-    "nextTag",
-    "originMainCommit",
-    "originMainHeadline",
-    "previousTag",
-    "previousTagCommit",
+    "candidateCommit", "candidateSelection", "historicalCandidateException", "nextTag",
+    "originMainCommit", "originMainHeadline", "previousTag", "previousTagCommit",
     "previousTagObject",
   ]);
   return { plan, result };
 }
 
 function confirmationFor(plan: Record<string, string>): string {
-  return `CONFIRM RELEASE ${plan.nextTag} ${plan.originMainCommit}`;
+  return `CONFIRM RELEASE ${plan.nextTag} ${plan.candidateCommit}`;
 }
 
 function completeBrief(plan: Record<string, string>): string {
+  const candidate = plan.candidateCommit ?? plan.originMainCommit;
   return [
     `# NemoClaw ${plan.nextTag} release brief`,
     "",
-    `- Candidate: \`${plan.originMainCommit}\``,
+    `- Candidate: \`${candidate}\``,
+    ...(plan.candidateSelection === "historical"
+      ? [`- Historical candidate exception: ${plan.historicalCandidateException}`]
+      : []),
     "",
     "## Canonical release entry",
     "",
@@ -265,8 +262,8 @@ function completeBrief(plan: Record<string, string>): string {
     "## Documentation coverage",
     "",
     "- Latest included cumulative docs PR: #100.",
-    `- Final PR commit and merge commit: \`${plan.originMainCommit}\``,
-    `- Final automated refresh coverage commit: \`${plan.originMainCommit}\``,
+    `- Final PR commit and merge commit: \`${candidate}\``,
+    `- Final automated refresh coverage commit: \`${candidate}\``,
     "- Later commits and merged PRs: Only the docs PR merge.",
     "- Changed paths: Allowed documentation paths only.",
     "- Review and checks: Approved and successful.",
@@ -275,7 +272,7 @@ function completeBrief(plan: Record<string, string>): string {
     "",
     "## Base and managed image evidence",
     "",
-    `- Base-image candidate: \`${plan.originMainCommit}\``,
+    `- Base-image candidate: \`${candidate}\``,
     "- Evidence: successful publication aggregate.",
     "",
     "## General E2E decision",
@@ -292,7 +289,14 @@ function writeBrief(fixture: Fixture, content?: string): string {
   const candidate = run(fixture.work, ["git", "rev-parse", "HEAD"]).trim();
   fs.writeFileSync(
     messageFile,
-    content ?? completeBrief({ nextTag: "v0.0.2", originMainCommit: candidate }),
+    content ??
+      completeBrief({
+        nextTag: "v0.0.2",
+        originMainCommit: candidate,
+        candidateCommit: candidate,
+        candidateSelection: "current-main",
+        historicalCandidateException: "None",
+      }),
     "utf8",
   );
   return messageFile;
@@ -1394,13 +1398,25 @@ describe("release-latest-tag.sh", () => {
     pushTag(fixture, "v0.0.1", orphanRelease);
     const releaseCommit = commit(fixture, "planned release commit");
     const planPath = path.join(fixture.root, "release", "plan.json");
-    const { plan } = createPlan(fixture, planPath, releaseCommit);
 
-    const result = cutFromPlan(fixture, planPath, confirmationFor(plan));
+    const result = runScript(
+      fixture.work,
+      [
+        "node",
+        "--experimental-strip-types",
+        "--no-warnings",
+        planScriptPath,
+        "--version",
+        "v0.0.2",
+        "--output",
+        planPath,
+      ],
+      { NEMOCLAW_RELEASE_ALLOW_NON_CANONICAL: "1" },
+    );
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("does not follow previous release v0.0.1");
-    expect(localTagObject(fixture, "v0.0.2")).toBe("");
+    expect(fs.existsSync(planPath)).toBe(false);
   });
 
   it("rejects replacement of the previous tag object at the same peeled commit", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Allow a maintainer to generate a release plan for an exact historical commit that remains reachable from `main`. The plan and signed release brief record the required exception reason while ordinary current-`main` releases retain the existing changelog requirement.

## Changes

- Add `--candidate <full-sha>` and `--exception <reason>` to `npm run release:plan`.
- Require a historical candidate to follow the previous release, remain reachable from refreshed `origin/main`, and differ from current `origin/main`.
- Bind the selected candidate and exact exception reason into the immutable plan, generated release brief, and signed tag validation.
- Keep signing, confirmation, remote semver checks, ancestry checks, and tag readback unchanged.
- Preserve the existing release-entry requirement for ordinary current-`main` plans.
- Add focused positive and denial-path tests for planning, evidence collection, brief generation, and tag cutting.

The current consumer is the `v0.0.114` QA qualification of commit `a41aa0f69d0304e3041d29f3a91d29704624fca8`. A direct current-`main` release cannot select that tested commit. The historical mode is therefore explicit, plan-bound, and denied without a maintainer reason.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer authorization is recorded in the request for an explicit historical-candidate release path. Tests cover unreachable commits, commits before the previous release, missing or mismatched exception reasons, changed remote state, signing, and remote readback.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/release-latest-tag.test.ts test/historical-release-candidate.test.ts test/handoff-summary.test.ts test/release-candidate-evidence.test.ts test/growth-guardrails.test.ts` passed 109 tests in 5 files; ShellCheck and focused TypeScript checks passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release planning defaults to the current main branch and supports explicitly approved historical candidates.
  * Release briefs identify the selected candidate and record any historical exception.
  * Release validation checks candidate commits, ancestry, exceptions, and evidence requirements.

* **Bug Fixes**
  * Prevented invalid, unreachable, outdated, or inconsistent candidates from being planned or released.
  * Preserved historical exceptions during revalidation and ensured they cannot replace required release evidence.

* **Tests**
  * Added coverage for historical candidate planning, validation, brief generation, evidence, and release tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->