### PR TITLE
fix(onboard): remove stale Hermes volumes on recreation

### DIFF
--- a/src/lib/onboard/managed-workload/hermes-state-volume.ts
+++ b/src/lib/onboard/managed-workload/hermes-state-volume.ts
@@ -13,7 +13,8 @@ import type { DockerRunOptions, DockerRunResult } from "../../adapters/docker/ru
  * whyNotSourceFix: the provider-neutral image cannot name a sandbox-scoped Docker volume, while
  *   weakening provider validation would accept absent, ambiguous, or read-only state mounts.
  * regressionTest: hermes-state-volume.test.ts covers create, reuse, ownership refusal, and
- *   removal; sandbox-create-plan.test.ts and destroy-flow.test.ts cover lifecycle integration.
+ *   removal; sandbox-create-plan.test.ts, sandbox-create/orchestration.test.ts, and
+ *   destroy-flow.test.ts cover lifecycle integration.
  * removalCondition: remove when the managed-image or runtime-provider contract creates,
  *   reconciles, and ownership-gates an equivalent durable Hermes state volume end to end.
  */

--- a/src/lib/onboard/managed-workload/onboard-orchestration.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.ts
@@ -98,7 +98,7 @@ export function createManagedHermesStateVolumeOnboardLifecycle(
     readonly runtimeProvider: RuntimeProviderBundle | null;
   },
   deps: ManagedHermesStateVolumeDeps = {},
