### PR TITLE
fix(cli): block recovery after lifecycle probe failures

### DIFF
--- a/src/lib/actions/sandbox/gateway-state-drift.test.ts
+++ b/src/lib/actions/sandbox/gateway-state-drift.test.ts
@@ -263,6 +263,23 @@ describe("sandbox gateway state drift guard", () => {
     expect(removeSandboxSpy).not.toHaveBeenCalled();
   });
 
+  it("does not select a gateway when its lifecycle probe blocks recovery (#10421)", async () => {
+    getNamedGatewayLifecycleStateSpy.mockReturnValue({
+      state: "connected_other",
+      activeGateway: "openshell",
+      status: "",
+      recoveryBlocked: true,
+    });
+    const missing = { state: "missing", output: "NotFound" };
+
+    await expect(
+      gatewayState.reconcileMissingAgainstNamedGateway("alpha", missing),
+    ).resolves.toEqual(missing);
+
+    expect(runOpenshellSpy).not.toHaveBeenCalled();
+    expect(removeSandboxSpy).not.toHaveBeenCalled();
+  });
+
   it("routes gateway-error recovery to the sandbox persisted gateway", async () => {
     detectPreflightIssueSpy.mockReturnValue(null);
     getSandboxSpy.mockReturnValue({

--- a/src/lib/actions/sandbox/gateway-state.ts
+++ b/src/lib/actions/sandbox/gateway-state.ts
@@ -442,6 +442,9 @@ export async function reconcileMissingAgainstNamedGateway(
     return tryRecoverDockerDriverSandbox(sandboxName, missingLookup, pinnedGatewayName);
   }
   const lifecycle = getNamedGatewayLifecycleState(targetGatewayName);
+  if (lifecycle.recoveryBlocked) {
+    return missingLookup;
+  }
   if (lifecycle.state === "connected_other") {
     runOpenshell(["gateway", "select", targetGatewayName], {
       ignoreError: true,

--- a/src/lib/adapters/openshell/sandbox-observer-cli.ts
+++ b/src/lib/adapters/openshell/sandbox-observer-cli.ts
@@ -143,7 +143,9 @@ function successfulCommandOutput(result: CapturedSandboxCommandResult): string {
   return stripOpenShellCliAnsi(result.stdout ?? result.output);
 }
 
-function commandError(result: CapturedSandboxCommandResult): OpenShellSandboxError | null {
+export function classifyCliOpenShellCommandError(
+  result: CapturedSandboxCommandResult,
+): OpenShellSandboxError | null {
   const output = stripOpenShellCliAnsi(commandOutput(result));
   const errorCode = (result.error as NodeJS.ErrnoException | undefined)?.code;
   if (errorCode === "ETIMEDOUT") {
@@ -156,7 +158,7 @@ function commandError(result: CapturedSandboxCommandResult): OpenShellSandboxErr
     };
   }
   if (
-    /\b(?:authentication failed|unauthorized|forbidden|permission denied|missing gateway auth token|device identity required|invalid token|expired token)\b/iu.test(
+    /\b(?:authentication failed|unauthorized|forbidden|permission denied|requires admin privileges|missing gateway auth token|device identity required|invalid token|expired token)\b/iu.test(
       output,
     )
   ) {
@@ -223,7 +225,7 @@ export function createCliOpenShellSandboxLookup(
       timeout: request.timeoutMs ?? deps.defaultTimeoutMs ?? OPENSHELL_PROBE_TIMEOUT_MS,
     });
     const output = commandOutput(result);
-    const error = commandError(result);
+    const error = classifyCliOpenShellCommandError(result);
     if (error && error.kind !== "command") {
       return { result: failure(error), displayOutput: "" };
     }
@@ -256,7 +258,7 @@ export function createCliOpenShellSandboxObserver(
       includeStreams: true,
       timeout: request.timeoutMs ?? deps.defaultTimeoutMs ?? OPENSHELL_PROBE_TIMEOUT_MS,
     });
-    const error = commandError(result);
+    const error = classifyCliOpenShellCommandError(result);
     if (error) return failure(error);
     return success(parseCliOpenShellSandboxInventory(successfulCommandOutput(result)));
   };

--- a/src/lib/gateway-runtime-action.test.ts
+++ b/src/lib/gateway-runtime-action.test.ts
@@ -155,6 +155,46 @@ describe("gateway-runtime-action per-sandbox gateway routing", () => {
   });
 
   describe("recoverNamedGatewayRuntime", () => {
+    it.each([
+      { label: "authentication", status: 1, output: "gateway info requires admin privileges" },
+      { label: "schema validation", status: 1, output: "protobuf decode error: invalid wire type" },
+      { label: "gateway identity validation", status: 1, output: "handshake verification failed" },
+      { label: "request validation", status: 2, output: "unknown option: --json" },
+    ] as const)(
+      "does not select or start a gateway when $label lifecycle probe fails (#10421)",
+      async ({ status, output }) => {
+        captureSpy.mockReturnValue({ status, output });
+        runSpy.mockReturnValue({ status: 0 } as never);
+
+        const result = await gatewayRuntime.recoverNamedGatewayRuntime({
+          gatewayName: "nemoclaw-8090",
+        });
+
+        expect(result).toMatchObject({ recovered: false, attempted: false });
+        expect(runSpy).not.toHaveBeenCalled();
+        expect(startGatewaySpy).not.toHaveBeenCalled();
+      },
+    );
+
+    it("does not start a gateway when the post-selection lifecycle probe fails (#10421)", async () => {
+      captureSpy
+        .mockReturnValueOnce({
+          status: 0,
+          output: "Status: Connected\nGateway: nemoclaw\n",
+        })
+        .mockReturnValueOnce({ status: 0, output: "Gateway: nemoclaw\n" })
+        .mockReturnValue({ status: 1, output: "gateway info requires admin privileges" });
+      runSpy.mockReturnValue({ status: 0 } as never);
+
+      const result = await gatewayRuntime.recoverNamedGatewayRuntime({
+        gatewayName: "nemoclaw-8090",
+      });
+
+      expect(result).toMatchObject({ recovered: false, attempted: true });
+      expect(runSpy).toHaveBeenCalledOnce();
+      expect(startGatewaySpy).not.toHaveBeenCalled();
+    });
+
     it("selects the supplied gateway name on the recovery path", async () => {
       captureSpy
         .mockReturnValueOnce({ status: 0, output: "Status: Disconnected\nGateway: nemoclaw\n" })

--- a/src/lib/gateway-runtime-action.ts
+++ b/src/lib/gateway-runtime-action.ts
@@ -4,6 +4,10 @@
 import { stripAnsi } from "./adapters/openshell/client";
 import * as openshellRuntime from "./adapters/openshell/runtime";
 import {
+  classifyCliOpenShellCommandError,
+  type CapturedSandboxCommandResult,
+} from "./adapters/openshell/sandbox-observer-cli";
+import {
   OPENSHELL_OPERATION_TIMEOUT_MS,
   OPENSHELL_PROBE_TIMEOUT_MS,
 } from "./adapters/openshell/timeouts";
@@ -54,6 +58,29 @@ function getActiveGatewayName(output = ""): string | null {
   return match ? match[1].trim() : null;
 }
 
+function blocksNamedGatewayRecovery(result: CapturedSandboxCommandResult): boolean {
+  const error = classifyCliOpenShellCommandError(result);
+  return (
+    error?.kind === "authentication" ||
+    error?.kind === "schema" ||
+    (error?.kind === "transport" && error.reason === "identity_mismatch") ||
+    (error?.kind === "command" && error.reason === "invalid_request")
+  );
+}
+
+export type NamedGatewayLifecycleState = {
+  state:
+    | "healthy_named"
+    | "named_unreachable"
+    | "named_unhealthy"
+    | "connected_other"
+    | "missing_named";
+  status: string;
+  gatewayInfo: string;
+  activeGateway: string | null;
+  recoveryBlocked?: boolean;
+};
+
 /**
  * Classify the lifecycle state of the named gateway (healthy_named,
  * named_unreachable, named_unhealthy, connected_other, or missing_named) from
@@ -64,7 +91,7 @@ function getActiveGatewayName(output = ""): string | null {
 export function getNamedGatewayLifecycleState(
   gatewayName: string = resolveGatewayName(GATEWAY_PORT),
   opts: { ignoreProbeErrors?: boolean } = {},
-) {
+): NamedGatewayLifecycleState {
   // #5714: callers that must stay non-fatal (e.g. plain `nemoclaw list`
   // recovery) opt into `ignoreProbeErrors` so a hung/timed-out `openshell
   // status` returns a not-healthy classification instead of `process.exit`ing
@@ -97,6 +124,12 @@ export function getNamedGatewayLifecycleState(
   const refusing = /Connection refused|client error \(Connect\)|tcp connect error/i.test(
     cleanStatus,
   );
+  const lifecycle = {
+    status: status.output,
+    gatewayInfo: gatewayInfo.output,
+    activeGateway,
+    recoveryBlocked: blocksNamedGatewayRecovery(status) || blocksNamedGatewayRecovery(gatewayInfo),
+  };
   // OpenShell 0.0.72 can serve status and sandbox RPCs but does not implement
   // GetGatewayInfo. The pre-upgrade backup deliberately uses the current CLI
   // against that existing gateway before replacing it. Accept only the exact
@@ -105,44 +138,34 @@ export function getNamedGatewayLifecycleState(
   if (connected && activeGateway === gatewayName && (named || gatewayInfoUnsupported)) {
     return {
       state: "healthy_named",
-      status: status.output,
-      gatewayInfo: gatewayInfo.output,
-      activeGateway,
+      ...lifecycle,
     };
   }
   if (activeGateway === gatewayName && named && refusing) {
     return {
       state: "named_unreachable",
-      status: status.output,
-      gatewayInfo: gatewayInfo.output,
-      activeGateway,
+      ...lifecycle,
     };
   }
   if (activeGateway === gatewayName && named) {
     return {
       state: "named_unhealthy",
-      status: status.output,
-      gatewayInfo: gatewayInfo.output,
-      activeGateway,
+      ...lifecycle,
     };
   }
   if (connected) {
     return {
       state: "connected_other",
-      status: status.output,
-      gatewayInfo: gatewayInfo.output,
-      activeGateway,
+      ...lifecycle,
     };
   }
   return {
     state: "missing_named",
-    status: status.output,
-    gatewayInfo: gatewayInfo.output,
-    activeGateway,
+    ...lifecycle,
   };
 }
 
-type NamedGatewayLifecycleStateName = ReturnType<typeof getNamedGatewayLifecycleState>["state"];
+type NamedGatewayLifecycleStateName = NamedGatewayLifecycleState["state"];
 
 export type RecoverNamedGatewayRuntimeOptions = {
   recoverableStates?: readonly NamedGatewayLifecycleStateName[];
@@ -161,6 +184,9 @@ export async function recoverNamedGatewayRuntime(options: RecoverNamedGatewayRun
     ],
   );
   const before = getNamedGatewayLifecycleState(gatewayName);
+  if (before.recoveryBlocked) {
+    return { recovered: false, before, after: before, attempted: false };
+  }
   if (before.state === "healthy_named") {
     return { recovered: true, before, after: before, attempted: false };
   }
@@ -174,6 +200,9 @@ export async function recoverNamedGatewayRuntime(options: RecoverNamedGatewayRun
     timeout: OPENSHELL_OPERATION_TIMEOUT_MS,
   });
   let after = getNamedGatewayLifecycleState(gatewayName);
+  if (after.recoveryBlocked) {
+    return { recovered: false, before, after, attempted: true };
+  }
   if (after.state === "healthy_named") {
     process.env.OPENSHELL_GATEWAY = gatewayName;
     return { recovered: true, before, after, attempted: true, via: "select" };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Named-gateway recovery now rejects non-recoverable lifecycle probe failures before it selects or starts a gateway. The change closes the fail-closed test gap left by #10424.

## Related Issue

Related to #10421. Follow-up to #10424.

## Changes

- Reuse the typed OpenShell CLI error classifier for gateway lifecycle probes.
- Block recovery for authentication, schema, gateway identity, and invalid-request failures.
- Stop after a failed post-selection probe without starting the gateway.
- Apply the same guard to the direct named-gateway reconciliation path.
- Add negative tests that assert `gateway select` and `gateway start` do not run.
- Root cause: raw lifecycle failures were classified as recoverable topology states.
- Detection gap: #10424 tested these errors only after its mocked recovery call returned success.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: The implementation review covered authentication, schema, gateway identity, invalid-request, and post-selection failure states. Negative tests assert that forbidden mutations do not run.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable; this PR does not change `scripts/prepare-dgx-station-host.sh`.
- Station profile/scenario: Not applicable.
- Result: Not applicable.
- Supporting evidence: Not applicable.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli --maxWorkers=1 src/lib/gateway-runtime-action.test.ts src/lib/adapters/openshell/sandbox-observer-cli.test.ts src/lib/actions/sandbox/gateway-state-drift.test.ts`: 3 files and 47 tests passed. `npm run test:titles:check` passed.
- [ ] Applicable broad gate passed — Not applicable; this change extends one lifecycle classifier and two current mutation guards.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

Informational local run: `npm run test:changed` passed 5,485 tests and failed 16 tests across nine unchanged files under host concurrency. Eight files passed sequentially; one unchanged uninstall test retained a five-second timeout. GitHub CI remains the authoritative broad result.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox recovery handling when gateway lifecycle checks detect authentication, schema, identity, or request-validation errors.
  * Prevented recovery from selecting or starting a gateway when recovery is blocked.
  * Preserved the original missing-sandbox result and existing registry data in blocked recovery scenarios.
  * Improved recognition of missing administrator privileges during gateway command checks.
* **Tests**
  * Added coverage for blocked recovery, lifecycle probe failures, and prevention of unintended gateway startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->