### PR TITLE
docs(skills): allow Git protocol switching

### DIFF
--- a/.agents/skills/_shared/git-github-hard-stop.md
+++ b/.agents/skills/_shared/git-github-hard-stop.md
@@ -20,7 +20,6 @@ Ask the user to correct the access problem.
 
 Do not try to bypass an access error. Do not:
 
-- switch remote protocols or remotes
 - edit credentials, tokens, or SSH config
 - generate new tokens or SSH keys
 - rewrite remotes to bypass permissions


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Remove the repository instruction that prohibits switching Git remote protocols after an access failure. Switching to another configured protocol can be a valid recovery path.

## Changes

- Delete the protocol-switch prohibition from the shared Git and GitHub access guidance.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [x] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This change deletes one policy bullet and does not change executable code.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The repository maintainer explicitly directed removal of this prohibition.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [ ] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `git diff --check` passed; the exact prohibited bullet is absent.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Git/GitHub access-error guidance to allow changing remote protocols or remotes when necessary.
  * Retained the remaining access-error safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->