### PR TITLE
perf(test): reduce retained slow-test runtime

### DIFF
--- a/src/lib/actions/sandbox/auto-pair-approval.test.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.test.ts
@@ -23,12 +23,25 @@ describe("auto-pair approval pass behaviour (#4616)", () => {
   pyIt25s("approves only one exact local clone pairing transition on a shared gateway", () => {
     const policy = readAutoPairApprovalPolicyModule();
     expect(policy).toBeTruthy();
-    const policyB64 = Buffer.from(policy as string, "utf-8").toString("base64");
+    const testPolicy = `${policy}
+class _NemoClawTestTime:
+    def __init__(self):
+        self.now = 0.0
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
+
+approval_time = _NemoClawTestTime()
+`;
+    const policyB64 = Buffer.from(testPolicy, "utf-8").toString("base64");
     const script = buildAutoPairApprovalScript(policyB64, {
       emitSummary: true,
       emitReceipt: true,
       localDeviceOnly: true,
-      budget: { maxApprovals: 1, pendingReadPollS: 0.001 },
+      budget: { maxApprovals: 1 },
     });
     const timeoutScript = buildAutoPairApprovalScript(policyB64, {
       emitSummary: true,
@@ -37,9 +50,6 @@ describe("auto-pair approval pass behaviour (#4616)", () => {
       budget: {
         maxApprovals: 1,
         approveTimeoutS: 0.25,
-        pendingReadPollS: 0.001,
-        postTimeoutObserveS: 0.02,
-        postTimeoutPollS: 0.001,
       },
     });
     const tmpDir = fs.realpathSync(
@@ -284,7 +294,7 @@ process.exit(2);
       );
       const devicesRaceBackup = path.join(stateDir, "devices-before-race");
       const transientRaceMarker = path.join(tmpDir, "transient-devices-race.marker");
-      const transientRacePolicy = `${policy}
+      const transientRacePolicy = `${testPolicy}
 import os as _nemoclaw_test_os
 _nemoclaw_test_original_open = _nemoclaw_test_os.open
 _nemoclaw_test_raced = False
@@ -339,7 +349,7 @@ _nemoclaw_test_os.open = _nemoclaw_test_race_open
       );
       const stateRaceBackup = path.join(tmpDir, "clone-state-before-child");
       const childRaceMarker = path.join(tmpDir, "child-entry-state-race.marker");
-      const childEntryRacePolicy = `${policy}
+      const childEntryRacePolicy = `${testPolicy}
 import os as _nemoclaw_test_os
 import subprocess as _nemoclaw_test_subprocess
 _nemoclaw_test_original_run = _nemoclaw_test_subprocess.run

--- a/src/lib/actions/sandbox/auto-pair-approval.test.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.test.ts
@@ -23,39 +23,25 @@ describe("auto-pair approval pass behaviour (#4616)", () => {
   pyIt25s("approves only one exact local clone pairing transition on a shared gateway", () => {
     const policy = readAutoPairApprovalPolicyModule();
     expect(policy).toBeTruthy();
-    const productionScript = buildAutoPairApprovalScript(
-      Buffer.from(policy as string, "utf-8").toString("base64"),
-      {
-        emitSummary: true,
-        emitReceipt: true,
-        localDeviceOnly: true,
-        budget: { maxApprovals: 1 },
+    const policyB64 = Buffer.from(policy as string, "utf-8").toString("base64");
+    const script = buildAutoPairApprovalScript(policyB64, {
+      emitSummary: true,
+      emitReceipt: true,
+      localDeviceOnly: true,
+      budget: { maxApprovals: 1, pendingReadPollS: 0.001 },
+    });
+    const timeoutScript = buildAutoPairApprovalScript(policyB64, {
+      emitSummary: true,
+      emitReceipt: true,
+      localDeviceOnly: true,
+      budget: {
+        maxApprovals: 1,
+        approveTimeoutS: 0.25,
+        pendingReadPollS: 0.001,
+        postTimeoutObserveS: 0.02,
+        postTimeoutPollS: 0.001,
       },
-    );
-    const script = productionScript.replace("PENDING_READ_POLL_S = 0.1", "PENDING_READ_POLL_S = 0.001");
-    expect(script).not.toBe(productionScript);
-    const productionTimeoutScript = buildAutoPairApprovalScript(
-      Buffer.from(policy as string, "utf-8").toString("base64"),
-      {
-        emitSummary: true,
-        emitReceipt: true,
-        localDeviceOnly: true,
-        budget: { maxApprovals: 1, approveTimeoutS: 0.25 },
-      },
-    );
-    const timeoutScript = productionTimeoutScript
-      .replace("PENDING_READ_POLL_S = 0.1", "PENDING_READ_POLL_S = 0.001")
-      .replace(
-        "observe_deadline = time.monotonic() + 4",
-        "observe_deadline = time.monotonic() + 0.02",
-      )
-      .replace(
-        "time.sleep(min(0.1, remaining_observe_time))",
-        "time.sleep(min(0.001, remaining_observe_time))",
-      );
-    expect(timeoutScript).toContain("PENDING_READ_POLL_S = 0.001");
-    expect(timeoutScript).toContain("observe_deadline = time.monotonic() + 0.02");
-    expect(timeoutScript).toContain("time.sleep(min(0.001, remaining_observe_time))");
+    });
     const tmpDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-restored-clone-pair-")),
     );

--- a/src/lib/actions/sandbox/auto-pair-approval.test.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.test.ts
@@ -23,7 +23,7 @@ describe("auto-pair approval pass behaviour (#4616)", () => {
   pyIt25s("approves only one exact local clone pairing transition on a shared gateway", () => {
     const policy = readAutoPairApprovalPolicyModule();
     expect(policy).toBeTruthy();
-    const script = buildAutoPairApprovalScript(
+    const productionScript = buildAutoPairApprovalScript(
       Buffer.from(policy as string, "utf-8").toString("base64"),
       {
         emitSummary: true,
@@ -32,18 +32,30 @@ describe("auto-pair approval pass behaviour (#4616)", () => {
         budget: { maxApprovals: 1 },
       },
     );
-    const timeoutScript = buildAutoPairApprovalScript(
+    const script = productionScript.replace("PENDING_READ_POLL_S = 0.1", "PENDING_READ_POLL_S = 0.001");
+    expect(script).not.toBe(productionScript);
+    const productionTimeoutScript = buildAutoPairApprovalScript(
       Buffer.from(policy as string, "utf-8").toString("base64"),
       {
         emitSummary: true,
         emitReceipt: true,
         localDeviceOnly: true,
-        // Keep production's 10s cap unchanged. This executable fixture only
-        // needs enough time to publish its synchronous canonical state before
-        // proving the generated TimeoutExpired branch.
         budget: { maxApprovals: 1, approveTimeoutS: 0.25 },
       },
     );
+    const timeoutScript = productionTimeoutScript
+      .replace("PENDING_READ_POLL_S = 0.1", "PENDING_READ_POLL_S = 0.001")
+      .replace(
+        "observe_deadline = time.monotonic() + 4",
+        "observe_deadline = time.monotonic() + 0.02",
+      )
+      .replace(
+        "time.sleep(min(0.1, remaining_observe_time))",
+        "time.sleep(min(0.001, remaining_observe_time))",
+      );
+    expect(timeoutScript).toContain("PENDING_READ_POLL_S = 0.001");
+    expect(timeoutScript).toContain("observe_deadline = time.monotonic() + 0.02");
+    expect(timeoutScript).toContain("time.sleep(min(0.001, remaining_observe_time))");
     const tmpDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-restored-clone-pair-")),
     );

--- a/src/lib/actions/sandbox/auto-pair-approval.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.ts
@@ -94,6 +94,9 @@ export type AutoPairApprovalBudget = {
   maxApprovals?: number;
   listTimeoutS?: number;
   approveTimeoutS?: number;
+  pendingReadPollS?: number;
+  postTimeoutObserveS?: number;
+  postTimeoutPollS?: number;
   timeoutMs?: number;
 };
 
@@ -263,6 +266,11 @@ def exit_with_receipt(receipt):
     : (options.budget?.maxApprovals ?? AUTO_PAIR_MAX_APPROVALS);
   const listTimeoutS = options.budget?.listTimeoutS ?? AUTO_PAIR_LIST_TIMEOUT_S;
   const approveTimeoutS = options.budget?.approveTimeoutS ?? AUTO_PAIR_APPROVE_TIMEOUT_S;
+  const pendingReadPollS =
+    options.budget?.pendingReadPollS ?? CONNECT_AUTO_PAIR_PENDING_READ_POLL_S;
+  const postTimeoutObserveS =
+    options.budget?.postTimeoutObserveS ?? CONNECT_AUTO_PAIR_POST_TIMEOUT_OBSERVE_S;
+  const postTimeoutPollS = options.budget?.postTimeoutPollS ?? AUTO_PAIR_POST_TIMEOUT_POLL_S;
   const approveEnv = options.localDeviceOnly
     ? `approve_env = gateway_approval_env(os.environ)
     approval_pass_fds = ()
@@ -356,12 +364,12 @@ def exit_with_receipt(receipt):
         approve_env.pop('NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING', None)
         approve_env.pop('NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING', None)
         local_paired_operator_token = ''
-        observe_deadline = time.monotonic() + ${CONNECT_AUTO_PAIR_POST_TIMEOUT_OBSERVE_S}
+        observe_deadline = time.monotonic() + ${postTimeoutObserveS}
         while not sync_approved_clone_device_auth(device, previous_approval_token):
             remaining_observe_time = observe_deadline - time.monotonic()
             if remaining_observe_time <= 0:
                 ${failedApproveAction}
-            time.sleep(min(${AUTO_PAIR_POST_TIMEOUT_POLL_S}, remaining_observe_time))
+            time.sleep(min(${postTimeoutPollS}, remaining_observe_time))
         approved_count += 1
     except (FileNotFoundError, OSError):
         ${failedApproveAction}
@@ -418,7 +426,7 @@ clone_file_flags = (
     | getattr(os, 'O_NONBLOCK', 0)
 )
 PENDING_READ_ATTEMPTS = ${CONNECT_AUTO_PAIR_PENDING_READ_ATTEMPTS}
-PENDING_READ_POLL_S = ${CONNECT_AUTO_PAIR_PENDING_READ_POLL_S}
+PENDING_READ_POLL_S = ${pendingReadPollS}
 
 class CloneStateEntryRotated(OSError):
     pass

--- a/src/lib/actions/sandbox/auto-pair-approval.ts
+++ b/src/lib/actions/sandbox/auto-pair-approval.ts
@@ -94,9 +94,6 @@ export type AutoPairApprovalBudget = {
   maxApprovals?: number;
   listTimeoutS?: number;
   approveTimeoutS?: number;
-  pendingReadPollS?: number;
-  postTimeoutObserveS?: number;
-  postTimeoutPollS?: number;
   timeoutMs?: number;
 };
 
@@ -266,11 +263,6 @@ def exit_with_receipt(receipt):
     : (options.budget?.maxApprovals ?? AUTO_PAIR_MAX_APPROVALS);
   const listTimeoutS = options.budget?.listTimeoutS ?? AUTO_PAIR_LIST_TIMEOUT_S;
   const approveTimeoutS = options.budget?.approveTimeoutS ?? AUTO_PAIR_APPROVE_TIMEOUT_S;
-  const pendingReadPollS =
-    options.budget?.pendingReadPollS ?? CONNECT_AUTO_PAIR_PENDING_READ_POLL_S;
-  const postTimeoutObserveS =
-    options.budget?.postTimeoutObserveS ?? CONNECT_AUTO_PAIR_POST_TIMEOUT_OBSERVE_S;
-  const postTimeoutPollS = options.budget?.postTimeoutPollS ?? AUTO_PAIR_POST_TIMEOUT_POLL_S;
   const approveEnv = options.localDeviceOnly
     ? `approve_env = gateway_approval_env(os.environ)
     approval_pass_fds = ()
@@ -364,12 +356,12 @@ def exit_with_receipt(receipt):
         approve_env.pop('NEMOCLAW_OPENCLAW_FORCE_DEVICE_PAIRING', None)
         approve_env.pop('NEMOCLAW_OPENCLAW_RESTORED_CLONE_PAIRING', None)
         local_paired_operator_token = ''
-        observe_deadline = time.monotonic() + ${postTimeoutObserveS}
+        observe_deadline = approval_time.monotonic() + ${CONNECT_AUTO_PAIR_POST_TIMEOUT_OBSERVE_S}
         while not sync_approved_clone_device_auth(device, previous_approval_token):
-            remaining_observe_time = observe_deadline - time.monotonic()
+            remaining_observe_time = observe_deadline - approval_time.monotonic()
             if remaining_observe_time <= 0:
                 ${failedApproveAction}
-            time.sleep(min(${postTimeoutPollS}, remaining_observe_time))
+            approval_time.sleep(min(${AUTO_PAIR_POST_TIMEOUT_POLL_S}, remaining_observe_time))
         approved_count += 1
     except (FileNotFoundError, OSError):
         ${failedApproveAction}
@@ -426,7 +418,7 @@ clone_file_flags = (
     | getattr(os, 'O_NONBLOCK', 0)
 )
 PENDING_READ_ATTEMPTS = ${CONNECT_AUTO_PAIR_PENDING_READ_ATTEMPTS}
-PENDING_READ_POLL_S = ${pendingReadPollS}
+PENDING_READ_POLL_S = ${CONNECT_AUTO_PAIR_PENDING_READ_POLL_S}
 
 class CloneStateEntryRotated(OSError):
     pass
@@ -559,7 +551,7 @@ for pending_read_attempt in range(PENDING_READ_ATTEMPTS):
             ${exitWithReceipt("list-pending-invalid-shape")}
         break
     if pending_read_attempt + 1 < PENDING_READ_ATTEMPTS:
-        time.sleep(PENDING_READ_POLL_S)
+        approval_time.sleep(PENDING_READ_POLL_S)
 else:
     if pending_read_failure == 'unavailable':
         ${exitWithReceipt("list-pending-unavailable")}
@@ -1028,6 +1020,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 ${receiptPrelude}
 try:
     policy_source = base64.b64decode(
@@ -1037,6 +1030,7 @@ try:
     exec(compile(policy_source, 'openclaw_device_approval_policy.py', 'exec'), policy_globals)
     approval_request_decision = policy_globals['approval_request_decision']
     gateway_approval_env = policy_globals['gateway_approval_env']
+    approval_time = policy_globals.get('approval_time', time)
 except Exception:
     ${exitWithReceipt("policy-missing")}
 

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -81,19 +81,23 @@ describe("destroySandbox flow", () => {
     expectStrictSandboxPresenceClassification();
   });
 
-  it("selects the sandbox gateway, deletes live resources, cleans host state, and removes registry state", async () => {
-    const harness = createDestroyHarness();
+  it(
+    "selects the sandbox gateway, deletes live resources, cleans host state, and removes registry state",
+    { timeout: 30_000 },
+    async () => {
+      const harness = createDestroyHarness();
 
-    await expect(
-      harness.destroySandbox("alpha", { yes: true, cleanupGateway: true }),
-    ).resolves.toBeUndefined();
+      await expect(
+        harness.destroySandbox("alpha", { yes: true, cleanupGateway: true }),
+      ).resolves.toBeUndefined();
 
-    expectSuccessfulLiveDestroy(harness, exitSpy);
-    expect(harness.retirePortableLifecycleReceiptSpy).toHaveBeenCalledWith("alpha");
-    expect(harness.removeSandboxSpy.mock.invocationCallOrder[0]).toBeLessThan(
-      harness.retirePortableLifecycleReceiptSpy.mock.invocationCallOrder[0],
-    );
-  });
+      expectSuccessfulLiveDestroy(harness, exitSpy);
+      expect(harness.retirePortableLifecycleReceiptSpy).toHaveBeenCalledWith("alpha");
+      expect(harness.removeSandboxSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        harness.retirePortableLifecycleReceiptSpy.mock.invocationCallOrder[0],
+      );
+    },
+  );
 
   it.each([
     ["--yes", false],

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -81,12 +81,6 @@ describe("destroySandbox flow", () => {
     expectStrictSandboxPresenceClassification();
   });
 
-  it("loads the destroy flow from TypeScript source (#10106)", { timeout: 30_000 }, () => {
-    const harness = createDestroyHarness();
-
-    expect(harness.destroySourcePath).toBe(path.join(import.meta.dirname, "destroy.ts"));
-  });
-
   it("selects the sandbox gateway, deletes live resources, cleans host state, and removes registry state", async () => {
     const harness = createDestroyHarness();
 

--- a/src/lib/actions/sandbox/destroy-flow.test.ts
+++ b/src/lib/actions/sandbox/destroy-flow.test.ts
@@ -81,7 +81,7 @@ describe("destroySandbox flow", () => {
     expectStrictSandboxPresenceClassification();
   });
 
-  it("loads the destroy flow from TypeScript source (#10106)", () => {
+  it("loads the destroy flow from TypeScript source (#10106)", { timeout: 30_000 }, () => {
     const harness = createDestroyHarness();
 
     expect(harness.destroySourcePath).toBe(path.join(import.meta.dirname, "destroy.ts"));

--- a/src/lib/actions/sandbox/start.test.ts
+++ b/src/lib/actions/sandbox/start.test.ts
@@ -222,6 +222,7 @@ describe("startSandbox", () => {
     async () => {
       const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-start-readiness-"));
       vi.stubEnv("HOME", home);
+      vi.stubEnv("NEMOCLAW_TEST_NO_SLEEP", "1");
       const listOutputs = ["my-sandbox Error", "my-sandbox Provisioning", "my-sandbox Ready"];
       const listSandboxes = vi.fn<OpenShellSandboxObserver["listSandboxes"]>(async () => {
         const output = listOutputs.shift() ?? "my-sandbox Ready";

--- a/test/agents/deepagents/dcode-session-supervisor.test.ts
+++ b/test/agents/deepagents/dcode-session-supervisor.test.ts
@@ -158,6 +158,14 @@ describe.runIf(canRun)("managed DCode session supervisor", () => {
     const pidFile = path.join(dir, "processes.pid");
     const session = path.join(dir, "session.py");
     const harness = path.join(dir, "harness.py");
+    const boundedSupervisor = path.join(dir, "dcode-session-supervisor.py");
+    fs.writeFileSync(
+      boundedSupervisor,
+      fs
+        .readFileSync(supervisor, "utf8")
+        .replace("_TERM_GRACE_SECONDS = 3.0", "_TERM_GRACE_SECONDS = 0.1")
+        .replace("_KILL_GRACE_SECONDS = 1.0", "_KILL_GRACE_SECONDS = 0.1"),
+    );
     fs.writeFileSync(
       session,
       [
@@ -184,7 +192,7 @@ describe.runIf(canRun)("managed DCode session supervisor", () => {
         "import sys",
         "import time",
         `pid_file = pathlib.Path(${JSON.stringify(pidFile)})`,
-        `supervisor = subprocess.Popen([sys.executable, ${JSON.stringify(supervisor)}, sys.executable, ${JSON.stringify(session)}])`,
+        `supervisor = subprocess.Popen([sys.executable, ${JSON.stringify(boundedSupervisor)}, sys.executable, ${JSON.stringify(session)}])`,
         "deadline = time.monotonic() + 5",
         "while not pid_file.exists() and time.monotonic() < deadline:",
         "    time.sleep(0.05)",

--- a/test/agents/deepagents/dcode-session-supervisor.test.ts
+++ b/test/agents/deepagents/dcode-session-supervisor.test.ts
@@ -158,14 +158,6 @@ describe.runIf(canRun)("managed DCode session supervisor", () => {
     const pidFile = path.join(dir, "processes.pid");
     const session = path.join(dir, "session.py");
     const harness = path.join(dir, "harness.py");
-    const boundedSupervisor = path.join(dir, "dcode-session-supervisor.py");
-    fs.writeFileSync(
-      boundedSupervisor,
-      fs
-        .readFileSync(supervisor, "utf8")
-        .replace("_TERM_GRACE_SECONDS = 3.0", "_TERM_GRACE_SECONDS = 0.1")
-        .replace("_KILL_GRACE_SECONDS = 1.0", "_KILL_GRACE_SECONDS = 0.1"),
-    );
     fs.writeFileSync(
       session,
       [
@@ -185,23 +177,31 @@ describe.runIf(canRun)("managed DCode session supervisor", () => {
     fs.writeFileSync(
       harness,
       [
+        "import importlib.util",
         "import os",
         "import pathlib",
         "import signal",
-        "import subprocess",
         "import sys",
         "import time",
+        `spec = importlib.util.spec_from_file_location('supervisor', ${JSON.stringify(supervisor)})`,
+        "module = importlib.util.module_from_spec(spec)",
+        "spec.loader.exec_module(module)",
+        "module._TERM_GRACE_SECONDS = 0.1",
+        "module._KILL_GRACE_SECONDS = 0.1",
         `pid_file = pathlib.Path(${JSON.stringify(pidFile)})`,
-        `supervisor = subprocess.Popen([sys.executable, ${JSON.stringify(boundedSupervisor)}, sys.executable, ${JSON.stringify(session)}])`,
-        "deadline = time.monotonic() + 5",
-        "while not pid_file.exists() and time.monotonic() < deadline:",
-        "    time.sleep(0.05)",
+        "notifier_pid = os.fork()",
+        "if notifier_pid == 0:",
+        "    deadline = time.monotonic() + 5",
+        "    while not pid_file.exists() and time.monotonic() < deadline:",
+        "        time.sleep(0.05)",
+        "    os.kill(os.getppid(), signal.SIGHUP)",
+        "    os._exit(0)",
+        `status = module.run([sys.executable, ${JSON.stringify(session)}])`,
         "if not pid_file.exists():",
-        "    supervisor.kill()",
         "    raise SystemExit('session did not publish process ids')",
         "pids = [int(value) for value in pid_file.read_text(encoding='utf-8').splitlines()]",
-        "os.kill(supervisor.pid, signal.SIGHUP)",
-        "supervisor.wait(timeout=10)",
+        "if status == 0:",
+        "    raise SystemExit('supervisor unexpectedly preserved a successful child status')",
         "for pid in pids:",
         "    try:",
         "        os.kill(pid, 0)",

--- a/test/agents/openclaw/openclaw-config-guard.test.ts
+++ b/test/agents/openclaw/openclaw-config-guard.test.ts
@@ -1417,11 +1417,11 @@ describe("openclaw-config-guard", () => {
   it("keeps restart journal bounded near the maximum config size", () => {
     const { root, configDir, configPath, hashPath } = fixture();
     const max = 16 * 1024 * 1024;
-    const prefix = Buffer.from('{"padding":"');
-    const suffix = Buffer.from('"}\n');
+    const prefix = Buffer.from('{"first":1,');
+    const suffix = Buffer.from('"last":2}\n');
     const large = Buffer.concat([
       prefix,
-      Buffer.alloc(max - prefix.length - suffix.length, 0x61),
+      Buffer.alloc(max - prefix.length - suffix.length, 0x20),
       suffix,
     ]);
     const digest = createHash("sha256").update(large).digest("hex");

--- a/test/automation/e2e/e2e-recommendations.test.ts
+++ b/test/automation/e2e/e2e-recommendations.test.ts
@@ -123,6 +123,7 @@ describe("E2E recommendation normalizer", () => {
         "tools/advisors/e2e-text.mts",
         "tools/advisors/json.mts",
         "tools/advisors/risk-plan.mts",
+        "tools/e2e/credential-free-tests.mts",
         "tools/e2e/execution-coverage.mts",
         "tools/e2e/onboard-timeout-contract.mts",
         "tools/e2e/selector-aliases.mts",

--- a/test/helpers/destroy-flow-test-harness.ts
+++ b/test/helpers/destroy-flow-test-harness.ts
@@ -23,7 +23,6 @@ export type DestroyHarness = {
   captureOpenshellSpy: MockInstance;
   compareAndSwapSessionSpy: MockInstance;
   destroySandbox: DestroySandbox;
-  destroySourcePath: string;
   dockerCaptureSpy: MockInstance;
   dockerRunSpy: MockInstance;
   errorSpy: MockInstance;
@@ -594,7 +593,6 @@ export function createDestroyHarness(options: DestroyHarnessOptions = {}): Destr
     dockerCaptureSpy,
     dockerRunSpy,
     destroySandbox: requireSource(destroyModulePath).destroySandbox,
-    destroySourcePath: requireSource.resolve(destroyModulePath),
     errorSpy,
     events,
     executeSandboxDestroySpy,

--- a/test/onboarding/onboard-selection.test.ts
+++ b/test/onboarding/onboard-selection.test.ts
@@ -1255,7 +1255,6 @@ describe("onboard provider selection UX", { timeout: PROVIDER_SELECTION_TEST_TIM
     const workspace = onboardProcessWorkspace("nemoclaw-onboard-ollama-validation-");
     const { root: tmpDir } = workspace;
     const fakeBin = workspace.binDir;
-
     writeAlwaysOkCurl(fakeBin, OLLAMA_CHAT_COMPLETIONS_TOOL_CALL_RESPONSE);
 
     const script = String.raw`
@@ -1312,6 +1311,7 @@ reportChildScenario(async () => {
         HOME: tmpDir,
         PATH: `${fakeBin}:${process.env.PATH || ""}`,
         NEMOCLAW_CONTEXT_WINDOW: "",
+        NEMOCLAW_TEST_NO_SLEEP: "1",
       },
     });
 

--- a/tools/advisors/e2e-recommendations.mts
+++ b/tools/advisors/e2e-recommendations.mts
@@ -31,6 +31,8 @@ const FREE_STANDING_LIVE_FILE_PATTERN = /^test\/e2e\/live\/[^/]+\.ts$/;
 const ALLOWED_WORKFLOWS = new Set<string>([E2E_WORKFLOW]);
 const TARGET_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const CONFIDENCES = ["low", "medium", "high"] as const;
+let trustedE2eWorkflowText: string | undefined;
+let trustedCredentialFreeTests: readonly E2eChangedCredentialFreeTest[] | undefined;
 const MODEL_COVERAGE_IDENTITY_FIELDS = ["workflow", "job", "script", "cost", "runner"] as const;
 const CLOUD_ONBOARD_E2E_PATTERNS: readonly RegExp[] = [
   /^src\/lib\/onboard(?:\.ts|\/)/,
@@ -371,7 +373,11 @@ function readE2eWorkflowText(): string | undefined {
 }
 
 function readTrustedE2eWorkflowText(): string {
-  return fs.readFileSync(path.join(TRUSTED_REPO_ROOT, E2E_WORKFLOW_PATH), "utf8");
+  trustedE2eWorkflowText ??= fs.readFileSync(
+    path.join(TRUSTED_REPO_ROOT, E2E_WORKFLOW_PATH),
+    "utf8",
+  );
+  return trustedE2eWorkflowText;
 }
 
 function buildE2eTargetNormalizationContext(
@@ -381,12 +387,10 @@ function buildE2eTargetNormalizationContext(
 ): E2eTargetNormalizationContext {
   const trustedWorkflowText = readTrustedE2eWorkflowText();
   const trustedCredentialFreeTests = discoverTrustedCredentialFreeTests();
-  const allowedJobIds = new Set(
-    [
-      ...extractAllowedE2eJobIds(trustedWorkflowText, trustedCredentialFreeTests),
-      ...catalogueRecommendationSelectorIds(),
-    ],
-  );
+  const allowedJobIds = new Set([
+    ...extractAllowedE2eJobIds(trustedWorkflowText, trustedCredentialFreeTests),
+    ...catalogueRecommendationSelectorIds(),
+  ]);
   // The analyzed workflow is untrusted input. It may explain why a changed test has
   // no trusted selector, but it must never introduce one absent from the trusted
   // workflow or catalogue.
@@ -466,6 +470,7 @@ function credentialFreeTestRow(
 }
 
 function discoverTrustedCredentialFreeTests(): E2eChangedCredentialFreeTest[] {
+  if (trustedCredentialFreeTests) return [...trustedCredentialFreeTests];
   const rows: E2eChangedCredentialFreeTest[] = [];
   const testRoot = path.join(TRUSTED_REPO_ROOT, "test");
   const pending = [testRoot];
@@ -484,7 +489,8 @@ function discoverTrustedCredentialFreeTests(): E2eChangedCredentialFreeTest[] {
       if (row) rows.push(row);
     }
   }
-  return rows.sort((left, right) => left.id.localeCompare(right.id));
+  trustedCredentialFreeTests = rows.sort((left, right) => left.id.localeCompare(right.id));
+  return [...trustedCredentialFreeTests];
 }
 
 function extractAllowedE2eJobIds(

--- a/tools/advisors/e2e-recommendations.mts
+++ b/tools/advisors/e2e-recommendations.mts
@@ -8,7 +8,12 @@ import path from "node:path";
 // the analyzed PR worktree. PR-provided TypeScript is never imported.
 import { getTarget, listTargets } from "../../test/e2e/registry/registry.ts";
 import { liveTargetSupport } from "../../test/e2e/registry/runtime-support.ts";
-import { moduleTagDeclarations } from "../e2e/module-tags.mts";
+import {
+  credentialFreeTestProjectForFile,
+  credentialFreeTestRowFromModule,
+  SHARED_E2E_JOB_ID,
+  type CredentialFreeTestProject,
+} from "../e2e/credential-free-tests.mts";
 import {
   catalogueRecommendationSelectorIds,
   E2E_TARGET_CATALOGUE,
@@ -23,8 +28,6 @@ const E2E_WORKFLOW_PATH = `.github/workflows/${E2E_WORKFLOW}`;
 export const E2E_RENDER_LIMIT = 20;
 const TRUSTED_REPO_ROOT = path.resolve(import.meta.dirname, "../..");
 const E2E_ALL_ID = "e2e-all";
-const CREDENTIAL_FREE_TEST_TAG = "e2e/credential-free";
-const SHARED_E2E_JOB_ID = "shared-e2e";
 const REGISTRY_LIVE_ENTRYPOINT = "test/e2e/live/registry-targets.test.ts";
 const FREE_STANDING_LIVE_TEST_PATTERN = /^test\/e2e\/live\/[^/]+\.test\.ts$/;
 const FREE_STANDING_LIVE_FILE_PATTERN = /^test\/e2e\/live\/[^/]+\.ts$/;
@@ -420,7 +423,7 @@ function buildE2eTargetNormalizationContext(
   }
   for (const [file, project] of changedCredentialFreeProjects) {
     const source = changedSource(file, changedFileSources);
-    const row = source ? credentialFreeTestRow(file, source) : undefined;
+    const row = source ? changedCredentialFreeTestRow(file, project, source) : undefined;
     if (!row || !project || !isPrE2ePlanningJob(row.id)) continue;
     addMapValue(liveTestToJobs, row.file, row.id);
     allowedJobIds.add(row.id);
@@ -437,38 +440,18 @@ function buildE2eTargetNormalizationContext(
   };
 }
 
-function credentialFreeTestProjectForFile(file: string): "e2e-live" | "integration" | undefined {
-  if (/^test\/e2e\/live\/(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+\.test\.ts$/.test(file)) {
-    return "e2e-live";
-  }
-  if (/^test\/(?!e2e\/)(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+\.test\.(?:js|ts)$/.test(file)) {
-    return "integration";
-  }
-  return undefined;
-}
-
-export function credentialFreeTestIdForFile(file: string): string | undefined {
-  if (!credentialFreeTestProjectForFile(file)) return undefined;
-  const id = path.posix.basename(file).replace(/\.test\.(?:js|ts)$/, "");
-  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id) ? id : undefined;
-}
-
-function credentialFreeTestRow(
+function changedCredentialFreeTestRow(
   file: string,
+  project: CredentialFreeTestProject,
   source: string,
 ): E2eChangedCredentialFreeTest | undefined {
-  const id = credentialFreeTestIdForFile(file);
-  if (!id) return undefined;
-  const declarations = moduleTagDeclarations(source);
-  if (
-    declarations.some(({ tag }) => tag.startsWith("e2e/") && tag !== CREDENTIAL_FREE_TEST_TAG) ||
-    declarations.filter(({ tag }) => tag === CREDENTIAL_FREE_TEST_TAG).length !== 1
-  ) {
+  try {
+    const row = credentialFreeTestRowFromModule({ file, project, source });
+    return { id: row.id, file: row.file };
+  } catch {
     return undefined;
   }
-  return { id, file };
 }
-
 function discoverTrustedCredentialFreeTests(): E2eChangedCredentialFreeTest[] {
   if (trustedCredentialFreeTests) return [...trustedCredentialFreeTests];
   const rows: E2eChangedCredentialFreeTest[] = [];
@@ -485,7 +468,9 @@ function discoverTrustedCredentialFreeTests(): E2eChangedCredentialFreeTest[] {
       }
       if (!entry.isFile() || !/\.test\.(?:js|ts)$/.test(entry.name)) continue;
       const file = path.relative(TRUSTED_REPO_ROOT, absolute).split(path.sep).join("/");
-      const row = credentialFreeTestRow(file, fs.readFileSync(absolute, "utf8"));
+      const project = credentialFreeTestProjectForFile(file);
+      if (!project) continue;
+      const row = changedCredentialFreeTestRow(file, project, fs.readFileSync(absolute, "utf8"));
       if (row) rows.push(row);
     }
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Reduces runtime in six tests that recent retained CI reports identified as slow. The changes remove waits and repeated work that do not contribute to the tested outcomes. Production behavior, timeout values, process boundaries, security checks, and assertions remain unchanged.

## Reason

Recent retained CLI timing reports showed avoidable time in sandbox startup recovery, Ollama warmup, E2E recommendation inventory discovery, DCode process cleanup, auto-pair approval polling, and large OpenClaw configuration handling. Local comparison runs confirmed a specific source of unnecessary work in each test.

## Changes

| Test target | Retained CI evidence | Local before | Local after | Local reduction |
|---|---:|---:|---:|---:|
| Sandbox startup recovery | 20.57–22.58 seconds | 2.13 seconds | 0.27 seconds | 87% |
| Ollama warmup | 53.1-second file median | 3.41 seconds | 1.69–1.72 seconds | 50% |
| E2E recommendation inventory | 44.1-second median | 2.78 seconds | 0.28 seconds | 90% |
| DCode disconnect cleanup | 7.31-second median | Not recorded | 0.88 seconds | Not a direct comparison |
| Auto-pair approval | Not recorded | 8.34–8.45 seconds | 2.39–3.38 seconds | 60–72% |
| 16 MiB OpenClaw configuration | Not recorded | 4.00 seconds | 1.07 seconds | 73% |

The retained CI values identify the slow test files or paths. The local values measure focused tests before and after the change in the same checkout, except for DCode, where no local baseline was recorded.

Implementation details:

- Use the existing test-only no-sleep control for sandbox startup recovery and the Ollama warmup child process.
- Cache immutable workflow text and credential-free test inventory in the E2E recommendation advisor.
- Load the production DCode supervisor and shorten only the grace periods set by its test harness.
- Supply deterministic time through the auto-pair test policy. Production continues to use the standard Python clock and existing timeout values.
- Keep the OpenClaw configuration fixture at exactly 16 MiB while using valid JSON5 whitespace instead of a pathological token.
- Reuse the shared credential-free test parser and remove a redundant destroy source-path assertion in response to automated review.
- Give the first import-heavy destroy behavior test the file's established 30-second CI timeout. Its behavior and assertions remain unchanged.

## Verification

- Final focused validation: 230 tests passed across six files.
- Pull request CI passed for commit b4ccc0ba98, including all 12 CLI test groups, static checks, builds, security scans, coverage gates, and sandbox image tests.
- CLI line coverage remained at 83%. Plugin line coverage remained at 96%.
- CLI type checking, repository checks, Oxfmt, Oxlint, source-size and growth checks, whitespace checks, NUL-byte checks, secret scanning, and commit hooks passed.
- CodeRabbit completed with no actionable comments.
- Six PR Review Advisor specialists completed with no findings. Three specialists could not configure their inference service after bounded retries; an independent final review found no issue that requires a change.
- The diff contains no secrets, API keys, or credentials.
- All feature and review-repair commits are signed off and shown as verified by GitHub.

<!-- nemoclaw-docs-review:start -->
- Documentation review: `no-docs-needed`
- Documentation evidence: The changes affect test execution and advisor internals only. User behavior and documentation are unchanged.
- Documentation agent: openai/openai/gpt-5.6-sol
<!-- docs-review-head-sha: b4ccc0ba98e851db8cd68aff6261875ec04fd27a -->
<!-- docs-review-agents-blob-sha: f3cb0c16c3e19f09b7dfdd6aba0f59ab0c4e0b9c -->
<!-- nemoclaw-docs-review:end -->

<!-- nemoclaw-targeted-validation:start -->
- Targeted validation: 230 tests passed across six files. Pull request CI passed for commit b4ccc0ba98.
<!-- nemoclaw-targeted-validation:end -->

<!-- nemoclaw-broad-gate:start -->
- Broad gate: passed — All 12 CLI test groups, static checks, builds, security scans, coverage gates, local type checks, repository checks, formatting, lint, and commit hooks passed.
<!-- nemoclaw-broad-gate:end -->

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>



