### PR TITLE
fix(package): ship native agent assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,11 +104,7 @@
   "files": [
     ".version",
     ".source-revision",
-    "agents/*/manifest.yaml",
-    "agents/*/state-lock-plan.json",
-    "agents/hermes/host/",
-    "agents/nemocua/Dockerfile",
-    "agents/nemocua/policy-additions.yaml",
+    "agents/",
     "bin/",
     "dist/",
     "src/lib/messaging/channels/**/policy/*.{yaml,yml}",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,12 @@
   "files": [
     ".version",
     ".source-revision",
-    "agents/",
+    "agents/*/manifest.yaml",
+    "agents/*/state-lock-plan.json",
+    "agents/hermes/host/",
+    "agents/nemocua/Dockerfile",
+    "agents/nemocua/policy-additions.yaml",
+    "agents/openclaw/policy-permissive.yaml",
     "bin/",
     "dist/",
     "src/lib/messaging/channels/**/policy/*.{yaml,yml}",

--- a/test/package-contract/openshell-policy-boundary.test.ts
+++ b/test/package-contract/openshell-policy-boundary.test.ts
@@ -181,15 +181,13 @@ describe("OpenShell policy boundary package contract", () => {
     ).toBe(false);
   });
 
-  it.each(
-    [
-        "managed-tool-gateway-matrix.json",
-        "runtime-refresh-credentials.ts",
-        "tool-gateway-broker.ts",
-        "tool-gateway-control-contract.ts",
-      ],
-  )("ships the Hermes host broker with its canonical sandbox-name boundary [%s]", (file) => {
-    expect(packageFiles(repoRoot)).toContain("agents/hermes/host/");
+  it.each([
+    "managed-tool-gateway-matrix.json",
+    "runtime-refresh-credentials.ts",
+    "tool-gateway-broker.ts",
+    "tool-gateway-control-contract.ts",
+  ])("ships the Hermes host broker with its canonical sandbox-name boundary [%s]", (file) => {
+    expect(packageFiles(repoRoot)).toContain("agents/");
 
     expect(fs.existsSync(path.join(repoRoot, "agents", "hermes", "host", file))).toBe(true);
 
@@ -215,19 +213,44 @@ describe("OpenShell policy boundary package contract", () => {
     expect(validation).toEqual([true, false]);
   });
 
-  it("ships agent manifests and generated state lock plans (#8006)", () => {
-    expect(packageFiles(repoRoot)).toContain("agents/*/manifest.yaml");
-    expect(packageFiles(repoRoot)).toContain("agents/*/state-lock-plan.json");
+  it("ships complete repository-owned agent definitions", () => {
+    expect(packageFiles(repoRoot)).toContain("agents/");
+  });
+
+  it.each(["hermes", "langchain-deepagents-code", "nemocua", "openclaw", "pi"])(
+    "ships the %s agent manifest",
+    (agent) => {
+      const manifest = fs.readFileSync(
+        path.join(repoRoot, "agents", agent, "manifest.yaml"),
+        "utf8",
+      );
+      expect(manifest).toMatch(new RegExp(`^name: ${agent}$`, "m"));
+    },
+  );
+
+  it.each([
+    "hermes/Dockerfile",
+    "hermes/Dockerfile.base",
+    "hermes/policy-additions.yaml",
+    "hermes/policy-permissive.yaml",
+    "hermes/start.sh",
+    "langchain-deepagents-code/Dockerfile",
+    "langchain-deepagents-code/Dockerfile.base",
+    "langchain-deepagents-code/policy-additions.yaml",
+    "langchain-deepagents-code/start.sh",
+    "nemocua/Dockerfile",
+    "nemocua/policy-additions.yaml",
+    "openclaw/policy-permissive.yaml",
+    "pi/Dockerfile",
+    "pi/Dockerfile.base",
+    "pi/policy-additions.yaml",
+    "pi/start.sh",
+  ])("ships the native agent asset %s", (asset) => {
+    expect(fs.existsSync(path.join(repoRoot, "agents", asset))).toBe(true);
   });
 
   it("ships the complete repository-owned NemoCUA agent definition (#9649)", () => {
-    expect(packageFiles(repoRoot)).toEqual(
-      expect.arrayContaining([
-        "agents/*/manifest.yaml",
-        "agents/nemocua/Dockerfile",
-        "agents/nemocua/policy-additions.yaml",
-      ]),
-    );
+    expect(packageFiles(repoRoot)).toEqual(expect.arrayContaining(["agents/"]));
     expect(fs.existsSync(path.join(repoRoot, "agents", "nemocua", "manifest.yaml"))).toBe(true);
     expect(fs.existsSync(path.join(repoRoot, "agents", "nemocua", "Dockerfile"))).toBe(true);
     expect(fs.existsSync(path.join(repoRoot, "agents", "nemocua", "policy-additions.yaml"))).toBe(

--- a/test/package-contract/openshell-policy-boundary.test.ts
+++ b/test/package-contract/openshell-policy-boundary.test.ts
@@ -25,15 +25,25 @@ function packageFiles(packageRoot: string): string[] {
 }
 
 function collectPackedPaths(): ReadonlySet<string> {
-
-  const packed = spawnSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    maxBuffer: 10 * 1024 * 1024,
+  const fixtureRoot = createPackageFixture({
+    prefix: "nemoclaw-agent-assets-pack-",
+    entries: ["agents"],
   });
-  expect(packed.status, `${packed.stdout}${packed.stderr}`).toBe(0);
-  const report = JSON.parse(packed.stdout) as Array<{ files?: Array<{ path?: string }> }>;
-  return new Set((report[0]?.files ?? []).flatMap((entry) => (entry.path ? [entry.path] : [])));
+  try {
+    const output = JSON.parse(
+      execFileSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+        cwd: fixtureRoot,
+        encoding: "utf8",
+        maxBuffer: 10 * 1024 * 1024,
+      }),
+    ) as
+      | Array<{ files?: Array<{ path?: string }> }>
+      | Record<string, { files?: Array<{ path?: string }> }>;
+    const report = Array.isArray(output) ? output[0] : Object.values(output)[0];
+    return new Set((report?.files ?? []).flatMap((entry) => (entry.path ? [entry.path] : [])));
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
 }
 
 const packedPaths = collectPackedPaths();
@@ -42,12 +52,11 @@ describe("OpenShell policy boundary package contract", () => {
   it.each([repoRoot, path.join(repoRoot, "nemoclaw")])(
     "pins the YAML parser used by both production package boundaries [case %#]",
     (packageRoot) => {
-      const dependencyVersion = JSON.parse(
-        execFileSync("npm", ["pkg", "get", "dependencies.yaml"], {
-          cwd: packageRoot,
-          encoding: "utf8",
-        }),
-      ) as string;
+      const output = execFileSync("npm", ["pkg", "get", "dependencies.yaml"], {
+        cwd: packageRoot,
+        encoding: "utf8",
+      }).trim();
+      const dependencyVersion = output.startsWith('"') ? (JSON.parse(output) as string) : output;
 
       expect(dependencyVersion).toBe("2.8.3");
     },
@@ -201,7 +210,7 @@ describe("OpenShell policy boundary package contract", () => {
     "tool-gateway-broker.ts",
     "tool-gateway-control-contract.ts",
   ])("ships the Hermes host broker with its canonical sandbox-name boundary [%s]", (file) => {
-    expect(packageFiles(repoRoot)).toContain("agents/");
+    expect(packageFiles(repoRoot)).toContain("agents/hermes/host/");
 
     expect(packedPaths).toContain(`agents/hermes/host/${file}`);
 
@@ -227,49 +236,29 @@ describe("OpenShell policy boundary package contract", () => {
     expect(validation).toEqual([true, false]);
   });
 
-  it("ships complete repository-owned agent definitions", () => {
-    expect(packageFiles(repoRoot)).toContain("agents/");
-  });
-
-  it.each(["hermes", "langchain-deepagents-code", "nemocua", "openclaw", "pi"])(
-    "ships the %s agent manifest",
-    (agent) => {
-      const manifest = fs.readFileSync(
-        path.join(repoRoot, "agents", agent, "manifest.yaml"),
-        "utf8",
-      );
-      expect(manifest).toMatch(new RegExp(`^name: ${agent}$`, "m"));
-      expect(packedPaths).toContain(`agents/${agent}/manifest.yaml`);
-    },
-  );
-
-  it.each([
-    "hermes/Dockerfile",
-    "hermes/Dockerfile.base",
-    "hermes/policy-additions.yaml",
-    "hermes/policy-permissive.yaml",
-    "hermes/start.sh",
-    "langchain-deepagents-code/Dockerfile",
-    "langchain-deepagents-code/Dockerfile.base",
-    "langchain-deepagents-code/policy-additions.yaml",
-    "langchain-deepagents-code/start.sh",
-    "nemocua/Dockerfile",
-    "nemocua/policy-additions.yaml",
-    "openclaw/policy-permissive.yaml",
-    "pi/Dockerfile",
-    "pi/Dockerfile.base",
-    "pi/policy-additions.yaml",
-    "pi/start.sh",
-  ])("ships the native agent asset %s", (asset) => {
-    expect(packedPaths).toContain(`agents/${asset}`);
+  it("ships agent manifests, generated state lock plans, and the OpenClaw policy asset", () => {
+    expect(packageFiles(repoRoot)).toEqual(
+      expect.arrayContaining([
+        "agents/*/manifest.yaml",
+        "agents/*/state-lock-plan.json",
+        "agents/openclaw/policy-permissive.yaml",
+      ]),
+    );
+    expect(packedPaths).toContain("agents/openclaw/manifest.yaml");
+    expect(packedPaths).toContain("agents/openclaw/policy-permissive.yaml");
   });
 
   it("ships the complete repository-owned NemoCUA agent definition (#9649)", () => {
-    expect(packageFiles(repoRoot)).toEqual(expect.arrayContaining(["agents/"]));
-    const packed = packedPaths;
-    expect(packed).toContain("agents/nemocua/manifest.yaml");
-    expect(packed).toContain("agents/nemocua/Dockerfile");
-    expect(packed).toContain("agents/nemocua/policy-additions.yaml");
+    expect(packageFiles(repoRoot)).toEqual(
+      expect.arrayContaining([
+        "agents/*/manifest.yaml",
+        "agents/nemocua/Dockerfile",
+        "agents/nemocua/policy-additions.yaml",
+      ]),
+    );
+    expect(packedPaths).toContain("agents/nemocua/manifest.yaml");
+    expect(packedPaths).toContain("agents/nemocua/Dockerfile");
+    expect(packedPaths).toContain("agents/nemocua/policy-additions.yaml");
   });
 
   it("ships an out-of-tree runtime sandbox-policy schema validator", { timeout: 240_000 }, () => {

--- a/test/package-contract/openshell-policy-boundary.test.ts
+++ b/test/package-contract/openshell-policy-boundary.test.ts
@@ -24,6 +24,20 @@ function packageFiles(packageRoot: string): string[] {
   return packageJson.files ?? [];
 }
 
+function collectPackedPaths(): ReadonlySet<string> {
+
+  const packed = spawnSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  expect(packed.status, `${packed.stdout}${packed.stderr}`).toBe(0);
+  const report = JSON.parse(packed.stdout) as Array<{ files?: Array<{ path?: string }> }>;
+  return new Set((report[0]?.files ?? []).flatMap((entry) => (entry.path ? [entry.path] : [])));
+}
+
+const packedPaths = collectPackedPaths();
+
 describe("OpenShell policy boundary package contract", () => {
   it.each([repoRoot, path.join(repoRoot, "nemoclaw")])(
     "pins the YAML parser used by both production package boundaries [case %#]",
@@ -189,7 +203,7 @@ describe("OpenShell policy boundary package contract", () => {
   ])("ships the Hermes host broker with its canonical sandbox-name boundary [%s]", (file) => {
     expect(packageFiles(repoRoot)).toContain("agents/");
 
-    expect(fs.existsSync(path.join(repoRoot, "agents", "hermes", "host", file))).toBe(true);
+    expect(packedPaths).toContain(`agents/hermes/host/${file}`);
 
     const controlContractPath = path.join(
       repoRoot,
@@ -225,6 +239,7 @@ describe("OpenShell policy boundary package contract", () => {
         "utf8",
       );
       expect(manifest).toMatch(new RegExp(`^name: ${agent}$`, "m"));
+      expect(packedPaths).toContain(`agents/${agent}/manifest.yaml`);
     },
   );
 
@@ -246,16 +261,15 @@ describe("OpenShell policy boundary package contract", () => {
     "pi/policy-additions.yaml",
     "pi/start.sh",
   ])("ships the native agent asset %s", (asset) => {
-    expect(fs.existsSync(path.join(repoRoot, "agents", asset))).toBe(true);
+    expect(packedPaths).toContain(`agents/${asset}`);
   });
 
   it("ships the complete repository-owned NemoCUA agent definition (#9649)", () => {
     expect(packageFiles(repoRoot)).toEqual(expect.arrayContaining(["agents/"]));
-    expect(fs.existsSync(path.join(repoRoot, "agents", "nemocua", "manifest.yaml"))).toBe(true);
-    expect(fs.existsSync(path.join(repoRoot, "agents", "nemocua", "Dockerfile"))).toBe(true);
-    expect(fs.existsSync(path.join(repoRoot, "agents", "nemocua", "policy-additions.yaml"))).toBe(
-      true,
-    );
+    const packed = packedPaths;
+    expect(packed).toContain("agents/nemocua/manifest.yaml");
+    expect(packed).toContain("agents/nemocua/Dockerfile");
+    expect(packed).toContain("agents/nemocua/policy-additions.yaml");
   });
 
   it("ships an out-of-tree runtime sandbox-policy schema validator", { timeout: 240_000 }, () => {

--- a/test/package-contract/openshell-policy-boundary.test.ts
+++ b/test/package-contract/openshell-policy-boundary.test.ts
@@ -251,7 +251,6 @@ describe("OpenShell policy boundary package contract", () => {
   it("ships the complete repository-owned NemoCUA agent definition (#9649)", () => {
     expect(packageFiles(repoRoot)).toEqual(
       expect.arrayContaining([
-        "agents/*/manifest.yaml",
         "agents/nemocua/Dockerfile",
         "agents/nemocua/policy-additions.yaml",
       ]),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The npm package omitted the OpenClaw permissive-policy asset used by installed CLI policy paths. The package now adds that asset to the existing explicit runtime allowlist and verifies the packed artifact without publishing the complete `agents/` source tree.

## Changes

- Add `agents/openclaw/policy-permissive.yaml` to the existing explicit agent-file allowlist.
- Verify the packed runtime assets through a scriptless package fixture.
- Normalize supported npm array and object pack reports and quoted or plain `npm pkg get` output.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: repository review is required before merge.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project package-contract test/package-contract/openshell-policy-boundary.test.ts`: 14 passed. `npm pack --dry-run --json --ignore-scripts` contains 14 agent runtime files and no agent tests or review records.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: ugden-unak <221760556+ugden-unak@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Published packages now include required agent manifests, state information, host components, and configuration assets.
  * Improved package completeness and consistency for installations and deployments.
  * Updated package validation to support multiple packaging report formats and dependency output variations.

* **Tests**
  * Expanded package checks to verify required host files and agent-related assets are included.
  * Streamlined validation to focus on supported package contents and reduce false failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->