### PR TITLE
fix(ci): repair regrouped validation gates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,6 +135,7 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-merge-conflict
+        args: ["--assume-in-merge"]
         priority: 10
       - id: check-added-large-files
         args: ["--maxkb=2000"]
@@ -334,10 +335,10 @@ repos:
 
       - id: test-skills-yaml
         name: Test (skills YAML)
-        entry: npx vitest run test/skills-frontmatter.test.ts
+        entry: npx vitest run test/skills/skills-frontmatter.test.ts
         language: system
         pass_filenames: false
-        files: ^(\.agents/skills/|skills/|test/skills-frontmatter\.test\.ts$)
+        files: ^(\.agents/skills/|skills/|test/skills/skills-frontmatter\.test\.ts$)
         priority: 20
 
 default_language_version:

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -82,11 +82,6 @@
       "category": "security"
     },
     {
-      "file": "test/agents/hermes/hermes-final-image-layout.test.ts",
-      "test": "pins $source to its current bytes at $target",
-      "category": "security"
-    },
-    {
       "file": "test/agents/hermes/hermes-runtime-config-guard-topology.test.ts",
       "test": "allows the sandbox identity to create runtime state but refuses sealed configuration writes, unlinks, and renames (#7865)",
       "category": "security"

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -82,6 +82,11 @@
       "category": "security"
     },
     {
+      "file": "test/agents/hermes/hermes-final-image-layout.test.ts",
+      "test": "pins $source to its current bytes at $target",
+      "category": "security"
+    },
+    {
       "file": "test/agents/hermes/hermes-runtime-config-guard-topology.test.ts",
       "test": "allows the sandbox identity to create runtime state but refuses sealed configuration writes, unlinks, and renames (#7865)",
       "category": "security"


### PR DESCRIPTION
## Summary

Repair two validation hooks left inconsistent after the test-directory migration. Normal validation will scan committed conflict markers, and the skills contract hook will invoke the relocated test suite.

## Changes

- Run `check-merge-conflict` with `--assume-in-merge` so normal CI scans committed files.
- Run the skills YAML hook from `test/skills/skills-frontmatter.test.ts` and match that path for changed-file selection.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the configured hooks execute the upstream conflict-marker scanner and the 53-test skills contract suite.
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every authored commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed
- [x] Targeted behavior tests pass — `npx prek run check-merge-conflict --all-files` and `npx prek run test-skills-yaml --all-files` (53 tests).
- [ ] Applicable broad gate passed — `npm run check` completed the pre-commit stage; the manual full-coverage stage was interrupted before completion.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>