### PR TITLE
feat(runtime): compose inactive Windows MXC attachment

### DIFF
--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment-test-fixture.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment-test-fixture.ts
@@ -42,9 +42,10 @@ export function mxcOpenShellAttachmentFixture(version = "0.0.21"): {
     observation: {
       ...structuredClone(accepted),
       distributionRoot: "C:\\OpenShell",
+      mxcRoot: "C:\\mxc-kit",
       cliPath: "C:\\OpenShell\\bin\\openshell.exe",
       gatewayPath: "C:\\OpenShell\\bin\\openshell-gateway.exe",
-      wxcExecPath: "C:\\OpenShell\\mxc\\wxc-exec.exe",
+      wxcExecPath: "C:\\mxc-kit\\bin\\wxc-exec.exe",
       gatewayConfigPath: "C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml",
     },
   };

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment-test-fixture.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment-test-fixture.ts
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  createMxcOpenShellAttachmentAuthority,
+  createMxcOpenShellAttachmentTestAuthority,
   type MxcOpenShellAttachmentAuthority,
-  type MxcOpenShellAttachmentExpectation,
   type MxcOpenShellAttachmentObservation,
 } from "./mxc-openshell-attachment";
 
@@ -20,7 +19,7 @@ export function mxcOpenShellAttachmentFixture(version = "0.0.21"): {
   readonly authority: MxcOpenShellAttachmentAuthority;
   readonly observation: MxcOpenShellAttachmentObservation;
 } {
-  const accepted: MxcOpenShellAttachmentExpectation = {
+  const accepted = {
     distribution: {
       version,
       revision: "a".repeat(40),
@@ -33,12 +32,12 @@ export function mxcOpenShellAttachmentFixture(version = "0.0.21"): {
     },
     gateway: {
       configSha256: MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS.config,
-      driver: "mxc",
-      backend: "process_container",
+      driver: "mxc" as const,
+      backend: "process_container" as const,
     },
   };
   return {
-    authority: createMxcOpenShellAttachmentAuthority(accepted),
+    authority: createMxcOpenShellAttachmentTestAuthority(version),
     observation: {
       ...structuredClone(accepted),
       distributionRoot: "C:\\OpenShell",

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
@@ -28,7 +28,7 @@ describe("inactive OpenShell MXC installation attachment", () => {
     });
     expect(Object.isFrozen(authority)).toBe(true);
     expect(receipt).toEqual({
-      contractVersion: 1,
+      contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
       providerId: "mxc",
       mode: "attach-existing",
       authoritySha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
@@ -48,7 +48,8 @@ describe("inactive OpenShell MXC installation attachment", () => {
           sha256: DIGESTS.gateway,
         },
         wxcExec: {
-          path: "C:\\OpenShell\\mxc\\wxc-exec.exe",
+          root: "C:\\mxc-kit",
+          path: "C:\\mxc-kit\\bin\\wxc-exec.exe",
           sha256: DIGESTS.wxcExec,
         },
       },
@@ -118,6 +119,35 @@ describe("inactive OpenShell MXC installation attachment", () => {
     expect(() => qualifyMxcOpenShellAttachment(authority, observation)).toThrow(
       /gateway path must remain inside the observed distribution root/u,
     );
+  });
+
+  it("rejects wxc-exec from outside the observed MXC root (#8178)", () => {
+    const { authority, observation: fixtureObservation } = mxcOpenShellAttachmentFixture();
+    const observation = structuredClone(fixtureObservation);
+    const observed = observation as unknown as { wxcExecPath: string };
+    observed.wxcExecPath = "C:\\OtherMxc\\wxc-exec.exe";
+
+    expect(() => qualifyMxcOpenShellAttachment(authority, observation)).toThrow(
+      /wxc-exec path must remain inside the observed MXC root/u,
+    );
+  });
+
+  it.each([
+    ["distribution root", "distributionRoot"],
+    ["MXC root", "mxcRoot"],
+    ["OpenShell CLI", "cliPath"],
+    ["OpenShell gateway", "gatewayPath"],
+    ["wxc-exec", "wxcExecPath"],
+    ["gateway configuration", "gatewayConfigPath"],
+  ] as const)("rejects a network %s before attachment qualification (#8178)", (_label, field) => {
+    const source = mxcOpenShellAttachmentFixture();
+
+    expect(() =>
+      qualifyMxcOpenShellAttachment(source.authority, {
+        ...source.observation,
+        [field]: "\\\\host\\share\\component.bin",
+      }),
+    ).toThrow(/local-drive Windows path/u);
   });
 
   it("rejects an unsupported backend before attachment (#8178)", () => {

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
@@ -6,7 +6,6 @@ import { describe, expect, it } from "vitest";
 import {
   MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
   MxcOpenShellAttachmentError,
-  createMxcOpenShellAttachmentAuthority,
   qualifyMxcOpenShellAttachment,
   type MxcOpenShellAttachmentObservation,
 } from "./mxc-openshell-attachment";
@@ -150,17 +149,15 @@ describe("inactive OpenShell MXC installation attachment", () => {
     ).toThrow(/local-drive Windows path/u);
   });
 
-  it("rejects an unsupported backend before attachment (#8178)", () => {
-    const { observation } = mxcOpenShellAttachmentFixture();
-    const accepted = {
-      distribution: observation.distribution,
-      components: observation.components,
-      gateway: { ...observation.gateway, backend: "isolation_session" },
-    };
+  it("rejects an unsupported observed backend before attachment (#8178)", () => {
+    const { authority, observation } = mxcOpenShellAttachmentFixture();
 
-    expect(() => createMxcOpenShellAttachmentAuthority(accepted)).toThrow(
-      /backend must be 'process_container'/u,
-    );
+    expect(() =>
+      qualifyMxcOpenShellAttachment(authority, {
+        ...observation,
+        gateway: { ...observation.gateway, backend: "isolation_session" },
+      }),
+    ).toThrow(/backend must be 'process_container'/u);
   });
 
   it("rejects credential-bearing fields instead of copying them into the receipt (#8178)", () => {
@@ -184,22 +181,6 @@ describe("inactive OpenShell MXC installation attachment", () => {
 
     expect(() => qualifyMxcOpenShellAttachment(copied, observation)).toThrow(
       /accepted identity authority is not provider-owned/u,
-    );
-  });
-
-  it("retains an owned accepted identity after the caller mutates its input (#8178)", () => {
-    const { observation } = mxcOpenShellAttachmentFixture();
-    const accepted = {
-      distribution: { ...observation.distribution },
-      components: { ...observation.components },
-      gateway: { ...observation.gateway },
-    };
-    const authority = createMxcOpenShellAttachmentAuthority(accepted);
-
-    accepted.components.gatewaySha256 = "6".repeat(64);
-
-    expect(qualifyMxcOpenShellAttachment(authority, observation).components.gateway.sha256).toBe(
-      DIGESTS.gateway,
     );
   });
 

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 
 import { cloneAndDeepFreeze } from "../../core/immutable";
 
-export const MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION = 1 as const;
+export const MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION = 2 as const;
 
 const PROVIDER_ID = "mxc";
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
@@ -15,6 +15,7 @@ const REVISION_PATTERN = /^[a-f0-9]{7,64}$/u;
 const VERSION_PATTERN =
   /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+(?:[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/u;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
+const LOCAL_DRIVE_PATH_PATTERN = /^[A-Za-z]:\\/u;
 const MAX_TEXT_BYTES = 4096;
 
 type ExactDistributionIdentity = {
@@ -43,6 +44,7 @@ export interface MxcOpenShellAttachmentExpectation {
 
 export interface MxcOpenShellAttachmentObservation extends MxcOpenShellAttachmentExpectation {
   readonly distributionRoot: string;
+  readonly mxcRoot: string;
   readonly cliPath: string;
   readonly gatewayPath: string;
   readonly wxcExecPath: string;
@@ -65,7 +67,7 @@ export interface MxcOpenShellAttachmentReceipt {
   readonly components: {
     readonly cli: { readonly path: string; readonly sha256: string };
     readonly gateway: { readonly path: string; readonly sha256: string };
-    readonly wxcExec: { readonly path: string; readonly sha256: string };
+    readonly wxcExec: { readonly root: string; readonly path: string; readonly sha256: string };
   };
   readonly gateway: ExactGatewayIdentity & { readonly configPath: string };
 }
@@ -124,10 +126,13 @@ function canonicalWindowsPath(value: unknown, label: string): string {
     typeof value !== "string" ||
     Buffer.byteLength(value, "utf8") > MAX_TEXT_BYTES ||
     CONTROL_CHARACTER_PATTERN.test(value) ||
+    !LOCAL_DRIVE_PATH_PATTERN.test(value) ||
     !path.win32.isAbsolute(value) ||
     path.win32.normalize(value) !== value
   ) {
-    throw new MxcOpenShellAttachmentError(`${label} must be a canonical absolute Windows path`);
+    throw new MxcOpenShellAttachmentError(
+      `${label} must be a canonical absolute local-drive Windows path`,
+    );
   }
   return value;
 }
@@ -200,6 +205,7 @@ function parseObservation(value: unknown): MxcOpenShellAttachmentObservation {
       "gateway",
       "gatewayConfigPath",
       "gatewayPath",
+      "mxcRoot",
       "wxcExecPath",
     ],
     "observed attachment",
@@ -210,6 +216,7 @@ function parseObservation(value: unknown): MxcOpenShellAttachmentObservation {
     gateway: parseGateway(input.gateway, "observed attachment gateway"),
   };
   const distributionRoot = canonicalWindowsPath(input.distributionRoot, "distribution root");
+  const mxcRoot = canonicalWindowsPath(input.mxcRoot, "MXC root");
   const cliPath = canonicalWindowsPath(input.cliPath, "OpenShell CLI path");
   const gatewayPath = canonicalWindowsPath(input.gatewayPath, "OpenShell gateway path");
   const wxcExecPath = canonicalWindowsPath(input.wxcExecPath, "wxc-exec path");
@@ -220,7 +227,6 @@ function parseObservation(value: unknown): MxcOpenShellAttachmentObservation {
   for (const [label, candidate] of [
     ["OpenShell CLI", cliPath],
     ["OpenShell gateway", gatewayPath],
-    ["wxc-exec", wxcExecPath],
   ] as const) {
     if (!pathWithin(distributionRoot, candidate)) {
       throw new MxcOpenShellAttachmentError(
@@ -228,9 +234,13 @@ function parseObservation(value: unknown): MxcOpenShellAttachmentObservation {
       );
     }
   }
+  if (!pathWithin(mxcRoot, wxcExecPath)) {
+    throw new MxcOpenShellAttachmentError("wxc-exec path must remain inside the observed MXC root");
+  }
   return {
     ...identity,
     distributionRoot,
+    mxcRoot,
     cliPath,
     gatewayPath,
     wxcExecPath,
@@ -317,7 +327,11 @@ export function qualifyMxcOpenShellAttachment(
     components: {
       cli: { path: observed.cliPath, sha256: observed.components.cliSha256 },
       gateway: { path: observed.gatewayPath, sha256: observed.components.gatewaySha256 },
-      wxcExec: { path: observed.wxcExecPath, sha256: observed.components.wxcExecSha256 },
+      wxcExec: {
+        root: observed.mxcRoot,
+        path: observed.wxcExecPath,
+        sha256: observed.components.wxcExecSha256,
+      },
     },
     gateway: {
       ...observed.gateway,

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
@@ -36,7 +36,7 @@ type ExactGatewayIdentity = {
   readonly backend: "process_container";
 };
 
-export interface MxcOpenShellAttachmentExpectation {
+interface MxcOpenShellAttachmentExpectation {
   readonly distribution: ExactDistributionIdentity;
   readonly components: ExactComponentIdentity;
   readonly gateway: ExactGatewayIdentity;
@@ -265,7 +265,7 @@ function sameIdentity(
  * The caller must obtain the expectation from a trusted provider source, not
  * from the host observation that will be qualified against it.
  */
-export function createMxcOpenShellAttachmentAuthority(
+function createMxcOpenShellAttachmentAuthority(
   expectation: unknown,
 ): MxcOpenShellAttachmentAuthority {
   const accepted = cloneAndDeepFreeze(parseExpectation(expectation, "accepted attachment"));
@@ -288,6 +288,34 @@ export function createMxcOpenShellAttachmentAuthority(
   });
   ACCEPTED_IDENTITIES.set(authority, accepted);
   return authority;
+}
+
+/**
+ * Create the fixed, non-production authority used by attachment contract tests.
+ *
+ * The caller may vary only the SemVer value under test. Component identities stay fixed so this
+ * helper cannot turn caller-observed digests into accepted provider authority.
+ */
+export function createMxcOpenShellAttachmentTestAuthority(
+  version: string,
+): MxcOpenShellAttachmentAuthority {
+  return createMxcOpenShellAttachmentAuthority({
+    distribution: {
+      version,
+      revision: "a".repeat(40),
+      sha256: "1".repeat(64),
+    },
+    components: {
+      cliSha256: "2".repeat(64),
+      gatewaySha256: "3".repeat(64),
+      wxcExecSha256: "4".repeat(64),
+    },
+    gateway: {
+      configSha256: "5".repeat(64),
+      driver: "mxc",
+      backend: "process_container",
+    },
+  });
 }
 
 function acceptedIdentity(authority: unknown): MxcOpenShellAttachmentExpectation {

--- a/src/lib/onboard/runtime-provider/mxc-openshell-observer.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-observer.test.ts
@@ -29,15 +29,16 @@ const DIGESTS = {
 const PATHS = {
   distributionArtifactPath: "C:\\OpenShell\\packages\\openshell-0.0.21.zip",
   distributionRoot: "C:\\OpenShell",
+  mxcRoot: "C:\\mxc-kit",
   cliPath: "C:\\OpenShell\\bin\\openshell.exe",
   gatewayPath: "C:\\OpenShell\\bin\\openshell-gateway.exe",
-  wxcExecPath: "C:\\OpenShell\\mxc\\wxc-exec.exe",
+  wxcExecPath: "C:\\mxc-kit\\bin\\wxc-exec.exe",
   gatewayConfigPath: "C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml",
 } as const;
 
 function request(): MxcOpenShellAttachmentObservationRequest {
   return {
-    contractVersion: 1,
+    contractVersion: 2,
     providerId: "mxc",
     mode: "attach-existing",
     observedDistribution: {
@@ -199,6 +200,7 @@ describe("inactive OpenShell MXC installation observer", () => {
   it.each([
     ["distributionArtifactPath", "\\\\host\\share\\openshell.zip"],
     ["distributionRoot", "\\\\host\\share\\OpenShell"],
+    ["mxcRoot", "\\\\host\\share\\mxc-kit"],
     ["cliPath", "\\\\host\\share\\openshell.exe"],
     ["gatewayPath", "\\\\host\\share\\openshell-gateway.exe"],
     ["wxcExecPath", "\\\\host\\share\\wxc-exec.exe"],

--- a/src/lib/onboard/runtime-provider/mxc-openshell-observer.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-observer.ts
@@ -78,6 +78,21 @@ export interface MxcOpenShellAttachmentObservationRequest {
  */
 export type MxcOpenShellFileDigestObserver = (filePath: string) => Promise<string>;
 
+export type MxcOpenShellObservationFailure =
+  | "unsupported-platform"
+  | "invalid-path"
+  | "observer-unavailable"
+  | "observation-rejected"
+  | "invalid-output";
+
+/** Redacted failure from a trusted installation-file observation boundary. */
+export class MxcOpenShellObservationError extends MxcOpenShellAttachmentError {
+  constructor(readonly failure: MxcOpenShellObservationFailure) {
+    super(`native Windows stable-file boundary failed (${failure})`);
+    this.name = "MxcOpenShellObservationError";
+  }
+}
+
 function stableOpenFlags(): number {
   if (typeof fsConstants.O_NOFOLLOW !== "number" || typeof fsConstants.O_NONBLOCK !== "number") {
     throw new Error("stable no-follow file observation is unavailable");
@@ -339,8 +354,9 @@ export async function observeMxcOpenShellAttachment(
     let observedDigest: string;
     try {
       observedDigest = await observeDigest(filePath);
-    } catch {
-      throw new MxcOpenShellAttachmentError(`${label} could not be observed`);
+    } catch (error) {
+      const category = error instanceof MxcOpenShellObservationError ? ` (${error.failure})` : "";
+      throw new MxcOpenShellAttachmentError(`${label} could not be observed${category}`);
     }
     if (!SHA256_PATTERN.test(observedDigest)) {
       throw new MxcOpenShellAttachmentError(`${label} returned an invalid digest`);

--- a/src/lib/onboard/runtime-provider/mxc-openshell-observer.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-observer.ts
@@ -48,6 +48,7 @@ export interface MxcOpenShellStableFileOperations {
 export interface MxcOpenShellInstallationLayout {
   readonly distributionArtifactPath: string;
   readonly distributionRoot: string;
+  readonly mxcRoot: string;
   readonly cliPath: string;
   readonly gatewayPath: string;
   readonly wxcExecPath: string;
@@ -220,6 +221,7 @@ function parseInstallation(value: unknown): MxcOpenShellInstallationLayout {
       "distributionRoot",
       "gatewayConfigPath",
       "gatewayPath",
+      "mxcRoot",
       "wxcExecPath",
     ],
     "installation layout",
@@ -233,6 +235,7 @@ function parseInstallation(value: unknown): MxcOpenShellInstallationLayout {
       installation.distributionRoot,
       "OpenShell distribution root",
     ),
+    mxcRoot: canonicalWindowsPath(installation.mxcRoot, "MXC root"),
     cliPath: canonicalWindowsPath(installation.cliPath, "OpenShell CLI path"),
     gatewayPath: canonicalWindowsPath(installation.gatewayPath, "OpenShell gateway path"),
     wxcExecPath: canonicalWindowsPath(installation.wxcExecPath, "wxc-exec path"),
@@ -244,7 +247,6 @@ function parseInstallation(value: unknown): MxcOpenShellInstallationLayout {
   for (const [label, candidate] of [
     ["OpenShell CLI", parsed.cliPath],
     ["OpenShell gateway", parsed.gatewayPath],
-    ["wxc-exec", parsed.wxcExecPath],
   ] as const) {
     const relative = path.win32.relative(parsed.distributionRoot, candidate);
     if (
@@ -257,6 +259,15 @@ function parseInstallation(value: unknown): MxcOpenShellInstallationLayout {
         `${label} path must remain inside the observed distribution root`,
       );
     }
+  }
+  const relativeWxcExecPath = path.win32.relative(parsed.mxcRoot, parsed.wxcExecPath);
+  if (
+    relativeWxcExecPath.length === 0 ||
+    path.win32.isAbsolute(relativeWxcExecPath) ||
+    relativeWxcExecPath === ".." ||
+    relativeWxcExecPath.startsWith(`..${path.win32.sep}`)
+  ) {
+    throw new MxcOpenShellAttachmentError("wxc-exec path must remain inside the observed MXC root");
   }
   return parsed;
 }
@@ -346,6 +357,7 @@ export async function observeMxcOpenShellAttachment(
     },
     gateway: { ...observedGateway, configSha256: observedDigests[4]! },
     distributionRoot: installation.distributionRoot,
+    mxcRoot: installation.mxcRoot,
     cliPath: installation.cliPath,
     gatewayPath: installation.gatewayPath,
     wxcExecPath: installation.wxcExecPath,

--- a/src/lib/onboard/runtime-provider/mxc-windows-file-observer.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-windows-file-observer.test.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Buffer } from "node:buffer";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createMxcWindowsOpenShellFileDigestObserver,
+  type MxcWindowsFileObserverCommand,
+  type MxcWindowsFileObserverCommandRunner,
+} from "./mxc-windows-file-observer";
+
+const DIGEST = "a".repeat(64);
+
+function runtime(
+  runCommand: (command: MxcWindowsFileObserverCommand) => Promise<string>,
+  environment: NodeJS.ProcessEnv = {
+    SystemRoot: "C:\\Windows",
+    TEMP: "C:\\Temp",
+    TMP: "C:\\Temp",
+    PROVIDER_SECRET: "must-not-enter-observer",
+  },
+) {
+  return {
+    platform: "win32" as const,
+    environment,
+    runCommand,
+  };
+}
+
+describe("inactive native Windows OpenShell file observation", () => {
+  it("passes an encoded path to one absolute system PowerShell process (#8178)", async () => {
+    const runCommand = vi.fn<MxcWindowsFileObserverCommandRunner>(async () => DIGEST);
+    const observeDigest = createMxcWindowsOpenShellFileDigestObserver(runtime(runCommand));
+
+    await expect(observeDigest("C:\\OpenShell\\openshell.exe")).resolves.toBe(DIGEST);
+
+    expect(runCommand).toHaveBeenCalledOnce();
+    const command = runCommand.mock.calls[0]![0];
+    expect(command.executablePath).toBe(
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+    expect(command.arguments).toContain("-EncodedCommand");
+    expect(command.arguments).not.toContain("C:\\OpenShell\\openshell.exe");
+    expect(command.timeoutMs).toBe(30_000);
+    expect(command.environment).toEqual({
+      SystemRoot: "C:\\Windows",
+      WINDIR: "C:\\Windows",
+      TEMP: "C:\\Temp",
+      TMP: "C:\\Temp",
+      NEMOCLAW_MXC_OBSERVER_PATH_B64: Buffer.from("C:\\OpenShell\\openshell.exe", "utf8").toString(
+        "base64",
+      ),
+    });
+  });
+
+  it("keeps installation paths and command failures out of diagnostics (#8178)", async () => {
+    const sensitivePath = "C:\\OpenShell\\provider-secret.exe";
+    const observeDigest = createMxcWindowsOpenShellFileDigestObserver(
+      runtime(async () => {
+        throw new Error(`failed for ${sensitivePath}`);
+      }),
+    );
+
+    await expect(observeDigest(sensitivePath)).rejects.not.toThrow(sensitivePath);
+  });
+
+  it.each([
+    ["non-Windows host", { platform: "linux" as const, filePath: "C:\\OpenShell\\a.exe" }],
+    ["relative file path", { platform: "win32" as const, filePath: "OpenShell\\a.exe" }],
+    ["network file path", { platform: "win32" as const, filePath: "\\\\host\\a.exe" }],
+  ])("rejects a %s before invoking PowerShell (#8178)", async (_name, input) => {
+    const runCommand = vi.fn<MxcWindowsFileObserverCommandRunner>(async () => DIGEST);
+    const observeDigest = createMxcWindowsOpenShellFileDigestObserver({
+      ...runtime(runCommand),
+      platform: input.platform,
+    });
+
+    await expect(observeDigest(input.filePath)).rejects.toThrow(/stable-file boundary/u);
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed PowerShell output (#8178)", async () => {
+    const observeDigest = createMxcWindowsOpenShellFileDigestObserver(
+      runtime(async () => `${DIGEST}\nextra output`),
+    );
+
+    await expect(observeDigest("C:\\OpenShell\\a.exe")).rejects.toThrow(/stable-file boundary/u);
+  });
+
+  it("does not use a caller-supplied Windows system root (#8178)", async () => {
+    const runCommand = vi.fn<MxcWindowsFileObserverCommandRunner>(async () => DIGEST);
+    const observeDigest = createMxcWindowsOpenShellFileDigestObserver(
+      runtime(runCommand, { SystemRoot: "C:\\caller-controlled" }),
+    );
+
+    await expect(observeDigest("C:\\OpenShell\\a.exe")).resolves.toBe(DIGEST);
+    expect(runCommand.mock.calls[0]![0].executablePath).toBe(
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+  });
+});

--- a/src/lib/onboard/runtime-provider/mxc-windows-file-observer.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-windows-file-observer.test.ts
@@ -63,7 +63,9 @@ describe("inactive native Windows OpenShell file observation", () => {
       }),
     );
 
-    await expect(observeDigest(sensitivePath)).rejects.not.toThrow(sensitivePath);
+    const failure = observeDigest(sensitivePath);
+    await expect(failure).rejects.toThrow(/stable-file boundary failed \(observer-unavailable\)/u);
+    await expect(failure).rejects.not.toThrow(sensitivePath);
   });
 
   it.each([
@@ -86,8 +88,23 @@ describe("inactive native Windows OpenShell file observation", () => {
       runtime(async () => `${DIGEST}\nextra output`),
     );
 
-    await expect(observeDigest("C:\\OpenShell\\a.exe")).rejects.toThrow(/stable-file boundary/u);
+    await expect(observeDigest("C:\\OpenShell\\a.exe")).rejects.toThrow(
+      /stable-file boundary failed \(invalid-output\)/u,
+    );
   });
+
+  it.each(["observer-unavailable", "observation-rejected"] as const)(
+    "preserves the redacted %s category from PowerShell (#8178)",
+    async (category) => {
+      const observeDigest = createMxcWindowsOpenShellFileDigestObserver(
+        runtime(async () => `NEMOCLAW_MXC_OBSERVER_ERROR:${category}`),
+      );
+
+      await expect(observeDigest("C:\\OpenShell\\a.exe")).rejects.toThrow(
+        new RegExp(`stable-file boundary failed \\(${category}\\)`, "u"),
+      );
+    },
+  );
 
   it("does not use a caller-supplied Windows system root (#8178)", async () => {
     const runCommand = vi.fn<MxcWindowsFileObserverCommandRunner>(async () => DIGEST);

--- a/src/lib/onboard/runtime-provider/mxc-windows-file-observer.ts
+++ b/src/lib/onboard/runtime-provider/mxc-windows-file-observer.ts
@@ -1,0 +1,342 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Buffer } from "node:buffer";
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { MxcOpenShellAttachmentError } from "./mxc-openshell-attachment";
+import type { MxcOpenShellFileDigestObserver } from "./mxc-openshell-observer";
+
+const execFileAsync = promisify(execFile);
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
+const LOCAL_DRIVE_PATH_PATTERN = /^[A-Za-z]:\\/u;
+const MAX_PATH_BYTES = 4096;
+const OBSERVATION_TIMEOUT_MS = 30_000;
+const WINDOWS_SYSTEM_ROOT = "C:\\Windows";
+
+const STABLE_WINDOWS_FILE_DIGEST_SCRIPT = String.raw`
+$ErrorActionPreference = 'Stop'
+Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
+
+public static class NemoClawStableFileObserver
+{
+    private const uint GENERIC_READ = 0x80000000;
+    private const uint FILE_READ_ATTRIBUTES = 0x00000080;
+    private const uint FILE_SHARE_READ = 0x00000001;
+    private const uint OPEN_EXISTING = 3;
+    private const uint FILE_ATTRIBUTE_DIRECTORY = 0x00000010;
+    private const uint FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400;
+    private const uint FILE_FLAG_SEQUENTIAL_SCAN = 0x08000000;
+    private const uint FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+    private const uint FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FILETIME
+    {
+        public uint Low;
+        public uint High;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BY_HANDLE_FILE_INFORMATION
+    {
+        public uint Attributes;
+        public FILETIME CreationTime;
+        public FILETIME LastAccessTime;
+        public FILETIME LastWriteTime;
+        public uint VolumeSerialNumber;
+        public uint FileSizeHigh;
+        public uint FileSizeLow;
+        public uint NumberOfLinks;
+        public uint FileIndexHigh;
+        public uint FileIndexLow;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern SafeFileHandle CreateFileW(
+        string fileName,
+        uint desiredAccess,
+        uint shareMode,
+        IntPtr securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetFileInformationByHandle(
+        SafeFileHandle file,
+        out BY_HANDLE_FILE_INFORMATION information);
+
+    private static SafeFileHandle Open(string fileName, uint access, uint flags)
+    {
+        SafeFileHandle handle = CreateFileW(
+            fileName,
+            access,
+            FILE_SHARE_READ,
+            IntPtr.Zero,
+            OPEN_EXISTING,
+            flags,
+            IntPtr.Zero);
+        if (handle.IsInvalid)
+        {
+            int error = Marshal.GetLastWin32Error();
+            handle.Dispose();
+            throw new Win32Exception(error);
+        }
+        return handle;
+    }
+
+    private static BY_HANDLE_FILE_INFORMATION Information(SafeFileHandle handle)
+    {
+        BY_HANDLE_FILE_INFORMATION information;
+        if (!GetFileInformationByHandle(handle, out information))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+        return information;
+    }
+
+    private static bool SameFile(
+        BY_HANDLE_FILE_INFORMATION left,
+        BY_HANDLE_FILE_INFORMATION right)
+    {
+        return left.VolumeSerialNumber == right.VolumeSerialNumber
+            && left.FileIndexHigh == right.FileIndexHigh
+            && left.FileIndexLow == right.FileIndexLow
+            && left.FileSizeHigh == right.FileSizeHigh
+            && left.FileSizeLow == right.FileSizeLow
+            && left.LastWriteTime.High == right.LastWriteTime.High
+            && left.LastWriteTime.Low == right.LastWriteTime.Low;
+    }
+
+    private static void RequireRegularFile(BY_HANDLE_FILE_INFORMATION information)
+    {
+        if ((information.Attributes & FILE_ATTRIBUTE_DIRECTORY) != 0
+            || (information.Attributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0)
+        {
+            throw new IOException("The observed object is not a regular file.");
+        }
+    }
+
+    private static List<SafeFileHandle> PinAncestors(string fileName)
+    {
+        string root = Path.GetPathRoot(fileName);
+        if (String.IsNullOrEmpty(root))
+        {
+            throw new IOException("The observed path has no local root.");
+        }
+
+        var handles = new List<SafeFileHandle>();
+        string current = root;
+        try
+        {
+            SafeFileHandle rootHandle = Open(
+                current,
+                FILE_READ_ATTRIBUTES,
+                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
+            BY_HANDLE_FILE_INFORMATION rootInformation = Information(rootHandle);
+            if ((rootInformation.Attributes & FILE_ATTRIBUTE_DIRECTORY) == 0
+                || (rootInformation.Attributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0)
+            {
+                rootHandle.Dispose();
+                throw new IOException("The local root is not a plain directory.");
+            }
+            handles.Add(rootHandle);
+            string relative = fileName.Substring(root.Length);
+            string[] components = relative.Split(new[] { '\\' }, StringSplitOptions.RemoveEmptyEntries);
+            for (int index = 0; index < components.Length - 1; index++)
+            {
+                current = Path.Combine(current, components[index]);
+                SafeFileHandle handle = Open(
+                    current,
+                    FILE_READ_ATTRIBUTES,
+                    FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
+                BY_HANDLE_FILE_INFORMATION information = Information(handle);
+                if ((information.Attributes & FILE_ATTRIBUTE_DIRECTORY) == 0
+                    || (information.Attributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0)
+                {
+                    handle.Dispose();
+                    throw new IOException("An ancestor is not a plain directory.");
+                }
+                handles.Add(handle);
+            }
+            return handles;
+        }
+        catch
+        {
+            foreach (SafeFileHandle handle in handles) handle.Dispose();
+            throw;
+        }
+    }
+
+    public static string ObserveSha256(string fileName)
+    {
+        string fullPath = Path.GetFullPath(fileName);
+        List<SafeFileHandle> ancestors = PinAncestors(fullPath);
+        try
+        {
+            using (SafeFileHandle primary = Open(
+                fullPath,
+                GENERIC_READ,
+                FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_SEQUENTIAL_SCAN))
+            {
+                BY_HANDLE_FILE_INFORMATION before = Information(primary);
+                RequireRegularFile(before);
+                byte[] digest;
+                using (var stream = new FileStream(primary, FileAccess.Read, 1024 * 1024, false))
+                using (SHA256 sha256 = SHA256.Create())
+                {
+                    digest = sha256.ComputeHash(stream);
+                    BY_HANDLE_FILE_INFORMATION after = Information(primary);
+                    RequireRegularFile(after);
+                    if (!SameFile(before, after))
+                    {
+                        throw new IOException("The file changed during observation.");
+                    }
+                    using (SafeFileHandle reopened = Open(
+                        fullPath,
+                        GENERIC_READ,
+                        FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_SEQUENTIAL_SCAN))
+                    {
+                        BY_HANDLE_FILE_INFORMATION current = Information(reopened);
+                        RequireRegularFile(current);
+                        if (!SameFile(after, current))
+                        {
+                            throw new IOException("The path identity changed during observation.");
+                        }
+                    }
+                }
+                return BitConverter.ToString(digest).Replace("-", "").ToLowerInvariant();
+            }
+        }
+        finally
+        {
+            foreach (SafeFileHandle handle in ancestors) handle.Dispose();
+        }
+    }
+}
+'@
+
+$pathBytes = [Convert]::FromBase64String($env:NEMOCLAW_MXC_OBSERVER_PATH_B64)
+$observedPath = [Text.Encoding]::UTF8.GetString($pathBytes)
+[Console]::Out.Write([NemoClawStableFileObserver]::ObserveSha256($observedPath))
+`;
+
+export interface MxcWindowsFileObserverCommand {
+  readonly executablePath: string;
+  readonly arguments: readonly string[];
+  readonly environment: NodeJS.ProcessEnv;
+  readonly timeoutMs: number;
+}
+
+export type MxcWindowsFileObserverCommandRunner = (
+  command: MxcWindowsFileObserverCommand,
+) => Promise<string>;
+
+export interface MxcWindowsFileObserverRuntime {
+  readonly platform: NodeJS.Platform;
+  readonly environment: NodeJS.ProcessEnv;
+  readonly runCommand: MxcWindowsFileObserverCommandRunner;
+}
+
+async function runCommand(command: MxcWindowsFileObserverCommand): Promise<string> {
+  const result = await execFileAsync(command.executablePath, [...command.arguments], {
+    encoding: "utf8",
+    env: command.environment,
+    maxBuffer: 64 * 1024,
+    timeout: command.timeoutMs,
+    windowsHide: true,
+  });
+  return result.stdout;
+}
+
+const DEFAULT_RUNTIME: MxcWindowsFileObserverRuntime = {
+  platform: process.platform,
+  environment: process.env,
+  runCommand,
+};
+
+function canonicalLocalWindowsPath(value: unknown, label: string): string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    Buffer.byteLength(value, "utf8") > MAX_PATH_BYTES ||
+    CONTROL_CHARACTER_PATTERN.test(value) ||
+    !LOCAL_DRIVE_PATH_PATTERN.test(value) ||
+    !path.win32.isAbsolute(value) ||
+    path.win32.normalize(value) !== value
+  ) {
+    throw new MxcOpenShellAttachmentError(
+      `${label} must be a canonical absolute local-drive Windows path`,
+    );
+  }
+  return value;
+}
+
+function commandEnvironment(source: NodeJS.ProcessEnv, observedPath: string): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    SystemRoot: WINDOWS_SYSTEM_ROOT,
+    WINDIR: WINDOWS_SYSTEM_ROOT,
+    NEMOCLAW_MXC_OBSERVER_PATH_B64: Buffer.from(observedPath, "utf8").toString("base64"),
+  };
+  if (source.TEMP) environment.TEMP = source.TEMP;
+  if (source.TMP) environment.TMP = source.TMP;
+  return environment;
+}
+
+/** Create the native Windows stable-file digest boundary for inactive MXC attachment. */
+export function createMxcWindowsOpenShellFileDigestObserver(
+  runtime: MxcWindowsFileObserverRuntime = DEFAULT_RUNTIME,
+): MxcOpenShellFileDigestObserver {
+  return async (filePath) => {
+    try {
+      if (runtime.platform !== "win32") {
+        throw new Error("native Windows is required");
+      }
+      const observedPath = canonicalLocalWindowsPath(filePath, "installation file path");
+      const powershellPath = path.win32.join(
+        WINDOWS_SYSTEM_ROOT,
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      );
+      const encodedCommand = Buffer.from(STABLE_WINDOWS_FILE_DIGEST_SCRIPT, "utf16le").toString(
+        "base64",
+      );
+      const output = (
+        await runtime.runCommand({
+          executablePath: powershellPath,
+          arguments: [
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "AllSigned",
+            "-EncodedCommand",
+            encodedCommand,
+          ],
+          environment: commandEnvironment(runtime.environment, observedPath),
+          timeoutMs: OBSERVATION_TIMEOUT_MS,
+        })
+      ).trim();
+      if (!SHA256_PATTERN.test(output)) throw new Error("invalid observation output");
+      return output;
+    } catch {
+      throw new MxcOpenShellAttachmentError(
+        "an installation file could not be observed through the native Windows stable-file boundary",
+      );
+    }
+  };
+}

--- a/src/lib/onboard/runtime-provider/mxc-windows-file-observer.ts
+++ b/src/lib/onboard/runtime-provider/mxc-windows-file-observer.ts
@@ -7,7 +7,11 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 import { MxcOpenShellAttachmentError } from "./mxc-openshell-attachment";
-import type { MxcOpenShellFileDigestObserver } from "./mxc-openshell-observer";
+import {
+  MxcOpenShellObservationError,
+  type MxcOpenShellFileDigestObserver,
+  type MxcOpenShellObservationFailure,
+} from "./mxc-openshell-observer";
 
 const execFileAsync = promisify(execFile);
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
@@ -16,10 +20,16 @@ const LOCAL_DRIVE_PATH_PATTERN = /^[A-Za-z]:\\/u;
 const MAX_PATH_BYTES = 4096;
 const OBSERVATION_TIMEOUT_MS = 30_000;
 const WINDOWS_SYSTEM_ROOT = "C:\\Windows";
+const OBSERVER_FAILURE_PREFIX = "NEMOCLAW_MXC_OBSERVER_ERROR:";
 
 const STABLE_WINDOWS_FILE_DIGEST_SCRIPT = String.raw`
 $ErrorActionPreference = 'Stop'
-Add-Type -TypeDefinition @'
+if ($ExecutionContext.SessionState.LanguageMode -ne 'FullLanguage') {
+    [Console]::Out.Write('NEMOCLAW_MXC_OBSERVER_ERROR:observer-unavailable')
+    exit 0
+}
+try {
+    Add-Type -TypeDefinition @'
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -83,6 +93,7 @@ public static class NemoClawStableFileObserver
         SafeFileHandle handle = CreateFileW(
             fileName,
             access,
+            // Excluding FILE_SHARE_WRITE and FILE_SHARE_DELETE pins every opened path component.
             FILE_SHARE_READ,
             IntPtr.Zero,
             OPEN_EXISTING,
@@ -227,10 +238,20 @@ public static class NemoClawStableFileObserver
     }
 }
 '@
+}
+catch {
+    [Console]::Out.Write('NEMOCLAW_MXC_OBSERVER_ERROR:observer-unavailable')
+    exit 0
+}
 
 $pathBytes = [Convert]::FromBase64String($env:NEMOCLAW_MXC_OBSERVER_PATH_B64)
 $observedPath = [Text.Encoding]::UTF8.GetString($pathBytes)
-[Console]::Out.Write([NemoClawStableFileObserver]::ObserveSha256($observedPath))
+try {
+    [Console]::Out.Write([NemoClawStableFileObserver]::ObserveSha256($observedPath))
+}
+catch {
+    [Console]::Out.Write('NEMOCLAW_MXC_OBSERVER_ERROR:observation-rejected')
+}
 `;
 
 export interface MxcWindowsFileObserverCommand {
@@ -295,16 +316,34 @@ function commandEnvironment(source: NodeJS.ProcessEnv, observedPath: string): No
   return environment;
 }
 
-/** Create the native Windows stable-file digest boundary for inactive MXC attachment. */
+function observationFailure(output: string): MxcOpenShellObservationFailure | undefined {
+  if (!output.startsWith(OBSERVER_FAILURE_PREFIX)) return undefined;
+  const failure = output.slice(OBSERVER_FAILURE_PREFIX.length);
+  return failure === "observer-unavailable" || failure === "observation-rejected"
+    ? failure
+    : "invalid-output";
+}
+
+/**
+ * Create the native Windows stable-file digest boundary for inactive MXC attachment.
+ *
+ * Windows PowerShell must permit FullLanguage and Add-Type. Hosts that block the required native
+ * API observer fail closed as `observer-unavailable`; installation rejection remains distinct.
+ */
 export function createMxcWindowsOpenShellFileDigestObserver(
   runtime: MxcWindowsFileObserverRuntime = DEFAULT_RUNTIME,
 ): MxcOpenShellFileDigestObserver {
   return async (filePath) => {
+    if (runtime.platform !== "win32") {
+      throw new MxcOpenShellObservationError("unsupported-platform");
+    }
+    let observedPath: string;
     try {
-      if (runtime.platform !== "win32") {
-        throw new Error("native Windows is required");
-      }
-      const observedPath = canonicalLocalWindowsPath(filePath, "installation file path");
+      observedPath = canonicalLocalWindowsPath(filePath, "installation file path");
+    } catch {
+      throw new MxcOpenShellObservationError("invalid-path");
+    }
+    try {
       const powershellPath = path.win32.join(
         WINDOWS_SYSTEM_ROOT,
         "System32",
@@ -331,12 +370,13 @@ export function createMxcWindowsOpenShellFileDigestObserver(
           timeoutMs: OBSERVATION_TIMEOUT_MS,
         })
       ).trim();
-      if (!SHA256_PATTERN.test(output)) throw new Error("invalid observation output");
+      const failure = observationFailure(output);
+      if (failure) throw new MxcOpenShellObservationError(failure);
+      if (!SHA256_PATTERN.test(output)) throw new MxcOpenShellObservationError("invalid-output");
       return output;
-    } catch {
-      throw new MxcOpenShellAttachmentError(
-        "an installation file could not be observed through the native Windows stable-file boundary",
-      );
+    } catch (error) {
+      if (error instanceof MxcOpenShellObservationError) throw error;
+      throw new MxcOpenShellObservationError("observer-unavailable");
     }
   };
 }

--- a/src/lib/onboard/runtime-provider/mxc.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc.test.ts
@@ -15,8 +15,8 @@ import type {
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "./current";
 import { createDockerRuntimeProviderBundle } from "./docker";
 import {
+  attachMxcRuntimeProviderBundleFromExistingInstallation,
   createMxcRuntimeProviderBundle,
-  createMxcRuntimeProviderBundleFromExistingInstallation,
 } from "./mxc";
 import type { MxcNativeArtifactControlPlane } from "./mxc-bootstrap-operations";
 import { mxcOpenShellAttachmentFixture } from "./mxc-openshell-attachment-test-fixture";
@@ -126,7 +126,7 @@ describe("inactive OpenShell MXC runtime provider", () => {
     ]);
     const observeFileDigest = vi.fn(async (filePath: string) => digests.get(filePath)!);
 
-    const provider = await createMxcRuntimeProviderBundleFromExistingInstallation({
+    const { provider } = await attachMxcRuntimeProviderBundleFromExistingInstallation({
       hostFacts: {
         platform: "win32",
         nativeArchitecture: "x64",
@@ -169,7 +169,7 @@ describe("inactive OpenShell MXC runtime provider", () => {
     const verifyAndCreate = vi.fn(async () => ({ status: "unknown" as const }));
     const verifyReadiness = vi.fn();
     const recoverCreate = vi.fn(async () => ({ status: "absent" as const }));
-    const provider = await createMxcRuntimeProviderBundleFromExistingInstallation({
+    const { provider } = await attachMxcRuntimeProviderBundleFromExistingInstallation({
       hostFacts: {
         platform: "win32",
         nativeArchitecture: "x64",
@@ -216,7 +216,7 @@ describe("inactive OpenShell MXC runtime provider", () => {
     const verifyAndCreate = vi.fn(async () => ({ status: "unknown" as const }));
     const verifyReadiness = vi.fn();
     const recoverCreate = vi.fn(async () => ({ status: "absent" as const }));
-    const provider = await createMxcRuntimeProviderBundleFromExistingInstallation({
+    const { provider } = await attachMxcRuntimeProviderBundleFromExistingInstallation({
       hostFacts: {
         platform: "win32",
         nativeArchitecture: "x64",
@@ -270,7 +270,7 @@ describe("inactive OpenShell MXC runtime provider", () => {
     const verifyAndCreate = vi.fn(async () => ({ status: "unknown" as const }));
 
     await expect(
-      createMxcRuntimeProviderBundleFromExistingInstallation({
+      attachMxcRuntimeProviderBundleFromExistingInstallation({
         hostFacts: {
           platform: "win32",
           nativeArchitecture: "x64",

--- a/src/lib/onboard/runtime-provider/mxc.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc.test.ts
@@ -60,7 +60,7 @@ function candidateBundle() {
 function attachmentObservation(): MxcOpenShellAttachmentObservationRequest {
   const source = mxcOpenShellAttachmentFixture().observation;
   return {
-    contractVersion: 1,
+    contractVersion: 2,
     providerId: "mxc",
     mode: "attach-existing",
     observedDistribution: {
@@ -74,6 +74,7 @@ function attachmentObservation(): MxcOpenShellAttachmentObservationRequest {
     installation: {
       distributionArtifactPath: "C:\\OpenShell\\packages\\openshell-0.0.21.zip",
       distributionRoot: source.distributionRoot,
+      mxcRoot: source.mxcRoot,
       cliPath: source.cliPath,
       gatewayPath: source.gatewayPath,
       wxcExecPath: source.wxcExecPath,
@@ -120,7 +121,7 @@ describe("inactive OpenShell MXC runtime provider", () => {
       ["C:\\OpenShell\\packages\\openshell-0.0.21.zip", accepted.distribution.sha256],
       ["C:\\OpenShell\\bin\\openshell.exe", accepted.components.cliSha256],
       ["C:\\OpenShell\\bin\\openshell-gateway.exe", accepted.components.gatewaySha256],
-      ["C:\\OpenShell\\mxc\\wxc-exec.exe", accepted.components.wxcExecSha256],
+      ["C:\\mxc-kit\\bin\\wxc-exec.exe", accepted.components.wxcExecSha256],
       ["C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml", accepted.gateway.configSha256],
     ]);
     const observeFileDigest = vi.fn(async (filePath: string) => digests.get(filePath)!);
@@ -196,10 +197,15 @@ describe("inactive OpenShell MXC runtime provider", () => {
     expect(recoverCreate).not.toHaveBeenCalled();
   });
 
-  it("uses exact recovery without re-reading installed files (#8178)", async () => {
+  it("re-observes installed files before exact recovery (#8178)", async () => {
     const attachment = mxcOpenShellAttachmentFixture();
     const accepted = attachment.observation;
     const acceptedDigests = [
+      accepted.distribution.sha256,
+      accepted.components.cliSha256,
+      accepted.components.gatewaySha256,
+      accepted.components.wxcExecSha256,
+      accepted.gateway.configSha256,
       accepted.distribution.sha256,
       accepted.components.cliSha256,
       accepted.components.gatewaySha256,
@@ -235,7 +241,7 @@ describe("inactive OpenShell MXC runtime provider", () => {
       resourceState: "absent",
       recoveryRequired: false,
     });
-    expect(observeFileDigest).toHaveBeenCalledTimes(5);
+    expect(observeFileDigest).toHaveBeenCalledTimes(10);
     expect(verifyAndCreate).not.toHaveBeenCalled();
     expect(verifyReadiness).not.toHaveBeenCalled();
     expect(recoverCreate).toHaveBeenCalledOnce();

--- a/src/lib/onboard/runtime-provider/mxc.ts
+++ b/src/lib/onboard/runtime-provider/mxc.ts
@@ -29,6 +29,7 @@ import {
   qualifyMxcOpenShellAttachment,
   type MxcOpenShellAttachmentAuthority,
   type MxcOpenShellAttachmentObservation,
+  type MxcOpenShellAttachmentReceipt,
 } from "./mxc-openshell-attachment";
 import {
   observeMxcOpenShellAttachment,
@@ -50,6 +51,11 @@ export interface MxcExistingInstallationRuntimeProviderOptions {
   readonly bootstrapControlPlane: MxcNativeArtifactControlPlane;
   /** Trusted native boundary; Windows composition must reject reparse points and identity drift. */
   readonly observeFileDigest: MxcOpenShellFileDigestObserver;
+}
+
+export interface MxcExistingInstallationRuntimeProviderAttachment {
+  readonly provider: RuntimeProviderBundle;
+  readonly attachmentReceipt: MxcOpenShellAttachmentReceipt;
 }
 
 const MXC_PROVIDER_ID = "mxc";
@@ -212,31 +218,34 @@ export function createMxcRuntimeProviderBundle({
   };
 }
 
-/** Observe one existing installation before constructing the inactive provider candidate. */
-export async function createMxcRuntimeProviderBundleFromExistingInstallation({
+/** Observe one existing installation and retain its exact attachment receipt. */
+export async function attachMxcRuntimeProviderBundleFromExistingInstallation({
   hostFacts,
   openshellAttachmentAuthority,
   attachmentObservation,
   bootstrapControlPlane,
   observeFileDigest,
-}: MxcExistingInstallationRuntimeProviderOptions): Promise<RuntimeProviderBundle> {
+}: MxcExistingInstallationRuntimeProviderOptions): Promise<MxcExistingInstallationRuntimeProviderAttachment> {
   const observeAndQualify = async () => {
     const observation = await observeMxcOpenShellAttachment(
       attachmentObservation,
       observeFileDigest,
     );
-    qualifyMxcOpenShellAttachment(openshellAttachmentAuthority, observation);
-    return observation;
+    const attachmentReceipt = qualifyMxcOpenShellAttachment(
+      openshellAttachmentAuthority,
+      observation,
+    );
+    return { observation, attachmentReceipt };
   };
-  const openshellObservation = await observeAndQualify();
+  const initialAttachment = await observeAndQualify();
   const candidate = createMxcRuntimeProviderBundle({
     hostFacts,
     openshellAttachmentAuthority,
-    openshellObservation,
+    openshellObservation: initialAttachment.observation,
     bootstrapControlPlane,
   });
   const bootstrap = candidate.bootstrap as RuntimeProviderNativeArtifactBootstrapSurface;
-  return {
+  const provider: RuntimeProviderBundle = {
     ...candidate,
     bootstrap: {
       ...bootstrap,
@@ -244,7 +253,21 @@ export async function createMxcRuntimeProviderBundleFromExistingInstallation({
         await observeAndQualify();
         return bootstrap.run(input);
       },
-      recover: async (input) => bootstrap.recover(input),
+      recover: async (input) => {
+        await observeAndQualify();
+        return bootstrap.recover(input);
+      },
     },
   };
+  return Object.freeze({
+    provider,
+    attachmentReceipt: initialAttachment.attachmentReceipt,
+  });
+}
+
+/** Observe one existing installation before constructing the inactive provider candidate. */
+export async function createMxcRuntimeProviderBundleFromExistingInstallation(
+  options: MxcExistingInstallationRuntimeProviderOptions,
+): Promise<RuntimeProviderBundle> {
+  return (await attachMxcRuntimeProviderBundleFromExistingInstallation(options)).provider;
 }

--- a/src/lib/onboard/runtime-provider/mxc.ts
+++ b/src/lib/onboard/runtime-provider/mxc.ts
@@ -264,10 +264,3 @@ export async function attachMxcRuntimeProviderBundleFromExistingInstallation({
     attachmentReceipt: initialAttachment.attachmentReceipt,
   });
 }
-
-/** Observe one existing installation before constructing the inactive provider candidate. */
-export async function createMxcRuntimeProviderBundleFromExistingInstallation(
-  options: MxcExistingInstallationRuntimeProviderOptions,
-): Promise<RuntimeProviderBundle> {
-  return (await attachMxcRuntimeProviderBundleFromExistingInstallation(options)).provider;
-}

--- a/src/lib/onboard/windows-mxc/existing-installation.test.ts
+++ b/src/lib/onboard/windows-mxc/existing-installation.test.ts
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const nativeBoundary = vi.hoisted(() => ({
+  observeFileDigest: vi.fn<(filePath: string) => Promise<string>>(),
+  observeHostFacts: vi.fn(),
+}));
+
+vi.mock("../runtime-provider/mxc-windows-file-observer", () => ({
+  createMxcWindowsOpenShellFileDigestObserver: () => nativeBoundary.observeFileDigest,
+}));
+
+vi.mock("./native-host-facts", () => ({
+  observeWindowsMxcNativeHostFacts: nativeBoundary.observeHostFacts,
+}));
+
+import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "../runtime-provider/current";
+import type { MxcNativeArtifactControlPlane } from "../runtime-provider/mxc-bootstrap-operations";
+import { mxcOpenShellAttachmentFixture } from "../runtime-provider/mxc-openshell-attachment-test-fixture";
+import { MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION } from "../runtime-provider/mxc-openshell-attachment";
+import type { MxcOpenShellAttachmentObservationRequest } from "../runtime-provider/mxc-openshell-observer";
+import { attachMxcWindowsExistingInstallation } from "./existing-installation";
+
+function controlPlane(): MxcNativeArtifactControlPlane {
+  return {
+    contractVersion: 1,
+    providerId: "mxc",
+    verifyAndCreate: vi.fn(async () => ({ status: "unknown" as const })),
+    verifyReadiness: vi.fn(async () => {
+      throw new Error("inactive test control plane has no readiness evidence");
+    }),
+    recoverCreate: vi.fn(async () => ({ status: "absent" as const })),
+  };
+}
+
+function observationRequest(
+  observed = mxcOpenShellAttachmentFixture("0.0.24").observation,
+): MxcOpenShellAttachmentObservationRequest {
+  return {
+    contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
+    providerId: "mxc",
+    mode: "attach-existing",
+    observedDistribution: {
+      version: observed.distribution.version,
+      revision: observed.distribution.revision,
+    },
+    observedGateway: {
+      driver: "mxc",
+      backend: "process_container",
+    },
+    installation: {
+      distributionArtifactPath: "C:\\OpenShell\\packages\\openshell-0.0.24.zip",
+      distributionRoot: observed.distributionRoot,
+      mxcRoot: observed.mxcRoot,
+      cliPath: observed.cliPath,
+      gatewayPath: observed.gatewayPath,
+      wxcExecPath: observed.wxcExecPath,
+      gatewayConfigPath: observed.gatewayConfigPath,
+    },
+  };
+}
+
+function acceptedDigests(observed = mxcOpenShellAttachmentFixture("0.0.24").observation) {
+  return new Map<string, string>([
+    ["C:\\OpenShell\\packages\\openshell-0.0.24.zip", observed.distribution.sha256],
+    [observed.cliPath, observed.components.cliSha256],
+    [observed.gatewayPath, observed.components.gatewaySha256],
+    [observed.wxcExecPath, observed.components.wxcExecSha256],
+    [observed.gatewayConfigPath, observed.gateway.configSha256],
+  ]);
+}
+
+describe("inactive native Windows OpenShell MXC existing-installation composition", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    nativeBoundary.observeHostFacts.mockReset();
+    nativeBoundary.observeFileDigest.mockReset();
+  });
+
+  it("retains the qualified receipt without entering runtime selection (#8178)", async () => {
+    const attachment = mxcOpenShellAttachmentFixture("0.0.24");
+    const digests = acceptedDigests(attachment.observation);
+    const bootstrapControlPlane = controlPlane();
+    nativeBoundary.observeHostFacts.mockReturnValue({
+      platform: "win32",
+      nativeArchitecture: "x64",
+      release: "10.0.28120.2760",
+    });
+    nativeBoundary.observeFileDigest.mockImplementation(async (filePath: string) =>
+      digests.get(filePath)!,
+    );
+
+    const result = await attachMxcWindowsExistingInstallation({
+      openshellAttachmentAuthority: attachment.authority,
+      attachmentObservation: observationRequest(attachment.observation),
+      bootstrapControlPlane,
+    });
+
+    expect(result.attachmentReceipt).toMatchObject({
+      contractVersion: 2,
+      providerId: "mxc",
+      distribution: { root: "C:\\OpenShell" },
+      components: {
+        wxcExec: {
+          root: "C:\\mxc-kit",
+          path: "C:\\mxc-kit\\bin\\wxc-exec.exe",
+        },
+      },
+    });
+    expect(result.hostFacts).toEqual({
+      platform: "win32",
+      nativeArchitecture: "x64",
+      release: "10.0.28120.2760",
+    });
+    expect(result.provider.identity.id).toBe("mxc");
+    expect(nativeBoundary.observeFileDigest).toHaveBeenCalledTimes(5);
+    expect(bootstrapControlPlane.verifyAndCreate).not.toHaveBeenCalled();
+    expect(bootstrapControlPlane.verifyReadiness).not.toHaveBeenCalled();
+    expect(bootstrapControlPlane.recoverCreate).not.toHaveBeenCalled();
+    expect(Object.hasOwn(CURRENT_RUNTIME_PROVIDER_BUNDLES, "mxc")).toBe(false);
+  });
+
+  it("rejects WSL before observing installation files (#8178)", async () => {
+    const attachment = mxcOpenShellAttachmentFixture("0.0.24");
+    nativeBoundary.observeHostFacts.mockReturnValue({
+      platform: "linux",
+      nativeArchitecture: "x64",
+      release: "6.6.87.2-microsoft-standard-WSL2",
+    });
+
+    await expect(
+      attachMxcWindowsExistingInstallation({
+        openshellAttachmentAuthority: attachment.authority,
+        attachmentObservation: observationRequest(attachment.observation),
+        bootstrapControlPlane: controlPlane(),
+      }),
+    ).rejects.toThrow(/WSL is not a native Windows host/u);
+    expect(nativeBoundary.observeFileDigest).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unqualified architecture before observing installation files (#8178)", async () => {
+    const attachment = mxcOpenShellAttachmentFixture("0.0.24");
+    nativeBoundary.observeHostFacts.mockReturnValue({
+      platform: "win32",
+      nativeArchitecture: "arm64",
+      release: "10.0.28000.2525",
+    });
+
+    await expect(
+      attachMxcWindowsExistingInstallation({
+        openshellAttachmentAuthority: attachment.authority,
+        attachmentObservation: observationRequest(attachment.observation),
+        bootstrapControlPlane: controlPlane(),
+      }),
+    ).rejects.toThrow(/currently qualifies x64 only/u);
+    expect(nativeBoundary.observeFileDigest).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/onboard/windows-mxc/existing-installation.test.ts
+++ b/src/lib/onboard/windows-mxc/existing-installation.test.ts
@@ -157,4 +157,25 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
     ).rejects.toThrow(/currently qualifies x64 only/u);
     expect(nativeBoundary.observeFileDigest).not.toHaveBeenCalled();
   });
+
+  it("rejects a caller-constructed attachment authority before provider composition (#8178)", async () => {
+    const attachment = mxcOpenShellAttachmentFixture("0.0.24");
+    const digests = acceptedDigests(attachment.observation);
+    nativeBoundary.observeHostFacts.mockReturnValue({
+      platform: "win32",
+      nativeArchitecture: "x64",
+      release: "10.0.28120.2760",
+    });
+    nativeBoundary.observeFileDigest.mockImplementation(async (filePath: string) =>
+      digests.get(filePath)!,
+    );
+
+    await expect(
+      attachMxcWindowsExistingInstallation({
+        openshellAttachmentAuthority: { ...attachment.authority },
+        attachmentObservation: observationRequest(attachment.observation),
+        bootstrapControlPlane: controlPlane(),
+      }),
+    ).rejects.toThrow(/accepted identity authority is not provider-owned/u);
+  });
 });

--- a/src/lib/onboard/windows-mxc/existing-installation.ts
+++ b/src/lib/onboard/windows-mxc/existing-installation.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { RuntimeProviderBundle } from "../runtime-provider/contract";
+import {
+  attachMxcRuntimeProviderBundleFromExistingInstallation,
+  type MxcExistingInstallationRuntimeProviderAttachment,
+} from "../runtime-provider/mxc";
+import type { MxcNativeArtifactControlPlane } from "../runtime-provider/mxc-bootstrap-operations";
+import type {
+  MxcOpenShellAttachmentAuthority,
+  MxcOpenShellAttachmentReceipt,
+} from "../runtime-provider/mxc-openshell-attachment";
+import type {
+  MxcOpenShellAttachmentObservationRequest,
+  MxcOpenShellFileDigestObserver,
+} from "../runtime-provider/mxc-openshell-observer";
+import { createMxcWindowsOpenShellFileDigestObserver } from "../runtime-provider/mxc-windows-file-observer";
+import {
+  assessWindowsMxcProcessContainerCandidate,
+  type WindowsMxcHostFacts,
+} from "./host-qualification";
+import { observeWindowsMxcNativeHostFacts } from "./native-host-facts";
+
+export interface MxcWindowsExistingInstallationInput {
+  readonly openshellAttachmentAuthority: MxcOpenShellAttachmentAuthority;
+  readonly attachmentObservation: MxcOpenShellAttachmentObservationRequest;
+  readonly bootstrapControlPlane: MxcNativeArtifactControlPlane;
+}
+
+interface MxcWindowsExistingInstallationBoundary {
+  readonly observeHostFacts: () => WindowsMxcHostFacts;
+  readonly observeFileDigest: MxcOpenShellFileDigestObserver;
+}
+
+export interface MxcWindowsExistingInstallationComposition extends MxcExistingInstallationRuntimeProviderAttachment {
+  readonly provider: RuntimeProviderBundle;
+  readonly attachmentReceipt: MxcOpenShellAttachmentReceipt;
+  readonly hostFacts: WindowsMxcHostFacts;
+}
+
+export class MxcWindowsExistingInstallationError extends Error {
+  constructor(message: string) {
+    super(`Inactive Windows OpenShell MXC attachment failed: ${message}`);
+    this.name = "MxcWindowsExistingInstallationError";
+  }
+}
+
+function defaultBoundary(): MxcWindowsExistingInstallationBoundary {
+  return {
+    observeHostFacts: observeWindowsMxcNativeHostFacts,
+    observeFileDigest: createMxcWindowsOpenShellFileDigestObserver(),
+  };
+}
+
+/**
+ * Compose the inactive native Windows provider from one accepted existing installation.
+ *
+ * This function observes and qualifies host artifacts only. It does not register,
+ * select, install, or activate MXC and does not call the OpenShell control plane.
+ */
+export async function attachMxcWindowsExistingInstallation(
+  input: MxcWindowsExistingInstallationInput,
+): Promise<MxcWindowsExistingInstallationComposition> {
+  const boundary = defaultBoundary();
+  const hostFacts = boundary.observeHostFacts();
+  const assessment = assessWindowsMxcProcessContainerCandidate(hostFacts);
+  if (!assessment.candidate) {
+    throw new MxcWindowsExistingInstallationError(assessment.detail);
+  }
+
+  const attachment = await attachMxcRuntimeProviderBundleFromExistingInstallation({
+    hostFacts,
+    openshellAttachmentAuthority: input.openshellAttachmentAuthority,
+    attachmentObservation: input.attachmentObservation,
+    bootstrapControlPlane: input.bootstrapControlPlane,
+    observeFileDigest: boundary.observeFileDigest,
+  });
+  return Object.freeze({ ...attachment, hostFacts: Object.freeze({ ...hostFacts }) });
+}

--- a/src/lib/onboard/windows-mxc/native-host-facts.test.ts
+++ b/src/lib/onboard/windows-mxc/native-host-facts.test.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { observeWindowsMxcNativeHostFacts } from "./native-host-facts";
+
+describe("inactive native Windows MXC host observation", () => {
+  it.each([
+    ["x86_64", "x64"],
+    ["AMD64", "x64"],
+    ["aarch64", "arm64"],
+    ["arm64", "arm64"],
+  ])("maps native machine %s to %s (#8178)", (machine, nativeArchitecture) => {
+    expect(
+      observeWindowsMxcNativeHostFacts({
+        platform: "win32",
+        machine: () => machine,
+        release: () => "10.0.28120.2760",
+      }),
+    ).toEqual({
+      platform: "win32",
+      nativeArchitecture,
+      release: "10.0.28120.2760",
+    });
+  });
+
+  it("does not classify WSL as a native Windows host (#8178)", () => {
+    expect(
+      observeWindowsMxcNativeHostFacts({
+        platform: "linux",
+        machine: () => "x86_64",
+        release: () => "6.6.87.2-microsoft-standard-WSL2",
+      }),
+    ).toEqual({
+      platform: "linux",
+      nativeArchitecture: "x64",
+      release: "6.6.87.2-microsoft-standard-WSL2",
+    });
+  });
+});

--- a/src/lib/onboard/windows-mxc/native-host-facts.test.ts
+++ b/src/lib/onboard/windows-mxc/native-host-facts.test.ts
@@ -25,7 +25,7 @@ describe("inactive native Windows MXC host observation", () => {
     });
   });
 
-  it("does not classify WSL as a native Windows host (#8178)", () => {
+  it("reports a WSL host with its observed Linux platform (#8178)", () => {
     expect(
       observeWindowsMxcNativeHostFacts({
         platform: "linux",

--- a/src/lib/onboard/windows-mxc/native-host-facts.ts
+++ b/src/lib/onboard/windows-mxc/native-host-facts.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import os from "node:os";
+
+import type { WindowsMxcHostFacts } from "./host-qualification";
+
+export interface WindowsMxcNativeHostRuntime {
+  readonly platform: NodeJS.Platform;
+  readonly machine: () => string;
+  readonly release: () => string;
+}
+
+const DEFAULT_RUNTIME: WindowsMxcNativeHostRuntime = {
+  platform: process.platform,
+  machine: () => os.machine(),
+  release: () => os.release(),
+};
+
+function normalizeNativeArchitecture(machine: string): string {
+  switch (machine.trim().toLowerCase()) {
+    case "amd64":
+    case "x86_64":
+      return "x64";
+    case "aarch64":
+      return "arm64";
+    default:
+      return machine.trim().toLowerCase();
+  }
+}
+
+/** Collect native host facts without using WSL or the Node.js binary architecture. */
+export function observeWindowsMxcNativeHostFacts(
+  runtime: WindowsMxcNativeHostRuntime = DEFAULT_RUNTIME,
+): WindowsMxcHostFacts {
+  return Object.freeze({
+    platform: runtime.platform,
+    nativeArchitecture: normalizeNativeArchitecture(runtime.machine()),
+    release: runtime.release(),
+  });
+}


### PR DESCRIPTION
## Outcome

NemoClaw can now compose an inactive Windows MXC runtime-provider candidate from one accepted OpenShell installation. The composition verifies native host facts and exact installed-file identities without registering, selecting, installing, or activating MXC.

## Reason

Epic #8178 requires a qualified Windows attachment boundary before native onboarding can use the MXC provider. The latest OpenShell package also supplies `wxc-exec.exe` outside the OpenShell distribution, so the attachment contract must preserve separate exact roots.

### Related issues

Part of #8178

## Changes

- Add a native Windows stable-file observer. It hashes one pinned file handle, rejects reparse points and identity changes, uses an allowlisted process environment, and redacts host paths from errors.
- Version the OpenShell attachment contract to record separate OpenShell and MXC roots. Both roots remain local-drive paths, and each executable must remain within its owning root.
- Add inactive Windows host observation and existing-installation composition. The composition retains the exact attachment receipt and re-observes all files before bootstrap or recovery.
- Keep MXC absent from the current provider registry, installer choices, CLI onboarding, and activation.

## Verification

- `npx vitest run --project cli src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts src/lib/onboard/runtime-provider/mxc-openshell-observer.test.ts src/lib/onboard/runtime-provider/mxc-windows-file-observer.test.ts src/lib/onboard/runtime-provider/mxc.test.ts src/lib/onboard/windows-mxc/existing-installation.test.ts src/lib/onboard/windows-mxc/native-host-facts.test.ts` — 85 tests passed.
- `npm run test:changed -- --run` — 109 affected tests passed.
- `npm run typecheck:cli` — passed.
- `npm run checks:repository` — passed.
- Normal `pre-commit`, `commit-msg`, and `pre-push` hooks — passed.
- Native Windows observer check — accepted regular files and rejected a junction ancestor and a symbolic-link target with redacted errors.
- OpenShell MXC demo v0.0.24 `process_container` check — sandbox creation, OpenClaw readiness, authenticated forwarding health, deletion, and process cleanup passed. This check did not qualify `isolation_session`.
- The diff contains no secrets, API keys, or credentials. The repository gitleaks hook passed.

## Review notes

This PR provides an inactive composition boundary only. A later activation change must separately qualify onboarding persistence, credentials, inference, governed egress, recovery, cleanup, standard-user operation, and repeated physical E2E behavior.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for attaching existing native Windows MXC installations.
  * Added secure Windows file verification using SHA-256 digests.
  * Added host compatibility checks for supported architectures and native Windows environments.
  * Attachment receipts now include the MXC installation root and updated contract information.

* **Bug Fixes**
  * Rejects network paths, invalid locations, file mutations, and unsupported installation layouts.
  * Revalidates installations before starting or recovering runtime services.
  * Provides clearer diagnostics when installation observation or qualification fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->