### PR TITLE
fix(onboard): scope input prompt to OpenClaw

### DIFF
--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -4950,12 +4950,12 @@ Set them before running `$$nemoclaw onboard`.
 | `NEMOCLAW_TRUSTED_PRIVATE_HOSTS` | comma-separated exact hostnames or IP literals | Allows operator-owned RFC1918, CGNAT, or IPv6 unique local destinations through supported inference, managed MCP, and custom-policy registration paths. Link-local metadata and other reserved ranges remain blocked; DNS resolution and exact address pinning remain active; wildcards are not supported. |
 | `NEMOCLAW_TRUSTED_PRIVATE_INFERENCE_HOSTS` | comma-separated exact hostnames or IP literals | Inference-only compatibility alias. Inference onboarding combines entries from this variable and `NEMOCLAW_TRUSTED_PRIVATE_HOSTS`. |
 | `NEMOCLAW_PREFERRED_API` | `completions` (currently the only honored value) | Forces the validation probe to use the `/v1/chat/completions` API path instead of the newer `/v1/responses` API. |
-| `NEMOCLAW_INFERENCE_INPUTS` | comma-separated list of `text` and/or `image` | Declares model input modalities for vision-capable models. Validated strictly; unknown tokens are ignored. |
 | `NEMOCLAW_OLLAMA_REQUIRE_TOOLS` | `0` to disable, anything else to keep the default | When set to `0`, skips the Ollama tool-calling capability check during local-inference onboarding. |
 | `NEMOCLAW_OLLAMA_INSTALL_MODE` | `system`, `user`, or empty/unset | Pins the Linux Ollama install location. Refer to the Linux Ollama install mode details below. |
 | `NEMOCLAW_PROXY_HOST` | hostname or IP | Overrides the sandbox-side outbound HTTP proxy host. Defaults to `10.200.0.1`. |
 | `NEMOCLAW_PROXY_PORT` | integer port | Overrides the sandbox-side outbound HTTP proxy port. Defaults to `3128`. |
 <AgentOnly variant="openclaw">
+| `NEMOCLAW_INFERENCE_INPUTS` | comma-separated list of `text` and/or `image` | OpenClaw only. Declares model input modalities. Unsupported or duplicate values are rejected. |
 | `NEMOCLAW_OPENCLAW_OTEL` | `1` to enable | Enables OpenClaw conversation diagnostics export through the `diagnostics-otel` plugin. Disabled by default. |
 | `NEMOCLAW_OPENCLAW_OTEL_ENDPOINT` | OTLP/HTTP URL | Sets the OpenTelemetry collector endpoint for OpenClaw diagnostics. Defaults to `http://host.openshell.internal:4318` when `NEMOCLAW_OPENCLAW_OTEL=1`. |
 | `NEMOCLAW_OPENCLAW_OTEL_SERVICE_NAME` | service name | Sets the OTEL `service.name` for OpenClaw gateway spans. Defaults to `openclaw-gateway`. |

--- a/src/lib/onboard/setup-nim-flow.test.ts
+++ b/src/lib/onboard/setup-nim-flow.test.ts
@@ -315,7 +315,8 @@ describe("createSetupNim", () => {
     expect(detectInferenceProviderHostState).not.toHaveBeenCalled();
   });
 
