### PR TITLE
fix(ci): pass comparison refs to advisor preparation

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -241,7 +241,9 @@ jobs:
       # analysis-phase step with a GitHub token, and it has no model credential.
       - name: Prepare advisor sandbox inputs
         env:
+          BASE_REF: ${{ github.event_name == 'pull_request_target' && 'target/base' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'target/base' || inputs.base_ref) }}
           GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event_name == 'pull_request_target' && 'HEAD' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'HEAD' || inputs.head_ref) }}
         run: node --experimental-strip-types --no-warnings "$ADVISOR_DIR/tools/pr-review-advisor/openshell.mts" prepare
 
       - name: Install OpenShell

--- a/test/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/pr-review-advisor-workflow-boundary.test.ts
@@ -151,6 +151,22 @@ describe("PR review advisor workflow boundary", () => {
     );
   });
 
+  it("supplies comparison refs while preparing specialist context", () => {
+    const errors = validateMutation((value) => {
+      const prepare = value.jobs["review-specialists"].steps.find(
+        (step: Record<string, any>) => step.name === "Prepare advisor sandbox inputs",
+      );
+      delete prepare.env.BASE_REF;
+      delete prepare.env.HEAD_REF;
+    });
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        "Prepare advisor sandbox inputs must receive the selected base ref",
+        "Prepare advisor sandbox inputs must receive the selected head ref",
+      ]),
+    );
+  });
+
   it("keeps trusted code and same-run artifacts", () => {
     const errors = validateMutation((value) => {
       const checkout = value.jobs.review.steps.find(

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -17,6 +17,10 @@ const SANDBOX_NAME = /^(?!.*--)[a-z]([a-z0-9-]*[a-z0-9])?$/u;
 const INTERESTS = new Set(ADVISOR_INTERESTS);
 const SPECIALIST_MATRIX_EXPRESSION =
   "${{ fromJSON(needs.discover-specialists.outputs.matrix) }}";
+const BASE_REF_EXPRESSION =
+  "${{ github.event_name == 'pull_request_target' && 'target/base' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'target/base' || inputs.base_ref) }}";
+const HEAD_REF_EXPRESSION =
+  "${{ github.event_name == 'pull_request_target' && 'HEAD' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'HEAD' || inputs.head_ref) }}";
 const READ_PERMISSIONS = {
   actions: "read",
   checks: "read",
@@ -197,6 +201,12 @@ export function validatePrReviewAdvisorWorkflowBoundary(
     errors.push(
       "specialist job env.PR_REVIEW_ADVISOR_INTEREST must be ${{ matrix.advisor.interest }}",
     );
+  const prepareInputs = namedStep(specialists, "Prepare advisor sandbox inputs");
+  const prepareEnvironment = object(prepareInputs?.env);
+  if (prepareEnvironment.BASE_REF !== BASE_REF_EXPRESSION)
+    errors.push("Prepare advisor sandbox inputs must receive the selected base ref");
+  if (prepareEnvironment.HEAD_REF !== HEAD_REF_EXPRESSION)
+    errors.push("Prepare advisor sandbox inputs must receive the selected head ref");
   requireWith(
     errors,
     namedStep(specialists, "Upload native specialist session"),


### PR DESCRIPTION
## Summary

The advisor now supplies its selected base and head refs while preparing specialist context. Without them, every specialist stops before analysis and no review artifact is produced.

This completes the specialist-context wiring introduced in #10075 and restores automated review for the current merge train.

## Related issue

Regression from #10075.

## Changes

- Pass the selected comparison refs to the trusted preparation step.
- Extend the workflow-boundary validator to require both inputs.
- Add a mutation test that removes the inputs and proves validation fails.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Maintainer review confirms the new values are repository-owned expressions passed only to trusted preparation code. PR content remains read-only data, the GitHub token remains confined to the preparation step, and model credentials are unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; no DGX Station host preparation changes.
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a Signed-off-by line and every published commit appears as Verified in GitHub
- [x] Normal pre-commit, commit-msg, and pre-push hooks passed
- [x] Workflow-boundary test passes: 9 tests
- [x] Repository checks pass
- [x] JavaScript configuration type-checking passes after building the CLI
- [ ] Applicable broad gate passed — npm test for broad runtime/test-harness changes; npm run check for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] npm run docs builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request review analyses by consistently selecting the correct base and head revisions.
  * Added validation to detect missing revision references before specialist analysis begins.

* **Tests**
  * Added workflow coverage for validating required base and head revision inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->