### PR TITLE
ci(advisor): limit automatic review events

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -8,7 +8,7 @@ on:
   # advisor secrets available for both internal and fork PRs. The analysis job
   # never executes PR-controlled content and has no write permission.
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review, edited]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       base_ref:
@@ -46,7 +46,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: pr-review-advisor-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.target_repo || github.repository }}-${{ inputs.target_pr || '' }}-${{ github.event_name != 'pull_request_target' || github.event.action != 'edited' || github.event.changes.base != null }}
+  group: pr-review-advisor-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.target_repo || github.repository }}-${{ inputs.target_pr || '' }}
   cancel-in-progress: true
 
 jobs:
@@ -72,7 +72,7 @@ jobs:
 
   review-specialists:
     name: Specialist / ${{ matrix.advisor.label }}
-    if: ${{ github.repository == 'NVIDIA/NemoClaw' && (github.event_name != 'pull_request_target' || github.event.action != 'edited' || github.event.changes.base != null) }}
+    if: ${{ github.repository == 'NVIDIA/NemoClaw' }}
     permissions:
       actions: read
       checks: read
@@ -356,7 +356,7 @@ jobs:
   publish:
     name: Publish advisor link
     needs: review-specialists
-    if: ${{ always() && github.event_name == 'pull_request_target' && (github.event.action != 'edited' || github.event.changes.base != null) && needs.review-specialists.result == 'success' }}
+    if: ${{ always() && github.event_name == 'pull_request_target' && needs.review-specialists.result == 'success' }}
     # Publication is best-effort and must never hide a specialist review failure.
     continue-on-error: true
     permissions:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Limit automatic PR Review Advisor runs to pull request opens, new commits, and reopens. Draft pull requests still receive reviews when opened and when their head changes, while metadata edits and ready-for-review transitions no longer create redundant runs.

## Changes

- Remove `edited` and `ready_for_review` from the `pull_request_target` event types.
- Remove conditions that existed only to suppress analysis for ordinary edit events.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: The PR Review Advisor workflow boundary test parses and validates the workflow definition.
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/automation/pull-requests/pr-review-advisor-workflow-boundary.test.ts`: 11 passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request review automation to run on a streamlined set of pull request events.
  * Improved review workflow consistency for the NVIDIA/NemoClaw repository.
  * Simplified conditions for publishing successful automated review results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->