### PR TITLE
fix(onboard): accept release from pinned catalog

### DIFF
--- a/src/lib/onboard/sandbox-workload-preparation.test.ts
+++ b/src/lib/onboard/sandbox-workload-preparation.test.ts
@@ -185,13 +185,24 @@ describe("sandbox workload preparation", () => {
     });
   });
 
-  it("rejects a resolver-pinned catalog from another release (#8142)", async () => {
-    await expect(
-      prepareSandboxWorkloadSource(
-        { ...input("openclaw"), version: "0.1.0", catalogRevision: REVISION },
-        { resolveCatalog: async () => CATALOG },
-      ),
-    ).rejects.toThrow(`belongs to '${RELEASE}', not 'v0.1.0'`);
+  it("uses a resolver-fetched exact-revision catalog when local release labels differ", async () => {
+    const resolveCatalog = vi.fn(async () => CATALOG);
+
+    const prepared = await prepareSandboxWorkloadSource(
+      { ...input("openclaw"), version: "0.1.0", catalogRevision: REVISION },
+      { resolveCatalog },
+    );
+
+    expect(resolveCatalog).toHaveBeenCalledExactlyOnceWith({
+      release: "v0.1.0",
+      platform: MANAGED_IMAGE_PLATFORM,
+      revision: REVISION,
+    });
+    expect(prepared.release).toBe(RELEASE);
+    expect(prepared.source).toMatchObject({
+      kind: "managed-image",
+      contract: { source: { release: RELEASE, revision: REVISION } },
+    });
   });
 
   it("rejects an exact catalog from another PR commit (#9464)", async () => {

--- a/src/lib/onboard/sandbox-workload-preparation.test.ts
+++ b/src/lib/onboard/sandbox-workload-preparation.test.ts
@@ -184,7 +184,7 @@ describe("sandbox workload preparation", () => {
     });
   });
 
-  it("uses the pinned registry catalog release when candidate and image revisions differ (#8142)", async () => {
+  it("uses the catalog release when the requested release differs and the pinned revision matches (#8142)", async () => {
     const resolveCatalog = vi.fn(async () => CATALOG);
 
     const prepared = await prepareSandboxWorkloadSource(

--- a/src/lib/onboard/sandbox-workload-preparation.test.ts
+++ b/src/lib/onboard/sandbox-workload-preparation.test.ts
@@ -184,37 +184,6 @@ describe("sandbox workload preparation", () => {
     });
   });
 
-  it("uses the catalog release when the requested release differs and the pinned revision matches (#8142)", async () => {
-    const resolveCatalog = vi.fn(async () => CATALOG);
-
-    const prepared = await prepareSandboxWorkloadSource(
-      { ...input("openclaw"), version: "0.1.0", catalogRevision: REVISION },
-      { resolveCatalog },
-    );
-
-    expect(resolveCatalog).toHaveBeenCalledExactlyOnceWith({
-      release: "v0.1.0",
-      platform: MANAGED_IMAGE_PLATFORM,
-      revision: REVISION,
-    });
-    expect(prepared).toMatchObject({
-      release: RELEASE,
-      source: {
-        kind: "managed-image",
-        contract: { source: { release: RELEASE, revision: REVISION } },
-      },
-    });
-  });
-
-  it("rejects a pinned registry catalog from another revision (#8142)", async () => {
-    await expect(
-      prepareSandboxWorkloadSource(
-        { ...input("openclaw"), catalogRevision: "b".repeat(40) },
-        { resolveCatalog: async () => CATALOG },
-      ),
-    ).rejects.toThrow("does not match the live E2E candidate revision");
-  });
-
   it("rejects an exact catalog from another PR commit (#9464)", async () => {
     const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-managed-catalog-"));
     const catalogPath = path.join(fixtureRoot, "catalog.json");

--- a/src/lib/onboard/sandbox-workload-preparation.test.ts
+++ b/src/lib/onboard/sandbox-workload-preparation.test.ts
@@ -184,6 +184,28 @@ describe("sandbox workload preparation", () => {
     });
   });
 
+  it("uses the pinned registry catalog release when candidate and image revisions differ (#8142)", async () => {
+    const resolveCatalog = vi.fn(async () => CATALOG);
+
+    const prepared = await prepareSandboxWorkloadSource(
+      { ...input("openclaw"), version: "0.1.0", catalogRevision: REVISION },
+      { resolveCatalog },
+    );
+
+    expect(resolveCatalog).toHaveBeenCalledExactlyOnceWith({
+      release: "v0.1.0",
+      platform: MANAGED_IMAGE_PLATFORM,
+      revision: REVISION,
+    });
+    expect(prepared).toMatchObject({
+      release: RELEASE,
+      source: {
+        kind: "managed-image",
+        contract: { source: { release: RELEASE, revision: REVISION } },
+      },
+    });
+  });
+
   it("rejects an exact catalog from another PR commit (#9464)", async () => {
     const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-managed-catalog-"));
     const catalogPath = path.join(fixtureRoot, "catalog.json");

--- a/src/lib/onboard/sandbox-workload-preparation.test.ts
+++ b/src/lib/onboard/sandbox-workload-preparation.test.ts
@@ -147,27 +147,28 @@ describe("sandbox workload preparation", () => {
     }
   });
 
-  it.each(
-    SHIPPED_MANAGED_IMAGE_AGENTS,
-  )("resolves the complete release catalog and exact %s image (#7744)", async (agent) => {
-    const resolveCatalog = vi.fn(async () => CATALOG);
+  it.each(SHIPPED_MANAGED_IMAGE_AGENTS)(
+    "resolves the complete release catalog and exact %s image (#7744)",
+    async (agent) => {
+      const resolveCatalog = vi.fn(async () => CATALOG);
 
-    const prepared = await prepareSandboxWorkloadSource(input(agent), { resolveCatalog });
+      const prepared = await prepareSandboxWorkloadSource(input(agent), { resolveCatalog });
 
-    expect(resolveCatalog).toHaveBeenCalledExactlyOnceWith({
-      release: RELEASE,
-      platform: MANAGED_IMAGE_PLATFORM,
-    });
-    expect(prepared).toEqual({
-      source: {
-        kind: "managed-image",
-        reference: contract(agent, SHIPPED_MANAGED_IMAGE_AGENTS.indexOf(agent)).reference,
-        contract: contract(agent, SHIPPED_MANAGED_IMAGE_AGENTS.indexOf(agent)),
-      },
-      release: RELEASE,
-      fallbackDiagnostic: null,
-    });
-  });
+      expect(resolveCatalog).toHaveBeenCalledExactlyOnceWith({
+        release: RELEASE,
+        platform: MANAGED_IMAGE_PLATFORM,
+      });
+      expect(prepared).toEqual({
+        source: {
+          kind: "managed-image",
+          reference: contract(agent, SHIPPED_MANAGED_IMAGE_AGENTS.indexOf(agent)).reference,
+          contract: contract(agent, SHIPPED_MANAGED_IMAGE_AGENTS.indexOf(agent)),
+        },
+        release: RELEASE,
+        fallbackDiagnostic: null,
+      });
+    },
+  );
 
   it("passes an immutable qualification revision to catalog resolution (#9385)", async () => {
     const resolveCatalog = vi.fn(async () => CATALOG);
@@ -182,6 +183,15 @@ describe("sandbox workload preparation", () => {
       platform: MANAGED_IMAGE_PLATFORM,
       revision: REVISION,
     });
+  });
+
+  it("rejects a resolver-pinned catalog from another release (#8142)", async () => {
+    await expect(
+      prepareSandboxWorkloadSource(
+        { ...input("openclaw"), version: "0.1.0", catalogRevision: REVISION },
+        { resolveCatalog: async () => CATALOG },
+      ),
+    ).rejects.toThrow(`belongs to '${RELEASE}', not 'v0.1.0'`);
   });
 
   it("rejects an exact catalog from another PR commit (#9464)", async () => {
@@ -619,6 +629,8 @@ describe("sandbox workload preparation", () => {
         { ...input("pi"), runtime: runtime("docker") },
         { resolveCatalog: async () => CATALOG },
       ),
-    ).rejects.toThrow("the selected agent is a release candidate and candidate selection is disabled");
+    ).rejects.toThrow(
+      "the selected agent is a release candidate and candidate selection is disabled",
+    );
   });
 });

--- a/src/lib/onboard/sandbox-workload-preparation.test.ts
+++ b/src/lib/onboard/sandbox-workload-preparation.test.ts
@@ -206,6 +206,15 @@ describe("sandbox workload preparation", () => {
     });
   });
 
+  it("rejects a pinned registry catalog from another revision (#8142)", async () => {
+    await expect(
+      prepareSandboxWorkloadSource(
+        { ...input("openclaw"), catalogRevision: "b".repeat(40) },
+        { resolveCatalog: async () => CATALOG },
+      ),
+    ).rejects.toThrow("does not match the live E2E candidate revision");
+  });
+
   it("rejects an exact catalog from another PR commit (#9464)", async () => {
     const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-managed-catalog-"));
     const catalogPath = path.join(fixtureRoot, "catalog.json");

--- a/src/lib/onboard/workload/preparation.ts
+++ b/src/lib/onboard/workload/preparation.ts
@@ -369,7 +369,7 @@ export async function prepareSandboxWorkloadSource(
       catalog,
       release,
       platform,
-      input.expectedCatalogRevision ?? null,
+      input.expectedCatalogRevision ?? input.catalogRevision ?? null,
     );
     release = catalogIdentity.release;
   }

--- a/src/lib/onboard/workload/preparation.ts
+++ b/src/lib/onboard/workload/preparation.ts
@@ -185,7 +185,6 @@ function requireCompleteManagedImageCatalog(
   expectedRelease: string,
   expectedPlatform: ManagedImagePlatform,
   expectedRevision: string | null,
-  acceptCatalogRelease: boolean,
 ): { readonly release: string; readonly revision: string } {
   let cohortRevision: string | null = null;
   let cohortRelease: string | null = null;
@@ -199,7 +198,7 @@ function requireCompleteManagedImageCatalog(
     }
     try {
       const contract = parseManagedImageContractV1(candidate, agent, expectedPlatform);
-      if (!acceptCatalogRelease && contract.source.release !== expectedRelease) {
+      if (expectedRevision === null && contract.source.release !== expectedRelease) {
         throw new SandboxWorkloadPreparationError(
           `managed image catalog contract for '${agent}' belongs to '${contract.source.release}', not '${expectedRelease}'`,
         );
@@ -368,13 +367,12 @@ export async function prepareSandboxWorkloadSource(
   } else {
     const trustedCatalogRevision = input.catalogPath
       ? (input.expectedCatalogRevision ?? null)
-      : null;
+      : (input.catalogRevision ?? null);
     const catalogIdentity = requireCompleteManagedImageCatalog(
       catalog,
       release,
       platform,
-      trustedCatalogRevision ?? input.catalogRevision ?? null,
-      trustedCatalogRevision !== null,
+      trustedCatalogRevision,
     );
     release = catalogIdentity.release;
   }

--- a/src/lib/onboard/workload/preparation.ts
+++ b/src/lib/onboard/workload/preparation.ts
@@ -185,6 +185,7 @@ function requireCompleteManagedImageCatalog(
   expectedRelease: string,
   expectedPlatform: ManagedImagePlatform,
   expectedRevision: string | null,
+  acceptCatalogRelease: boolean,
 ): { readonly release: string; readonly revision: string } {
   let cohortRevision: string | null = null;
   let cohortRelease: string | null = null;
@@ -198,7 +199,7 @@ function requireCompleteManagedImageCatalog(
     }
     try {
       const contract = parseManagedImageContractV1(candidate, agent, expectedPlatform);
-      if (expectedRevision === null && contract.source.release !== expectedRelease) {
+      if (!acceptCatalogRelease && contract.source.release !== expectedRelease) {
         throw new SandboxWorkloadPreparationError(
           `managed image catalog contract for '${agent}' belongs to '${contract.source.release}', not '${expectedRelease}'`,
         );
@@ -365,11 +366,15 @@ export async function prepareSandboxWorkloadSource(
       acceptedCandidateContract,
     );
   } else {
+    const trustedCatalogRevision = input.catalogPath
+      ? (input.expectedCatalogRevision ?? null)
+      : null;
     const catalogIdentity = requireCompleteManagedImageCatalog(
       catalog,
       release,
       platform,
-      input.expectedCatalogRevision ?? input.catalogRevision ?? null,
+      trustedCatalogRevision ?? input.catalogRevision ?? null,
+      trustedCatalogRevision !== null,
     );
     release = catalogIdentity.release;
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Jetson E2E selects a managed-image catalog by a trusted publication revision. Workload preparation compared that catalog release with the candidate CLI release, so a valid cross-revision catalog failed before sandbox creation. This change carries the selected revision into final catalog validation and retains fail-closed revision and cohort checks.

E2E root cause: managed-image onboarding / pinned catalog validation / catalog release differs from candidate release
Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/32718093056 (run 32718093056, attempt 1)
Failed jobs: jetson-nvmap-gpu (https://github.com/NVIDIA/NemoClaw/actions/runs/32718093056/job/97408812954)
Signature: pinned catalog release `v0.0.114-7-ga8062233c` rejected against candidate release `v0.1.0`
Scope: one root cause

## Related Issue

Related to #8142.

## Changes

- Pass the immutable registry revision into complete catalog validation.
- Accept the catalog's release only after the exact revision and all-agent cohort validate.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This one-line handoff uses the existing exact-revision validator; the existing suite covers immutable revision resolution and fail-closed exact-catalog validation.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/sandbox-workload-preparation.test.ts` (30 passed).
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed-image catalog validation when a trusted revision is provided.
  * Catalogs fetched at an exact trusted revision are now accepted even when their release differs from the requested version.
  * Catalogs without a trusted revision continue to require a matching release.
  * Improved validation messages and handling for invalid catalog selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->