### PR TITLE
feat(review): add reduction specialists

### DIFF
--- a/tools/pr-review-advisor/README.md
+++ b/tools/pr-review-advisor/README.md
@@ -40,8 +40,8 @@ It intentionally does not report GitHub mergeability, branch protection, CI stat
 1. Runs on `pull_request_target` for internal and fork PRs, plus trusted manual dispatch.
 2. Prepares the target PR as inert analysis data and executes the trusted Advisor entrypoint from the workflow checkout.
 3. Runs model analysis inside OpenShell. The sandbox receives neither a GitHub token nor the upstream model credential.
-4. Runs five required specialist Pi sessions for Behavior, Trust, Design / Architecture, Operations, and Documentation. Each specialist reads repository evidence and records a native session trace.
-5. Runs one synthesis advisor after all five specialist sessions complete. The synthesis advisor reads the traces as untrusted evidence, verifies retained concerns against the repository, and performs the two-turn review protocol.
+4. Runs one required Pi session for each valid Markdown prompt in `tools/pr-review-advisor/specialists`. Each specialist reads repository evidence and records a native session trace.
+5. Runs one synthesis advisor after every discovered specialist session completes. The synthesis advisor reads the traces as untrusted evidence, verifies retained concerns against the repository, and performs the two-turn review protocol.
 6. The `investigate` turn has repo-confined `read`, `grep`, `find`, and `ls` tools, deterministic PR context tools, and trusted terminology tracing. If the advisor calls every required context tool but omits the analysis receipt, the runner permits one prose-only continuation.
 7. The `challenge-and-record` turn adds `record_findings`, `record_review_receipt`, `recommend_e2e`, and `submit_review`. The recording tools replace complete in-memory draft sections without updating canonical state. `submit_review` validates and assembles pending state. The session runner commits that state only after it accepts the complete terminal flow. Provider failures, invalid submissions, and rejected terminal flows leave canonical state unchanged.
 8. Trusted code writes the synthesis session transcript, result, and summary artifacts.
@@ -134,7 +134,7 @@ Configure this repository secret for review analysis:
 The trusted host uses this secret only to register the OpenAI-compatible
 `https://inference-api.nvidia.com/v1` service with OpenShell. The sandboxed analyzer reaches that
 provider through `https://inference.local/v1` and does not receive the secret.
-The five specialists and the synthesis advisor use the workflow-configured model and share the same credential boundary.
+The discovered specialists and the synthesis advisor use the workflow-configured model and share the same credential boundary.
 
 If advisor credentials are unavailable, the advisor writes a low-confidence unavailable result
 instead of failing closed without artifacts.
@@ -148,9 +148,9 @@ instead of failing closed without artifacts.
 
 ## Specialist synthesis
 
-Five focused, read-only Pi sessions cover Behavior, Trust, Design / Architecture, Operations, and Documentation. All five specialist sessions are required. Each specialist uploads Pi's unchanged native JSONL session. Specialists have repository read tools but cannot record or submit the canonical review.
+Each valid Markdown prompt in `tools/pr-review-advisor/specialists` creates a focused, read-only Pi session. Every discovered specialist session is required. Each specialist uploads Pi's unchanged native JSONL session. Specialists have repository read tools but cannot record or submit the canonical review.
 
-The synthesis advisor places the five traces beside the read-only repository inside OpenShell. It treats model-authored trace content as untrusted evidence and verifies retained concerns against repository evidence. It uses the atomic submission tools to create the canonical result. An absent, invalid, or oversized specialist trace fails synthesis.
+The synthesis advisor places every discovered specialist trace beside the read-only repository inside OpenShell. It treats model-authored trace content as untrusted evidence and verifies retained concerns against repository evidence. It uses the atomic submission tools to create the canonical result. An absent, invalid, or oversized specialist trace fails synthesis.
 
 The publisher has the only pull-request write permission. It receives neither the model credential nor the specialist traces. It validates and publishes only the synthesis artifact.
 

--- a/tools/pr-review-advisor/specialists/code-reduction.md
+++ b/tools/pr-review-advisor/specialists/code-reduction.md
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Code reduction
+
+Determine whether the change delivers its required outcome with the least code and smallest supported surface that fits the repository.
+
+A good code reduction review owns concrete deletion and consolidation proposals. It considers the change and the surrounding implementation as one end state, then identifies exact code, branches, helpers, fixtures, tests, compatibility paths, and documentation that can disappear. It accounts for the complete source-and-test result rather than moving the same structure behind another name.
+
+Report a finding when an identified deletion or consolidation produces a smaller coherent implementation with the same required behavior. Name the exact code to remove or merge, the behavior and trust-boundary guarantees that remain, and the resulting reduction in owners, concepts, branches, files, or lines.

