### PR TITLE
refactor(test): group process recovery coverage

### DIFF
--- a/internal/security-reviews/openshell-0.0.71-gateway-auth-review.mdx
+++ b/internal/security-reviews/openshell-0.0.71-gateway-auth-review.mdx
@@ -38,7 +38,7 @@ Scope: NemoClaw Docker-driver gateway config generated for OpenShell `0.0.71`.
   Source boundary is the Hermes image entrypoint and `validate-hermes-env-secret-boundary.py`; NemoClaw re-runs that source validator through the topology-specific gateway controller before recovery/probe paths can succeed.
   The direct root-entrypoint supervisor validates the boundary in `agents/hermes/start.sh`, while the OpenShell-managed topology validates it in `scripts/managed-gateway-control.py`; both surface typed failures through the root-only gateway-control path.
   This PR cannot retroactively bake the validator into already-created older Hermes sandbox images, so missing-validator recovery fails closed with a re-image instruction instead of claiming the boundary was checked.
-  Regression coverage lives in `test/process-recovery.test.ts`, `test/managed-gateway-control.test.ts`, and `test/hermes-gateway-supervisor-recovery.test.ts`.
+  Regression coverage lives in `test/process-recovery/process-recovery.test.ts`, `test/managed-gateway-control.test.ts`, and `test/hermes-gateway-supervisor-recovery.test.ts`.
   Remove the NemoClaw recovery-side checks when every supported Hermes topology exposes a stable recovery entrypoint that always re-enters the validator.
 - Gateway JWT generation lock recovery: invalid state is a crashed NemoClaw process leaving `.jwt-generating` behind after taking the exclusive host-side bundle-generation lock.
   The source boundary is NemoClaw's own atomic JWT bundle writer; OpenShell consumes the resulting paths but does not own this lock, so the source fix belongs here.
@@ -49,7 +49,7 @@ Scope: NemoClaw Docker-driver gateway config generated for OpenShell `0.0.71`.
   Remove the lock and its recovery together if JWT bundle generation moves into OpenShell or to an OS-backed locking primitive.
 - Authenticated sandbox gateway recovery completion: invalid state is treating markerless OpenShell sandbox exec output as proof that a built-in gateway started.
   NemoClaw accepts built-in recovery only when the topology-specific controller emits a `GATEWAY_PID=` completion marker and the managed health probe passes.
-  Regression coverage lives in `test/process-recovery.test.ts` and `test/process-recovery-managed-controller.test.ts`.
+  Regression coverage lives in `test/process-recovery/process-recovery.test.ts` and `test/process-recovery/process-recovery-managed-controller.test.ts`.
   Remove the completion parser when OpenShell provides a stable machine-readable controller response.
 - Sessions admin gateway RPC helper: invalid state is a host CLI session reset/delete action that needs OpenClaw backend/operator scope while preserving gateway token, loopback, and auto-pair boundaries.
   Source boundary is OpenClaw's gateway-runtime API; NemoClaw's helper is limited to `sessions.reset` and `sessions.delete`.

