### PR TITLE
fix(onboard): wait for Portable pairing convergence

### DIFF
--- a/src/lib/actions/sandbox/launch-readiness.ts
+++ b/src/lib/actions/sandbox/launch-readiness.ts
@@ -60,7 +60,12 @@ import {
   observeOpenClawPairingQualification,
   observeOpenClawPairingRepairSettlement,
   observeOpenClawPairingSettlement,
+  OpenClawPairingObservationRetryableError,
   OpenClawPairingQualificationError,
+  OPENCLAW_ONBOARDING_PAIRING_FINAL_OBSERVATION_TIMEOUT_MS,
+  OPENCLAW_ONBOARDING_PAIRING_POLL_MS,
+  OPENCLAW_ONBOARDING_PAIRING_SETTLEMENT_TIMEOUT_MS,
+  OPENCLAW_ONBOARDING_PAIRING_TIMEOUT_MS,
   type OpenClawPairingRepairObservation,
   type OpenClawPairingSettlementObservation,
 } from "./launch-readiness/openclaw-pairing-qualification";
@@ -123,6 +128,8 @@ export interface LaunchReadinessDeps extends LaunchReadinessHealthDeps {
   storeOptions?: LaunchReadinessStoreOptions;
   withSandboxLock?: typeof withSandboxMutationLock;
   withGatewayLock?: typeof withGatewayRouteMutationLock;
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
 }
 
 export interface LaunchReadinessPublication {
@@ -986,8 +993,49 @@ export function resolveOrdinaryOpenClawPairingTarget(
  * Settle current Portable OpenClaw pairing under the lifecycle then owning
  * gateway-route locks. The repair observation admits only one canonical local
  * write request; a final strict observation requires that request to be gone.
- * An ambiguous approval receives one final observation and never another write.
+ * An ambiguous approval receives one bounded final observation window and
+ * never another write.
  */
+type PortablePairingWaitResult =
+  | { readonly kind: "observed"; readonly value: OpenClawPairingRepairObservation }
+  | { readonly kind: "rejected" }
+  | { readonly kind: "timeout" };
+
+async function waitForPortablePairingObservation(
+  sandboxName: string,
+  target: OpenClawPairingSettlementTarget,
+  deadline: number,
+  observe: typeof observeOpenClawPairingRepairSettlement,
+  decide: (value: OpenClawPairingRepairObservation) => "accept" | "reject" | "retry",
+  now: () => number,
+  sleep: (milliseconds: number) => Promise<void>,
+): Promise<PortablePairingWaitResult> {
+  while (true) {
+    const remaining = deadline - now();
+    if (remaining <= 0) return { kind: "timeout" };
+    try {
+      const value = observe(
+        sandboxName,
+        target.gatewayName,
+        target.version,
+        target.stateDirectory,
+      );
+      if (deadline - now() <= 0) return { kind: "timeout" };
+      const decision = decide(value);
+      if (deadline - now() <= 0) return { kind: "timeout" };
+      if (decision === "accept") return { kind: "observed", value };
+      if (decision === "reject") return { kind: "rejected" };
+    } catch (error) {
+      if (!(error instanceof OpenClawPairingObservationRetryableError)) {
+        return { kind: "rejected" };
+      }
+    }
+    const remainingAfterAttempt = deadline - now();
+    if (remainingAfterAttempt <= 0) return { kind: "timeout" };
+    await sleep(Math.min(OPENCLAW_ONBOARDING_PAIRING_POLL_MS, remainingAfterAttempt));
+  }
+}
+
 export async function settlePortableOpenClawPairing(
   sandboxName: string,
   options: {
@@ -1006,6 +1054,9 @@ export async function settlePortableOpenClawPairing(
     deps.observeOpenClawPairingSettlement ?? observeOpenClawPairingSettlement;
   const runProducer = deps.runPortablePairingProducer ?? runPortableOpenClawPairingRequestProducer;
   const runApproval = deps.runPortablePairingApproval ?? runPortableOpenClawPairingApproval;
+  const now = deps.now ?? (() => performance.now());
+  const sleep =
+    deps.sleep ?? ((milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
 
   return withSandboxLock(sandboxName, async () => {
     let firstEntry = getSandbox(sandboxName);
@@ -1082,17 +1133,24 @@ export async function settlePortableOpenClawPairing(
         return incompletePortablePairing("portable-runtime-identity-invalid");
       }
 
-      let first: OpenClawPairingRepairObservation;
-      try {
-        first = observeRepairPairing(
-          sandboxName,
-          target.gatewayName,
-          target.version,
-          target.stateDirectory,
-        );
-      } catch {
+      const settlementDeadline = now() + OPENCLAW_ONBOARDING_PAIRING_SETTLEMENT_TIMEOUT_MS;
+      const initialDeadline = Math.min(
+        settlementDeadline,
+        now() + OPENCLAW_ONBOARDING_PAIRING_TIMEOUT_MS,
+      );
+      const initial = await waitForPortablePairingObservation(
+        sandboxName,
+        target,
+        initialDeadline,
+        observeRepairPairing,
+        () => "accept",
+        now,
+        sleep,
+      );
+      if (initial.kind !== "observed") {
         return incompletePortablePairing("portable-pairing-incomplete");
       }
+      const first = initial.value;
       if (first.state === "settled") return { kind: "settled" };
 
       // A canonical pending transition is the producer's completed output.
@@ -1101,20 +1159,33 @@ export async function settlePortableOpenClawPairing(
       }
       runApproval(sandboxName, target.gatewayName, first.deviceIdentitySha256);
 
-      try {
-        const final: OpenClawPairingSettlementObservation = observeSettledPairing(
-          sandboxName,
-          target.gatewayName,
-          target.version,
-          target.stateDirectory,
-        );
-        return final.state === "settled" &&
-          final.deviceIdentitySha256 === first.deviceIdentitySha256
-          ? { kind: "settled" }
-          : incompletePortablePairing("portable-pairing-incomplete");
-      } catch {
-        return incompletePortablePairing("portable-pairing-incomplete");
-      }
+      const finalDeadline = Math.min(
+        settlementDeadline,
+        now() + OPENCLAW_ONBOARDING_PAIRING_FINAL_OBSERVATION_TIMEOUT_MS,
+      );
+      const final = await waitForPortablePairingObservation(
+        sandboxName,
+        target,
+        finalDeadline,
+        observeRepairPairing,
+        (candidate) => {
+          if (candidate.deviceIdentitySha256 !== first.deviceIdentitySha256) return "reject";
+          if (candidate.state !== "settled") return "retry";
+          const strict: OpenClawPairingSettlementObservation = observeSettledPairing(
+            sandboxName,
+            target.gatewayName,
+            target.version,
+            target.stateDirectory,
+          );
+          if (strict.deviceIdentitySha256 !== first.deviceIdentitySha256) return "reject";
+          return strict.state === "settled" ? "accept" : "retry";
+        },
+        now,
+        sleep,
+      );
+      return final.kind === "observed"
+        ? { kind: "settled" }
+        : incompletePortablePairing("portable-pairing-incomplete");
     });
   });
 }

--- a/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.test.ts
+++ b/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.test.ts
@@ -21,6 +21,8 @@ import {
   observeOpenClawPairingRepairSettlement,
   observeOpenClawPairingSettlement,
   observeOrdinaryOpenClawPairingSettlement,
+  OpenClawPairingObservationRetryableError,
+  OpenClawPairingQualificationError,
   OPENCLAW_PAIRING_REQUEST_SCOPES,
   OPENCLAW_PAIRING_REQUIRED_SCOPES,
   parseOpenClawPairingObservation,
@@ -395,6 +397,35 @@ describe("OpenClaw launch-readiness pairing qualification", () => {
       expect(() => observeRepairSettlement()).toThrow(
         "OpenClaw pairing qualification is unavailable",
       );
+    });
+
+    it("classifies a canonical state file that is not visible yet as retryable (#9817)", () => {
+      fs.rmSync(path.join(stateDirectory, "devices", "pending.json"));
+
+      expect(() => observeRepairSettlement()).toThrow(
+        OpenClawPairingObservationRetryableError,
+      );
+    });
+
+    it("keeps unrelated pending requests terminal instead of retrying them (#9817)", () => {
+      writeJson(path.join(stateDirectory, "devices", "pending.json"), {
+        unrelated: {
+          requestId: "unrelated",
+          deviceId: "b".repeat(64),
+          publicKey: "unrelated-public-key",
+          clientId: "unknown-client",
+          scopes: ["operator.admin"],
+        },
+      });
+
+      let failure: unknown;
+      try {
+        observeRepairSettlement();
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toBeInstanceOf(OpenClawPairingQualificationError);
+      expect(failure).not.toBeInstanceOf(OpenClawPairingObservationRetryableError);
     });
 
     it("rejects a non-repair request from Portable repair settlement (#9817)", () => {

--- a/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.ts
+++ b/src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification.ts
@@ -8,12 +8,30 @@ import path from "node:path";
 import { resolveOpenshellBinary } from "../../../adapters/openshell/command-argv";
 import type { LaunchReadinessOpenClawSessionQualification } from "../../../state/launch-readiness-lease";
 import { ROOT } from "../../../state/paths";
+import { WARMUP_TIMEOUT_MS } from "../auto-pair-warmup";
 import { readAutoPairApprovalPolicyModule } from "../auto-pair-approval";
+import { CONNECT_AUTO_PAIR_TIMEOUT_MS } from "../connect-autopair-budget";
 
 const QUALIFICATION_MARKER = "__NEMOCLAW_OPENCLAW_PAIRING_QUALIFICATION__=";
 const SETTLEMENT_MARKER = "__NEMOCLAW_OPENCLAW_PAIRING_SETTLEMENT__=";
+const RETRYABLE_OBSERVATION_EXIT_STATUS = 3;
 const SHA256_RE = /^[a-f0-9]{64}$/;
 export const OPENCLAW_PAIRING_OBSERVATION_TIMEOUT_MS = 3_000;
+// Reuse one fixed pairing lifecycle across ordinary onboarding and Portable.
+// A contended gateway list can consume the watcher's complete child bound, so
+// the appearance window retains room for another observation after three
+// attempts (#9817).
+export const OPENCLAW_ONBOARDING_PAIRING_TIMEOUT_MS = 60_000;
+export const OPENCLAW_ONBOARDING_PAIRING_POLL_MS = 1_000;
+export const OPENCLAW_ONBOARDING_PAIRING_FINAL_OBSERVATION_TIMEOUT_MS = 30_000;
+// Reserve every existing bounded child without allowing one stage to consume
+// the approval or final-observation window.
+export const OPENCLAW_ONBOARDING_PAIRING_SETTLEMENT_TIMEOUT_MS =
+  OPENCLAW_PAIRING_OBSERVATION_TIMEOUT_MS +
+  OPENCLAW_ONBOARDING_PAIRING_TIMEOUT_MS +
+  WARMUP_TIMEOUT_MS +
+  CONNECT_AUTO_PAIR_TIMEOUT_MS +
+  OPENCLAW_ONBOARDING_PAIRING_FINAL_OBSERVATION_TIMEOUT_MS;
 const OBSERVATION_MAX_OUTPUT_BYTES = 4 * 1_024;
 
 export const OPENCLAW_PAIRING_REQUIRED_ROLES = ["operator"] as const;
@@ -55,6 +73,13 @@ export class OpenClawPairingQualificationError extends Error {
   constructor() {
     super("OpenClaw pairing qualification is unavailable.");
     this.name = "OpenClawPairingQualificationError";
+  }
+}
+
+export class OpenClawPairingObservationRetryableError extends OpenClawPairingQualificationError {
+  constructor() {
+    super();
+    this.name = "OpenClawPairingObservationRetryableError";
   }
 }
 
@@ -211,6 +236,12 @@ RAW_PUBLIC_KEY_RE = re.compile(r'^[A-Za-z0-9_-]{43}$')
 def reject():
     sys.exit(1)
 
+def retry_observation():
+    sys.exit(${RETRYABLE_OBSERVATION_EXIT_STATUS})
+
+class StateChangedError(Exception):
+    pass
+
 try:
     policy_source = base64.b64decode(
         os.environ.get('NEMOCLAW_APPROVAL_POLICY_B64', ''), validate=True,
@@ -290,7 +321,7 @@ def open_state_root():
             root_fd = next_fd
         directory_metadata(root_fd)
         if not state_root_is_current(root_fd):
-            raise OSError('state root changed')
+            raise StateChangedError('state root changed')
         return root_fd
     except Exception:
         os.close(root_fd)
@@ -311,7 +342,7 @@ def open_directory(parent_fd, name):
     directory_metadata(fd)
     if not directory_is_current(parent_fd, name, fd):
         os.close(fd)
-        raise OSError('directory changed')
+        raise StateChangedError('directory changed')
     return fd
 
 def read_entry(directory_fd, name):
@@ -341,7 +372,7 @@ def read_entry(directory_fd, name):
             current.st_mtime_ns,
             current.st_mode & 0o7777,
         ) != after:
-            raise OSError('entry changed')
+            raise StateChangedError('entry changed')
         return b''.join(chunks), after
     finally:
         os.close(fd)
@@ -362,7 +393,7 @@ def read_snapshot():
             or not directory_is_current(state_fd, 'devices', devices_fd)
             or not directory_is_current(state_fd, 'identity', identity_fd)
         ):
-            raise OSError('state root changed')
+            raise StateChangedError('state root changed')
         return {
             'directories': [directory_metadata(state_fd), directory_metadata(devices_fd), directory_metadata(identity_fd)],
             'identity': (identity_raw, identity_metadata),
@@ -444,7 +475,7 @@ try:
     first = read_snapshot()
     second = read_snapshot()
     if first != second:
-        reject()
+        retry_observation()
     identity = parse_json(first['identity'][0])
     auth = parse_json(first['auth'][0])
     paired = parse_json(first['paired'][0])
@@ -623,6 +654,8 @@ try:
         'requiredScopes': TOKEN_SCOPES,
     }
     print(MARKER + json.dumps(projection, sort_keys=True, separators=(',', ':')))
+except (FileNotFoundError, StateChangedError):
+    retry_observation()
 except (OSError, ValueError, TypeError, KeyError, binascii.Error, UnicodeError):
     reject()
 PYQUALIFY
@@ -680,6 +713,13 @@ function runOpenClawPairingObservation(
       timeout: OPENCLAW_PAIRING_OBSERVATION_TIMEOUT_MS,
     },
   );
+  if (
+    !result.error &&
+    !result.signal &&
+    result.status === RETRYABLE_OBSERVATION_EXIT_STATUS
+  ) {
+    throw new OpenClawPairingObservationRetryableError();
+  }
   if (result.error || result.signal || result.status !== 0) {
     throw new OpenClawPairingQualificationError();
   }

--- a/src/lib/actions/sandbox/launch-readiness/portable-openclaw-pairing-settlement.test.ts
+++ b/src/lib/actions/sandbox/launch-readiness/portable-openclaw-pairing-settlement.test.ts
@@ -22,9 +22,10 @@ import {
 } from "../auto-pair-approval";
 import { settlePortableOpenClawPairing } from "../launch-readiness";
 import { buildTrustedProxyEnvSourceShell } from "../trusted-proxy-env";
-import type {
-  OpenClawPairingRepairObservation,
-  OpenClawPairingSettlementObservation,
+import {
+  OpenClawPairingObservationRetryableError,
+  type OpenClawPairingRepairObservation,
+  type OpenClawPairingSettlementObservation,
 } from "./openclaw-pairing-qualification";
 
 const AUTHORITY: CheckpointPortableRuntimeAuthority = {
@@ -76,12 +77,17 @@ function settlementDeps(overrides: Parameters<typeof settlePortableOpenClawPairi
   }));
   const runProducer = vi.fn();
   const runApproval = vi.fn((): PortableOpenClawPairingApprovalReceipt => "approved");
+  let now = 0;
+  const sleep = vi.fn(async (milliseconds: number) => {
+    now += milliseconds;
+  });
   return {
     calls,
     observePairing,
     observeFinalPairing,
     runProducer,
     runApproval,
+    sleep,
     deps: {
       classifyPortableLifecycleReceipt: vi.fn(() => currentReceipt()),
       getSandbox: vi.fn(() => ENTRY),
@@ -91,6 +97,8 @@ function settlementDeps(overrides: Parameters<typeof settlePortableOpenClawPairi
       observeOpenClawPairingSettlement: observeFinalPairing,
       runPortablePairingProducer: runProducer,
       runPortablePairingApproval: runApproval,
+      now: () => now,
+      sleep,
       withSandboxLock: vi.fn(async (_name, operation) => {
         calls.push("sandbox-lock");
         return operation();
@@ -377,10 +385,15 @@ describe("Portable OpenClaw pairing settlement", () => {
 
   it("repairs pairing-only state with one producer, one approval, and one final observation (#9207)", async () => {
     const scope = settlementDeps();
-    scope.observePairing.mockReturnValueOnce({
-      state: "pairing-only",
-      deviceIdentitySha256: "b".repeat(64),
-    });
+    scope.observePairing
+      .mockReturnValueOnce({
+        state: "pairing-only",
+        deviceIdentitySha256: "b".repeat(64),
+      })
+      .mockReturnValueOnce({
+        state: "settled",
+        deviceIdentitySha256: "b".repeat(64),
+      });
     scope.observeFinalPairing.mockReturnValueOnce({
       state: "settled",
       deviceIdentitySha256: "b".repeat(64),
@@ -391,16 +404,80 @@ describe("Portable OpenClaw pairing settlement", () => {
     });
     expect(scope.runProducer).toHaveBeenCalledOnce();
     expect(scope.runApproval).toHaveBeenCalledExactlyOnceWith("alpha", "nemoclaw", "b".repeat(64));
-    expect(scope.observePairing).toHaveBeenCalledOnce();
+    expect(scope.observePairing).toHaveBeenCalledTimes(2);
     expect(scope.observeFinalPairing).toHaveBeenCalledOnce();
+  });
+
+  it("waits for the canonical Portable device to appear before producing one repair (#9817)", async () => {
+    const scope = settlementDeps();
+    scope.observePairing
+      .mockImplementationOnce(() => {
+        throw new OpenClawPairingObservationRetryableError();
+      })
+      .mockReturnValueOnce({
+        state: "pairing-only",
+        deviceIdentitySha256: "b".repeat(64),
+      })
+      .mockReturnValue({
+        state: "settled",
+        deviceIdentitySha256: "b".repeat(64),
+      });
+    scope.observeFinalPairing.mockReturnValueOnce({
+      state: "settled",
+      deviceIdentitySha256: "b".repeat(64),
+    });
+
+    await expect(settlePortableOpenClawPairing("alpha", {}, scope.deps)).resolves.toEqual({
+      kind: "settled",
+    });
+    expect(scope.observePairing).toHaveBeenCalledTimes(3);
+    expect(scope.sleep).toHaveBeenCalledOnce();
+    expect(scope.runProducer).toHaveBeenCalledOnce();
+    expect(scope.runApproval).toHaveBeenCalledOnce();
+  });
+
+  it("waits for the approved Portable scopes to persist before strict settlement (#9817)", async () => {
+    const scope = settlementDeps();
+    scope.observePairing
+      .mockReturnValueOnce({
+        state: "pairing-pending",
+        deviceIdentitySha256: "b".repeat(64),
+      })
+      .mockReturnValue({
+        state: "settled",
+        deviceIdentitySha256: "b".repeat(64),
+      });
+    scope.observeFinalPairing
+      .mockReturnValueOnce({
+        state: "pairing-only",
+        deviceIdentitySha256: "b".repeat(64),
+      })
+      .mockReturnValueOnce({
+        state: "settled",
+        deviceIdentitySha256: "b".repeat(64),
+      });
+
+    await expect(settlePortableOpenClawPairing("alpha", {}, scope.deps)).resolves.toEqual({
+      kind: "settled",
+    });
+    expect(scope.runProducer).not.toHaveBeenCalled();
+    expect(scope.runApproval).toHaveBeenCalledOnce();
+    expect(scope.observePairing).toHaveBeenCalledTimes(3);
+    expect(scope.observeFinalPairing).toHaveBeenCalledTimes(2);
+    expect(scope.sleep).toHaveBeenCalledOnce();
   });
 
   it("approves one canonical pending transition without producing a second request (#9817)", async () => {
     const scope = settlementDeps();
-    scope.observePairing.mockReturnValueOnce({
-      state: "pairing-pending",
-      deviceIdentitySha256: "b".repeat(64),
-    });
+    scope.observePairing
+      .mockReturnValueOnce({
+        state: "pairing-pending",
+        deviceIdentitySha256: "b".repeat(64),
+      })
+      .mockReturnValueOnce({
+        state: "settled",
+        deviceIdentitySha256: "b".repeat(64),
+      });
     scope.observeFinalPairing.mockReturnValueOnce({
       state: "settled",
       deviceIdentitySha256: "b".repeat(64),
@@ -411,7 +488,7 @@ describe("Portable OpenClaw pairing settlement", () => {
     });
     expect(scope.runProducer).not.toHaveBeenCalled();
     expect(scope.runApproval).toHaveBeenCalledExactlyOnceWith("alpha", "nemoclaw", "b".repeat(64));
-    expect(scope.observePairing).toHaveBeenCalledOnce();
+    expect(scope.observePairing).toHaveBeenCalledTimes(2);
     expect(scope.observeFinalPairing).toHaveBeenCalledOnce();
   });
 
@@ -436,10 +513,15 @@ describe("Portable OpenClaw pairing settlement", () => {
         }),
     );
     const scope = settlementDeps({ runPortablePairingApproval: runApproval });
-    scope.observePairing.mockReturnValueOnce({
-      state: "pairing-pending",
-      deviceIdentitySha256: fixture.identityDigest,
-    });
+    scope.observePairing
+      .mockReturnValueOnce({
+        state: "pairing-pending",
+        deviceIdentitySha256: fixture.identityDigest,
+      })
+      .mockReturnValueOnce({
+        state: "settled",
+        deviceIdentitySha256: fixture.identityDigest,
+      });
     scope.observeFinalPairing.mockReturnValueOnce({
       state: "settled",
       deviceIdentitySha256: fixture.identityDigest,
@@ -474,10 +556,15 @@ describe("Portable OpenClaw pairing settlement", () => {
 
   it("rejects a settled replacement identity after canonical approval (#9817)", async () => {
     const scope = settlementDeps();
-    scope.observePairing.mockReturnValueOnce({
-      state: "pairing-pending",
-      deviceIdentitySha256: "b".repeat(64),
-    });
+    scope.observePairing
+      .mockReturnValueOnce({
+        state: "pairing-pending",
+        deviceIdentitySha256: "b".repeat(64),
+      })
+      .mockReturnValueOnce({
+        state: "settled",
+        deviceIdentitySha256: "b".repeat(64),
+      });
     scope.observeFinalPairing.mockReturnValueOnce({
       state: "settled",
       deviceIdentitySha256: "d".repeat(64),
@@ -496,10 +583,15 @@ describe("Portable OpenClaw pairing settlement", () => {
     "does not retry a %s approval and reports incomplete after one re-observation (#9207)",
     async (receipt) => {
       const scope = settlementDeps();
-      scope.observePairing.mockReturnValue({
-        state: "pairing-only",
-        deviceIdentitySha256: "c".repeat(64),
-      });
+      scope.observePairing
+        .mockReturnValueOnce({
+          state: "pairing-only",
+          deviceIdentitySha256: "c".repeat(64),
+        })
+        .mockReturnValue({
+          state: "settled",
+          deviceIdentitySha256: "c".repeat(64),
+        });
       scope.observeFinalPairing.mockReturnValue({
         state: "pairing-only",
         deviceIdentitySha256: "c".repeat(64),
@@ -511,8 +603,8 @@ describe("Portable OpenClaw pairing settlement", () => {
         reason: "portable-pairing-incomplete",
       });
       expect(scope.runApproval).toHaveBeenCalledOnce();
-      expect(scope.observePairing).toHaveBeenCalledOnce();
-      expect(scope.observeFinalPairing).toHaveBeenCalledOnce();
+      expect(scope.observePairing).toHaveBeenCalledTimes(31);
+      expect(scope.observeFinalPairing).toHaveBeenCalledTimes(30);
     },
   );
 

--- a/src/lib/onboard/machine/finalization-deps.ts
+++ b/src/lib/onboard/machine/finalization-deps.ts
@@ -2,12 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  OPENCLAW_PAIRING_OBSERVATION_TIMEOUT_MS,
+  OPENCLAW_ONBOARDING_PAIRING_FINAL_OBSERVATION_TIMEOUT_MS,
+  OPENCLAW_ONBOARDING_PAIRING_POLL_MS,
+  OPENCLAW_ONBOARDING_PAIRING_SETTLEMENT_TIMEOUT_MS,
+  OPENCLAW_ONBOARDING_PAIRING_TIMEOUT_MS,
   type OpenClawPairingSettlementObservation,
 } from "../../actions/sandbox/launch-readiness/openclaw-pairing-qualification";
 import type { OpenClawPairingSettlementTarget } from "../../actions/sandbox/launch-readiness";
-import { WARMUP_TIMEOUT_MS } from "../../actions/sandbox/auto-pair-warmup";
 import { CONNECT_AUTO_PAIR_TIMEOUT_MS } from "../../actions/sandbox/connect-autopair-budget";
+
+export {
+  OPENCLAW_ONBOARDING_PAIRING_FINAL_OBSERVATION_TIMEOUT_MS,
+  OPENCLAW_ONBOARDING_PAIRING_POLL_MS,
+  OPENCLAW_ONBOARDING_PAIRING_SETTLEMENT_TIMEOUT_MS,
+  OPENCLAW_ONBOARDING_PAIRING_TIMEOUT_MS,
+} from "../../actions/sandbox/launch-readiness/openclaw-pairing-qualification";
 
 // The lazy `require` calls avoid an import cycle because connect.ts and
 // process-recovery.ts both import onboarding helpers.
@@ -18,23 +27,6 @@ type ProcessRecoveryDeps = Pick<
 type SandboxLifecycleLock = typeof import("../../state/mcp-lifecycle-lock").withMcpLifecycleLock;
 type GatewayRouteLock =
   typeof import("../../inference/gateway-route-mutation-lock").withGatewayRouteMutationLock;
-
-// A contended gateway list can consume the watcher's full 10-second child
-// bound. Keep enough room for another complete observation window after the
-// first three attempts instead of racing the watcher at 30 seconds (#9817).
-export const OPENCLAW_ONBOARDING_PAIRING_TIMEOUT_MS = 60_000;
-export const OPENCLAW_ONBOARDING_PAIRING_POLL_MS = 1_000;
-export const OPENCLAW_ONBOARDING_PAIRING_FINAL_OBSERVATION_TIMEOUT_MS = 30_000;
-// Keep one outer cap while reserving each bounded child's fixed budget,
-// including the settled/already-pending precheck. Pairing appearance retains
-// its existing limit, and
-// a capped warm-up can no longer consume the approval or final-read budget.
-export const OPENCLAW_ONBOARDING_PAIRING_SETTLEMENT_TIMEOUT_MS =
-  OPENCLAW_PAIRING_OBSERVATION_TIMEOUT_MS +
-  OPENCLAW_ONBOARDING_PAIRING_TIMEOUT_MS +
-  WARMUP_TIMEOUT_MS +
-  CONNECT_AUTO_PAIR_TIMEOUT_MS +
-  OPENCLAW_ONBOARDING_PAIRING_FINAL_OBSERVATION_TIMEOUT_MS;
 
 export type OrdinaryOpenClawPairingSettlementResult =
   | { readonly kind: "settled" }

--- a/test/helpers/openclaw-real-device-self-approval-proof.ts
+++ b/test/helpers/openclaw-real-device-self-approval-proof.ts
@@ -12,9 +12,13 @@ import {
   buildAutoPairApprovalScript,
   parseAutoPairApprovalReceipt,
   readAutoPairApprovalPolicyModule,
+  runPortableOpenClawPairingRequestProducer,
 } from "../../src/lib/actions/sandbox/auto-pair-approval";
+import { settlePortableOpenClawPairing } from "../../src/lib/actions/sandbox/launch-readiness";
 import {
   buildOpenClawPairingObservationScript,
+  observeOpenClawPairingRepairSettlement,
+  observeOpenClawPairingSettlement,
   parseOpenClawPairingRepairObservation,
   parseOpenClawPairingSettlementObservation,
 } from "../../src/lib/actions/sandbox/launch-readiness/openclaw-pairing-qualification";
@@ -24,6 +28,7 @@ import {
   CONNECT_AUTO_PAIR_MAX_APPROVALS,
   CONNECT_AUTO_PAIR_TIMEOUT_MS,
 } from "../../src/lib/actions/sandbox/connect-autopair-budget";
+import { resolveGatewayName } from "../../src/lib/onboard/gateway-binding";
 
 interface ProofOptions {
   dist: string;
@@ -31,6 +36,7 @@ interface ProofOptions {
   patchScript: string;
   timeoutMs: number;
   tmp: string;
+  version: string;
 }
 
 function requireSuccess(
@@ -1493,6 +1499,218 @@ fs.statSync = function nemoclawProofStatSync(candidate, ...args) {
       "pairing settlement list",
     );
 
+    proofPhase = "portable-controller-delayed-settlement";
+    const baselinePortableState = {
+      auth: fs.readFileSync(deviceAuthPath, "utf8"),
+      paired: fs.readFileSync(pairedPath, "utf8"),
+      pending: fs.readFileSync(pendingPath, "utf8"),
+    };
+    const portableControllerBin = path.join(liveRoot, "portable-controller-bin");
+    fs.mkdirSync(portableControllerBin);
+    fs.writeFileSync(
+      path.join(portableControllerBin, "openclaw"),
+      [
+        "#!/bin/sh",
+        'exec "$NEMOCLAW_PROOF_NODE" "$NEMOCLAW_PROOF_OPENCLAW" "$@"',
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+    const controllerEnv: NodeJS.ProcessEnv = {
+      ...env,
+      OPENCLAW_CONFIG_PATH: configPath,
+      PATH: `${portableControllerBin}:${inheritedEnv.PATH ?? ""}`,
+    };
+    const runControllerScript = ((
+      _binary: string,
+      _args: readonly string[],
+      spawnOptions: Parameters<typeof spawnSync>[2],
+    ) =>
+      spawnSync("sh", ["-s"], {
+        ...(spawnOptions ?? {}),
+        cwd: packageDir,
+        env: controllerEnv,
+      })) as typeof spawnSync;
+    const controllerExecDeps = {
+      getOpenshellBinary: () => "openshell",
+      readApprovalPolicy: () => approvalPolicy,
+      spawnSync: runControllerScript,
+    };
+    const controllerEntry = {
+      name: "portable-controller-proof",
+      agent: "openclaw",
+      agentVersion: options.version,
+      policyPresetsFinalized: true,
+      lifecycleGeneration: "portable-controller-generation",
+      lifecycleLiveIdentityFingerprint: "portable-controller-live-identity",
+      gatewayName: resolveGatewayName(port),
+      gatewayPort: port,
+    };
+    const controllerReceipt = {
+      kind: "current" as const,
+      registryGeneration: controllerEntry.lifecycleGeneration,
+      runtimeAuthority: {
+        schemaVersion: 1,
+        kind: "podman",
+        ownership: "current-user",
+        uid: process.getuid?.() ?? 0,
+        homeDir,
+        configHome: homeDir,
+        runtimeDir: liveRoot,
+        socketPath: path.join(liveRoot, "podman.sock"),
+      },
+    };
+    const delayedPairedPath = `${pairedPath}.not-yet-visible`;
+    const delayedAuthPath = `${deviceAuthPath}.not-yet-visible`;
+    fs.renameSync(pairedPath, delayedPairedPath);
+    fs.renameSync(deviceAuthPath, delayedAuthPath);
+    const restoreInitialState = () => {
+      if (fs.existsSync(delayedPairedPath)) fs.renameSync(delayedPairedPath, pairedPath);
+      if (fs.existsSync(delayedAuthPath)) fs.renameSync(delayedAuthPath, deviceAuthPath);
+    };
+    const delayedFinalState: { value: typeof baselinePortableState | null } = { value: null };
+    let controllerNow = 0;
+    let controllerSleeps = 0;
+    let producerCalls = 0;
+    let approvalCalls = 0;
+    let controllerResult: Awaited<ReturnType<typeof settlePortableOpenClawPairing>>;
+    try {
+      controllerResult = await settlePortableOpenClawPairing(
+        controllerEntry.name,
+        { portableRequired: true },
+        {
+          classifyPortableLifecycleReceipt: () => controllerReceipt as never,
+          getSandbox: () => controllerEntry as never,
+          listAgents: () => ["openclaw"],
+          loadAgent: () =>
+            ({
+              name: "openclaw",
+              expected_version: options.version,
+              config: { dir: stateDir },
+              runtime: { interactive_command: "openclaw tui" },
+            }) as never,
+          observeOpenClawPairingRepairSettlement: (
+            sandboxName,
+            gatewayName,
+            openclawVersion,
+            stateDirectory,
+          ) =>
+            observeOpenClawPairingRepairSettlement(
+              sandboxName,
+              gatewayName,
+              openclawVersion,
+              stateDirectory,
+              controllerExecDeps,
+            ),
+          observeOpenClawPairingSettlement: (
+            sandboxName,
+            gatewayName,
+            openclawVersion,
+            stateDirectory,
+          ) =>
+            observeOpenClawPairingSettlement(
+              sandboxName,
+              gatewayName,
+              openclawVersion,
+              stateDirectory,
+              controllerExecDeps,
+            ),
+          runPortablePairingProducer: (sandboxName, gatewayName) => {
+            producerCalls += 1;
+            runPortableOpenClawPairingRequestProducer(
+              sandboxName,
+              gatewayName,
+              controllerExecDeps,
+            );
+          },
+          runPortablePairingApproval: (_sandboxName, _gatewayName, _expectedIdentity) => {
+            approvalCalls += 1;
+            const beforeApproval = {
+              auth: fs.readFileSync(deviceAuthPath, "utf8"),
+              paired: fs.readFileSync(pairedPath, "utf8"),
+              pending: fs.readFileSync(pendingPath, "utf8"),
+            };
+            const pending = readJsonObject(
+              pendingPath,
+              "production Portable controller pending state",
+            );
+            const pendingRequests = Object.values(pending).map(asRecord);
+            requireLiveProof(
+              pendingRequests.length === 1 && pendingRequests[0],
+              "production Portable controller did not produce one canonical request",
+            );
+            const requestId = pendingRequests[0].requestId;
+            requireLiveProof(
+              typeof requestId === "string" && requestId.length > 0,
+              "production Portable controller request id was invalid",
+            );
+            const approval = runCli(["devices", "approve", requestId, "--json"]);
+            requireLiveProof(
+              approval.status === 0,
+              "production Portable controller approval failed",
+            );
+            delayedFinalState.value = {
+              auth: fs.readFileSync(deviceAuthPath, "utf8"),
+              paired: fs.readFileSync(pairedPath, "utf8"),
+              pending: fs.readFileSync(pendingPath, "utf8"),
+            };
+            fs.writeFileSync(deviceAuthPath, beforeApproval.auth);
+            fs.writeFileSync(pairedPath, beforeApproval.paired);
+            fs.writeFileSync(pendingPath, beforeApproval.pending);
+            return "approved";
+          },
+          withSandboxLock: async (_name, operation) => operation(),
+          withGatewayLock: async (_name, operation) => operation(),
+          now: () => controllerNow,
+          sleep: async (milliseconds) => {
+            controllerNow += milliseconds;
+            controllerSleeps += 1;
+            if (controllerSleeps === 1) {
+              restoreInitialState();
+            } else if (controllerSleeps === 2 && delayedFinalState.value) {
+              fs.writeFileSync(deviceAuthPath, delayedFinalState.value.auth);
+              fs.writeFileSync(pairedPath, delayedFinalState.value.paired);
+              fs.writeFileSync(pendingPath, delayedFinalState.value.pending);
+              delayedFinalState.value = null;
+            }
+          },
+        },
+      );
+    } finally {
+      restoreInitialState();
+      if (delayedFinalState.value) {
+        fs.writeFileSync(deviceAuthPath, delayedFinalState.value.auth);
+        fs.writeFileSync(pairedPath, delayedFinalState.value.paired);
+        fs.writeFileSync(pendingPath, delayedFinalState.value.pending);
+      }
+    }
+    proofPhase = [
+      "portable-controller-result",
+      controllerResult.kind,
+      controllerResult.kind === "incomplete" ? controllerResult.reason : "complete",
+      `producer-${producerCalls}`,
+      `approval-${approvalCalls}`,
+      `sleeps-${controllerSleeps}`,
+    ].join("-");
+    requireLiveProof(
+      controllerResult.kind === "settled",
+      "production Portable controller did not settle delayed canonical state",
+    );
+    requireLiveProof(
+      producerCalls === 1 && approvalCalls === 1,
+      "production Portable controller repeated its request producer or approval",
+    );
+    requireLiveProof(
+      controllerSleeps === 2,
+      "production Portable controller did not observe both delayed state transitions",
+    );
+    proofPhase = "portable-controller-state-reset";
+    await stopChild(gateway);
+    fs.writeFileSync(deviceAuthPath, baselinePortableState.auth);
+    fs.writeFileSync(pairedPath, baselinePortableState.paired);
+    fs.writeFileSync(pendingPath, baselinePortableState.pending);
+    gateway = startGateway({ ...env, OPENCLAW_GATEWAY_TOKEN: gatewayToken }, true);
+    await waitForGatewayReady(gateway, port, options.timeoutMs);
+
     proofPhase = "scope-upgrade-trigger";
     const createSession = runCli([
       "gateway",
@@ -1634,7 +1852,7 @@ fs.statSync = function nemoclawProofStatSync(candidate, ...args) {
     requireLiveProof(
       portableRepairObservation.state === "pairing-pending" &&
         portableRepairObservation.deviceIdentitySha256 ===
-          pairingOnlyObservation.deviceIdentitySha256,
+          pendingUpgradeObservation.deviceIdentitySha256,
       "Portable repair observation did not preserve the canonical pending transition",
     );
     const pendingBeforeOrdinaryApproval = fs.readFileSync(pendingPath, "utf8");

--- a/test/openclaw-real-patched-dist-harness.test.ts
+++ b/test/openclaw-real-patched-dist-harness.test.ts
@@ -775,6 +775,7 @@ describe.skipIf(process.env.NEMOCLAW_REAL_OPENCLAW_DIST_HARNESS !== "1")(
           patchScript: path.join(REPO_ROOT, "scripts", "patch-openclaw-device-self-approval.mts"),
           timeoutMs: PATCH_COMMAND_TIMEOUT_MS,
           tmp,
+          version,
         });
       } finally {
         fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Portable OpenClaw onboarding now waits within its existing fixed lifecycle for the canonical CLI device to appear and for approved baseline scopes to persist. Invalid, unrelated, multiple-request, or changed-device state still fails closed, and the controller still runs at most one request producer and one approval.

## Related Issue

Related to #9817.

## Changes

- Give not-yet-visible or concurrently changing canonical state a typed retryable observation result while retaining terminal rejection for invalid state.
- Reuse the accepted 60-second appearance window, 30-second final observation window, one-second polling interval, and existing total settlement cap in the Portable controller.
- Require the final strict observation to retain the same device identity, no pending request, and exact baseline scopes.
- Add deterministic delayed-appearance and delayed-persistence controller regressions, plus a pinned OpenClaw 2026.7.1 production-controller proof.
- Preserve PR #10062 as the separate owner for the ordinary `scope-upgrade-pending` parser and proof baseline.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Issue #9817 and the maintainer decision fix the contract to one canonical CLI identity with exact baseline scopes and no pending request. The change preserves that conjunction, retries only typed absence or state change, and keeps unrelated, multiple, malformed, or changed-identity state terminal.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: local complete changed-test and pinned-runtime lanes reach the separate PR #10062 `scope-upgrade-pending` baseline after this PR's tests pass; no acceptance is claimed here.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: This change does not modify `scripts/prepare-dgx-station-host.sh`.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 27/27 Portable settlement tests; 2/2 focused observer tests; 29/29 finalization dependency tests; CLI typecheck; repository architecture checks; pinned OpenClaw 2026.7.1 proof crossed the new production Portable-controller phase.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — `npm run test:changed` passed 529/531 tests; the remaining two tests are the separate PR #10062 baseline. The full pinned harness likewise crossed this PR's phase and then stopped at that baseline.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pairing readiness checks to tolerate temporary state changes and delayed device availability.
  * Added bounded retries for transient observation errors during pairing approval and settlement.
  * Rejects mismatched device identities and reports incomplete status when settlement times out or is declined.
  * Prevents unrelated pending requests from being mistaken for temporary pairing states.

* **Tests**
  * Expanded coverage for delayed pairing, retries, timeouts, and final settlement validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->