### PR TITLE
fix(cli): show documented <name> action grammar in sandbox --help text

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "target": "./dist/commands"
     },
     "flexibleTaxonomy": true,
+    "helpClass": "./dist/lib/cli/nemoclaw-sandbox-help.js",
     "topicSeparator": " "
   },
   "scripts": {

--- a/src/commands/sandbox/exec.ts
+++ b/src/commands/sandbox/exec.ts
@@ -19,9 +19,9 @@ export default class SandboxExecCommand extends NemoClawCommand {
     "<name> [--workdir <dir>] [--tty|--no-tty] [--timeout <s>] [--stdin|--no-stdin] -- <cmd> [args...]",
   ];
   static examples = [
-    "<%= config.bin %> sandbox exec alpha -- openclaw agent --agent main -m hi",
-    "<%= config.bin %> sandbox exec alpha --workdir /sandbox -- ls -la",
-    "printf 'hello' | <%= config.bin %> sandbox exec alpha --stdin -- cat",
+    "<%= config.bin %> alpha exec -- openclaw agent --agent main -m hi",
+    "<%= config.bin %> alpha exec --workdir /sandbox -- ls -la",
+    "printf 'hello' | <%= config.bin %> alpha exec --stdin -- cat",
   ];
   static args = {
     sandboxName: Args.string({ name: "sandbox", description: "Sandbox name", required: true }),

--- a/src/lib/cli/nemoclaw-sandbox-help.test.ts
+++ b/src/lib/cli/nemoclaw-sandbox-help.test.ts
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Command, Interfaces } from "@oclif/core";
+import { describe, expect, it } from "vitest";
+import { SandboxScopedCommandHelp } from "./nemoclaw-sandbox-help";
+
+class TestableHelp extends SandboxScopedCommandHelp {
+  public callUsage(): string {
+    return this.usage();
+  }
+}
+
+function makeConfig(topicSeparator: string): Interfaces.Config {
+  return { bin: "nemoclaw", topicSeparator } as unknown as Interfaces.Config;
+}
+
+function makeCommand(id: string, usage: string | string[] | undefined): Command.Loadable {
+  return { id, usage } as unknown as Command.Loadable;
+}
+
+const opts = { maxWidth: 80, stripAnsi: false } as unknown as Interfaces.HelpOptions;
+
+describe("SandboxScopedCommandHelp", () => {
+  it("moves the action verb after <name> for a sandbox: id (unmutated colon form)", () => {
+    const help = new TestableHelp(
+      makeCommand("sandbox:exec", ["<name> [--workdir <dir>] -- <cmd>"]),
+      makeConfig(" "),
+      opts,
+    );
+    expect(help.callUsage()).toBe("$ nemoclaw <name> exec [--workdir <dir>] -- <cmd>");
+  });
+
+  it("still resolves the action when Help.formatCommand already rewrote id's colons to the topic separator", () => {
+    // Help.formatCommand mutates command.id's `:` to the configured topicSeparator
+    // before handing the command to this class (#10095's actual failure mode).
+    const help = new TestableHelp(
+      makeCommand("sandbox exec", ["<name> [--workdir <dir>] -- <cmd>"]),
+      makeConfig(" "),
+      opts,
+    );
+    expect(help.callUsage()).toBe("$ nemoclaw <name> exec [--workdir <dir>] -- <cmd>");
+  });
+
+  it("joins nested subcommand ids with a space", () => {
+    const help = new TestableHelp(
+      makeCommand("sandbox:share:mount", ["<name> [sandbox-path] [local-mount-point]"]),
+      makeConfig(" "),
+      opts,
+    );
+    expect(help.callUsage()).toBe(
+      "$ nemoclaw <name> share mount [sandbox-path] [local-mount-point]",
+    );
+  });
+
+  it("falls back to default rendering for a usage line that does not start with <name>", () => {
+    const help = new TestableHelp(
+      makeCommand("sandbox:share", ["<mount|unmount|status> <name>"]),
+      makeConfig(" "),
+      opts,
+    );
+    expect(help.callUsage()).toContain("$ nemoclaw sandbox:share <mount|unmount|status> <name>");
+  });
+
+  it("falls back to default rendering for a non-sandbox command", () => {
+    const help = new TestableHelp(
+      makeCommand("onboard", ["[--profile <name>]"]),
+      makeConfig(" "),
+      opts,
+    );
+    expect(help.callUsage()).toContain("$ nemoclaw onboard [--profile <name>]");
+  });
+
+  it("falls back to default rendering when the command declares no usage", () => {
+    const help = new TestableHelp(makeCommand("sandbox:status", undefined), makeConfig(" "), opts);
+    expect(help.callUsage()).not.toContain("undefined");
+  });
+
+  it("wraps a usage line longer than the allowed width, same as oclif's default", () => {
+    const longUsage =
+      "<name> [--yes|-y|--force] [--verbose|-v] [--tool-disclosure <progressive|direct>] [--dcode-auto-approval <disabled|thread-opt-in>] [--observability|--no-observability]";
+    const help = new TestableHelp(
+      makeCommand("sandbox:rebuild", [longUsage]),
+      makeConfig(" "),
+      opts,
+    );
+    const result = help.callUsage();
+    const lines = result.split("\n");
+    expect(result).toContain("$ nemoclaw <name> rebuild");
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines.every((line) => line.length <= opts.maxWidth)).toBe(true);
+  });
+});

