### PR TITLE
refactor(test): group credential coverage

### DIFF
--- a/ci/cli-test-timing-hints.json
+++ b/ci/cli-test-timing-hints.json
@@ -81,7 +81,7 @@
     "test/cli/sandbox-status-text.test.ts": 14597,
     "test/cli/snapshot-shields.test.ts": 14050,
     "test/cli/tunnel-command.test.ts": 16882,
-    "test/credentials.test.ts": 6328,
+    "test/credentials/credentials.test.ts": 6328,
     "test/dcode-session-supervisor.test.ts": 7644,
     "test/dcode-wrapper-identity.test.ts": 11176,
     "test/deepagents-code-tui-startup-check.test.ts": 28222,

--- a/test/README.md
+++ b/test/README.md
@@ -28,7 +28,7 @@ The project globs in `vitest.config.ts` must remain disjoint and exhaustive.
 
 Choose the execution lane from the boundary that the test exercises.
 Within the integration project, group new tests by the behavior that owns the assertion.
-For example, `process-recovery/` owns sandbox process and forward recovery coverage, and `channels/` owns channel lifecycle coverage.
+For example, `process-recovery/` owns sandbox process and forward recovery coverage, `channels/` owns channel lifecycle coverage, and `credentials/` owns host credential storage and reset coverage.
 Do not put an ordinary integration test in `e2e/` or `package-contract/`.
 
 Run `npm run test:projects:check` after adding or moving a test.

--- a/test/credentials/credentials-reset-outcome.test.ts
+++ b/test/credentials/credentials-reset-outcome.test.ts
@@ -3,8 +3,8 @@
 
 import { describe, expect, it } from "vitest";
 
