### PR TITLE
fix(ci): avoid API calls for base image metadata

### DIFF
--- a/.github/actions/build-base-image-platform/action.yaml
+++ b/.github/actions/build-base-image-platform/action.yaml
@@ -44,10 +44,6 @@ inputs:
     description: Optional OpenClaw version build argument.
     required: false
     default: ""
-  metadata-tags:
-    description: Optional docker/metadata-action tag rules.
-    required: false
-    default: ""
 
 runs:
   using: composite
@@ -61,15 +57,6 @@ runs:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.registry-username }}
         password: ${{ inputs.registry-password }}
-
-    - name: Extract metadata
-      id: meta
-      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-      env:
-        DOCKER_METADATA_SHORT_SHA_LENGTH: 8
-      with:
-        images: ${{ inputs.registry }}/${{ inputs.image }}
-        tags: ${{ inputs.metadata-tags }}
 
     - name: Validate production Docker build args
       id: production-build-args
@@ -109,7 +96,9 @@ runs:
         context: .
         file: ${{ inputs.dockerfile }}
         platforms: ${{ inputs.platform }}
-        labels: ${{ steps.meta.outputs.labels }}
+        labels: |
+          org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          org.opencontainers.image.revision=${{ github.sha }}
         outputs: type=image,name=${{ inputs.registry }}/${{ inputs.image }},push-by-digest=true,name-canonical=true,push=true
         cache-from: type=registry,ref=${{ inputs.registry }}/${{ inputs.image }}:buildcache-${{ inputs.arch }}
         cache-to: type=registry,ref=${{ inputs.registry }}/${{ inputs.image }}:buildcache-${{ inputs.arch }},mode=max

--- a/.github/actions/publish-base-image-manifest/action.yaml
+++ b/.github/actions/publish-base-image-manifest/action.yaml
@@ -66,17 +66,14 @@ runs:
         username: ${{ inputs.registry-username }}
         password: ${{ inputs.registry-password }}
 
-    - name: Extract metadata
+    - name: Generate manifest tags
       id: meta
-      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+      shell: bash
       env:
-        DOCKER_METADATA_SHORT_SHA_LENGTH: 8
-      with:
-        images: ${{ inputs.registry }}/${{ inputs.image }}
-        tags: |
-          type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-          type=ref,event=tag
-          type=sha,prefix=,format=short
+        IMAGE: ${{ inputs.registry }}/${{ inputs.image }}
+        REF: ${{ github.ref }}
+        REVISION: ${{ github.sha }}
+      run: bash "$GITHUB_ACTION_PATH/tags.sh"
 
     - name: Create and verify multi-platform manifest
       id: manifest

--- a/.github/actions/publish-base-image-manifest/tags.sh
+++ b/.github/actions/publish-base-image-manifest/tags.sh
@@ -18,6 +18,7 @@ if [[ ! "$REVISION" =~ ^[0-9a-f]{40}$ ]]; then
 fi
 
 tags=()
+publish_release_latest=false
 case "$REF" in
   refs/heads/main)
     tags+=("$IMAGE:latest")
@@ -30,6 +31,7 @@ case "$REF" in
       exit 1
     fi
     tags+=("$IMAGE:$tag")
+    publish_release_latest=true
     ;;
   *)
     echo "ERROR: base-image publication ref is invalid." >&2
@@ -37,6 +39,9 @@ case "$REF" in
     ;;
 esac
 tags+=("$IMAGE:${REVISION:0:8}")
