### PR TITLE
fix(rebuild): isolate unavailable WSL Docker helper

### DIFF
--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -278,7 +278,7 @@ Back up those paths outside the sandbox before you approve legacy recovery.
 $$nemoclaw <sandbox-name> rebuild
 ```
 
-On WSL with Docker Desktop, a generated replacement image build uses a temporary credential-free Docker configuration when the configured `desktop.exe` credential helper is unavailable.
+On WSL with Docker Desktop, a generated replacement image build uses a temporary credential-free Docker configuration when the configured Docker Desktop credential helper is unavailable.
 NemoClaw removes the temporary configuration after the build and does not modify your Docker configuration.
 An explicit custom Dockerfile continues to use your configured Docker credentials because its base image or build steps might require a private registry.
 If that custom rebuild cannot reach the credential helper, restore the Docker Desktop session or credential-helper access before retrying.

--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -278,6 +278,11 @@ Back up those paths outside the sandbox before you approve legacy recovery.
 $$nemoclaw <sandbox-name> rebuild
 ```
 
+On WSL with Docker Desktop, a generated replacement image build uses a temporary credential-free Docker configuration when the configured `desktop.exe` credential helper is unavailable.
+NemoClaw removes the temporary configuration after the build and does not modify your Docker configuration.
+An explicit custom Dockerfile continues to use your configured Docker credentials because its base image or build steps might require a private registry.
+If that custom rebuild cannot reach the credential helper, restore the Docker Desktop session or credential-helper access before retrying.
+
 <AgentOnly variant="openclaw">
 
 After post-restore writes, rebuild verifies that the final `openclaw.json` and `.config-hash` pair match.

--- a/src/lib/actions/sandbox/rebuild-custom-image-preflight.test.ts
+++ b/src/lib/actions/sandbox/rebuild-custom-image-preflight.test.ts
@@ -316,6 +316,8 @@ describe("preflightRebuildImage", () => {
             isolatedConfig = String(options.env?.DOCKER_CONFIG);
             expect(isolatedConfig).toContain("nemoclaw-wsl-buildkit-docker-config-");
             expect(isolatedConfig).not.toBe(dockerConfig);
+            expect(options.env?.DOCKER_HOST).toBe("unix:///selected-docker.sock");
+            expect(options.env?.DOCKER_CONTEXT).toBeUndefined();
             expect(options.env?.DOCKER_BUILDKIT).toBe("1");
             expect(
               JSON.parse(fs.readFileSync(path.join(isolatedConfig, "config.json"), "utf8")),
@@ -323,7 +325,12 @@ describe("preflightRebuildImage", () => {
             return { status: 0 } as never;
           }),
           removeImage: vi.fn(() => ({ status: 0 }) as never),
-          env: { DOCKER_CONFIG: dockerConfig, WSL_DISTRO_NAME: "Ubuntu" },
+          env: {
+            DOCKER_CONFIG: dockerConfig,
+            DOCKER_CONTEXT: "ambient-remote",
+            DOCKER_HOST: "unix:///selected-docker.sock",
+            WSL_DISTRO_NAME: "Ubuntu",
+          },
           credentialHelperResponds,
           isWslHost: true,
         }),
@@ -338,6 +345,90 @@ describe("preflightRebuildImage", () => {
       fs.rmSync(dockerConfig, { recursive: true, force: true });
     }
   });
