### PR TITLE
fix(e2e): remove MXC token artifacts after failure

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -487,8 +487,7 @@ values. Do not put credentials in them.
 | `NEMOCLAW_WINDOWS_MXC_OPENCLAW_ENTRY_SHA256` | Expected OpenClaw entrypoint SHA-256 |
 
 The target creates a random OpenClaw gateway token for readiness, forwarding,
-and chat checks. It
-passes that token through the MXC agent environment; current OpenShell
+and chat checks. It passes that token through the MXC agent environment. Current OpenShell
 `process_container` packaging can therefore expose its encoded configuration,
 including the token, to privileged host process inspection while `wxc-exec.exe`
 starts the sandbox. The token is never written to the receipt or supplied in
@@ -496,7 +495,8 @@ the OpenClaw command arguments, is not reused, and is useful only for the
 temporary loopback OpenClaw gateway. The host client uses a temporary config
 file that is deleted before a passing receipt is written. Cleanup attempts sandbox deletion, stops
 the recorded OpenClaw process, clears the in-memory environment value, and
-removes the runtime home, state, configuration, and gateway logs. A direct
+removes both test-owned run directories, including the MXC agent environment
+file, runtime home, state, configuration, and gateway logs. A direct
 process-tree termination is an emergency cleanup fallback only. The host-side
 OpenShell processes receive an allowlist of Windows runtime variables rather
 than the complete caller environment. Before using a termination fallback,
@@ -521,22 +521,24 @@ npx vitest run --project e2e-live test/e2e/live/windows-mxc-openclaw-process-con
 
 The target verifies OpenClaw startup and in-sandbox health, read-write and denied
 filesystem behavior, an authenticated host-loopback forward, and one
-credential-free mock-backed agent turn that returns exactly `CHAT_OK`. It keeps
+provider-credential-free mock-backed agent turn that returns exactly `CHAT_OK`. It keeps
 the forward active while deleting the sandbox and requires the listener,
 forward process, sandbox registry entry, and recorded OpenClaw process to stop.
 The complete create, forward, chat, and cleanup flow runs twice to detect stale
 state. After preflight and local setup succeed, it
 writes a secret-free receipt for either verdict and records whether sensitive
-runtime artifacts were removed. When that cleanup succeeds, a failed run retains
-only non-sensitive probe files for diagnosis.
+runtime artifacts were removed. Cleanup removes both test-owned run directories
+for every verdict because MXC can write the temporary gateway token to its agent
+environment file. A failed run retains only the secret-free receipt.
 The host-preparation declaration is operator evidence, not an ACL attestation.
 Gateway mTLS, governed egress policy enforcement, managed inference,
 gateway-restart recovery, standard-user operation, and production activation
 remain outside this target.
 
 If a failed receipt has a non-null `cleanup.retainedSandboxName`, OpenShell did
