### PR TITLE
fix(e2e): flush Discord gateway upgrade first

### DIFF
--- a/test/e2e/lib/fake-discord-gateway.cjs
+++ b/test/e2e/lib/fake-discord-gateway.cjs
@@ -14,9 +14,22 @@ const portFile = process.env.FAKE_DISCORD_GATEWAY_PORT_FILE || "";
 const captureFile = process.env.FAKE_DISCORD_GATEWAY_CAPTURE_FILE || "";
 const expectedToken = process.env.FAKE_DISCORD_GATEWAY_EXPECTED_TOKEN || "";
 
-if (!expectedToken) {
+if (require.main === module && !expectedToken) {
   console.error("FAKE_DISCORD_GATEWAY_EXPECTED_TOKEN is required");
   process.exit(2);
+}
+
+function writeWebSocketUpgrade(socket, accept, onFlushed) {
+  socket.write(
+    [
+      "HTTP/1.1 101 Switching Protocols",
+      "Upgrade: websocket",
+      "Connection: Upgrade",
+      `Sec-WebSocket-Accept: ${accept}`,
+      "\r\n",
+    ].join("\r\n"),
+    onFlushed,
+  );
 }
 
 function record(event) {
@@ -169,18 +182,11 @@ const server = net.createServer((socket) => {
         .createHash("sha1")
         .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
         .digest("base64");
-      socket.write(
-        [
-          "HTTP/1.1 101 Switching Protocols",
-          "Upgrade: websocket",
-          "Connection: Upgrade",
-          `Sec-WebSocket-Accept: ${accept}`,
-          "\r\n",
-        ].join("\r\n"),
-      );
       upgraded = true;
       record({ event: "upgrade", requestLine });
-      sendJson(socket, { op: 10, d: { heartbeat_interval: 30000 } });
+      writeWebSocketUpgrade(socket, accept, () => {
+        sendJson(socket, { op: 10, d: { heartbeat_interval: 30000 } });
+      });
       framed = Buffer.concat([framed, handshake.slice(end + 4)]);
     } else {
       framed = Buffer.concat([framed, chunk]);
@@ -202,17 +208,21 @@ const server = net.createServer((socket) => {
   });
 });
 
-server.listen(port, host, () => {
-  const address = server.address();
-  if (portFile) {
-    fs.writeFileSync(portFile, `${address.port}\n`, { mode: 0o600 });
-  }
-  record({ event: "listening", host, port: address.port });
-});
-
-for (const signal of ["SIGTERM", "SIGINT"]) {
-  process.on(signal, () => {
-    server.close(() => process.exit(0));
-    setTimeout(() => process.exit(0), 1000).unref();
+if (require.main === module) {
+  server.listen(port, host, () => {
+    const address = server.address();
+    if (portFile) {
+      fs.writeFileSync(portFile, `${address.port}\n`, { mode: 0o600 });
+    }
+    record({ event: "listening", host, port: address.port });
   });
+
+  for (const signal of ["SIGTERM", "SIGINT"]) {
+    process.on(signal, () => {
+      server.close(() => process.exit(0));
+      setTimeout(() => process.exit(0), 1000).unref();
+    });
+  }
 }
+
+module.exports = { writeWebSocketUpgrade };

--- a/test/e2e/support/fake-discord-gateway.test.ts
+++ b/test/e2e/support/fake-discord-gateway.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { writeWebSocketUpgrade } = require(
+  path.resolve(import.meta.dirname, "../lib/fake-discord-gateway.cjs"),
+) as {
+  writeWebSocketUpgrade: (
+    socket: { write: (data: string | Buffer, callback?: () => void) => boolean },
+    accept: string,
+    onFlushed: () => void,
+  ) => void;
+};
+
+describe("fake Discord Gateway", () => {
+  it("flushes the protocol upgrade before sending the first Gateway frame (#10155)", () => {
+    const writes: Array<string | Buffer> = [];
+    let flush: (() => void) | undefined;
+    const socket = {
+      write: vi.fn((data: string | Buffer, callback?: () => void) => {
+        writes.push(data);
+        flush = callback;
+        return true;
+      }),
+    };
+    const sendHello = vi.fn(() => socket.write(Buffer.from([0x81, 0x00])));
+
+    writeWebSocketUpgrade(socket, "fake-accept", sendHello);
+
+    expect(writes).toHaveLength(1);
+    expect(String(writes[0])).toContain("HTTP/1.1 101 Switching Protocols");
+    expect(sendHello).not.toHaveBeenCalled();
+
+    flush?.();
+
+    expect(sendHello).toHaveBeenCalledOnce();
+    expect(writes).toHaveLength(2);
+    expect(writes[1]).toEqual(Buffer.from([0x81, 0x00]));
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The fake Discord Gateway now waits for its HTTP 101 upgrade response to flush before it sends Gateway HELLO. This prevents the first WebSocket frame from being lost during the Node HTTP upgrade transition, which previously left the Hermes Discord rebuild scenario without an observed upgrade.

## Related Issue

Part of #10155. Root-cause evidence: [Hermes Discord rebuild job 97600247958](https://github.com/NVIDIA/NemoClaw/actions/runs/32779535634/job/97600247958).

## Changes

- Send Gateway HELLO only from the HTTP upgrade write callback.
- Preserve the existing WebSocket accept derivation, IDENTIFY token check, heartbeat, capture, close, and redaction behavior.
- Add deterministic fixture coverage that holds the 101 callback and proves HELLO cannot be sent first.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior. Justification:
- [ ] Tests not applicable. Justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded. Justification: An independent nine-category review passed at exact commit `cfe555e057ff959467710792335a3ca634f6fc6e`. It verified the token check, WebSocket headers and accept derivation, framing, redaction, and network-policy behavior remain unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer. Check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass for the current change set. The fake Discord Gateway support suite passed 17 tests.
- [ ] Applicable broad gate passed. Not run because the changed fake-gateway ordering boundary has focused deterministic coverage.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] Focused live E2E target `hermes-discord` passed for this exact commit. Repository policy currently blocks credentialed target selectors on manual PR runs.
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Commit `cfe555e05` changes only the fake Discord Gateway E2E fixture and deterministic support coverage. It preserves the supported Discord command, configuration, credential, and network-policy behavior, so public documentation does not change. Changed test text follows the writing rules.
- Agent: Codex Desktop
<!-- docs-review-head-sha: cfe555e057ff959467710792335a3ca634f6fc6e -->
<!-- docs-review-agents-blob-sha: becb5c5864e9dcade3810bc71fbfa8ab848eae05 -->

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection handling so the initial Gateway message is sent only after the upgrade response is fully written.
  * Prevented duplicate initial Gateway messages during connection setup.

* **Tests**
  * Added end-to-end coverage validating WebSocket upgrade ordering and message delivery timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->