-  it("passes the Hermes Ollama context floor into local Ollama selection state (#6760)", async () => {
+  it("passes the Hermes Ollama context floor without showing the OpenClaw Input capability prompt (#6760)", async () => {
+    const maybePromptForInferenceInputCapability = vi.fn(async () => {});
     const handleRunningOllamaSelection = vi.fn<SetupNimFlowDeps["handleRunningOllamaSelection"]>(
       async (_gpu, _requestedModel, _recoveredModel, _ollamaRunning, state) => {
         expect(state.ollamaContextWindowFloor).toBe(MIN_HERMES_OLLAMA_CONTEXT_WINDOW);
@@ -335,6 +336,7 @@ describe("createSetupNim", () => {
         detectInferenceProviderHostState: () =>
           makeHostState({ hasOllama: true, ollamaHost: "127.0.0.1", ollamaRunning: true }),
         handleRunningOllamaSelection,
+        maybePromptForInferenceInputCapability,
       }),
     );
 
@@ -342,6 +344,7 @@ describe("createSetupNim", () => {
 
     expect(result.provider).toBe("ollama-local");
     expect(handleRunningOllamaSelection).toHaveBeenCalledTimes(1);
+    expect(maybePromptForInferenceInputCapability).not.toHaveBeenCalled();
   });
 
   it("reuses reachable Windows-host Ollama when PowerShell cannot find its executable (#7472)", async () => {

--- a/src/lib/onboard/setup-nim-flow.ts
+++ b/src/lib/onboard/setup-nim-flow.ts
@@ -241,6 +241,15 @@ export interface SetupNimFlowDeps {
   maybePromptForInferenceInputCapability(model: string | null): Promise<void>;
 }
 
+function maybePromptForSupportedInferenceInputCapability(
+  deps: Pick<SetupNimFlowDeps, "maybePromptForInferenceInputCapability">,
+  agent: AgentDefinition | null,
+  model: string | null,
+): Promise<void> {
+  if ((agent?.name ?? "openclaw") !== "openclaw") return Promise.resolve();
+  return deps.maybePromptForInferenceInputCapability(model);
+}
+
 function requireSelectedProvider(
   selected: ProviderMenuChoice | undefined,
   deps: Pick<SetupNimFlowDeps, "error" | "exitProcess">,
@@ -648,7 +657,7 @@ async function resolveFreshHermesPortableOllamaSelection(input: {
   state.preferredInferenceApi = "openai-completions";
   state.assertRouteCompatible?.();
   const selectedModel = isBackToSelection(state.model) ? null : state.model;
-  await input.deps.maybePromptForInferenceInputCapability(selectedModel);
+  await maybePromptForSupportedInferenceInputCapability(input.deps, input.agent, selectedModel);
   return {
     model: selectedModel,
     provider: state.provider,
@@ -1234,7 +1243,7 @@ export function createSetupNim(
       : endpointPinnedAddresses || endpointTrustedPrivateCapability
         ? "onboard"
         : null;
-    await deps.maybePromptForInferenceInputCapability(selectedModel);
+    await maybePromptForSupportedInferenceInputCapability(deps, agent, selectedModel);
     return {
       model: selectedModel,
       provider,

--- a/src/lib/onboard/setup-nim-portable-ollama.test.ts
+++ b/src/lib/onboard/setup-nim-portable-ollama.test.ts
@@ -65,11 +65,12 @@ describe("fresh Hermes Portable provider selection", () => {
     });
   });
 
-  it("uses the scoped Portable model before host discovery in interactive mode (#9596)", async () => {
+  it("uses the scoped Portable model without showing the OpenClaw Input capability prompt (#9596)", async () => {
     vi.stubEnv("NEMOCLAW_EXPERIMENTAL_PROFILE", "portable");
     const detectHostState = vi.fn(() => makeHostState());
     const handleRunningOllamaSelection = vi.fn(() => unexpected("host Ollama selection"));
     const handleInstallOllamaSelection = vi.fn(() => unexpected("host Ollama installation"));
+    const maybePromptForInferenceInputCapability = vi.fn(async () => {});
     const setupNim = createSetupNim(
       makeDeps({
         isNonInteractive: () => false,
@@ -78,6 +79,7 @@ describe("fresh Hermes Portable provider selection", () => {
         detectInferenceProviderHostState: detectHostState,
         handleRunningOllamaSelection,
         handleInstallOllamaSelection,
+        maybePromptForInferenceInputCapability,
       }),
     );
 
@@ -93,6 +95,7 @@ describe("fresh Hermes Portable provider selection", () => {
     expect(detectHostState).not.toHaveBeenCalled();
     expect(handleRunningOllamaSelection).not.toHaveBeenCalled();
     expect(handleInstallOllamaSelection).not.toHaveBeenCalled();
+    expect(maybePromptForInferenceInputCapability).not.toHaveBeenCalled();
   });
 
   it("prompts for a Portable model without discovering host runtimes (#9596)", async () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->

Before this change, interactive Hermes onboarding showed the OpenClaw **Input capability** prompt for model names that match the multimodal hint pattern. The prompt wrote an unsupported `NEMOCLAW_INFERENCE_INPUTS` value. The shared and Hermes Portable provider-selection paths now dispatch that prompt only for OpenClaw. Explicit non-empty values remain rejected for agents that do not support input modalities.

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

Fixes #10090

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->

- Limit input-capability prompt dispatch to OpenClaw in the Hermes Portable Ollama path and the shared provider-selection path.
- Preserve fail-closed managed startup profile validation for explicit unsupported input-modality settings.
- Add regression tests for the Hermes Portable and shared Hermes Ollama paths. Retain the existing OpenClaw prompt-dispatch assertion.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Prompt dispatch is OpenClaw-only. Explicit Hermes values remain rejected before sandbox creation. Credential, inference route, policy, and secret handling are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: This change does not modify `scripts/prepare-dgx-station-host.sh`.

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx --no-install vitest run --project cli src/lib/onboard/setup-nim-flow.test.ts src/lib/onboard/setup-nim-portable-ollama.test.ts -t 'announces detected Ollama|passes the Hermes Ollama context floor|uses the scoped Portable model'` passed 3 tests. `npx --no-install oxlint src/lib/onboard/setup-nim-flow.ts src/lib/onboard/setup-nim-flow.test.ts src/lib/onboard/setup-nim-portable-ollama.test.ts`, `npm run typecheck:cli`, `npm run build:cli`, `npm run format:check`, and `npm run test:titles:check` passed. `npm run docs` exited 0 with 0 errors; Fern reported 2 unrelated warnings for an unauthenticated redirect check and the existing light-mode accent contrast.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this change is confined to input-capability prompt dispatch, one reference-table row, and co-located regression tests.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Limited inference-input capability prompts to OpenClaw onboarding.
  - Other agent setup flows now skip irrelevant capability prompts.
  - Unsupported or duplicate inference-input values are rejected instead of ignored.

- **Documentation**
  - Clarified that the inference-input setting applies only to OpenClaw.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->