### PR TITLE
fix(inference): close rejected Expect requests

### DIFF
--- a/src/lib/onboard/runtime-provider/docker-llama-cpp-private-bridge-process.ts
+++ b/src/lib/onboard/runtime-provider/docker-llama-cpp-private-bridge-process.ts
@@ -180,6 +180,16 @@ function writeUpstreamUnavailable(
   response.end(body);
 }
 
+function closeIncompleteRequestAfterResponse(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+): void {
+  request.pause();
+  const destroyRequest = () => request.destroy();
+  response.once("finish", destroyRequest);
+  response.once("close", destroyRequest);
+}
+
 function createLlamaCppPrivateBridgeRequestHandler(
   authority: Pick<LlamaCppPrivateBridgeArguments, "targetHost" | "targetPort">,
   apiKey: string,
@@ -229,9 +239,16 @@ function createLlamaCppPrivateBridgeRequestHandler(
       (upstreamResponse) => {
         clearContinueTimer();
         upstreamResponded = true;
+        const closeConnection = expectsContinue && !forwardingRequestBody;
         request.unpipe(upstream);
-        request.resume();
-        response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+        if (closeConnection) closeIncompleteRequestAfterResponse(request, response);
+        else request.resume();
+        response.writeHead(
+          upstreamResponse.statusCode ?? 502,
+          closeConnection
+            ? { ...upstreamResponse.headers, connection: "close" }
+            : upstreamResponse.headers,
+        );
         upstreamResponse.once("error", () => response.destroy());
         upstreamResponse.pipe(response);
         upstreamResponse.once("end", () => {
@@ -275,9 +292,8 @@ function createLlamaCppPrivateBridgeRequestHandler(
       continueTimer = setTimeout(() => {
         continueTimer = undefined;
         request.unpipe(upstream);
-        request.pause();
         upstream.destroy();
-        response.once("finish", () => request.destroy());
+        closeIncompleteRequestAfterResponse(request, response);
         writeUpstreamUnavailable(response, { closeConnection: true });
       }, UPSTREAM_CONTINUE_TIMEOUT_MS);
       continueTimer.unref();

--- a/src/lib/onboard/runtime-provider/docker-llama-cpp-private-bridge.test.ts
+++ b/src/lib/onboard/runtime-provider/docker-llama-cpp-private-bridge.test.ts
@@ -333,6 +333,7 @@ async function request(
     readonly keepAlive?: boolean;
     readonly method?: string;
     readonly path?: string;
+    readonly waitForServerClose?: boolean;
   } = {},
 ): Promise<{
   readonly body: string;
@@ -367,13 +368,16 @@ async function request(
         const chunks: Buffer[] = [];
         response.on("data", (chunk: Buffer) => chunks.push(chunk));
         response.once("end", () => {
-          resolve({
-            body: Buffer.concat(chunks).toString("utf8"),
-            continued,
-            headers: response.headers,
-            status: response.statusCode ?? 0,
-          });
-          outgoing.destroy();
+          const finish = () => {
+            resolve({
+              body: Buffer.concat(chunks).toString("utf8"),
+              continued,
+              headers: response.headers,
+              status: response.statusCode ?? 0,
+            });
+            outgoing.destroy();
+          };
+          (input.waitForServerClose ? () => outgoing.once("close", finish) : finish)();
         });
       },
     );
@@ -503,6 +507,7 @@ describe("llama.cpp private bridge request authentication", () => {
         keepAlive: true,
         method: "POST",
         path: "/v1/chat/completions",
+        waitForServerClose: true,
       });
 
       expect(result).toMatchObject({
@@ -510,6 +515,7 @@ describe("llama.cpp private bridge request authentication", () => {
         continued: false,
         status: 413,
       });
+      expect(result.headers.connection).toBe("close");
       expect(receivedBodyBytes).toBe(0);
       await upstreamSocketClosed;
     } finally {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This follow-up to #10254 closes an incomplete client connection when the upstream server rejects an `Expect: 100-continue` request before accepting its body. The bridge now returns the upstream response, declares connection closure, and destroys the incoming request after the response finishes.

Tinson Lai remains the primary contributor for the continuation support merged in #10254. Apurv Kumaria authors only this post-merge connection-lifecycle repair.

## Changes

- Close an incomplete incoming request after an early upstream response finishes or closes.
- Override the downstream `Connection` response header with `close` for this rejection path.
- Extend the loopback 413 regression test to wait for server-side client closure while confirming that the upstream receives zero body bytes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: A current GitHub security review will be added after publication.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this change does not modify `scripts/prepare-dgx-station-host.sh`.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm run test:changed` passed 32 growth-guard tests and 21 affected bridge tests.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable. CLI type checking and repository checks passed for this two-file change.
- [ ] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete HTTP requests when upstream responses finish, close, or time out.
  * Prevented request bodies from being forwarded when `Expect: 100-continue` requests are rejected.
  * Added `Connection: close` to applicable rejection responses to ensure connections close cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->