### PR TITLE
fix(cli): accept managed OpenClaw registry identity

### DIFF
--- a/src/lib/actions/uninstall/portable-runtime-cleanup.test.ts
+++ b/src/lib/actions/uninstall/portable-runtime-cleanup.test.ts
@@ -791,6 +791,7 @@ describe("portable runtime uninstall cleanup", () => {
     expect(hasPortableRetirementRecord(scope.test.homeDir)).toBe(true);
   });
 
+  const setRegistryAgentDrift = (value: any) => (value.sandboxes["later-sandbox"].agent = "hermes");
   it.each([
     ["an unknown profile", "session", (value: any) => (value.checkpoint.profile.value = "unknown")],
     ["a profile mismatch", "session", (value: any) => (value.checkpoint.profile.value = "default")],
@@ -817,6 +818,7 @@ describe("portable runtime uninstall cleanup", () => {
       "registry",
       (value: any) => delete value.sandboxes["later-sandbox"].openshellDriver,
     ],
+    ["a registry agent identity drift", "registry", setRegistryAgentDrift],
     [
       "a registry gateway drift",
       "registry",

--- a/src/lib/actions/uninstall/run-plan-portable-leftover-state.test.ts
+++ b/src/lib/actions/uninstall/run-plan-portable-leftover-state.test.ts
@@ -129,6 +129,7 @@ function abandonedPortableConfig(host: ReturnType<typeof scope>, mode: number): 
 function completedOpenClawAuthority(
   host: ReturnType<typeof scope>,
   profile: "default" | "portable",
+  registryAgent: null | "openclaw" = null,
 ): void {
   const portable = profile === "portable";
   const uid = process.getuid?.() ?? 1001;
@@ -201,7 +202,7 @@ function completedOpenClawAuthority(
       sandboxes: {
         [sandboxName]: {
           name: sandboxName,
-          agent: null,
+          agent: registryAgent,
           dashboardPort: 18789,
           gatewayName: gateway.gatewayName,
           gatewayPort: gateway.gatewayPort,
@@ -260,6 +261,13 @@ describe("uninstall on a host that owns no portable lifecycle resource", () => {
   it("completes ordinary uninstall after completed default OpenClaw onboarding", () => {
     const host = scope("nemoclaw-uninstall-completed-openclaw-");
     completedOpenClawAuthority(host, "default");
+
+    expectOrdinaryUninstall(host);
+  });
+
+  it("completes ordinary uninstall when managed OpenClaw registration records its explicit agent (#10073)", () => {
+    const host = scope("nemoclaw-uninstall-managed-openclaw-");
+    completedOpenClawAuthority(host, "default", "openclaw");
 
     expectOrdinaryUninstall(host);
   });

--- a/src/lib/actions/uninstall/run-plan-portable-leftover-state.test.ts
+++ b/src/lib/actions/uninstall/run-plan-portable-leftover-state.test.ts
@@ -129,7 +129,7 @@ function abandonedPortableConfig(host: ReturnType<typeof scope>, mode: number): 
 function completedOpenClawAuthority(
   host: ReturnType<typeof scope>,
   profile: "default" | "portable",
-  registryAgent: null | "openclaw" = null,
+  registryAgent: null | "openclaw" | "hermes" = null,
 ): void {
   const portable = profile === "portable";
   const uid = process.getuid?.() ?? 1001;
@@ -270,6 +270,26 @@ describe("uninstall on a host that owns no portable lifecycle resource", () => {
     completedOpenClawAuthority(host, "default", "openclaw");
 
     expectOrdinaryUninstall(host);
+  });
+
+  it("reports the registry agent field and recovery when completed onboarding identity drifts (#10073)", () => {
+    const host = scope("nemoclaw-uninstall-agent-drift-");
+    completedOpenClawAuthority(host, "default", "hermes");
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const result = uninstall(host);
+
+    expect(result.exitCode).toBe(1);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('registry field "agent"'));
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('sandbox "openclaw-sandbox"'));
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Restore the registry entry from trusted completed-onboarding state, then retry uninstall.",
+      ),
+    );
+    expect(host.runModelCleanup).not.toHaveBeenCalled();
+    expect(host.rmSync).not.toHaveBeenCalled();
+    expect(host.runPortableCleanup).not.toHaveBeenCalled();
   });
 
   it("refuses completed portable authority after its lifecycle receipt disappears", () => {

--- a/src/lib/onboard/portable-retirement-authority.ts
+++ b/src/lib/onboard/portable-retirement-authority.ts
@@ -172,7 +172,8 @@ function verifyAuthority(
   if (!fs.readFileSync(boundary.registryFile).equals(registryBytes))
     throw new Error("Completed onboarding registry changed while normalizing");
   const row = registry.sandboxes[sandboxName];
-  const expectedAgent = identity?.agent === "openclaw" ? null : identity?.agent;
+  const matchesRegistryAgent = (agent: unknown) =>
+    agent === identity?.agent || (identity?.agent === "openclaw" && agent === null);
   if (
     !identity ||
     !gateway ||
@@ -182,8 +183,8 @@ function verifyAuthority(
     row?.name !== sandboxName ||
     rawEntry.name !== sandboxName ||
     row.pendingRouteReservation === true ||
-    row.agent !== expectedAgent ||
-    rawEntry.agent !== expectedAgent ||
+    rawEntry.agent !== row.agent ||
+    !matchesRegistryAgent(row.agent) ||
     row.openshellDriver !== "docker" ||
     rawEntry.openshellDriver !== "docker" ||
     row.gatewayName !== gateway.gatewayName ||

--- a/src/lib/onboard/portable-retirement-authority.ts
+++ b/src/lib/onboard/portable-retirement-authority.ts
@@ -175,6 +175,15 @@ function verifyAuthority(
   const matchesRegistryAgent = (agent: unknown) =>
     agent === identity?.agent || (identity?.agent === "openclaw" && agent === null);
   if (
+    identity &&
+    rawEntry &&
+    row &&
+    (rawEntry.agent !== row.agent || !matchesRegistryAgent(row.agent))
+  )
+    throw new Error(
+      `Completed onboarding registry field "agent" does not match trusted onboarding for sandbox ${JSON.stringify(sandboxName)}. Restore the registry entry from trusted completed-onboarding state, then retry uninstall.`,
+    );
+  if (
     !identity ||
     !gateway ||
     !rawEntry ||
@@ -183,8 +192,6 @@ function verifyAuthority(
     row?.name !== sandboxName ||
     rawEntry.name !== sandboxName ||
     row.pendingRouteReservation === true ||
-    rawEntry.agent !== row.agent ||
-    !matchesRegistryAgent(row.agent) ||
     row.openshellDriver !== "docker" ||
     rawEntry.openshellDriver !== "docker" ||
     row.gatewayName !== gateway.gatewayName ||


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Uninstall no longer rejects completed managed OpenClaw onboarding state when the sandbox registry records `agent: "openclaw"`. The lifecycle authority check continues to accept legacy `agent: null` records and rejects non-OpenClaw identity drift.

## Related Issue

Fixes #10073

## Changes

- Accept explicit `openclaw` and legacy `null` registry identities when the completed onboarding checkpoint identifies OpenClaw.
- Require the raw and normalized registry rows to record the same agent identity.
- Add regression coverage for managed OpenClaw uninstall and rejection coverage for registry agent drift.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed completed onboarding authority for managed OpenClaw, legacy OpenClaw, raw/normalized registry drift, and non-OpenClaw identity drift. The change does not modify credential or policy handling.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/actions/uninstall/run-plan-portable-leftover-state.test.ts src/lib/actions/uninstall/portable-runtime-cleanup.test.ts --testTimeout 30000` — 82 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of onboarding and uninstall state when registry agent information is present.
  * Prevented onboarding supersession when the recorded sandbox agent does not match the expected identity.
  * Ensured valid OpenClaw registrations complete successfully.
  * Added recovery guidance for mismatched agent registrations and prevented cleanup actions from running until the issue is resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->