### PR TITLE
fix(e2e): read Brave placeholder from plugin config

### DIFF
--- a/test/e2e/live/brave-search-helpers.ts
+++ b/test/e2e/live/brave-search-helpers.ts
@@ -196,7 +196,7 @@ export async function onboardBrave(
 
 export function assertBraveConfig(configText: string): string {
   const parsedConfig = JSON.parse(configText) as {
-    tools?: { web?: { search?: { enabled?: unknown; provider?: unknown } } };
+    tools?: { web?: { search?: { enabled?: unknown; provider?: unknown; apiKey?: unknown } } };
     plugins?: {
       entries?: { brave?: { config?: { webSearch?: { apiKey?: unknown } } } };
     };
@@ -204,6 +204,7 @@ export function assertBraveConfig(configText: string): string {
   const searchConfig = parsedConfig.tools?.web?.search;
   expect(searchConfig?.enabled, configText).toBe(true);
   expect(searchConfig?.provider, configText).toBe("brave");
+  expect(searchConfig?.apiKey, configText).toBeUndefined();
   const placeholderValue = parsedConfig.plugins?.entries?.brave?.config?.webSearch?.apiKey;
   const placeholder =
     typeof placeholderValue === "string" && placeholderValue ? placeholderValue : undefined;

--- a/test/e2e/live/brave-search-helpers.ts
+++ b/test/e2e/live/brave-search-helpers.ts
@@ -17,7 +17,7 @@ import { isTransientProviderValidationFailure } from "./network-policy-transient
 export const SANDBOX_NAME = process.env.NEMOCLAW_SANDBOX_NAME ?? "e2e-brave-search";
 validateSandboxName(SANDBOX_NAME);
 const INSTALL_ATTEMPTS = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true" ? 3 : 1;
-const PLACEHOLDER_PATTERN = /^openshell:resolve:env:([A-Za-z0-9_]+_)?BRAVE_API_KEY$/;
+const PLACEHOLDER_PATTERN = /^openshell:resolve:env:(?:v[0-9]+_)?BRAVE_API_KEY$/;
 
 export function commandEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
@@ -80,16 +80,6 @@ export async function cleanupBraveNemoClawSandbox(host: HostCliClient): Promise<
       ),
     `cleanup Brave sandbox ${SANDBOX_NAME}: ${output}`,
   ).toBe(true);
-}
-
-function parsePlaceholder(configText: string): string | undefined {
-  const parsed = JSON.parse(configText) as {
-    plugins?: {
-      entries?: { brave?: { config?: { webSearch?: { apiKey?: unknown } } } };
-    };
-  };
-  const value = parsed.plugins?.entries?.brave?.config?.webSearch?.apiKey;
-  return typeof value === "string" && value ? value : undefined;
 }
 
 function firstJsonObject(output: string): unknown {
@@ -207,11 +197,16 @@ export async function onboardBrave(
 export function assertBraveConfig(configText: string): string {
   const parsedConfig = JSON.parse(configText) as {
     tools?: { web?: { search?: { enabled?: unknown; provider?: unknown } } };
+    plugins?: {
+      entries?: { brave?: { config?: { webSearch?: { apiKey?: unknown } } } };
+    };
   };
   const searchConfig = parsedConfig.tools?.web?.search;
   expect(searchConfig?.enabled, configText).toBe(true);
   expect(searchConfig?.provider, configText).toBe("brave");
-  const placeholder = parsePlaceholder(configText);
+  const placeholderValue = parsedConfig.plugins?.entries?.brave?.config?.webSearch?.apiKey;
+  const placeholder =
+    typeof placeholderValue === "string" && placeholderValue ? placeholderValue : undefined;
   expect(placeholder, configText).toMatch(PLACEHOLDER_PATTERN);
   return placeholder ?? "";
 }

--- a/test/e2e/live/brave-search-helpers.ts
+++ b/test/e2e/live/brave-search-helpers.ts
@@ -84,9 +84,11 @@ export async function cleanupBraveNemoClawSandbox(host: HostCliClient): Promise<
 
 function parsePlaceholder(configText: string): string | undefined {
   const parsed = JSON.parse(configText) as {
-    tools?: { web?: { search?: { apiKey?: unknown } } };
+    plugins?: {
+      entries?: { brave?: { config?: { webSearch?: { apiKey?: unknown } } } };
+    };
   };
-  const value = parsed.tools?.web?.search?.apiKey;
+  const value = parsed.plugins?.entries?.brave?.config?.webSearch?.apiKey;
   return typeof value === "string" && value ? value : undefined;
 }
 
@@ -204,7 +206,7 @@ export async function onboardBrave(
 
 export function assertBraveConfig(configText: string): string {
   const parsedConfig = JSON.parse(configText) as {
-    tools?: { web?: { search?: { enabled?: unknown; provider?: unknown; apiKey?: unknown } } };
+    tools?: { web?: { search?: { enabled?: unknown; provider?: unknown } } };
   };
   const searchConfig = parsedConfig.tools?.web?.search;
   expect(searchConfig?.enabled, configText).toBe(true);

--- a/test/e2e/support/brave-search-config.test.ts
+++ b/test/e2e/support/brave-search-config.test.ts
@@ -10,7 +10,11 @@ const UNVERSIONED_PLACEHOLDER = "openshell:resolve:env:BRAVE_API_KEY";
 
 function openClawConfig(apiKey?: unknown, retiredApiKey?: unknown): string {
   return JSON.stringify({
-    tools: { web: { search: { enabled: true, provider: "brave", apiKey: retiredApiKey } } },
+    tools: {
+      web: {
+        search: { enabled: true, provider: "brave", apiKey: retiredApiKey },
+      },
+    },
     plugins: { entries: { brave: { config: { webSearch: { apiKey } } } } },
   });
 }
@@ -34,6 +38,8 @@ describe("Brave Search E2E configuration assertion", () => {
   });
 
   it("rejects a credential from the retired inline search configuration", () => {
-    expect(() => assertBraveConfig(openClawConfig(undefined, VERSIONED_PLACEHOLDER))).toThrow();
+    expect(() =>
+      assertBraveConfig(openClawConfig(VERSIONED_PLACEHOLDER, "test-raw-brave-key")),
+    ).toThrow();
   });
 });

--- a/test/e2e/support/brave-search-config.test.ts
+++ b/test/e2e/support/brave-search-config.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { assertBraveConfig } from "../live/brave-search-helpers.ts";
+
+const PLACEHOLDER = "openshell:resolve:env:v12590243949725316565_BRAVE_API_KEY";
+
+function openClawConfig(apiKey?: unknown): string {
+  return JSON.stringify({
+    tools: { web: { search: { enabled: true, provider: "brave" } } },
+    plugins: { entries: { brave: { config: { webSearch: { apiKey } } } } },
+  });
+}
+
+describe("Brave Search E2E configuration assertion", () => {
+  it("returns the credential placeholder from the current OpenClaw plugin configuration", () => {
+    expect(assertBraveConfig(openClawConfig(PLACEHOLDER))).toBe(PLACEHOLDER);
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["raw", "test-raw-brave-key"],
+    ["wrong-provider", "openshell:resolve:env:TAVILY_API_KEY"],
+  ])("rejects a %s Brave Search credential value", (_case, apiKey) => {
+    expect(() => assertBraveConfig(openClawConfig(apiKey))).toThrow();
+  });
+});

--- a/test/e2e/support/brave-search-config.test.ts
+++ b/test/e2e/support/brave-search-config.test.ts
@@ -5,25 +5,35 @@ import { describe, expect, it } from "vitest";
 
 import { assertBraveConfig } from "../live/brave-search-helpers.ts";
 
-const PLACEHOLDER = "openshell:resolve:env:v12590243949725316565_BRAVE_API_KEY";
+const VERSIONED_PLACEHOLDER = "openshell:resolve:env:v12590243949725316565_BRAVE_API_KEY";
+const UNVERSIONED_PLACEHOLDER = "openshell:resolve:env:BRAVE_API_KEY";
 
-function openClawConfig(apiKey?: unknown): string {
+function openClawConfig(apiKey?: unknown, retiredApiKey?: unknown): string {
   return JSON.stringify({
-    tools: { web: { search: { enabled: true, provider: "brave" } } },
+    tools: { web: { search: { enabled: true, provider: "brave", apiKey: retiredApiKey } } },
     plugins: { entries: { brave: { config: { webSearch: { apiKey } } } } },
   });
 }
 
 describe("Brave Search E2E configuration assertion", () => {
-  it("returns the credential placeholder from the current OpenClaw plugin configuration", () => {
-    expect(assertBraveConfig(openClawConfig(PLACEHOLDER))).toBe(PLACEHOLDER);
+  it.each([
+    ["versioned", VERSIONED_PLACEHOLDER],
+    ["unversioned", UNVERSIONED_PLACEHOLDER],
+  ])("returns a %s credential placeholder from the Brave plugin configuration", (_case, value) => {
+    expect(assertBraveConfig(openClawConfig(value))).toBe(value);
   });
 
   it.each([
     ["missing", undefined],
     ["raw", "test-raw-brave-key"],
     ["wrong-provider", "openshell:resolve:env:TAVILY_API_KEY"],
+    ["noncanonical-prefix", "openshell:resolve:env:OTHER_BRAVE_API_KEY"],
+    ["malformed-version-prefix", "openshell:resolve:env:vABC_BRAVE_API_KEY"],
   ])("rejects a %s Brave Search credential value", (_case, apiKey) => {
     expect(() => assertBraveConfig(openClawConfig(apiKey))).toThrow();
+  });
+
+  it("rejects a credential from the retired inline search configuration", () => {
+    expect(() => assertBraveConfig(openClawConfig(undefined, VERSIONED_PLACEHOLDER))).toThrow();
   });
 });


### PR DESCRIPTION
## Outcome

The Brave Search live E2E now validates the credential placeholder from the current OpenClaw Brave plugin configuration. The workflow no longer fails after a successful Brave request because it reads the retired inline search-key path.

## Reason

Onboarding stores the resolved credential placeholder at `plugins.entries.brave.config.webSearch.apiKey`, while the live E2E helper still read `tools.web.search.apiKey`. That returned `undefined` and caused the post-onboarding assertion to throw even though Brave Search egress succeeded.

## Changes

- Read the Brave credential placeholder from the plugin configuration written by onboarding.
- Accept only canonical versioned or unversioned `BRAVE_API_KEY` resolver placeholders.
- Reject any credential left in the retired inline search-key field.
- Add deterministic E2E-support coverage for the current and retired configuration paths.

## Verification

- `npm run validate:pr` — passed the repository pre-commit, commitlint, and pre-push gates.
- `npx vitest run --project e2e-support test/e2e/support/brave-search-config.test.ts` — 8 tests passed.
- `npm run test:projects:check` — confirmed exact Vitest project membership.
- `npm run build:cli` — passed.
- `npm --prefix nemoclaw run build` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Reviewed the diff for secrets, API keys, and credentials — none are present.

## Review notes

The [manual Brave Search run on `main`](https://github.com/NVIDIA/NemoClaw/actions/runs/33046837642) completed a real Brave request and reported verified egress before failing in this stale assertion. The candidate branch keeps the credential flow unchanged. The [exact-revision Brave Search E2E](https://github.com/NVIDIA/NemoClaw/actions/runs/33094685090) passed against commit `0bb3357e`, including the live request, credential-boundary assertion, evidence upload, and cleanup.

---
Signed-off-by: prekshivyas <prekshiv@nvidia.com>
