### PR TITLE
fix(portable): requalify Hermes after home transitions

### DIFF
--- a/src/commands/sandbox/oclif-command-adapters.test.ts
+++ b/src/commands/sandbox/oclif-command-adapters.test.ts
@@ -294,10 +294,15 @@ describe("sandbox oclif command adapters", () => {
     expect(fetchToken).toHaveBeenCalledOnce();
     vi.clearAllMocks();
 
-    vi.spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthority").mockReturnValue({
+    const authority = {
       kind: "hermes",
       snapshot: { receipt: { phase: "active" } } as never,
-    });
+    } as const;
+    vi.spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthority").mockReturnValue(authority);
+    vi.spyOn(
+      receiptAuthority,
+      "inspectPortableAgentReceiptAuthorityForClassification",
+    ).mockReturnValue(authority);
 
     await expect(SandboxLogsCommand.run(["alpha"], rootDir)).rejects.toThrow(
       "not supported for an experimental Hermes portable sandbox",
@@ -476,7 +481,7 @@ describe("sandbox oclif command adapters", () => {
         processToken: "a".repeat(32),
       }),
     );
-    vi.spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthority").mockReturnValue({
+    const authority = {
       kind: "hermes",
       snapshot: {
         receipt: {
@@ -486,7 +491,12 @@ describe("sandbox oclif command adapters", () => {
           container: { sandboxId: "sandbox-id" },
         },
       } as never,
-    });
+    } as const;
+    vi.spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthority").mockReturnValue(authority);
+    vi.spyOn(
+      receiptAuthority,
+      "inspectPortableAgentReceiptAuthorityForClassification",
+    ).mockReturnValue(authority);
     const mutation = vi.fn();
     mocks.shieldsDown.mockImplementation(
       (_sandboxName: string, options: { assertCommandAvailable?: () => void }) => {

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -635,6 +635,13 @@ describe("connectSandbox flow", () => {
 
     await expect(harness.connectSandbox("alpha", { probeOnly: true })).resolves.toBeUndefined();
 
+    expect(harness.requalifyPortableAgentAuthoritySpy).toHaveBeenCalledWith(
+      "alpha",
+      expect.objectContaining({ readRegistry: expect.any(Function) }),
+    );
+    expect(harness.requalifyPortableAgentAuthoritySpy.mock.invocationCallOrder[0]!).toBeLessThan(
+      harness.inspectLaunchReadinessSpy.mock.invocationCallOrder[0]!,
+    );
     expect(harness.checkAndRecoverSpy).not.toHaveBeenCalled();
     expect(harness.ensureLiveSandboxSpy).not.toHaveBeenCalled();
     expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -84,6 +84,7 @@ import {
   type HermesPortableActiveLifecycleAuthority,
   printGatewayLifecycleHint,
   qualifyPortableAgentLifecycleAuthority,
+  requalifyPortableAgentSandboxAuthority,
   recoverPortableDemoSandboxLifecycleForConnect,
   isTerminalSandboxPhase,
   TERMINAL_SANDBOX_PHASES,
@@ -462,7 +463,7 @@ function portableAgentLifecycleAuthorityDeps() {
   return { readRegistry: registry.getSandbox };
 }
 
-/** Verify the recorded schema-5 route without invoking any inference repair. */
+/** Verify the recorded Hermes route without invoking any inference repair. */
 function verifyHermesPortableInferenceRouteOrExit(
   sandboxName: string,
   agent: InferenceRouteProbeAgent,
@@ -1725,6 +1726,9 @@ async function prepareConnectSandboxWithinLifecycleFence(
   probeTiming?: ProbeTimingRecorder,
 ): Promise<PreparedConnectChild | null> {
   if (probeOnly) {
+    probeTiming!.measure("authority", () =>
+      requalifyPortableAgentSandboxAuthority(sandboxName, portableAgentLifecycleAuthorityDeps()),
+    );
     let readiness = await probeTiming!.measureAsync("readiness", () =>
       inspectLaunchReadiness(sandboxName),
     );

--- a/src/lib/actions/sandbox/gateway-state.ts
+++ b/src/lib/actions/sandbox/gateway-state.ts
@@ -71,6 +71,7 @@ import {
   buildHermesPortableCommandAuthority,
   inspectPortableAgentReceiptDisposition,
   qualifyPortableAgentLifecycleAuthority,
+  requalifyPortableAgentSandboxAuthority,
   recoverPortableAgentSandboxLifecycle,
   requireHermesPortableActiveLifecycleAuthority,
 } from "../../onboard/experimental/portable-agent-lifecycle";
@@ -116,6 +117,7 @@ export {
   buildHermesPortableCommandEnvironment,
   inspectPortableAgentReceiptDisposition,
   qualifyPortableAgentLifecycleAuthority,
+  requalifyPortableAgentSandboxAuthority,
   requireHermesPortableActiveLifecycleAuthority,
 };
 export const withSandboxLifecycleLock = withMcpLifecycleLock;

--- a/src/lib/actions/uninstall/hermes-portable-uninstall.ts
+++ b/src/lib/actions/uninstall/hermes-portable-uninstall.ts
@@ -350,10 +350,10 @@ function loadAuthority(
         `Hermes Portable uninstall receipt '${sandboxName}' is missing or incomplete`,
       );
     }
-    const receipt = snapshot.receipt;
+    const historicalReceipt = snapshot.receipt;
     const row = registry.sandboxes[sandboxName] as SandboxEntry | undefined;
     if (!row) throw new Error(`Hermes Portable uninstall registry row '${sandboxName}' is missing`);
-    requireSandboxRow(row, receipt);
+    requireSandboxRow(row, historicalReceipt);
     const expectedTarget = expected?.targets.find((target) => target.sandboxName === sandboxName);
     const lifecycleDeps: HermesPortableLifecycleDeps = {
       ...deps.lifecycle,
@@ -368,8 +368,8 @@ function loadAuthority(
       {
         agent: "hermes",
         openshellDriver: "docker",
-        gatewayName: receipt.gatewayName,
-        lifecycleGeneration: receipt.lifecycleGeneration,
+        gatewayName: historicalReceipt.gatewayName,
+        lifecycleGeneration: historicalReceipt.lifecycleGeneration,
       },
       lifecycleDeps,
       {
@@ -377,6 +377,7 @@ function loadAuthority(
         ...(expectedTarget ? { expectedReceiptSha256: expectedTarget.lifecycleReceiptSha256 } : {}),
       },
     );
+    const receipt = sandbox.receipt;
     const runtime = createHermesPortableOllamaRuntimeAuthority({
       receipt,
       stateDir: input.stateDir,

--- a/src/lib/cli/nemoclaw-oclif-command.test.ts
+++ b/src/lib/cli/nemoclaw-oclif-command.test.ts
@@ -5,11 +5,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { Args } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as receiptAuthority from "../onboard/experimental/hermes-portable-receipt";
 import * as portableHostAuthority from "../state/portable-uninstall-retirement";
-import { withMcpLifecycleLock } from "../state/mcp-lifecycle-lock-acquisition";
+import {
+  isMcpLifecycleLockHeld,
+  withMcpLifecycleLock,
+} from "../state/mcp-lifecycle-lock-acquisition";
 import { log } from "./logger";
 import { type CommandExitResult, NemoClawCommand } from "./nemoclaw-oclif-command";
 
@@ -143,10 +146,38 @@ class GlobalUseMutationCommand extends NemoClawCommand {
   }
 }
 
+class ProbeOnlyConnectCommand extends NemoClawCommand {
+  static id = "sandbox:connect";
+  static args = { sandboxName: Args.string({ required: true }) };
+  static flags = { "probe-only": Flags.boolean() };
+  static observed = { host: false, lifecycle: false };
+
+  public async run(): Promise<void> {
+    const { args } = await this.parse(ProbeOnlyConnectCommand);
+    const sandboxName = args.sandboxName!;
+    ProbeOnlyConnectCommand.observed = {
+      host: fs.existsSync(
+        portableHostAuthority.portableHostFencePath(process.env.HOME || os.homedir()),
+      ),
+      lifecycle: isMcpLifecycleLockHeld(sandboxName),
+    };
+  }
+}
+
 function useHermesPortableAuthority(): void {
-  vi.spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthority").mockReturnValue({
+  vi.spyOn(
+    receiptAuthority,
+    "inspectPortableAgentReceiptAuthorityForClassification",
+  ).mockReturnValue({
     kind: "hermes",
-    snapshot: { receipt: { phase: "active" } } as never,
+    snapshot: {
+      receipt: {
+        phase: "active",
+        gatewayName: "nemoclaw",
+        lifecycleGeneration: "generation-1",
+        container: { sandboxId: "sandbox-id" },
+      },
+    } as never,
   });
 }
 
@@ -259,6 +290,18 @@ describe("NemoClawCommand", () => {
     expect(ParsedUnsupportedSandboxCommand.ran).toBe(false);
   });
 
+  it("holds the Portable host fence outside the probe-only lifecycle fence (#10423)", async () => {
+    vi.stubEnv("HOME", stateDir);
+    vi.stubEnv("NEMOCLAW_TEST_BASE_HOME", stateDir);
+    useHermesPortableAuthority();
+    await ProbeOnlyConnectCommand.run(["alpha", "--probe-only"], process.cwd());
+
+    expect(ProbeOnlyConnectCommand.observed).toEqual({ host: true, lifecycle: true });
+    expect(
+      fs.existsSync(portableHostAuthority.portableHostFencePath(process.env.HOME || os.homedir())),
+    ).toBe(false);
+  });
+
   it("resolves a flag-first parsed sandbox before acquiring the lifecycle fence (#9203)", async () => {
     useHermesPortableAuthority();
 
@@ -269,9 +312,10 @@ describe("NemoClawCommand", () => {
   });
 
   it("holds the lifecycle fence through the ordinary action before schema-5 publication (#9203)", async () => {
-    vi.spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthority").mockReturnValue({
-      kind: "none",
-    });
+    vi.spyOn(
+      receiptAuthority,
+      "inspectPortableAgentReceiptAuthorityForClassification",
+    ).mockReturnValue({ kind: "none" });
     let releaseAction!: () => void;
     const actionWaiting = new Promise<void>((resolve) => {
       releaseAction = resolve;
@@ -301,7 +345,7 @@ describe("NemoClawCommand", () => {
 
   it("classifies schema-5 publication that wins the lifecycle fence before dispatch (#9203)", async () => {
     const inspect = vi
-      .spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthority")
+      .spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthorityForClassification")
       .mockReturnValue({ kind: "none" });
     let releasePublisher!: () => void;
     const publisherWaiting = new Promise<void>((resolve) => {
@@ -352,7 +396,7 @@ describe("NemoClawCommand", () => {
 
   it("reclassifies raw commands after waiting for schema-5 publication (#9203)", async () => {
     const inspect = vi
-      .spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthority")
+      .spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthorityForClassification")
       .mockReturnValue({ kind: "none" });
     let releasePublisher!: () => void;
     const publisherWaiting = new Promise<void>((resolve) => {

--- a/src/lib/cli/nemoclaw-oclif-command.ts
+++ b/src/lib/cli/nemoclaw-oclif-command.ts
@@ -8,6 +8,7 @@ import {
   classifyHermesPortableCommand,
   HERMES_PORTABLE_UNSUPPORTED_COMMAND_MESSAGE,
   HERMES_PORTABLE_UNSUPPORTED_DOCTOR_FIX_MESSAGE,
+  inspectPortableAgentReceiptDisposition,
 } from "../onboard/experimental/portable-agent-lifecycle";
 import { defaultPortableDemoStateDir } from "../onboard/experimental/portable-runtime-receipt-readiness";
 import { redactForLog } from "../security/redact";
@@ -105,12 +106,26 @@ export abstract class NemoClawCommand extends Command {
     const sandboxName = await this.resolveLifecycleSandboxName(portablePolicy);
     if (!sandboxName) return await super._run<T>();
     if (this.isInteractiveConnect(commandId)) return await super._run<T>();
-    return await withMcpLifecycleLock(sandboxName, () => {
-      if (typeof commandId === "string" && portablePolicy?.rawSandboxName) {
-        assertHermesPortableCommandSupported(commandId, sandboxName, this.argv);
-      }
-      return super._run<T>();
-    });
+    const runWithLifecycleFence = () =>
+      withMcpLifecycleLock(sandboxName, () => {
+        if (typeof commandId === "string" && portablePolicy?.rawSandboxName) {
+          assertHermesPortableCommandSupported(commandId, sandboxName, this.argv);
+        }
+        return super._run<T>();
+      });
+    if (
+      this.isProbeOnlyConnect(commandId) &&
+      inspectPortableAgentReceiptDisposition(sandboxName).kind === "hermes"
+    ) {
+      return await withCurrentPortableHostFence(runWithLifecycleFence);
+    }
+    return await runWithLifecycleFence();
+  }
+
+  private isProbeOnlyConnect(commandId: string | undefined): boolean {
+    return (
+      commandId === "sandbox:connect" && this.lifecycleParserOutput?.flags["probe-only"] === true
+    );
   }
 
   private isInteractiveConnect(commandId: string | undefined): boolean {

--- a/src/lib/cli/oclif-runner.test.ts
+++ b/src/lib/cli/oclif-runner.test.ts
@@ -65,10 +65,15 @@ class RunnerUnsupportedCommand extends NemoClawCommand {
 }
 
 function useHermesPortableAuthority(): void {
-  vi.spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthority").mockReturnValue({
+  const authority = {
     kind: "hermes",
     snapshot: { receipt: { phase: "active" } } as never,
-  });
+  } as const;
+  vi.spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthority").mockReturnValue(authority);
+  vi.spyOn(
+    receiptAuthority,
+    "inspectPortableAgentReceiptAuthorityForClassification",
+  ).mockReturnValue(authority);
 }
 
 describe("Hermes portable command admission through both oclif runners", () => {
@@ -184,9 +189,9 @@ describe("runOclifArgv", () => {
     expect(config.pjson.oclif.bin).toBe("nemoclaw");
     expect(config.options.pjson.oclif.bin).toBe("nemoclaw");
     expect(config.plugins.get("root")?.pjson.oclif.bin).toBe("nemoclaw");
-    expect(
-      (config.pjson.oclif as Record<string, unknown>)[PUBLIC_HELP_SANDBOX_NAME_PROPERTY],
-    ).toBe("alpha");
+    expect((config.pjson.oclif as Record<string, unknown>)[PUBLIC_HELP_SANDBOX_NAME_PROPERTY]).toBe(
+      "alpha",
+    );
     expect(
       (config.plugins.get("root")?.pjson.oclif as Record<string, unknown>)[
         PUBLIC_HELP_SANDBOX_NAME_PROPERTY
@@ -314,9 +319,9 @@ describe("runOclifCommandById", () => {
     expect(config.pjson.oclif.bin).toBe("nemoclaw");
     expect(config.options.pjson.oclif.bin).toBe("nemoclaw");
     expect(config.plugins.get("root")?.pjson.oclif.bin).toBe("nemoclaw");
-    expect(
-      (config.pjson.oclif as Record<string, unknown>)[PUBLIC_HELP_SANDBOX_NAME_PROPERTY],
-    ).toBe("alpha");
+    expect((config.pjson.oclif as Record<string, unknown>)[PUBLIC_HELP_SANDBOX_NAME_PROPERTY]).toBe(
+      "alpha",
+    );
     expect(
       (config.plugins.get("root")?.pjson.oclif as Record<string, unknown>)[
         PUBLIC_HELP_SANDBOX_NAME_PROPERTY

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { loadAgent } from "../../agent/defs";
 import { withMcpLifecycleLockSync } from "../../state/mcp-lifecycle-lock";
+import { withPortableHostFence } from "../../state/portable-uninstall-retirement";
 import type { SandboxEntry } from "../../state/registry";
 import { fingerprintOpenShellSandboxLiveIdentity } from "../../adapters/openshell/sandbox-identity";
 import type { HermesPortableOpenShellExecutableAuthority } from "../../adapters/openshell/resolve-shared";
@@ -22,6 +23,7 @@ import {
   hermesPortableLifecycleInternals,
   prepareHermesPortableSandboxRemoval,
   recoverHermesPortableSandboxLifecycle,
+  requalifyHermesPortableSandboxAuthority,
   stopHermesPortableSandboxLifecycle,
 } from "./hermes-portable-lifecycle";
 import {
@@ -32,6 +34,8 @@ import {
   captureHermesPortablePolicySource,
   publishHermesPortableDurablePolicySource,
   publishHermesPortableLifecycleReceipt,
+  publishHermesPortableSuccessorReceipt,
+  readHermesPortableLifecycleReceipt,
   type HermesPortableConfiguredReceipt,
   type HermesPortablePendingReceipt,
 } from "./hermes-portable-receipt";
@@ -165,7 +169,7 @@ function podmanExecutableAuthorityDeps(): PodmanExecutableAuthorityDeps {
   };
 }
 
-function activeReceipt(): HermesPortableConfiguredReceipt {
+function activeReceipt(homeDir = "/home/test"): HermesPortableConfiguredReceipt {
   const uid = process.getuid!();
   const socketPath = `/run/user/${String(uid)}/podman/podman.sock`;
   const transactionId = randomUUID();
@@ -192,8 +196,8 @@ function activeReceipt(): HermesPortableConfiguredReceipt {
       kind: "podman",
       ownership: "current-user",
       uid,
-      homeDir: "/home/test",
-      configHome: "/home/test/.config",
+      homeDir,
+      configHome: path.join(homeDir, ".config"),
       runtimeDir: `/run/user/${String(uid)}`,
       socketPath,
     },
@@ -332,10 +336,10 @@ function lifecycleDeps(
     deps: {
       stateDir,
       env: {
-        HOME: "/home/test",
+        HOME: receipt.runtimeAuthority.homeDir,
         PATH: "/usr/bin",
-        XDG_CONFIG_HOME: "/home/test/.config",
-        XDG_RUNTIME_DIR: `/run/user/${String(process.getuid!())}`,
+        XDG_CONFIG_HOME: receipt.runtimeAuthority.configHome,
+        XDG_RUNTIME_DIR: receipt.runtimeAuthority.runtimeDir,
       },
       readRegistry: () =>
         ({
@@ -350,6 +354,17 @@ function lifecycleDeps(
         }) as SandboxEntry,
       captureOpenShell,
       assertOpenShellExecutableAuthority: vi.fn(() => "/usr/bin/openshell"),
+      operatingAuthority: {
+        env: {
+          HOME: receipt.runtimeAuthority.homeDir,
+          PATH: "/usr/bin",
+          XDG_CONFIG_HOME: receipt.runtimeAuthority.configHome,
+          XDG_RUNTIME_DIR: receipt.runtimeAuthority.runtimeDir,
+        },
+        captureSocketAuthority: () => ({ ...receipt.socketAuthority, inode: "102" }),
+        captureOpenShellExecutableAuthority: () => receipt.openshellExecutableAuthority,
+        capturePodmanExecutableAuthority: () => receipt.podmanExecutableAuthority,
+      },
       container: { podman, assertSocketAuthority: vi.fn() },
       sleep: vi.fn(),
     },
@@ -380,6 +395,70 @@ afterEach(() => {
 });
 
 describe("Hermes portable lifecycle", () => {
+  it("migrates an identical same-path schema-5 copy only under both probe fences (#10423)", async () => {
+    const receipt = activeReceipt(stateDir);
+    const copiedPolicy = `${receipt.policy.sourcePath}.copy`;
+    fs.writeFileSync(copiedPolicy, fs.readFileSync(receipt.policy.sourcePath), { mode: 0o600 });
+    fs.renameSync(copiedPolicy, receipt.policy.sourcePath);
+    const fixture = lifecycleDeps(receipt);
+
+    expect(() =>
+      withMcpLifecycleLockSync(
+        SANDBOX,
+        () => recoverHermesPortableSandboxLifecycle(SANDBOX, lifecycleContext(), fixture.deps),
+        { stateDir: path.join(stateDir, "state") },
+      ),
+    ).toThrow("durable policy source disagrees with its receipt authority");
+
+    const migrated = await withPortableHostFence(stateDir, () =>
+      withMcpLifecycleLockSync(
+        SANDBOX,
+        () => requalifyHermesPortableSandboxAuthority(SANDBOX, lifecycleContext(), fixture.deps),
+        { stateDir: path.join(stateDir, "state") },
+      ),
+    );
+
+    expect(migrated.kind).toBe("migrated");
+    expect(readHermesPortableLifecycleReceipt(SANDBOX, stateDir)?.successor).toBeDefined();
+    expect(
+      fixture.podman.mock.calls.some(([args]) => args[1] === "start" || args[1] === "stop"),
+    ).toBe(false);
+    const removal = withMcpLifecycleLockSync(
+      SANDBOX,
+      () => prepareHermesPortableSandboxRemoval(SANDBOX, lifecycleContext(), fixture.deps),
+      { stateDir: path.join(stateDir, "state") },
+    );
+    expect(removal.receipt.socketAuthority.inode).toBe("102");
+  });
+
+  it("reconciles an interrupted schema-6 publication through the public probe path (#10423)", async () => {
+    const receipt = activeReceipt(stateDir);
+    expect(() =>
+      withMcpLifecycleLockSync(
+        SANDBOX,
+        () =>
+          publishHermesPortableSuccessorReceipt(SANDBOX, stateDir, {
+            afterCanonicalLink: () => {
+              throw new Error("simulated schema-6 process exit");
+            },
+          }),
+        { stateDir: path.join(stateDir, "state") },
+      ),
+    ).toThrow("simulated schema-6 process exit");
+    const fixture = lifecycleDeps(receipt);
+
+    const recovered = await withPortableHostFence(stateDir, () =>
+      withMcpLifecycleLockSync(
+        SANDBOX,
+        () => requalifyHermesPortableSandboxAuthority(SANDBOX, lifecycleContext(), fixture.deps),
+        { stateDir: path.join(stateDir, "state") },
+      ),
+    );
+
+    expect(recovered.kind).toBe("already-current");
+    expect(readHermesPortableLifecycleReceipt(SANDBOX, stateDir)?.successor).toBeDefined();
+  });
+
   it("passes only private state, terminal, locale, and TLS variables to child commands (#9203)", () => {
     const runtimeAuthority = {
       schemaVersion: 1 as const,

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
@@ -410,6 +410,14 @@ describe("Hermes portable lifecycle", () => {
       ),
     ).toThrow("durable policy source disagrees with its receipt authority");
 
+    expect(() =>
+      withMcpLifecycleLockSync(
+        SANDBOX,
+        () => requalifyHermesPortableSandboxAuthority(SANDBOX, lifecycleContext(), fixture.deps),
+        { stateDir: path.join(stateDir, "state") },
+      ),
+    ).toThrow("Portable host authority mutation requires the current HOME fence");
+
     const migrated = await withPortableHostFence(stateDir, () =>
       withMcpLifecycleLockSync(
         SANDBOX,

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
@@ -22,6 +22,7 @@ import {
   type HermesPortableOpenShellExecutableAuthority,
 } from "../../adapters/openshell/resolve-shared";
 import { isMcpLifecycleLockHeld } from "../../state/mcp-lifecycle-lock-acquisition";
+import { assertCurrentPortableHostFenceHeld } from "../../state/portable-uninstall-retirement";
 import type { SandboxEntry } from "../../state/registry/types";
 import {
   PODMAN_MANAGED_LABEL,
@@ -51,10 +52,16 @@ import {
 import {
   assertHermesPortableDurablePolicyAuthority,
   readHermesPortableLifecycleReceipt,
+  readHermesPortableLifecycleReceiptForRequalification,
+  publishHermesPortableSuccessorReceipt,
   type HermesPortableConfiguredReceipt,
   type HermesPortableLifecycleReceipt,
   type HermesPortableReceiptSnapshot,
 } from "./hermes-portable-receipt";
+import {
+  qualifyHermesPortableOperatingAuthority,
+  type HermesPortableOperatingAuthorityDeps,
+} from "./hermes-portable-operating-authority";
 import type {
   PortableDemoLifecycleContext,
   PortableDemoLifecycleRecoveryResult,
@@ -93,6 +100,7 @@ export interface HermesPortableLifecycleDeps {
     | HermesPortableContainerDeps
     | ((receipt: HermesPortableConfiguredReceipt) => HermesPortableContainerDeps);
   readonly podmanAuthorityDeps?: HermesPortablePodmanAuthorityDeps;
+  readonly operatingAuthority?: HermesPortableOperatingAuthorityDeps;
   readonly now?: () => number;
   readonly sleep?: (milliseconds: number) => void;
   readonly log?: (message: string) => void;
@@ -160,7 +168,7 @@ export interface HermesPortableOpenShellCommandAuthority {
   readonly executablePath: string;
 }
 
-/** Requalify the exact schema-5 executable and child environment for one command. */
+/** Requalify the receipt-owned executable and child environment for one command. */
 export function buildHermesPortableOpenShellCommandAuthority(
   receipt: HermesPortableLifecycleReceipt,
   commandEnv: NodeJS.ProcessEnv,
@@ -220,7 +228,14 @@ function sameSnapshot(
     left.identity.dev === right.identity.dev &&
     left.identity.ino === right.identity.ino &&
     left.sha256 === right.sha256 &&
-    left.bytes.equals(right.bytes)
+    left.bytes.equals(right.bytes) &&
+    left.successor?.path === right.successor?.path &&
+    left.successor?.identity.dev === right.successor?.identity.dev &&
+    left.successor?.identity.ino === right.successor?.identity.ino &&
+    left.successor?.sha256 === right.successor?.sha256 &&
+    (left.successor === undefined ||
+      right.successor === undefined ||
+      left.successor.bytes.equals(right.successor.bytes))
   );
 }
 
@@ -318,6 +333,7 @@ function qualify(
   deps: HermesPortableLifecycleDeps,
   expected?: HermesPortableReceiptSnapshot,
   acceptedPhases: readonly string[] = ["Ready"],
+  options: { readonly permitSchema5Requalification?: boolean } = {},
 ): QualifiedHermesPortableLifecycle {
   const commandEnv = deps.env ?? process.env;
   assertNoOpenShellGatewayEndpointOverride(commandEnv);
@@ -326,13 +342,22 @@ function qualify(
   if (!isMcpLifecycleLockHeld(sandboxName, lockStateDir)) {
     fail("mutation requires the sandbox lifecycle lock");
   }
-  const snapshot = readHermesPortableLifecycleReceipt(sandboxName, stateDir);
+  const snapshot = options.permitSchema5Requalification
+    ? readHermesPortableLifecycleReceiptForRequalification(sandboxName, stateDir)
+    : readHermesPortableLifecycleReceipt(sandboxName, stateDir);
   if (!snapshot) fail("active receipt authority disappeared");
   if (expected && !sameSnapshot(snapshot, expected)) fail("receipt authority changed");
   if (snapshot.receipt.phase !== "active") {
     fail(`receipt phase '${snapshot.receipt.phase}' is incomplete and cannot run commands`);
   }
-  const receipt = snapshot.receipt;
+  const operatingAuthority = qualifyHermesPortableOperatingAuthority(
+    snapshot as HermesPortableReceiptSnapshot & {
+      readonly receipt: HermesPortableConfiguredReceipt;
+    },
+    deps.operatingAuthority,
+    options,
+  );
+  const receipt = operatingAuthority.receipt;
   if (!contextMatches(receipt, context)) fail("registry context disagrees with the active receipt");
   assertCurrentHermesPortableStoredStartupContract(receipt.startup, sandboxName);
   const durablePolicy = assertHermesPortableDurablePolicyAuthority(receipt.policy);
@@ -385,6 +410,7 @@ function qualify(
   if (container.paused || container.authority.restartPolicy !== "unless-stopped") {
     fail("container state or restart policy disagrees with active authority");
   }
+  operatingAuthority.assertCurrent();
   return {
     snapshot: snapshot as QualifiedHermesPortableLifecycle["snapshot"],
     receipt,
@@ -393,6 +419,32 @@ function qualify(
     capture,
     openShellPhase: liveIdentity.phase,
   };
+}
+
+export type HermesPortableAuthorityRequalificationResult =
+  | { readonly kind: "not-installed" }
+  | { readonly kind: "already-current"; readonly snapshot: HermesPortableReceiptSnapshot }
+  | { readonly kind: "migrated"; readonly snapshot: HermesPortableReceiptSnapshot };
+
+/** Publish schema 6 only after the exact schema-5 authority passes the probe fence. */
+export function requalifyHermesPortableSandboxAuthority(
+  sandboxName: string,
+  context: PortableDemoLifecycleContext,
+  deps: HermesPortableLifecycleDeps = {},
+): HermesPortableAuthorityRequalificationResult {
+  const stateDir = deps.stateDir ?? defaultPortableDemoStateDir(deps.env ?? process.env);
+  const snapshot = readHermesPortableLifecycleReceiptForRequalification(sandboxName, stateDir);
+  if (!snapshot) return { kind: "not-installed" };
+  if (snapshot.receipt.phase !== "active") {
+    fail(`receipt phase '${snapshot.receipt.phase}' is incomplete and cannot be requalified`);
+  }
+  assertCurrentPortableHostFenceHeld(snapshot.receipt.runtimeAuthority.homeDir);
+  qualify(sandboxName, context, deps, snapshot, ["Ready", "Error", "Stopped"], {
+    permitSchema5Requalification: true,
+  });
+  const published = publishHermesPortableSuccessorReceipt(sandboxName, stateDir);
+  qualify(sandboxName, context, deps, undefined, ["Ready", "Error", "Stopped"]);
+  return { kind: snapshot.successor ? "already-current" : "migrated", snapshot: published };
 }
 
 function openshellExecArgs(receipt: HermesPortableConfiguredReceipt, command: readonly string[]) {
@@ -442,7 +494,7 @@ function rollbackStartedHermesPortableRecovery(
   }
 }
 
-/** Recover the exact schema-5 container and manifest-owned Hermes startup. */
+/** Recover the exact receipt-owned container and manifest-owned Hermes startup. */
 export function recoverHermesPortableSandboxLifecycle(
   sandboxName: string,
   context: PortableDemoLifecycleContext,
@@ -535,7 +587,7 @@ export function recoverHermesPortableSandboxLifecycle(
   }
 }
 
-/** Requalify active schema-5 authority without starting or changing the sandbox. */
+/** Requalify active Hermes authority without starting or changing the sandbox. */
 export function assertHermesPortableSandboxLifecycleAuthority(
   sandboxName: string,
   context: PortableDemoLifecycleContext,
@@ -679,7 +731,13 @@ export function prepareHermesPortableSandboxRemoval(
   ) {
     fail("receipt authority changed");
   }
-  const receipt = expectedSnapshot.receipt;
+  const operatingAuthority = qualifyHermesPortableOperatingAuthority(
+    expectedSnapshot as HermesPortableReceiptSnapshot & {
+      readonly receipt: HermesPortableConfiguredReceipt;
+    },
+    deps.operatingAuthority,
+  );
+  const receipt = operatingAuthority.receipt;
   if (!contextMatches(receipt, context)) fail("registry context disagrees with the active receipt");
 
   const inspect = (
@@ -692,6 +750,7 @@ export function prepareHermesPortableSandboxRemoval(
   } => {
     const snapshot = readHermesPortableLifecycleReceipt(sandboxName, stateDir);
     if (!snapshot || !sameSnapshot(snapshot, expectedSnapshot)) fail("receipt authority changed");
+    operatingAuthority.assertCurrent();
     assertCurrentHermesPortableStoredStartupContract(receipt.startup, sandboxName);
     assertHermesPortableDurablePolicyAuthority(receipt.policy);
     requireStaticRegistry(receipt, deps);
@@ -731,6 +790,7 @@ export function prepareHermesPortableSandboxRemoval(
       if (presence !== "absent") fail("cannot prove the current OpenShell sandbox");
       if (!admitAbsence) fail("sandbox disappeared before uninstall journal publication");
       assertHermesPortableContainerAbsent(receipt, containerDeps);
+      operatingAuthority.assertCurrent();
       return { present: false, capture, containerDeps };
     }
     const qualified = qualify(sandboxName, context, deps, expectedSnapshot, [
@@ -738,6 +798,7 @@ export function prepareHermesPortableSandboxRemoval(
       "Stopped",
       "Error",
     ]);
+    operatingAuthority.assertCurrent();
     return { present: true, qualified, capture, containerDeps: qualified.containerDeps };
   };
 
@@ -767,7 +828,7 @@ export function prepareHermesPortableSandboxRemoval(
   });
 }
 
-/** Stop only the exact schema-5 full ID after revalidating after the callback. */
+/** Stop only the exact receipt-owned full ID after revalidating after the callback. */
 export function stopHermesPortableSandboxLifecycle(
   sandboxName: string,
   context: PortableDemoLifecycleContext,

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
@@ -443,7 +443,7 @@ export function requalifyHermesPortableSandboxAuthority(
     permitSchema5Requalification: true,
   });
   const published = publishHermesPortableSuccessorReceipt(sandboxName, stateDir);
-  qualify(sandboxName, context, deps, undefined, ["Ready", "Error", "Stopped"]);
+  qualify(sandboxName, context, deps, published, ["Ready", "Error", "Stopped"]);
   return { kind: snapshot.successor ? "already-current" : "migrated", snapshot: published };
 }
 

--- a/src/lib/onboard/experimental/hermes-portable-onboarding-authority-recovery.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-onboarding-authority-recovery.test.ts
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { withMcpLifecycleLock } from "../../state/mcp-lifecycle-lock-acquisition";
+import {
+  createHermesPortableTestInput,
+  createHermesPortableTransactionFixture,
+  HERMES_PORTABLE_TEST_POLICY as POLICY,
+} from "../../../../test/helpers/hermes-portable-onboarding-fixture";
+import { runHermesPortableOnboardingTransaction } from "./hermes-portable-onboarding";
+import {
+  hermesPortableReceiptDirectory,
+  publishHermesPortableSuccessorReceipt,
+} from "./hermes-portable-receipt";
+
+const SANDBOX = "alpha";
+let stateDir: string;
+let policyPath: string;
+
+function input() {
+  return createHermesPortableTestInput(stateDir, policyPath);
+}
+
+beforeEach(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-authority-recovery-"));
+  policyPath = path.join(stateDir, "create.yaml");
+  fs.writeFileSync(policyPath, POLICY, { mode: 0o600 });
+});
+
+afterEach(() => fs.rmSync(stateDir, { recursive: true, force: true }));
+
+describe("Hermes portable onboarding authority recovery", () => {
+  it("leaves a pre-existing active schema-5 receipt for probe-only migration (#10423)", async () => {
+    const fixture = createHermesPortableTransactionFixture(input());
+    await runHermesPortableOnboardingTransaction(input(), fixture.value);
+    const authorityPath = path.join(
+      hermesPortableReceiptDirectory(SANDBOX, stateDir),
+      "authority.json",
+    );
+    fs.unlinkSync(authorityPath);
+    fs.writeFileSync(policyPath, POLICY, { mode: 0o600 });
+
+    const resumed = await runHermesPortableOnboardingTransaction(input(), fixture.value);
+
+    expect(resumed.active.successor).toBeUndefined();
+    expect(fs.existsSync(authorityPath)).toBe(false);
+  });
+
+  it("finishes only an interrupted schema-6 publication during active resume (#10423)", async () => {
+    const fixture = createHermesPortableTransactionFixture(input());
+    await runHermesPortableOnboardingTransaction(input(), fixture.value);
+    const authorityPath = path.join(
+      hermesPortableReceiptDirectory(SANDBOX, stateDir),
+      "authority.json",
+    );
+    fs.unlinkSync(authorityPath);
+    await withMcpLifecycleLock(
+      SANDBOX,
+      async () => {
+        expect(() =>
+          publishHermesPortableSuccessorReceipt(SANDBOX, stateDir, {
+            afterCanonicalLink: () => {
+              throw new Error("simulated schema-6 process exit");
+            },
+          }),
+        ).toThrow("simulated schema-6 process exit");
+      },
+      { stateDir: path.join(stateDir, "state") },
+    );
+    fs.writeFileSync(policyPath, POLICY, { mode: 0o600 });
+
+    const resumed = await runHermesPortableOnboardingTransaction(input(), fixture.value);
+
+    expect(resumed.active.successor?.receipt.schemaVersion).toBe(6);
+    expect(fs.statSync(authorityPath).nlink).toBe(1);
+  });
+});

--- a/src/lib/onboard/experimental/hermes-portable-onboarding.ts
+++ b/src/lib/onboard/experimental/hermes-portable-onboarding.ts
@@ -72,6 +72,7 @@ import {
   inspectPortableAgentReceiptAuthorityForPublicationRecovery,
   publishHermesPortableDurablePolicySource,
   publishHermesPortableLifecycleReceipt,
+  publishHermesPortableSuccessorReceipt,
   readHermesPortableLifecycleReceipt,
   reconcileHermesPortableCurrentPhasePublication,
   recoverableHermesPortablePolicyTransactionId,
@@ -775,11 +776,7 @@ function classifyHermesPortableRegistryForCurrentRoute(
   entry: SandboxEntry | null,
   pendingReservationSessionId?: string,
 ): HermesPortableRegistryDisposition {
-  const disposition = classifyHermesPortableRegistry(
-    receipt,
-    entry,
-    pendingReservationSessionId,
-  );
+  const disposition = classifyHermesPortableRegistry(receipt, entry, pendingReservationSessionId);
   if (
     (disposition.kind === "matching" || disposition.kind === "matching-without-gateway-port") &&
     !isDeepStrictEqual(
@@ -1131,8 +1128,7 @@ export async function runHermesPortableOnboardingTransaction<T>(
       );
       if (
         entry?.pendingRouteReservation === true &&
-        (registered.kind === "matching" ||
-          registered.kind === "matching-without-gateway-port")
+        (registered.kind === "matching" || registered.kind === "matching-without-gateway-port")
       ) {
         return !committedRegistryEntry || !isDeepStrictEqual(entry, committedRegistryEntry)
           ? {
@@ -1201,11 +1197,7 @@ export async function runHermesPortableOnboardingTransaction<T>(
       }
       if (
         gatewayPort === null ||
-        !deps.compareAndSetRegistryGatewayPort(
-          receipt.sandboxName,
-          disposition.entry,
-          gatewayPort,
-        )
+        !deps.compareAndSetRegistryGatewayPort(receipt.sandboxName, disposition.entry, gatewayPort)
       ) {
         fail("registry gateway port repair did not complete");
       }
@@ -1284,6 +1276,7 @@ export async function runHermesPortableOnboardingTransaction<T>(
     let created = false;
     if (snapshot.receipt.phase === "active") {
       let activeSnapshot = requireConfiguredReceiptSnapshot(snapshot);
+      const recoverSuccessorPublication = activeSnapshot.successorPublicationPending === true;
       const liveIdentity = requireCurrentOpenShellIdentity(
         activeSnapshot.receipt,
         observeSandbox(),
@@ -1302,7 +1295,11 @@ export async function runHermesPortableOnboardingTransaction<T>(
         liveIdentity.liveIdentityFingerprint,
       );
       probeHermesPortableAuthenticatedHealth(activeSnapshot.receipt, containerDeps);
-      activeSnapshot = requireCurrentReceiptSnapshot(activeSnapshot, input.stateDir);
+      activeSnapshot = requireCurrentReceiptSnapshot(
+        activeSnapshot,
+        input.stateDir,
+        recoverSuccessorPublication,
+      );
       const finalIdentity = requireCurrentOpenShellIdentity(
         activeSnapshot.receipt,
         observeSandbox(),
@@ -1320,6 +1317,9 @@ export async function runHermesPortableOnboardingTransaction<T>(
         repairRegistryGatewayPort(activeSnapshot.receipt, finalIdentity.liveIdentityFingerprint),
         finalIdentity.liveIdentityFingerprint,
       );
+      if (activeSnapshot.successor || activeSnapshot.successorPublicationPending) {
+        activeSnapshot = publishHermesPortableSuccessorReceipt(input.sandboxName, input.stateDir);
+      }
       return { active: activeSnapshot, createResult, created };
     }
 
@@ -1532,10 +1532,11 @@ export async function runHermesPortableOnboardingTransaction<T>(
       repairRegistryGatewayPort(configuringSnapshot.receipt, liveIdentity.liveIdentityFingerprint),
       liveIdentity.liveIdentityFingerprint,
     );
-    const active = publishHermesPortableLifecycleReceipt(
+    publishHermesPortableLifecycleReceipt(
       activeReceipt(configuringSnapshot, currentContainer),
       input.stateDir,
     );
+    const active = publishHermesPortableSuccessorReceipt(input.sandboxName, input.stateDir);
     return { active, createResult, created };
   });
 }
@@ -1559,9 +1560,7 @@ export interface HermesPortableOnboardingFromOnboardInput<T> {
     buildContextPath: string,
   ) => Promise<T>;
   readonly readRegistry: () => SandboxEntry | null;
-  readonly compareAndSetRegistryGatewayPort: HermesPortableOnboardingDeps<T>[
-    "compareAndSetRegistryGatewayPort"
-  ];
+  readonly compareAndSetRegistryGatewayPort: HermesPortableOnboardingDeps<T>["compareAndSetRegistryGatewayPort"];
   readonly registerSandbox: HermesPortableOnboardingDeps<T>["registerSandbox"];
   readonly sourceRoot: string;
   readonly buildContextSettings: HermesPortableBuildContextSettings;

--- a/src/lib/onboard/experimental/hermes-portable-operating-authority.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-operating-authority.test.ts
@@ -6,7 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PodmanExecutableAuthority, PodmanSocketAuthority } from "../../adapters/podman";
 import type { HermesPortableOpenShellExecutableAuthority } from "../../adapters/openshell/resolve-shared";
@@ -79,7 +79,7 @@ function environment(): NodeJS.ProcessEnv {
   };
 }
 
-function snapshot(): HermesPortableReceiptSnapshot & {
+function snapshot(withSuccessor = true): HermesPortableReceiptSnapshot & {
   readonly receipt: HermesPortableConfiguredReceipt;
 } {
   const bytes = fs.readFileSync(policyPath);
@@ -165,16 +165,18 @@ function snapshot(): HermesPortableReceiptSnapshot & {
     path: path.join(root, "active.json"),
     identity: { dev: 1n, ino: 2n },
   };
-  return {
-    ...historical,
-    successor: {
-      receipt: createHermesPortableSuccessorReceipt(historical),
-      bytes: Buffer.from("successor"),
-      sha256: "5".repeat(64),
-      path: path.join(root, "authority.json"),
-      identity: { dev: 1n, ino: 3n },
-    },
-  };
+  return withSuccessor
+    ? {
+        ...historical,
+        successor: {
+          receipt: createHermesPortableSuccessorReceipt(historical),
+          bytes: Buffer.from("successor"),
+          sha256: "5".repeat(64),
+          path: path.join(root, "authority.json"),
+          identity: { dev: 1n, ino: 3n },
+        },
+      }
+    : historical;
 }
 
 beforeEach(() => {
@@ -186,6 +188,54 @@ beforeEach(() => {
 afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
 
 describe("Hermes Portable schema-6 operation authority", () => {
+  it("keeps schema-5 authority durable unless requalification is explicit (#10423)", () => {
+    const durable = snapshot(false);
+    const captureSocketAuthority = vi.fn(() => socket("99"));
+    const captureOpenShellExecutableAuthority = vi.fn();
+    const capturePodmanExecutableAuthority = vi.fn();
+
+    const authority = qualifyHermesPortableOperatingAuthority(durable, {
+      env: environment(),
+      captureSocketAuthority,
+      captureOpenShellExecutableAuthority,
+      capturePodmanExecutableAuthority,
+    });
+
+    expect(authority.receipt).toBe(durable.receipt);
+    expect(authority.assertCurrent).not.toThrow();
+    expect(captureSocketAuthority).not.toHaveBeenCalled();
+    expect(captureOpenShellExecutableAuthority).not.toHaveBeenCalled();
+    expect(capturePodmanExecutableAuthority).not.toHaveBeenCalled();
+  });
+
+  it("captures operation-local authority for an explicitly admitted schema-5 receipt (#10423)", () => {
+    const captureSocketAuthority = vi.fn(() => socket("99"));
+    const captureOpenShellExecutableAuthority = vi.fn(() => ({
+      version: "0.0.106" as const,
+      executable: executable("/usr/bin/openshell", "b".repeat(64)),
+    }));
+    const capturePodmanExecutableAuthority = vi.fn(() => ({
+      version: "5.7.0" as const,
+      executable: executable("/usr/bin/podman", "c".repeat(64)),
+    }));
+
+    const authority = qualifyHermesPortableOperatingAuthority(
+      snapshot(false),
+      {
+        env: environment(),
+        captureSocketAuthority,
+        captureOpenShellExecutableAuthority,
+        capturePodmanExecutableAuthority,
+      },
+      { permitSchema5Requalification: true },
+    );
+
+    expect(authority.receipt.socketAuthority.inode).toBe("99");
+    expect(captureSocketAuthority).toHaveBeenCalledOnce();
+    expect(captureOpenShellExecutableAuthority).toHaveBeenCalledOnce();
+    expect(capturePodmanExecutableAuthority).toHaveBeenCalledOnce();
+  });
+
   it("admits new filesystem-instance identities while stable semantics agree (#10423)", () => {
     const authority = qualifyHermesPortableOperatingAuthority(snapshot(), {
       env: environment(),

--- a/src/lib/onboard/experimental/hermes-portable-operating-authority.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-operating-authority.test.ts
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { PodmanExecutableAuthority, PodmanSocketAuthority } from "../../adapters/podman";
+import type { HermesPortableOpenShellExecutableAuthority } from "../../adapters/openshell/resolve-shared";
+import type { HermesPortablePodmanExecutableAuthority } from "./hermes-portable-podman-authority";
+import {
+  createHermesPortableSuccessorReceipt,
+  type HermesPortableConfiguredReceipt,
+  type HermesPortableReceiptSnapshot,
+} from "./hermes-portable-receipt";
+import { qualifyHermesPortableOperatingAuthority } from "./hermes-portable-operating-authority";
+
+const SHA = "a".repeat(64);
+let root: string;
+let policyPath: string;
+
+function uid(): number {
+  return process.getuid!();
+}
+
+function executable(executablePath: string, sha256: string): PodmanExecutableAuthority {
+  return {
+    executablePath,
+    device: "1",
+    inode: "2",
+    mode: String(0o100755),
+    ownerUid: "0",
+    size: "1024",
+    modifiedTimeNanoseconds: "3",
+    changedTimeNanoseconds: "4",
+    sha256,
+    directoryChain: [path.dirname(executablePath), "/usr", "/"].map((directory, index) => ({
+      device: "1",
+      inode: String(index + 5),
+      mode: String(0o40755),
+      ownerUid: "0",
+      path: directory,
+    })),
+  };
+}
+
+function socket(inode = "11"): PodmanSocketAuthority {
+  const currentUid = String(uid());
+  return {
+    device: "1",
+    inode,
+    mode: String(0o140600),
+    ownerUid: currentUid,
+    socketPath: `/run/user/${currentUid}/podman/podman.sock`,
+    directoryChain: [
+      `/run/user/${currentUid}/podman`,
+      `/run/user/${currentUid}`,
+      "/run/user",
+      "/run",
+      "/",
+    ].map((directory, index) => ({
+      device: "1",
+      inode: String(index + 20),
+      mode: String(index === 0 ? 0o40700 : 0o40755),
+      ownerUid: String(index === 0 ? uid() : 0),
+      path: directory,
+    })),
+  };
+}
+
+function environment(): NodeJS.ProcessEnv {
+  return {
+    HOME: root,
+    XDG_CONFIG_HOME: path.join(root, ".config"),
+    XDG_RUNTIME_DIR: `/run/user/${String(uid())}`,
+  };
+}
+
+function snapshot(): HermesPortableReceiptSnapshot & {
+  readonly receipt: HermesPortableConfiguredReceipt;
+} {
+  const bytes = fs.readFileSync(policyPath);
+  const stat = fs.statSync(policyPath, { bigint: true });
+  const openshellExecutableAuthority: HermesPortableOpenShellExecutableAuthority = {
+    version: "0.0.106",
+    executable: executable("/usr/bin/openshell", "b".repeat(64)),
+  };
+  const podmanExecutableAuthority: HermesPortablePodmanExecutableAuthority = {
+    version: "5.7.0",
+    executable: executable("/usr/bin/podman", "c".repeat(64)),
+  };
+  const receipt: HermesPortableConfiguredReceipt = {
+    schemaVersion: 5,
+    phase: "active",
+    agent: "hermes",
+    transactionId: randomUUID(),
+    createIntentSha256: SHA,
+    sandboxName: "alpha",
+    gatewayName: "nemoclaw",
+    lifecycleGeneration: "generation-1",
+    runtimeAuthority: {
+      schemaVersion: 1,
+      kind: "podman",
+      ownership: "current-user",
+      uid: uid(),
+      homeDir: root,
+      configHome: path.join(root, ".config"),
+      runtimeDir: `/run/user/${String(uid())}`,
+      socketPath: socket().socketPath,
+    },
+    openshellExecutableAuthority,
+    podmanExecutableAuthority,
+    socketAuthority: socket("10"),
+    startup: {
+      manifestSha256: SHA,
+      startupDescriptorSha256: "d".repeat(64),
+      argv: ["/usr/local/bin/nemoclaw-start"],
+      gatewayCommand: "hermes gateway run",
+      interactiveCommand: "hermes",
+      health: {
+        url: "http://localhost:8642/health",
+        port: 8642,
+        method: "GET",
+        auth: "bearer_token",
+        credentialEnv: "API_SERVER_KEY",
+        successStatus: 200,
+      },
+      devicePairing: false,
+      configDir: "/sandbox/.hermes",
+      stateIdentitySha256: "e".repeat(64),
+    },
+    policy: {
+      sourcePath: policyPath,
+      sourceSha256: createHash("sha256").update(bytes).digest("hex"),
+      intendedSemanticSha256: "f".repeat(64),
+      sourceIdentity: {
+        dev: String(stat.dev),
+        ino: String(stat.ino),
+        size: String(stat.size),
+        mode: 0o600,
+        uid: uid(),
+        mtimeNs: String(stat.mtimeNs),
+        ctimeNs: String(stat.ctimeNs),
+      },
+    },
+    previousPhaseSha256: SHA,
+    verifiedLivePolicySemanticSha256: "f".repeat(64),
+    container: {
+      containerId: "1".repeat(64),
+      sandboxId: "sandbox-id",
+      imageId: `sha256:${"2".repeat(64)}`,
+      labelsSha256: "3".repeat(64),
+      name: "openshell-default--alpha-sandbox-id",
+      running: true,
+      restartPolicy: "unless-stopped",
+    },
+  };
+  const historical = {
+    receipt,
+    bytes: Buffer.from("historical"),
+    sha256: "4".repeat(64),
+    path: path.join(root, "active.json"),
+    identity: { dev: 1n, ino: 2n },
+  };
+  return {
+    ...historical,
+    successor: {
+      receipt: createHermesPortableSuccessorReceipt(historical),
+      bytes: Buffer.from("successor"),
+      sha256: "5".repeat(64),
+      path: path.join(root, "authority.json"),
+      identity: { dev: 1n, ino: 3n },
+    },
+  };
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-operation-authority-"));
+  policyPath = path.join(root, "policy.yaml");
+  fs.writeFileSync(policyPath, "version: 1\nnetwork_policies: {}\n", { mode: 0o600 });
+});
+
+afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe("Hermes Portable schema-6 operation authority", () => {
+  it("admits new filesystem-instance identities while stable semantics agree (#10423)", () => {
+    const authority = qualifyHermesPortableOperatingAuthority(snapshot(), {
+      env: environment(),
+      captureSocketAuthority: () => socket("99"),
+      captureOpenShellExecutableAuthority: () => ({
+        version: "0.0.106",
+        executable: executable("/usr/bin/openshell", "b".repeat(64)),
+      }),
+      capturePodmanExecutableAuthority: () => ({
+        version: "5.7.0",
+        executable: executable("/usr/bin/podman", "c".repeat(64)),
+      }),
+    });
+
+    expect(authority.receipt.socketAuthority.inode).toBe("99");
+    expect(authority.assertCurrent).not.toThrow();
+  });
+
+  it("rejects operation-local socket replacement before completion (#10423)", () => {
+    let captures = 0;
+    const authority = qualifyHermesPortableOperatingAuthority(snapshot(), {
+      env: environment(),
+      captureSocketAuthority: () => socket(String(100 + captures++)),
+      captureOpenShellExecutableAuthority: () => ({
+        version: "0.0.106",
+        executable: executable("/usr/bin/openshell", "b".repeat(64)),
+      }),
+      capturePodmanExecutableAuthority: () => ({
+        version: "5.7.0",
+        executable: executable("/usr/bin/podman", "c".repeat(64)),
+      }),
+    });
+
+    expect(authority.assertCurrent).toThrow(
+      "operation-local filesystem or runtime identity changed",
+    );
+  });
+
+  it("rejects operation-local policy replacement before completion (#10423)", () => {
+    const authority = qualifyHermesPortableOperatingAuthority(snapshot(), {
+      env: environment(),
+      captureSocketAuthority: () => socket("99"),
+      captureOpenShellExecutableAuthority: () => ({
+        version: "0.0.106",
+        executable: executable("/usr/bin/openshell", "b".repeat(64)),
+      }),
+      capturePodmanExecutableAuthority: () => ({
+        version: "5.7.0",
+        executable: executable("/usr/bin/podman", "c".repeat(64)),
+      }),
+    });
+    const replacement = `${policyPath}.replacement`;
+    fs.writeFileSync(replacement, fs.readFileSync(policyPath), { mode: 0o600 });
+    fs.renameSync(replacement, policyPath);
+
+    expect(authority.assertCurrent).toThrow(
+      "operation-local filesystem or runtime identity changed",
+    );
+  });
+
+  it.each(["openshell", "podman"] as const)(
+    "rejects %s executable semantic drift before an operation begins (#10423)",
+    (owner) => {
+      expect(() =>
+        qualifyHermesPortableOperatingAuthority(snapshot(), {
+          env: environment(),
+          captureSocketAuthority: () => socket("99"),
+          captureOpenShellExecutableAuthority: () => ({
+            version: "0.0.106",
+            executable: executable(
+              "/usr/bin/openshell",
+              (owner === "openshell" ? "0" : "b").repeat(64),
+            ),
+          }),
+          capturePodmanExecutableAuthority: () => ({
+            version: "5.7.0",
+            executable: executable("/usr/bin/podman", (owner === "podman" ? "0" : "c").repeat(64)),
+          }),
+        }),
+      ).toThrow("current filesystem or runtime semantics disagree");
+    },
+  );
+});

--- a/src/lib/onboard/experimental/hermes-portable-operating-authority.ts
+++ b/src/lib/onboard/experimental/hermes-portable-operating-authority.ts
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { isDeepStrictEqual } from "node:util";
+
+import {
+  captureHermesPortableOpenShellExecutableAuthority,
+  buildOpenShellSubprocessEnv,
+  type HermesPortableOpenShellExecutableAuthority,
+} from "../../adapters/openshell/resolve-shared";
+import { capturePodmanSocketAuthority, type PodmanSocketAuthority } from "../../adapters/podman";
+import {
+  captureHermesPortablePodmanExecutableAuthority,
+  type HermesPortablePodmanExecutableAuthority,
+} from "./hermes-portable-podman-authority";
+import {
+  assertHermesPortableDurablePolicyAuthority,
+  createHermesPortableSuccessorReceipt,
+  requalifyHermesPortablePolicyAuthority,
+  stableHermesPortableExecutableAuthority,
+  stableHermesPortableSocketAuthority,
+  type HermesPortableConfiguredReceipt,
+  type HermesPortablePolicyAuthority,
+  type HermesPortableReceiptSnapshot,
+  type HermesPortableSuccessorReceipt,
+} from "./hermes-portable-receipt";
+
+export interface HermesPortableOperatingAuthorityDeps {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly captureSocketAuthority?: (socketPath: string, uid: number) => PodmanSocketAuthority;
+  readonly captureOpenShellExecutableAuthority?: (
+    executablePath: string,
+    childEnv: NodeJS.ProcessEnv,
+    resolutionEnv: NodeJS.ProcessEnv,
+  ) => HermesPortableOpenShellExecutableAuthority;
+  readonly capturePodmanExecutableAuthority?: (
+    socketAuthority: PodmanSocketAuthority,
+    receipt: HermesPortableConfiguredReceipt,
+    env: NodeJS.ProcessEnv,
+  ) => HermesPortablePodmanExecutableAuthority;
+}
+
+export interface QualifiedHermesPortableOperatingAuthority {
+  readonly receipt: HermesPortableConfiguredReceipt;
+  readonly assertCurrent: () => void;
+}
+
+function fail(message: string): never {
+  throw new Error(`Hermes portable schema-6 authority ${message}`);
+}
+
+function requireStableAuthority(
+  expected: HermesPortableSuccessorReceipt,
+  receipt: HermesPortableConfiguredReceipt,
+  policy: HermesPortablePolicyAuthority,
+  socket: PodmanSocketAuthority,
+  openshell: HermesPortableOpenShellExecutableAuthority,
+  podman: HermesPortablePodmanExecutableAuthority,
+): void {
+  if (
+    !isDeepStrictEqual(expected.runtimeAuthority, receipt.runtimeAuthority) ||
+    !isDeepStrictEqual(expected.startup, receipt.startup) ||
+    !isDeepStrictEqual(expected.container, receipt.container) ||
+    expected.policy.sourcePath !== policy.sourcePath ||
+    expected.policy.sourceSha256 !== policy.sourceSha256 ||
+    expected.policy.intendedSemanticSha256 !== policy.intendedSemanticSha256 ||
+    expected.policy.size !== policy.sourceIdentity.size ||
+    expected.policy.mode !== policy.sourceIdentity.mode ||
+    expected.policy.uid !== policy.sourceIdentity.uid ||
+    !isDeepStrictEqual(expected.socketAuthority, stableHermesPortableSocketAuthority(socket)) ||
+    expected.openshellExecutableAuthority.version !== openshell.version ||
+    !isDeepStrictEqual(
+      expected.openshellExecutableAuthority.executable,
+      stableHermesPortableExecutableAuthority(openshell.executable),
+    ) ||
+    expected.podmanExecutableAuthority.version !== podman.version ||
+    !isDeepStrictEqual(
+      expected.podmanExecutableAuthority.executable,
+      stableHermesPortableExecutableAuthority(podman.executable),
+    )
+  ) {
+    fail("current filesystem or runtime semantics disagree with durable authority");
+  }
+}
+
+/** Capture one operation-local filesystem/runtime generation from durable schema-6 semantics. */
+export function qualifyHermesPortableOperatingAuthority(
+  snapshot: HermesPortableReceiptSnapshot & {
+    readonly receipt: HermesPortableConfiguredReceipt;
+  },
+  deps: HermesPortableOperatingAuthorityDeps = {},
+  options: { readonly permitSchema5Requalification?: boolean } = {},
+): QualifiedHermesPortableOperatingAuthority {
+  if (snapshot.receipt.phase !== "active") fail("requires active Hermes receipt authority");
+  if (!snapshot.successor && options.permitSchema5Requalification !== true) {
+    assertHermesPortableDurablePolicyAuthority(snapshot.receipt.policy);
+    return {
+      receipt: snapshot.receipt,
+      assertCurrent: () => assertHermesPortableDurablePolicyAuthority(snapshot.receipt.policy),
+    };
+  }
+  const env = deps.env ?? process.env;
+  const expected = snapshot.successor?.receipt ?? createHermesPortableSuccessorReceipt(snapshot);
+  const captureSocket =
+    deps.captureSocketAuthority ??
+    ((socketPath: string, uid: number) => capturePodmanSocketAuthority(socketPath, { uid }));
+  const captureOpenShell =
+    deps.captureOpenShellExecutableAuthority ?? captureHermesPortableOpenShellExecutableAuthority;
+  const capturePodman =
+    deps.capturePodmanExecutableAuthority ??
+    ((socketAuthority, receipt, sourceEnv) =>
+      captureHermesPortablePodmanExecutableAuthority(
+        socketAuthority,
+        receipt.runtimeAuthority,
+        sourceEnv,
+      ));
+  const capture = () => {
+    const policy = requalifyHermesPortablePolicyAuthority(snapshot.receipt.policy).authority;
+    const socket = captureSocket(
+      snapshot.receipt.runtimeAuthority.socketPath,
+      snapshot.receipt.runtimeAuthority.uid,
+    );
+    const childEnv = buildOpenShellSubprocessEnv(env, snapshot.receipt.runtimeAuthority);
+    const openshell = captureOpenShell(
+      expected.openshellExecutableAuthority.executable.executablePath,
+      childEnv,
+      env,
+    );
+    const receiptWithCurrentSocket = { ...snapshot.receipt, policy, socketAuthority: socket };
+    const podman = capturePodman(socket, receiptWithCurrentSocket, env);
+    requireStableAuthority(expected, snapshot.receipt, policy, socket, openshell, podman);
+    return {
+      policy,
+      socket,
+      openshell,
+      podman,
+      receipt: {
+        ...snapshot.receipt,
+        policy,
+        socketAuthority: socket,
+        openshellExecutableAuthority: openshell,
+        podmanExecutableAuthority: podman,
+      } satisfies HermesPortableConfiguredReceipt,
+    };
+  };
+  const initial = capture();
+  return {
+    receipt: initial.receipt,
+    assertCurrent: () => {
+      const current = capture();
+      if (
+        !isDeepStrictEqual(current.policy, initial.policy) ||
+        !isDeepStrictEqual(current.socket, initial.socket) ||
+        !isDeepStrictEqual(current.openshell, initial.openshell) ||
+        !isDeepStrictEqual(current.podman, initial.podman)
+      ) {
+        fail("operation-local filesystem or runtime identity changed");
+      }
+    },
+  };
+}

--- a/src/lib/onboard/experimental/hermes-portable-receipt.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-receipt.test.ts
@@ -15,6 +15,7 @@ import type { HermesPortableOpenShellExecutableAuthority } from "../../adapters/
 import type { HermesPortablePodmanExecutableAuthority } from "./hermes-portable-podman-authority";
 import {
   HERMES_PORTABLE_RECEIPT_SCHEMA_VERSION,
+  HERMES_PORTABLE_SUCCESSOR_SCHEMA_VERSION,
   captureHermesPortablePolicySource,
   hermesPortablePolicySourcePath,
   hermesPortableReceiptDirectory,
@@ -22,8 +23,10 @@ import {
   hermesPortableReceiptRoot,
   inspectPortableAgentReceiptAuthority,
   inspectPortableAgentReceiptAuthorityForPublicationRecovery,
+  readHermesPortableLifecycleReceiptForClassification,
   publishHermesPortableDurablePolicySource,
   publishHermesPortableLifecycleReceipt,
+  publishHermesPortableSuccessorReceipt,
   readHermesPortableLifecycleReceipt,
   type HermesPortableConfiguredReceipt,
   type HermesPortablePendingReceipt,
@@ -308,6 +311,20 @@ function publish(
   });
 }
 
+function publishActiveReceipt() {
+  const reserved = publish(pending());
+  const configured = publish(configuring(reserved));
+  return publish(active(configured));
+}
+
+function publishSuccessor() {
+  return withMcpLifecycleLockSync(
+    SANDBOX,
+    () => publishHermesPortableSuccessorReceipt(SANDBOX, stateDir),
+    { stateDir: path.join(stateDir, "state") },
+  );
+}
+
 function leaveInterruptedReceiptPrefix(receipt: HermesPortablePendingReceipt): string {
   const originalWrite = fs.writeSync;
   const writeSpy = vi.spyOn(fs, "writeSync") as unknown as {
@@ -483,6 +500,122 @@ describe("Hermes portable receipt authority", () => {
       phase: "active",
       container: { containerId: CONTAINER_ID, restartPolicy: "unless-stopped", running: true },
     });
+  });
+
+  it("publishes deterministic schema-6 authority without changing schema-5 history (#10423)", () => {
+    const historical = publishActiveReceipt();
+    const historicalIdentity = fs.statSync(historical.path, { bigint: true });
+
+    const published = publishSuccessor();
+    const repeated = publishSuccessor();
+
+    expect(published.successor.receipt).toMatchObject({
+      schemaVersion: HERMES_PORTABLE_SUCCESSOR_SCHEMA_VERSION,
+      predecessorActiveSha256: historical.sha256,
+      phase: "active",
+    });
+    expect(repeated.successor.bytes).toEqual(published.successor.bytes);
+    expect(fs.readFileSync(historical.path)).toEqual(historical.bytes);
+    const after = fs.statSync(historical.path, { bigint: true });
+    expect({ dev: after.dev, ino: after.ino }).toEqual({
+      dev: historicalIdentity.dev,
+      ino: historicalIdentity.ino,
+    });
+  });
+
+  it("requalifies an identical same-path policy copy only through schema 6 (#10423)", () => {
+    const historical = publishActiveReceipt();
+    const policyTarget = historical.receipt.policy.sourcePath;
+    const replacement = `${policyTarget}.replacement`;
+    fs.writeFileSync(replacement, fs.readFileSync(policyTarget), { mode: 0o600 });
+    fs.renameSync(replacement, policyTarget);
+
+    expect(() => readHermesPortableLifecycleReceipt(SANDBOX, stateDir)).toThrow(
+      "durable policy source disagrees with its receipt authority",
+    );
+    expect(
+      readHermesPortableLifecycleReceiptForClassification(SANDBOX, stateDir)?.receipt.phase,
+    ).toBe("active");
+
+    const migrated = publishSuccessor();
+    expect(migrated.successor.receipt.predecessorActiveSha256).toBe(historical.sha256);
+    expect(readHermesPortableLifecycleReceipt(SANDBOX, stateDir)?.successor?.sha256).toBe(
+      migrated.successor.sha256,
+    );
+  });
+
+  it("rejects changed policy bytes before schema-6 publication (#10423)", () => {
+    publishActiveReceipt();
+    const policyTarget = readHermesPortableLifecycleReceipt(SANDBOX, stateDir)!.receipt.policy
+      .sourcePath;
+    fs.writeFileSync(policyTarget, "version: 1\nnetwork_policies:\n  changed: {}\n", {
+      mode: 0o600,
+    });
+
+    expect(() => readHermesPortableLifecycleReceiptForClassification(SANDBOX, stateDir)).toThrow(
+      "durable policy source disagrees with its semantic authority",
+    );
+    expect(() => publishSuccessor()).toThrow(
+      "durable policy source disagrees with its semantic authority",
+    );
+  });
+
+  it.each([
+    [
+      "symlink substitution",
+      (target: string) => {
+        const backing = path.join(stateDir, "policy-symlink-backing.yaml");
+        fs.renameSync(target, backing);
+        fs.symlinkSync(backing, target);
+      },
+    ],
+    [
+      "hard-link substitution",
+      (target: string) => fs.linkSync(target, path.join(stateDir, "policy-hardlink.yaml")),
+    ],
+    ["unsafe mode", (target: string) => fs.chmodSync(target, 0o644)],
+  ])("rejects %s during schema-6 requalification (#10423)", (_label, mutate) => {
+    publishActiveReceipt();
+    const target = readHermesPortableLifecycleReceipt(SANDBOX, stateDir)!.receipt.policy.sourcePath;
+    mutate(target);
+
+    expect(() => readHermesPortableLifecycleReceiptForClassification(SANDBOX, stateDir)).toThrow();
+    expect(() => publishSuccessor()).toThrow();
+  });
+
+  it("reconciles an exact interrupted schema-6 publication (#10423)", () => {
+    publishActiveReceipt();
+    expect(() =>
+      withMcpLifecycleLockSync(
+        SANDBOX,
+        () =>
+          publishHermesPortableSuccessorReceipt(SANDBOX, stateDir, {
+            afterCanonicalLink: () => {
+              throw new Error("simulated schema-6 process exit");
+            },
+          }),
+        { stateDir: path.join(stateDir, "state") },
+      ),
+    ).toThrow("simulated schema-6 process exit");
+    expect(() => readHermesPortableLifecycleReceipt(SANDBOX, stateDir)).toThrow(
+      "incomplete or unknown publication evidence",
+    );
+    expect(
+      withMcpLifecycleLockSync(
+        SANDBOX,
+        () => inspectPortableAgentReceiptAuthorityForPublicationRecovery(SANDBOX, stateDir),
+        { stateDir: path.join(stateDir, "state") },
+      ),
+    ).toMatchObject({
+      kind: "hermes",
+      snapshot: { receipt: { phase: "active" }, successor: { receipt: { schemaVersion: 6 } } },
+    });
+
+    const recovered = publishSuccessor();
+    expect(recovered.successor.receipt.schemaVersion).toBe(
+      HERMES_PORTABLE_SUCCESSOR_SCHEMA_VERSION,
+    );
+    expect(fs.statSync(recovered.successor.path).nlink).toBe(1);
   });
 
   it("rejects a phase whose previous digest does not match the durable prior bytes (#9203)", () => {

--- a/src/lib/onboard/experimental/hermes-portable-receipt.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-receipt.test.ts
@@ -504,7 +504,6 @@ describe("Hermes portable receipt authority", () => {
 
   it("publishes deterministic schema-6 authority without changing schema-5 history (#10423)", () => {
     const historical = publishActiveReceipt();
-    const historicalIdentity = fs.statSync(historical.path, { bigint: true });
 
     const published = publishSuccessor();
     const repeated = publishSuccessor();
@@ -515,12 +514,10 @@ describe("Hermes portable receipt authority", () => {
       phase: "active",
     });
     expect(repeated.successor.bytes).toEqual(published.successor.bytes);
-    expect(fs.readFileSync(historical.path)).toEqual(historical.bytes);
-    const after = fs.statSync(historical.path, { bigint: true });
-    expect({ dev: after.dev, ino: after.ino }).toEqual({
-      dev: historicalIdentity.dev,
-      ino: historicalIdentity.ino,
-    });
+    expect(published.bytes).toEqual(historical.bytes);
+    expect(published.identity).toEqual(historical.identity);
+    expect(repeated.bytes).toEqual(historical.bytes);
+    expect(repeated.identity).toEqual(historical.identity);
   });
 
   it("requalifies an identical same-path policy copy only through schema 6 (#10423)", () => {
@@ -568,19 +565,27 @@ describe("Hermes portable receipt authority", () => {
         fs.renameSync(target, backing);
         fs.symlinkSync(backing, target);
       },
+      () => "ELOOP",
     ],
     [
       "hard-link substitution",
       (target: string) => fs.linkSync(target, path.join(stateDir, "policy-hardlink.yaml")),
+      (target: string) => `file is unsafe: ${target}`,
     ],
-    ["unsafe mode", (target: string) => fs.chmodSync(target, 0o644)],
-  ])("rejects %s during schema-6 requalification (#10423)", (_label, mutate) => {
+    [
+      "unsafe mode",
+      (target: string) => fs.chmodSync(target, 0o644),
+      (target: string) => `file is unsafe: ${target}`,
+    ],
+  ])("rejects %s during schema-6 requalification (#10423)", (_label, mutate, expected) => {
     publishActiveReceipt();
     const target = readHermesPortableLifecycleReceipt(SANDBOX, stateDir)!.receipt.policy.sourcePath;
     mutate(target);
 
-    expect(() => readHermesPortableLifecycleReceiptForClassification(SANDBOX, stateDir)).toThrow();
-    expect(() => publishSuccessor()).toThrow();
+    expect(() => readHermesPortableLifecycleReceiptForClassification(SANDBOX, stateDir)).toThrow(
+      expected(target),
+    );
+    expect(() => publishSuccessor()).toThrow(expected(target));
   });
 
   it("reconciles an exact interrupted schema-6 publication (#10423)", () => {

--- a/src/lib/onboard/experimental/hermes-portable-receipt.ts
+++ b/src/lib/onboard/experimental/hermes-portable-receipt.ts
@@ -11,7 +11,7 @@ import {
   HERMES_PORTABLE_OPENSHELL_VERSION,
   type HermesPortableOpenShellExecutableAuthority,
 } from "../../adapters/openshell/resolve-shared";
-import type { PodmanSocketAuthority } from "../../adapters/podman";
+import type { PodmanExecutableAuthority, PodmanSocketAuthority } from "../../adapters/podman";
 import { isMcpLifecycleLockHeld } from "../../state/mcp-lifecycle-lock-acquisition";
 import type { CheckpointPortableRuntimeAuthority } from "../../state/onboard-checkpoint-types";
 import { parsePortableRuntimeAuthority } from "../../state/onboard/portable-runtime-authority";
@@ -22,6 +22,7 @@ import {
 } from "./hermes-portable-podman-authority";
 
 export const HERMES_PORTABLE_RECEIPT_SCHEMA_VERSION = 5 as const;
+export const HERMES_PORTABLE_SUCCESSOR_SCHEMA_VERSION = 6 as const;
 export const HERMES_PORTABLE_RECEIPT_DIRECTORY = "hermes-portable-lifecycle";
 
 const RECEIPT_MODE = 0o600;
@@ -85,6 +86,72 @@ export interface HermesPortableContainerAuthority {
   readonly restartPolicy: string;
 }
 
+export interface HermesPortableStableDirectoryAuthority {
+  readonly mode: string;
+  readonly ownerUid: string;
+  readonly path: string;
+}
+
+export interface HermesPortableStableExecutableAuthority {
+  readonly executablePath: string;
+  readonly sha256: string;
+  readonly size: string;
+  readonly mode: string;
+  readonly ownerUid: string;
+  readonly directoryChain: readonly HermesPortableStableDirectoryAuthority[];
+}
+
+export interface HermesPortableStableSocketAuthority {
+  readonly socketPath: string;
+  readonly mode: string;
+  readonly ownerUid: string;
+  readonly directoryChain: readonly HermesPortableStableDirectoryAuthority[];
+}
+
+export interface HermesPortableSuccessorReceipt {
+  readonly schemaVersion: typeof HERMES_PORTABLE_SUCCESSOR_SCHEMA_VERSION;
+  readonly phase: "active";
+  readonly agent: "hermes";
+  readonly predecessorActiveSha256: string;
+  readonly transactionId: string;
+  readonly createIntentSha256: string;
+  readonly sandboxName: string;
+  readonly gatewayName: string;
+  readonly lifecycleGeneration: string;
+  readonly runtimeAuthority: CheckpointPortableRuntimeAuthority;
+  readonly openshellExecutableAuthority: {
+    readonly version: typeof HERMES_PORTABLE_OPENSHELL_VERSION;
+    readonly executable: HermesPortableStableExecutableAuthority;
+  };
+  readonly podmanExecutableAuthority: {
+    readonly version: typeof HERMES_PORTABLE_PODMAN_VERSION;
+    readonly executable: HermesPortableStableExecutableAuthority;
+  };
+  readonly socketAuthority: HermesPortableStableSocketAuthority;
+  readonly startup: HermesPortableStartupContract;
+  readonly policy: {
+    readonly sourcePath: string;
+    readonly sourceSha256: string;
+    readonly intendedSemanticSha256: string;
+    readonly size: string;
+    readonly mode: 384;
+    readonly uid: number;
+  };
+  readonly verifiedLivePolicySemanticSha256: string;
+  readonly container: HermesPortableContainerAuthority;
+}
+
+export interface HermesPortableSuccessorSnapshot {
+  readonly receipt: HermesPortableSuccessorReceipt;
+  readonly bytes: Buffer;
+  readonly sha256: string;
+  readonly path: string;
+  readonly identity: {
+    readonly dev: bigint;
+    readonly ino: bigint;
+  };
+}
+
 interface HermesPortableReceiptCommon {
   readonly schemaVersion: typeof HERMES_PORTABLE_RECEIPT_SCHEMA_VERSION;
   readonly agent: "hermes";
@@ -125,6 +192,9 @@ export interface HermesPortableReceiptSnapshot {
     readonly dev: bigint;
     readonly ino: bigint;
   };
+  readonly successor?: HermesPortableSuccessorSnapshot;
+  /** Exact same-predecessor schema-6 publication evidence awaiting reconciliation. */
+  readonly successorPublicationPending?: true;
 }
 
 export type PortableAgentReceiptAuthority =
@@ -469,6 +539,214 @@ function parsePodmanExecutableAuthority(value: unknown): HermesPortablePodmanExe
   return authority as unknown as HermesPortablePodmanExecutableAuthority;
 }
 
+function parseStableDirectoryChain(
+  value: unknown,
+  firstPath: string,
+  owner: "current-user" | "root-or-current-user",
+): readonly HermesPortableStableDirectoryAuthority[] {
+  if (!Array.isArray(value) || value.length < 1 || value.length > 64) {
+    fail("has invalid stable directory authority");
+  }
+  const uid = String(currentUid());
+  let expectedPath = firstPath;
+  const chain = value.map((entry, index) => {
+    const directory = record(entry);
+    const mode = DECIMAL.test(String(directory?.mode)) ? BigInt(directory!.mode as string) : -1n;
+    if (
+      !directory ||
+      !exactKeys(directory, ["mode", "ownerUid", "path"]) ||
+      !DECIMAL.test(String(directory.mode)) ||
+      !DECIMAL.test(String(directory.ownerUid)) ||
+      (mode & 0o022n) !== 0n ||
+      directory.path !== expectedPath ||
+      (owner === "current-user"
+        ? index === 0 && directory.ownerUid !== uid
+        : directory.ownerUid !== "0" && directory.ownerUid !== uid)
+    ) {
+      fail("has invalid stable directory authority");
+    }
+    expectedPath = path.dirname(expectedPath);
+    return directory as unknown as HermesPortableStableDirectoryAuthority;
+  });
+  if (expectedPath !== path.dirname(expectedPath)) {
+    fail("has incomplete stable directory authority");
+  }
+  return chain;
+}
+
+function parseStableExecutableAuthority(value: unknown): HermesPortableStableExecutableAuthority {
+  const executable = record(value);
+  const mode = DECIMAL.test(String(executable?.mode)) ? BigInt(executable!.mode as string) : -1n;
+  const uid = String(currentUid());
+  if (
+    !executable ||
+    !exactKeys(executable, [
+      "directoryChain",
+      "executablePath",
+      "mode",
+      "ownerUid",
+      "sha256",
+      "size",
+    ]) ||
+    !exactAbsolutePath(executable.executablePath) ||
+    !DECIMAL.test(String(executable.mode)) ||
+    !DECIMAL.test(String(executable.ownerUid)) ||
+    (executable.ownerUid !== "0" && executable.ownerUid !== uid) ||
+    (mode & 0o022n) !== 0n ||
+    (mode & 0o111n) === 0n ||
+    !SHA256.test(String(executable.sha256)) ||
+    !DECIMAL.test(String(executable.size))
+  ) {
+    fail("has invalid stable executable authority");
+  }
+  return {
+    executablePath: executable.executablePath as string,
+    sha256: executable.sha256 as string,
+    size: executable.size as string,
+    mode: executable.mode as string,
+    ownerUid: executable.ownerUid as string,
+    directoryChain: parseStableDirectoryChain(
+      executable.directoryChain,
+      path.dirname(executable.executablePath as string),
+      "root-or-current-user",
+    ),
+  };
+}
+
+function parseStableSocketAuthority(
+  value: unknown,
+  runtimeAuthority: CheckpointPortableRuntimeAuthority,
+): HermesPortableStableSocketAuthority {
+  const socket = record(value);
+  const mode = DECIMAL.test(String(socket?.mode)) ? BigInt(socket!.mode as string) : -1n;
+  const directoryChain = parseStableDirectoryChain(
+    socket?.directoryChain,
+    path.dirname(runtimeAuthority.socketPath),
+    "current-user",
+  );
+  const parentMode = directoryChain[0] ? BigInt(directoryChain[0].mode) : 0o777n;
+  if (
+    !socket ||
+    !exactKeys(socket, ["directoryChain", "mode", "ownerUid", "socketPath"]) ||
+    socket.socketPath !== runtimeAuthority.socketPath ||
+    !DECIMAL.test(String(socket.mode)) ||
+    socket.ownerUid !== String(currentUid()) ||
+    (mode & 0o002n) !== 0n ||
+    ((mode & 0o020n) !== 0n && (parentMode & 0o077n) !== 0n)
+  ) {
+    fail("has invalid stable Podman socket authority");
+  }
+  return {
+    socketPath: socket.socketPath as string,
+    mode: socket.mode as string,
+    ownerUid: socket.ownerUid as string,
+    directoryChain,
+  };
+}
+
+function parseSuccessorBytes(bytes: Buffer): HermesPortableSuccessorReceipt {
+  let value: unknown;
+  try {
+    value = JSON.parse(UTF8.decode(bytes));
+  } catch {
+    fail("schema-6 successor is malformed or is not strict UTF-8");
+  }
+  const receipt = record(value);
+  const openshell = record(receipt?.openshellExecutableAuthority);
+  const podman = record(receipt?.podmanExecutableAuthority);
+  const policy = record(receipt?.policy);
+  const runtimeAuthority = parsePortableRuntimeAuthority(receipt?.runtimeAuthority);
+  if (
+    !receipt ||
+    !exactKeys(receipt, [
+      "agent",
+      "container",
+      "createIntentSha256",
+      "gatewayName",
+      "lifecycleGeneration",
+      "openshellExecutableAuthority",
+      "phase",
+      "podmanExecutableAuthority",
+      "policy",
+      "predecessorActiveSha256",
+      "runtimeAuthority",
+      "sandboxName",
+      "schemaVersion",
+      "socketAuthority",
+      "startup",
+      "transactionId",
+      "verifiedLivePolicySemanticSha256",
+    ]) ||
+    receipt.schemaVersion !== HERMES_PORTABLE_SUCCESSOR_SCHEMA_VERSION ||
+    receipt.phase !== "active" ||
+    receipt.agent !== "hermes" ||
+    !SHA256.test(String(receipt.predecessorActiveSha256)) ||
+    !UUID.test(String(receipt.transactionId)) ||
+    !SHA256.test(String(receipt.createIntentSha256)) ||
+    !SANDBOX.test(String(receipt.sandboxName)) ||
+    !safeString(receipt.gatewayName, 256) ||
+    !GENERATION.test(String(receipt.lifecycleGeneration)) ||
+    !runtimeAuthority ||
+    runtimeAuthority.uid !== currentUid() ||
+    !openshell ||
+    !exactKeys(openshell, ["executable", "version"]) ||
+    openshell.version !== HERMES_PORTABLE_OPENSHELL_VERSION ||
+    !podman ||
+    !exactKeys(podman, ["executable", "version"]) ||
+    podman.version !== HERMES_PORTABLE_PODMAN_VERSION ||
+    !policy ||
+    !exactKeys(policy, [
+      "intendedSemanticSha256",
+      "mode",
+      "size",
+      "sourcePath",
+      "sourceSha256",
+      "uid",
+    ]) ||
+    !exactAbsolutePath(policy.sourcePath) ||
+    !SHA256.test(String(policy.sourceSha256)) ||
+    !SHA256.test(String(policy.intendedSemanticSha256)) ||
+    !DECIMAL.test(String(policy.size)) ||
+    policy.mode !== RECEIPT_MODE ||
+    policy.uid !== currentUid() ||
+    !SHA256.test(String(receipt.verifiedLivePolicySemanticSha256))
+  ) {
+    fail("has invalid schema-6 successor authority");
+  }
+  return {
+    schemaVersion: HERMES_PORTABLE_SUCCESSOR_SCHEMA_VERSION,
+    phase: "active",
+    agent: "hermes",
+    predecessorActiveSha256: receipt.predecessorActiveSha256 as string,
+    transactionId: receipt.transactionId as string,
+    createIntentSha256: receipt.createIntentSha256 as string,
+    sandboxName: receipt.sandboxName as string,
+    gatewayName: receipt.gatewayName as string,
+    lifecycleGeneration: receipt.lifecycleGeneration as string,
+    runtimeAuthority,
+    openshellExecutableAuthority: {
+      version: HERMES_PORTABLE_OPENSHELL_VERSION,
+      executable: parseStableExecutableAuthority(openshell.executable),
+    },
+    podmanExecutableAuthority: {
+      version: HERMES_PORTABLE_PODMAN_VERSION,
+      executable: parseStableExecutableAuthority(podman.executable),
+    },
+    socketAuthority: parseStableSocketAuthority(receipt.socketAuthority, runtimeAuthority),
+    startup: parseStartup(receipt.startup),
+    policy: {
+      sourcePath: policy.sourcePath as string,
+      sourceSha256: policy.sourceSha256 as string,
+      intendedSemanticSha256: policy.intendedSemanticSha256 as string,
+      size: policy.size as string,
+      mode: RECEIPT_MODE,
+      uid: currentUid(),
+    },
+    verifiedLivePolicySemanticSha256: receipt.verifiedLivePolicySemanticSha256 as string,
+    container: parseContainer(receipt.container, "active"),
+  };
+}
+
 function parseReceiptBytes(bytes: Buffer): HermesPortableLifecycleReceipt {
   let value: unknown;
   try {
@@ -559,6 +837,90 @@ function receiptHash(bytes: Buffer): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
+export function stableHermesPortableExecutableAuthority(
+  authority: PodmanExecutableAuthority,
+): HermesPortableStableExecutableAuthority {
+  return {
+    executablePath: authority.executablePath,
+    sha256: authority.sha256,
+    size: authority.size,
+    mode: authority.mode,
+    ownerUid: authority.ownerUid,
+    directoryChain: authority.directoryChain.map(({ path, mode, ownerUid }) => ({
+      path,
+      mode,
+      ownerUid,
+    })),
+  };
+}
+
+export function stableHermesPortableSocketAuthority(
+  authority: PodmanSocketAuthority,
+): HermesPortableStableSocketAuthority {
+  return {
+    socketPath: authority.socketPath,
+    mode: authority.mode,
+    ownerUid: authority.ownerUid,
+    directoryChain: authority.directoryChain.map(({ path, mode, ownerUid }) => ({
+      path,
+      mode,
+      ownerUid,
+    })),
+  };
+}
+
+export function createHermesPortableSuccessorReceipt(
+  active: HermesPortableReceiptSnapshot & { readonly receipt: HermesPortableConfiguredReceipt },
+): HermesPortableSuccessorReceipt {
+  if (active.receipt.phase !== "active") fail("schema-6 successor requires active authority");
+  const receipt = active.receipt;
+  return {
+    schemaVersion: HERMES_PORTABLE_SUCCESSOR_SCHEMA_VERSION,
+    phase: "active",
+    agent: "hermes",
+    predecessorActiveSha256: active.sha256,
+    transactionId: receipt.transactionId,
+    createIntentSha256: receipt.createIntentSha256,
+    sandboxName: receipt.sandboxName,
+    gatewayName: receipt.gatewayName,
+    lifecycleGeneration: receipt.lifecycleGeneration,
+    runtimeAuthority: receipt.runtimeAuthority,
+    openshellExecutableAuthority: {
+      version: receipt.openshellExecutableAuthority.version,
+      executable: stableHermesPortableExecutableAuthority(
+        receipt.openshellExecutableAuthority.executable,
+      ),
+    },
+    podmanExecutableAuthority: {
+      version: receipt.podmanExecutableAuthority.version,
+      executable: stableHermesPortableExecutableAuthority(
+        receipt.podmanExecutableAuthority.executable,
+      ),
+    },
+    socketAuthority: stableHermesPortableSocketAuthority(receipt.socketAuthority),
+    startup: receipt.startup,
+    policy: {
+      sourcePath: receipt.policy.sourcePath,
+      sourceSha256: receipt.policy.sourceSha256,
+      intendedSemanticSha256: receipt.policy.intendedSemanticSha256,
+      size: receipt.policy.sourceIdentity.size,
+      mode: receipt.policy.sourceIdentity.mode,
+      uid: receipt.policy.sourceIdentity.uid,
+    },
+    verifiedLivePolicySemanticSha256: receipt.verifiedLivePolicySemanticSha256,
+    container: receipt.container,
+  };
+}
+
+function serializeSuccessor(receipt: HermesPortableSuccessorReceipt): Buffer {
+  const normalized = parseSuccessorBytes(Buffer.from(`${JSON.stringify(receipt)}\n`, "utf8"));
+  const bytes = Buffer.from(`${JSON.stringify(normalized)}\n`, "utf8");
+  if (bytes.byteLength > Number(MAX_RECEIPT_BYTES)) {
+    fail("serialized schema-6 successor exceeds the bounded receipt size");
+  }
+  return bytes;
+}
+
 function sandboxReceiptStem(sandboxName: string): string {
   return createHash("sha256").update(sandboxName).digest("hex");
 }
@@ -573,6 +935,14 @@ export function hermesPortableReceiptDirectory(sandboxName: string, stateDir: st
 
 function phasePath(directory: string, phase: HermesPortableReceiptPhase): string {
   return path.join(directory, `${phase}.json`);
+}
+
+function successorPath(directory: string): string {
+  return path.join(directory, "authority.json");
+}
+
+function successorStagePath(directory: string, predecessorActiveSha256: string): string {
+  return path.join(directory, `.authority.${predecessorActiveSha256}.tmp`);
 }
 
 function policySourceBasename(transactionId: string): string {
@@ -624,6 +994,14 @@ function phasePublicationIdentity(entry: string): {
     generationSha256: match[4]!,
     cleanup: Boolean(match[5]),
   };
+}
+
+function successorPublicationIdentity(entry: string): {
+  readonly predecessorActiveSha256: string;
+  readonly cleanup: boolean;
+} | null {
+  const match = /^\.authority\.([a-f0-9]{64})\.tmp(\.cleanup)?$/u.exec(entry);
+  return match ? { predecessorActiveSha256: match[1]!, cleanup: match[2] === ".cleanup" } : null;
 }
 
 function stagePath(directory: string, receipt: HermesPortableLifecycleReceipt): string {
@@ -902,6 +1280,28 @@ export function assertHermesPortableDurablePolicyAuthority(
     fail("durable policy source is not strict UTF-8");
   }
   return file.bytes;
+}
+
+export function requalifyHermesPortablePolicyAuthority(authority: HermesPortablePolicyAuthority): {
+  readonly authority: HermesPortablePolicyAuthority;
+  readonly bytes: Buffer;
+} {
+  const file = readExactFile(authority.sourcePath, 1n, MAX_POLICY_BYTES);
+  if (
+    !file ||
+    authority.sourceSha256 !== receiptHash(file.bytes) ||
+    authority.sourceIdentity.size !== String(file.identity.size) ||
+    authority.sourceIdentity.mode !== RECEIPT_MODE ||
+    authority.sourceIdentity.uid !== currentUid()
+  ) {
+    fail("durable policy source disagrees with its semantic authority");
+  }
+  const current = policyAuthorityFromFile(
+    authority.sourcePath,
+    file,
+    authority.intendedSemanticSha256,
+  );
+  return { authority: current, bytes: file.bytes };
 }
 
 function writeStage(
@@ -1328,10 +1728,15 @@ export function recoverableHermesPortablePolicyTransactionId(
 function validateReceiptPolicySource(
   directoryPath: string,
   receipt: HermesPortableLifecycleReceipt,
-): void {
+  semanticOnly = false,
+): HermesPortablePolicyAuthority {
   const expected = path.join(directoryPath, policySourceBasename(receipt.transactionId));
   if (receipt.policy.sourcePath !== expected) fail("policy source path is outside receipt custody");
-  assertHermesPortableDurablePolicyAuthority(receipt.policy);
+  if (!semanticOnly) {
+    assertHermesPortableDurablePolicyAuthority(receipt.policy);
+    return receipt.policy;
+  }
+  return requalifyHermesPortablePolicyAuthority(receipt.policy).authority;
 }
 
 function readPhase(
@@ -1344,6 +1749,23 @@ function readPhase(
   if (!file) return null;
   const receipt = parseReceiptBytes(file.bytes);
   if (receipt.phase !== phase) fail(`phase file '${phase}' contains another phase`);
+  return {
+    receipt,
+    bytes: file.bytes,
+    sha256: receiptHash(file.bytes),
+    path: target,
+    identity: { dev: file.identity.dev, ino: file.identity.ino },
+  };
+}
+
+function readSuccessor(
+  directory: string,
+  allowPublicationLinks = false,
+): HermesPortableSuccessorSnapshot | null {
+  const target = successorPath(directory);
+  const file = allowPublicationLinks ? readPublicationArtifact(target) : readExactFile(target);
+  if (!file) return null;
+  const receipt = parseSuccessorBytes(file.bytes);
   return {
     receipt,
     bytes: file.bytes,
@@ -1437,6 +1859,8 @@ function readHermesPortableLifecycleReceiptInternal(
   sandboxName: string,
   stateDir: string,
   allowPublicationRecovery: boolean,
+  allowSuccessorPublicationRecovery = false,
+  semanticPolicyRequalification = false,
 ): HermesPortableReceiptSnapshot | null {
   const directoryPath = hermesPortableReceiptDirectory(sandboxName, stateDir);
   let directory: OpenReceiptDirectory;
@@ -1449,13 +1873,15 @@ function readHermesPortableLifecycleReceiptInternal(
   try {
     const entries = fs.readdirSync(directory.path).sort();
     const completePolicy = /^policy\.[a-f0-9-]{36}\.yaml$/u;
+    const hasSuccessor = entries.includes("authority.json");
     if (
       entries.length > MAX_DIRECTORY_ENTRIES ||
       entries.some(
         (entry) =>
-          !["active.json", "configuring.json", "pending.json"].includes(entry) &&
+          !["active.json", "authority.json", "configuring.json", "pending.json"].includes(entry) &&
           !completePolicy.test(entry) &&
-          !(allowPublicationRecovery && phasePublicationIdentity(entry)),
+          !(allowPublicationRecovery && phasePublicationIdentity(entry)) &&
+          !(allowSuccessorPublicationRecovery && successorPublicationIdentity(entry)),
       )
     ) {
       fail(`directory contains incomplete or unknown publication evidence for '${sandboxName}'`);
@@ -1472,6 +1898,7 @@ function readHermesPortableLifecycleReceiptInternal(
     }
     const allowedEntries = new Set([
       "active.json",
+      "authority.json",
       "configuring.json",
       "pending.json",
       policySourceBasename(pending.receipt.transactionId),
@@ -1484,12 +1911,17 @@ function readHermesPortableLifecycleReceiptInternal(
       entries.some(
         (entry) =>
           !allowedEntries.has(entry) &&
-          !(allowPublicationRecovery && phasePublicationIdentity(entry)),
+          !(allowPublicationRecovery && phasePublicationIdentity(entry)) &&
+          !(allowSuccessorPublicationRecovery && successorPublicationIdentity(entry)),
       )
     ) {
       fail(`directory contains incomplete or unknown publication evidence for '${sandboxName}'`);
     }
-    validateReceiptPolicySource(directoryPath, pending.receipt);
+    const currentPolicy = validateReceiptPolicySource(
+      directoryPath,
+      pending.receipt,
+      hasSuccessor || semanticPolicyRequalification,
+    );
     revalidateDirectory(directory);
     if (!configuring && active) fail("phase chain is missing configuring authority");
     if (pending.receipt.sandboxName !== sandboxName)
@@ -1522,7 +1954,54 @@ function readHermesPortableLifecycleReceiptInternal(
         fail("active phase does not extend configuring authority");
       }
     }
-    return active ?? configuring ?? pending;
+    const highest = active ?? configuring ?? pending;
+    const successorArtifacts = entries
+      .map((entry) => successorPublicationIdentity(entry))
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+    if (
+      successorArtifacts.length > 0 &&
+      (!allowSuccessorPublicationRecovery ||
+        !active ||
+        successorArtifacts.some(
+          ({ predecessorActiveSha256 }) => predecessorActiveSha256 !== active.sha256,
+        ))
+    ) {
+      fail("schema-6 publication recovery evidence disagrees with active authority");
+    }
+    if (hasSuccessor) {
+      if (!active || highest.receipt.phase !== "active") {
+        fail("schema-6 successor has no active schema-5 predecessor");
+      }
+      const successor = readSuccessor(directoryPath, allowSuccessorPublicationRecovery);
+      if (!successor) fail("schema-6 successor authority disappeared");
+      const expected = createHermesPortableSuccessorReceipt(
+        active as HermesPortableReceiptSnapshot & {
+          readonly receipt: HermesPortableConfiguredReceipt;
+        },
+      );
+      if (
+        successor.receipt.predecessorActiveSha256 !== active.sha256 ||
+        !isDeepStrictEqual(successor.receipt, expected)
+      ) {
+        fail("schema-6 successor disagrees with its schema-5 predecessor");
+      }
+      return {
+        ...active,
+        receipt: { ...active.receipt, policy: currentPolicy },
+        successor,
+        ...(successorArtifacts.length > 0 ? { successorPublicationPending: true as const } : {}),
+      };
+    }
+    if (semanticPolicyRequalification && active) {
+      return {
+        ...active,
+        receipt: { ...active.receipt, policy: currentPolicy },
+        ...(successorArtifacts.length > 0 ? { successorPublicationPending: true as const } : {}),
+      };
+    }
+    return successorArtifacts.length > 0
+      ? { ...highest, successorPublicationPending: true }
+      : highest;
   } finally {
     fs.closeSync(directory.descriptor);
   }
@@ -1536,6 +2015,25 @@ export function readHermesPortableLifecycleReceipt(
   return readHermesPortableLifecycleReceiptInternal(sandboxName, stateDir, false);
 }
 
+/** Read exact schema-5 bytes while permitting only operation-local policy identity drift. */
+export function readHermesPortableLifecycleReceiptForRequalification(
+  sandboxName: string,
+  stateDir: string,
+): HermesPortableReceiptSnapshot | null {
+  if (!isMcpLifecycleLockHeld(sandboxName, path.join(stateDir, "state"))) {
+    fail(`schema-6 requalification requires the sandbox lifecycle lock for '${sandboxName}'`);
+  }
+  return readHermesPortableLifecycleReceiptInternal(sandboxName, stateDir, false, true, true);
+}
+
+/** Classify copied same-path authority without publishing or admitting staged evidence. */
+export function readHermesPortableLifecycleReceiptForClassification(
+  sandboxName: string,
+  stateDir: string,
+): HermesPortableReceiptSnapshot | null {
+  return readHermesPortableLifecycleReceiptInternal(sandboxName, stateDir, false, false, true);
+}
+
 /** Select stable receipt authority while its same-transaction publisher resumes under the lock. */
 export function inspectPortableAgentReceiptAuthorityForPublicationRecovery(
   sandboxName: string,
@@ -1546,7 +2044,7 @@ export function inspectPortableAgentReceiptAuthorityForPublicationRecovery(
   }
   const legacyPath = portableDemoReceiptPath(sandboxName, stateDir);
   const openclaw = existingPath(legacyPath);
-  const hermes = readHermesPortableLifecycleReceiptInternal(sandboxName, stateDir, true);
+  const hermes = readHermesPortableLifecycleReceiptInternal(sandboxName, stateDir, true, true);
   if (openclaw && hermes) fail(`agent authority is ambiguous for '${sandboxName}'`);
   if (hermes) return { kind: "hermes", snapshot: hermes };
   if (openclaw) return { kind: "openclaw", path: legacyPath };
@@ -1593,6 +2091,7 @@ export function publishHermesPortableLifecycleReceipt(
     assertLifecycleLock();
     const allowedEntries = new Set([
       "active.json",
+      "authority.json",
       "configuring.json",
       "pending.json",
       policySourceBasename(receipt.transactionId),
@@ -1602,6 +2101,22 @@ export function publishHermesPortableLifecycleReceipt(
     const unexpected = fs.readdirSync(directory.path).filter((entry) => !allowedEntries.has(entry));
     if (unexpected.length > 0) {
       fail(`directory contains other publication evidence for '${receipt.sandboxName}'`);
+    }
+    const successor = readSuccessor(directory.path);
+    if (successor) {
+      if (receipt.phase !== "active") {
+        fail("schema-6 successor conflicts with incomplete schema-5 publication");
+      }
+      const expected = createHermesPortableSuccessorReceipt({
+        receipt,
+        bytes,
+        sha256: receiptHash(bytes),
+        path: target,
+        identity: successor.identity,
+      });
+      if (!isDeepStrictEqual(successor.receipt, expected)) {
+        fail("schema-6 successor disagrees with the active schema-5 publication");
+      }
     }
     const prior =
       receipt.phase === "pending"
@@ -1660,6 +2175,119 @@ export function publishHermesPortableLifecycleReceipt(
   }
 }
 
+/** Publish the deterministic schema-6 operating authority without replacing schema-5 history. */
+export function publishHermesPortableSuccessorReceipt(
+  sandboxName: string,
+  stateDir: string,
+  hooks: HermesPortableReceiptPublicationHooks = {},
+): HermesPortableReceiptSnapshot & {
+  readonly receipt: HermesPortableConfiguredReceipt;
+  readonly successor: HermesPortableSuccessorSnapshot;
+} {
+  const assertLifecycleLock =
+    hooks.assertLifecycleLock ??
+    (() => {
+      if (!isMcpLifecycleLockHeld(sandboxName, path.join(stateDir, "state"))) {
+        fail(`schema-6 publication requires the sandbox lifecycle lock for '${sandboxName}'`);
+      }
+    });
+  assertLifecycleLock();
+  if (existingPath(portableDemoReceiptPath(sandboxName, stateDir))) {
+    fail(`will not publish schema-6 authority over OpenClaw authority for '${sandboxName}'`);
+  }
+  const active = readHermesPortableLifecycleReceiptInternal(
+    sandboxName,
+    stateDir,
+    false,
+    true,
+    true,
+  );
+  if (!active || active.receipt.phase !== "active") {
+    fail("schema-6 publication requires complete active schema-5 authority");
+  }
+  const receipt = createHermesPortableSuccessorReceipt(
+    active as HermesPortableReceiptSnapshot & {
+      readonly receipt: HermesPortableConfiguredReceipt;
+    },
+  );
+  const bytes = serializeSuccessor(receipt);
+  const directory = validateDirectory(path.dirname(active.path));
+  const target = successorPath(directory.path);
+  const staged = successorStagePath(directory.path, active.sha256);
+  const cleanup = cleanupPath(staged);
+  try {
+    revalidateDirectory(directory);
+    assertLifecycleLock();
+    const allowedEntries = new Set([
+      "active.json",
+      "authority.json",
+      "configuring.json",
+      "pending.json",
+      policySourceBasename(active.receipt.transactionId),
+      path.basename(staged),
+      path.basename(cleanup),
+    ]);
+    const unexpected = fs.readdirSync(directory.path).filter((entry) => !allowedEntries.has(entry));
+    if (unexpected.length > 0) {
+      fail(`directory contains other schema-6 publication evidence for '${sandboxName}'`);
+    }
+    retireInterruptedEmptyStage(target, staged, cleanup, directory, assertLifecycleLock);
+    retireInterruptedExactPrefixStage(
+      target,
+      staged,
+      cleanup,
+      directory,
+      bytes,
+      assertLifecycleLock,
+      hooks,
+    );
+    const disposition = reconcilePublicationArtifacts(target, staged, cleanup, bytes, hooks);
+    const reconciled = readSuccessor(directory.path);
+    if (reconciled) {
+      if (!reconciled.bytes.equals(bytes)) fail("schema-6 successor has other authority");
+      fs.fsyncSync(directory.descriptor);
+      const current = readHermesPortableLifecycleReceipt(sandboxName, stateDir);
+      if (!current?.successor || current.receipt.phase !== "active") {
+        fail("schema-6 successor could not be requalified after reconciliation");
+      }
+      return current as typeof current & {
+        readonly receipt: HermesPortableConfiguredReceipt;
+        readonly successor: HermesPortableSuccessorSnapshot;
+      };
+    }
+    if (disposition === "complete") fail("completed schema-6 publication is unreadable");
+    if (disposition === "absent") writeStage(staged, bytes, hooks);
+    revalidateDirectory(directory);
+    assertLifecycleLock();
+    fsyncExactStage(staged, bytes, hooks);
+    revalidateDirectory(directory);
+    try {
+      fs.linkSync(staged, target);
+    } catch (error) {
+      if (!isErrnoException(error) || error.code !== "EEXIST") throw error;
+      const raced = readSuccessor(directory.path);
+      if (!raced || !raced.bytes.equals(bytes)) fail("schema-6 publication raced other authority");
+    }
+    hooks.afterCanonicalLink?.();
+    assertLifecycleLock();
+    fs.fsyncSync(directory.descriptor);
+    hooks.afterDirectoryFsync?.();
+    detachPublishedStage(target, staged, cleanup, bytes, hooks);
+    assertLifecycleLock();
+    fs.fsyncSync(directory.descriptor);
+    const published = readHermesPortableLifecycleReceipt(sandboxName, stateDir);
+    if (!published?.successor || published.receipt.phase !== "active") {
+      fail("schema-6 successor disappeared after publication");
+    }
+    return published as typeof published & {
+      readonly receipt: HermesPortableConfiguredReceipt;
+      readonly successor: HermesPortableSuccessorSnapshot;
+    };
+  } finally {
+    fs.closeSync(directory.descriptor);
+  }
+}
+
 function existingPath(target: string): boolean {
   try {
     const stat = fs.lstatSync(target);
@@ -1685,13 +2313,30 @@ export function inspectPortableAgentReceiptAuthority(
   return { kind: "none" };
 }
 
+/** Select agent authority for read-only routing across a replaceable-HOME transition. */
+export function inspectPortableAgentReceiptAuthorityForClassification(
+  sandboxName: string,
+  stateDir: string,
+): PortableAgentReceiptAuthority {
+  const legacyPath = portableDemoReceiptPath(sandboxName, stateDir);
+  const openclaw = existingPath(legacyPath);
+  const hermes = readHermesPortableLifecycleReceiptForClassification(sandboxName, stateDir);
+  if (openclaw && hermes) fail(`agent authority is ambiguous for '${sandboxName}'`);
+  if (hermes) return { kind: "hermes", snapshot: hermes };
+  if (openclaw) return { kind: "openclaw", path: legacyPath };
+  return { kind: "none" };
+}
+
 export function createHermesPortableTransactionId(): string {
   return randomUUID();
 }
 
 export const hermesPortableReceiptInternals = {
   parseReceiptBytes,
+  parseSuccessorBytes,
   phasePath,
   policyStagePath,
   stagePath,
+  successorPath,
+  successorStagePath,
 };

--- a/src/lib/onboard/experimental/portable-agent-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/portable-agent-lifecycle.test.ts
@@ -8,11 +8,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   isLifecycleLockHeld: vi.fn(),
   inspect: vi.fn(),
+  inspectClassification: vi.fn(),
   readRegistry: vi.fn(),
   buildOpenShellCommandAuthority: vi.fn(),
   buildOpenShellEnv: vi.fn(),
   assertHermesAuthority: vi.fn(),
   recoverHermes: vi.fn(),
+  requalifyHermes: vi.fn(),
+  qualifyOperatingAuthority: vi.fn(),
   recoverOpenClaw: vi.fn(),
   stopHermes: vi.fn(),
   stopOpenClaw: vi.fn(),
@@ -24,13 +27,18 @@ vi.mock("../../state/mcp-lifecycle-lock-acquisition", () => ({
 
 vi.mock("./hermes-portable-receipt", () => ({
   inspectPortableAgentReceiptAuthority: mocks.inspect,
+  inspectPortableAgentReceiptAuthorityForClassification: mocks.inspectClassification,
 }));
 vi.mock("./hermes-portable-lifecycle", () => ({
   assertHermesPortableSandboxLifecycleAuthority: mocks.assertHermesAuthority,
   buildHermesPortableOpenShellCommandAuthority: mocks.buildOpenShellCommandAuthority,
   buildHermesPortableOpenShellEnv: mocks.buildOpenShellEnv,
   recoverHermesPortableSandboxLifecycle: mocks.recoverHermes,
+  requalifyHermesPortableSandboxAuthority: mocks.requalifyHermes,
   stopHermesPortableSandboxLifecycle: mocks.stopHermes,
+}));
+vi.mock("./hermes-portable-operating-authority", () => ({
+  qualifyHermesPortableOperatingAuthority: mocks.qualifyOperatingAuthority,
 }));
 vi.mock("./portable-demo-lifecycle", () => ({
   recoverPortableDemoSandboxLifecycle: mocks.recoverOpenClaw,
@@ -45,6 +53,7 @@ import {
   inspectPortableAgentReceiptDisposition,
   qualifyPortableAgentLifecycleAuthority,
   recoverPortableAgentSandboxLifecycle,
+  requalifyPortableAgentSandboxAuthority,
   requireHermesPortableActiveLifecycleAuthority,
   stopPortableAgentSandboxLifecycle,
 } from "./portable-agent-lifecycle";
@@ -106,6 +115,7 @@ const lifecycleAuthorityDeps = {
 describe("portable agent lifecycle dispatch", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.inspectClassification.mockImplementation((...args) => mocks.inspect(...args));
     mocks.buildOpenShellEnv.mockImplementation(
       (env: NodeJS.ProcessEnv, authority: Record<string, string>) => ({
         PATH: env.PATH,
@@ -121,7 +131,50 @@ describe("portable agent lifecycle dispatch", () => {
       env: { HOME: "/home/test" },
       executablePath: "/usr/bin/openshell",
     });
+    mocks.qualifyOperatingAuthority.mockImplementation((snapshot) => ({
+      receipt: snapshot.receipt,
+      assertCurrent: vi.fn(),
+    }));
     mocks.readRegistry.mockReturnValue(null);
+  });
+
+  it("directs copied active schema-5 authority to probe instead of migrating on launch (#10423)", () => {
+    mocks.isLifecycleLockHeld.mockReturnValue(true);
+    mocks.inspectClassification.mockReturnValue({
+      kind: "hermes",
+      snapshot: { receipt: { phase: "active" } },
+    });
+    mocks.inspect.mockImplementation(() => {
+      throw new Error("durable policy source disagrees with its receipt authority");
+    });
+
+    expect(() => buildHermesPortableCommandAuthority("alpha", {}, "/state")).toThrow(
+      "nemoclaw alpha connect --probe-only",
+    );
+    expect(mocks.requalifyHermes).not.toHaveBeenCalled();
+  });
+
+  it("routes probe-only schema migration to the exact Hermes lifecycle owner (#10423)", () => {
+    mocks.inspect.mockReturnValue(hermes("active"));
+    mocks.readRegistry.mockReturnValue(hermesRegistryEntry({ provider: "ollama-local" }));
+    mocks.requalifyHermes.mockReturnValue({ kind: "migrated" });
+
+    expect(
+      requalifyPortableAgentSandboxAuthority("alpha", {
+        ...lifecycleAuthorityDeps,
+        stateDir: "/state",
+      }),
+    ).toEqual({ kind: "migrated" });
+    expect(mocks.requalifyHermes).toHaveBeenCalledWith(
+      "alpha",
+      expect.objectContaining({
+        agent: "hermes",
+        gatewayName: "nemoclaw",
+        lifecycleGeneration: "generation-1",
+      }),
+      expect.objectContaining({ stateDir: "/state" }),
+    );
+    expect(mocks.recoverOpenClaw).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -148,6 +201,26 @@ describe("portable agent lifecycle dispatch", () => {
       });
     },
   );
+
+  it("uses operation-local schema-6 authority for a direct command (#10423)", () => {
+    const historical = hermes("active").snapshot.receipt;
+    const current = { ...historical, socketAuthority: { dev: "current" } };
+    const assertCurrent = vi.fn();
+    mocks.inspect.mockReturnValue({
+      kind: "hermes",
+      snapshot: { receipt: historical, successor: { receipt: { schemaVersion: 6 } } },
+    });
+    mocks.qualifyOperatingAuthority.mockReturnValue({ receipt: current, assertCurrent });
+
+    expect(buildHermesPortableCommandAuthority("alpha", { HOME: "/home/test" }, "/state")).toEqual({
+      env: { HOME: "/home/test" },
+      executablePath: "/usr/bin/openshell",
+    });
+    expect(mocks.buildOpenShellCommandAuthority).toHaveBeenCalledWith(current, {
+      HOME: "/home/test",
+    });
+    expect(assertCurrent).toHaveBeenCalledOnce();
+  });
 
   it("permits an incomplete receipt without a registry row and rejects active absence (#9203)", () => {
     mocks.inspect.mockReturnValue(hermes("pending"));

--- a/src/lib/onboard/experimental/portable-agent-lifecycle.ts
+++ b/src/lib/onboard/experimental/portable-agent-lifecycle.ts
@@ -11,10 +11,15 @@ import {
   buildHermesPortableOpenShellCommandAuthority,
   buildHermesPortableOpenShellEnv,
   recoverHermesPortableSandboxLifecycle,
+  requalifyHermesPortableSandboxAuthority,
   stopHermesPortableSandboxLifecycle,
   type HermesPortableLifecycleDeps,
 } from "./hermes-portable-lifecycle";
-import { inspectPortableAgentReceiptAuthority } from "./hermes-portable-receipt";
+import {
+  inspectPortableAgentReceiptAuthority,
+  inspectPortableAgentReceiptAuthorityForClassification,
+} from "./hermes-portable-receipt";
+import { qualifyHermesPortableOperatingAuthority } from "./hermes-portable-operating-authority";
 import {
   recoverPortableDemoSandboxLifecycle,
   stopPortableDemoSandboxLifecycle,
@@ -107,13 +112,13 @@ export function classifyHermesPortableCommand(
   };
 }
 
-/** Reject one unsupported command while schema-5 receipt authority exists. */
+/** Reject one unsupported command while Hermes receipt authority exists. */
 export function assertHermesPortableCommandSupported(
   commandId: string,
   sandboxName: string,
   argv: readonly string[],
 ): void {
-  const authority = inspectPortableAgentReceiptAuthority(
+  const authority = inspectPortableAgentReceiptAuthorityForClassification(
     sandboxName,
     defaultPortableDemoStateDir(process.env),
   );
@@ -164,13 +169,13 @@ export interface PortableAgentLifecycleAuthorityDeps {
   readonly inspectReceiptDisposition?: (sandboxName: string) => PortableAgentReceiptDisposition;
   readonly readRegistry: (sandboxName: string) => SandboxEntry | null;
 }
-/** Strictly distinguish absent, schema-4 OpenClaw, and schema-5 Hermes authority. */
+/** Strictly distinguish absent, OpenClaw, and Hermes receipt authority. */
 export function inspectPortableAgentReceiptDisposition(
   sandboxName: string,
   env: NodeJS.ProcessEnv = process.env,
   stateDir = defaultPortableDemoStateDir(env),
 ): PortableAgentReceiptDisposition {
-  const authority = inspectPortableAgentReceiptAuthority(sandboxName, stateDir);
+  const authority = inspectPortableAgentReceiptAuthorityForClassification(sandboxName, stateDir);
   if (authority.kind === "none") return { kind: "absent" };
   if (authority.kind === "openclaw") return { kind: "openclaw" };
   const { receipt } = authority.snapshot;
@@ -186,7 +191,30 @@ export function inspectPortableAgentReceiptDisposition(
   };
 }
 
-/** Classify receipt authority and enforce the shared schema-5 registry invariant. */
+/** Requalify only Hermes authority while the probe owns both Portable fences. */
+export function requalifyPortableAgentSandboxAuthority(
+  sandboxName: string,
+  deps: PortableAgentLifecycleDeps & PortableAgentLifecycleAuthorityDeps,
+) {
+  const authority = qualifyPortableAgentLifecycleAuthority(sandboxName, deps);
+  if (authority.kind !== "hermes") return { kind: "not-hermes" as const };
+  if (authority.phase !== "active" || !authority.entry) {
+    throw new Error("Hermes portable lifecycle authority is missing or incomplete.");
+  }
+  return requalifyHermesPortableSandboxAuthority(
+    sandboxName,
+    {
+      agent: "hermes",
+      gatewayName: authority.gatewayName,
+      lifecycleGeneration: authority.lifecycleGeneration,
+      openshellDriver: "docker",
+      provider: authority.entry.provider,
+    },
+    deps,
+  );
+}
+
+/** Classify receipt authority and enforce the Hermes registry invariant. */
 export function qualifyPortableAgentLifecycleAuthority(
   sandboxName: string,
   deps: PortableAgentLifecycleAuthorityDeps,
@@ -221,7 +249,7 @@ export function qualifyPortableAgentLifecycleAuthority(
   return { ...disposition, entry };
 }
 
-/** Require an active schema-5 receipt and its exact registry authority. */
+/** Require active Hermes receipt and exact registry authority. */
 export function requireHermesPortableActiveLifecycleAuthority(
   sandboxName: string,
   expected: HermesPortableActiveLifecycleAuthority | undefined,
@@ -242,7 +270,7 @@ export function requireHermesPortableActiveLifecycleAuthority(
   return current as HermesPortableActiveLifecycleAuthority;
 }
 
-/** Build a child environment from the exact active schema-5 runtime authority. */
+/** Build a child environment from the exact active Hermes runtime authority. */
 export function buildHermesPortableCommandEnvironment(
   sandboxName: string,
   env: NodeJS.ProcessEnv = process.env,
@@ -255,7 +283,7 @@ export function buildHermesPortableCommandEnvironment(
   return buildHermesPortableOpenShellEnv(env, authority.snapshot.receipt.runtimeAuthority);
 }
 
-/** Requalify the exact executable and environment for one direct schema-5 child. */
+/** Requalify the exact executable and environment for one direct Hermes child. */
 export function buildHermesPortableCommandAuthority(
   sandboxName: string,
   env: NodeJS.ProcessEnv = process.env,
@@ -264,11 +292,43 @@ export function buildHermesPortableCommandAuthority(
   if (!isMcpLifecycleLockHeld(sandboxName, path.join(stateDir, "state"))) {
     throw new Error("Hermes portable command authority requires the sandbox lifecycle lock");
   }
-  const authority = inspectPortableAgentReceiptAuthority(sandboxName, stateDir);
+  const classified = inspectPortableAgentReceiptAuthorityForClassification(sandboxName, stateDir);
+  let authority: ReturnType<typeof inspectPortableAgentReceiptAuthority>;
+  try {
+    authority = inspectPortableAgentReceiptAuthority(sandboxName, stateDir);
+  } catch (error) {
+    if (
+      classified.kind === "hermes" &&
+      classified.snapshot.receipt.phase === "active" &&
+      classified.snapshot.successor === undefined
+    ) {
+      throw new Error(
+        `Hermes portable authority requires 'nemoclaw ${sandboxName} connect --probe-only' before launch.`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
   if (authority.kind !== "hermes" || authority.snapshot.receipt.phase === "pending") {
     throw new Error("Hermes portable lifecycle authority is missing or incomplete");
   }
-  return buildHermesPortableOpenShellCommandAuthority(authority.snapshot.receipt, env);
+  if (!authority.snapshot.successor) {
+    return buildHermesPortableOpenShellCommandAuthority(authority.snapshot.receipt, env);
+  }
+  if (authority.snapshot.receipt.phase !== "active") {
+    throw new Error("Hermes portable operating authority requires an active receipt");
+  }
+  const operatingAuthority = qualifyHermesPortableOperatingAuthority(
+    authority.snapshot as typeof authority.snapshot & {
+      readonly receipt: { readonly phase: "active" };
+    },
+  );
+  const commandAuthority = buildHermesPortableOpenShellCommandAuthority(
+    operatingAuthority.receipt,
+    env,
+  );
+  operatingAuthority.assertCurrent();
+  return commandAuthority;
 }
 
 /** Requalify a pending/configuring receipt only for its schema-5 onboarding child. */
@@ -349,7 +409,7 @@ export function recoverPortableAgentSandboxLifecycle(
   return recoverHermesPortableSandboxLifecycle(sandboxName, context, deps);
 }
 
-/** Requalify schema-5 authority without permitting lifecycle recovery or fallback. */
+/** Requalify Hermes authority without permitting lifecycle recovery or fallback. */
 export function assertHermesPortableAgentLifecycleAuthority(
   sandboxName: string,
   context: PortableDemoLifecycleContext,

--- a/src/lib/state/portable-uninstall-retirement.ts
+++ b/src/lib/state/portable-uninstall-retirement.ts
@@ -105,6 +105,14 @@ const tails = new Map<string, Promise<void>>();
 export const portableHostFencePath = (homeDir: string): string =>
   path.join(homeDir, ".nemoclaw-portable-host.lock");
 
+/** Require the current asynchronous operation to own the exact Portable host fence. */
+export function assertCurrentPortableHostFenceHeld(homeDir: string): void {
+  const owner = owners.getStore();
+  if (!owner?.active || owner.path !== portableHostFencePath(homeDir)) {
+    throw new Error("Portable host authority mutation requires the current HOME fence");
+  }
+}
+
 /** Resolve the portable state root while admitting only the isolated Vitest override. */
 export function defaultPortableStateDir(env: NodeJS.ProcessEnv): string {
   if (

--- a/src/lib/status-command-deps.test.ts
+++ b/src/lib/status-command-deps.test.ts
@@ -4,8 +4,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import * as receiptAuthority from "./onboard/experimental/hermes-portable-receipt";
+import * as registry from "./state/registry";
 import { buildStatusCommandDeps } from "./status-command-deps";
 
 function writeExecutable(target: string, body: string): void {
@@ -27,12 +29,44 @@ describe("buildStatusCommandDeps", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (previousOverride === undefined) {
       delete process.env.NEMOCLAW_OPENSHELL_BIN;
     } else {
       process.env.NEMOCLAW_OPENSHELL_BIN = previousOverride;
     }
     fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("classifies copied Hermes authority for status before probe migration (#10423)", () => {
+    const classify = vi
+      .spyOn(receiptAuthority, "inspectPortableAgentReceiptAuthorityForClassification")
+      .mockReturnValue({
+        kind: "hermes",
+        snapshot: {
+          receipt: {
+            phase: "active",
+            sandboxName: "alpha",
+            gatewayName: "nemoclaw",
+            lifecycleGeneration: "generation-1",
+            openshellExecutableAuthority: { version: "0.0.106" },
+          },
+        } as never,
+      });
+    vi.spyOn(registry, "getSandbox").mockReturnValue({
+      name: "alpha",
+      agent: "hermes",
+      gatewayName: "nemoclaw",
+      gatewayPort: 8080,
+      lifecycleGeneration: "generation-1",
+      openshellDriver: "docker",
+      openshellVersion: "0.0.106",
+    } as never);
+
+    const deps = buildStatusCommandDeps(tmp);
+
+    expect(deps.getHermesPortablePhase?.("alpha")).toBe("active");
+    expect(classify).toHaveBeenCalledOnce();
   });
 
   it("detects Telegram conflict signatures from the gateway log", () => {

--- a/src/lib/status-command-deps.ts
+++ b/src/lib/status-command-deps.ts
@@ -25,7 +25,7 @@ import {
 import type { MessagingAgentId } from "./messaging/manifest";
 import { resolveGatewayName } from "./onboard/gateway-binding";
 import { classifyHermesPortableRegistry } from "./onboard/experimental/hermes-portable-onboarding";
-import { inspectPortableAgentReceiptAuthority } from "./onboard/experimental/hermes-portable-receipt";
+import { inspectPortableAgentReceiptAuthorityForClassification } from "./onboard/experimental/hermes-portable-receipt";
 import { defaultPortableDemoStateDir } from "./onboard/experimental/portable-runtime-receipt-readiness";
 import { summarizeForDebug } from "./state/onboard-session";
 import * as registry from "./state/registry";
@@ -302,7 +302,7 @@ export function buildStatusCommandDeps(rootDir: string): ShowStatusCommandDeps {
     findMessagingOverlaps,
     readGatewayLog: (sandboxName) => readGatewayLog(rootDir, sandboxName),
     getHermesPortablePhase: (sandboxName) => {
-      const authority = inspectPortableAgentReceiptAuthority(
+      const authority = inspectPortableAgentReceiptAuthorityForClassification(
         sandboxName,
         defaultPortableDemoStateDir(process.env),
       );

--- a/test/support/connect-flow-test-harness.ts
+++ b/test/support/connect-flow-test-harness.ts
@@ -53,6 +53,7 @@ export type ConnectHarness = {
   probeOllamaAuthProxyHealthSpy: MockInstance;
   readSandboxConfigSpy: MockInstance;
   recoverPortableDemoLifecycleSpy: MockInstance;
+  requalifyPortableAgentAuthoritySpy: MockInstance;
   inspectPortableReceiptDispositionSpy: MockInstance;
   registryEntries: SandboxEntry[];
   resolveAgentConfigSpy: MockInstance;
@@ -261,6 +262,9 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
       expected,
       portableAuthorityDeps(),
     )) as never);
+  const requalifyPortableAgentAuthoritySpy = vi
+    .spyOn(gatewayState, "requalifyPortableAgentSandboxAuthority")
+    .mockReturnValue({ kind: "not-hermes" });
   const sandboxExec = requireDist("../../src/lib/actions/sandbox/exec.js");
   const runSandboxExecChildSpy = vi.spyOn(sandboxExec, "runSandboxExecChild").mockResolvedValue({
     status: spawnStatusFromOptions(options),
@@ -462,9 +466,7 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
   // - `getSessionAgent` returns null for OpenClaw, which `??` alone turned into `{ name: "openclaw" }`.
   // - Distinguish "not supplied" from an explicit null so a test can model that production shape.
   vi.spyOn(agentRuntime, "getSessionAgent").mockReturnValue(
-    (Object.hasOwn(options, "sessionAgent")
-      ? options.sessionAgent
-      : { name: "openclaw" }) as never,
+    (Object.hasOwn(options, "sessionAgent") ? options.sessionAgent : { name: "openclaw" }) as never,
   );
   vi.spyOn(agentRuntime, "getAgentDisplayName").mockReturnValue("OpenClaw");
   const runAutoPairSpy = vi
@@ -499,6 +501,7 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
     probeOllamaAuthProxyHealthSpy,
     readSandboxConfigSpy,
     recoverPortableDemoLifecycleSpy,
+    requalifyPortableAgentAuthoritySpy,
     inspectPortableReceiptDispositionSpy,
     registryEntries,
     resolveAgentConfigSpy,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Allow experimental Portable Hermes authority to survive an intentional same-path home filesystem replacement without weakening policy, registry, container, or OpenShell checks. Existing schema-5 receipts remain immutable audit history; `connect --probe-only` publishes a deterministic schema-6 operating authority only after the current installation passes full requalification.

## Related Issue

Fixes #10423

## Changes

- Add a schema-6 successor receipt bound to the exact active schema-5 SHA-256. A direct update to schema 5 would erase the original filesystem audit identity, so the append-only successor is protected by receipt and crash-recovery tests.
- Requalify current policy bytes and semantic digest, file safety, socket and executable identity, registry generation, exact container, OpenShell identity, and live policy under a host fence outside the lifecycle fence. Probe-flow and lifecycle tests protect the only supported migration path.
- Keep ordinary onboarding, launch, status, recovery, and uninstall fail closed: onboarding cannot migrate legacy schema 5, launch directs the operator to probe, status remains read-only before migration, and lifecycle or uninstall mutations require current schema-6 authority.
- Reconcile an interrupted schema-6 publication through the same probe path, then require a strict post-publication qualification. Receipt and onboarding recovery tests cover stage-only, canonical-link, copied, stale, foreign, unsafe-file, and mid-operation identity changes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [ ] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: pending repository maintainer review
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli <22 focused files>`: 22 files and 454 tests passed; `npm run typecheck:cli` passed
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: not run; focused tests, repository checks, source-shape checks, growth guardrails, formatting, and typecheck passed
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added stronger Portable sandbox authority validation during connections and probe-only operations.
  - Added operating-environment checks for changes to policies, sockets, and executables.
  - Added automatic recovery and migration for older or interrupted sandbox authority records.
  - Improved handling of copied or relocated sandbox state during status and lifecycle checks.

- **Bug Fixes**
  - Probe-only commands now use appropriate host protection and clean up reliably.
  - Sandbox removal and resumed onboarding now use the latest verified authority state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->