### PR TITLE
fix(onboard): keep tier-default Brave on reuse in the fresh-selection branch

### DIFF
--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -178,6 +178,8 @@ Hermes can select `tavily` only.
 Deep Agents can use the maintained `tavily` opt-in path, but messaging channel presets are omitted because the terminal harness does not run a NemoClaw messaging bridge today.
 </AgentOnly>
 NemoClaw automatically suggests the preset that matches the selected provider and removes stale web search presets during resume reconciliation when you switch providers or disable web search.
+This removal preserves an already-applied preset that is a default of the sandbox's recorded tier — on Balanced or Open, disabling web search during reuse keeps the tier's `brave` default and its egress rather than treating it as a stale leftover.
+`tavily` is never a tier default, so it is always removed when you disable web search; a recorded Restricted tier has no web search default and removes `brave` the same way.
 <AgentOnly variant="openclaw,hermes">
 When a later onboarding run does not select a messaging channel and the environment no longer supplies that channel's required values, NemoClaw treats the channel as disabled.
 NemoClaw then removes that channel's matching policy preset instead of carrying it forward.

--- a/src/lib/onboard/policy-selection.ts
+++ b/src/lib/onboard/policy-selection.ts
@@ -446,6 +446,12 @@ async function setupPoliciesWithSelectionInner(
     supportOptions,
     customPresetNames,
   );
