### PR TITLE
feat(onboard): compose inactive Windows MXC onboarding

### DIFF
--- a/src/lib/onboard/windows-mxc/inactive-onboarding.test.ts
+++ b/src/lib/onboard/windows-mxc/inactive-onboarding.test.ts
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+
+const nativeBoundary = vi.hoisted(() => ({
+  observeFileDigest: vi.fn<(filePath: string) => Promise<string>>(),
+  observeHostFacts: vi.fn(),
+}));
+
+vi.mock("../runtime-provider/mxc-windows-file-observer", () => ({
+  createMxcWindowsOpenShellFileDigestObserver: () => nativeBoundary.observeFileDigest,
+}));
+
+vi.mock("./native-host-facts", () => ({
+  observeWindowsMxcNativeHostFacts: nativeBoundary.observeHostFacts,
+}));
+
+import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "../runtime-provider/current";
+import type { MxcNativeArtifactControlPlane } from "../runtime-provider/mxc-bootstrap-operations";
+import { mxcOpenShellAttachmentFixture } from "../runtime-provider/mxc-openshell-attachment-test-fixture";
+import { MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION } from "../runtime-provider/mxc-openshell-attachment";
+import type { MxcOpenShellAttachmentObservationRequest } from "../runtime-provider/mxc-openshell-observer";
+import { encodeManagedStartupProfile } from "../managed-startup/profile";
+import { nativeArtifactWorkloadReceiptFixture } from "../workload/native-artifact-test-fixture";
+import {
+  recoverMxcWindowsInactiveOnboarding,
+  runMxcWindowsInactiveOnboarding,
+  type MxcWindowsInactiveOnboardingInput,
+} from "./inactive-onboarding";
+
+const REQUIRED_ENVIRONMENT = [
+  "HOME",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_HOME",
+  "OPENCLAW_STATE_DIR",
+  "PATH",
+  "TEMP",
+  "TMP",
+  "USERPROFILE",
+] as const;
+
+function controlPlane(): MxcNativeArtifactControlPlane {
+  return {
+    contractVersion: 1,
+    providerId: "mxc",
+    verifyAndCreate: vi.fn(async (plan) => ({
+      status: "created" as const,
+      authoritySha256: plan.authoritySha256,
+      providerHandle: plan.providerHandle,
+      sandboxName: plan.sandboxName,
+      lifecycleGeneration: plan.lifecycleGeneration,
+      artifactDigest: plan.workload.artifact.digest,
+      executableDigest: plan.workload.launch.executable.digest,
+    })),
+    verifyReadiness: vi.fn(async (plan) => ({
+      authoritySha256: plan.authoritySha256,
+      providerHandle: plan.providerHandle,
+      sandboxName: plan.sandboxName,
+      lifecycleGeneration: plan.lifecycleGeneration,
+      artifactDigest: plan.workload.artifact.digest,
+      executableDigest: plan.workload.launch.executable.digest,
+      ready: true as const,
+    })),
+    recoverCreate: vi.fn(async () => ({ status: "absent" as const })),
+  };
+}
+
+function observationRequest(): MxcOpenShellAttachmentObservationRequest {
+  const observed = mxcOpenShellAttachmentFixture("0.0.24").observation;
+  return {
+    contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
+    providerId: "mxc",
+    mode: "attach-existing",
+    observedDistribution: {
+      version: observed.distribution.version,
+      revision: observed.distribution.revision,
+    },
+    observedGateway: { driver: "mxc", backend: "process_container" },
+    installation: {
+      distributionArtifactPath: "C:\\OpenShell\\packages\\openshell-0.0.24.zip",
+      distributionRoot: observed.distributionRoot,
+      mxcRoot: observed.mxcRoot,
+      cliPath: observed.cliPath,
+      gatewayPath: observed.gatewayPath,
+      wxcExecPath: observed.wxcExecPath,
+      gatewayConfigPath: observed.gatewayConfigPath,
+    },
+  };
+}
+
+function acceptedDigests(): Map<string, string> {
+  const observed = mxcOpenShellAttachmentFixture("0.0.24").observation;
+  return new Map([
+    ["C:\\OpenShell\\packages\\openshell-0.0.24.zip", observed.distribution.sha256],
+    [observed.cliPath, observed.components.cliSha256],
+    [observed.gatewayPath, observed.components.gatewaySha256],
+    [observed.wxcExecPath, observed.components.wxcExecSha256],
+    [observed.gatewayConfigPath, observed.gateway.configSha256],
+  ]);
+}
+
+function onboardingInput(
+  bootstrapControlPlane: MxcNativeArtifactControlPlane,
+): MxcWindowsInactiveOnboardingInput {
+  const attachment = mxcOpenShellAttachmentFixture("0.0.24");
+  const workload = nativeArtifactWorkloadReceiptFixture(
+    encodeManagedStartupProfile(managedStartupE2eProfile("openclaw")),
+  );
+  return {
+    installation: {
+      openshellAttachmentAuthority: attachment.authority,
+      attachmentObservation: observationRequest(),
+      bootstrapControlPlane,
+    },
+    bootstrap: {
+      sandboxName: "openclaw-mxc",
+      lifecycleGeneration: "generation-1",
+      driveRoot: "C:\\",
+      artifactRoot: "C:\\openclaw-artifact",
+      workload: {
+        ...workload,
+        launch: { ...workload.launch, environmentNames: REQUIRED_ENVIRONMENT },
+      },
+    },
+  };
+}
+
+describe("inactive native Windows OpenShell MXC onboarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    nativeBoundary.observeHostFacts.mockReturnValue({
+      platform: "win32",
+      nativeArchitecture: "x64",
+      release: "10.0.28120.2760",
+    });
+    const digests = acceptedDigests();
+    nativeBoundary.observeFileDigest.mockImplementation(async (filePath) =>
+      Promise.resolve(digests.get(filePath) ?? "0".repeat(64)),
+    );
+  });
+
+  it("runs the qualified native artifact without activating MXC (#8178)", async () => {
+    const operations = controlPlane();
+
+    const result = await runMxcWindowsInactiveOnboarding(onboardingInput(operations));
+
+    expect(result.computePlan).toEqual({ driverName: "mxc", gatewayLauncher: "openshell" });
+    expect(result.bootstrapResult).toMatchObject({
+      outcome: "ready",
+      resourceState: "active",
+      recoveryRequired: false,
+    });
+    expect(nativeBoundary.observeFileDigest).toHaveBeenCalledTimes(10);
+    expect(operations.verifyAndCreate).toHaveBeenCalledTimes(1);
+    expect(operations.verifyReadiness).toHaveBeenCalledTimes(1);
+    expect(operations.recoverCreate).not.toHaveBeenCalled();
+    expect(Object.hasOwn(CURRENT_RUNTIME_PROVIDER_BUNDLES, "mxc")).toBe(false);
+  });
+
+  it("rejects attachment drift before the create operation (#8178)", async () => {
+    const operations = controlPlane();
+    const digests = acceptedDigests();
+    let observations = 0;
+    nativeBoundary.observeFileDigest.mockImplementation(async (filePath) => {
+      observations += 1;
+      return observations > 5 ? "f".repeat(64) : (digests.get(filePath) ?? "0".repeat(64));
+    });
+
+    await expect(runMxcWindowsInactiveOnboarding(onboardingInput(operations))).rejects.toThrow(
+      /observed distribution identity does not match the accepted identity/u,
+    );
+    expect(operations.verifyAndCreate).not.toHaveBeenCalled();
+    expect(operations.verifyReadiness).not.toHaveBeenCalled();
+    expect(operations.recoverCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unaccepted workload before the create operation (#8178)", async () => {
+    const operations = controlPlane();
+    const input = onboardingInput(operations);
+    const workload = { ...input.bootstrap.workload, agent: "hermes" };
+
+    await expect(
+      runMxcWindowsInactiveOnboarding({
+        ...input,
+        bootstrap: { ...input.bootstrap, workload } as typeof input.bootstrap,
+      }),
+    ).rejects.toThrow(/does not match the attached provider workload contract/u);
+    expect(nativeBoundary.observeFileDigest).toHaveBeenCalledTimes(5);
+    expect(operations.verifyAndCreate).not.toHaveBeenCalled();
+  });
+
+  it("requalifies the installation before recovery (#8178)", async () => {
+    const operations = controlPlane();
+
+    const result = await recoverMxcWindowsInactiveOnboarding(onboardingInput(operations));
+
+    expect(result.bootstrapResult).toMatchObject({
+      outcome: "not-created",
+      reason: "recovered",
+      resourceState: "absent",
+      recoveryRequired: false,
+    });
+    expect(nativeBoundary.observeFileDigest).toHaveBeenCalledTimes(10);
+    expect(operations.recoverCreate).toHaveBeenCalledTimes(1);
+    expect(operations.verifyAndCreate).not.toHaveBeenCalled();
+    expect(operations.verifyReadiness).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/onboard/windows-mxc/inactive-onboarding.ts
+++ b/src/lib/onboard/windows-mxc/inactive-onboarding.ts
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { projectRuntimeProviderComputePlan, type OpenShellComputePlan } from "../compute/plan";
+import type {
+  RuntimeProviderBundle,
+  RuntimeProviderNativeArtifactBootstrapInput,
+  RuntimeProviderNativeArtifactBootstrapResult,
+  RuntimeProviderNativeArtifactBootstrapSurface,
+} from "../runtime-provider/contract";
+import type { MxcOpenShellAttachmentReceipt } from "../runtime-provider/mxc-openshell-attachment";
+import {
+  attachMxcWindowsExistingInstallation,
+  type MxcWindowsExistingInstallationInput,
+} from "./existing-installation";
+import type { WindowsMxcHostFacts } from "./host-qualification";
+
+const PROVIDER_ID = "mxc" as const;
+
+export type MxcWindowsInactiveOnboardingBootstrapInput = Omit<
+  RuntimeProviderNativeArtifactBootstrapInput,
+  "providerId"
+>;
+
+export interface MxcWindowsInactiveOnboardingInput {
+  readonly installation: MxcWindowsExistingInstallationInput;
+  readonly bootstrap: MxcWindowsInactiveOnboardingBootstrapInput;
+}
+
+export interface MxcWindowsInactiveOnboardingResult {
+  readonly provider: RuntimeProviderBundle;
+  readonly computePlan: OpenShellComputePlan;
+  readonly attachmentReceipt: MxcOpenShellAttachmentReceipt;
+  readonly hostFacts: WindowsMxcHostFacts;
+  readonly bootstrapResult: RuntimeProviderNativeArtifactBootstrapResult;
+}
+
+export class MxcWindowsInactiveOnboardingError extends Error {
+  constructor(message: string) {
+    super(`Inactive Windows OpenShell MXC onboarding failed: ${message}`);
+    this.name = "MxcWindowsInactiveOnboardingError";
+  }
+}
+
+function requireNativeArtifactBootstrap(
+  provider: RuntimeProviderBundle,
+): RuntimeProviderNativeArtifactBootstrapSurface {
+  if (
+    !provider.bootstrap.supported ||
+    provider.bootstrap.providerId !== PROVIDER_ID ||
+    provider.bootstrap.bootstrapKind !== "native-artifact"
+  ) {
+    throw new MxcWindowsInactiveOnboardingError(
+      "the attached provider does not expose the accepted native-artifact bootstrap contract",
+    );
+  }
+  return provider.bootstrap;
+}
+
+async function execute(
+  input: MxcWindowsInactiveOnboardingInput,
+  operation: "run" | "recover",
+): Promise<MxcWindowsInactiveOnboardingResult> {
+  const attachment = await attachMxcWindowsExistingInstallation(input.installation);
+  if (!attachment.provider.workload.supported) {
+    throw new MxcWindowsInactiveOnboardingError(
+      "the attached provider does not expose a workload contract",
+    );
+  }
+  if (!attachment.provider.workload.acceptsReceipt(input.bootstrap.workload)) {
+    throw new MxcWindowsInactiveOnboardingError(
+      "the native artifact does not match the attached provider workload contract",
+    );
+  }
+  const bootstrap = requireNativeArtifactBootstrap(attachment.provider);
+  const bootstrapResult = await bootstrap[operation]({
+    ...input.bootstrap,
+    providerId: PROVIDER_ID,
+  });
+  return Object.freeze({
+    provider: attachment.provider,
+    computePlan: Object.freeze(projectRuntimeProviderComputePlan(attachment.provider)),
+    attachmentReceipt: attachment.attachmentReceipt,
+    hostFacts: attachment.hostFacts,
+    bootstrapResult,
+  });
+}
+
+/**
+ * Exercise the inactive native Windows onboarding path without registering or selecting MXC.
+ *
+ * The existing installation is observed once during attachment and again immediately before the
+ * provider-owned atomic verify-and-create operation.
+ */
+export function runMxcWindowsInactiveOnboarding(
+  input: MxcWindowsInactiveOnboardingInput,
+): Promise<MxcWindowsInactiveOnboardingResult> {
+  return execute(input, "run");
+}
+
+/** Reconcile one prior inactive bootstrap attempt after requalifying the existing installation. */
+export function recoverMxcWindowsInactiveOnboarding(
+  input: MxcWindowsInactiveOnboardingInput,
+): Promise<MxcWindowsInactiveOnboardingResult> {
+  return execute(input, "recover");
+}


### PR DESCRIPTION
## Outcome

NemoClaw can compose a qualified existing Windows OpenShell+MXC installation with the dormant native-artifact bootstrap contract for start and recovery tests. MXC remains absent from production provider selection, CLI onboarding, and activation.

## Reason

Epic #8178 needs an evidence-backed bridge from the merged Windows package attachment contract to the merged MXC bootstrap operations before user-facing onboarding can be designed safely.

### Related issues

Part of #8178

## Changes

- Add an inactive Windows MXC onboarding composition that attaches the accepted OpenShell package, validates the OpenClaw workload receipt, and invokes provider-owned start or recovery.
- Reobserve package identities immediately before each control-plane operation so attachment drift fails before mutation.
- Add tests for the ready path, attachment drift, workload substitution, recovery, and continued absence from the production provider registry.

## Verification

- `npx vitest run --project cli src/lib/onboard/windows-mxc/inactive-onboarding.test.ts src/lib/onboard/windows-mxc/existing-installation.test.ts src/lib/onboard/runtime-provider/mxc-provider.test.ts src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts src/lib/onboard/runtime-provider/mxc-bootstrap-operations.test.ts` — 4 files and 38 tests passed.
- `npx vitest run --project e2e-support test/e2e/support/windows-mxc-openclaw-process-container.test.ts` — 55 tests passed on the host execution boundary.
- `npm run typecheck:cli` — passed.
- `npm run checks:repository` — passed.
- Normal `pre-commit`, `commit-msg`, and `pre-push` hooks — passed.
- Security review — all nine categories passed; the diff contains no secrets, API keys, or credentials.

## Review notes

This is a dormant composition seam only. It does not add MXC to the current provider registry, expose a CLI option, install a package, or activate Windows support.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for onboarding existing inactive Windows OpenShell MXC installations.
  - Added recovery support for previously onboarded inactive installations.
  - Validates installation attachments, requested workloads, and required native artifacts before proceeding.
  - Executes provider operations without activating the MXC runtime bundle.
  - Rechecks installation eligibility during recovery and reports clear onboarding failures when requirements are not met.

- **Tests**
  - Added comprehensive coverage for successful onboarding, recovery, validation failures, and attachment changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->