### PR TITLE
docs: complete v0.0.114 remediation coverage

### DIFF
--- a/docs/changelog/2026-08-23.mdx
+++ b/docs/changelog/2026-08-23.mdx
@@ -43,3 +43,27 @@ It also improves managed local inference, Portable and Hermes onboarding, image 
   The inference model-limit documentation now shows each agent only the settings it supports and states that Deep Agents Code has no equivalent model-limit operation.
   For more information, refer to [Configure Model Limits](/user-guide/deepagents/inference/manage-inference/configure-model-limits).
   Related changes: [PR #9785](https://github.com/NVIDIA/NemoClaw/pull/9785) and [PR #9867](https://github.com/NVIDIA/NemoClaw/pull/9867).
+- Ordinary Docker-driver onboarding for stock OpenClaw, Hermes, and LangChain Deep Agents Code now selects an immutable managed-image digest for the release and host architecture.
+  If registry or catalog availability prevents selection, NemoClaw can build the shipped reviewed Dockerfile; invalid or inconsistent managed-image evidence stops before sandbox creation.
+  Explicit `--from` Dockerfiles and Portable onboarding retain their separate paths.
+  For more information, refer to the [NemoClaw Quickstart with OpenClaw](/user-guide/openclaw/get-started/quickstart) and [Architecture Details](/user-guide/openclaw/reference/architecture).
+  Related change: [PR #9323](https://github.com/NVIDIA/NemoClaw/pull/9323).
+- Managed single-host vLLM onboarding can select the host GPU by index or full NVIDIA GPU UUID with `--vllm-gpu-device`.
+  The selection is independent of sandbox GPU access, controls Docker placement and GPU preflight checks, and persists across resume.
+  For more information, refer to [Set Up vLLM](/user-guide/openclaw/inference/local-inference/set-up-vllm) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+  Related change: [PR #10025](https://github.com/NVIDIA/NemoClaw/pull/10025).
+- Static messaging credentials now use validated endpointless OpenShell provider profiles across onboarding and channel lifecycle operations.
+  Paused detailed channel status keeps its schema-version-1 `report` envelope, skips the live probe, and returns an informational success.
+  Channel start defers credential-bound policy activation until rebuild attaches the required provider; stopped Hermes Discord retains only its exact validated static provider without starting the channel or recreating credentials.
+  For more information, refer to [Manage Messaging Channels](/user-guide/openclaw/manage-sandboxes/messaging-channels/manage-messaging-channels) and the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+  Related changes: [PR #9913](https://github.com/NVIDIA/NemoClaw/pull/9913), [PR #10021](https://github.com/NVIDIA/NemoClaw/pull/10021), [PR #10026](https://github.com/NVIDIA/NemoClaw/pull/10026), [PR #10047](https://github.com/NVIDIA/NemoClaw/pull/10047), and [PR #10052](https://github.com/NVIDIA/NemoClaw/pull/10052).
+- Deep Agents Code progressive disclosure now derives loaded MCP tools from the pinned executable catalog and rejects duplicate loaded implementations.
+  Tools discovered after startup become searchable only after the runtime loads them.
+  For more information, refer to [Configure Progressive Tool Disclosure](/user-guide/deepagents/configure-agents/progressive-tool-disclosure).
+  Related change: [PR #10031](https://github.com/NVIDIA/NemoClaw/pull/10031).
+- Portable lifecycle recovery now reports one credential-free timing line with fixed stage durations, selected actions, attempt counts, result, and failed stage.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+  Related change: [PR #9964](https://github.com/NVIDIA/NemoClaw/pull/9964).
+- The maintained `nemoclaw update` installer request and every redirect now require HTTPS.
+  For more information, refer to the [NemoClaw CLI Commands Reference](/user-guide/openclaw/reference/commands).
+  Related change: [PR #9862](https://github.com/NVIDIA/NemoClaw/pull/9862).

--- a/docs/configure-agents/progressive-tool-disclosure.mdx
+++ b/docs/configure-agents/progressive-tool-disclosure.mdx
@@ -44,6 +44,8 @@ Hermes core tools remain directly visible.
 ## Understand Deep Agents Tool Search
 
 Deep Agents Code activates its middleware after at least one MCP tool loads successfully.
+It derives loaded tools from the pinned runtime's executable catalog and rejects duplicate loaded implementations before disclosure.
+A late managed MCP discovery becomes available to `search_tools` after the tool loads; a gateway tool that is not loaded does not appear.
 It initially exposes `search_tools` and the core filesystem, shell, user-input, and todo tools.
 
 Each search returns up to 20 name-sorted tools whose names or descriptions match case-insensitively.

--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -132,6 +132,23 @@ If `NEMOCLAW_SERVING_PRESET` is already set, it must select the same stable prof
 
 The profile selector is model-independent, so a catalog can add profiles without adding model-specific CLI flags.
 Omitting `--profile` preserves the existing provider and model defaults.
+
+### Select a Managed vLLM GPU
+
+Use `--vllm-gpu-device <index-or-uuid>` to select the host GPU for a managed single-host vLLM container.
+The value must be a non-negative index or a full `GPU-...` UUID reported by `nvidia-smi`.
+This selection is independent of `--sandbox-gpu-device`, which controls direct GPU access inside the sandbox.
+NemoClaw applies the vLLM selection to Docker placement, compute-capability validation, and GPU-memory checks.
+It rejects this selector for a non-vLLM provider or a managed multi-node topology.
+
+```bash
+$$nemoclaw onboard --profile <profile-id> --vllm-gpu-device <index-or-uuid>
+```
+
+NemoClaw requires a resumed session to reuse the recorded GPU selector.
+A legacy in-progress session cannot add one, and a resumed session cannot change one.
+Run `$$nemoclaw onboard --fresh` when you need a different GPU selection.
+
 If onboarding is interrupted, `$$nemoclaw onboard --resume` reuses the recorded catalog, preset, and recipe digests.
 It exits before runtime effects if the installed catalog changed instead of silently switching the recipe; use `$$nemoclaw onboard --fresh --profile <profile-id>` to review and start with the current definition.
 Legacy sessions that predate profile provenance still resume with their original behavior, but you cannot add `--profile` to one of those in-progress sessions.
@@ -194,6 +211,8 @@ NemoClaw also accepts `HUGGING_FACE_HUB_TOKEN` as a compatibility alias, but new
 When neither variable is present, public-model downloads continue anonymously.
 
 If `hf download` reports HTTP `429`, export `HF_TOKEN` and resume onboarding.
+After an image-pull or managed-vLLM setup failure, resume retains the validated selected model and recorded GPU selector.
+A conflicting model, a changed GPU selector, or a selector introduced only during resume stops instead of changing the recorded install intent.
 The downloader reuses files already stored in `~/.cache/huggingface` instead of starting the model download from an empty cache.
 
 ```bash

--- a/docs/manage-sandboxes/manage-messaging-channels.mdx
+++ b/docs/manage-sandboxes/manage-messaging-channels.mdx
@@ -115,6 +115,10 @@ Hermes Google Chat does not use the dedicated webhook endpoint or `$$nemoclaw tu
 
 When `channels start` re-enables a channel, NemoClaw records the channel as enabled in the messaging plan.
 The rebuild attaches the existing bridge provider before applying its matching built-in policy preset to the replacement sandbox.
+While a channel remains stopped, the rebuild omits its runtime configuration, token upsert, and startup effects.
+Generic providers and refresh bridges remain detached.
+For stopped Hermes Discord, a preserved credential-bound policy requires the exact validated static provider, so the rebuild retains and attaches only that provider without starting Discord or recreating its credentials.
+A missing or incompatible required provider stops the rebuild before the replacement can use the policy.
 If the command queues the change without rebuilding, the running sandbox keeps its existing bridge and network policy until you rebuild it.
 
 ## Avoid Cross-Sandbox Conflicts

--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -314,6 +314,10 @@ The session then follows the current default selected through `inference set`, w
 
 <AgentOnly variant="hermes">
 The rebuild command preserves Hermes state, registered policies, and managed MCP configuration while recreating the container.
+It reuses a messaging provider only when its exact type and credential keys match the recorded channel binding.
+A stopped channel remains inactive and contributes no token upsert, rendered runtime configuration, or startup effect.
+When a stopped Hermes Discord channel retains a credential-bound policy, rebuild attaches the exact validated static provider that policy requires without starting Discord.
+If the required provider is missing or incompatible, restore or re-add the channel credentials, then rerun the rebuild.
 A rebuild creates a new sandbox home and a new Hermes API bearer token.
 After the rebuild succeeds, retrieve the replacement token before reconnecting API clients:
 

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -203,7 +203,7 @@ The concrete files differ by agent because each runtime has its own plugin syste
 | OpenClaw | `nemoclaw/openclaw.plugin.json`, `nemoclaw/src/runtime-context.ts`, and the TypeScript package under `nemoclaw/src/` | Registers the `/nemoclaw` slash command, adds the NemoClaw inference provider, and injects sandbox and policy context into OpenClaw turns. |
 </AgentOnly>
 <AgentOnly variant="hermes">
-| Hermes | `agents/hermes/manifest.yaml`, `agents/hermes/plugin/plugin.yaml`, `agents/hermes/generate-config.ts`, `agents/hermes/config/`, and `agents/hermes/start.sh` | Declares the Hermes agent contract, installs the NemoClaw Hermes plugin, writes `/sandbox/.hermes/config.yaml` and `/sandbox/.hermes/.env`, and launches `hermes gateway run` behind the OpenShell proxy. |
+| Hermes | `agents/hermes/manifest.yaml`, `agents/hermes/runtime-config-guard.py`, `agents/hermes/config/`, and `agents/hermes/start.sh` | Declares the Hermes agent contract, materializes and guards managed runtime configuration during startup, and launches `hermes gateway run` behind the OpenShell proxy. |
 </AgentOnly>
 <AgentOnly variant="deepagents">
 | Deep Agents | `agents/langchain-deepagents-code/manifest.yaml`, `agents/langchain-deepagents-code/generate-config.ts`, `agents/langchain-deepagents-code/start.sh`, and the managed `dcode` launchers | Declares the terminal agent contract, writes `/sandbox/.deepagents/config.toml`, installs managed wrappers for `dcode` and `dcode -n`, and routes inference through `inference.local`. |
@@ -225,7 +225,8 @@ The context tells the agent to try allowed network and filesystem operations bef
 The Hermes integration follows the generic agent-manifest path instead of the OpenClaw plugin package path.
 The manifest declares Hermes' binary, health probe, config directory, state directories, and OpenAI-compatible API endpoint.
 Messaging channel availability is declared by each channel manifest's `supportedAgents` list under `src/lib/messaging/channels/`, not by the Hermes agent manifest.
-The configuration generator turns NemoClaw onboarding choices into Hermes YAML and environment files, and the Hermes plugin manifest exposes NemoClaw tools and an `on_session_start` hook.
+Managed startup materializes Hermes YAML and environment state from the recorded onboarding choices.
+The runtime configuration guard validates that state before the supervised Hermes gateway starts.
 </AgentOnly>
 <AgentOnly variant="deepagents">
 The Deep Agents integration follows the generic agent-manifest path for terminal runtimes.

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1366,6 +1366,12 @@ Stages that do not apply or do not run report `0ms`.
 Timing collection and output are fail-open: clock or writer failures do not change the readiness work, command diagnostics, or exit status.
 Use the command exit status, not a duration or action field, as the readiness decision.
 
+<AgentOnly variant="openclaw,hermes">
+Portable lifecycle recovery also emits one credential-free `Portable lifecycle timing:` line.
+It reports fixed authority, container, exec-readiness, Ollama, startup, and gateway stages with their durations, selected actions, attempt counts, result, and failed stage when available.
+This diagnostic does not change recovery behavior or the command exit status.
+</AgentOnly>
+
 Run it for health checks and scripted readiness probes; users continue to run only `$$nemoclaw launch <name>`.
 
 <AgentOnly variant="openclaw">
@@ -2920,6 +2926,10 @@ It pulls inbound events from Pub/Sub over REST and does not create a public webh
 After registering the channel, NemoClaw asks whether to rebuild immediately.
 Running `add` for an already-configured channel overwrites the stored credentials where applicable.
 The operation is idempotent.
+Static channel credentials use a validated endpointless OpenShell provider profile so the gateway can replace their sandbox placeholders.
+NemoClaw validates the existing profile, provider type, and credential keys before it reuses a provider.
+A missing, malformed, conflicting, or incompatible provider state stops the operation before reuse.
+Hermes Discord uses its dedicated static provider type because its policy binds the Discord API and Gateway endpoints.
 Channel names are trimmed and lowercased before NemoClaw stores credentials, names bridge providers, or prints rebuild messages.
 NemoClaw requires the matching built-in network policy preset YAML to be present.
 A missing or malformed preset YAML (no `network_policies:` section) aborts `channels add` before any token prompt, registry write, or rebuild prompt.
@@ -2988,8 +2998,11 @@ Host-side removal is the supported path because managed startup (or an explicit 
 Pause one configured messaging channel without clearing its credentials.
 The command verifies that the sandbox's agent runtime supports the channel before reading configured or disabled channel state.
 It then requires the channel to be configured for the sandbox.
-The channel is marked disabled in the per-sandbox registry, and the sandbox is rebuilt so the onboard step skips registering the bridge with the gateway.
-The provider stays registered with the OpenShell gateway, so a later `channels start` brings the bridge back without re-entering tokens.
+The channel is marked disabled in the per-sandbox registry, and the rebuild omits its runtime configuration, token upsert, and startup effects.
+Generic channel providers and refresh bridges remain detached while the channel is stopped.
+When a stopped Hermes Discord channel keeps a credential-bound policy, the rebuild retains and attaches only the exact validated static provider that the policy requires.
+It does not start Discord or recreate the provider credentials.
+The provider remains registered with the OpenShell gateway, so a later `channels start` brings the bridge back without re-entering tokens.
 
 ```bash
 $$nemoclaw my-assistant channels stop telegram
@@ -3049,6 +3062,8 @@ Rerun `$$nemoclaw <sandbox> channels status --channel whatsapp`.
 NemoClaw does not treat a Hermes session file as live inbound-health evidence.
 
 For Telegram, `--channel telegram` probes the sandbox to report the gateway process, Bot API reachability, and inbound delivery alongside the config comparison.
+Detailed non-wait JSON keeps the schema-version-1 `{schemaVersion,sandbox,channel,report}` envelope.
+When a probe-capable channel is paused, the command skips the live probe, returns `report.verdict` as `info` with paused registration and runtime-health signals, and exits 0.
 It classifies the state as `healthy`, `idle`, `token_rejected`, `unreachable`, `not_started`, `policy_gap`, `config_gap`, `unknown`, or `probe_failed`.
 A network or egress failure, or a non-authentication Bot API startup HTTP error, produces `unreachable`; a 401 or 404 response produces `token_rejected`.
 It reads the gateway's own startup and poll log breadcrumbs rather than issuing its own Bot API request, so the resolved bot token never leaves the gateway.
@@ -3798,10 +3813,11 @@ Use rebuild after a failed Deep Agents version check, after enabling Tavily Sear
 ### `$$nemoclaw update`
 
 Check for a NemoClaw CLI update and, when requested, run the maintained installer flow.
-This command is a discoverable CLI wrapper around the supported installer path:
+This command is a discoverable CLI wrapper around the supported installer path.
+The update request and every redirect require HTTPS:
 
 ```bash
-curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
+curl -fsSL --proto '=https' --proto-redir '=https' https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
 ```bash

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1366,7 +1366,7 @@ Stages that do not apply or do not run report `0ms`.
 Timing collection and output are fail-open: clock or writer failures do not change the readiness work, command diagnostics, or exit status.
 Use the command exit status, not a duration or action field, as the readiness decision.
 
-<AgentOnly variant="openclaw,hermes">
+<AgentOnly variant="openclaw">
 Portable lifecycle recovery also emits one credential-free `Portable lifecycle timing:` line.
 It reports fixed authority, container, exec-readiness, Ollama, startup, and gateway stages with their durations, selected actions, attempt counts, result, and failed stage when available.
 This diagnostic does not change recovery behavior or the command exit status.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Complete the v0.0.114 documentation for user-visible behavior that the cumulative post-merge workflow missed. The update covers managed-image onboarding, managed vLLM GPU selection, messaging provider lifecycle, paused channel status, Deep Agents tool discovery, Portable lifecycle timing, HTTPS-only updates, and current Hermes runtime architecture.

## Changes

- Complete the v0.0.114 changelog for merged PRs #9323, #9862, #9913, #9964, #10021, #10025, #10026, #10031, #10047, and #10052.
- Document managed vLLM GPU selection, resume constraints, and GPU-specific preflight behavior.
- Document exact endpointless messaging-provider validation and stopped Hermes Discord provider retention across rebuild.
- Document the paused detailed channel-status JSON contract and Portable lifecycle timing output.
- Correct the Hermes managed-startup architecture description and Deep Agents loaded MCP tool discovery behavior.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [x] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This PR updates public documentation to match already tested source behavior and adds no runtime code.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: An independent documentation review checked credential custody, provider reuse, stopped-channel effects, pairing claim boundaries, GPU selection, variant routing, and recovery guidance against current source and tests. The first review's blockers were corrected, and the final review is recorded in the authoring evidence.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: This documentation-only change does not modify `scripts/prepare-dgx-station-host.sh`.

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — documentation-only change; targeted runtime tests are not applicable
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — not run; the PR changes documentation only
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — completed with 0 errors and 2 existing Fern warnings hidden by default
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — no new pages

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for selecting managed vLLM GPUs by index or UUID, including validation and session-resume behavior.
  * Clarified immutable managed-image selection and reviewed Dockerfile fallback behavior.
  * Documented safer messaging-channel rebuilds, credential validation, exact provider matching, and inactive stopped-channel handling.
  * Explained catalog-based Deep Agents Code tool discovery, duplicate rejection, and late-discovered tool availability.
  * Added Portable lifecycle timing diagnostics for OpenClaw recovery and paused-channel status behavior.
  * Documented HTTPS-only installer requests and updated architecture guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->