### PR TITLE
fix(e2e): record Jetson cancellation recovery

### DIFF
--- a/test/e2e/docs/jetson-dispatch.md
+++ b/test/e2e/docs/jetson-dispatch.md
@@ -153,11 +153,11 @@ of `success`, `cleanup: "succeeded"`, a device identity, and the artifact
 archive.
 
 If a workflow fails after submission begins, inspect `jetson-dispatch.json`
-before another dispatch. If it contains `cancellation`, inspect the recorded job
-in the operator service. If artifact upload failed and the file is unavailable,
-use the job ID from the workflow error or logs. Cancel the job or confirm
-completion before another dispatch, regardless of whether the cancellation
-outcome is pending, succeeded, or failed.
+before another dispatch. Use its job ID to inspect the operator-service job,
+even when the receipt has no `cancellation` record. If artifact upload failed
+and the file is unavailable, use the job ID from the workflow error or logs.
+Cancel the job or confirm completion before another dispatch, regardless of
+whether the cancellation outcome is absent, pending, succeeded, or failed.
 
 ## Live Target
 

--- a/test/e2e/docs/jetson-dispatch.md
+++ b/test/e2e/docs/jetson-dispatch.md
@@ -140,10 +140,10 @@ workflow run ID and attempt, selectors, event, and hardware opt-in decisions.
 The Jetson controller writes private files under the target artifact directory:
 
 - `jetson-dispatch.json` records the validated request and job ID after the
-  service accepts a job. It records each cancellation request and whether the
-  operator service accepted that request. A completed artifact replaces this
-  recovery state with the validated status and bounded log. The file excludes
-  the base64 archive payload.
+  service accepts a job. It records the first cancellation reason and whether
+  the operator service accepted the shared cancellation request. A completed
+  artifact replaces this recovery state with the validated status and bounded
+  log. The file excludes the base64 archive payload.
 - `jetson-e2e-artifacts.tar.gz` contains the decoded target evidence when the
   service returns an archive.
 

--- a/test/e2e/docs/jetson-dispatch.md
+++ b/test/e2e/docs/jetson-dispatch.md
@@ -139,9 +139,9 @@ workflow run ID and attempt, selectors, event, and hardware opt-in decisions.
 
 The Jetson controller writes private files under the target artifact directory:
 
-- `jetson-dispatch.json` records the validated request and job ID after the
-  service accepts a job. It records the first cancellation reason and whether
-  the operator service accepted the shared cancellation request. A completed
+- `jetson-dispatch.json` records the validated request and derived job ID before
+  submission begins. It records the first cancellation reason and whether the
+  operator service accepted the shared cancellation request. A completed
   artifact replaces this recovery state with the validated status and bounded
   log. The file excludes the base64 archive payload.
 - `jetson-e2e-artifacts.tar.gz` contains the decoded target evidence when the
@@ -152,12 +152,12 @@ failure. A successful proof requires the exact candidate request, a conclusion
 of `success`, `cleanup: "succeeded"`, a device identity, and the artifact
 archive.
 
-If a workflow fails after job acceptance, inspect `jetson-dispatch.json` before
-another dispatch. If it contains `cancellation`, inspect the recorded job in the
-operator service. If the file is missing or lacks cancellation data, use the job
-ID from the workflow error or logs to inspect the operator service. Cancel the
-job or confirm completion before another dispatch, regardless of whether the
-cancellation outcome is pending, succeeded, or failed.
+If a workflow fails after submission begins, inspect `jetson-dispatch.json`
+before another dispatch. If it contains `cancellation`, inspect the recorded job
+in the operator service. If artifact upload failed and the file is unavailable,
+use the job ID from the workflow error or logs. Cancel the job or confirm
+completion before another dispatch, regardless of whether the cancellation
+outcome is pending, succeeded, or failed.
 
 ## Live Target
 

--- a/test/e2e/docs/jetson-dispatch.md
+++ b/test/e2e/docs/jetson-dispatch.md
@@ -141,8 +141,8 @@ The Jetson controller writes private files under the target artifact directory:
 
 - `jetson-dispatch.json` records the validated request and derived job ID before
   submission begins. It records the cancellation reason and final outcome. If
-  an early request reports that the job is absent before submission settles,
-  the controller records one follow-up request after submission. A completed
+  cancellation reports that the job is absent after submission may have reached
+  the dispatcher, the controller records one follow-up request. A completed
   artifact replaces this recovery state with the validated status and bounded
   log. The file excludes the base64 archive payload.
 - `jetson-e2e-artifacts.tar.gz` contains the decoded target evidence when the

--- a/test/e2e/docs/jetson-dispatch.md
+++ b/test/e2e/docs/jetson-dispatch.md
@@ -153,9 +153,9 @@ of `success`, `cleanup: "succeeded"`, a device identity, and the artifact
 archive.
 
 If a workflow fails after job acceptance, inspect `jetson-dispatch.json` before
-another dispatch. If it records `cancellation-failed`, inspect the recorded job
-in the operator service. Cancel the job or confirm completion before another
-dispatch.
+another dispatch. If it contains `cancellation`, inspect the recorded job in the
+operator service. Cancel the job or confirm completion before another dispatch,
+regardless of whether the cancellation outcome is pending, succeeded, or failed.
 
 ## Live Target
 

--- a/test/e2e/docs/jetson-dispatch.md
+++ b/test/e2e/docs/jetson-dispatch.md
@@ -154,8 +154,10 @@ archive.
 
 If a workflow fails after job acceptance, inspect `jetson-dispatch.json` before
 another dispatch. If it contains `cancellation`, inspect the recorded job in the
-operator service. Cancel the job or confirm completion before another dispatch,
-regardless of whether the cancellation outcome is pending, succeeded, or failed.
+operator service. If the file is missing or lacks cancellation data, use the job
+ID from the workflow error or logs to inspect the operator service. Cancel the
+job or confirm completion before another dispatch, regardless of whether the
+cancellation outcome is pending, succeeded, or failed.
 
 ## Live Target
 

--- a/test/e2e/docs/jetson-dispatch.md
+++ b/test/e2e/docs/jetson-dispatch.md
@@ -140,8 +140,9 @@ workflow run ID and attempt, selectors, event, and hardware opt-in decisions.
 The Jetson controller writes private files under the target artifact directory:
 
 - `jetson-dispatch.json` records the validated request and derived job ID before
-  submission begins. It records the first cancellation reason and whether the
-  operator service accepted the shared cancellation request. A completed
+  submission begins. It records the cancellation reason and final outcome. If
+  an early request reports that the job is absent before submission settles,
+  the controller records one follow-up request after submission. A completed
   artifact replaces this recovery state with the validated status and bounded
   log. The file excludes the base64 archive payload.
 - `jetson-e2e-artifacts.tar.gz` contains the decoded target evidence when the

--- a/test/e2e/docs/jetson-dispatch.md
+++ b/test/e2e/docs/jetson-dispatch.md
@@ -139,8 +139,11 @@ workflow run ID and attempt, selectors, event, and hardware opt-in decisions.
 
 The Jetson controller writes private files under the target artifact directory:
 
-- `jetson-dispatch.json` contains the validated completed status and bounded
-  log. It excludes the base64 archive payload.
+- `jetson-dispatch.json` records the validated request and job ID after the
+  service accepts a job. It records each cancellation request and whether the
+  operator service accepted that request. A completed artifact replaces this
+  recovery state with the validated status and bounded log. The file excludes
+  the base64 archive payload.
 - `jetson-e2e-artifacts.tar.gz` contains the decoded target evidence when the
   service returns an archive.
 
@@ -148,6 +151,11 @@ The workflow uploads that directory as `e2e-jetson-nvmap-gpu`, including on job
 failure. A successful proof requires the exact candidate request, a conclusion
 of `success`, `cleanup: "succeeded"`, a device identity, and the artifact
 archive.
+
+If a workflow fails after job acceptance, inspect `jetson-dispatch.json` before
+another dispatch. If it records `cancellation-failed`, inspect the recorded job
+in the operator service. Cancel the job or confirm completion before another
+dispatch.
 
 ## Live Target
 

