### PR TITLE
fix(e2e): align base image publisher jobs

### DIFF
--- a/test/e2e/support/base-image-publication.test.ts
+++ b/test/e2e/support/base-image-publication.test.ts
@@ -147,15 +147,15 @@ function publisherJob(
 function successfulJobs(overrides: { runAttempt?: number } = {}): Record<string, unknown>[] {
   const runAttempt = overrides.runAttempt ?? 1;
   return [
-    publisherJob("Build and push OpenClaw base image", {
+    publisherJob("Manifests / OpenClaw", {
       id: 1,
       run_attempt: runAttempt,
     }),
-    publisherJob("Build and push Hermes base image", {
+    publisherJob("Manifests / Hermes", {
       id: 2,
       run_attempt: runAttempt,
     }),
-    publisherJob("Build and push Deep Agents Code base image", {
+    publisherJob("Manifests / Deep Agents Code", {
       id: 3,
       run_attempt: runAttempt,
     }),
@@ -578,7 +578,7 @@ describe("base-image publication evidence", () => {
 
   it("classifies an incomplete required publisher as pending only while the selected run is in progress (#9549)", () => {
     const jobs = successfulJobs().map((job) =>
-      job.name === "Build and push Hermes base image"
+      job.name === "Manifests / Hermes"
         ? { ...job, status: "in_progress", conclusion: null }
         : job,
     );
@@ -598,7 +598,7 @@ describe("base-image publication evidence", () => {
     "rejects a required publisher that concludes %s before the workflow completes (#9549)",
     (conclusion) => {
       const jobs = successfulJobs().map((job) =>
-        job.name === "Build and push Hermes base image" ? { ...job, conclusion } : job,
+        job.name === "Manifests / Hermes" ? { ...job, conclusion } : job,
       );
 
       expect(() =>
@@ -643,13 +643,13 @@ describe("base-image publication evidence", () => {
     ["missing", successfulJobs().slice(0, 2), /missing required/u],
     [
       "duplicated",
-      [...successfulJobs(), publisherJob("Build and push Hermes base image", { id: 9 })],
+      [...successfulJobs(), publisherJob("Manifests / Hermes", { id: 9 })],
       /duplicated in attempt/u,
     ],
     [
       "failed selected attempt",
       successfulJobs().map((job) =>
-        job.name === "Build and push Hermes base image" ? { ...job, conclusion: "failure" } : job,
+        job.name === "Manifests / Hermes" ? { ...job, conclusion: "failure" } : job,
       ),
       /did not complete successfully/u,
     ],

--- a/tools/e2e/base-image-publication.mts
+++ b/tools/e2e/base-image-publication.mts
@@ -71,9 +71,9 @@ const COMPLETED_CONCLUSIONS = new Set([
 ]);
 
 export const REQUIRED_PUBLISHER_JOBS = [
-  "Build and push OpenClaw base image",
-  "Build and push Hermes base image",
-  "Build and push Deep Agents Code base image",
+  "Manifests / OpenClaw",
+  "Manifests / Hermes",
+  "Manifests / Deep Agents Code",
 ] as const;
 
 type JsonRecord = Record<string, unknown>;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Update the trusted base-image publication verifier to require the current manifest job names. This lets self-hosted PR selection verify successful publication runs after the workflow naming migration.

## Changes

- Replace the obsolete base-image publisher job names with Manifests / OpenClaw, Manifests / Hermes, and Manifests / Deep Agents Code.
- Update publication fixtures so the verifier tests exercise the current GitHub Actions job names.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — Normal pre-commit, commit-msg, and pre-push hooks passed.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/base-image-publication.test.ts` — 52 passed
- [x] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: `npm run checks:repository` passed.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Chris Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated base image publication validation to recognize the current manifest job names.
  * Corrected pending, failure, duplicate, and validation scenarios to use the updated publication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->