### PR TITLE
fix(e2e): preserve managed-image producer attempts

### DIFF
--- a/.github/workflows/managed-images.yaml
+++ b/.github/workflows/managed-images.yaml
@@ -2968,6 +2968,7 @@ jobs:
                     digest,
                     reference,
                     baseReference,
+                    run,
                     publicationEvidence
                   }
                 }) | from_entries)
@@ -2976,7 +2977,11 @@ jobs:
 
           cohort_manifests="$RUNNER_TEMP/managed-image-cohort-manifests.json"
           jq -s 'sort_by(.agent)' "$manifests" > "$cohort_manifests"
-          if ! jq -e '
+          if ! jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --argjson runAttempt "$GITHUB_RUN_ATTEMPT" \
+            --argjson runId "$GITHUB_RUN_ID" \
+            '
             length == 3
             and ([.[].agent] | sort) == [
               "hermes",
@@ -2997,6 +3002,12 @@ jobs:
               and all(.platforms[];
                 (.digest | test("^sha256:[0-9a-f]{64}$"))
                 and (.baseReference | test("@sha256:[0-9a-f]{64}$"))
+                and (.run | keys | sort) == ["attempt", "id"]
+                and .run.id == $runId
+                and (.run.attempt | type) == "number"
+                and .run.attempt >= 1
+                and (.run.attempt | floor) == .run.attempt
+                and .run.attempt <= $runAttempt
                 and .publicationEvidence.candidateDescriptor.digest == .digest
                 and .publicationEvidence.attestations.manifestDescriptor.annotations[
                   "vnd.docker.reference.digest"
@@ -3005,6 +3016,9 @@ jobs:
                   .publicationEvidence.workloadDescriptor.digest
                 and .publicationEvidence.attestations.spdx.statement.subject.digest ==
                   .publicationEvidence.workloadDescriptor.digest
+                and .publicationEvidence.attestations.slsa.statement.builderId ==
+                  ("https://github.com/" + $repository + "/actions/runs/" +
+                   ($runId | tostring) + "/attempts/" + (.run.attempt | tostring))
               )
             )
           ' "$cohort_manifests" >/dev/null; then
@@ -3150,6 +3164,7 @@ jobs:
             }' > "$cohort_contract"
           jq -e \
             --arg cohort "$cohort" \
+            --arg repository "$GITHUB_REPOSITORY" \
             --arg revision "$GITHUB_SHA" \
             --argjson runAttempt "$GITHUB_RUN_ATTEMPT" \
             --argjson runId "$GITHUB_RUN_ID" \
@@ -3184,10 +3199,19 @@ jobs:
                and .alias == (.image + ":cohort-" + $cohort)
                and (.platforms | keys | sort) == ["linux/amd64", "linux/arm64"]
                and all(.platforms[];
-                 .publicationEvidence.candidateDescriptor.digest == .digest
+                 (.run | keys | sort) == ["attempt", "id"]
+                 and .run.id == $runId
+                 and (.run.attempt | type) == "number"
+                 and .run.attempt >= 1
+                 and (.run.attempt | floor) == .run.attempt
+                 and .run.attempt <= $runAttempt
+                 and .publicationEvidence.candidateDescriptor.digest == .digest
                  and .publicationEvidence.attestations.manifestDescriptor.annotations[
                    "vnd.docker.reference.digest"
                  ] == .publicationEvidence.workloadDescriptor.digest
+                 and .publicationEvidence.attestations.slsa.statement.builderId ==
+                   ("https://github.com/" + $repository + "/actions/runs/" +
+                    ($runId | tostring) + "/attempts/" + (.run.attempt | tostring))
                )
              )' "$cohort_contract" >/dev/null
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -95,6 +95,8 @@ first-parent history. It downloads the complete cohort contract and Deep Agents 
 by immutable artifact ID. It binds each artifact to the selected workflow run, attempt, revision,
 artifact ID, and artifact digest. The cohort validator requires OpenClaw, Hermes, and LangChain Deep
 Agents Code on `linux/amd64` and `linux/arm64` before it emits `managed_image_revision`.
+Each cohort platform entry records its workflow run and producer attempt.
+The validator binds each SLSA builder ID to that attempt and rejects an attempt newer than the selected publication.
 `generate-matrix` and every stock-onboarding job depend on this job, so a missing, failed,
 incomplete, or mixed publication starts no onboarding consumer.
 

--- a/test/e2e/support/managed-image-cohort-contract.test.ts
+++ b/test/e2e/support/managed-image-cohort-contract.test.ts
@@ -11,16 +11,19 @@ import { validateManagedImageCohort } from "../../../tools/e2e/managed-image-coh
 
 const REVISION = "a".repeat(40);
 const RUN_ID = 32707920950;
