### PR TITLE
fix(onboard): admit pending OpenClaw pairing observation

### DIFF
--- a/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.test.ts
+++ b/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.test.ts
@@ -414,7 +414,7 @@ describe("OpenClaw launch-readiness pairing qualification", () => {
       });
 
       expect(observeOrdinarySettlement()).toEqual({
-        state: "pairing-only",
+        state: "scope-upgrade-pending",
         deviceIdentitySha256: expect.stringMatching(/^[a-f0-9]{64}$/),
       });
       expect(() => observeRepairSettlement()).toThrow(

--- a/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.ts
+++ b/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.ts
@@ -137,7 +137,14 @@ export function parseOpenClawPairingSettlementObservation(
   output: string,
 ): OpenClawPairingSettlementObservation | null {
   const record = parseOpenClawPairingSettlementRecord(output);
-  if (!record || (record.state !== "pairing-only" && record.state !== "settled")) return null;
+  if (
+    !record ||
+    (record.state !== "pairing-only" &&
+      record.state !== "scope-upgrade-pending" &&
+      record.state !== "settled")
+  ) {
+    return null;
+  }
   return record as OpenClawPairingSettlementObservation;
 }
 

--- a/test/helpers/openclaw-real-device-self-approval-proof.ts
+++ b/test/helpers/openclaw-real-device-self-approval-proof.ts
@@ -1634,7 +1634,7 @@ fs.statSync = function nemoclawProofStatSync(candidate, ...args) {
     requireLiveProof(
       portableRepairObservation.state === "pairing-pending" &&
         portableRepairObservation.deviceIdentitySha256 ===
-          pairingOnlyObservation.deviceIdentitySha256,
+          pendingUpgradeObservation.deviceIdentitySha256,
       "Portable repair observation did not preserve the canonical pending transition",
     );
     const pendingBeforeOrdinaryApproval = fs.readFileSync(pendingPath, "utf8");


### PR DESCRIPTION
## Summary

OpenClaw ordinary pairing observation now accepts the typed `scope-upgrade-pending` state that its observer already emits. The real-device proof also compares the Portable repair result with the current pending-upgrade observation instead of a removed variable.

Related to #9211 and #9817.

## Changes

- Admit the exact `scope-upgrade-pending` state in the ordinary settlement parser.
- Keep Portable repair settlement on its separate fail-closed state parser and reject a non-repair request.
- Update the real-device proof to preserve the same-device identity comparison.
- Correct the regression expectation for an ordinary non-repair pending upgrade.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The parser still requires the bounded final marker, exact keys, a SHA-256 device identity, and one allowlisted state. Portable repair uses its separate parser and still rejects non-repair requests. No scopes, credentials, retries, time budgets, or runtime authority change.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.test.ts` (40/40); `npm run test:changed` (32/32 growth checks and 527/527 changed tests); `npm run typecheck:cli`; `npm run checks:repository`; CLI/plugin builds and source-map validation
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new doc pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Portable repair validation by matching the device identity hash with the pending upgrade observation, ensuring more accurate device verification.
  * Improved settlement status handling for pending scope upgrades, providing more accurate readiness and repair results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->