--- a/tools/pr-review-advisor/specialists/dependency-use.md
+++ b/tools/pr-review-advisor/specialists/dependency-use.md
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Dependency use
+
+Determine whether the change uses existing dependencies and platform capabilities directly and proportionately.
+
+A good dependency review compares new wrappers, adapters, parsers, caches, registries, and compatibility code with the capabilities already provided by the repository, language runtime, and selected dependencies. It considers whether removing custom code would preserve the required behavior and trust boundaries.
+
+Report a finding when an existing supported capability can replace new repository code, or when a dependency introduces more integration code than the outcome warrants. Name the code that can be removed, the capability that replaces it, and the required behavior and trust-boundary guarantees the replacement retains.

--- a/tools/pr-review-advisor/specialists/migration-completion.md
+++ b/tools/pr-review-advisor/specialists/migration-completion.md
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Migration completion
+
+Determine whether the change completes each replacement it introduces.
+
+A good migration completion review follows every affected caller, state path, test, script, workflow, and document to the intended implementation. It identifies old behavior that the change makes obsolete and confirms that one owner remains for each responsibility.
+
+Report a finding when the new and old paths remain active without a current compatibility requirement, when callers still reach the superseded path, or when tests and documentation continue to preserve obsolete behavior. Name the old path to remove, the current path that replaces it, and the required behavior and trust-boundary guarantees the replacement retains.

--- a/tools/pr-review-advisor/specialists/migration-completion.md
+++ b/tools/pr-review-advisor/specialists/migration-completion.md
@@ -9,4 +9,4 @@ Determine whether the change completes each replacement it introduces.
 
 A good migration completion review follows every affected caller, state path, test, script, workflow, and document to the intended implementation. It identifies old behavior that the change makes obsolete and confirms that one owner remains for each responsibility.
 
-Report a finding when the new and old paths remain active without a current compatibility requirement, when callers still reach the superseded path, or when tests and documentation continue to preserve obsolete behavior. Name the old path to remove, the current path that replaces it, and the required behavior and trust-boundary guarantees the replacement retains.
+Report a finding when repository evidence shows that an old path, caller, test, or document remains after its replacement and no current compatibility, rollback, client-version, or migration-sequencing requirement still needs it. Name the old path to remove, the current path that replaces it, and the required behavior and trust-boundary guarantees the replacement retains.

--- a/tools/pr-review-advisor/specialists/test-design.md
+++ b/tools/pr-review-advisor/specialists/test-design.md
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Test design
+
+Determine whether the changed behavior has clear evidence with the smallest maintainable test structure.
+
+A good test design review owns the structure of the test evidence rather than deciding whether changed behavior has enough evidence. It identifies the distinct behavior each test proves and looks for repeated fixtures, self-derived expectations, overlapping matrices, and assertions tied to incidental implementation details.
+
+Report a finding when tests duplicate the same proof, preserve obsolete behavior, or create another fixture owner. Name the exact tests, fixtures, setup, or matrix entries to remove or merge, the distinct coverage that must remain, and the smallest test structure that preserves it.


### PR DESCRIPTION
## Summary

Add four PR Review Advisor specialists that look for concrete ways to reduce repository size and finish replacements. Each specialist must preserve required behavior and trust boundaries while naming exact code or test structure to remove or consolidate.

## Changes

- Add a Code reduction specialist for measurable deletion and consolidation proposals.
- Add a Migration completion specialist for removing superseded paths.
- Add a Test design specialist for consolidating duplicate test evidence and fixture ownership.
- Add a Dependency use specialist for replacing custom integration code with supported existing capabilities.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/pr-review-advisor-specialists.test.ts test/pr-review-advisor-specialist-sessions.test.ts test/pr-review-advisor-workflow-boundary.test.ts test/pr-review-advisor-openshell-workflow-boundary.test.ts test/pr-review-advisor-openshell.test.ts` — 83 tests passed; Markdown lint, matrix rendering, repository checks, and diff checks passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added review guidance for reducing unnecessary code and making better use of existing capabilities.
  * Added migration-completion guidance to identify obsolete paths and ensure changes are fully adopted.
  * Added test-design guidance to improve test maintainability while preserving meaningful behavioral coverage.
  * Expanded review coverage with consistent criteria for simplification, migration completeness, dependency usage, and test quality.
* **Documentation**
  * Updated review documentation to support automatically discovered specialist guidance and comprehensive review synthesis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->