### PR TITLE
fix(ci): preserve policy command coverage

### DIFF
--- a/.github/actions/ci-cli-coverage-shard/action.yaml
+++ b/.github/actions/ci-cli-coverage-shard/action.yaml
@@ -176,11 +176,37 @@ runs:
           --coverage.exclude="test/**/*.js" \
           --coverage.exclude="test/**/*.ts"
 
+    # The V8 provider can replace earlier function counts when the same source
+    # is loaded in several isolated workers. Keep the exact 100%-ratcheted
+    # policy command test in one separate report so the final merge retains its
+    # observed execution instead of an uncovered later copy.
+    - name: Run policy command coverage supplement
+      if: ${{ inputs.shard == '1' }}
+      shell: bash
+      run: |
+        npx vitest run --project cli src/lib/policy/commands.test.ts \
+          --shard="1/1" \
+          --reporter=blob \
+          --outputFile.blob=".vitest-reports/blob-policy-command-ratchet.json" \
+          --coverage \
+          --coverage.reporter=json-summary \
+          --coverage.reportsDirectory="coverage/cli/policy-command-ratchet" \
+          --coverage.include="src/lib/policy/commands.ts"
+
     - name: Upload CLI shard blob report
       if: ${{ always() && steps.validate-shard-inputs.outcome == 'success' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: cli-blob-report-${{ inputs.shard }}
         path: .vitest-reports/blob-${{ inputs.shard }}-${{ inputs.shard-count }}.json
+        if-no-files-found: error
+        retention-days: 1
+
+    - name: Upload policy command coverage supplement
+      if: ${{ inputs.shard == '1' && success() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: cli-blob-report-policy-command-ratchet
+        path: .vitest-reports/blob-policy-command-ratchet.json
         if-no-files-found: error
         retention-days: 1

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -162,6 +162,11 @@
       "category": "security"
     },
     {
+      "file": "test/automation/pull-requests/pr-workflow-contract.test.ts",
+      "test": "keeps policy command coverage in a separate mergeable report",
+      "category": "compatibility"
+    },
+    {
       "file": "test/automation/releases/release-daily-brev-image.test.ts",
       "test": "attests one daily request before the isolated dispatch job (#9799)",
       "category": "security"

--- a/test/automation/pull-requests/pr-workflow-contract.test.ts
+++ b/test/automation/pull-requests/pr-workflow-contract.test.ts
@@ -473,6 +473,30 @@ describe("pull request and main workflow contracts", () => {
     }
   });
 
+  // source-shape-contract: compatibility -- The focused coverage blob name and its upload artifact must stay aligned so the trusted merge retains observed command-builder execution
+  it("keeps policy command coverage in a separate mergeable report", () => {
+    const run = requiredStep(
+      sharedActions.cliCoverageShard,
+      "Run policy command coverage supplement",
+    );
+    const upload = requiredStep(
+      sharedActions.cliCoverageShard,
+      "Upload policy command coverage supplement",
+    );
+
+    expect(run.if).toBe("${{ inputs.shard == '1' }}");
+    expect(run.run).toContain("src/lib/policy/commands.test.ts");
+    expect(run.run).toContain('--shard="1/1"');
+    expect(run.run).toContain("--reporter=blob");
+    expect(run.run).toContain("blob-policy-command-ratchet.json");
+    expect(upload.if).toBe("${{ inputs.shard == '1' && success() }}");
+    expect(upload.with).toMatchObject({
+      name: "cli-blob-report-policy-command-ratchet",
+      path: ".vitest-reports/blob-policy-command-ratchet.json",
+      "if-no-files-found": "error",
+    });
+  });
+
   const coverageEntrypointCases = [
     {
       action: sharedActions.cliCoverageShard,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->\n## Summary\n\nPreserve the policy command coverage that current main loses while merging isolated Vitest worker reports. The fix adds one focused report and merges it with the normal twelve shard reports without lowering any coverage threshold.\n\n## Related Issue\n\nSupports #9872 and unblocks #10368.\n\n## Changes\n\n- Run the existing policy command builder test once in a separate coverage report.\n- Upload that report through the existing CLI blob artifact pattern.\n- Protect the report and upload contract with a workflow test and an approved compatibility exception.\n\n## Type of Change\n\n- [x] Code change (feature, bug fix, or refactor)\n- [ ] Code change with doc updates\n- [ ] Doc only (prose changes, no code sample modifications)\n- [ ] Doc only (includes code sample changes)\n\n## Quality Gates\n\n- [x] Tests added or updated for changed behavior\n- [ ] Existing tests cover changed behavior — justification:\n- [ ] Tests not applicable — justification:\n- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)\n- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Local review confirmed that the change adds no permission, credential, network, or product behavior. It preserves existing coverage evidence and thresholds.\n- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:\n\n## DGX Station Hardware Evidence\n\n- [ ] Tested on DGX Station\n- Tested commit: Not applicable; this change does not modify scripts/prepare-dgx-station-host.sh.\n- Station profile/scenario: Not applicable.\n- Result: Not applicable.\n- Supporting evidence: Not applicable.\n\n## Verification\n\n- [x] PR description includes a Signed-off-by line and every commit appears as Verified in GitHub\n- [x] Normal pre-commit, commit-msg, and pre-push hooks passed, or npm run validate:pr passed after refreshing origin/main when hooks were skipped or unavailable\n- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 17 workflow-contract tests passed; the focused report was created successfully; repository checks passed.\n- [x] Applicable broad gate passed — the twelve exact CI shard reports plus the focused report merged to 100% lines, functions, and statements for the affected policy command source.\n- [x] Quality Gates section completed with required justifications or waivers\n- [x] No secrets, API keys, or credentials committed\n- [ ] npm run docs builds without warnings (doc changes only)\n- [ ] Doc pages follow the style guide (doc changes only)\n- [ ] New doc pages include SPDX header and frontmatter (new doc pages only)\n\n---\nSigned-off-by: Apurv Kumaria <akumaria@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved automated validation for policy command coverage.
  - Added checks to ensure coverage reporting runs consistently and produces the expected artifacts.

- **Chores**
  - Updated continuous integration safeguards and test-budget configuration to support more reliable pull-request checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->