### PR TITLE
ci(installer): trust grouped test template

### DIFF
--- a/scripts/checks/extract-installer-pins.mts
+++ b/scripts/checks/extract-installer-pins.mts
@@ -335,15 +335,17 @@ const TRUSTED_OPENSHELL_RELEASES: readonly OpenShellReleaseTrust[] = [
     },
     // The first template came from the downstream 0.0.106 pin. The second authorizes its
     // fail-before-download strings preflight. The third authorizes repair when an existing formula
-    // has an invalid checksum or its release formula is unavailable. Homebrew owns that source
+    // has an invalid checksum or its release formula is unavailable. The fourth preserves that
+    // template after installer tests moved under test/install. Homebrew owns the formula source
     // state, so NemoClaw cannot correct it there; the installer verifies the trusted release
     // formula before reuse. installer-homebrew-formula-reuse-trust.test.ts and
     // installer-hash-check.test.ts lock the template and trust transitions. Remove the repair
-    // digest when supported Homebrew installs no longer need this repair path.
+    // digests when supported Homebrew installs no longer need this repair path.
     installerTemplateSha256: [
       "5d4cdb2db60df7539193b486ac15bb9be96ec1d40fc0f739a94d4d2f0bf597a0",
       "e850e927aab619d52c5de72967137569d65dd7fa669920c7c5b558f0770140d1",
       "e7d51536442b217e3d5e77c4ba3b7c25e6a74898bf22523f7fb58627d34329cb",
+      "18175cf47a0fece8ce75e5d523185062c7a7c913a3f4ceafbba4a7ca4df7c69b",
     ],
     manifests: [
       {

--- a/test/install/installer-hash-check.test.ts
+++ b/test/install/installer-hash-check.test.ts
@@ -390,7 +390,7 @@ function addInstallerReleaseTable(
 }
 
 function applyReviewedReleaseCohorts(source: string): string {
-  const currentComment = `# regressionTest: test/install/install-openshell-version-check.test.ts exercises all
+  const currentComment = `# regressionTest: test/install-openshell-version-check.test.ts exercises all
 # nine mappings, and scripts/check-installer-hash.sh compares them with the
 # GitHub release API on every PR, main push, weekly run, and manual dispatch.
 # removalCondition: remove these entries only when NemoClaw drops that
@@ -709,10 +709,8 @@ function removeV00106OperationalTrust(source: string): string {
 }
 
 function renderInstallerTemplate(openshellVersion: string, pinFunction: string): string {
-  const selected = INSTALLER_TEMPLATE.replace(
-    /^MIN_VERSION="[0-9]+\.[0-9]+\.[0-9]+"$/m,
-    `MIN_VERSION="${openshellVersion}"`,
-  )
+  const selected = INSTALLER_TEMPLATE.replaceAll("test/install/", "test/")
+    .replace(/^MIN_VERSION="[0-9]+\.[0-9]+\.[0-9]+"$/m, `MIN_VERSION="${openshellVersion}"`)
     .replace(/^MAX_VERSION="[0-9]+\.[0-9]+\.[0-9]+"$/m, `MAX_VERSION="${openshellVersion}"`)
     .replace(
       /^DEV_MIN_VERSION="[0-9]+\.[0-9]+\.[0-9]+"$/m,

--- a/test/install/installer-homebrew-formula-reuse-trust.test.ts
+++ b/test/install/installer-homebrew-formula-reuse-trust.test.ts
@@ -17,6 +17,7 @@ const TRUSTED_V00106_TEMPLATE_DIGESTS = [
   "5d4cdb2db60df7539193b486ac15bb9be96ec1d40fc0f739a94d4d2f0bf597a0",
   "e850e927aab619d52c5de72967137569d65dd7fa669920c7c5b558f0770140d1",
   "e7d51536442b217e3d5e77c4ba3b7c25e6a74898bf22523f7fb58627d34329cb",
+  "18175cf47a0fece8ce75e5d523185062c7a7c913a3f4ceafbba4a7ca4df7c69b",
 ] as const;
 const tempDirs: string[] = [];
 
@@ -59,6 +60,13 @@ command -v strings >/dev/null 2>&1 \\
   );
 }
 
+function restoreFlatInstallTestPaths(source: string): string {
+  return source.replaceAll(
+    "test/install/install-openshell-version-check.test.ts",
+    "test/install-openshell-version-check.test.ts",
+  );
+}
+
 function runTrustCheck(source: string) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-homebrew-reuse-trust-"));
   const installer = path.join(tempDir, "install-openshell.sh");
@@ -85,11 +93,13 @@ function runTrustCheck(source: string) {
 }
 
 describe("installer Homebrew formula reuse trust", () => {
-  const baseTemplate = removeHomebrewFormulaReuseRepair(INSTALLER_SOURCE);
+  const previousTemplate = restoreFlatInstallTestPaths(INSTALLER_SOURCE);
+  const baseTemplate = removeHomebrewFormulaReuseRepair(previousTemplate);
   const templates = [
     ["downstream", TRUSTED_V00106_TEMPLATE_DIGESTS[0], baseTemplate],
     ["strings preflight", TRUSTED_V00106_TEMPLATE_DIGESTS[1], addStringsPreflight(baseTemplate)],
-    ["formula repair", TRUSTED_V00106_TEMPLATE_DIGESTS[2], INSTALLER_SOURCE],
+    ["formula repair", TRUSTED_V00106_TEMPLATE_DIGESTS[2], previousTemplate],
+    ["grouped install tests", TRUSTED_V00106_TEMPLATE_DIGESTS[3], INSTALLER_SOURCE],
   ] as const;
 
   it.each(templates)("accepts the %s template with digest %s", (_label, digest, source) => {


### PR DESCRIPTION
## Summary

Restores the installer hash gate after the install-test grouping changed two reviewed security-comment paths inside the trusted installer template. The exact current template is trusted without changing installer runtime behavior, while the three historical template identities remain covered.

## Changes

- Add the exact current v0.0.106 installer-template digest to the trusted record.
- Keep historical synthetic installer fixtures byte-stable after the test-directory move.
- Cover the current grouped-test template and all three historical template digests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `scripts/check-installer-hash.sh`; 5 Homebrew trust tests; 3 affected installer-table/cohort tests
- [ ] Applicable broad gate passed — not applicable to this exact trust-metadata and fixture update
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Final `npm run validate:pr` is currently blocked by unrelated moved-test import failures already being repaired in #10172. Documentation review found no user-facing impact.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved installer integrity verification by recognizing an additional trusted template signature.
  - Fixed installer checks for test and grouped-install scenarios, including consistent path handling.
  - Improved validation when reusing Homebrew-based installer templates.
- **Tests**
  - Expanded regression coverage for installer trust, template rendering, formula repair, and grouped installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->