-import { formatResetOutcome } from "../src/lib/actions/credentials/reset";
-import type { ProviderDeleteWithRecoveryResult } from "../src/lib/onboard/sandbox-provider-cleanup";
+import { formatResetOutcome } from "../../src/lib/actions/credentials/reset";
+import type { ProviderDeleteWithRecoveryResult } from "../../src/lib/onboard/sandbox-provider-cleanup";
 
 function result(over: Partial<ProviderDeleteWithRecoveryResult>): ProviderDeleteWithRecoveryResult {
   return {

--- a/test/credentials/credentials.test.ts
+++ b/test/credentials/credentials.test.ts
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const require = createRequire(import.meta.url);
 
-type CredentialsModule = typeof import("../src/lib/credentials/store.js");
+type CredentialsModule = typeof import("../../src/lib/credentials/store.js");
 
 function isCredentialsModule(value: object | null): value is CredentialsModule {
   return (
@@ -28,7 +28,7 @@ function isCredentialsModule(value: object | null): value is CredentialsModule {
 // Pull the credential-env-key allowlist from the production module so
 // future additions only need to be made in one place. Plus a few
 // fixture-only names this suite mutates directly.
-import { KNOWN_CREDENTIAL_ENV_KEYS } from "../src/lib/credentials/store.js";
+import { KNOWN_CREDENTIAL_ENV_KEYS } from "../../src/lib/credentials/store.js";
 
 const TEST_FIXTURE_ENV_KEYS = ["TEST_API_KEY", "OTHER_KEY", "EMPTY_VALUE", "ZETA", "ALPHA"];
 const TRACKED_ENV_KEYS = [...KNOWN_CREDENTIAL_ENV_KEYS, ...TEST_FIXTURE_ENV_KEYS];
@@ -49,7 +49,7 @@ async function importCredentialsModule(
   vi.doUnmock("readline");
   vi.stubEnv("HOME", home);
   vi.stubEnv("NEMOCLAW_GATEWAY_PORT", gatewayPort === undefined ? "" : String(gatewayPort));
-  const module = await import("../src/lib/credentials/store.js");
+  const module = await import("../../src/lib/credentials/store.js");
   const loaded = "default" in module ? module.default : module;
   const moduleObject = typeof loaded === "object" && loaded !== null ? loaded : null;
   if (!isCredentialsModule(moduleObject)) {
@@ -134,50 +134,51 @@ describe("host-side credential staging", () => {
     expect(credentials.getCredential("NVIDIA_INFERENCE_API_KEY")).toBe("nvapi-from-env");
   });
 
-  it.each(
-    ["secret\nheader", "secret\rheader", "secret\0tail"],
-  )("scopes a runtime credential without exporting or enumerating it [%s]", async (value) => {
-    const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-creds-"));
-    try {
-      const credentials = await importCredentialsModule(home);
+  it.each(["secret\nheader", "secret\rheader", "secret\0tail"])(
+    "scopes a runtime credential without exporting or enumerating it [%s]",
+    async (value) => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-creds-"));
+      try {
+        const credentials = await importCredentialsModule(home);
 
-      await credentials.withCredentialOverrides(
-        { COMPATIBLE_API_KEY: "runtime-only-secret" },
-        async () => {
-          await Promise.resolve();
-          expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBe("runtime-only-secret");
-          expect(credentials.resolveProviderCredential("COMPATIBLE_API_KEY")).toBe(
-            "runtime-only-secret",
-          );
-          expect(process.env.COMPATIBLE_API_KEY).toBeUndefined();
-          expect(credentials.loadCredentials()).not.toHaveProperty("COMPATIBLE_API_KEY");
-          expect(credentials.listCredentialKeys()).not.toContain("COMPATIBLE_API_KEY");
+        await credentials.withCredentialOverrides(
+          { COMPATIBLE_API_KEY: "runtime-only-secret" },
+          async () => {
+            await Promise.resolve();
+            expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBe("runtime-only-secret");
+            expect(credentials.resolveProviderCredential("COMPATIBLE_API_KEY")).toBe(
+              "runtime-only-secret",
+            );
+            expect(process.env.COMPATIBLE_API_KEY).toBeUndefined();
+            expect(credentials.loadCredentials()).not.toHaveProperty("COMPATIBLE_API_KEY");
+            expect(credentials.listCredentialKeys()).not.toContain("COMPATIBLE_API_KEY");
 
-          const child = spawnSync(
-            process.execPath,
-            ["-e", "process.stdout.write(process.env.COMPATIBLE_API_KEY || '')"],
-            { encoding: "utf8" },
-          );
-          expect(child.status).toBe(0);
-          expect(child.stdout).toBe("");
-        },
-      );
+            const child = spawnSync(
+              process.execPath,
+              ["-e", "process.stdout.write(process.env.COMPATIBLE_API_KEY || '')"],
+              { encoding: "utf8" },
+            );
+            expect(child.status).toBe(0);
+            expect(child.stdout).toBe("");
+          },
+        );
 
-      expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBeNull();
-      await credentials.withCredentialOverrides(
-        { COMPATIBLE_API_KEY: " runtime-only-secret " },
-        async () => {
-          expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBe(" runtime-only-secret ");
-        },
-      );
+        expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBeNull();
+        await credentials.withCredentialOverrides(
+          { COMPATIBLE_API_KEY: " runtime-only-secret " },
+          async () => {
+            expect(credentials.getCredential("COMPATIBLE_API_KEY")).toBe(" runtime-only-secret ");
+          },
+        );
 
-      await expect(
-        credentials.withCredentialOverrides({ COMPATIBLE_API_KEY: value }, async () => {}),
-      ).rejects.toThrow(/must not contain NUL, CR, or LF/);
-    } finally {
-      fs.rmSync(home, { recursive: true, force: true });
-    }
-  });
+        await expect(
+          credentials.withCredentialOverrides({ COMPATIBLE_API_KEY: value }, async () => {}),
+        ).rejects.toThrow(/must not contain NUL, CR, or LF/);
+      } finally {
+        fs.rmSync(home, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("returns null for missing or blank credential values", async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-creds-"));
@@ -729,7 +730,7 @@ describe("prompt machinery (unchanged)", () => {
         sleep 1
         printf 'n\\n'
       } > "$pipe" &
-      ${JSON.stringify(process.execPath)} -e 'const { prompt } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "bin", "lib", "credentials"))}); (async()=>{ await prompt("first: "); await prompt("second: "); })().catch(err=>{ console.error(err); process.exit(1); });' < "$pipe"
+      ${JSON.stringify(process.execPath)} -e 'const { prompt } = require(${JSON.stringify(path.join(import.meta.dirname, "../..", "bin", "lib", "credentials"))}); (async()=>{ await prompt("first: "); await prompt("second: "); })().catch(err=>{ console.error(err); process.exit(1); });' < "$pipe"
     `;
 
     const result = spawnSync("bash", ["--noprofile", "--norc"], {
@@ -744,8 +745,8 @@ describe("prompt machinery (unchanged)", () => {
 
   it("settles the outer prompt promise on secret prompt errors", () => {
     const script = `
-const { prompt } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "credentials", "store.ts"))});
-const { isAnyPromptActive } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "core", "prompt-activity.ts"))});
+const { prompt } = require(${JSON.stringify(path.join(import.meta.dirname, "../..", "src", "lib", "credentials", "store.ts"))});
+const { isAnyPromptActive } = require(${JSON.stringify(path.join(import.meta.dirname, "../..", "src", "lib", "core", "prompt-activity.ts"))});
 process.stdin.isTTY = true;
 process.stderr.isTTY = true;
 process.stdin.ref = () => process.stdin;
@@ -770,8 +771,8 @@ prompt('secret: ', { secret: true })
 
   it("releases secret prompt activity when stdin closes before an answer (#6651)", () => {
     const script = `
-const { prompt } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "credentials", "store.ts"))});
-const { isAnyPromptActive } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "core", "prompt-activity.ts"))});
+const { prompt } = require(${JSON.stringify(path.join(import.meta.dirname, "../..", "src", "lib", "credentials", "store.ts"))});
+const { isAnyPromptActive } = require(${JSON.stringify(path.join(import.meta.dirname, "../..", "src", "lib", "core", "prompt-activity.ts"))});
 process.stdin.isTTY = true;
 process.stderr.isTTY = true;
 process.stdin.ref = () => process.stdin;
@@ -820,8 +821,8 @@ pending
 
   it("re-prompts shared credential prompts after help input", () => {
     const script = `
-const credentials = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "credentials", "store.ts"))});
-const { createCredentialPromptHelpers } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "onboard", "credential-navigation.ts"))});
+const credentials = require(${JSON.stringify(path.join(import.meta.dirname, "../..", "src", "lib", "credentials", "store.ts"))});
+const { createCredentialPromptHelpers } = require(${JSON.stringify(path.join(import.meta.dirname, "../..", "src", "lib", "onboard", "credential-navigation.ts"))});
 const answers = ["help", "sk-TEST-NOT-A-REAL-KEY"];
 const logs = [];
 credentials.prompt = async () => answers.shift() || "";
