### PR TITLE
ci(e2e): restore manual PR dispatch authentication

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -262,7 +262,6 @@ jobs:
           BASE_SHA: ${{ inputs.base_sha }}
           CHECKOUT_REPOSITORY: ${{ inputs.checkout_repository }}
           CHECKOUT_SHA: ${{ inputs.checkout_sha }}
-          GITHUB_TOKEN: ${{ github.token }}
           EXPECTED_WORKFLOW_SHA: ${{ inputs.workflow_sha }}
 
           INCLUDE_LAUNCHABLE: ${{ inputs.include_staging_brev_launchable && 'true' || 'false' }}
@@ -287,7 +286,6 @@ jobs:
           [[ "$EXPECTED_WORKFLOW_SHA" =~ ^[a-f0-9]{40}$ && "$EXPECTED_WORKFLOW_SHA" == "$WORKFLOW_SHA" ]] || { echo "::error::workflow_sha must match the trusted main workflow SHA" >&2; exit 1; }
 
           pull_json="$(curl --fail --silent --show-error --proto '=https' \
-            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
             --header "Accept: application/vnd.github+json" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
@@ -611,7 +609,6 @@ jobs:
           BASE_SHA: ${{ inputs.base_sha }}
           CHECKOUT_REPOSITORY: ${{ inputs.checkout_repository }}
           CHECKOUT_SHA: ${{ inputs.checkout_sha }}
-          GITHUB_TOKEN: ${{ github.token }}
           NVIDIA_OWNED: ${{ steps.candidate_authorization.outputs.nvidia_owned }}
           PR_NUMBER: ${{ inputs.pr_number }}
         shell: bash
@@ -619,7 +616,6 @@ jobs:
           set -euo pipefail
           [[ "$(git rev-parse --verify HEAD)" == "$CHECKOUT_SHA" ]] || { echo "::error::checked-out commit does not match checkout_sha" >&2; exit 1; }
           pull_json="$(curl --fail --silent --show-error --proto '=https' \
-            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
             --header "Accept: application/vnd.github+json" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"

