### PR TITLE
test(voice): bound package fixture lifecycle

### DIFF
--- a/test/fixtures/voice-gateway/process-launcher.test.ts
+++ b/test/fixtures/voice-gateway/process-launcher.test.ts
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawn } from "node:child_process";
+import http from "node:http";
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+
+import { describe, expect, test } from "../../helpers/owned-test-resources";
+import { requestSession, stopGateway } from "./process-launcher";
+
+describe("voice gateway process fixture containment", () => {
+  test.skipIf(process.platform === "win32")(
+    "escalates from SIGTERM when the gateway child refuses to exit",
+    async ({ resources }) => {
+      const child = resources.ownChild(
+        spawn(
+          process.execPath,
+          [
+            "-e",
+            'process.on("SIGTERM", () => {}); process.stdout.write("ready\\n"); setInterval(() => {}, 1_000);',
+          ],
+          { stdio: ["ignore", "pipe", "ignore"] },
+        ),
+      );
+      await once(child.stdout!, "data");
+
+      await stopGateway(child);
+
+      expect(child.signalCode).toBe("SIGKILL");
+    },
+  );
+
+  test("bounds a stalled loopback session request and omits credentials from its error", async ({
+    resources,
+  }) => {
+    const server = resources.ownServer(http.createServer(() => undefined));
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    expect(address).not.toBeNull();
+    expect(typeof address).not.toBe("string");
+    const bearer = "fixture-bearer-must-not-leak";
+
+    let failure: Error | null = null;
+    try {
+      await requestSession((address as AddressInfo).port, bearer, 50);
+    } catch (error) {
+      failure = error as Error;
+    } finally {
+      server.closeAllConnections();
+    }
+
+    expect(failure?.message).toContain("voice gateway session request timed out after 50 ms");
+    expect(failure?.message).not.toContain(bearer);
+  });
+});

--- a/test/fixtures/voice-gateway/process-launcher.ts
+++ b/test/fixtures/voice-gateway/process-launcher.ts
@@ -7,6 +7,25 @@ import fs from "node:fs";
 import http from "node:http";
 import net from "node:net";
 
+import { ownChildProcess } from "../../helpers/child-process-lifecycle";
+
+export const VOICE_GATEWAY_STARTUP_TIMEOUT_MS = 15_000;
+export const VOICE_GATEWAY_SESSION_REQUEST_TIMEOUT_MS = 5_000;
+export const VOICE_GATEWAY_GRACEFUL_STOP_TIMEOUT_MS = 1_000;
+export const VOICE_GATEWAY_FORCE_STOP_TIMEOUT_MS = 1_000;
+const VOICE_GATEWAY_PROCESS_CONTRACT_CLEANUP_MARGIN_MS = 5_000;
+
+/**
+ * Two launches, three session requests, and two bounded shutdowns make up the
+ * real-process package contract. Keep its test ceiling outside every fixture
+ * phase so a phase-specific error wins before Vitest's generic timeout.
+ */
+export const VOICE_GATEWAY_PROCESS_CONTRACT_TIMEOUT_MS =
+  2 * VOICE_GATEWAY_STARTUP_TIMEOUT_MS +
+  3 * VOICE_GATEWAY_SESSION_REQUEST_TIMEOUT_MS +
+  2 * (VOICE_GATEWAY_GRACEFUL_STOP_TIMEOUT_MS + VOICE_GATEWAY_FORCE_STOP_TIMEOUT_MS) +
+  VOICE_GATEWAY_PROCESS_CONTRACT_CLEANUP_MARGIN_MS;
+
 /** Reserve and release an ephemeral loopback port for a process-contract test. */
 export async function reserveLoopbackPort(): Promise<number> {
   const server = net.createServer();
@@ -25,22 +44,34 @@ export async function reserveLoopbackPort(): Promise<number> {
 export async function waitForGatewayListening(child: ChildProcess): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     let stdout = "";
-    const timeout = setTimeout(() => reject(new Error("voice gateway did not start")), 15_000);
-    const rejectAfterCleanup = (error: Error) => {
+    const cleanup = (): void => {
       clearTimeout(timeout);
+      child.off("error", onError);
+      child.off("exit", onExit);
+      child.stdout?.off("data", onData);
+    };
+    const fail = (error: Error): void => {
+      cleanup();
       reject(error);
     };
-    child.once("error", rejectAfterCleanup);
-    child.once("exit", (code) =>
-      rejectAfterCleanup(new Error(`voice gateway exited before startup: ${code}`)),
-    );
-    child.stdout?.on("data", (chunk) => {
+    const onError = (error: Error): void => fail(error);
+    const onExit = (code: number | null): void =>
+      fail(new Error(`voice gateway exited before startup: ${code}`));
+    const onData = (chunk: Buffer | string): void => {
       stdout += String(chunk);
       if (stdout.includes('"state":"listening"')) {
-        clearTimeout(timeout);
+        cleanup();
         resolve();
       }
-    });
+    };
+    const timeout = setTimeout(
+      () => fail(new Error("voice gateway startup timed out")),
+      VOICE_GATEWAY_STARTUP_TIMEOUT_MS,
+    );
+    timeout.unref();
+    child.once("error", onError);
+    child.once("exit", onExit);
+    child.stdout?.on("data", onData);
   });
 }
 
