### PR TITLE
fix(messaging): retain stopped channel providers

### DIFF
--- a/src/lib/onboard/messaging-prep.ts
+++ b/src/lib/onboard/messaging-prep.ts
@@ -102,7 +102,12 @@ export function prepareCreateSandboxMessaging(
         retainWhileDisabled: staticProviderType !== null,
       };
     })
-    .filter(({ envKey }) => !enabledEnvKeys || enabledEnvKeys.has(envKey));
+    .filter(
+      ({ envKey, retainWhileDisabled }) =>
+        !enabledEnvKeys ||
+        enabledEnvKeys.has(envKey) ||
+        (retainWhileDisabled && disabledEnvKeys.has(envKey)),
+    );
   const messagingTokenDefs: MessagingTokenDef[] = messagingCredentialDefs
     .filter(({ envKey }) => !disabledEnvKeys.has(envKey))
     .map(({ retainWhileDisabled: _retainWhileDisabled, ...definition }) => definition);
@@ -196,8 +201,11 @@ export function prepareCreateSandboxMessaging(
       retainWhileDisabled,
     } of messagingCredentialDefs) {
       const channel = input.getMessagingChannelForEnvKey(envKey);
-      if (!channel || !input.enabledChannels.includes(channel)) continue;
+      if (!channel) continue;
       const channelDisabled = disabledChannelNames.has(channel);
+      if (!input.enabledChannels.includes(channel) && !(channelDisabled && retainWhileDisabled)) {
+        continue;
+      }
       if (channelDisabled && !retainWhileDisabled) continue;
       // Disabled definitions are intentionally absent from messagingTokenDefs,
       // so even a still-readable source token cannot recreate their provider.

--- a/test/hermes-discord-credential-binding.test.ts
+++ b/test/hermes-discord-credential-binding.test.ts
@@ -25,7 +25,7 @@ function prepareDiscord(
     sandboxName: SANDBOX_NAME,
     agentName: "hermes",
     channels: discord,
-    enabledChannels: ["discord"],
+    enabledChannels: disabled ? [] : ["discord"],
     disabledChannels: disabled ? ["discord"] : [],
     webSearchConfig: null,
     env: token ? { DISCORD_BOT_TOKEN: token } : {},
@@ -66,9 +66,12 @@ describe("Hermes Discord credential endpoint binding", () => {
     expect(profileYaml.endpoints).toEqual([]);
   });
 
-  it("does not reuse an untyped provider for the endpoint-bound credential", () => {
+  it.each([
+    { state: "active", disabled: false },
+    { state: "stopped", disabled: true },
+  ])("does not reuse an untyped provider for a $state channel", ({ disabled }) => {
     const providerMatches = vi.fn(() => false);
-    const result = prepareDiscord(null, providerMatches);
+    const result = prepareDiscord(null, providerMatches, disabled);
 
     expect(result.reusableMessagingProviders).toEqual([]);
     expect(result.reusableMessagingChannels).toEqual([]);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

PR #10047 retained a stopped Discord provider only when Discord also appeared in the active channel list. Sandbox rebuilds exclude stopped channels from that list, so this change retains the exact existing static provider for the actual rebuild state.

## Changes

- Include retained static provider definitions when a channel is stopped and absent from `enabledChannels`.
- Continue to exclude stopped-channel token definitions and runtime activation.
- Test the production state with `enabledChannels: []` and `disabledChannels: ["discord"]`.
- Confirm that active and stopped channels reject a provider with the wrong type.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Exact provider name, type, and credential-key matching remains required. The regression test confirms that mismatched active and stopped providers remain detached.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/onboard/messaging-prep.test.ts src/lib/onboard/sandbox-messaging-preflight.test.ts` (29 passed); `npx vitest run --project integration test/hermes-discord-credential-binding.test.ts` (7 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved static provider credentials when a messaging channel is disabled but retained in the selected configuration.
  * Improved provider matching for disabled channels while preventing reuse of incompatible or untyped providers.
  * Added coverage for both active and stopped channel states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->