### PR TITLE
fix(review): isolate specialist discovery

### DIFF
--- a/test/pr-review-advisor-specialists.test.ts
+++ b/test/pr-review-advisor-specialists.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
@@ -82,6 +83,39 @@ describe("PR review advisor specialist prompts", () => {
     expect(() => parseAdvisorInterest("missing-specialist")).toThrowError(
       `interest must be one of: ${ADVISOR_INTERESTS.join(", ")}`,
     );
+  });
+
+  it("renders the workflow matrix without installed packages", () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "specialist-renderer-"));
+    onTestFinished(() => fs.rmSync(directory, { recursive: true, force: true }));
+    expect(() =>
+      execFileSync(process.execPath, ["--eval", "import('@earendil-works/pi-coding-agent')"], {
+        cwd: directory,
+        stdio: "ignore",
+      }),
+    ).toThrow();
+    const sourceDirectory = path.join(process.cwd(), "tools/pr-review-advisor");
+    fs.copyFileSync(
+      path.join(sourceDirectory, "render-specialist-matrix.mts"),
+      path.join(directory, "render-specialist-matrix.mts"),
+    );
+    fs.copyFileSync(
+      path.join(sourceDirectory, "specialist-catalog.mts"),
+      path.join(directory, "specialist-catalog.mts"),
+    );
+    fs.cpSync(path.join(sourceDirectory, "specialists"), path.join(directory, "specialists"), {
+      recursive: true,
+    });
+
+    const output = execFileSync(
+      process.execPath,
+      ["--experimental-strip-types", "render-specialist-matrix.mts"],
+      { cwd: directory, encoding: "utf8", env: { PATH: process.env.PATH } },
+    );
+    const matrix = JSON.parse(output) as Array<{ interest: string; sandbox_name: string }>;
+
+    expect(matrix.map(({ interest }) => interest)).toEqual(ADVISOR_INTERESTS);
+    expect(matrix.every(({ sandbox_name: sandboxName }) => sandboxName.length <= 19)).toBe(true);
   });
 
   it("discovers a specialist from one Markdown prompt file", () => {

--- a/tools/pr-review-advisor/render-specialist-matrix.mts
+++ b/tools/pr-review-advisor/render-specialist-matrix.mts
@@ -3,7 +3,7 @@
 
 import fs from "node:fs";
 
-import { ADVISOR_SPECIALISTS } from "./specialists.mts";
+import { ADVISOR_SPECIALISTS } from "./specialist-catalog.mts";
 
 const model = process.env.PR_REVIEW_ADVISOR_MODEL?.trim() || "azure/openai/gpt-5.6-terra";
 const matrix = ADVISOR_SPECIALISTS.map(({ interest, label, sandboxName }) => ({

--- a/tools/pr-review-advisor/specialist-catalog.mts
+++ b/tools/pr-review-advisor/specialist-catalog.mts
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SPECIALIST_NAME = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/u;
+const MAX_SPECIALIST_NAME_LENGTH = 48;
+const MARKDOWN_SPDX_HEADER = `<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->`;
+const DEFAULT_SPECIALIST_DIRECTORY = fileURLToPath(new URL("specialists", import.meta.url));
+
+export type AdvisorInterest = string;
+
+export type AdvisorSpecialist = Readonly<{
+  interest: AdvisorInterest;
+  label: string;
+  prompt: string;
+  sandboxName: string;
+}>;
+
+function specialistLabel(interest: string): string {
+  return interest
+    .split("-")
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join(" / ");
+}
+
+function specialistSandboxName(interest: string): string {
+  const stem = interest.replaceAll("-", "").slice(0, 4);
+  const suffix = createHash("sha256").update(interest).digest("hex").slice(0, 4);
+  return `pr-adv-sp-${stem}-${suffix}`;
+}
+
+export function readAdvisorSpecialists(
+  directory = DEFAULT_SPECIALIST_DIRECTORY,
+): readonly AdvisorSpecialist[] {
+  const directoryStat = fs.lstatSync(directory);
+  if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+    throw new Error("Specialist prompt input must be a regular directory");
+  }
+
+  const specialists = fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.name.endsWith(".md"))
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map((entry) => {
+      const interest = entry.name.slice(0, -3);
+      if (
+        interest.length > MAX_SPECIALIST_NAME_LENGTH ||
+        !SPECIALIST_NAME.test(interest) ||
+        !entry.isFile() ||
+        entry.isSymbolicLink()
+      ) {
+        throw new Error(`Invalid specialist prompt file: ${entry.name}`);
+      }
+      const file = path.join(directory, entry.name);
+      const content = fs.readFileSync(file, "utf8").trim();
+      const markdown = content.startsWith(MARKDOWN_SPDX_HEADER)
+        ? content.slice(MARKDOWN_SPDX_HEADER.length).trim()
+        : content;
+      const [heading, ...promptLines] = markdown.split("\n");
+      const label = heading?.startsWith("# ") ? heading.slice(2).trim() : specialistLabel(interest);
+      const prompt = heading?.startsWith("# ") ? promptLines.join("\n").trim() : markdown;
+      if (!label) throw new Error(`Specialist label is empty: ${interest}`);
+      if (!prompt) throw new Error(`Specialist prompt is empty: ${interest}`);
+      return {
+        interest,
+        label,
+        prompt,
+        sandboxName: specialistSandboxName(interest),
+      };
+    });
+
+  if (specialists.length === 0) throw new Error("No specialist prompt files found");
+  const sandboxNames = specialists.map(({ sandboxName }) => sandboxName);
+  if (new Set(sandboxNames).size !== sandboxNames.length) {
+    throw new Error("Specialist prompt names must produce unique sandbox names");
+  }
+  return specialists;
+}
+
+export const ADVISOR_SPECIALISTS = readAdvisorSpecialists();
+export const ADVISOR_INTERESTS = ADVISOR_SPECIALISTS.map(({ interest }) => interest);
+
+export function parseAdvisorInterest(value: string): AdvisorInterest {
+  if (ADVISOR_INTERESTS.includes(value)) return value;
+  throw new Error(`interest must be one of: ${ADVISOR_INTERESTS.join(", ")}`);
+}

--- a/tools/pr-review-advisor/specialists.mts
+++ b/tools/pr-review-advisor/specialists.mts
@@ -1,99 +1,26 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createHash } from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-
 import type { AdvisorPromptTurn } from "../advisors/session.mts";
 import { buildInvestigateTurn, type InvestigateTurnContext } from "./investigate-turn.mts";
+import {
+  ADVISOR_INTERESTS,
+  ADVISOR_SPECIALISTS,
+  parseAdvisorInterest,
+  readAdvisorSpecialists,
+  type AdvisorInterest,
+  type AdvisorSpecialist,
+} from "./specialist-catalog.mts";
 import { TERMINOLOGY_TRACE_TOOL } from "./terminology.mts";
 
-const SPECIALIST_NAME = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/u;
-const MAX_SPECIALIST_NAME_LENGTH = 48;
-const MARKDOWN_SPDX_HEADER = `<!--
-SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-SPDX-License-Identifier: Apache-2.0
--->`;
-const DEFAULT_SPECIALIST_DIRECTORY = fileURLToPath(new URL("specialists", import.meta.url));
-
-export type AdvisorInterest = string;
-
-export type AdvisorSpecialist = Readonly<{
-  interest: AdvisorInterest;
-  label: string;
-  prompt: string;
-  sandboxName: string;
-}>;
-
-function specialistLabel(interest: string): string {
-  return interest
-    .split("-")
-    .map((part) => part[0]!.toUpperCase() + part.slice(1))
-    .join(" / ");
-}
-
-function specialistSandboxName(interest: string): string {
-  const stem = interest.replaceAll("-", "").slice(0, 4);
-  const suffix = createHash("sha256").update(interest).digest("hex").slice(0, 4);
-  return `pr-adv-sp-${stem}-${suffix}`;
-}
-
-export function readAdvisorSpecialists(
-  directory = DEFAULT_SPECIALIST_DIRECTORY,
-): readonly AdvisorSpecialist[] {
-  const directoryStat = fs.lstatSync(directory);
-  if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
-    throw new Error("Specialist prompt input must be a regular directory");
-  }
-
-  const specialists = fs
-    .readdirSync(directory, { withFileTypes: true })
-    .filter((entry) => entry.name.endsWith(".md"))
-    .sort((left, right) => left.name.localeCompare(right.name))
-    .map((entry) => {
-      const interest = entry.name.slice(0, -3);
-      if (
-        interest.length > MAX_SPECIALIST_NAME_LENGTH ||
-        !SPECIALIST_NAME.test(interest) ||
-        !entry.isFile() ||
-        entry.isSymbolicLink()
-      ) {
-        throw new Error(`Invalid specialist prompt file: ${entry.name}`);
-      }
-      const file = path.join(directory, entry.name);
-      const content = fs.readFileSync(file, "utf8").trim();
-      const markdown = content.startsWith(MARKDOWN_SPDX_HEADER)
-        ? content.slice(MARKDOWN_SPDX_HEADER.length).trim()
-        : content;
-      const [heading, ...promptLines] = markdown.split("\n");
-      const label = heading?.startsWith("# ") ? heading.slice(2).trim() : specialistLabel(interest);
-      const prompt = heading?.startsWith("# ") ? promptLines.join("\n").trim() : markdown;
-      if (!prompt) throw new Error(`Specialist prompt is empty: ${interest}`);
-      return {
-        interest,
-        label,
-        prompt,
-        sandboxName: specialistSandboxName(interest),
-      };
-    });
-
-  if (specialists.length === 0) throw new Error("No specialist prompt files found");
-  const sandboxNames = specialists.map(({ sandboxName }) => sandboxName);
-  if (new Set(sandboxNames).size !== sandboxNames.length) {
-    throw new Error("Specialist prompt names must produce unique sandbox names");
-  }
-  return specialists;
-}
-
-export const ADVISOR_SPECIALISTS = readAdvisorSpecialists();
-export const ADVISOR_INTERESTS = ADVISOR_SPECIALISTS.map(({ interest }) => interest);
-
-export function parseAdvisorInterest(value: string): AdvisorInterest {
-  if (ADVISOR_INTERESTS.includes(value)) return value;
-  throw new Error(`interest must be one of: ${ADVISOR_INTERESTS.join(", ")}`);
-}
+export {
+  ADVISOR_INTERESTS,
+  ADVISOR_SPECIALISTS,
+  parseAdvisorInterest,
+  readAdvisorSpecialists,
+  type AdvisorInterest,
+  type AdvisorSpecialist,
+};
 
 function advisorSpecialist(interest: AdvisorInterest): AdvisorSpecialist {
   const specialist = ADVISOR_SPECIALISTS.find((candidate) => candidate.interest === interest);


### PR DESCRIPTION
## Summary

Restore PR Review Advisor runs after specialist discovery began loading the full advisor runtime before dependencies were installed. The discovery job now reads prompts through a dependency-free catalog.

## Changes

- Move specialist prompt discovery and validation into a module that imports only Node.js built-ins.
- Keep the specialist review runtime as the owner of review-turn construction and terminology tools.
- Point the workflow matrix renderer at the dependency-free catalog.
- Run the renderer from an isolated temporary directory where advisor packages cannot resolve.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: `Discover review specialists` still runs trusted code from the base workflow revision, so this PR cannot use its own repair before merge. The isolated renderer test reproduces the no-install environment and passes. Maintainer acceptance is still required if this check remains non-success.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/pr-review-advisor-specialists.test.ts test/pr-review-advisor-workflow-boundary.test.ts` — 28 tests passed; `npm run checks:repository` passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a centralized catalog for advisor specialties, labels, prompts, and sandbox names.
  - Added validation for specialist definitions, requested interests, prompt files, and duplicate names.
  - Improved consistency when generating the specialist matrix.

- **Bug Fixes**
  - Prevented malformed, missing, empty, or invalid specialist configurations from being used.

- **Tests**
  - Added isolated coverage to verify specialist discovery, JSON matrix output, supported interests, and sandbox-name limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->