### PR TITLE
feat(blueprint): prepare external target observation

### DIFF
--- a/nemoclaw/src/shared/openshell-external-target-boundary.cts
+++ b/nemoclaw/src/shared/openshell-external-target-boundary.cts
@@ -32,13 +32,23 @@ export interface OpenShellCompatibilityRange {
   maxVersion: string;
 }
 
-export interface SanitizedExternalOpenShellTargetPlan {
+export type SanitizedExternalOpenShellTargetPlan = Readonly<{
   endpoint: string;
   workspace: string;
   expected_release: string;
   lifecycle: "external";
   authentication_source: "file";
   ca_fingerprint: string;
+}>;
+
+const validatedExternalOpenShellTargetPlans = new WeakSet<object>();
+
+export function isValidatedSanitizedExternalOpenShellTargetPlan(
+  value: unknown,
+): value is SanitizedExternalOpenShellTargetPlan {
+  return (
+    typeof value === "object" && value !== null && validatedExternalOpenShellTargetPlans.has(value)
+  );
 }
 
 type UnknownRecord = Record<string, unknown>;
@@ -327,12 +337,14 @@ export function buildSanitizedExternalOpenShellTargetPlan(
   for (const certificate of caCertificates) {
     caFingerprint.update(certificate);
   }
-  return {
+  const plan: SanitizedExternalOpenShellTargetPlan = Object.freeze({
     endpoint: target.endpoint,
     workspace: target.workspace,
     expected_release: target.expected_release,
     lifecycle: "external",
     authentication_source: "file",
     ca_fingerprint: `sha256:${caFingerprint.digest("hex")}`,
-  };
+  });
+  validatedExternalOpenShellTargetPlans.add(plan);
+  return plan;
 }

--- a/nemoclaw/src/shared/openshell-observation-boundary.cts
+++ b/nemoclaw/src/shared/openshell-observation-boundary.cts
@@ -14,13 +14,18 @@
 // removalCondition: remove only when no NemoClaw consumer observes OpenShell
 // gateway, workspace, or sandbox state through a transport-neutral contract.
 
+import {
+  isValidatedSanitizedExternalOpenShellTargetPlan,
+  type SanitizedExternalOpenShellTargetPlan,
+} from "./openshell-external-target-boundary.cjs";
+
 export type OpenShellExternalGatewayTarget = Readonly<{
   kind: "external";
-  endpoint: string;
-  workspace: string;
-  expectedRelease: string;
+  plan: SanitizedExternalOpenShellTargetPlan;
   allWorkspaces: false;
 }>;
+
+const validatedExternalOpenShellGatewayTargets = new WeakSet<object>();
 
 export type OpenShellGatewayTarget =
   | Readonly<{ kind: "named"; gatewayName: string }>
@@ -168,11 +173,18 @@ export function selectedOpenShellGateway(): OpenShellGatewayTarget {
 }
 
 export function externalOpenShellGateway(
-  endpoint: string,
-  workspace: string,
-  expectedRelease: string,
+  plan: SanitizedExternalOpenShellTargetPlan,
 ): OpenShellExternalGatewayTarget {
-  return { kind: "external", endpoint, workspace, expectedRelease, allWorkspaces: false };
+  if (!isValidatedSanitizedExternalOpenShellTargetPlan(plan)) {
+    throw new Error("external OpenShell observation requires a validated target plan");
+  }
+  const target: OpenShellExternalGatewayTarget = Object.freeze({
+    kind: "external",
+    plan,
+    allWorkspaces: false,
+  });
+  validatedExternalOpenShellGatewayTargets.add(target);
+  return target;
 }
 
 function failure<T>(error: OpenShellSandboxError): OpenShellSandboxResult<T> {
@@ -212,6 +224,68 @@ function sanitizedExternalObservationError(error: OpenShellSandboxError): OpenSh
   }
 }
 