-): ManagedHermesStateVolumeOnboardLifecycle {
+): ManagedHermesStateVolumeOnboardLifecycle | null {
   const scope = prepareManagedHermesStateVolume(
     {
       agentName: input.agentName,
@@ -108,12 +108,13 @@ export function createManagedHermesStateVolumeOnboardLifecycle(
     },
     deps,
   );
+  if (!scope) return null;
   return {
     materializeSandboxCreatePlan(input, materialize) {
-      return materialize({ ...input, managedStateMount: scope?.mount });
+      return materialize({ ...input, managedStateMount: scope.mount });
     },
     commit() {
-      scope?.commit();
+      scope.commit();
     },
   };
 }

--- a/src/lib/onboard/sandbox-create/orchestration.test.ts
+++ b/src/lib/onboard/sandbox-create/orchestration.test.ts
@@ -5,18 +5,49 @@ import { describe, expect, it, vi } from "vitest";
 
 import { PolicyAuthorityRefusalError } from "../../adapters/openshell/policy-authority";
 import type { SandboxEntry } from "../../state/registry";
+import { createHermesStateVolumeDockerHarness } from "../__test-helpers__/hermes-state-volume";
+import { createManagedHermesStateVolumeOnboardLifecycle } from "../managed-workload/onboard-orchestration";
 import {
   applyManagedSandboxRebuildPolicyCarryForward,
   assertApfCreateIntent,
   backfillVerifiedExternalSandboxPolicyAuthority,
   completeHermesPortableSandboxRegistration,
   createProviderEffectBoundary,
+  finalizeRecreatedSourceHermesStateVolume,
   hasManagedMcpRebuildHandoff,
   readManagedDcodeCreateSelectionDrift,
   readSandboxRecreateRegistryEntry,
   resolveSandboxCreatePolicyAuthority,
   runSandboxCreateWithPolicyAuthorityChecks,
 } from "./orchestration";
+
+const managedHermesSourceEntry = {
+  name: "alpha",
+  agent: "hermes",
+  openshellDriver: "docker",
+  workload: { kind: "managed-image" },
+} as SandboxEntry;
+const managedHermesCleanupCalls = [
+  [
+    {
+      agentName: "hermes",
+      runtimeProviderId: "docker",
+      sandboxName: "alpha",
+      workloadKind: "managed-image",
+    },
+  ],
+] as const;
+
+function recreatedHermesVolumeFinalizationDeps() {
+  return {
+    normalizeRuntimeProviderIdentity: vi.fn(() => "docker"),
+    removeManagedHermesStateVolume: vi.fn(() => ({ status: "removed" as const })),
+    removeSourceRegistryEntry: vi.fn(),
+    note: vi.fn(),
+    warn: vi.fn(),
+    redact: vi.fn((message: string) => message),
+  };
+}
 
 describe("APF create policy selection", () => {
   it("selects a policyless external plan only from an absent global policy (#9833)", () => {
@@ -297,6 +328,70 @@ describe("sandbox recreate registry authority", () => {
     ).toBe(inspected);
     expect(readRegistry).not.toHaveBeenCalled();
   });
+});
+
+describe("managed Hermes state volume recreation", () => {
+  it.each([
+    [
+      "OpenClaw and removes the source volume",
+      "openclaw",
+      "docker",
+      "managed-image",
+      managedHermesCleanupCalls,
+    ],
+    [
+      "a custom Dockerfile and removes the source volume",
+      "hermes",
+      "docker",
+      "legacy-dockerfile",
+      managedHermesCleanupCalls,
+    ],
+    [
+      "a non-Docker provider and removes the source volume",
+      "hermes",
+      "kubernetes",
+      "managed-image",
+      managedHermesCleanupCalls,
+    ],
+    [
+      "managed Docker Hermes and preserves the source volume",
+      "hermes",
+      "docker",
+      "managed-image",
+      [],
+    ],
+  ] as const)(
+    "recreates with %s",
+    (_label, agentName, runtimeProviderId, workloadKind, expectedCleanupCalls) => {
+      const docker = createHermesStateVolumeDockerHarness();
+      const targetLifecycle = createManagedHermesStateVolumeOnboardLifecycle(
+        {
+          agentName,
+          runtimeProvider: { identity: { id: runtimeProviderId } } as never,
+          sandboxName: "alpha",
+          workloadKind,
+        },
+        { runDocker: docker.runDocker as never, registerExitCleanup: () => vi.fn() },
+      );
+      const deps = recreatedHermesVolumeFinalizationDeps();
+
+      finalizeRecreatedSourceHermesStateVolume(
+        {
+          sandboxName: "alpha",
+          sourceConfirmedAbsent: true,
+          sourceEntry: managedHermesSourceEntry,
+          targetKeepsManagedHermesStateVolume: targetLifecycle !== null,
+        },
+        deps,
+      );
+
+      expect(deps.removeManagedHermesStateVolume.mock.calls).toEqual(expectedCleanupCalls);
+      expect(deps.removeSourceRegistryEntry).toHaveBeenCalledExactlyOnceWith(
+        managedHermesSourceEntry,
+        "alpha",
+      );
+    },
+  );
 });
 
 describe("managed DCode sandbox create selection", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Remove a recreated sandbox's stale Hermes state volume when the replacement target does not use managed Hermes state. Previously, the lifecycle wrapper was truthy even when volume preparation returned no lifecycle, so recreation incorrectly retained the old volume for OpenClaw, custom-Dockerfile, and non-Docker targets.

## Changes

- Return `null` from the managed Hermes state lifecycle wrapper when no managed volume is prepared.
- Keep the existing managed-Hermes volume only when the replacement target actually prepares that lifecycle.
- Add transition tests proving stale-volume removal for non-Hermes targets and preservation for a managed Docker Hermes target.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Reviewed recreation cleanup and failure behavior; deletion still occurs only after confirmed sandbox absence and continues to use the existing exact NemoClaw volume-ownership gate. Failed removal still preserves the registry entry.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — command/result or justification: `npx vitest run --project cli src/lib/onboard/sandbox-create/orchestration.test.ts src/lib/onboard/managed-workload/onboard-orchestration.test.ts src/lib/onboard/managed-workload/hermes-state-volume.test.ts` (54 passed)
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result:
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed Hermes state-volume onboarding when preparation is unavailable, preventing incomplete setup operations.
  - Added safer handling for state-volume recreation scenarios.

- **Tests**
  - Expanded coverage for recreating workloads with OpenClaw, custom Dockerfiles, and non-Docker configurations.
  - Verified appropriate source-volume cleanup and preservation for managed Docker Hermes workloads.
  - Confirmed source registry entries are removed consistently.

- **Documentation**
  - Updated integration test coverage documentation for managed Hermes state-volume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->