--- a/test/e2e/support/jetson-dispatch-client.test.ts
+++ b/test/e2e/support/jetson-dispatch-client.test.ts
@@ -14,6 +14,7 @@ import {
   dispatcherRequest,
   jetsonDispatchRequestFromEnvironment,
   pollJetsonDispatch,
+  submitJetsonDispatch,
 } from "../../../tools/e2e/jetson-dispatch-client.mts";
 import {
   JETSON_DISPATCH_AUDIENCE,
@@ -604,9 +605,9 @@ describe("Jetson dispatch GitHub controller", () => {
       });
     const cancel = createJetsonCancellation({
       baseUrl: new URL("https://dispatch.test/"),
+      dispatch: queuedStatus,
       receiptFile,
       request: requestImpl,
-      status: queuedStatus,
     });
 
     const deadlineCancellation = cancel("controller-deadline");
@@ -623,6 +624,79 @@ describe("Jetson dispatch GitHub controller", () => {
     );
     expect(readReceipt(receiptFile)).toMatchObject({
       cancellation: { outcome: "succeeded", reason: "controller-deadline" },
+    });
+  });
+
+  it("records and cancels a job when submission times out after acceptance (#8142)", async () => {
+    const receiptFile = temporaryReceiptFile();
+    const requestImpl = vi
+      .fn<typeof dispatcherRequest>()
+      .mockImplementationOnce(async () => {
+        expect(readReceipt(receiptFile)).toEqual({
+          schemaVersion: 1,
+          jobId: queuedStatusV2.jobId,
+          request: requestV2,
+        });
+        throw Object.assign(new Error("submission response timed out"), { name: "TimeoutError" });
+      })
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      submitJetsonDispatch({
+        baseUrl: new URL("https://dispatch.test/"),
+        dispatchRequest: requestV2,
+        receiptFile,
+        request: requestImpl,
+      }),
+    ).rejects.toThrow(
+      `Jetson dispatch ${queuedStatusV2.jobId} submission outcome was not confirmed; cancellation request succeeded`,
+    );
+    expect(requestImpl).toHaveBeenCalledTimes(2);
+    expect(requestImpl).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ method: "POST", path: "v1/jobs", body: requestV2 }),
+    );
+    expect(requestImpl).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ method: "DELETE", path: `v1/jobs/${queuedStatusV2.jobId}` }),
+    );
+    expect(readReceipt(receiptFile)).toEqual({
+      schemaVersion: 1,
+      jobId: queuedStatusV2.jobId,
+      request: requestV2,
+      cancellation: { outcome: "succeeded", reason: "submission-outcome-unknown" },
+    });
+  });
+
+  it("cancels an accepted job when a signal arrives before the submission response (#8142)", async () => {
+    const receiptFile = temporaryReceiptFile();
+    let stopping = false;
+    const requestImpl = vi
+      .fn<typeof dispatcherRequest>()
+      .mockImplementationOnce(async () => {
+        stopping = true;
+        return { job: queuedStatusV2 };
+      })
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      submitJetsonDispatch({
+        baseUrl: new URL("https://dispatch.test/"),
+        dispatchRequest: requestV2,
+        receiptFile,
+        request: requestImpl,
+        stopping: () => stopping,
+      }),
+    ).rejects.toThrow(
+      `Jetson dispatch ${queuedStatusV2.jobId} cancellation requested; cancellation request succeeded`,
+    );
+    expect(requestImpl).toHaveBeenCalledTimes(2);
+    expect(requestImpl).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ method: "DELETE", path: `v1/jobs/${queuedStatusV2.jobId}` }),
+    );
+    expect(readReceipt(receiptFile)).toMatchObject({
+      cancellation: { outcome: "succeeded", reason: "signal" },
     });
   });
 