+function unexpectedExternalObservationError(): OpenShellSandboxError {
+  return {
+    kind: "transport",
+    reason: "unreachable",
+    message: "NemoClaw could not reach the external OpenShell target.",
+  };
+}
+
+async function invokeExternalObserver<T>(
+  operation: () => Promise<OpenShellSandboxResult<T>>,
+): Promise<OpenShellSandboxResult<T>> {
+  try {
+    return await operation();
+  } catch {
+    return failure(unexpectedExternalObservationError());
+  }
+}
+
+function snapshotGatewayHealth(
+  value: OpenShellGatewayHealthObservation,
+): OpenShellGatewayHealthObservation {
+  return Object.freeze({ status: value.status, release: value.release });
+}
+
+function snapshotCurrentUser(
+  value: OpenShellCurrentUserObservation,
+): OpenShellCurrentUserObservation {
+  return Object.freeze({ subjectFingerprint: value.subjectFingerprint });
+}
+
+function snapshotWorkspace(value: OpenShellWorkspaceObservation): OpenShellWorkspaceObservation {
+  return Object.freeze({ name: value.name, phase: value.phase });
+}
+
+function snapshotInventory(value: OpenShellSandboxInventory): OpenShellSandboxInventory {
+  return Object.freeze({
+    sandboxes: Object.freeze(
+      value.sandboxes.map((sandbox) =>
+        Object.freeze({
+          name: sandbox.name,
+          phase: sandbox.phase,
+          readiness: sandbox.readiness,
+        }),
+      ),
+    ),
+  });
+}
+
+function snapshotExternalObservationRequest(
+  request: ObserveExternalOpenShellTargetRequest,
+): ObserveExternalOpenShellTargetRequest | null {
+  const { target: sourceTarget, timeoutMs } = request;
+  if (!validatedExternalOpenShellGatewayTargets.has(sourceTarget)) return null;
+  const target: OpenShellExternalGatewayTarget = Object.freeze({
+    kind: "external",
+    plan: sourceTarget.plan,
+    allWorkspaces: false,
+  });
+  validatedExternalOpenShellGatewayTargets.add(target);
+  return Object.freeze({ target, timeoutMs });
+}
+
 /**
  * Collect the read-only external-target receipt through one shared observer.
  * Public health and release validation complete before the opaque credential
@@ -223,40 +297,71 @@ export async function observeExternalOpenShellTarget(
   observer: OpenShellExternalTargetObserver,
   request: ObserveExternalOpenShellTargetRequest,
 ): Promise<OpenShellExternalTargetResult<ExternalOpenShellTargetObservation>> {
-  const health = await observer.getGatewayHealth(request);
-  if (!health.ok) return failure(sanitizedExternalObservationError(health.error));
-  if (health.value.release !== request.target.expectedRelease) {
+  const validatedRequest = snapshotExternalObservationRequest(request);
+  if (validatedRequest === null) {
+    return externalFailure({
+      kind: "command",
+      reason: "invalid_request",
+      message: "The external OpenShell observation target is not a validated target plan.",
+    });
+  }
+
+  const healthResult = await invokeExternalObserver(() =>
+    observer.getGatewayHealth(validatedRequest),
+  );
+  if (!healthResult.ok) {
+    return failure(sanitizedExternalObservationError(healthResult.error));
+  }
+  const health = snapshotGatewayHealth(healthResult.value);
+  if (health.release !== validatedRequest.target.plan.expected_release) {
     return externalFailure({
       kind: "compatibility",
       message: "The external OpenShell target release does not match the configured release.",
     });
   }
 
-  const authenticated = await observer.connectWithCredentialFile(request);
+  const authenticated = await invokeExternalObserver(() =>
+    observer.connectWithCredentialFile(validatedRequest),
+  );
   if (!authenticated.ok) {
     return failure(sanitizedExternalObservationError(authenticated.error));
   }
-  const identity = await authenticated.value.getCurrentUser(request);
-  if (!identity.ok) return failure(sanitizedExternalObservationError(identity.error));
-  const workspace = await authenticated.value.getWorkspace(request);
-  if (!workspace.ok) return failure(sanitizedExternalObservationError(workspace.error));
-  if (workspace.value.name !== request.target.workspace) {
+  const identityResult = await invokeExternalObserver(() =>
+    authenticated.value.getCurrentUser(validatedRequest),
+  );
+  if (!identityResult.ok) {
+    return failure(sanitizedExternalObservationError(identityResult.error));
+  }
+  const identity = snapshotCurrentUser(identityResult.value);
+  const workspaceResult = await invokeExternalObserver(() =>
+    authenticated.value.getWorkspace(validatedRequest),
+  );
+  if (!workspaceResult.ok) {
+    return failure(sanitizedExternalObservationError(workspaceResult.error));
+  }
+  const workspace = snapshotWorkspace(workspaceResult.value);
+  if (workspace.name !== validatedRequest.target.plan.workspace) {
     return failure({
       kind: "schema",
       message: "OpenShell returned a workspace other than the explicitly configured workspace.",
     });
   }
-  const inventory = await authenticated.value.listSandboxes(request);
-  if (!inventory.ok) return failure(sanitizedExternalObservationError(inventory.error));
+  const inventoryResult = await invokeExternalObserver(() =>
+    authenticated.value.listSandboxes(validatedRequest),
+  );
+  if (!inventoryResult.ok) {
+    return failure(sanitizedExternalObservationError(inventoryResult.error));
+  }
+  const inventory = snapshotInventory(inventoryResult.value);
 
-  return {
+  return Object.freeze({
     ok: true,
-    value: {
-      target: request.target,
-      health: health.value,
-      identity: identity.value,
-      workspace: workspace.value,
-      inventory: inventory.value,
-    },
-  };
+    value: Object.freeze({
+      target: validatedRequest.target,
+      health,
+      identity,
+      workspace,
+      inventory,
+    }),
+  });
 }

--- a/nemoclaw/src/shared/openshell-observation-boundary.cts
+++ b/nemoclaw/src/shared/openshell-observation-boundary.cts
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// sourceOfTruth: Transport-neutral OpenShell observation contracts shared by
+// the root CLI adapters and the Blueprint Runner. Transport implementations
+// must return sanitized errors and must not expose authentication material.
+// consumers: src/lib/adapters/openshell/sandbox-observer.ts re-exports this
+// contract for CLI callers. The Blueprint Runner consumes the generated .cjs
+// boundary for external-target observation without importing root CLI source.
+// sourceBoundary: Explicit external endpoint and workspace identity may cross
+// this boundary. CA and authentication file paths or contents must not.
+// regressionTest: openshell-observation-boundary.test.ts and the root CLI
+// sandbox-observer tests.
+// removalCondition: remove only when no NemoClaw consumer observes OpenShell
+// gateway, workspace, or sandbox state through a transport-neutral contract.
+
+export type OpenShellExternalGatewayTarget = Readonly<{
+  kind: "external";
+  endpoint: string;
+  workspace: string;
+  expectedRelease: string;
+  allWorkspaces: false;
+}>;
+
+export type OpenShellGatewayTarget =
+  | Readonly<{ kind: "named"; gatewayName: string }>
+  | Readonly<{ kind: "selected" }>
+  | OpenShellExternalGatewayTarget;
+
+export type OpenShellSandboxReadiness = "ready" | "not_ready" | "terminal";
+
+export type OpenShellSandboxObservation = Readonly<{
+  name: string;
+  phase: string | null;
+  readiness: OpenShellSandboxReadiness;
+}>;
+
+export type OpenShellSandboxInventory = Readonly<{
+  sandboxes: readonly OpenShellSandboxObservation[];
+}>;
+
+export type OpenShellSandboxLookup =
+  | Readonly<{ state: "present"; sandbox: OpenShellSandboxObservation }>
+  | Readonly<{ state: "missing" }>;
+
+export type OpenShellSandboxErrorKind =
+  | "authentication"
+  | "command"
+  | "schema"
+  | "timeout"
+  | "transport";
+
+export type OpenShellSandboxTransportReason = "identity_mismatch" | "unreachable";
+
+export type OpenShellSandboxError =
+  | Readonly<{
+      kind: Exclude<OpenShellSandboxErrorKind, "command" | "transport">;
+      message: string;
+    }>
+  | Readonly<{
+      kind: "transport";
+      reason: OpenShellSandboxTransportReason;
+      message: string;
+    }>
+  | Readonly<{
+      kind: "command";
+      reason: "failed" | "invalid_request";
+      message: string;
+    }>;
+
+export type OpenShellSandboxResult<T> =
+  | Readonly<{ ok: true; value: T }>
+  | Readonly<{ ok: false; error: OpenShellSandboxError }>;
+
+export type OpenShellExternalTargetError =
+  | OpenShellSandboxError
+  | Readonly<{
+      kind: "compatibility";
+      message: string;
+    }>;
+
+export type OpenShellExternalTargetResult<T> =
+  | Readonly<{ ok: true; value: T }>
+  | Readonly<{ ok: false; error: OpenShellExternalTargetError }>;
+
+export type ListOpenShellSandboxesRequest = Readonly<{
+  target: OpenShellGatewayTarget;
+  timeoutMs?: number;
+}>;
+
+export type LookupOpenShellSandboxRequest = ListOpenShellSandboxesRequest &
+  Readonly<{
+    sandboxName: string;
+  }>;
+
+/** Transport-neutral sandbox observation capabilities used by NemoClaw. */
+export interface OpenShellSandboxObserver {
+  listSandboxes(
+    request: ListOpenShellSandboxesRequest,
+  ): Promise<OpenShellSandboxResult<OpenShellSandboxInventory>>;
+}
+
+export type OpenShellGatewayHealthStatus = "unspecified" | "healthy" | "degraded" | "unhealthy";
+
+export type OpenShellGatewayHealthObservation = Readonly<{
+  status: OpenShellGatewayHealthStatus;
+  release: string;
+}>;
+
+export type OpenShellWorkspacePhase = "unspecified" | "active" | "terminating";
+
+export type OpenShellWorkspaceObservation = Readonly<{
+  name: string;
+  phase: OpenShellWorkspacePhase;
+}>;
+
+export type OpenShellCurrentUserObservation = Readonly<{
+  subjectFingerprint: string;
+}>;
+
+export type ObserveExternalOpenShellTargetRequest = Readonly<{
+  target: OpenShellExternalGatewayTarget;
+  timeoutMs?: number;
+}>;
+
+export type ExternalOpenShellTargetObservation = Readonly<{
+  target: OpenShellExternalGatewayTarget;
+  health: OpenShellGatewayHealthObservation;
+  identity: OpenShellCurrentUserObservation;
+  workspace: OpenShellWorkspaceObservation;
+  inventory: OpenShellSandboxInventory;
+}>;
+
+/**
+ * Authenticated read-only observations required after release compatibility
+ * passes. For an external target, `listSandboxes` must send the target's exact
+ * workspace and `allWorkspaces: false` to the OpenShell raw request.
+ */
+export interface AuthenticatedOpenShellExternalTargetObserver extends OpenShellSandboxObserver {
+  getCurrentUser(
+    request: ObserveExternalOpenShellTargetRequest,
+  ): Promise<OpenShellSandboxResult<OpenShellCurrentUserObservation>>;
+  getWorkspace(
+    request: ObserveExternalOpenShellTargetRequest,
+  ): Promise<OpenShellSandboxResult<OpenShellWorkspaceObservation>>;
+}
+
+/**
+ * Public probe and delayed file-backed credential boundary for one external
+ * target. The transport owns the future validated file reference; this
+ * boundary exposes only when the opaque handoff may occur.
+ */
+export interface OpenShellExternalTargetObserver {
+  getGatewayHealth(
+    request: ObserveExternalOpenShellTargetRequest,
+  ): Promise<OpenShellSandboxResult<OpenShellGatewayHealthObservation>>;
+  connectWithCredentialFile(
+    request: ObserveExternalOpenShellTargetRequest,
+  ): Promise<OpenShellSandboxResult<AuthenticatedOpenShellExternalTargetObserver>>;
+}
+
+export function namedOpenShellGateway(gatewayName: string): OpenShellGatewayTarget {
+  return { kind: "named", gatewayName };
+}
+
+export function selectedOpenShellGateway(): OpenShellGatewayTarget {
+  return { kind: "selected" };
+}
+
+export function externalOpenShellGateway(
+  endpoint: string,
+  workspace: string,
+  expectedRelease: string,
+): OpenShellExternalGatewayTarget {
+  return { kind: "external", endpoint, workspace, expectedRelease, allWorkspaces: false };
+}
+
+function failure<T>(error: OpenShellSandboxError): OpenShellSandboxResult<T> {
+  return { ok: false, error };
+}
+
+function externalFailure<T>(error: OpenShellExternalTargetError): OpenShellExternalTargetResult<T> {
+  return { ok: false, error };
+}
+
+function sanitizedExternalObservationError(error: OpenShellSandboxError): OpenShellSandboxError {
+  switch (error.kind) {
+    case "authentication":
+      return {
+        kind: "authentication",
+        message: "OpenShell could not authenticate the external target observation.",
+      };
+    case "timeout":
+      return { kind: "timeout", message: "The external OpenShell target observation timed out." };
+    case "schema":
+      return { kind: "schema", message: "OpenShell returned an invalid observation response." };
+    case "transport":
+      return {
+        kind: "transport",
+        reason: error.reason,
+        message:
+          error.reason === "identity_mismatch"
+            ? "The external OpenShell target identity does not match the configured identity."
+            : "NemoClaw could not reach the external OpenShell target.",
+      };
+    case "command":
+      return {
+        kind: "command",
+        reason: error.reason,
+        message: "The external OpenShell target observation failed.",
+      };
+  }
+}
+
+/**
+ * Collect the read-only external-target receipt through one shared observer.
+ * Public health and release validation complete before the opaque credential
+ * handoff. Authenticated identity, workspace, and inventory
+ * calls then run in that order with the same bounded operation timeout. The
+ * transport remains responsible for enforcing each timeout.
+ */
+export async function observeExternalOpenShellTarget(
+  observer: OpenShellExternalTargetObserver,
+  request: ObserveExternalOpenShellTargetRequest,
+): Promise<OpenShellExternalTargetResult<ExternalOpenShellTargetObservation>> {
+  const health = await observer.getGatewayHealth(request);
+  if (!health.ok) return failure(sanitizedExternalObservationError(health.error));
+  if (health.value.release !== request.target.expectedRelease) {
+    return externalFailure({
+      kind: "compatibility",
+      message: "The external OpenShell target release does not match the configured release.",
+    });
+  }
+
+  const authenticated = await observer.connectWithCredentialFile(request);
+  if (!authenticated.ok) {
+    return failure(sanitizedExternalObservationError(authenticated.error));
+  }
+  const identity = await authenticated.value.getCurrentUser(request);
+  if (!identity.ok) return failure(sanitizedExternalObservationError(identity.error));
+  const workspace = await authenticated.value.getWorkspace(request);
+  if (!workspace.ok) return failure(sanitizedExternalObservationError(workspace.error));
+  if (workspace.value.name !== request.target.workspace) {
+    return failure({
+      kind: "schema",
+      message: "OpenShell returned a workspace other than the explicitly configured workspace.",
+    });
+  }
+  const inventory = await authenticated.value.listSandboxes(request);
+  if (!inventory.ok) return failure(sanitizedExternalObservationError(inventory.error));
+
+  return {
+    ok: true,
+    value: {
+      target: request.target,
+      health: health.value,
+      identity: identity.value,
+      workspace: workspace.value,
+      inventory: inventory.value,
+    },
+  };
+}

