### PR TITLE
test(e2e): record MXC startup exit evidence

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -540,6 +540,10 @@ state. After preflight and local setup succeed, it
 writes a secret-free receipt for either verdict and records whether sensitive
 runtime artifacts were removed. Receipt schema version 3 also classifies startup
 as not observed, spawn failed, exited before readiness, health timeout, or ready.
+The ready outcome means that the in-sandbox health probe succeeded.
+It does not mean that the qualification passed.
+Use `verdict` and `startup.versionExitCode` to diagnose the result.
+A nonzero version exit code produces a failed qualification.
 It retains only bounded numeric child and version exit codes; it does not retain
 child output, error text, command arguments, paths, or credentials. Cleanup
 removes both test-owned run directories for every verdict because MXC can write

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -538,9 +538,13 @@ It does not inspect OpenShell terminal wording or repeat the forward mutation.
 The complete create, forward, chat, and cleanup flow runs twice to detect stale
 state. After preflight and local setup succeed, it
 writes a secret-free receipt for either verdict and records whether sensitive
-runtime artifacts were removed. Cleanup removes both test-owned run directories
-for every verdict because MXC can write the temporary gateway token to its agent
-environment file. A failed run retains only the secret-free receipt.
+runtime artifacts were removed. Receipt schema version 3 also classifies startup
+as not observed, spawn failed, exited before readiness, health timeout, or ready.
+It retains only bounded numeric child and version exit codes; it does not retain
+child output, error text, command arguments, paths, or credentials. Cleanup
+removes both test-owned run directories for every verdict because MXC can write
+the temporary gateway token to its agent environment file. A failed run retains
+only the secret-free receipt.
 The host-preparation declaration is operator evidence, not an ACL attestation.
 Gateway mTLS, governed egress policy enforcement, managed inference,
 gateway-restart recovery, standard-user operation, and production activation

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -544,7 +544,8 @@ It retains only bounded numeric child and version exit codes; it does not retain
 child output, error text, command arguments, paths, or credentials. Cleanup
 removes both test-owned run directories for every verdict because MXC can write
 the temporary gateway token to its agent environment file. A failed run retains
-only the secret-free receipt.
+the secret-free receipt and any secret-free forward-readiness artifact written
+before the failure.
 The host-preparation declaration is operator evidence, not an ACL attestation.
 Gateway mTLS, governed egress policy enforcement, managed inference,
 gateway-restart recovery, standard-user operation, and production activation

--- a/test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts
+++ b/test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts
@@ -1427,13 +1427,15 @@ export function windowsMxcOpenClawStartupPreconditionsPass(input: {
   readonly openClawHealth: boolean;
   readonly openClawProcessPresentWhileReady: boolean;
   readonly registryPresentWhileReady: boolean;
+  readonly versionExitCode: number | null;
 }): boolean {
   return (
     input.filesystemControlWrite &&
     input.filesystemDeniedWrite &&
     input.openClawHealth &&
     input.openClawProcessPresentWhileReady &&
-    input.registryPresentWhileReady
+    input.registryPresentWhileReady &&
+    input.versionExitCode === 0
   );
 }
 
@@ -2166,7 +2168,12 @@ export async function runWindowsMxcOpenClawProcessContainerQualification(
       ...checks,
       sandboxCreateAccepted: create.exitCode === 0,
     };
