### PR TITLE
Fix workspace file list in transfer-state-manually docs (#10482)

### DIFF
--- a/docs/manage-sandboxes/transfer-state-manually.mdx
+++ b/docs/manage-sandboxes/transfer-state-manually.mdx
@@ -186,6 +186,8 @@ Restore the most recent backup or a specific timestamp:
 ./scripts/backup-workspace.sh restore my-assistant 20260320-120000
 ```
 
+The helper saves `POLICY.md` during a backup but never uploads it during a restore, for the same reason as the manual flow above.
+
 Verify the saved files:
 
 ```bash

--- a/docs/manage-sandboxes/transfer-state-manually.mdx
+++ b/docs/manage-sandboxes/transfer-state-manually.mdx
@@ -108,11 +108,14 @@ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/IDENTITY.md" /sandbox/.openclaw
 openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/AGENTS.md" /sandbox/.openclaw/workspace/
 openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/TOOLS.md" /sandbox/.openclaw/workspace/
 openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/HEARTBEAT.md" /sandbox/.openclaw/workspace/
-openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/POLICY.md" /sandbox/.openclaw/workspace/
 # If long-term or daily memory was backed up:
 # openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/MEMORY.md" /sandbox/.openclaw/workspace/
 # openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/memory/" /sandbox/.openclaw/workspace/memory/
 ```
+
+Do not upload a downloaded `POLICY.md` back into a sandbox.
+NemoClaw regenerates that file from the managed policy whenever a preset is added or removed and at the end of onboarding, so restoring a stale copy can reintroduce drift.
+Run `$$nemoclaw my-assistant policy explain --write` to refresh it in place instead.
 
 </AgentOnly>
 <AgentOnly variant="hermes">
@@ -171,6 +174,8 @@ Expected output:
 
 ```text
 Backing up workspace from sandbox 'my-assistant'...
+Skipped MEMORY.md (not found or download failed)
+Skipped memory/ (not found or download failed)
 Backup saved to /home/user/.nemoclaw/backups/20260320-120000/ (7 items)
 ```
 

--- a/docs/manage-sandboxes/transfer-state-manually.mdx
+++ b/docs/manage-sandboxes/transfer-state-manually.mdx
@@ -29,8 +29,12 @@ openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/SOUL.md "$BAC
 openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/USER.md "$BACKUP_DIR/"
 openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/IDENTITY.md "$BACKUP_DIR/"
 openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/AGENTS.md "$BACKUP_DIR/"
-openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/MEMORY.md "$BACKUP_DIR/"
-openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/memory/ "$BACKUP_DIR/memory/"
+openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/TOOLS.md "$BACKUP_DIR/"
+openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/HEARTBEAT.md "$BACKUP_DIR/"
+openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/POLICY.md "$BACKUP_DIR/"
+# If long-term or daily memory has been used:
+# openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/MEMORY.md "$BACKUP_DIR/"
+# openshell sandbox download "$SANDBOX" /sandbox/.openclaw/workspace/memory/ "$BACKUP_DIR/memory/"
 ```
 
 </AgentOnly>
@@ -102,8 +106,12 @@ openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/SOUL.md" /sandbox/.openclaw/wor
 openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/USER.md" /sandbox/.openclaw/workspace/
 openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/IDENTITY.md" /sandbox/.openclaw/workspace/
 openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/AGENTS.md" /sandbox/.openclaw/workspace/
-openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/MEMORY.md" /sandbox/.openclaw/workspace/
-openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/memory/" /sandbox/.openclaw/workspace/memory/
+openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/TOOLS.md" /sandbox/.openclaw/workspace/
+openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/HEARTBEAT.md" /sandbox/.openclaw/workspace/
+openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/POLICY.md" /sandbox/.openclaw/workspace/
+# If long-term or daily memory was backed up:
+# openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/MEMORY.md" /sandbox/.openclaw/workspace/
+# openshell sandbox upload "$SANDBOX" "$BACKUP_DIR/memory/" /sandbox/.openclaw/workspace/memory/
 ```
 
 </AgentOnly>
@@ -163,7 +171,7 @@ Expected output:
 
 ```text
 Backing up workspace from sandbox 'my-assistant'...
-Backup saved to /home/user/.nemoclaw/backups/20260320-120000/ (6 items)
+Backup saved to /home/user/.nemoclaw/backups/20260320-120000/ (7 items)
 ```
 
 Restore the most recent backup or a specific timestamp:
@@ -183,11 +191,12 @@ Expected output:
 
 ```text
 AGENTS.md
+HEARTBEAT.md
 IDENTITY.md
-MEMORY.md
+POLICY.md
 SOUL.md
+TOOLS.md
 USER.md
-memory/
 ```
 
 </AgentOnly>

--- a/docs/manage-sandboxes/workspace-files.mdx
+++ b/docs/manage-sandboxes/workspace-files.mdx
@@ -112,7 +112,12 @@ Set `NEMOCLAW_MINIMAL_BOOTSTRAP=1` before onboarding to skip default workspace t
 | `AGENTS.md` | Behavioral rules, memory conventions, safety guidelines, and session workflow. |
 | `TOOLS.md` | Records workspace-specific tool guidance and operational notes. |
 | `HEARTBEAT.md` | Defines recurring heartbeat checks when heartbeat processing is enabled. |
-| `POLICY.md` | Redacted summary of the sandbox's active policy context. NemoClaw renders this file, not OpenClaw: it refreshes automatically when a preset is added or removed and once at the end of onboarding, and can be refreshed on demand with `$$nemoclaw <name> policy explain --write`. |
+
+Three more entries can appear in the same directory without being seeded templates.
+
+| File | Purpose |
+|---|---|
+| `POLICY.md` | Redacted summary of the sandbox's active policy context. NemoClaw renders this file separately from the seeded templates: it refreshes automatically when a preset is added or removed and once at the end of onboarding, and can be refreshed on demand with `$$nemoclaw <name> policy explain --write`. |
 | `MEMORY.md` | Curated long-term memory distilled from daily notes. OpenClaw creates this file when it first stores long-term memory. |
 | `memory/` | Directory of daily note files (`YYYY-MM-DD.md`) for session continuity. OpenClaw creates this directory when it first stores a daily note. |
 

--- a/docs/manage-sandboxes/workspace-files.mdx
+++ b/docs/manage-sandboxes/workspace-files.mdx
@@ -112,6 +112,7 @@ Set `NEMOCLAW_MINIMAL_BOOTSTRAP=1` before onboarding to skip default workspace t
 | `AGENTS.md` | Behavioral rules, memory conventions, safety guidelines, and session workflow. |
 | `TOOLS.md` | Records workspace-specific tool guidance and operational notes. |
 | `HEARTBEAT.md` | Defines recurring heartbeat checks when heartbeat processing is enabled. |
+| `POLICY.md` | Redacted summary of the sandbox's active policy context. NemoClaw renders this file, not OpenClaw: it refreshes automatically when a preset is added or removed and once at the end of onboarding, and can be refreshed on demand with `$$nemoclaw <name> policy explain --write`. |
 | `MEMORY.md` | Curated long-term memory distilled from daily notes. OpenClaw creates this file when it first stores long-term memory. |
 | `memory/` | Directory of daily note files (`YYYY-MM-DD.md`) for session continuity. OpenClaw creates this directory when it first stores a daily note. |
 
@@ -125,6 +126,7 @@ All workspace files reside inside the sandbox filesystem:
 ├── HEARTBEAT.md
 ├── IDENTITY.md
 ├── MEMORY.md             # created on first long-term memory use
+├── POLICY.md             # rendered by NemoClaw, not OpenClaw
 ├── SOUL.md
 ├── TOOLS.md
 ├── USER.md

--- a/scripts/backup-workspace.sh
+++ b/scripts/backup-workspace.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 
 WORKSPACE_PATH="/sandbox/.openclaw/workspace"
 BACKUP_BASE="${HOME}/.nemoclaw/backups"
-FILES=(SOUL.md USER.md IDENTITY.md AGENTS.md TOOLS.md HEARTBEAT.md POLICY.md MEMORY.md)
+BACKUP_FILES=(SOUL.md USER.md IDENTITY.md AGENTS.md TOOLS.md HEARTBEAT.md POLICY.md MEMORY.md)
+# POLICY.md is backed up for inspection only. NemoClaw regenerates it from the managed
+# policy, so uploading a saved copy can reintroduce drift.
+RESTORE_FILES=(SOUL.md USER.md IDENTITY.md AGENTS.md TOOLS.md HEARTBEAT.md MEMORY.md)
 DIRS=(memory)
 
 RED='\033[0;31m'
@@ -95,7 +98,7 @@ do_backup() {
   info "Backing up workspace from sandbox '${sandbox}'..."
 
   local count=0
-  for f in "${FILES[@]}"; do
+  for f in "${BACKUP_FILES[@]}"; do
     if openshell sandbox download "$sandbox" "${WORKSPACE_PATH}/${f}" "${dest}/" 2>/dev/null; then
       count=$((count + 1))
     else
@@ -135,7 +138,7 @@ do_restore() {
   info "Restoring workspace to sandbox '${sandbox}' from ${src}..."
 
   local count=0
-  for f in "${FILES[@]}"; do
+  for f in "${RESTORE_FILES[@]}"; do
     if [ -f "${src}/${f}" ]; then
       if openshell sandbox upload "$sandbox" "${src}/${f}" "${WORKSPACE_PATH}/"; then
         count=$((count + 1))

--- a/scripts/backup-workspace.sh
+++ b/scripts/backup-workspace.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 WORKSPACE_PATH="/sandbox/.openclaw/workspace"
 BACKUP_BASE="${HOME}/.nemoclaw/backups"
-FILES=(SOUL.md USER.md IDENTITY.md AGENTS.md MEMORY.md)
+FILES=(SOUL.md USER.md IDENTITY.md AGENTS.md TOOLS.md HEARTBEAT.md POLICY.md MEMORY.md)
 DIRS=(memory)
 
 RED='\033[0;31m'


### PR DESCRIPTION
The Download State section of the transfer-state-manually doc listed `MEMORY.md` and `memory/` as files to back up, but neither exists in a fresh v0.0.114 OpenClaw sandbox's workspace — and the doc was missing `HEARTBEAT.md`, `POLICY.md`, and `TOOLS.md`, which do exist. Closes #10482.

Updated the file list and the example expected-output block to match what `backup-workspace.sh` actually does on a real sandbox, including the skip lines it prints for the two files that no longer exist. Also added a note that `POLICY.md` shouldn't be restored from a downloaded copy — NemoClaw regenerates it whenever a policy preset changes or at onboarding, so re-uploading a stale one can reintroduce drift; `policy explain --write` is the right way to refresh it. Added `POLICY.md` to the workspace-files reference page too, since it was missing there and would otherwise contradict this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated manual sandbox transfer instructions to include tools, heartbeat, and policy files.
  * Clarified that memory transfers are optional and that policy files must not be uploaded.
  * Documented seeded and runtime-created workspace files, including separately rendered policy content.
* **Bug Fixes**
  * Backups now include policy content, while restores correctly exclude it and restore the remaining workspace files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Signed-off-by: wakqasahmed <training@saerintech.com>
