### PR TITLE
fix(sandbox): surface stopped-sandbox recovery hint for a not-ready exec detail

### DIFF
--- a/src/lib/sandbox/config-read-not-ready.test.ts
+++ b/src/lib/sandbox/config-read-not-ready.test.ts
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// readSandboxConfig's stopped-sandbox contract (#10251, a regression of
+// #6997): when `sandbox exec` fails because the sandbox itself is not ready,
+// the actionable "Is the sandbox running?" guidance must survive — not just
+// for a completely empty `cat` read, but also when OpenShell's CLI reports a
+// non-empty "not ready (phase: ...)" detail on stderr.
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const clientModulePath = require.resolve("../adapters/openshell/client");
+const configModulePath = require.resolve("./config");
+
+type CaptureResult = {
+  status: number;
+  signal: null;
+  error?: undefined;
+  stdout: string;
+  output: string;
+  stderr: string;
+};
+
+const client = require(clientModulePath) as {
+  captureOpenshellCommand: (...args: unknown[]) => CaptureResult;
+};
+const realCapture = client.captureOpenshellCommand;
+
+function stubFailedExec(stderr: string, status = 1): void {
+  client.captureOpenshellCommand = () => ({
+    status,
+    signal: null,
+    stdout: "",
+    output: "",
+    stderr,
+  });
+}
+
+function loadReadSandboxConfig(): (name: string, target: { agentName: string; configPath: string; format: string }) => unknown {
+  delete require.cache[configModulePath];
+  const mod = require(configModulePath) as {
+    readSandboxConfig: (name: string, target: unknown) => unknown;
+  };
+  return mod.readSandboxConfig as never;
+}
+
+const OPENCLAW_TARGET = {
+  agentName: "OpenClaw",
+  configPath: "/sandbox/.openclaw/openclaw.json",
+  format: "json",
+};
+
+describe("readSandboxConfig stopped-sandbox detail (#10251)", () => {
+  afterEach(() => {
+    client.captureOpenshellCommand = realCapture;
+    delete require.cache[configModulePath];
+  });
+
+  it("surfaces the stopped-sandbox recovery hint for a wrapped OpenShell not-ready detail", () => {
+    stubFailedExec(
+      "Error:   x sandbox 'sandbox-a' is not ready (phase: Error); wait for it to\n  reach Ready state",
+    );
+    const readSandboxConfig = loadReadSandboxConfig();
+
+    let error: unknown;
+    try {
+      readSandboxConfig("sandbox-a", OPENCLAW_TARGET);
+    } catch (thrown) {
+      error = thrown;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    const lines = (error as { lines?: readonly string[] }).lines ?? [];
+    expect(lines.some((line) => /is the sandbox running/i.test(line))).toBe(true);
+    // The raw OpenShell detail must not leak into the user-facing message —
+    // the generic stopped-sandbox message replaces it, matching the
+    // already-empty-read case.
+    expect((error as Error).message).not.toContain("phase: Error");
+  });
+
+  it("still surfaces the raw detail for an unrelated exec failure", () => {
+    stubFailedExec("Error: connection refused");
+    const readSandboxConfig = loadReadSandboxConfig();
+
+    let error: unknown;
+    try {
+      readSandboxConfig("sandbox-a", OPENCLAW_TARGET);
+    } catch (thrown) {
+      error = thrown;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("connection refused");
+  });
+});

--- a/src/lib/sandbox/config.ts
+++ b/src/lib/sandbox/config.ts
@@ -20,6 +20,9 @@ const {
   DEFAULT_AGENT_CONFIG,
   resolveAgentConfig: resolveAgentConfigTarget,
 }: typeof import("./agent-config") = require("./agent-config");
+const { stripAnsi }: typeof import("../adapters/openshell/client") = require(
+  "../adapters/openshell/client",
+);
 const { createHash } = require("node:crypto");
 const fs = require("fs");
 const os = require("os");
@@ -443,6 +446,21 @@ function parseCliConfigValue(rawValue: string): ConfigValue {
 }
 
 /**
+ * True when an OpenShell `sandbox exec` failure detail reports the sandbox
+ * itself is not ready (for example, stopped), rather than an unrelated exec
+ * failure. Normalizes ANSI codes, the CLI's box-drawing error marker, and
+ * line-wrapping whitespace so a wrapped multi-line rendering of the same
+ * message still matches (#10251).
+ */
+function isSandboxNotReadyExecDetail(detail: string): boolean {
+  const normalized = stripAnsi(detail)
+    .replace(/[×│]/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+  return /sandbox '[^']*' is not ready \(phase: \w+\)/i.test(normalized);
+}
+
+/**
  * Read the agent's config from a running sandbox.
  * Resolves the correct config path based on the agent type.
  */
@@ -468,7 +486,12 @@ function readSandboxConfig(sandboxName: string, target: AgentConfigTarget): Conf
       const detail = result.error?.message || result.stderr?.trim();
       // Preserve a failed exec's detail. `configFail` throws, so it must not be
       // caught and replaced with the generic stopped-sandbox message below.
-      if (detail) {
+      // Exception: a "sandbox is not ready" detail IS the stopped-sandbox case
+      // (#10251, a regression of #6997) — fall through to the generic message
+      // below instead, so the actionable "Is the sandbox running?" / "Start
+      // the sandbox and retry." guidance survives instead of a raw OpenShell
+      // error.
+      if (detail && !isSandboxNotReadyExecDetail(detail)) {
         configFail(`  Cannot read ${target.agentName} config (${target.configPath}): ${detail}`);
       }
       raw = "";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Regression of the #6997 stopped-sandbox contract. `readSandboxConfig` only attached the "Is the sandbox running? / Start the sandbox and retry." recovery guidance when the sandbox exec's `cat` output was completely empty (the original #6997 repro shape). A stopped sandbox's `openshell sandbox exec` instead now fails with a non-empty stderr detail — OpenShell's "sandbox 'X' is not ready (phase: Error); wait for it to reach Ready state" message — so that case fell through to the raw-detail-preserving branch and lost the actionable guidance entirely, matching the issue's exact reproduction.

## Related Issue

Fixes #10251

## Changes

- `src/lib/sandbox/config.ts`: added `isSandboxNotReadyExecDetail()`, which normalizes ANSI codes, the CLI's box-drawing error marker, and line-wrapping whitespace (so a wrapped multi-line rendering of the message still matches), then checks for the `sandbox '...' is not ready (phase: ...)` pattern. When it matches, `readSandboxConfig` no longer calls `configFail` with the raw OpenShell detail and instead falls through to the existing generic `Cannot read ... config (...). / Is the sandbox running?` message — which `inference-set.ts`'s `readInSandboxConfigOrFail` (unchanged) already upgrades to add "Start the sandbox and retry." whenever any error line matches `/is the sandbox running/i`, so the full guidance is restored without touching that conversion logic. An unrelated exec failure detail (e.g. a connection error) is untouched and still surfaces its own specific detail.
- `src/lib/sandbox/config-read-not-ready.test.ts` (new): 2 tests — a wrapped not-ready detail produces the stopped-sandbox guidance and drops the raw OpenShell text, and an unrelated failure detail still surfaces its own raw text.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/sandbox/config-read-not-ready.test.ts src/lib/actions/inference-set-degraded-state.test.ts` — 6/6 passed locally (confirming the existing #6997 regression test for the empty-read case still passes unchanged) and again on a clean host checkout (fresh clone + `npm ci`) on the auto-fix loop's ubuntu verify host.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jason Ma <jama@nvidia.com>
