### PR TITLE
fix(onboard): restore managed catalog fallback

### DIFF
--- a/src/lib/onboard/managed-workload/onboard-orchestration.test.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.test.ts
@@ -26,12 +26,18 @@ import {
   shouldActivateStockManagedRuntime,
 } from "./onboard-orchestration";
 
-function createFreshOnboardingRuntime(environment: Readonly<Record<string, string>>) {
+function createFreshOnboardingRuntime(
+  environment: Readonly<Record<string, string>>,
+  options: {
+    readonly stockManagedRuntime?: boolean;
+    readonly tempManagedRuntime?: boolean;
+  } = {},
+) {
   const prepared = {
     source: {
       kind: "legacy-dockerfile",
       dockerfilePath: "agents/openclaw/Dockerfile",
-      reason: "managed-image-unavailable",
+      reason: "contract-unavailable",
     },
     release: "v0.0.0",
     fallbackDiagnostic: null,
@@ -43,7 +49,8 @@ function createFreshOnboardingRuntime(environment: Readonly<Record<string, strin
     {
       computePlan: { driverName: "docker" },
       managedWorkloadRebuild: null,
-      tempManagedRuntime: false,
+      tempManagedRuntime: options.tempManagedRuntime ?? false,
+      stockManagedRuntime: options.stockManagedRuntime ?? false,
       tempManagedRuntimeCatalog: null,
       agentName: "openclaw",
       legacyDockerfilePath: "agents/openclaw/Dockerfile",
@@ -148,6 +155,38 @@ describe("managed workload onboard orchestration", () => {
         agentName: "hermes",
       }),
     ).toBe(false);
+  });
+
+  it("allows ordinary stock onboarding to use the trusted Dockerfile fallback", async () => {
+    const { prepared, runtime } = createFreshOnboardingRuntime({}, { stockManagedRuntime: true });
+
+    await expect(runtime.ensurePreparedWorkload()).resolves.toBe(prepared);
+    expect(prepareSandboxWorkloadSource).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        policy: "prefer-managed",
+        runtime: expect.objectContaining({
+          legacyDockerfileBuilds: true,
+          managedImageSelectionPolicy: "require-managed",
+          managedImages: expect.any(Object),
+        }),
+      }),
+    );
+  });
+
+  it("keeps explicit temporary managed-image onboarding strict", async () => {
+    const { prepared, runtime } = createFreshOnboardingRuntime(
+      {},
+      { stockManagedRuntime: true, tempManagedRuntime: true },
+    );
+
+    await expect(runtime.ensurePreparedWorkload()).resolves.toBe(prepared);
+    const preparationInput = prepareSandboxWorkloadSource.mock.calls[0]?.[0];
+    expect(preparationInput).not.toHaveProperty("policy");
+    expect(preparationInput.runtime).toMatchObject({
+      legacyDockerfileBuilds: true,
+      managedImageSelectionPolicy: "require-managed",
+    });
+    expect(preparationInput.runtime.managedImages).not.toBeNull();
   });
 
   it("selects only the shipped Hermes Dockerfile fallback without profile or prebuild work", async () => {

--- a/src/lib/onboard/managed-workload/onboard-orchestration.test.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.test.ts
@@ -9,12 +9,26 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createHermesStateVolumeDockerHarness } from "../__test-helpers__/hermes-state-volume";
 
+const preparationState = vi.hoisted(() => ({
+  prepared: undefined as unknown,
+  useUnavailableCatalog: false,
+}));
 const prepareSandboxWorkloadSource = vi.hoisted(() => vi.fn());
 
-vi.mock("../workload/preparation", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../workload/preparation")>()),
-  prepareSandboxWorkloadSource,
-}));
+vi.mock("../workload/preparation", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../workload/preparation")>();
+  const { ManagedImageCatalogUnavailableError } = await import("../managed-image/catalog");
+  prepareSandboxWorkloadSource.mockImplementation((input) =>
+    preparationState.useUnavailableCatalog
+      ? original.prepareSandboxWorkloadSource(input, {
+          resolveCatalog: async () => {
+            throw new ManagedImageCatalogUnavailableError("registry offline");
+          },
+        })
+      : Promise.resolve(preparationState.prepared),
+  );
+  return { ...original, prepareSandboxWorkloadSource };
+});
 
 vi.mock("../../core/version", () => ({ getVersion: () => "v0.0.0" }));
 
