### PR TITLE
fix(onboard): accept revision-pinned legacy image release

### DIFF
--- a/src/lib/onboard/managed-image-catalog.test.ts
+++ b/src/lib/onboard/managed-image-catalog.test.ts
@@ -498,6 +498,31 @@ describe("managed image GHCR catalog", () => {
     ).toEqual(SHIPPED_MANAGED_IMAGE_AGENTS.map(() => publishedRelease));
   });
 
+  it("uses the requested release for a revision-pinned legacy latest label", async () => {
+    const fixture = catalogFixture({
+      openclaw: {
+        rootReference: REVISION,
+        labels: { "org.opencontainers.image.version": "latest" },
+      },
+      hermes: { labels: { "org.opencontainers.image.version": "latest" } },
+      "langchain-deepagents-code": {
+        labels: { "org.opencontainers.image.version": "latest" },
+      },
+    });
+
+    const catalog = await resolveManagedImageCatalogFromGhcr({
+      release: RELEASE,
+      revision: REVISION,
+      fetchImpl: fixture.fetchImpl,
+    });
+
+    expect(
+      SHIPPED_MANAGED_IMAGE_AGENTS.map(
+        (agent) => (catalog[agent] as { source: { release: string } }).source.release,
+      ),
+    ).toEqual(SHIPPED_MANAGED_IMAGE_AGENTS.map(() => RELEASE));
+  });
+
   it.each(["", "0.0.97", "latest"])(
     "rejects malformed image release label %j",
     async (release) => {

--- a/src/lib/onboard/managed-image/catalog.ts
+++ b/src/lib/onboard/managed-image/catalog.ts
@@ -443,6 +443,7 @@ function validateImageLabels(
   imageConfig: OciImageConfig,
   platform: ManagedImagePlatform,
   expectedRelease?: string,
+  revisionPinnedRelease?: string,
 ): {
   readonly cohort: ManagedImagePublicationCohort;
   readonly release: string;
@@ -475,8 +476,16 @@ function validateImageLabels(
   if (typeof cohort !== "string" || !COHORT_PATTERN.test(cohort)) {
     return invalid(`'${agent}' image publication cohort is not a supported identity`);
   }
-  const release = labels["org.opencontainers.image.version"];
-  if (typeof release !== "string" || !RELEASE_PATTERN.test(release)) {
+  const imageRelease = labels["org.opencontainers.image.version"];
+  // Older main publications used `latest` as metadata. Only an exact source
+  // revision can bind that legacy label to the requested release.
+  const release =
+    typeof imageRelease === "string" && RELEASE_PATTERN.test(imageRelease)
+      ? imageRelease
+      : imageRelease === "latest" && revisionPinnedRelease !== undefined
+        ? revisionPinnedRelease
+        : null;
+  if (release === null) {
     return invalid(`'${agent}' image release is not a supported release version`);
   }
   if (expectedRelease !== undefined && release !== expectedRelease) {
@@ -529,6 +538,7 @@ async function resolveManagedImageContractAtReferenceFromGhcr(options: {
     imageConfig,
     options.platform,
     options.expectedRelease,
+    options.expectedRevision === undefined ? undefined : release,
   );
   if (options.expectedCohort !== undefined && identity.cohort !== options.expectedCohort) {
     return invalid(`'${agent}' image publication cohort does not match the OpenClaw cohort`);


### PR DESCRIPTION
## Summary

Allow an exact revision-pinned managed-image lookup to consume legacy main publications whose version metadata is `latest`. Unpinned release aliases still reject `latest`, and the returned catalog remains bound to the requested revision, all-agent cohort, platform, and normalized CLI release.

## Changes

- Canonicalize a legacy `latest` image label to the requested release only when the resolver requires an exact source revision.
- Cover the real three-agent GHCR resolver path while retaining the existing unpinned `latest` rejection.
- This compatibility path is required by the Jetson `jetson-nvmap-gpu` consumer: the trusted successful publisher at `e38db201413b457614904187377ed9fd002d281d` has immutable revision and cohort labels but legacy `latest` version metadata. Changing only the later workload validator is insufficient because GHCR resolution rejects that metadata first.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 75 focused managed-image catalog and workload-preparation tests passed
- [ ] Applicable broad gate passed — not applicable; this is a bounded resolver validation change
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional evidence: the exact public `linux/arm64` catalog lookup for revision `e38db201413b457614904187377ed9fd002d281d` resolved OpenClaw, Hermes, and LangChain Deep Agents Code to one cohort and canonical release `v0.1.0` after this change. Failed Jetson run [32736036343](https://github.com/NVIDIA/NemoClaw/actions/runs/32736036343) recorded cleanup succeeded.

---
Signed-off-by: San Dang <sdang@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image catalog validation for revision-pinned releases.
  - Legacy `latest` image labels are now correctly associated with the requested release when validating a specific revision.
  - Prevented valid revision-pinned catalog entries from being rejected due to legacy release labeling.

- **Tests**
  - Added regression coverage for revision-pinned catalog resolution using legacy `latest` labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->