@@ -77,9 +108,51 @@ export function openFileTargets(pid: number): string[] {
 export async function requestSession(
   port: number,
   bearer: string,
+  timeoutMs = VOICE_GATEWAY_SESSION_REQUEST_TIMEOUT_MS,
 ): Promise<{ readonly status: number; readonly body: string }> {
   const body = JSON.stringify({ runtimeConversationId: "process-contract" });
   return new Promise((resolve, reject) => {
+    let response: http.IncomingMessage | null = null;
+    let settled = false;
+    const chunks: Buffer[] = [];
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      request.off("error", onRequestError);
+      response?.off("data", onResponseData);
+      response?.off("end", onResponseEnd);
+      response?.off("error", onResponseError);
+      response?.off("aborted", onResponseAborted);
+    };
+    const fail = (error: Error, destroy = false): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (destroy) {
+        response?.once("error", () => undefined);
+        request.once("error", () => undefined);
+        response?.destroy();
+        request.destroy();
+      }
+      reject(error);
+    };
+    const onRequestError = (error: Error): void =>
+      fail(new Error(`voice gateway session request transport failed: ${error.message}`));
+    const onResponseData = (chunk: Buffer | string): void => {
+      chunks.push(Buffer.from(chunk));
+    };
+    const onResponseEnd = (): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve({
+        status: response?.statusCode ?? 0,
+        body: Buffer.concat(chunks).toString("utf8"),
+      });
+    };
+    const onResponseError = (error: Error): void =>
+      fail(new Error(`voice gateway session response failed: ${error.message}`));
+    const onResponseAborted = (): void =>
+      fail(new Error("voice gateway session response was aborted"));
     const request = http.request(
       {
         host: "127.0.0.1",
@@ -92,29 +165,28 @@ export async function requestSession(
           "content-type": "application/json",
         },
       },
-      (response) => {
-        const chunks: Buffer[] = [];
-        response.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
-        response.on("end", () =>
-          resolve({
-            status: response.statusCode ?? 0,
-            body: Buffer.concat(chunks).toString("utf8"),
-          }),
-        );
+      (incoming) => {
+        response = incoming;
+        response.on("data", onResponseData);
+        response.once("end", onResponseEnd);
+        response.once("error", onResponseError);
+        response.once("aborted", onResponseAborted);
       },
     );
-    request.once("error", reject);
+    const timeout = setTimeout(
+      () => fail(new Error(`voice gateway session request timed out after ${timeoutMs} ms`), true),
+      timeoutMs,
+    );
+    timeout.unref();
+    request.once("error", onRequestError);
     request.end(body);
   });
 }
 
 /** Stop a gateway child and wait for process termination. */
 export async function stopGateway(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) return;
-  const exited = new Promise<void>((resolve, reject) => {
-    child.once("error", reject);
-    child.once("exit", () => resolve());
-  });
-  child.kill("SIGTERM");
-  await exited;
+  await ownChildProcess(child, {
+    gracefulTimeoutMs: VOICE_GATEWAY_GRACEFUL_STOP_TIMEOUT_MS,
+    forceTimeoutMs: VOICE_GATEWAY_FORCE_STOP_TIMEOUT_MS,
+  }).terminate();
 }

