### PR TITLE
fix(onboard): skip systemd loopback repair for Windows-host Ollama on…

### DIFF
--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3421,6 +3421,13 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
           ...reasoningMode.compatibleEndpointReasoningConfigureDeps,
           ...reasoningMode.compatibleEndpointReasoningClearDeps,
           repairLocalInferenceSystemdOverrideOrExit,
+          resolveIsWindowsHostOllama: () =>
+            detectInferenceProviderHostState({
+              gpu: null,
+              experimental: EXPERIMENTAL,
+              probeVllm: false,
+              log: () => {},
+            }).isWindowsHostOllama,
           isNonInteractive,
           getOpenshellBinary,
           needsBedrockRuntimeAdapter: (providerName, url) => providerName === "compatible-anthropic-endpoint" && bedrockRuntimeOnboard.needsBedrockRuntimeAdapter(url),

--- a/src/lib/onboard/local-inference-topology.test.ts
+++ b/src/lib/onboard/local-inference-topology.test.ts
@@ -184,6 +184,37 @@ describe("repairLocalInferenceSystemdOverrideOrExit (#6760)", () => {
     expect(mockedApplyRuntimeContext).not.toHaveBeenCalled();
   });
 
+  it("skips the systemd override repair for a Windows-host Ollama but still verifies the model", () => {
+    const callOrder: string[] = [];
+    mockedFindReachableHost.mockImplementation(() => {
+      callOrder.push("host");
+      return "127.0.0.1";
+    });
+    mockedValidateModel.mockImplementation(() => {
+      callOrder.push("warm");
+      return { ok: true };
+    });
+    mockedApplyRuntimeContext.mockImplementation(() => {
+      callOrder.push("runtime-context");
+      return { ok: true };
+    });
+
+    repairLocalInferenceSystemdOverrideOrExit({
+      provider: "ollama-local",
+      model: recordedModel,
+      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
+      isNonInteractive,
+      isWindowsHostOllama: true,
+    });
+
+    expect(mockedEnsureSystemdOverride).not.toHaveBeenCalled();
+    expect(mockedValidateModel).toHaveBeenCalledWith(recordedModel);
+    expect(mockedApplyRuntimeContext).toHaveBeenCalledWith(recordedModel, {
+      contextWindowFloor: MIN_HERMES_OLLAMA_CONTEXT_WINDOW,
+    });
+    expect(callOrder).toEqual(["host", "warm", "runtime-context"]);
+  });
+
   it("rejects a strict resume when the recorded model is missing", () => {
     expectFailure(
       () =>

--- a/src/lib/onboard/local-inference-topology.ts
+++ b/src/lib/onboard/local-inference-topology.ts
@@ -156,6 +156,10 @@ export interface RepairLocalInferenceSystemdOverrideOptions {
   model: string | null | undefined;
   contextWindowFloor: number;
   isNonInteractive: () => boolean;
+  /** True when the recorded ollama-local resolves to a Windows-host Ollama daemon
+   * (host.docker.internal or mirrored loopback). Linux does not own that daemon,
+   * so the systemd loopback-override repair must not run against it. */
+  isWindowsHostOllama?: boolean;
 }
 
 function failOllamaResumeRepair(message: string): never {
@@ -170,14 +174,16 @@ function failOllamaResumeRepair(message: string): never {
 export function repairLocalInferenceSystemdOverrideOrExit(
   options: RepairLocalInferenceSystemdOverrideOptions,
 ): void {
-  const { provider, model, isNonInteractive } = options;
+  const { provider, model, isNonInteractive, isWindowsHostOllama } = options;
   if (provider !== "ollama-local") return;
   const contextWindowFloor = resolveOllamaContextWindowFloor(options.contextWindowFloor);
-  const state = ensureOllamaLoopbackSystemdOverride({ isNonInteractive, contextWindowFloor });
-  if (state === "failed") {
-    failOllamaResumeRepair(
-      "Ollama systemd restart did not recover after applying the loopback override.",
-    );
+  if (!isWindowsHostOllama) {
+    const state = ensureOllamaLoopbackSystemdOverride({ isNonInteractive, contextWindowFloor });
+    if (state === "failed") {
+      failOllamaResumeRepair(
+        "Ollama systemd restart did not recover after applying the loopback override.",
+      );
+    }
   }
   if (contextWindowFloor <= MIN_AUTODETECTED_OLLAMA_CONTEXT_WINDOW) return;
   if (!model) {

--- a/src/lib/onboard/machine/handlers/provider-inference.test-support.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test-support.ts
@@ -124,6 +124,7 @@ export function createDeps(
     repairEvent: vi.fn(async () => createSession()),
     hydrate: vi.fn(),
     repair: vi.fn(),
+    resolveIsWindowsHostOllama: vi.fn(() => false),
     routeReady: vi.fn((_gatewayName: string, _provider: string, _model: string) => false),
     reconcileRouter: vi.fn(async () => undefined),
     reupsertRoutedProvider: vi.fn(
@@ -199,6 +200,7 @@ export function createDeps(
       },
       clearCompatibleEndpointReasoningEffort: () => null,
       repairLocalInferenceSystemdOverrideOrExit: calls.repair,
+      resolveIsWindowsHostOllama: calls.resolveIsWindowsHostOllama,
       isNonInteractive: () => true,
       getOpenshellBinary: () => "/usr/bin/openshell",
       needsBedrockRuntimeAdapter: () => false,

--- a/src/lib/onboard/machine/handlers/provider-inference.test.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.test.ts
@@ -462,6 +462,7 @@ describe("handleProviderInferenceState", () => {
       model: "llama3.1",
       contextWindowFloor: 16_384,
       isNonInteractive: deps.isNonInteractive,
+      isWindowsHostOllama: false,
     });
     expect(calls.repairEvent).toHaveBeenCalledWith("state.repair.completed", {
       state: "provider_selection",
@@ -474,6 +475,38 @@ describe("handleProviderInferenceState", () => {
       model: "llama3.1",
     });
     expect(result).toMatchObject({ provider: "ollama-local", model: "llama3.1" });
+  });
+
+  it("rechecks the Windows-host topology before resume repairs the systemd loopback (#9348)", async () => {
+    const session = createSession({
+      provider: "ollama-local",
+      model: "llama3.1",
+      credentialEnv: null,
+    });
+    session.steps.provider_selection.status = "complete";
+    const { deps, calls } = createDeps({
+      isInferenceRouteReady: vi.fn(() => true),
+      resolveIsWindowsHostOllama: () => true,
+    });
+
+    await handleProviderInferenceState({
+      ...baseOptions(deps, session),
+      resume: true,
+      sandboxName: "my-assistant",
+    });
+
+    expect(calls.resolveIsWindowsHostOllama).toHaveBeenCalledTimes(1);
+    expect(calls.repair).toHaveBeenCalledWith({
+      provider: "ollama-local",
+      model: "llama3.1",
+      contextWindowFloor: 16_384,
+      isNonInteractive: deps.isNonInteractive,
+      isWindowsHostOllama: true,
+    });
+    expect(calls.repairEvent).toHaveBeenCalledWith("state.repair.completed", {
+      state: "provider_selection",
+      metadata: { repair: "ollama-systemd-loopback" },
+    });
   });
 
   it("reuses a persisted vLLM served alias when resume repairs inference (#7023)", async () => {

--- a/src/lib/onboard/machine/handlers/provider-inference.ts
+++ b/src/lib/onboard/machine/handlers/provider-inference.ts
@@ -245,6 +245,9 @@ export interface ProviderInferenceStateOptions<Gpu, Agent, Host> {
     repairLocalInferenceSystemdOverrideOrExit(
       options: RepairLocalInferenceSystemdOverrideOptions,
     ): void;
+    /** Recheck whether the recorded ollama-local is a Windows-host daemon before
+     * resume runs the Linux systemd override repair. */
+    resolveIsWindowsHostOllama?(): boolean;
     isNonInteractive(): boolean;
     getOpenshellBinary(): string;
     needsBedrockRuntimeAdapter(provider: string, endpointUrl: string | null): boolean;
@@ -846,7 +849,7 @@ async function configureResumeReasoning(
 
 type LocalInferenceRepairDeps = Pick<
   ProviderInferenceStateOptions<unknown, unknown, unknown>["deps"],
-  "recordRepairEvent" | "repairLocalInferenceSystemdOverrideOrExit"
+  "recordRepairEvent" | "repairLocalInferenceSystemdOverrideOrExit" | "resolveIsWindowsHostOllama"
 >;
 
 async function repairResumedLocalInference(
@@ -860,6 +863,7 @@ async function repairResumedLocalInference(
     model,
     contextWindowFloor: getOllamaContextWindowFloorForAgent(agentName(agent)),
     isNonInteractive: () => false,
+    isWindowsHostOllama: deps.resolveIsWindowsHostOllama?.(),
   };
   if (provider !== "ollama-local") {
     deps.repairLocalInferenceSystemdOverrideOrExit(options);


### PR DESCRIPTION
… resume

Resume re-runs the Linux systemd loopback-override repair (`sudo systemctl restart ollama`) for a recorded ollama-local without rechecking whether that daemon actually lives on the Windows host. When the recorded host resolves to host.docker.internal or a mirrored loopback, Linux does not own the daemon, so restarting systemd there is wrong and can wedge the resume.

Recheck the recorded host's topology before the repair and skip the systemd restart when it is a Windows-host daemon, while still verifying the recorded model's runtime context window.

Refs #9348

<!-- markdownlint-disable MD041 -->
## Summary
<!-- 1-3 plain sentences: what changes and why. Describe before-and-after behavior when it applies. Follow the NemoClaw Writing Guide: https://github.com/NVIDIA/NemoClaw/blob/main/WRITING.md. Do not add unrelated prose cleanup. -->

## Related Issue
<!-- Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- List concrete changes. If this adds an abstraction, configuration, fallback, migration, or compatibility path, name its current requirement and consumer, explain why a direct change is insufficient, and identify the test that protects it. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates
<!-- Check one tests line. Check other lines when applicable. Add every requested justification or approval reference. -->
- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence
<!-- Required only when scripts/prepare-dgx-station-host.sh changes. Maintainers must review the linked evidence before approving or merging. This is human-reviewed evidence, not authenticated hardware provenance. Exceptional bypasses use existing repository governance and must be documented on the PR. -->
- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification
<!-- Check each applicable item only when supported by the requested evidence. Run targeted tests once per relevant change set and rerun after later edits or hook autofixes that can affect the tested behavior. Do not rerun hook-covered checks. -->
- [ ] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [ ] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [ ] Quality Gates section completed with required justifications or waivers
- [ ] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- DCO sign-off is required in this PR description, and every commit must appear as Verified in GitHub. Run: git config user.name && git config user.email -->
Signed-off-by: Your Name <your-email@example.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ollama setup for Windows-hosted environments by skipping Linux-specific system configuration repairs.
  * Continued validating host connectivity, selected models, context-window settings, and runtime readiness for Windows-hosted Ollama.
  * Preserved existing repair behavior for non-Windows Ollama configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->