### PR TITLE
fix(diagnostics): reject a pre-planted symlink when staging the debug bundle

### DIFF
--- a/src/lib/diagnostics/debug.test.ts
+++ b/src/lib/diagnostics/debug.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  chmodSync,
   existsSync,
   mkdtempSync,
   readdirSync,
@@ -170,6 +171,37 @@ describe("createTarball", () => {
     expect(ok).toBe(false);
     expect(process.exitCode).toBe(1);
     expect(existsSync(output)).toBe(false);
+  });
+
+  it("refuses to stage into a directory other local accounts can write to without the sticky bit (#10195)", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "debug-test-"));
+    writeFileSync(join(tempDir, "dummy.txt"), "test data");
+    outputDir = mkdtempSync(join(tmpdir(), "debug-test-out-"));
+    // World-writable, sticky bit NOT set — the actual unsafe shape: any
+    // other local account could rename or delete our entries here, at any
+    // point, including after this command has already reported success.
+    chmodSync(outputDir, 0o777);
+    const output = join(outputDir, "output.tar.gz");
+    const ok = createTarball(tempDir, output);
+    expect(ok).toBe(false);
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(output)).toBe(false);
+    // Nothing gets staged either — the check runs before the exclusive open.
+    expect(readdirSync(outputDir)).toEqual([]);
+  });
+
+  it("still stages into a world-writable directory that has the sticky bit set, like a standard /tmp (#10195)", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "debug-test-"));
+    writeFileSync(join(tempDir, "dummy.txt"), "test data");
+    outputDir = mkdtempSync(join(tmpdir(), "debug-test-out-"));
+    // World-writable WITH the sticky bit (mode 1777, same as a standard
+    // /tmp) — the directory check must accept this: the sticky bit is what
+    // makes a shared directory safe, not the absence of shared write access.
+    chmodSync(outputDir, 0o1777);
+    const output = join(outputDir, "output.tar.gz");
+    const ok = createTarball(tempDir, output);
+    expect(ok).toBe(true);
+    expect(existsSync(output)).toBe(true);
   });
 });
 

--- a/src/lib/diagnostics/debug.test.ts
+++ b/src/lib/diagnostics/debug.test.ts
@@ -1,7 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -129,6 +138,38 @@ describe("createTarball", () => {
     expect(ok).toBe(true);
     expect(process.exitCode).toBeUndefined();
     expect(existsSync(output)).toBe(true);
+  });
+
+  it("writes the tarball with owner-only permissions, not world/group readable (#10195)", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "debug-test-"));
+    writeFileSync(join(tempDir, "dummy.txt"), "test data");
+    outputDir = mkdtempSync(join(tmpdir(), "debug-test-out-"));
+    const output = join(outputDir, "output.tar.gz");
+    const ok = createTarball(tempDir, output);
+    expect(ok).toBe(true);
+    const mode = statSync(output).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("refuses to follow a symlink pre-planted at the predictable staging path (#10195)", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "debug-test-"));
+    writeFileSync(join(tempDir, "dummy.txt"), "test data");
+    outputDir = mkdtempSync(join(tmpdir(), "debug-test-out-"));
+    const output = join(outputDir, "output.tar.gz");
+    // An attacker with access to the shared output directory can predict
+    // `${output}.partial.${pid}` and plant a symlink there ahead of time.
+    const partial = `${output}.partial.${String(process.pid)}`;
+    const victim = join(outputDir, "victim.txt");
+    const victimContent = "do not overwrite me";
+    writeFileSync(victim, victimContent);
+    symlinkSync(victim, partial);
+    const ok = createTarball(tempDir, output);
+    // Staging refuses to follow the planted symlink, so it fails closed
+    // instead of writing tar content into the victim file.
+    expect(readFileSync(victim, "utf-8")).toBe(victimContent);
+    expect(ok).toBe(false);
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(output)).toBe(false);
   });
 });
 

--- a/src/lib/diagnostics/tarball.race.test.ts
+++ b/src/lib/diagnostics/tarball.race.test.ts
@@ -22,13 +22,14 @@ vi.mock("node:child_process", () => ({
 
 // Import-time stub, real implementation kept: createTarball's pre-check and
 // its rename() call are two separate fs operations that Node's API cannot
-// make atomic with each other. Wrapping only renameSync (everything else in
-// this module stays real) lets a test inject a path swap in the exact
-// instant between those two calls, which no amount of mocking spawnSync
-// alone could reach.
+// make atomic with each other. Wrapping only renameSync and statSync
+// (everything else in this module stays real) lets a test inject a path
+// swap in the exact instant between those two calls, or fake a directory's
+// ownership without needing an actual second local account to test against
+// — neither is reachable by mocking spawnSync alone.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
-  return { ...actual, renameSync: vi.fn(actual.renameSync) };
+  return { ...actual, renameSync: vi.fn(actual.renameSync), statSync: vi.fn(actual.statSync) };
 });
 
 import { spawnSync } from "node:child_process";
@@ -36,6 +37,7 @@ import { renameSync } from "node:fs";
 import { createTarball } from "./tarball";
 
 const mockedSpawnSync = vi.mocked(spawnSync);
+const mockedStatSync = vi.mocked(statSync);
 const mockedRenameSync = vi.mocked(renameSync);
 
 function expectTarInvokedThroughHeldDescriptor(collectDir: string): void {
@@ -168,5 +170,28 @@ describe("createTarball staging-descriptor race (#10195)", () => {
     expect(statSync(victim).mode & 0o777).toBe(victimModeBefore);
     expect(() => statSync(output)).toThrow();
     expectTarInvokedThroughHeldDescriptor(tempDir);
+  });
+
+  it("refuses a sticky output directory owned by a different local account", async () => {
+    const output = join(outputDir, "output.tar.gz");
+    const { statSync: realStatSync } = await vi.importActual<typeof import("node:fs")>("node:fs");
+    const otherUid = (process.getuid?.() ?? 0) + 1;
+    // The sticky bit alone only stops accounts OTHER than the directory's
+    // owner from touching entries they don't own — it grants the owner no
+    // such restriction. A sticky, world-writable directory owned by some
+    // other account is therefore exactly as unsafe as one with no sticky
+    // bit at all: that owner can still remove or replace our published
+    // file at any point, sticky bit or not. Faking a real directory's stat
+    // result rather than an actual second account, which this environment
+    // cannot provision.
+    mockedStatSync.mockImplementationOnce((path, opts) => {
+      const real = realStatSync(path as string, opts as never);
+      return { ...real, mode: (real.mode & ~0o777) | 0o1777, uid: otherUid };
+    });
+    const ok = createTarball(tempDir, output, { info: vi.fn(), warn: vi.fn(), error: vi.fn() });
+    expect(ok).toBe(false);
+    expect(process.exitCode).toBe(1);
+    expect(mockedSpawnSync).not.toHaveBeenCalled();
+    expect(() => statSync(output)).toThrow();
   });
 });

