### PR TITLE
feat(runtime): add inactive MXC native bootstrap

### DIFF
--- a/scripts/checks/run-managed-image-openshell-e2e.ts
+++ b/scripts/checks/run-managed-image-openshell-e2e.ts
@@ -34,8 +34,8 @@ import {
 import { encodeManagedStartupProfile } from "../../src/lib/onboard/managed-startup/profile.ts";
 import { createManagedStartupRootApplyRequest } from "../../src/lib/onboard/managed-startup/root-apply.ts";
 import type {
-  RuntimeProviderBootstrapSurface,
   RuntimeProviderBundle,
+  RuntimeProviderManagedImageBootstrapSurface,
 } from "../../src/lib/onboard/runtime-provider/contract.ts";
 import { createDockerRuntimeProviderBundle } from "../../src/lib/onboard/runtime-provider/docker.ts";
 import { parseLiveSandboxNames } from "../../src/lib/runtime-recovery.ts";
@@ -1009,7 +1009,7 @@ async function run<T extends ManagedImageOpenShellE2eLocalInferenceEvidence = ne
       ...createDockerRuntimeProviderBundle(),
       bootstrap: createDockerManagedBootstrapSurface("docker"),
     } as RuntimeProviderBundle & {
-      readonly bootstrap: Extract<RuntimeProviderBootstrapSurface, { readonly supported: true }>;
+      readonly bootstrap: RuntimeProviderManagedImageBootstrapSurface;
     };
     let flow: Awaited<ReturnType<typeof runSandboxGpuCreateFlow>> | null = null;
     try {

--- a/src/lib/onboard/managed-bootstrap/docker-runtime.ts
+++ b/src/lib/onboard/managed-bootstrap/docker-runtime.ts
@@ -18,7 +18,7 @@ import {
   queryOpenShellDockerSandboxContainers,
   queryOpenShellDockerSandboxRuntimeSnapshot,
 } from "../openshell-docker-sandbox-containers";
-import type { RuntimeProviderBootstrapSurface } from "../runtime-provider/contract";
+import type { RuntimeProviderManagedImageBootstrapSurface } from "../runtime-provider/contract";
 import * as sandboxGpuCreateAttempt from "../sandbox-gpu-create-attempt";
 import {
   activateManagedBootstrapSequence,
@@ -39,11 +39,6 @@ import type {
   ManagedBootstrapRuntimeOnboardRoutingInput,
 } from "./runtime-create";
 import { createManagedBootstrapTerminalFinalizer } from "./runtime-create";
-
-type SupportedBootstrapSurface = Extract<
-  RuntimeProviderBootstrapSurface,
-  { readonly supported: true }
->;
 
 const MANAGED_BOOTSTRAP_IMAGE_INSPECT_TIMEOUT_MS = 30_000;
 const MANAGED_BOOTSTRAP_IMAGE_PULL_MAX_TIMEOUT_MS = 30 * 60 * 1000;
@@ -394,10 +389,11 @@ function createDockerOnboardRouting(input: ManagedBootstrapRuntimeOnboardRouting
 /** Complete Docker bootstrap surface selected only through a runtime bundle. */
 export function createDockerManagedBootstrapSurface(
   providerId = "docker",
-): SupportedBootstrapSurface {
+): RuntimeProviderManagedImageBootstrapSurface {
   return {
     providerId,
     supported: true,
+    bootstrapKind: "managed-image",
     createAuthorityStore: ({ stateRoot }) => createDockerManagedBootstrapAuthorityStore(stateRoot),
     createLifecycle: (input) => createDockerLifecycle(providerId, input),
     createOnboardRouting: createDockerOnboardRouting,

--- a/src/lib/onboard/managed-workload/onboard-orchestration.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.ts
@@ -35,7 +35,7 @@ import {
   type RuntimeProviderBundle,
   resolveRuntimeProviderBundle,
 } from "../runtime-provider/access";
-import type { RuntimeProviderBootstrapSurface } from "../runtime-provider/contract";
+import type { RuntimeProviderManagedImageBootstrapSurface } from "../runtime-provider/contract";
 import type {
   MaterializeSandboxCreatePlanInput,
   SandboxCreateIntent,
@@ -77,8 +77,9 @@ type ManagedProfileInput = Omit<
 >;
 type ResolveBuildPatchInput = Parameters<typeof resolveSandboxBuildPatch>[0];
 type SandboxInferenceConfig = import("../../inference/config").SandboxInferenceConfig;
-type SupportedBootstrap = Extract<RuntimeProviderBootstrapSurface, { readonly supported: true }>;
-type BootstrapProvider = RuntimeProviderBundle & { readonly bootstrap: SupportedBootstrap };
+type BootstrapProvider = RuntimeProviderBundle & {
+  readonly bootstrap: RuntimeProviderManagedImageBootstrapSurface;
+};
 
 export type ManagedHermesStateVolumeOnboardLifecycle = {
   materializeSandboxCreatePlan(
@@ -204,7 +205,11 @@ export async function prepareHermesPortableSandboxWorkloadForLifecycle(
 }
 
 function requireBootstrapProvider(provider: RuntimeProviderBundle | null): BootstrapProvider {
-  if (!provider || !provider.bootstrap.supported) {
+  if (
+    !provider ||
+    !provider.bootstrap.supported ||
+    provider.bootstrap.bootstrapKind !== "managed-image"
+  ) {
     throw new Error("Selected runtime provider does not support managed bootstrap onboarding.");
   }
   return provider as BootstrapProvider;

--- a/src/lib/onboard/runtime-provider/activation.test.ts
+++ b/src/lib/onboard/runtime-provider/activation.test.ts
@@ -33,6 +33,7 @@ import {
   type RuntimeProviderActivationTransport,
 } from "./activation";
 import {
+  RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION,
   RUNTIME_PROVIDER_SNAPSHOT_CONTRACT_VERSION,
   RUNTIME_PROVIDER_STATE_MUTATION_CONTRACT_VERSION,
   type RuntimeProviderBundle,
@@ -123,6 +124,7 @@ function completeBundle(providerId: string): RuntimeProviderBundle {
     bootstrap: {
       providerId,
       supported: true,
+      bootstrapKind: "managed-image",
       createAuthorityStore: unreachable,
       createLifecycle: unreachable,
       createOnboardRouting: unreachable,
@@ -279,6 +281,25 @@ describe("runtime provider activation catalog", () => {
     expect(Object.keys(createCurrentRuntimeProviderBundles())).toEqual(["docker", "kubernetes"]);
     expect(CURRENT_RUNTIME_PROVIDER_BUNDLES).not.toHaveProperty("podman");
     expect(CURRENT_RUNTIME_PROVIDER_BUNDLES).not.toHaveProperty("mxc");
+  });
+
+  it("rejects native-artifact bootstrap from production activation (#8178)", () => {
+    const candidate = CANDIDATE_TOPOLOGIES[2];
+    const complete = completeBundle(candidate.providerId);
+    const inactive = {
+      ...complete,
+      bootstrap: {
+        providerId: candidate.providerId,
+        supported: true,
+        bootstrapKind: "native-artifact",
+        contractVersion: RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION,
+        run: unreachable,
+      },
+    } as RuntimeProviderBundle;
+
+    expect(() =>
+      createRuntimeProviderActivationCatalog([registration(candidate, inactive)]),
+    ).toThrow("does not provide managed-image bootstrap authority");
   });
 
   it.each(INCOMPLETE_SURFACES)(

--- a/src/lib/onboard/runtime-provider/activation.ts
+++ b/src/lib/onboard/runtime-provider/activation.ts
@@ -425,6 +425,11 @@ function validateCompleteBundle(bundle: RuntimeProviderBundle): void {
       `provider '${providerId}' does not declare the complete lifecycle capability set`,
     );
   }
+  if (bundle.bootstrap.supported !== true || bundle.bootstrap.bootstrapKind !== "managed-image") {
+    throw new RuntimeProviderActivationError(
+      `provider '${providerId}' does not provide managed-image bootstrap authority`,
+    );
+  }
   const workload = bundle.workload.profile;
   const managedImages = workload.support;
   if (

--- a/src/lib/onboard/runtime-provider/contract.ts
+++ b/src/lib/onboard/runtime-provider/contract.ts
@@ -21,7 +21,7 @@ export const RUNTIME_PROVIDER_SNAPSHOT_CONTRACT_VERSION = 1 as const;
 export const RUNTIME_PROVIDER_SNAPSHOT_PREFLIGHT_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_PROVIDER_STATE_MUTATION_CONTRACT_VERSION = 2 as const;
 export const RUNTIME_PROVIDER_STATE_MUTATION_PLAN_SCHEMA_VERSION = 2 as const;
-export const RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION = 1 as const;
+export const RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION = 2 as const;
 export const RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_PLAN_SCHEMA_VERSION = 1 as const;
 
 export type RuntimeProviderGatewayLauncher = "nemoclaw" | "openshell";
@@ -144,9 +144,21 @@ export interface RuntimeProviderNativeArtifactReadinessEvidence {
   readonly ready: boolean;
 }
 
+export interface RuntimeProviderNativeArtifactIdentityEvidence {
+  readonly authoritySha256: string;
+  readonly artifactRoot: string;
+  readonly artifactDigest: string;
+  readonly executablePath: string;
+  readonly executableDigest: string;
+}
+
 export interface RuntimeProviderNativeArtifactBootstrapOperations {
+  verifyArtifactIdentity(
+    plan: RuntimeProviderNativeArtifactBootstrapPlan,
+  ): Promise<RuntimeProviderNativeArtifactIdentityEvidence>;
   create(
     plan: RuntimeProviderNativeArtifactBootstrapPlan,
+    identity: RuntimeProviderNativeArtifactIdentityEvidence,
   ): Promise<RuntimeProviderNativeArtifactCreateOutcome>;
   verifyReadiness(
     plan: RuntimeProviderNativeArtifactBootstrapPlan,
@@ -157,6 +169,7 @@ export type RuntimeProviderNativeArtifactBootstrapResult = Readonly<{
   readonly outcome: "ready" | "not-created" | "retained";
   readonly reason:
     | null
+    | "artifact-verification-failed"
     | "create-rejected"
     | "create-outcome-unknown"
     | "create-authority-mismatch"

--- a/src/lib/onboard/runtime-provider/contract.ts
+++ b/src/lib/onboard/runtime-provider/contract.ts
@@ -8,6 +8,7 @@ import type {
   ManagedBootstrapRuntimeOnboardRouting,
   ManagedBootstrapRuntimeOnboardRoutingInput,
 } from "../managed-bootstrap/runtime-create";
+import type { NativeArtifactWorkloadReceiptV1 } from "../workload/native-artifact";
 import type { ManagedImageSelectionPolicy } from "../workload/source";
 import type {
   HostLocalInferenceOperation,
@@ -20,6 +21,8 @@ export const RUNTIME_PROVIDER_SNAPSHOT_CONTRACT_VERSION = 1 as const;
 export const RUNTIME_PROVIDER_SNAPSHOT_PREFLIGHT_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_PROVIDER_STATE_MUTATION_CONTRACT_VERSION = 2 as const;
 export const RUNTIME_PROVIDER_STATE_MUTATION_PLAN_SCHEMA_VERSION = 2 as const;
+export const RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION = 1 as const;
+export const RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_PLAN_SCHEMA_VERSION = 1 as const;
 
 export type RuntimeProviderGatewayLauncher = "nemoclaw" | "openshell";
 export type RuntimeProviderLifecycleAction = "start" | "stop";
@@ -85,6 +88,86 @@ export interface RuntimeProviderNormalizedCapabilities {
   readonly workloadImageCleanup: boolean;
   readonly readOnlyHostMounts: RuntimeProviderReadOnlyHostMountCapability;
 }
+
+export interface RuntimeProviderNativeArtifactBootstrapInput {
+  readonly providerId: string;
+  readonly sandboxName: string;
+  readonly lifecycleGeneration: string;
+  readonly driveRoot: string;
+  readonly artifactRoot: string;
+  readonly workload: NativeArtifactWorkloadReceiptV1;
+}
+
+export interface RuntimeProviderNativeArtifactBootstrapPlan {
+  readonly schemaVersion: typeof RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_PLAN_SCHEMA_VERSION;
+  readonly providerId: string;
+  readonly sandboxName: string;
+  readonly lifecycleGeneration: string;
+  readonly authoritySha256: string;
+  readonly driveRoot: string;
+  readonly artifactRoot: string;
+  readonly shareDirectory: string;
+  readonly homeDirectory: string;
+  readonly stateDirectory: string;
+  readonly temporaryDirectory: string;
+  readonly executablePath: string;
+  readonly workingDirectory: string;
+  readonly environment: {
+    readonly HOME: string;
+    readonly OPENCLAW_CONFIG_PATH: string;
+    readonly OPENCLAW_HOME: string;
+    readonly OPENCLAW_STATE_DIR: string;
+    readonly TEMP: string;
+    readonly TMP: string;
+    readonly USERPROFILE: string;
+  };
+  readonly workload: NativeArtifactWorkloadReceiptV1;
+}
+
+export type RuntimeProviderNativeArtifactCreateOutcome =
+  | {
+      readonly status: "created";
+      readonly authoritySha256: string;
+    }
+  | {
+      readonly status: "not-created";
+    }
+  | {
+      readonly status: "unknown";
+    };
+
+export interface RuntimeProviderNativeArtifactReadinessEvidence {
+  readonly authoritySha256: string;
+  readonly lifecycleGeneration: string;
+  readonly artifactDigest: string;
+  readonly executableDigest: string;
+  readonly ready: boolean;
+}
+
+export interface RuntimeProviderNativeArtifactBootstrapOperations {
+  create(
+    plan: RuntimeProviderNativeArtifactBootstrapPlan,
+  ): Promise<RuntimeProviderNativeArtifactCreateOutcome>;
+  verifyReadiness(
+    plan: RuntimeProviderNativeArtifactBootstrapPlan,
+  ): Promise<RuntimeProviderNativeArtifactReadinessEvidence>;
+}
+
+export type RuntimeProviderNativeArtifactBootstrapResult = Readonly<{
+  readonly outcome: "ready" | "not-created" | "retained";
+  readonly reason:
+    | null
+    | "create-rejected"
+    | "create-outcome-unknown"
+    | "create-authority-mismatch"
+    | "readiness-not-proven";
+  readonly authoritySha256: string;
+  readonly resourceState: "active" | "absent" | "possibly-retained";
+  readonly cleanup: {
+    readonly attempted: false;
+    readonly resourceRemovalAuthorized: false;
+  };
+}>;
 
 export type RuntimeProviderManagedImageSupport = {
   readonly exactDigestReferences: boolean;
@@ -434,18 +517,31 @@ export type RuntimeProviderStateMutationSurface =
     }>
   | RuntimeProviderUnsupportedSurface;
 
+export type RuntimeProviderManagedImageBootstrapSurface = RuntimeProviderSupportedSurface<{
+  readonly bootstrapKind: "managed-image";
+  createAuthorityStore(input: {
+    readonly stateRoot: string;
+  }): import("../managed-bootstrap/adapter").ManagedBootstrapAuthorityStore;
+  createLifecycle(
+    input: ManagedBootstrapRuntimeCreateLifecycleInput,
+  ): ManagedBootstrapRuntimeCreateLifecycle;
+  createOnboardRouting(
+    input: ManagedBootstrapRuntimeOnboardRoutingInput,
+  ): ManagedBootstrapRuntimeOnboardRouting;
+}>;
+
+export type RuntimeProviderNativeArtifactBootstrapSurface = RuntimeProviderSupportedSurface<{
+  readonly bootstrapKind: "native-artifact";
+  readonly contractVersion: typeof RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION;
+  run(
+    input: RuntimeProviderNativeArtifactBootstrapInput,
+    operations: RuntimeProviderNativeArtifactBootstrapOperations,
+  ): Promise<RuntimeProviderNativeArtifactBootstrapResult>;
+}>;
+
 export type RuntimeProviderBootstrapSurface =
-  | RuntimeProviderSupportedSurface<{
-      createAuthorityStore(input: {
-        readonly stateRoot: string;
-      }): import("../managed-bootstrap/adapter").ManagedBootstrapAuthorityStore;
-      createLifecycle(
-        input: ManagedBootstrapRuntimeCreateLifecycleInput,
-      ): ManagedBootstrapRuntimeCreateLifecycle;
-      createOnboardRouting(
-        input: ManagedBootstrapRuntimeOnboardRoutingInput,
-      ): ManagedBootstrapRuntimeOnboardRouting;
-    }>
+  | RuntimeProviderManagedImageBootstrapSurface
+  | RuntimeProviderNativeArtifactBootstrapSurface
   | RuntimeProviderUnsupportedSurface;
 
 export type RuntimeProviderSnapshotSurface =

--- a/src/lib/onboard/runtime-provider/contract.ts
+++ b/src/lib/onboard/runtime-provider/contract.ts
@@ -21,7 +21,7 @@ export const RUNTIME_PROVIDER_SNAPSHOT_CONTRACT_VERSION = 1 as const;
 export const RUNTIME_PROVIDER_SNAPSHOT_PREFLIGHT_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_PROVIDER_STATE_MUTATION_CONTRACT_VERSION = 2 as const;
 export const RUNTIME_PROVIDER_STATE_MUTATION_PLAN_SCHEMA_VERSION = 2 as const;
-export const RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION = 2 as const;
+export const RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION = 3 as const;
 export const RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_PLAN_SCHEMA_VERSION = 1 as const;
 
 export type RuntimeProviderGatewayLauncher = "nemoclaw" | "openshell";
@@ -124,13 +124,16 @@ export interface RuntimeProviderNativeArtifactBootstrapPlan {
   readonly workload: NativeArtifactWorkloadReceiptV1;
 }
 
-export type RuntimeProviderNativeArtifactCreateOutcome =
+export type RuntimeProviderNativeArtifactVerifyAndCreateOutcome =
   | {
       readonly status: "created";
       readonly authoritySha256: string;
+      readonly artifactDigest: string;
+      readonly executableDigest: string;
     }
   | {
       readonly status: "not-created";
+      readonly reason: "artifact-verification-failed" | "create-rejected";
     }
   | {
       readonly status: "unknown";
@@ -144,22 +147,14 @@ export interface RuntimeProviderNativeArtifactReadinessEvidence {
   readonly ready: boolean;
 }
 
-export interface RuntimeProviderNativeArtifactIdentityEvidence {
-  readonly authoritySha256: string;
-  readonly artifactRoot: string;
-  readonly artifactDigest: string;
-  readonly executablePath: string;
-  readonly executableDigest: string;
-}
-
 export interface RuntimeProviderNativeArtifactBootstrapOperations {
-  verifyArtifactIdentity(
+  /**
+   * Verify artifact and executable digests, then create while holding the same stable filesystem
+   * object authority. The provider must not re-resolve plan paths after verification.
+   */
+  verifyAndCreate(
     plan: RuntimeProviderNativeArtifactBootstrapPlan,
-  ): Promise<RuntimeProviderNativeArtifactIdentityEvidence>;
-  create(
-    plan: RuntimeProviderNativeArtifactBootstrapPlan,
-    identity: RuntimeProviderNativeArtifactIdentityEvidence,
-  ): Promise<RuntimeProviderNativeArtifactCreateOutcome>;
+  ): Promise<RuntimeProviderNativeArtifactVerifyAndCreateOutcome>;
   verifyReadiness(
     plan: RuntimeProviderNativeArtifactBootstrapPlan,
   ): Promise<RuntimeProviderNativeArtifactReadinessEvidence>;

--- a/src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts
@@ -9,6 +9,7 @@ import { encodeManagedStartupProfile } from "../managed-startup/profile";
 import { nativeArtifactWorkloadReceiptFixture } from "../workload/native-artifact-test-fixture";
 import type {
   RuntimeProviderNativeArtifactBootstrapInput,
+  RuntimeProviderNativeArtifactIdentityEvidence,
   RuntimeProviderNativeArtifactBootstrapOperations,
   RuntimeProviderNativeArtifactBootstrapPlan,
   RuntimeProviderNativeArtifactReadinessEvidence,
@@ -75,16 +76,32 @@ function readyEvidence(
   };
 }
 
+function artifactIdentityEvidence(
+  plan: RuntimeProviderNativeArtifactBootstrapPlan,
+): RuntimeProviderNativeArtifactIdentityEvidence {
+  return {
+    authoritySha256: plan.authoritySha256,
+    artifactRoot: plan.artifactRoot,
+    artifactDigest: plan.workload.artifact.digest,
+    executablePath: plan.executablePath,
+    executableDigest: plan.workload.launch.executable.digest,
+  };
+}
+
 describe("inactive MXC native-artifact bootstrap", () => {
   it("preserves drive-root launch authority across create and readiness checks (#8178)", async () => {
     let observedPlan: RuntimeProviderNativeArtifactBootstrapPlan | null = null;
     const operations: RuntimeProviderNativeArtifactBootstrapOperations = {
-      create: vi.fn(async (plan) => {
+      verifyArtifactIdentity: vi.fn(async (plan) => artifactIdentityEvidence(plan)),
+      create: vi.fn(async (plan, identity) => {
         observedPlan = plan;
         const authoritySha256 = plan.authoritySha256;
+        expect(identity).toEqual(artifactIdentityEvidence(plan));
         Reflect.set(plan, "artifactRoot", SHARE_DIRECTORY);
         Reflect.set(plan.workload.artifact, "digest", "sha256:" + "0".repeat(64));
         Reflect.set(plan.workload.launch.environmentNames, "0", "MUTATED");
+        Reflect.set(identity, "artifactDigest", "sha256:" + "0".repeat(64));
+        expect(identity.artifactDigest).toBe(NATIVE_RECEIPT.artifact.digest);
         return { status: "created" as const, authoritySha256 };
       }),
       verifyReadiness: vi.fn(async (plan) => {
@@ -180,6 +197,22 @@ describe("inactive MXC native-artifact bootstrap", () => {
       /artifact root and provider-owned writable share must remain separate/u,
     ],
     [
+      "writable share with a trailing period reused as the artifact root",
+      (input: RuntimeProviderNativeArtifactBootstrapInput) => ({
+        ...input,
+        artifactRoot: `${SHARE_DIRECTORY}.`,
+      }),
+      /artifact root must be a direct child/u,
+    ],
+    [
+      "writable share with a trailing space reused as the artifact root",
+      (input: RuntimeProviderNativeArtifactBootstrapInput) => ({
+        ...input,
+        artifactRoot: `${SHARE_DIRECTORY} `,
+      }),
+      /artifact root must be a direct child/u,
+    ],
+    [
       "OpenClaw writable mappings omitted",
       (input: RuntimeProviderNativeArtifactBootstrapInput) => ({
         ...input,
@@ -194,6 +227,7 @@ describe("inactive MXC native-artifact bootstrap", () => {
     const create = vi.fn();
     await expect(
       nativeBootstrap().run(mutate(bootstrapInput()), {
+        verifyArtifactIdentity: vi.fn(),
         create,
         verifyReadiness: vi.fn(),
       }),
@@ -201,9 +235,75 @@ describe("inactive MXC native-artifact bootstrap", () => {
     expect(create).not.toHaveBeenCalled();
   });
 
+  it("requires provider-owned artifact verification before the create boundary (#8178)", async () => {
+    const create = vi.fn();
+
+    await expect(
+      nativeBootstrap().run(bootstrapInput(), {
+        create,
+        verifyReadiness: vi.fn(),
+      } as unknown as RuntimeProviderNativeArtifactBootstrapOperations),
+    ).rejects.toThrow(/artifact verification, create, and readiness operations/u);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: "missing artifact evidence",
+      verifyArtifactIdentity: async () =>
+        undefined as unknown as RuntimeProviderNativeArtifactIdentityEvidence,
+    },
+    {
+      label: "malformed artifact evidence",
+      verifyArtifactIdentity: async () =>
+        ({
+          authoritySha256: "malformed",
+        }) as unknown as RuntimeProviderNativeArtifactIdentityEvidence,
+    },
+    {
+      label: "artifact digest drift",
+      verifyArtifactIdentity: async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
+        ...artifactIdentityEvidence(plan),
+        artifactDigest: `sha256:${"0".repeat(64)}`,
+      }),
+    },
+    {
+      label: "executable digest drift",
+      verifyArtifactIdentity: async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
+        ...artifactIdentityEvidence(plan),
+        executableDigest: `sha256:${"0".repeat(64)}`,
+      }),
+    },
+    {
+      label: "artifact verification failure",
+      verifyArtifactIdentity: async (_plan: RuntimeProviderNativeArtifactBootstrapPlan) => {
+        throw new Error("untrusted artifact verification detail");
+      },
+    },
+  ])("rejects $label before the create boundary (#8178)", async ({ verifyArtifactIdentity }) => {
+    const create = vi.fn();
+    const verifyReadiness = vi.fn();
+    const receipt = await nativeBootstrap().run(bootstrapInput(), {
+      verifyArtifactIdentity,
+      create,
+      verifyReadiness,
+    });
+
+    expect(receipt).toMatchObject({
+      outcome: "not-created",
+      reason: "artifact-verification-failed",
+      resourceState: "absent",
+      cleanup: { attempted: false, resourceRemovalAuthorized: false },
+    });
+    expect(JSON.stringify(receipt)).not.toContain("untrusted artifact verification detail");
+    expect(create).not.toHaveBeenCalled();
+    expect(verifyReadiness).not.toHaveBeenCalled();
+  });
+
   it("isolates writable shares by sandbox lifecycle generation (#8178)", async () => {
     const plans: RuntimeProviderNativeArtifactBootstrapPlan[] = [];
     const operations: RuntimeProviderNativeArtifactBootstrapOperations = {
+      verifyArtifactIdentity: vi.fn(async (plan) => artifactIdentityEvidence(plan)),
       create: vi.fn(async (plan) => {
         plans.push(plan);
         return { status: "not-created" as const };
@@ -256,6 +356,7 @@ describe("inactive MXC native-artifact bootstrap", () => {
   ])("retains safe state after $label (#8178)", async ({ create, expected }) => {
     const verifyReadiness = vi.fn();
     const receipt = await nativeBootstrap().run(bootstrapInput(), {
+      verifyArtifactIdentity: async (plan) => artifactIdentityEvidence(plan),
       create,
       verifyReadiness,
     });
@@ -309,6 +410,7 @@ describe("inactive MXC native-artifact bootstrap", () => {
     async (_label, create, verifyReadiness, reason, verificationExpected) => {
       const verify = vi.fn(verifyReadiness);
       const receipt = await nativeBootstrap().run(bootstrapInput(), {
+        verifyArtifactIdentity: async (plan) => artifactIdentityEvidence(plan),
         create,
         verifyReadiness: verify,
       });

--- a/src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts
@@ -9,7 +9,6 @@ import { encodeManagedStartupProfile } from "../managed-startup/profile";
 import { nativeArtifactWorkloadReceiptFixture } from "../workload/native-artifact-test-fixture";
 import type {
   RuntimeProviderNativeArtifactBootstrapInput,
-  RuntimeProviderNativeArtifactIdentityEvidence,
   RuntimeProviderNativeArtifactBootstrapOperations,
   RuntimeProviderNativeArtifactBootstrapPlan,
   RuntimeProviderNativeArtifactReadinessEvidence,
@@ -76,33 +75,26 @@ function readyEvidence(
   };
 }
 
-function artifactIdentityEvidence(
-  plan: RuntimeProviderNativeArtifactBootstrapPlan,
-): RuntimeProviderNativeArtifactIdentityEvidence {
+function verifiedCreateOutcome(plan: RuntimeProviderNativeArtifactBootstrapPlan) {
   return {
+    status: "created" as const,
     authoritySha256: plan.authoritySha256,
-    artifactRoot: plan.artifactRoot,
     artifactDigest: plan.workload.artifact.digest,
-    executablePath: plan.executablePath,
     executableDigest: plan.workload.launch.executable.digest,
   };
 }
 
 describe("inactive MXC native-artifact bootstrap", () => {
-  it("preserves drive-root launch authority across create and readiness checks (#8178)", async () => {
+  it("preserves drive-root launch authority across atomic create and readiness checks (#8178)", async () => {
     let observedPlan: RuntimeProviderNativeArtifactBootstrapPlan | null = null;
     const operations: RuntimeProviderNativeArtifactBootstrapOperations = {
-      verifyArtifactIdentity: vi.fn(async (plan) => artifactIdentityEvidence(plan)),
-      create: vi.fn(async (plan, identity) => {
+      verifyAndCreate: vi.fn(async (plan) => {
         observedPlan = plan;
-        const authoritySha256 = plan.authoritySha256;
-        expect(identity).toEqual(artifactIdentityEvidence(plan));
+        const created = verifiedCreateOutcome(plan);
         Reflect.set(plan, "artifactRoot", SHARE_DIRECTORY);
         Reflect.set(plan.workload.artifact, "digest", "sha256:" + "0".repeat(64));
         Reflect.set(plan.workload.launch.environmentNames, "0", "MUTATED");
-        Reflect.set(identity, "artifactDigest", "sha256:" + "0".repeat(64));
-        expect(identity.artifactDigest).toBe(NATIVE_RECEIPT.artifact.digest);
-        return { status: "created" as const, authoritySha256 };
+        return created;
       }),
       verifyReadiness: vi.fn(async (plan) => {
         expect(plan.artifactRoot).toBe("C:\\openclaw-2026-7-1");
@@ -224,68 +216,57 @@ describe("inactive MXC native-artifact bootstrap", () => {
       /bind OpenClaw home, state, config, TEMP, and TMP/u,
     ],
   ] as const)("rejects %s before the create boundary (#8178)", async (_label, mutate, message) => {
-    const create = vi.fn();
+    const verifyAndCreate = vi.fn();
     await expect(
       nativeBootstrap().run(mutate(bootstrapInput()), {
-        verifyArtifactIdentity: vi.fn(),
-        create,
+        verifyAndCreate,
         verifyReadiness: vi.fn(),
       }),
     ).rejects.toThrow(message);
-    expect(create).not.toHaveBeenCalled();
+    expect(verifyAndCreate).not.toHaveBeenCalled();
   });
 
-  it("requires provider-owned artifact verification before the create boundary (#8178)", async () => {
+  it("rejects the obsolete separated verification and create operations (#8178)", async () => {
+    const verifyArtifactIdentity = vi.fn();
     const create = vi.fn();
 
     await expect(
       nativeBootstrap().run(bootstrapInput(), {
+        verifyArtifactIdentity,
         create,
         verifyReadiness: vi.fn(),
       } as unknown as RuntimeProviderNativeArtifactBootstrapOperations),
-    ).rejects.toThrow(/artifact verification, create, and readiness operations/u);
+    ).rejects.toThrow(/atomic artifact verification and create plus readiness operations/u);
+    expect(verifyArtifactIdentity).not.toHaveBeenCalled();
     expect(create).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      label: "missing artifact evidence",
-      verifyArtifactIdentity: async () =>
-        undefined as unknown as RuntimeProviderNativeArtifactIdentityEvidence,
-    },
-    {
-      label: "malformed artifact evidence",
-      verifyArtifactIdentity: async () =>
-        ({
-          authoritySha256: "malformed",
-        }) as unknown as RuntimeProviderNativeArtifactIdentityEvidence,
-    },
-    {
-      label: "artifact digest drift",
-      verifyArtifactIdentity: async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
-        ...artifactIdentityEvidence(plan),
-        artifactDigest: `sha256:${"0".repeat(64)}`,
-      }),
-    },
-    {
-      label: "executable digest drift",
-      verifyArtifactIdentity: async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
-        ...artifactIdentityEvidence(plan),
-        executableDigest: `sha256:${"0".repeat(64)}`,
-      }),
-    },
-    {
-      label: "artifact verification failure",
-      verifyArtifactIdentity: async (_plan: RuntimeProviderNativeArtifactBootstrapPlan) => {
-        throw new Error("untrusted artifact verification detail");
-      },
-    },
-  ])("rejects $label before the create boundary (#8178)", async ({ verifyArtifactIdentity }) => {
-    const create = vi.fn();
+  it("refuses launch when a reparse target changes inside atomic verification and create (#8178)", async () => {
+    let resolvedExecutableTarget = "C:\\verified-artifact\\node.exe";
+    const launch = vi.fn();
     const verifyReadiness = vi.fn();
+    const verifyAndCreate = vi.fn(async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => {
+      const verifiedTarget = resolvedExecutableTarget;
+      const createForVerifiedTarget = new Map([
+        [
+          verifiedTarget,
+          () => {
+            launch(plan.executablePath);
+            return verifiedCreateOutcome(plan);
+          },
+        ],
+      ]);
+      resolvedExecutableTarget = "C:\\substituted-artifact\\node.exe";
+      return (
+        createForVerifiedTarget.get(resolvedExecutableTarget)?.() ?? {
+          status: "not-created" as const,
+          reason: "artifact-verification-failed" as const,
+        }
+      );
+    });
+
     const receipt = await nativeBootstrap().run(bootstrapInput(), {
-      verifyArtifactIdentity,
-      create,
+      verifyAndCreate,
       verifyReadiness,
     });
 
@@ -295,18 +276,69 @@ describe("inactive MXC native-artifact bootstrap", () => {
       resourceState: "absent",
       cleanup: { attempted: false, resourceRemovalAuthorized: false },
     });
-    expect(JSON.stringify(receipt)).not.toContain("untrusted artifact verification detail");
-    expect(create).not.toHaveBeenCalled();
+    expect(verifyAndCreate).toHaveBeenCalledOnce();
+    expect(launch).not.toHaveBeenCalled();
     expect(verifyReadiness).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      label: "malformed atomic outcome",
+      verifyAndCreate: async () =>
+        undefined as unknown as Awaited<
+          ReturnType<RuntimeProviderNativeArtifactBootstrapOperations["verifyAndCreate"]>
+        >,
+      reason: "create-outcome-unknown",
+    },
+    {
+      label: "artifact digest drift",
+      verifyAndCreate: async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
+        ...verifiedCreateOutcome(plan),
+        artifactDigest: `sha256:${"0".repeat(64)}`,
+      }),
+      reason: "create-authority-mismatch",
+    },
+    {
+      label: "executable digest drift",
+      verifyAndCreate: async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
+        ...verifiedCreateOutcome(plan),
+        executableDigest: `sha256:${"0".repeat(64)}`,
+      }),
+      reason: "create-authority-mismatch",
+    },
+    {
+      label: "atomic operation failure",
+      verifyAndCreate: async (_plan: RuntimeProviderNativeArtifactBootstrapPlan) => {
+        throw new Error("untrusted artifact verification detail");
+      },
+      reason: "create-outcome-unknown",
+    },
+  ] as const)(
+    "retains an ambiguous resource after $label (#8178)",
+    async ({ verifyAndCreate, reason }) => {
+      const verifyReadiness = vi.fn();
+      const receipt = await nativeBootstrap().run(bootstrapInput(), {
+        verifyAndCreate,
+        verifyReadiness,
+      });
+
+      expect(receipt).toMatchObject({
+        outcome: "retained",
+        reason,
+        resourceState: "possibly-retained",
+        cleanup: { attempted: false, resourceRemovalAuthorized: false },
+      });
+      expect(JSON.stringify(receipt)).not.toContain("untrusted artifact verification detail");
+      expect(verifyReadiness).not.toHaveBeenCalled();
+    },
+  );
 
   it("isolates writable shares by sandbox lifecycle generation (#8178)", async () => {
     const plans: RuntimeProviderNativeArtifactBootstrapPlan[] = [];
     const operations: RuntimeProviderNativeArtifactBootstrapOperations = {
-      verifyArtifactIdentity: vi.fn(async (plan) => artifactIdentityEvidence(plan)),
-      create: vi.fn(async (plan) => {
+      verifyAndCreate: vi.fn(async (plan) => {
         plans.push(plan);
-        return { status: "not-created" as const };
+        return { status: "not-created" as const, reason: "create-rejected" as const };
       }),
       verifyReadiness: vi.fn(),
     };
@@ -326,7 +358,10 @@ describe("inactive MXC native-artifact bootstrap", () => {
   it.each([
     {
       label: "explicit create rejection",
-      create: async () => ({ status: "not-created" as const }),
+      verifyAndCreate: async () => ({
+        status: "not-created" as const,
+        reason: "create-rejected" as const,
+      }),
       expected: {
         outcome: "not-created",
         reason: "create-rejected",
@@ -335,7 +370,7 @@ describe("inactive MXC native-artifact bootstrap", () => {
     },
     {
       label: "ambiguous create result",
-      create: async () => ({ status: "unknown" as const }),
+      verifyAndCreate: async () => ({ status: "unknown" as const }),
       expected: {
         outcome: "retained",
         reason: "create-outcome-unknown",
@@ -344,7 +379,7 @@ describe("inactive MXC native-artifact bootstrap", () => {
     },
     {
       label: "create transport failure",
-      create: async () => {
+      verifyAndCreate: async () => {
         throw new Error("nvapi-secret-must-not-escape");
       },
       expected: {
@@ -353,11 +388,10 @@ describe("inactive MXC native-artifact bootstrap", () => {
         resourceState: "possibly-retained",
       },
     },
-  ])("retains safe state after $label (#8178)", async ({ create, expected }) => {
+  ])("reports fail-closed state after $label (#8178)", async ({ verifyAndCreate, expected }) => {
     const verifyReadiness = vi.fn();
     const receipt = await nativeBootstrap().run(bootstrapInput(), {
-      verifyArtifactIdentity: async (plan) => artifactIdentityEvidence(plan),
-      create,
+      verifyAndCreate,
       verifyReadiness,
     });
 
@@ -372,8 +406,8 @@ describe("inactive MXC native-artifact bootstrap", () => {
   it.each([
     [
       "create authority drift",
-      async (_plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
-        status: "created" as const,
+      async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
+        ...verifiedCreateOutcome(plan),
         authoritySha256: "0".repeat(64),
       }),
       async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => readyEvidence(plan),
@@ -382,10 +416,7 @@ describe("inactive MXC native-artifact bootstrap", () => {
     ],
     [
       "readiness identity drift",
-      async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
-        status: "created" as const,
-        authoritySha256: plan.authoritySha256,
-      }),
+      async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => verifiedCreateOutcome(plan),
       async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
         ...readyEvidence(plan),
         lifecycleGeneration: `${plan.lifecycleGeneration}-drift`,
@@ -395,10 +426,7 @@ describe("inactive MXC native-artifact bootstrap", () => {
     ],
     [
       "readiness transport failure",
-      async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
-        status: "created" as const,
-        authoritySha256: plan.authoritySha256,
-      }),
+      async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => verifiedCreateOutcome(plan),
       async (_plan: RuntimeProviderNativeArtifactBootstrapPlan) => {
         throw new Error("untrusted readiness detail");
       },
@@ -407,11 +435,10 @@ describe("inactive MXC native-artifact bootstrap", () => {
     ],
   ] as const)(
     "retains a created or ambiguous resource after %s (#8178)",
-    async (_label, create, verifyReadiness, reason, verificationExpected) => {
+    async (_label, verifyAndCreate, verifyReadiness, reason, verificationExpected) => {
       const verify = vi.fn(verifyReadiness);
       const receipt = await nativeBootstrap().run(bootstrapInput(), {
-        verifyArtifactIdentity: async (plan) => artifactIdentityEvidence(plan),
-        create,
+        verifyAndCreate,
         verifyReadiness: verify,
       });
 

--- a/src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts
@@ -76,17 +76,23 @@ function readyEvidence(
 }
 
 describe("inactive MXC native-artifact bootstrap", () => {
-  it("freezes drive-root launch authority before create and proves exact readiness (#8178)", async () => {
+  it("preserves drive-root launch authority across create and readiness checks (#8178)", async () => {
     let observedPlan: RuntimeProviderNativeArtifactBootstrapPlan | null = null;
     const operations: RuntimeProviderNativeArtifactBootstrapOperations = {
       create: vi.fn(async (plan) => {
         observedPlan = plan;
-        expect(Object.isFrozen(plan)).toBe(true);
-        expect(Object.isFrozen(plan.workload)).toBe(true);
-        expect(Object.isFrozen(plan.workload.launch.environmentNames)).toBe(true);
-        return { status: "created" as const, authoritySha256: plan.authoritySha256 };
+        const authoritySha256 = plan.authoritySha256;
+        Reflect.set(plan, "artifactRoot", SHARE_DIRECTORY);
+        Reflect.set(plan.workload.artifact, "digest", "sha256:" + "0".repeat(64));
+        Reflect.set(plan.workload.launch.environmentNames, "0", "MUTATED");
+        return { status: "created" as const, authoritySha256 };
       }),
-      verifyReadiness: vi.fn(async (plan) => readyEvidence(plan)),
+      verifyReadiness: vi.fn(async (plan) => {
+        expect(plan.artifactRoot).toBe("C:\\openclaw-2026-7-1");
+        expect(plan.workload.artifact.digest).toBe(NATIVE_RECEIPT.artifact.digest);
+        expect(plan.workload.launch.environmentNames[0]).toBe("HOME");
+        return readyEvidence(plan);
+      }),
     };
 
     const receipt = await nativeBootstrap().run(bootstrapInput(), operations);
@@ -162,6 +168,14 @@ describe("inactive MXC native-artifact bootstrap", () => {
       (input: RuntimeProviderNativeArtifactBootstrapInput) => ({
         ...input,
         artifactRoot: SHARE_DIRECTORY,
+      }),
+      /artifact root and provider-owned writable share must remain separate/u,
+    ],
+    [
+      "writable share with a trailing separator reused as the artifact root",
+      (input: RuntimeProviderNativeArtifactBootstrapInput) => ({
+        ...input,
+        artifactRoot: `${SHARE_DIRECTORY}\\`,
       }),
       /artifact root and provider-owned writable share must remain separate/u,
     ],

--- a/src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+
+import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import { encodeManagedStartupProfile } from "../managed-startup/profile";
+import { nativeArtifactWorkloadReceiptFixture } from "../workload/native-artifact-test-fixture";
+import type {
+  RuntimeProviderNativeArtifactBootstrapInput,
+  RuntimeProviderNativeArtifactBootstrapOperations,
+  RuntimeProviderNativeArtifactBootstrapPlan,
+  RuntimeProviderNativeArtifactReadinessEvidence,
+  RuntimeProviderNativeArtifactBootstrapSurface,
+} from "./contract";
+import { createMxcRuntimeProviderBundle } from "./mxc";
+
+const NATIVE_RECEIPT = nativeArtifactWorkloadReceiptFixture(
+  encodeManagedStartupProfile(managedStartupE2eProfile("openclaw")),
+);
+const LIFECYCLE_GENERATION = "generation-7";
+const SHARE_DIRECTORY = `C:\\nemoclaw-alpha-${createHash("sha256")
+  .update(LIFECYCLE_GENERATION, "utf8")
+  .digest("hex")
+  .slice(0, 12)}`;
+
+function bootstrapInput(): RuntimeProviderNativeArtifactBootstrapInput {
+  return {
+    providerId: "mxc",
+    sandboxName: "alpha",
+    lifecycleGeneration: LIFECYCLE_GENERATION,
+    driveRoot: "C:\\",
+    artifactRoot: "C:\\openclaw-2026-7-1",
+    workload: {
+      ...NATIVE_RECEIPT,
+      launch: {
+        ...NATIVE_RECEIPT.launch,
+        environmentNames: [
+          "HOME",
+          "OPENCLAW_CONFIG_PATH",
+          "OPENCLAW_HOME",
+          "OPENCLAW_STATE_DIR",
+          "PATH",
+          "TEMP",
+          "TMP",
+          "USERPROFILE",
+        ],
+      },
+    },
+  };
+}
+
+function nativeBootstrap() {
+  const surface = createMxcRuntimeProviderBundle({
+    hostFacts: {
+      platform: "win32",
+      nativeArchitecture: "x64",
+      release: "10.0.28120",
+    },
+  }).bootstrap;
+  expect(surface).toMatchObject({ supported: true, bootstrapKind: "native-artifact" });
+  return surface as RuntimeProviderNativeArtifactBootstrapSurface;
+}
+
+function readyEvidence(
+  plan: RuntimeProviderNativeArtifactBootstrapPlan,
+): RuntimeProviderNativeArtifactReadinessEvidence {
+  return {
+    authoritySha256: plan.authoritySha256,
+    lifecycleGeneration: plan.lifecycleGeneration,
+    artifactDigest: plan.workload.artifact.digest,
+    executableDigest: plan.workload.launch.executable.digest,
+    ready: true,
+  };
+}
+
+describe("inactive MXC native-artifact bootstrap", () => {
+  it("freezes drive-root launch authority before create and proves exact readiness (#8178)", async () => {
+    let observedPlan: RuntimeProviderNativeArtifactBootstrapPlan | null = null;
+    const operations: RuntimeProviderNativeArtifactBootstrapOperations = {
+      create: vi.fn(async (plan) => {
+        observedPlan = plan;
+        expect(Object.isFrozen(plan)).toBe(true);
+        expect(Object.isFrozen(plan.workload)).toBe(true);
+        expect(Object.isFrozen(plan.workload.launch.environmentNames)).toBe(true);
+        return { status: "created" as const, authoritySha256: plan.authoritySha256 };
+      }),
+      verifyReadiness: vi.fn(async (plan) => readyEvidence(plan)),
+    };
+
+    const receipt = await nativeBootstrap().run(bootstrapInput(), operations);
+
+    expect(observedPlan).toMatchObject({
+      schemaVersion: 1,
+      providerId: "mxc",
+      sandboxName: "alpha",
+      lifecycleGeneration: LIFECYCLE_GENERATION,
+      driveRoot: "C:\\",
+      artifactRoot: "C:\\openclaw-2026-7-1",
+      shareDirectory: SHARE_DIRECTORY,
+      homeDirectory: `${SHARE_DIRECTORY}\\home`,
+      stateDirectory: `${SHARE_DIRECTORY}\\openclaw-state`,
+      temporaryDirectory: `${SHARE_DIRECTORY}\\temp`,
+      executablePath: "C:\\openclaw-2026-7-1\\node\\node.exe",
+      workingDirectory: "C:\\openclaw-2026-7-1",
+      environment: {
+        HOME: `${SHARE_DIRECTORY}\\home`,
+        OPENCLAW_CONFIG_PATH: `${SHARE_DIRECTORY}\\openclaw-state\\openclaw.json`,
+        OPENCLAW_HOME: `${SHARE_DIRECTORY}\\home`,
+        OPENCLAW_STATE_DIR: `${SHARE_DIRECTORY}\\openclaw-state`,
+        TEMP: `${SHARE_DIRECTORY}\\temp`,
+        TMP: `${SHARE_DIRECTORY}\\temp`,
+        USERPROFILE: `${SHARE_DIRECTORY}\\home`,
+      },
+      authoritySha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+    });
+    expect(receipt).toEqual({
+      outcome: "ready",
+      reason: null,
+      authoritySha256: observedPlan!.authoritySha256,
+      resourceState: "active",
+      cleanup: { attempted: false, resourceRemovalAuthorized: false },
+    });
+    expect(Object.isFrozen(receipt)).toBe(true);
+    expect(Object.isFrozen(receipt.cleanup)).toBe(true);
+    expect(JSON.stringify(observedPlan)).not.toMatch(/C:\\\\Users/iu);
+  });
+
+  it.each([
+    [
+      "provider drift",
+      (input: RuntimeProviderNativeArtifactBootstrapInput) => ({ ...input, providerId: "docker" }),
+      /provider identity/u,
+    ],
+    [
+      "missing lifecycle generation",
+      (input: RuntimeProviderNativeArtifactBootstrapInput) => ({
+        ...input,
+        lifecycleGeneration: "",
+      }),
+      /lifecycle generation/u,
+    ],
+    [
+      "nested artifact staging",
+      (input: RuntimeProviderNativeArtifactBootstrapInput) => ({
+        ...input,
+        artifactRoot: "C:\\stage\\openclaw-2026-7-1",
+      }),
+      /artifact root must be a direct child/u,
+    ],
+    [
+      "broad user directory as the provider root",
+      (input: RuntimeProviderNativeArtifactBootstrapInput) => ({
+        ...input,
+        driveRoot: "C:\\Users\\alpha",
+      }),
+      /drive root must name one Windows drive root/u,
+    ],
+    [
+      "writable share reused as the artifact root",
+      (input: RuntimeProviderNativeArtifactBootstrapInput) => ({
+        ...input,
+        artifactRoot: SHARE_DIRECTORY,
+      }),
+      /artifact root and provider-owned writable share must remain separate/u,
+    ],
+    [
+      "OpenClaw writable mappings omitted",
+      (input: RuntimeProviderNativeArtifactBootstrapInput) => ({
+        ...input,
+        workload: {
+          ...input.workload,
+          launch: { ...input.workload.launch, environmentNames: ["PATH"] },
+        },
+      }),
+      /bind OpenClaw home, state, config, TEMP, and TMP/u,
+    ],
+  ] as const)("rejects %s before the create boundary (#8178)", async (_label, mutate, message) => {
+    const create = vi.fn();
+    await expect(
+      nativeBootstrap().run(mutate(bootstrapInput()), {
+        create,
+        verifyReadiness: vi.fn(),
+      }),
+    ).rejects.toThrow(message);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("isolates writable shares by sandbox lifecycle generation (#8178)", async () => {
+    const plans: RuntimeProviderNativeArtifactBootstrapPlan[] = [];
+    const operations: RuntimeProviderNativeArtifactBootstrapOperations = {
+      create: vi.fn(async (plan) => {
+        plans.push(plan);
+        return { status: "not-created" as const };
+      }),
+      verifyReadiness: vi.fn(),
+    };
+
+    await nativeBootstrap().run(bootstrapInput(), operations);
+    await nativeBootstrap().run(
+      { ...bootstrapInput(), lifecycleGeneration: "generation-8" },
+      operations,
+    );
+
+    expect(plans).toHaveLength(2);
+    expect(plans[0]!.shareDirectory).not.toBe(plans[1]!.shareDirectory);
+    expect(plans[0]!.shareDirectory).toMatch(/^C:\\nemoclaw-alpha-[a-f0-9]{12}$/u);
+    expect(plans[1]!.shareDirectory).toMatch(/^C:\\nemoclaw-alpha-[a-f0-9]{12}$/u);
+  });
+
+  it.each([
+    {
+      label: "explicit create rejection",
+      create: async () => ({ status: "not-created" as const }),
+      expected: {
+        outcome: "not-created",
+        reason: "create-rejected",
+        resourceState: "absent",
+      },
+    },
+    {
+      label: "ambiguous create result",
+      create: async () => ({ status: "unknown" as const }),
+      expected: {
+        outcome: "retained",
+        reason: "create-outcome-unknown",
+        resourceState: "possibly-retained",
+      },
+    },
+    {
+      label: "create transport failure",
+      create: async () => {
+        throw new Error("nvapi-secret-must-not-escape");
+      },
+      expected: {
+        outcome: "retained",
+        reason: "create-outcome-unknown",
+        resourceState: "possibly-retained",
+      },
+    },
+  ])("retains safe state after $label (#8178)", async ({ create, expected }) => {
+    const verifyReadiness = vi.fn();
+    const receipt = await nativeBootstrap().run(bootstrapInput(), {
+      create,
+      verifyReadiness,
+    });
+
+    expect(receipt).toMatchObject({
+      ...expected,
+      cleanup: { attempted: false, resourceRemovalAuthorized: false },
+    });
+    expect(JSON.stringify(receipt)).not.toContain("nvapi-secret-must-not-escape");
+    expect(verifyReadiness).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "create authority drift",
+      async (_plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
+        status: "created" as const,
+        authoritySha256: "0".repeat(64),
+      }),
+      async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => readyEvidence(plan),
+      "create-authority-mismatch",
+      false,
+    ],
+    [
+      "readiness identity drift",
+      async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
+        status: "created" as const,
+        authoritySha256: plan.authoritySha256,
+      }),
+      async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
+        ...readyEvidence(plan),
+        lifecycleGeneration: `${plan.lifecycleGeneration}-drift`,
+      }),
+      "readiness-not-proven",
+      true,
+    ],
+    [
+      "readiness transport failure",
+      async (plan: RuntimeProviderNativeArtifactBootstrapPlan) => ({
+        status: "created" as const,
+        authoritySha256: plan.authoritySha256,
+      }),
+      async (_plan: RuntimeProviderNativeArtifactBootstrapPlan) => {
+        throw new Error("untrusted readiness detail");
+      },
+      "readiness-not-proven",
+      true,
+    ],
+  ] as const)(
+    "retains a created or ambiguous resource after %s (#8178)",
+    async (_label, create, verifyReadiness, reason, verificationExpected) => {
+      const verify = vi.fn(verifyReadiness);
+      const receipt = await nativeBootstrap().run(bootstrapInput(), {
+        create,
+        verifyReadiness: verify,
+      });
+
+      expect(receipt).toMatchObject({
+        outcome: "retained",
+        reason,
+        resourceState: "possibly-retained",
+        cleanup: { attempted: false, resourceRemovalAuthorized: false },
+      });
+      expect(verify).toHaveBeenCalledTimes(verificationExpected ? 1 : 0);
+    },
+  );
+});

--- a/src/lib/onboard/runtime-provider/mxc-bootstrap.ts
+++ b/src/lib/onboard/runtime-provider/mxc-bootstrap.ts
@@ -138,7 +138,10 @@ function preparePlan(
     input.sandboxName,
     input.lifecycleGeneration,
   );
-  if (artifactRoot.toLowerCase() === shareDirectory.toLowerCase()) {
+  if (
+    path.win32.resolve(artifactRoot).toLowerCase() ===
+    path.win32.resolve(shareDirectory).toLowerCase()
+  ) {
     throw new MxcNativeArtifactBootstrapError(
       "artifact root and provider-owned writable share must remain separate",
     );

--- a/src/lib/onboard/runtime-provider/mxc-bootstrap.ts
+++ b/src/lib/onboard/runtime-provider/mxc-bootstrap.ts
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+import { parseNativeArtifactWorkloadReceiptV1 } from "../workload/native-artifact";
+import {
+  RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION,
+  RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_PLAN_SCHEMA_VERSION,
+  type RuntimeProviderNativeArtifactBootstrapInput,
+  type RuntimeProviderNativeArtifactBootstrapOperations,
+  type RuntimeProviderNativeArtifactBootstrapPlan,
+  type RuntimeProviderNativeArtifactBootstrapResult,
+  type RuntimeProviderNativeArtifactBootstrapSurface,
+} from "./contract";
+
+const MXC_PROVIDER_ID = "mxc";
+const SANDBOX_NAME_PATTERN = /^[a-z][a-z0-9-]{0,62}$/u;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
+const MAX_PATH_BYTES = 4096;
+
+export class MxcNativeArtifactBootstrapError extends Error {
+  constructor(message: string) {
+    super(`Invalid MXC native artifact bootstrap: ${message}`);
+    this.name = "MxcNativeArtifactBootstrapError";
+  }
+}
+
+function frozen<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) frozen(child);
+  return Object.freeze(value);
+}
+
+function canonicalWindowsPath(value: unknown, label: string): string {
+  if (
+    typeof value !== "string" ||
+    Buffer.byteLength(value, "utf8") > MAX_PATH_BYTES ||
+    CONTROL_CHARACTER_PATTERN.test(value) ||
+    !path.win32.isAbsolute(value) ||
+    path.win32.normalize(value) !== value
+  ) {
+    throw new MxcNativeArtifactBootstrapError(`${label} must be a canonical absolute path`);
+  }
+  return value;
+}
+
+function requireDriveRoot(value: unknown): string {
+  const driveRoot = canonicalWindowsPath(value, "drive root");
+  if (path.win32.parse(driveRoot).root !== driveRoot || !/^[A-Za-z]:\\$/u.test(driveRoot)) {
+    throw new MxcNativeArtifactBootstrapError("drive root must name one Windows drive root");
+  }
+  return driveRoot;
+}
+
+function requireDirectChild(
+  root: string,
+  value: unknown,
+  label: string,
+  parentLabel: string,
+): string {
+  const child = canonicalWindowsPath(value, label);
+  const relative = path.win32.relative(root, child);
+  if (
+    relative.length === 0 ||
+    path.win32.isAbsolute(relative) ||
+    relative.startsWith("..") ||
+    relative.includes("\\") ||
+    relative.includes("/")
+  ) {
+    throw new MxcNativeArtifactBootstrapError(
+      `${label} must be a direct child of the ${parentLabel}`,
+    );
+  }
+  return child;
+}
+
+function providerOwnedShareDirectory(
+  driveRoot: string,
+  sandboxName: string,
+  lifecycleGeneration: string,
+): string {
+  const generationSha256 = createHash("sha256").update(lifecycleGeneration, "utf8").digest("hex");
+  return path.win32.join(driveRoot, `nemoclaw-${sandboxName}-${generationSha256.slice(0, 12)}`);
+}
+
+function planAuthoritySha256(
+  input: Omit<RuntimeProviderNativeArtifactBootstrapPlan, "authoritySha256">,
+): string {
+  return createHash("sha256").update(JSON.stringify(input), "utf8").digest("hex");
+}
+
+function preparePlan(
+  input: RuntimeProviderNativeArtifactBootstrapInput,
+): RuntimeProviderNativeArtifactBootstrapPlan {
+  if (input.providerId !== MXC_PROVIDER_ID) {
+    throw new MxcNativeArtifactBootstrapError("provider identity does not match 'mxc'");
+  }
+  if (!SANDBOX_NAME_PATTERN.test(input.sandboxName)) {
+    throw new MxcNativeArtifactBootstrapError("sandbox name is not a canonical OpenShell name");
+  }
+  if (
+    typeof input.lifecycleGeneration !== "string" ||
+    input.lifecycleGeneration.length === 0 ||
+    input.lifecycleGeneration.length > 256 ||
+    CONTROL_CHARACTER_PATTERN.test(input.lifecycleGeneration)
+  ) {
+    throw new MxcNativeArtifactBootstrapError("lifecycle generation is not a bounded identity");
+  }
+  const workload = parseNativeArtifactWorkloadReceiptV1(input.workload);
+  const requiredEnvironmentNames = [
+    "HOME",
+    "OPENCLAW_CONFIG_PATH",
+    "OPENCLAW_HOME",
+    "OPENCLAW_STATE_DIR",
+    "TEMP",
+    "TMP",
+    "USERPROFILE",
+  ] as const;
+  const environmentNames = new Set(workload.launch.environmentNames);
+  if (requiredEnvironmentNames.some((name) => !environmentNames.has(name))) {
+    throw new MxcNativeArtifactBootstrapError(
+      "workload launch must bind OpenClaw home, state, config, TEMP, and TMP to the writable share",
+    );
+  }
+  const driveRoot = requireDriveRoot(input.driveRoot);
+  const artifactRoot = requireDirectChild(
+    driveRoot,
+    input.artifactRoot,
+    "artifact root",
+    "drive root",
+  );
+  const shareDirectory = providerOwnedShareDirectory(
+    driveRoot,
+    input.sandboxName,
+    input.lifecycleGeneration,
+  );
+  if (artifactRoot.toLowerCase() === shareDirectory.toLowerCase()) {
+    throw new MxcNativeArtifactBootstrapError(
+      "artifact root and provider-owned writable share must remain separate",
+    );
+  }
+  const homeDirectory = path.win32.join(shareDirectory, "home");
+  const stateDirectory = path.win32.join(shareDirectory, "openclaw-state");
+  const temporaryDirectory = path.win32.join(shareDirectory, "temp");
+  const executablePath = path.win32.join(
+    artifactRoot,
+    workload.launch.executable.relativePath.replaceAll("/", "\\"),
+  );
+  const workingDirectory =
+    workload.launch.workingDirectory === "."
+      ? artifactRoot
+      : path.win32.join(artifactRoot, workload.launch.workingDirectory.replaceAll("/", "\\"));
+  const authority = {
+    schemaVersion: RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_PLAN_SCHEMA_VERSION,
+    providerId: MXC_PROVIDER_ID,
+    sandboxName: input.sandboxName,
+    lifecycleGeneration: input.lifecycleGeneration,
+    driveRoot,
+    artifactRoot,
+    shareDirectory,
+    homeDirectory,
+    stateDirectory,
+    temporaryDirectory,
+    executablePath,
+    workingDirectory,
+    environment: {
+      HOME: homeDirectory,
+      OPENCLAW_CONFIG_PATH: path.win32.join(stateDirectory, "openclaw.json"),
+      OPENCLAW_HOME: homeDirectory,
+      OPENCLAW_STATE_DIR: stateDirectory,
+      TEMP: temporaryDirectory,
+      TMP: temporaryDirectory,
+      USERPROFILE: homeDirectory,
+    },
+    workload,
+  } as const;
+  return frozen({ ...authority, authoritySha256: planAuthoritySha256(authority) });
+}
+
+function result(
+  plan: RuntimeProviderNativeArtifactBootstrapPlan,
+  outcome: RuntimeProviderNativeArtifactBootstrapResult["outcome"],
+  reason: RuntimeProviderNativeArtifactBootstrapResult["reason"],
+  resourceState: RuntimeProviderNativeArtifactBootstrapResult["resourceState"],
+): RuntimeProviderNativeArtifactBootstrapResult {
+  return frozen({
+    outcome,
+    reason,
+    authoritySha256: plan.authoritySha256,
+    resourceState,
+    cleanup: { attempted: false, resourceRemovalAuthorized: false },
+  });
+}
+
+async function runMxcNativeArtifactBootstrap(
+  input: RuntimeProviderNativeArtifactBootstrapInput,
+  operations: RuntimeProviderNativeArtifactBootstrapOperations,
+): Promise<RuntimeProviderNativeArtifactBootstrapResult> {
+  if (
+    typeof operations?.create !== "function" ||
+    typeof operations.verifyReadiness !== "function"
+  ) {
+    throw new MxcNativeArtifactBootstrapError(
+      "create and readiness operations are required before bootstrap",
+    );
+  }
+  const plan = preparePlan(input);
+  try {
+    const created = await operations.create(plan);
+    if (created?.status === "not-created") {
+      return result(plan, "not-created", "create-rejected", "absent");
+    }
+    if (created?.status === "unknown") {
+      return result(plan, "retained", "create-outcome-unknown", "possibly-retained");
+    }
+    if (
+      created?.status !== "created" ||
+      !SHA256_PATTERN.test(created.authoritySha256) ||
+      created.authoritySha256 !== plan.authoritySha256
+    ) {
+      return result(plan, "retained", "create-authority-mismatch", "possibly-retained");
+    }
+  } catch {
+    return result(plan, "retained", "create-outcome-unknown", "possibly-retained");
+  }
+  try {
+    const readiness = await operations.verifyReadiness(plan);
+    if (
+      readiness?.authoritySha256 !== plan.authoritySha256 ||
+      readiness.lifecycleGeneration !== plan.lifecycleGeneration ||
+      readiness.artifactDigest !== plan.workload.artifact.digest ||
+      readiness.executableDigest !== plan.workload.launch.executable.digest ||
+      readiness.ready !== true
+    ) {
+      return result(plan, "retained", "readiness-not-proven", "possibly-retained");
+    }
+  } catch {
+    return result(plan, "retained", "readiness-not-proven", "possibly-retained");
+  }
+  return result(plan, "ready", null, "active");
+}
+
+export function createMxcNativeArtifactBootstrapSurface(): RuntimeProviderNativeArtifactBootstrapSurface {
+  return {
+    providerId: MXC_PROVIDER_ID,
+    supported: true,
+    bootstrapKind: "native-artifact",
+    contractVersion: RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION,
+    run: runMxcNativeArtifactBootstrap,
+  };
+}

--- a/src/lib/onboard/runtime-provider/mxc-bootstrap.ts
+++ b/src/lib/onboard/runtime-provider/mxc-bootstrap.ts
@@ -10,6 +10,7 @@ import {
   RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION,
   RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_PLAN_SCHEMA_VERSION,
   type RuntimeProviderNativeArtifactBootstrapInput,
+  type RuntimeProviderNativeArtifactIdentityEvidence,
   type RuntimeProviderNativeArtifactBootstrapOperations,
   type RuntimeProviderNativeArtifactBootstrapPlan,
   type RuntimeProviderNativeArtifactBootstrapResult,
@@ -69,7 +70,9 @@ function requireDirectChild(
     path.win32.isAbsolute(relative) ||
     relative.startsWith("..") ||
     relative.includes("\\") ||
-    relative.includes("/")
+    relative.includes("/") ||
+    relative.endsWith(".") ||
+    relative.endsWith(" ")
   ) {
     throw new MxcNativeArtifactBootstrapError(
       `${label} must be a direct child of the ${parentLabel}`,
@@ -199,21 +202,55 @@ function result(
   });
 }
 
+async function verifyArtifactIdentity(
+  plan: RuntimeProviderNativeArtifactBootstrapPlan,
+  operation: RuntimeProviderNativeArtifactBootstrapOperations["verifyArtifactIdentity"],
+): Promise<RuntimeProviderNativeArtifactIdentityEvidence | null> {
+  try {
+    const evidence = await operation(plan);
+    if (typeof evidence !== "object" || evidence === null) return null;
+    const identity = {
+      authoritySha256: evidence.authoritySha256,
+      artifactRoot: evidence.artifactRoot,
+      artifactDigest: evidence.artifactDigest,
+      executablePath: evidence.executablePath,
+      executableDigest: evidence.executableDigest,
+    };
+    if (
+      identity.authoritySha256 !== plan.authoritySha256 ||
+      identity.artifactRoot !== plan.artifactRoot ||
+      identity.artifactDigest !== plan.workload.artifact.digest ||
+      identity.executablePath !== plan.executablePath ||
+      identity.executableDigest !== plan.workload.launch.executable.digest
+    ) {
+      return null;
+    }
+    return frozen(identity);
+  } catch {
+    return null;
+  }
+}
+
 async function runMxcNativeArtifactBootstrap(
   input: RuntimeProviderNativeArtifactBootstrapInput,
   operations: RuntimeProviderNativeArtifactBootstrapOperations,
 ): Promise<RuntimeProviderNativeArtifactBootstrapResult> {
   if (
+    typeof operations?.verifyArtifactIdentity !== "function" ||
     typeof operations?.create !== "function" ||
     typeof operations.verifyReadiness !== "function"
   ) {
     throw new MxcNativeArtifactBootstrapError(
-      "create and readiness operations are required before bootstrap",
+      "artifact verification, create, and readiness operations are required before bootstrap",
     );
   }
   const plan = preparePlan(input);
+  const identity = await verifyArtifactIdentity(plan, operations.verifyArtifactIdentity);
+  if (identity === null) {
+    return result(plan, "not-created", "artifact-verification-failed", "absent");
+  }
   try {
-    const created = await operations.create(plan);
+    const created = await operations.create(plan, identity);
     if (created?.status === "not-created") {
       return result(plan, "not-created", "create-rejected", "absent");
     }

--- a/src/lib/onboard/runtime-provider/mxc-bootstrap.ts
+++ b/src/lib/onboard/runtime-provider/mxc-bootstrap.ts
@@ -10,7 +10,6 @@ import {
   RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION,
   RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_PLAN_SCHEMA_VERSION,
   type RuntimeProviderNativeArtifactBootstrapInput,
-  type RuntimeProviderNativeArtifactIdentityEvidence,
   type RuntimeProviderNativeArtifactBootstrapOperations,
   type RuntimeProviderNativeArtifactBootstrapPlan,
   type RuntimeProviderNativeArtifactBootstrapResult,
@@ -202,65 +201,38 @@ function result(
   });
 }
 
-async function verifyArtifactIdentity(
-  plan: RuntimeProviderNativeArtifactBootstrapPlan,
-  operation: RuntimeProviderNativeArtifactBootstrapOperations["verifyArtifactIdentity"],
-): Promise<RuntimeProviderNativeArtifactIdentityEvidence | null> {
-  try {
-    const evidence = await operation(plan);
-    if (typeof evidence !== "object" || evidence === null) return null;
-    const identity = {
-      authoritySha256: evidence.authoritySha256,
-      artifactRoot: evidence.artifactRoot,
-      artifactDigest: evidence.artifactDigest,
-      executablePath: evidence.executablePath,
-      executableDigest: evidence.executableDigest,
-    };
-    if (
-      identity.authoritySha256 !== plan.authoritySha256 ||
-      identity.artifactRoot !== plan.artifactRoot ||
-      identity.artifactDigest !== plan.workload.artifact.digest ||
-      identity.executablePath !== plan.executablePath ||
-      identity.executableDigest !== plan.workload.launch.executable.digest
-    ) {
-      return null;
-    }
-    return frozen(identity);
-  } catch {
-    return null;
-  }
-}
-
 async function runMxcNativeArtifactBootstrap(
   input: RuntimeProviderNativeArtifactBootstrapInput,
   operations: RuntimeProviderNativeArtifactBootstrapOperations,
 ): Promise<RuntimeProviderNativeArtifactBootstrapResult> {
   if (
-    typeof operations?.verifyArtifactIdentity !== "function" ||
-    typeof operations?.create !== "function" ||
+    typeof operations?.verifyAndCreate !== "function" ||
     typeof operations.verifyReadiness !== "function"
   ) {
     throw new MxcNativeArtifactBootstrapError(
-      "artifact verification, create, and readiness operations are required before bootstrap",
+      "atomic artifact verification and create plus readiness operations are required before bootstrap",
     );
   }
   const plan = preparePlan(input);
-  const identity = await verifyArtifactIdentity(plan, operations.verifyArtifactIdentity);
-  if (identity === null) {
-    return result(plan, "not-created", "artifact-verification-failed", "absent");
-  }
   try {
-    const created = await operations.create(plan, identity);
-    if (created?.status === "not-created") {
-      return result(plan, "not-created", "create-rejected", "absent");
+    const created = await operations.verifyAndCreate(plan);
+    if (
+      created?.status === "not-created" &&
+      (created.reason === "artifact-verification-failed" || created.reason === "create-rejected")
+    ) {
+      return result(plan, "not-created", created.reason, "absent");
     }
     if (created?.status === "unknown") {
       return result(plan, "retained", "create-outcome-unknown", "possibly-retained");
     }
+    if (created?.status !== "created") {
+      return result(plan, "retained", "create-outcome-unknown", "possibly-retained");
+    }
     if (
-      created?.status !== "created" ||
       !SHA256_PATTERN.test(created.authoritySha256) ||
-      created.authoritySha256 !== plan.authoritySha256
+      created.authoritySha256 !== plan.authoritySha256 ||
+      created.artifactDigest !== plan.workload.artifact.digest ||
+      created.executableDigest !== plan.workload.launch.executable.digest
     ) {
       return result(plan, "retained", "create-authority-mismatch", "possibly-retained");
     }

--- a/src/lib/onboard/runtime-provider/mxc.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc.test.ts
@@ -157,7 +157,7 @@ describe("inactive OpenShell MXC runtime provider", () => {
       providerId: "mxc",
       supported: true,
       bootstrapKind: "native-artifact",
-      contractVersion: 2,
+      contractVersion: 3,
     });
     expect(provider.lifecycle).toMatchObject({
       providerId: "mxc",
@@ -176,11 +176,11 @@ describe("inactive OpenShell MXC runtime provider", () => {
     });
   });
 
-  it("rejects the version-1 native-artifact bootstrap operations contract (#8178)", () => {
+  it("rejects the version-2 separated native-artifact bootstrap operations contract (#8178)", () => {
     const provider = candidateBundle();
     const obsolete = {
       ...provider,
-      bootstrap: { ...provider.bootstrap, contractVersion: 1 },
+      bootstrap: { ...provider.bootstrap, contractVersion: 2 },
     } as unknown as typeof provider;
 
     expect(() => createRuntimeProviderBundleRegistry([["mxc", obsolete]])).toThrow(

--- a/src/lib/onboard/runtime-provider/mxc.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc.test.ts
@@ -108,7 +108,6 @@ describe("inactive OpenShell MXC runtime provider", () => {
     { scenario: "lifecycle" },
     { scenario: "mutation authority" },
     { scenario: "state mutation" },
-    { scenario: "bootstrap" },
     { scenario: "snapshot" },
     { scenario: "recovery" },
     { scenario: "cleanup" },
@@ -132,7 +131,6 @@ describe("inactive OpenShell MXC runtime provider", () => {
           lifecycle: provider.lifecycle,
           "mutation authority": provider.mutationAuthority,
           "state mutation": provider.stateMutation,
-          bootstrap: provider.bootstrap,
           snapshot: provider.snapshot,
           recovery: provider.recovery,
           cleanup: provider.cleanup,
@@ -144,13 +142,39 @@ describe("inactive OpenShell MXC runtime provider", () => {
 
       expect(provider.preflightDoctor.preflightLifecycle("start", {} as never)).toMatchObject({
         exitCode: 1,
-        message: expect.stringMatching(/has not passed live E2E/u),
+        message: expect.stringMatching(/direct start and stop/u),
       });
       expect(() => requireRuntimeProviderMutationAuthority(provider, "registration")).toThrow(
         /does not authorize 'registration'/u,
       );
     },
   );
+
+  it("exposes native-artifact bootstrap without enabling direct lifecycle or cleanup (#8178)", () => {
+    const provider = candidateBundle();
+
+    expect(provider.bootstrap).toMatchObject({
+      providerId: "mxc",
+      supported: true,
+      bootstrapKind: "native-artifact",
+      contractVersion: 1,
+    });
+    expect(provider.lifecycle).toMatchObject({
+      providerId: "mxc",
+      supported: false,
+      reason: expect.stringMatching(/direct start and stop/u),
+    });
+    expect(provider.cleanup).toMatchObject({
+      providerId: "mxc",
+      supported: false,
+      reason: expect.stringMatching(/immutable resource handle/u),
+    });
+    expect(provider.mutationAuthority).toMatchObject({ supported: false });
+    expect(provider.capabilities).toMatchObject({
+      directLifecycle: false,
+      workloadImageCleanup: false,
+    });
+  });
 
   it("rejects a native-artifact profile with an unaccepted agent (#8178)", () => {
     const provider = candidateBundle();

--- a/src/lib/onboard/runtime-provider/mxc.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc.test.ts
@@ -157,7 +157,7 @@ describe("inactive OpenShell MXC runtime provider", () => {
       providerId: "mxc",
       supported: true,
       bootstrapKind: "native-artifact",
-      contractVersion: 1,
+      contractVersion: 2,
     });
     expect(provider.lifecycle).toMatchObject({
       providerId: "mxc",
@@ -174,6 +174,18 @@ describe("inactive OpenShell MXC runtime provider", () => {
       directLifecycle: false,
       workloadImageCleanup: false,
     });
+  });
+
+  it("rejects the version-1 native-artifact bootstrap operations contract (#8178)", () => {
+    const provider = candidateBundle();
+    const obsolete = {
+      ...provider,
+      bootstrap: { ...provider.bootstrap, contractVersion: 1 },
+    } as unknown as typeof provider;
+
+    expect(() => createRuntimeProviderBundleRegistry([["mxc", obsolete]])).toThrow(
+      /native-artifact bootstrap has an unsupported contract version/u,
+    );
   });
 
   it("rejects a native-artifact profile with an unaccepted agent (#8178)", () => {

--- a/src/lib/onboard/runtime-provider/mxc.ts
+++ b/src/lib/onboard/runtime-provider/mxc.ts
@@ -19,6 +19,7 @@ import {
   type RuntimeProviderDoctorCheck,
   type RuntimeProviderWorkloadProfile,
 } from "./contract";
+import { createMxcNativeArtifactBootstrapSurface } from "./mxc-bootstrap";
 
 export interface MxcRuntimeProviderOptions {
   readonly hostFacts: WindowsMxcHostFacts;
@@ -83,9 +84,9 @@ export function createMxcRuntimeProviderBundle({
   hostFacts,
 }: MxcRuntimeProviderOptions): RuntimeProviderBundle {
   const lifecycleReason =
-    "OpenShell MXC process_container lifecycle termination has not passed live E2E.";
+    "OpenShell MXC direct start and stop of an existing sandbox are not qualified.";
   const cleanupReason =
-    "OpenShell MXC exact workload termination and orphan cleanup are not qualified.";
+    "OpenShell MXC does not expose an immutable resource handle for exact destructive cleanup.";
   return {
     identity: {
       contractVersion: RUNTIME_PROVIDER_BUNDLE_CONTRACT_VERSION,
@@ -137,9 +138,7 @@ export function createMxcRuntimeProviderBundle({
     stateMutation: unsupported(
       "The MXC runtime provider state mutation surface remains disabled until lifecycle and cleanup pass live E2E.",
     ),
-    bootstrap: unsupported(
-      "The OpenShell MXC driver does not expose a per-sandbox native artifact launch contract.",
-    ),
+    bootstrap: createMxcNativeArtifactBootstrapSurface(),
     snapshot: unsupported("OpenShell MXC snapshot and restore are unavailable."),
     recovery: unsupported(
       "OpenShell MXC gateway-restart reconciliation and orphan recovery are unavailable.",

--- a/src/lib/onboard/runtime-provider/registry.ts
+++ b/src/lib/onboard/runtime-provider/registry.ts
@@ -4,6 +4,7 @@
 import type { SandboxEntry } from "../../state/registry/types";
 import {
   RUNTIME_PROVIDER_BUNDLE_CONTRACT_VERSION,
+  RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION,
   RUNTIME_PROVIDER_SNAPSHOT_CONTRACT_VERSION,
   RUNTIME_PROVIDER_SNAPSHOT_PREFLIGHT_SCHEMA_VERSION,
   RUNTIME_PROVIDER_STATE_MUTATION_CONTRACT_VERSION,
@@ -465,11 +466,23 @@ function validateStateMutationSurface(providerId: string, surface: Record<string
 }
 
 function validateBootstrapSurface(surface: Record<string, unknown>): void {
-  if (surface.supported === true) {
+  if (surface.supported !== true) return;
+  if (surface.bootstrapKind === "managed-image") {
     requireFunction(surface, "createAuthorityStore", "bootstrap");
     requireFunction(surface, "createLifecycle", "bootstrap");
     requireFunction(surface, "createOnboardRouting", "bootstrap");
+    return;
   }
+  if (surface.bootstrapKind === "native-artifact") {
+    if (surface.contractVersion !== RUNTIME_PROVIDER_NATIVE_ARTIFACT_BOOTSTRAP_CONTRACT_VERSION) {
+      throw new RuntimeProviderRegistrationError(
+        "native-artifact bootstrap has an unsupported contract version",
+      );
+    }
+    requireFunction(surface, "run", "bootstrap");
+    return;
+  }
+  throw new RuntimeProviderRegistrationError("bootstrap has an unsupported kind");
 }
 
 function validateSnapshotSurface(providerId: string, surface: Record<string, unknown>): void {

--- a/src/lib/onboard/runtime-provider/runtime-provider-contract.test.ts
+++ b/src/lib/onboard/runtime-provider/runtime-provider-contract.test.ts
@@ -28,7 +28,11 @@ import {
   type ManagedStartupProfile,
 } from "../managed-startup/profile";
 import { registerCreatedSandbox } from "../sandbox-registration";
-import type { RuntimeProviderBundle, RuntimeProviderWorkloadProfile } from "./contract";
+import type {
+  RuntimeProviderBundle,
+  RuntimeProviderManagedImageBootstrapSurface,
+  RuntimeProviderWorkloadProfile,
+} from "./contract";
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "./current";
 import { createDockerRuntimeProviderBundle } from "./docker";
 import type { HostLocalInferenceOperation } from "./host-local-inference";
@@ -119,7 +123,9 @@ describe("RuntimeProviderBundle registry contract", () => {
     expect(Object.keys(CURRENT_RUNTIME_PROVIDER_BUNDLES)).toEqual(["docker", "kubernetes"]);
     Object.entries(CURRENT_RUNTIME_PROVIDER_BUNDLES).forEach(([providerId, bundle]) => {
       expect(bundle.identity.id).toBe(providerId);
-      expect(([
+      expect(
+        (
+          [
             "plan",
             "capabilities",
             "preflightDoctor",
@@ -134,7 +140,9 @@ describe("RuntimeProviderBundle registry contract", () => {
             "recovery",
             "cleanup",
             "containerEngine",
-          ] as const).every((surface) => Object.is(bundle[surface].providerId, providerId))).toBe(true);
+          ] as const
+        ).every((surface) => Object.is(bundle[surface].providerId, providerId)),
+      ).toBe(true);
       expect(bundle.bootstrap).toMatchObject({ supported: providerId === "docker" });
       expect(bundle.stateMutation).toMatchObject({
         supported: providerId === "docker",
@@ -280,6 +288,7 @@ describe("RuntimeProviderBundle registry contract", () => {
         replaceSurface(bundle, "bootstrap", {
           providerId: "mxc",
           supported: true,
+          bootstrapKind: "managed-image",
           createAuthorityStore,
           createLifecycle,
           createOnboardRouting,
@@ -288,8 +297,10 @@ describe("RuntimeProviderBundle registry contract", () => {
     ]);
     const registered = providers.mxc!;
     expectSupportedSurface(registered.bootstrap);
+    expect(registered.bootstrap.bootstrapKind).toBe("managed-image");
+    const managedBootstrap = registered.bootstrap as RuntimeProviderManagedImageBootstrapSurface;
 
-    const routing = registered.bootstrap.createOnboardRouting({
+    const routing = managedBootstrap.createOnboardRouting({
       sandboxName: "alpha",
       openshellArgv: (args) => args,
       nativeFallbackEnabled: false,

--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -75,8 +75,8 @@ import type {
 import { encodeManagedStartupProfile } from "./managed-startup/profile";
 import { createManagedStartupRootApplyRequest } from "./managed-startup/root-apply";
 import type {
-  RuntimeProviderBootstrapSurface,
   RuntimeProviderBundle,
+  RuntimeProviderManagedImageBootstrapSurface,
 } from "./runtime-provider/contract";
 import { createRuntimeProviderBundleRegistry } from "./runtime-provider/registry";
 import { prepareSandboxCreateLaunch } from "./sandbox-create-launch";
@@ -302,6 +302,7 @@ describe("runSandboxGpuCreateFlow provider-owned managed create", () => {
           bootstrap: {
             providerId: "mxc",
             supported: true,
+            bootstrapKind: "managed-image",
             createAuthorityStore: vi.fn(() => ({
               recordPreparedAuthority: vi.fn(),
             })),
@@ -322,7 +323,7 @@ describe("runSandboxGpuCreateFlow provider-owned managed create", () => {
       ],
     ]);
     const runtimeProvider = registered.mxc as RuntimeProviderBundle & {
-      readonly bootstrap: Extract<RuntimeProviderBootstrapSurface, { readonly supported: true }>;
+      readonly bootstrap: RuntimeProviderManagedImageBootstrapSurface;
     };
     input.managedBootstrap = {
       bootstrapIdentity: launch.managedBootstrapIdentity!,

--- a/src/lib/onboard/sandbox-gpu-create-flow.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.ts
@@ -48,8 +48,8 @@ import { assertPortableManagedBootstrapNotSelected } from "./managed-workload/on
 import type { ManagedStartupRootApplyRequest } from "./managed-startup/root-apply";
 import { isImmutableDockerImageId } from "./openshell-docker-sandbox-containers";
 import type {
-  RuntimeProviderBootstrapSurface,
   RuntimeProviderBundle,
+  RuntimeProviderManagedImageBootstrapSurface,
 } from "./runtime-provider/contract";
 import * as sandboxGpuCreateAttempt from "./sandbox-gpu-create-attempt";
 import { createSandboxGpuCreateAttemptRunner } from "./sandbox-gpu-create-run-attempt";
@@ -234,7 +234,7 @@ export interface SandboxGpuCreateFlowInput {
     readonly bootstrapIdentity: string;
     readonly stateRoot: string;
     readonly runtimeProvider: RuntimeProviderBundle & {
-      readonly bootstrap: Extract<RuntimeProviderBootstrapSurface, { readonly supported: true }>;
+      readonly bootstrap: RuntimeProviderManagedImageBootstrapSurface;
     };
     readonly authorityStore: ManagedBootstrapAuthorityStore;
     readonly request: ManagedStartupRootApplyRequest;
@@ -388,10 +388,7 @@ export async function runSandboxGpuCreateFlow(
             ),
           ];
           const prepared = attemptRunner.managedRouting.prepareCompatibilityLaunch({
-            createArgs: managedBootstrapCreateArgs(
-              input.prebuild.createArgs,
-              bootstrapIdentity,
-            ),
+            createArgs: managedBootstrapCreateArgs(input.prebuild.createArgs, bootstrapIdentity),
             currentRegistryImageRef: registryImageRef,
             prebuildImageId: input.prebuild.imageId,
             allowUnbuiltSource: attemptRunner.state.allowUnbuiltCompatibilitySource,
@@ -477,8 +474,8 @@ export async function runSandboxGpuCreateFlow(
       gpuCreateOutcome.nativeCleanupHandoff
         ? `  Managed bootstrap retained exact owner-cleanup authority for sandbox '${input.sandboxName}'. Do not delete a runtime by mutable sandbox name; preserve it for identity-bound recovery.`
         : hermesPortableLifecycle
-        ? `  Hermes portable sandbox '${input.sandboxName}' did not complete receipt-owned creation. Preserve its lifecycle receipt and resume onboarding after correcting the reported failure.`
-        : `  Manual cleanup: openshell sandbox delete "${input.sandboxName}"`,
+          ? `  Hermes portable sandbox '${input.sandboxName}' did not complete receipt-owned creation. Preserve its lifecycle receipt and resume onboarding after correcting the reported failure.`
+          : `  Manual cleanup: openshell sandbox delete "${input.sandboxName}"`,
     );
     process.exit(1);
   }

--- a/src/lib/onboard/workload/native-artifact.ts
+++ b/src/lib/onboard/workload/native-artifact.ts
@@ -22,8 +22,8 @@ export type NativeArtifactDigest = `sha256:${string}`;
 /**
  * Inactive OpenClaw-on-Windows workload receipt.
  *
- * This schema records immutable identity and launch intent. The future staging
- * authority must verify each digest before a runtime provider consumes it.
+ * This schema records immutable identity and launch intent. The bootstrap provider
+ * must verify each digest and create without releasing stable artifact authority.
  */
 export interface NativeArtifactWorkloadReceiptV1 {
   readonly schemaVersion: typeof NATIVE_ARTIFACT_WORKLOAD_RECEIPT_SCHEMA_VERSION;

--- a/test/inference/managed/managed-image-protected-runtime-contract.test.ts
+++ b/test/inference/managed/managed-image-protected-runtime-contract.test.ts
@@ -121,6 +121,7 @@ describe("protected managed-image runtime contract", () => {
         runtimeProvider: {
           bootstrap: {
             supported: true,
+            bootstrapKind: "managed-image",
             createAuthorityStore: () => authorityStore,
           },
         },

--- a/test/onboarding/openshell-0.0.99-migration-review.test.ts
+++ b/test/onboarding/openshell-0.0.99-migration-review.test.ts
@@ -156,6 +156,7 @@ describe("OpenShell 0.0.99 migration review", () => {
         runtimeProvider: {
           bootstrap: {
             supported: true,
+            bootstrapKind: "managed-image",
             createAuthorityStore: () => authorityStore,
           },
         },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add an inactive OpenShell MXC native-artifact bootstrap surface for the accepted Windows provider candidate. The provider now freezes exact workload authority and derives shallow, sandbox-scoped OpenClaw state paths without making MXC production-selectable.

## Related Issue

Part of #8178

## Changes

- Add a typed `native-artifact` bootstrap facet for the inactive `mxc` `RuntimeProviderBundle`, with exact create and readiness evidence and fail-closed retained-resource results.
- Derive one shallow provider-owned read-write share per sandbox lifecycle generation. Bind `HOME`, `USERPROFILE`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, `TEMP`, and `TMP` beneath that share without a broad `C:\Users` grant.
- Keep direct lifecycle, cleanup, recovery, mutation, container-engine operations, and production activation unsupported.
- Distinguish native-artifact bootstrap from managed-image bootstrap in the shared bundle contract. Existing managed-image consumers use the discriminator because one direct managed-image-only contract cannot represent the accepted Windows native-artifact consumer without a central provider-name branch. Runtime-provider contract and activation tests protect this boundary.
- Add deterministic tests for exact authority, lifecycle isolation, malformed paths, provider drift, readiness drift, ambiguous create results, credential-free errors, and inactive activation.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `108/108` focused CLI tests, `22/22` layer-boundary tests, and `55/55` Windows MXC E2E-support tests passed; `npm run typecheck:cli` passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native-artifact bootstrap support for MXC runtime environments.
  * Added atomic artifact verification and creation with readiness reporting and explicit failure outcomes.
  * Added clear classification for managed-image and native-artifact workflows.

* **Bug Fixes**
  * Improved onboarding validation for unsupported or mismatched bootstrap configurations.
  * Prevented production activation from accepting incompatible bootstrap configurations.
  * Rejected outdated native-artifact contracts.

* **Tests**
  * Expanded coverage for path validation, authority changes, identity verification, readiness failures, and lifecycle isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->