--- a/test/package-contract/cli/voice-gateway-launcher.test.ts
+++ b/test/package-contract/cli/voice-gateway-launcher.test.ts
@@ -2,11 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import type { ChildProcess } from "node:child_process";
-
-import { afterEach, describe, expect, it } from "vitest";
 
 import { buildVoiceGatewayLaunchContract } from "../../../dist/lib/voice-gateway/launcher";
 import { runVoiceGatewayLaunch } from "../../../dist/lib/actions/voice-gateway/launch";
@@ -15,69 +11,62 @@ import {
   requestSession,
   reserveLoopbackPort,
   stopGateway,
+  VOICE_GATEWAY_PROCESS_CONTRACT_TIMEOUT_MS,
   waitForGatewayListening,
 } from "../../fixtures/voice-gateway/process-launcher";
+import { describe, expect, test } from "../../helpers/owned-test-resources";
 
 const DEPLOYMENT_BEARER = "deployment-bearer-for-process-contract";
 const ROTATED_DEPLOYMENT_BEARER = "rotated-deployment-bearer-for-process-contract";
 const OPENCLAW_CREDENTIAL = "openclaw-bearer-for-process-contract";
-const directories: string[] = [];
-const children: ChildProcess[] = [];
-
-afterEach(async () => {
-  await Promise.all(children.splice(0).map((child) => stopGateway(child)));
-  for (const directory of directories.splice(0)) {
-    fs.rmSync(directory, { force: true, recursive: true });
-  }
-});
-
 describe("voice gateway process launch contract", () => {
-  it("maps fixed descriptors, closes them before serving, and rotates on restart (#9235)", async () => {
-    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-voice-process-"));
-    directories.push(directory);
-    const deploymentCredentialPath = path.join(directory, "deployment");
-    const openClawCredentialPath = path.join(directory, "openclaw");
-    fs.writeFileSync(deploymentCredentialPath, DEPLOYMENT_BEARER, { mode: 0o600 });
-    fs.writeFileSync(openClawCredentialPath, OPENCLAW_CREDENTIAL, { mode: 0o600 });
-    const listenPort = await reserveLoopbackPort();
-    const options = {
-      deploymentCredentialPath,
-      openClawCredentialPath,
-      gatewayUrl: "ws://127.0.0.1:18789/ws",
-      runtimeIdentity: "voiceclaw-local",
-      runtimeProfile: "voiceclaw-pinned",
-      sandbox: "repository-fixture",
-      agent: "main",
-      listenPort,
-    };
-    const contract = buildVoiceGatewayLaunchContract(options);
+  test(
+    "maps fixed descriptors, closes them before serving, and rotates on restart (#9235)",
+    async ({ resources }) => {
+      const directory = resources.temporaryDirectory("nemoclaw-voice-process-");
+      const deploymentCredentialPath = path.join(directory, "deployment");
+      const openClawCredentialPath = path.join(directory, "openclaw");
+      fs.writeFileSync(deploymentCredentialPath, DEPLOYMENT_BEARER, { mode: 0o600 });
+      fs.writeFileSync(openClawCredentialPath, OPENCLAW_CREDENTIAL, { mode: 0o600 });
+      const listenPort = await reserveLoopbackPort();
+      const options = {
+        deploymentCredentialPath,
+        openClawCredentialPath,
+        gatewayUrl: "ws://127.0.0.1:18789/ws",
+        runtimeIdentity: "voiceclaw-local",
+        runtimeProfile: "voiceclaw-pinned",
+        sandbox: "repository-fixture",
+        agent: "main",
+        listenPort,
+      };
+      const contract = buildVoiceGatewayLaunchContract(options);
 
-    expect(JSON.stringify(contract)).not.toContain(deploymentCredentialPath);
-    expect(JSON.stringify(contract)).not.toContain(openClawCredentialPath);
-    expect(JSON.stringify(contract)).not.toContain(DEPLOYMENT_BEARER);
-    expect(JSON.stringify(contract)).not.toContain(OPENCLAW_CREDENTIAL);
+      expect(JSON.stringify(contract)).not.toContain(deploymentCredentialPath);
+      expect(JSON.stringify(contract)).not.toContain(openClawCredentialPath);
+      expect(JSON.stringify(contract)).not.toContain(DEPLOYMENT_BEARER);
+      expect(JSON.stringify(contract)).not.toContain(OPENCLAW_CREDENTIAL);
 
-    const first = await runVoiceGatewayLaunch(options);
-    children.push(first);
-    await waitForGatewayListening(first);
-    expect(openFileTargets(first.pid!)).not.toContain(deploymentCredentialPath);
-    expect(openFileTargets(first.pid!)).not.toContain(openClawCredentialPath);
-    expect(await requestSession(listenPort, DEPLOYMENT_BEARER)).toMatchObject({ status: 201 });
-    await stopGateway(first);
+      const first = resources.ownChild(await runVoiceGatewayLaunch(options));
+      await waitForGatewayListening(first);
+      expect(openFileTargets(first.pid!)).not.toContain(deploymentCredentialPath);
+      expect(openFileTargets(first.pid!)).not.toContain(openClawCredentialPath);
+      expect(await requestSession(listenPort, DEPLOYMENT_BEARER)).toMatchObject({ status: 201 });
+      await stopGateway(first);
 
-    fs.writeFileSync(deploymentCredentialPath, ROTATED_DEPLOYMENT_BEARER, { mode: 0o600 });
-    const second = await runVoiceGatewayLaunch(options);
-    children.push(second);
-    await waitForGatewayListening(second);
-    expect(openFileTargets(second.pid!)).not.toContain(deploymentCredentialPath);
-    expect(openFileTargets(second.pid!)).not.toContain(openClawCredentialPath);
-    expect(await requestSession(listenPort, DEPLOYMENT_BEARER)).toEqual({
-      status: 401,
-      body: '{"error":"authentication_failed"}',
-    });
-    expect(await requestSession(listenPort, ROTATED_DEPLOYMENT_BEARER)).toMatchObject({
-      status: 201,
-    });
-    await stopGateway(second);
-  });
+      fs.writeFileSync(deploymentCredentialPath, ROTATED_DEPLOYMENT_BEARER, { mode: 0o600 });
+      const second = resources.ownChild(await runVoiceGatewayLaunch(options));
+      await waitForGatewayListening(second);
+      expect(openFileTargets(second.pid!)).not.toContain(deploymentCredentialPath);
+      expect(openFileTargets(second.pid!)).not.toContain(openClawCredentialPath);
+      expect(await requestSession(listenPort, DEPLOYMENT_BEARER)).toEqual({
+        status: 401,
+        body: '{"error":"authentication_failed"}',
+      });
+      expect(await requestSession(listenPort, ROTATED_DEPLOYMENT_BEARER)).toMatchObject({
+        status: 201,
+      });
+      await stopGateway(second);
+    },
+    VOICE_GATEWAY_PROCESS_CONTRACT_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary

Bounds each real-process voice gateway fixture phase before Vitest reaches a generic timeout. Stalled loopback requests now fail with phase-specific, credential-free errors, and children that ignore SIGTERM escalate through the shared bounded lifecycle owner.

## Related Issue

Closes #9800

## Changes

- add a five-second session-request deadline with listener cleanup and socket destruction
- reuse the shared child-process owner for bounded SIGTERM-to-SIGKILL shutdown
- derive the real-process package-contract ceiling from two startups, three requests, two shutdowns, and cleanup margin
- add deterministic stalled-request and SIGTERM-resistant child coverage
- move the existing package contract onto owned temporary-directory and child cleanup

Production voice gateway source, global Vitest timeouts, workflows, retries, and live E2E targets are unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: Not applicable

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project integration test/fixtures/voice-gateway/process-launcher.test.ts test/automation/pull-requests/growth-guardrails.test.ts` (34 passed); `npx vitest run --project package-contract test/package-contract/cli/voice-gateway-launcher.test.ts` (1 passed)
- [x] Applicable broad gate passed — `npm run checks:repository`; `npm run typecheck:cli`; `npm run validate:pr`
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---

Signed-off-by: Ho Lim <subhoya@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved voice gateway startup and shutdown reliability with bounded timeouts and forced termination when needed.
  - Session requests now time out cleanly, release resources, and avoid exposing bearer credentials in errors.
  - Improved error reporting for gateway startup, connection, and shutdown failures.

- **Tests**
  - Added coverage for process termination, request timeouts, credential protection, and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->