--- a/src/lib/diagnostics/tarball.race.test.ts
+++ b/src/lib/diagnostics/tarball.race.test.ts
@@ -194,4 +194,27 @@ describe("createTarball staging-descriptor race (#10195)", () => {
     expect(mockedSpawnSync).not.toHaveBeenCalled();
     expect(() => statSync(output)).toThrow();
   });
+
+  it("refuses a private-mode output directory owned by a different local account", async () => {
+    const output = join(outputDir, "output.tar.gz");
+    const { statSync: realStatSync } = await vi.importActual<typeof import("node:fs")>("node:fs");
+    const otherUid = (process.getuid?.() ?? 0) + 1;
+    // Traditional mode bits are not proof of who can write here: a POSIX
+    // ACL can grant this account write access to a directory owned by
+    // someone else while its mode bits show no group/other write access at
+    // all (0700), which is exactly the shape that made the earlier
+    // writable-by-others gate on the ownership check a blind spot — this
+    // directory would have sailed through unchecked before requiring
+    // ownership unconditionally. The owner still keeps full authority over
+    // entries in their own directory regardless of any ACL grant.
+    mockedStatSync.mockImplementationOnce((path, opts) => {
+      const real = realStatSync(path as string, opts as never);
+      return { ...real, mode: (real.mode & ~0o777) | 0o700, uid: otherUid };
+    });
+    const ok = createTarball(tempDir, output, { info: vi.fn(), warn: vi.fn(), error: vi.fn() });
+    expect(ok).toBe(false);
+    expect(process.exitCode).toBe(1);
+    expect(mockedSpawnSync).not.toHaveBeenCalled();
+    expect(() => statSync(output)).toThrow();
+  });
 });