+  // Resume keeps the recorded tier so stale suppressed presets from that tier
+  // still get filtered. An interrupted create can reach this fresh-selection
+  // branch before presets are recorded, so its persisted tier must also win
+  // over a new prompt or non-interactive default.
+  const persistedTierName = deps.getRecordedPolicyTier?.(sandboxName) ?? null;
+  const recordedTierName = options.tierName ?? persistedTierName;
   const pruneUnavailablePresets = createUnavailablePolicyPresetPruner({
     disabledChannels,
     enabledChannels,
@@ -455,7 +461,17 @@ async function setupPoliciesWithSelectionInner(
     customPresetNames,
     customOwnsObservability,
   });
-  const appliedForPreservation = pruneUnavailablePresets(applied);
+  // Reuse reaches this fresh-selection branch whenever seeding is bypassed (a
+  // non-interactive env override, or a sandbox whose prior policy step never
+  // finalized), so the recorded tier has to reach the pruner here too — an
+  // already-applied tier egress default (e.g. `brave` on Balanced) is not a
+  // stale web-search leftover and must survive into the preservation pass.
+  // The recorded tier (not the freshly resolved one) keeps a genuinely fresh
+  // onboard on its conservative suggestion behaviour: no recorded tier means
+  // null, and null still prunes. (#10404, regression of #6844)
+  const appliedForPreservation = pruneUnavailablePresets(applied, {
+    tierName: recordedTierName,
+  });
   const filterSupportedPresetNames = (presetNames: string[]) =>
     filterSetupPolicyPresetNamesForAgent(excludePresets(presetNames), agent).filter(
       (name) =>
@@ -471,12 +487,6 @@ async function setupPoliciesWithSelectionInner(
           customPresetNames,
         )
       : null;
-  // Resume keeps the recorded tier so stale suppressed presets from that tier
-  // still get filtered. An interrupted create can reach this fresh-selection
-  // branch before presets are recorded, so its persisted tier must also win
-  // over a new prompt or non-interactive default.
-  const persistedTierName = deps.getRecordedPolicyTier?.(sandboxName) ?? null;
-  const recordedTierName = options.tierName ?? persistedTierName;
   const personalAlreadyActive =
     currentAppliedPresets.includes(PERSONAL_OPEN_INTERNET_PRESET_NAME) ||
     persistedTierName === PERSONAL_POLICY_TIER_NAME ||
@@ -553,7 +563,9 @@ async function setupPoliciesWithSelectionInner(
         ensureRequiredTierPolicyPresets(
           tierName,
           filterSuppressedAgentRequiredPresets(
-            excludePresets(pruneUnavailablePresets(currentAppliedPresets)),
+            excludePresets(
+              pruneUnavailablePresets(currentAppliedPresets, { tierName: recordedTierName }),
+            ),
             tierName,
             agent,
           ),
@@ -635,6 +647,7 @@ async function setupPoliciesWithSelectionInner(
     chosen = excludePresets(
       pruneUnavailablePresets(chosen, {
         preserveExplicitWebSearch: isAuthoritative || personalTier,
+        tierName: recordedTierName,
       }),
     );
     chosen = ensureRequiredTierPolicyPresets(tierName, chosen);

--- a/test/runtime/policy/policy-tiers-onboard.test.ts
+++ b/test/runtime/policy/policy-tiers-onboard.test.ts
@@ -612,7 +612,7 @@ describe("policy tier setup", () => {
     assert.ok(!result.appliedCalls.includes("brave"));
   });
 
-  it("removes a previously-applied built-in Brave preset when Brave search is declined", async () => {
+  it("removes a previously-applied built-in Brave preset when Brave search is declined with no recorded tier", async () => {
     const result = await runPolicySetup(
       { tierName: "balanced", currentApplied: ["brave", "npm"] },
       { webSearchConfig: null, webSearchSupported: true },
@@ -717,6 +717,100 @@ describe("policy tier setup", () => {
       },
     ]);
     assert.deepEqual(result.removedCalls, []);
+  });
+
+  it.each([
+    ["interactive", false],
+    ["non-interactive", true],
+  ] as const)(
+    "preserves a recorded Balanced tier default in the %s fresh-selection branch without web search (#10404)",
+    async (_label, nonInteractive) => {
+      const result = await runPolicySetup(
+        {
+          tierName: "balanced",
+          currentApplied: ["npm", "brave"],
+          recordedPolicyTier: "balanced",
+          nonInteractive,
+        },
+        { webSearchConfig: null, webSearchSupported: true },
+      );
+
+      assert.ok(result.applied.includes("brave"));
+      assert.deepEqual(result.removedCalls, []);
+    },
+  );
+
+  it("preserves a recorded Balanced tier default when NEMOCLAW_POLICY_MODE=skip bypasses reuse seeding (#10404)", async () => {
+    const result = await runPolicySetup(
+      {
+        tierName: "balanced",
+        policyMode: "skip",
+        currentApplied: ["npm", "brave"],
+        recordedPolicyTier: "balanced",
+      },
+      { webSearchConfig: null, webSearchSupported: true },
+    );
+
+    assert.deepEqual(result.removedCalls, []);
+    assert.deepEqual(result.syncCalls, []);
+  });
+
+  it("keeps a recorded Balanced tier default listed by NEMOCLAW_POLICY_PRESETS in suggested mode (#10404)", async () => {
+    const result = await runPolicySetup(
+      {
+        tierName: "balanced",
+        policyPresets: "npm,brave",
+        currentApplied: ["npm"],
+        recordedPolicyTier: "balanced",
+      },
+      { webSearchConfig: null, webSearchSupported: true },
+    );
+
+    assert.deepEqual(result.applied, ["npm", "brave"]);
+    assert.deepEqual(result.appliedCalls, ["brave"]);
+    assert.deepEqual(result.removedCalls, []);
+  });
+
+  it("still removes a previously-applied Brave preset on a recorded Restricted tier (#10404)", async () => {
+    const result = await runPolicySetup(
+      {
+        tierName: "restricted",
+        currentApplied: ["npm", "brave"],
+        recordedPolicyTier: "restricted",
+      },
+      { webSearchConfig: null, webSearchSupported: true },
+    );
+
+    assert.ok(!result.applied.includes("brave"));
+    assert.ok(result.removedCalls.includes("brave"));
+  });
+
+  it("still removes a previously-applied Tavily preset on a recorded Balanced tier (#10404)", async () => {
+    const result = await runPolicySetup(
+      {
+        tierName: "balanced",
+        currentApplied: ["npm", "tavily"],
+        recordedPolicyTier: "balanced",
+      },
+      { webSearchConfig: null, webSearchSupported: true },
+    );
+
+    assert.ok(!result.applied.includes("tavily"));
+    assert.ok(result.removedCalls.includes("tavily"));
+  });
+
+  it("still removes a recorded Balanced Brave default when web search is unsupported (#10404)", async () => {
+    const result = await runPolicySetup(
+      {
+        tierName: "balanced",
+        currentApplied: ["npm", "brave"],
+        recordedPolicyTier: "balanced",
+      },
+      { webSearchSupported: false },
+    );
+
+    assert.ok(!result.applied.includes("brave"));
+    assert.ok(result.removedCalls.includes("brave"));
   });
 
   it("clamps resumed policy presets to web-search-supported presets", async () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Re-onboarding a Balanced-tier sandbox and choosing reuse pruned the `brave` preset and narrowed `api.search.brave.com` egress whenever web search was declined, then failed finalization with an OpenClaw runtime identity error. `#6856` fixed this exact preservation contract for `#6844`, but only threaded the recorded policy tier into the resume branch of the shared policy-preset selection function — a fresh-selection branch that reuse can also reach (non-interactive env overrides, or a sandbox whose prior policy step never finalized) still pruned tier-default presets as if they were ordinary web-search leftovers. This threads the recorded tier into that branch's three affected prune sites too.

## Related Issue

Fixes #10404

## Changes

- `src/lib/onboard/policy-selection.ts`: `setupPoliciesWithSelectionInner`'s fresh-selection branch has five `pruneUnavailablePresets` call sites. Three passed no `tierName` and are fixed here: the preservation prune (feeds both the non-interactive carry-forward and the interactive pre-checked set), the `NEMOCLAW_POLICY_MODE=skip` retention prune, and the non-interactive env-preset prune. Two are deliberately left alone: the suggestion-list prune (`#6856` intentionally kept fresh-onboard suggestions conservative — unrelated to this reuse contract), and the final interactive prune, which already passes `preserveExplicitWebSearch` and never reaches the tier-blind fallback this bug depends on. `recordedTierName` is hoisted above the first affected call site so it's available there. The recorded tier is used rather than a freshly resolved one so a genuinely fresh onboard keeps its existing conservative suggestion behavior: with no recorded tier the value is `null`, and `null` still fails safe (prunes) — verified by mutation: widening this to the resolved tier breaks the pre-existing null-recorded-tier regression test for `#6844`.
- `test/runtime/policy/policy-tiers-onboard.test.ts`: 7 new tests covering the repro (interactive and non-interactive fresh-selection branches with a recorded Balanced tier), both reuse-seeding-bypass triggers (`NEMOCLAW_POLICY_MODE=skip`, `NEMOCLAW_POLICY_PRESETS` in suggested mode), and three boundary cases that must still prune (a recorded Restricted tier, `tavily` — not a Balanced default, and `webSearchSupported: false`). Retitled the pre-existing `#6844` fresh-branch test to `"...with no recorded tier"` — its assertions are unchanged, but its title read as a contradiction of the new recorded-tier tests sitting next to it once both exist.

**Why the reported failure hits the fresh branch, not the already-guarded resume branch.** The issue's repro steps narrate an interactive reuse, which for a normally-completed prior onboard would route through the resume branch `#6856` already fixed. But the issue's own log shows `"Applying policy presets: npm, pypi, huggingface, brew, openclaw-pricing"` with no `"Preserving previously-applied presets"` note — that message format matches only the fresh-selection branch's non-interactive log line (the resume branch logs `"Reapplying"`). So the reported failure is consistent with an automated non-interactive validation run (the issue carries `NV QA`/`UAT` labels) that hit a reuse-seeding bypass, not with the narrated interactive steps taking a still-broken resume branch.

**A related, out-of-scope observation, disclosed rather than folded in:** the same tier-blind gap exists in the sandbox rebuild target-preset filter (`src/lib/actions/sandbox/rebuild-backup-phase.ts:91-94`, also calling `isStaleBuiltinWebSearchPolicyPreset` with no `tierName`, despite the caller one level up already having `sandboxEntry.policyTier` available). Same predicate, different command (`nemoclaw sandbox rebuild`, not onboard reuse), pre-dating this fix. Not fixed here since it's a separate entry point this issue doesn't report against; flagging for a maintainer or a follow-up issue.

**A first correction, made after the automated PR Review Advisor's first pass:**

- *Code/Reduction:* the interactive and non-interactive fresh-selection regression tests differed only in `nonInteractive`. Merged them into one `it.each` case over both values, matching this file's existing parameterized-test convention.
- *Documentation:* `docs/reference/network-policies.mdx` said NemoClaw "removes stale web search presets during resume reconciliation... when you switch providers or disable web search" with no qualification — now incomplete for a reused sandbox with a recorded Balanced or Open tier. Qualified the statement: a tier-default preset (`brave` — confirmed against `nemoclaw-blueprint/policies/tiers.yaml` that only `brave`, never `tavily`, is a literal tier preset default) now survives reuse instead of being pruned as a leftover, and named the cases that still prune (`tavily` is never a tier default; Restricted has no web-search default).

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: implemented against an independent root-cause investigation, then independently adversarially reviewed by a second agent with no prior context on this PR; that review's findings (evidentiary clarity on which branch the reported failure hit, a miscounted call-site claim, two test titles overstating what they exercise, and the disclosed `rebuild-backup-phase.ts` sibling gap) are all addressed above. A maintainer pass is still expected before merge; this checkbox records contributor-side review completion, not a waiver of maintainer review.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

Not applicable — this PR does not change `scripts/prepare-dgx-station-host.sh`. (The issue was reproduced in automated release validation on WSL x86, Ubuntu 24 GPU, and DGX Station, but this fix targets shared onboard/policy-preset logic common to all of them, not a DGX-specific path.)

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result: `npx vitest run --project integration test/runtime/policy/policy-tiers-onboard.test.ts` — 100 tests passed (7 new for #10404, 4 of which were confirmed RED against unmodified `origin/main` and each new/changed production line was independently confirmed load-bearing by per-line mutation). `npx vitest run --project cli src/lib/onboard/policy-resume-selection.test.ts` — 19 tests passed, confirming no regression in the sibling resume branch `#6856` already guards. `npm run typecheck:cli` and `npm run checks:repository` both clean.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [x] `npm run docs` builds without warnings (doc changes only) — 0 errors; the 2 warnings reported (missing `FERN_TOKEN` for a redirects check, and a pre-existing brand accent-color contrast note) are unrelated to this content change and reproduce identically with the doc edit reverted.
- [x] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web-search policy handling during setup and resume.
  * Preserves Brave for recorded Balanced or Open tiers, even when web search is disabled.
  * Removes Brave for Restricted tiers and unsupported configurations.
  * Removes Tavily whenever web search is declined.
  * Keeps tier-appropriate settings across interactive, non-interactive, skipped, and suggested setup flows.

* **Tests**
  * Added regression coverage for web-search preset preservation and removal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->