### PR TITLE
fix(inference): bind health checks to sandbox gateway

### DIFF
--- a/src/lib/actions/sandbox/doctor-inference.test.ts
+++ b/src/lib/actions/sandbox/doctor-inference.test.ts
@@ -162,11 +162,12 @@ describe("doctor inference checks", () => {
   ])("probes inference.local for %s without a direct health check (#6192)", async (provider) => {
     const routeProbe = vi.fn(async () => gateway(false));
     const checks = await collectInferenceChecks("alpha", { provider, model: "model" }, true, {
+      gatewayName: "recorded-gateway",
       probeProviderHealthImpl: () => null,
       probeSandboxInferenceGatewayHealthImpl: routeProbe,
     });
 
-    expect(routeProbe).toHaveBeenCalledWith("alpha");
+    expect(routeProbe).toHaveBeenCalledWith("alpha", { gatewayName: "recorded-gateway" });
     expect(checks).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ label: "Inference route (gateway)", status: "fail" }),

--- a/src/lib/actions/sandbox/doctor-inference.ts
+++ b/src/lib/actions/sandbox/doctor-inference.ts
@@ -62,6 +62,7 @@ export function collectManagedLlamaCppDoctorChecks(
 }
 
 type DoctorInferenceDeps = {
+  gatewayName?: string | null;
   probeProviderHealthImpl?: typeof probeProviderHealth;
   probeSandboxInferenceGatewayHealthImpl?: typeof probeSandboxInferenceGatewayHealth;
   /** False for terminal agents that do not have a long-running gateway serving process. */
@@ -146,11 +147,12 @@ async function collectInferenceRouteProbe(
   sandboxName: string,
   sandboxReachable: boolean,
   probe: typeof probeSandboxInferenceGatewayHealth,
+  gatewayName?: string | null,
 ): Promise<ProviderHealthStatus> {
   if (!sandboxReachable) return skippedInferenceGatewayProbe();
   let gateway: Awaited<ReturnType<typeof probeSandboxInferenceGatewayHealth>> = null;
   try {
-    gateway = await probe(sandboxName);
+    gateway = gatewayName ? await probe(sandboxName, { gatewayName }) : await probe(sandboxName);
   } catch {
     gateway = null;
   }
@@ -217,6 +219,7 @@ export async function collectInferenceChecks(
     sandboxName,
     sandboxReachable,
     deps.probeSandboxInferenceGatewayHealthImpl ?? probeSandboxInferenceGatewayHealth,
+    deps.gatewayName,
   );
   pushInferenceHealthCheck(checks, gatewayProbe, { label: "Inference route (gateway)" });
   for (const diagnostic of collectProviderHealthDiagnostics(

--- a/src/lib/actions/sandbox/doctor.ts
+++ b/src/lib/actions/sandbox/doctor.ts
@@ -570,6 +570,7 @@ async function collectDoctorChecks(
     ...gateway.checks,
     ...sandbox.checks,
     ...(await collectInferenceChecks(sandboxName, route, sandbox.reachable, {
+      gatewayName,
       includeServingProcessCheck: shouldReportServingProcessHealth(sb?.agent),
     })),
     ...collectRegisteredSandboxChecks(sandboxName, sb, intent.wantsFix, sandbox.reachable),

--- a/src/lib/actions/sandbox/inference-route-health.test.ts
+++ b/src/lib/actions/sandbox/inference-route-health.test.ts
@@ -73,6 +73,7 @@ describe("sandbox inference route health", () => {
 
     const result = await probeSandboxInferenceGatewayHealth("deep-code", {
       captureOpenshellImpl,
+      gatewayName: "recorded-gateway",
       getSessionAgentImpl,
     });
 
@@ -84,6 +85,8 @@ describe("sandbox inference route health", () => {
         "exec",
         "--name",
         "deep-code",
+        "-g",
+        "recorded-gateway",
         "--no-tty",
         "--env",
         "HOME=/usr/local/lib/nemoclaw",

--- a/src/lib/actions/sandbox/inference-route-health.ts
+++ b/src/lib/actions/sandbox/inference-route-health.ts
@@ -41,6 +41,7 @@ export async function probeSandboxInferenceGatewayHealth(
   sandboxName: string,
   options: {
     captureOpenshellImpl?: typeof captureOpenshellForStatus;
+    gatewayName?: string;
     getSessionAgentImpl?: typeof agentRuntime.getSessionAgent;
   } = {},
 ): Promise<SandboxInferenceRouteHealth | null> {
@@ -50,7 +51,11 @@ export async function probeSandboxInferenceGatewayHealth(
   let result: Awaited<ReturnType<typeof captureOpenshellForStatus>>;
   try {
     result = await capture(
-      buildSandboxInferenceRouteProbeArgs(sandboxName, getSessionAgent(sandboxName)),
+      buildSandboxInferenceRouteProbeArgs(
+        sandboxName,
+        getSessionAgent(sandboxName),
+        options.gatewayName,
+      ),
       {
         ignoreError: true,
         includeStreams: true,

--- a/src/lib/actions/sandbox/launch-readiness-gateway-health.test.ts
+++ b/src/lib/actions/sandbox/launch-readiness-gateway-health.test.ts
@@ -90,6 +90,7 @@ describe("Deep Agents Code OpenRouter launch readiness", () => {
     expect(currentDeps.inferenceInvocationProbe).toHaveBeenCalledWith({
       sandboxName: SANDBOX,
       gatewayName: GATEWAY,
+      agentName: "langchain-deepagents-code",
       provider: "openrouter-api",
       model: MODEL,
       preferredInferenceApi: null,

--- a/src/lib/actions/sandbox/launch-readiness/health.ts
+++ b/src/lib/actions/sandbox/launch-readiness/health.ts
@@ -175,6 +175,7 @@ export async function requireLaunchSemanticHealth(
       const invocation = (deps.inferenceInvocationProbe ?? runSandboxInferenceInvocationProbe)({
         sandboxName,
         gatewayName,
+        agentName,
         provider,
         model,
         preferredInferenceApi: normalizedString(entry.preferredInferenceApi),

--- a/src/lib/actions/sandbox/start.test.ts
+++ b/src/lib/actions/sandbox/start.test.ts
@@ -715,11 +715,13 @@ describe("startSandbox", () => {
     await expect(startSandbox("my-sandbox", h.deps)).rejects.toThrow("probe exploded");
   });
 
-  it("reports the recorded route as ready only after it serves an agent request", async () => {
+  it("pins a Deep Agents Code start probe to its recorded gateway and managed launcher identity (#10080)", async () => {
     const probeInferenceInvocation = vi.fn(() => ({ ok: true }) as const);
     const h = harness({ probeInferenceInvocation });
     h.getSandbox.mockReturnValue(
       sandbox({
+        agent: "langchain-deepagents-code",
+        gatewayName: "nemoclaw-19080",
         provider: "ollama-local",
         model: "nemotron-3-nano:30b",
         preferredInferenceApi: "openai-completions",
@@ -732,6 +734,8 @@ describe("startSandbox", () => {
     expect(probeInferenceInvocation).toHaveBeenCalledWith(
       {
         sandboxName: "my-sandbox",
+        gatewayName: "nemoclaw-19080",
+        agentName: "langchain-deepagents-code",
         provider: "ollama-local",
         model: "nemotron-3-nano:30b",
         preferredInferenceApi: "openai-completions",

--- a/src/lib/actions/sandbox/start.ts
+++ b/src/lib/actions/sandbox/start.ts
@@ -15,6 +15,7 @@ import {
   type SandboxInferenceInvocationResult,
 } from "./inference-invocation-probe";
 import { withSandboxLifecycleLock } from "./gateway-state";
+import { getPersistedSandboxTargetGatewayName } from "./gateway-target";
 import {
   resolveSandboxLifecycleProvider,
   type SandboxLifecycleResult,
@@ -155,10 +156,13 @@ function checkStartedSandboxInference(
   const model = (sandbox.model ?? "").trim();
   const provider = (sandbox.provider ?? "").trim();
   if (!model || !provider) return null;
+  const gatewayName = getPersistedSandboxTargetGatewayName(sandbox);
   log("  Checking that the sandbox serves an agent request…");
   return (deps.probeInferenceInvocation ?? probeSandboxInferenceInvocation)(
     {
       sandboxName,
+      gatewayName,
+      ...(sandbox.agent === "langchain-deepagents-code" ? { agentName: sandbox.agent } : {}),
       provider,
       model,
       preferredInferenceApi: sandbox.preferredInferenceApi ?? null,

--- a/src/lib/actions/sandbox/status-inference.test.ts
+++ b/src/lib/actions/sandbox/status-inference.test.ts
@@ -155,7 +155,9 @@ describe("sandbox status inference.local route health (#6192)", () => {
 
     const snapshot = await collectSandboxStatusSnapshot("alpha", { deps });
 
-    expect(deps.probeSandboxInferenceGatewayHealthImpl).toHaveBeenCalledWith("alpha");
+    expect(deps.probeSandboxInferenceGatewayHealthImpl).toHaveBeenCalledWith("alpha", {
+      gatewayName: "nemoclaw",
+    });
     expect(snapshot.inferenceHealth).toMatchObject({ ok: true, probed: true });
   });
 
@@ -238,6 +240,7 @@ describe("sandbox status inference.local route health (#6192)", () => {
     expect(deps.probeSandboxInferenceInvocationImpl).toHaveBeenCalledWith(
       {
         sandboxName: "alpha",
+        gatewayName: "nemoclaw",
         provider: "openai-api",
         model: "gpt-5.2",
         preferredInferenceApi: null,
@@ -273,6 +276,7 @@ describe("sandbox status inference.local route health (#6192)", () => {
     expect(deps.probeSandboxInferenceInvocationImpl).toHaveBeenCalledWith(
       {
         sandboxName: "alpha",
+        gatewayName: "nemoclaw",
         provider: "compatible-endpoint",
         model: "nvidia/nemotron",
         preferredInferenceApi: "openai-responses",

--- a/src/lib/actions/sandbox/status-snapshot-inference-health.test.ts
+++ b/src/lib/actions/sandbox/status-snapshot-inference-health.test.ts
@@ -616,15 +616,18 @@ describe("collectSandboxStatusSnapshot inference route health", () => {
       { ok: true },
       {
         agent: "langchain-deepagents-code",
+        gatewayName: "nemoclaw-19080",
         provider: "openrouter-api",
         model: "openai/gpt-4o-mini",
       },
     );
     const probeSandboxInferenceInvocationImpl = vi.fn(() => ({ ok: true }) as const);
+    const probeSandboxInferenceGatewayHealthImpl = vi.fn(async () => gateway);
     const snapshot = await collectSandboxStatusSnapshot("alpha", {
       ...options,
       deps: {
         ...options.deps,
+        probeSandboxInferenceGatewayHealthImpl,
         probeSandboxInferenceInvocationImpl,
       },
     });
@@ -632,6 +635,7 @@ describe("collectSandboxStatusSnapshot inference route health", () => {
     expect(probeSandboxInferenceInvocationImpl).toHaveBeenCalledWith(
       {
         sandboxName: "alpha",
+        gatewayName: "nemoclaw-19080",
         agentName: "langchain-deepagents-code",
         provider: "openrouter-api",
         model: "openai/gpt-4o-mini",
@@ -640,6 +644,9 @@ describe("collectSandboxStatusSnapshot inference route health", () => {
       {},
       30_000,
     );
+    expect(probeSandboxInferenceGatewayHealthImpl).toHaveBeenCalledWith("alpha", {
+      gatewayName: "nemoclaw-19080",
+    });
     expect(snapshot.inferenceHealth).toMatchObject({ ok: true });
   });
 

--- a/src/lib/actions/sandbox/status-snapshot-recovery.test.ts
+++ b/src/lib/actions/sandbox/status-snapshot-recovery.test.ts
@@ -255,7 +255,9 @@ describe("collectSandboxStatusSnapshot Docker recovery", () => {
     const snapshot = await collectSandboxStatusSnapshot("alpha", { deps });
 
     expect(snapshot.lookup.state).toBe("present");
-    expect(deps.probeSandboxInferenceGatewayHealthImpl).toHaveBeenCalledWith("alpha");
+    expect(deps.probeSandboxInferenceGatewayHealthImpl).toHaveBeenCalledWith("alpha", {
+      gatewayName: "nemoclaw",
+    });
   });
 
   it("keeps a terminal runtime result neutral", async () => {

--- a/src/lib/actions/sandbox/status-snapshot.ts
+++ b/src/lib/actions/sandbox/status-snapshot.ts
@@ -608,15 +608,14 @@ export async function collectSandboxStatusSnapshot(
       const attempts = recoveredManagedGateway ? RECOVERED_INFERENCE_PROBE_ATTEMPTS : 1;
       await retryUntilAsync(
         async () => {
-          gatewayChain = await probe(sandboxName);
+          gatewayChain = gatewayName ? await probe(sandboxName, { gatewayName }) : null;
           invocation =
             gatewayChain?.ok && canProbeInvocation
               ? runSandboxInferenceInvocationProbe(
                   {
                     sandboxName,
-                    ...(sb?.agent === "langchain-deepagents-code"
-                      ? { agentName: sb.agent }
-                      : {}),
+                    gatewayName: gatewayName ?? undefined,
+                    ...(sb?.agent === "langchain-deepagents-code" ? { agentName: sb.agent } : {}),
                     provider: invocationProvider,
                     model: invocationModel,
                     preferredInferenceApi: invocationRoute.preferredInferenceApi,


### PR DESCRIPTION
## Summary

Follow up on #10228 by binding status, doctor, start, and launch-readiness inference evidence to the sandbox's recorded gateway. Deep Agents Code probes also retain the managed launcher identity, so health cannot be inferred through another gateway or a generic shell path.

## Related Issue

Related to #10080 and follow-up to #10228.

## Changes

- Pass the recorded gateway to route and invocation health probes.
- Preserve the Deep Agents Code identity when start and launch-readiness checks select the managed launcher.
- Add focused coverage for non-default gateway bindings across status, doctor, start, and launch readiness.

## Attribution

Dongni Yang authored the original #10228 change and remains the primary contributor to that behavior. Carlos Villela contributed its response-class correction. Apurv Kumaria contributed this limited post-merge repair and its tests.

## Documentation

No documentation change is needed. This repair makes existing health checks use their recorded sandbox gateway and does not change commands, options, configuration, or supported workflows.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this PR does not change `scripts/prepare-dgx-station-host.sh`.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 138 focused CLI tests passed across the seven changed behavior suites.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this is a focused health-probe repair. `npm run checks:repository` and CLI type checking passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox inference diagnostics by targeting the correct configured gateway during health and readiness checks.
  * Preserved agent identity when validating inference routes, including Deep Agents Code sandboxes.
  * Improved recovery and status reporting for configured and changing inference routes.

* **Tests**
  * Expanded coverage for gateway and agent propagation across sandbox startup, status, recovery, and readiness scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->