### PR TITLE
fix(messaging): allow line breaks in Google Chat service-account JSON

### DIFF
--- a/src/lib/messaging/channels/googlechat/manifest.ts
+++ b/src/lib/messaging/channels/googlechat/manifest.ts
@@ -24,6 +24,12 @@ export const googlechatManifest = {
       kind: "secret",
       required: true,
       envKey: "GOOGLECHAT_SERVICE_ACCOUNT",
+      // A downloaded SA JSON key file is pretty-printed (or a caller may `cat`
+      // it verbatim into the env var), so it legitimately contains embedded
+      // newlines. Safe to allow here only because this value is never
+      // rendered into an env-lines file or JSON-fragment string — see the
+      // "No credentials/secretFiles here" comment on `credentials` below.
+      allowLineBreaks: true,
       // Cap the mask — a ~2 KB SA JSON would otherwise echo thousands of stars.
       maskCap: 40,
       // Validate the paste now (token-paste hook re-prompts, then skips the

--- a/src/lib/messaging/compiler/manifest-compiler.test.ts
+++ b/src/lib/messaging/compiler/manifest-compiler.test.ts
@@ -1019,6 +1019,41 @@ describe("ManifestCompiler", () => {
     );
   });
 
+  it("accepts a Google Chat service-account JSON with embedded newlines (#10383)", async () => {
+    const serviceAccountJson = [
+      "{",
+      '  "client_email": "bot@test-project.iam.gserviceaccount.com",',
+      '  "private_key": "-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----\\n"',
+      "}",
+    ].join("\n");
+    await withEnv(
+      {
+        GOOGLECHAT_SERVICE_ACCOUNT: serviceAccountJson,
+      },
+      async () => {
+        const plan = await compiler().compile({
+          sandboxName: "demo",
+          agent: "openclaw",
+          workflow: "onboard",
+          isInteractive: false,
+          configuredChannels: ["googlechat"],
+          credentialAvailability: {
+            "googlechat.serviceAccount": true,
+          },
+        });
+
+        expect(
+          plan.channels
+            .find((channel) => channel.channelId === "googlechat")
+            ?.inputs.find((input) => input.inputId === "serviceAccount"),
+        ).toMatchObject({
+          kind: "secret",
+          credentialAvailable: true,
+        });
+      },
+    );
+  });
+
   it("reads config default values when env keys are unset", async () => {
     const customManifest = {
       schemaVersion: 1,

--- a/src/lib/messaging/compiler/manifest-compiler.test.ts
+++ b/src/lib/messaging/compiler/manifest-compiler.test.ts
@@ -1020,38 +1020,25 @@ describe("ManifestCompiler", () => {
   });
 
   it("accepts a Google Chat service-account JSON with embedded newlines (#10383)", async () => {
-    const serviceAccountJson = [
-      "{",
-      '  "client_email": "bot@test-project.iam.gserviceaccount.com",',
-      '  "private_key": "-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----\\n"',
-      "}",
-    ].join("\n");
-    await withEnv(
-      {
-        GOOGLECHAT_SERVICE_ACCOUNT: serviceAccountJson,
-      },
-      async () => {
-        const plan = await compiler().compile({
-          sandboxName: "demo",
-          agent: "openclaw",
-          workflow: "onboard",
-          isInteractive: false,
-          configuredChannels: ["googlechat"],
-          credentialAvailability: {
-            "googlechat.serviceAccount": true,
-          },
-        });
+    const serviceAccountJson =
+      '{\n  "client_email": "bot@test-project.iam.gserviceaccount.com",\n' +
+      '  "private_key": "-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----\\n"\n}';
+    await withEnv({ GOOGLECHAT_SERVICE_ACCOUNT: serviceAccountJson }, async () => {
+      const plan = await compiler().compile({
+        sandboxName: "demo",
+        agent: "openclaw",
+        workflow: "onboard",
+        isInteractive: false,
+        configuredChannels: ["googlechat"],
+        credentialAvailability: { "googlechat.serviceAccount": true },
+      });
 
-        expect(
-          plan.channels
-            .find((channel) => channel.channelId === "googlechat")
-            ?.inputs.find((input) => input.inputId === "serviceAccount"),
-        ).toMatchObject({
-          kind: "secret",
-          credentialAvailable: true,
-        });
-      },
-    );
+      expect(
+        plan.channels
+          .find((channel) => channel.channelId === "googlechat")
+          ?.inputs.find((input) => input.inputId === "serviceAccount"),
+      ).toMatchObject({ kind: "secret", credentialAvailable: true });
+    });
   });
 
   it("reads config default values when env keys are unset", async () => {

--- a/src/lib/messaging/compiler/manifest-compiler.ts
+++ b/src/lib/messaging/compiler/manifest-compiler.ts
@@ -383,7 +383,7 @@ function normalizeInputValue(
   input: ChannelInputSpec,
   raw: string | null | undefined,
 ): string | undefined {
-  if (raw && /[\r\n]/.test(raw)) {
+  if (raw && !input.allowLineBreaks && /[\r\n]/.test(raw)) {
     throw new Error("Messaging input values must not contain line breaks.");
   }
   const normalized = raw?.trim();

--- a/src/lib/messaging/manifest/types.ts
+++ b/src/lib/messaging/manifest/types.ts
@@ -91,6 +91,14 @@ interface ChannelInputBaseSpec {
   readonly validValues?: readonly string[];
   readonly formatPattern?: string;
   readonly formatHint?: string;
+  /**
+   * Allow a raw \r/\n in this input's value. Default false rejects line
+   * breaks because most inputs render into a single env-file line or JSON
+   * string where an embedded newline would corrupt the target. Set this only
+   * for a value that is never rendered into such a target (e.g. a JSON blob
+   * consumed solely as gateway-side credential material).
+   */
+  readonly allowLineBreaks?: boolean;
 }
 
 /** Secret input metadata; values must be referenced, not stored in manifests or plans. */


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`normalizeInputValue()` in `manifest-compiler.ts` blanket-rejects any messaging input value
containing a raw `\r`/`\n`, as a guard against injecting extra lines into an env-lines file or
JSON-fragment string during rendering. Google Chat's `serviceAccount` input is the one input this
guard does not actually protect — the manifest documents that the pasted service-account JSON is
"consumed only as gateway-side refresh material, never delivered into the sandbox" and has no
`credentials`/`secretFiles` entries. A downloaded GCP service-account JSON key is routinely
pretty-printed with embedded newlines, so the guard rejected every real-world credential set through
the documented `GOOGLECHAT_SERVICE_ACCOUNT` env var, making the channel impossible to configure
non-interactively.

## Related Issue

Fixes #10383

## Changes

- Added an opt-in `allowLineBreaks` flag on `ChannelInputBaseSpec` (`src/lib/messaging/manifest/types.ts`).
  Default stays `false`, preserving the existing injection guard for every other channel input.
- `normalizeInputValue()` skips the newline check only when the input sets `allowLineBreaks: true`.
- Set `allowLineBreaks: true` on Google Chat's `serviceAccount` input only, with a comment pointing at
  why it is safe there (never rendered into a file). The interactive token-paste path's own JSON
  structural validator (`serviceAccountJsonError` in `service-account-token-paste.ts`) is unaffected
  and still runs.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli src/lib/messaging/compiler/manifest-compiler.test.ts src/lib/messaging/channels/googlechat/hooks/service-account-token-paste.test.ts src/lib/messaging/channels/googlechat/runtime-contract.test.ts` — 3 files, 47 tests passed (including the new regression test), verified on a clean host checkout (fresh clone + `npm ci`); confirmed the new test fails on pre-fix code
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Jason Ma <jama@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Google Chat service-account credentials now accept embedded line breaks, including pretty-printed JSON and multiline environment values.
  * Improved validation ensures multiline values are accepted where supported while preserving single-line restrictions elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->