### PR TITLE
test: remove redundant source-shape coverage

### DIFF
--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -22,11 +22,6 @@
       "category": "security"
     },
     {
-      "file": "test/dashboard-remote-bind-lifecycle.test.ts",
-      "test": "rejects a mutated checked-in security inventory instruction (#6024)",
-      "category": "security"
-    },
-    {
       "file": "test/e2e/live/hermes-e2e.test.ts",
       "test": "hermes-e2e: install.sh onboards Hermes and proves health plus live inference",
       "category": "security"
@@ -164,11 +159,6 @@
     {
       "file": "test/openclaw-locked-install.test.ts",
       "test": "rejects $name even with a test-only matching lock digest",
-      "category": "security"
-    },
-    {
-      "file": "test/openclaw-locked-install.test.ts",
-      "test": "rejects a same-registry tarball with a substituted package manifest",
       "category": "security"
     },
     {

--- a/test/dashboard-remote-bind-lifecycle.test.ts
+++ b/test/dashboard-remote-bind-lifecycle.test.ts
@@ -141,29 +141,6 @@ describe("remote dashboard bind production lifecycle", () => {
     }
   });
 
-  // source-shape-contract: security -- The reviewed completed-image security inventory must stay bound to its exact Docker instruction.
-  it("rejects a mutated checked-in security inventory instruction (#6024)", () => {
-    vi.stubEnv("NEMOCLAW_DASHBOARD_BIND", "0.0.0.0");
-    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-remote-bind-mutated-"));
-    const dockerfile = path.join(directory, "Dockerfile");
-    const checkedInDockerfile = fs.readFileSync(path.join(process.cwd(), "Dockerfile"), "utf8");
-    const mutatedDockerfile = checkedInDockerfile.replace(
-      '"vim-common=2:9.2.0858-1"',
-      '"vim-common=2:9.2.0857-1"',
-    );
-    expect(mutatedDockerfile).not.toBe(checkedInDockerfile);
-    fs.writeFileSync(dockerfile, mutatedDockerfile);
-
-    try {
-      expect(() =>
-        patchStagedDockerfile(dockerfile, "test-model", "http://127.0.0.1:18789"),
-      ).toThrow(/preserve the generated remote dashboard output/);
-      expect(hasPreparedRemoteDashboardBind(dockerfile)).toBe(false);
-    } finally {
-      fs.rmSync(directory, { recursive: true, force: true });
-    }
-  });
-
   it("rejects config rewrites appended to checked-in metadata validation (#6024)", () => {
     vi.stubEnv("NEMOCLAW_DASHBOARD_BIND", "0.0.0.0");
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-remote-bind-metadata-"));

--- a/test/openclaw-locked-install.test.ts
+++ b/test/openclaw-locked-install.test.ts
@@ -278,13 +278,6 @@ describe("locked OpenClaw production installation (#5896)", () => {
     ).toEqual(["@scope/canonical@5.6.2"]);
   });
 
-  // source-shape-contract: security -- The installed production graph must reject package identity substitution after a reviewed tarball is extracted
-  it("rejects a same-registry tarball with a substituted package manifest", () => {
-    expect(() =>
-      verifyInstalledNpmLock(installedFixture({ actualName: "is-odd", actualVersion: "3.0.1" })),
-    ).toThrow("expected chalk@5.6.2, found is-odd@3.0.1");
-  });
-
   // source-shape-contract: security -- Production lock verification must fail closed when required package locations are absent or redirected through symlinks
   it("fails closed on missing required packages and symlinked package roots", () => {
     expect(() => verifyInstalledNpmLock(installedFixture({ omit: true }))).toThrow(


### PR DESCRIPTION
## Summary
Remove two source-shape tests whose security behavior is already exercised through stronger owning boundaries. Ratchet the exception inventory to match without changing production behavior.

## Changes
- remove the dashboard lifecycle mutation of an unrelated pinned Vim instruction; the completed-image package contract remains covered by the executable sandbox base security package tests
- remove the direct installed-package identity unit case; the reviewed npm audit workflow still proves the same fail-closed identity mismatch through package materialization
- remove both deleted tests from the source-shape exception inventory

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: test/sandbox-base-security-packages.test.ts executes the completed-image package contract, and test/reviewed-npm-audit-workflow.test.ts reaches the installed package identity rejection through production materialization.
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 5 files and 113 tests passed across the integration and e2e-support projects
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed obsolete security and compatibility test cases covering remote-bind preparation and same-registry package substitutions.
  * Updated test budgets to reflect the removal of these checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->