--- a/test/e2e/support/e2e-public-pr-metadata.test.ts
+++ b/test/e2e/support/e2e-public-pr-metadata.test.ts
@@ -12,7 +12,6 @@ import {
 
 function authenticationEnvironment(): NodeJS.ProcessEnv {
   return {
-    ...process.env,
     BASE_SHA: "b".repeat(40),
     CHECKOUT_REPOSITORY: "NVIDIA/NemoClaw",
     CHECKOUT_SHA: "a".repeat(40),
@@ -21,6 +20,7 @@ function authenticationEnvironment(): NodeJS.ProcessEnv {
     GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
     INCLUDE_LAUNCHABLE: "false",
     JOBS: "",
+    PATH: process.env.PATH,
     PR_NUMBER: "42",
     WORKFLOW_EVENT: "workflow_dispatch",
     WORKFLOW_REF: "refs/heads/main",
@@ -40,12 +40,12 @@ describe("public PR metadata authentication", () => {
 
     expect(authentication.env).not.toHaveProperty("GITHUB_TOKEN");
     expect(validation.env).not.toHaveProperty("GITHUB_TOKEN");
-    expect(authentication.run).not.toContain("Authorization:");
-    expect(validation.run).not.toContain("Authorization:");
+    expect(authentication.run).not.toMatch(/\bauthorization\s*:/iu);
+    expect(validation.run).not.toMatch(/\bauthorization\s*:/iu);
 
-    authentication.env!.GITHUB_TOKEN = "${{ github.token }}";
+    authentication.env = { ...(authentication.env ?? {}), GITHUB_TOKEN: "${{ github.token }}" };
     authentication.run = `${authentication.run}\ncurl --header "Authorization: Bearer token"`;
-    validation.env!.GITHUB_TOKEN = "${{ github.token }}";
+    validation.env = { ...(validation.env ?? {}), GITHUB_TOKEN: "${{ github.token }}" };
     validation.run = `${validation.run}\ncurl --header "Authorization: Bearer token"`;
 
     expect(validateE2eOperationsWorkflow(workflow)).toEqual(
@@ -55,6 +55,46 @@ describe("public PR metadata authentication", () => {
       ]),
     );
   });
+
+  it("rejects lowercase authorization headers", () => {
+    const workflow = readE2eOperationsWorkflow();
+    const authentication = workflow.jobs["generate-matrix"].steps!.find(
+      (step) => step.name === "Authenticate manual PR dispatch",
+    )!;
+    const validation = workflow.jobs["generate-matrix"].steps!.find(
+      (step) => step.name === "Validate manual PR checkout",
+    )!;
+
+    authentication.run = `${authentication.run}\ncurl --header "authorization : Bearer token"`;
+    validation.run = `${validation.run}\ncurl --header "authorization : Bearer token"`;
+
+    expect(validateE2eOperationsWorkflow(workflow)).toEqual(
+      expect.arrayContaining([
+        "Manual PR authentication must use the public read-only metadata endpoint",
+        "Manual PR checkout validation must use the public read-only metadata endpoint",
+      ]),
+    );
+  });
+
+  it.each(["workflow", "generate-matrix job"] as const)(
+    "rejects an inherited GITHUB_TOKEN from the %s scope",
+    (scope) => {
+      const workflow = readE2eOperationsWorkflow();
+      if (scope === "workflow") {
+        workflow.env = { ...(workflow.env ?? {}), GITHUB_TOKEN: "${{ github.token }}" };
+      } else {
+        const matrixJob = workflow.jobs["generate-matrix"];
+        matrixJob.env = { ...(matrixJob.env ?? {}), GITHUB_TOKEN: "${{ github.token }}" };
+      }
+
+      expect(validateE2eOperationsWorkflow(workflow)).toEqual(
+        expect.arrayContaining([
+          "Manual PR authentication must use the public read-only metadata endpoint",
+          "Manual PR checkout validation must use the public read-only metadata endpoint",
+        ]),
+      );
+    },
+  );
 
   it.each([
     ["denied response", "curl() { return 22; }"],
@@ -70,6 +110,7 @@ describe("public PR metadata authentication", () => {
       { encoding: "utf8", env: authenticationEnvironment() },
     );
 
+    expect(result.error).toBeUndefined();
     expect(result.status).not.toBe(0);
   });
 });

--- a/test/e2e/support/e2e-public-pr-metadata.test.ts
+++ b/test/e2e/support/e2e-public-pr-metadata.test.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  readE2eOperationsWorkflow,
+  validateE2eOperationsWorkflow,
+} from "../../../tools/e2e/operations-workflow-boundary.mts";
+
+function authenticationEnvironment(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    BASE_SHA: "b".repeat(40),
+    CHECKOUT_REPOSITORY: "NVIDIA/NemoClaw",
+    CHECKOUT_SHA: "a".repeat(40),
+    EXPECTED_WORKFLOW_SHA: "c".repeat(40),
+    GITHUB_OUTPUT: "/dev/null",
+    GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
+    INCLUDE_LAUNCHABLE: "false",
+    JOBS: "",
+    PR_NUMBER: "42",
+    WORKFLOW_EVENT: "workflow_dispatch",
+    WORKFLOW_REF: "refs/heads/main",
+    WORKFLOW_SHA: "c".repeat(40),
+  };
+}
+
+describe("public PR metadata authentication", () => {
+  it("does not widen workflow token permissions", () => {
+    const workflow = readE2eOperationsWorkflow();
+    const authentication = workflow.jobs["generate-matrix"].steps!.find(
+      (step) => step.name === "Authenticate manual PR dispatch",
+    )!;
+    const validation = workflow.jobs["generate-matrix"].steps!.find(
+      (step) => step.name === "Validate manual PR checkout",
+    )!;
+
+    expect(authentication.env).not.toHaveProperty("GITHUB_TOKEN");
+    expect(validation.env).not.toHaveProperty("GITHUB_TOKEN");
+    expect(authentication.run).not.toContain("Authorization:");
+    expect(validation.run).not.toContain("Authorization:");
+
+    authentication.env!.GITHUB_TOKEN = "${{ github.token }}";
+    authentication.run = `${authentication.run}\ncurl --header "Authorization: Bearer token"`;
+    validation.env!.GITHUB_TOKEN = "${{ github.token }}";
+    validation.run = `${validation.run}\ncurl --header "Authorization: Bearer token"`;
+
+    expect(validateE2eOperationsWorkflow(workflow)).toEqual(
+      expect.arrayContaining([
+        "Manual PR authentication must use the public read-only metadata endpoint",
+        "Manual PR checkout validation must use the public read-only metadata endpoint",
+      ]),
+    );
+  });
+
+  it.each([
+    ["denied response", "curl() { return 22; }"],
+    ["malformed response", "curl() { printf '{'; }"],
+  ])("fails closed on a terminal %s", (_caseName, curlStub) => {
+    const workflow = readE2eOperationsWorkflow();
+    const authentication = workflow.jobs["generate-matrix"].steps!.find(
+      (step) => step.name === "Authenticate manual PR dispatch",
+    )!;
+    const result = spawnSync(
+      "bash",
+      ["--noprofile", "--norc", "-e", "-o", "pipefail", "-c", `${curlStub}\n${authentication.run}`],
+      { encoding: "utf8", env: authenticationEnvironment() },
+    );
+
+    expect(result.status).not.toBe(0);
+  });
+});

--- a/test/e2e/support/e2e-public-pr-metadata.test.ts
+++ b/test/e2e/support/e2e-public-pr-metadata.test.ts
@@ -20,6 +20,7 @@ function authenticationEnvironment(): NodeJS.ProcessEnv {
     GITHUB_REPOSITORY: "NVIDIA/NemoClaw",
     INCLUDE_LAUNCHABLE: "false",
     JOBS: "",
+    NVIDIA_OWNED: "false",
     PATH: process.env.PATH,
     PR_NUMBER: "42",
     WORKFLOW_EVENT: "workflow_dispatch",
@@ -102,17 +103,42 @@ describe("public PR metadata authentication", () => {
   });
 
   it.each([
-    ["denied response", "curl() { return 22; }"],
-    ["malformed response", "curl() { printf '{'; }"],
-  ])("fails closed on a terminal %s", (_caseName, curlStub) => {
+    ["Authenticate manual PR dispatch", "denied response", "", "curl() { return 22; }"],
+    ["Authenticate manual PR dispatch", "malformed response", "", "curl() { printf '{'; }"],
+    [
+      "Validate manual PR checkout",
+      "denied response",
+      'git() { printf "%s\\n" "$CHECKOUT_SHA"; }',
+      "curl() { return 22; }",
+    ],
+    [
+      "Validate manual PR checkout",
+      "malformed response",
+      'git() { printf "%s\\n" "$CHECKOUT_SHA"; }',
+      "curl() { printf '{'; }",
+    ],
+  ])("fails closed on a terminal %s in %s", (stepName, _caseName, commandStub, curlStub) => {
     const workflow = readE2eOperationsWorkflow();
-    const authentication = workflow.jobs["generate-matrix"].steps!.find(
-      (step) => step.name === "Authenticate manual PR dispatch",
+    const step = workflow.jobs["generate-matrix"].steps!.find(
+      (candidate) => candidate.name === stepName,
     )!;
     const result = spawnSync(
       "bash",
-      ["--noprofile", "--norc", "-e", "-o", "pipefail", "-c", `${curlStub}\n${authentication.run}`],
-      { encoding: "utf8", env: authenticationEnvironment() },
+      [
+        "--noprofile",
+        "--norc",
+        "-e",
+        "-o",
+        "pipefail",
+        "-c",
+        `${commandStub}\n${curlStub}\n${step.run}`,
+      ],
+      {
+        encoding: "utf8",
+        env: authenticationEnvironment(),
+        killSignal: "SIGKILL",
+        timeout: 30_000,
+      },
     );
 
     expect(result.error).toBeUndefined();

--- a/test/e2e/support/e2e-public-pr-metadata.test.ts
+++ b/test/e2e/support/e2e-public-pr-metadata.test.ts
@@ -76,25 +76,30 @@ describe("public PR metadata authentication", () => {
     );
   });
 
-  it.each(["workflow", "generate-matrix job"] as const)(
-    "rejects an inherited GITHUB_TOKEN from the %s scope",
-    (scope) => {
-      const workflow = readE2eOperationsWorkflow();
-      if (scope === "workflow") {
-        workflow.env = { ...(workflow.env ?? {}), GITHUB_TOKEN: "${{ github.token }}" };
-      } else {
-        const matrixJob = workflow.jobs["generate-matrix"];
-        matrixJob.env = { ...(matrixJob.env ?? {}), GITHUB_TOKEN: "${{ github.token }}" };
-      }
+  it("rejects an inherited workflow GITHUB_TOKEN", () => {
+    const workflow = readE2eOperationsWorkflow();
+    workflow.env = { ...(workflow.env ?? {}), GITHUB_TOKEN: "${{ github.token }}" };
 
-      expect(validateE2eOperationsWorkflow(workflow)).toEqual(
-        expect.arrayContaining([
-          "Manual PR authentication must use the public read-only metadata endpoint",
-          "Manual PR checkout validation must use the public read-only metadata endpoint",
-        ]),
-      );
-    },
-  );
+    expect(validateE2eOperationsWorkflow(workflow)).toEqual(
+      expect.arrayContaining([
+        "Manual PR authentication must use the public read-only metadata endpoint",
+        "Manual PR checkout validation must use the public read-only metadata endpoint",
+      ]),
+    );
+  });
+
+  it("rejects an inherited generate-matrix GITHUB_TOKEN", () => {
+    const workflow = readE2eOperationsWorkflow();
+    const matrixJob = workflow.jobs["generate-matrix"];
+    matrixJob.env = { ...(matrixJob.env ?? {}), GITHUB_TOKEN: "${{ github.token }}" };
+
+    expect(validateE2eOperationsWorkflow(workflow)).toEqual(
+      expect.arrayContaining([
+        "Manual PR authentication must use the public read-only metadata endpoint",
+        "Manual PR checkout validation must use the public read-only metadata endpoint",
+      ]),
+    );
+  });
 
   it.each([
     ["denied response", "curl() { return 22; }"],

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -60,6 +60,7 @@ const PUBLICATION_CLASSIFIER_SCRIPT =
     'printf \'reuse=%s\\n\' "${reuse}" >> "${GITHUB_OUTPUT}"',
   ].join("\n") + "\n";
 const ISSUE_API_REFERENCE = /\bgithub\.rest\.issues\b/u;
+const AUTHORIZATION_HEADER = /\bauthorization\s*:/iu;
 const ISSUE_MUTATION_BEYOND_COMMENT =
   /github\.rest\.issues\.(?:addAssignees|addLabels|create|deleteComment|lock|removeAssignees|removeLabel|setLabels|unlock|update|updateComment)\s*\(/u;
 const GENERIC_GITHUB_WRITE_SURFACE =
@@ -328,7 +329,13 @@ function validateManualPrDispatch(errors: string[], workflow: OperationsWorkflow
       errors.push(`Manual PR authentication must bind ${name}`);
   }
   const authSource = String(authentication.run ?? "");
-  if (authentication.env?.GITHUB_TOKEN !== undefined || authSource.includes("Authorization:")) {
+  const inheritedGithubToken =
+    workflow.env?.GITHUB_TOKEN !== undefined || matrixJob.env?.GITHUB_TOKEN !== undefined;
+  if (
+    inheritedGithubToken ||
+    authentication.env?.GITHUB_TOKEN !== undefined ||
+    AUTHORIZATION_HEADER.test(authSource)
+  ) {
     errors.push("Manual PR authentication must use the public read-only metadata endpoint");
   }
   for (const fragment of [
@@ -393,7 +400,11 @@ function validateManualPrDispatch(errors: string[], workflow: OperationsWorkflow
   ) {
     errors.push("Manual PR checkout validation must bind authenticated NVIDIA ownership");
   }
-  if (validation.env?.GITHUB_TOKEN !== undefined || validationSource.includes("Authorization:")) {
+  if (
+    inheritedGithubToken ||
+    validation.env?.GITHUB_TOKEN !== undefined ||
+    AUTHORIZATION_HEADER.test(validationSource)
+  ) {
     errors.push("Manual PR checkout validation must use the public read-only metadata endpoint");
   }
   for (const fragment of [

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -316,7 +316,6 @@ function validateManualPrDispatch(errors: string[], workflow: OperationsWorkflow
     CHECKOUT_REPOSITORY: "${{ inputs.checkout_repository }}",
     CHECKOUT_SHA: "${{ inputs.checkout_sha }}",
     EXPECTED_WORKFLOW_SHA: "${{ inputs.workflow_sha }}",
-    GITHUB_TOKEN: "${{ github.token }}",
     INCLUDE_LAUNCHABLE: "${{ inputs.include_staging_brev_launchable && 'true' || 'false' }}",
     JOBS: "${{ inputs.jobs }}",
     PR_NUMBER: "${{ inputs.pr_number }}",
@@ -329,6 +328,9 @@ function validateManualPrDispatch(errors: string[], workflow: OperationsWorkflow
       errors.push(`Manual PR authentication must bind ${name}`);
   }
   const authSource = String(authentication.run ?? "");
+  if (authentication.env?.GITHUB_TOKEN !== undefined || authSource.includes("Authorization:")) {
+    errors.push("Manual PR authentication must use the public read-only metadata endpoint");
+  }
   for (const fragment of [
     '"$WORKFLOW_EVENT" == "workflow_dispatch"',
     '"$WORKFLOW_REF" == refs/heads/*',
@@ -390,6 +392,9 @@ function validateManualPrDispatch(errors: string[], workflow: OperationsWorkflow
     validation.env?.NVIDIA_OWNED !== "${{ steps.candidate_authorization.outputs.nvidia_owned }}"
   ) {
     errors.push("Manual PR checkout validation must bind authenticated NVIDIA ownership");
+  }
+  if (validation.env?.GITHUB_TOKEN !== undefined || validationSource.includes("Authorization:")) {
+    errors.push("Manual PR checkout validation must use the public read-only metadata endpoint");
   }
   for (const fragment of [
     '"$(git rev-parse --verify HEAD)" == "$CHECKOUT_SHA"',


### PR DESCRIPTION
## Summary

- read public pull-request metadata without sending the workflow token
- preserve open-state, repository, branch, head/base SHA, and NVIDIA-organization checks before and after checkout
- enforce the least-privilege metadata contract with deterministic success, denied-response, and malformed-response tests

## Why

The repository workflow token now receives HTTP 403 when the trusted manual E2E controller reads `GET /repos/NVIDIA/NemoClaw/pulls/{number}`. Because pull-request metadata for this public repository is itself public, sending that under-scoped token makes a permitted read fail. This keeps the existing identity checks but removes the unusable credential from both metadata reads; it does not add workflow permissions or expose secrets to candidate code.

## Validation

- `npm exec vitest run -- test/e2e/support/e2e-public-pr-metadata.test.ts test/e2e/support/e2e-operations-workflow-boundary.test.ts test/automation/pull-requests/growth-guardrails.test.ts` (111 passed)
- `npm run build:cli`
- `npm run typecheck`
- `npm run checks:repository`
- `npm run validate:pr`
- cache-free public API probe against PR #10359 verified exact state, head repository/SHA, and base repository/ref/SHA

## Limit

A fresh trusted exact-branch E2E dispatch remains the required hosted proof that matrix generation is reached. This PR does not rerun candidate E2E or broaden credential access.

Addresses #10360.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Manual pull request authentication and checkout validation now use public, read-only metadata without workflow tokens or authorization headers.
  * Validation rejects inherited, step-level, and case-insensitive token-based authentication.
  * Checks fail closed when metadata is denied or malformed, improving protection against unauthorized access.

* **Tests**
  * Added end-to-end coverage for secure metadata handling, process execution, and unauthorized token usage detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Signed-off-by: Ho Lim <subhoya@gmail.com>