--- a/src/lib/actions/sandbox/forward-recovery.ts
+++ b/src/lib/actions/sandbox/forward-recovery.ts
@@ -311,7 +311,7 @@ export function ensureSandboxPortForwardForPort(
   // its result is accepted below only after the list reports the exact target
   // owner. An unavailable list and forced bind replacement remain fail-closed.
   // NemoClaw must compensate while the supported OpenShell 0.0.85
-  // contract remains supported; test/process-recovery.test.ts locks both the
+  // contract remains supported; test/process-recovery/process-recovery.test.ts locks both the
   // delayed-release and fail-closed cases. Remove this wait only after every
   // supported OpenShell release either waits for host-listener release before
   // `forward stop` returns or exposes an authoritative listener-released state

--- a/test/README.md
+++ b/test/README.md
@@ -28,6 +28,7 @@ The project globs in `vitest.config.ts` must remain disjoint and exhaustive.
 
 Choose the execution lane from the boundary that the test exercises.
 Within the integration project, group new tests by the behavior that owns the assertion.
+For example, `process-recovery/` owns sandbox process and forward recovery coverage.
 Do not put an ordinary integration test in `e2e/` or `package-contract/`.
 
 Run `npm run test:projects:check` after adding or moving a test.

--- a/test/cli-coverage-sequencer.test.ts
+++ b/test/cli-coverage-sequencer.test.ts
@@ -117,9 +117,9 @@ describe("stable CLI coverage sharding", () => {
     expect(Object.fromEntries(owners)).toEqual({
       "cli:src/lib/example.test.ts": 6,
       "e2e-support:test/e2e/support/example.test.ts": 8,
-      "integration:test/hermes-restart-config-seal-write-lock.test.ts": 8,
-      "integration:test/local-credential-helper-fields.test.ts": 3,
-      "integration:test/regular-0.test.ts": 8,
+      "integration:test/hermes-restart-config-seal-write-lock.test.ts": 4,
+      "integration:test/local-credential-helper-fields.test.ts": 7,
+      "integration:test/regular-0.test.ts": 4,
     });
   });
 

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -191,7 +191,7 @@
         "test/managed-gateway-control.test.ts",
         "test/nemoclaw-start-guard-recovery.test.ts",
         "test/e2e/support/gateway-guard-legacy-keepalive-fixture.test.ts",
-        "test/process-recovery-supervisor-relaunch.test.ts"
+        "test/process-recovery/process-recovery-supervisor-relaunch.test.ts"
       ]
     },
     {

--- a/test/helpers/cli-coverage-sequencer.ts
+++ b/test/helpers/cli-coverage-sequencer.ts
@@ -42,7 +42,7 @@ const cliCoverageProjects = new Set(["cli", "integration", "e2e-support"]);
 // Integration coverage is serialized, so it needs an independent salt instead
 // of relying on combined weight from the parallel CLI and E2E-support lanes.
 const stableShardSalt = "7257";
-const integrationShardSalt = "6941";
+const integrationShardSalt = "12432";
 const e2eSupportShardSalt = "13930";
 // Only measured outliers are stored; new and ordinary files share the
 // conservative fallback used to estimate each stable shard's load.

--- a/test/process-recovery/process-recovery-custom-agent.test.ts
+++ b/test/process-recovery/process-recovery-custom-agent.test.ts
@@ -10,8 +10,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const requireSource = createRequire(import.meta.url);
 const { checkAndRecoverSandboxProcesses: checkAndRecoverSandboxProcessesImpl } = requireSource(
-  "../src/lib/actions/sandbox/process-recovery.ts",
-) as typeof import("../src/lib/actions/sandbox/process-recovery.js");
+  "../../src/lib/actions/sandbox/process-recovery.ts",
+) as typeof import("../../src/lib/actions/sandbox/process-recovery.js");
 
 function checkAndRecoverSandboxProcesses(
   sandboxName: string,
@@ -108,10 +108,10 @@ function withFakeOpenshellBinary<T>(fn: () => T): T {
 
 describe("checkAndRecoverSandboxProcesses custom agent recovery", () => {
   it("retains SSH health-probe compatibility for an explicitly loaded custom gateway agent", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.ts");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.ts");
-    const registry = requireSource("../src/lib/state/registry.ts");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.ts");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.ts");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.ts");
+    const registry = requireSource("../../src/lib/state/registry.ts");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.ts");
     const childProcess = requireSource("node:child_process");
     const sshCommands: string[] = [];
 
@@ -164,10 +164,10 @@ custom-box  127.0.0.1  19000  12345  running`,
   });
 
   it("recovers a stopped custom gateway agent over SSH fallback", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.ts");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.ts");
-    const registry = requireSource("../src/lib/state/registry.ts");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.ts");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.ts");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.ts");
+    const registry = requireSource("../../src/lib/state/registry.ts");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.ts");
     const childProcess = requireSource("node:child_process");
     const runningForward = `SANDBOX  BIND  PORT  PID  STATUS
 custom-box  127.0.0.1  19000  12345  running`;
@@ -248,8 +248,8 @@ custom-box  127.0.0.1  19000  12345  running`;
   });
 
   it("fails closed when a persisted non-OpenClaw manifest cannot be loaded", () => {
-    const agentRuntime = requireSource("../src/lib/agent/runtime.ts");
-    const registry = requireSource("../src/lib/state/registry.ts");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.ts");
+    const registry = requireSource("../../src/lib/state/registry.ts");
     const childProcess = requireSource("node:child_process");
     const commands: string[] = [];
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/test/process-recovery/process-recovery-forward-failure.test.ts
+++ b/test/process-recovery/process-recovery-forward-failure.test.ts
@@ -7,14 +7,14 @@ import os from "node:os";
 import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import * as forwardHealth from "../src/lib/actions/sandbox/forward-health.js";
-import { ensureSandboxPortForwardForPort } from "../src/lib/actions/sandbox/forward-recovery.js";
-import * as openshellRuntime from "../src/lib/adapters/openshell/runtime.js";
+import * as forwardHealth from "../../src/lib/actions/sandbox/forward-health.js";
+import { ensureSandboxPortForwardForPort } from "../../src/lib/actions/sandbox/forward-recovery.js";
+import * as openshellRuntime from "../../src/lib/adapters/openshell/runtime.js";
 
 const requireSource = createRequire(import.meta.url);
 const { checkAndRecoverSandboxProcesses: checkAndRecoverSandboxProcessesImpl } = requireSource(
-  "../src/lib/actions/sandbox/process-recovery.ts",
-) as typeof import("../src/lib/actions/sandbox/process-recovery.js");
+  "../../src/lib/actions/sandbox/process-recovery.ts",
+) as typeof import("../../src/lib/actions/sandbox/process-recovery.js");
 
 function checkAndRecoverSandboxProcesses(
   sandboxName: string,
@@ -90,9 +90,9 @@ function compactTeamsMessagingPlan(port = "3978") {
 
 describe("checkAndRecoverSandboxProcesses primary forward failure", () => {
   it("fails closed when OpenShell forward state is unavailable", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.ts");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.ts");
-    const registry = requireSource("../src/lib/state/registry.ts");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.ts");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.ts");
+    const registry = requireSource("../../src/lib/state/registry.ts");
     const childProcess = requireSource("node:child_process");
 
     vi.spyOn(childProcess, "spawnSync").mockReturnValue({
@@ -127,10 +127,10 @@ describe("checkAndRecoverSandboxProcesses primary forward failure", () => {
   });
 
   it("reports failure when a messaging forward cannot recover even if the primary is healthy", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.ts");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.ts");
-    const registry = requireSource("../src/lib/state/registry.ts");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.ts");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.ts");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.ts");
+    const registry = requireSource("../../src/lib/state/registry.ts");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.ts");
     const childProcess = requireSource("node:child_process");
 
     vi.spyOn(childProcess, "spawnSync").mockReturnValue({
@@ -172,10 +172,10 @@ beta  127.0.0.1  18789  12345  running`,
   });
 
   it("reports failure when the primary forward cannot recover even if secondary forwards recover", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.ts");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.ts");
-    const registry = requireSource("../src/lib/state/registry.ts");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.ts");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.ts");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.ts");
+    const registry = requireSource("../../src/lib/state/registry.ts");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.ts");
     const childProcess = requireSource("node:child_process");
     let teamsForwardStarted = false;
 

--- a/test/process-recovery/process-recovery-managed-controller.test.ts
+++ b/test/process-recovery/process-recovery-managed-controller.test.ts
@@ -11,8 +11,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const requireSource = createRequire(import.meta.url);
 const { checkAndRecoverSandboxProcesses: checkAndRecoverSandboxProcessesImpl } = requireSource(
-  "../src/lib/actions/sandbox/process-recovery.ts",
-) as typeof import("../src/lib/actions/sandbox/process-recovery.js");
+  "../../src/lib/actions/sandbox/process-recovery.ts",
+) as typeof import("../../src/lib/actions/sandbox/process-recovery.js");
 
 function checkAndRecoverSandboxProcesses(
   sandboxName: string,
@@ -63,7 +63,8 @@ describe("managed gateway recovery controller", () => {
   };
   const timedOutGateway = {
     ...unrecoveredGateway,
-    recoveryFailureDetail: "the recovered gateway did not become responsive before the recovery timeout",
+    recoveryFailureDetail:
+      "the recovered gateway did not become responsive before the recovery timeout",
   };
   const controllerNonce = "a".repeat(64);
   const restartingContainerId = "b".repeat(64);
@@ -350,94 +351,97 @@ describe("managed gateway recovery controller", () => {
       expectedActions: ["recover"],
       settleSeconds: "0",
     },
-  ])("enforces managed recovery for $label", ({
-    recoverResults,
-    expectedResult,
-    expectedActions,
-    managedProbeResult,
-    managedProbeResults,
-    settleSeconds,
-  }) => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const childProcess = requireSource("node:child_process");
-    const runningForward = `SANDBOX  BIND  PORT  PID  STATUS
+  ])(
+    "enforces managed recovery for $label",
+    ({
+      recoverResults,
+      expectedResult,
+      expectedActions,
+      managedProbeResult,
+      managedProbeResults,
+      settleSeconds,
+    }) => {
+      const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+      const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+      const registry = requireSource("../../src/lib/state/registry.js");
+      const childProcess = requireSource("node:child_process");
+      const runningForward = `SANDBOX  BIND  PORT  PID  STATUS
 beta  127.0.0.1  18789  12345  running`;
-    const previousWaitSeconds = process.env.NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS;
-    const previousPollInterval = process.env.NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS;
-    const previousSettleSeconds = process.env.NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS;
-    let recoveryActionCalls = 0;
-    let managedProbeCalls = 0;
-    const requestGatewaySupervisorAction = vi.fn(
-      (_sandboxName: string, action: "restart" | "recover" | "probe") => {
-        const isProbe = action === "probe";
-        const probeResults = managedProbeResults ?? [managedProbeResult ?? successfulProbe];
-        const result = isProbe
-          ? probeResults[Math.min(managedProbeCalls, probeResults.length - 1)]
-          : recoverResults[Math.min(recoveryActionCalls, recoverResults.length - 1)];
-        recoveryActionCalls += Number(!isProbe);
-        managedProbeCalls += Number(isProbe);
-        return result;
-      },
-    );
-    let healthProbeCalls = 0;
-    const spawnedCommands: string[] = [];
-
-    process.env.NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS = "2";
-    process.env.NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS = "0";
-    process.env.NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS = settleSeconds;
-
-    try {
-      vi.spyOn(childProcess, "spawnSync").mockImplementation(
-        (command: unknown, rawArgs: unknown) => {
-          spawnedCommands.push(String(command));
-          const isHealthProbe = getSandboxExecShellCommand(rawArgs).includes("HTTP_CODE=$(curl");
-          healthProbeCalls += Number(isHealthProbe);
-          return (
-            isHealthProbe
-              ? {
-                  status: 0,
-                  stdout: "__NEMOCLAW_SANDBOX_EXEC_STARTED__\nSTOPPED\n",
-                  stderr: "",
-                }
-              : { status: 0, stdout: "", stderr: "" }
-          ) as never;
+      const previousWaitSeconds = process.env.NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS;
+      const previousPollInterval = process.env.NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS;
+      const previousSettleSeconds = process.env.NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS;
+      let recoveryActionCalls = 0;
+      let managedProbeCalls = 0;
+      const requestGatewaySupervisorAction = vi.fn(
+        (_sandboxName: string, action: "restart" | "recover" | "probe") => {
+          const isProbe = action === "probe";
+          const probeResults = managedProbeResults ?? [managedProbeResult ?? successfulProbe];
+          const result = isProbe
+            ? probeResults[Math.min(managedProbeCalls, probeResults.length - 1)]
+            : recoverResults[Math.min(recoveryActionCalls, recoverResults.length - 1)];
+          recoveryActionCalls += Number(!isProbe);
+          managedProbeCalls += Number(isProbe);
+          return result;
         },
       );
-      vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue(null);
-      vi.spyOn(registry, "getSandbox").mockReturnValue({
-        name: "beta",
-        agent: "openclaw",
-        dashboardPort: 18789,
-      });
-      vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue({
-        status: 0,
-        output: runningForward,
-      });
+      let healthProbeCalls = 0;
+      const spawnedCommands: string[] = [];
 
-      const result = withFakeOpenshellBinary(() =>
-        checkAndRecoverSandboxProcesses("beta", {
-          quiet: true,
-          requestGatewaySupervisorAction,
-        }),
-      );
-      expect(result).toEqual(expectedResult);
-      expect(requestGatewaySupervisorAction.mock.calls).toEqual(
-        expectedActions.map((action) => ["beta", action]),
-      );
-      expect(healthProbeCalls).toBe(1);
-      expect(spawnedCommands).not.toContain("ssh");
-    } finally {
-      previousWaitSeconds === undefined
-        ? delete process.env.NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS
-        : (process.env.NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS = previousWaitSeconds);
-      previousPollInterval === undefined
-        ? delete process.env.NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS
-        : (process.env.NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS = previousPollInterval);
-      previousSettleSeconds === undefined
-        ? delete process.env.NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS
-        : (process.env.NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS = previousSettleSeconds);
-    }
-  });
+      process.env.NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS = "2";
+      process.env.NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS = "0";
+      process.env.NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS = settleSeconds;
+
+      try {
+        vi.spyOn(childProcess, "spawnSync").mockImplementation(
+          (command: unknown, rawArgs: unknown) => {
+            spawnedCommands.push(String(command));
+            const isHealthProbe = getSandboxExecShellCommand(rawArgs).includes("HTTP_CODE=$(curl");
+            healthProbeCalls += Number(isHealthProbe);
+            return (
+              isHealthProbe
+                ? {
+                    status: 0,
+                    stdout: "__NEMOCLAW_SANDBOX_EXEC_STARTED__\nSTOPPED\n",
+                    stderr: "",
+                  }
+                : { status: 0, stdout: "", stderr: "" }
+            ) as never;
+          },
+        );
+        vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue(null);
+        vi.spyOn(registry, "getSandbox").mockReturnValue({
+          name: "beta",
+          agent: "openclaw",
+          dashboardPort: 18789,
+        });
+        vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue({
+          status: 0,
+          output: runningForward,
+        });
+
+        const result = withFakeOpenshellBinary(() =>
+          checkAndRecoverSandboxProcesses("beta", {
+            quiet: true,
+            requestGatewaySupervisorAction,
+          }),
+        );
+        expect(result).toEqual(expectedResult);
+        expect(requestGatewaySupervisorAction.mock.calls).toEqual(
+          expectedActions.map((action) => ["beta", action]),
+        );
+        expect(healthProbeCalls).toBe(1);
+        expect(spawnedCommands).not.toContain("ssh");
+      } finally {
+        previousWaitSeconds === undefined
+          ? delete process.env.NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS
+          : (process.env.NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS = previousWaitSeconds);
+        previousPollInterval === undefined
+          ? delete process.env.NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS
+          : (process.env.NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS = previousPollInterval);
+        previousSettleSeconds === undefined
+          ? delete process.env.NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS
+          : (process.env.NEMOCLAW_GATEWAY_RECOVERY_SETTLE_SECONDS = previousSettleSeconds);
+      }
+    },
+  );
 });

--- a/test/process-recovery/process-recovery-primitives.test.ts
+++ b/test/process-recovery/process-recovery-primitives.test.ts
@@ -19,8 +19,8 @@ const {
   resolveSandboxDashboardPort,
   waitForManagedGatewaySupervisor,
 } = requireSource(
-  "../src/lib/actions/sandbox/process-recovery.ts",
-) as typeof import("../src/lib/actions/sandbox/process-recovery.js");
+  "../../src/lib/actions/sandbox/process-recovery.ts",
+) as typeof import("../../src/lib/actions/sandbox/process-recovery.js");
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -292,7 +292,7 @@ describe("executeGatewaySupervisorAction", () => {
   const targetContainerId = "a".repeat(64);
 
   it("sanitizes a temporarily unavailable direct container into the retry marker", () => {
-    const privilegedExec = requireSource("../src/lib/sandbox/privileged-exec.ts");
+    const privilegedExec = requireSource("../../src/lib/sandbox/privileged-exec.ts");
     vi.spyOn(privilegedExec, "privilegedSandboxExecArgv").mockImplementation(() => {
       throw new Error("temporary direct-container discovery detail");
     });
@@ -306,7 +306,7 @@ describe("executeGatewaySupervisorAction", () => {
   });
 
   it("keeps other privileged-control refusals terminal and classified", () => {
-    const privilegedExec = requireSource("../src/lib/sandbox/privileged-exec.ts");
+    const privilegedExec = requireSource("../../src/lib/sandbox/privileged-exec.ts");
     vi.spyOn(privilegedExec, "privilegedSandboxExecArgv").mockImplementation(() => {
       throw new Error(
         "OpenShell container identity changed for sandbox 'new-clone'; refusing privileged execution against a different container.",
@@ -323,7 +323,7 @@ describe("executeGatewaySupervisorAction", () => {
   });
 
   it("emits the managed-control identity marker for a pinned container refusal (#9364)", () => {
-    const privilegedExec = requireSource("../src/lib/sandbox/privileged-exec.ts");
+    const privilegedExec = requireSource("../../src/lib/sandbox/privileged-exec.ts");
     vi.spyOn(privilegedExec, "privilegedSandboxExecArgv").mockImplementation(() => {
       throw new Error(
         "OpenShell container identity changed for sandbox 'new-clone'; refusing privileged execution against a different container.",
@@ -341,8 +341,8 @@ describe("executeGatewaySupervisorAction", () => {
   });
 
   it("binds an exact Docker restart transition to the selected container (#8726)", () => {
-    const dockerExec = requireSource("../src/lib/adapters/docker/exec.ts");
-    const privilegedExec = requireSource("../src/lib/sandbox/privileged-exec.ts");
+    const dockerExec = requireSource("../../src/lib/adapters/docker/exec.ts");
+    const privilegedExec = requireSource("../../src/lib/sandbox/privileged-exec.ts");
     vi.spyOn(privilegedExec, "privilegedSandboxExecArgv").mockReturnValue([
       "exec",
       "--user",
@@ -371,30 +371,33 @@ describe("executeGatewaySupervisorAction", () => {
     ["a status-2 error", 2, "", targetContainerId, ""],
     ["a result with stdout", 1, "unexpected", targetContainerId, ""],
     ["an error with an additional line", 1, "", targetContainerId, "\nunexpected"],
-  ])("does not bind %s as a Docker restart transition (#8726)", (_case, status, stdout, id, suffix) => {
-    const dockerExec = requireSource("../src/lib/adapters/docker/exec.ts");
-    const privilegedExec = requireSource("../src/lib/sandbox/privileged-exec.ts");
-    vi.spyOn(privilegedExec, "privilegedSandboxExecArgv").mockReturnValue([
-      "exec",
-      "--user",
-      "root",
-      targetContainerId,
-      controlPath,
-      "probe",
-      "b".repeat(64),
-    ]);
-    vi.spyOn(dockerExec, "dockerSpawnSync").mockReturnValue({
-      status,
-      stdout,
-      stderr: `Error response from daemon: Container ${id} is restarting, wait until the container is running${suffix}`,
-    } as never);
+  ])(
+    "does not bind %s as a Docker restart transition (#8726)",
+    (_case, status, stdout, id, suffix) => {
+      const dockerExec = requireSource("../../src/lib/adapters/docker/exec.ts");
+      const privilegedExec = requireSource("../../src/lib/sandbox/privileged-exec.ts");
+      vi.spyOn(privilegedExec, "privilegedSandboxExecArgv").mockReturnValue([
+        "exec",
+        "--user",
+        "root",
+        targetContainerId,
+        controlPath,
+        "probe",
+        "b".repeat(64),
+      ]);
+      vi.spyOn(dockerExec, "dockerSpawnSync").mockReturnValue({
+        status,
+        stdout,
+        stderr: `Error response from daemon: Container ${id} is restarting, wait until the container is running${suffix}`,
+      } as never);
 
-    expect(executeGatewaySupervisorAction("new-clone", "probe", 100)).toEqual({
-      status,
-      stdout,
-      stderr: `Error response from daemon: Container ${id} is restarting, wait until the container is running${suffix}`,
-    });
-  });
+      expect(executeGatewaySupervisorAction("new-clone", "probe", 100)).toEqual({
+        status,
+        stdout,
+        stderr: `Error response from daemon: Container ${id} is restarting, wait until the container is running${suffix}`,
+      });
+    },
+  );
 });
 
 function withFakeOpenshellBinary<T>(fn: () => T): T {
@@ -701,8 +704,8 @@ describe("executeSandboxExecCommand", () => {
 
   it("honors the sandbox-exec timeout without falling back to SSH", () => {
     const childProcess = requireSource("node:child_process");
-    const dockerExec = requireSource("../src/lib/adapters/docker/exec.ts");
-    const privilegedExec = requireSource("../src/lib/sandbox/privileged-exec.ts");
+    const dockerExec = requireSource("../../src/lib/adapters/docker/exec.ts");
+    const privilegedExec = requireSource("../../src/lib/sandbox/privileged-exec.ts");
     const timeoutError = Object.assign(new Error("timed out"), { code: "ETIMEDOUT" });
     const spawn = vi.spyOn(childProcess, "spawnSync").mockReturnValue({
       status: null,
@@ -765,8 +768,8 @@ describe("executeSandboxExecCommand", () => {
 
   it("rejects a non-frame preamble and surfaces a missing trusted fallback identity", () => {
     const childProcess = requireSource("node:child_process");
-    const dockerExec = requireSource("../src/lib/adapters/docker/exec.ts");
-    const privilegedExec = requireSource("../src/lib/sandbox/privileged-exec.ts");
+    const dockerExec = requireSource("../../src/lib/adapters/docker/exec.ts");
+    const privilegedExec = requireSource("../../src/lib/sandbox/privileged-exec.ts");
     vi.spyOn(childProcess, "spawnSync").mockReturnValue({
       status: 0,
       stdout: [
@@ -810,8 +813,8 @@ describe("executeSandboxExecCommand", () => {
 
   it("falls back to local Docker root exec when OpenShell exec output has no marker", () => {
     const childProcess = requireSource("node:child_process");
-    const dockerExec = requireSource("../src/lib/adapters/docker/exec.ts");
-    const privilegedExec = requireSource("../src/lib/sandbox/privileged-exec.ts");
+    const dockerExec = requireSource("../../src/lib/adapters/docker/exec.ts");
+    const privilegedExec = requireSource("../../src/lib/sandbox/privileged-exec.ts");
     vi.spyOn(childProcess, "spawnSync").mockReturnValue({
       status: 0,
       stdout: "OpenShell transport preamble\n",
@@ -871,8 +874,8 @@ describe("executeSandboxExecCommand", () => {
 
   it("does not let Docker fallback satisfy a strict provider credential proof", () => {
     const childProcess = requireSource("node:child_process");
-    const dockerExec = requireSource("../src/lib/adapters/docker/exec.ts");
-    const privilegedExec = requireSource("../src/lib/sandbox/privileged-exec.ts");
+    const dockerExec = requireSource("../../src/lib/adapters/docker/exec.ts");
+    const privilegedExec = requireSource("../../src/lib/sandbox/privileged-exec.ts");
     const spawn = vi.spyOn(childProcess, "spawnSync").mockReturnValue({
       status: 1,
       stdout: "OpenShell transport failed before the child marker\n",
@@ -899,7 +902,7 @@ describe("executeSandboxExecCommand", () => {
 
 describe("executeSandboxCommand", () => {
   it("does not forward an MCP credential to the SSH child process", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.ts");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.ts");
     const childProcess = requireSource("node:child_process");
     vi.spyOn(openshellRuntime, "captureSandboxSshConfig").mockReturnValue({
       status: 0,

--- a/test/process-recovery/process-recovery-supervisor-relaunch.test.ts
+++ b/test/process-recovery/process-recovery-supervisor-relaunch.test.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import * as forwardHealth from "../src/lib/actions/sandbox/forward-health.ts";
-import { checkAndRecoverSandboxProcesses } from "../src/lib/actions/sandbox/process-recovery.ts";
-import { relaunchManagedSupervisorSession } from "../src/lib/actions/sandbox/supervisor-relaunch.ts";
-import * as openshellRuntime from "../src/lib/adapters/openshell/runtime.ts";
-import * as agentRuntime from "../src/lib/agent/runtime.ts";
-import { finalizeDockerGpuPatchBackup } from "../src/lib/onboard/docker-gpu-patch-finalize.ts";
-import * as registry from "../src/lib/state/registry.ts";
+import * as forwardHealth from "../../src/lib/actions/sandbox/forward-health.ts";
+import { checkAndRecoverSandboxProcesses } from "../../src/lib/actions/sandbox/process-recovery.ts";
+import { relaunchManagedSupervisorSession } from "../../src/lib/actions/sandbox/supervisor-relaunch.ts";
+import * as openshellRuntime from "../../src/lib/adapters/openshell/runtime.ts";
+import * as agentRuntime from "../../src/lib/agent/runtime.ts";
+import { finalizeDockerGpuPatchBackup } from "../../src/lib/onboard/docker-gpu-patch-finalize.ts";
+import * as registry from "../../src/lib/state/registry.ts";
 
 const OPENSHELL_RELAY_CHANNEL_DROPPED_STDERR = `Error:   × status: Unavailable, message: "relay
   │ channel dropped", details: [], metadata: MetadataMap { headers: {} }
@@ -781,7 +781,8 @@ describe("checkAndRecoverSandboxProcesses supervisor relaunch", () => {
       wasRunning: false,
       recovered: false,
       forwardRecovered: false,
-      recoveryFailureDetail: "Sandbox recovery did not complete; the previous container was restored",
+      recoveryFailureDetail:
+        "Sandbox recovery did not complete; the previous container was restored",
     });
     expect(order).toEqual(["restore-state", "post-restore-restart", "rollback-container"]);
     expect(requestPinnedGatewaySupervisorAction).toHaveBeenCalledTimes(4);
@@ -1073,55 +1074,56 @@ describe("checkAndRecoverSandboxProcesses supervisor relaunch", () => {
         throw new Error("opaque-finalizer-sentinel");
       },
     },
-  ])("reports the readiness failure and unconfirmed rollback when $condition (#9364)", ({
-    finalizeOutcome,
-  }) => {
-    mockOpenClawSandbox("rollback-box");
-    setImmediateRecoveryPolling();
-    const finalize = vi.fn((_supervisorReady: boolean) => finalizeOutcome());
-    const relaunchManagedSupervisorSessionImpl = vi.fn(() => ({
-      containerId: "replacement-container-id",
-      finalize,
-    }));
-    const requestGatewaySupervisorAction = vi.fn(() => MISSING_MANAGED_SUPERVISOR);
-    const requestPinnedGatewaySupervisorAction = vi.fn(() => ACCEPTED_MANAGED_PROBE);
-    const waitForRecreatedSandboxOpenShellReadyImpl = vi.fn(() => false);
-    const captureOpenshell = vi
-      .spyOn(openshellRuntime, "captureOpenshell")
-      .mockReturnValue({ status: 0, output: "" });
-    const runOpenshell = vi
-      .spyOn(openshellRuntime, "runOpenshell")
-      .mockReturnValue({ status: 0 } as never);
+  ])(
+    "reports the readiness failure and unconfirmed rollback when $condition (#9364)",
+    ({ finalizeOutcome }) => {
+      mockOpenClawSandbox("rollback-box");
+      setImmediateRecoveryPolling();
+      const finalize = vi.fn((_supervisorReady: boolean) => finalizeOutcome());
+      const relaunchManagedSupervisorSessionImpl = vi.fn(() => ({
+        containerId: "replacement-container-id",
+        finalize,
+      }));
+      const requestGatewaySupervisorAction = vi.fn(() => MISSING_MANAGED_SUPERVISOR);
+      const requestPinnedGatewaySupervisorAction = vi.fn(() => ACCEPTED_MANAGED_PROBE);
+      const waitForRecreatedSandboxOpenShellReadyImpl = vi.fn(() => false);
+      const captureOpenshell = vi
+        .spyOn(openshellRuntime, "captureOpenshell")
+        .mockReturnValue({ status: 0, output: "" });
+      const runOpenshell = vi
+        .spyOn(openshellRuntime, "runOpenshell")
+        .mockReturnValue({ status: 0 } as never);
 
-    const result = checkAndRecoverSandboxProcesses("rollback-box", {
-      quiet: true,
-      isSandboxGatewayRunningImpl: () => false,
-      requestGatewaySupervisorAction,
-      requestPinnedGatewaySupervisorAction,
-      relaunchManagedSupervisorSessionImpl,
-      waitForRecreatedSandboxOpenShellReadyImpl,
-    });
+      const result = checkAndRecoverSandboxProcesses("rollback-box", {
+        quiet: true,
+        isSandboxGatewayRunningImpl: () => false,
+        requestGatewaySupervisorAction,
+        requestPinnedGatewaySupervisorAction,
+        relaunchManagedSupervisorSessionImpl,
+        waitForRecreatedSandboxOpenShellReadyImpl,
+      });
 
-    expect(result).toMatchObject({
-      checked: true,
-      wasRunning: false,
-      recovered: false,
-      forwardRecovered: false,
-      recoveryFailureDetail: expect.stringContaining(
-        "NemoClaw could not confirm rollback to the previous sandbox container",
-      ),
-    });
-    expect("recoveryFailureDetail" in result ? result.recoveryFailureDetail : "").toContain(
-      "did not become ready in OpenShell",
-    );
-    expect("recoveryFailureDetail" in result ? result.recoveryFailureDetail : "").not.toContain(
-      "opaque-finalizer-sentinel",
-    );
-    expect(finalize).toHaveBeenCalledOnce();
-    expect(finalize).toHaveBeenCalledWith(false);
-    expect(captureOpenshell).not.toHaveBeenCalled();
-    expect(runOpenshell).not.toHaveBeenCalled();
-  });
+      expect(result).toMatchObject({
+        checked: true,
+        wasRunning: false,
+        recovered: false,
+        forwardRecovered: false,
+        recoveryFailureDetail: expect.stringContaining(
+          "NemoClaw could not confirm rollback to the previous sandbox container",
+        ),
+      });
+      expect("recoveryFailureDetail" in result ? result.recoveryFailureDetail : "").toContain(
+        "did not become ready in OpenShell",
+      );
+      expect("recoveryFailureDetail" in result ? result.recoveryFailureDetail : "").not.toContain(
+        "opaque-finalizer-sentinel",
+      );
+      expect(finalize).toHaveBeenCalledOnce();
+      expect(finalize).toHaveBeenCalledWith(false);
+      expect(captureOpenshell).not.toHaveBeenCalled();
+      expect(runOpenshell).not.toHaveBeenCalled();
+    },
+  );
 
   it("reports the last structured OpenShell error when readiness times out", () => {
     mockOpenClawSandbox("relay-dropped-box");

--- a/test/process-recovery/process-recovery.test.ts
+++ b/test/process-recovery/process-recovery.test.ts
@@ -11,14 +11,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const requireSource = createRequire(import.meta.url);
 const { checkAndRecoverSandboxProcesses: checkAndRecoverSandboxProcessesImpl } = requireSource(
-  "../src/lib/actions/sandbox/process-recovery.ts",
-) as typeof import("../src/lib/actions/sandbox/process-recovery.js");
+  "../../src/lib/actions/sandbox/process-recovery.ts",
+) as typeof import("../../src/lib/actions/sandbox/process-recovery.js");
 const { ensureSandboxPortForwardForPort } = requireSource(
-  "../src/lib/actions/sandbox/forward-recovery.ts",
-) as typeof import("../src/lib/actions/sandbox/forward-recovery.js");
+  "../../src/lib/actions/sandbox/forward-recovery.ts",
+) as typeof import("../../src/lib/actions/sandbox/forward-recovery.js");
 const { createProbeTimingRecorder } = requireSource(
-  "../src/lib/actions/sandbox/probe/timing.ts",
-) as typeof import("../src/lib/actions/sandbox/probe/timing.js");
+  "../../src/lib/actions/sandbox/probe/timing.ts",
+) as typeof import("../../src/lib/actions/sandbox/probe/timing.js");
 
 function checkAndRecoverSandboxProcesses(
   sandboxName: string,
@@ -100,7 +100,7 @@ function compactTeamsMessagingPlan(port = "3978") {
 
 describe("checkAndRecoverSandboxProcesses", () => {
   it("does not attempt gateway recovery for terminal agents", () => {
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
     vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue({
       runtime: { kind: "terminal" },
     } as never);
@@ -115,10 +115,10 @@ describe("checkAndRecoverSandboxProcesses", () => {
   });
 
   it("scopes forward stop to the target sandbox when restarting a dead forward", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const childProcess = requireSource("node:child_process");
     const deadForward = `SANDBOX  BIND  PORT  PID  STATUS
 beta  127.0.0.1  18789  12345  dead`;
@@ -198,65 +198,65 @@ beta  127.0.0.1  18789  12345  running`;
   it.each([
     { dashboardBind: "0.0.0.0", isWsl: false, requirement: "remote bind" },
     { dashboardBind: "", isWsl: true, requirement: "WSL" },
-  ])("restarts a loopback forward when $requirement requires all interfaces (#6024)", ({
-    dashboardBind,
-    isWsl,
-  }) => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
-    const childProcess = requireSource("node:child_process");
-    let forwardStarted = false;
+  ])(
+    "restarts a loopback forward when $requirement requires all interfaces (#6024)",
+    ({ dashboardBind, isWsl }) => {
+      const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+      const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+      const registry = requireSource("../../src/lib/state/registry.js");
+      const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
+      const childProcess = requireSource("node:child_process");
+      let forwardStarted = false;
 
-    vi.stubEnv("NEMOCLAW_DASHBOARD_BIND", dashboardBind);
-    vi.stubEnv("NEMOCLAW_FORWARD_RECOVERY_WAIT_MS", "0");
-    vi.spyOn(childProcess, "spawnSync").mockReturnValue({
-      status: 0,
-      stdout: "__NEMOCLAW_SANDBOX_EXEC_STARTED__\nRUNNING\n",
-      stderr: "",
-    } as never);
-    vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue(null);
-    vi.spyOn(registry, "getSandbox").mockReturnValue({
-      name: "beta",
-      agent: "openclaw",
-      dashboardPort: 18789,
-      dashboardRemoteBindPrepared: true,
-    });
-    vi.spyOn(forwardHealth, "isLocalForwardReachable").mockReturnValue(true);
-    vi.spyOn(openshellRuntime, "captureOpenshell").mockImplementation(() => ({
-      status: 0,
-      output:
-        "SANDBOX  BIND  PORT  PID  STATUS\n" +
-        `beta  ${forwardStarted ? "0.0.0.0" : "127.0.0.1"}  18789  12345  running`,
-    }));
-    const runOpenshell = vi
-      .spyOn(openshellRuntime, "runOpenshell")
-      .mockImplementation((rawArgs: unknown) => {
-        const args = Array.isArray(rawArgs) ? rawArgs.map(String) : [];
-        forwardStarted ||= args[0] === "forward" && args[1] === "start";
-        return { status: 0 } as never;
+      vi.stubEnv("NEMOCLAW_DASHBOARD_BIND", dashboardBind);
+      vi.stubEnv("NEMOCLAW_FORWARD_RECOVERY_WAIT_MS", "0");
+      vi.spyOn(childProcess, "spawnSync").mockReturnValue({
+        status: 0,
+        stdout: "__NEMOCLAW_SANDBOX_EXEC_STARTED__\nRUNNING\n",
+        stderr: "",
+      } as never);
+      vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue(null);
+      vi.spyOn(registry, "getSandbox").mockReturnValue({
+        name: "beta",
+        agent: "openclaw",
+        dashboardPort: 18789,
+        dashboardRemoteBindPrepared: true,
       });
+      vi.spyOn(forwardHealth, "isLocalForwardReachable").mockReturnValue(true);
+      vi.spyOn(openshellRuntime, "captureOpenshell").mockImplementation(() => ({
+        status: 0,
+        output:
+          "SANDBOX  BIND  PORT  PID  STATUS\n" +
+          `beta  ${forwardStarted ? "0.0.0.0" : "127.0.0.1"}  18789  12345  running`,
+      }));
+      const runOpenshell = vi
+        .spyOn(openshellRuntime, "runOpenshell")
+        .mockImplementation((rawArgs: unknown) => {
+          const args = Array.isArray(rawArgs) ? rawArgs.map(String) : [];
+          forwardStarted ||= args[0] === "forward" && args[1] === "start";
+          return { status: 0 } as never;
+        });
 
-    expect(
-      withFakeOpenshellBinary(() =>
-        checkAndRecoverSandboxProcesses("beta", { isWsl, quiet: true }),
-      ),
-    ).toEqual({
-      checked: true,
-      wasRunning: true,
-      recovered: false,
-      forwardRecovered: true,
-    });
-    expect(runOpenshell).toHaveBeenCalledWith(
-      ["forward", "start", "--background", "0.0.0.0:18789", "beta"],
-      { ignoreError: true, stdio: "ignore" },
-    );
-  });
+      expect(
+        withFakeOpenshellBinary(() =>
+          checkAndRecoverSandboxProcesses("beta", { isWsl, quiet: true }),
+        ),
+      ).toEqual({
+        checked: true,
+        wasRunning: true,
+        recovered: false,
+        forwardRecovered: true,
+      });
+      expect(runOpenshell).toHaveBeenCalledWith(
+        ["forward", "start", "--background", "0.0.0.0:18789", "beta"],
+        { ignoreError: true, stdio: "ignore" },
+      );
+    },
+  );
 
   it("waits for a stopped forward listener to release before starting its replacement", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const events: string[] = [];
     let staleListenerProbes = 2;
     let forwardStarted = false;
@@ -293,8 +293,8 @@ beta  127.0.0.1  18789  12345  running`;
   });
 
   it("fails closed after start reconciliation when a listener remains unowned", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
 
     vi.stubEnv("NEMOCLAW_FORWARD_RECOVERY_WAIT_MS", "25");
     vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue({ status: 0, output: "" });
@@ -314,10 +314,10 @@ beta  127.0.0.1  18789  12345  running`;
   });
 
   it("checkAndRecoverSandboxProcesses re-establishes an active Teams messaging host forward from a compact plan when the dashboard forward is healthy", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const childProcess = requireSource("node:child_process");
     const dashboardForward = `SANDBOX  BIND  PORT  PID  STATUS
 beta  127.0.0.1  18789  12345  running`;
@@ -385,10 +385,10 @@ beta  127.0.0.1  3978  12346  running`;
   });
 
   it("checkAndRecoverSandboxProcesses reports messaging webhook recovery failure without claiming forwardRecovered", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const childProcess = requireSource("node:child_process");
     const dashboardForward = `SANDBOX  BIND  PORT  PID  STATUS
 beta  127.0.0.1  18789  12345  running`;
@@ -446,10 +446,10 @@ beta  127.0.0.1  18789  12345  running`;
   });
 
   it("waits for stopped Hermes recovery after managed OpenShell control succeeds", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const childProcess = requireSource("node:child_process");
     const runningForward = `SANDBOX  BIND  PORT  PID  STATUS
 hermes-box  127.0.0.1  18789  12345  running`;
@@ -545,8 +545,8 @@ hermes-box  127.0.0.1  18789  12345  running`;
     ["an extra self-recovery error", "", "SUPERVISOR_UNAVAILABLE\nGATEWAY_FAILED"],
     ["a self-recovery marker on stdout", "SUPERVISOR_UNAVAILABLE", ""],
   ])("does not accept %s for Hermes", (_label, stdout, stderr) => {
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
     const childProcess = requireSource("node:child_process");
     const requestGatewaySupervisorAction = vi.fn(() => ({
       status: 1,
@@ -603,10 +603,10 @@ hermes-box  127.0.0.1  18789  12345  running`;
   });
 
   it("leaves enabled Hermes dashboard recovery to the PID 1 supervisor", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const childProcess = requireSource("node:child_process");
     const previousWaitSeconds = process.env.NEMOCLAW_GATEWAY_RECOVERY_WAIT_SECONDS;
     const previousPollInterval = process.env.NEMOCLAW_GATEWAY_RECOVERY_POLL_INTERVAL_SECONDS;
@@ -704,8 +704,8 @@ hermes-box  127.0.0.1  18789  12345  running`;
   });
 
   it("keeps quiet stopped-Hermes recovery failures off stderr", () => {
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
     const childProcess = requireSource("node:child_process");
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
@@ -726,10 +726,10 @@ hermes-box  127.0.0.1  18789  12345  running`;
   });
 
   it("re-establishes manifest-declared non-primary forward ports when only the primary is healthy", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const childProcess = requireSource("node:child_process");
     const onlyPrimaryForward = `SANDBOX  BIND  PORT  PID  STATUS
 hermes-box  127.0.0.1  18789  12345  running`;
@@ -819,10 +819,10 @@ hermes-box  127.0.0.1  8642  12346  running`;
   });
 
   it("leaves a non-primary forward owned by another sandbox alone instead of taking it over", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const childProcess = requireSource("node:child_process");
     const occupiedForwardList = `SANDBOX  BIND  PORT  PID  STATUS
 hermes-box  127.0.0.1  18789  12345  running
@@ -878,10 +878,10 @@ sibling-box  127.0.0.1  8642  99999  running`;
   });
 
   it("ignores invalid forward_ports entries and never invokes openshell forward start for them", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const childProcess = requireSource("node:child_process");
     const primaryOnlyForward = `SANDBOX  BIND  PORT  PID  STATUS
 hermes-box  127.0.0.1  18789  12345  running`;
@@ -931,10 +931,10 @@ hermes-box  127.0.0.1  18789  12345  running`;
   });
 
   it("reports forward recovery failure when one declared secondary recovers and another fails", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const childProcess = requireSource("node:child_process");
     const partialForward = `SANDBOX  BIND  PORT  PID  STATUS
 hermes-box  127.0.0.1  18789  12345  running
@@ -997,9 +997,9 @@ hermes-box  127.0.0.1  8642  12346  running`;
   });
 
   it("refuses recovery of a running Hermes gateway when /sandbox/.hermes/.env contains raw secret-shaped values", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
     const childProcess = requireSource("node:child_process");
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     let forwardListCalls = 0;
@@ -1078,9 +1078,9 @@ hermes-box  127.0.0.1  8642  12346  running`;
   });
 
   it("fails safe on a running Hermes sandbox when the agent definition cannot be loaded", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
     const childProcess = requireSource("node:child_process");
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     let forwardListCalls = 0;
@@ -1142,56 +1142,59 @@ hermes-box  127.0.0.1  8642  12346  running`;
   it.each([
     ["PID 1 supervisor", { status: 0, stdout: "GATEWAY_PID=4242\n", stderr: "" }],
     ["OpenShell managed controller", { status: 0, stdout: "GATEWAY_PID=4242\n", stderr: "" }],
-  ])("falls through when the Hermes $label reports a healthy gateway", (_label, supervisorResult) => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
-    const childProcess = requireSource("node:child_process");
-    const requestGatewaySupervisorAction = vi.fn(() => supervisorResult);
+  ])(
+    "falls through when the Hermes $label reports a healthy gateway",
+    (_label, supervisorResult) => {
+      const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+      const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+      const registry = requireSource("../../src/lib/state/registry.js");
+      const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
+      const childProcess = requireSource("node:child_process");
+      const requestGatewaySupervisorAction = vi.fn(() => supervisorResult);
 
-    vi.spyOn(childProcess, "spawnSync").mockReturnValue({
-      status: 0,
-      stdout: "stdout: __NEMOCLAW_SANDBOX_EXEC_STARTED__\nstdout: RUNNING\n",
-      stderr: "",
-    } as never);
-    vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue({
-      name: "hermes",
-      forwardPort: 8642,
-      displayName: "Hermes Agent",
-    });
-    vi.spyOn(registry, "getSandbox").mockReturnValue({
-      name: "hermes-box",
-      agent: "hermes",
-      dashboardPort: 18789,
-    });
-    vi.spyOn(forwardHealth, "isLocalForwardReachable").mockReturnValue(true);
-    vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue({
-      status: 0,
-      output: `SANDBOX  BIND  PORT  PID  STATUS\nhermes-box  127.0.0.1  8642  12346  running\nhermes-box  127.0.0.1  18789  12345  running`,
-    });
-    vi.spyOn(openshellRuntime, "runOpenshell").mockReturnValue({ status: 0 } as never);
-    const result = withFakeOpenshellBinary(() =>
-      checkAndRecoverSandboxProcesses("hermes-box", {
-        quiet: true,
-        requestGatewaySupervisorAction,
-      }),
-    );
-    expect(result).toEqual({
-      checked: true,
-      wasRunning: true,
-      recovered: false,
-      forwardRecovered: false,
-    });
-    expect(requestGatewaySupervisorAction).toHaveBeenCalledOnce();
-    expect(requestGatewaySupervisorAction).toHaveBeenCalledWith("hermes-box", "recover");
-  });
+      vi.spyOn(childProcess, "spawnSync").mockReturnValue({
+        status: 0,
+        stdout: "stdout: __NEMOCLAW_SANDBOX_EXEC_STARTED__\nstdout: RUNNING\n",
+        stderr: "",
+      } as never);
+      vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue({
+        name: "hermes",
+        forwardPort: 8642,
+        displayName: "Hermes Agent",
+      });
+      vi.spyOn(registry, "getSandbox").mockReturnValue({
+        name: "hermes-box",
+        agent: "hermes",
+        dashboardPort: 18789,
+      });
+      vi.spyOn(forwardHealth, "isLocalForwardReachable").mockReturnValue(true);
+      vi.spyOn(openshellRuntime, "captureOpenshell").mockReturnValue({
+        status: 0,
+        output: `SANDBOX  BIND  PORT  PID  STATUS\nhermes-box  127.0.0.1  8642  12346  running\nhermes-box  127.0.0.1  18789  12345  running`,
+      });
+      vi.spyOn(openshellRuntime, "runOpenshell").mockReturnValue({ status: 0 } as never);
+      const result = withFakeOpenshellBinary(() =>
+        checkAndRecoverSandboxProcesses("hermes-box", {
+          quiet: true,
+          requestGatewaySupervisorAction,
+        }),
+      );
+      expect(result).toEqual({
+        checked: true,
+        wasRunning: true,
+        recovered: false,
+        forwardRecovered: false,
+      });
+      expect(requestGatewaySupervisorAction).toHaveBeenCalledOnce();
+      expect(requestGatewaySupervisorAction).toHaveBeenCalledWith("hermes-box", "recover");
+    },
+  );
 
   it("falls through to the forward-refresh path when the Hermes secret-boundary check passes", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const childProcess = requireSource("node:child_process");
     let forwardStarted = false;
     const requestGatewaySupervisorAction = vi.fn(() => ({
@@ -1259,10 +1262,10 @@ hermes-box  127.0.0.1  8642  12346  running`;
   });
 
   it("refuses recovery when the Hermes secret-boundary validator is absent on an older sandbox image", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const childProcess = requireSource("node:child_process");
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const requestGatewaySupervisorAction = vi.fn(() => ({
@@ -1325,10 +1328,10 @@ hermes-box  127.0.0.1  8642  12346  running`;
   });
 
   it("does not invoke the Hermes PID 1 supervisor path for a running OpenClaw sandbox", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
-    const forwardHealth = requireSource("../src/lib/actions/sandbox/forward-health.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
+    const forwardHealth = requireSource("../../src/lib/actions/sandbox/forward-health.js");
     const childProcess = requireSource("node:child_process");
     const requestGatewaySupervisorAction = vi.fn();
 
@@ -1367,9 +1370,9 @@ hermes-box  127.0.0.1  8642  12346  running`;
   });
 
   it("fails safe on a running Hermes gateway when the supervisor channel is unreachable", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
     const childProcess = requireSource("node:child_process");
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     let forwardListCalls = 0;
@@ -1434,9 +1437,9 @@ hermes-box  127.0.0.1  8642  12346  running`;
   });
 
   it("treats a non-zero boundary check without the REFUSED marker as unexpected, not raw-secret", () => {
-    const openshellRuntime = requireSource("../src/lib/adapters/openshell/runtime.js");
-    const agentRuntime = requireSource("../src/lib/agent/runtime.js");
-    const registry = requireSource("../src/lib/state/registry.js");
+    const openshellRuntime = requireSource("../../src/lib/adapters/openshell/runtime.js");
+    const agentRuntime = requireSource("../../src/lib/agent/runtime.js");
+    const registry = requireSource("../../src/lib/state/registry.js");
     const childProcess = requireSource("node:child_process");
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const requestGatewaySupervisorAction = vi.fn(() => ({
@@ -1492,8 +1495,6 @@ hermes-box  127.0.0.1  8642  12346  running`;
     expect(requestGatewaySupervisorAction).toHaveBeenCalledWith("hermes-box", "recover");
     const errorOutput = errorSpy.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
     expect(errorOutput).toContain("python3: validator crashed: ImportError: no module named foo");
-    expect(errorOutput).toContain(
-      "Secret-boundary check did not complete cleanly for Hermes gateway in 'hermes-box'",
-    );
+    expect(errorOutput).toMatch(/Secret-boundary check did not complete cleanly.*hermes-box/);
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Group process and forward recovery integration tests under one behavior-owned directory without changing their Vitest execution lane.

## Changes

- Move six process-recovery test files into test/process-recovery/ and update their source imports.
- Update security review, source comment, and E2E parity references to the relocated tests.
- Document process-recovery/ as an integration-project behavior directory.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — Normal pre-commit, commit-msg, and pre-push hooks passed.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run test:projects:check`; `npx vitest run --project integration test/process-recovery` (147 passed); `npm run checks:repository`; `npm run typecheck:cli`
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Focused validation and repository hooks passed; broad matrix deferred to required CI.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [x] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified integration-test organization for sandbox process and forward-recovery coverage.

- **Tests**
  - Updated recovery test references and import paths following test reorganization.
  - Preserved existing recovery, forwarding, authentication, secret-boundary, and failure-handling coverage.
  - Refined test formatting and compatibility references without changing expected behavior.
  - Updated integration test shard assignments to maintain stable coverage distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->