### PR TITLE
fix(e2e): resolve installed OpenShell launch command

### DIFF
--- a/test/e2e/fixtures/clients/host.ts
+++ b/test/e2e/fixtures/clients/host.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isAbsolute } from "node:path";
+
 import { buildAvailabilityProbeEnv } from "../availability-env.ts";
 import type { ShellProbeResult, ShellProbeRunOptions } from "../shell-probe.ts";
 import { trustedShellCommand } from "../shell-probe.ts";
@@ -29,7 +31,7 @@ export class HostCliClient {
   private readonly runner: CommandRunner;
   private readonly cliPath: string;
   private readonly cwd?: string;
-  private readonly openshellPath: string;
+  private openshellPath: string;
 
   constructor(runner: CommandRunner, options: HostClientOptions = {}) {
     this.runner = runner;
@@ -80,6 +82,34 @@ export class HostCliClient {
     if (result.exitCode === 1) return false;
     assertExitZero(result, `probe command availability for ${command}`);
     return false;
+  }
+
+  async resolveOpenShellCommandPath(options: ShellProbeRunOptions = {}): Promise<string> {
+    const result = await this.command(
+      "bash",
+      ["-lc", 'command -v -- "$1"', "resolve-openshell-command", this.openshellPath],
+      {
+        artifactName: "resolve-openshell-command",
+        env: buildAvailabilityProbeEnv(),
+        timeoutMs: 30_000,
+        ...options,
+      },
+    );
+    assertExitZero(result, "resolve OpenShell command path");
+    const candidates = result.stdout.split(/\r?\n/u).filter((line) => line.length > 0);
+    const resolvedPath = candidates[0];
+    if (
+      candidates.length !== 1 ||
+      resolvedPath === undefined ||
+      !isAbsolute(resolvedPath) ||
+      resolvedPath.includes("\0")
+    ) {
+      throw new Error(
+        "resolve OpenShell command path failed: expected exactly one non-empty absolute path",
+      );
+    }
+    this.openshellPath = resolvedPath;
+    return resolvedPath;
   }
 
   nemoclaw(args: string[] = [], options: ShellProbeRunOptions = {}): Promise<ShellProbeResult> {

--- a/test/e2e/live/full-e2e.test.ts
+++ b/test/e2e/live/full-e2e.test.ts
@@ -495,6 +495,12 @@ test("full e2e: install, onboard, inference, cli operations, and cleanup", {
       });
   const installCompletedAtMs = Date.now();
   expect(install.exitCode, resultText(install)).toBe(0);
+  await host.resolveOpenShellCommandPath({
+    artifactName: "phase-2-resolve-openshell-command",
+    env: env(),
+    redactionValues,
+    timeoutMs: 60_000,
+  });
   await (coldOnboard
     ? assertColdOnboardPerformance({
         apiKey: hosted.apiKey,

--- a/test/e2e/support/e2e-clients.test.ts
+++ b/test/e2e/support/e2e-clients.test.ts
@@ -146,6 +146,47 @@ describe("E2E fixture clients", () => {
     );
   });
 
+  it("host client resolves the configured OpenShell command through the fixture child environment", async () => {
+    const runner = new FakeRunner();
+    runner.enqueue({ stdout: "/home/runner/.local/bin/openshell\n" });
+    const host = new HostCliClient(runner);
+
+    await expect(host.resolveOpenShellCommandPath()).resolves.toBe(
+      "/home/runner/.local/bin/openshell",
+    );
+
+    expect(host.openshellCommandPath).toBe("/home/runner/.local/bin/openshell");
+    expect(runner.calls).toEqual([
+      {
+        command: "bash",
+        args: ["-lc", 'command -v -- "$1"', "resolve-openshell-command", "openshell"],
+        options: {
+          artifactName: "resolve-openshell-command",
+          env: expect.objectContaining({ PATH: expect.any(String) }),
+          timeoutMs: 30_000,
+        },
+      },
+    ]);
+  });
+
+  it.each([
+    { label: "empty output", stdout: "" },
+    { label: "a relative path", stdout: "openshell\n" },
+    {
+      label: "multiple absolute paths",
+      stdout: "/home/runner/.local/bin/openshell\n/usr/bin/openshell\n",
+    },
+  ])("host client keeps its configured OpenShell command for $label", async ({ stdout }) => {
+    const runner = new FakeRunner();
+    runner.enqueue({ stdout });
+    const host = new HostCliClient(runner);
+
+    await expect(host.resolveOpenShellCommandPath()).rejects.toThrow(
+      "resolve OpenShell command path failed: expected exactly one non-empty absolute path",
+    );
+    expect(host.openshellCommandPath).toBe("openshell");
+  });
+
   it("host client validates list/status and cleans up sandbox destroys", async () => {
     const runner = new FakeRunner();
     runner.stdout = "NAME\nassistant\n";

--- a/test/e2e/support/e2e-clients.test.ts
+++ b/test/e2e/support/e2e-clients.test.ts
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import {
   assertExitZero,
   type CommandRunner,
@@ -25,6 +25,7 @@ import type {
   ShellProbeRunOptions,
   TrustedShellCommand,
 } from "../fixtures/shell-probe.ts";
+import { LAUNCH_TURN_SCRIPT, runOpenClawLaunchSession } from "../live/launch-agent-turn.ts";
 import { sandboxShWithArgs } from "../live/phase6-messaging-helpers.ts";
 
 interface RunnerCall {
@@ -185,6 +186,42 @@ describe("E2E fixture clients", () => {
       "resolve OpenShell command path failed: expected exactly one non-empty absolute path",
     );
     expect(host.openshellCommandPath).toBe("openshell");
+  });
+
+  it("composes installation, OpenShell resolution, and launch in authority order", async () => {
+    const runner = new FakeRunner();
+    runner.enqueue({ stdout: "installation complete\n" });
+    runner.enqueue({ stdout: "/home/runner/.local/bin/openshell\n" });
+    runner.enqueue({});
+    const host = new HostCliClient(runner);
+    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+
+    try {
+      const install = await host.command("bash", ["install.sh", "--non-interactive", "--fresh"], {
+        artifactName: "phase-1-install-sh",
+      });
+      expect(install.exitCode).toBe(0);
+      await host.resolveOpenShellCommandPath();
+      await runOpenClawLaunchSession({
+        artifactName: "phase-4-openclaw-launch-turn",
+        cliCommand: "nemoclaw",
+        env: {},
+        host,
+        redactionValues: [],
+        sandboxName: "alpha",
+      });
+
+      expect(runner.calls.map(({ args }) => args)).toEqual([
+        ["install.sh", "--non-interactive", "--fresh"],
+        ["-lc", 'command -v -- "$1"', "resolve-openshell-command", "openshell"],
+        ["-lc", LAUNCH_TURN_SCRIPT],
+      ]);
+      expect(runner.calls[2]?.options?.env?.NEMOCLAW_OPENSHELL_COMMAND).toBe(
+        "/home/runner/.local/bin/openshell",
+      );
+    } finally {
+      platform.mockRestore();
+    }
   });
 
   it("host client validates list/status and cleans up sandbox destroys", async () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Portable full E2E created its host fixture before installation with a relative `openshell` fallback, so phase 4 correctly rejected the untrusted command authority. The fixture now resolves the installed executable through its child environment after onboarding and stores it only when `command -v` returns one absolute path.

## Changes

- Add `HostCliClient.resolveOpenShellCommandPath` with an argument-safe `command -v` probe, fixture-owned child environment, and fail-closed absolute-path validation.
- Resolve and bind the installed OpenShell executable immediately after successful install/onboard and before phase-4 launch.
- Add positive, invalid-output, and install-to-launch composition coverage.
- Preserve the existing phase-4 absolute-path assertion and relative-authority regression unchanged.

## E2E Root Cause

- E2E root cause: Portable live E2E fixture / phase-4 launch session / relative OpenShell command authority
- Source workflow: https://github.com/NVIDIA/NemoClaw/actions/runs/32701022146
- Source run: 32701022146, attempt 1
- Failed job: portable-launch, 97352360126
- Failed job URL: https://github.com/NVIDIA/NemoClaw/actions/runs/32701022146/job/97352360126
- Failure signature: `launch session coverage requires an absolute OpenShell command path`
- Scope: one root cause

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: [Advisor Trust and synthesis](https://github.com/NVIDIA/NemoClaw/actions/runs/32706299216) and [CodeQL](https://github.com/NVIDIA/NemoClaw/actions/runs/32706008837) passed on the implementation commit.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
  - `npx vitest run --project e2e-support test/e2e/support/e2e-clients.test.ts test/e2e/support/launch-agent-turn.test.ts` passed 95 tests in 2 files; 25 platform-specific cases skipped.
  - `npm run test:changed` passed its growth guardrails, 42 changed-test files, and 761 tests. Its two remaining cases are Linux user-service fixtures that exit 75 on this Darwin host.
  - `npm run checks:repository` passed.
  - `npm run validate:pr` passed all fallback pre-commit, commit-message, and pre-push checks.
  - Live E2E was not dispatched or rerun.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this is a focused fixture correction with E2E-support coverage.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
