### PR TITLE
fix(tools): return isolated worktree paths

### DIFF
--- a/.dsh/tools/collect_pr_feedback/index.ts
+++ b/.dsh/tools/collect_pr_feedback/index.ts
@@ -37,7 +37,7 @@ export default async function collect_pr_feedback(input: {
     throw new Error("bodyLimit must be between 100 and 10000");
   const repo = input.repository;
   const pr = input.pullNumber;
-  const run = async (args, allowed = [0]) => {
+  const run = async (args: string[], allowed: Integer[] = [0]): Promise<string> => {
     const result = await tools.run_github_cli({
       workdir: input.workdir,
       args,
@@ -45,16 +45,34 @@ export default async function collect_pr_feedback(input: {
     });
     return result.stdout.trim();
   };
-  const collectPages = async (path, projection, _description, _jqProjection) => {
-    const page = await tools.read_github_pages({
-      workdir: input.workdir,
-      repository: repo,
-      path,
-      pageSize: 10,
-      pageLimit: 10,
-    });
-    return { items: page.items.map(projection), pages: page.pagesRead, truncated: page.truncated };
+  const collectProjectedPages = async (
+    path: string,
+    projection: string,
+  ): Promise<{ items: Open<{}>[]; truncated: boolean }> => {
+    const items: Open<{}>[] = [];
+    const pageSize = 10;
+    const pageLimit = 10;
+    for (let page = 1; page <= pageLimit; page += 1) {
+      const text = await run([
+        "api",
+        "repos/" + repo + "/" + path + "?per_page=" + pageSize + "&page=" + page,
+        "--jq",
+        projection,
+      ]);
+      const values = text ? JSON.parse(text) : [];
+      if (
+        !Array.isArray(values) ||
+        values.some((item) => item === null || typeof item !== "object" || Array.isArray(item))
+      )
+        throw new Error("GitHub REST projection must be an array of objects");
+      items.push(...values);
+      if (items.length > 100) throw new Error("GitHub REST projection exceeded 100 items");
+      if (values.length < pageSize) return { items, truncated: false };
+      if (page === pageLimit) return { items, truncated: true };
+    }
+    throw new Error("GitHub REST projection did not terminate");
   };
+  const slice = "[:" + bodyLimit + "]";
   const [pullText, checksText, reviewsPage, inlinePage, discussionPage] = await Promise.all([
     run([
       "pr",
@@ -66,43 +84,21 @@ export default async function collect_pr_feedback(input: {
       "url,state,headRefOid,baseRefOid,mergeStateStatus,reviewDecision",
     ]),
     run(["pr", "checks", String(pr), "--repo", repo, "--json", "name,state,bucket,link"], [0, 8]),
-    collectPages(
+    collectProjectedPages(
       "pulls/" + pr + "/reviews",
-      (item) => ({
-        id: item.id,
-        user: item.user?.login ?? "",
-        state: item.state ?? "",
-        commitId: item.commit_id ?? "",
-        body: String(item.body ?? "").slice(0, bodyLimit),
-      }),
-      "Collect submitted pull request reviews",
-      'map({id,user:{login:.user.login},state,commit_id,body:((.body // "")[:' + bodyLimit + "])})",
+      'map({id,user:(.user.login // ""),state:(.state // ""),commitId:(.commit_id // ""),body:((.body // "")' +
+        slice +
+        ")})",
     ),
-    collectPages(
+    collectProjectedPages(
       "pulls/" + pr + "/comments",
-      (item) => ({
-        id: item.id,
-        user: item.user?.login ?? "",
-        path: item.path ?? "",
-        line: Number.isInteger(item.line) ? item.line : null,
-        body: String(item.body ?? "").slice(0, bodyLimit),
-        url: item.html_url ?? "",
-      }),
-      "Collect inline pull request comments",
-      'map({id,user:{login:.user.login},path,line,body:((.body // "")[:' +
-        bodyLimit +
-        "]),html_url})",
+      'map({id,user:(.user.login // ""),path:(.path // ""),line:(if (.line|type)=="number" then .line else null end),body:((.body // "")' +
+        slice +
+        '),url:(.html_url // "")})',
     ),
-    collectPages(
+    collectProjectedPages(
       "issues/" + pr + "/comments",
-      (item) => ({
-        id: item.id,
-        user: item.user?.login ?? "",
-        body: String(item.body ?? "").slice(0, bodyLimit),
-        url: item.html_url ?? "",
-      }),
-      "Collect pull request discussion comments",
-      'map({id,user:{login:.user.login},body:((.body // "")[:' + bodyLimit + "]),html_url})",
+      'map({id,user:(.user.login // ""),body:((.body // "")' + slice + '),url:(.html_url // "")})',
     ),
   ]);
   const pull = pullText ? JSON.parse(pullText) : {};
@@ -116,15 +112,33 @@ export default async function collect_pr_feedback(input: {
       mergeStateStatus: pull.mergeStateStatus ?? "",
       reviewDecision: pull.reviewDecision ?? "",
     },
-    checks: checks.map((item) => ({
-      name: item.name ?? "",
-      state: item.state ?? "",
-      bucket: item.bucket ?? "",
-      link: item.link ?? "",
+    checks: checks.map((item: Open<{}>) => ({
+      name: String(item.name ?? ""),
+      state: String(item.state ?? ""),
+      bucket: String(item.bucket ?? ""),
+      link: String(item.link ?? ""),
     })),
-    reviews: reviewsPage.items,
-    inlineComments: inlinePage.items,
-    discussionComments: discussionPage.items,
+    reviews: reviewsPage.items.map((item) => ({
+      id: item.id as Integer,
+      user: String(item.user ?? ""),
+      state: String(item.state ?? ""),
+      commitId: String(item.commitId ?? ""),
+      body: String(item.body ?? ""),
+    })),
+    inlineComments: inlinePage.items.map((item) => ({
+      id: item.id as Integer,
+      user: String(item.user ?? ""),
+      path: String(item.path ?? ""),
+      line: Number.isInteger(item.line) ? (item.line as Integer) : null,
+      body: String(item.body ?? ""),
+      url: String(item.url ?? ""),
+    })),
+    discussionComments: discussionPage.items.map((item) => ({
+      id: item.id as Integer,
+      user: String(item.user ?? ""),
+      body: String(item.body ?? ""),
+      url: String(item.url ?? ""),
+    })),
     truncation: {
       reviews: reviewsPage.truncated,
       inlineComments: inlinePage.truncated,

--- a/.dsh/tools/collect_pr_feedback/index.ts
+++ b/.dsh/tools/collect_pr_feedback/index.ts
@@ -55,11 +55,16 @@ export default async function collect_pr_feedback(input: {
     for (let page = 1; page <= pageLimit; page += 1) {
       const text = await run([
         "api",
+        "--include",
         "repos/" + repo + "/" + path + "?per_page=" + pageSize + "&page=" + page,
         "--jq",
         projection,
       ]);
-      const values = text ? JSON.parse(text) : [];
+      const boundary = text.indexOf("\n\n");
+      if (boundary < 0) throw new Error("GitHub REST projection response omitted headers");
+      const headers = text.slice(0, boundary);
+      const body = text.slice(boundary + 2);
+      const values = body ? JSON.parse(body) : [];
       if (
         !Array.isArray(values) ||
         values.some((item) => item === null || typeof item !== "object" || Array.isArray(item))
@@ -67,7 +72,8 @@ export default async function collect_pr_feedback(input: {
         throw new Error("GitHub REST projection must be an array of objects");
       items.push(...values);
       if (items.length > 100) throw new Error("GitHub REST projection exceeded 100 items");
-      if (values.length < pageSize) return { items, truncated: false };
+      const hasNext = /^link:.*rel="next"/imu.test(headers);
+      if (!hasNext) return { items, truncated: false };
       if (page === pageLimit) return { items, truncated: true };
     }
     throw new Error("GitHub REST projection did not terminate");

--- a/.dsh/tools/collect_pr_feedback/index.ts
+++ b/.dsh/tools/collect_pr_feedback/index.ts
@@ -60,10 +60,11 @@ export default async function collect_pr_feedback(input: {
         "--jq",
         projection,
       ]);
-      const boundary = text.indexOf("\n\n");
-      if (boundary < 0) throw new Error("GitHub REST projection response omitted headers");
-      const headers = text.slice(0, boundary);
-      const body = text.slice(boundary + 2);
+      const separator = text.match(/\r?\n\r?\n/u);
+      if (!separator || separator.index === undefined)
+        throw new Error("GitHub REST projection response omitted headers");
+      const headers = text.slice(0, separator.index);
+      const body = text.slice(separator.index + separator[0].length);
       const values = body ? JSON.parse(body) : [];
       if (
         !Array.isArray(values) ||

--- a/.dsh/tools/prepare_isolated_pr_worktree/index.ts
+++ b/.dsh/tools/prepare_isolated_pr_worktree/index.ts
@@ -25,6 +25,7 @@ export default async function prepare_isolated_pr_worktree(input: {
   number: Integer;
   url: string;
   path: string;
+  absolutePath: string;
   commit: string;
   baseCommit: string;
   baseBranch: string;
@@ -222,6 +223,7 @@ export default async function prepare_isolated_pr_worktree(input: {
     number: item.number,
     url: item.url,
     path: relativePath,
+    absolutePath: targetPath,
     commit: item.headRefOid,
     baseCommit: item.baseRefOid,
     baseBranch: item.baseRefName,

--- a/.dsh/tools/prepare_isolated_pr_worktrees/index.ts
+++ b/.dsh/tools/prepare_isolated_pr_worktrees/index.ts
@@ -34,6 +34,7 @@ export default async function prepare_isolated_pr_worktrees(input: {
     number: Integer;
     url: string;
     path: string;
+    absolutePath: string;
     commit: string;
     baseCommit: string;
     baseBranch: string;

--- a/test/automation/pull-requests/dsh-github-review-tools.test.ts
+++ b/test/automation/pull-requests/dsh-github-review-tools.test.ts
@@ -16,6 +16,7 @@ let prepareIsolatedPrWorktree: (input: any) => Promise<any>;
 let removeIsolatedPrWorktrees: (input: any) => Promise<any>;
 let runIndependentDocumentationWriterReview: (input: any) => Promise<any>;
 let summarizeNemoclawPlanningItems: (input: any) => Promise<any>;
+let collectPrFeedback: (input: any) => Promise<any>;
 const fixtureRoots: string[] = [];
 
 beforeAll(async () => {
@@ -32,6 +33,7 @@ beforeAll(async () => {
     await load("run_independent_documentation_writer_review")
   ).default;
   summarizeNemoclawPlanningItems = (await load("summarize_nemoclaw_planning_items")).default;
+  collectPrFeedback = (await load("collect_pr_feedback")).default;
 });
 
 const HEAD_SHA = "a".repeat(40);
@@ -515,5 +517,68 @@ describe("isolated worktree namespace guards", () => {
     ).rejects.toThrow("outside the primary checkout");
     expect(bash.mock.calls.some(([call]) => call.command.includes("mkdir -p"))).toBe(false);
     expect(bash.mock.calls.some(([call]) => call.command.includes("git worktree"))).toBe(false);
+  });
+});
+
+describe("bounded PR feedback pagination", () => {
+  it("treats ten full pages without a next link as complete", async () => {
+    const pullResponse = {
+      ok: true,
+      code: 0,
+      stdout: JSON.stringify({
+        url: "https://github.com/NVIDIA/NemoClaw/pull/1",
+        state: "OPEN",
+        headRefOid: HEAD_SHA,
+        baseRefOid: "b".repeat(40),
+        mergeStateStatus: "CLEAN",
+        reviewDecision: "",
+      }),
+      stderr: "",
+    };
+    const checksResponse = { ok: true, code: 0, stdout: "[]", stderr: "" };
+    const runGithubCli = vi.fn(async ({ args }: { args: string[] }) => {
+      const endpoint = args.find((arg) => arg.startsWith("repos/")) ?? "";
+      const page = Number(new URL("https://github.invalid/" + endpoint).searchParams.get("page"));
+      const isReviews = endpoint.includes("/reviews?");
+      const values = isReviews
+        ? Array.from({ length: 10 }, (_, index) => ({
+            id: (page - 1) * 10 + index + 1,
+            user: "reviewer",
+            state: "COMMENTED",
+            commitId: HEAD_SHA,
+            body: "review",
+          }))
+        : [];
+      const link =
+        isReviews && page < 10 ? 'Link: <https://api.github.com/next>; rel="next"\n' : "";
+      const apiResponse = {
+        ok: true,
+        code: 0,
+        stdout: "HTTP/2.0 200 OK\n" + link + "\n" + JSON.stringify(values),
+        stderr: "",
+      };
+      const command = args[0] + " " + args[1];
+      return command === "pr view"
+        ? pullResponse
+        : command === "pr checks"
+          ? checksResponse
+          : apiResponse;
+    });
+    vi.stubGlobal("tools", { run_github_cli: runGithubCli });
+
+    const result = await collectPrFeedback({
+      repository: "NVIDIA/NemoClaw",
+      pullNumber: 1,
+      workdir: "/workspace",
+      bodyLimit: 100,
+    });
+
+    expect(result.reviews).toHaveLength(100);
+    expect(result.truncation.reviews).toBe(false);
+    expect(
+      runGithubCli.mock.calls.filter(([call]) =>
+        call.args.some((arg: string) => arg.includes("/reviews?")),
+      ),
+    ).toHaveLength(10);
   });
 });

--- a/test/automation/pull-requests/dsh-github-review-tools.test.ts
+++ b/test/automation/pull-requests/dsh-github-review-tools.test.ts
@@ -424,7 +424,12 @@ describe("isolated worktree namespace guards", () => {
         path: target,
         isolationKey: "session",
       }),
-    ).resolves.toMatchObject({ action: "planned", dryRun: true, path: "1" });
+    ).resolves.toMatchObject({
+      action: "planned",
+      dryRun: true,
+      path: "1",
+      absolutePath: target,
+    });
   });
 
   it.each(["root", "intermediate"] as const)(
@@ -546,7 +551,7 @@ describe("bounded PR feedback pagination", () => {
             user: "reviewer",
             state: "COMMENTED",
             commitId: HEAD_SHA,
-            body: "review",
+            body: "r".repeat(100),
           }))
         : [];
       const link =
@@ -554,7 +559,7 @@ describe("bounded PR feedback pagination", () => {
       const apiResponse = {
         ok: true,
         code: 0,
-        stdout: "HTTP/2.0 200 OK\n" + link + "\n" + JSON.stringify(values),
+        stdout: "HTTP/2.0 200 OK\r\n" + link + "\r\n" + JSON.stringify(values),
         stderr: "",
       };
       const command = args[0] + " " + args[1];
@@ -574,7 +579,13 @@ describe("bounded PR feedback pagination", () => {
     });
 
     expect(result.reviews).toHaveLength(100);
+    expect(result.reviews[0].body).toBe("r".repeat(100));
     expect(result.truncation.reviews).toBe(false);
+    expect(
+      runGithubCli.mock.calls
+        .filter(([call]) => call.args.some((arg: string) => arg.includes("/reviews?")))
+        .every(([call]) => call.args.some((arg: string) => arg.includes("[:100]"))),
+    ).toBe(true);
     expect(
       runGithubCli.mock.calls.filter(([call]) =>
         call.args.some((arg: string) => arg.includes("/reviews?")),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Isolated worktree tools now return the complete worktree path with each result. Callers can pass the returned path to review and validation agents without reconstructing the isolation namespace.

## Changes

- Add `absolutePath` to the singular isolated worktree result while preserving the namespace-relative `path` field.
- Expose the same `absolutePath` field through the batch isolated worktree result contract.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: The change extends result objects without changing worktree behavior. Existing dry-run execution covers both result contracts.
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — The signed commit passed pre-commit and commit-msg hooks. Focused validation passed Oxfmt, Oxlint, repository checks, diff checks, and NUL-byte checks.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: Singular and batch dry-run calls returned the expected complete paths.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; focused repository validation covers the two tool contract changes.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worktree preparation results now include each worktree’s absolute path.

* **Bug Fixes**
  * Improved pull request feedback collection with more reliable pagination across multiple pages.
  * Enhanced handling of response headers, including varied line endings and missing pagination details.
  * Reviews and comments are now normalized consistently, with bounded feedback content and preserved identifiers.
  * Improved support for complete review results while retaining configured page and item limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->