### PR TITLE
fix(policy): accept Hermes GPU baseline enrichment

### DIFF
--- a/src/lib/onboard/experimental/hermes-portable-onboarding.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-onboarding.test.ts
@@ -902,14 +902,14 @@ describe("Hermes portable onboarding transaction", () => {
 
   it("rejects a different allowed GPU policy enrichment after configuring publication (#10121)", async () => {
     fs.writeFileSync(policyPath, NATIVE_GPU_CREATE, { mode: 0o600 });
-    const first = deps({ failAfterRegistry: true, policySource: NATIVE_GPU_LIVE });
+    const first = deps({ updateFails: true, policySource: NATIVE_GPU_LIVE });
     await expect(runHermesPortableOnboardingTransaction(input(), first.value)).rejects.toThrow(
-      "registry-to-active exit",
+      "restart-policy update failed",
     );
+    expect(first.events).not.toContain("registry");
     fs.writeFileSync(policyPath, NATIVE_GPU_CREATE, { mode: 0o600 });
     const second = deps({
       existingSandbox: true,
-      existingRegistry: true,
       policySource: NATIVE_GPU_LIVE.replace("/dev/nvidia0", "/dev/nvidia1"),
     });
 

--- a/src/lib/onboard/experimental/hermes-portable-onboarding.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-onboarding.test.ts
@@ -45,6 +45,34 @@ import {
 let stateDir: string;
 let policyPath: string;
 
+const NATIVE_GPU_CREATE = `version: 1
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /etc
+    - /app
+    - /var/log
+    - /dev/urandom
+  read_write:
+    - /tmp
+network_policies:
+  inference:
+    name: inference
+    endpoints:
+      - host: inference.local
+        port: 443
+`;
+
+const NATIVE_GPU_LIVE = `${NATIVE_GPU_CREATE.replace(
+  "    - /dev/urandom\n",
+  "    - /dev/urandom\n    - /run/nvidia-persistenced\n    - /usr/lib/wsl\n",
+).replace(
+  "    - /tmp\n",
+  "    - /tmp\n    - /proc\n    - /dev/nvidiactl\n    - /dev/nvidia-uvm\n    - /dev/nvidia0\n",
+)}`;
+
 function interruptReceiptWrite(
   marker: Buffer,
   message: string,
@@ -870,6 +898,34 @@ describe("Hermes portable onboarding transaction", () => {
     expect(resumed.active.receipt.phase).toBe("active");
     expect(fixture.events.filter((event) => event === "create")).toHaveLength(1);
     expect(fixture.events.filter((event) => event === "registry")).toHaveLength(1);
+  });
+
+  it("rejects a different allowed GPU policy enrichment after configuring publication (#10121)", async () => {
+    fs.writeFileSync(policyPath, NATIVE_GPU_CREATE, { mode: 0o600 });
+    const first = deps({ failAfterRegistry: true, policySource: NATIVE_GPU_LIVE });
+    await expect(runHermesPortableOnboardingTransaction(input(), first.value)).rejects.toThrow(
+      "registry-to-active exit",
+    );
+    fs.writeFileSync(policyPath, NATIVE_GPU_CREATE, { mode: 0o600 });
+    const second = deps({
+      existingSandbox: true,
+      existingRegistry: true,
+      policySource: NATIVE_GPU_LIVE.replace("/dev/nvidia0", "/dev/nvidia1"),
+    });
+
+    await expect(runHermesPortableOnboardingTransaction(input(), second.value)).rejects.toThrow(
+      "live policy authority disagrees with the configured receipt",
+    );
+
+    expect(
+      second.podman.mock.calls.some(
+        ([args]) => Array.isArray(args) && args[0] === "container" && args[1] === "update",
+      ),
+    ).toBe(false);
+    expect(second.events).not.toContain("registry");
+    expect(
+      fs.existsSync(path.join(hermesPortableReceiptDirectory("alpha", stateDir), "active.json")),
+    ).toBe(false);
   });
 
   it("keeps a contender outside the lock through registry and active publication (#9203)", async () => {

--- a/src/lib/onboard/experimental/hermes-portable-onboarding.ts
+++ b/src/lib/onboard/experimental/hermes-portable-onboarding.ts
@@ -736,6 +736,12 @@ function proveLivePolicy(
   if (proof.intendedSemanticSha256 !== receipt.policy.intendedSemanticSha256) {
     fail("live policy proof disagrees with pending intent");
   }
+  if (
+    receipt.phase !== "pending" &&
+    proof.verifiedLivePolicySemanticSha256 !== receipt.verifiedLivePolicySemanticSha256
+  ) {
+    fail("live policy authority disagrees with the configured receipt");
+  }
   return proof.verifiedLivePolicySemanticSha256;
 }
 

--- a/src/lib/onboard/experimental/hermes-portable-policy-authority.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-policy-authority.test.ts
@@ -26,6 +26,56 @@ network_policies:
 version: 1
 `);
 
+const NATIVE_GPU_CREATE = Buffer.from(`version: 1
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /etc
+    - /app
+    - /var/log
+    - /dev/urandom
+  read_write:
+    - /tmp
+network_policies:
+  inference:
+    name: inference
+    endpoints:
+      - host: inference.local
+        port: 443
+`);
+
+const NATIVE_GPU_LIVE = Buffer.from(`version: 1
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /etc
+    - /app
+    - /var/log
+    - /dev/urandom
+    - /run/nvidia-persistenced
+    - /usr/lib/wsl
+  read_write:
+    - /tmp
+    - /proc
+    - /dev/nvidiactl
+    - /dev/nvidia-uvm
+    - /dev/nvidia-uvm-tools
+    - /dev/nvidia-modeset
+    - /dev/dxg
+    - /dev/nvidia0
+    - /dev/nvidia1
+network_policies:
+  inference:
+    name: inference
+    endpoints:
+      - host: inference.local
+        port: 443
+`);
+
 function result(
   stdout: Buffer,
   status = 0,
@@ -60,6 +110,72 @@ describe("Hermes portable policy authority", () => {
       [["policy", "get", "-g", "nemoclaw", "--base", "alpha"]],
       [["policy", "get", "-g", "nemoclaw", "--full", "alpha"]],
     ]);
+  });
+
+  it("accepts only OpenShell's documented native-GPU baseline enrichment (#10121)", () => {
+    const capture = vi.fn(() => result(NATIVE_GPU_LIVE));
+
+    const proof = proveHermesPortableLivePolicy({
+      gatewayName: "nemoclaw",
+      sandboxName: "alpha",
+      createPolicyBytes: NATIVE_GPU_CREATE,
+      capture,
+    });
+
+    expect(proof.verifiedLivePolicySemanticSha256).not.toBe(proof.intendedSemanticSha256);
+    expect(capture).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      label: "an arbitrary added path",
+      create: NATIVE_GPU_CREATE,
+      live: NATIVE_GPU_LIVE.toString("utf8").replace("    - /dev/nvidia0\n", "    - /home\n"),
+    },
+    {
+      label: "an intended path removal",
+      create: NATIVE_GPU_CREATE,
+      live: NATIVE_GPU_LIVE.toString("utf8").replace("    - /usr\n", ""),
+    },
+    {
+      label: "a non-filesystem change",
+      create: NATIVE_GPU_CREATE,
+      live: NATIVE_GPU_LIVE.toString("utf8").replace("port: 443", "port: 8443"),
+    },
+    {
+      label: "a near-match GPU device path",
+      create: NATIVE_GPU_CREATE,
+      live: NATIVE_GPU_LIVE.toString("utf8").replace("/dev/nvidia0", "/dev/nvidia0/escape"),
+    },
+    {
+      label: "a duplicate live path",
+      create: NATIVE_GPU_CREATE,
+      live: NATIVE_GPU_LIVE.toString("utf8").replace(
+        "    - /dev/nvidia0\n",
+        "    - /dev/nvidia0\n    - /dev/nvidia0\n",
+      ),
+    },
+    {
+      label: "GPU additions without the documented /proc promotion",
+      create: NATIVE_GPU_CREATE,
+      live: NATIVE_GPU_LIVE.toString("utf8").replace("    - /proc\n", ""),
+    },
+    {
+      label: "GPU enrichment of an ordinary policy",
+      create: Buffer.from(
+        NATIVE_GPU_CREATE.toString("utf8").replace("    - /etc\n", "    - /etc\n    - /proc\n"),
+      ),
+      live: NATIVE_GPU_LIVE.toString("utf8"),
+    },
+  ])("rejects $label as unproven policy drift (#10121)", ({ create, live }) => {
+    expect(() =>
+      proveHermesPortableLivePolicy({
+        gatewayName: "nemoclaw",
+        sandboxName: "alpha",
+        createPolicyBytes: Buffer.isBuffer(create) ? create : Buffer.from(create),
+        capture: () => result(Buffer.from(live)),
+      }),
+    ).toThrow("base policy disagrees");
   });
 
   it("rejects a reserved provider entry in the exact create input (#9203)", () => {

--- a/src/lib/onboard/experimental/hermes-portable-policy-authority.ts
+++ b/src/lib/onboard/experimental/hermes-portable-policy-authority.ts
@@ -11,6 +11,26 @@ import { parseOpenShellPolicy } from "../../policy/merge";
 const UTF8 = new TextDecoder("utf-8", { fatal: true });
 const MAX_POLICY_BYTES = 256 * 1024;
 const NAME = /^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/u;
+const PROC_PATH = "/proc";
+const OPENSHELL_PROXY_REQUIRED_READ_ONLY_PATHS = new Set([
+  "/usr",
+  "/lib",
+  "/etc",
+  "/app",
+  "/var/log",
+  "/dev/urandom",
+]);
+const OPENSHELL_PROXY_REQUIRED_READ_WRITE_PATHS = new Set(["/tmp"]);
+const OPENSHELL_GPU_READ_ONLY_PATHS = new Set(["/run/nvidia-persistenced", "/usr/lib/wsl"]);
+const OPENSHELL_GPU_READ_WRITE_PATHS = new Set([
+  "/dev/nvidiactl",
+  "/dev/nvidia-uvm",
+  "/dev/nvidia-uvm-tools",
+  "/dev/nvidia-modeset",
+  "/dev/dxg",
+  PROC_PATH,
+]);
+const OPENSHELL_GPU_DEVICE_PATH = /^\/dev\/nvidia[0-9]+$/u;
 
 export interface HermesPortablePolicyCaptureResult {
   readonly status: number | null;
@@ -112,6 +132,113 @@ function semanticDigest(policy: Record<string, unknown>): string {
     .digest("hex");
 }
 
+function policyWithoutFilesystemPolicy(policy: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = Object.create(null);
+  for (const key of Object.keys(policy)) {
+    if (key !== "filesystem_policy") result[key] = policy[key];
+  }
+  return result;
+}
+
+function filesystemPolicyWithoutPaths(policy: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = Object.create(null);
+  for (const key of Object.keys(policy)) {
+    if (key !== "read_only" && key !== "read_write") result[key] = policy[key];
+  }
+  return result;
+}
+
+function readUniquePaths(
+  policy: Record<string, unknown>,
+  key: "read_only" | "read_write",
+): Set<string> | null {
+  const value = policy[key];
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) return null;
+  const paths = new Set(value);
+  return paths.size === value.length ? paths : null;
+}
+
+function isSubset(subset: ReadonlySet<string>, superset: ReadonlySet<string>): boolean {
+  return [...subset].every((entry) => superset.has(entry));
+}
+
+function setsOverlap(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  return [...left].some((entry) => right.has(entry));
+}
+
+function isOpenShellNativeGpuBaselineEnrichment(
+  intended: Record<string, unknown>,
+  live: Record<string, unknown>,
+): boolean {
+  if (
+    semanticDigest(policyWithoutFilesystemPolicy(intended)) !==
+    semanticDigest(policyWithoutFilesystemPolicy(live))
+  ) {
+    return false;
+  }
+  const intendedFilesystem = intended.filesystem_policy;
+  const liveFilesystem = live.filesystem_policy;
+  if (
+    !intendedFilesystem ||
+    typeof intendedFilesystem !== "object" ||
+    Array.isArray(intendedFilesystem) ||
+    !liveFilesystem ||
+    typeof liveFilesystem !== "object" ||
+    Array.isArray(liveFilesystem)
+  ) {
+    return false;
+  }
+  const intendedFilesystemRecord = intendedFilesystem as Record<string, unknown>;
+  const liveFilesystemRecord = liveFilesystem as Record<string, unknown>;
+  if (
+    semanticDigest(filesystemPolicyWithoutPaths(intendedFilesystemRecord)) !==
+    semanticDigest(filesystemPolicyWithoutPaths(liveFilesystemRecord))
+  ) {
+    return false;
+  }
+  const intendedReadOnly = readUniquePaths(intendedFilesystemRecord, "read_only");
+  const intendedReadWrite = readUniquePaths(intendedFilesystemRecord, "read_write");
+  const liveReadOnly = readUniquePaths(liveFilesystemRecord, "read_only");
+  const liveReadWrite = readUniquePaths(liveFilesystemRecord, "read_write");
+  if (!intendedReadOnly || !intendedReadWrite || !liveReadOnly || !liveReadWrite) return false;
+  if (
+    setsOverlap(intendedReadOnly, intendedReadWrite) ||
+    setsOverlap(liveReadOnly, liveReadWrite)
+  ) {
+    return false;
+  }
+
+  // The native direct-GPU create policy deliberately omits /proc so OpenShell
+  // can add it read-write only after it observes the GPU devices. Treat that
+  // exact omission as the authority signal; ordinary/non-GPU policies retain
+  // /proc read-only and cannot use this exception.
+  if (intendedReadOnly.has(PROC_PATH) || intendedReadWrite.has(PROC_PATH)) return false;
+  if (
+    !isSubset(OPENSHELL_PROXY_REQUIRED_READ_ONLY_PATHS, intendedReadOnly) ||
+    !isSubset(OPENSHELL_PROXY_REQUIRED_READ_WRITE_PATHS, intendedReadWrite)
+  ) {
+    return false;
+  }
+  if (liveReadOnly.has(PROC_PATH) || !liveReadWrite.has(PROC_PATH)) return false;
+  if (!isSubset(intendedReadOnly, liveReadOnly) || !isSubset(intendedReadWrite, liveReadWrite)) {
+    return false;
+  }
+
+  for (const path of liveReadOnly) {
+    if (!intendedReadOnly.has(path) && !OPENSHELL_GPU_READ_ONLY_PATHS.has(path)) return false;
+  }
+  for (const path of liveReadWrite) {
+    if (
+      !intendedReadWrite.has(path) &&
+      !OPENSHELL_GPU_READ_WRITE_PATHS.has(path) &&
+      !OPENSHELL_GPU_DEVICE_PATH.test(path)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function rejectReservedCreateEntries(policy: Record<string, unknown>): void {
   const policies = policy.network_policies;
   if (!policies || typeof policies !== "object" || Array.isArray(policies)) return;
@@ -120,11 +247,15 @@ function rejectReservedCreateEntries(policy: Record<string, unknown>): void {
   }
 }
 
-/** Capture and bind the exact create-policy bytes before sandbox creation. */
-export function hermesPortableCreatePolicySemanticDigest(bytes: Buffer): string {
+function parseCreatePolicy(bytes: Buffer): Record<string, unknown> {
   const policy = parseOnePolicyDocument(decode(bytes, "create input"), "create input");
   rejectReservedCreateEntries(policy);
-  return semanticDigest(policy);
+  return policy;
+}
+
+/** Capture and bind the exact create-policy bytes before sandbox creation. */
+export function hermesPortableCreatePolicySemanticDigest(bytes: Buffer): string {
+  return semanticDigest(parseCreatePolicy(bytes));
 }
 
 function capturePolicy(
@@ -154,7 +285,8 @@ export function proveHermesPortableLivePolicy(input: {
   if (!NAME.test(input.gatewayName) || !NAME.test(input.sandboxName)) {
     fail("gateway or sandbox identity is invalid");
   }
-  const intendedSemanticSha256 = hermesPortableCreatePolicySemanticDigest(input.createPolicyBytes);
+  const intended = parseCreatePolicy(input.createPolicyBytes);
+  const intendedSemanticSha256 = semanticDigest(intended);
   const prefix = ["policy", "get", "-g", input.gatewayName] as const;
   const base = capturePolicy(
     input.capture,
@@ -168,7 +300,12 @@ export function proveHermesPortableLivePolicy(input: {
   );
   const baseDigest = semanticDigest(base);
   const fullDigest = semanticDigest(full);
-  if (baseDigest !== intendedSemanticSha256) fail("scoped base policy disagrees with create input");
+  if (
+    baseDigest !== intendedSemanticSha256 &&
+    !isOpenShellNativeGpuBaselineEnrichment(intended, base)
+  ) {
+    fail("scoped base policy disagrees with create input");
+  }
   if (fullDigest !== baseDigest) {
     fail("scoped full policy contains an unproven provider-composed or out-of-band delta");
   }
@@ -178,4 +315,7 @@ export function proveHermesPortableLivePolicy(input: {
   };
 }
 
-export const hermesPortablePolicyAuthorityInternals = { semanticDigest };
+export const hermesPortablePolicyAuthorityInternals = {
+  isOpenShellNativeGpuBaselineEnrichment,
+  semanticDigest,
+};


### PR DESCRIPTION
## Summary

Hermes Portable previously rejected the live policy after OpenShell added its documented native-GPU filesystem baseline. This change accepts only that bounded enrichment while preserving strict rejection of unrelated policy drift.

## Related Issue

Fixes #10121

## Changes

- Recognize the OpenShell v0.0.106 native-GPU baseline as a semantic enrichment of the exact create policy.
- Require the direct-GPU authority signal, preserve every intended path, allow only documented GPU paths, and keep scoped base/full policy equality mandatory.
- Continue recording distinct intended and verified-live semantic digests for receipt and lifecycle revalidation.
- Add deterministic acceptance and fail-closed drift regressions, including arbitrary paths, removed paths, non-filesystem changes, near matches, duplicates, missing `/proc` promotion, and ordinary-policy misuse.
- No documentation change is required because CLI syntax, output, and supported configuration are unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: fail-closed exact-allowlist review completed; no credential, command, transport, dependency, network, or cleanup boundary changed.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: 3 affected Vitest files, 89 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Additional verification: `npm run build:cli`, `npm run typecheck:cli`, `npm run checks:repository`, Oxlint, Prettier, diff checks, and all commit/push hooks passed.

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for validating native GPU policy configurations with approved filesystem and device access paths.
  - GPU-specific policy enrichment is accepted only when it matches the documented configuration.

- **Bug Fixes**
  - Improved validation to reject unexpected additions, removals, duplicates, near-match paths, and unrelated changes.
  - Prevented GPU access rules from being applied to ordinary policies.
  - Added checks to detect live policy changes that differ from the configured policy.
  - Prevented invalid GPU policy updates from being applied after a failed restart-policy update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->