### PR TITLE
fix(e2e): restore Hermes rebuild provider attachment

### DIFF
--- a/test/e2e/live/rebuild-hermes-env.ts
+++ b/test/e2e/live/rebuild-hermes-env.ts
@@ -15,6 +15,18 @@ export interface RebuildHermesBaseReusePlan {
   childEnv: NodeJS.ProcessEnv;
 }
 
+/** Supply the current Discord credential when rebuild replaces the legacy provider. */
+export function buildRebuildHermesRecreateEnv(
+  discordBotToken: string,
+  baseImageEnv: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+  return {
+    ...baseImageEnv,
+    DISCORD_BOT_TOKEN: discordBotToken,
+    NEMOCLAW_REBUILD_VERBOSE: "1",
+  };
+}
+
 /** Select the normal lane's exact phase 1 image under a test-owned local alias. */
 export function planRebuildHermesBaseReuse(
   staleBaseMode: boolean,

--- a/test/e2e/live/rebuild-hermes.test.ts
+++ b/test/e2e/live/rebuild-hermes.test.ts
@@ -45,7 +45,11 @@ import {
   createRebuildHermesCronRestoreFixture,
   hermesRuntimeExecArgs,
 } from "./rebuild-hermes-cron-restore.ts";
-import { buildRebuildHermesChildEnv, planRebuildHermesBaseReuse } from "./rebuild-hermes-env.ts";
+import {
+  buildRebuildHermesChildEnv,
+  buildRebuildHermesRecreateEnv,
+  planRebuildHermesBaseReuse,
+} from "./rebuild-hermes-env.ts";
 import { ensureRebuildHermesHostTools, hermesApiTokenDigest } from "./rebuild-hermes-host-tools.ts";
 import {
   cleanupTrackedRebuildHermesImage,
@@ -1107,10 +1111,11 @@ test(STALE_BASE_REBUILD
   );
   await artifacts.writeJson("phase-5-inference-route-before-rebuild.json", routeBeforeRebuild);
   progress.phase("rebuild the Hermes sandbox");
-  const rebuildEnv = testEnv(undefined, {
-    NEMOCLAW_REBUILD_VERBOSE: "1",
-    ...baseReusePlan?.childEnv,
-  });
+  const rebuildEnv = testEnv(
+    undefined,
+    buildRebuildHermesRecreateEnv(DISCORD_FAKE_TOKEN, baseReusePlan?.childEnv),
+  );
+  expect(rebuildEnv.DISCORD_BOT_TOKEN).toBe(DISCORD_FAKE_TOKEN);
   expect(rebuildEnv).not.toHaveProperty("NVIDIA_INFERENCE_API_KEY");
   expect(rebuildEnv).not.toHaveProperty("COMPATIBLE_API_KEY");
   expect(rebuildEnv).not.toHaveProperty("NVIDIA_API_KEY");

--- a/test/e2e/support/rebuild-hermes-env.test.ts
+++ b/test/e2e/support/rebuild-hermes-env.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import type { SandboxBaseImageResolutionMetadata } from "../../../src/lib/sandbox-base-image/types";
 import {
   buildRebuildHermesChildEnv,
+  buildRebuildHermesRecreateEnv,
   planRebuildHermesBaseReuse,
 } from "../live/rebuild-hermes-env.ts";
 
@@ -98,5 +99,25 @@ describe("rebuild-Hermes base reuse", () => {
     expect(childEnv.NVIDIA_API_KEY).toBeUndefined();
     expect(childEnv.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
     expect(childEnv.BUILDX_BUILDER).toBeUndefined();
+  });
+
+  it("forwards the Discord credential needed to replace the legacy rebuild provider (#10155)", () => {
+    const childEnv = buildRebuildHermesChildEnv(
+      {
+        COMPATIBLE_API_KEY: "must-not-reach-child",
+        NVIDIA_API_KEY: "must-not-reach-child",
+        NVIDIA_INFERENCE_API_KEY: "must-not-reach-child",
+      },
+      buildRebuildHermesRecreateEnv("fixture-discord-token", {
+        NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF: preparedRef,
+      }),
+    );
+
+    expect(childEnv.DISCORD_BOT_TOKEN).toBe("fixture-discord-token");
+    expect(childEnv.NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF).toBe(preparedRef);
+    expect(childEnv.NEMOCLAW_REBUILD_VERBOSE).toBe("1");
+    expect(childEnv.COMPATIBLE_API_KEY).toBeUndefined();
+    expect(childEnv.NVIDIA_API_KEY).toBeUndefined();
+    expect(childEnv.NVIDIA_INFERENCE_API_KEY).toBeUndefined();
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Before this change, the Hermes rebuild E2E fixture deleted its sandbox and then tried to recreate it with a retained Discord policy but no attached replacement provider, so OpenShell rejected the create request. The fixture now supplies its existing fake Discord credential during recreation, allowing the current static provider profile to replace the legacy generic provider.

## Related Issue

Part of #10155

## Changes

- Build the explicit Hermes recreation environment with the fake Discord credential, verbose rebuild diagnostics, and the selected base-image override.
- Use that environment in both the normal and stale-base Hermes rebuild lanes while continuing to omit host inference credentials.
- Add deterministic E2E support coverage for the provider credential, base-image override, and inference-credential exclusions.
- Draft PR #10110 contains the same `DISCORD_BOT_TOKEN` call-site hunk inside a broader lifecycle change. This PR isolates that hunk and adds deterministic coverage at the owned child-environment boundary so the correction can be reviewed and landed independently.

The small recreation-environment helper is owned by the two rebuild-Hermes lanes. A call-site-only literal would not expose the complete child-environment contract to deterministic support coverage; `test/e2e/support/rebuild-hermes-env.test.ts` protects that contract.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Self-review completed. The change forwards only the existing fake E2E Discord token, which remains covered by the fixture's redaction values and backup credential leak scan. No production credential, messaging policy, or network boundary changes.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/rebuild-hermes-env.test.ts` passed 1 file and 6 tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Documentation Writer Review
- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: This commit changes only the Hermes rebuild E2E fixture. Existing documentation already states that Hermes rebuild preserves messaging credentials and attaches the exact validated static provider required by a retained Discord policy.
- Agent: Codex Desktop
<!-- docs-review-head-sha: 4640fc96b -->
<!-- docs-review-agents-blob-sha: becb5c586 -->

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for Hermes rebuild environment recreation.
  - Verified that required Discord credentials and prepared base settings are preserved during rebuilds.
  - Confirmed unsupported credentials are excluded and verbose rebuild output is enabled.
  - Added checks to ensure environment configuration remains consistent across rebuild scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->