### PR TITLE
fix(e2e): bind Hermes Discord websocket endpoint

### DIFF
--- a/test/e2e/fixtures/hermes-discord-policy-binding.ts
+++ b/test/e2e/fixtures/hermes-discord-policy-binding.ts
@@ -25,7 +25,7 @@ export function bindHermesDiscordPolicyEndpoint(
   providerName: string,
   host: string,
   port: number,
-  protocol?: string,
+  protocol: string,
 ): void {
   const source = fs.readFileSync(policyFile, "utf8");
   const policy = parseOpenShellPolicy(source).policy;
@@ -42,7 +42,7 @@ export function bindHermesDiscordPolicyEndpoint(
     return (
       value.host === host &&
       value.port === port &&
-      (protocol === undefined || value.protocol === protocol)
+      value.protocol === protocol
     );
   }) as Record<string, unknown> | undefined;
   if (!endpoint) throw new Error("fake Discord endpoint is missing from the base policy");
@@ -54,8 +54,10 @@ export function bindHermesDiscordPolicyEndpoint(
 
 function main(): void {
   const [policyFile, providerName, host, rawPort, protocol] = process.argv.slice(2);
-  if (!policyFile || !providerName || !host || !rawPort) {
-    throw new Error("usage: hermes-discord-policy-binding <policy-file> <provider> <host> <port>");
+  if (!policyFile || !providerName || !host || !rawPort || !protocol) {
+    throw new Error(
+      "usage: hermes-discord-policy-binding <policy-file> <provider> <host> <port> <protocol>",
+    );
   }
   bindHermesDiscordPolicyEndpoint(policyFile, providerName, host, Number(rawPort), protocol);
 }

--- a/test/e2e/live/hermes-discord.test.ts
+++ b/test/e2e/live/hermes-discord.test.ts
@@ -177,7 +177,7 @@ async function applyHermesFakeDiscordPolicy(options: {
 policy_file="$(mktemp)"
 trap 'rm -f "$policy_file"' EXIT
 "$1" policy get --base "$2" >"$policy_file"
-node --import tsx "$6" "$policy_file" "$3" "$4" "$5"
+node --import tsx "$6" "$policy_file" "$3" "$4" "$5" websocket
 "$1" policy set --policy "$policy_file" --wait "$2"`,
       "bind-hermes-fake-discord-policy",
       options.host.openshellCommandPath,

--- a/test/e2e/support/hermes-discord-policy-binding.test.ts
+++ b/test/e2e/support/hermes-discord-policy-binding.test.ts
@@ -16,7 +16,7 @@ const TYPESCRIPT = path.resolve("node_modules/typescript/bin/tsc");
 const POLICY_BOUNDARY_CONFIG = path.resolve("nemoclaw/tsconfig.shared.json");
 const tempDirs: string[] = [];
 
-function runBinding(policyFile: string, protocol?: string) {
+function runBinding(policyFile: string, protocol = "websocket") {
   return spawnSync(
     process.execPath,
     [
@@ -28,7 +28,7 @@ function runBinding(policyFile: string, protocol?: string) {
       "e2e-hermes-discord-discord-bridge",
       "host.docker.internal",
       "43117",
-      ...(protocol ? [protocol] : []),
+      protocol,
     ],
     { encoding: "utf8", killSignal: "SIGKILL", timeout: 15_000 },
   );
@@ -65,6 +65,7 @@ describe("Hermes Discord E2E policy binding", () => {
         "    endpoints:",
         "      - host: host.docker.internal",
         "        port: 43117",
+        "        protocol: websocket",
         "      - host: discord.com",
         "        port: 443",
         "",
@@ -83,6 +84,7 @@ describe("Hermes Discord E2E policy binding", () => {
             {
               host: "host.docker.internal",
               port: 43117,
+              protocol: "websocket",
               credential_binding: { provider: "e2e-hermes-discord-discord-bridge" },
             },
             { host: "discord.com", port: 443 },
@@ -91,6 +93,31 @@ describe("Hermes Discord E2E policy binding", () => {
       },
     });
     expect(fs.statSync(policyFile).mode & 0o777).toBe(0o600);
+  });
+
+  it("rejects a missing protocol before choosing among shared endpoints (#10155)", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-messaging-policy-"));
+    tempDirs.push(tempDir);
+    const policyFile = path.join(tempDir, "policy.yaml");
+    fs.writeFileSync(policyFile, "version: 1\nnetwork_policies: {}\n");
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--disable-warning=DEP0205",
+        "--import",
+        "tsx",
+        HELPER,
+        policyFile,
+        "e2e-hermes-discord-discord-bridge",
+        "host.docker.internal",
+        "43117",
+      ],
+      { encoding: "utf8", killSignal: "SIGKILL", timeout: 15_000 },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("<protocol>");
   });
 
   it("binds only the requested protocol when a fake host and port are shared", () => {

--- a/test/e2e/support/hermes-discord-policy-binding.test.ts
+++ b/test/e2e/support/hermes-discord-policy-binding.test.ts
@@ -16,7 +16,7 @@ const TYPESCRIPT = path.resolve("node_modules/typescript/bin/tsc");
 const POLICY_BOUNDARY_CONFIG = path.resolve("nemoclaw/tsconfig.shared.json");
 const tempDirs: string[] = [];
 
-function runBinding(policyFile: string, protocol = "websocket") {
+function runBinding(policyFile: string, protocol?: string) {
   return spawnSync(
     process.execPath,
     [
@@ -28,7 +28,7 @@ function runBinding(policyFile: string, protocol = "websocket") {
       "e2e-hermes-discord-discord-bridge",
       "host.docker.internal",
       "43117",
-      protocol,
+      ...(protocol === undefined ? [] : [protocol]),
     ],
     { encoding: "utf8", killSignal: "SIGKILL", timeout: 15_000 },
   );
@@ -72,7 +72,7 @@ describe("Hermes Discord E2E policy binding", () => {
       ].join("\n"),
     );
 
-    const result = runBinding(policyFile);
+    const result = runBinding(policyFile, "websocket");
 
     expect(result.stderr).toBe("");
     expect(result.status).toBe(0);
@@ -101,20 +101,7 @@ describe("Hermes Discord E2E policy binding", () => {
     const policyFile = path.join(tempDir, "policy.yaml");
     fs.writeFileSync(policyFile, "version: 1\nnetwork_policies: {}\n");
 
-    const result = spawnSync(
-      process.execPath,
-      [
-        "--disable-warning=DEP0205",
-        "--import",
-        "tsx",
-        HELPER,
-        policyFile,
-        "e2e-hermes-discord-discord-bridge",
-        "host.docker.internal",
-        "43117",
-      ],
-      { encoding: "utf8", killSignal: "SIGKILL", timeout: 15_000 },
-    );
+    const result = runBinding(policyFile, undefined);
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("<protocol>");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Hermes Discord E2E now binds its fake Gateway credential provider to the WebSocket endpoint explicitly. Before this change, an HTTP and WebSocket endpoint sharing the same host and port could leave the credential on the wrong endpoint, causing OpenShell to close the native Discord Gateway connection before READY.

## Related Issue

Part of #10155.

## Changes

- Require the policy-binding fixture to receive an endpoint protocol.
- Pass `websocket` from the live Hermes Discord scenario.
- Cover missing-protocol rejection and same-host/port protocol disambiguation.
- Reuse the support-test invocation helper for the missing-protocol case.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Codex reviewed the exact commit `a21a881b4f23c21d51224545487efeef4882e926` against the nine-category security checklist. The change narrows credential binding to the WebSocket endpoint and the follow-up commit only centralizes a test invocation; it does not change credential values, redaction, endpoint access, or sandbox permissions. The revision-specific PR Review Advisor Trust specialist and synthesis also completed with no findings. Verdict: PASS.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — all normal hooks passed for `a21a881b4f23c21d51224545487efeef4882e926`; the pre-push CLI build/typecheck passed after generating the clean worktree's ignored `dist/` artifacts.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — revision-specific local evidence: Hermes Discord policy-binding support tests 3/3, codebase growth guardrails 32/32, Biome, and `git diff --check`; the revision-specific PR Review Advisor completed all specialists and synthesis with high-confidence `merge_as_is` and no findings.
- [ ] Applicable broad gate passed — revision-specific ordinary CI passed, while the exact `hermes-discord` live E2E is waiting on the trusted catalogue-profile correction in #10263; this PR remains draft until that live target passes.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

## Documentation Writer Review

- [x] Documentation writer reviewed the exact change.
- Result: `no-docs-needed`
- Evidence: `a21a881b4f23c21d51224545487efeef4882e926` changes only three E2E fixture/live/support files and does not change shipped Hermes Discord behavior or user workflow.

## Exact E2E Validation

- Required selector: `hermes-discord`
- Candidate commit: `a21a881b4f23c21d51224545487efeef4882e926`
- Run `32915283135` attempt 1 stopped in `Authenticate manual PR dispatch` because the workflow token returned HTTP 403; the selector did not execute.
- Run `32915283135` attempt 2 passed manual-PR authentication and matrix generation, but onboarding stopped before the Discord assertions because the reusable catalogue profile did not receive the trusted managed-image revision and GHCR correctly returned HTTP 404 for unpublished PR version `v0.0.114-107-ga21a881b4`.
- Issue #10153 identifies PR #10263 as the owning catalogue-profile correction. Its current head passes the focused workflow-boundary suites and is completing CI.
- This PR remains draft until the revision-specific selector passes.

---
Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>