--- a/test/e2e/support/jetson-dispatch-client.test.ts
+++ b/test/e2e/support/jetson-dispatch-client.test.ts
@@ -449,7 +449,6 @@ describe("Jetson dispatch GitHub controller", () => {
         baseUrl: new URL("https://dispatch.test/"),
         deadlineMs: 10_000,
         initialStatus: queuedStatus,
-        jobId: queuedStatus.jobId,
         now: () => 0,
         receiptFile,
         request: requestImpl,
@@ -472,7 +471,6 @@ describe("Jetson dispatch GitHub controller", () => {
         baseUrl: new URL("https://dispatch.test/"),
         deadlineMs: 10_000,
         initialStatus: queuedStatus,
-        jobId: queuedStatus.jobId,
         now: () => 0,
         receiptFile,
         request: requestImpl,
@@ -501,7 +499,6 @@ describe("Jetson dispatch GitHub controller", () => {
         baseUrl: new URL("https://dispatch.test/"),
         deadlineMs: 10_000,
         initialStatus: queuedStatus,
-        jobId: queuedStatus.jobId,
         now: () => 0,
         receiptFile: directory,
         request: requestImpl,
@@ -524,7 +521,6 @@ describe("Jetson dispatch GitHub controller", () => {
         baseUrl: new URL("https://dispatch.test/"),
         deadlineMs: 10_000,
         initialStatus: queuedStatus,
-        jobId: queuedStatus.jobId,
         now: () => 10_000,
         receiptFile: temporaryReceiptFile(),
         request: requestImpl,
@@ -549,7 +545,6 @@ describe("Jetson dispatch GitHub controller", () => {
         baseUrl: new URL("https://dispatch.test/"),
         deadlineMs: 10_000,
         initialStatus: queuedStatus,
-        jobId: queuedStatus.jobId,
         now: () => 10_000,
         receiptFile,
         request: requestImpl,
@@ -582,7 +577,6 @@ describe("Jetson dispatch GitHub controller", () => {
         baseUrl: new URL("https://dispatch.test/"),
         deadlineMs: 10_000,
         initialStatus: queuedStatus,
-        jobId: queuedStatus.jobId,
         now: () => 10_000,
         receiptFile,
         request: requestImpl,
@@ -671,23 +665,50 @@ describe("Jetson dispatch GitHub controller", () => {
   it("cancels an accepted job when a signal arrives before the submission response (#8142)", async () => {
     const receiptFile = temporaryReceiptFile();
     let stopping = false;
+    let markPostStarted!: () => void;
+    const postStarted = new Promise<void>((resolve) => {
+      markPostStarted = resolve;
+    });
+    let releasePost!: () => void;
+    const postRelease = new Promise<void>((resolve) => {
+      releasePost = resolve;
+    });
     const requestImpl = vi
       .fn<typeof dispatcherRequest>()
       .mockImplementationOnce(async () => {
-        stopping = true;
+        markPostStarted();
+        await postRelease;
         return { job: queuedStatusV2 };
       })
       .mockResolvedValueOnce(undefined);
+    const cancel = createJetsonCancellation({
+      baseUrl: new URL("https://dispatch.test/"),
+      dispatch: queuedStatusV2,
+      receiptFile,
+      request: requestImpl,
+    });
 
-    await expect(
-      submitJetsonDispatch({
-        baseUrl: new URL("https://dispatch.test/"),
-        dispatchRequest: requestV2,
-        receiptFile,
-        request: requestImpl,
-        stopping: () => stopping,
-      }),
-    ).rejects.toThrow(
+    const submission = submitJetsonDispatch({
+      baseUrl: new URL("https://dispatch.test/"),
+      cancel,
+      dispatchRequest: requestV2,
+      receiptFile,
+      request: requestImpl,
+      stopping: () => stopping,
+    });
+    await postStarted;
+    stopping = true;
+    await expect(cancel("signal")).resolves.toEqual({
+      outcome: "succeeded",
+      receiptWritten: true,
+    });
+    expect(requestImpl).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ method: "DELETE", path: `v1/jobs/${queuedStatusV2.jobId}` }),
+    );
+    releasePost();
+
+    await expect(submission).rejects.toThrow(
       `Jetson dispatch ${queuedStatusV2.jobId} cancellation requested; cancellation request succeeded`,
     );
     expect(requestImpl).toHaveBeenCalledTimes(2);
@@ -711,7 +732,6 @@ describe("Jetson dispatch GitHub controller", () => {
       baseUrl: new URL("https://dispatch.test/"),
       deadlineMs: 10_000,
       initialStatus: queuedStatus,
-      jobId: queuedStatus.jobId,
       now: () => 0,
       receiptFile,
       request: requestImpl,

--- a/test/e2e/support/jetson-dispatch-client.test.ts
+++ b/test/e2e/support/jetson-dispatch-client.test.ts
@@ -662,6 +662,47 @@ describe("Jetson dispatch GitHub controller", () => {
     });
   });
 
+  it("retries a missing job cancellation after an unconfirmed submission (#8142)", async () => {
+    const receiptFile = temporaryReceiptFile();
+    const requestImpl = vi
+      .fn<typeof dispatcherRequest>()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("submission response timed out"), { name: "TimeoutError" }),
+      )
+      .mockRejectedValueOnce(new Error("Jetson dispatcher returned HTTP 404: request failed"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      submitJetsonDispatch({
+        baseUrl: new URL("https://dispatch.test/"),
+        dispatchRequest: requestV2,
+        receiptFile,
+        request: requestImpl,
+      }),
+    ).rejects.toThrow(
+      `Jetson dispatch ${queuedStatusV2.jobId} submission outcome was not confirmed; cancellation request succeeded`,
+    );
+    expect(requestImpl).toHaveBeenCalledTimes(3);
+    expect(requestImpl).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ method: "POST", path: "v1/jobs", body: requestV2 }),
+    );
+    expect(requestImpl).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ method: "DELETE", path: `v1/jobs/${queuedStatusV2.jobId}` }),
+    );
+    expect(requestImpl).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ method: "DELETE", path: `v1/jobs/${queuedStatusV2.jobId}` }),
+    );
+    expect(readReceipt(receiptFile)).toEqual({
+      schemaVersion: 1,
+      jobId: queuedStatusV2.jobId,
+      request: requestV2,
+      cancellation: { outcome: "succeeded", reason: "submission-outcome-unknown" },
+    });
+  });
+
   it("cancels an accepted job when a signal arrives before the submission response (#8142)", async () => {
     const receiptFile = temporaryReceiptFile();
     let stopping = false;

--- a/test/e2e/support/jetson-dispatch-client.test.ts
+++ b/test/e2e/support/jetson-dispatch-client.test.ts
@@ -593,15 +593,15 @@ describe("Jetson dispatch GitHub controller", () => {
     });
   });
 
-  it("shares one cancellation request across concurrent callers (#8142)", async () => {
+  it("accepts one empty successful response for concurrent cancellation callers (#8142)", async () => {
     const receiptFile = temporaryReceiptFile();
-    let completeRequest: ((value: unknown) => void) | undefined;
-    const requestImpl = vi.fn(
-      () =>
-        new Promise((resolve) => {
-          completeRequest = resolve;
-        }),
-    );
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 204 }));
+    const requestImpl: typeof dispatcherRequest = async (options) =>
+      dispatcherRequest({
+        ...options,
+        fetchImpl,
+        tokenProvider: async () => "oidc-token",
+      });
     const cancel = createJetsonCancellation({
       baseUrl: new URL("https://dispatch.test/"),
       receiptFile,
@@ -611,13 +611,16 @@ describe("Jetson dispatch GitHub controller", () => {
 
     const deadlineCancellation = cancel("controller-deadline");
     const signalCancellation = cancel("signal");
-    completeRequest?.({ job: queuedStatus });
 
     await expect(Promise.all([deadlineCancellation, signalCancellation])).resolves.toEqual([
       { outcome: "succeeded", receiptWritten: true },
       { outcome: "succeeded", receiptWritten: true },
     ]);
-    expect(requestImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL(`https://dispatch.test/v1/jobs/${queuedStatus.jobId}`),
+      expect.objectContaining({ method: "DELETE" }),
+    );
     expect(readReceipt(receiptFile)).toMatchObject({
       cancellation: { outcome: "succeeded", reason: "controller-deadline" },
     });

--- a/test/e2e/support/jetson-dispatch-client.test.ts
+++ b/test/e2e/support/jetson-dispatch-client.test.ts
@@ -721,6 +721,63 @@ describe("Jetson dispatch GitHub controller", () => {
     });
   });
 
+  it("retries an early job-not-found cancellation after submission settles (#8142)", async () => {
+    const receiptFile = temporaryReceiptFile();
+    let stopping = false;
+    let markPostStarted!: () => void;
+    const postStarted = new Promise<void>((resolve) => {
+      markPostStarted = resolve;
+    });
+    let releasePost!: () => void;
+    const postRelease = new Promise<void>((resolve) => {
+      releasePost = resolve;
+    });
+    const requestImpl = vi
+      .fn<typeof dispatcherRequest>()
+      .mockImplementationOnce(async () => {
+        markPostStarted();
+        await postRelease;
+        return { job: queuedStatusV2 };
+      })
+      .mockRejectedValueOnce(new Error("Jetson dispatcher returned HTTP 404: request failed"))
+      .mockResolvedValueOnce(undefined);
+    const cancel = createJetsonCancellation({
+      baseUrl: new URL("https://dispatch.test/"),
+      dispatch: queuedStatusV2,
+      receiptFile,
+      request: requestImpl,
+    });
+
+    const submission = submitJetsonDispatch({
+      baseUrl: new URL("https://dispatch.test/"),
+      cancel,
+      dispatchRequest: requestV2,
+      receiptFile,
+      request: requestImpl,
+      stopping: () => stopping,
+    });
+    await postStarted;
+    stopping = true;
+    await expect(cancel("signal")).resolves.toEqual({
+      failure: "job-not-found",
+      outcome: "failed",
+      receiptWritten: true,
+    });
+    releasePost();
+
+    await expect(submission).rejects.toThrow(
+      `Jetson dispatch ${queuedStatusV2.jobId} cancellation requested; cancellation request succeeded`,
+    );
+    expect(requestImpl).toHaveBeenCalledTimes(3);
+    expect(requestImpl).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ method: "DELETE", path: `v1/jobs/${queuedStatusV2.jobId}` }),
+    );
+    expect(readReceipt(receiptFile)).toMatchObject({
+      cancellation: { outcome: "succeeded", reason: "signal" },
+    });
+  });
+
   it("records a rejected cancellation after repeated status failures (#8142)", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const receiptFile = temporaryReceiptFile();

--- a/test/e2e/support/jetson-dispatch-client.test.ts
+++ b/test/e2e/support/jetson-dispatch-client.test.ts
@@ -3,6 +3,7 @@
 
 import { createHash } from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -62,9 +63,23 @@ const invalidV2RequestErrors: Record<string, string> = {
   "noncanonical managed-image revision":
     "managedImageRevision must be a lowercase 40-character commit SHA",
 };
+const temporaryDirectories: string[] = [];
+
+function temporaryReceiptFile(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-jetson-dispatch-"));
+  temporaryDirectories.push(directory);
+  return path.join(directory, "jetson-dispatch.json");
+}
+
+function readReceipt(receiptFile: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(receiptFile, "utf8")) as Record<string, unknown>;
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true });
+  }
 });
 
 describe("Jetson dispatch static HTTP contract", () => {
@@ -421,6 +436,7 @@ describe("Jetson dispatch GitHub controller", () => {
 
   it("retries status transport failures and validates the completed status (#8142)", async () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
+    const receiptFile = temporaryReceiptFile();
     const requestImpl = vi
       .fn()
       .mockRejectedValueOnce(new Error("transport reset"))
@@ -433,10 +449,17 @@ describe("Jetson dispatch GitHub controller", () => {
         initialStatus: queuedStatus,
         jobId: queuedStatus.jobId,
         now: () => 0,
+        receiptFile,
         request: requestImpl,
         wait: async () => {},
       }),
     ).resolves.toEqual(completedStatus);
+    expect(readReceipt(receiptFile)).toEqual({
+      schemaVersion: 1,
+      jobId: queuedStatus.jobId,
+      request: queuedStatus.request,
+      controllerState: "accepted",
+    });
   });
 
   it("requests cancellation when the controller deadline expires (#8142)", async () => {
@@ -449,13 +472,87 @@ describe("Jetson dispatch GitHub controller", () => {
         initialStatus: queuedStatus,
         jobId: queuedStatus.jobId,
         now: () => 10_000,
+        receiptFile: temporaryReceiptFile(),
         request: requestImpl,
         wait: async () => {},
       }),
-    ).rejects.toThrow("Jetson dispatcher did not complete before the controller deadline");
+    ).rejects.toThrow(
+      `Jetson dispatch ${queuedStatus.jobId} did not complete before the controller deadline; cancellation request succeeded`,
+    );
     expect(requestImpl).toHaveBeenCalledWith(
       expect.objectContaining({ method: "DELETE", path: `v1/jobs/${queuedStatus.jobId}` }),
     );
+  });
+
+  it("records a rejected deadline cancellation for operator recovery (#8142)", async () => {
+    const receiptFile = temporaryReceiptFile();
+    const requestImpl = vi.fn(async () => {
+      throw new Error("untrusted cancellation response text");
+    });
+
+    await expect(
+      pollJetsonDispatch({
+        baseUrl: new URL("https://dispatch.test/"),
+        deadlineMs: 10_000,
+        initialStatus: queuedStatus,
+        jobId: queuedStatus.jobId,
+        now: () => 10_000,
+        receiptFile,
+        request: requestImpl,
+        wait: async () => {},
+      }),
+    ).rejects.toThrow(
+      `Jetson dispatch ${queuedStatus.jobId} did not complete before the controller deadline; cancellation request failed (transport-error)`,
+    );
+    expect(readReceipt(receiptFile)).toEqual({
+      schemaVersion: 1,
+      jobId: queuedStatus.jobId,
+      request: queuedStatus.request,
+      controllerState: "cancellation-failed",
+      cancellation: {
+        attempt: 1,
+        outcome: "failed",
+        reason: "controller-deadline",
+        failure: "transport-error",
+      },
+    });
+    expect(fs.statSync(receiptFile).mode & 0o777).toBe(0o600);
+  });
+
+  it("records a rejected cancellation after repeated status failures (#8142)", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const receiptFile = temporaryReceiptFile();
+    const requestImpl = vi.fn(async () => {
+      throw new Error("status transport reset");
+    });
+
+    await expect(
+      pollJetsonDispatch({
+        baseUrl: new URL("https://dispatch.test/"),
+        deadlineMs: 10_000,
+        initialStatus: queuedStatus,
+        jobId: queuedStatus.jobId,
+        now: () => 0,
+        receiptFile,
+        request: requestImpl,
+        wait: async () => {},
+      }),
+    ).rejects.toThrow(
+      `Jetson dispatch ${queuedStatus.jobId} status failed 3 consecutive times; cancellation request failed (transport-error)`,
+    );
+    expect(requestImpl).toHaveBeenCalledTimes(4);
+    expect(readReceipt(receiptFile)).toEqual({
+      schemaVersion: 1,
+      jobId: queuedStatus.jobId,
+      request: queuedStatus.request,
+      controllerState: "cancellation-failed",
+      cancellation: {
+        attempt: 1,
+        outcome: "failed",
+        reason: "status-request-failures",
+        failure: "transport-error",
+      },
+    });
   });
 
   it("keeps the published response types compatible with the controller (#8142)", () => {

--- a/test/e2e/support/jetson-dispatch-client.test.ts
+++ b/test/e2e/support/jetson-dispatch-client.test.ts
@@ -459,8 +459,60 @@ describe("Jetson dispatch GitHub controller", () => {
       schemaVersion: 1,
       jobId: queuedStatus.jobId,
       request: queuedStatus.request,
-      controllerState: "accepted",
     });
+  });
+
+  it("cancels an accepted job when stopping was requested during submission (#8142)", async () => {
+    const receiptFile = temporaryReceiptFile();
+    const requestImpl = vi.fn(async () => ({ job: queuedStatus }));
+
+    await expect(
+      pollJetsonDispatch({
+        baseUrl: new URL("https://dispatch.test/"),
+        deadlineMs: 10_000,
+        initialStatus: queuedStatus,
+        jobId: queuedStatus.jobId,
+        now: () => 0,
+        receiptFile,
+        request: requestImpl,
+        stopping: () => true,
+        wait: async () => {},
+      }),
+    ).rejects.toThrow(
+      `Jetson dispatch ${queuedStatus.jobId} cancellation requested; cancellation request succeeded`,
+    );
+    expect(requestImpl).toHaveBeenCalledOnce();
+    expect(requestImpl).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "DELETE", path: `v1/jobs/${queuedStatus.jobId}` }),
+    );
+    expect(readReceipt(receiptFile)).toMatchObject({
+      cancellation: { outcome: "succeeded", reason: "signal" },
+    });
+  });
+
+  it("cancels an accepted job when the initial receipt cannot be written (#8142)", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-jetson-dispatch-"));
+    temporaryDirectories.push(directory);
+    const requestImpl = vi.fn(async () => ({ job: queuedStatus }));
+
+    await expect(
+      pollJetsonDispatch({
+        baseUrl: new URL("https://dispatch.test/"),
+        deadlineMs: 10_000,
+        initialStatus: queuedStatus,
+        jobId: queuedStatus.jobId,
+        now: () => 0,
+        receiptFile: directory,
+        request: requestImpl,
+        wait: async () => {},
+      }),
+    ).rejects.toThrow(
+      `Jetson dispatch ${queuedStatus.jobId} was accepted but its recovery receipt could not be written; cancellation request succeeded; recovery receipt update failed`,
+    );
+    expect(requestImpl).toHaveBeenCalledOnce();
+    expect(requestImpl).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "DELETE", path: `v1/jobs/${queuedStatus.jobId}` }),
+    );
   });
 
   it("requests cancellation when the controller deadline expires (#8142)", async () => {
@@ -509,9 +561,7 @@ describe("Jetson dispatch GitHub controller", () => {
       schemaVersion: 1,
       jobId: queuedStatus.jobId,
       request: queuedStatus.request,
-      controllerState: "cancellation-failed",
       cancellation: {
-        attempt: 1,
         outcome: "failed",
         reason: "controller-deadline",
         failure: "transport-error",
@@ -569,8 +619,7 @@ describe("Jetson dispatch GitHub controller", () => {
     ]);
     expect(requestImpl).toHaveBeenCalledOnce();
     expect(readReceipt(receiptFile)).toMatchObject({
-      controllerState: "cancellation-request-succeeded",
-      cancellation: { attempt: 1, outcome: "succeeded", reason: "controller-deadline" },
+      cancellation: { outcome: "succeeded", reason: "controller-deadline" },
     });
   });
 
@@ -600,9 +649,7 @@ describe("Jetson dispatch GitHub controller", () => {
       schemaVersion: 1,
       jobId: queuedStatus.jobId,
       request: queuedStatus.request,
-      controllerState: "cancellation-failed",
       cancellation: {
-        attempt: 1,
         outcome: "failed",
         reason: "status-request-failures",
         failure: "transport-error",

--- a/test/e2e/support/jetson-dispatch-client.test.ts
+++ b/test/e2e/support/jetson-dispatch-client.test.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createGitHubOidcTokenProvider,
+  createJetsonCancellation,
   dispatcherBaseUrl,
   dispatcherRequest,
   jetsonDispatchRequestFromEnvironment,
@@ -519,11 +520,10 @@ describe("Jetson dispatch GitHub controller", () => {
     expect(fs.statSync(receiptFile).mode & 0o777).toBe(0o600);
   });
 
-  it("records a rejected cancellation after repeated status failures (#8142)", async () => {
-    vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("classifies a non-object cancellation error as an invalid response (#8142)", async () => {
     const receiptFile = temporaryReceiptFile();
     const requestImpl = vi.fn(async () => {
-      throw new Error("status transport reset");
+      throw new Error("Jetson dispatcher error must be an object");
     });
 
     await expect(
@@ -532,14 +532,69 @@ describe("Jetson dispatch GitHub controller", () => {
         deadlineMs: 10_000,
         initialStatus: queuedStatus,
         jobId: queuedStatus.jobId,
-        now: () => 0,
+        now: () => 10_000,
         receiptFile,
         request: requestImpl,
         wait: async () => {},
       }),
-    ).rejects.toThrow(
+    ).rejects.toThrow("cancellation request failed (invalid-response)");
+    expect(readReceipt(receiptFile)).toMatchObject({
+      cancellation: { failure: "invalid-response" },
+    });
+  });
+
+  it("shares one cancellation request across concurrent callers (#8142)", async () => {
+    const receiptFile = temporaryReceiptFile();
+    let completeRequest: ((value: unknown) => void) | undefined;
+    const requestImpl = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          completeRequest = resolve;
+        }),
+    );
+    const cancel = createJetsonCancellation({
+      baseUrl: new URL("https://dispatch.test/"),
+      receiptFile,
+      request: requestImpl,
+      status: queuedStatus,
+    });
+
+    const deadlineCancellation = cancel("controller-deadline");
+    const signalCancellation = cancel("signal");
+    completeRequest?.({ job: queuedStatus });
+
+    await expect(Promise.all([deadlineCancellation, signalCancellation])).resolves.toEqual([
+      { outcome: "succeeded", receiptWritten: true },
+      { outcome: "succeeded", receiptWritten: true },
+    ]);
+    expect(requestImpl).toHaveBeenCalledOnce();
+    expect(readReceipt(receiptFile)).toMatchObject({
+      controllerState: "cancellation-request-succeeded",
+      cancellation: { attempt: 1, outcome: "succeeded", reason: "controller-deadline" },
+    });
+  });
+
+  it("records a rejected cancellation after repeated status failures (#8142)", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const receiptFile = temporaryReceiptFile();
+    const requestImpl = vi.fn(async () => {
+      throw new Error("status transport reset");
+    });
+
+    const failure = pollJetsonDispatch({
+      baseUrl: new URL("https://dispatch.test/"),
+      deadlineMs: 10_000,
+      initialStatus: queuedStatus,
+      jobId: queuedStatus.jobId,
+      now: () => 0,
+      receiptFile,
+      request: requestImpl,
+      wait: async () => {},
+    });
+    await expect(failure).rejects.toThrow(
       `Jetson dispatch ${queuedStatus.jobId} status failed 3 consecutive times; cancellation request failed (transport-error)`,
     );
+    await expect(failure).rejects.not.toHaveProperty("cause");
     expect(requestImpl).toHaveBeenCalledTimes(4);
     expect(readReceipt(receiptFile)).toEqual({
       schemaVersion: 1,

--- a/tools/e2e/jetson-dispatch-client.mts
+++ b/tools/e2e/jetson-dispatch-client.mts
@@ -184,13 +184,7 @@ function delay(milliseconds: number): Promise<void> {
 function writeJetsonRecoveryReceipt(
   receiptFile: string,
   status: JetsonDispatchStatus,
-  controllerState:
-    | "accepted"
-    | "cancellation-failed"
-    | "cancellation-request-succeeded"
-    | "cancellation-requested",
   cancellation?: {
-    attempt: 1;
     failure?: JetsonCancellationFailure;
     outcome: "failed" | "pending" | "succeeded";
     reason: JetsonCancellationReason;
@@ -203,7 +197,6 @@ function writeJetsonRecoveryReceipt(
         schemaVersion: 1,
         jobId: status.jobId,
         request: status.request,
-        controllerState,
         ...(cancellation === undefined ? {} : { cancellation }),
       },
       null,
@@ -233,14 +226,9 @@ async function cancelJetsonDispatch(options: {
   request: typeof dispatcherRequest;
   status: JetsonDispatchStatus;
 }): Promise<JetsonCancellationResult> {
-  const cancellation = { attempt: 1, outcome: "pending", reason: options.reason } as const;
+  const cancellation = { outcome: "pending", reason: options.reason } as const;
   try {
-    writeJetsonRecoveryReceipt(
-      options.receiptFile,
-      options.status,
-      "cancellation-requested",
-      cancellation,
-    );
+    writeJetsonRecoveryReceipt(options.receiptFile, options.status, cancellation);
   } catch {
     // The cancellation request must continue when the local recovery receipt cannot be updated.
   }
@@ -260,17 +248,11 @@ async function cancelJetsonDispatch(options: {
 
   let receiptWritten = true;
   try {
-    writeJetsonRecoveryReceipt(
-      options.receiptFile,
-      options.status,
-      result.outcome === "succeeded" ? "cancellation-request-succeeded" : "cancellation-failed",
-      {
-        attempt: 1,
-        outcome: result.outcome,
-        reason: options.reason,
-        ...(result.outcome === "failed" ? { failure: result.failure } : {}),
-      },
-    );
+    writeJetsonRecoveryReceipt(options.receiptFile, options.status, {
+      outcome: result.outcome,
+      reason: options.reason,
+      ...(result.outcome === "failed" ? { failure: result.failure } : {}),
+    });
   } catch {
     receiptWritten = false;
   }
@@ -329,7 +311,7 @@ export async function pollJetsonDispatch(options: {
     throw new Error("Jetson dispatcher status does not match the accepted job");
   }
   try {
-    writeJetsonRecoveryReceipt(options.receiptFile, status, "accepted");
+    writeJetsonRecoveryReceipt(options.receiptFile, status);
   } catch {
     const cancellation = await cancel("recovery-receipt-failure");
     throw new Error(
@@ -338,7 +320,10 @@ export async function pollJetsonDispatch(options: {
   }
   while (status.state !== "completed") {
     if (options.stopping?.()) {
-      throw new Error(`Jetson dispatch ${options.jobId} cancellation requested`);
+      const cancellation = await cancel("signal");
+      throw new Error(
+        `Jetson dispatch ${options.jobId} cancellation requested; ${cancellationResultMessage(cancellation)}`,
+      );
     }
     if (now() >= options.deadlineMs) {
       const cancellation = await cancel("controller-deadline");

--- a/tools/e2e/jetson-dispatch-client.mts
+++ b/tools/e2e/jetson-dispatch-client.mts
@@ -295,6 +295,7 @@ export function createJetsonCancellation(options: {
 
 export async function submitJetsonDispatch(options: {
   baseUrl: URL;
+  cancel?: CancelJetsonDispatch;
   dispatchRequest: JetsonDispatchRequest;
   receiptFile: string;
   request?: typeof dispatcherRequest;
@@ -307,12 +308,14 @@ export async function submitJetsonDispatch(options: {
     throw new Error(`Jetson dispatch ${jobId} stopped before submission`);
   }
   const request = options.request ?? dispatcherRequest;
-  const cancel = createJetsonCancellation({
-    baseUrl: options.baseUrl,
-    dispatch,
-    receiptFile: options.receiptFile,
-    request,
-  });
+  const cancel =
+    options.cancel ??
+    createJetsonCancellation({
+      baseUrl: options.baseUrl,
+      dispatch,
+      receiptFile: options.receiptFile,
+      request,
+    });
 
   let status: JetsonDispatchStatus;
   try {
@@ -347,7 +350,6 @@ export async function pollJetsonDispatch(options: {
   cancel?: CancelJetsonDispatch;
   deadlineMs: number;
   initialStatus: JetsonDispatchStatus;
-  jobId: string;
   now?: () => number;
   receiptFile: string;
   request?: typeof dispatcherRequest;
@@ -356,6 +358,7 @@ export async function pollJetsonDispatch(options: {
 }): Promise<JetsonDispatchStatus> {
   const now = options.now ?? Date.now;
   const request = options.request ?? dispatcherRequest;
+  const jobId = options.initialStatus.jobId;
   const cancel =
     options.cancel ??
     createJetsonCancellation({
@@ -367,28 +370,25 @@ export async function pollJetsonDispatch(options: {
   const wait = options.wait ?? delay;
   let consecutiveFailures = 0;
   let status = options.initialStatus;
-  if (status.jobId !== options.jobId) {
-    throw new Error("Jetson dispatcher status does not match the accepted job");
-  }
   try {
     writeJetsonRecoveryReceipt(options.receiptFile, status);
   } catch {
     const cancellation = await cancel("recovery-receipt-failure");
     throw new Error(
-      `Jetson dispatch ${options.jobId} was accepted but its recovery receipt could not be written; ${cancellationResultMessage(cancellation)}`,
+      `Jetson dispatch ${jobId} was accepted but its recovery receipt could not be written; ${cancellationResultMessage(cancellation)}`,
     );
   }
   while (status.state !== "completed") {
     if (options.stopping?.()) {
       const cancellation = await cancel("signal");
       throw new Error(
-        `Jetson dispatch ${options.jobId} cancellation requested; ${cancellationResultMessage(cancellation)}`,
+        `Jetson dispatch ${jobId} cancellation requested; ${cancellationResultMessage(cancellation)}`,
       );
     }
     if (now() >= options.deadlineMs) {
       const cancellation = await cancel("controller-deadline");
       throw new Error(
-        `Jetson dispatch ${options.jobId} did not complete before the controller deadline; ${cancellationResultMessage(cancellation)}`,
+        `Jetson dispatch ${jobId} did not complete before the controller deadline; ${cancellationResultMessage(cancellation)}`,
       );
     }
     await wait(POLL_INTERVAL_MS);
@@ -397,12 +397,12 @@ export async function pollJetsonDispatch(options: {
         await request({
           baseUrl: options.baseUrl,
           method: "GET",
-          path: `v1/jobs/${options.jobId}`,
+          path: `v1/jobs/${jobId}`,
           maxBytes: MAX_STATUS_BYTES,
         }),
         options.initialStatus.request,
       );
-      if (status.jobId !== options.jobId) {
+      if (status.jobId !== jobId) {
         throw new Error("Jetson dispatcher status does not match the accepted job");
       }
       consecutiveFailures = 0;
@@ -412,7 +412,7 @@ export async function pollJetsonDispatch(options: {
       if (consecutiveFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
         const cancellation = await cancel("status-request-failures");
         throw new Error(
-          `Jetson dispatch ${options.jobId} status failed ${MAX_CONSECUTIVE_POLL_FAILURES} consecutive times; ${cancellationResultMessage(cancellation)}`,
+          `Jetson dispatch ${jobId} status failed ${MAX_CONSECUTIVE_POLL_FAILURES} consecutive times; ${cancellationResultMessage(cancellation)}`,
         );
       }
       console.warn("Jetson dispatch status request failed; retrying");
@@ -443,32 +443,38 @@ async function main(): Promise<void> {
   fs.chmodSync(artifactDirectory, 0o700);
   const receiptFile = path.join(artifactDirectory, "jetson-dispatch.json");
 
-  let dispatched: JetsonDispatchStatus | undefined;
-  let cancelDispatch: CancelJetsonDispatch | undefined;
+  const jobId = jetsonDispatchJobId(request);
+  const cancelDispatch = createJetsonCancellation({
+    baseUrl,
+    dispatch: { jobId, request },
+    receiptFile,
+    request: dispatcherRequest,
+  });
+  let submissionStarted = false;
   let stopping = false;
   const cancel = (): void => {
     if (stopping) return;
     stopping = true;
-    if (!dispatched) {
+    if (!submissionStarted) {
       process.exitCode = 1;
       return;
     }
-    void cancelDispatch?.("signal").finally(() => {
+    void cancelDispatch("signal").finally(() => {
       process.exitCode = 1;
     });
   };
   process.on("SIGINT", cancel);
   process.on("SIGTERM", cancel);
 
+  submissionStarted = true;
   const submission = await submitJetsonDispatch({
     baseUrl,
+    cancel: cancelDispatch,
     dispatchRequest: request,
     receiptFile,
     stopping: () => stopping,
   });
-  dispatched = submission.status;
-  const jobId = dispatched.jobId;
-  cancelDispatch = submission.cancel;
+  const dispatched = submission.status;
   console.log(`Jetson dispatch accepted as ${jobId}`);
   const deadline = Date.now() + MAX_WAIT_MS;
   await pollJetsonDispatch({
@@ -476,7 +482,6 @@ async function main(): Promise<void> {
     cancel: cancelDispatch,
     deadlineMs: deadline,
     initialStatus: dispatched,
-    jobId,
     receiptFile,
     stopping: () => stopping,
   });

--- a/tools/e2e/jetson-dispatch-client.mts
+++ b/tools/e2e/jetson-dispatch-client.mts
@@ -290,9 +290,8 @@ export function createJetsonCancellation(options: {
   let inFlight: Promise<JetsonCancellationResult> | undefined;
   let retry: Promise<JetsonCancellationResult> | undefined;
   return (reason, callOptions) => {
-    const cancellationAlreadyStarted = inFlight !== undefined;
     inFlight ??= cancelJetsonDispatch({ ...options, reason });
-    if (!cancellationAlreadyStarted || !callOptions?.retryJobNotFound) return inFlight;
+    if (!callOptions?.retryJobNotFound) return inFlight;
     retry ??= inFlight.then((result) =>
       result.outcome === "failed" && result.failure === "job-not-found"
         ? cancelJetsonDispatch({ ...options, reason })

--- a/tools/e2e/jetson-dispatch-client.mts
+++ b/tools/e2e/jetson-dispatch-client.mts
@@ -278,6 +278,7 @@ function cancellationResultMessage(result: JetsonCancellationResult): string {
 
 export type CancelJetsonDispatch = (
   reason: JetsonCancellationReason,
+  options?: { retryJobNotFound?: boolean },
 ) => Promise<JetsonCancellationResult>;
 
 export function createJetsonCancellation(options: {
@@ -287,9 +288,17 @@ export function createJetsonCancellation(options: {
   request: typeof dispatcherRequest;
 }): CancelJetsonDispatch {
   let inFlight: Promise<JetsonCancellationResult> | undefined;
-  return (reason) => {
+  let retry: Promise<JetsonCancellationResult> | undefined;
+  return (reason, callOptions) => {
+    const cancellationAlreadyStarted = inFlight !== undefined;
     inFlight ??= cancelJetsonDispatch({ ...options, reason });
-    return inFlight;
+    if (!cancellationAlreadyStarted || !callOptions?.retryJobNotFound) return inFlight;
+    retry ??= inFlight.then((result) =>
+      result.outcome === "failed" && result.failure === "job-not-found"
+        ? cancelJetsonDispatch({ ...options, reason })
+        : result,
+    );
+    return retry;
   };
 }
 
@@ -331,13 +340,13 @@ export async function submitJetsonDispatch(options: {
     );
   } catch {
     const reason = options.stopping?.() ? "signal" : "submission-outcome-unknown";
-    const cancellation = await cancel(reason);
+    const cancellation = await cancel(reason, { retryJobNotFound: true });
     throw new Error(
       `Jetson dispatch ${jobId} submission outcome was not confirmed; ${cancellationResultMessage(cancellation)}`,
     );
   }
   if (options.stopping?.()) {
-    const cancellation = await cancel("signal");
+    const cancellation = await cancel("signal", { retryJobNotFound: true });
     throw new Error(
       `Jetson dispatch ${jobId} cancellation requested; ${cancellationResultMessage(cancellation)}`,
     );

--- a/tools/e2e/jetson-dispatch-client.mts
+++ b/tools/e2e/jetson-dispatch-client.mts
@@ -147,7 +147,10 @@ export async function dispatcherRequest(options: {
   ) {
     throw new Error("Jetson dispatcher response is too large");
   }
-  if (!response.body) throw new Error("Jetson dispatcher returned an empty response");
+  if (!response.body) {
+    if (response.ok && options.method === "DELETE") return undefined;
+    throw new Error("Jetson dispatcher returned an empty response");
+  }
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let responseBytes = 0;
@@ -162,6 +165,10 @@ export async function dispatcherRequest(options: {
     chunks.push(value);
   }
   const bytes = Buffer.concat(chunks, responseBytes);
+  if (responseBytes === 0) {
+    if (response.ok && options.method === "DELETE") return undefined;
+    throw new Error("Jetson dispatcher returned an empty response");
+  }
   let payload: unknown;
   try {
     payload = JSON.parse(bytes.toString("utf8"));

--- a/tools/e2e/jetson-dispatch-client.mts
+++ b/tools/e2e/jetson-dispatch-client.mts
@@ -25,6 +25,22 @@ const MAX_WAIT_MS = 54 * 60_000;
 const MAX_CONSECUTIVE_POLL_FAILURES = 3;
 const OIDC_TOKEN_CACHE_MS = 4 * 60_000;
 
+type JetsonCancellationFailure =
+  | "authorization-failed"
+  | "dispatcher-http-error"
+  | "invalid-response"
+  | "job-not-found"
+  | "request-timeout"
+  | "transport-error";
+type JetsonCancellationReason =
+  | "controller-deadline"
+  | "recovery-receipt-failure"
+  | "signal"
+  | "status-request-failures";
+type JetsonCancellationResult =
+  | { outcome: "failed"; failure: JetsonCancellationFailure; receiptWritten: boolean }
+  | { outcome: "succeeded"; receiptWritten: boolean };
+
 function record(value: unknown, name: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`${name} must be an object`);
@@ -165,12 +181,115 @@ function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
+function writeJetsonRecoveryReceipt(
+  receiptFile: string,
+  status: JetsonDispatchStatus,
+  controllerState:
+    | "accepted"
+    | "cancellation-failed"
+    | "cancellation-request-succeeded"
+    | "cancellation-requested",
+  cancellation?: {
+    attempt: 1;
+    failure?: JetsonCancellationFailure;
+    outcome: "failed" | "pending" | "succeeded";
+    reason: JetsonCancellationReason;
+  },
+): void {
+  writePrivateRegularFile(
+    receiptFile,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        jobId: status.jobId,
+        request: status.request,
+        controllerState,
+        ...(cancellation === undefined ? {} : { cancellation }),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function classifyCancellationFailure(error: unknown): JetsonCancellationFailure {
+  const message = error instanceof Error ? error.message : "";
+  if (error instanceof Error && ["AbortError", "TimeoutError"].includes(error.name)) {
+    return "request-timeout";
+  }
+  if (/returned HTTP (?:401|403)(?::|$)/u.test(message)) return "authorization-failed";
+  if (/returned HTTP 404(?::|$)/u.test(message)) return "job-not-found";
+  if (/returned HTTP [0-9]{3}(?::|$)/u.test(message)) return "dispatcher-http-error";
+  if (/empty response|invalid JSON|response is too large/u.test(message)) return "invalid-response";
+  return "transport-error";
+}
+
+async function cancelJetsonDispatch(options: {
+  baseUrl: URL;
+  reason: JetsonCancellationReason;
+  receiptFile: string;
+  request: typeof dispatcherRequest;
+  status: JetsonDispatchStatus;
+}): Promise<JetsonCancellationResult> {
+  const cancellation = { attempt: 1, outcome: "pending", reason: options.reason } as const;
+  try {
+    writeJetsonRecoveryReceipt(
+      options.receiptFile,
+      options.status,
+      "cancellation-requested",
+      cancellation,
+    );
+  } catch {
+    // The cancellation request must continue when the local recovery receipt cannot be updated.
+  }
+
+  let result: { outcome: "failed"; failure: JetsonCancellationFailure } | { outcome: "succeeded" };
+  try {
+    await options.request({
+      baseUrl: options.baseUrl,
+      method: "DELETE",
+      path: `v1/jobs/${options.status.jobId}`,
+      maxBytes: MAX_STATUS_BYTES,
+    });
+    result = { outcome: "succeeded" };
+  } catch (error) {
+    result = { outcome: "failed", failure: classifyCancellationFailure(error) };
+  }
+
+  let receiptWritten = true;
+  try {
+    writeJetsonRecoveryReceipt(
+      options.receiptFile,
+      options.status,
+      result.outcome === "succeeded" ? "cancellation-request-succeeded" : "cancellation-failed",
+      {
+        attempt: 1,
+        outcome: result.outcome,
+        reason: options.reason,
+        ...(result.outcome === "failed" ? { failure: result.failure } : {}),
+      },
+    );
+  } catch {
+    receiptWritten = false;
+  }
+  return { ...result, receiptWritten } as JetsonCancellationResult;
+}
+
+function cancellationResultMessage(result: JetsonCancellationResult): string {
+  const outcome =
+    result.outcome === "succeeded"
+      ? "cancellation request succeeded"
+      : `cancellation request failed (${result.failure})`;
+  return result.receiptWritten ? outcome : `${outcome}; recovery receipt update failed`;
+}
+
 export async function pollJetsonDispatch(options: {
   baseUrl: URL;
   deadlineMs: number;
   initialStatus: JetsonDispatchStatus;
   jobId: string;
   now?: () => number;
+  receiptFile: string;
   request?: typeof dispatcherRequest;
   stopping?: () => boolean;
   wait?: typeof delay;
@@ -183,16 +302,35 @@ export async function pollJetsonDispatch(options: {
   if (status.jobId !== options.jobId) {
     throw new Error("Jetson dispatcher status does not match the accepted job");
   }
+  try {
+    writeJetsonRecoveryReceipt(options.receiptFile, status, "accepted");
+  } catch {
+    const cancellation = await cancelJetsonDispatch({
+      baseUrl: options.baseUrl,
+      reason: "recovery-receipt-failure",
+      receiptFile: options.receiptFile,
+      request,
+      status,
+    });
+    throw new Error(
+      `Jetson dispatch ${options.jobId} was accepted but its recovery receipt could not be written; ${cancellationResultMessage(cancellation)}`,
+    );
+  }
   while (status.state !== "completed") {
-    if (options.stopping?.()) throw new Error("Jetson dispatch cancellation requested");
+    if (options.stopping?.()) {
+      throw new Error(`Jetson dispatch ${options.jobId} cancellation requested`);
+    }
     if (now() >= options.deadlineMs) {
-      await request({
+      const cancellation = await cancelJetsonDispatch({
         baseUrl: options.baseUrl,
-        method: "DELETE",
-        path: `v1/jobs/${options.jobId}`,
-        maxBytes: MAX_STATUS_BYTES,
-      }).catch(() => undefined);
-      throw new Error("Jetson dispatcher did not complete before the controller deadline");
+        reason: "controller-deadline",
+        receiptFile: options.receiptFile,
+        request,
+        status,
+      });
+      throw new Error(
+        `Jetson dispatch ${options.jobId} did not complete before the controller deadline; ${cancellationResultMessage(cancellation)}`,
+      );
     }
     await wait(POLL_INTERVAL_MS);
     try {
@@ -213,13 +351,17 @@ export async function pollJetsonDispatch(options: {
     } catch (error) {
       consecutiveFailures += 1;
       if (consecutiveFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
-        await request({
+        const cancellation = await cancelJetsonDispatch({
           baseUrl: options.baseUrl,
-          method: "DELETE",
-          path: `v1/jobs/${options.jobId}`,
-          maxBytes: MAX_STATUS_BYTES,
-        }).catch(() => undefined);
-        throw error;
+          reason: "status-request-failures",
+          receiptFile: options.receiptFile,
+          request,
+          status,
+        });
+        throw new Error(
+          `Jetson dispatch ${options.jobId} status failed ${MAX_CONSECUTIVE_POLL_FAILURES} consecutive times; ${cancellationResultMessage(cancellation)}`,
+          { cause: error },
+        );
       }
       console.warn("Jetson dispatch status request failed; retrying");
     }
@@ -247,21 +389,23 @@ async function main(): Promise<void> {
   if (!path.isAbsolute(artifactDirectory)) throw new Error("E2E_ARTIFACT_DIR must be absolute");
   fs.mkdirSync(artifactDirectory, { recursive: true, mode: 0o700 });
   fs.chmodSync(artifactDirectory, 0o700);
+  const receiptFile = path.join(artifactDirectory, "jetson-dispatch.json");
 
-  let jobId: string | undefined;
+  let dispatched: JetsonDispatchStatus | undefined;
   let stopping = false;
   const cancel = (): void => {
     if (stopping) return;
     stopping = true;
-    if (!jobId) {
+    if (!dispatched) {
       process.exitCode = 1;
       return;
     }
-    void dispatcherRequest({
+    void cancelJetsonDispatch({
       baseUrl,
-      method: "DELETE",
-      path: `v1/jobs/${jobId}`,
-      maxBytes: MAX_STATUS_BYTES,
+      reason: "signal",
+      receiptFile,
+      request: dispatcherRequest,
+      status: dispatched,
     }).finally(() => {
       process.exitCode = 1;
     });
@@ -269,7 +413,7 @@ async function main(): Promise<void> {
   process.on("SIGINT", cancel);
   process.on("SIGTERM", cancel);
 
-  const dispatched = parseJetsonDispatchStatusResponse(
+  dispatched = parseJetsonDispatchStatusResponse(
     await dispatcherRequest({
       baseUrl,
       method: "POST",
@@ -279,7 +423,7 @@ async function main(): Promise<void> {
     }),
     request,
   );
-  jobId = dispatched.jobId;
+  const jobId = dispatched.jobId;
   console.log(`Jetson dispatch accepted as ${jobId}`);
   const deadline = Date.now() + MAX_WAIT_MS;
   await pollJetsonDispatch({
@@ -287,6 +431,7 @@ async function main(): Promise<void> {
     deadlineMs: deadline,
     initialStatus: dispatched,
     jobId,
+    receiptFile,
     stopping: () => stopping,
   });
 
@@ -298,10 +443,7 @@ async function main(): Promise<void> {
   });
   const artifact: JetsonDispatchArtifact = parseJetsonDispatchArtifact(artifactValue, jobId);
   const { artifactArchiveBase64, ...artifactReceipt } = artifact;
-  writePrivateRegularFile(
-    path.join(artifactDirectory, "jetson-dispatch.json"),
-    `${JSON.stringify(artifactReceipt, null, 2)}\n`,
-  );
+  writePrivateRegularFile(receiptFile, `${JSON.stringify(artifactReceipt, null, 2)}\n`);
   if (artifactArchiveBase64 !== undefined) {
     writePrivateRegularFile(
       path.join(artifactDirectory, "jetson-e2e-artifacts.tar.gz"),

--- a/tools/e2e/jetson-dispatch-client.mts
+++ b/tools/e2e/jetson-dispatch-client.mts
@@ -220,7 +220,9 @@ function classifyCancellationFailure(error: unknown): JetsonCancellationFailure 
   if (/returned HTTP (?:401|403)(?::|$)/u.test(message)) return "authorization-failed";
   if (/returned HTTP 404(?::|$)/u.test(message)) return "job-not-found";
   if (/returned HTTP [0-9]{3}(?::|$)/u.test(message)) return "dispatcher-http-error";
-  if (/empty response|invalid JSON|response is too large/u.test(message)) return "invalid-response";
+  if (/empty response|invalid JSON|response is too large|must be an object/u.test(message)) {
+    return "invalid-response";
+  }
   return "transport-error";
 }
 
@@ -283,8 +285,24 @@ function cancellationResultMessage(result: JetsonCancellationResult): string {
   return result.receiptWritten ? outcome : `${outcome}; recovery receipt update failed`;
 }
 
+type CancelJetsonDispatch = (reason: JetsonCancellationReason) => Promise<JetsonCancellationResult>;
+
+export function createJetsonCancellation(options: {
+  baseUrl: URL;
+  receiptFile: string;
+  request: typeof dispatcherRequest;
+  status: JetsonDispatchStatus;
+}): CancelJetsonDispatch {
+  let inFlight: Promise<JetsonCancellationResult> | undefined;
+  return (reason) => {
+    inFlight ??= cancelJetsonDispatch({ ...options, reason });
+    return inFlight;
+  };
+}
+
 export async function pollJetsonDispatch(options: {
   baseUrl: URL;
+  cancel?: CancelJetsonDispatch;
   deadlineMs: number;
   initialStatus: JetsonDispatchStatus;
   jobId: string;
@@ -296,6 +314,14 @@ export async function pollJetsonDispatch(options: {
 }): Promise<JetsonDispatchStatus> {
   const now = options.now ?? Date.now;
   const request = options.request ?? dispatcherRequest;
+  const cancel =
+    options.cancel ??
+    createJetsonCancellation({
+      baseUrl: options.baseUrl,
+      receiptFile: options.receiptFile,
+      request,
+      status: options.initialStatus,
+    });
   const wait = options.wait ?? delay;
   let consecutiveFailures = 0;
   let status = options.initialStatus;
@@ -305,13 +331,7 @@ export async function pollJetsonDispatch(options: {
   try {
     writeJetsonRecoveryReceipt(options.receiptFile, status, "accepted");
   } catch {
-    const cancellation = await cancelJetsonDispatch({
-      baseUrl: options.baseUrl,
-      reason: "recovery-receipt-failure",
-      receiptFile: options.receiptFile,
-      request,
-      status,
-    });
+    const cancellation = await cancel("recovery-receipt-failure");
     throw new Error(
       `Jetson dispatch ${options.jobId} was accepted but its recovery receipt could not be written; ${cancellationResultMessage(cancellation)}`,
     );
@@ -321,13 +341,7 @@ export async function pollJetsonDispatch(options: {
       throw new Error(`Jetson dispatch ${options.jobId} cancellation requested`);
     }
     if (now() >= options.deadlineMs) {
-      const cancellation = await cancelJetsonDispatch({
-        baseUrl: options.baseUrl,
-        reason: "controller-deadline",
-        receiptFile: options.receiptFile,
-        request,
-        status,
-      });
+      const cancellation = await cancel("controller-deadline");
       throw new Error(
         `Jetson dispatch ${options.jobId} did not complete before the controller deadline; ${cancellationResultMessage(cancellation)}`,
       );
@@ -351,16 +365,9 @@ export async function pollJetsonDispatch(options: {
     } catch (error) {
       consecutiveFailures += 1;
       if (consecutiveFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
-        const cancellation = await cancelJetsonDispatch({
-          baseUrl: options.baseUrl,
-          reason: "status-request-failures",
-          receiptFile: options.receiptFile,
-          request,
-          status,
-        });
+        const cancellation = await cancel("status-request-failures");
         throw new Error(
           `Jetson dispatch ${options.jobId} status failed ${MAX_CONSECUTIVE_POLL_FAILURES} consecutive times; ${cancellationResultMessage(cancellation)}`,
-          { cause: error },
         );
       }
       console.warn("Jetson dispatch status request failed; retrying");
@@ -392,6 +399,7 @@ async function main(): Promise<void> {
   const receiptFile = path.join(artifactDirectory, "jetson-dispatch.json");
 
   let dispatched: JetsonDispatchStatus | undefined;
+  let cancelDispatch: CancelJetsonDispatch | undefined;
   let stopping = false;
   const cancel = (): void => {
     if (stopping) return;
@@ -400,13 +408,7 @@ async function main(): Promise<void> {
       process.exitCode = 1;
       return;
     }
-    void cancelJetsonDispatch({
-      baseUrl,
-      reason: "signal",
-      receiptFile,
-      request: dispatcherRequest,
-      status: dispatched,
-    }).finally(() => {
+    void cancelDispatch?.("signal").finally(() => {
       process.exitCode = 1;
     });
   };
@@ -424,10 +426,17 @@ async function main(): Promise<void> {
     request,
   );
   const jobId = dispatched.jobId;
+  cancelDispatch = createJetsonCancellation({
+    baseUrl,
+    receiptFile,
+    request: dispatcherRequest,
+    status: dispatched,
+  });
   console.log(`Jetson dispatch accepted as ${jobId}`);
   const deadline = Date.now() + MAX_WAIT_MS;
   await pollJetsonDispatch({
     baseUrl,
+    cancel: cancelDispatch,
     deadlineMs: deadline,
     initialStatus: dispatched,
     jobId,

--- a/tools/e2e/jetson-dispatch-client.mts
+++ b/tools/e2e/jetson-dispatch-client.mts
@@ -9,6 +9,7 @@ import {
   decodeJetsonArtifactArchive,
   JETSON_DISPATCH_AUDIENCE,
   JETSON_DISPATCH_TARGET,
+  jetsonDispatchJobId,
   type JetsonDispatchArtifact,
   type JetsonDispatchRequest,
   type JetsonDispatchStatus,
@@ -36,6 +37,7 @@ type JetsonCancellationReason =
   | "controller-deadline"
   | "recovery-receipt-failure"
   | "signal"
+  | "submission-outcome-unknown"
   | "status-request-failures";
 type JetsonCancellationResult =
   | { outcome: "failed"; failure: JetsonCancellationFailure; receiptWritten: boolean }
@@ -190,7 +192,7 @@ function delay(milliseconds: number): Promise<void> {
 
 function writeJetsonRecoveryReceipt(
   receiptFile: string,
-  status: JetsonDispatchStatus,
+  dispatch: Pick<JetsonDispatchStatus, "jobId" | "request">,
   cancellation?: {
     failure?: JetsonCancellationFailure;
     outcome: "failed" | "pending" | "succeeded";
@@ -202,8 +204,8 @@ function writeJetsonRecoveryReceipt(
     `${JSON.stringify(
       {
         schemaVersion: 1,
-        jobId: status.jobId,
-        request: status.request,
+        jobId: dispatch.jobId,
+        request: dispatch.request,
         ...(cancellation === undefined ? {} : { cancellation }),
       },
       null,
@@ -228,14 +230,14 @@ function classifyCancellationFailure(error: unknown): JetsonCancellationFailure 
 
 async function cancelJetsonDispatch(options: {
   baseUrl: URL;
+  dispatch: Pick<JetsonDispatchStatus, "jobId" | "request">;
   reason: JetsonCancellationReason;
   receiptFile: string;
   request: typeof dispatcherRequest;
-  status: JetsonDispatchStatus;
 }): Promise<JetsonCancellationResult> {
   const cancellation = { outcome: "pending", reason: options.reason } as const;
   try {
-    writeJetsonRecoveryReceipt(options.receiptFile, options.status, cancellation);
+    writeJetsonRecoveryReceipt(options.receiptFile, options.dispatch, cancellation);
   } catch {
     // The cancellation request must continue when the local recovery receipt cannot be updated.
   }
@@ -245,7 +247,7 @@ async function cancelJetsonDispatch(options: {
     await options.request({
       baseUrl: options.baseUrl,
       method: "DELETE",
-      path: `v1/jobs/${options.status.jobId}`,
+      path: `v1/jobs/${options.dispatch.jobId}`,
       maxBytes: MAX_STATUS_BYTES,
     });
     result = { outcome: "succeeded" };
@@ -255,7 +257,7 @@ async function cancelJetsonDispatch(options: {
 
   let receiptWritten = true;
   try {
-    writeJetsonRecoveryReceipt(options.receiptFile, options.status, {
+    writeJetsonRecoveryReceipt(options.receiptFile, options.dispatch, {
       outcome: result.outcome,
       reason: options.reason,
       ...(result.outcome === "failed" ? { failure: result.failure } : {}),
@@ -274,19 +276,70 @@ function cancellationResultMessage(result: JetsonCancellationResult): string {
   return result.receiptWritten ? outcome : `${outcome}; recovery receipt update failed`;
 }
 
-type CancelJetsonDispatch = (reason: JetsonCancellationReason) => Promise<JetsonCancellationResult>;
+export type CancelJetsonDispatch = (
+  reason: JetsonCancellationReason,
+) => Promise<JetsonCancellationResult>;
 
 export function createJetsonCancellation(options: {
   baseUrl: URL;
+  dispatch: Pick<JetsonDispatchStatus, "jobId" | "request">;
   receiptFile: string;
   request: typeof dispatcherRequest;
-  status: JetsonDispatchStatus;
 }): CancelJetsonDispatch {
   let inFlight: Promise<JetsonCancellationResult> | undefined;
   return (reason) => {
     inFlight ??= cancelJetsonDispatch({ ...options, reason });
     return inFlight;
   };
+}
+
+export async function submitJetsonDispatch(options: {
+  baseUrl: URL;
+  dispatchRequest: JetsonDispatchRequest;
+  receiptFile: string;
+  request?: typeof dispatcherRequest;
+  stopping?: () => boolean;
+}): Promise<{ cancel: CancelJetsonDispatch; status: JetsonDispatchStatus }> {
+  const jobId = jetsonDispatchJobId(options.dispatchRequest);
+  const dispatch = { jobId, request: options.dispatchRequest };
+  writeJetsonRecoveryReceipt(options.receiptFile, dispatch);
+  if (options.stopping?.()) {
+    throw new Error(`Jetson dispatch ${jobId} stopped before submission`);
+  }
+  const request = options.request ?? dispatcherRequest;
+  const cancel = createJetsonCancellation({
+    baseUrl: options.baseUrl,
+    dispatch,
+    receiptFile: options.receiptFile,
+    request,
+  });
+
+  let status: JetsonDispatchStatus;
+  try {
+    status = parseJetsonDispatchStatusResponse(
+      await request({
+        baseUrl: options.baseUrl,
+        method: "POST",
+        path: "v1/jobs",
+        body: options.dispatchRequest,
+        maxBytes: MAX_STATUS_BYTES,
+      }),
+      options.dispatchRequest,
+    );
+  } catch {
+    const reason = options.stopping?.() ? "signal" : "submission-outcome-unknown";
+    const cancellation = await cancel(reason);
+    throw new Error(
+      `Jetson dispatch ${jobId} submission outcome was not confirmed; ${cancellationResultMessage(cancellation)}`,
+    );
+  }
+  if (options.stopping?.()) {
+    const cancellation = await cancel("signal");
+    throw new Error(
+      `Jetson dispatch ${jobId} cancellation requested; ${cancellationResultMessage(cancellation)}`,
+    );
+  }
+  return { cancel, status };
 }
 
 export async function pollJetsonDispatch(options: {
@@ -307,9 +360,9 @@ export async function pollJetsonDispatch(options: {
     options.cancel ??
     createJetsonCancellation({
       baseUrl: options.baseUrl,
+      dispatch: options.initialStatus,
       receiptFile: options.receiptFile,
       request,
-      status: options.initialStatus,
     });
   const wait = options.wait ?? delay;
   let consecutiveFailures = 0;
@@ -407,23 +460,15 @@ async function main(): Promise<void> {
   process.on("SIGINT", cancel);
   process.on("SIGTERM", cancel);
 
-  dispatched = parseJetsonDispatchStatusResponse(
-    await dispatcherRequest({
-      baseUrl,
-      method: "POST",
-      path: "v1/jobs",
-      body: request,
-      maxBytes: MAX_STATUS_BYTES,
-    }),
-    request,
-  );
-  const jobId = dispatched.jobId;
-  cancelDispatch = createJetsonCancellation({
+  const submission = await submitJetsonDispatch({
     baseUrl,
+    dispatchRequest: request,
     receiptFile,
-    request: dispatcherRequest,
-    status: dispatched,
+    stopping: () => stopping,
   });
+  dispatched = submission.status;
+  const jobId = dispatched.jobId;
+  cancelDispatch = submission.cancel;
   console.log(`Jetson dispatch accepted as ${jobId}`);
   const deadline = Date.now() + MAX_WAIT_MS;
   await pollJetsonDispatch({

--- a/tools/e2e/jetson-dispatch-contract.mts
+++ b/tools/e2e/jetson-dispatch-contract.mts
@@ -168,7 +168,7 @@ export function parseJetsonDispatchRequest(value: unknown): JetsonDispatchReques
   };
 }
 
-function expectedJobId(request: JetsonDispatchRequest): string {
+export function jetsonDispatchJobId(request: JetsonDispatchRequest): string {
   const managedImageRevision =
     request.schemaVersion === 2 ? `:${request.managedImageRevision}` : "";
   return createHash("sha256")
@@ -226,7 +226,7 @@ export function parseJetsonDispatchStatus(value: unknown): JetsonDispatchStatus 
     status.schemaVersion !== request.schemaVersion ||
     typeof status.jobId !== "string" ||
     !JOB_ID_PATTERN.test(status.jobId) ||
-    status.jobId !== expectedJobId(request)
+    status.jobId !== jetsonDispatchJobId(request)
   ) {
     throw new Error("Jetson dispatch status does not match its request and job ID");
   }
@@ -332,7 +332,7 @@ export function parseJetsonDispatchStatusResponse(
   const response = record(value, "Jetson dispatcher response");
   requireFields(response, "Jetson dispatcher response", ["job"]);
   const status = parseJetsonDispatchStatus(response.job);
-  if (expectedRequest !== undefined && status.jobId !== expectedJobId(expectedRequest)) {
+  if (expectedRequest !== undefined && status.jobId !== jetsonDispatchJobId(expectedRequest)) {
     throw new Error("Jetson dispatcher response does not match the submitted request");
   }
   return status;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

After PR #10072, the Jetson controller could lose recovery evidence when a cancellation request failed. This change records accepted jobs and bounded cancellation request outcomes so operators can recover before another dispatch.

## Related Issue

Related to #8142. Follow-up to #10072.

## Changes

- Create a private `jetson-dispatch.json` receipt when the operator service accepts a validated request.
- Route deadline, signal, and polling cancellation through one helper. The helper records whether the operator service accepted each request.
- Store fixed failure classifications instead of remote error text. Include the job ID in terminal controller errors.
- Test rejected cancellation requests after a deadline and repeated polling failures. Document the required operator recovery action.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Security review passed. The receipt contains the validated request, job ID, controller state, and fixed failure classifications. It excludes OIDC tokens and remote error text. The failure-path test verifies mode `0600`.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm exec -- vitest run --project e2e-support test/e2e/support/jetson-dispatch-client.test.ts test/e2e/support/jetson-workflow-boundary.test.ts test/e2e/support/e2e-operations-workflow-boundary.test.ts` (133 passed); `npm run test:e2e-phases:check`; `npm run typecheck:cli`; `npm run checks:repository`
- [ ] Applicable broad gate passed — Not applicable; this change updates one Jetson controller boundary and its focused tests.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only) — Not applicable; the owning E2E operator guide changed with code and passed Markdown lint.
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only) — Not applicable
- [ ] New doc pages include SPDX header and frontmatter (new pages only) — Not applicable

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dispatch receipts now capture the derived job ID before submission and report cancellation and completion outcomes.
  * Added recovery guidance for interrupted or uncertain submissions, including inspecting dispatch status before retrying.
  * Successful cancellation responses with empty bodies are now supported.

* **Bug Fixes**
  * Improved handling of submission interruptions, unknown outcomes, repeated status failures, and receipt errors.
  * Prevented duplicate cancellation attempts during concurrent operations.
  * Improved dispatch response validation and cancellation failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->