+if [ "$publish_release_latest" = true ]; then
+  tags+=("$IMAGE:latest")
+fi
 
 {
   echo "tags<<NEMOCLAW_BASE_IMAGE_TAGS"

--- a/.github/actions/publish-base-image-manifest/tags.sh
+++ b/.github/actions/publish-base-image-manifest/tags.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+: "${IMAGE:?}"
+: "${REF:?}"
+: "${REVISION:?}"
+: "${GITHUB_OUTPUT:?}"
+
+if [[ ! "$IMAGE" =~ ^[a-z0-9.-]+/[a-z0-9._/-]+$ ]]; then
+  echo "ERROR: base-image repository is invalid." >&2
+  exit 1
+fi
+if [[ ! "$REVISION" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: base-image revision must be an exact commit SHA." >&2
+  exit 1
+fi
+
+tags=()
+case "$REF" in
+  refs/heads/main)
+    tags+=("$IMAGE:latest")
+    ;;
+  refs/heads/*) ;;
+  refs/tags/*)
+    tag="${REF#refs/tags/}"
+    if [[ ! "$tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+      echo "ERROR: base-image tag is invalid." >&2
+      exit 1
+    fi
+    tags+=("$IMAGE:$tag")
+    ;;
+  *)
+    echo "ERROR: base-image publication ref is invalid." >&2
+    exit 1
+    ;;
+esac
+tags+=("$IMAGE:${REVISION:0:8}")
+
+{
+  echo "tags<<NEMOCLAW_BASE_IMAGE_TAGS"
+  printf '%s\n' "${tags[@]}"
+  echo "NEMOCLAW_BASE_IMAGE_TAGS"
+} >>"$GITHUB_OUTPUT"

--- a/.github/workflows/base-image-platform.yaml
+++ b/.github/workflows/base-image-platform.yaml
@@ -77,7 +77,3 @@ jobs:
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.registry_password }}
           openclaw-version: ${{ inputs.openclaw-version }}
-          metadata-tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=ref,event=tag
-            type=sha,prefix=,format=short

--- a/test/helpers/vitest-watch-triggers.ts
+++ b/test/helpers/vitest-watch-triggers.ts
@@ -213,6 +213,14 @@ export const vitestWatchTriggerPatterns: VitestWatchTriggerPattern[] = [
     testsToRun: runTests(
       "test/agents/deepagents/dcode-base-image-workflow.test.ts",
       "test/agents/openclaw/openclaw-dependency-review.test.ts",
+      "test/inference/managed/managed-image-publication-workflow.test.ts",
+    ),
+  },
+  {
+    pattern: /(?:^|\/)\.github\/actions\/publish-base-image-manifest\//,
+    testsToRun: runTests(
+      "test/inference/managed/managed-image-publication-workflow.test.ts",
+      "test/platform/images/publish-base-image-manifest.test.ts",
     ),
   },
   {

--- a/test/inference/managed/managed-image-publication-workflow.test.ts
+++ b/test/inference/managed/managed-image-publication-workflow.test.ts
@@ -309,6 +309,43 @@ describe("complete managed-image publication workflow", () => {
     );
     expect(exportDigest.run).toContain('printf \'%s_digest=%s\\n\' "$ARCH" "$DIGEST"');
   });
+
+  it("publishes native base images without GitHub API metadata", () => {
+    const action = readAction("build-base-image-platform");
+    const platformBuild = step(
+      { steps: action.runs?.steps },
+      "Build and push platform digest",
+      "build-base-image-platform action",
+    );
+    expect(platformBuild.with?.labels).toBe(
+      "org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}\n" +
+        "org.opencontainers.image.revision=${{ github.sha }}\n",
+    );
+    expect(JSON.stringify(action)).not.toContain('"metadata-tags"');
+    expect(
+      action.runs?.steps?.some((candidate) => candidate.uses?.includes("metadata-action")),
+    ).toBe(false);
+
+    const manifestAction = readAction("publish-base-image-manifest");
+    const manifestTags = step(
+      { steps: manifestAction.runs?.steps },
+      "Generate manifest tags",
+      "publish-base-image-manifest action",
+    );
+    expect(manifestTags).toMatchObject({
+      id: "meta",
+      env: {
+        IMAGE: "${{ inputs.registry }}/${{ inputs.image }}",
+        REF: "${{ github.ref }}",
+        REVISION: "${{ github.sha }}",
+      },
+      run: 'bash "$GITHUB_ACTION_PATH/tags.sh"',
+      shell: "bash",
+    });
+    expect(
+      manifestAction.runs?.steps?.some((candidate) => candidate.uses?.includes("metadata-action")),
+    ).toBe(false);
+  });
   it("builds and exercises every shipped agent from an exact PR image before merge (#7744)", () => {
     const workflow = readWorkflow("managed-images.yaml");
     const reviewedAudit = managedPrReviewedAudit(workflow);

--- a/test/platform/images/publish-base-image-manifest.test.ts
+++ b/test/platform/images/publish-base-image-manifest.test.ts
@@ -161,7 +161,7 @@ describe("base-image manifest publication", () => {
     expect(result.status).toBe(0);
     expect(result.output).toContain("ghcr.io/nvidia/nemoclaw/sandbox-base:v0.0.114\n");
     expect(result.output).toContain("ghcr.io/nvidia/nemoclaw/sandbox-base:eeeeeeee\n");
-    expect(result.output).not.toContain("sandbox-base:latest");
+    expect(result.output).toContain("ghcr.io/nvidia/nemoclaw/sandbox-base:latest\n");
   });
 
   it("rejects a malformed publication revision", () => {

--- a/test/platform/images/publish-base-image-manifest.test.ts
+++ b/test/platform/images/publish-base-image-manifest.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -15,6 +15,10 @@ const SHA_PUBLISHED = `sha256:${"d".repeat(64)}`;
 const helper = resolve(
   import.meta.dirname,
   "../../../.github/actions/publish-base-image-manifest/publish.sh",
+);
+const tagHelper = resolve(
+  import.meta.dirname,
+  "../../../.github/actions/publish-base-image-manifest/tags.sh",
 );
 const temporaryRoots: string[] = [];
 
@@ -122,7 +126,51 @@ printf '{"containerimage.descriptor":{"digest":"%s"}}\n' "$digest" > "$metadata"
   });
 }
 
+function runTagHelper(ref: string, revision = "e".repeat(40)) {
+  const root = mkdtempSync(join(tmpdir(), "nemoclaw-base-tags-"));
+  temporaryRoots.push(root);
+  const output = join(root, "github-output");
+  const result = spawnSync("bash", [tagHelper], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: output,
+      IMAGE: "ghcr.io/nvidia/nemoclaw/sandbox-base",
+      REF: ref,
+      REVISION: revision,
+    },
+  });
+  return {
+    ...result,
+    output: result.status === 0 ? readFileSync(output, "utf8") : "",
+  };
+}
+
 describe("base-image manifest publication", () => {
+  it("generates main and immutable SHA tags without a GitHub API request", () => {
+    const result = runTagHelper("refs/heads/main");
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("ghcr.io/nvidia/nemoclaw/sandbox-base:latest\n");
+    expect(result.output).toContain("ghcr.io/nvidia/nemoclaw/sandbox-base:eeeeeeee\n");
+  });
+
+  it("generates release and immutable SHA tags without a GitHub API request", () => {
+    const result = runTagHelper("refs/tags/v0.0.114");
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("ghcr.io/nvidia/nemoclaw/sandbox-base:v0.0.114\n");
+    expect(result.output).toContain("ghcr.io/nvidia/nemoclaw/sandbox-base:eeeeeeee\n");
+    expect(result.output).not.toContain("sandbox-base:latest");
+  });
+
+  it("rejects a malformed publication revision", () => {
+    const result = runTagHelper("refs/heads/main", "not-a-commit");
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("base-image revision must be an exact commit SHA");
+  });
+
   it("rejects a malformed platform digest artifact", () => {
     const result = runManifest({ digestFiles: ["amd64-invalid", `arm64-${SHA_ARM64}`] });
 

--- a/test/repository/vitest-watch-triggers.test.ts
+++ b/test/repository/vitest-watch-triggers.test.ts
@@ -261,6 +261,11 @@ describe("Vitest opaque-input watch triggers", () => {
     expect(triggeredBy(".github/actions/build-base-image-platform/action.yaml")).toEqual([
       "test/agents/deepagents/dcode-base-image-workflow.test.ts",
       "test/agents/openclaw/openclaw-dependency-review.test.ts",
+      "test/inference/managed/managed-image-publication-workflow.test.ts",
+    ]);
+    expect(triggeredBy(".github/actions/publish-base-image-manifest/action.yaml")).toEqual([
+      "test/inference/managed/managed-image-publication-workflow.test.ts",
+      "test/platform/images/publish-base-image-manifest.test.ts",
     ]);
     expect(triggeredBy(".github/workflows/base-image-platform.yaml")).toEqual([
       "test/agents/deepagents/dcode-base-image-workflow.test.ts",


### PR DESCRIPTION
## Summary

Base-image publication no longer consumes GitHub REST quota to derive tags and labels. The automatic publisher now derives its required OCI labels and `latest`, release, and immutable commit tags from trusted workflow context, so installation-token rate exhaustion cannot prevent every platform build from starting.

Root cause key: `base-image publisher / metadata extraction / GitHub App installation REST quota exhausted`

Automatic-run evidence:

- Downstream E2E run: [32897885640](https://github.com/NVIDIA/NemoClaw/actions/runs/32897885640)
- Managed-image publisher: [32895027598](https://github.com/NVIDIA/NemoClaw/actions/runs/32895027598), attempt 1
- Stable signature: `API rate limit exceeded for installation`
- Failed publisher jobs:
  - [OpenClaw amd64](https://github.com/NVIDIA/NemoClaw/actions/runs/32895027598/job/97956682291)
  - [OpenClaw arm64](https://github.com/NVIDIA/NemoClaw/actions/runs/32895027598/job/97956682432)
  - [Hermes amd64](https://github.com/NVIDIA/NemoClaw/actions/runs/32895027598/job/97956682292)
  - [Hermes arm64](https://github.com/NVIDIA/NemoClaw/actions/runs/32895027598/job/97956682439)
  - [Deep Agents Code amd64](https://github.com/NVIDIA/NemoClaw/actions/runs/32895027598/job/97956682390)
  - [Deep Agents Code arm64](https://github.com/NVIDIA/NemoClaw/actions/runs/32895027598/job/97956682406)
  - [Pi amd64](https://github.com/NVIDIA/NemoClaw/actions/runs/32895027598/job/97956682483)
  - [Pi arm64](https://github.com/NVIDIA/NemoClaw/actions/runs/32895027598/job/97956682491)

## Changes

- Set the required OCI source and revision labels directly from GitHub workflow context.
- Generate validated manifest tags locally while preserving current main, release, immutable short-commit, and release-`latest` behavior.
- Add behavior and source-shape tests that reject a return to API-dependent base-image metadata, plus affected-test routing for both composite actions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: @prekshivyas approved latest PR commit `140737dac` after a nine-category security review: https://github.com/NVIDIA/NemoClaw/pull/10301#pullrequestreview-5024487719
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: `cli-test-shards (7)` timed out in unchanged `host-local-vllm-selection.test.ts`; the exact file passes 17/17 locally and is classified as an unrelated timing flake: https://github.com/NVIDIA/NemoClaw/pull/10301#issuecomment-5417172368. The latest commit has a fresh CI cycle; no product-code follow-up applies.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — `npm run validate:pr` passed at latest PR commit `140737dac`
- [x] Targeted behavior tests pass for the current change set — 104 managed-publication/watch-trigger tests and all three focused tag-helper tests passed
- [x] Applicable broad gate passed — repository checks, ShellCheck, gitleaks, formatting, lint, CLI typecheck, source-shape budget, and growth guardrails passed through `npm run validate:pr`
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Base image publication now generates consistent tags for main-branch builds, releases, and immutable commit revisions.
  - Published images include standardized source and revision information.
  - Invalid image references, revisions, and publication tags are rejected before publishing.

- **Bug Fixes**
  - Improved reliability of platform image builds and manifest publication by removing inconsistent metadata handling.

- **Tests**
  - Added coverage for tag generation, validation, image labels, and publication workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
