### PR TITLE
chore(tooling): format value stream analyzer

### DIFF
--- a/.dsh/tools/analyze_pr_value_stream/index.ts
+++ b/.dsh/tools/analyze_pr_value_stream/index.ts
@@ -410,160 +410,162 @@ export default async function analyze_pr_value_stream(input: {
   for (let index = 0; index < waterfallRuns.length; index += 4) {
     const batch = await Promise.all(
       waterfallRuns.slice(index, index + 4).map(async (run: any) => {
-      const runResult = await tools.run_github_cli({
-        workdir: input.workdir,
-        args: [
-          "api",
-          "repos/" + repository + "/actions/runs/" + run.id,
-          "--jq",
-          "{id,name,event,run_attempt,head_sha,status,conclusion,created_at,run_started_at,updated_at,html_url}",
-        ],
-      });
-      const runDetails = JSON.parse(runResult.stdout);
-      if (
-        runDetails?.id !== run.id ||
-        runDetails?.head_sha !== pull.headRefOid ||
-        !Number.isSafeInteger(runDetails?.run_attempt)
-      )
-        throw new Error("workflow run did not match the exact-head waterfall contract");
-      const jobsResult = await tools.run_github_cli({
-        workdir: input.workdir,
-        args: [
-          "api",
-          "repos/" + repository + "/actions/runs/" + run.id + "/jobs?filter=latest&per_page=100",
-          "--jq",
-          "{total_count,jobs:[.jobs[] | {id,name,status,conclusion,created_at,started_at,completed_at,runner_name,runner_group_name,labels,html_url,steps}]}",
-        ],
-      });
-      const jobsPayload = JSON.parse(jobsResult.stdout);
-      if (
-        !Number.isSafeInteger(jobsPayload?.total_count) ||
-        !Array.isArray(jobsPayload?.jobs) ||
-        jobsPayload.total_count > 100 ||
-        jobsPayload.jobs.length !== jobsPayload.total_count
-      )
-        throw new Error("workflow job list exceeded the complete bounded waterfall contract");
-      const runCreated = parseTime(run.created_at, "workflow createdAt");
-      const shardJobs = jobsPayload.jobs.filter((job: any) => shardJobName.test(job?.name));
-      let artifactsByName = new Map<string, any>();
-      if (shardJobs.length > 0 && maxTestArtifacts > 0) {
-        try {
-          const artifactsResult = await tools.run_github_cli({
-            workdir: input.workdir,
-            args: [
-              "api",
-              "repos/" + repository + "/actions/runs/" + run.id + "/artifacts?per_page=100",
-              "--jq",
-              "{total_count,artifacts:[.artifacts[] | {id,name,size_in_bytes,expired,workflow_run_id:.workflow_run.id,workflow_run_head_sha:.workflow_run.head_sha}]}",
-            ],
-          });
-          const payload = JSON.parse(artifactsResult.stdout);
-          if (
-            Number.isSafeInteger(payload?.total_count) &&
-            payload.total_count <= 100 &&
-            Array.isArray(payload?.artifacts) &&
-            payload.artifacts.length === payload.total_count
-          ) {
-            const counts = new Map<string, number>();
-            for (const artifact of payload.artifacts)
-              counts.set(artifact?.name, (counts.get(artifact?.name) ?? 0) + 1);
-            artifactsByName = new Map(
-              payload.artifacts
-                .filter((artifact: any) => counts.get(artifact?.name) === 1)
-                .map((artifact: any) => [artifact.name, artifact]),
-            );
-          }
-        } catch {
-          artifactsByName = new Map();
-        }
-      }
-      const jobs = [];
-      for (const job of jobsPayload.jobs) {
-        if (!Number.isSafeInteger(job?.id) || !Array.isArray(job?.steps))
-          throw new Error("workflow job did not match the waterfall contract");
-        const jobCreated = parseTime(job.created_at, "job createdAt");
-        const jobStarted = parseTime(job.started_at, "job startedAt");
-        const jobCompleted =
-          job.completed_at === null ? null : parseTime(job.completed_at, "job completedAt");
-        let testRun = null;
-        const match = shardJobName.exec(job.name);
-        if (match !== null && testArtifactsRead < maxTestArtifacts) {
-          const artifact = artifactsByName.get("cli-blob-report-" + match[1]);
-          if (artifact !== undefined) {
-            testArtifactsRead += 1;
-            testRun = await readTestRun(run.id, pull.headRefOid, Number(match[1]), artifact);
-          }
-        }
-        const steps = job.steps.map((step: any) => {
-          if (!Number.isSafeInteger(step?.number))
-            throw new Error("workflow step did not match the waterfall contract");
-          const stepStarted = parseTime(step.started_at, "step startedAt");
-          const stepCompleted =
-            step.completed_at === null ? null : parseTime(step.completed_at, "step completedAt");
-          return {
-            number: step.number,
-            name: String(step.name ?? "").slice(0, 200),
-            status: String(step.status ?? "").slice(0, 40),
-            conclusion:
-              step.conclusion === null ? null : String(step.conclusion ?? "").slice(0, 40),
-            startedAt: iso(stepStarted),
-            completedAt: stepCompleted === null ? null : iso(stepCompleted),
-            offsetSeconds: offsetSeconds(headObserved, stepStarted),
-            durationSeconds: stepCompleted === null ? null : seconds(stepStarted, stepCompleted),
-          };
+        const runResult = await tools.run_github_cli({
+          workdir: input.workdir,
+          args: [
+            "api",
+            "repos/" + repository + "/actions/runs/" + run.id,
+            "--jq",
+            "{id,name,event,run_attempt,head_sha,status,conclusion,created_at,run_started_at,updated_at,html_url}",
+          ],
         });
-        const normalizedJob = {
-          id: job.id,
-          name: String(job.name ?? "").slice(0, 200),
-          status: String(job.status ?? "").slice(0, 40),
-          conclusion: job.conclusion === null ? null : String(job.conclusion ?? "").slice(0, 40),
-          url: String(job.html_url ?? "").slice(0, 500),
-          runner: job.runner_name === null ? null : String(job.runner_name ?? "").slice(0, 200),
-          runnerGroup:
-            job.runner_group_name === null
+        const runDetails = JSON.parse(runResult.stdout);
+        if (
+          runDetails?.id !== run.id ||
+          runDetails?.head_sha !== pull.headRefOid ||
+          !Number.isSafeInteger(runDetails?.run_attempt)
+        )
+          throw new Error("workflow run did not match the exact-head waterfall contract");
+        const jobsResult = await tools.run_github_cli({
+          workdir: input.workdir,
+          args: [
+            "api",
+            "repos/" + repository + "/actions/runs/" + run.id + "/jobs?filter=latest&per_page=100",
+            "--jq",
+            "{total_count,jobs:[.jobs[] | {id,name,status,conclusion,created_at,started_at,completed_at,runner_name,runner_group_name,labels,html_url,steps}]}",
+          ],
+        });
+        const jobsPayload = JSON.parse(jobsResult.stdout);
+        if (
+          !Number.isSafeInteger(jobsPayload?.total_count) ||
+          !Array.isArray(jobsPayload?.jobs) ||
+          jobsPayload.total_count > 100 ||
+          jobsPayload.jobs.length !== jobsPayload.total_count
+        )
+          throw new Error("workflow job list exceeded the complete bounded waterfall contract");
+        const runCreated = parseTime(run.created_at, "workflow createdAt");
+        const shardJobs = jobsPayload.jobs.filter((job: any) => shardJobName.test(job?.name));
+        let artifactsByName = new Map<string, any>();
+        if (shardJobs.length > 0 && maxTestArtifacts > 0) {
+          try {
+            const artifactsResult = await tools.run_github_cli({
+              workdir: input.workdir,
+              args: [
+                "api",
+                "repos/" + repository + "/actions/runs/" + run.id + "/artifacts?per_page=100",
+                "--jq",
+                "{total_count,artifacts:[.artifacts[] | {id,name,size_in_bytes,expired,workflow_run_id:.workflow_run.id,workflow_run_head_sha:.workflow_run.head_sha}]}",
+              ],
+            });
+            const payload = JSON.parse(artifactsResult.stdout);
+            if (
+              Number.isSafeInteger(payload?.total_count) &&
+              payload.total_count <= 100 &&
+              Array.isArray(payload?.artifacts) &&
+              payload.artifacts.length === payload.total_count
+            ) {
+              const counts = new Map<string, number>();
+              for (const artifact of payload.artifacts)
+                counts.set(artifact?.name, (counts.get(artifact?.name) ?? 0) + 1);
+              artifactsByName = new Map(
+                payload.artifacts
+                  .filter((artifact: any) => counts.get(artifact?.name) === 1)
+                  .map((artifact: any) => [artifact.name, artifact]),
+              );
+            }
+          } catch {
+            artifactsByName = new Map();
+          }
+        }
+        const jobs = [];
+        for (const job of jobsPayload.jobs) {
+          if (!Number.isSafeInteger(job?.id) || !Array.isArray(job?.steps))
+            throw new Error("workflow job did not match the waterfall contract");
+          const jobCreated = parseTime(job.created_at, "job createdAt");
+          const jobStarted = parseTime(job.started_at, "job startedAt");
+          const jobCompleted =
+            job.completed_at === null ? null : parseTime(job.completed_at, "job completedAt");
+          let testRun = null;
+          const match = shardJobName.exec(job.name);
+          if (match !== null && testArtifactsRead < maxTestArtifacts) {
+            const artifact = artifactsByName.get("cli-blob-report-" + match[1]);
+            if (artifact !== undefined) {
+              testArtifactsRead += 1;
+              testRun = await readTestRun(run.id, pull.headRefOid, Number(match[1]), artifact);
+            }
+          }
+          const steps = job.steps.map((step: any) => {
+            if (!Number.isSafeInteger(step?.number))
+              throw new Error("workflow step did not match the waterfall contract");
+            const stepStarted = parseTime(step.started_at, "step startedAt");
+            const stepCompleted =
+              step.completed_at === null ? null : parseTime(step.completed_at, "step completedAt");
+            return {
+              number: step.number,
+              name: String(step.name ?? "").slice(0, 200),
+              status: String(step.status ?? "").slice(0, 40),
+              conclusion:
+                step.conclusion === null ? null : String(step.conclusion ?? "").slice(0, 40),
+              startedAt: iso(stepStarted),
+              completedAt: stepCompleted === null ? null : iso(stepCompleted),
+              offsetSeconds: offsetSeconds(headObserved, stepStarted),
+              durationSeconds: stepCompleted === null ? null : seconds(stepStarted, stepCompleted),
+            };
+          });
+          const normalizedJob = {
+            id: job.id,
+            name: String(job.name ?? "").slice(0, 200),
+            status: String(job.status ?? "").slice(0, 40),
+            conclusion: job.conclusion === null ? null : String(job.conclusion ?? "").slice(0, 40),
+            url: String(job.html_url ?? "").slice(0, 500),
+            runner: job.runner_name === null ? null : String(job.runner_name ?? "").slice(0, 200),
+            runnerGroup:
+              job.runner_group_name === null
+                ? null
+                : String(job.runner_group_name ?? "").slice(0, 200),
+            labels: job.labels.slice(0, 20).map((label: any) => String(label).slice(0, 100)),
+            createdAt: iso(jobCreated),
+            startedAt: iso(jobStarted),
+            completedAt: jobCompleted === null ? null : iso(jobCompleted),
+            offsetSeconds: offsetSeconds(headObserved, jobStarted),
+            queueSeconds: jobCreated <= jobStarted ? seconds(jobCreated, jobStarted) : null,
+            durationSeconds: jobCompleted === null ? null : seconds(jobStarted, jobCompleted),
+            testRun,
+            steps,
+          };
+          jobs.push(normalizedJob);
+        }
+        const earliestJobStart =
+          jobs.length > 0
+            ? Math.min(
+                ...jobs.map((job: any) => parseTime(job.startedAt, "normalized job startedAt")),
+              )
+            : parseTime(runDetails.run_started_at, "workflow startedAt");
+        const runStarted = Math.min(
+          parseTime(runDetails.run_started_at, "workflow startedAt"),
+          earliestJobStart,
+        );
+        const runCompleted =
+          runDetails.status === "completed"
+            ? parseTime(runDetails.updated_at, "workflow completedAt")
+            : null;
+        return {
+          id: runDetails.id,
+          name: String(runDetails.name ?? "").slice(0, 200),
+          event: String(runDetails.event ?? "").slice(0, 60),
+          attempt: runDetails.run_attempt,
+          status: String(runDetails.status ?? "").slice(0, 40),
+          conclusion:
+            runDetails.conclusion === null
               ? null
-              : String(job.runner_group_name ?? "").slice(0, 200),
-          labels: job.labels.slice(0, 20).map((label: any) => String(label).slice(0, 100)),
-          createdAt: iso(jobCreated),
-          startedAt: iso(jobStarted),
-          completedAt: jobCompleted === null ? null : iso(jobCompleted),
-          offsetSeconds: offsetSeconds(headObserved, jobStarted),
-          queueSeconds: jobCreated <= jobStarted ? seconds(jobCreated, jobStarted) : null,
-          durationSeconds: jobCompleted === null ? null : seconds(jobStarted, jobCompleted),
-          testRun,
-          steps,
-        };
-        jobs.push(normalizedJob);
-      }
-      const earliestJobStart =
-        jobs.length > 0
-          ? Math.min(
-              ...jobs.map((job: any) => parseTime(job.startedAt, "normalized job startedAt")),
-            )
-          : parseTime(runDetails.run_started_at, "workflow startedAt");
-      const runStarted = Math.min(
-        parseTime(runDetails.run_started_at, "workflow startedAt"),
-        earliestJobStart,
-      );
-      const runCompleted =
-        runDetails.status === "completed"
-          ? parseTime(runDetails.updated_at, "workflow completedAt")
-          : null;
-      return {
-        id: runDetails.id,
-        name: String(runDetails.name ?? "").slice(0, 200),
-        event: String(runDetails.event ?? "").slice(0, 60),
-        attempt: runDetails.run_attempt,
-        status: String(runDetails.status ?? "").slice(0, 40),
-        conclusion:
-          runDetails.conclusion === null ? null : String(runDetails.conclusion ?? "").slice(0, 40),
-        url: String(runDetails.html_url ?? "").slice(0, 500),
-        createdAt: iso(runCreated),
-        startedAt: iso(runStarted),
-        completedAt: runCompleted === null ? null : iso(runCompleted),
-        offsetSeconds: offsetSeconds(headObserved, runCreated),
-        queueSeconds: seconds(runCreated, runStarted),
-        durationSeconds: runCompleted === null ? null : seconds(runStarted, runCompleted),
+              : String(runDetails.conclusion ?? "").slice(0, 40),
+          url: String(runDetails.html_url ?? "").slice(0, 500),
+          createdAt: iso(runCreated),
+          startedAt: iso(runStarted),
+          completedAt: runCompleted === null ? null : iso(runCompleted),
+          offsetSeconds: offsetSeconds(headObserved, runCreated),
+          queueSeconds: seconds(runCreated, runStarted),
+          durationSeconds: runCompleted === null ? null : seconds(runStarted, runCompleted),
           jobs,
         };
       }),
@@ -686,8 +688,7 @@ export default async function analyze_pr_value_stream(input: {
       .flatMap((run: any) => run.jobs)
       .filter((job: any) => job.queueSeconds !== null)
       .sort(
-        (a: any, b: any) =>
-          b.queueSeconds - a.queueSeconds || a.name.localeCompare(b.name),
+        (a: any, b: any) => b.queueSeconds - a.queueSeconds || a.name.localeCompare(b.name),
       )[0] ?? null;
   const longestChecks = checkRows
     .slice()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Oxfmt currently rewrites the value-stream analyzer during repository-wide pre-commit checks, which makes unrelated pull requests fail Static Checks. This change applies Oxfmt's deterministic indentation and line wrapping without changing the TypeScript token sequence.

## Related Issue

Related to #10153.

## Changes

- Format `.dsh/tools/analyze_pr_value_stream/index.ts` with the repository-pinned Oxfmt version.
- Preserve all 5,871 non-trivia TypeScript tokens and every runtime behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior, justification: Not applicable.
- [x] Tests not applicable, justification: The formatter-only diff preserves the exact 5,871-token TypeScript sequence. Focused Oxfmt validation and `git diff --check` passed.
- [ ] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded, reviewer/approval link/justification: Not applicable.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer, check name, approval link, and follow-up issue: None accepted.

## Documentation Writer Review

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Reviewed the complete formatter-only effective diff at commit `ee6b0e9ced6b04277e6fa109c00ae26a127c815e` against base `8bbc5b94c2bef63c6111796f19414181bbb3ff3e`. The change only reformats the internal DSH value-stream analyzer. A TypeScript scanner confirmed the same 5,871 non-trivia tokens before and after. It changes no documentation, explanatory text, diagnostic, runtime contract, CLI surface, configuration, or user workflow. Focused Oxfmt validation and `git diff --check` passed.
- Agent: Codex documentation writer subagent (`/root/watch_trigger_merge_blocker`)
<!-- docs-review-head-sha: ee6b0e9ce -->
<!-- docs-review-agents-blob-sha: c7de0eb73c13df83dd97dfb6e3f664cac8d75305 -->

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: `scripts/prepare-dgx-station-host.sh` is unchanged.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above, command/result or justification: Tests are not applicable because the exact TypeScript token sequence is unchanged. `npx oxfmt --check --no-error-on-unmatched-pattern -- .dsh/tools/analyze_pr_value_stream/index.ts` and `git diff --check` passed.
- [ ] Applicable broad gate passed, `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes, command/result: The exact all-files pre-commit command reached Oxfmt PASS with no mutation. Its only local failure was the existing all-files Hadolint warning inventory, which this PR does not accept or change.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted internal processing code for improved consistency and readability.
  * No user-visible behavior or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->