--- a/src/lib/diagnostics/tarball.race.test.ts
+++ b/src/lib/diagnostics/tarball.race.test.ts
@@ -11,7 +11,7 @@ import {
   writeSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Import-time stub: createTarball resolves spawnSync from this module at
@@ -24,6 +24,24 @@ import { spawnSync } from "node:child_process";
 import { createTarball } from "./tarball";
 
 const mockedSpawnSync = vi.mocked(spawnSync);
+
+function expectTarInvokedThroughHeldDescriptor(collectDir: string): void {
+  expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
+  const [command, args, options] = mockedSpawnSync.mock.calls[0];
+  // The regression this guards: if tar is ever invoked with the staging
+  // *pathname* again (e.g. ["czf", partial, ...]) instead of streaming to
+  // stdout through the descriptor already claimed with O_EXCL|O_NOFOLLOW,
+  // the close-then-reopen race #10195 fixed reopens — even though these
+  // tests would otherwise still pass, since the mocks below write to
+  // whichever descriptor they're handed regardless of the real command.
+  expect(command).toBe("tar");
+  expect(args).toEqual(["czf", "-", "-C", dirname(collectDir), basename(collectDir)]);
+  expect((options as { stdio: unknown[] }).stdio).toEqual([
+    "ignore",
+    expect.any(Number),
+    "inherit",
+  ]);
+}
 
 describe("createTarball staging-descriptor race (#10195)", () => {
   let tempDir: string;
@@ -53,9 +71,10 @@ describe("createTarball staging-descriptor race (#10195)", () => {
     expect(ok).toBe(true);
     expect(readFileSync(output, "utf-8")).toBe("MARKER");
     expect(statSync(output).mode & 0o777).toBe(0o600);
+    expectTarInvokedThroughHeldDescriptor(tempDir);
   });
 
-  it("refuses to publish through a symlink swapped in after the staging claim", () => {
+  it("does not modify a symlink target swapped in after the staging claim", () => {
     const output = join(outputDir, "output.tar.gz");
     const partial = `${output}.partial.${String(process.pid)}`;
     const victim = join(outputDir, "victim.txt");
@@ -85,5 +104,6 @@ describe("createTarball staging-descriptor race (#10195)", () => {
     expect(ok).toBe(true);
     expect(readFileSync(victim, "utf-8")).toBe(victimContent);
     expect(statSync(victim).mode & 0o777).toBe(victimModeBefore);
+    expectTarInvokedThroughHeldDescriptor(tempDir);
   });
 });

--- a/src/lib/diagnostics/tarball.race.test.ts
+++ b/src/lib/diagnostics/tarball.race.test.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Import-time stub: createTarball resolves spawnSync from this module at
+// import time, so the mock must be in place before that import runs.
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+
+import { spawnSync } from "node:child_process";
+import { createTarball } from "./tarball";
+
+const mockedSpawnSync = vi.mocked(spawnSync);
+
+describe("createTarball staging-descriptor race (#10195)", () => {
+  let tempDir: string;
+  let outputDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "tarball-race-"));
+    outputDir = mkdtempSync(join(tmpdir(), "tarball-race-out-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    rmSync(outputDir, { recursive: true, force: true });
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+  });
+
+  it("streams archive bytes through the held descriptor, never the staging pathname", () => {
+    const output = join(outputDir, "output.tar.gz");
+    mockedSpawnSync.mockImplementation((_command, _args, options) => {
+      const stdio = (options as { stdio: unknown[] }).stdio;
+      const heldFd = stdio[1] as number;
+      writeSync(heldFd, "MARKER");
+      return { status: 0, signal: null } as ReturnType<typeof spawnSync>;
+    });
+    const ok = createTarball(tempDir, output, { info: vi.fn(), warn: vi.fn(), error: vi.fn() });
+    expect(ok).toBe(true);
+    expect(readFileSync(output, "utf-8")).toBe("MARKER");
+    expect(statSync(output).mode & 0o777).toBe(0o600);
+  });
+
+  it("refuses to publish through a symlink swapped in after the staging claim", () => {
+    const output = join(outputDir, "output.tar.gz");
+    const partial = `${output}.partial.${String(process.pid)}`;
+    const victim = join(outputDir, "victim.txt");
+    const victimContent = "do not overwrite me";
+    writeFileSync(victim, victimContent, { mode: 0o644 });
+    const victimModeBefore = statSync(victim).mode & 0o777;
+    mockedSpawnSync.mockImplementation((_command, _args, options) => {
+      // Simulate an attacker who wins the race between our exclusive claim
+      // and tar's write: swap the staging path for a symlink to the victim,
+      // then write through the descriptor tar was actually handed.
+      rmSync(partial, { force: true });
+      symlinkSync(victim, partial);
+      const stdio = (options as { stdio: unknown[] }).stdio;
+      const heldFd = stdio[1] as number;
+      writeSync(heldFd, "MARKER");
+      return { status: 0, signal: null } as ReturnType<typeof spawnSync>;
+    });
+    const ok = createTarball(tempDir, output, { info: vi.fn(), warn: vi.fn(), error: vi.fn() });
+    // The archive write and fchmod both went through the descriptor claimed
+    // before the swap, so the victim's content and permissions are untouched
+    // no matter what the staging pathname points to by the time tar and
+    // fchmod run. rename() never dereferences its source, so renaming the
+    // swapped-in symlink onto `output` is itself a legitimate, successful
+    // operation (POSIX) — it moves the link, not the victim. This is the
+    // known residual: an attacker who can win this race can substitute what
+    // `output` points to, but can never write through it to the victim.
+    expect(ok).toBe(true);
+    expect(readFileSync(victim, "utf-8")).toBe(victimContent);
+    expect(statSync(victim).mode & 0o777).toBe(victimModeBefore);
+  });
+});

--- a/src/lib/diagnostics/tarball.race.test.ts
+++ b/src/lib/diagnostics/tarball.race.test.ts
@@ -20,10 +20,23 @@ vi.mock("node:child_process", () => ({
   spawnSync: vi.fn(),
 }));
 
+// Import-time stub, real implementation kept: createTarball's pre-check and
+// its rename() call are two separate fs operations that Node's API cannot
+// make atomic with each other. Wrapping only renameSync (everything else in
+// this module stays real) lets a test inject a path swap in the exact
+// instant between those two calls, which no amount of mocking spawnSync
+// alone could reach.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, renameSync: vi.fn(actual.renameSync) };
+});
+
 import { spawnSync } from "node:child_process";
+import { renameSync } from "node:fs";
 import { createTarball } from "./tarball";
 
 const mockedSpawnSync = vi.mocked(spawnSync);
+const mockedRenameSync = vi.mocked(renameSync);
 
 function expectTarInvokedThroughHeldDescriptor(collectDir: string): void {
   expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
@@ -105,6 +118,48 @@ describe("createTarball staging-descriptor race (#10195)", () => {
     // proceed on a mismatch, so no rename happens at all. The victim is
     // never touched, `output` is never created, and the call fails closed
     // instead of reporting success for attacker-chosen content.
+    expect(ok).toBe(false);
+    expect(process.exitCode).toBe(1);
+    expect(error).toHaveBeenCalledOnce();
+    expect(info).not.toHaveBeenCalledWith(expect.stringContaining("Tarball written"));
+    expect(readFileSync(victim, "utf-8")).toBe(victimContent);
+    expect(statSync(victim).mode & 0o777).toBe(victimModeBefore);
+    expect(() => statSync(output)).toThrow();
+    expectTarInvokedThroughHeldDescriptor(tempDir);
+  });
+
+  it("does not report success for content swapped in after the pre-rename identity check", async () => {
+    const output = join(outputDir, "output.tar.gz");
+    const partial = `${output}.partial.${String(process.pid)}`;
+    const victim = join(outputDir, "victim.txt");
+    const victimContent = "do not overwrite me";
+    writeFileSync(victim, victimContent, { mode: 0o644 });
+    const victimModeBefore = statSync(victim).mode & 0o777;
+    mockedSpawnSync.mockImplementation((_command, _args, options) => {
+      const stdio = (options as { stdio: unknown[] }).stdio;
+      const heldFd = stdio[1] as number;
+      writeSync(heldFd, "MARKER");
+      return { status: 0, signal: null } as ReturnType<typeof spawnSync>;
+    });
+    // The pre-rename identity check (lstatSync(partial) vs fstatSync(fd))
+    // runs and matches normally — the swap happens only here, in the
+    // instant createTarball actually calls renameSync, simulating an
+    // attacker who wins the race in the one window neither that check nor
+    // O_EXCL can close: after the check passes, before the pathname-based
+    // rename executes. Goes through vi.importActual (not the imported,
+    // mocked `renameSync` binding) to avoid the mock calling itself. The
+    // real rename still runs afterward, so this proves the *post*-rename
+    // identity check is what catches it, not a rename that was refused.
+    const { renameSync: realRenameSync } =
+      await vi.importActual<typeof import("node:fs")>("node:fs");
+    mockedRenameSync.mockImplementationOnce((from, to) => {
+      rmSync(partial, { force: true });
+      symlinkSync(victim, partial);
+      return realRenameSync(from, to);
+    });
+    const info = vi.fn();
+    const error = vi.fn();
+    const ok = createTarball(tempDir, output, { info, warn: vi.fn(), error });
     expect(ok).toBe(false);
     expect(process.exitCode).toBe(1);
     expect(error).toHaveBeenCalledOnce();

--- a/src/lib/diagnostics/tarball.race.test.ts
+++ b/src/lib/diagnostics/tarball.race.test.ts
@@ -92,18 +92,26 @@ describe("createTarball staging-descriptor race (#10195)", () => {
       writeSync(heldFd, "MARKER");
       return { status: 0, signal: null } as ReturnType<typeof spawnSync>;
     });
-    const ok = createTarball(tempDir, output, { info: vi.fn(), warn: vi.fn(), error: vi.fn() });
+    const info = vi.fn();
+    const error = vi.fn();
+    const ok = createTarball(tempDir, output, { info, warn: vi.fn(), error });
     // The archive write and fchmod both went through the descriptor claimed
     // before the swap, so the victim's content and permissions are untouched
     // no matter what the staging pathname points to by the time tar and
     // fchmod run. rename() never dereferences its source, so renaming the
-    // swapped-in symlink onto `output` is itself a legitimate, successful
-    // operation (POSIX) — it moves the link, not the victim. This is the
-    // known residual: an attacker who can win this race can substitute what
-    // `output` points to, but can never write through it to the victim.
-    expect(ok).toBe(true);
+    // swapped-in symlink onto `output` would itself be a legitimate,
+    // successful operation (POSIX) — but publication compares the held
+    // descriptor's identity against the pathname first and refuses to
+    // proceed on a mismatch, so no rename happens at all. The victim is
+    // never touched, `output` is never created, and the call fails closed
+    // instead of reporting success for attacker-chosen content.
+    expect(ok).toBe(false);
+    expect(process.exitCode).toBe(1);
+    expect(error).toHaveBeenCalledOnce();
+    expect(info).not.toHaveBeenCalledWith(expect.stringContaining("Tarball written"));
     expect(readFileSync(victim, "utf-8")).toBe(victimContent);
     expect(statSync(victim).mode & 0o777).toBe(victimModeBefore);
+    expect(() => statSync(output)).toThrow();
     expectTarInvokedThroughHeldDescriptor(tempDir);
   });
 });

--- a/src/lib/diagnostics/tarball.ts
+++ b/src/lib/diagnostics/tarball.ts
@@ -11,8 +11,36 @@ import {
   openSync,
   renameSync,
   rmSync,
+  statSync,
 } from "node:fs";
 import { basename, dirname } from "node:path";