@@ -31,6 +45,7 @@ function createFreshOnboardingRuntime(
   options: {
     readonly stockManagedRuntime?: boolean;
     readonly tempManagedRuntime?: boolean;
+    readonly unavailableCatalog?: boolean;
   } = {},
 ) {
   const prepared = {
@@ -42,8 +57,9 @@ function createFreshOnboardingRuntime(
     release: "v0.0.0",
     fallbackDiagnostic: null,
   };
+  preparationState.prepared = prepared;
+  preparationState.useUnavailableCatalog = options.unavailableCatalog ?? false;
   prepareSandboxWorkloadSource.mockClear();
-  prepareSandboxWorkloadSource.mockResolvedValueOnce(prepared);
 
   const runtime = createManagedWorkloadOnboardRuntime(
     {
@@ -157,36 +173,29 @@ describe("managed workload onboard orchestration", () => {
     ).toBe(false);
   });
 
-  it("allows ordinary stock onboarding to use the trusted Dockerfile fallback", async () => {
-    const { prepared, runtime } = createFreshOnboardingRuntime({}, { stockManagedRuntime: true });
-
-    await expect(runtime.ensurePreparedWorkload()).resolves.toBe(prepared);
-    expect(prepareSandboxWorkloadSource).toHaveBeenCalledExactlyOnceWith(
-      expect.objectContaining({
-        policy: "prefer-managed",
-        runtime: expect.objectContaining({
-          legacyDockerfileBuilds: true,
-          managedImageSelectionPolicy: "require-managed",
-          managedImages: expect.any(Object),
-        }),
-      }),
+  it("uses the trusted Dockerfile when the stock managed-image catalog is unavailable", async () => {
+    const { runtime } = createFreshOnboardingRuntime(
+      {},
+      { stockManagedRuntime: true, unavailableCatalog: true },
     );
+
+    await expect(runtime.ensurePreparedWorkload()).resolves.toMatchObject({
+      source: {
+        kind: "legacy-dockerfile",
+        dockerfilePath: "agents/openclaw/Dockerfile",
+        reason: "contract-unavailable",
+      },
+      fallbackDiagnostic: expect.stringContaining("registry offline"),
+    });
   });
 
-  it("keeps explicit temporary managed-image onboarding strict", async () => {
-    const { prepared, runtime } = createFreshOnboardingRuntime(
+  it("rejects an unavailable catalog for explicit temporary managed-image onboarding", async () => {
+    const { runtime } = createFreshOnboardingRuntime(
       {},
-      { stockManagedRuntime: true, tempManagedRuntime: true },
+      { stockManagedRuntime: true, tempManagedRuntime: true, unavailableCatalog: true },
     );
 
-    await expect(runtime.ensurePreparedWorkload()).resolves.toBe(prepared);
-    const preparationInput = prepareSandboxWorkloadSource.mock.calls[0]?.[0];
-    expect(preparationInput).not.toHaveProperty("policy");
-    expect(preparationInput.runtime).toMatchObject({
-      legacyDockerfileBuilds: true,
-      managedImageSelectionPolicy: "require-managed",
-    });
-    expect(preparationInput.runtime.managedImages).not.toBeNull();
+    await expect(runtime.ensurePreparedWorkload()).rejects.toThrow("registry offline");
   });
 
   it("selects only the shipped Hermes Dockerfile fallback without profile or prebuild work", async () => {

--- a/src/lib/onboard/managed-workload/onboard-orchestration.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.ts
@@ -124,6 +124,7 @@ export interface CreateManagedWorkloadOnboardRuntimeInput {
   readonly computePlan: OpenShellComputePlan;
   readonly managedWorkloadRebuild: ManagedWorkloadRebuildHandoff | null;
   readonly tempManagedRuntime: boolean;
+  readonly stockManagedRuntime: boolean;
   readonly tempManagedRuntimeCatalog: string | null;
   readonly agentName: string;
   readonly legacyDockerfilePath: string;
@@ -219,14 +220,21 @@ export function createManagedWorkloadOnboardRuntime(
   const discoveredRuntimeCapabilities = resolveSandboxWorkloadRuntimeCapabilities(
     input.computePlan,
   );
+  const strictManagedRuntime = input.tempManagedRuntime || input.managedWorkloadRebuild !== null;
   const runtimeCapabilities =
-    input.tempManagedRuntime || input.managedWorkloadRebuild !== null
+    strictManagedRuntime || input.stockManagedRuntime
       ? discoveredRuntimeCapabilities
       : {
           ...discoveredRuntimeCapabilities,
           managedImageSelectionPolicy: "prefer-managed" as const,
           managedImages: null,
         };
+  const stockManagedImagePolicy =
+    input.stockManagedRuntime &&
+    !strictManagedRuntime &&
+    discoveredRuntimeCapabilities.legacyDockerfileBuilds
+      ? ("prefer-managed" as const)
+      : null;
   const runtimeProvider = resolveRuntimeProviderBundle(
     input.computePlan.driverName,
     CURRENT_RUNTIME_PROVIDER_BUNDLES,
@@ -256,6 +264,7 @@ export function createManagedWorkloadOnboardRuntime(
           runtime: runtimeCapabilities,
           version: getVersion({ rootDir: input.rootDir }),
           catalogPath: input.tempManagedRuntimeCatalog ?? liveCatalog?.path ?? null,
+          ...(stockManagedImagePolicy ? { policy: stockManagedImagePolicy } : {}),
           ...(liveCatalog ? { expectedCatalogRevision: liveCatalog.revision } : {}),
           ...(catalogRevision ? { catalogRevision } : {}),
           acceptedCandidateContract: isCandidateAgent(input.agentName)

--- a/src/lib/onboard/sandbox-create/orchestration.ts
+++ b/src/lib/onboard/sandbox-create/orchestration.ts
@@ -483,13 +483,12 @@ export function createSandboxWithBaseImageResolution(runtime: SandboxCreateOrche
       {
         computePlan,
         managedWorkloadRebuild,
-        tempManagedRuntime:
-          tempManagedRuntime ||
-          managedWorkloadOnboard.shouldActivateStockManagedRuntime({
-            portableLifecycle: sandboxGpuCreateFlow.resolvePortableLifecycleMode(agent),
-            hermesPortableLifecycle: agentCreateInput.hermesPortableLifecycle,
-            agentName: requestedAgentName,
-          }),
+        tempManagedRuntime,
+        stockManagedRuntime: managedWorkloadOnboard.shouldActivateStockManagedRuntime({
+          portableLifecycle: sandboxGpuCreateFlow.resolvePortableLifecycleMode(agent),
+          hermesPortableLifecycle: agentCreateInput.hermesPortableLifecycle,
+          agentName: requestedAgentName,
+        }),
         tempManagedRuntimeCatalog,
         agentName: requestedAgentName,
         legacyDockerfilePath,

--- a/test/helpers/onboard-script-mocks.cjs
+++ b/test/helpers/onboard-script-mocks.cjs
@@ -357,24 +357,6 @@ function mockManagedImageFallback() {
       "integration fixture intentionally exercises the trusted Dockerfile fallback",
     );
   };
-
-  const dockerProvider = require(
-    path.resolve(__dirname, "../../src/lib/onboard/runtime-provider/docker.ts"),
-  );
-  const createDockerRuntimeProviderBundle = dockerProvider.createDockerRuntimeProviderBundle;
-  dockerProvider.createDockerRuntimeProviderBundle = (...args) => {
-    const bundle = createDockerRuntimeProviderBundle(...args);
-    return {
-      ...bundle,
-      workload: {
-        ...bundle.workload,
-        profile: {
-          ...bundle.workload.profile,
-          managedImageSelectionPolicy: "prefer-managed",
-        },
-      },
-    };
-  };
 }
 
 process.env.NEMOCLAW_TEST_MANAGED_IMAGE_FALLBACK === "1" && mockManagedImageFallback();


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Ordinary Docker onboarding now falls back to the trusted Dockerfile when the stock managed-image catalog is unavailable. Temporary catalogs, managed-image rebuilds, and runtime providers without Dockerfile builds remain strict.

## Changes

- Separate ordinary stock managed-image activation from temporary and rebuild activation.
- Apply `prefer-managed` only when the Docker runtime can build the trusted Dockerfile. Changing the Docker provider policy directly would also weaken temporary and rebuild flows.
- Remove the test-only Docker provider policy override so onboarding integration tests exercise the production fallback decision.
- Add regression tests for ordinary fallback and strict temporary managed-image selection.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed stock, temporary, rebuild, and buildless runtime states. Only ordinary Docker onboarding receives the availability fallback policy.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: CLI source tests passed, 40 tests; onboarding integration tests passed, 5 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed workload onboarding for standard and temporary managed-runtime configurations.
  - Standard stock onboarding now falls back to a trusted Dockerfile when managed images are unavailable.
  - Added diagnostics when the managed-image catalog cannot be reached.
  - Temporary managed-image onboarding remains strict and reports catalog errors instead of falling back unexpectedly.
  - Improved runtime capability handling across portable and agent-based configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->