--- a/src/lib/cli/nemoclaw-sandbox-help.ts
+++ b/src/lib/cli/nemoclaw-sandbox-help.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CommandHelp, Help, toStandardizedId } from "@oclif/core";
+import type { Interfaces } from "@oclif/core";
+
+const SANDBOX_TOPIC_PREFIX = "sandbox:";
+const SANDBOX_NAME_PLACEHOLDER = "<name>";
+
+/**
+ * NemoClaw's permanent product grammar is `nemoclaw <name> <action>`, while
+ * every sandbox-scoped command's internal oclif id is `sandbox:<action>`
+ * (`sandbox:agents:add` etc). oclif's default usage formatter unconditionally
+ * renders the id-derived prefix ("sandbox <action>") ahead of any custom
+ * `usage` string, so `--help` shows the internal form instead of the
+ * documented one for every one of these commands (#10095). Only usage lines
+ * that start with the `<name>` placeholder are rewritten; anything else
+ * falls back to oclif's default rendering unchanged.
+ *
+ * `Help.formatCommand` rewrites `command.id`'s `:` separators to the
+ * configured `topicSeparator` (a space, here) before handing the command to
+ * this class, so the id can arrive as either `sandbox:exec` or
+ * `sandbox exec` depending on the caller. Standardize back to `:` first.
+ */
+function sandboxCommandAction(id: string | undefined, config: Interfaces.Config): string | null {
+  if (!id) return null;
+  const standardized = toStandardizedId(id, config);
+  if (!standardized.startsWith(SANDBOX_TOPIC_PREFIX)) return null;
+  const action = standardized.slice(SANDBOX_TOPIC_PREFIX.length).replaceAll(":", " ").trim();
+  return action.length > 0 ? action : null;
+}
+
+export class SandboxScopedCommandHelp extends CommandHelp {
+  protected usage(): string {
+    const action = sandboxCommandAction(this.command.id, this.config);
+    const rawUsage = this.command.usage;
+    if (!action || !rawUsage) return super.usage();
+
+    const lines = Array.isArray(rawUsage) ? rawUsage : [rawUsage];
+    if (lines.length === 0 || !lines.every((line) => line.startsWith(SANDBOX_NAME_PLACEHOLDER))) {
+      return super.usage();
+    }
+
+    const allowedSpacing = this.opts.maxWidth - this.indentSpacing;
+    return lines
+      .map((line) => {
+        const rest = line.slice(SANDBOX_NAME_PLACEHOLDER.length).trim();
+        const full = `$ ${this.config.bin} ${SANDBOX_NAME_PLACEHOLDER} ${action}${rest ? ` ${rest}` : ""}`;
+        if (full.length > allowedSpacing) {
+          const splitIndex = full.slice(0, Math.max(0, allowedSpacing)).lastIndexOf(" ");
+          return (
+            full.slice(0, Math.max(0, splitIndex)) +
+            "\n" +
+            this.indent(this.wrap(full.slice(Math.max(0, splitIndex)), this.indentSpacing * 2))
+          );
+        }
+        return this.wrap(full);
+      })
+      .join("\n");
+  }
+}
+
+export class NemoClawHelp extends Help {
+  protected CommandHelpClass = SandboxScopedCommandHelp;
+}
+
+export default NemoClawHelp;