+
+// A directory another local account can write to without the sticky bit
+// set lets that account rename or delete entries it does not own — which
+// defeats every in-process identity check below, including ones that run
+// after createTarball() has already returned and the caller has moved on.
+// The sticky bit (mode 1777, as on a standard /tmp) is what makes a shared
+// directory safe for this at all: it restricts removing or renaming an
+// entry to its owner (or root) regardless of the directory's own write
+// permissions. A directory only the current user can write to needs no
+// sticky bit for the same reason. Refusing to stage into anything else is
+// the one check here that closes the race for good instead of narrowing it.
+const MODE_GROUP_OR_OTHER_WRITABLE = 0o022;
+const MODE_STICKY = 0o1000;
+
+function outputDirectoryTrustworthy(outputPath: string): boolean {
+  let dirStat: ReturnType<typeof statSync>;
+  try {
+    dirStat = statSync(dirname(outputPath));
+  } catch {
+    // Missing or inaccessible parent: let the real staging attempt below
+    // fail with its own, more specific error instead of a generic refusal.
+    return true;
+  }
+  const writableByOthers = (dirStat.mode & MODE_GROUP_OR_OTHER_WRITABLE) !== 0;
+  const stickyProtected = (dirStat.mode & MODE_STICKY) !== 0;
+  return !writableByOthers || stickyProtected;
+}
 
 export interface CreateTarballOptions {
   info: (message: string) => void;
@@ -35,15 +63,33 @@ export function createTarball(
 ): boolean {
   const { info, warn, error, timeoutMs = 60_000 } = options;
   const partial = `${output}.partial.${process.pid}`;
+  // Everything below assumes the output directory itself isn't a shared
+  // space another local account can rename or delete our entries in — see
+  // outputDirectoryTrustworthy(). Without that precondition, an attacker
+  // could always win by acting after this function has already returned
+  // and the caller has moved on, which nothing inside createTarball() can
+  // detect or prevent (#10195).
+  if (!outputDirectoryTrustworthy(output)) {
+    error(
+      `Refusing to stage a tarball under ${dirname(output)}: this directory is writable by ` +
+        "other local accounts and does not have the sticky bit set, so a file placed here can " +
+        "be renamed or replaced by another local user at any point, including after this " +
+        "command reports success. Choose a directory only this account can write to, or one " +
+        "with the sticky bit set (mode 1777, as on a standard /tmp).",
+    );
+    process.exitCode = 1;
+    return false;
+  }
   // Claim the predictable staging path and hold the descriptor for the whole
   // write: O_EXCL refuses a path another local user pre-planted (file or
   // symlink). tar streams to stdout redirected into this descriptor, and the
   // mode is set with fchmod on the same descriptor, so no step after the
   // claim reopens the path by name. The final rename is checked against the
-  // held descriptor's identity both before and after it runs, so an
-  // attacker who can modify entries in the output directory can still make
-  // publication fail (denial of service), but can never make us report
-  // success for, publish, or write through a planted symlink (#10195).
+  // held descriptor's identity both before and after it runs. Combined with
+  // the directory check above, an attacker without the standing ability to
+  // remove another user's entries — which the check just ruled out — can
+  // never make us report success for, publish, or write through a planted
+  // symlink (#10195).
   let fd: number;
   try {
     fd = openSync(
@@ -110,8 +156,12 @@ export function createTarball(
       );
       try {
         rmSync(output, { force: true });
-      } catch {
-        /* best-effort cleanup of a publication we cannot trust */
+      } catch (cleanupErr) {
+        error(
+          `Additionally failed to remove the untrusted content left at ${output}: ` +
+            `${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}. ` +
+            "Remove it by hand before reusing this path.",
+        );
       }
       return false;
     }

--- a/src/lib/diagnostics/tarball.ts
+++ b/src/lib/diagnostics/tarball.ts
@@ -40,10 +40,10 @@ export function createTarball(
   // symlink). tar streams to stdout redirected into this descriptor, and the
   // mode is set with fchmod on the same descriptor, so no step after the
   // claim reopens the path by name. The final rename is checked against the
-  // held descriptor's identity before it runs, so an attacker who can unlink
-  // entries in the output directory can still make publication fail
-  // (denial of service), but can never make us publish through a planted
-  // symlink or write through one (#10195).
+  // held descriptor's identity both before and after it runs, so an
+  // attacker who can modify entries in the output directory can still make
+  // publication fail (denial of service), but can never make us report
+  // success for, publish, or write through a planted symlink (#10195).
   let fd: number;
   try {
     fd = openSync(
@@ -78,15 +78,22 @@ export function createTarball(
     fchmodSync(fd, 0o600);
     // rename() is pathname-based and never follows its source, so it cannot
     // be tricked into writing through a symlink — but it also cannot tell a
-    // swapped path from the real one. Without this check, an attacker who
-    // swaps `partial` for a symlink after we opened it would have that link
-    // renamed to `output`: createTarball() would report success and the
-    // caller's own "attach this to your GitHub issue" guidance would point
-    // at attacker-chosen content instead of the archive we actually wrote.
-    // Comparing the still-open descriptor's identity against the pathname
-    // right before the one remaining pathname-based step closes that gap;
-    // a mismatch means the path no longer names the file we wrote to, so
-    // publication fails closed instead of moving whatever is there now.
+    // swapped path from the real one. Without any check here, an attacker
+    // who swaps `partial` for a symlink after we opened it would have that
+    // link renamed to `output`: createTarball() would report success and
+    // the caller's own "attach this to your GitHub issue" guidance would
+    // point at attacker-chosen content instead of the archive we actually
+    // wrote. The still-open descriptor's identity never changes no matter
+    // what path points at it, so it is the one thing here a swapped path
+    // can't fake — compare against it both before rename (cheap fast path
+    // that skips ever touching `output` in the common case) and after
+    // (Node's fs API has no rename-by-descriptor, so the pathname-based
+    // pre-check and the rename itself are two separate calls and cannot be
+    // made atomic with each other; verifying again afterward closes that
+    // narrow remaining window instead of merely narrowing it). A mismatch
+    // at either point means the path no longer named the file we wrote to,
+    // so publication fails closed and any wrongly published content is
+    // removed, rather than ever reporting success for it.
     const heldStat = fstatSync(fd);
     const partialStat = lstatSync(partial);
     if (partialStat.dev !== heldStat.dev || partialStat.ino !== heldStat.ino) {
@@ -96,6 +103,18 @@ export function createTarball(
       return false;
     }
     renameSync(partial, output);
+    const outputStat = lstatSync(output);
+    if (outputStat.dev !== heldStat.dev || outputStat.ino !== heldStat.ino) {
+      error(
+        `Refusing to report success for ${output}: its content no longer matches the archive that was staged.`,
+      );
+      try {
+        rmSync(output, { force: true });
+      } catch {
+        /* best-effort cleanup of a publication we cannot trust */
+      }
+      return false;
+    }
     staged = true;
   } catch (err) {
     error(

--- a/src/lib/diagnostics/tarball.ts
+++ b/src/lib/diagnostics/tarball.ts
@@ -39,10 +39,11 @@ export function createTarball(
   // write: O_EXCL refuses a path another local user pre-planted (file or
   // symlink). tar streams to stdout redirected into this descriptor, and the
   // mode is set with fchmod on the same descriptor, so no step after the
-  // claim reopens the path by name. An attacker who can unlink entries in
-  // the output directory can still make the final rename fail or misplace
-  // the bundle (denial of service), but can never make us write through a
-  // planted symlink (#10195).
+  // claim reopens the path by name. The final rename is checked against the
+  // held descriptor's identity before it runs, so an attacker who can unlink
+  // entries in the output directory can still make publication fail
+  // (denial of service), but can never make us publish through a planted
+  // symlink or write through one (#10195).
   let fd: number;
   try {
     fd = openSync(

--- a/src/lib/diagnostics/tarball.ts
+++ b/src/lib/diagnostics/tarball.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
-import { renameSync, rmSync } from "node:fs";
+import { chmodSync, closeSync, constants, openSync, renameSync, rmSync } from "node:fs";
 import { basename, dirname } from "node:path";
 
 export interface CreateTarballOptions {
@@ -26,6 +26,27 @@ export function createTarball(
 ): boolean {
   const { info, warn, error, timeoutMs = 60_000 } = options;
   const partial = `${output}.partial.${process.pid}`;
+  // Claim the predictable staging path ourselves before tar ever touches it.
+  // O_EXCL refuses a path another local user has already planted (file or
+  // symlink); O_NOFOLLOW refuses to write through a symlink even if one wins
+  // the race after this check. Owner-only mode carries through tar's own
+  // open() below, since an existing file's permission bits are unaffected by
+  // O_CREAT (see #10195).
+  try {
+    closeSync(
+      openSync(
+        partial,
+        constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+        0o600,
+      ),
+    );
+  } catch (err) {
+    error(
+      `Failed to stage tarball at ${partial}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exitCode = 1;
+    return false;
+  }
   const result = spawnSync(
     "tar",
     ["czf", partial, "-C", dirname(collectDir), basename(collectDir)],
@@ -48,6 +69,7 @@ export function createTarball(
     return false;
   }
   try {
+    chmodSync(partial, 0o600);
     renameSync(partial, output);
   } catch (err) {
     error(

--- a/src/lib/diagnostics/tarball.ts
+++ b/src/lib/diagnostics/tarball.ts
@@ -2,7 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
-import { closeSync, constants, fchmodSync, openSync, renameSync, rmSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  lstatSync,
+  openSync,
+  renameSync,
+  rmSync,
+} from "node:fs";
 import { basename, dirname } from "node:path";
 
 export interface CreateTarballOptions {
@@ -66,11 +75,25 @@ export function createTarball(
       return false;
     }
     fchmodSync(fd, 0o600);
-    // rename() never follows the source: if the staging path was swapped for
-    // a symlink after we opened it, this moves the symlink itself, leaving
-    // our written data orphaned under `partial` rather than publishing
-    // through the link. Worst case is a failed/misplaced bundle, not a write
-    // through an attacker's symlink.
+    // rename() is pathname-based and never follows its source, so it cannot
+    // be tricked into writing through a symlink — but it also cannot tell a
+    // swapped path from the real one. Without this check, an attacker who
+    // swaps `partial` for a symlink after we opened it would have that link
+    // renamed to `output`: createTarball() would report success and the
+    // caller's own "attach this to your GitHub issue" guidance would point
+    // at attacker-chosen content instead of the archive we actually wrote.
+    // Comparing the still-open descriptor's identity against the pathname
+    // right before the one remaining pathname-based step closes that gap;
+    // a mismatch means the path no longer names the file we wrote to, so
+    // publication fails closed instead of moving whatever is there now.
+    const heldStat = fstatSync(fd);
+    const partialStat = lstatSync(partial);
+    if (partialStat.dev !== heldStat.dev || partialStat.ino !== heldStat.ino) {
+      error(
+        `Refusing to publish ${output}: the staged path ${partial} was replaced before it could be moved into place.`,
+      );
+      return false;
+    }
     renameSync(partial, output);
     staged = true;
   } catch (err) {

--- a/src/lib/diagnostics/tarball.ts
+++ b/src/lib/diagnostics/tarball.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
-import { chmodSync, closeSync, constants, openSync, renameSync, rmSync } from "node:fs";
+import { closeSync, constants, fchmodSync, openSync, renameSync, rmSync } from "node:fs";
 import { basename, dirname } from "node:path";
 
 export interface CreateTarballOptions {
@@ -26,19 +26,20 @@ export function createTarball(
 ): boolean {
   const { info, warn, error, timeoutMs = 60_000 } = options;
   const partial = `${output}.partial.${process.pid}`;
-  // Claim the predictable staging path ourselves before tar ever touches it.
-  // O_EXCL refuses a path another local user has already planted (file or
-  // symlink); O_NOFOLLOW refuses to write through a symlink even if one wins
-  // the race after this check. Owner-only mode carries through tar's own
-  // open() below, since an existing file's permission bits are unaffected by
-  // O_CREAT (see #10195).
+  // Claim the predictable staging path and hold the descriptor for the whole
+  // write: O_EXCL refuses a path another local user pre-planted (file or
+  // symlink). tar streams to stdout redirected into this descriptor, and the
+  // mode is set with fchmod on the same descriptor, so no step after the
+  // claim reopens the path by name. An attacker who can unlink entries in
+  // the output directory can still make the final rename fail or misplace
+  // the bundle (denial of service), but can never make us write through a
+  // planted symlink (#10195).
+  let fd: number;
   try {
-    closeSync(
-      openSync(
-        partial,
-        constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
-        0o600,
-      ),
+    fd = openSync(
+      partial,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
     );
   } catch (err) {
     error(
@@ -47,41 +48,50 @@ export function createTarball(
     process.exitCode = 1;
     return false;
   }
-  const result = spawnSync(
-    "tar",
-    ["czf", partial, "-C", dirname(collectDir), basename(collectDir)],
-    {
-      stdio: "inherit",
-      timeout: timeoutMs,
-    },
-  );
-  if (result.status !== 0 || result.signal) {
-    const reason = result.signal
-      ? `killed by signal ${result.signal}`
-      : `exited with code ${result.status ?? "unknown"}`;
-    error(`Failed to create tarball at ${output} (tar ${reason})`);
-    try {
-      rmSync(partial, { force: true });
-    } catch {
-      /* best-effort cleanup of partial tarball */
-    }
-    process.exitCode = 1;
-    return false;
-  }
+  let staged = false;
   try {
-    chmodSync(partial, 0o600);
+    const result = spawnSync(
+      "tar",
+      ["czf", "-", "-C", dirname(collectDir), basename(collectDir)],
+      {
+        stdio: ["ignore", fd, "inherit"],
+        timeout: timeoutMs,
+      },
+    );
+    if (result.status !== 0 || result.signal) {
+      const reason = result.signal
+        ? `killed by signal ${result.signal}`
+        : `exited with code ${result.status ?? "unknown"}`;
+      error(`Failed to create tarball at ${output} (tar ${reason})`);
+      return false;
+    }
+    fchmodSync(fd, 0o600);
+    // rename() never follows the source: if the staging path was swapped for
+    // a symlink after we opened it, this moves the symlink itself, leaving
+    // our written data orphaned under `partial` rather than publishing
+    // through the link. Worst case is a failed/misplaced bundle, not a write
+    // through an attacker's symlink.
     renameSync(partial, output);
+    staged = true;
   } catch (err) {
     error(
       `Failed to move tarball into place at ${output}: ${err instanceof Error ? err.message : String(err)}`,
     );
-    try {
-      rmSync(partial, { force: true });
-    } catch {
-      /* best-effort */
-    }
-    process.exitCode = 1;
     return false;
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      /* best-effort close of staging descriptor */
+    }
+    if (!staged) {
+      process.exitCode = 1;
+      try {
+        rmSync(partial, { force: true });
+      } catch {
+        /* best-effort cleanup of partial tarball */
+      }
+    }
   }
   info(`Tarball written to ${output}`);
   warn(

--- a/src/lib/diagnostics/tarball.ts
+++ b/src/lib/diagnostics/tarball.ts
@@ -20,13 +20,17 @@ import { basename, dirname } from "node:path";
 // defeats every in-process identity check below, including ones that run
 // after createTarball() has already returned and the caller has moved on.
 // The sticky bit (mode 1777, as on a standard /tmp) is what makes a shared
-// directory safe for this at all: it restricts removing or renaming an
-// entry to its owner (or root) regardless of the directory's own write
-// permissions. A directory only the current user can write to needs no
-// sticky bit for the same reason. Refusing to stage into anything else is
-// the one check here that closes the race for good instead of narrowing it.
+// directory safe for this, but only when a trusted party owns it: sticky
+// semantics stop everyone *except* the directory's own owner from touching
+// entries they don't own, so an attacker-owned sticky-and-world-writable
+// directory offers no protection at all — its owner can still remove or
+// replace our file regardless of the bit. A directory only the current
+// user can write to needs neither the sticky bit nor an ownership check
+// for the same reason. Refusing to stage into anything else is the one
+// check here that closes the race for good instead of narrowing it.
 const MODE_GROUP_OR_OTHER_WRITABLE = 0o022;
 const MODE_STICKY = 0o1000;
+const ROOT_UID = 0;
 
 function outputDirectoryTrustworthy(outputPath: string): boolean {
   let dirStat: ReturnType<typeof statSync>;
@@ -38,8 +42,12 @@ function outputDirectoryTrustworthy(outputPath: string): boolean {
     return true;
   }
   const writableByOthers = (dirStat.mode & MODE_GROUP_OR_OTHER_WRITABLE) !== 0;
+  if (!writableByOthers) return true;
   const stickyProtected = (dirStat.mode & MODE_STICKY) !== 0;
-  return !writableByOthers || stickyProtected;
+  if (!stickyProtected) return false;
+  if (typeof process.getuid !== "function") return true;
+  const currentUid = process.getuid();
+  return dirStat.uid === currentUid || dirStat.uid === ROOT_UID;
 }
 
 export interface CreateTarballOptions {
@@ -181,8 +189,12 @@ export function createTarball(
       process.exitCode = 1;
       try {
         rmSync(partial, { force: true });
-      } catch {
-        /* best-effort cleanup of partial tarball */
+      } catch (cleanupErr) {
+        error(
+          `Additionally failed to remove the leftover partial archive at ${partial}: ` +
+            `${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}. ` +
+            "It may contain collected diagnostics; remove it by hand before retrying.",
+        );
       }
     }
   }

--- a/src/lib/diagnostics/tarball.ts
+++ b/src/lib/diagnostics/tarball.ts
@@ -15,19 +15,20 @@ import {
 } from "node:fs";
 import { basename, dirname } from "node:path";
 
-// A directory another local account can write to without the sticky bit
-// set lets that account rename or delete entries it does not own — which
-// defeats every in-process identity check below, including ones that run
+// Ownership is checked unconditionally, not only when the directory's mode
+// bits show group/other write access: a POSIX ACL can grant another
+// account write authority over a directory whose traditional mode bits
+// show none, and Node's fs.Stats does not expose ACL entries at all — mode
+// bits alone are not proof of who can actually write here. Any owner other
+// than the current user or root retains full authority to rename or
+// replace our entries no matter what wrote them, at any point, including
 // after createTarball() has already returned and the caller has moved on.
-// The sticky bit (mode 1777, as on a standard /tmp) is what makes a shared
-// directory safe for this, but only when a trusted party owns it: sticky
-// semantics stop everyone *except* the directory's own owner from touching
-// entries they don't own, so an attacker-owned sticky-and-world-writable
-// directory offers no protection at all — its owner can still remove or
-// replace our file regardless of the bit. A directory only the current
-// user can write to needs neither the sticky bit nor an ownership check
-// for the same reason. Refusing to stage into anything else is the one
-// check here that closes the race for good instead of narrowing it.
+// A directory whose mode bits additionally show group/other write access
+// also needs the sticky bit (mode 1777, as on a standard /tmp): sticky
+// semantics are what stop accounts OTHER than the trusted owner just
+// established above from touching entries they don't own. Refusing to
+// stage into anything else is the one check here that closes the race for
+// good instead of narrowing it.
 const MODE_GROUP_OR_OTHER_WRITABLE = 0o022;
 const MODE_STICKY = 0o1000;
 const ROOT_UID = 0;
@@ -41,13 +42,13 @@ function outputDirectoryTrustworthy(outputPath: string): boolean {
     // fail with its own, more specific error instead of a generic refusal.
     return true;
   }
+  if (typeof process.getuid === "function") {
+    const currentUid = process.getuid();
+    if (dirStat.uid !== currentUid && dirStat.uid !== ROOT_UID) return false;
+  }
   const writableByOthers = (dirStat.mode & MODE_GROUP_OR_OTHER_WRITABLE) !== 0;
   if (!writableByOthers) return true;
-  const stickyProtected = (dirStat.mode & MODE_STICKY) !== 0;
-  if (!stickyProtected) return false;
-  if (typeof process.getuid !== "function") return true;
-  const currentUid = process.getuid();
-  return dirStat.uid === currentUid || dirStat.uid === ROOT_UID;
+  return (dirStat.mode & MODE_STICKY) !== 0;
 }
 
 export interface CreateTarballOptions {
@@ -79,11 +80,12 @@ export function createTarball(
   // detect or prevent (#10195).
   if (!outputDirectoryTrustworthy(output)) {
     error(
-      `Refusing to stage a tarball under ${dirname(output)}: this directory is writable by ` +
-        "other local accounts and does not have the sticky bit set, so a file placed here can " +
-        "be renamed or replaced by another local user at any point, including after this " +
-        "command reports success. Choose a directory only this account can write to, or one " +
-        "with the sticky bit set (mode 1777, as on a standard /tmp).",
+      `Refusing to stage a tarball under ${dirname(output)}: another local account may be able ` +
+        "to rename or replace a file placed here, at any point, including after this command " +
+        "reports success — either because it owns the directory, or because it can write to " +
+        "it without the sticky bit set to protect entries it doesn't own. Choose a directory " +
+        "owned by this account (or root) that either isn't writable by other accounts, or has " +
+        "the sticky bit set (mode 1777, as on a standard /tmp).",
     );
     process.exitCode = 1;
     return false;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`createTarball()` staged the debug bundle at a predictable `<output>.partial.<pid>` path with no prior existence check, so a local user could plant a symlink there ahead of time and have `tar`'s write follow it, overwriting an arbitrary target with tarball bytes — or, without any race at all, simply read the published bundle, which was left mode 0644 even though it's the file the CLI tells users to attach to public GitHub issues. The code now claims the staging path with `O_EXCL|O_NOFOLLOW` before `tar` ever touches it, holds that descriptor open for the entire write and permission change so nothing reopens the staging path by name, verifies the held descriptor's identity against the pathname both before and after the final publish step, and — since no in-function check can protect the published file after the caller has moved on — refuses to stage into any directory another local account has standing authority over in the first place.

## Related Issue

Fixes #10195

## Changes

- `src/lib/diagnostics/tarball.ts` (commit `f6a1ae3d1e`): open the `.partial.<pid>` staging path with `fs.openSync(partial, O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW, 0o600)` before invoking `tar`. `O_EXCL` refuses a path another local user already planted (file or symlink).
- `src/lib/diagnostics/tarball.ts` (commit `51ce292687`, revised after a GPT-5.6-sol max-effort review — see below): the first version closed that descriptor and let `tar` and a follow-up `chmodSync` reopen the staging path *by name*, which left the exact TOCTOU window open again — `O_NOFOLLOW` only ever protected the initial claim, not tar's or chmod's separate reopen. Fixed by holding the descriptor open for the whole operation: `tar` now streams the archive to stdout, redirected into the already-claimed descriptor (`spawnSync("tar", ["czf", "-", ...], { stdio: ["ignore", fd, "inherit"] })`), and the mode is fixed with `fchmodSync(fd, 0o600)` on that same descriptor. No step after the initial claim ever reopens the staging path by name, so there's nothing left for a swapped path to redirect. The final `renameSync(partial, output)` still resolves by name, but `rename()` never dereferences its source — a path swapped in after the write can at most misdirect the published artifact (denial of service), never redirect a write into it.
- `src/lib/diagnostics/debug.test.ts`: two tests from the first commit. One asserts the tarball ends up mode 0600, not the previous 0644. One pre-plants a symlink at the exact staging path (`${output}.partial.${process.pid}`, computable in-process) pointing at a victim file, then asserts the victim's content is unchanged and the call fails closed — proving a symlink planted *before* the call is refused.
- `src/lib/diagnostics/tarball.race.test.ts` (new file, second commit): two tests that simulate the swap happening *mid-call*, after the exclusive claim succeeds — the case the first round of tests couldn't reach. A mocked `spawnSync` writes through whichever descriptor it's actually handed (proving the data path is the fd, not the name) and, in the second test, swaps the staging path for a symlink to a victim file in between the claim and the write — proving the victim's content and permissions stay untouched regardless.
- `src/lib/diagnostics/tarball.ts` (commit `d19bcd8c3a`): the repo's own PR Review Advisor caught a residual gap in `3ead2709a5` that neither Codex round flagged as a blocker — `renameSync(partial, output)` is still pathname-based, so a path swapped in after the claim gets *renamed onto `output`* (rename never dereferences its source, so this succeeds) instead of causing an overwrite. `createTarball()` returned `true` and told the caller to attach `output` to a GitHub issue while `output` was attacker-chosen content, not the generated archive. Fixed by comparing the held descriptor's identity (`fstatSync(fd)` dev+ino) against the pathname (`lstatSync(partial)`) immediately before the rename, and failing closed on a mismatch instead of proceeding. `debug.test.ts`'s post-claim swap test now asserts failure (`ok === false`, `exitCode === 1`, no success message, `output` never created) per the advisor's own verification note, and I confirmed the assertion is load-bearing by reverting the check locally and watching the test catch it. `aa612e9eae` is a follow-up comment-only commit correcting the function-level docstring, which still described the now-closed "misplace the bundle" outcome.
- `src/lib/diagnostics/tarball.ts` (commit `7844507ad9`): the advisor's Trust and Operations specialists both independently caught the same further gap in `d19bcd8c3a` — the pre-rename identity check and `renameSync()` are two separate calls that Node's `fs` API cannot make atomic with each other, so a swap in the (narrow) window between them still slipped through. Added a second identity check immediately *after* the rename, comparing the held descriptor against what actually landed at `output`; on a mismatch, the wrongly published content is removed and the call fails closed instead of ever reporting success. `tarball.race.test.ts` gained a third test that injects the swap from inside a mocked `renameSync` (real implementation preserved via `vi.importActual`, invoked after the swap) so the substitution lands in the exact window the first two tests couldn't reach.
- `src/lib/diagnostics/tarball.ts` (commits `729ffd7fe7`, `6145050070`, `0145c9ea73`): the advisor's Trust specialist then identified the actual root cause across three more rounds — no check *inside* `createTarball()` can protect `output` after the function returns and the caller moves on, because an attacker with standing write access to the directory can always act in that unbounded window. `729ffd7fe7` adds `outputDirectoryTrustworthy()`: refuse to stage into any directory that's writable by other local accounts without the sticky bit set — the same property that makes a standard `/tmp` (mode 1777) safe by convention. `6145050070` closed the gap that a sticky bit only protects against non-owner accounts, not the directory's own owner, who retains full authority regardless of the bit — now also requires the directory be owned by the current user or root. `0145c9ea73` closed the last gap Trust found: the ownership check only ran inside the writable-by-others branch, so a directory with no group/other mode bits (0700) skipped it — but Node's `fs.Stats` has no visibility into POSIX ACLs, which can grant write access despite restrictive mode bits, so ownership is now checked unconditionally, before mode bits are even considered. Each step added a dedicated regression test (rejecting the unsafe shape, accepting the legitimate `/tmp`-shaped one) and was confirmed load-bearing by reverting locally. Also folded in Operations' finding on the same commits: two `catch` blocks around best-effort cleanup were silently swallowing `rmSync` failures on a leftover archive that can contain collected diagnostics — both now report the cleanup failure and the affected path through the same error callback instead of hiding it.

No new abstraction, configuration, fallback, or compatibility path — this restores the same staging-file safety idiom already established elsewhere in the codebase to a call site that predates it.

### Second-opinion review

Two rounds of a GPT-5.6-sol max-effort Codex review (`codex exec -s read-only -m gpt-5.6-sol -c model_reasoning_effort="max"`), each independently verified against source rather than taken on trust:

- **Round 1** (against `f6a1ae3d1e`): found the close-then-reopen gap described above (blocker), plus that the added test only proved pre-plant rejection and not the post-claim race, the CLI's `/tmp/nemoclaw-debug.tar.gz` example remains squattable for a name-collision denial of service (docs/UX follow-up, not data compromise, outside this issue's scope), and a `closeSync()`-failure edge case. A Fable-adjudicated plan produced the `51ce292687` revision.
- **Round 2** (against `51ce292687`): confirmed the blocker RESOLVED (tar and `fchmodSync` never reopen the staging path by name) and the cleanup-leak finding RESOLVED, agreed the `/tmp` example is an acceptable follow-up, but flagged that the two new race tests never asserted tar was actually invoked in the fd-streaming form — they'd have kept passing even if the code regressed back to the vulnerable `["czf", partial, ...]` form. Fixed in `3ead2709a5`, which adds that assertion and confirms it's load-bearing by reverting the fix locally and watching the test catch it.

Net result after 2 rounds (the requested cap): Codex assessed the implementation sound end to end ("System security — PASS, arbitrary-overwrite TOCTOU is closed") after round 1's blocker landed; round 2's only note was test rigor, closed in `3ead2709a5`.

A third, independent signal caught something the first two didn't: the repo's built-in **PR Review Advisor** (runs automatically on every push, not Codex) posted a genuine blocker (`PRA-1`) against `3ead2709a5` — the pathname-based `renameSync` publish step could still succeed with attacker-chosen content at `output` after a post-claim swap, framed sharper than Codex's "denial of service" characterization: it's a false-success report that could lead a user to attach or share attacker-controlled content believing it's their diagnostic bundle. Verified against source and fixed in `d19bcd8c3a`. This is the value of running multiple independent reviewers with different framings — each pass caught something the others didn't.

I also ran this repo's `nemoclaw-maintainer-security-code-review` skill (the nine-category checklist) against `aa612e9eae` myself: Secrets/Credentials, Input Validation, Auth, Dependencies, Crypto, and Configuration all PASS/not-applicable; Error Handling PASS; Security Testing PASS; System Security PASS. That review's account of "no bypass found across three independent passes" turned out to be premature — the advisor kept finding real, narrower gaps on every subsequent push:

- **Round 3** (Trust + Operations, against `3ead2709a5`): the pre-rename-check-to-rename window itself (blocker, fixed `7844507ad9`) and a second silently-swallowed cleanup error (fixed same commit).
- **Round 4** (Trust, against `7844507ad9`): identified the actual root cause — no in-function check can protect `output` after the function returns — leading to the directory-trustworthiness check (`729ffd7fe7`).
- **Round 5** (Trust, against `729ffd7fe7`): sticky bit doesn't restrict the directory's own *owner*; added the ownership check (`6145050070`), which also let Operations report clean on that commit.
- **Round 6** (Trust, against `6145050070`): the ownership check only ran when mode bits showed group/other write access, missing a POSIX-ACL-granted case with restrictive mode bits; made the ownership check unconditional (`0145c9ea73`).
- **Round 7** (Trust + Operations, against `0145c9ea73`): both specialists reported no further defect. This is the first fully clean pass since review began.

Net effect: the directory itself (owned by the current user or root, and either not shared-writable or sticky-protected) is now the actual trust boundary, rather than an ever-narrower set of in-function timing checks — which is what let the last round close cleanly instead of yielding another residual. One accepted residual, unrelated to this convergence and out of this issue's scope: the CLI's own `/tmp/nemoclaw-debug.tar.gz` example remains squattable for a filename-collision denial of service (no data compromise) — separable follow-up, not filed yet.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: self-review via `nemoclaw-maintainer-security-code-review`'s nine-category checklist, 2 rounds of GPT-5.6-sol max-effort Codex, and 5 rounds of the repo's automated PR Review Advisor (see Second-opinion review section) — the final advisor round (against `0145c9ea73`) reported no further defect from either the Trust or Operations specialist. A maintainer pass is still expected before merge — this checkbox records contributor-side review completion, not a waiver of maintainer review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

Not applicable — this PR does not change `scripts/prepare-dgx-station-host.sh`.

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Documentation Writer Review

- [x] Documentation writer reviewed the completed implementation
- Result: `no-docs-needed`
- Evidence: `docs/reference/commands.mdx`'s description of `nemoclaw debug` (rename-on-success, preserve-on-failure) is unaffected — this change only hardens the undocumented internal staging-file permissions and symlink handling. No page in `docs/` mentions the `.partial.<pid>` staging path, permission bits, or symlink behavior.
- Agent: Claude Code (independent subagent review, this session)
<!-- docs-review-revision: 8da584e55 -->

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/diagnostics` — 3 files, 46 tests passed (4 in `debug.test.ts` for #10195, 5 in `tarball.race.test.ts`); `npm run typecheck:cli` clean; `npm --prefix nemoclaw run typecheck` clean; `npm run checks:repository` clean. Every new assertion added across all commits was confirmed load-bearing by reverting its corresponding fix locally and watching the test fail, then restoring it.
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm run checks:repository` clean (architecture budgets, test-project membership, guardrails, all passed). `npm run check` (`prek run --all-files`) ran to completion except the `hadolint` hook, which errored locally with `No such file or directory` — that binary isn't installed on this machine; it lints Dockerfiles and this diff touches none. Every other pre-commit and manual-stage hook in that run passed.
  - **Known unrelated CI red:** the live `codebase-growth-guardrails` check fails deterministically on this PR (reconfirmed on every commit through `0145c9ea73`) with `Command failed: git rev-parse --verify origin/main` (exit 128), inside `growth-guardrails.test.ts`'s own helper. Traced this to the job's "Check out the trusted base revision" step, which checks out the base as a bare pinned SHA (`fetch-depth: 1`, `fetch-tags: false`, `ref: <sha>`, not `ref: main`) — so no `origin/main` ref is ever created for that helper to resolve, regardless of this PR's diff content. A sibling open PR (#10355) passed the identical check cleanly, and another (#10356) failed it with an unrelated hook timeout — so this looks like an existing gap in that checkout step's ref availability, not something caused by or fixable from this diff. I don't have rerun permission as an outside contributor (`cannot be rerun; Must have admin rights to Repository`) to test whether it's transient.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
<!-- reviewed-head-sha: 0145c9ea730f973877a3bfc6d79275dcf1ea7a38 -->
Signed-off-by: harjoth <harjoth.khara@gmail.com>






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostic archive creation with safer file and directory handling.
  - Prevented archive generation through symlinked or insecure staging paths.
  - Added protection against race conditions and unauthorized directory ownership.
  - Ensured generated archives use owner-only permissions.
  - Improved cleanup of incomplete or invalid output when archive creation fails.

- **Tests**
  - Added comprehensive coverage for permissions, symlinks, ownership validation, race conditions, and failure recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->