--- a/nemoclaw/src/shared/openshell-observation-boundary.test.ts
+++ b/nemoclaw/src/shared/openshell-observation-boundary.test.ts
@@ -1,0 +1,239 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  externalOpenShellGateway,
+  observeExternalOpenShellTarget,
+  type AuthenticatedOpenShellExternalTargetObserver,
+  type OpenShellExternalTargetObserver,
+  type OpenShellSandboxError,
+  type OpenShellSandboxResult,
+} from "./openshell-observation-boundary.cjs";
+
+const TARGET = externalOpenShellGateway(
+  "https://openshell.example.test:8443",
+  "research",
+  "configured-release",
+);
+const REQUEST = { target: TARGET, timeoutMs: 2_500 } as const;
+const INVENTORY = {
+  sandboxes: [
+    { name: "ready-agent", phase: "Ready", readiness: "ready" },
+    { name: "pending-agent", phase: "Provisioning", readiness: "not_ready" },
+  ],
+} as const;
+
+function rejected<T>(error: OpenShellSandboxError): Promise<OpenShellSandboxResult<T>> {
+  return Promise.resolve({ ok: false, error });
+}
+
+function successfulClient(callOrder: string[]): AuthenticatedOpenShellExternalTargetObserver {
+  return {
+    getCurrentUser: vi.fn(async () => {
+      callOrder.push("identity");
+      return {
+        ok: true as const,
+        value: { subjectFingerprint: `sha256:${"a".repeat(64)}` },
+      };
+    }),
+    getWorkspace: vi.fn(async () => {
+      callOrder.push("workspace");
+      return {
+        ok: true as const,
+        value: { name: "research", phase: "active" as const },
+      };
+    }),
+    listSandboxes: vi.fn(async () => {
+      callOrder.push("inventory");
+      return { ok: true as const, value: INVENTORY };
+    }),
+  };
+}
+
+function successfulObserver(
+  callOrder: string[],
+  client = successfulClient(callOrder),
+): OpenShellExternalTargetObserver {
+  return {
+    getGatewayHealth: vi.fn(async () => {
+      callOrder.push("health");
+      return {
+        ok: true as const,
+        value: { status: "healthy" as const, release: "configured-release" },
+      };
+    }),
+    connectWithCredentialFile: vi.fn(async () => {
+      callOrder.push("credential");
+      return { ok: true as const, value: client };
+    }),
+  };
+}
+
+describe("external OpenShell target observation boundary", () => {
+  it("collects release, identity, workspace, status, and inventory in the required order (#9872)", async () => {
+    const callOrder: string[] = [];
+    const client = successfulClient(callOrder);
+    const observer = successfulObserver(callOrder, client);
+
+    await expect(observeExternalOpenShellTarget(observer, REQUEST)).resolves.toEqual({
+      ok: true,
+      value: {
+        target: TARGET,
+        health: { status: "healthy", release: "configured-release" },
+        identity: { subjectFingerprint: `sha256:${"a".repeat(64)}` },
+        workspace: { name: "research", phase: "active" },
+        inventory: INVENTORY,
+      },
+    });
+    expect(callOrder).toEqual(["health", "credential", "identity", "workspace", "inventory"]);
+    expect(observer.getGatewayHealth).toHaveBeenCalledWith(REQUEST);
+    expect(observer.connectWithCredentialFile).toHaveBeenCalledWith(REQUEST);
+    expect(client.getCurrentUser).toHaveBeenCalledWith(REQUEST);
+    expect(client.getWorkspace).toHaveBeenCalledWith(REQUEST);
+    expect(client.listSandboxes).toHaveBeenCalledWith(REQUEST);
+  });
+
+  it("stops before credential handoff when the public release does not match (#9872)", async () => {
+    const callOrder: string[] = [];
+    const observer = successfulObserver(callOrder);
+    vi.mocked(observer.getGatewayHealth).mockImplementationOnce(async () => {
+      callOrder.push("health");
+      return {
+        ok: true,
+        value: { status: "healthy", release: "reported-release" },
+      };
+    });
+
+    const result = await observeExternalOpenShellTarget(observer, REQUEST);
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        kind: "compatibility",
+        message: "The external OpenShell target release does not match the configured release.",
+      },
+    });
+    expect(callOrder).toEqual(["health"]);
+    expect(observer.connectWithCredentialFile).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain("reported-release");
+  });
+
+  it("preserves a non-ready gateway and terminating workspace as read-only status (#9872)", async () => {
+    const callOrder: string[] = [];
+    const client = successfulClient(callOrder);
+    vi.mocked(client.getWorkspace).mockImplementationOnce(async () => {
+      callOrder.push("workspace");
+      return {
+        ok: true,
+        value: { name: "research", phase: "terminating" },
+      };
+    });
+    const observer = successfulObserver(callOrder, client);
+    vi.mocked(observer.getGatewayHealth).mockImplementationOnce(async () => {
+      callOrder.push("health");
+      return {
+        ok: true,
+        value: { status: "degraded", release: "configured-release" },
+      };
+    });
+
+    const result = await observeExternalOpenShellTarget(observer, REQUEST);
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        health: { status: "degraded" },
+        workspace: { phase: "terminating" },
+      },
+    });
+    expect(callOrder).toEqual(["health", "credential", "identity", "workspace", "inventory"]);
+  });
+
+  it.each([
+    [
+      "authentication",
+      { kind: "authentication", message: "denied: private-credential-value" },
+      "OpenShell could not authenticate the external target observation.",
+    ],
+    [
+      "timeout",
+      { kind: "timeout", message: "timeout while reading /private/credential-file" },
+      "The external OpenShell target observation timed out.",
+    ],
+    [
+      "schema",
+      { kind: "schema", message: "invalid response included private-credential-value" },
+      "OpenShell returned an invalid observation response.",
+    ],
+  ] as const)(
+    "returns a sanitized %s denial from the authenticated fake client (#9872)",
+    async (_label, error, message) => {
+      const callOrder: string[] = [];
+      const client = successfulClient(callOrder);
+      vi.mocked(client.getCurrentUser).mockImplementationOnce(async () => {
+        callOrder.push("identity");
+        return rejected(error);
+      });
+      const observer = successfulObserver(callOrder, client);
+
+      const result = await observeExternalOpenShellTarget(observer, REQUEST);
+
+      expect(result).toEqual({ ok: false, error: { kind: error.kind, message } });
+      expect(callOrder).toEqual(["health", "credential", "identity"]);
+      expect(JSON.stringify(result)).not.toContain("private-credential-value");
+      expect(JSON.stringify(result)).not.toContain("/private/credential-file");
+    },
+  );
+
+  it("sanitizes a credential-stage denial without creating an authenticated client (#9872)", async () => {
+    const callOrder: string[] = [];
+    const observer = successfulObserver(callOrder);
+    vi.mocked(observer.connectWithCredentialFile).mockImplementationOnce(async () => {
+      callOrder.push("credential");
+      return rejected({
+        kind: "authentication",
+        message: "invalid credential from /private/credential-file",
+      });
+    });
+
+    const result = await observeExternalOpenShellTarget(observer, REQUEST);
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        kind: "authentication",
+        message: "OpenShell could not authenticate the external target observation.",
+      },
+    });
+    expect(callOrder).toEqual(["health", "credential"]);
+    expect(JSON.stringify(result)).not.toContain("/private/credential-file");
+  });
+
+  it("rejects a workspace response outside the explicit target before inventory (#9872)", async () => {
+    const callOrder: string[] = [];
+    const client = successfulClient(callOrder);
+    vi.mocked(client.getWorkspace).mockImplementationOnce(async () => {
+      callOrder.push("workspace");
+      return {
+        ok: true,
+        value: { name: "ambient-private-workspace", phase: "active" },
+      };
+    });
+    const observer = successfulObserver(callOrder, client);
+
+    const result = await observeExternalOpenShellTarget(observer, REQUEST);
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        kind: "schema",
+        message: "OpenShell returned a workspace other than the explicitly configured workspace.",
+      },
+    });
+    expect(callOrder).toEqual(["health", "credential", "identity", "workspace"]);
+    expect(client.listSandboxes).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain("ambient-private-workspace");
+  });
+});

