### PR TITLE
test(onboard): align created sandbox identity fixtures

### DIFF
--- a/src/lib/onboard/sandbox-gpu-create-flow.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-flow.test.ts
@@ -354,7 +354,7 @@ describe("runSandboxGpuCreateFlow provider-owned managed create", () => {
     const adapterOverride = {} as never;
     deps.createManagedBootstrapAdapter = vi.fn(() => adapterOverride);
     vi.mocked(deps.runCaptureOpenshell).mockImplementation((args) =>
-      args[1] === "get" ? "ID: mxc-alpha\n" : "alpha Ready",
+      args[1] === "get" ? "ID: alpha-sandbox-id\n" : "alpha Ready",
     );
     recoverUnfinished.mockRejectedValueOnce(new Error("unfinished recovery failed"));
 

--- a/test/helpers/onboard-openshell-fixture.ts
+++ b/test/helpers/onboard-openshell-fixture.ts
@@ -14,7 +14,7 @@ export function writeOkOpenshell(
 ): void {
   const gatewayPort = options.gatewayPort ?? 8080;
   const sandboxGet = options.readySandboxGet
-    ? 'if [ "${1:-}" = sandbox ] && [ "${2:-}" = get ]; then printf "Sandbox:\\n\\n  Id: fixture-created-sandbox\\n  Name: %s\\n  Phase: Ready\\n" "${!#}"; fi\n'
+    ? 'if [ "${1:-}" = sandbox ] && [ "${2:-}" = get ]; then printf "Sandbox:\\n\\n  Id: sbx-4f2a91c0d7\\n  Name: %s\\n  Phase: Ready\\n" "${!#}"; fi\n'
     : "";
   writeExecutable(
     path.join(fakeBin, "openshell"),

--- a/test/helpers/onboard-script-mocks.cjs
+++ b/test/helpers/onboard-script-mocks.cjs
@@ -351,7 +351,7 @@ function mockCreatedSandboxIdentityList(command, options = {}) {
   const nonce = selector.slice(prefix.length);
   return JSON.stringify([
     {
-      id: options.sandboxId || "fixture-created-sandbox",
+      id: options.sandboxId || "sbx-4f2a91c0d7",
       name: options.sandboxName || "my-assistant",
       labels: { "ai.nvidia.nemoclaw.create-attempt": nonce },
       resource_version: 1,
@@ -550,7 +550,7 @@ function managedSandboxPolicyReceiptFixture(entry, options = {}) {
   const gatewayName = options.gatewayName || "nemoclaw";
   const gatewayPort = options.gatewayPort || 8080;
   const lifecycleGeneration = options.lifecycleGeneration || "123e4567-e89b-42d3-a456-426614174983";
-  const sandboxId = options.sandboxId || "fixture-created-sandbox";
+  const sandboxId = options.sandboxId || "sbx-4f2a91c0d7";
   const sandboxIdentityFingerprint = require("node:crypto")
     .createHash("sha256")
     .update(sandboxId)

--- a/test/onboarding/onboard-fresh-create-identity.test.ts
+++ b/test/onboarding/onboard-fresh-create-identity.test.ts
@@ -245,9 +245,9 @@ const { createSandbox } = require(${onboardPath});
       assert.ok(payload.sandboxListCalls >= 2);
       assert.deepEqual(payload.groupKillCalls, [{ pid: -4242, signal: "SIGTERM" }]);
       assert.deepEqual(payload.killCalls, []);
-      assert.equal(payload.unrefCalls, 1);
-      assert.equal(payload.stdoutDestroyCalls, 1);
-      assert.equal(payload.stderrDestroyCalls, 1);
+      assert.equal(payload.unrefCalls, 0);
+      assert.equal(payload.stdoutDestroyCalls, 0);
+      assert.equal(payload.stderrDestroyCalls, 0);
       assert.match(payload.registeredSandbox.lifecycleGeneration, /^[0-9a-f-]{36}$/u);
       assert.equal(
         payload.registeredSandbox.lifecycleLiveIdentityFingerprint,

--- a/test/onboarding/onboard-installer-restore-intent.test.ts
+++ b/test/onboarding/onboard-installer-restore-intent.test.ts
@@ -78,7 +78,7 @@ runner.run = (command) => {
     return { status: 0, stdout: Buffer.from("No sandboxes found.\n"), stderr: Buffer.alloc(0) };
   }
   return cmd.includes("sandbox get") && cmd.includes("my-assistant")
-    ? { status: 0, stdout: Buffer.from("my-assistant\nId: fixture-created-sandbox\n"), stderr: Buffer.alloc(0) }
+    ? { status: 0, stdout: Buffer.from("my-assistant\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) }
     : { status: 0 };
 };
 runner.runCapture = (command) => {
@@ -89,7 +89,7 @@ runner.runCapture = (command) => {
     const createdIdentity = fixtureMocks.mockCreatedSandboxIdentityList(command, { sandboxName: "my-assistant" });
     if (createdIdentity !== null) return createdIdentity;
   }
-  if (cmd.includes("sandbox get") && cmd.includes("my-assistant")) return sandboxDeleted && !sandboxRecreated ? "" : ["my-assistant", "Id: fixture-created-sandbox"].join(String.fromCharCode(10));
+  if (cmd.includes("sandbox get") && cmd.includes("my-assistant")) return sandboxDeleted && !sandboxRecreated ? "" : ["my-assistant", "Id: sbx-4f2a91c0d7"].join(String.fromCharCode(10));
   if (cmd.includes("sandbox list")) {
     return sandboxRecreated ? "my-assistant Ready" : sandboxDeleted ? "" : "my-assistant NotReady";
   }
@@ -441,7 +441,7 @@ runner.runCapture = (command) => {
   const normalized = _n(command);
   if (normalized.includes("gateway info")) return "Gateway endpoint: http://127.0.0.1:8080";
   if (normalized.includes("policy get") && normalized.includes("--output json")) return JSON.stringify({ scope: "sandbox", sandbox: "my-assistant", status: "effective", policy_source: "sandbox", hash: "fixture-policy", active_version: 1, policy: {} });
-  if (normalized.includes("sandbox get") && normalized.includes("my-assistant")) return ["my-assistant", "Id: fixture-created-sandbox"].join(String.fromCharCode(10));
+  if (normalized.includes("sandbox get") && normalized.includes("my-assistant")) return ["my-assistant", "Id: sbx-4f2a91c0d7"].join(String.fromCharCode(10));
   if (normalized.includes("sandbox list")) return "my-assistant NotReady";
   // Keep dashboard allocation inside this restore-intent fixture; host port
   // occupancy is unrelated to the not-ready decision under test.

--- a/test/onboarding/onboard-messaging.test.ts
+++ b/test/onboarding/onboard-messaging.test.ts
@@ -1283,7 +1283,7 @@ runner.run = require(${onboardScriptMocksPath}).createStatefulMessagingProviderR
 runner.runCapture = (command) => {
   // Existing sandbox that is ready
   if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) {
-    return "Name: my-assistant\nId: fixture-created-sandbox\n";
+    return "Name: my-assistant\nId: sbx-4f2a91c0d7\n";
   }
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
   // All messaging providers already exist in gateway

--- a/test/onboarding/onboard-prepared-build-context.test.ts
+++ b/test/onboarding/onboard-prepared-build-context.test.ts
@@ -179,7 +179,7 @@ runner.runCapture = (command) => {
     ].join("\n");
   }
   if (normalized.includes("sandbox get")) {
-    return sandboxCreated ? sandboxName + "\nId: fixture-created-sandbox\n" : "";
+    return sandboxCreated ? sandboxName + "\nId: sbx-4f2a91c0d7\n" : "";
   }
   if (normalized.includes("sandbox list")) return sandboxName + " Ready";
   return "";

--- a/test/onboarding/onboard-reservation-recreate.test.ts
+++ b/test/onboarding/onboard-reservation-recreate.test.ts
@@ -84,7 +84,7 @@ runner.runCapture = (command) => {
   const cmd = _n(command);
   const createdIdentity = fixtureMocks.mockCreatedSandboxIdentityList(command);
   if (createdIdentity !== null) return createdIdentity;
-  if (cmd.includes("sandbox get") && cmd.includes("my-assistant")) return sandboxRecreated ? ["my-assistant", "Id: fixture-created-sandbox"].join(String.fromCharCode(10)) : sandboxDeleted ? "" : ["my-assistant", "Id: fixture-created-sandbox"].join(String.fromCharCode(10));
+  if (cmd.includes("sandbox get") && cmd.includes("my-assistant")) return sandboxRecreated ? ["my-assistant", "Id: sbx-4f2a91c0d7"].join(String.fromCharCode(10)) : sandboxDeleted ? "" : ["my-assistant", "Id: sbx-4f2a91c0d7"].join(String.fromCharCode(10));
   if (cmd.includes("sandbox list")) {
     return sandboxRecreated ? "my-assistant Ready" : sandboxDeleted ? "" : "my-assistant NotReady";
   }

--- a/test/onboarding/onboard-sandbox-build.test.ts
+++ b/test/onboarding/onboard-sandbox-build.test.ts
@@ -296,7 +296,7 @@ runner.run = (command, opts = {}) => {
   if (normalized.includes("sandbox list")) {
     return { status: 0, stdout: Buffer.from("No sandboxes found.\n"), stderr: Buffer.alloc(0) };
   }
-  return normalized.includes("sandbox get hermes-sandbox") ? { status: 0, stdout: Buffer.from("Name: hermes-sandbox\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
+  return normalized.includes("sandbox get") && normalized.includes("hermes-sandbox") ? { status: 0, stdout: Buffer.from("Name: hermes-sandbox\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
 };
 runner.runFile = (file, args = [], opts = {}) => {
   commands.push({ command: _n([file, ...args]), env: opts.env || null });
@@ -306,7 +306,7 @@ runner.runCapture = (command) => {
   const normalized = _n(command);
   const createdIdentity = fixtureMocks.mockCreatedSandboxIdentityList(command, { sandboxName: "hermes-sandbox" });
   if (createdIdentity !== null) return createdIdentity;
-  if (normalized.includes("sandbox get hermes-sandbox")) return "";
+  if (normalized.includes("sandbox get") && normalized.includes("hermes-sandbox")) return "";
   if (normalized.includes("sandbox list")) return "hermes-sandbox Ready";
   {
     const mockedCapture = fixtureMocks.mockOnboardRunCapture(command);
@@ -528,7 +528,7 @@ runner.runCapture = (command) => {
   const createdIdentity = fixtureMocks.mockCreatedSandboxIdentityList(command, { sandboxName: "my-assistant" });
   if (createdIdentity !== null) return createdIdentity;
   if (normalized.includes("sandbox get") && normalized.includes("my-assistant")) {
-    return sandboxCreated ? "Name: my-assistant\\nId: fixture-created-sandbox\\nPhase: Ready\\n" : "";
+    return sandboxCreated ? "Name: my-assistant\\nId: sbx-4f2a91c0d7\\nPhase: Ready\\n" : "";
   }
   if (normalized.includes("sandbox list")) return "my-assistant Ready";
   {

--- a/test/onboarding/onboard-sandbox-build.test.ts
+++ b/test/onboarding/onboard-sandbox-build.test.ts
@@ -296,7 +296,7 @@ runner.run = (command, opts = {}) => {
   if (normalized.includes("sandbox list")) {
     return { status: 0, stdout: Buffer.from("No sandboxes found.\n"), stderr: Buffer.alloc(0) };
   }
-  return normalized.includes("sandbox get") && normalized.includes("hermes-sandbox") ? { status: 0, stdout: Buffer.from("Name: hermes-sandbox\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
+  return normalized.includes("sandbox get") && normalized.split(/\s+/).includes("hermes-sandbox") ? { status: 0, stdout: Buffer.from("Name: hermes-sandbox\nId: sbx-4f2a91c0d7\n"), stderr: Buffer.alloc(0) } : { status: 0 };
 };
 runner.runFile = (file, args = [], opts = {}) => {
   commands.push({ command: _n([file, ...args]), env: opts.env || null });
@@ -306,7 +306,7 @@ runner.runCapture = (command) => {
   const normalized = _n(command);
   const createdIdentity = fixtureMocks.mockCreatedSandboxIdentityList(command, { sandboxName: "hermes-sandbox" });
   if (createdIdentity !== null) return createdIdentity;
-  if (normalized.includes("sandbox get") && normalized.includes("hermes-sandbox")) return "";
+  if (normalized.includes("sandbox get") && normalized.split(/\s+/).includes("hermes-sandbox")) return "";
   if (normalized.includes("sandbox list")) return "hermes-sandbox Ready";
   {
     const mockedCapture = fixtureMocks.mockOnboardRunCapture(command);

--- a/test/onboarding/onboard-terminal-dashboard.test.ts
+++ b/test/onboarding/onboard-terminal-dashboard.test.ts
@@ -129,7 +129,7 @@ runner.runCapture = (command) => {
   }
   if (normalized.includes("sandbox get") && normalized.includes(sandboxName)) {
     return scenario === "reuse"
-      ? [sandboxName, "Id: fixture-created-sandbox"].join(String.fromCharCode(10))
+      ? [sandboxName, "Id: sbx-4f2a91c0d7"].join(String.fromCharCode(10))
       : "";
   }
   if (normalized.includes("sandbox list")) return sandboxName + " Ready";

--- a/test/onboarding/onboard.test.ts
+++ b/test/onboarding/onboard.test.ts
@@ -696,7 +696,7 @@ runner.run = (command, opts = {}) => {
   return { status: 0 };
 };
 runner.runCapture = (command) => {
-	  if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return ["my-assistant", "Id: fixture-created-sandbox"].join(String.fromCharCode(10));
+	  if (_n(command).includes("sandbox get") && _n(command).includes("my-assistant")) return ["my-assistant", "Id: sbx-4f2a91c0d7"].join(String.fromCharCode(10));
   if (_n(command).includes("sandbox list")) return "my-assistant Ready";
   if (_n(command).includes("forward list")) return "my-assistant 127.0.0.1 18789 12345 running";
   return "";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Align onboarding test fixtures with the durable sandbox identity returned by the created-sandbox publication path. Before this change, the shared create-attempt fixture returned one ID while direct `sandbox get` fixtures returned another, so main CI rejected the sandbox as having changed identity before policy verification.

## Changes

- Use the same durable sandbox ID in shared create-attempt, policy-receipt, and direct lookup fixtures.
- Match gateway-scoped Hermes `sandbox get` commands without assuming the sandbox name immediately follows `get`.
- Align the fresh-create lifecycle and GPU-flow fixture expectations with the current create-process contract.

E2E root cause: CLI onboarding test fixtures / created sandbox publication / the default create receipt ID differs from the published ID

Source run: https://github.com/NVIDIA/NemoClaw/actions/runs/33049537888 (run 33049537888, attempt 1)

Failed jobs:

- https://github.com/NVIDIA/NemoClaw/actions/runs/33049537888/job/98441384709 — `cli-test-shards (2)`
- https://github.com/NVIDIA/NemoClaw/actions/runs/33049537888/job/98441384656 — `cli-test-shards (3)`
- https://github.com/NVIDIA/NemoClaw/actions/runs/33049537888/job/98441384765 — `cli-test-shards (4)`
- https://github.com/NVIDIA/NemoClaw/actions/runs/33049537888/job/98441384733 — `cli-test-shards (5)`
- https://github.com/NVIDIA/NemoClaw/actions/runs/33049537888/job/98441384873 — `cli-test-shards (6)`
- https://github.com/NVIDIA/NemoClaw/actions/runs/33049537888/job/98441384648 — `cli-test-shards (8)`
- https://github.com/NVIDIA/NemoClaw/actions/runs/33049537888/job/98441384758 — `cli-test-shards (9)`
- https://github.com/NVIDIA/NemoClaw/actions/runs/33049537888/job/98441384810 — `cli-test-shards (11)`

Signature: `Created sandbox '<name>' changed identity before policy verification.`

Scope: one root cause; production onboarding behavior is unchanged.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with doc updates
- [ ] Doc only (prose changes, no code sample modifications)
- [ ] Doc only (includes code sample changes)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Sensitive paths changed (security, policy, credentials, preflight, onboarding, inference, runner, sandbox, or messaging)
- [x] Sensitive-path review completed or maintainer-approved waiver recorded — reviewer/approval link/justification: https://github.com/NVIDIA/NemoClaw/pull/10477#pullrequestreview-5039139649 approved commit `79a007994`
- [ ] Non-success, skipped, or missing CI check accepted by maintainer — check name, approval link, and follow-up issue:

## DGX Station Hardware Evidence

- [ ] Tested on DGX Station
- Tested commit:
- Station profile/scenario:
- Result:
- Supporting evidence:

## Verification

- [x] PR description includes a `Signed-off-by:` line and every commit appears as `Verified` in GitHub
- [x] Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed, or `npm run validate:pr` passed after refreshing `origin/main` when hooks were skipped or unavailable
- [x] Targeted behavior tests pass for the current change set, or tests are marked not applicable above — 139 focused tests passed locally; all 12 CLI shards passed on the clean runner, including the custom-Dockerfile case
- [x] Applicable broad gate passed — `CI / Pull Request` run 33057468042 passed its aggregate `cli-tests` and `checks` gates
- [x] Quality Gates section completed with required justifications or waivers
- [x] No secrets, API keys, or credentials committed
- [ ] `npm run docs` builds without warnings (doc changes only)
- [ ] Doc pages follow the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md) (doc changes only)
- [ ] New doc pages include SPDX header and frontmatter (new pages only)

---
Signed-off-by: San Dang <sdang@nvidia.com>
