### PR TITLE
feat(runtime): validate MXC OpenShell attachment

### DIFF
--- a/src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts
@@ -15,6 +15,7 @@ import type {
   RuntimeProviderNativeArtifactBootstrapSurface,
 } from "./contract";
 import { createMxcRuntimeProviderBundle } from "./mxc";
+import type { MxcOpenShellAttachmentInput } from "./mxc-openshell-attachment";
 
 const NATIVE_RECEIPT = nativeArtifactWorkloadReceiptFixture(
   encodeManagedStartupProfile(managedStartupE2eProfile("openclaw")),
@@ -24,6 +25,40 @@ const SHARE_DIRECTORY = `C:\\nemoclaw-alpha-${createHash("sha256")
   .update(LIFECYCLE_GENERATION, "utf8")
   .digest("hex")
   .slice(0, 12)}`;
+
+function openshellAttachment(): MxcOpenShellAttachmentInput {
+  const identity = {
+    distribution: {
+      version: "0.0.21",
+      revision: "a".repeat(40),
+      sha256: "1".repeat(64),
+    },
+    components: {
+      cliSha256: "2".repeat(64),
+      gatewaySha256: "3".repeat(64),
+      wxcExecSha256: "4".repeat(64),
+    },
+    gateway: {
+      configSha256: "5".repeat(64),
+      driver: "mxc" as const,
+      backend: "process_container" as const,
+    },
+  };
+  return {
+    contractVersion: 1,
+    providerId: "mxc",
+    mode: "attach-existing",
+    expected: identity,
+    observed: {
+      ...structuredClone(identity),
+      distributionRoot: "C:\\OpenShell",
+      cliPath: "C:\\OpenShell\\bin\\openshell.exe",
+      gatewayPath: "C:\\OpenShell\\bin\\openshell-gateway.exe",
+      wxcExecPath: "C:\\OpenShell\\mxc\\wxc-exec.exe",
+      gatewayConfigPath: "C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml",
+    },
+  };
+}
 
 function bootstrapInput(): RuntimeProviderNativeArtifactBootstrapInput {
   return {
@@ -61,6 +96,7 @@ function nativeBootstrap(
       nativeArchitecture: "x64",
       release: "10.0.28120",
     },
+    openshellAttachment: openshellAttachment(),
     bootstrapControlPlane: {
       contractVersion: 1,
       providerId: "mxc",

--- a/src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts
@@ -15,7 +15,7 @@ import type {
   RuntimeProviderNativeArtifactBootstrapSurface,
 } from "./contract";
 import { createMxcRuntimeProviderBundle } from "./mxc";
-import type { MxcOpenShellAttachmentInput } from "./mxc-openshell-attachment";
+import { mxcOpenShellAttachmentFixture } from "./mxc-openshell-attachment-test-fixture";
 
 const NATIVE_RECEIPT = nativeArtifactWorkloadReceiptFixture(
   encodeManagedStartupProfile(managedStartupE2eProfile("openclaw")),
@@ -25,40 +25,6 @@ const SHARE_DIRECTORY = `C:\\nemoclaw-alpha-${createHash("sha256")
   .update(LIFECYCLE_GENERATION, "utf8")
   .digest("hex")
   .slice(0, 12)}`;
-
-function openshellAttachment(): MxcOpenShellAttachmentInput {
-  const identity = {
-    distribution: {
-      version: "0.0.21",
-      revision: "a".repeat(40),
-      sha256: "1".repeat(64),
-    },
-    components: {
-      cliSha256: "2".repeat(64),
-      gatewaySha256: "3".repeat(64),
-      wxcExecSha256: "4".repeat(64),
-    },
-    gateway: {
-      configSha256: "5".repeat(64),
-      driver: "mxc" as const,
-      backend: "process_container" as const,
-    },
-  };
-  return {
-    contractVersion: 1,
-    providerId: "mxc",
-    mode: "attach-existing",
-    expected: identity,
-    observed: {
-      ...structuredClone(identity),
-      distributionRoot: "C:\\OpenShell",
-      cliPath: "C:\\OpenShell\\bin\\openshell.exe",
-      gatewayPath: "C:\\OpenShell\\bin\\openshell-gateway.exe",
-      wxcExecPath: "C:\\OpenShell\\mxc\\wxc-exec.exe",
-      gatewayConfigPath: "C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml",
-    },
-  };
-}
 
 function bootstrapInput(): RuntimeProviderNativeArtifactBootstrapInput {
   return {
@@ -90,13 +56,15 @@ function nativeBootstrap(
   operations: Omit<RuntimeProviderNativeArtifactBootstrapOperations, "recoverCreate"> &
     Partial<Pick<RuntimeProviderNativeArtifactBootstrapOperations, "recoverCreate">>,
 ) {
+  const attachment = mxcOpenShellAttachmentFixture();
   const surface = createMxcRuntimeProviderBundle({
     hostFacts: {
       platform: "win32",
       nativeArchitecture: "x64",
       release: "10.0.28120",
     },
-    openshellAttachment: openshellAttachment(),
+    openshellAttachmentAuthority: attachment.authority,
+    openshellObservation: attachment.observation,
     bootstrapControlPlane: {
       contractVersion: 1,
       providerId: "mxc",

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment-test-fixture.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment-test-fixture.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  createMxcOpenShellAttachmentAuthority,
+  type MxcOpenShellAttachmentAuthority,
+  type MxcOpenShellAttachmentExpectation,
+  type MxcOpenShellAttachmentObservation,
+} from "./mxc-openshell-attachment";
+
+export const MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS = {
+  distribution: "1".repeat(64),
+  cli: "2".repeat(64),
+  gateway: "3".repeat(64),
+  wxcExec: "4".repeat(64),
+  config: "5".repeat(64),
+} as const;
+
+export function mxcOpenShellAttachmentFixture(version = "0.0.21"): {
+  readonly authority: MxcOpenShellAttachmentAuthority;
+  readonly observation: MxcOpenShellAttachmentObservation;
+} {
+  const accepted: MxcOpenShellAttachmentExpectation = {
+    distribution: {
+      version,
+      revision: "a".repeat(40),
+      sha256: MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS.distribution,
+    },
+    components: {
+      cliSha256: MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS.cli,
+      gatewaySha256: MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS.gateway,
+      wxcExecSha256: MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS.wxcExec,
+    },
+    gateway: {
+      configSha256: MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS.config,
+      driver: "mxc",
+      backend: "process_container",
+    },
+  };
+  return {
+    authority: createMxcOpenShellAttachmentAuthority(accepted),
+    observation: {
+      ...structuredClone(accepted),
+      distributionRoot: "C:\\OpenShell",
+      cliPath: "C:\\OpenShell\\bin\\openshell.exe",
+      gatewayPath: "C:\\OpenShell\\bin\\openshell-gateway.exe",
+      wxcExecPath: "C:\\OpenShell\\mxc\\wxc-exec.exe",
+      gatewayConfigPath: "C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml",
+    },
+  };
+}

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
@@ -157,6 +157,22 @@ describe("inactive OpenShell MXC installation attachment", () => {
     );
   });
 
+  it("retains an owned accepted identity after the caller mutates its input (#8178)", () => {
+    const { observation } = mxcOpenShellAttachmentFixture();
+    const accepted = {
+      distribution: { ...observation.distribution },
+      components: { ...observation.components },
+      gateway: { ...observation.gateway },
+    };
+    const authority = createMxcOpenShellAttachmentAuthority(accepted);
+
+    accepted.components.gatewaySha256 = "6".repeat(64);
+
+    expect(qualifyMxcOpenShellAttachment(authority, observation).components.gateway.sha256).toBe(
+      DIGESTS.gateway,
+    );
+  });
+
   it.each(["0.0.21-rc.1+build.2", "1.0.0-alpha.0", "1.0.0+build.2"])(
     "accepts complete SemVer identity %s (#8178)",
     (version) => {

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
+  MxcOpenShellAttachmentError,
+  qualifyMxcOpenShellAttachment,
+  type MxcOpenShellAttachmentInput,
+} from "./mxc-openshell-attachment";
+
+const DIGESTS = {
+  distribution: "1".repeat(64),
+  cli: "2".repeat(64),
+  gateway: "3".repeat(64),
+  wxcExec: "4".repeat(64),
+  config: "5".repeat(64),
+} as const;
+
+function attachment(): MxcOpenShellAttachmentInput {
+  const identity = {
+    distribution: {
+      version: "0.0.21",
+      revision: "a".repeat(40),
+      sha256: DIGESTS.distribution,
+    },
+    components: {
+      cliSha256: DIGESTS.cli,
+      gatewaySha256: DIGESTS.gateway,
+      wxcExecSha256: DIGESTS.wxcExec,
+    },
+    gateway: {
+      configSha256: DIGESTS.config,
+      driver: "mxc" as const,
+      backend: "process_container" as const,
+    },
+  };
+  return {
+    contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
+    providerId: "mxc",
+    mode: "attach-existing",
+    expected: identity,
+    observed: {
+      ...structuredClone(identity),
+      distributionRoot: "C:\\OpenShell",
+      cliPath: "C:\\OpenShell\\bin\\openshell.exe",
+      gatewayPath: "C:\\OpenShell\\bin\\openshell-gateway.exe",
+      wxcExecPath: "C:\\OpenShell\\mxc\\wxc-exec.exe",
+      gatewayConfigPath: "C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml",
+    },
+  };
+}
+
+describe("inactive OpenShell MXC installation attachment", () => {
+  it("binds one accepted distribution and gateway configuration without installing it (#8178)", () => {
+    const receipt = qualifyMxcOpenShellAttachment(attachment());
+
+    expect(receipt).toEqual({
+      contractVersion: 1,
+      providerId: "mxc",
+      mode: "attach-existing",
+      authoritySha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      distribution: {
+        version: "0.0.21",
+        revision: "a".repeat(40),
+        sha256: DIGESTS.distribution,
+        root: "C:\\OpenShell",
+      },
+      components: {
+        cli: {
+          path: "C:\\OpenShell\\bin\\openshell.exe",
+          sha256: DIGESTS.cli,
+        },
+        gateway: {
+          path: "C:\\OpenShell\\bin\\openshell-gateway.exe",
+          sha256: DIGESTS.gateway,
+        },
+        wxcExec: {
+          path: "C:\\OpenShell\\mxc\\wxc-exec.exe",
+          sha256: DIGESTS.wxcExec,
+        },
+      },
+      gateway: {
+        configSha256: DIGESTS.config,
+        driver: "mxc",
+        backend: "process_container",
+        configPath: "C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml",
+      },
+    });
+    expect(Object.isFrozen(receipt)).toBe(true);
+    expect(Object.isFrozen(receipt.components.gateway)).toBe(true);
+  });
+
+  it.each([
+    [
+      "distribution package",
+      (input: MxcOpenShellAttachmentInput) => {
+        const observed = input.observed as unknown as { distribution: { sha256: string } };
+        observed.distribution.sha256 = "6".repeat(64);
+      },
+    ],
+    [
+      "OpenShell CLI",
+      (input: MxcOpenShellAttachmentInput) => {
+        const observed = input.observed as unknown as { components: { cliSha256: string } };
+        observed.components.cliSha256 = "6".repeat(64);
+      },
+    ],
+    [
+      "OpenShell gateway",
+      (input: MxcOpenShellAttachmentInput) => {
+        const observed = input.observed as unknown as { components: { gatewaySha256: string } };
+        observed.components.gatewaySha256 = "6".repeat(64);
+      },
+    ],
+    [
+      "wxc-exec",
+      (input: MxcOpenShellAttachmentInput) => {
+        const observed = input.observed as unknown as { components: { wxcExecSha256: string } };
+        observed.components.wxcExecSha256 = "6".repeat(64);
+      },
+    ],
+    [
+      "gateway configuration",
+      (input: MxcOpenShellAttachmentInput) => {
+        const observed = input.observed as unknown as { gateway: { configSha256: string } };
+        observed.gateway.configSha256 = "6".repeat(64);
+      },
+    ],
+  ])("rejects %s identity drift before attachment (#8178)", (_label, mutate) => {
+    const input = structuredClone(attachment());
+    mutate(input);
+
+    expect(() => qualifyMxcOpenShellAttachment(input)).toThrow(
+      /observed distribution identity does not match/u,
+    );
+  });
+
+  it("rejects components from another distribution root (#8178)", () => {
+    const input = structuredClone(attachment());
+    const observed = input.observed as unknown as { gatewayPath: string };
+    observed.gatewayPath = "C:\\OtherOpenShell\\openshell-gateway.exe";
+
+    expect(() => qualifyMxcOpenShellAttachment(input)).toThrow(
+      /gateway path must remain inside the observed distribution root/u,
+    );
+  });
+
+  it("rejects an unsupported backend before attachment (#8178)", () => {
+    const input = structuredClone(attachment()) as unknown as Record<string, unknown>;
+    const expected = input.expected as Record<string, unknown>;
+    const gateway = expected.gateway as Record<string, unknown>;
+    gateway.backend = "isolation_session";
+
+    expect(() => qualifyMxcOpenShellAttachment(input)).toThrow(
+      /backend must be 'process_container'/u,
+    );
+  });
+
+  it("rejects credential-bearing fields instead of copying them into the receipt (#8178)", () => {
+    const input = structuredClone(attachment()) as unknown as Record<string, unknown>;
+    input.providerToken = "must-not-enter-attachment-receipt";
+
+    expect(() => qualifyMxcOpenShellAttachment(input)).toThrow(MxcOpenShellAttachmentError);
+    expect(() => qualifyMxcOpenShellAttachment(input)).toThrow(/unknown or missing fields/u);
+  });
+
+  it.each([
+    ["provider identity", { providerId: "docker" }],
+    ["contract version", { contractVersion: 2 }],
+    ["installation mutation", { mode: "install" }],
+  ])("rejects $0 drift before attachment (#8178)", (_label, change) => {
+    const input = { ...attachment(), ...change };
+
+    expect(() => qualifyMxcOpenShellAttachment(input)).toThrow(MxcOpenShellAttachmentError);
+  });
+});

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
@@ -6,56 +6,27 @@ import { describe, expect, it } from "vitest";
 import {
   MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
   MxcOpenShellAttachmentError,
+  createMxcOpenShellAttachmentAuthority,
   qualifyMxcOpenShellAttachment,
-  type MxcOpenShellAttachmentInput,
+  type MxcOpenShellAttachmentObservation,
 } from "./mxc-openshell-attachment";
-
-const DIGESTS = {
-  distribution: "1".repeat(64),
-  cli: "2".repeat(64),
-  gateway: "3".repeat(64),
-  wxcExec: "4".repeat(64),
-  config: "5".repeat(64),
-} as const;
-
-function attachment(): MxcOpenShellAttachmentInput {
-  const identity = {
-    distribution: {
-      version: "0.0.21",
-      revision: "a".repeat(40),
-      sha256: DIGESTS.distribution,
-    },
-    components: {
-      cliSha256: DIGESTS.cli,
-      gatewaySha256: DIGESTS.gateway,
-      wxcExecSha256: DIGESTS.wxcExec,
-    },
-    gateway: {
-      configSha256: DIGESTS.config,
-      driver: "mxc" as const,
-      backend: "process_container" as const,
-    },
-  };
-  return {
-    contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
-    providerId: "mxc",
-    mode: "attach-existing",
-    expected: identity,
-    observed: {
-      ...structuredClone(identity),
-      distributionRoot: "C:\\OpenShell",
-      cliPath: "C:\\OpenShell\\bin\\openshell.exe",
-      gatewayPath: "C:\\OpenShell\\bin\\openshell-gateway.exe",
-      wxcExecPath: "C:\\OpenShell\\mxc\\wxc-exec.exe",
-      gatewayConfigPath: "C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml",
-    },
-  };
-}
+import {
+  MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS as DIGESTS,
+  mxcOpenShellAttachmentFixture,
+} from "./mxc-openshell-attachment-test-fixture";
 
 describe("inactive OpenShell MXC installation attachment", () => {
   it("binds one accepted distribution and gateway configuration without installing it (#8178)", () => {
-    const receipt = qualifyMxcOpenShellAttachment(attachment());
+    const { authority, observation } = mxcOpenShellAttachmentFixture();
+    const receipt = qualifyMxcOpenShellAttachment(authority, observation);
 
+    expect(authority).toEqual({
+      contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
+      providerId: "mxc",
+      mode: "attach-existing",
+      acceptedIdentitySha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+    });
+    expect(Object.isFrozen(authority)).toBe(true);
     expect(receipt).toEqual({
       contractVersion: 1,
       providerId: "mxc",
@@ -95,84 +66,112 @@ describe("inactive OpenShell MXC installation attachment", () => {
   it.each([
     [
       "distribution package",
-      (input: MxcOpenShellAttachmentInput) => {
-        const observed = input.observed as unknown as { distribution: { sha256: string } };
+      (observation: MxcOpenShellAttachmentObservation) => {
+        const observed = observation as unknown as { distribution: { sha256: string } };
         observed.distribution.sha256 = "6".repeat(64);
       },
     ],
     [
       "OpenShell CLI",
-      (input: MxcOpenShellAttachmentInput) => {
-        const observed = input.observed as unknown as { components: { cliSha256: string } };
+      (observation: MxcOpenShellAttachmentObservation) => {
+        const observed = observation as unknown as { components: { cliSha256: string } };
         observed.components.cliSha256 = "6".repeat(64);
       },
     ],
     [
       "OpenShell gateway",
-      (input: MxcOpenShellAttachmentInput) => {
-        const observed = input.observed as unknown as { components: { gatewaySha256: string } };
+      (observation: MxcOpenShellAttachmentObservation) => {
+        const observed = observation as unknown as { components: { gatewaySha256: string } };
         observed.components.gatewaySha256 = "6".repeat(64);
       },
     ],
     [
       "wxc-exec",
-      (input: MxcOpenShellAttachmentInput) => {
-        const observed = input.observed as unknown as { components: { wxcExecSha256: string } };
+      (observation: MxcOpenShellAttachmentObservation) => {
+        const observed = observation as unknown as { components: { wxcExecSha256: string } };
         observed.components.wxcExecSha256 = "6".repeat(64);
       },
     ],
     [
       "gateway configuration",
-      (input: MxcOpenShellAttachmentInput) => {
-        const observed = input.observed as unknown as { gateway: { configSha256: string } };
+      (observation: MxcOpenShellAttachmentObservation) => {
+        const observed = observation as unknown as { gateway: { configSha256: string } };
         observed.gateway.configSha256 = "6".repeat(64);
       },
     ],
   ])("rejects %s identity drift before attachment (#8178)", (_label, mutate) => {
-    const input = structuredClone(attachment());
-    mutate(input);
+    const { authority, observation: fixtureObservation } = mxcOpenShellAttachmentFixture();
+    const observation = structuredClone(fixtureObservation);
+    mutate(observation);
 
-    expect(() => qualifyMxcOpenShellAttachment(input)).toThrow(
+    expect(() => qualifyMxcOpenShellAttachment(authority, observation)).toThrow(
       /observed distribution identity does not match/u,
     );
   });
 
   it("rejects components from another distribution root (#8178)", () => {
-    const input = structuredClone(attachment());
-    const observed = input.observed as unknown as { gatewayPath: string };
+    const { authority, observation: fixtureObservation } = mxcOpenShellAttachmentFixture();
+    const observation = structuredClone(fixtureObservation);
+    const observed = observation as unknown as { gatewayPath: string };
     observed.gatewayPath = "C:\\OtherOpenShell\\openshell-gateway.exe";
 
-    expect(() => qualifyMxcOpenShellAttachment(input)).toThrow(
+    expect(() => qualifyMxcOpenShellAttachment(authority, observation)).toThrow(
       /gateway path must remain inside the observed distribution root/u,
     );
   });
 
   it("rejects an unsupported backend before attachment (#8178)", () => {
-    const input = structuredClone(attachment()) as unknown as Record<string, unknown>;
-    const expected = input.expected as Record<string, unknown>;
-    const gateway = expected.gateway as Record<string, unknown>;
-    gateway.backend = "isolation_session";
+    const { observation } = mxcOpenShellAttachmentFixture();
+    const accepted = {
+      distribution: observation.distribution,
+      components: observation.components,
+      gateway: { ...observation.gateway, backend: "isolation_session" },
+    };
 
-    expect(() => qualifyMxcOpenShellAttachment(input)).toThrow(
+    expect(() => createMxcOpenShellAttachmentAuthority(accepted)).toThrow(
       /backend must be 'process_container'/u,
     );
   });
 
   it("rejects credential-bearing fields instead of copying them into the receipt (#8178)", () => {
-    const input = structuredClone(attachment()) as unknown as Record<string, unknown>;
-    input.providerToken = "must-not-enter-attachment-receipt";
+    const { authority, observation } = mxcOpenShellAttachmentFixture();
+    const candidate = {
+      ...structuredClone(observation),
+      providerToken: "must-not-enter-attachment-receipt",
+    };
 
-    expect(() => qualifyMxcOpenShellAttachment(input)).toThrow(MxcOpenShellAttachmentError);
-    expect(() => qualifyMxcOpenShellAttachment(input)).toThrow(/unknown or missing fields/u);
+    expect(() => qualifyMxcOpenShellAttachment(authority, candidate)).toThrow(
+      MxcOpenShellAttachmentError,
+    );
+    expect(() => qualifyMxcOpenShellAttachment(authority, candidate)).toThrow(
+      /unknown or missing fields/u,
+    );
   });
 
-  it.each([
-    ["provider identity", { providerId: "docker" }],
-    ["contract version", { contractVersion: 2 }],
-    ["installation mutation", { mode: "install" }],
-  ])("rejects $0 drift before attachment (#8178)", (_label, change) => {
-    const input = { ...attachment(), ...change };
+  it("rejects a copied or caller-constructed accepted identity authority (#8178)", () => {
+    const { authority, observation } = mxcOpenShellAttachmentFixture();
+    const copied = { ...authority };
 
-    expect(() => qualifyMxcOpenShellAttachment(input)).toThrow(MxcOpenShellAttachmentError);
+    expect(() => qualifyMxcOpenShellAttachment(copied, observation)).toThrow(
+      /accepted identity authority is not provider-owned/u,
+    );
   });
+
+  it.each(["0.0.21-rc.1+build.2", "1.0.0-alpha.0", "1.0.0+build.2"])(
+    "accepts complete SemVer identity %s (#8178)",
+    (version) => {
+      const { authority, observation } = mxcOpenShellAttachmentFixture(version);
+
+      expect(qualifyMxcOpenShellAttachment(authority, observation).distribution.version).toBe(
+        version,
+      );
+    },
+  );
+
+  it.each(["01.0.0", "1.01.0", "1.0.01", "1.0.0-01", "1.0.0-", "1.0.0+"])(
+    "rejects noncanonical SemVer identity %s (#8178)",
+    (version) => {
+      expect(() => mxcOpenShellAttachmentFixture(version)).toThrow(/version is invalid/u);
+    },
+  );
 });

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
@@ -10,7 +10,8 @@ export const MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION = 1 as const;
 const PROVIDER_ID = "mxc";
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
 const REVISION_PATTERN = /^[a-f0-9]{7,64}$/u;
-const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u;
+const VERSION_PATTERN =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+(?:[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/u;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
 const MAX_TEXT_BYTES = 4096;
 
@@ -46,12 +47,11 @@ export interface MxcOpenShellAttachmentObservation extends MxcOpenShellAttachmen
   readonly gatewayConfigPath: string;
 }
 
-export interface MxcOpenShellAttachmentInput {
+export interface MxcOpenShellAttachmentAuthority {
   readonly contractVersion: typeof MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION;
   readonly providerId: "mxc";
   readonly mode: "attach-existing";
-  readonly expected: MxcOpenShellAttachmentExpectation;
-  readonly observed: MxcOpenShellAttachmentObservation;
+  readonly acceptedIdentitySha256: string;
 }
 
 export interface MxcOpenShellAttachmentReceipt {
@@ -74,6 +74,11 @@ export class MxcOpenShellAttachmentError extends Error {
     this.name = "MxcOpenShellAttachmentError";
   }
 }
+
+const ACCEPTED_IDENTITIES = new WeakMap<
+  MxcOpenShellAttachmentAuthority,
+  MxcOpenShellAttachmentExpectation
+>();
 
 function record(value: unknown, label: string): Record<string, unknown> {
   if (
@@ -249,38 +254,66 @@ function frozen<T>(value: T): T {
 }
 
 /**
- * Bind an accepted OpenShell distribution to one observed Windows installation.
+ * Bind a provider-owned accepted identity to an opaque attachment authority.
+ *
+ * The caller must obtain the expectation from a trusted provider source, not
+ * from the host observation that will be qualified against it.
+ */
+export function createMxcOpenShellAttachmentAuthority(
+  expectation: unknown,
+): MxcOpenShellAttachmentAuthority {
+  const accepted = frozen(parseExpectation(expectation, "accepted attachment"));
+  const acceptedIdentitySha256 = createHash("sha256")
+    .update(
+      JSON.stringify({
+        contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
+        providerId: PROVIDER_ID,
+        mode: "attach-existing",
+        accepted,
+      }),
+      "utf8",
+    )
+    .digest("hex");
+  const authority = Object.freeze({
+    contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
+    providerId: PROVIDER_ID,
+    mode: "attach-existing" as const,
+    acceptedIdentitySha256,
+  });
+  ACCEPTED_IDENTITIES.set(authority, accepted);
+  return authority;
+}
+
+function acceptedIdentity(authority: unknown): MxcOpenShellAttachmentExpectation {
+  if (typeof authority !== "object" || authority === null) {
+    throw new MxcOpenShellAttachmentError("accepted identity authority is not provider-owned");
+  }
+  const accepted = ACCEPTED_IDENTITIES.get(authority as MxcOpenShellAttachmentAuthority);
+  if (!accepted) {
+    throw new MxcOpenShellAttachmentError("accepted identity authority is not provider-owned");
+  }
+  return accepted;
+}
+
+/**
+ * Bind a provider-owned accepted OpenShell identity to one observed Windows installation.
  *
  * The trusted host adapter must collect the observation without executing the
  * untrusted agent artifact. This function does not install, start, or replace a
  * gateway and does not authorize MXC activation.
  */
-export function qualifyMxcOpenShellAttachment(input: unknown): MxcOpenShellAttachmentReceipt {
-  const candidate = record(input, "attachment");
-  exactKeys(
-    candidate,
-    ["contractVersion", "expected", "mode", "observed", "providerId"],
-    "attachment",
-  );
-  if (candidate.contractVersion !== MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION) {
-    throw new MxcOpenShellAttachmentError("contract version is unsupported");
-  }
-  if (candidate.providerId !== PROVIDER_ID) {
-    throw new MxcOpenShellAttachmentError("provider identity does not match 'mxc'");
-  }
-  if (candidate.mode !== "attach-existing") {
-    throw new MxcOpenShellAttachmentError(
-      "only an existing OpenShell installation can be attached",
-    );
-  }
-  const expected = parseExpectation(candidate.expected, "expected attachment");
-  const observed = parseObservation(candidate.observed);
+export function qualifyMxcOpenShellAttachment(
+  authority: MxcOpenShellAttachmentAuthority,
+  observation: unknown,
+): MxcOpenShellAttachmentReceipt {
+  const expected = acceptedIdentity(authority);
+  const observed = parseObservation(observation);
   if (!sameIdentity(expected, observed)) {
     throw new MxcOpenShellAttachmentError(
       "observed distribution identity does not match the accepted identity",
     );
   }
-  const authority = {
+  const receiptIdentity = {
     contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
     providerId: PROVIDER_ID,
     mode: "attach-existing" as const,
@@ -296,7 +329,7 @@ export function qualifyMxcOpenShellAttachment(input: unknown): MxcOpenShellAttac
     },
   } as const;
   const authoritySha256 = createHash("sha256")
-    .update(JSON.stringify(authority), "utf8")
+    .update(JSON.stringify(receiptIdentity), "utf8")
     .digest("hex");
-  return frozen({ ...authority, authoritySha256 });
+  return frozen({ ...receiptIdentity, authoritySha256 });
 }

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+export const MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION = 1 as const;
+
+const PROVIDER_ID = "mxc";
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
+const REVISION_PATTERN = /^[a-f0-9]{7,64}$/u;
+const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/u;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
+const MAX_TEXT_BYTES = 4096;
+
+type ExactDistributionIdentity = {
+  readonly version: string;
+  readonly revision: string;
+  readonly sha256: string;
+};
+
+type ExactComponentIdentity = {
+  readonly cliSha256: string;
+  readonly gatewaySha256: string;
+  readonly wxcExecSha256: string;
+};
+
+type ExactGatewayIdentity = {
+  readonly configSha256: string;
+  readonly driver: "mxc";
+  readonly backend: "process_container";
+};
+
+export interface MxcOpenShellAttachmentExpectation {
+  readonly distribution: ExactDistributionIdentity;
+  readonly components: ExactComponentIdentity;
+  readonly gateway: ExactGatewayIdentity;
+}
+
+export interface MxcOpenShellAttachmentObservation extends MxcOpenShellAttachmentExpectation {
+  readonly distributionRoot: string;
+  readonly cliPath: string;
+  readonly gatewayPath: string;
+  readonly wxcExecPath: string;
+  readonly gatewayConfigPath: string;
+}
+
+export interface MxcOpenShellAttachmentInput {
+  readonly contractVersion: typeof MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION;
+  readonly providerId: "mxc";
+  readonly mode: "attach-existing";
+  readonly expected: MxcOpenShellAttachmentExpectation;
+  readonly observed: MxcOpenShellAttachmentObservation;
+}
+
+export interface MxcOpenShellAttachmentReceipt {
+  readonly contractVersion: typeof MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION;
+  readonly providerId: "mxc";
+  readonly mode: "attach-existing";
+  readonly authoritySha256: string;
+  readonly distribution: ExactDistributionIdentity & { readonly root: string };
+  readonly components: {
+    readonly cli: { readonly path: string; readonly sha256: string };
+    readonly gateway: { readonly path: string; readonly sha256: string };
+    readonly wxcExec: { readonly path: string; readonly sha256: string };
+  };
+  readonly gateway: ExactGatewayIdentity & { readonly configPath: string };
+}
+
+export class MxcOpenShellAttachmentError extends Error {
+  constructor(message: string) {
+    super(`Invalid OpenShell MXC attachment: ${message}`);
+    this.name = "MxcOpenShellAttachmentError";
+  }
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null)
+  ) {
+    throw new MxcOpenShellAttachmentError(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[], label: string): void {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new MxcOpenShellAttachmentError(`${label} has unknown or missing fields`);
+  }
+}
+
+function exactText(value: unknown, label: string, pattern: RegExp): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    Buffer.byteLength(value, "utf8") > MAX_TEXT_BYTES ||
+    CONTROL_CHARACTER_PATTERN.test(value) ||
+    !pattern.test(value)
+  ) {
+    throw new MxcOpenShellAttachmentError(`${label} is invalid`);
+  }
+  return value;
+}
+
+function sha256(value: unknown, label: string): string {
+  return exactText(value, label, SHA256_PATTERN);
+}
+
+function canonicalWindowsPath(value: unknown, label: string): string {
+  if (
+    typeof value !== "string" ||
+    Buffer.byteLength(value, "utf8") > MAX_TEXT_BYTES ||
+    CONTROL_CHARACTER_PATTERN.test(value) ||
+    !path.win32.isAbsolute(value) ||
+    path.win32.normalize(value) !== value
+  ) {
+    throw new MxcOpenShellAttachmentError(`${label} must be a canonical absolute Windows path`);
+  }
+  return value;
+}
+
+function parseDistribution(value: unknown, label: string): ExactDistributionIdentity {
+  const input = record(value, label);
+  exactKeys(input, ["revision", "sha256", "version"], label);
+  return {
+    version: exactText(input.version, `${label} version`, VERSION_PATTERN),
+    revision: exactText(input.revision, `${label} revision`, REVISION_PATTERN),
+    sha256: sha256(input.sha256, `${label} digest`),
+  };
+}
+
+function parseComponents(value: unknown, label: string): ExactComponentIdentity {
+  const input = record(value, label);
+  exactKeys(input, ["cliSha256", "gatewaySha256", "wxcExecSha256"], label);
+  return {
+    cliSha256: sha256(input.cliSha256, `${label} CLI digest`),
+    gatewaySha256: sha256(input.gatewaySha256, `${label} gateway digest`),
+    wxcExecSha256: sha256(input.wxcExecSha256, `${label} wxc-exec digest`),
+  };
+}
+
+function parseGateway(value: unknown, label: string): ExactGatewayIdentity {
+  const input = record(value, label);
+  exactKeys(input, ["backend", "configSha256", "driver"], label);
+  if (input.driver !== "mxc") {
+    throw new MxcOpenShellAttachmentError(`${label} driver must be 'mxc'`);
+  }
+  if (input.backend !== "process_container") {
+    throw new MxcOpenShellAttachmentError(`${label} backend must be 'process_container'`);
+  }
+  return {
+    configSha256: sha256(input.configSha256, `${label} config digest`),
+    driver: "mxc",
+    backend: "process_container",
+  };
+}
+
+function parseExpectation(value: unknown, label: string): MxcOpenShellAttachmentExpectation {
+  const input = record(value, label);
+  exactKeys(input, ["components", "distribution", "gateway"], label);
+  return {
+    distribution: parseDistribution(input.distribution, `${label} distribution`),
+    components: parseComponents(input.components, `${label} components`),
+    gateway: parseGateway(input.gateway, `${label} gateway`),
+  };
+}
+
+function pathWithin(root: string, candidate: string): boolean {
+  const relative = path.win32.relative(root, candidate);
+  return (
+    relative.length > 0 &&
+    !path.win32.isAbsolute(relative) &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.win32.sep}`)
+  );
+}
+
+function parseObservation(value: unknown): MxcOpenShellAttachmentObservation {
+  const input = record(value, "observed attachment");
+  exactKeys(
+    input,
+    [
+      "cliPath",
+      "components",
+      "distribution",
+      "distributionRoot",
+      "gateway",
+      "gatewayConfigPath",
+      "gatewayPath",
+      "wxcExecPath",
+    ],
+    "observed attachment",
+  );
+  const identity = {
+    distribution: parseDistribution(input.distribution, "observed attachment distribution"),
+    components: parseComponents(input.components, "observed attachment components"),
+    gateway: parseGateway(input.gateway, "observed attachment gateway"),
+  };
+  const distributionRoot = canonicalWindowsPath(input.distributionRoot, "distribution root");
+  const cliPath = canonicalWindowsPath(input.cliPath, "OpenShell CLI path");
+  const gatewayPath = canonicalWindowsPath(input.gatewayPath, "OpenShell gateway path");
+  const wxcExecPath = canonicalWindowsPath(input.wxcExecPath, "wxc-exec path");
+  const gatewayConfigPath = canonicalWindowsPath(
+    input.gatewayConfigPath,
+    "OpenShell gateway config path",
+  );
+  for (const [label, candidate] of [
+    ["OpenShell CLI", cliPath],
+    ["OpenShell gateway", gatewayPath],
+    ["wxc-exec", wxcExecPath],
+  ] as const) {
+    if (!pathWithin(distributionRoot, candidate)) {
+      throw new MxcOpenShellAttachmentError(
+        `${label} path must remain inside the observed distribution root`,
+      );
+    }
+  }
+  return {
+    ...identity,
+    distributionRoot,
+    cliPath,
+    gatewayPath,
+    wxcExecPath,
+    gatewayConfigPath,
+  };
+}
+
+function sameIdentity(
+  expected: MxcOpenShellAttachmentExpectation,
+  observed: MxcOpenShellAttachmentExpectation,
+): boolean {
+  return (
+    JSON.stringify(expected.distribution) === JSON.stringify(observed.distribution) &&
+    JSON.stringify(expected.components) === JSON.stringify(observed.components) &&
+    JSON.stringify(expected.gateway) === JSON.stringify(observed.gateway)
+  );
+}
+
+function frozen<T>(value: T): T {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) frozen(child);
+  return Object.freeze(value);
+}
+
+/**
+ * Bind an accepted OpenShell distribution to one observed Windows installation.
+ *
+ * The trusted host adapter must collect the observation without executing the
+ * untrusted agent artifact. This function does not install, start, or replace a
+ * gateway and does not authorize MXC activation.
+ */
+export function qualifyMxcOpenShellAttachment(input: unknown): MxcOpenShellAttachmentReceipt {
+  const candidate = record(input, "attachment");
+  exactKeys(
+    candidate,
+    ["contractVersion", "expected", "mode", "observed", "providerId"],
+    "attachment",
+  );
+  if (candidate.contractVersion !== MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION) {
+    throw new MxcOpenShellAttachmentError("contract version is unsupported");
+  }
+  if (candidate.providerId !== PROVIDER_ID) {
+    throw new MxcOpenShellAttachmentError("provider identity does not match 'mxc'");
+  }
+  if (candidate.mode !== "attach-existing") {
+    throw new MxcOpenShellAttachmentError(
+      "only an existing OpenShell installation can be attached",
+    );
+  }
+  const expected = parseExpectation(candidate.expected, "expected attachment");
+  const observed = parseObservation(candidate.observed);
+  if (!sameIdentity(expected, observed)) {
+    throw new MxcOpenShellAttachmentError(
+      "observed distribution identity does not match the accepted identity",
+    );
+  }
+  const authority = {
+    contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
+    providerId: PROVIDER_ID,
+    mode: "attach-existing" as const,
+    distribution: { ...observed.distribution, root: observed.distributionRoot },
+    components: {
+      cli: { path: observed.cliPath, sha256: observed.components.cliSha256 },
+      gateway: { path: observed.gatewayPath, sha256: observed.components.gatewaySha256 },
+      wxcExec: { path: observed.wxcExecPath, sha256: observed.components.wxcExecSha256 },
+    },
+    gateway: {
+      ...observed.gateway,
+      configPath: observed.gatewayConfigPath,
+    },
+  } as const;
+  const authoritySha256 = createHash("sha256")
+    .update(JSON.stringify(authority), "utf8")
+    .digest("hex");
+  return frozen({ ...authority, authoritySha256 });
+}

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
@@ -5,6 +5,8 @@ import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import path from "node:path";
 
+import { cloneAndDeepFreeze } from "../../core/immutable";
+
 export const MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION = 1 as const;
 
 const PROVIDER_ID = "mxc";
@@ -247,12 +249,6 @@ function sameIdentity(
   );
 }
 
-function frozen<T>(value: T): T {
-  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return value;
-  for (const child of Object.values(value)) frozen(child);
-  return Object.freeze(value);
-}
-
 /**
  * Bind a provider-owned accepted identity to an opaque attachment authority.
  *
@@ -262,7 +258,7 @@ function frozen<T>(value: T): T {
 export function createMxcOpenShellAttachmentAuthority(
   expectation: unknown,
 ): MxcOpenShellAttachmentAuthority {
-  const accepted = frozen(parseExpectation(expectation, "accepted attachment"));
+  const accepted = cloneAndDeepFreeze(parseExpectation(expectation, "accepted attachment"));
   const acceptedIdentitySha256 = createHash("sha256")
     .update(
       JSON.stringify({
@@ -331,5 +327,5 @@ export function qualifyMxcOpenShellAttachment(
   const authoritySha256 = createHash("sha256")
     .update(JSON.stringify(receiptIdentity), "utf8")
     .digest("hex");
-  return frozen({ ...receiptIdentity, authoritySha256 });
+  return cloneAndDeepFreeze({ ...receiptIdentity, authoritySha256 });
 }

--- a/src/lib/onboard/runtime-provider/mxc.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc.test.ts
@@ -12,6 +12,7 @@ import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "./current";
 import { createDockerRuntimeProviderBundle } from "./docker";
 import { createMxcRuntimeProviderBundle } from "./mxc";
 import type { MxcNativeArtifactControlPlane } from "./mxc-bootstrap-operations";
+import type { MxcOpenShellAttachmentInput } from "./mxc-openshell-attachment";
 import {
   createRuntimeProviderBundleRegistry,
   RuntimeProviderRegistrationError,
@@ -34,6 +35,40 @@ function inactiveBootstrapControlPlane(): MxcNativeArtifactControlPlane {
   };
 }
 
+function openshellAttachment(): MxcOpenShellAttachmentInput {
+  const identity = {
+    distribution: {
+      version: "0.0.21",
+      revision: "a".repeat(40),
+      sha256: "1".repeat(64),
+    },
+    components: {
+      cliSha256: "2".repeat(64),
+      gatewaySha256: "3".repeat(64),
+      wxcExecSha256: "4".repeat(64),
+    },
+    gateway: {
+      configSha256: "5".repeat(64),
+      driver: "mxc" as const,
+      backend: "process_container" as const,
+    },
+  };
+  return {
+    contractVersion: 1,
+    providerId: "mxc",
+    mode: "attach-existing",
+    expected: identity,
+    observed: {
+      ...structuredClone(identity),
+      distributionRoot: "C:\\OpenShell",
+      cliPath: "C:\\OpenShell\\bin\\openshell.exe",
+      gatewayPath: "C:\\OpenShell\\bin\\openshell-gateway.exe",
+      wxcExecPath: "C:\\OpenShell\\mxc\\wxc-exec.exe",
+      gatewayConfigPath: "C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml",
+    },
+  };
+}
+
 function candidateBundle() {
   return createMxcRuntimeProviderBundle({
     hostFacts: {
@@ -41,6 +76,7 @@ function candidateBundle() {
       nativeArchitecture: "x64",
       release: "10.0.28000.1836",
     },
+    openshellAttachment: openshellAttachment(),
     bootstrapControlPlane: inactiveBootstrapControlPlane(),
   });
 }
@@ -95,8 +131,9 @@ describe("inactive OpenShell MXC runtime provider", () => {
       group: "Host",
       label: "OpenShell MXC process_container candidate",
       status: "info",
-      detail: "Windows x64 build 28000 meets the inactive host floor.",
-      hint: "MXC remains unavailable until the OpenShell package and live E2E gates pass.",
+      detail:
+        "Windows x64 build 28000 and OpenShell 0.0.21 match the inactive attachment contract.",
+      hint: "MXC remains unavailable until the OpenShell distribution and live E2E gates pass.",
     });
 
     const rejected = createMxcRuntimeProviderBundle({
@@ -105,11 +142,34 @@ describe("inactive OpenShell MXC runtime provider", () => {
         nativeArchitecture: "x64",
         release: "6.6.87.2-microsoft-standard-WSL2",
       },
+      openshellAttachment: openshellAttachment(),
       bootstrapControlPlane: inactiveBootstrapControlPlane(),
     });
     expect(rejected.preflightDoctor.inspectHost()).toMatchObject({
       status: "fail",
       detail: expect.stringMatching(/WSL is not a native Windows host/u),
+    });
+  });
+
+  it("rejects OpenShell distribution drift during host preflight (#8178)", () => {
+    const attachment = structuredClone(openshellAttachment());
+    const observed = attachment.observed as unknown as {
+      components: { gatewaySha256: string };
+    };
+    observed.components.gatewaySha256 = "6".repeat(64);
+    const rejected = createMxcRuntimeProviderBundle({
+      hostFacts: {
+        platform: "win32",
+        nativeArchitecture: "x64",
+        release: "10.0.28000.1836",
+      },
+      openshellAttachment: attachment,
+      bootstrapControlPlane: inactiveBootstrapControlPlane(),
+    });
+
+    expect(rejected.preflightDoctor.inspectHost()).toMatchObject({
+      status: "fail",
+      detail: expect.stringMatching(/observed distribution identity does not match/u),
     });
   });
 

--- a/src/lib/onboard/runtime-provider/mxc.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc.test.ts
@@ -1,18 +1,19 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
 import type { SandboxWorkloadReceipt } from "../../state/registry/types";
 import { cloneSandboxWorkloadReceipt } from "../../state/registry/workload";
 import { encodeManagedStartupProfile } from "../managed-startup/profile";
 import { nativeArtifactWorkloadReceiptFixture } from "../workload/native-artifact-test-fixture";
+import type { RuntimeProviderNativeArtifactBootstrapSurface } from "./contract";
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "./current";
 import { createDockerRuntimeProviderBundle } from "./docker";
 import { createMxcRuntimeProviderBundle } from "./mxc";
 import type { MxcNativeArtifactControlPlane } from "./mxc-bootstrap-operations";
-import type { MxcOpenShellAttachmentInput } from "./mxc-openshell-attachment";
+import { mxcOpenShellAttachmentFixture } from "./mxc-openshell-attachment-test-fixture";
 import {
   createRuntimeProviderBundleRegistry,
   RuntimeProviderRegistrationError,
@@ -35,48 +36,16 @@ function inactiveBootstrapControlPlane(): MxcNativeArtifactControlPlane {
   };
 }
 
-function openshellAttachment(): MxcOpenShellAttachmentInput {
-  const identity = {
-    distribution: {
-      version: "0.0.21",
-      revision: "a".repeat(40),
-      sha256: "1".repeat(64),
-    },
-    components: {
-      cliSha256: "2".repeat(64),
-      gatewaySha256: "3".repeat(64),
-      wxcExecSha256: "4".repeat(64),
-    },
-    gateway: {
-      configSha256: "5".repeat(64),
-      driver: "mxc" as const,
-      backend: "process_container" as const,
-    },
-  };
-  return {
-    contractVersion: 1,
-    providerId: "mxc",
-    mode: "attach-existing",
-    expected: identity,
-    observed: {
-      ...structuredClone(identity),
-      distributionRoot: "C:\\OpenShell",
-      cliPath: "C:\\OpenShell\\bin\\openshell.exe",
-      gatewayPath: "C:\\OpenShell\\bin\\openshell-gateway.exe",
-      wxcExecPath: "C:\\OpenShell\\mxc\\wxc-exec.exe",
-      gatewayConfigPath: "C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml",
-    },
-  };
-}
-
 function candidateBundle() {
+  const attachment = mxcOpenShellAttachmentFixture();
   return createMxcRuntimeProviderBundle({
     hostFacts: {
       platform: "win32",
       nativeArchitecture: "x64",
       release: "10.0.28000.1836",
     },
-    openshellAttachment: openshellAttachment(),
+    openshellAttachmentAuthority: attachment.authority,
+    openshellObservation: attachment.observation,
     bootstrapControlPlane: inactiveBootstrapControlPlane(),
   });
 }
@@ -133,16 +102,20 @@ describe("inactive OpenShell MXC runtime provider", () => {
       status: "info",
       detail:
         "Windows x64 build 28000 and OpenShell 0.0.21 match the inactive attachment contract.",
-      hint: "MXC remains unavailable until the OpenShell distribution and live E2E gates pass.",
+      hint:
+        "This check does not enable MXC. Maintainers must qualify the accepted OpenShell " +
+        "distribution and required live E2E coverage before adding production selection.",
     });
 
+    const attachment = mxcOpenShellAttachmentFixture();
     const rejected = createMxcRuntimeProviderBundle({
       hostFacts: {
         platform: "linux",
         nativeArchitecture: "x64",
         release: "6.6.87.2-microsoft-standard-WSL2",
       },
-      openshellAttachment: openshellAttachment(),
+      openshellAttachmentAuthority: attachment.authority,
+      openshellObservation: attachment.observation,
       bootstrapControlPlane: inactiveBootstrapControlPlane(),
     });
     expect(rejected.preflightDoctor.inspectHost()).toMatchObject({
@@ -152,8 +125,9 @@ describe("inactive OpenShell MXC runtime provider", () => {
   });
 
   it("rejects OpenShell distribution drift during host preflight (#8178)", () => {
-    const attachment = structuredClone(openshellAttachment());
-    const observed = attachment.observed as unknown as {
+    const attachment = mxcOpenShellAttachmentFixture();
+    const observation = structuredClone(attachment.observation);
+    const observed = observation as unknown as {
       components: { gatewaySha256: string };
     };
     observed.components.gatewaySha256 = "6".repeat(64);
@@ -163,7 +137,8 @@ describe("inactive OpenShell MXC runtime provider", () => {
         nativeArchitecture: "x64",
         release: "10.0.28000.1836",
       },
-      openshellAttachment: attachment,
+      openshellAttachmentAuthority: attachment.authority,
+      openshellObservation: observation,
       bootstrapControlPlane: inactiveBootstrapControlPlane(),
     });
 
@@ -171,6 +146,47 @@ describe("inactive OpenShell MXC runtime provider", () => {
       status: "fail",
       detail: expect.stringMatching(/observed distribution identity does not match/u),
     });
+  });
+
+  it("blocks attachment drift before every bootstrap control-plane operation (#8178)", async () => {
+    const attachment = mxcOpenShellAttachmentFixture();
+    const observation = structuredClone(attachment.observation);
+    const observed = observation as unknown as {
+      components: { gatewaySha256: string };
+    };
+    observed.components.gatewaySha256 = "6".repeat(64);
+    const verifyAndCreate = vi.fn(async () => ({ status: "unknown" as const }));
+    const verifyReadiness = vi.fn(async () => {
+      throw new Error("attachment drift must block readiness");
+    });
+    const recoverCreate = vi.fn(async () => ({ status: "absent" as const }));
+    const provider = createMxcRuntimeProviderBundle({
+      hostFacts: {
+        platform: "win32",
+        nativeArchitecture: "x64",
+        release: "10.0.28000.1836",
+      },
+      openshellAttachmentAuthority: attachment.authority,
+      openshellObservation: observation,
+      bootstrapControlPlane: {
+        contractVersion: 1,
+        providerId: "mxc",
+        verifyAndCreate,
+        verifyReadiness,
+        recoverCreate,
+      },
+    });
+    const bootstrap = provider.bootstrap as RuntimeProviderNativeArtifactBootstrapSurface;
+
+    await expect(bootstrap.run({} as never)).rejects.toThrow(
+      /observed distribution identity does not match/u,
+    );
+    await expect(bootstrap.recover({} as never)).rejects.toThrow(
+      /observed distribution identity does not match/u,
+    );
+    expect(verifyAndCreate).not.toHaveBeenCalled();
+    expect(verifyReadiness).not.toHaveBeenCalled();
+    expect(recoverCreate).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/lib/onboard/runtime-provider/mxc.ts
+++ b/src/lib/onboard/runtime-provider/mxc.ts
@@ -24,9 +24,14 @@ import {
   createMxcNativeArtifactBootstrapOperations,
   type MxcNativeArtifactControlPlane,
 } from "./mxc-bootstrap-operations";
+import {
+  qualifyMxcOpenShellAttachment,
+  type MxcOpenShellAttachmentInput,
+} from "./mxc-openshell-attachment";
 
 export interface MxcRuntimeProviderOptions {
   readonly hostFacts: WindowsMxcHostFacts;
+  readonly openshellAttachment: MxcOpenShellAttachmentInput;
   readonly bootstrapControlPlane: MxcNativeArtifactControlPlane;
 }
 
@@ -50,23 +55,38 @@ function unsupported(reason: string) {
   return { providerId: MXC_PROVIDER_ID, supported: false as const, reason };
 }
 
-function inspectMxcHost(hostFacts: WindowsMxcHostFacts): RuntimeProviderDoctorCheck {
+function inspectMxcHost(
+  hostFacts: WindowsMxcHostFacts,
+  openshellAttachment: MxcOpenShellAttachmentInput,
+): RuntimeProviderDoctorCheck {
   const assessment = assessWindowsMxcProcessContainerCandidate(hostFacts);
-  if (assessment.candidate) {
+  if (!assessment.candidate) {
+    return {
+      group: "Host",
+      label: "OpenShell MXC process_container candidate",
+      status: "fail",
+      detail: assessment.detail,
+    };
+  }
+  try {
+    const attachment = qualifyMxcOpenShellAttachment(openshellAttachment);
     return {
       group: "Host",
       label: "OpenShell MXC process_container candidate",
       status: "info",
-      detail: `Windows x64 build ${assessment.windowsBuild} meets the inactive host floor.`,
-      hint: "MXC remains unavailable until the OpenShell package and live E2E gates pass.",
+      detail:
+        `Windows x64 build ${assessment.windowsBuild} and OpenShell ${attachment.distribution.version} ` +
+        "match the inactive attachment contract.",
+      hint: "MXC remains unavailable until the OpenShell distribution and live E2E gates pass.",
+    };
+  } catch (error) {
+    return {
+      group: "Host",
+      label: "OpenShell MXC process_container candidate",
+      status: "fail",
+      detail: error instanceof Error ? error.message : "OpenShell attachment validation failed.",
     };
   }
-  return {
-    group: "Host",
-    label: "OpenShell MXC process_container candidate",
-    status: "fail",
-    detail: assessment.detail,
-  };
 }
 
 function acceptsNativeArtifactReceipt(receipt: SandboxWorkloadReceipt | undefined): boolean {
@@ -87,6 +107,7 @@ function acceptsNativeArtifactReceipt(receipt: SandboxWorkloadReceipt | undefine
  */
 export function createMxcRuntimeProviderBundle({
   hostFacts,
+  openshellAttachment,
   bootstrapControlPlane,
 }: MxcRuntimeProviderOptions): RuntimeProviderBundle {
   const lifecycleReason =
@@ -119,7 +140,7 @@ export function createMxcRuntimeProviderBundle({
     preflightDoctor: {
       providerId: MXC_PROVIDER_ID,
       supported: true,
-      inspectHost: () => inspectMxcHost(hostFacts),
+      inspectHost: () => inspectMxcHost(hostFacts, openshellAttachment),
       preflightLifecycle: () => ({ exitCode: 1, message: lifecycleReason }),
     },
     gateway: {

--- a/src/lib/onboard/runtime-provider/mxc.ts
+++ b/src/lib/onboard/runtime-provider/mxc.ts
@@ -26,12 +26,14 @@ import {
 } from "./mxc-bootstrap-operations";
 import {
   qualifyMxcOpenShellAttachment,
-  type MxcOpenShellAttachmentInput,
+  type MxcOpenShellAttachmentAuthority,
+  type MxcOpenShellAttachmentObservation,
 } from "./mxc-openshell-attachment";
 
 export interface MxcRuntimeProviderOptions {
   readonly hostFacts: WindowsMxcHostFacts;
-  readonly openshellAttachment: MxcOpenShellAttachmentInput;
+  readonly openshellAttachmentAuthority: MxcOpenShellAttachmentAuthority;
+  readonly openshellObservation: MxcOpenShellAttachmentObservation;
   readonly bootstrapControlPlane: MxcNativeArtifactControlPlane;
 }
 
@@ -57,7 +59,7 @@ function unsupported(reason: string) {
 
 function inspectMxcHost(
   hostFacts: WindowsMxcHostFacts,
-  openshellAttachment: MxcOpenShellAttachmentInput,
+  qualifyAttachment: () => ReturnType<typeof qualifyMxcOpenShellAttachment>,
 ): RuntimeProviderDoctorCheck {
   const assessment = assessWindowsMxcProcessContainerCandidate(hostFacts);
   if (!assessment.candidate) {
@@ -69,7 +71,7 @@ function inspectMxcHost(
     };
   }
   try {
-    const attachment = qualifyMxcOpenShellAttachment(openshellAttachment);
+    const attachment = qualifyAttachment();
     return {
       group: "Host",
       label: "OpenShell MXC process_container candidate",
@@ -77,7 +79,9 @@ function inspectMxcHost(
       detail:
         `Windows x64 build ${assessment.windowsBuild} and OpenShell ${attachment.distribution.version} ` +
         "match the inactive attachment contract.",
-      hint: "MXC remains unavailable until the OpenShell distribution and live E2E gates pass.",
+      hint:
+        "This check does not enable MXC. Maintainers must qualify the accepted OpenShell " +
+        "distribution and required live E2E coverage before adding production selection.",
     };
   } catch (error) {
     return {
@@ -107,13 +111,19 @@ function acceptsNativeArtifactReceipt(receipt: SandboxWorkloadReceipt | undefine
  */
 export function createMxcRuntimeProviderBundle({
   hostFacts,
-  openshellAttachment,
+  openshellAttachmentAuthority,
+  openshellObservation,
   bootstrapControlPlane,
 }: MxcRuntimeProviderOptions): RuntimeProviderBundle {
   const lifecycleReason =
     "OpenShell MXC direct start and stop of an existing sandbox are not qualified.";
   const cleanupReason =
     "OpenShell MXC does not expose an immutable resource handle for exact destructive cleanup.";
+  const qualifyAttachment = () =>
+    qualifyMxcOpenShellAttachment(openshellAttachmentAuthority, openshellObservation);
+  const bootstrap = createMxcNativeArtifactBootstrapSurface(
+    createMxcNativeArtifactBootstrapOperations(bootstrapControlPlane),
+  );
   return {
     identity: {
       contractVersion: RUNTIME_PROVIDER_BUNDLE_CONTRACT_VERSION,
@@ -140,7 +150,7 @@ export function createMxcRuntimeProviderBundle({
     preflightDoctor: {
       providerId: MXC_PROVIDER_ID,
       supported: true,
-      inspectHost: () => inspectMxcHost(hostFacts, openshellAttachment),
+      inspectHost: () => inspectMxcHost(hostFacts, qualifyAttachment),
       preflightLifecycle: () => ({ exitCode: 1, message: lifecycleReason }),
     },
     gateway: {
@@ -165,9 +175,17 @@ export function createMxcRuntimeProviderBundle({
     stateMutation: unsupported(
       "The MXC runtime provider state mutation surface remains disabled until lifecycle and cleanup pass live E2E.",
     ),
-    bootstrap: createMxcNativeArtifactBootstrapSurface(
-      createMxcNativeArtifactBootstrapOperations(bootstrapControlPlane),
-    ),
+    bootstrap: {
+      ...bootstrap,
+      run: async (input) => {
+        qualifyAttachment();
+        return bootstrap.run(input);
+      },
+      recover: async (input) => {
+        qualifyAttachment();
+        return bootstrap.recover(input);
+      },
+    },
     snapshot: unsupported("OpenShell MXC snapshot and restore are unavailable."),
     recovery: unsupported(
       "OpenShell MXC gateway-restart reconciliation and orphan recovery are unavailable.",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The inactive MXC provider previously checked only Windows host eligibility before reporting a candidate. This change adds a fail-closed, versioned attachment contract that binds one accepted OpenShell/MXC distribution, gateway configuration, and executable identity to one observed Windows installation without installing, starting, selecting, or activating MXC.

## Related Issue

Advances #8178.

## Changes

- Add an `attach-existing` contract for the inactive MXC provider. NemoClaw onboarding needs to qualify a preinstalled Windows OpenShell distribution before later bootstrap and lifecycle work; a direct installer path is not accepted yet. The attachment tests cover exact distribution and component identity, canonical installation paths, backend selection, unknown fields, and credential-bearing input rejection.
- Return a frozen attachment receipt with an authority digest so later runtime operations can bind to the qualified installation.
- Require the attachment during MXC host preflight and fail when the observed OpenShell distribution drifts from the accepted identity.
- Keep MXC absent from production provider selection and add no installation, gateway launch, sandbox mutation, or activation path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification: Not applicable; this change adds new attachment and preflight behavior.
- [ ] Tests not applicable — justification: Not applicable.
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: Epic #8178 accepts an inactive MXC provider foundation. The contract remains fail-closed on identity, path, backend, schema, and credential drift and does not create mutation or activation authority.
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue: None accepted.

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit: Not applicable
- Station profile/scenario: Not applicable
- Result: Not applicable
- Supporting evidence: `scripts/prepare-dgx-station-host.sh` is unchanged.

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — `npx vitest run --project cli` passed 145 focused tests; layer-import-boundary integration passed 22 tests; Windows MXC E2E support passed 55 tests; `npm run typecheck:cli -- --pretty false` passed.
- [ ] Applicable broad gate passed — `npm test` for broad runtime/test-harness changes; `npm run check` for repo-wide validation/coverage changes — command/result: Not applicable; this inactive provider attachment is covered by focused contract, preflight, architecture, and E2E-support checks.
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive OpenShell attachment verification during MXC runtime-provider setup.
  * Validation now checks identity, version, installation paths, gateway settings, supported configuration, and distribution containment.
  * Successful verification provides version details and an integrity-protected receipt.

* **Bug Fixes**
  * MXC preflight and bootstrap operations now reject invalid, mismatched, unsupported, or unsafe OpenShell installations.
  * Distribution identity changes are detected before control-plane operations begin.

* **Tests**
  * Expanded coverage for valid attachments, identity drift, invalid paths, unsupported configurations, credential exposure, metadata mismatches, and version formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->