-not confirm removal of that exact sandbox. Inspect the registry and delete only
-the recorded name:
+not confirm removal of that exact sandbox. The retained process environment can
+hold the temporary gateway token until sandbox deletion is confirmed. Inspect
+the registry and delete only the recorded name:
 
 ```powershell
 $receipt = Get-Content "C:\path\to\receipt.json" -Raw | ConvertFrom-Json

--- a/test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts
+++ b/test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts
@@ -321,6 +321,31 @@ export async function runWindowsMxcForwardCleanup(input: {
   };
 }
 
+export function removeWindowsMxcRuntimeArtifacts(input: {
+  readonly runRoot: string;
+  readonly sensitivePaths: readonly string[];
+  readonly shareDirectory: string;
+}): {
+  readonly failures: readonly unknown[];
+  readonly runDirectoryRemoved: boolean;
+  readonly sensitiveRuntimeArtifactsRemoved: boolean;
+} {
+  const paths = [...new Set([...input.sensitivePaths, input.runRoot, input.shareDirectory])];
+  const failures: unknown[] = [];
+  for (const artifactPath of paths) {
+    try {
+      fs.rmSync(artifactPath, { force: true, recursive: true });
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  return {
+    failures,
+    runDirectoryRemoved: !fs.existsSync(input.runRoot) && !fs.existsSync(input.shareDirectory),
+    sensitiveRuntimeArtifactsRemoved: paths.every((artifactPath) => !fs.existsSync(artifactPath)),
+  };
+}
+
 function buildWindowsMxcSetupFailureReceipt(
   inputs: WindowsMxcOpenClawQualificationInputs,
   processElevated: boolean,
@@ -2325,29 +2350,26 @@ export async function runWindowsMxcOpenClawProcessContainerQualification(
         cleanupFailures.push(error);
       }
     }
-    const sensitivePaths = [
-      clientHomeDirectory,
-      homeDirectory,
-      configDirectory,
-      stateDirectory,
-      gatewayLogPath,
-      gatewayErrorPath,
-      forwardLogPath,
-      forwardErrorPath,
-    ];
-    for (const sensitivePath of sensitivePaths) {
-      try {
-        fs.rmSync(sensitivePath, { force: true, recursive: true });
-      } catch (error) {
-        cleanupFailures.push(error);
-      }
-    }
-    sensitiveRuntimeArtifactsRemoved = sensitivePaths.every(
-      (sensitivePath) => !fs.existsSync(sensitivePath),
-    );
+    const runtimeArtifactCleanup = removeWindowsMxcRuntimeArtifacts({
+      runRoot,
+      shareDirectory,
+      sensitivePaths: [
+        clientHomeDirectory,
+        homeDirectory,
+        configDirectory,
+        stateDirectory,
+        gatewayLogPath,
+        gatewayErrorPath,
+        forwardLogPath,
+        forwardErrorPath,
+      ],
+    });
+    cleanupFailures.push(...runtimeArtifactCleanup.failures);
+    runDirectoryRemoved = runtimeArtifactCleanup.runDirectoryRemoved;
+    sensitiveRuntimeArtifactsRemoved = runtimeArtifactCleanup.sensitiveRuntimeArtifactsRemoved;
   }
 
-  const lifecyclePassedBeforeDirectoryRemoval =
+  const lifecyclePassed =
     receiptPasses(checks) &&
     !boundedStopMarkerNeeded &&
     !emergencyProcessTerminationNeeded &&
@@ -2358,24 +2380,15 @@ export async function runWindowsMxcOpenClawProcessContainerQualification(
     forwardProcessStopped &&
     gatewayStopped &&
     openClawProcessStopped &&
+    runDirectoryRemoved &&
     sensitiveRuntimeArtifactsRemoved &&
     primaryFailure === null &&
     cleanupFailures.length === 0;
-  if (lifecyclePassedBeforeDirectoryRemoval) {
-    try {
-      fs.rmSync(runRoot, { force: true, recursive: true });
-      fs.rmSync(shareDirectory, { force: true, recursive: true });
-      runDirectoryRemoved = !fs.existsSync(runRoot) && !fs.existsSync(shareDirectory);
-      if (runDirectoryRemoved) {
-        localSetup.releaseRoot(runRoot);
-        localSetup.releaseRoot(shareDirectory);
-      }
-      if (!runDirectoryRemoved) {
-        cleanupFailures.push(new Error("qualification run directory remains after cleanup"));
-      }
-    } catch (error) {
-      cleanupFailures.push(error);
-    }
+  if (runDirectoryRemoved) {
+    localSetup.releaseRoot(runRoot);
+    localSetup.releaseRoot(shareDirectory);
+  } else {
+    cleanupFailures.push(new Error("qualification run directory remains after cleanup"));
   }
 
   const retainedSandboxName = retainedWindowsMxcSandboxName({
@@ -2432,10 +2445,7 @@ export async function runWindowsMxcOpenClawProcessContainerQualification(
       sandboxDeleteRetried,
       sensitiveRuntimeArtifactsRemoved,
     },
-    verdict:
-      lifecyclePassedBeforeDirectoryRemoval && runDirectoryRemoved && cleanupFailures.length === 0
-        ? "pass"
-        : "fail",
+    verdict: lifecyclePassed && cleanupFailures.length === 0 ? "pass" : "fail",
     deferred: [
       "gateway-mtls",
       "managed-inference",

--- a/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
+++ b/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
@@ -25,6 +25,7 @@ import {
   renderWindowsMxcFilesystemPolicy,
   renderWindowsMxcGatewayConfig,
   renderWindowsMxcOpenClawProbeAgent,
+  removeWindowsMxcRuntimeArtifacts,
   retainedWindowsMxcSandboxName,
   runWindowsMxcForwardCleanup,
   sameWindowsProcessIdentity,
@@ -88,6 +89,32 @@ afterEach(() => {
 });
 
 describe("inactive Windows MXC OpenClaw process_container qualification", () => {
+  it("removes a token-bearing MXC environment file after a runtime failure (#8178)", () => {
+    const { root } = fixture();
+    const runRoot = fs.mkdtempSync(path.join(root, "runtime-failure-"));
+    const shareDirectory = fs.mkdtempSync(path.join(root, "runtime-share-"));
+    const token = "runtime-only-secret";
+    fs.writeFileSync(
+      path.join(shareDirectory, "agent-env.txt"),
+      `NEMOCLAW_MXC_E2E_TOKEN=${token}\n`,
+      "utf8",
+    );
+
+    const result = removeWindowsMxcRuntimeArtifacts({
+      runRoot,
+      sensitivePaths: [],
+      shareDirectory,
+    });
+
+    expect(result).toEqual({
+      failures: [],
+      runDirectoryRemoved: true,
+      sensitiveRuntimeArtifactsRemoved: true,
+    });
+    expect(fs.existsSync(runRoot)).toBe(false);
+    expect(fs.existsSync(shareDirectory)).toBe(false);
+  });
+
   it("removes token-bearing setup state and closes descriptors after a setup failure (#8178)", async () => {
     const { root } = fixture();
     const receiptPath = path.join(root, "setup-failure-receipt.json");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Remove every test-owned Windows MXC runtime directory after qualification succeeds or fails. This prevents the generated process-environment file, including its temporary OpenClaw gateway token, from remaining on the host after a failed live run.

## Related Issue

Refs #8178

## Changes

- centralize removal of the Windows MXC run directory, share directory, and sensitive runtime files
- record cleanup receipt fields from post-cleanup filesystem checks
- add a regression test using a token-bearing process-environment file
- document token lifetime and cleanup behavior for pass and failure verdicts

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: https://github.com/NVIDIA/NemoClaw/pull/10304#pullrequestreview-5024813279
- [x] Non-success, skipped, or missing CI check accepted by maintainer — CLI shards 11 and 12; https://github.com/NVIDIA/NemoClaw/pull/10304#issuecomment-5417659931; unrelated flakes rerun once.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: not applicable
- Station profile/scenario: not applicable
- Result: not applicable
- Supporting evidence: not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project e2e-support test/e2e/support/windows-mxc-openclaw-process-container.test.ts` (30 passed)
- [x] Applicable broad gate passed — `npm run validate:pr` passed at latest PR commit `ea40d54`.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Live failure-path evidence

The cleanup behavior was exercised on the exact pre-rebase change against a qualified Windows x64 MXC host and pinned OpenShell/OpenClaw artifacts. Forwarded health reproduced the known WebSocket `1006` failure. Both test-owned runtime roots were absent afterward, and the receipt reported `runDirectoryRemoved=true` and `sensitiveRuntimeArtifactsRemoved=true`. No provider credential was used.

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows MXC OpenClaw test cleanup to consistently remove sensitive runtime artifacts, environment files, run directories, and share directories.
  * Cleanup status is now accurately reflected in lifecycle results and receipt verdicts, including when removal fails.
  * Added safeguards to retain tracking information when cleanup is incomplete, enabling targeted artifact removal.

* **Documentation**
  * Clarified cleanup behavior, including handling of failed verdicts and potentially retained sensitive artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

