### PR TITLE
test: enforce growth workflow through validator

### DIFF
--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -97,11 +97,6 @@
       "category": "security"
     },
     {
-      "file": "test/growth-guardrails-workflow-boundary.test.ts",
-      "test": "runs the trusted Vitest guardrails against pull request data",
-      "category": "security"
-    },
-    {
       "file": "test/hermes-runtime-config-guard-topology.test.ts",
       "test": "allows the sandbox identity to create runtime state but refuses sealed configuration writes, unlinks, and renames (#7865)",
       "category": "security"

--- a/scripts/checks/growth-guardrails-workflow-boundary.mts
+++ b/scripts/checks/growth-guardrails-workflow-boundary.mts
@@ -4,6 +4,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
 
 import YAML from "yaml";
 
@@ -27,7 +28,7 @@ function array(value: unknown): unknown[] {
 }
 
 function same(value: unknown, expected: unknown): boolean {
-  return JSON.stringify(value) === JSON.stringify(expected);
+  return isDeepStrictEqual(value, expected);
 }
 
 export function validateGrowthGuardrailsWorkflowBoundary(

--- a/scripts/checks/growth-guardrails-workflow-boundary.mts
+++ b/scripts/checks/growth-guardrails-workflow-boundary.mts
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import YAML from "yaml";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const WORKFLOW_PATH = join(ROOT, ".github", "workflows", "codebase-growth-guardrails.yaml");
+const STATIC_ACTION_PATH = join(ROOT, ".github", "actions", "ci-static-checks", "action.yaml");
+const CHECKOUT = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1";
+const TEST_COMMAND =
+  "set -euo pipefail\nnpx vitest run --project integration test/growth-guardrails.test.ts";
+const STATIC_COMMAND =
+  "npx prek run --all-files --stage pre-commit \\\n  --skip source-shape-test-budget \\\n  --skip test-skills-yaml";
+
+type Value = Record<string, unknown>;
+
+function object(value: unknown): Value {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Value) : {};
+}
+
+function array(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function same(value: unknown, expected: unknown): boolean {
+  return JSON.stringify(value) === JSON.stringify(expected);
+}
+
+export function validateGrowthGuardrailsWorkflowBoundary(
+  workflowSource = readFileSync(WORKFLOW_PATH, "utf8"),
+  staticActionSource = readFileSync(STATIC_ACTION_PATH, "utf8"),
+): string[] {
+  let workflow: Value;
+  let action: Value;
+  try {
+    workflow = object(YAML.parse(workflowSource));
+    action = object(YAML.parse(staticActionSource));
+  } catch {
+    return ["growth guardrail workflow configuration must be valid YAML"];
+  }
+
+  const expectedWorkflow = {
+    name: "Governance / Enforce Codebase Growth Limits",
+    on: {
+      pull_request_target: { types: ["opened", "reopened", "synchronize", "ready_for_review"] },
+    },
+    permissions: { contents: "read", "pull-requests": "read" },
+    jobs: {
+      "codebase-growth-guardrails": {
+        name: "codebase-growth-guardrails",
+        "runs-on": "ubuntu-latest",
+        "timeout-minutes": 5,
+        steps: [
+          {
+            name: "Check out the trusted base revision",
+            uses: CHECKOUT,
+            with: {
+              ref: "${{ github.event.pull_request.base.sha }}",
+              "persist-credentials": false,
+            },
+          },
+          {
+            name: "Install trusted dependencies",
+            run: "npm ci --ignore-scripts --no-audit --no-fund",
+          },
+          {
+            name: "Test codebase growth guardrails",
+            env: {
+              NEMOCLAW_GROWTH_PR: "1",
+              GH_TOKEN: "${{ github.token }}",
+              PR_NUMBER: "${{ github.event.pull_request.number }}",
+              REPO: "${{ github.repository }}",
+              BASE_SHA: "${{ github.event.pull_request.base.sha }}",
+              HEAD_REPO: "${{ github.event.pull_request.head.repo.full_name }}",
+              HEAD_SHA: "${{ github.event.pull_request.head.sha }}",
+            },
+            run: TEST_COMMAND + "\n",
+          },
+        ],
+      },
+    },
+  };
+  const normalizedWorkflow: Value = { ...workflow, on: workflow.on ?? workflow.true };
+  delete normalizedWorkflow.true;
+  const errors: string[] = [];
+  if (!same(normalizedWorkflow, expectedWorkflow)) {
+    errors.push("growth guardrail workflow must match the reviewed trust boundary");
+  }
+
+  const staticSteps = array(object(action.runs).steps).map(object);
+  const namedStaticSteps = staticSteps.filter((step) => step.name === "Run static hook checks");
+  if (
+    namedStaticSteps.length !== 1 ||
+    !same(namedStaticSteps[0], {
+      name: "Run static hook checks",
+      shell: "bash",
+      run: STATIC_COMMAND + "\n",
+    })
+  ) {
+    errors.push("static action must retain the reviewed hook-check step");
+  }
+  if (JSON.stringify(action).includes("test-size:check")) {
+    errors.push("static checks must not recursively invoke test-size:check");
+  }
+  return errors;
+}
+
+const currentModule = fileURLToPath(import.meta.url);
+if (process.argv[1] === currentModule) {
+  const errors = validateGrowthGuardrailsWorkflowBoundary();
+  if (errors.length > 0) {
+    errors.forEach((error) => console.error(error));
+    process.exit(1);
+  }
+  console.log("Codebase growth guardrail workflow boundary passed.");
+}

--- a/scripts/checks/run.mts
+++ b/scripts/checks/run.mts
@@ -123,6 +123,11 @@ export const CHECKS: readonly CheckCommand[] = [
     command: TSX,
     args: ["scripts/checks/test-registration-boundary.mts"],
   },
+  {
+    name: "growth-guardrails-workflow-boundary",
+    command: TSX,
+    args: ["scripts/checks/growth-guardrails-workflow-boundary.mts"],
+  },
 ];
 
 type RunChecksOptions = {

--- a/test/growth-guardrails-workflow-boundary.test.ts
+++ b/test/growth-guardrails-workflow-boundary.test.ts
@@ -7,74 +7,94 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import YAML from "yaml";
 
-const WORKFLOW_PATH = path.resolve(
-  import.meta.dirname,
-  "../.github/workflows/codebase-growth-guardrails.yaml",
+import { validateGrowthGuardrailsWorkflowBoundary } from "../scripts/checks/growth-guardrails-workflow-boundary.mts";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+const WORKFLOW_SOURCE = readFileSync(
+  path.join(ROOT, ".github/workflows/codebase-growth-guardrails.yaml"),
+  "utf8",
 );
-const STATIC_CHECK_ACTION_PATH = path.resolve(
-  import.meta.dirname,
-  "../.github/actions/ci-static-checks/action.yaml",
+const STATIC_ACTION_SOURCE = readFileSync(
+  path.join(ROOT, ".github/actions/ci-static-checks/action.yaml"),
+  "utf8",
 );
+
+type Value = Record<string, any>;
+
+function mutatedWorkflow(mutate: (workflow: Value) => void): string[] {
+  const workflow = YAML.parse(WORKFLOW_SOURCE) as Value;
+  mutate(workflow);
+  return validateGrowthGuardrailsWorkflowBoundary(YAML.stringify(workflow), STATIC_ACTION_SOURCE);
+}
 
 describe("codebase growth guardrails workflow trust boundary", () => {
-  // source-shape-contract: security -- The pull_request_target guardrail must run only the trusted base test and treat pull request files as data
-  it("runs the trusted Vitest guardrails against pull request data", () => {
-    const workflow = YAML.parse(readFileSync(WORKFLOW_PATH, "utf8"));
+  it("accepts the checked-in trusted workflow configuration", () => {
+    expect(validateGrowthGuardrailsWorkflowBoundary()).toEqual([]);
+  });
 
-    expect(workflow).toEqual({
-      name: "Governance / Enforce Codebase Growth Limits",
-      on: {
-        pull_request_target: {
-          types: ["opened", "reopened", "synchronize", "ready_for_review"],
-        },
-      },
-      permissions: { contents: "read", "pull-requests": "read" },
-      jobs: {
-        "codebase-growth-guardrails": {
-          name: "codebase-growth-guardrails",
-          "runs-on": "ubuntu-latest",
-          "timeout-minutes": 5,
-          steps: [
-            {
-              name: "Check out the trusted base revision",
-              uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
-              with: {
-                ref: "${{ github.event.pull_request.base.sha }}",
-                "persist-credentials": false,
-              },
-            },
-            {
-              name: "Install trusted dependencies",
-              run: "npm ci --ignore-scripts --no-audit --no-fund",
-            },
-            {
-              name: "Test codebase growth guardrails",
-              env: {
-                NEMOCLAW_GROWTH_PR: "1",
-                GH_TOKEN: "${{ github.token }}",
-                PR_NUMBER: "${{ github.event.pull_request.number }}",
-                REPO: "${{ github.repository }}",
-                BASE_SHA: "${{ github.event.pull_request.base.sha }}",
-                HEAD_REPO: "${{ github.event.pull_request.head.repo.full_name }}",
-                HEAD_SHA: "${{ github.event.pull_request.head.sha }}",
-              },
-              run: "set -euo pipefail\nnpx vitest run --project integration test/growth-guardrails.test.ts\n",
-            },
-          ],
-        },
-      },
-    });
+  it.each([
+    ["trigger", (workflow: Value) => (workflow.on.pull_request = {})],
+    ["permissions", (workflow: Value) => (workflow.permissions.contents = "write")],
+    [
+      "base checkout",
+      (workflow: Value) => (workflow.jobs["codebase-growth-guardrails"].steps[0].with.ref = "main"),
+    ],
+    [
+      "checkout pin",
+      (workflow: Value) =>
+        (workflow.jobs["codebase-growth-guardrails"].steps[0].uses =
+          "actions/checkout@0000000000000000000000000000000000000000"),
+    ],
+    [
+      "checkout credentials",
+      (workflow: Value) =>
+        (workflow.jobs["codebase-growth-guardrails"].steps[0].with["persist-credentials"] = true),
+    ],
+    [
+      "dependency install",
+      (workflow: Value) =>
+        (workflow.jobs["codebase-growth-guardrails"].steps[1].run = "npm install"),
+    ],
+    [
+      "test invocation",
+      (workflow: Value) => (workflow.jobs["codebase-growth-guardrails"].steps[2].run = "npm test"),
+    ],
+    [
+      "pull request metadata",
+      (workflow: Value) =>
+        (workflow.jobs["codebase-growth-guardrails"].steps[2].env.HEAD_SHA = "untrusted"),
+    ],
+    [
+      "job permission override",
+      (workflow: Value) =>
+        (workflow.jobs["codebase-growth-guardrails"].permissions = { contents: "write" }),
+    ],
+    [
+      "failure tolerance",
+      (workflow: Value) =>
+        (workflow.jobs["codebase-growth-guardrails"].steps[2]["continue-on-error"] = true),
+    ],
+  ])("rejects a mutation to %s", (_boundary, mutate) => {
+    expect(mutatedWorkflow(mutate)).toContain(
+      "growth guardrail workflow must match the reviewed trust boundary",
+    );
+  });
 
-    const action = YAML.parse(readFileSync(STATIC_CHECK_ACTION_PATH, "utf8"));
+  it("rejects recursive test-size checks from the static action", () => {
+    const action = YAML.parse(STATIC_ACTION_SOURCE) as Value;
+    action.runs.steps.push({ run: "npm run test-size:check", shell: "bash" });
     expect(
-      action.runs.steps.filter((step: { name?: string }) => step.name === "Run static hook checks"),
-    ).toEqual([
-      {
-        name: "Run static hook checks",
-        shell: "bash",
-        run: "npx prek run --all-files --stage pre-commit \\\n  --skip source-shape-test-budget \\\n  --skip test-skills-yaml\n",
-      },
-    ]);
-    expect(JSON.stringify(action)).not.toContain("test-size:check");
+      validateGrowthGuardrailsWorkflowBoundary(WORKFLOW_SOURCE, YAML.stringify(action)),
+    ).toContain("static checks must not recursively invoke test-size:check");
+  });
+
+  it("rejects removal of the reviewed static hook step", () => {
+    const action = YAML.parse(STATIC_ACTION_SOURCE) as Value;
+    action.runs.steps = action.runs.steps.filter(
+      (step: Value) => step.name !== "Run static hook checks",
+    );
+    expect(
+      validateGrowthGuardrailsWorkflowBoundary(WORKFLOW_SOURCE, YAML.stringify(action)),
+    ).toContain("static action must retain the reviewed hook-check step");
   });
 });

--- a/test/growth-guardrails-workflow-boundary.test.ts
+++ b/test/growth-guardrails-workflow-boundary.test.ts
@@ -32,6 +32,26 @@ describe("codebase growth guardrails workflow trust boundary", () => {
     expect(validateGrowthGuardrailsWorkflowBoundary()).toEqual([]);
   });
 
+  it("accepts equivalent workflow mappings with reordered keys", () => {
+    const workflow = YAML.parse(WORKFLOW_SOURCE) as Value;
+    const reorderedWorkflow = {
+      jobs: workflow.jobs,
+      permissions: {
+        "pull-requests": workflow.permissions["pull-requests"],
+        contents: workflow.permissions.contents,
+      },
+      on: workflow.on,
+      name: workflow.name,
+    };
+
+    expect(
+      validateGrowthGuardrailsWorkflowBoundary(
+        YAML.stringify(reorderedWorkflow),
+        STATIC_ACTION_SOURCE,
+      ),
+    ).toEqual([]);
+  });
+
   it.each([
     ["trigger", (workflow: Value) => (workflow.on.pull_request = {})],
     ["permissions", (workflow: Value) => (workflow.permissions.contents = "write")],


### PR DESCRIPTION
## Summary
Replace the growth-guardrail workflow's test-owned configuration snapshot with a repository check and mutation-focused tests. The trust contract now runs in every repository check while the source-shape exception inventory drops by one.

## Changes
- add a repository validator for the growth-guardrail workflow and static-check action trust boundary
- register the validator in `npm run checks:repository`
- replace the exact test snapshot with negative mutations covering trigger, permissions, checkout, credentials, dependency installation, test invocation, pull request metadata, and failure handling
- remove the retired source-shape exception

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: independent local security review verified exact trust-boundary preservation after the validator was registered as a repository check.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 13 growth workflow boundary tests passed
- [x] Applicable broad gate passed — `npm run checks:repository`, `npm run source-shape:check`, and CLI type-check passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated validation for growth-guardrail workflow and static-check configuration.
  * Checks detect unsafe triggers, permission changes, altered test execution, pull-request metadata changes, and recursive test checks.

* **Bug Fixes**
  * Improved protection against configuration changes that could weaken workflow safeguards.

* **Tests**
  * Expanded coverage for workflow security and configuration protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->