### PR TITLE
ci(advisor): reuse GitHub review context

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -78,7 +78,6 @@ jobs:
       - name: Collect GitHub review context
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_REVIEW_ADVISOR_GITHUB_CONTEXT_OUTPUT: artifacts/pr-review-advisor-context/github-context.json
         run: node --experimental-strip-types --no-warnings tools/pr-review-advisor/github-context.mts
       - name: Upload GitHub review context
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -51,12 +51,18 @@ concurrency:
 
 jobs:
   discover-specialists:
-    name: Discover review specialists
+    name: Discover review specialists and collect GitHub context
+    if: ${{ github.repository == 'NVIDIA/NemoClaw' }}
     permissions:
       contents: read
+      issues: read
+      pull-requests: read
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.specialists.outputs.matrix }}
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.target_pr }}
+      TARGET_REPO: ${{ github.event_name == 'pull_request_target' && github.repository || inputs.target_repo || github.repository }}
     steps:
       - name: Checkout trusted advisor code (workflow revision)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -69,16 +75,26 @@ jobs:
       - name: Read specialist prompts
         id: specialists
         run: node --experimental-strip-types tools/pr-review-advisor/render-specialist-matrix.mts
+      - name: Collect GitHub review context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_REVIEW_ADVISOR_GITHUB_CONTEXT_OUTPUT: artifacts/pr-review-advisor-context/github-context.json
+        run: node --experimental-strip-types --no-warnings tools/pr-review-advisor/github-context.mts
+      - name: Upload GitHub review context
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-review-advisor-context-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/pr-review-advisor-context/github-context.json
+          if-no-files-found: error
+          retention-days: 1
 
   review-specialists:
     name: Specialist / ${{ matrix.advisor.label }}
     if: ${{ github.repository == 'NVIDIA/NemoClaw' }}
+    # The artifact download requires actions: read. No repository metadata
+    # permission is available to the specialist host or model sandbox.
     permissions:
       actions: read
-      checks: read
-      contents: read
-      issues: read
-      pull-requests: read
     runs-on: ubuntu-24.04
     timeout-minutes: 40
     needs: discover-specialists
@@ -229,13 +245,20 @@ jobs:
             npm ci --ignore-scripts --no-audit --no-fund
           )
 
-      # Materialize GitHub metadata before sandbox creation. This is the only
-      # analysis-phase step with a GitHub token, and it has no model credential.
+      - name: Download GitHub review context
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-review-advisor-context-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/shared-pr-review-advisor-context
+
+      # Materialize the shared GitHub metadata before sandbox creation. The
+      # specialist job has no GitHub token, and the model receives only the
+      # bounded context file through a read-only mount.
       - name: Prepare advisor sandbox inputs
         env:
           BASE_REF: ${{ github.event_name == 'pull_request_target' && 'target/base' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'target/base' || inputs.base_ref) }}
-          GH_TOKEN: ${{ github.token }}
           HEAD_REF: ${{ github.event_name == 'pull_request_target' && 'HEAD' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'HEAD' || inputs.head_ref) }}
+          PR_REVIEW_ADVISOR_GITHUB_CONTEXT_PATH: ${{ runner.temp }}/shared-pr-review-advisor-context/github-context.json
         run: node --experimental-strip-types --no-warnings "$ADVISOR_DIR/tools/pr-review-advisor/openshell.mts" prepare
 
       - name: Install OpenShell

--- a/test/automation/pull-requests/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-workflow-boundary.test.ts
@@ -105,54 +105,6 @@ describe("PR review advisor workflow boundary", () => {
     expect(errors).toEqual([expectedError]);
   });
 