-    if (!windowsMxcOpenClawStartupPreconditionsPass(checks)) {
+    if (
+      !windowsMxcOpenClawStartupPreconditionsPass({
+        ...checks,
+        versionExitCode: startup.versionExitCode,
+      })
+    ) {
       throw new Error("Windows MXC OpenClaw startup preconditions failed before forwarding");
     }
 

--- a/test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts
+++ b/test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts
@@ -1072,7 +1072,7 @@ while (healthObserved && gateway.exitCode === null && !existsSync(stopPath)) {
   await sleep(250);
 }
 
-if (gateway.exitCode === null) {
+if (gateway.exitCode === null && !gatewaySpawnFailed) {
   gateway.kill();
   await Promise.race([
     new Promise((resolve) => gateway.once("exit", resolve)),
@@ -1455,7 +1455,10 @@ export function classifyWindowsMxcOpenClawStartupObservation(
   if (result.gatewayExitedBeforeReadiness === true) {
     return { outcome: "exited-before-readiness", gatewayExitCode, versionExitCode };
   }
-  return { outcome: "health-timeout", gatewayExitCode, versionExitCode };
+  if (result.healthObserved === false) {
+    return { outcome: "health-timeout", gatewayExitCode, versionExitCode };
+  }
+  return { outcome: "not-observed", gatewayExitCode, versionExitCode };
 }
 
 export function classifyWindowsMxcForwardHealthObservation(

--- a/test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts
+++ b/test/e2e/live/windows-mxc-openclaw-process-container-helpers.ts
@@ -156,8 +156,19 @@ type QualificationChecks = {
   readonly workloadTerminatedByDelete: boolean;
 };
 
+export type WindowsMxcOpenClawStartupObservation = {
+  readonly outcome:
+    | "not-observed"
+    | "spawn-failed"
+    | "exited-before-readiness"
+    | "health-timeout"
+    | "ready";
+  readonly gatewayExitCode: number | null;
+  readonly versionExitCode: number | null;
+};
+
 export interface WindowsMxcOpenClawQualificationReceipt {
-  readonly schemaVersion: 2;
+  readonly schemaVersion: 3;
   readonly classification: "inactive-candidate";
   readonly backend: "process_container";
   readonly configuration: {
@@ -191,6 +202,7 @@ export interface WindowsMxcOpenClawQualificationReceipt {
     readonly wxcExecSha256: string;
   };
   readonly checks: QualificationChecks;
+  readonly startup: WindowsMxcOpenClawStartupObservation;
   readonly cleanup: {
     readonly boundedStopMarkerNeeded: boolean;
     readonly emergencyProcessTerminationNeeded: boolean;
@@ -374,7 +386,7 @@ function buildWindowsMxcSetupFailureReceipt(
   localArtifactsRemoved: boolean,
 ): WindowsMxcOpenClawQualificationReceipt {
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     classification: "inactive-candidate",
     backend: "process_container",
     configuration: {
@@ -421,6 +433,11 @@ function buildWindowsMxcSetupFailureReceipt(
       sandboxCreateAccepted: false,
       sandboxDeleteAccepted: false,
       workloadTerminatedByDelete: false,
+    },
+    startup: {
+      outcome: "not-observed",
+      gatewayExitCode: null,
+      versionExitCode: null,
     },
     cleanup: {
       boundedStopMarkerNeeded: false,
@@ -1011,16 +1028,16 @@ const gateway = spawn(
   ],
   { env, stdio: "ignore", windowsHide: true },
 );
-let gatewaySpawnError = null;
-gateway.once("error", (error) => {
-  gatewaySpawnError = error instanceof Error ? error.message : String(error);
+let gatewaySpawnFailed = false;
+gateway.once("error", () => {
+  gatewaySpawnFailed = true;
 });
 if (gateway.pid !== undefined) writeFileSync(openClawPidPath, String(gateway.pid), "utf8");
 
 let healthObserved = false;
 let lastHealth = { exitCode: null, stdout: "", stderr: "" };
 const deadline = Date.now() + 120000;
-while (Date.now() < deadline && gateway.exitCode === null && gatewaySpawnError === null) {
+while (Date.now() < deadline && gateway.exitCode === null && !gatewaySpawnFailed) {
   lastHealth = await run([
     entry,
     "gateway",
@@ -1039,8 +1056,9 @@ while (Date.now() < deadline && gateway.exitCode === null && gatewaySpawnError =
 const result = {
   controlWrite: true,
   deniedWrite,
+  gatewayExitCode: Number.isInteger(gateway.exitCode) ? gateway.exitCode : null,
   gatewayExitedBeforeReadiness: gateway.exitCode !== null,
-  gatewaySpawnError,
+  gatewaySpawnFailed,
   healthObserved,
   openClawVersion: version.stdout.trim(),
   versionExitCode: version.exitCode,
@@ -1417,6 +1435,27 @@ export function windowsMxcOpenClawStartupPreconditionsPass(input: {
     input.openClawProcessPresentWhileReady &&
     input.registryPresentWhileReady
   );
+}
+
+function boundedExitCode(value: unknown): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) ? value : null;
+}
+
+export function classifyWindowsMxcOpenClawStartupObservation(
+  result: Record<string, unknown>,
+): WindowsMxcOpenClawStartupObservation {
+  const gatewayExitCode = boundedExitCode(result.gatewayExitCode);
+  const versionExitCode = boundedExitCode(result.versionExitCode);
+  if (result.healthObserved === true) {
+    return { outcome: "ready", gatewayExitCode, versionExitCode };
+  }
+  if (result.gatewaySpawnFailed === true) {
+    return { outcome: "spawn-failed", gatewayExitCode, versionExitCode };
+  }
+  if (result.gatewayExitedBeforeReadiness === true) {
+    return { outcome: "exited-before-readiness", gatewayExitCode, versionExitCode };
+  }
+  return { outcome: "health-timeout", gatewayExitCode, versionExitCode };
 }
 
 export function classifyWindowsMxcForwardHealthObservation(
@@ -1969,6 +2008,11 @@ export async function runWindowsMxcOpenClawProcessContainerQualification(
   let trustedForwardProcess: WindowsProcessIdentity | null = null;
   let primaryFailure: unknown = null;
   const cleanupFailures: unknown[] = [];
+  let startup: WindowsMxcOpenClawStartupObservation = {
+    outcome: "not-observed",
+    gatewayExitCode: null,
+    versionExitCode: null,
+  };
   let checks: QualificationChecks = {
     artifactIdentity: true,
     filesystemControlWrite: false,
@@ -2078,6 +2122,7 @@ export async function runWindowsMxcOpenClawProcessContainerQualification(
     const probeResult = fs.existsSync(resultPath)
       ? (JSON.parse(fs.readFileSync(resultPath, "utf8")) as Record<string, unknown>)
       : {};
+    startup = classifyWindowsMxcOpenClawStartupObservation(probeResult);
     openClawProcessId = readProcessId(openClawPidPath);
     if (openClawProcessId !== null) {
       trustedOpenClawProcess = await observeTrustedOpenClawProcessIdentity({
@@ -2554,7 +2599,7 @@ export async function runWindowsMxcOpenClawProcessContainerQualification(
     sandboxName,
   });
   const receipt: WindowsMxcOpenClawQualificationReceipt = {
-    schemaVersion: 2,
+    schemaVersion: 3,
     classification: "inactive-candidate",
     backend: "process_container",
     configuration: {
@@ -2588,6 +2633,7 @@ export async function runWindowsMxcOpenClawProcessContainerQualification(
       wxcExecSha256: inputs.expected.wxcExecSha256,
     },
     checks,
+    startup,
     cleanup: {
       boundedStopMarkerNeeded,
       emergencyProcessTerminationNeeded,

--- a/test/e2e/live/windows-mxc-openclaw-process-container.test.ts
+++ b/test/e2e/live/windows-mxc-openclaw-process-container.test.ts
@@ -16,10 +16,16 @@ function expectQualificationReceipt(
   expectedConfiguration: WindowsMxcOpenClawQualificationReceipt["configuration"],
   expectedCleanup: WindowsMxcOpenClawQualificationReceipt["cleanup"],
 ): void {
+  expect(receipt.schemaVersion).toBe(3);
   expect(receipt.verdict).toBe("pass");
   expect(receipt.configuration).toEqual(expectedConfiguration);
   expect(receipt.checks.forwardAuthenticatedHealth).toBe(true);
   expect(receipt.checks.forwardedChatExactReply).toBe(true);
+  expect(receipt.startup).toEqual({
+    outcome: "ready",
+    gatewayExitCode: null,
+    versionExitCode: 0,
+  });
   expect(receipt.cleanup).toEqual(expectedCleanup);
 }
 

--- a/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
+++ b/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
@@ -840,6 +840,7 @@ describe("inactive Windows MXC OpenClaw process_container qualification", () => 
       openClawHealth: true,
       openClawProcessPresentWhileReady: true,
       registryPresentWhileReady: true,
+      versionExitCode: 0,
     };
     checks[failedCheck] = false;
 
@@ -854,8 +855,22 @@ describe("inactive Windows MXC OpenClaw process_container qualification", () => 
         openClawHealth: true,
         openClawProcessPresentWhileReady: true,
         registryPresentWhileReady: true,
+        versionExitCode: 0,
       }),
     ).toBe(true);
+  });
+
+  it("rejects readiness when the OpenClaw version command fails (#8178)", () => {
+    expect(
+      windowsMxcOpenClawStartupPreconditionsPass({
+        filesystemControlWrite: true,
+        filesystemDeniedWrite: true,
+        openClawHealth: true,
+        openClawProcessPresentWhileReady: true,
+        registryPresentWhileReady: true,
+        versionExitCode: 1,
+      }),
+    ).toBe(false);
   });
 
   it.each([" CHAT_OK", "CHAT_OK ", "CHAT_OK\n", "\tCHAT_OK"])(

--- a/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
+++ b/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
@@ -16,6 +16,7 @@ import {
   assertExpectedOpenClawProcessIdentity,
   assertExpectedOpenShellForwardProcessIdentity,
   assertExpectedOpenShellGatewayProcessIdentity,
+  classifyWindowsMxcOpenClawStartupObservation,
   classifyWindowsMxcForwardHealthObservation,
   createWindowsMxcQualificationFailure,
   normalizeReportedVersion,
@@ -484,10 +485,53 @@ describe("inactive Windows MXC OpenClaw process_container qualification", () => 
     expect(agent).toContain('message.role === "user"');
     expect(agent).toContain("if (gateway.pid !== undefined)");
     expect(agent).toContain('gateway.once("error"');
+    expect(agent).toContain("gatewaySpawnFailed = true");
+    expect(agent).toContain("gatewayExitCode: Number.isInteger(gateway.exitCode)");
     expect(agent).toContain("writeFileSync(outcomePath");
     expect(agent).toContain('"gateway",\n    "health"');
     expect(agent).not.toContain('"--token"');
+    expect(agent).not.toContain("gatewaySpawnError");
     expect(agent).not.toMatch(/[A-Za-z0-9_-]{40,}/u);
+  });
+
+  it.each([
+    {
+      expected: { outcome: "ready", gatewayExitCode: null, versionExitCode: 0 },
+      result: { healthObserved: true, versionExitCode: 0 },
+    },
+    {
+      expected: { outcome: "spawn-failed", gatewayExitCode: null, versionExitCode: 0 },
+      result: { gatewaySpawnFailed: true, versionExitCode: 0 },
+    },
+    {
+      expected: {
+        outcome: "exited-before-readiness",
+        gatewayExitCode: 3221225794,
+        versionExitCode: 0,
+      },
+      result: {
+        gatewayExitCode: 3221225794,
+        gatewayExitedBeforeReadiness: true,
+        versionExitCode: 0,
+      },
+    },
+    {
+      expected: { outcome: "health-timeout", gatewayExitCode: null, versionExitCode: null },
+      result: {
+        gatewayExitCode: "C:\\sensitive\\path",
+        gatewaySpawnError: "token-bearing raw diagnostic",
+        versionExitCode: 1.5,
+      },
+    },
+  ])("classifies bounded secret-free startup evidence for $expected.outcome (#8178)", ({
+    expected,
+    result,
+  }) => {
+    const observation = classifyWindowsMxcOpenClawStartupObservation(result);
+
+    expect(observation).toEqual(expected);
+    expect(JSON.stringify(observation)).not.toContain("sensitive");
+    expect(JSON.stringify(observation)).not.toContain("token-bearing");
   });
 
   it("renders a syntactically valid native OpenClaw probe agent (#8178)", () => {

--- a/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
+++ b/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
@@ -485,13 +485,63 @@ describe("inactive Windows MXC OpenClaw process_container qualification", () => 
     expect(agent).toContain('message.role === "user"');
     expect(agent).toContain("if (gateway.pid !== undefined)");
     expect(agent).toContain('gateway.once("error"');
-    expect(agent).toContain("gatewaySpawnFailed = true");
-    expect(agent).toContain("gatewayExitCode: Number.isInteger(gateway.exitCode)");
     expect(agent).toContain("writeFileSync(outcomePath");
     expect(agent).toContain('"gateway",\n    "health"');
     expect(agent).not.toContain('"--token"');
-    expect(agent).not.toContain("gatewaySpawnError");
     expect(agent).not.toMatch(/[A-Za-z0-9_-]{40,}/u);
+  });
+
+  it("serializes a generated probe spawn failure without raw diagnostics (#8178)", async () => {
+    const { root } = fixture();
+    const agentPath = path.join(root, "probe-agent.mjs");
+    const home = path.join(root, "probe-home");
+    const resultPath = path.join(root, "probe-result.json");
+    const outcomePath = path.join(root, "probe-outcome.json");
+    const token = "runtime-only-secret";
+    const missingNodePath = path.join(root, "missing-node.exe");
+    fs.writeFileSync(agentPath, renderWindowsMxcOpenClawProbeAgent(), "utf8");
+
+    const executed = spawnSync(process.execPath, [agentPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NEMOCLAW_MXC_E2E_DENY_PATH: path.join(root, "missing-parent", "denied.txt"),
+        NEMOCLAW_MXC_E2E_ENTRY: path.join(root, "missing-openclaw.mjs"),
+        NEMOCLAW_MXC_E2E_HEARTBEAT_PATH: path.join(root, "heartbeat.txt"),
+        NEMOCLAW_MXC_E2E_HOME: home,
+        NEMOCLAW_MXC_E2E_MOCK_PORT: "0",
+        NEMOCLAW_MXC_E2E_NODE: missingNodePath,
+        NEMOCLAW_MXC_E2E_OPENCLAW_PID_PATH: path.join(root, "openclaw.pid"),
+        NEMOCLAW_MXC_E2E_OPENCLAW_PORT: "0",
+        NEMOCLAW_MXC_E2E_OUTCOME_PATH: outcomePath,
+        NEMOCLAW_MXC_E2E_READY_PATH: path.join(root, "ready.json"),
+        NEMOCLAW_MXC_E2E_RESULT_PATH: resultPath,
+        NEMOCLAW_MXC_E2E_STOP_PATH: path.join(root, "stop.txt"),
+        NEMOCLAW_MXC_E2E_TOKEN: token,
+      },
+      timeout: 15_000,
+      windowsHide: true,
+    });
+
+    expect(executed.status, executed.stderr).toBe(1);
+    const resultText = fs.readFileSync(resultPath, "utf8");
+    const outcomeText = fs.readFileSync(outcomePath, "utf8");
+    const result = JSON.parse(resultText) as Record<string, unknown>;
+    expect(result).toMatchObject({
+      gatewaySpawnFailed: true,
+      healthObserved: false,
+      versionExitCode: 1,
+    });
+    expect(result).not.toHaveProperty("gatewaySpawnError");
+    expect(Number.isSafeInteger(result.gatewayExitCode)).toBe(true);
+    expect(classifyWindowsMxcOpenClawStartupObservation(result)).toEqual({
+      outcome: "spawn-failed",
+      gatewayExitCode: result.gatewayExitCode,
+      versionExitCode: 1,
+    });
+    expect(outcomeText).toBe(resultText);
+    expect(resultText).not.toContain(missingNodePath);
+    expect(resultText).not.toContain(token);
   });
 
   it.each([
@@ -517,6 +567,10 @@ describe("inactive Windows MXC OpenClaw process_container qualification", () => 
     },
     {
       expected: { outcome: "health-timeout", gatewayExitCode: null, versionExitCode: null },
+      result: { healthObserved: false },
+    },
+    {
+      expected: { outcome: "not-observed", gatewayExitCode: null, versionExitCode: null },
       result: {
         gatewayExitCode: "C:\\sensitive\\path",
         gatewaySpawnError: "token-bearing raw diagnostic",

--- a/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
+++ b/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
@@ -577,29 +577,16 @@ describe("inactive Windows MXC OpenClaw process_container qualification", () => 
         versionExitCode: 1.5,
       },
     },
-  ])("classifies bounded secret-free startup evidence for $expected.outcome (#8178)", ({
-    expected,
-    result,
-  }) => {
-    const observation = classifyWindowsMxcOpenClawStartupObservation(result);
+  ])(
+    "classifies bounded secret-free startup evidence for $expected.outcome (#8178)",
+    ({ expected, result }) => {
+      const observation = classifyWindowsMxcOpenClawStartupObservation(result);
 
-    expect(observation).toEqual(expected);
-    expect(JSON.stringify(observation)).not.toContain("sensitive");
-    expect(JSON.stringify(observation)).not.toContain("token-bearing");
-  });
-
-  it("renders a syntactically valid native OpenClaw probe agent (#8178)", () => {
-    const { root } = fixture();
-    const agentPath = path.join(root, "probe-agent.mjs");
-    fs.writeFileSync(agentPath, renderWindowsMxcOpenClawProbeAgent(), "utf8");
-
-    const checked = spawnSync(process.execPath, ["--check", agentPath], {
-      encoding: "utf8",
-      windowsHide: true,
-    });
-
-    expect(checked.status, checked.stderr).toBe(0);
-  });
+      expect(observation).toEqual(expected);
+      expect(JSON.stringify(observation)).not.toContain("sensitive");
+      expect(JSON.stringify(observation)).not.toContain("token-bearing");
+    },
+  );
 
   it("accepts only authenticated health and one exact chat payload (#8178)", () => {
     expect(parseOpenClawHealthResult('notice\n{"ok":true}\n')).toBe(true);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The inactive Windows MXC qualification receipt now distinguishes a spawn failure,
an early OpenClaw exit, a readiness timeout, and successful readiness. It retains
only bounded exit codes, so failed physical qualification can identify the startup
stage without keeping runtime output, paths, arguments, or credentials.

## Related Issue

Refs #8178

## Changes

- Add a version 3 qualification receipt startup observation.
- Replace the probe's raw spawn error with a boolean and bounded child exit code.
- Cover every startup classification and reject unbounded or string diagnostics.
- Require a successful live receipt to report the ready startup outcome.
- Document the retained and excluded startup evidence.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight,
  onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded —
  reviewer/approval link/justification:
  [security approval](https://github.com/NVIDIA/NemoClaw/pull/10333#pullrequestreview-5026646882)
  Review confirmed the receipt
  accepts only named outcomes and safe integer exit codes. Raw output, error text,
  arguments, paths, and credentials remain excluded, and failure cleanup remains
  unchanged.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name,
  approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; `scripts/prepare-dgx-station-host.sh` is unchanged.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as
  `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or
  `npm run validate:pr` passed after refreshing `origin/main` when hooks were
  skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked
  not applicable above — command/result or justification:
  `npx vitest run --project e2e-support`
  `test/e2e/support/windows-mxc-openclaw-process-container.test.ts` passed 51 tests.
  `npm run validate:pr` passed at `6d55953d4`.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness
  changes; `npm run check` for repo-wide validation/coverage changes —
  command/result: Not applicable; this changes one inactive live target's receipt
  and its focused support tests, not shared runtime behavior or release coverage.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the
  [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md)
  (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Windows qualification guidance for receipt schema version 3 and structured startup outcome classifications.
  * Clarified that a ready startup confirms sandbox health, while qualification also requires a successful version check.
  * Documented bounded exit codes and removal of sensitive diagnostic details from retained artifacts.

* **Tests**
  * Added coverage for ready, spawn-failed, timed-out, prematurely exited, and unobserved startup scenarios.
  * Strengthened receipt validation for sanitized diagnostics, successful version checks, and accurate startup observations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

