### PR TITLE
fix(portable): requalify recreated Podman socket ancestry

### DIFF
--- a/src/lib/onboard/experimental/hermes-portable-operating-authority.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-operating-authority.test.ts
@@ -47,7 +47,7 @@ function executable(executablePath: string, sha256: string): PodmanExecutableAut
   };
 }
 
-function socket(inode = "11"): PodmanSocketAuthority {
+function socket(inode = "11", parentMode = 0o40700): PodmanSocketAuthority {
   const currentUid = String(uid());
   return {
     device: "1",
@@ -64,7 +64,7 @@ function socket(inode = "11"): PodmanSocketAuthority {
     ].map((directory, index) => ({
       device: "1",
       inode: String(index + 20),
-      mode: String(index === 0 ? 0o40700 : 0o40755),
+      mode: String(index === 0 ? parentMode : 0o40755),
       ownerUid: String(index === 0 ? uid() : 0),
       path: directory,
     })),
@@ -252,6 +252,62 @@ describe("Hermes Portable schema-6 operation authority", () => {
 
     expect(authority.receipt.socketAuthority.inode).toBe("99");
     expect(authority.assertCurrent).not.toThrow();
+  });
+
+  it("admits a safe recreated socket-directory mode for a new user session (#10423)", () => {
+    const authority = qualifyHermesPortableOperatingAuthority(snapshot(), {
+      env: environment(),
+      captureSocketAuthority: () => socket("99", 0o40710),
+      captureOpenShellExecutableAuthority: () => ({
+        version: "0.0.106",
+        executable: executable("/usr/bin/openshell", "b".repeat(64)),
+      }),
+      capturePodmanExecutableAuthority: () => ({
+        version: "5.7.0",
+        executable: executable("/usr/bin/podman", "c".repeat(64)),
+      }),
+    });
+
+    expect(authority.receipt.socketAuthority.directoryChain[0]?.mode).toBe(String(0o40710));
+    expect(authority.assertCurrent).not.toThrow();
+  });
+
+  it.each([
+    ["writable socket directory", () => socket("99", 0o40720)],
+    [
+      "foreign socket-directory owner",
+      () => ({
+        ...socket("99"),
+        directoryChain: socket("99").directoryChain.map((component, index) =>
+          index === 0 ? { ...component, ownerUid: "2000" } : component,
+        ),
+      }),
+    ],
+    [
+      "alternate socket directory",
+      () => ({
+        ...socket("99"),
+        directoryChain: socket("99").directoryChain.map((component, index) =>
+          index === 0 ? { ...component, path: "/run/user/1000/alternate" } : component,
+        ),
+      }),
+    ],
+    ["changed socket mode", () => ({ ...socket("99"), mode: String(0o140660) })],
+  ] as const)("rejects %s semantics after a user-session transition (#10423)", (_case, capture) => {
+    expect(() =>
+      qualifyHermesPortableOperatingAuthority(snapshot(), {
+        env: environment(),
+        captureSocketAuthority: capture,
+        captureOpenShellExecutableAuthority: () => ({
+          version: "0.0.106",
+          executable: executable("/usr/bin/openshell", "b".repeat(64)),
+        }),
+        capturePodmanExecutableAuthority: () => ({
+          version: "5.7.0",
+          executable: executable("/usr/bin/podman", "c".repeat(64)),
+        }),
+      }),
+    ).toThrow("current filesystem or runtime semantics disagree");
   });
 
   it("rejects operation-local socket replacement before completion (#10423)", () => {

--- a/src/lib/onboard/experimental/hermes-portable-operating-authority.ts
+++ b/src/lib/onboard/experimental/hermes-portable-operating-authority.ts
@@ -22,6 +22,7 @@ import {
   type HermesPortableConfiguredReceipt,
   type HermesPortablePolicyAuthority,
   type HermesPortableReceiptSnapshot,
+  type HermesPortableStableSocketAuthority,
   type HermesPortableSuccessorReceipt,
 } from "./hermes-portable-receipt";
 
@@ -49,6 +50,60 @@ function fail(message: string): never {
   throw new Error(`Hermes portable schema-6 authority ${message}`);
 }
 
+const MODE_TYPE_MASK = 0o170000n;
+const DIRECTORY_MODE = 0o040000n;
+const SOCKET_MODE = 0o140000n;
+
+function parsedMode(value: string): bigint | null {
+  if (!/^[0-9]+$/u.test(value)) return null;
+  const mode = BigInt(value);
+  return mode <= 0o177777n ? mode : null;
+}
+
+function hasSafeDirectoryMode(value: string): boolean {
+  const mode = parsedMode(value);
+  return mode !== null && (mode & MODE_TYPE_MASK) === DIRECTORY_MODE && (mode & 0o022n) === 0n;
+}
+
+function hasSafeSocketMode(socketMode: string, parentMode: string | undefined): boolean {
+  const mode = parsedMode(socketMode);
+  const parent = parentMode === undefined ? null : parsedMode(parentMode);
+  return (
+    mode !== null &&
+    parent !== null &&
+    (mode & MODE_TYPE_MASK) === SOCKET_MODE &&
+    (mode & 0o002n) === 0n &&
+    ((mode & 0o020n) === 0n || (parent & 0o077n) === 0n)
+  );
+}
+
+function sameStableSocketSemantics(
+  expected: HermesPortableStableSocketAuthority,
+  currentSocket: PodmanSocketAuthority,
+): boolean {
+  const current = stableHermesPortableSocketAuthority(currentSocket);
+  if (
+    expected.socketPath !== current.socketPath ||
+    expected.mode !== current.mode ||
+    expected.ownerUid !== current.ownerUid ||
+    expected.directoryChain.length !== current.directoryChain.length ||
+    !hasSafeSocketMode(expected.mode, expected.directoryChain[0]?.mode) ||
+    !hasSafeSocketMode(current.mode, current.directoryChain[0]?.mode)
+  ) {
+    return false;
+  }
+  return expected.directoryChain.every((component, index) => {
+    const candidate = current.directoryChain[index];
+    return (
+      candidate !== undefined &&
+      component.path === candidate.path &&
+      component.ownerUid === candidate.ownerUid &&
+      hasSafeDirectoryMode(component.mode) &&
+      hasSafeDirectoryMode(candidate.mode)
+    );
+  });
+}
+
 function requireStableAuthority(
   expected: HermesPortableSuccessorReceipt,
   receipt: HermesPortableConfiguredReceipt,
@@ -67,7 +122,7 @@ function requireStableAuthority(
     expected.policy.size !== policy.sourceIdentity.size ||
     expected.policy.mode !== policy.sourceIdentity.mode ||
     expected.policy.uid !== policy.sourceIdentity.uid ||
-    !isDeepStrictEqual(expected.socketAuthority, stableHermesPortableSocketAuthority(socket)) ||
+    !sameStableSocketSemantics(expected.socketAuthority, socket) ||
     expected.openshellExecutableAuthority.version !== openshell.version ||
     !isDeepStrictEqual(
       expected.openshellExecutableAuthority.executable,


### PR DESCRIPTION
## Outcome

Hermes Portable schema-6 requalification now admits a recreated Podman socket directory when the canonical socket and ancestry constraints still agree. It continues to reject writable ancestry, foreign ownership, alternate paths, and socket-mode changes.

## Reason

A new rootless user session can recreate the Podman socket directory with different non-writable permission bits. Exact equality for those directory bits rejected an authorized replaceable-HOME transition before lifecycle recovery.

### Related issues

Related to #10423

## Changes

- Compare the durable and current socket path, socket mode, socket owner, directory paths, and directory owners exactly.
- Validate socket and directory file types and non-writable ancestry for both authority generations.
- Keep the current socket and directory generation pinned for the complete operation.
- Add positive coverage for a safe recreated directory mode and negative coverage for writable ancestry, foreign ownership, alternate paths, and socket-mode drift.

## Verification

- `npx vitest run --project cli src/lib/onboard/experimental/hermes-portable-operating-authority.test.ts src/lib/onboard/experimental/hermes-portable-receipt.test.ts src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts src/lib/onboard/experimental/portable-agent-lifecycle.test.ts` — 4 files and 133 tests passed.
- `npm run build:cli` — passed.
- `npm run typecheck:cli` — passed.
- Normal pre-commit and commit-message hooks — passed, including repository checks, source-shape checks, growth guardrails, lint, formatting, and secret scanning.
- Normal pre-push hook — passed.
- `git diff --check` — passed.
- The diff contains no secrets, API keys, or credentials.

## Review notes

This change updates the Hermes Portable socket-authority comparison. Independent code review found no authorization, path-substitution, information-disclosure, or operation-local identity-pinning blocker. Exact-commit field requalification remains a separate merge gate.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Hermes portable authority sockets and their containing directories.
  * Rejects sockets with unsafe permissions, incorrect ownership, unexpected paths, or changed socket modes.
  * Preserves valid authority when a socket directory is safely recreated.
  * More reliably detects whether socket authority remains unchanged across user-session transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->