### PR TITLE
fix(inference): select Nemotron by default on DGX Spark

### DIFF
--- a/managed-inference/presets/llama-cpp.dgx-spark-gb10.single.muse-glimmer-30b.yaml
+++ b/managed-inference/presets/llama-cpp.dgx-spark-gb10.single.muse-glimmer-30b.yaml
@@ -13,7 +13,7 @@ metadata:
     evidence: managed-inference-catalog-compiler-v1
 
 spec:
-  selection: automatic
+  selection: explicit-only
   priority: 500
 
   requirements:

--- a/src/lib/inference/llama-cpp/managed-selection.test.ts
+++ b/src/lib/inference/llama-cpp/managed-selection.test.ts
@@ -156,7 +156,7 @@ describe("managed llama.cpp selection", () => {
     expect(resolveManagedLlamaCppSelection({}, catalog, report).kind).toBe("selected");
   });
 
-  it("selects Muse Glimmer as the highest-priority qualified DGX Spark recipe by default", () => {
+  it("selects Nemotron by default on a qualified DGX Spark (#10239)", () => {
     const { catalog, report } = fixture();
 
     const resolved = resolveManagedLlamaCppSelection({}, catalog, report);
@@ -165,9 +165,9 @@ describe("managed llama.cpp selection", () => {
       kind: "selected",
       selection: {
         selection: "automatic",
-        recipe: { metadata: { id: MUSE_RECIPE_ID } },
+        recipe: { metadata: { id: RECIPE_ID } },
         preset: {
-          metadata: { id: MUSE_PRESET_ID },
+          metadata: { id: SPARK_PRESET_ID },
           spec: { plan: { backend: "install-llama-cpp" } },
         },
       },
@@ -194,27 +194,26 @@ describe("managed llama.cpp selection", () => {
       ),
     ).toEqual([
       [550, synthetic.recipeId],
-      [500, MUSE_RECIPE_ID],
       [450, RECIPE_ID],
     ]);
   });
 
   it("rejects equal-priority automatic recipes instead of choosing by catalog order", () => {
     const { catalog, report } = fixture();
-    const synthetic = withSyntheticRecipe(catalog, 500);
+    const synthetic = withSyntheticRecipe(catalog, 450);
 
     expect(resolveManagedLlamaCppSelection({}, synthetic.catalog, report)).toEqual({
       kind: "rejected",
-      reason: `Automatic managed llama.cpp selection is ambiguous at priority 500: ${MUSE_PRESET_ID}, ${synthetic.presetId}.`,
+      reason: `Automatic managed llama.cpp selection is ambiguous at priority 450: ${SPARK_PRESET_ID}, ${synthetic.presetId}.`,
     });
   });
 
-  it("allows an explicit recipe to override automatic priority", () => {
+  it("selects explicit Muse instead of a higher-priority automatic recipe (#10239)", () => {
     const { catalog, report } = fixture();
     const synthetic = withSyntheticRecipe(catalog, 550);
 
     const resolved = resolveManagedLlamaCppSelection(
-      { [LLAMA_CPP_RECIPE_ENV]: RECIPE_ID },
+      { [LLAMA_CPP_RECIPE_ENV]: MUSE_RECIPE_ID },
       synthetic.catalog,
       report,
     );
@@ -223,8 +222,8 @@ describe("managed llama.cpp selection", () => {
       kind: "selected",
       selection: {
         selection: "explicit",
-        recipe: { metadata: { id: RECIPE_ID } },
-        preset: { metadata: { id: SPARK_PRESET_ID } },
+        recipe: { metadata: { id: MUSE_RECIPE_ID } },
+        preset: { metadata: { id: MUSE_PRESET_ID } },
       },
     });
   });

--- a/test/inference/managed/managed-inference-catalog-compiler.test.ts
+++ b/test/inference/managed/managed-inference-catalog-compiler.test.ts
@@ -199,7 +199,7 @@ describe("managed inference YAML profile contract", () => {
     });
   });
 
-  it("compiles Muse Glimmer as the highest-priority Experimental DGX Spark llama.cpp profile", () => {
+  it("compiles Muse Glimmer as an explicit-only Experimental DGX Spark llama.cpp profile (#10239)", () => {
     const catalog = compile(catalogSources());
     const preset = catalog.presets.find(
       ({ metadata }) => metadata.id === MUSE_LLAMA_CPP_PROFILE_ID,
@@ -210,7 +210,7 @@ describe("managed inference YAML profile contract", () => {
 
     expect(preset?.metadata.supportState).toBe("experimental");
     expect(preset?.spec).toMatchObject({
-      selection: "automatic",
+      selection: "explicit-only",
       priority: 500,
       plan: { backend: "install-llama-cpp", recipeRef: MUSE_LLAMA_CPP_RECIPE_ID },
     });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Automatic DGX Spark onboarding selected Muse Glimmer even though its qualified 16,384-byte request guard rejects a default OpenClaw request. This change makes Muse Glimmer explicit-only, so new or unowned automatic onboarding selects Nemotron with its qualified 32,768-byte limit. Existing Muse owners are not migrated automatically.

## Related Issue

Fixes #10239

## Changes

- Change the Muse Glimmer DGX Spark llama.cpp preset from automatic to explicit-only without changing its request guard.
- Update the existing catalog and selection tests to verify automatic Nemotron selection, explicit Muse selection, and equal-priority rejection.
- Defer current user-documentation updates to `Docs / Post-Merge Catch-Up`. The catch-up must update the llama.cpp setup, local inference selection, and command reference pages.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed managed selection and owner lifecycle. Muse remains guarded at 16,384 bytes, and Nemotron remains guarded at 32,768 bytes. Existing Muse owners are outside this containment and are not migrated automatically.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this change does not modify `scripts/prepare-dgx-station-host.sh`.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npm run catalog:check`; catalog compiler test, 18 passed; managed selection test, 10 passed; `npm run typecheck:cli`; `npm run test:changed`; and `npm run test:titles:check` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this focused preset and existing-test change does not modify runtime or test-harness code.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated managed inference selection so Muse Glimmer requires explicit selection.
  * Improved automatic DGX Spark recipe selection, with Nemotron now chosen as the default qualified option.
  * Explicitly selecting Muse Glimmer overrides higher-priority automatic recipes.

* **Bug Fixes**
  * Clarified catalog behavior and selection handling for managed llama.cpp profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->