### PR TITLE
docs: clarify v0.0.114 recovery contracts

### DIFF
--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -139,7 +139,7 @@ Use `--vllm-gpu-device <index-or-uuid>` to select the host GPU for a managed sin
 The value must be a non-negative index or a full `GPU-...` UUID reported by `nvidia-smi`.
 This selection is independent of `--sandbox-gpu-device`, which controls direct GPU access inside the sandbox.
 NemoClaw applies the vLLM selection to Docker placement, compute-capability validation, and GPU-memory checks.
-It rejects this selector for a non-vLLM provider or a managed multi-node topology.
+It rejects this selector unless NemoClaw installs managed single-host vLLM, including for an existing local vLLM provider and a managed multi-node topology.
 
 ```bash
 $$nemoclaw onboard --profile <profile-id> --vllm-gpu-device <index-or-uuid>

--- a/docs/inference/set-up-vllm.mdx
+++ b/docs/inference/set-up-vllm.mdx
@@ -139,7 +139,8 @@ Use `--vllm-gpu-device <index-or-uuid>` to select the host GPU for a managed sin
 The value must be a non-negative index or a full `GPU-...` UUID reported by `nvidia-smi`.
 This selection is independent of `--sandbox-gpu-device`, which controls direct GPU access inside the sandbox.
 NemoClaw applies the vLLM selection to Docker placement, compute-capability validation, and GPU-memory checks.
-It rejects this selector unless NemoClaw installs managed single-host vLLM, including for an existing local vLLM provider and a managed multi-node topology.
+It rejects this selector for an existing local vLLM provider or a managed multi-node topology.
+Only managed single-host vLLM installation accepts this selector.
 
 ```bash
 $$nemoclaw onboard --profile <profile-id> --vllm-gpu-device <index-or-uuid>

--- a/docs/manage-sandboxes/manage-messaging-channels.mdx
+++ b/docs/manage-sandboxes/manage-messaging-channels.mdx
@@ -115,7 +115,7 @@ Hermes Google Chat does not use the dedicated webhook endpoint or `$$nemoclaw tu
 
 When `channels start` re-enables a channel, NemoClaw records the channel as enabled in the messaging plan.
 The rebuild attaches the existing bridge provider before applying its matching built-in policy preset to the replacement sandbox.
-While a channel remains stopped, the rebuild omits its runtime configuration, token upsert, and startup effects.
+While a channel remains stopped, the rebuild omits its runtime configuration, token upsert, and channel startup effects.
 Generic providers and refresh bridges remain detached.
 <AgentOnly variant="hermes">
 For stopped Hermes Discord, a preserved credential-bound policy requires the exact validated static provider, so the rebuild retains and attaches only that provider without starting Discord or recreating its credentials.

--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -315,9 +315,9 @@ The session then follows the current default selected through `inference set`, w
 <AgentOnly variant="hermes">
 The rebuild command preserves Hermes state, registered policies, and managed MCP configuration while recreating the container.
 It reuses a messaging provider only when its exact type and credential keys match the recorded channel binding.
-A stopped channel remains inactive and contributes no token upsert, rendered runtime configuration, or startup effect.
-When a stopped Hermes Discord channel retains a credential-bound policy, rebuild attaches the exact validated static provider that policy requires without starting Discord.
-If the required provider is missing or incompatible, restore or re-add the channel credentials, then rerun the rebuild.
+A stopped channel remains inactive and contributes no token upsert, rendered runtime configuration, or channel startup effect.
+A policy-required provider attachment is the narrow exception: when stopped Hermes Discord retains a credential-bound policy, rebuild attaches its exact validated static provider without starting Discord.
+If that required provider is missing or incompatible, restore or re-add the channel credentials, then rerun the rebuild.
 A rebuild creates a new sandbox home and a new Hermes API bearer token.
 After the rebuild succeeds, retrieve the replacement token before reconnecting API clients:
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Apply the final documentation review corrections for the v0.0.114 release entry and owning guides. The changes clarify managed vLLM GPU selector eligibility and distinguish stopped-channel runtime effects from the policy-required Hermes Discord provider attachment.

## Changes

- State that `--vllm-gpu-device` applies only when NemoClaw installs managed single-host vLLM, not to an existing local server or a multi-node topology.
- Narrow stopped-channel language to channel startup effects.
- State the exact Hermes Discord static-provider exception and recovery action.

## Type of Change
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This PR corrects documentation wording and changes no runtime behavior.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: CodeRabbit identified the two documentation ambiguities. The final wording matches the managed-vLLM selector tests and stopped Hermes Discord provider lifecycle.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: This documentation-only PR does not change `scripts/prepare-dgx-station-host.sh`.

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — documentation-only correction; runtime tests are not applicable
- [ ] Applicable broad gate passed — not run; the PR changes documentation only
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — completed with 0 errors and 2 existing Fern warnings hidden by default
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — no new pages

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified when GPU device selection is supported for managed single-host vLLM setups, and which configurations are rejected.
  * Explained that rebuilding a stopped messaging channel does not update its token, runtime configuration, or startup behavior.
  * Clarified rebuild behavior for stopped Hermes and Discord channels, including the exception for policy-required Discord channels using validated static providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->