### PR TITLE
test(inference): cover Hermes recorded gateway health

### DIFF
--- a/src/lib/actions/sandbox/connect-inference-route-probe.test.ts
+++ b/src/lib/actions/sandbox/connect-inference-route-probe.test.ts
@@ -66,6 +66,7 @@ describe("sandbox connect inference route probe argv", () => {
 
   it.each([
     null,
+    { name: "hermes" },
     { name: "langchain-deepagents-code" },
   ])("pins the probe to the owning OpenShell gateway for agent %j (#8942)", (agent) => {
     expect(

--- a/src/lib/actions/sandbox/doctor-flow.test.ts
+++ b/src/lib/actions/sandbox/doctor-flow.test.ts
@@ -713,7 +713,7 @@ describe("runSandboxDoctor flow", () => {
   });
 
   it.each(["openclaw", "hermes"] as const)(
-    "keeps serving-process health explicitly unchecked for the %s gateway (#7003)",
+    "pins %s health to the recorded gateway and leaves serving-process health unchecked (#7003)",
     async (agent) => {
       const harness = createDoctorHarness();
       harness.loadAgentSpy.mockReturnValue({
@@ -743,6 +743,10 @@ describe("runSandboxDoctor flow", () => {
       const report = await harness.runSandboxDoctor("alpha", ["--json"], { quietJson: true });
 
       expect(harness.loadAgentSpy).toHaveBeenCalledWith(agent);
+      expect(harness.probeSandboxInferenceGatewayHealthSpy).toHaveBeenCalledWith("alpha", {
+        gatewayName: "nemoclaw-19080",
+      });
+      expect(harness.probeSandboxInferenceGatewayHealthSpy).toHaveBeenCalledOnce();
       expect(report?.checks).toContainEqual(
         expect.objectContaining({
           group: "Inference",

--- a/src/lib/actions/sandbox/inference-invocation-probe.test.ts
+++ b/src/lib/actions/sandbox/inference-invocation-probe.test.ts
@@ -104,6 +104,35 @@ describe("sandbox inference invocation probe", () => {
     );
   });
 
+  it("pins a Hermes invocation to its recorded OpenShell gateway", () => {
+    const execute = vi.fn(() => ({
+      status: 0,
+      stdout: '200\n{"choices":[{"message":{"content":"OK"}}]}',
+      stderr: "",
+    }));
+    const runOpenshell = vi.fn();
+
+    expect(
+      probeSandboxInferenceInvocation(
+        {
+          ...input,
+          sandboxName: "hermes-workspace",
+          agentName: "hermes",
+          gatewayName: "nemoclaw-19080",
+        },
+        { execute, runOpenshell },
+      ),
+    ).toEqual({ ok: true });
+    expect(execute).toHaveBeenCalledWith(
+      "hermes-workspace",
+      expect.any(String),
+      expect.any(Number),
+      { gatewayName: "nemoclaw-19080", allowLocalDockerFallback: false },
+    );
+    expect(execute).toHaveBeenCalledOnce();
+    expect(runOpenshell).not.toHaveBeenCalled();
+  });
+
   it("runs Deep Agents Code through the managed launcher on the recorded gateway (#10080)", () => {
     const runOpenshell = vi.fn(() =>
       openshellResult(0, '200\n{"choices":[{"message":{"content":"OK"}}]}', ""),

--- a/src/lib/actions/sandbox/inference-invocation-probe.test.ts
+++ b/src/lib/actions/sandbox/inference-invocation-probe.test.ts
@@ -104,7 +104,7 @@ describe("sandbox inference invocation probe", () => {
     );
   });
 
-  it("pins a Hermes invocation to its recorded OpenShell gateway", () => {
+  it("pins a Hermes invocation to its recorded OpenShell gateway (#10302)", () => {
     const execute = vi.fn(() => ({
       status: 0,
       stdout: '200\n{"choices":[{"message":{"content":"OK"}}]}',

--- a/src/lib/actions/sandbox/launch-readiness-gateway-health.test.ts
+++ b/src/lib/actions/sandbox/launch-readiness-gateway-health.test.ts
@@ -40,6 +40,39 @@ describe("launch-readiness gateway health scope", () => {
       "--",
     ]);
   });
+
+  it("pins Hermes readiness checks to its recorded OpenShell gateway", async () => {
+    const gatewayHealth = vi.fn(async () => true);
+    const forwardsHealthy = vi.fn(() => true);
+    const inferenceProbe = vi.fn(() => ({
+      healthy: true,
+      broken: false,
+      httpStatus: 200,
+      detail: "OK 200",
+    }));
+    const agent = loadAgent("hermes");
+    const entry = {
+      name: "alpha",
+      agent: "hermes",
+      provider: "ollama-local",
+      model: "nemotron-3-nano:30b",
+    } as SandboxEntry;
+
+    await expect(
+      requireLaunchSemanticHealth("alpha", "nemoclaw-19080", "hermes", entry, agent, true, {
+        gatewayHealth,
+        forwardsHealthy,
+        inferenceProbe,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(gatewayHealth).toHaveBeenCalledWith("alpha", "nemoclaw-19080");
+    expect(gatewayHealth).toHaveBeenCalledOnce();
+    expect(forwardsHealthy).toHaveBeenCalledWith("alpha", "nemoclaw-19080");
+    expect(forwardsHealthy).toHaveBeenCalledOnce();
+    expect(inferenceProbe).toHaveBeenCalledWith("alpha", agent, "nemoclaw-19080");
+    expect(inferenceProbe).toHaveBeenCalledOnce();
+  });
 });
 
 const SANDBOX = "alpha";

--- a/src/lib/actions/sandbox/launch-readiness-gateway-health.test.ts
+++ b/src/lib/actions/sandbox/launch-readiness-gateway-health.test.ts
@@ -41,7 +41,7 @@ describe("launch-readiness gateway health scope", () => {
     ]);
   });
 
-  it("pins Hermes readiness checks to its recorded OpenShell gateway", async () => {
+  it("pins Hermes readiness checks to its recorded OpenShell gateway (#10302)", async () => {
     const gatewayHealth = vi.fn(async () => true);
     const forwardsHealthy = vi.fn(() => true);
     const inferenceProbe = vi.fn(() => ({

--- a/src/lib/actions/sandbox/start.test.ts
+++ b/src/lib/actions/sandbox/start.test.ts
@@ -767,7 +767,7 @@ describe("startSandbox", () => {
     );
   });
 
-  it("pins a Hermes start probe to its recorded OpenShell gateway", async () => {
+  it("pins a Hermes start probe to its recorded OpenShell gateway (#10302)", async () => {
     const probeInferenceInvocation = vi.fn(() => ({ ok: true }) as const);
     const h = harness({ probeInferenceInvocation });
     h.getSandbox.mockReturnValue(
@@ -794,6 +794,7 @@ describe("startSandbox", () => {
       {},
       30_000,
     );
+    expect(probeInferenceInvocation).toHaveBeenCalledOnce();
     expect(probeInferenceInvocation.mock.invocationCallOrder[0]).toBeGreaterThan(
       h.verifyGateway.mock.invocationCallOrder[0],
     );

--- a/src/lib/actions/sandbox/start.test.ts
+++ b/src/lib/actions/sandbox/start.test.ts
@@ -761,6 +761,39 @@ describe("startSandbox", () => {
       {},
       30_000,
     );
+    expect(probeInferenceInvocation).toHaveBeenCalledOnce();
+    expect(probeInferenceInvocation.mock.invocationCallOrder[0]).toBeGreaterThan(
+      h.verifyGateway.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("pins a Hermes start probe to its recorded OpenShell gateway", async () => {
+    const probeInferenceInvocation = vi.fn(() => ({ ok: true }) as const);
+    const h = harness({ probeInferenceInvocation });
+    h.getSandbox.mockReturnValue(
+      sandbox({
+        agent: "hermes",
+        gatewayName: "nemoclaw-19080",
+        provider: "ollama-local",
+        model: "nemotron-3-nano:30b",
+        preferredInferenceApi: "openai-completions",
+      }),
+    );
+
+    const result = await startSandbox("my-sandbox", h.deps);
+
+    expect(result.exitCode).toBe(0);
+    expect(probeInferenceInvocation).toHaveBeenCalledWith(
+      {
+        sandboxName: "my-sandbox",
+        gatewayName: "nemoclaw-19080",
+        provider: "ollama-local",
+        model: "nemotron-3-nano:30b",
+        preferredInferenceApi: "openai-completions",
+      },
+      {},
+      30_000,
+    );
     expect(probeInferenceInvocation.mock.invocationCallOrder[0]).toBeGreaterThan(
       h.verifyGateway.mock.invocationCallOrder[0],
     );

--- a/src/lib/actions/sandbox/status-snapshot-inference-health.test.ts
+++ b/src/lib/actions/sandbox/status-snapshot-inference-health.test.ts
@@ -651,7 +651,7 @@ describe("collectSandboxStatusSnapshot inference route health", () => {
     expect(snapshot.inferenceHealth).toMatchObject({ ok: true });
   });
 
-  it("pins Hermes status health to its recorded OpenShell gateway", async () => {
+  it("pins Hermes status health to its recorded OpenShell gateway (#10302)", async () => {
     const gateway: SandboxInferenceRouteHealth = {
       ok: true,
       endpoint: "https://inference.local/v1/models",
@@ -685,6 +685,7 @@ describe("collectSandboxStatusSnapshot inference route health", () => {
     expect(probeSandboxInferenceGatewayHealthImpl).toHaveBeenCalledWith("alpha", {
       gatewayName: "nemoclaw-19080",
     });
+    expect(probeSandboxInferenceGatewayHealthImpl).toHaveBeenCalledOnce();
     expect(probeSandboxInferenceInvocationImpl).toHaveBeenCalledWith(
       {
         sandboxName: "alpha",

--- a/src/lib/actions/sandbox/status-snapshot-inference-health.test.ts
+++ b/src/lib/actions/sandbox/status-snapshot-inference-health.test.ts
@@ -647,6 +647,56 @@ describe("collectSandboxStatusSnapshot inference route health", () => {
     expect(probeSandboxInferenceGatewayHealthImpl).toHaveBeenCalledWith("alpha", {
       gatewayName: "nemoclaw-19080",
     });
+    expect(probeSandboxInferenceGatewayHealthImpl).toHaveBeenCalledOnce();
+    expect(snapshot.inferenceHealth).toMatchObject({ ok: true });
+  });
+
+  it("pins Hermes status health to its recorded OpenShell gateway", async () => {
+    const gateway: SandboxInferenceRouteHealth = {
+      ok: true,
+      endpoint: "https://inference.local/v1/models",
+      httpStatus: 200,
+      detail: "reachable",
+    };
+    const options = snapshotDeps(
+      gateway,
+      null,
+      { ok: true },
+      {
+        agent: "hermes",
+        gatewayName: "nemoclaw-19080",
+        provider: "ollama-local",
+        model: "nemotron-3-nano:30b",
+        preferredInferenceApi: "openai-completions",
+      },
+    );
+    const probeSandboxInferenceGatewayHealthImpl = vi.fn(async () => gateway);
+    const probeSandboxInferenceInvocationImpl = vi.fn(() => ({ ok: true }) as const);
+
+    const snapshot = await collectSandboxStatusSnapshot("alpha", {
+      ...options,
+      deps: {
+        ...options.deps,
+        probeSandboxInferenceGatewayHealthImpl,
+        probeSandboxInferenceInvocationImpl,
+      },
+    });
+
+    expect(probeSandboxInferenceGatewayHealthImpl).toHaveBeenCalledWith("alpha", {
+      gatewayName: "nemoclaw-19080",
+    });
+    expect(probeSandboxInferenceInvocationImpl).toHaveBeenCalledWith(
+      {
+        sandboxName: "alpha",
+        gatewayName: "nemoclaw-19080",
+        provider: "ollama-local",
+        model: "nemotron-3-nano:30b",
+        preferredInferenceApi: "openai-completions",
+      },
+      {},
+      30_000,
+    );
+    expect(probeSandboxInferenceInvocationImpl).toHaveBeenCalledOnce();
     expect(snapshot.inferenceHealth).toMatchObject({ ok: true });
   });
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Adds explicit Hermes coverage for the recorded OpenShell gateway contract introduced in #10302. The tests prove that Hermes status, doctor, start, launch readiness, route construction, and inference invocation use the sandbox's non-default gateway without a default-gateway or Deep Agents Code launcher fallback.

## Changes

- Cover Hermes route and inference invocation commands on a recorded non-default OpenShell gateway.
- Cover Hermes status, doctor, start, and launch-readiness wiring to the same gateway.
- Require each gateway probe to run once so a second default-gateway result cannot satisfy the check.

This PR adds no production behavior, configuration, fallback, compatibility path, or documentation surface.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Fresh review pending.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli` for the six changed test files: 6 files passed, 178 tests passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not run; this change adds focused cases to existing test files and does not change the test harness.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox health checks for OpenClaw and Hermes inference gateways.
  * Ensured launch readiness and startup checks consistently use the configured gateway, provider, model, and API settings.
  * Improved status reporting so successfully recovered inference routes are recognized as healthy.
* **Tests**
  * Expanded coverage for gateway routing, inference invocation, port forwarding, and startup behavior to improve reliability across supported agents.
  * Added validation that inference probes run exactly once and use the expected configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->