--- a/nemoclaw/src/shared/openshell-observation-boundary.test.ts
+++ b/nemoclaw/src/shared/openshell-observation-boundary.test.ts
@@ -1,7 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { rootCertificates } from "node:tls";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildSanitizedExternalOpenShellTargetPlan,
+  type SanitizedExternalOpenShellTargetPlan,
+} from "./openshell-external-target-boundary.cjs";
 
 import {
   externalOpenShellGateway,
@@ -12,18 +22,41 @@ import {
   type OpenShellSandboxResult,
 } from "./openshell-observation-boundary.cjs";
 
-const TARGET = externalOpenShellGateway(
-  "https://openshell.example.test:8443",
-  "research",
-  "configured-release",
-);
-const REQUEST = { target: TARGET, timeoutMs: 2_500 } as const;
 const INVENTORY = {
   sandboxes: [
     { name: "ready-agent", phase: "Ready", readiness: "ready" },
     { name: "pending-agent", phase: "Provisioning", readiness: "not_ready" },
   ],
 } as const;
+
+let fixtureDirectory = "";
+let target: ReturnType<typeof externalOpenShellGateway>;
+let request: Readonly<{ target: typeof target; timeoutMs: number }>;
+
+beforeEach(() => {
+  fixtureDirectory = mkdtempSync(path.join(tmpdir(), "nemoclaw-observation-boundary-"));
+  const caFile = path.join(fixtureDirectory, "ca.pem");
+  const credentialFile = path.join(fixtureDirectory, "credential");
+  writeFileSync(caFile, `${rootCertificates[0]}\n`, { mode: 0o400 });
+  writeFileSync(credentialFile, "opaque-placeholder\n", { mode: 0o400 });
+  const plan = buildSanitizedExternalOpenShellTargetPlan(
+    {
+      endpoint: "https://openshell.example.test:8443",
+      workspace: "research",
+      expected_release: "0.0.106",
+      lifecycle: "external",
+      trust: { ca_file: caFile },
+      authentication: { credential_file: credentialFile },
+    },
+    { minVersion: "0.0.106", maxVersion: "0.0.106" },
+  );
+  target = externalOpenShellGateway(plan);
+  request = Object.freeze({ target, timeoutMs: 2_500 });
+});
+
+afterEach(() => {
+  rmSync(fixtureDirectory, { recursive: true, force: true });
+});
 
 function rejected<T>(error: OpenShellSandboxError): Promise<OpenShellSandboxResult<T>> {
   return Promise.resolve({ ok: false, error });
@@ -61,7 +94,7 @@ function successfulObserver(
       callOrder.push("health");
       return {
         ok: true as const,
-        value: { status: "healthy" as const, release: "configured-release" },
+        value: { status: "healthy" as const, release: "0.0.106" },
       };
     }),
     connectWithCredentialFile: vi.fn(async () => {
@@ -71,28 +104,83 @@ function successfulObserver(
   };
 }
 
+type RejectObservationStage = (
+  observer: OpenShellExternalTargetObserver,
+  client: AuthenticatedOpenShellExternalTargetObserver,
+  callOrder: string[],
+) => void;
+
+const REJECTED_OBSERVATION_STAGES: readonly [string, readonly string[], RejectObservationStage][] =
+  [
+    [
+      "public health",
+      ["health"],
+      (observer, _client, callOrder) =>
+        vi.mocked(observer.getGatewayHealth).mockImplementationOnce(async () => {
+          callOrder.push("health");
+          throw new Error("private-token from /private/credential-file");
+        }),
+    ],
+    [
+      "credential handoff",
+      ["health", "credential"],
+      (observer, _client, callOrder) =>
+        vi.mocked(observer.connectWithCredentialFile).mockImplementationOnce(async () => {
+          callOrder.push("credential");
+          throw new Error("private-token from /private/credential-file");
+        }),
+    ],
+    [
+      "identity",
+      ["health", "credential", "identity"],
+      (_observer, client, callOrder) =>
+        vi.mocked(client.getCurrentUser).mockImplementationOnce(async () => {
+          callOrder.push("identity");
+          throw new Error("private-token from /private/credential-file");
+        }),
+    ],
+    [
+      "workspace",
+      ["health", "credential", "identity", "workspace"],
+      (_observer, client, callOrder) =>
+        vi.mocked(client.getWorkspace).mockImplementationOnce(async () => {
+          callOrder.push("workspace");
+          throw new Error("private-token from /private/credential-file");
+        }),
+    ],
+    [
+      "inventory",
+      ["health", "credential", "identity", "workspace", "inventory"],
+      (_observer, client, callOrder) =>
+        vi.mocked(client.listSandboxes).mockImplementationOnce(async () => {
+          callOrder.push("inventory");
+          throw new Error("private-token from /private/credential-file");
+        }),
+    ],
+  ];
+
 describe("external OpenShell target observation boundary", () => {
   it("collects release, identity, workspace, status, and inventory in the required order (#9872)", async () => {
     const callOrder: string[] = [];
     const client = successfulClient(callOrder);
     const observer = successfulObserver(callOrder, client);
 
-    await expect(observeExternalOpenShellTarget(observer, REQUEST)).resolves.toEqual({
+    await expect(observeExternalOpenShellTarget(observer, request)).resolves.toEqual({
       ok: true,
       value: {
-        target: TARGET,
-        health: { status: "healthy", release: "configured-release" },
+        target,
+        health: { status: "healthy", release: "0.0.106" },
         identity: { subjectFingerprint: `sha256:${"a".repeat(64)}` },
         workspace: { name: "research", phase: "active" },
         inventory: INVENTORY,
       },
     });
     expect(callOrder).toEqual(["health", "credential", "identity", "workspace", "inventory"]);
-    expect(observer.getGatewayHealth).toHaveBeenCalledWith(REQUEST);
-    expect(observer.connectWithCredentialFile).toHaveBeenCalledWith(REQUEST);
-    expect(client.getCurrentUser).toHaveBeenCalledWith(REQUEST);
-    expect(client.getWorkspace).toHaveBeenCalledWith(REQUEST);
-    expect(client.listSandboxes).toHaveBeenCalledWith(REQUEST);
+    expect(observer.getGatewayHealth).toHaveBeenCalledWith(request);
+    expect(observer.connectWithCredentialFile).toHaveBeenCalledWith(request);
+    expect(client.getCurrentUser).toHaveBeenCalledWith(request);
+    expect(client.getWorkspace).toHaveBeenCalledWith(request);
+    expect(client.listSandboxes).toHaveBeenCalledWith(request);
   });
 
   it("stops before credential handoff when the public release does not match (#9872)", async () => {
@@ -106,7 +194,7 @@ describe("external OpenShell target observation boundary", () => {
       };
     });
 
-    const result = await observeExternalOpenShellTarget(observer, REQUEST);
+    const result = await observeExternalOpenShellTarget(observer, request);
 
     expect(result).toEqual({
       ok: false,
@@ -135,11 +223,11 @@ describe("external OpenShell target observation boundary", () => {
       callOrder.push("health");
       return {
         ok: true,
-        value: { status: "degraded", release: "configured-release" },
+        value: { status: "degraded", release: "0.0.106" },
       };
     });
 
-    const result = await observeExternalOpenShellTarget(observer, REQUEST);
+    const result = await observeExternalOpenShellTarget(observer, request);
 
     expect(result).toMatchObject({
       ok: true,
@@ -178,7 +266,7 @@ describe("external OpenShell target observation boundary", () => {
       });
       const observer = successfulObserver(callOrder, client);
 
-      const result = await observeExternalOpenShellTarget(observer, REQUEST);
+      const result = await observeExternalOpenShellTarget(observer, request);
 
       expect(result).toEqual({ ok: false, error: { kind: error.kind, message } });
       expect(callOrder).toEqual(["health", "credential", "identity"]);
@@ -198,7 +286,7 @@ describe("external OpenShell target observation boundary", () => {
       });
     });
 
-    const result = await observeExternalOpenShellTarget(observer, REQUEST);
+    const result = await observeExternalOpenShellTarget(observer, request);
 
     expect(result).toEqual({
       ok: false,
@@ -223,7 +311,7 @@ describe("external OpenShell target observation boundary", () => {
     });
     const observer = successfulObserver(callOrder, client);
 
-    const result = await observeExternalOpenShellTarget(observer, REQUEST);
+    const result = await observeExternalOpenShellTarget(observer, request);
 
     expect(result).toEqual({
       ok: false,
@@ -235,5 +323,144 @@ describe("external OpenShell target observation boundary", () => {
     expect(callOrder).toEqual(["health", "credential", "identity", "workspace"]);
     expect(client.listSandboxes).not.toHaveBeenCalled();
     expect(JSON.stringify(result)).not.toContain("ambient-private-workspace");
+  });
+
+  it("rejects an unvalidated target before any observer call (#9872)", async () => {
+    const unvalidatedPlan = {
+      endpoint: "http://user:private-token@openshell.example.test/path?secret=private-token",
+      workspace: "",
+      expected_release: "not-a-release",
+      lifecycle: "external",
+      authentication_source: "file",
+      ca_fingerprint: "private-path-value",
+    } as SanitizedExternalOpenShellTargetPlan;
+    expect(() => externalOpenShellGateway(unvalidatedPlan)).toThrow(
+      "external OpenShell observation requires a validated target plan",
+    );
+
+    const callOrder: string[] = [];
+    const observer = successfulObserver(callOrder);
+    const result = await observeExternalOpenShellTarget(observer, {
+      target: {
+        kind: "external",
+        plan: unvalidatedPlan,
+        allWorkspaces: false,
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        kind: "command",
+        reason: "invalid_request",
+        message: "The external OpenShell observation target is not a validated target plan.",
+      },
+    });
+    expect(observer.getGatewayHealth).not.toHaveBeenCalled();
+    expect(observer.connectWithCredentialFile).not.toHaveBeenCalled();
+    expect(callOrder).toEqual([]);
+    expect(JSON.stringify(result)).not.toContain("private-token");
+    expect(JSON.stringify(result)).not.toContain("private-path-value");
+  });
+
+  it.each(REJECTED_OBSERVATION_STAGES)(
+    "sanitizes a rejected %s observation and stops (#9872)",
+    async (_stage, expectedCallOrder, rejectStage) => {
+      const callOrder: string[] = [];
+      const client = successfulClient(callOrder);
+      const observer = successfulObserver(callOrder, client);
+      rejectStage(observer, client, callOrder);
+
+      const result = await observeExternalOpenShellTarget(observer, request);
+
+      expect(result).toEqual({
+        ok: false,
+        error: {
+          kind: "transport",
+          reason: "unreachable",
+          message: "NemoClaw could not reach the external OpenShell target.",
+        },
+      });
+      expect(callOrder).toEqual(expectedCallOrder);
+      expect(JSON.stringify(result)).not.toContain("private-token");
+      expect(JSON.stringify(result)).not.toContain("/private/credential-file");
+    },
+  );
+
+  it("keeps one immutable target snapshot across every observation stage (#9872)", async () => {
+    const callOrder: string[] = [];
+    const client = successfulClient(callOrder);
+    const observer = successfulObserver(callOrder, client);
+    const mutationResults: boolean[] = [];
+    vi.mocked(observer.getGatewayHealth).mockImplementationOnce(async ({ target: observed }) => {
+      callOrder.push("health");
+      mutationResults.push(
+        Reflect.set(observed.plan, "endpoint", "https://changed.example.test"),
+        Reflect.set(observed.plan, "workspace", "changed"),
+        Reflect.set(observed.plan, "expected_release", "9.9.9"),
+      );
+      return { ok: true, value: { status: "healthy", release: "0.0.106" } };
+    });
+
+    const result = await observeExternalOpenShellTarget(observer, request);
+
+    expect(result).toMatchObject({ ok: true, value: { target } });
+    expect(mutationResults).toEqual([false, false, false]);
+    const observedRequest = vi.mocked(observer.getGatewayHealth).mock.calls[0]![0];
+    expect(vi.mocked(observer.connectWithCredentialFile).mock.calls[0]![0]).toBe(observedRequest);
+    expect(vi.mocked(client.getCurrentUser).mock.calls[0]![0]).toBe(observedRequest);
+    expect(vi.mocked(client.getWorkspace).mock.calls[0]![0]).toBe(observedRequest);
+    expect(vi.mocked(client.listSandboxes).mock.calls[0]![0]).toBe(observedRequest);
+    expect(observedRequest).not.toBe(request);
+    expect(Object.isFrozen(observedRequest)).toBe(true);
+    expect(Object.isFrozen(observedRequest.target)).toBe(true);
+    expect(Object.isFrozen(observedRequest.target.plan)).toBe(true);
+  });
+
+  it("returns a detached frozen observation receipt (#9872)", async () => {
+    const health = { status: "healthy" as const, release: "0.0.106" };
+    const identity = { subjectFingerprint: `sha256:${"a".repeat(64)}` };
+    const workspace = { name: "research", phase: "active" as const };
+    const sandbox = { name: "ready-agent", phase: "Ready", readiness: "ready" as const };
+    const sandboxes = [sandbox];
+    const inventory = { sandboxes };
+    const client: AuthenticatedOpenShellExternalTargetObserver = {
+      getCurrentUser: vi.fn(async () => ({ ok: true as const, value: identity })),
+      getWorkspace: vi.fn(async () => ({ ok: true as const, value: workspace })),
+      listSandboxes: vi.fn(async () => ({ ok: true as const, value: inventory })),
+    };
+    const observer: OpenShellExternalTargetObserver = {
+      getGatewayHealth: vi.fn(async () => ({ ok: true as const, value: health })),
+      connectWithCredentialFile: vi.fn(async () => ({ ok: true as const, value: client })),
+    };
+
+    const result = await observeExternalOpenShellTarget(observer, request);
+    const receipt = (result as Extract<typeof result, { ok: true }>).value;
+
+    expect(Reflect.set(health, "release", "changed-release")).toBe(true);
+    expect(Reflect.set(identity, "subjectFingerprint", "private-token")).toBe(true);
+    expect(Reflect.set(workspace, "name", "changed-workspace")).toBe(true);
+    expect(Reflect.set(sandbox, "name", "changed-sandbox")).toBe(true);
+    sandboxes.push({ name: "late-sandbox", phase: "Ready", readiness: "ready" });
+    expect(Reflect.set(inventory, "sandboxes", [])).toBe(true);
+    expect(receipt).toEqual({
+      target,
+      health: { status: "healthy", release: "0.0.106" },
+      identity: { subjectFingerprint: `sha256:${"a".repeat(64)}` },
+      workspace: { name: "research", phase: "active" },
+      inventory: {
+        sandboxes: [{ name: "ready-agent", phase: "Ready", readiness: "ready" }],
+      },
+    });
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(receipt)).toBe(true);
+    expect(Object.isFrozen(receipt.target)).toBe(true);
+    expect(Object.isFrozen(receipt.target.plan)).toBe(true);
+    expect(Object.isFrozen(receipt.health)).toBe(true);
+    expect(Object.isFrozen(receipt.identity)).toBe(true);
+    expect(Object.isFrozen(receipt.workspace)).toBe(true);
+    expect(Object.isFrozen(receipt.inventory)).toBe(true);
+    expect(Object.isFrozen(receipt.inventory.sandboxes)).toBe(true);
+    expect(Object.isFrozen(receipt.inventory.sandboxes[0])).toBe(true);
   });
 });

--- a/nemoclaw/tsconfig.shared.json
+++ b/nemoclaw/tsconfig.shared.json
@@ -8,6 +8,7 @@
     "src/shared/banner-boundary.cts",
     "src/shared/credential-filter-boundary.cts",
     "src/shared/openshell-external-target-boundary.cts",
+    "src/shared/openshell-observation-boundary.cts",
     "src/shared/openshell-policy-boundary.cts",
     "src/shared/private-networks-boundary.cts",
     "src/shared/sandbox-name.cts",

--- a/nemoclaw/vitest.project.ts
+++ b/nemoclaw/vitest.project.ts
@@ -13,6 +13,10 @@ const canonicalOpenShellExternalTargetBoundary = path.resolve(
   import.meta.dirname,
   "src/shared/openshell-external-target-boundary.cts",
 );
+const canonicalOpenShellObservationBoundary = path.resolve(
+  import.meta.dirname,
+  "src/shared/openshell-observation-boundary.cts",
+);
 const canonicalOpenShellPolicyBoundary = path.resolve(
   import.meta.dirname,
   "src/shared/openshell-policy-boundary.cts",
@@ -67,6 +71,10 @@ const pluginVitestProjectOptions = {
       {
         find: /^.*openshell-external-target-boundary\.cjs$/,
         replacement: canonicalOpenShellExternalTargetBoundary,
+      },
+      {
+        find: /^.*openshell-observation-boundary\.cjs$/,
+        replacement: canonicalOpenShellObservationBoundary,
       },
       {
         find: /^.*openshell-policy-boundary\.cjs$/,

--- a/src/lib/adapters/openshell/sandbox-observer-cli.test.ts
+++ b/src/lib/adapters/openshell/sandbox-observer-cli.test.ts
@@ -10,7 +10,11 @@ import {
   type CliOpenShellSandboxObserverDeps,
   parseCliOpenShellSandboxInventory,
 } from "./sandbox-observer-cli";
-import { namedOpenShellGateway, selectedOpenShellGateway } from "./sandbox-observer";
+import {
+  externalOpenShellGateway,
+  namedOpenShellGateway,
+  selectedOpenShellGateway,
+} from "./sandbox-observer";
 
 function createCliOpenShellSandboxObserver(
   deps: Omit<CliOpenShellSandboxObserverDeps, "defaultTimeoutMs">,
@@ -217,5 +221,37 @@ describe("CLI OpenShell sandbox observer", () => {
       ok: false,
       error: { kind: "timeout", message: "OpenShell sandbox observation timed out." },
     });
+  });
+
+  it("does not route an explicit external target through ambient CLI state (#9872)", async () => {
+    const capture = vi.fn(() => captured(0, "ambient Ready"));
+    const observer = createCliOpenShellSandboxObserver({ capture });
+    const lookup = createCliOpenShellSandboxLookup({ capture });
+    const target = externalOpenShellGateway(
+      "https://openshell.example.test:8443",
+      "research",
+      "configured-release",
+    );
+
+    await expect(observer.listSandboxes({ target })).resolves.toEqual({
+      ok: false,
+      error: {
+        kind: "command",
+        reason: "invalid_request",
+        message: "The CLI sandbox observer does not accept external OpenShell targets.",
+      },
+    });
+    await expect(lookup({ target, sandboxName: "alpha" })).resolves.toEqual({
+      result: {
+        ok: false,
+        error: {
+          kind: "command",
+          reason: "invalid_request",
+          message: "The CLI sandbox lookup does not accept external OpenShell targets.",
+        },
+      },
+      displayOutput: "",
+    });
+    expect(capture).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/adapters/openshell/sandbox-observer-cli.test.ts
+++ b/src/lib/adapters/openshell/sandbox-observer-cli.test.ts
@@ -11,9 +11,9 @@ import {
   parseCliOpenShellSandboxInventory,
 } from "./sandbox-observer-cli";
 import {
-  externalOpenShellGateway,
   namedOpenShellGateway,
   selectedOpenShellGateway,
+  type OpenShellExternalGatewayTarget,
 } from "./sandbox-observer";
 
 function createCliOpenShellSandboxObserver(
@@ -227,11 +227,18 @@ describe("CLI OpenShell sandbox observer", () => {
     const capture = vi.fn(() => captured(0, "ambient Ready"));
     const observer = createCliOpenShellSandboxObserver({ capture });
     const lookup = createCliOpenShellSandboxLookup({ capture });
-    const target = externalOpenShellGateway(
-      "https://openshell.example.test:8443",
-      "research",
-      "configured-release",
-    );
+    const target: OpenShellExternalGatewayTarget = {
+      kind: "external",
+      plan: {
+        endpoint: "https://openshell.example.test:8443",
+        workspace: "research",
+        expected_release: "0.0.106",
+        lifecycle: "external",
+        authentication_source: "file",
+        ca_fingerprint: `sha256:${"a".repeat(64)}`,
+      },
+      allWorkspaces: false,
+    };
 
     await expect(observer.listSandboxes({ target })).resolves.toEqual({
       ok: false,

--- a/src/lib/adapters/openshell/sandbox-observer-cli.ts
+++ b/src/lib/adapters/openshell/sandbox-observer-cli.ts
@@ -216,6 +216,16 @@ export function createCliOpenShellSandboxLookup(
   deps: Pick<CliOpenShellSandboxObserverDeps, "capture" | "defaultTimeoutMs">,
 ): CliOpenShellSandboxLookup {
   return async (request) => {
+    if (request.target.kind === "external") {
+      return {
+        result: failure({
+          kind: "command",
+          reason: "invalid_request",
+          message: "The CLI sandbox lookup does not accept external OpenShell targets.",
+        }),
+        displayOutput: "",
+      };
+    }
     const result = await deps.capture(targetArgs("get", request.target, request.sandboxName), {
       ignoreError: true,
       includeStderr: true,
@@ -250,6 +260,13 @@ export function createCliOpenShellSandboxObserver(
   const listSandboxes = async (
     request: ListOpenShellSandboxesRequest,
   ): Promise<OpenShellSandboxResult<OpenShellSandboxInventory>> => {
+    if (request.target.kind === "external") {
+      return failure({
+        kind: "command",
+        reason: "invalid_request",
+        message: "The CLI sandbox observer does not accept external OpenShell targets.",
+      });
+    }
     const result = await capture(targetArgs("list", request.target), {
       ignoreError: true,
       includeStderr: true,

--- a/src/lib/adapters/openshell/sandbox-observer.ts
+++ b/src/lib/adapters/openshell/sandbox-observer.ts
@@ -1,74 +1,39 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export type OpenShellGatewayTarget = { kind: "named"; gatewayName: string } | { kind: "selected" };
+// sourceOfTruth: nemoclaw/src/shared/openshell-observation-boundary.cts
+// generatedBoundary: build:cli emits the canonical .cjs/.d.cts before this
+// implementation-free CLI wrapper is compiled.
+export {
+  externalOpenShellGateway,
+  namedOpenShellGateway,
+  observeExternalOpenShellTarget,
+  selectedOpenShellGateway,
+} from "../../../../nemoclaw/dist/shared/openshell-observation-boundary.cjs";
 
-export type OpenShellSandboxReadiness = "ready" | "not_ready" | "terminal";
-
-export type OpenShellSandboxObservation = Readonly<{
-  name: string;
-  phase: string | null;
-  readiness: OpenShellSandboxReadiness;
-}>;
-
-export type OpenShellSandboxInventory = Readonly<{
-  sandboxes: readonly OpenShellSandboxObservation[];
-}>;
-
-export type OpenShellSandboxLookup =
-  | Readonly<{ state: "present"; sandbox: OpenShellSandboxObservation }>
-  | Readonly<{ state: "missing" }>;
-
-export type OpenShellSandboxErrorKind =
-  | "authentication"
-  | "command"
-  | "schema"
-  | "timeout"
-  | "transport";
-
-export type OpenShellSandboxTransportReason = "identity_mismatch" | "unreachable";
-
-export type OpenShellSandboxError =
-  | Readonly<{
-      kind: Exclude<OpenShellSandboxErrorKind, "command" | "transport">;
-      message: string;
-    }>
-  | Readonly<{
-      kind: "transport";
-      reason: OpenShellSandboxTransportReason;
-      message: string;
-    }>
-  | Readonly<{
-      kind: "command";
-      reason: "failed" | "invalid_request";
-      message: string;
-    }>;
-
-export type OpenShellSandboxResult<T> =
-  | Readonly<{ ok: true; value: T }>
-  | Readonly<{ ok: false; error: OpenShellSandboxError }>;
-
-export type ListOpenShellSandboxesRequest = Readonly<{
-  target: OpenShellGatewayTarget;
-  timeoutMs?: number;
-}>;
-
-export type LookupOpenShellSandboxRequest = ListOpenShellSandboxesRequest &
-  Readonly<{
-    sandboxName: string;
-  }>;
-
-/** Transport-neutral sandbox observation capabilities used by NemoClaw. */
-export interface OpenShellSandboxObserver {
-  listSandboxes(
-    request: ListOpenShellSandboxesRequest,
-  ): Promise<OpenShellSandboxResult<OpenShellSandboxInventory>>;
-}
-
-export function namedOpenShellGateway(gatewayName: string): OpenShellGatewayTarget {
-  return { kind: "named", gatewayName };
-}
-
-export function selectedOpenShellGateway(): OpenShellGatewayTarget {
-  return { kind: "selected" };
-}
+export type {
+  AuthenticatedOpenShellExternalTargetObserver,
+  ExternalOpenShellTargetObservation,
+  ListOpenShellSandboxesRequest,
+  LookupOpenShellSandboxRequest,
+  ObserveExternalOpenShellTargetRequest,
+  OpenShellCurrentUserObservation,
+  OpenShellExternalGatewayTarget,
+  OpenShellExternalTargetError,
+  OpenShellExternalTargetObserver,
+  OpenShellExternalTargetResult,
+  OpenShellGatewayHealthObservation,
+  OpenShellGatewayHealthStatus,
+  OpenShellGatewayTarget,
+  OpenShellSandboxError,
+  OpenShellSandboxErrorKind,
+  OpenShellSandboxInventory,
+  OpenShellSandboxLookup,
+  OpenShellSandboxObservation,
+  OpenShellSandboxObserver,
+  OpenShellSandboxReadiness,
+  OpenShellSandboxResult,
+  OpenShellSandboxTransportReason,
+  OpenShellWorkspaceObservation,
+  OpenShellWorkspacePhase,
+} from "../../../../nemoclaw/dist/shared/openshell-observation-boundary.cjs";

--- a/test/package-contract/blueprint-external-target-plan.test.ts
+++ b/test/package-contract/blueprint-external-target-plan.test.ts
@@ -43,13 +43,13 @@ import dns from "node:dns";
 import fs from "node:fs";
 import http from "node:http";
 import https from "node:https";
-import { syncBuiltinESMExports } from "node:module";
+import { createRequire, syncBuiltinESMExports } from "node:module";
 import net from "node:net";
 import path from "node:path";
 import tls from "node:tls";
 import { pathToFileURL } from "node:url";
 
-const [runnerPath, blueprintRoot, ambientRoot, credentialPath] = process.argv.slice(2);
+const [runnerPath, blueprintRoot, ambientRoot, credentialPath, caPath] = process.argv.slice(2);
 const effects = [];
 const forbid = (kind) => (..._args) => {
   effects.push(kind);
@@ -145,6 +145,45 @@ process.env.NEMOCLAW_BLUEPRINT_PATH = blueprintRoot;
 
 const runnerUrl = pathToFileURL(runnerPath).href;
 const runner = await import(runnerUrl);
+const require = createRequire(import.meta.url);
+const sharedRoot = path.join(path.dirname(runnerPath), "..", "shared");
+const targetBoundary = require(path.join(sharedRoot, "openshell-external-target-boundary.cjs"));
+const observationBoundary = require(path.join(sharedRoot, "openshell-observation-boundary.cjs"));
+const issuedPlan = targetBoundary.buildSanitizedExternalOpenShellTargetPlan(
+  {
+    endpoint: "https://openshell.example.test:8443",
+    workspace: "default",
+    expected_release: "0.0.106",
+    lifecycle: "external",
+    trust: { ca_file: caPath },
+    authentication: { credential_file: credentialPath },
+  },
+  { minVersion: "0.0.106", maxVersion: "0.0.106" },
+);
+const acceptedTarget = observationBoundary.externalOpenShellGateway(issuedPlan);
+let forgedPlanRejected = false;
+try {
+  observationBoundary.externalOpenShellGateway({ ...issuedPlan });
+} catch {
+  forgedPlanRejected = true;
+}
+let forgedObserverCalls = 0;
+const forgedObservation = await observationBoundary.observeExternalOpenShellTarget(
+  {
+    getGatewayHealth: async () => {
+      forgedObserverCalls += 1;
+      throw new Error("forged target reached observer");
+    },
+    connectWithCredentialFile: async () => {
+      forgedObserverCalls += 1;
+      throw new Error("forged target reached observer");
+    },
+  },
+  {
+    target: { kind: "external", plan: { ...issuedPlan }, allWorkspaces: false },
+    timeoutMs: 2500,
+  },
+);
 let planOutput = "";
 const originalWrite = process.stdout.write.bind(process.stdout);
 process.stdout.write = (chunk) => {
@@ -164,7 +203,22 @@ try {
   process.stdout.write = originalWrite;
 }
 
-originalWrite(JSON.stringify({ applyError, effects, planOutput, runnerUrl }));
+originalWrite(
+  JSON.stringify({
+    applyError,
+    effects,
+    planOutput,
+    runnerUrl,
+    packageBoundary: {
+      acceptedIssuedPlan: acceptedTarget.plan === issuedPlan,
+      acceptedPlanKeys: Object.keys(acceptedTarget.plan).sort(),
+      allWorkspaces: acceptedTarget.allWorkspaces,
+      forgedPlanRejected,
+      forgedObservation,
+      forgedObserverCalls,
+    },
+  }),
+);
 `,
   );
 }
@@ -294,7 +348,14 @@ describe("packaged Blueprint Runner external target", () => {
         writeRuntimeProbe(probePath);
         const probe = spawnSync(
           process.execPath,
-          [probePath, installedRunner, blueprintRoot, ambientRoot, privateAuthenticationPath],
+          [
+            probePath,
+            installedRunner,
+            blueprintRoot,
+            ambientRoot,
+            privateAuthenticationPath,
+            privateCaPath,
+          ],
           {
             cwd: runtimeRoot,
             encoding: "utf8",
@@ -319,9 +380,39 @@ describe("packaged Blueprint Runner external target", () => {
           effects: string[];
           planOutput: string;
           runnerUrl: string;
+          packageBoundary: {
+            acceptedIssuedPlan: boolean;
+            acceptedPlanKeys: string[];
+            allWorkspaces: boolean;
+            forgedPlanRejected: boolean;
+            forgedObservation: unknown;
+            forgedObserverCalls: number;
+          };
         };
         expect(result.runnerUrl.startsWith("file://" + installedPackage)).toBe(true);
         expect(result.effects).toEqual([]);
+        expect(result.packageBoundary).toEqual({
+          acceptedIssuedPlan: true,
+          acceptedPlanKeys: [
+            "authentication_source",
+            "ca_fingerprint",
+            "endpoint",
+            "expected_release",
+            "lifecycle",
+            "workspace",
+          ],
+          allWorkspaces: false,
+          forgedPlanRejected: true,
+          forgedObservation: {
+            ok: false,
+            error: {
+              kind: "command",
+              reason: "invalid_request",
+              message: "The external OpenShell observation target is not a validated target plan.",
+            },
+          },
+          forgedObserverCalls: 0,
+        });
         expect(result.applyError).toBe(
           "External OpenShell target apply is not available until typed readiness and inventory are implemented.",
         );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,6 +33,9 @@ const canonicalCredentialFilterBoundary = path.resolve(
 const canonicalOpenShellExternalTargetBoundary = path.resolve(
   "nemoclaw/src/shared/openshell-external-target-boundary.cts",
 );
+const canonicalOpenShellObservationBoundary = path.resolve(
+  "nemoclaw/src/shared/openshell-observation-boundary.cts",
+);
 const canonicalOpenShellPolicyBoundary = path.resolve(
   "nemoclaw/src/shared/openshell-policy-boundary.cts",
 );
@@ -58,6 +61,10 @@ const canonicalSourceAliases = [
   {
     find: /^.*openshell-external-target-boundary\.cjs$/,
     replacement: canonicalOpenShellExternalTargetBoundary,
+  },
+  {
+    find: /^.*openshell-observation-boundary\.cjs$/,
+    replacement: canonicalOpenShellObservationBoundary,
   },
   {
     find: /^.*openshell-policy-boundary\.cjs$/,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

This PR prepares the typed, read-only observation boundary for an explicit external OpenShell target. The boundary checks the public release before an opaque credential handoff and then sequences identity, workspace, and inventory observations without using ambient CLI state.

Machine authentication and the exact supported OpenShell release remain undecided. This PR adds no credential read, SDK transport, authenticated call, or remote mutation.

## Related Issue

Related to #9872

## Changes

- Move the merged #9803 sandbox observer types into one generated shared boundary for the Blueprint Runner and root CLI adapters. The two packages cannot directly share source imports, and the focused boundary tests protect the shared contract.
- Add an external target request with an explicit endpoint, workspace, configured release, and `allWorkspaces: false`.
- Sequence public health and release validation before the opaque file-backed credential handoff. Fake-only tests verify positive, release-mismatch, denial, timeout, schema, workspace-mismatch, and diagnostic-redaction behavior.
- Reject external targets in the CLI observer before it can read ambient CLI state.
- Add the shared boundary to the TypeScript build and Vitest source aliases.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Local review covered credential boundaries, explicit targeting, authorization, diagnostic redaction, dependencies, sequencing, and remote effects. It found no blocking issue.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification:
  - `npx vitest run --project plugin nemoclaw/src/shared/openshell-observation-boundary.test.ts --project cli src/lib/adapters/openshell/sandbox-observer-cli.test.ts`: 22 tests passed.
  - `npm run typecheck:cli`: passed.
  - `npm --prefix nemoclaw run typecheck`: passed.
  - Clean root and plugin builds: passed.
  - `npx vitest run --project package-contract test/package-contract/blueprint-external-target-plan.test.ts`: 1 test passed.
  - `npm run checks:repository`: passed.
  - `npm run validate:pr`: passed.
  - `npm run test:package`: 1,230 tests passed. Ten credential-command tests stopped at the installed OpenShell lifecycle-authority check; exact `origin/main` reproduced the same ten failures.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added external OpenShell target observation, including gateway health, release compatibility, workspace identity, current user, and sandbox inventory.
  * Added structured sandbox readiness, lookup, and observation results.
  * Added sanitized error reporting that avoids exposing credentials or authentication details.

* **Bug Fixes**
  * External targets are rejected early by CLI-based sandbox operations with clear invalid-request errors.
  * Workspace mismatches and incompatible gateway releases are detected before inventory access.
  * Observation requests now reject unvalidated targets and protect returned results from unexpected changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->