### PR TITLE
fix(ci): install review discovery dependencies

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -66,6 +66,13 @@ jobs:
           persist-credentials: false
           lfs: false
           submodules: false
+      - name: Setup Node for specialist discovery
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install specialist discovery dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Read specialist prompts
         id: specialists
         run: node --experimental-strip-types tools/pr-review-advisor/render-specialist-matrix.mts

--- a/test/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-workflow-boundary.test.ts
@@ -138,6 +138,40 @@ describe("PR review advisor workflow boundary", () => {
     );
   });
 
+  it("requires the specialist discovery Node setup action", () => {
+    const errors = validateMutation((value) => {
+      const steps = value.jobs["discover-specialists"].steps as Array<Record<string, any>>;
+      const setup = steps.find((step) => step.name === "Setup Node for specialist discovery")!;
+      setup.uses = `actions/checkout@${"a".repeat(40)}`;
+    });
+
+    expect(errors).toContain(
+      "specialist discovery must use actions/setup-node pinned to a full commit SHA",
+    );
+  });
+
+  it("rejects a specialist discovery Node setup step without an action", () => {
+    const errors = validateMutation((value) => {
+      const steps = value.jobs["discover-specialists"].steps as Array<Record<string, any>>;
+      const setup = steps.find((step) => step.name === "Setup Node for specialist discovery")!;
+      delete setup.uses;
+    });
+
+    expect(errors).toContain(
+      "specialist discovery must use actions/setup-node pinned to a full commit SHA",
+    );
+  });
+
+  it("requires one specialist discovery Node setup step", () => {
+    const errors = validateMutation((value) => {
+      const steps = value.jobs["discover-specialists"].steps as Array<Record<string, any>>;
+      const setup = steps.find((step) => step.name === "Setup Node for specialist discovery")!;
+      steps.push({ ...setup, with: { ...setup.with } });
+    });
+
+    expect(errors).toContain("specialist discovery must declare exactly one Node setup step");
+  });
+
   it("keeps model jobs read-only and the publisher separate", () => {
     const errors = validateMutation((value) => {
       value.jobs["review-specialists"].permissions["pull-requests"] = "write";

--- a/test/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-workflow-boundary.test.ts
@@ -116,6 +116,28 @@ describe("PR review advisor workflow boundary", () => {
     expect(validatePrReviewAdvisorWorkflowBoundary()).toEqual([]);
   });
 
+  it("installs trusted dependencies before specialist discovery", () => {
+    const errors = validateMutation((value) => {
+      const steps = value.jobs["discover-specialists"].steps as Array<Record<string, any>>;
+      const setup = steps.find((step) => step.name === "Setup Node for specialist discovery")!;
+      setup.with["node-version"] = "latest";
+      const install = steps.find(
+        (step) => step.name === "Install specialist discovery dependencies",
+      )!;
+      install.run = "npm install";
+      steps.splice(steps.indexOf(install), 1);
+      steps.push(install);
+    });
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        "specialist discovery must use Node 22",
+        "specialist discovery must install trusted locked dependencies",
+        "specialist discovery must set up Node and install dependencies before rendering",
+      ]),
+    );
+  });
+
   it("keeps model jobs read-only and the publisher separate", () => {
     const errors = validateMutation((value) => {
       value.jobs["review-specialists"].permissions["pull-requests"] = "write";

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -13,6 +13,7 @@ const DEFAULT_WORKFLOW = join(ROOT, ".github", "workflows", "pr-review-advisor.y
 const DEFAULT_LOCK = join(ROOT, "package-lock.json");
 const DEFAULT_POLICY = join(ROOT, "tools", "pr-review-advisor", "openshell-policy.yaml");
 const ACTION_PIN = /^[^@\s]+\/[^@\s]+@[0-9a-f]{40}(?:\s*#.*)?$/u;
+const SETUP_NODE_PIN = /^actions\/setup-node@[0-9a-f]{40}$/u;
 const SANDBOX_NAME = /^(?!.*--)[a-z]([a-z0-9-]*[a-z0-9])?$/u;
 const INTERESTS = new Set(ADVISOR_INTERESTS);
 const SPECIALIST_MATRIX_EXPRESSION =
@@ -80,11 +81,14 @@ function checkActionPins(errors: string[], name: string, job: Value): void {
 
 function checkSpecialistDiscoveryRuntime(errors: string[], discovery: Value): void {
   const steps = jobSteps(discovery);
-  const setup = namedStep(discovery, "Setup Node for specialist discovery");
+  const setupSteps = steps.filter((item) => item.name === "Setup Node for specialist discovery");
+  const setup = setupSteps.length === 1 ? setupSteps[0] : undefined;
   const install = namedStep(discovery, "Install specialist discovery dependencies");
   const render = namedStep(discovery, "Read specialist prompts");
-  if (!setup) {
-    errors.push("specialist discovery must set up Node");
+  if (setupSteps.length !== 1) {
+    errors.push("specialist discovery must declare exactly one Node setup step");
+  } else if (!setup || !SETUP_NODE_PIN.test(setup.uses ?? "")) {
+    errors.push("specialist discovery must use actions/setup-node pinned to a full commit SHA");
   } else if (object(setup.with)["node-version"] !== "22") {
     errors.push("specialist discovery must use Node 22");
   }

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -78,6 +78,32 @@ function checkActionPins(errors: string[], name: string, job: Value): void {
   }
 }
 
+function checkSpecialistDiscoveryRuntime(errors: string[], discovery: Value): void {
+  const steps = jobSteps(discovery);
+  const setup = namedStep(discovery, "Setup Node for specialist discovery");
+  const install = namedStep(discovery, "Install specialist discovery dependencies");
+  const render = namedStep(discovery, "Read specialist prompts");
+  if (!setup) {
+    errors.push("specialist discovery must set up Node");
+  } else if (object(setup.with)["node-version"] !== "22") {
+    errors.push("specialist discovery must use Node 22");
+  }
+  if (install?.run !== "npm ci --ignore-scripts --no-audit --no-fund") {
+    errors.push("specialist discovery must install trusted locked dependencies");
+  }
+  const setupIndex = steps.indexOf(setup ?? {});
+  const installIndex = steps.indexOf(install ?? {});
+  const renderIndex = steps.indexOf(render ?? {});
+  if (
+    setupIndex < 0 ||
+    installIndex < 0 ||
+    renderIndex < 0 ||
+    !(setupIndex < installIndex && installIndex < renderIndex)
+  ) {
+    errors.push("specialist discovery must set up Node and install dependencies before rendering");
+  }
+}
+
 function checkLock(errors: string[], path: string): void {
   try {
     const packages = object(object(JSON.parse(readFileSync(path, "utf8"))).packages);
@@ -171,6 +197,7 @@ export function validatePrReviewAdvisorWorkflowBoundary(
   checkPermissions(errors, "review-specialists", specialists, READ_PERMISSIONS);
   checkPermissions(errors, "review", review, READ_PERMISSIONS);
   checkPermissions(errors, "publish", publish, { contents: "read", "pull-requests": "write" });
+  checkSpecialistDiscoveryRuntime(errors, discovery);
   for (const [name, job] of Object.entries(jobs)) {
     if (name !== "publish" && object(object(job).permissions)["pull-requests"] === "write")
       errors.push("publish must be the only job with pull-requests: write");


### PR DESCRIPTION
## Summary

The PR Review Advisor specialist-discovery job now installs the repository's locked Node dependencies before it renders the specialist matrix. This fixes the `ERR_MODULE_NOT_FOUND` failure introduced when the renderer began importing the terminology helper.

## Changes

- Set up Node.js 22 in the specialist-discovery job.
- Install the locked dependencies with lifecycle scripts disabled before rendering the matrix.
- Extend the workflow boundary check and its regression test to protect the runtime version, install command, and step order.

The existing workflow boundary validator owns this requirement because it already protects the security and execution contract of this `pull_request_target` workflow. The updated `PR review advisor workflow boundary` test protects the new checks.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/pr-review-advisor-workflow-boundary.test.ts test/pr-review-advisor-openshell-workflow-boundary.test.ts` passed 13 tests; the specialist matrix renderer, repository checks, builds, and CLI type check also passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable to this focused workflow repair
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved specialist discovery workflow setup with Node.js 22 and locked, safer dependency installation.
  - Added a securely pinned Node.js setup step and validation for required workflow steps and ordering.

- **Tests**
  - Added coverage for missing, incorrect, or duplicate Node.js setup steps.
  - Expanded validation coverage for unsupported Node versions, unlocked installs, and incorrect step ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->