### PR TITLE
fix(state): re-own agent heartbeat cadence during managed rebuild

### DIFF
--- a/src/lib/state/openclaw-config-merge.test.ts
+++ b/src/lib/state/openclaw-config-merge.test.ts
@@ -119,6 +119,39 @@ describe("mergeOpenClawRestoredConfig", () => {
     ]);
   });
 
+  it("re-owns a fresh heartbeat over an older backed-up interval (#10244)", () => {
+    const merged = mergeOpenClawRestoredConfig(
+      {
+        agents: {
+          defaults: { heartbeat: { every: "30m" }, thinkingDefault: "off" },
+        },
+      },
+      { agents: { defaults: { heartbeat: { every: "2m" } } } },
+    ) as { agents: { defaults: { heartbeat: unknown; thinkingDefault: unknown } } };
+
+    expect(merged.agents.defaults.heartbeat).toEqual({ every: "2m" });
+    // Unrelated durable agent config is still inherited from the backup.
+    expect(merged.agents.defaults.thinkingDefault).toBe("off");
+  });
+
+  it("re-owns a fresh heartbeat when the backup has none configured (#10244)", () => {
+    const merged = mergeOpenClawRestoredConfig(
+      { agents: { defaults: {} } },
+      { agents: { defaults: { heartbeat: { every: "2m" } } } },
+    ) as { agents: { defaults: { heartbeat: unknown } } };
+
+    expect(merged.agents.defaults.heartbeat).toEqual({ every: "2m" });
+  });
+
+  it("re-owns intentional heartbeat absence so a stale backup cannot re-enable it (#10244)", () => {
+    const merged = mergeOpenClawRestoredConfig(
+      { agents: { defaults: { heartbeat: { every: "30m" } } } },
+      { agents: { defaults: {} } },
+    ) as { agents: { defaults: { heartbeat: unknown } } };
+
+    expect(merged.agents.defaults.heartbeat).toBeUndefined();
+  });
+
   it("keeps rebuilt runtime-owned config while restoring durable backup-only settings", () => {
     const merged = mergeOpenClawRestoredConfig(
       {

--- a/src/lib/state/openclaw-config-merge.ts
+++ b/src/lib/state/openclaw-config-merge.ts
@@ -544,6 +544,13 @@ function reconcileAgentHeartbeat(
   }
 }
 
+/**
+ * Merge a backed-up `openclaw.json` snapshot onto a freshly regenerated one
+ * per `OPENCLAW_CONFIG_RESTORE_OWNERSHIP`: fresh output wins for
+ * rebuild-owned sections and fields, the backup restores durable user
+ * settings, and the reconcile helpers above re-own the routing/heartbeat
+ * fields inside the otherwise backup-durable `agents` section.
+ */
 export function mergeOpenClawRestoredConfig(
   backedUpConfig: unknown,
   currentConfig: unknown,

--- a/src/lib/state/openclaw-config-merge.ts
+++ b/src/lib/state/openclaw-config-merge.ts
@@ -43,6 +43,11 @@ export const OPENCLAW_CONFIG_RESTORE_OWNERSHIP = {
   backupDurableSections: ["mcp", "mcpServers", "customAgents", "agents"],
   /** Fresh rebuild owns the agent's primary model routing within `agents`. */
   agentPrimaryModelPath: ["agents", "defaults", "model", "primary"],
+  /**
+   * Fresh rebuild owns the agent heartbeat cadence within `agents`, including
+   * its intentional absence.
+   */
+  agentHeartbeatPath: ["agents", "defaults", "heartbeat"],
   /** NemoClaw's cross-agent disclosure selection owns this generated key. */
   currentGeneratedToolFields: ["toolSearch"],
 } as const;
@@ -499,6 +504,46 @@ function reconcileAgentPrimaryModel(
   updateMainAgentListModel(agents, freshPrimary);
 }
 
+/** Read the fresh rebuild's `agents.defaults`, or undefined. */
+function readAgentDefaults(config: Record<string, unknown>): Record<string, unknown> | undefined {
+  const agents = config.agents;
+  if (!isPlainObject(agents)) return undefined;
+  const defaults = agents.defaults;
+  return isPlainObject(defaults) ? defaults : undefined;
+}
+
+/**
+ * Re-own the agent heartbeat cadence from the fresh rebuild, including its
+ * intentional absence.
+ *
+ * `agents` is backup-durable (see `backupDurableSections`), so without this
+ * the overlay inherits the backup's `agents.defaults.heartbeat` wholesale —
+ * an older interval overwrites the freshly configured
+ * `NEMOCLAW_AGENT_HEARTBEAT_EVERY`, and a stale backed-up value can resurrect
+ * a heartbeat the fresh config intentionally omits. This is issue #10244:
+ * the profile-owned heartbeat must survive rebuild the same way
+ * `agents.defaults.model.primary` already does.
+ */
+function reconcileAgentHeartbeat(
+  merged: Record<string, unknown>,
+  currentConfig: Record<string, unknown>,
+): void {
+  const currentDefaults = readAgentDefaults(currentConfig);
+  const hasFreshHeartbeat = currentDefaults !== undefined && "heartbeat" in currentDefaults;
+  const mergedDefaults = readAgentDefaults(merged);
+  const hasMergedHeartbeat = mergedDefaults !== undefined && "heartbeat" in mergedDefaults;
+  // Nothing to reconcile: avoid materializing an empty `agents.defaults`
+  // when neither the fresh rebuild nor the merge result has a heartbeat.
+  if (!hasFreshHeartbeat && !hasMergedHeartbeat) return;
+  const agents = ensureMergedObject(merged, "agents");
+  const defaults = ensureMergedObject(agents, "defaults");
+  if (hasFreshHeartbeat) {
+    defaults.heartbeat = cloneJson(currentDefaults!.heartbeat);
+  } else {
+    delete defaults.heartbeat;
+  }
+}
+
 export function mergeOpenClawRestoredConfig(
   backedUpConfig: unknown,
   currentConfig: unknown,
@@ -537,6 +582,7 @@ export function mergeOpenClawRestoredConfig(
   );
   merged.tools = mergeOpenClawTools(backedUpConfig.tools, currentConfig.tools);
   reconcileAgentPrimaryModel(merged, currentConfig);
+  reconcileAgentHeartbeat(merged, currentConfig);
 
   return merged;
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`mergeOpenClawRestoredConfig()` overlays the backed-up OpenClaw `agents` tree onto the fresh rebuild output and only re-owns `agents.defaults.model.primary`, so a backup with an absent or older `NEMOCLAW_AGENT_HEARTBEAT_EVERY` interval can silently replace the freshly generated heartbeat during a managed rebuild or state restore. This re-owns `agents.defaults.heartbeat` from the fresh rebuild the same way, including its intentional absence, so the configured cadence survives rebuild.

## Related Issue

Fixes #10244

## Changes

- `src/lib/state/openclaw-config-merge.ts`: added `reconcileAgentHeartbeat()`, mirroring the existing `reconcileAgentPrimaryModel()` pattern, and call it after model-primary reconciliation in `mergeOpenClawRestoredConfig()`. It sets `agents.defaults.heartbeat` from the fresh rebuild when present, and deletes it when the fresh rebuild intentionally omits it — so a stale backed-up interval can neither survive nor be silently reintroduced. Documented the new ownership path in `OPENCLAW_CONFIG_RESTORE_OWNERSHIP.agentHeartbeatPath`, matching the existing `agentPrimaryModelPath` entry. The requirement and consumer are the managed rebuild/state-restore path (`openclaw-config-restore-input.ts`) generating `openclaw.json` for a running OpenClaw sandbox; a direct change to the merge's default "backup overlay wins" semantics isn't sufficient because `agents` is intentionally backup-durable for other settings (thinking defaults, custom instructions, etc.) — only the heartbeat cadence needs fresh-rebuild ownership, same rationale as the existing primary-model carve-out.
- `src/lib/state/openclaw-config-merge.test.ts`: added 3 regression tests — fresh heartbeat wins over an older backed-up interval, fresh heartbeat wins when the backup has none, and fresh intentional heartbeat omission wins over a stale backed-up value (while confirming unrelated durable `agents.defaults` settings are still inherited from the backup).

Note: this fixes the merge-ownership root cause the issue's own investigation identified (the exact function, `mergeOpenClawRestoredConfig`, and mechanism). It does not add the broader managed-image lifecycle evidence test the issue's acceptance criteria also mention (binding the startup profile receipt through a live OpenClaw process to the effective 120000 ms interval) — that's an integration-level lifecycle test beyond this file's unit-test scope; flagging it as a possible follow-up rather than claiming full acceptance-criteria coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/state/openclaw-config-merge.test.ts src/lib/state/openclaw-config-merge-tool-search.test.ts` — 30/30 passed locally and again on a clean host checkout (fresh clone + `npm ci`) on the auto-fix loop's ubuntu verify host.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jason Ma <jama@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration restoration so current heartbeat settings are preserved over outdated backup values.
  * Ensured newly configured heartbeat settings are restored when backups do not contain them.
  * Prevented intentionally removed heartbeat settings from being re-enabled by stale backups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->