@@ -866,7 +867,7 @@ createCredentialPromptHelpers(() => { throw new Error("unexpected exit"); }).rea
     const stdinUnref = vi.spyOn(process.stdin, "unref").mockImplementation(() => process.stdin);
 
     try {
-      const credentials = await import("../src/lib/credentials/store.js");
+      const credentials = await import("../../src/lib/credentials/store.js");
       const pending = credentials.prompt("question: ");
       rl.emit("SIGINT");
       await expect(pending).rejects.toMatchObject({
@@ -899,7 +900,7 @@ createCredentialPromptHelpers(() => { throw new Error("unexpected exit"); }).rea
     const stdinUnref = vi.spyOn(process.stdin, "unref").mockImplementation(() => process.stdin);
 
     try {
-      const credentials = await import("../src/lib/credentials/store.js");
+      const credentials = await import("../../src/lib/credentials/store.js");
       const pending = credentials.prompt("question: ");
       // Simulate stdin EOF (e.g. `< /dev/null`): readline closes without ever
       // invoking the question callback.
@@ -932,8 +933,8 @@ createCredentialPromptHelpers(() => { throw new Error("unexpected exit"); }).rea
     const stdinUnref = vi.spyOn(process.stdin, "unref").mockImplementation(() => process.stdin);
 
     try {
-      const credentials = await import("../src/lib/credentials/store.js");
-      const promptActivity = await import("../src/lib/core/prompt-activity.js");
+      const credentials = await import("../../src/lib/credentials/store.js");
+      const promptActivity = await import("../../src/lib/core/prompt-activity.js");
       expect(promptActivity.isAnyPromptActive()).toBe(false);
 
       const pending = credentials.prompt("question: ");
@@ -963,7 +964,7 @@ createCredentialPromptHelpers(() => { throw new Error("unexpected exit"); }).rea
     expect(credentials.normalizeCredentialValue("  nvapi-good-key\r\n")).toBe("nvapi-good-key");
 
     const script = `
-const { ensureApiKey } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "credentials", "store.ts"))});
+const { ensureApiKey } = require(${JSON.stringify(path.join(import.meta.dirname, "../..", "src", "lib", "credentials", "store.ts"))});
 delete process.env.NVIDIA_INFERENCE_API_KEY;
 ensureApiKey()
   .then(() => console.log('STAGED=' + process.env.NVIDIA_INFERENCE_API_KEY))
@@ -1006,7 +1007,7 @@ ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptFile)} < "$pipe"
 
   it("returns navigation from the NVIDIA API key prompt without staging it", () => {
     const script = `
-const { ensureApiKey } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "credentials", "store.ts"))});
+const { ensureApiKey } = require(${JSON.stringify(path.join(import.meta.dirname, "../..", "src", "lib", "credentials", "store.ts"))});
 delete process.env.NVIDIA_INFERENCE_API_KEY;
 ensureApiKey()
   .then((result) => console.log(JSON.stringify({ result, key: process.env.NVIDIA_INFERENCE_API_KEY || null })))
@@ -1026,7 +1027,7 @@ ensureApiKey()
 
   it("returns exit from the NVIDIA API key prompt without staging it", () => {
     const script = `
-const { ensureApiKey } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "credentials", "store.ts"))});
+const { ensureApiKey } = require(${JSON.stringify(path.join(import.meta.dirname, "../..", "src", "lib", "credentials", "store.ts"))});
 delete process.env.NVIDIA_INFERENCE_API_KEY;
 ensureApiKey()
   .then((result) => console.log(JSON.stringify({ result, key: process.env.NVIDIA_INFERENCE_API_KEY || null })))
@@ -1046,7 +1047,7 @@ ensureApiKey()
 
   it("normal and secret prompts re-ref, cleanup stdin, and preserve masked input", () => {
     const script = `
-const { prompt } = require(${JSON.stringify(path.join(import.meta.dirname, "..", "src", "lib", "credentials", "store.ts"))});
+const { prompt } = require(${JSON.stringify(path.join(import.meta.dirname, "../..", "src", "lib", "credentials", "store.ts"))});
 const counts = { ref: 0, resume: 0, pause: 0, unref: 0, raw: [] };
 process.stdin.ref = () => { counts.ref += 1; return process.stdin; };
 process.stdin.resume = () => { counts.resume += 1; return process.stdin; };

--- a/test/e2e/support/retired-selector-compatibility.test.ts
+++ b/test/e2e/support/retired-selector-compatibility.test.ts
@@ -29,7 +29,7 @@ const REPLACEMENT_FILES = [
   "test/package-contract/cli/public-cli-contracts.test.ts",
   "test/gateway-drift-preflight.test.ts",
   "test/gateway-health-honest.test.ts",
-  "test/credentials.test.ts",
+  "test/credentials/credentials.test.ts",
   "test/package-contract/onboard/invalid-nvidia-key.test.ts",
   "test/installer-integration/install-openshell-version-pin.test.ts",
   "test/rebuild-stale-recovery.test.ts",
@@ -112,7 +112,7 @@ describe("retired E2E selector compatibility", () => {
       expect(selected).toEqual([...RETIRED_CONTROLLER_SELECTOR_IDS].sort());
       expect(commands).toEqual([
         "npx vitest run --project cli src/lib/actions/sandbox/rebuild-flow-helpers.test.ts src/lib/actions/sandbox/rebuild-post-restore-phase.test.ts src/lib/actions/sandbox/rebuild-recreate-observability.test.ts src/lib/actions/sandbox/rebuild-route-preflight.test.ts src/lib/actions/upgrade-sandboxes-recovery.test.ts src/lib/sandbox/version.test.ts src/lib/security/credential-filter.test.ts",
-        "npx vitest run --project integration test/cli/list-share-live-inference.test.ts test/credential-migration-reconciliation.test.ts test/credentials.test.ts test/gateway-drift-preflight.test.ts test/gateway-health-honest.test.ts test/rebuild-stale-recovery.test.ts",
+        "npx vitest run --project integration test/cli/list-share-live-inference.test.ts test/credential-migration-reconciliation.test.ts test/credentials/credentials.test.ts test/gateway-drift-preflight.test.ts test/gateway-health-honest.test.ts test/rebuild-stale-recovery.test.ts",
         "npx vitest run --project installer-integration test/installer-integration/install-openshell-version-pin.test.ts",
         "npx vitest run --project package-contract test/package-contract/cli/debug-cli-command.test.ts test/package-contract/cli/public-cli-contracts.test.ts test/package-contract/onboard/invalid-nvidia-key.test.ts",
       ]);

--- a/tools/e2e/retired-selector-compatibility.mts
+++ b/tools/e2e/retired-selector-compatibility.mts
@@ -86,7 +86,7 @@ const REPLACEMENTS: Readonly<Record<RetiredControllerSelectorId, Replacement>> =
   "onboard-negative-paths": {
     legacyFile: "test/e2e/live/onboard-negative-paths.test.ts",
     tests: [
-      { files: ["test/credentials.test.ts"], project: "integration" },
+      { files: ["test/credentials/credentials.test.ts"], project: "integration" },
       {
         files: ["test/package-contract/onboard/invalid-nvidia-key.test.ts"],
         project: "package-contract",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Group host credential storage and reset integration coverage under a behavior-owned test directory. The tests remain in the existing integration project while source imports, timing metadata, and retired E2E selector references follow the new paths.

## Changes

- Move the credential store and reset outcome integration tests into test/credentials/.
- Update source imports and repository-root calculations for the additional directory depth.
- Update CLI timing hints and retired-selector replacement coverage to reference the moved credential test.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: This change only moves existing tests and updates path-dependent contracts; the moved tests, retired selector test, and shard sequencer test exercise every affected path.
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — Normal pre-commit, commit-msg, and pre-push hooks passed.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run test:projects:check`; `npx vitest run --project integration test/credentials` (51 passed); `npx vitest run --project e2e-support test/e2e/support/retired-selector-compatibility.test.ts` (5 passed); `npx vitest run --project integration test/cli-coverage-sequencer.test.ts` (13 passed); `npm run checks:repository`; `npm run typecheck:cli`
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized credential test coverage under a dedicated credentials directory.
  * Updated related test references and integration checks to use the new test locations.
  * Preserved existing credential behavior while improving test organization.

* **Documentation**
  * Clarified that credential storage and reset coverage belong to the credentials test area.

* **Chores**
  * Updated test timing hints and compatibility tooling for the reorganized test paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->