--- a/test/package-contract/cli/sandbox-command-help.test.ts
+++ b/test/package-contract/cli/sandbox-command-help.test.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `nemoclaw <name> exec --help` must show the documented grammar
+ * (`nemoclaw <name> exec ...`), not oclif's internal topic:command id form
+ * (`nemoclaw sandbox exec <name> ...`) (#10095).
+ *
+ * Drives the real `oclif.helpClass` wired in package.json through
+ * `loadHelpClass`, the same entry point oclif itself uses for `--help`, so
+ * this proves the package.json wiring and the Help class together.
+ */
+
+import { type Command, Config as OclifConfig, Help, loadHelpClass } from "@oclif/core";
+import { describe, expect, it } from "vitest";
+
+async function renderCommandHelp(id: string): Promise<string> {
+  const config = await OclifConfig.load(process.cwd());
+  // Asserted, not guarded: a missing id is a broken test fixture, and the
+  // resulting TypeError names the id-lookup line directly.
+  const loadable = config.commands.find((command) => command.id === id) as Command.Loadable;
+  // loadHelpClass reads config.pjson.oclif.helpClass, the same entry point oclif
+  // uses for --help; ExposedHelp only republishes its protected formatCommand
+  // for the assertion below, it does not change what gets rendered.
+  const HelpClass = (await loadHelpClass(config)) as typeof Help;
+  class ExposedHelp extends HelpClass {
+    public renderCommand(command: Command.Loadable): string {
+      return this.formatCommand(command);
+    }
+  }
+  const help = new ExposedHelp(config);
+  return help.renderCommand(loadable);
+}
+
+describe("sandbox command --help grammar", () => {
+  it("renders the documented <name> exec form, not the internal sandbox exec <name> form", async () => {
+    const text = await renderCommandHelp("sandbox:exec");
+    expect(text).toContain("$ nemoclaw <name> exec");
+    expect(text).not.toContain("$ nemoclaw sandbox exec <name>");
+  });
+
+  it("rewrites every affected sandbox-scoped command, not just exec", async () => {
+    const text = await renderCommandHelp("sandbox:policy:restore");
+    expect(text).toContain("$ nemoclaw <name> policy restore");
+    expect(text).not.toContain("$ nemoclaw sandbox policy restore <name>");
+  });
+
+  it("leaves a non-sandbox command's usage untouched", async () => {
+    const text = await renderCommandHelp("onboard");
+    expect(text).toContain("USAGE");
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
`nemoclaw <name> exec --help` (and every other sandbox-scoped command's `--help`) showed the internal oclif form `nemoclaw sandbox exec <name> ...` instead of the documented `nemoclaw <name> exec ...`. oclif's default usage formatter always prepends the internal `sandbox:<action>` topic-id ahead of any custom `usage` string, so no per-command override could fix it. This adds a small custom Help class, wired through `package.json`'s `oclif.helpClass`, that rewrites the USAGE line for every affected command in one place.

## Related Issue
Fixes #10095

## Changes
- `src/lib/cli/nemoclaw-sandbox-help.ts` (new): `SandboxScopedCommandHelp` overrides oclif's `usage()` for `sandbox:*` commands whose usage starts with the `<name>` placeholder, moving the action verb (e.g. `exec`, `share mount`) after `<name>` instead of before it. Anything that doesn't match that shape (e.g. `sandbox share`'s `<mount|unmount|status> <name>` grammar, or a non-sandbox command) falls back to oclif's default rendering unchanged.
- `package.json`: wires the class via `oclif.helpClass`, the officially supported oclif extension point.
- `src/commands/sandbox/exec.ts`: fixes the EXAMPLES section, which hardcoded the internal `sandbox exec alpha` form.

This fixes the USAGE line for every sandbox-scoped command (~50), since the root cause is in the shared formatter, not `exec` specifically. It does not rewrite every command's EXAMPLES text — most of those are hand-authored per-command copy that predates and is independent of this defect (some, like `status.ts`, already show the correct form alongside an internal-form alias). `exec.ts` is fixed because its examples were wholly wrong and directly part of the reported repro.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
Not applicable — no changes to `scripts/prepare-dgx-station-host.sh`.

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/cli/nemoclaw-sandbox-help.test.ts --project package-contract test/package-contract/cli/sandbox-command-help.test.ts` → 22/22 passed; real CLI spot check `node bin/nemoclaw.js alpha exec --help` shows `$ nemoclaw <name> exec ...`
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Proof
Real `--help` output, before and after, on `sandbox:exec`:
```
# before
USAGE
  $ nemoclaw sandbox exec <name> [--workdir <dir>] [--tty|--no-tty]
    [--timeout <s>] [--stdin|--no-stdin] -- <cmd> [args...]

# after
USAGE
  $ nemoclaw <name> exec [--workdir <dir>] [--tty|--no-tty] [--timeout <s>]
    [--stdin|--no-stdin] -- <cmd> [args...]
```
Spot-checked `sandbox:status`, `sandbox:policy:restore`, `sandbox:channels:add`, `sandbox:snapshot:create`, `sandbox:hosts:add` — all now show the `<name> <action>` form. `nemoclaw --help`, `nemoclaw onboard --help`, and `sandbox share --help` (the one command whose usage grammar doesn't start with `<name>`) render unchanged.

Baseline comparison against `origin/main`: `npx vitest run --project package-contract` gives 37/38 files passing both before and after this change, with the one pre-existing failure (`onboard-stdin-eof.test.ts`, a host Python `os.waitstatus_to_exitcode` issue unrelated to this diff) identical in both runs. `npm run checks:repository`, `oxlint`, and `biome check` are clean on the changed files.

### Known limitation
EXAMPLES text for other sandbox commands is not touched — it's independent per-command copy, some already correct, and rewriting all of it is a separate documentation-content sweep outside this defect's scope.

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>

P.S. — you should hire me. 115+ contributions to open source: https://github.com/harjothkhara