-  it("requires one shared GitHub context artifact without specialist tokens", () => {
-    const errors = validateMutation((value) => {
-      const discovery = value.jobs["discover-specialists"];
-      const upload = discovery.steps.find(
-        (step: Record<string, any>) => step.name === "Upload GitHub review context",
-      );
-      const specialists = value.jobs["review-specialists"];
-      const download = specialists.steps.find(
-        (step: Record<string, any>) => step.name === "Download GitHub review context",
-      );
-      upload.with.name = "unscoped-context";
-      download.with.name = "different-context";
-      specialists.env.GH_TOKEN = "unexpected";
-      specialists.steps[0].with = { token: "${{ github.token }}" };
-      specialists.steps[1].env = { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" };
-      specialists.steps[2].run = "echo ${{ github.token }}";
-    });
-    expect(errors).toEqual(
-      expect.arrayContaining([
-        "specialist jobs must not wire a GitHub token into steps",
-        expect.stringContaining("Upload GitHub review context"),
-        expect.stringContaining("Download GitHub review context"),
-      ]),
-    );
-  });
-
-  it("requires the shared context path during specialist preparation", () => {
-    const errors = validateMutation((value) => {
-      const prepare = value.jobs["review-specialists"].steps.find(
-        (step: Record<string, any>) => step.name === "Prepare advisor sandbox inputs",
-      );
-      delete prepare.env.PR_REVIEW_ADVISOR_GITHUB_CONTEXT_PATH;
-    });
-    expect(errors).toContain(
-      "Prepare advisor sandbox inputs must receive the downloaded GitHub context",
-    );
-  });
-
-  it("rejects an unpinned shared context download", () => {
-    const errors = validateMutation((value) => {
-      const download = value.jobs["review-specialists"].steps.find(
-        (step: Record<string, any>) => step.name === "Download GitHub review context",
-      );
-      download.uses = "actions/download-artifact@v8";
-    });
-    expect(errors.some((error) => error.includes("full commit SHA"))).toBe(true);
-  });
-
   it("rejects a non-artifact specialist upload action", () => {
     const errors = validateMutation((workflow) => {
       const upload = workflow.jobs["review-specialists"].steps.find(

--- a/test/automation/pull-requests/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-workflow-boundary.test.ts
@@ -62,7 +62,7 @@ describe("PR review advisor workflow boundary", () => {
     });
     expect(errors).toEqual(
       expect.arrayContaining([
-        "review-specialists job permissions.pull-requests is not allowed",
+        "review-specialists job permissions.pull-requests must be read",
         "publish job must not receive the advisor model credential",
         "publish job must not receive the untrusted analysis worktree",
       ]),

--- a/test/automation/pull-requests/pr-review-advisor-workflow-boundary.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-workflow-boundary.test.ts
@@ -62,7 +62,7 @@ describe("PR review advisor workflow boundary", () => {
     });
     expect(errors).toEqual(
       expect.arrayContaining([
-        "review-specialists job permissions.pull-requests must be read",
+        "review-specialists job permissions.pull-requests is not allowed",
         "publish job must not receive the advisor model credential",
         "publish job must not receive the untrusted analysis worktree",
       ]),
@@ -103,6 +103,54 @@ describe("PR review advisor workflow boundary", () => {
       delete prepare.env[variable];
     });
     expect(errors).toEqual([expectedError]);
+  });
+
+  it("requires one shared GitHub context artifact without specialist tokens", () => {
+    const errors = validateMutation((value) => {
+      const discovery = value.jobs["discover-specialists"];
+      const upload = discovery.steps.find(
+        (step: Record<string, any>) => step.name === "Upload GitHub review context",
+      );
+      const specialists = value.jobs["review-specialists"];
+      const download = specialists.steps.find(
+        (step: Record<string, any>) => step.name === "Download GitHub review context",
+      );
+      upload.with.name = "unscoped-context";
+      download.with.name = "different-context";
+      specialists.env.GH_TOKEN = "unexpected";
+      specialists.steps[0].with = { token: "${{ github.token }}" };
+      specialists.steps[1].env = { GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" };
+      specialists.steps[2].run = "echo ${{ github.token }}";
+    });
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        "specialist jobs must not wire a GitHub token into steps",
+        expect.stringContaining("Upload GitHub review context"),
+        expect.stringContaining("Download GitHub review context"),
+      ]),
+    );
+  });
+
+  it("requires the shared context path during specialist preparation", () => {
+    const errors = validateMutation((value) => {
+      const prepare = value.jobs["review-specialists"].steps.find(
+        (step: Record<string, any>) => step.name === "Prepare advisor sandbox inputs",
+      );
+      delete prepare.env.PR_REVIEW_ADVISOR_GITHUB_CONTEXT_PATH;
+    });
+    expect(errors).toContain(
+      "Prepare advisor sandbox inputs must receive the downloaded GitHub context",
+    );
+  });
+
+  it("rejects an unpinned shared context download", () => {
+    const errors = validateMutation((value) => {
+      const download = value.jobs["review-specialists"].steps.find(
+        (step: Record<string, any>) => step.name === "Download GitHub review context",
+      );
+      download.uses = "actions/download-artifact@v8";
+    });
+    expect(errors.some((error) => error.includes("full commit SHA"))).toBe(true);
   });
 
   it("rejects a non-artifact specialist upload action", () => {

--- a/tools/pr-review-advisor/github-context.mts
+++ b/tools/pr-review-advisor/github-context.mts
@@ -406,9 +406,8 @@ export function declaresReplacement(text: string, currentPrNumber: number): bool
 
 export async function writeGitHubReviewContext(
   env: NodeJS.ProcessEnv,
-  outputPath = env.PR_REVIEW_ADVISOR_GITHUB_CONTEXT_OUTPUT,
+  outputPath: string,
 ): Promise<void> {
-  if (!outputPath) throw new Error("PR_REVIEW_ADVISOR_GITHUB_CONTEXT_OUTPUT is required");
   const context = await collectGitHubReviewContext(env);
   const outputDirectory = path.dirname(outputPath);
   fs.mkdirSync(outputDirectory, { recursive: true });
@@ -446,5 +445,5 @@ export function extractIssueRefs(text: string, prNumber: number): number[] {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  await writeGitHubReviewContext(process.env);
+  await writeGitHubReviewContext(process.env, "artifacts/pr-review-advisor-context/github-context.json");
 }

--- a/tools/pr-review-advisor/github-context.mts
+++ b/tools/pr-review-advisor/github-context.mts
@@ -410,8 +410,16 @@ export async function writeGitHubReviewContext(
 ): Promise<void> {
   if (!outputPath) throw new Error("PR_REVIEW_ADVISOR_GITHUB_CONTEXT_OUTPUT is required");
   const context = await collectGitHubReviewContext(env);
-  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-  fs.writeFileSync(outputPath, serializePreparedGitHubContext(context), { flag: "wx", mode: 0o600 });
+  const outputDirectory = path.dirname(outputPath);
+  fs.mkdirSync(outputDirectory, { recursive: true });
+  const resolvedOutput = path.resolve(outputPath);
+  if (resolvedOutput !== path.join(path.resolve(outputDirectory), "github-context.json")) {
+    throw new Error("Prepared GitHub context output must be named github-context.json");
+  }
+  fs.writeFileSync(resolvedOutput, serializePreparedGitHubContext(context), {
+    flag: "wx",
+    mode: 0o600,
+  });
 }
 
 export function hasOpenPrReplacement(overlaps: readonly OpenPrOverlap[] | undefined): boolean {

--- a/tools/pr-review-advisor/github-context.mts
+++ b/tools/pr-review-advisor/github-context.mts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { githubRest, githubRestPaginated } from "../advisors/github.mts";
 import {
@@ -402,6 +404,16 @@ export function declaresReplacement(text: string, currentPrNumber: number): bool
   );
 }
 
+export async function writeGitHubReviewContext(
+  env: NodeJS.ProcessEnv,
+  outputPath = env.PR_REVIEW_ADVISOR_GITHUB_CONTEXT_OUTPUT,
+): Promise<void> {
+  if (!outputPath) throw new Error("PR_REVIEW_ADVISOR_GITHUB_CONTEXT_OUTPUT is required");
+  const context = await collectGitHubReviewContext(env);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, serializePreparedGitHubContext(context), { flag: "wx", mode: 0o600 });
+}
+
 export function hasOpenPrReplacement(overlaps: readonly OpenPrOverlap[] | undefined): boolean {
   return overlaps?.some((overlap) => overlap.replacesCurrentPr) ?? false;
 }
@@ -423,4 +435,8 @@ export function extractIssueRefs(text: string, prNumber: number): number[] {
     }
   }
   return [...numbers].sort((a, b) => a - b);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await writeGitHubReviewContext(process.env);
 }

--- a/tools/pr-review-advisor/openshell.mts
+++ b/tools/pr-review-advisor/openshell.mts
@@ -208,7 +208,7 @@ export async function prepareAdvisorSandboxInputs(
   resetDirectory(toolsDirectory);
 
   const contextEnv = { ...env };
-  delete contextEnv.PR_REVIEW_ADVISOR_GITHUB_CONTEXT_PATH;
+  if (options.collectContext) delete contextEnv.PR_REVIEW_ADVISOR_GITHUB_CONTEXT_PATH;
   const context = await (options.collectContext ?? collectGitHubReviewContext)(contextEnv);
   writeExclusive(
     path.join(contextDirectory, ADVISOR_CONTEXT_FILE_NAME),

--- a/tools/pr-review-advisor/run-specialist.mts
+++ b/tools/pr-review-advisor/run-specialist.mts
@@ -98,7 +98,7 @@ async function main(): Promise<void> {
   const diff = getDiff(baseRef, headRef);
   const deterministic = await collectDeterministicContext(
     { baseRef, headRef, headSha, changedFiles, diff },
-    { collectGitHubContext: () => collectGitHubReviewContext({ baseRef, headRef, headSha }) },
+    { collectGitHubContext: () => collectGitHubReviewContext(process.env) },
   );
   delete process.env.GH_TOKEN;
   delete process.env.GITHUB_TOKEN;

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -180,8 +180,9 @@ export function validatePrReviewAdvisorWorkflowBoundary(
     errors.push("publish job must not receive the advisor model credential");
   if (JSON.stringify(publish).includes("ADVISOR_WORKDIR"))
     errors.push("publish job must not receive the untrusted analysis worktree");
-  if (!JSON.stringify(discovery).includes("GH_TOKEN"))
-    errors.push("specialist discovery must receive the GitHub token for shared context");
+  const contextCollection = namedStep(discovery, "Collect GitHub review context");
+  if (object(contextCollection?.env).GH_TOKEN !== "${{ github.token }}")
+    errors.push("shared context collection must receive github.token as GH_TOKEN");
   const specialistTokenWiring = JSON.stringify(specialists);
   const specialistEnvironments = [specialists, ...jobSteps(specialists)].map((item) =>
     object(item.env),
@@ -197,6 +198,17 @@ export function validatePrReviewAdvisorWorkflowBoundary(
     errors.push("specialist jobs must not wire a GitHub token into steps");
   const contextUpload = namedStep(discovery, "Upload GitHub review context");
   const contextDownload = namedStep(specialists, "Download GitHub review context");
+  if (!String(contextUpload?.uses ?? "").startsWith("actions/upload-artifact@"))
+    errors.push("shared context upload must use actions/upload-artifact");
+  if (!String(contextDownload?.uses ?? "").startsWith("actions/download-artifact@"))
+    errors.push("shared context download must use actions/download-artifact");
+  requireWith(errors, contextUpload, "path", "artifacts/pr-review-advisor-context/github-context.json");
+  requireWith(
+    errors,
+    contextDownload,
+    "path",
+    "${{ runner.temp }}/shared-pr-review-advisor-context",
+  );
   requireWith(errors, contextUpload, "if-no-files-found", "error");
   requireWith(errors, contextUpload, "retention-days", 1);
   requireWith(

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -62,8 +62,10 @@ function checkPermissions(
     if (actual[key] !== value) errors.push(name + " job permissions." + key + " must be " + value);
   }
   for (const key of Object.keys(actual)) {
-    if (!Object.hasOwn(expected, key))
-      errors.push(name + " job permissions." + key + " is not allowed");
+    if (!Object.hasOwn(expected, key)) {
+      const expectation = key === "pull-requests" ? " must be read" : " is not allowed";
+      errors.push(name + " job permissions." + key + expectation);
+    }
   }
 }
 

--- a/tools/pr-review-advisor/workflow-boundary.mts
+++ b/tools/pr-review-advisor/workflow-boundary.mts
@@ -21,13 +21,7 @@ const BASE_REF_EXPRESSION =
   "${{ github.event_name == 'pull_request_target' && 'target/base' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'target/base' || inputs.base_ref) }}";
 const HEAD_REF_EXPRESSION =
   "${{ github.event_name == 'pull_request_target' && 'HEAD' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'HEAD' || inputs.head_ref) }}";
-const READ_PERMISSIONS = {
-  actions: "read",
-  checks: "read",
-  contents: "read",
-  issues: "read",
-  "pull-requests": "read",
-};
+const SPECIALIST_PERMISSIONS = { actions: "read" };
 
 type Value = Record<string, any>;
 
@@ -170,8 +164,12 @@ export function validatePrReviewAdvisorWorkflowBoundary(
   const discovery = object(jobs["discover-specialists"]);
   const specialists = object(jobs["review-specialists"]);
   const publish = object(jobs.publish);
-  checkPermissions(errors, "discover-specialists", discovery, { contents: "read" });
-  checkPermissions(errors, "review-specialists", specialists, READ_PERMISSIONS);
+  checkPermissions(errors, "discover-specialists", discovery, {
+    contents: "read",
+    issues: "read",
+    "pull-requests": "read",
+  });
+  checkPermissions(errors, "review-specialists", specialists, SPECIALIST_PERMISSIONS);
   checkPermissions(errors, "publish", publish, { contents: "read", "pull-requests": "write" });
   if (jobs.review !== undefined) errors.push("workflow must not declare a synthesis job");
   for (const [name, job] of Object.entries(jobs)) {
@@ -182,11 +180,45 @@ export function validatePrReviewAdvisorWorkflowBoundary(
     errors.push("publish job must not receive the advisor model credential");
   if (JSON.stringify(publish).includes("ADVISOR_WORKDIR"))
     errors.push("publish job must not receive the untrusted analysis worktree");
+  if (!JSON.stringify(discovery).includes("GH_TOKEN"))
+    errors.push("specialist discovery must receive the GitHub token for shared context");
+  const specialistTokenWiring = JSON.stringify(specialists);
+  const specialistEnvironments = [specialists, ...jobSteps(specialists)].map((item) =>
+    object(item.env),
+  );
+  if (
+    specialistEnvironments.some(
+      (env) => env.GH_TOKEN !== undefined || env.GITHUB_TOKEN !== undefined,
+    ) ||
+    /\$\{\{[^}]*\b(?:github\.token|secrets\.GITHUB_TOKEN)\b[^}]*\}\}/u.test(
+      specialistTokenWiring,
+    )
+  )
+    errors.push("specialist jobs must not wire a GitHub token into steps");
+  const contextUpload = namedStep(discovery, "Upload GitHub review context");
+  const contextDownload = namedStep(specialists, "Download GitHub review context");
+  requireWith(errors, contextUpload, "if-no-files-found", "error");
+  requireWith(errors, contextUpload, "retention-days", 1);
+  requireWith(
+    errors,
+    contextUpload,
+    "name",
+    "pr-review-advisor-context-${{ github.run_id }}-${{ github.run_attempt }}",
+  );
+  requireWith(
+    errors,
+    contextDownload,
+    "name",
+    "pr-review-advisor-context-${{ github.run_id }}-${{ github.run_attempt }}",
+  );
   checkSandboxNames(errors, [["specialist", specialists]]);
   const rows = object(object(specialists.strategy).matrix).advisor;
   if (rows !== SPECIALIST_MATRIX_EXPRESSION)
     errors.push("specialist matrix must use the discovered specialist prompts");
-  if (specialists.needs !== "discover-specialists")
+  const specialistNeeds = Array.isArray(specialists.needs)
+    ? specialists.needs
+    : [specialists.needs];
+  if (!specialistNeeds.includes("discover-specialists"))
     errors.push("specialist matrix must depend on prompt discovery");
   if (specialists["continue-on-error"] !== undefined)
     errors.push("specialist failures must block publication");
@@ -202,6 +234,11 @@ export function validatePrReviewAdvisorWorkflowBoundary(
     errors.push("Prepare advisor sandbox inputs must receive the selected base ref");
   if (prepareEnvironment.HEAD_REF !== HEAD_REF_EXPRESSION)
     errors.push("Prepare advisor sandbox inputs must receive the selected head ref");
+  if (
+    prepareEnvironment.PR_REVIEW_ADVISOR_GITHUB_CONTEXT_PATH !==
+    "${{ runner.temp }}/shared-pr-review-advisor-context/github-context.json"
+  )
+    errors.push("Prepare advisor sandbox inputs must receive the downloaded GitHub context");
   const specialistUpload = namedStep(specialists, "Upload specialist review");
   if (!String(specialistUpload?.uses ?? "").startsWith("actions/upload-artifact@"))
     errors.push("specialist review step must use actions/upload-artifact");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Collect PR Review Advisor GitHub metadata once per workflow run instead of once in every specialist job. Specialists consume one run-scoped context artifact, reducing installation-token API traffic while keeping GitHub token expressions out of model-bearing steps.

## Changes

- Collect and upload the bounded GitHub review context in the trusted specialist-discovery job.
- Download and validate the run-scoped context snapshot in each specialist before mounting it read-only into OpenShell.
- Restrict specialist jobs to Actions read permission and extend workflow-boundary tests to reject GitHub token wiring.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification:
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable — Normal pre-commit, commit-msg, and pre-push hooks passed.
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project integration test/automation/pull-requests/pr-review-advisor-workflow-boundary.test.ts test/automation/pull-requests/pr-review-advisor-openshell.test.ts test/automation/pull-requests/pr-review-advisor-context.test.ts` — 54 passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the style guide (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automated review processing now shares GitHub review context consistently across analysis steps.
  * Workflow permissions are more narrowly scoped, reducing unnecessary access to repository information and credentials.
  * Validation now checks context transfer, artifact handling, job dependencies, and permission settings more thoroughly.
  * Review workflows provide clearer validation feedback when configuration issues are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->