### PR TITLE
fix(state): let the current build own the agent heartbeat on restore

### DIFF
--- a/docs/configure-agents/configure-agent-heartbeats.mdx
+++ b/docs/configure-agents/configure-agent-heartbeats.mdx
@@ -48,3 +48,6 @@ Recreate an existing sandbox to apply a new cadence.
 ```bash
 nemoclaw onboard --fresh --name <sandbox-name> --recreate-sandbox
 ```
+
+Recreating re-reads `NEMOCLAW_AGENT_HEARTBEAT_EVERY` from the current shell environment, not from the sandbox's prior setting.
+Re-export the variable before recreating a sandbox for an unrelated reason (for example, applying a base image update) to keep the same cadence — an unset variable resets the sandbox to OpenClaw's own default instead of carrying the previous cadence forward.

--- a/src/lib/state/openclaw-config-merge.test.ts
+++ b/src/lib/state/openclaw-config-merge.test.ts
@@ -722,6 +722,103 @@ describe("mergeOpenClawRestoredConfig", () => {
     });
   });
 
+  it("keeps the current build's heartbeat when the backup carries a different interval (#10244)", () => {
+    // #10244: the backup was captured while the sandbox ran a 45m cadence; the
+    // current build (e.g. `onboard --recreate-sandbox` or `snapshot restore`
+    // — not a plain `rebuild`, see reconcileAgentHeartbeat's doc comment)
+    // generated agents.defaults.heartbeat from NEMOCLAW_AGENT_HEARTBEAT_EVERY
+    // (2m). `agents` is backup-durable, so without an ownership carve-out the
+    // stale interval wins on restore.
+    const freshHeartbeat = { every: "2m" };
+    const freshConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "inference/Qwen/Qwen3.6-27B-FP8" },
+          heartbeat: freshHeartbeat,
+          timeoutSeconds: 300,
+        },
+      },
+    };
+    const merged = mergeOpenClawRestoredConfig(
+      {
+        agents: {
+          defaults: {
+            heartbeat: { every: "45m" },
+            thinkingDefault: "off",
+            subagents: { researcher: { maxDepth: 2 } },
+          },
+        },
+        customAgents: { researcher: { prompt: "be thorough" } },
+      },
+      freshConfig,
+    ) as {
+      agents: { defaults: Record<string, unknown> };
+      customAgents: unknown;
+    };
+
+    // The current build owns the heartbeat schedule.
+    expect(merged.agents.defaults.heartbeat).toEqual({ every: "2m" });
+    // The merge clones rather than aliases: mutating the merged result must
+    // not reach back into the caller's own fresh-config object.
+    (merged.agents.defaults.heartbeat as { every: string }).every = "9m";
+    expect(freshHeartbeat.every).toBe("2m");
+    // Unrelated durable backup content under `agents` still restores.
+    expect(merged.agents.defaults.thinkingDefault).toBe("off");
+    expect(merged.agents.defaults.subagents).toEqual({ researcher: { maxDepth: 2 } });
+    expect(merged.customAgents).toEqual({ researcher: { prompt: "be thorough" } });
+  });
+
+  it("does not resurrect a backed-up heartbeat when the current build omits it (#10244)", () => {
+    // Omission is authoritative: the generator writes agents.defaults.heartbeat
+    // only when NEMOCLAW_AGENT_HEARTBEAT_EVERY is set, so a build without it
+    // must not have the backup's cadence restored underneath the agent.
+    const merged = mergeOpenClawRestoredConfig(
+      {
+        agents: {
+          defaults: { heartbeat: { every: "45m" }, thinkingDefault: "off" },
+        },
+      },
+      {
+        agents: {
+          defaults: {
+            model: { primary: "inference/Qwen/Qwen3.6-27B-FP8" },
+            timeoutSeconds: 300,
+          },
+        },
+      },
+    ) as { agents: { defaults: Record<string, unknown> } };
+
+    expect(merged.agents.defaults.heartbeat).toBeUndefined();
+    expect(merged.agents.defaults.thinkingDefault).toBe("off");
+  });
+
+  it("keeps the current build's heartbeat when the backup has none (#10244)", () => {
+    const merged = mergeOpenClawRestoredConfig(
+      { agents: { defaults: { thinkingDefault: "off" } } },
+      {
+        agents: {
+          defaults: {
+            model: { primary: "inference/Qwen/Qwen3.6-27B-FP8" },
+            heartbeat: { every: "2m" },
+          },
+        },
+      },
+    ) as { agents: { defaults: Record<string, unknown> } };
+
+    expect(merged.agents.defaults.heartbeat).toEqual({ every: "2m" });
+    expect(merged.agents.defaults.thinkingDefault).toBe("off");
+  });
+
+  it("leaves backup heartbeat untouched when the current build carries no agents defaults (#10244)", () => {
+    const merged = mergeOpenClawRestoredConfig(
+      { agents: { defaults: { heartbeat: { every: "45m" }, thinkingDefault: "off" } } },
+      { gateway: { auth: { token: "fresh-token" } } },
+    ) as { agents: { defaults: Record<string, unknown> } };
+
+    expect(merged.agents.defaults.heartbeat).toEqual({ every: "45m" });
+    expect(merged.agents.defaults.thinkingDefault).toBe("off");
+  });
+
   it("fails closed when reconciliation receives incomplete or one-sided provenance", () => {
     expect(() =>
       mergeOpenClawRestoredConfig(pluginConfig({}, {}, []), pluginConfig({}, {}, []), {

--- a/src/lib/state/openclaw-config-merge.ts
+++ b/src/lib/state/openclaw-config-merge.ts
@@ -38,13 +38,12 @@ export const OPENCLAW_CONFIG_RESTORE_OWNERSHIP = {
    * `agents` is durable except its primary model routing reference, which the
    * fresh rebuild re-owns (see `agentPrimaryModelPath`) so a managed-model
    * switch followed by rebuild does not leave the agent pinned to the old
-   * model, and its heartbeat schedule (see `agentHeartbeatPath`).
+   * model, and its heartbeat schedule, which the fresh rebuild re-owns in
+   * `reconcileAgentHeartbeat`.
    */
   backupDurableSections: ["mcp", "mcpServers", "customAgents", "agents"],
   /** Fresh rebuild owns the agent's primary model routing within `agents`. */
   agentPrimaryModelPath: ["agents", "defaults", "model", "primary"],
-  /** Fresh rebuild owns the agent heartbeat schedule, including its absence. */
-  agentHeartbeatPath: ["agents", "defaults", "heartbeat"],
   /** NemoClaw's cross-agent disclosure selection owns this generated key. */
   currentGeneratedToolFields: ["toolSearch"],
 } as const;

--- a/src/lib/state/openclaw-config-merge.ts
+++ b/src/lib/state/openclaw-config-merge.ts
@@ -38,11 +38,13 @@ export const OPENCLAW_CONFIG_RESTORE_OWNERSHIP = {
    * `agents` is durable except its primary model routing reference, which the
    * fresh rebuild re-owns (see `agentPrimaryModelPath`) so a managed-model
    * switch followed by rebuild does not leave the agent pinned to the old
-   * model.
+   * model, and its heartbeat schedule (see `agentHeartbeatPath`).
    */
   backupDurableSections: ["mcp", "mcpServers", "customAgents", "agents"],
   /** Fresh rebuild owns the agent's primary model routing within `agents`. */
   agentPrimaryModelPath: ["agents", "defaults", "model", "primary"],
+  /** Fresh rebuild owns the agent heartbeat schedule, including its absence. */
+  agentHeartbeatPath: ["agents", "defaults", "heartbeat"],
   /** NemoClaw's cross-agent disclosure selection owns this generated key. */
   currentGeneratedToolFields: ["toolSearch"],
 } as const;
@@ -499,6 +501,43 @@ function reconcileAgentPrimaryModel(
   updateMainAgentListModel(agents, freshPrimary);
 }
 
+/**
+ * The current build owns `agents.defaults.heartbeat`, including its
+ * intentional absence: `NEMOCLAW_AGENT_HEARTBEAT_EVERY` is a build-time
+ * managed default (#3158, #2880), and a stale backup's interval (or a
+ * backup-only heartbeat the current build deliberately omits) must not
+ * silently override it after restore (#10244).
+ *
+ * A plain `rebuild` cannot actually trigger this: it re-derives
+ * `NEMOCLAW_AGENT_HEARTBEAT_EVERY` from the outgoing sandbox's own
+ * persisted profile (`managedWorkloadRebuildProfileEnvironment` in
+ * `../onboard/workload/rebuild.ts`), which the backup was itself sourced
+ * from — the two already agree in the steady state. The divergence this
+ * guards is reachable through `onboard --recreate-sandbox` and
+ * `snapshot restore`, both of which build a fresh config against the
+ * target sandbox's live backup through this same merge.
+ */
+function reconcileAgentHeartbeat(
+  merged: Record<string, unknown>,
+  currentConfig: Record<string, unknown>,
+): void {
+  const currentAgents = currentConfig.agents;
+  if (!isPlainObject(currentAgents)) return;
+  const currentDefaults = currentAgents.defaults;
+  if (!isPlainObject(currentDefaults)) return;
+  if ("heartbeat" in currentDefaults) {
+    const agents = ensureMergedObject(merged, "agents");
+    const defaults = ensureMergedObject(agents, "defaults");
+    defaults.heartbeat = cloneJson(currentDefaults.heartbeat);
+    return;
+  }
+  const mergedAgents = merged.agents;
+  if (!isPlainObject(mergedAgents)) return;
+  const mergedDefaults = mergedAgents.defaults;
+  if (!isPlainObject(mergedDefaults)) return;
+  delete mergedDefaults.heartbeat;
+}
+
 export function mergeOpenClawRestoredConfig(
   backedUpConfig: unknown,
   currentConfig: unknown,
@@ -537,6 +576,7 @@ export function mergeOpenClawRestoredConfig(
   );
   merged.tools = mergeOpenClawTools(backedUpConfig.tools, currentConfig.tools);
   reconcileAgentPrimaryModel(merged, currentConfig);
+  reconcileAgentHeartbeat(merged, currentConfig);
 
   return merged;
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`mergeOpenClawRestoredConfig` treats `agents` as a backup-durable section, so a state restore lets the backed-up snapshot overwrite the freshly-generated `agents.defaults.heartbeat` — the managed `NEMOCLAW_AGENT_HEARTBEAT_EVERY` interval a sandbox was actually built with. The only existing carve-out from that overlay is for `agents.defaults.model.primary`. This adds the same ownership carve-out for the heartbeat schedule, including its intentional absence, so the current build's cadence (or deliberate lack of one) survives restore instead of a stale backup value silently winning.

## Related Issue

Fixes #10244

## Changes

- `src/lib/state/openclaw-config-merge.ts`: add `reconcileAgentHeartbeat`, mirroring the existing `reconcileAgentPrimaryModel` carve-out. After the base merge, it re-owns `agents.defaults.heartbeat` from the current build's config — cloning it when present, deleting it from the merged result when the current build's `agents.defaults` block exists but intentionally omits the key. It only acts when the current build carries a shaped `agents.defaults` object (same gating as the primary-model carve-out), so a non-managed config is left untouched.
- `src/lib/state/openclaw-config-merge.test.ts`: four new tests exercising the real `mergeOpenClawRestoredConfig` function (not a reimplementation) — a differing backup interval, a backup-only heartbeat against a build that omits it, an absent-backup case, and a build with no `agents.defaults` at all leaving the backup's heartbeat untouched (conservatism guard). Also added a clone-vs-alias assertion proving the reconciled value doesn't leak a live reference back into the caller's own config object.
- `docs/configure-agents/configure-agent-heartbeats.mdx`: documents the real, user-visible consequence of the fix on the recreate path (see "Behavior change" below), since it wasn't stated anywhere before.

**Two corrections to the issue report**, both verified by tracing the real code path and running the actual merge function rather than assumed from the issue's own analysis:

1. The issue's "backup with no heartbeat" failure mode already merged correctly and is unchanged by this PR — I confirmed this by running the real function before making any change. The two real failures are a backup carrying a *different* interval, and a backup-only heartbeat that the current build deliberately omits.
2. A plain `nemoclaw rebuild` cannot trigger either failure. It re-derives `NEMOCLAW_AGENT_HEARTBEAT_EVERY` from the outgoing sandbox's own persisted profile (`managedWorkloadRebuildProfileEnvironment` in `src/lib/onboard/workload/rebuild.ts`), which the backup was itself sourced from — the two already agree in the steady state. The divergence is reachable through `onboard --recreate-sandbox` and `snapshot restore`, both of which build a fresh config against a target sandbox's live backup through this same merge. I corrected the new function's doc comment and the test titles/comments to name the actual trigger.

**Behavior change worth flagging explicitly:** the intentional-absence branch is a real, user-visible change on the recreate path. Today, recreating a sandbox for an unrelated reason (base image update, dashboard bind change) without re-exporting `NEMOCLAW_AGENT_HEARTBEAT_EVERY` still keeps the previous cadence, because the backup wins by default. After this fix it does not — an unset variable now resets the sandbox to OpenClaw's own default. This matches issue #10244's own acceptance criteria ("Fresh profile omits heartbeat, backup has a value: fresh omission must win"), but since it's a behavior a user could notice, I documented it in `configure-agent-heartbeats.mdx` rather than leaving it undisclosed, and I'm flagging it here for a maintainer's explicit awareness rather than treating the acceptance criteria as automatic license to change user-visible behavior silently.

**Known related gap, out of scope for this PR:** the config generator owns several other `agents.defaults` fields the same way it owns heartbeat — `timeoutSeconds`, `skipBootstrap`, `thinkingDefault`, `subagents`, `compaction` (`scripts/generate-openclaw-config.mts` around the `agentDefaults` object). All of them have the identical unprotected-by-backup-merge exposure; `timeoutSeconds` in particular has the exact same trigger set as heartbeat did. I did not widen this PR to cover them since #10244 is field-specific, but a maintainer may want a follow-up issue to cover the rest of the class.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

Not applicable — this PR does not change `scripts/prepare-dgx-station-host.sh`.

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project cli src/lib/state/openclaw-config-merge.test.ts src/lib/state/openclaw-config-merge-tool-search.test.ts` — 2 files, 31 tests passed (4 new for #10244, 2 of which were confirmed RED against unmodified `origin/main` before the fix and GREEN after; every new assertion independently confirmed load-bearing by targeted mutation — reverting the call site, neutering the delete branch alone, neutering the conservatism gate alone, and bypassing the clone). `npm run typecheck:cli` and `npm --prefix nemoclaw run typecheck` both clean.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — 0 errors; 2 warnings, both structural and unrelated to this change's content (an unauthenticated redirects check, and a global theme accent-contrast ratio setting) — neither references `configure-agent-heartbeats.mdx`
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restoring or recreating a sandbox now correctly applies the current heartbeat schedule instead of retaining stale backup settings.
  * Heartbeat configuration is removed when omitted from the current setup, preventing outdated values from returning.
  * Existing heartbeat settings are preserved when no replacement schedule is provided.

* **Documentation**
  * Updated guidance explains how to re-export `NEMOCLAW_AGENT_HEARTBEAT_EVERY` before sandbox recreation.
  * Leaving the variable unset now clearly indicates that the default OpenClaw cadence will be used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->