-const RUN_ATTEMPT = 1;
+const RUN_ATTEMPT = 2;
 const COHORT = `ghrun-${RUN_ID}-${RUN_ATTEMPT}`;
 const PLATFORMS = ["linux/amd64", "linux/arm64"] as const;
 type JsonObject = Record<string, unknown>;
 type PlatformPublication = {
+  run: { attempt: number; id: number };
   publicationEvidence: {
     workloadDescriptor: JsonObject;
     attestations: {
       manifestDescriptor: { annotations: JsonObject };
-      slsa: { statement: { bindings: JsonObject; subject: JsonObject } };
+      slsa: {
+        statement: { bindings: JsonObject; builderId: string; subject: JsonObject };
+      };
       spdx: { statement: { subject: JsonObject } };
     };
   };
@@ -61,6 +64,7 @@ function cohortContract(): Record<string, unknown> {
                     digest: platformDigest,
                     reference: `${image}@${platformDigest}`,
                     baseReference,
+                    run: { id: RUN_ID, attempt: RUN_ATTEMPT },
                     publicationEvidence: {
                       candidateDescriptor: {
                         digest: platformDigest,
@@ -175,6 +179,49 @@ describe("managed-image cohort publication contract", () => {
       runAttempt: RUN_ATTEMPT,
       runId: RUN_ID,
     });
+  });
+
+  it("accepts a platform candidate from an earlier workflow attempt", () => {
+    const value = cohortContract();
+    const publication = platformPublication(value);
+    publication.run.attempt = 1;
+    publication.publicationEvidence.attestations.slsa.statement.builderId = `https://github.com/NVIDIA/NemoClaw/actions/runs/${RUN_ID}/attempts/1`;
+
+    expect(
+      validateManagedImageCohort(value, {
+        revision: REVISION,
+        runAttempt: RUN_ATTEMPT,
+        runId: RUN_ID,
+      }),
+    ).toMatchObject({ cohort: COHORT, runAttempt: RUN_ATTEMPT, runId: RUN_ID });
+  });
+
+  it("rejects SLSA provenance from a different attempt than the platform producer", () => {
+    const value = cohortContract();
+    platformPublication(value).run.attempt = 1;
+
+    expect(() =>
+      validateManagedImageCohort(value, {
+        revision: REVISION,
+        runAttempt: RUN_ATTEMPT,
+        runId: RUN_ID,
+      }),
+    ).toThrow("builder must be");
+  });
+
+  it("rejects a platform producer attempt newer than the selected publication", () => {
+    const value = cohortContract();
+    const publication = platformPublication(value);
+    publication.run.attempt = RUN_ATTEMPT + 1;
+    publication.publicationEvidence.attestations.slsa.statement.builderId = `https://github.com/NVIDIA/NemoClaw/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT + 1}`;
+
+    expect(() =>
+      validateManagedImageCohort(value, {
+        revision: REVISION,
+        runAttempt: RUN_ATTEMPT,
+        runId: RUN_ID,
+      }),
+    ).toThrow("producer attempt must not be newer");
   });
 
   it("rejects a cohort that omits one image architecture", () => {

--- a/tools/e2e/managed-image-cohort-contract.mts
+++ b/tools/e2e/managed-image-cohort-contract.mts
@@ -83,6 +83,22 @@ function validatePlatformEvidence(
   },
 ): void {
   const platform = record(value, `${expected.agent} ${expected.platform} publication`);
+  const producerRun = record(platform.run, `${expected.agent} ${expected.platform} producer run`);
+  exactKeys(producerRun, ["attempt", "id"], `${expected.agent} ${expected.platform} producer run`);
+  if (producerRun.id !== expected.runId) {
+    throw new Error(
+      `${expected.agent} ${expected.platform} producer run id must be ${expected.runId}`,
+    );
+  }
+  const producerAttempt = positiveInteger(
+    producerRun.attempt,
+    `${expected.agent} ${expected.platform} producer attempt`,
+  );
+  if (producerAttempt > expected.runAttempt) {
+    throw new Error(
+      `${expected.agent} ${expected.platform} producer attempt must not be newer than the selected publication attempt`,
+    );
+  }
   const platformDigest = digest(platform.digest, `${expected.agent} ${expected.platform} digest`);
   const image =
     MANAGED_IMAGE_REPOSITORIES[expected.agent as keyof typeof MANAGED_IMAGE_REPOSITORIES];
@@ -159,7 +175,7 @@ function validatePlatformEvidence(
   );
   exactString(
     statement.builderId,
-    `https://github.com/${REPOSITORY}/actions/runs/${expected.runId}/attempts/${expected.runAttempt}`,
+    `https://github.com/${REPOSITORY}/actions/runs/${expected.runId}/attempts/${producerAttempt}`,
     `${expected.agent} ${expected.platform} builder`,
   );
   const bindings = record(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Preserve each managed-image cohort entry's producer run attempt instead of replacing it with the selected publication attempt. This allows a retried cohort publication to reuse successful platform artifacts from earlier attempts while still binding every SLSA provenance builder ID to the exact producing workflow attempt.

## Changes

- Copy each candidate artifact's `run` identity into the final cohort platform entry.
- Validate platform run keys, run ID, attempt bounds, and the SLSA builder ID before publishing or consuming the cohort.
- Add regression coverage for mixed-attempt cohorts, mismatched builder identities, and impossible future producer attempts.
- Document the per-platform producer identity contract in the owning E2E guide.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed artifact identity validation end to end; the consumer rejects missing, malformed, mismatched, or future producer attempts and requires the SLSA builder ID to match the exact producing workflow attempt.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project e2e-support test/e2e/support/managed-image-cohort-contract.test.ts` (12 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened artifact verification to ensure published platform images are tied to the correct workflow runs and attempts.
  * Rejected image publications with mismatched, incomplete, or newer provenance information.
  * Improved cohort validation so earlier valid publication attempts remain supported.

* **Tests**
  * Added coverage for valid earlier attempts and invalid provenance or newer producer attempts.
  * Updated end-to-end validation guidance for workflow and provenance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->