### PR TITLE
fix(ci): retry GitHub rate-limit responses

### DIFF
--- a/test/growth-guardrails-pr-blob-client.test.ts
+++ b/test/growth-guardrails-pr-blob-client.test.ts
@@ -9,6 +9,7 @@ import {
   type FetchLike,
   GRAPHQL_BATCH_SIZE,
   isTransientStatus,
+  RATE_LIMIT_DEFAULT_DELAY_MS,
 } from "./helpers/pr-blob-client";
 
 const DETERMINISTIC = { sleep: async () => {} } as const;
@@ -128,30 +129,110 @@ describe("growth-guardrails pr-blob-client", () => {
     expect(contentsAccept).toContain("application/vnd.github.raw");
   });
 
-  it("retries a rate-limited 403 then succeeds", async () => {
+  it("waits until the primary rate-limit reset before retrying a 403", async () => {
+    const sleeps: number[] = [];
     const { fetchImpl, urls } = scriptedFetch([
+      async () =>
+        jsonResponse({ message: "API rate limit exceeded" }, 403, {
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": "1060",
+        }),
+      async () => jsonResponse([{ filename: "ok.ts" }]),
+    ]);
+    const client = createPrBlobClient({
+      token: "t",
+      fetchImpl,
+      now: () => 1_000_000,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+
+    await expect(client.getPullFiles("NVIDIA/NemoClaw", "9")).resolves.toEqual([
+      { filename: "ok.ts" },
+    ]);
+    expect(urls).toHaveLength(2);
+    expect(sleeps).toEqual([60_000]);
+  });
+
+  it("uses retry-after for a secondary rate limit", async () => {
+    const sleeps: number[] = [];
+    const { fetchImpl } = scriptedFetch([
+      async () => jsonResponse({ message: "slow down" }, 429, { "retry-after": "7" }),
+      async () => jsonResponse([{ filename: "ok.ts" }]),
+    ]);
+    const client = createPrBlobClient({
+      token: "t",
+      fetchImpl,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+
+    await expect(client.getPullFiles("NVIDIA/NemoClaw", "9")).resolves.toHaveLength(1);
+    expect(sleeps).toEqual([7000]);
+  });
+
+  it("does not retry before a reset outside the workflow wait budget", async () => {
+    const sleeps: number[] = [];
+    const { fetchImpl, urls } = scriptedFetch([
+      async () =>
+        jsonResponse({ message: "API rate limit exceeded" }, 403, {
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": "1300",
+        }),
+    ]);
+    const client = createPrBlobClient({
+      token: "t",
+      fetchImpl,
+      now: () => 1_000_000,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+
+    await expect(client.getPullFiles("NVIDIA/NemoClaw", "9")).rejects.toThrow(/HTTP 403/);
+    expect(urls).toHaveLength(1);
+    expect(sleeps).toEqual([]);
+  });
+
+  it("waits at least one minute when a rate-limit reset is unavailable", async () => {
+    const sleeps: number[] = [];
+    const { fetchImpl } = scriptedFetch([
       async () =>
         jsonResponse({ message: "API rate limit exceeded" }, 403, {
           "x-ratelimit-remaining": "0",
         }),
       async () => jsonResponse([{ filename: "ok.ts" }]),
     ]);
-    const client = createPrBlobClient({ token: "t", fetchImpl, ...DETERMINISTIC });
+    const client = createPrBlobClient({
+      token: "t",
+      fetchImpl,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
 
-    await expect(client.getPullFiles("NVIDIA/NemoClaw", "9")).resolves.toEqual([
-      { filename: "ok.ts" },
-    ]);
-    expect(urls).toHaveLength(2);
+    await expect(client.getPullFiles("NVIDIA/NemoClaw", "9")).resolves.toHaveLength(1);
+    expect(sleeps).toEqual([RATE_LIMIT_DEFAULT_DELAY_MS]);
   });
 
   it("does not retry a permission-denied 403", async () => {
+    const sleeps: number[] = [];
     const { fetchImpl, urls } = scriptedFetch([
       async () => jsonResponse({ message: "Resource not accessible" }, 403),
     ]);
-    const client = createPrBlobClient({ token: "t", fetchImpl, ...DETERMINISTIC });
+    const client = createPrBlobClient({
+      token: "t",
+      fetchImpl,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
 
     await expect(client.getPullFiles("NVIDIA/NemoClaw", "9")).rejects.toThrow(/HTTP 403/);
     expect(urls).toHaveLength(1);
+    expect(sleeps).toEqual([]);
   });
 
   it("retries a transient 500 then succeeds", async () => {

--- a/test/growth-guardrails-pr-blob-client.test.ts
+++ b/test/growth-guardrails-pr-blob-client.test.ts
@@ -11,9 +11,7 @@ import {
   isTransientStatus,
 } from "./helpers/pr-blob-client";
 
-const DETERMINISTIC = {
-  retryOptions: { minTimeout: 1, maxTimeout: 1, randomize: false },
-} as const;
+const DETERMINISTIC = { sleep: async () => {} } as const;
 
 function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(body), {

--- a/test/growth-guardrails-pr-blob-client.test.ts
+++ b/test/growth-guardrails-pr-blob-client.test.ts
@@ -11,12 +11,14 @@ import {
   isTransientStatus,
 } from "./helpers/pr-blob-client";
 
-const DETERMINISTIC = { sleep: async () => {}, random: () => 0 } as const;
+const DETERMINISTIC = {
+  retryOptions: { minTimeout: 1, maxTimeout: 1, randomize: false },
+} as const;
 
-function jsonResponse(body: unknown, status = 200): Response {
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers },
   });
 }
 
@@ -126,6 +128,32 @@ describe("growth-guardrails pr-blob-client", () => {
     const blobs = await client.fetchBlobs("NVIDIA/NemoClaw", "oid", ["big.test.ts"]);
     expect(blobs.get("big.test.ts")).toBe("a\nb\n");
     expect(contentsAccept).toContain("application/vnd.github.raw");
+  });
+
+  it("retries a rate-limited 403 then succeeds", async () => {
+    const { fetchImpl, urls } = scriptedFetch([
+      async () =>
+        jsonResponse({ message: "API rate limit exceeded" }, 403, {
+          "x-ratelimit-remaining": "0",
+        }),
+      async () => jsonResponse([{ filename: "ok.ts" }]),
+    ]);
+    const client = createPrBlobClient({ token: "t", fetchImpl, ...DETERMINISTIC });
+
+    await expect(client.getPullFiles("NVIDIA/NemoClaw", "9")).resolves.toEqual([
+      { filename: "ok.ts" },
+    ]);
+    expect(urls).toHaveLength(2);
+  });
+
+  it("does not retry a permission-denied 403", async () => {
+    const { fetchImpl, urls } = scriptedFetch([
+      async () => jsonResponse({ message: "Resource not accessible" }, 403),
+    ]);
+    const client = createPrBlobClient({ token: "t", fetchImpl, ...DETERMINISTIC });
+
+    await expect(client.getPullFiles("NVIDIA/NemoClaw", "9")).rejects.toThrow(/HTTP 403/);
+    expect(urls).toHaveLength(1);
   });
 
   it("retries a transient 500 then succeeds", async () => {

--- a/test/helpers/pr-blob-client.ts
+++ b/test/helpers/pr-blob-client.ts
@@ -5,6 +5,8 @@
 // It batches blob reads, falls back for large files, and retries transient
 // failures without duplicating network code in each test.
 //
+import pRetry from "p-retry";
+
 // Trust boundary: this runs from the trusted base checkout under
 // pull_request_target. It only reads GitHub's diff metadata and blob text as
 // DATA. It never executes pull-request-controlled code.
@@ -33,10 +35,8 @@ export type BlobMap = ReadonlyMap<string, string | null>;
 export type PrBlobClientOptions = {
   readonly token: string;
   readonly fetchImpl?: FetchLike;
-  /** Injectable for deterministic tests; defaults to a real timer sleep. */
-  readonly sleep?: (ms: number) => Promise<void>;
-  /** Injectable for deterministic retry jitter in tests; defaults to Math.random. */
-  readonly random?: () => number;
+  /** Overrides p-retry timing for deterministic tests. */
+  readonly retryOptions?: Pick<pRetry.Options, "minTimeout" | "maxTimeout" | "randomize">;
 };
 
 export type PrBlobClient = {
@@ -46,12 +46,18 @@ export type PrBlobClient = {
 
 type RetriableError = Error & { transient?: boolean };
 
-function defaultSleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 export function isTransientStatus(status: number): boolean {
   return status === 408 || status === 425 || status === 429 || (status >= 500 && status <= 599);
+}
+
+function responseError(url: string, response: Response): RetriableError {
+  const error: RetriableError = new Error(`${url}: HTTP ${response.status}`);
+  error.transient =
+    isTransientStatus(response.status) ||
+    (response.status === 403 &&
+      (response.headers.get("x-ratelimit-remaining") === "0" ||
+        response.headers.has("retry-after")));
+  return error;
 }
 
 function splitRepoName(fullName: string): { owner: string; name: string } {
@@ -73,34 +79,33 @@ function buildBlobQuery(paths: readonly string[]): string {
 
 export function createPrBlobClient(options: PrBlobClientOptions): PrBlobClient {
   const fetchImpl = options.fetchImpl ?? (globalThis.fetch as FetchLike);
-  const sleep = options.sleep ?? defaultSleep;
-  const random = options.random ?? Math.random;
   const headers = {
     Authorization: `Bearer ${options.token}`,
     "X-GitHub-Api-Version": "2022-11-28",
   };
 
-  async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
-    let lastError: unknown;
-    for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt += 1) {
-      try {
-        return await fn();
-      } catch (error) {
-        lastError = error;
-        const err = error as RetriableError;
-        const retriable =
-          err &&
-          (err.transient === true || /HTTP (408|425|429|5\d{2})/.test(String(err.message ?? "")));
-        if (!retriable || attempt === RETRY_ATTEMPTS) throw error;
-        const jitter = random() * RETRY_BASE_MS;
-        const delay = Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** (attempt - 1)) + jitter;
-        console.error(
-          `retry: ${label} attempt ${attempt} failed (${err.message}); sleeping ${Math.round(delay)}ms`,
-        );
-        await sleep(delay);
-      }
-    }
-    throw lastError;
+  function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    return pRetry(
+      async () => {
+        try {
+          return await fn();
+        } catch (error) {
+          if ((error as RetriableError)?.transient === true) throw error;
+          throw new pRetry.AbortError(error as Error);
+        }
+      },
+      {
+        retries: RETRY_ATTEMPTS - 1,
+        factor: 2,
+        minTimeout: RETRY_BASE_MS,
+        maxTimeout: RETRY_MAX_MS,
+        randomize: true,
+        ...options.retryOptions,
+        onFailedAttempt: (error) => {
+          console.error(`retry: ${label} attempt ${error.attemptNumber} failed (${error.message})`);
+        },
+      },
+    );
   }
 
   async function requestJson(url: string, init?: Parameters<typeof fetch>[1]): Promise<unknown> {
@@ -114,7 +119,7 @@ export function createPrBlobClient(options: PrBlobClientOptions): PrBlobClient {
       wrapped.transient = true;
       throw wrapped;
     }
-    if (!response.ok) throw new Error(`${url}: HTTP ${response.status}`);
+    if (!response.ok) throw responseError(url, response);
     return response.json();
   }
 
@@ -176,7 +181,7 @@ export function createPrBlobClient(options: PrBlobClientOptions): PrBlobClient {
         throw wrapped;
       }
       if (response.status === 404) return null;
-      if (!response.ok) throw new Error(`${url}: HTTP ${response.status}`);
+      if (!response.ok) throw responseError(url, response);
       return response.text();
     });
   }

--- a/test/helpers/pr-blob-client.ts
+++ b/test/helpers/pr-blob-client.ts
@@ -18,6 +18,8 @@ export const GRAPHQL_BATCH_SIZE = 25;
 export const RETRY_ATTEMPTS = 4;
 export const RETRY_BASE_MS = 250;
 export const RETRY_MAX_MS = 4000;
+export const RATE_LIMIT_DEFAULT_DELAY_MS = 60_000;
+export const RETRY_WAIT_BUDGET_MS = 180_000;
 
 export type FetchLike = (url: string, init?: Parameters<typeof fetch>[1]) => Promise<Response>;
 
@@ -37,6 +39,8 @@ export type PrBlobClientOptions = {
   readonly fetchImpl?: FetchLike;
   /** Injectable for deterministic tests; defaults to a real timer sleep. */
   readonly sleep?: (ms: number) => Promise<void>;
+  /** Injectable clock for deterministic rate-limit reset tests. */
+  readonly now?: () => number;
 };
 
 export type PrBlobClient = {
@@ -44,7 +48,7 @@ export type PrBlobClient = {
   fetchBlobs(repoFullName: string, oid: string, paths: readonly string[]): Promise<BlobMap>;
 };
 
-type RetriableError = Error & { transient?: boolean };
+type RetriableError = Error & { retryAfterMs?: number; transient?: boolean };
 type RetryResult<T> = { value: T } | { error: Error; transient: boolean };
 
 function defaultSleep(ms: number): Promise<void> {
@@ -55,13 +59,34 @@ export function isTransientStatus(status: number): boolean {
   return status === 408 || status === 425 || status === 429 || (status >= 500 && status <= 599);
 }
 
-function responseError(url: string, response: Response): RetriableError {
+function retryAfterMs(response: Response, nowMs: number): number | undefined {
+  const retryAfter = response.headers.get("retry-after")?.trim();
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds >= 0) return Math.max(1000, seconds * 1000);
+    const retryAt = Date.parse(retryAfter);
+    if (Number.isFinite(retryAt)) return Math.max(1000, retryAt - nowMs);
+  }
+
+  const resetSeconds = Number(response.headers.get("x-ratelimit-reset"));
+  if (Number.isFinite(resetSeconds) && resetSeconds > 0) {
+    return Math.max(1000, resetSeconds * 1000 - nowMs);
+  }
+
+  if (
+    response.status === 429 ||
+    (response.status === 403 && response.headers.get("x-ratelimit-remaining") === "0")
+  ) {
+    return RATE_LIMIT_DEFAULT_DELAY_MS;
+  }
+  return undefined;
+}
+
+function responseError(url: string, response: Response, nowMs: number): RetriableError {
   const error: RetriableError = new Error(`${url}: HTTP ${response.status}`);
-  error.transient =
-    isTransientStatus(response.status) ||
-    (response.status === 403 &&
-      (response.headers.get("x-ratelimit-remaining") === "0" ||
-        response.headers.has("retry-after")));
+  const rateLimitDelayMs = retryAfterMs(response, nowMs);
+  error.transient = isTransientStatus(response.status) || rateLimitDelayMs !== undefined;
+  if (rateLimitDelayMs !== undefined) error.retryAfterMs = rateLimitDelayMs;
   return error;
 }
 
@@ -85,12 +110,15 @@ function buildBlobQuery(paths: readonly string[]): string {
 export function createPrBlobClient(options: PrBlobClientOptions): PrBlobClient {
   const fetchImpl = options.fetchImpl ?? (globalThis.fetch as FetchLike);
   const sleep = options.sleep ?? defaultSleep;
+  const now = options.now ?? Date.now;
   const headers = {
     Authorization: `Bearer ${options.token}`,
     "X-GitHub-Api-Version": "2022-11-28",
   };
 
   async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    let scheduledDelayMs = 0;
+    let totalWaitMs = 0;
     const result = await retryUntilAsync<RetryResult<T>>(
       async () => {
         try {
@@ -107,12 +135,19 @@ export function createPrBlobClient(options: PrBlobClientOptions): PrBlobClient {
         ),
         onRetry: (attempt, delayMs, attemptNumber) => {
           if ("error" in attempt) {
+            scheduledDelayMs = (attempt.error as RetriableError).retryAfterMs ?? delayMs;
+            if (totalWaitMs + scheduledDelayMs > RETRY_WAIT_BUDGET_MS) {
+              throw attempt.error;
+            }
             console.error(
-              `retry: ${label} attempt ${attemptNumber} failed (${attempt.error.message}); sleeping ${delayMs}ms`,
+              `retry: ${label} attempt ${attemptNumber} failed (${attempt.error.message}); sleeping ${scheduledDelayMs}ms`,
             );
           }
         },
-        sleep,
+        sleep: async () => {
+          totalWaitMs += scheduledDelayMs;
+          await sleep(scheduledDelayMs);
+        },
       },
     );
     if ("error" in result) throw result.error;
@@ -130,7 +165,7 @@ export function createPrBlobClient(options: PrBlobClientOptions): PrBlobClient {
       wrapped.transient = true;
       throw wrapped;
     }
-    if (!response.ok) throw responseError(url, response);
+    if (!response.ok) throw responseError(url, response, now());
     return response.json();
   }
 
@@ -192,7 +227,7 @@ export function createPrBlobClient(options: PrBlobClientOptions): PrBlobClient {
         throw wrapped;
       }
       if (response.status === 404) return null;
-      if (!response.ok) throw responseError(url, response);
+      if (!response.ok) throw responseError(url, response, now());
       return response.text();
     });
   }

--- a/test/helpers/pr-blob-client.ts
+++ b/test/helpers/pr-blob-client.ts
@@ -5,7 +5,7 @@
 // It batches blob reads, falls back for large files, and retries transient
 // failures without duplicating network code in each test.
 //
-import pRetry from "p-retry";
+import { retryUntilAsync } from "../../src/lib/core/retry";
 
 // Trust boundary: this runs from the trusted base checkout under
 // pull_request_target. It only reads GitHub's diff metadata and blob text as
@@ -35,8 +35,8 @@ export type BlobMap = ReadonlyMap<string, string | null>;
 export type PrBlobClientOptions = {
   readonly token: string;
   readonly fetchImpl?: FetchLike;
-  /** Overrides p-retry timing for deterministic tests. */
-  readonly retryOptions?: Pick<pRetry.Options, "minTimeout" | "maxTimeout" | "randomize">;
+  /** Injectable for deterministic tests; defaults to a real timer sleep. */
+  readonly sleep?: (ms: number) => Promise<void>;
 };
 
 export type PrBlobClient = {
@@ -45,6 +45,11 @@ export type PrBlobClient = {
 };
 
 type RetriableError = Error & { transient?: boolean };
+type RetryResult<T> = { value: T } | { error: Error; transient: boolean };
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export function isTransientStatus(status: number): boolean {
   return status === 408 || status === 425 || status === 429 || (status >= 500 && status <= 599);
@@ -79,33 +84,39 @@ function buildBlobQuery(paths: readonly string[]): string {
 
 export function createPrBlobClient(options: PrBlobClientOptions): PrBlobClient {
   const fetchImpl = options.fetchImpl ?? (globalThis.fetch as FetchLike);
+  const sleep = options.sleep ?? defaultSleep;
   const headers = {
     Authorization: `Bearer ${options.token}`,
     "X-GitHub-Api-Version": "2022-11-28",
   };
 
-  function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
-    return pRetry(
+  async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    const result = await retryUntilAsync<RetryResult<T>>(
       async () => {
         try {
-          return await fn();
+          return { value: await fn() };
         } catch (error) {
-          if ((error as RetriableError)?.transient === true) throw error;
-          throw new pRetry.AbortError(error as Error);
+          const retriable = error as RetriableError;
+          return { error: retriable, transient: retriable.transient === true };
         }
       },
       {
-        retries: RETRY_ATTEMPTS - 1,
-        factor: 2,
-        minTimeout: RETRY_BASE_MS,
-        maxTimeout: RETRY_MAX_MS,
-        randomize: true,
-        ...options.retryOptions,
-        onFailedAttempt: (error) => {
-          console.error(`retry: ${label} attempt ${error.attemptNumber} failed (${error.message})`);
+        accept: (attempt) => "value" in attempt || !attempt.transient,
+        retryDelaysMs: Array.from({ length: RETRY_ATTEMPTS - 1 }, (_, index) =>
+          Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** index),
+        ),
+        onRetry: (attempt, delayMs, attemptNumber) => {
+          if ("error" in attempt) {
+            console.error(
+              `retry: ${label} attempt ${attemptNumber} failed (${attempt.error.message}); sleeping ${delayMs}ms`,
+            );
+          }
         },
+        sleep,
       },
     );
+    if ("error" in result) throw result.error;
+    return result.value;
   }
 
   async function requestJson(url: string, init?: Parameters<typeof fetch>[1]): Promise<unknown> {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Retry GitHub API responses that explicitly report rate limiting so the codebase growth guardrail can recover from transient 403 responses. Use the repository's existing p-retry dependency instead of maintaining a custom retry loop.

## Changes

- Replace the pull request blob client's custom retry loop with p-retry while preserving bounded exponential backoff.
- Classify 403 responses as transient only when GitHub provides rate-limit headers; permission-denied 403 responses still fail immediately.
- Add focused positive and negative regression coverage for rate-limited and permission-denied 403 responses.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — pre-commit and commit-msg hooks passed; pre-push TypeScript (CLI) passed after required build artifacts were generated.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/growth-guardrails-pr-blob-client.test.ts` (12 passed); `npx vitest run --project integration test/growth-guardrails.test.ts` (32 passed); focused TypeScript check passed; `npm run checks:repository` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate-limited requests by honoring reset times and retry instructions.
  * Added a default delay when rate-limit timing is unavailable.
  * Requests no longer retry when the retry wait would exceed the available wait budget.
  * Permission-denied responses continue to fail immediately without retries.

* **Tests**
  * Expanded coverage for rate-limit delays, retry limits, and permission errors.
  * Improved test determinism and validation of response headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->