### PR TITLE
fix(onboard): bind source installs to image revision

### DIFF
--- a/src/lib/onboard/managed-workload/onboard-orchestration.test.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.test.ts
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 
 import { createHermesStateVolumeDockerHarness } from "../__test-helpers__/hermes-state-volume";
 
@@ -14,6 +14,9 @@ const preparationState = vi.hoisted(() => ({
   useUnavailableCatalog: false,
 }));
 const prepareSandboxWorkloadSource = vi.hoisted(() => vi.fn());
+const INSTALLED_REVISION = vi.hoisted(() => "d".repeat(40));
+const releaseRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-release-root-"));
+fs.writeFileSync(path.join(releaseRoot, ".version"), "0.0.0\n");
 
 vi.mock("../workload/preparation", async (importOriginal) => {
   const original = await importOriginal<typeof import("../workload/preparation")>();
@@ -30,7 +33,10 @@ vi.mock("../workload/preparation", async (importOriginal) => {
   return { ...original, prepareSandboxWorkloadSource };
 });
 
-vi.mock("../../core/version", () => ({ getVersion: () => "v0.0.0" }));
+vi.mock("../../core/version", () => ({
+  getBuildIdentity: () => ({ nemoclawVersion: "0.0.0", sourceRevision: INSTALLED_REVISION }),
+  getVersion: () => "v0.0.0",
+}));
 
 import {
   createManagedHermesStateVolumeOnboardLifecycle,
@@ -71,7 +77,7 @@ function createFreshOnboardingRuntime(
       agentName: "openclaw",
       legacyDockerfilePath: "agents/openclaw/Dockerfile",
       customDockerfilePath: null,
-      rootDir: "/tmp/nemoclaw",
+      rootDir: releaseRoot,
       model: "model",
       provider: "provider",
       preferredInferenceApi: null,
@@ -118,6 +124,10 @@ async function expectUnsupportedHermesPortableSources(
 }
 
 describe("managed workload onboard orchestration", () => {
+  afterAll(() => {
+    fs.rmSync(releaseRoot, { force: true, recursive: true });
+  });
+
   it("activates stock managed images only for shipped agents outside Portable", () => {
     expect(
       shouldActivateStockManagedRuntime({
@@ -293,6 +303,17 @@ describe("managed workload onboard orchestration", () => {
     await expect(runtime.ensurePreparedWorkload()).resolves.toBe(prepared);
     expect(prepareSandboxWorkloadSource).toHaveBeenCalledOnce();
     expect(prepareSandboxWorkloadSource.mock.calls[0]?.[0]).not.toHaveProperty("catalogRevision");
+  });
+
+  it("retains an exact installed revision outside GitHub Actions", async () => {
+    const { prepared, runtime } = createFreshOnboardingRuntime({
+      NEMOCLAW_INSTALL_REF: INSTALLED_REVISION,
+    });
+
+    await expect(runtime.ensurePreparedWorkload()).resolves.toBe(prepared);
+    expect(prepareSandboxWorkloadSource).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ catalogRevision: INSTALLED_REVISION }),
+    );
   });
 
   it("resolves final-image patch metadata after managed build-context staging", async () => {

--- a/src/lib/onboard/managed-workload/onboard-orchestration.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.ts
@@ -20,10 +20,7 @@ import {
 } from "../docker-gpu-route";
 import type { HermesDashboardOnboardState } from "../hermes-dashboard";
 import type { InitialSandboxPolicy } from "../initial-policy";
-import {
-  isShippedManagedImageAgent,
-  managedImageRuntimeIdentity,
-} from "../managed-image/contract";
+import { isShippedManagedImageAgent, managedImageRuntimeIdentity } from "../managed-image/contract";
 import {
   type BuiltManagedStartupOnboardProfile,
   buildManagedStartupOnboardProfile,
@@ -57,6 +54,7 @@ import {
 import { getSandboxReadyTimeoutSecs } from "../sandbox-gpu-create";
 import type { SandboxGpuConfig } from "../sandbox-gpu-mode";
 import {
+  installedManagedImageCatalogRevision,
   liveE2eManagedImageCatalog,
   liveE2eManagedImageRevision,
   type PreparedSandboxWorkloadSource,
@@ -238,11 +236,16 @@ export function createManagedWorkloadOnboardRuntime(
   let preparedProfile: BuiltManagedStartupOnboardProfile | null = null;
 
   const ensurePreparedWorkload = async (): Promise<PreparedSandboxWorkloadSource> => {
-    const catalogRevision = liveE2eManagedImageRevision(input.startupProfile.environment);
+    const liveCatalogRevision = liveE2eManagedImageRevision(input.startupProfile.environment);
     const liveCatalog = liveE2eManagedImageCatalog(input.startupProfile.environment);
-    if (catalogRevision && liveCatalog) {
+    if (liveCatalogRevision && liveCatalog) {
       throw new Error("live E2E managed-image revision and catalog authority conflict");
     }
+    const catalogRevision =
+      liveCatalogRevision ??
+      (liveCatalog || input.tempManagedRuntimeCatalog || input.managedWorkloadRebuild
+        ? null
+        : installedManagedImageCatalogRevision(input.startupProfile.environment, input.rootDir));
     preparedWorkloadPromise ??= input.managedWorkloadRebuild
       ? Promise.resolve(
           prepareSandboxWorkloadSourceFromRebuildHandoff(

--- a/src/lib/onboard/sandbox-workload-preparation.test.ts
+++ b/src/lib/onboard/sandbox-workload-preparation.test.ts
@@ -25,6 +25,7 @@ import {
 } from "./managed-image/contract";
 import { createRuntimeProviderBundleRegistry } from "./runtime-provider/registry";
 import {
+  installedManagedImageCatalogRevision,
   liveE2eManagedImageCatalog,
   prepareSandboxWorkloadSource,
   SandboxWorkloadPreparationError,
@@ -86,6 +87,66 @@ function input(agentName: string) {
 }
 
 describe("sandbox workload preparation", () => {
+  it("pins an untagged installed build to its exact source revision", () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-untagged-build-"));
+    fs.writeFileSync(path.join(fixtureRoot, "package.json"), JSON.stringify({ version: "0.1.0" }));
+    fs.writeFileSync(path.join(fixtureRoot, ".source-revision"), REVISION);
+    try {
+      expect(installedManagedImageCatalogRevision({}, fixtureRoot)).toBe(REVISION);
+    } finally {
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps a matching tagged install on its release catalog", () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-release-build-"));
+    fs.writeFileSync(path.join(fixtureRoot, "package.json"), JSON.stringify({ version: "0.0.97" }));
+    fs.writeFileSync(path.join(fixtureRoot, ".source-revision"), REVISION);
+    fs.writeFileSync(path.join(fixtureRoot, ".version"), "0.0.97\n");
+    try {
+      expect(installedManagedImageCatalogRevision({}, fixtureRoot)).toBeNull();
+    } finally {
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("honors an exact install ref only when it matches the installed build", () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-exact-build-"));
+    fs.writeFileSync(path.join(fixtureRoot, "package.json"), JSON.stringify({ version: "0.0.97" }));
+    fs.writeFileSync(path.join(fixtureRoot, ".source-revision"), REVISION);
+    fs.writeFileSync(path.join(fixtureRoot, ".version"), "0.0.97\n");
+    try {
+      expect(
+        installedManagedImageCatalogRevision({ NEMOCLAW_INSTALL_REF: REVISION }, fixtureRoot),
+      ).toBe(REVISION);
+      expect(() =>
+        installedManagedImageCatalogRevision({ NEMOCLAW_INSTALL_REF: "a".repeat(40) }, fixtureRoot),
+      ).toThrow("the exact install ref does not match the installed build identity");
+      expect(() =>
+        installedManagedImageCatalogRevision(
+          { NEMOCLAW_INSTALL_REF: REVISION.toUpperCase() },
+          fixtureRoot,
+        ),
+      ).toThrow("is not a supported lowercase 40-character source revision");
+    } finally {
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("does not treat a mutable install ref as revision authority", () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-mutable-build-"));
+    fs.writeFileSync(path.join(fixtureRoot, "package.json"), JSON.stringify({ version: "0.0.97" }));
+    fs.writeFileSync(path.join(fixtureRoot, ".source-revision"), REVISION);
+    fs.writeFileSync(path.join(fixtureRoot, ".version"), "0.0.97\n");
+    try {
+      expect(
+        installedManagedImageCatalogRevision({ NEMOCLAW_INSTALL_REF: "main" }, fixtureRoot),
+      ).toBeNull();
+    } finally {
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
   it("selects an exact embedded catalog only for live PR E2E (#9464)", () => {
     const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-live-e2e-catalog-"));
     const catalogPath = path.join(fixtureRoot, "catalog.json");

--- a/src/lib/onboard/sandbox-workload-preparation.test.ts
+++ b/src/lib/onboard/sandbox-workload-preparation.test.ts
@@ -123,6 +123,9 @@ describe("sandbox workload preparation", () => {
         installedManagedImageCatalogRevision({ NEMOCLAW_INSTALL_REF: "a".repeat(40) }, fixtureRoot),
       ).toThrow("the exact install ref does not match the installed build identity");
       expect(() =>
+        installedManagedImageCatalogRevision({ NEMOCLAW_INSTALL_REF: "a".repeat(39) }, fixtureRoot),
+      ).toThrow("is not a supported lowercase 40-character source revision");
+      expect(() =>
         installedManagedImageCatalogRevision(
           { NEMOCLAW_INSTALL_REF: REVISION.toUpperCase() },
           fixtureRoot,

--- a/src/lib/onboard/sandbox-workload-preparation.test.ts
+++ b/src/lib/onboard/sandbox-workload-preparation.test.ts
@@ -98,6 +98,19 @@ describe("sandbox workload preparation", () => {
     }
   });
 
+  it("rejects a truncated installed source revision (#8379)", () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-truncated-build-"));
+    fs.writeFileSync(path.join(fixtureRoot, "package.json"), JSON.stringify({ version: "0.1.0" }));
+    fs.writeFileSync(path.join(fixtureRoot, ".source-revision"), "a".repeat(39));
+    try {
+      expect(() => installedManagedImageCatalogRevision({}, fixtureRoot)).toThrow(
+        "Could not resolve the immutable NemoClaw source revision.",
+      );
+    } finally {
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
   it("keeps a matching tagged install on its release catalog", () => {
     const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-release-build-"));
     fs.writeFileSync(path.join(fixtureRoot, "package.json"), JSON.stringify({ version: "0.0.97" }));

--- a/src/lib/onboard/workload/preparation.ts
+++ b/src/lib/onboard/workload/preparation.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 
+import { getBuildIdentity } from "../../core/version";
 import {
   ManagedImageCatalogUnavailableError,
   normalizeManagedImageRelease,
@@ -35,6 +36,9 @@ type ResolveManagedImageCatalog = (options: {
   readonly revision?: string;
 }) => Promise<ManagedImageContractCatalog>;
 
+const EXACT_SOURCE_REVISION_PATTERN = /^[0-9a-f]{40}$/u;
+const SOURCE_REVISION_REF_PATTERN = /^[0-9A-Fa-f]{40,64}$/u;
+
 export interface PrepareSandboxWorkloadSourceInput {
   readonly agentName: string;
   readonly legacyDockerfilePath: string;
@@ -53,6 +57,57 @@ export function liveE2eManagedImageRevision(environment: NodeJS.ProcessEnv): str
   if (environment.GITHUB_ACTIONS !== "true") return null;
   const revision = environment.E2E_MANAGED_IMAGE_REVISION?.trim();
   return revision ? revision : null;
+}
+
+function hasMatchingReleaseStamp(rootDir: string, version: string): boolean {
+  let stampedVersion: string;
+  try {
+    stampedVersion = fs.readFileSync(path.join(rootDir, ".version"), "utf8").trim();
+  } catch {
+    return false;
+  }
+  if (!stampedVersion) return false;
+  try {
+    return normalizeManagedImageRelease(stampedVersion) === normalizeManagedImageRelease(version);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Select the installed source revision for an untagged or exact-SHA install.
+ * Tagged release installs retain the release catalog alias written by the
+ * installer. The build identity, not the caller-provided ref, remains the
+ * source of revision authority.
+ */
+export function installedManagedImageCatalogRevision(
+  environment: NodeJS.ProcessEnv,
+  rootDir: string,
+): string | null {
+  const identity = getBuildIdentity({ rootDir });
+  const installRef = environment.NEMOCLAW_INSTALL_REF?.trim() ?? "";
+  if (EXACT_SOURCE_REVISION_PATTERN.test(installRef)) {
+    if (installRef !== identity.sourceRevision) {
+      throw new SandboxWorkloadPreparationError(
+        "the exact install ref does not match the installed build identity",
+      );
+    }
+    return identity.sourceRevision;
+  }
+  if (SOURCE_REVISION_REF_PATTERN.test(installRef)) {
+    throw new SandboxWorkloadPreparationError(
+      "the exact install ref is not a supported lowercase 40-character source revision",
+    );
+  }
+
+  if (hasMatchingReleaseStamp(rootDir, identity.nemoclawVersion)) return null;
+  if (!EXACT_SOURCE_REVISION_PATTERN.test(identity.sourceRevision)) {
+    throw new SandboxWorkloadPreparationError(
+      "the installed build identity does not contain an exact managed-image source revision",
+    );
+  }
+
+  return identity.sourceRevision;
 }
 
 export interface LiveE2eManagedImageCatalog {

--- a/src/lib/onboard/workload/preparation.ts
+++ b/src/lib/onboard/workload/preparation.ts
@@ -37,7 +37,7 @@ type ResolveManagedImageCatalog = (options: {
 }) => Promise<ManagedImageContractCatalog>;
 
 const EXACT_SOURCE_REVISION_PATTERN = /^[0-9a-f]{40}$/u;
-const SOURCE_REVISION_REF_PATTERN = /^[0-9A-Fa-f]{40,64}$/u;
+const SOURCE_REVISION_REF_PATTERN = /^[0-9A-Fa-f]{39,64}$/u;
 
 export interface PrepareSandboxWorkloadSourceInput {
   readonly agentName: string;

--- a/test/helpers/managed-image-buildless-e2e.ts
+++ b/test/helpers/managed-image-buildless-e2e.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 
 import { expect } from "vitest";
 
+import { getBuildIdentity } from "../../src/lib/core/version";
 import {
   MANAGED_IMAGE_CAPABILITY_CONTRACT_VERSION,
   MANAGED_IMAGE_CONTRACT_VERSION,
@@ -30,7 +31,7 @@ const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
 const MANAGED_IMAGE_PLATFORM = "linux/amd64" as const;
 const MODEL = "nvidia/test-managed-model";
 const PROVIDER = "nvidia-prod";
-const SOURCE_REVISION = "2f03907c3a7ec151d7f5d4bb2a73abafc2849f83";
+const SOURCE_REVISION = getBuildIdentity({ rootDir: REPO_ROOT }).sourceRevision;
 const CATALOG_RELEASE = "v0.0.97";
 const AUTHENTICATED_PROXY_ENVIRONMENT = {
   HTTP_PROXY: "http://upper-http:upper-secret@upper-http.example.test:18080",

--- a/test/helpers/onboard-script-mocks.cjs
+++ b/test/helpers/onboard-script-mocks.cjs
@@ -469,6 +469,10 @@ function mockManagedImageCatalog() {
   const contract = require(
     path.resolve(__dirname, "../../src/lib/onboard/managed-image/contract.ts"),
   );
+  const { getBuildIdentity } = require(path.resolve(__dirname, "../../src/lib/core/version.ts"));
+  const sourceRevision = getBuildIdentity({
+    rootDir: path.resolve(__dirname, "../.."),
+  }).sourceRevision;
   catalog.resolveManagedImageCatalogFromGhcr = async ({ release, platform }) =>
     Object.fromEntries(
       contract.SHIPPED_MANAGED_IMAGE_AGENTS.map((agent, index) => {
@@ -485,7 +489,7 @@ function mockManagedImageCatalog() {
             reference: `${image}@${digest}`,
             source: {
               repository: contract.MANAGED_IMAGE_SOURCE_REPOSITORY,
-              revision: "a".repeat(40),
+              revision: sourceRevision,
               release,
               cohort: "ghrun-9068-1",
             },

--- a/test/onboarding/onboard.test.ts
+++ b/test/onboarding/onboard.test.ts
@@ -1011,7 +1011,7 @@ catalog.resolveManagedImageCatalogFromGhcr = async ({ release, platform }) =>
       reference: image + "@" + digest,
       source: {
         repository: contract.MANAGED_IMAGE_SOURCE_REPOSITORY,
-        revision: "a".repeat(40),
+        revision: process.env.NEMOCLAW_E2E_EXPECTED_SHA?.trim() || "a".repeat(40),
         release,
         cohort: "ghrun-9068-1",
       },

--- a/test/onboarding/onboard.test.ts
+++ b/test/onboarding/onboard.test.ts
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { getBuildIdentity } from "../../src/lib/core/version.js";
 import { appendHostProxyEnvArgs } from "../../src/lib/onboard/host-proxy-env.js";
 import {
   isValidInferenceInputsOverride,
@@ -942,6 +943,7 @@ const { createSandbox } = require(${onboardPath});
 
   it("rejects portable managed bootstrap before recreate state mutation (#9068)", () => {
     const repoRoot = path.join(import.meta.dirname, "../..");
+    const catalogRevision = getBuildIdentity({ rootDir: repoRoot }).sourceRevision;
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-portable-managed-recreate-"));
     const fakeBin = path.join(tmpDir, "bin");
     const scriptPath = path.join(tmpDir, "portable-managed-recreate.js");
@@ -1011,7 +1013,7 @@ catalog.resolveManagedImageCatalogFromGhcr = async ({ release, platform }) =>
       reference: image + "@" + digest,
       source: {
         repository: contract.MANAGED_IMAGE_SOURCE_REPOSITORY,
-        revision: process.env.NEMOCLAW_E2E_EXPECTED_SHA?.trim() || "a".repeat(40),
+        revision: ${JSON.stringify(catalogRevision)},
         release,
         cohort: "ghrun-9068-1",
       },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Bind ordinary exact-source installs to the managed-image catalog published for the installed build revision. Tagged releases continue to use their release catalog alias, while mismatched or malformed exact refs fail before sandbox preparation.

## Related Issue

Related to #8379. This follows the source-install managed-image contract established by #4080.

## Changes

- Derive the catalog revision from the installed build identity for untagged source installs.
- Require a lowercase 40-character install ref to match the installed source revision.
- Preserve tagged-release alias resolution and the existing live E2E, temporary-catalog, and rebuild authorities.
- Cover exact, mismatched, malformed, mutable, tagged-release, and non-GitHub source-install behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: https://github.com/NVIDIA/NemoClaw/pull/10320#pullrequestreview-5026174576
- [x] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: Eight PR Review Advisor specialists exhausted inference retries with HTTP 429 and produced no finding. Triage: https://github.com/NVIDIA/NemoClaw/pull/10320#issuecomment-5419705528.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npm run test:changed` (32 integration and 388 affected tests); `npm run typecheck:cli`; `npm run format:check`
- [x] Applicable broad gate passed — `npm run validate:pr` passed at latest PR commit `8e13db510`; all nine files implicated by the live-candidate fixture failures pass after binding their catalogs to the exact build identity.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

### Physical DGX Spark validation

The unmodified exact install at `b1823afc8b39f51f98138406cac22ae5a64742e9` failed sandbox creation because it requested the unavailable `v0.1.0` catalog alias even though the immutable catalog for that source revision existed. Applying this two-file source patch to the same detached checkout resolved the exact-revision image. Onboarding then completed with product-derived Spark defaults, followed by passing direct inference, real OpenClaw chat, host-verified tool artifact, and public TUI launch/chat/status/exit checks.

This is patched defect validation, not a release-qualification claim. Factory-clean Spark preparation and a complete post-merge lifecycle qualification remain separate gates.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed workload onboarding across live, temporary, rebuilt, and release environments.
  * Added stricter validation for installation references, including lowercase and exact-length revision checks.
  * Prevented mutable or invalid installation references from being used during workload preparation.
  * Improved release installation handling and catalog revision selection for more reliable workload setup.

* **Tests**
  * Expanded coverage for installation references, release catalogs, and onboarding revision selection across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