+
+  it.runIf(process.platform !== "win32")(
+    "uses the isolated config across the WSL helper and Docker subprocess boundary (#7111)",
+    async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-wsl-rebuild-process-"));
+      const executableRoot = path.join(root, "bin");
+      const dockerConfig = path.join(root, "docker-config");
+      const buildCtx = path.join(root, "context");
+      const dockerfile = path.join(buildCtx, "Dockerfile");
+      const helperMarker = path.join(root, "helper-invoked");
+      const dockerMarker = path.join(root, "docker-config-used");
+      fs.mkdirSync(executableRoot);
+      fs.mkdirSync(dockerConfig);
+      fs.mkdirSync(buildCtx);
+      fs.writeFileSync(dockerfile, "FROM scratch\n");
+      fs.writeFileSync(
+        path.join(dockerConfig, "config.json"),
+        JSON.stringify({
+          auths: { "registry.example.com": { auth: "must-remain-private" } },
+          credsStore: "desktop.exe",
+        }),
+      );
+      fs.writeFileSync(
+        path.join(executableRoot, "docker-credential-desktop.exe"),
+        ["#!/bin/sh", `printf 'invoked\\n' > "${helperMarker}"`, "exit 1", ""].join("\n"),
+        { mode: 0o700 },
+      );
+      fs.writeFileSync(
+        path.join(executableRoot, "docker"),
+        [
+          "#!/bin/sh",
+          "set -eu",
+          'if [ "$1" = "build" ]; then',
+          '  [ "$DOCKER_HOST" = "unix:///selected-docker.sock" ]',
+          '  [ -z "${DOCKER_CONTEXT+x}" ]',
+          '  [ -n "${DOCKER_CONFIG:-}" ]',
+          `  [ "$DOCKER_CONFIG" != "${dockerConfig}" ]`,
+          '  grep -Fqx \'{"auths":{}}\' "$DOCKER_CONFIG/config.json"',
+          `  printf '%s\\n' "$DOCKER_CONFIG" > "${dockerMarker}"`,
+          "fi",
+          "",
+        ].join("\n"),
+        { mode: 0o700 },
+      );
+      vi.stubEnv(
+        "PATH",
+        `${executableRoot}${path.delimiter}${String(process.env.PATH ?? "")}`,
+      );
+
+      try {
+        const result = successful(
+          await preflightRebuildImage(input(null), {
+            stageBuildContext: vi.fn(() => ({
+              buildCtx,
+              stagedDockerfile: dockerfile,
+              cleanupBuildCtx: () => true,
+              origin: "generated" as const,
+            })),
+            prepareDockerfilePatch: vi.fn(async () => ({
+              buildId: "wsl-process-boundary",
+              dashboardRemoteBindPrepared: false,
+              resolvedBaseImage: null,
+            })),
+            env: {
+              DOCKER_CONFIG: dockerConfig,
+              DOCKER_CONTEXT: "ambient-remote",
+              DOCKER_HOST: "unix:///selected-docker.sock",
+              WSL_DISTRO_NAME: "Ubuntu",
+            },
+            isWslHost: true,
+          }),
+        );
+
+        expect(fs.readFileSync(helperMarker, "utf8")).toBe("invoked\n");
+        const isolatedConfig = fs.readFileSync(dockerMarker, "utf8").trim();
+        expect(isolatedConfig).toContain("nemoclaw-wsl-buildkit-docker-config-");
+        expect(fs.existsSync(isolatedConfig)).toBe(false);
+        expect(disposePreparedBuildContext(result.prepared)).toBe(true);
+      } finally {
+        vi.unstubAllEnvs();
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("preserves Docker credentials while building the exact staged custom context", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-custom-preflight-"));

--- a/src/lib/actions/sandbox/rebuild-custom-image-preflight.test.ts
+++ b/src/lib/actions/sandbox/rebuild-custom-image-preflight.test.ts
@@ -286,12 +286,75 @@ describe("preflightRebuildImage", () => {
     }
   });
 
-  it("builds and removes the exact staged custom context on success", async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-custom-preflight-"));
-    const dockerfile = path.join(dir, "Dockerfile.custom");
+  it("isolates rebuild preflight from an unavailable WSL Docker Desktop helper (#7111)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-wsl-rebuild-preflight-"));
+    const dockerConfig = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-wsl-docker-config-"));
+    const dockerfile = path.join(dir, "Dockerfile");
+    const originalConfig = JSON.stringify({
+      auths: { "registry.example.com": { auth: "must-remain-private" } },
+      credsStore: "desktop.exe",
+    });
     fs.writeFileSync(dockerfile, "FROM scratch\n");
-    const buildImage = vi.fn(() => ({ status: 0 }) as never);
+    fs.writeFileSync(path.join(dockerConfig, "config.json"), originalConfig);
+    let isolatedConfig = "";
+    const credentialHelperResponds = vi.fn(() => false);
+    try {
+      const result = successful(
+        await preflightRebuildImage(input(null), {
+          stageBuildContext: vi.fn(() => ({
+            buildCtx: dir,
+            stagedDockerfile: dockerfile,
+            cleanupBuildCtx: () => true,
+            origin: "generated" as const,
+          })),
+          prepareDockerfilePatch: vi.fn(async () => ({
+            buildId: "wsl-safe-preflight",
+            dashboardRemoteBindPrepared: false,
+            resolvedBaseImage: null,
+          })),
+          buildImage: vi.fn((_dockerfile, _tag, _context, options) => {
+            isolatedConfig = String(options.env?.DOCKER_CONFIG);
+            expect(isolatedConfig).toContain("nemoclaw-wsl-buildkit-docker-config-");
+            expect(isolatedConfig).not.toBe(dockerConfig);
+            expect(options.env?.DOCKER_BUILDKIT).toBe("1");
+            expect(
+              JSON.parse(fs.readFileSync(path.join(isolatedConfig, "config.json"), "utf8")),
+            ).toEqual({ auths: {} });
+            return { status: 0 } as never;
+          }),
+          removeImage: vi.fn(() => ({ status: 0 }) as never),
+          env: { DOCKER_CONFIG: dockerConfig, WSL_DISTRO_NAME: "Ubuntu" },
+          credentialHelperResponds,
+          isWslHost: true,
+        }),
+      );
+
+      expect(credentialHelperResponds).toHaveBeenCalledOnce();
+      expect(fs.existsSync(isolatedConfig)).toBe(false);
+      expect(fs.readFileSync(path.join(dockerConfig, "config.json"), "utf8")).toBe(originalConfig);
+      expect(disposePreparedBuildContext(result.prepared)).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(dockerConfig, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves Docker credentials while building the exact staged custom context", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-custom-preflight-"));
+    const dockerConfig = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-custom-docker-config-"));
+    const dockerfile = path.join(dir, "Dockerfile.custom");
+    const originalConfig = JSON.stringify({
+      auths: { "private.example.com": { auth: "required-by-custom-image" } },
+      credsStore: "desktop.exe",
+    });
+    fs.writeFileSync(dockerfile, "FROM scratch\n");
+    fs.writeFileSync(path.join(dockerConfig, "config.json"), originalConfig);
+    const buildImage = vi.fn((_dockerfile, _tag, _context, options) => {
+      expect(options.env?.DOCKER_CONFIG).toBe(dockerConfig);
+      return { status: 0 } as never;
+    });
     const removeImage = vi.fn(() => ({ status: 0 }) as never);
+    const credentialHelperResponds = vi.fn(() => false);
     try {
       const result = successful(
         await preflightRebuildImage(input(dockerfile), {
@@ -302,6 +365,9 @@ describe("preflightRebuildImage", () => {
           })),
           buildImage,
           removeImage,
+          env: { DOCKER_CONFIG: dockerConfig, WSL_DISTRO_NAME: "Ubuntu" },
+          credentialHelperResponds,
+          isWslHost: true,
         }),
       );
       expect(buildImage).toHaveBeenCalledWith(
@@ -311,10 +377,13 @@ describe("preflightRebuildImage", () => {
         expect.objectContaining({ ignoreError: true }),
       );
       expect(removeImage).toHaveBeenCalledOnce();
+      expect(credentialHelperResponds).not.toHaveBeenCalled();
+      expect(fs.readFileSync(path.join(dockerConfig, "config.json"), "utf8")).toBe(originalConfig);
       expect(fs.existsSync(result.prepared.buildCtx)).toBe(true);
       expect(disposePreparedBuildContext(result.prepared)).toBe(true);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(dockerConfig, { recursive: true, force: true });
     }
   });
 
@@ -404,10 +473,13 @@ describe("preflightRebuildImage", () => {
 });
 
 describe("finalizePreparedRebuildImageMessagingPlan", () => {
-  it("rebuilds and re-fingerprints the retained context with backup-captured home channels (#7803)", () => {
+  it("rebuilds backup-captured home channels with the WSL-safe Docker environment (#7111, #7803)", () => {
     const buildCtx = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-rebuild-finalize-"));
+    const dockerConfig = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-finalize-wsl-config-"));
     const stagedDockerfile = path.join(buildCtx, "Dockerfile");
+    const originalDockerConfig = JSON.stringify({ credsStore: "desktop.exe" });
     fs.writeFileSync(stagedDockerfile, "FROM scratch\nARG NEMOCLAW_MESSAGING_PLAN_B64=old\n");
+    fs.writeFileSync(path.join(dockerConfig, "config.json"), originalDockerConfig);
     const cleanupBuildCtx = vi.fn(() => {
       fs.rmSync(buildCtx, { recursive: true, force: true });
       return true;
@@ -424,6 +496,7 @@ describe("finalizePreparedRebuildImageMessagingPlan", () => {
       rebuildTarget: { agentName: "hermes", fromDockerfile: null },
     };
     const builtDockerfiles: string[] = [];
+    let isolatedConfig = "";
     const removeImage = vi.fn(() => ({ status: 0 }) as never);
     try {
       const result = successful(
@@ -437,11 +510,19 @@ describe("finalizePreparedRebuildImageMessagingPlan", () => {
             },
           ],
           {
-            buildImage: vi.fn((dockerfile) => {
+            buildImage: vi.fn((dockerfile, _tag, _context, options) => {
               builtDockerfiles.push(fs.readFileSync(dockerfile, "utf8"));
+              isolatedConfig = String(options.env?.DOCKER_CONFIG);
+              expect(isolatedConfig).not.toBe(dockerConfig);
+              expect(
+                JSON.parse(fs.readFileSync(path.join(isolatedConfig, "config.json"), "utf8")),
+              ).toEqual({ auths: {} });
               return { status: 0 } as never;
             }),
             removeImage,
+            env: { DOCKER_CONFIG: dockerConfig, WSL_DISTRO_NAME: "Ubuntu" },
+            credentialHelperResponds: () => false,
+            isWslHost: true,
           },
         ),
       );
@@ -460,9 +541,14 @@ describe("finalizePreparedRebuildImageMessagingPlan", () => {
       expect(result.prepared.contextFingerprint).not.toBe(originalFingerprint);
       expect(verifyPreparedBuildContext(result.prepared)).toBe(true);
       expect(removeImage).toHaveBeenCalledOnce();
+      expect(fs.existsSync(isolatedConfig)).toBe(false);
+      expect(fs.readFileSync(path.join(dockerConfig, "config.json"), "utf8")).toBe(
+        originalDockerConfig,
+      );
       expect(disposePreparedBuildContext(result.prepared)).toBe(true);
     } finally {
       fs.rmSync(buildCtx, { recursive: true, force: true });
+      fs.rmSync(dockerConfig, { recursive: true, force: true });
     }
   });
 

--- a/src/lib/actions/sandbox/rebuild-custom-image-preflight.ts
+++ b/src/lib/actions/sandbox/rebuild-custom-image-preflight.ts
@@ -12,6 +12,10 @@ import type { SandboxMessagingPlan } from "../../messaging";
 import { stageCreateSandboxBuildContext } from "../../onboard/build-context-stage";
 import { patchStagedDockerfileMessagingPlan } from "../../onboard/dockerfile-patch";
 import {
+  prepareDockerBuildEnvironment,
+  type DockerBuildEnvironmentInput,
+} from "../../onboard/sandbox-prebuild";
+import {
   applyReasoningEffortEnv,
   REASONING_EFFORT_ENV,
   type ReasoningEffort,
@@ -57,7 +61,7 @@ type PreflightDeps = {
   buildImage?: typeof dockerBuild;
   removeImage?: typeof dockerRmi;
   registerExitHandler?: (listener: () => void) => void;
-};
+} & RebuildImageBuildEnvironmentDeps;
 
 export type PreparedRebuildImage = FingerprintedPreparedBuildContext & {
   rebuildTarget: {
@@ -75,6 +79,10 @@ type FinalizePreparedImageDeps = {
   buildImage?: typeof dockerBuild;
   removeImage?: typeof dockerRmi;
   registerExitHandler?: (listener: () => void) => void;
+} & RebuildImageBuildEnvironmentDeps;
+
+type RebuildImageBuildEnvironmentDeps = DockerBuildEnvironmentInput & {
+  prepareBuildEnvironment?: typeof prepareDockerBuildEnvironment;
 };
 
 function resultDetail(result: {
@@ -87,6 +95,32 @@ function resultDetail(result: {
     formatBuildFailureDiagnostics(result) ||
     `docker build exited with status ${String(result.status ?? "unknown")}`
   );
+}
+
+function buildReplacementImage(
+  dockerfile: string,
+  imageTag: string,
+  buildContext: string,
+  origin: PreparedRebuildImage["origin"],
+  buildImage: typeof dockerBuild,
+  deps: RebuildImageBuildEnvironmentDeps,
+) {
+  const preparedEnvironment = (deps.prepareBuildEnvironment ?? prepareDockerBuildEnvironment)({
+    env: deps.env,
+    credentialHelperResponds: deps.credentialHelperResponds,
+    isWslHost: deps.isWslHost,
+    allowCredentialIsolation: origin === "generated",
+  });
+  try {
+    return buildImage(dockerfile, imageTag, buildContext, {
+      env: preparedEnvironment.env,
+      ignoreError: true,
+      suppressOutput: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } finally {
+    preparedEnvironment.cleanup();
+  }
 }
 
 function removeTemporaryRebuildImage(
@@ -176,11 +210,14 @@ export async function preflightRebuildImage(
     });
     const contextFingerprint = fingerprintBuildContext(staged.buildCtx);
     imageTag = `nemoclaw-rebuild-preflight:${String(process.pid)}-${String(Date.now())}`;
-    const result = buildImage(staged.stagedDockerfile, imageTag, staged.buildCtx, {
-      ignoreError: true,
-      suppressOutput: true,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const result = buildReplacementImage(
+      staged.stagedDockerfile,
+      imageTag,
+      staged.buildCtx,
+      staged.origin,
+      buildImage,
+      deps,
+    );
     if (result.status !== 0) return { ok: false, detail: resultDetail(result) };
     imageBuilt = true;
     if (fingerprintBuildContext(staged.buildCtx) !== contextFingerprint) {
@@ -246,11 +283,14 @@ export function finalizePreparedRebuildImageMessagingPlan(
   try {
     patchMessagingPlan(prepared.stagedDockerfile, messagingPlan, preservedEnv);
     const contextFingerprint = fingerprintBuildContext(prepared.buildCtx);
-    const result = buildImage(prepared.stagedDockerfile, imageTag, prepared.buildCtx, {
-      ignoreError: true,
-      suppressOutput: true,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const result = buildReplacementImage(
+      prepared.stagedDockerfile,
+      imageTag,
+      prepared.buildCtx,
+      prepared.origin,
+      buildImage,
+      deps,
+    );
     if (result.status !== 0) return { ok: false, detail: resultDetail(result) };
     imageBuilt = true;
     if (fingerprintBuildContext(prepared.buildCtx) !== contextFingerprint) {

--- a/src/lib/onboard/sandbox-prebuild.test.ts
+++ b/src/lib/onboard/sandbox-prebuild.test.ts
@@ -69,7 +69,6 @@ describe("sandbox BuildKit prebuild", () => {
       vi.stubEnv("PATH", "/usr/bin");
       vi.stubEnv("HOME", "/home/user");
       vi.stubEnv("CONTAINERS_CONF", "/home/user/.config/nemoclaw/portable/containers.conf");
-      vi.stubEnv("DOCKER_HOST", "unix:///var/run/docker.sock");
       vi.stubEnv("DOCKER_CONFIG", "/home/user/.docker-ci");
       vi.stubEnv("DOCKER_CONTEXT", "remote-builder");
       vi.stubEnv("BUILDX_BUILDER", "external-builder");
@@ -90,7 +89,6 @@ describe("sandbox BuildKit prebuild", () => {
         PATH: "/usr/bin",
         HOME: "/home/user",
         CONTAINERS_CONF: "/home/user/.config/nemoclaw/portable/containers.conf",
-        DOCKER_HOST: "unix:///var/run/docker.sock",
         DOCKER_CONFIG: "/home/user/.docker-ci",
         DOCKER_CONTEXT: "remote-builder",
         XDG_CONFIG_HOME: "/home/user/.config",
@@ -100,6 +98,17 @@ describe("sandbox BuildKit prebuild", () => {
       expect(env[key], key).toBeUndefined();
     },
   );
+
+  it("keeps Docker host precedence over an ambient Docker context", () => {
+    vi.stubEnv("DOCKER_HOST", "unix:///selected-docker.sock");
+    vi.stubEnv("DOCKER_CONTEXT", "ambient-remote");
+    vi.stubEnv("DOCKER_CONFIG", "/home/user/.docker-ambient");
+
+    const env = dockerBuildSubprocessEnv();
+    expect(env).toMatchObject({ DOCKER_HOST: "unix:///selected-docker.sock" });
+    expect(env).not.toHaveProperty("DOCKER_CONTEXT");
+    expect(env).not.toHaveProperty("DOCKER_CONFIG");
+  });
 
   it("never enables a local-image handoff for a remote gateway", () => {
     expect(resolveSandboxPrebuildEnabled({}, false)).toBe(false);

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -69,6 +69,19 @@ export interface SandboxPrebuildResult {
   imageId: string | null;
 }
 
+export interface DockerBuildEnvironmentInput {
+  env?: NodeJS.ProcessEnv;
+  credentialHelperResponds?: (credsStore: string) => boolean;
+  isWslHost?: boolean;
+  allowCredentialIsolation?: boolean;
+}
+
+export interface PreparedDockerBuildEnvironment {
+  env: NodeJS.ProcessEnv;
+  isolatedCredentialConfig: boolean;
+  cleanup(): void;
+}
+
 interface TrustedStagedBuildContext {
   buildCtx: string;
   dockerfile: string;
@@ -200,6 +213,40 @@ function dockerDesktopCredentialHelperRespondsFromBuild(
   });
 }
 
+/**
+ * Prepare the Docker environment shared by normal creation and rebuild image
+ * preflight. Docker Desktop can leave WSL pointing at a Windows credential
+ * helper that is unavailable from the current session; generated image builds
+ * do not need registry credentials, so isolate that case without modifying the
+ * user's Docker config.
+ */
+export function prepareDockerBuildEnvironment(
+  input: DockerBuildEnvironmentInput = {},
+): PreparedDockerBuildEnvironment {
+  const sourceEnv = input.env ?? process.env;
+  const helperResponds =
+    input.credentialHelperResponds ??
+    ((credsStore: string) => dockerDesktopCredentialHelperRespondsFromBuild(credsStore, sourceEnv));
+  const credentialFreeConfig =
+    input.allowCredentialIsolation !== false &&
+    requiresCredentialFreeWslBuildConfig(sourceEnv, helperResponds, input.isWslHost)
+    ? createCredentialFreeDockerConfig("wsl-buildkit")
+    : null;
+  return {
+    env: {
+      ...dockerBuildSubprocessEnv(sourceEnv),
+      DOCKER_BUILDKIT: "1",
+      ...(credentialFreeConfig ? { DOCKER_CONFIG: credentialFreeConfig } : {}),
+    },
+    isolatedCredentialConfig: credentialFreeConfig !== null,
+    cleanup: () => {
+      if (credentialFreeConfig !== null) {
+        fs.rmSync(credentialFreeConfig, { recursive: true, force: true });
+      }
+    },
+  };
+}
+
 export function resolveSandboxPrebuildEnabled(
   env: NodeJS.ProcessEnv,
   dockerDriverGateway: boolean,
@@ -312,21 +359,17 @@ export async function prebuildSandboxImageIfEligible(
   log(`  Building sandbox image with ${builderName} (skips the slower in-gateway builder)...`);
 
   let status: number | null;
-  let credentialFreeWslConfig: string | null = null;
+  let preparedDockerEnvironment: PreparedDockerBuildEnvironment | null = null;
   try {
-    const buildEnv: NodeJS.ProcessEnv = {
-      ...dockerBuildSubprocessEnv(env),
-      ...(portable ? {} : { DOCKER_BUILDKIT: "1" }),
-    };
-    const helperResponds =
-      input.credentialHelperResponds ??
-      ((credsStore: string) => dockerDesktopCredentialHelperRespondsFromBuild(credsStore, env));
-    if (
-      !portable &&
-      requiresCredentialFreeWslBuildConfig(env, helperResponds, input.isWslHost)
-    ) {
-      credentialFreeWslConfig = createCredentialFreeDockerConfig("wsl-buildkit");
-      buildEnv.DOCKER_CONFIG = credentialFreeWslConfig;
+    preparedDockerEnvironment = portable
+      ? null
+      : prepareDockerBuildEnvironment({
+          env,
+          credentialHelperResponds: input.credentialHelperResponds,
+          isWslHost: input.isWslHost,
+        });
+    const buildEnv = preparedDockerEnvironment?.env ?? dockerBuildSubprocessEnv(env);
+    if (preparedDockerEnvironment?.isolatedCredentialConfig) {
       log(
         "  Docker Desktop credential helper is unavailable in this WSL session; using an isolated credential-free config for the generated sandbox image build.",
       );
@@ -348,9 +391,7 @@ export async function prebuildSandboxImageIfEligible(
     );
     return { createArgs, imageRef: null, imageId: null };
   } finally {
-    if (credentialFreeWslConfig !== null) {
-      fs.rmSync(credentialFreeWslConfig, { recursive: true, force: true });
-    }
+    preparedDockerEnvironment?.cleanup();
   }
 
   if (status !== 0) {

--- a/src/lib/onboard/sandbox-prebuild.ts
+++ b/src/lib/onboard/sandbox-prebuild.ts
@@ -35,6 +35,7 @@ const DOCKER_ENV_NAMES = [
   "DOCKER_CERT_PATH",
   "DOCKER_CONFIG",
   "DOCKER_CONTEXT",
+  "DOCKER_HOST",
   "DOCKER_TLS_VERIFY",
 ] as const;
 
@@ -177,6 +178,13 @@ export function dockerBuildSubprocessEnv(
     ) {
       delete env[key];
     }
+  }
+  // Match the runner and Docker probe contract: an explicitly selected host
+  // owns daemon authority, so an ambient context and its credentials must not
+  // redirect the build to another daemon.
+  if (env.DOCKER_HOST !== undefined) {
+    delete env.DOCKER_CONFIG;
+    delete env.DOCKER_CONTEXT;
   }
   return env;
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Rebuild preflight now uses the same WSL-safe Docker build environment as normal sandbox creation. Generated replacement images no longer fail when Docker Desktop configures `desktop.exe` but that credential helper is unavailable inside WSL; explicit custom Dockerfiles continue to receive the user's Docker credentials.

## Related Issue

Fixes #7111

## Changes

- Share Docker build-environment preparation between normal sandbox creation and rebuild preflight.
- Isolate generated rebuilds with a temporary credential-free Docker config only when the WSL Docker Desktop helper is unavailable, and remove it after each build.
- Preserve configured credentials for explicit custom Dockerfiles because they may use private registries.
- Cover initial preflight and post-messaging-plan rebuilds with regressions for credential isolation, cleanup, and config preservation.
- Document the WSL behavior and custom-Dockerfile recovery path.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (credentials, preflight, onboarding, and sandbox rebuild)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — generated builds receive only an empty temporary config with private permissions and `finally` cleanup; custom Dockerfiles preserve existing credentials; no credentials are copied or logged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — `npm run check:diff` passes all diff-scoped checks except `source-shape-test-budget`; clean `origin/main` at `68415d6d4` fails identically on the unrelated Hermes exception introduced by #10172. Remote CI remains the merge gate.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set — `npx vitest run --project cli src/lib/actions/sandbox/rebuild-custom-image-preflight.test.ts src/lib/onboard/sandbox-prebuild.test.ts` (50 passed); `npm run typecheck:cli` passed
- [ ] Applicable broad gate passed — not run; this is a focused rebuild-preflight change and Windows QA remains required
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — passed with 0 errors and 2 existing warnings
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved replacement-image builds on WSL with isolated, temporary Docker configuration.
  * Enabled BuildKit for applicable Docker builds.
  * Ensured explicitly selected Docker daemons take precedence over ambient Docker settings.
  * Automatically cleans up temporary Docker settings after builds.

* **Bug Fixes**
  * Preserved existing Docker credentials and configuration.
  * Prevented unrelated Docker context settings from redirecting builds.
  * Added guidance for recovering unavailable Docker credential helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->