### PR TITLE
fix(ci): update growth guardrail hook path

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -120,8 +120,8 @@ jobs:
       - name: Install test dependencies
         run: npm ci --ignore-scripts
 
-      - name: Compile the managed inference catalog
-        run: npm run catalog:compile
+      - name: Build generated harness inputs
+        run: npm run build:policy-boundary && npm run catalog:compile
 
       - name: Audit the real patched OpenClaw distribution
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -326,7 +326,7 @@ repos:
 
       - id: codebase-growth-guardrails
         name: Codebase growth guardrails
-        entry: npx vitest run --project integration test/growth-guardrails.test.ts
+        entry: npx vitest run --project integration test/automation/pull-requests/growth-guardrails.test.ts
         language: system
         always_run: true
         pass_filenames: false


### PR DESCRIPTION
## Summary

Complete the post-migration CI repair by updating the local growth-guardrail hook and building both generated inputs required by the OpenClaw distribution harness.

## Changes

- Point the `codebase-growth-guardrails` pre-commit hook at `test/automation/pull-requests/growth-guardrails.test.ts`.
- Build the shared sandbox-name policy boundary before compiling the managed inference catalog and running the OpenClaw harness.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: this only repairs the hook command for an existing relocated test.
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal hooks passed, or `npm run validate:pr` passed
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — Clean generated-output validation: `npm run build:policy-boundary && npm run catalog:compile && npx vitest run --project integration test/agents/openclaw/openclaw-real-patched-dist-harness.test.ts` — 5 passed, 1 skipped. Guardrail validation: 46 passed.
- [ ] Applicable broad gate passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated preparation workflows to build policy-boundary inputs before compiling the catalog.
  * Updated pre-commit validation to run the growth-guardrails integration test from its new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->