### PR TITLE
fix(e2e): bind Brev workflow process environment

### DIFF
--- a/.github/workflows/issue-9880-staging-reproduction.yaml
+++ b/.github/workflows/issue-9880-staging-reproduction.yaml
@@ -101,6 +101,7 @@ jobs:
           NEMOCLAW_IMAGE_DISPATCH_TOKEN: ${{ secrets.NEMOCLAW_IMAGE_DISPATCH_TOKEN }}
           NEMOCLAW_RUN_LIVE_E2E: "1"
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          PATH: /usr/local/bin:/usr/bin:/bin
         run: ./node_modules/.bin/vitest run --project e2e-live test/e2e/live/issue-9880-staging-launchable.test.ts --silent=false --reporter=default
 
       - name: Verify workflow-owned workspace cleanup
@@ -110,7 +111,8 @@ jobs:
           BREV_WORKSPACE_OWNERSHIP_FILE: ${{ steps.prepare.outputs.work_dir }}/workspace-owner.json
           E2E_ARTIFACT_DIR: ${{ steps.prepare.outputs.work_dir }}
           HOME: ${{ runner.temp }}/issue-9880-home
-        run: ./node_modules/.bin/tsx tools/e2e/cleanup-brev-workspace.mts
+          NEMOCLAW_RUN_LIVE_E2E: "1"
+        run: ./node_modules/.bin/vitest run --project e2e-live test/e2e/live/brev-workspace-cleanup.test.ts --silent=false --reporter=default
 
       - name: Remove Brev credentials
         if: always()

--- a/.github/workflows/issue-9880-staging-reproduction.yaml
+++ b/.github/workflows/issue-9880-staging-reproduction.yaml
@@ -112,6 +112,7 @@ jobs:
           E2E_ARTIFACT_DIR: ${{ steps.prepare.outputs.work_dir }}
           HOME: ${{ runner.temp }}/issue-9880-home
           NEMOCLAW_RUN_LIVE_E2E: "1"
+          PATH: /usr/local/bin:/usr/bin:/bin
         run: ./node_modules/.bin/vitest run --project e2e-live test/e2e/live/brev-workspace-cleanup.test.ts --silent=false --reporter=default
 
       - name: Remove Brev credentials

--- a/test/e2e/fixtures/brev-launchable.ts
+++ b/test/e2e/fixtures/brev-launchable.ts
@@ -71,6 +71,7 @@ export class BrevLaunchableFixture {
   private readonly home: string;
   private readonly host: HostCliClient;
   private readonly ownershipFile?: string;
+  private readonly path?: string;
   private readonly secrets: SecretStore;
   private readonly pollMs: number;
 
@@ -81,6 +82,7 @@ export class BrevLaunchableFixture {
     this.home = home;
     this.host = options.host;
     this.ownershipFile = options.ownershipFile ?? process.env.BREV_WORKSPACE_OWNERSHIP_FILE;
+    this.path = process.env.PATH;
     this.secrets = options.secrets;
     this.pollMs = options.pollMs ?? DEFAULT_POLL_MS;
   }
@@ -476,7 +478,7 @@ export class BrevLaunchableFixture {
   ): Promise<ShellProbeResult> {
     return this.host.command("brev", args, {
       ...options,
-      env: { ...(options.env ?? {}), HOME: this.home },
+      env: { PATH: this.path, ...(options.env ?? {}), HOME: this.home },
     });
   }
 }

--- a/test/e2e/fixtures/shell-probe.ts
+++ b/test/e2e/fixtures/shell-probe.ts
@@ -222,7 +222,7 @@ export class ShellProbe {
       spawn: {
         cwd: options.cwd,
         detached: true,
-        env: { ...(options.env ?? {}) },
+        env: { PATH: process.env.PATH, ...(options.env ?? {}) },
         stdio: ["ignore", "pipe", "pipe"],
       },
     });

--- a/test/e2e/live/brev-workspace-cleanup.test.ts
+++ b/test/e2e/live/brev-workspace-cleanup.test.ts
@@ -11,8 +11,7 @@ test(
       e2ePhases: ["load the workflow ownership receipt", "remove the owned Brev workspace"],
     },
   },
-  async ({ progress }) => {
-    progress.phase("remove the owned Brev workspace");
-    await removePersistedWorkspace();
+  async ({ artifacts, host, progress, secrets }) => {
+    await removePersistedWorkspace({ artifacts, host, progress, secrets });
   },
 );

--- a/test/e2e/live/brev-workspace-cleanup.test.ts
+++ b/test/e2e/live/brev-workspace-cleanup.test.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { test } from "../fixtures/e2e-test.ts";
+import { removePersistedWorkspace } from "./brev-workspace-cleanup.ts";
+
+test(
+  "removes a persisted workflow-owned Brev workspace",
+  {
+    meta: {
+      e2ePhases: ["load the workflow ownership receipt", "remove the owned Brev workspace"],
+    },
+  },
+  async ({ progress }) => {
+    progress.phase("remove the owned Brev workspace");
+    await removePersistedWorkspace();
+  },
+);

--- a/test/e2e/live/brev-workspace-cleanup.ts
+++ b/test/e2e/live/brev-workspace-cleanup.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { ArtifactSink } from "../fixtures/artifacts.ts";
+import { BrevLaunchableFixture, type BrevWorkspaceOwnership } from "../fixtures/brev-launchable.ts";
+import { HostCliClient } from "../fixtures/clients/host.ts";
+import { startTestProgress } from "../fixtures/progress.ts";
+import { SecretStore } from "../fixtures/secrets.ts";
+import { ShellProbe } from "../fixtures/shell-probe.ts";
+
+export async function removePersistedWorkspace(): Promise<void> {
+  const ownershipFile = requiredAbsolutePath("BREV_WORKSPACE_OWNERSHIP_FILE");
+  if (!fs.existsSync(ownershipFile)) return;
+  const artifactDir = requiredAbsolutePath("E2E_ARTIFACT_DIR");
+  const ownership = JSON.parse(fs.readFileSync(ownershipFile, "utf8")) as BrevWorkspaceOwnership;
+  const artifacts = new ArtifactSink(artifactDir);
+  const secrets = new SecretStore(process.env, (message) => {
+    throw new Error(message ?? "required cleanup secret is missing");
+  });
+  const progress = startTestProgress("Brev workspace cleanup", [
+    "load the workflow ownership receipt",
+    "remove the owned Brev workspace",
+  ]);
+  progress.phase("remove the owned Brev workspace");
+  const shellProbe = new ShellProbe({
+    artifacts,
+    progress,
+    redact: (text) => secrets.redact(text),
+    signal: new AbortController().signal,
+  });
+  try {
+    await new BrevLaunchableFixture({
+      artifacts,
+      host: new HostCliClient(shellProbe),
+      ownershipFile,
+      secrets,
+    }).delete(ownership);
+  } finally {
+    progress.stop();
+  }
+}
+
+function requiredAbsolutePath(name: string): string {
+  const value = process.env[name];
+  if (!value || !path.isAbsolute(value)) throw new Error(`${name} must be an absolute path`);
+  return value;
+}

--- a/test/e2e/live/brev-workspace-cleanup.ts
+++ b/test/e2e/live/brev-workspace-cleanup.ts
@@ -4,43 +4,31 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { ArtifactSink } from "../fixtures/artifacts.ts";
+import type { ArtifactSink } from "../fixtures/artifacts.ts";
 import { BrevLaunchableFixture, type BrevWorkspaceOwnership } from "../fixtures/brev-launchable.ts";
-import { HostCliClient } from "../fixtures/clients/host.ts";
-import { startTestProgress } from "../fixtures/progress.ts";
-import { SecretStore } from "../fixtures/secrets.ts";
-import { ShellProbe } from "../fixtures/shell-probe.ts";
+import type { HostCliClient } from "../fixtures/clients/host.ts";
+import type { TestProgress } from "../fixtures/progress.ts";
+import type { SecretStore } from "../fixtures/secrets.ts";
 
-export async function removePersistedWorkspace(): Promise<void> {
+interface CleanupResources {
+  artifacts: ArtifactSink;
+  host: HostCliClient;
+  progress: TestProgress;
+  secrets: SecretStore;
+}
+
+export async function removePersistedWorkspace(resources: CleanupResources): Promise<void> {
   const ownershipFile = requiredAbsolutePath("BREV_WORKSPACE_OWNERSHIP_FILE");
   if (!fs.existsSync(ownershipFile)) return;
-  const artifactDir = requiredAbsolutePath("E2E_ARTIFACT_DIR");
+  resources.progress.phase("load the workflow ownership receipt");
   const ownership = JSON.parse(fs.readFileSync(ownershipFile, "utf8")) as BrevWorkspaceOwnership;
-  const artifacts = new ArtifactSink(artifactDir);
-  const secrets = new SecretStore(process.env, (message) => {
-    throw new Error(message ?? "required cleanup secret is missing");
-  });
-  const progress = startTestProgress("Brev workspace cleanup", [
-    "load the workflow ownership receipt",
-    "remove the owned Brev workspace",
-  ]);
-  progress.phase("remove the owned Brev workspace");
-  const shellProbe = new ShellProbe({
-    artifacts,
-    progress,
-    redact: (text) => secrets.redact(text),
-    signal: new AbortController().signal,
-  });
-  try {
-    await new BrevLaunchableFixture({
-      artifacts,
-      host: new HostCliClient(shellProbe),
-      ownershipFile,
-      secrets,
-    }).delete(ownership);
-  } finally {
-    progress.stop();
-  }
+  resources.progress.phase("remove the owned Brev workspace");
+  await new BrevLaunchableFixture({
+    artifacts: resources.artifacts,
+    host: resources.host,
+    ownershipFile,
+    secrets: resources.secrets,
+  }).delete(ownership);
 }
 
 function requiredAbsolutePath(name: string): string {

--- a/test/e2e/live/brev-workspace-cleanup.ts
+++ b/test/e2e/live/brev-workspace-cleanup.ts
@@ -18,17 +18,23 @@ interface CleanupResources {
 }
 
 export async function removePersistedWorkspace(resources: CleanupResources): Promise<void> {
-  const ownershipFile = requiredAbsolutePath("BREV_WORKSPACE_OWNERSHIP_FILE");
-  if (!fs.existsSync(ownershipFile)) return;
   resources.progress.phase("load the workflow ownership receipt");
-  const ownership = JSON.parse(fs.readFileSync(ownershipFile, "utf8")) as BrevWorkspaceOwnership;
+  const ownershipFile = requiredAbsolutePath("BREV_WORKSPACE_OWNERSHIP_FILE");
+  const ownership = readOwnershipReceipt(ownershipFile);
   resources.progress.phase("remove the owned Brev workspace");
+  if (!ownership) return;
   await new BrevLaunchableFixture({
     artifacts: resources.artifacts,
     host: resources.host,
     ownershipFile,
     secrets: resources.secrets,
   }).delete(ownership);
+}
+
+function readOwnershipReceipt(file: string): BrevWorkspaceOwnership | null {
+  return fs.existsSync(file)
+    ? (JSON.parse(fs.readFileSync(file, "utf8")) as BrevWorkspaceOwnership)
+    : null;
 }
 
 function requiredAbsolutePath(name: string): string {

--- a/test/e2e/mock-parity.json
+++ b/test/e2e/mock-parity.json
@@ -703,6 +703,13 @@
       ]
     },
     {
+      "live": "test/e2e/live/brev-workspace-cleanup.test.ts",
+      "fast": [
+        "test/e2e/support/brev-launchable-fixture.test.ts",
+        "test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts"
+      ]
+    },
+    {
       "live": "test/e2e/live/whatsapp-qr-compact.test.ts",
       "fast": [
         "test/e2e/support/e2e-progress-fixture.test.ts",

--- a/test/e2e/support/brev-launchable-fixture.test.ts
+++ b/test/e2e/support/brev-launchable-fixture.test.ts
@@ -86,6 +86,7 @@ describe("the Brev Launchable fixture binds staging identity and workspace lifec
     const root = temporaryRoot();
     const credentialHome = path.join(root, "brev-home");
     vi.stubEnv("HOME", credentialHome);
+    vi.stubEnv("PATH", "/usr/local/bin:/usr/bin:/bin");
     const expected = stagingHandoff();
     const identity = runtimeIdentity(expected);
     const command = vi.fn(ownedExecCommand(`probe\n${JSON.stringify(identity)}`));
@@ -94,6 +95,7 @@ describe("the Brev Launchable fixture binds staging identity and workspace lifec
     await expect(fixture.verifyIdentity(recordedOwnership(), expected)).resolves.toEqual(identity);
     expect(command.mock.calls.find((call) => call[1][0] === "exec")?.[2]?.env).toEqual({
       HOME: credentialHome,
+      PATH: "/usr/local/bin:/usr/bin:/bin",
     });
     expect(
       JSON.parse(fs.readFileSync(path.join(root, "brev-runtime-identity.json"), "utf8")),
@@ -124,6 +126,7 @@ describe("the Brev Launchable fixture binds staging identity and workspace lifec
     const root = temporaryRoot();
     const credentialHome = path.join(root, "brev-home");
     vi.stubEnv("HOME", credentialHome);
+    vi.stubEnv("PATH", "/usr/local/bin:/usr/bin:/bin");
     const lifecycle = lifecycleCommand();
     const command = vi.fn(lifecycle.command);
     const fixture = createFixture(root, command);
@@ -145,9 +148,11 @@ describe("the Brev Launchable fixture binds staging identity and workspace lifec
     ]);
     expect(command.mock.calls.find((call) => call[1][0] === "create")?.[2]?.env).toEqual({
       HOME: credentialHome,
+      PATH: "/usr/local/bin:/usr/bin:/bin",
     });
     expect(command.mock.calls.find((call) => call[1][0] === "delete")?.[2]?.env).toEqual({
       HOME: credentialHome,
+      PATH: "/usr/local/bin:/usr/bin:/bin",
     });
     expect(command.mock.calls.every((call) => call[2]?.env?.HOME === credentialHome)).toBe(true);
     expect(
@@ -386,6 +391,7 @@ describe("the Brev Launchable fixture binds staging identity and workspace lifec
     const root = temporaryRoot();
     const credentialHome = path.join(root, "brev-home");
     vi.stubEnv("HOME", credentialHome);
+    vi.stubEnv("PATH", "/usr/local/bin:/usr/bin:/bin");
     let observedScript = "";
     const command = vi.fn(
       async (_binary: string, args: string[], options?: ShellProbeRunOptions) => {
@@ -393,7 +399,11 @@ describe("the Brev Launchable fixture binds staging identity and workspace lifec
           case "ls":
             return workspaceResult("owned-id");
           case "exec": {
-            expect(options?.env).toEqual({ FIXTURE_VALUE: "fixture", HOME: credentialHome });
+            expect(options?.env).toEqual({
+              FIXTURE_VALUE: "fixture",
+              HOME: credentialHome,
+              PATH: "/usr/local/bin:/usr/bin:/bin",
+            });
             observedScript = args[2]?.slice(1) ?? "";
             const descriptor = fs.openSync(observedScript, "r");
             try {

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -344,7 +344,8 @@ function validateScenario(
       scenario.env[contract.inferenceCredential] ===
         `\${{ secrets.${contract.inferenceCredential} }}` &&
       scenario.env.BREV_API_KEY === undefined &&
-      scenario.env.BREV_ORG_ID === undefined,
+      scenario.env.BREV_ORG_ID === undefined &&
+      scenario.env.PATH === "/usr/local/bin:/usr/bin:/bin",
     "workflow credentials must remain scoped to their owning steps",
   );
 }
@@ -367,7 +368,9 @@ function validateWorkspaceCleanup(
       cleanup.env?.BREV_WORKSPACE_OWNERSHIP_FILE ===
         scenario?.env?.BREV_WORKSPACE_OWNERSHIP_FILE &&
       cleanup.env?.HOME === prepare?.env?.HOME &&
-      cleanupCommand === "./node_modules/.bin/tsx tools/e2e/cleanup-brev-workspace.mts" &&
+      cleanup.env?.NEMOCLAW_RUN_LIVE_E2E === "1" &&
+      cleanupCommand ===
+        "./node_modules/.bin/vitest run --project e2e-live test/e2e/live/brev-workspace-cleanup.test.ts --silent=false --reporter=default" &&
       Number(cleanup["timeout-minutes"]) * MINUTE_MS >= timeouts.cleanupTimeoutMs,
     "workflow must always reconcile its owned Brev workspace before removing credentials",
   );

--- a/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
+++ b/test/e2e/support/issue-9880-staging-reproduction-workflow.test.ts
@@ -369,6 +369,7 @@ function validateWorkspaceCleanup(
         scenario?.env?.BREV_WORKSPACE_OWNERSHIP_FILE &&
       cleanup.env?.HOME === prepare?.env?.HOME &&
       cleanup.env?.NEMOCLAW_RUN_LIVE_E2E === "1" &&
+      cleanup.env?.PATH === "/usr/local/bin:/usr/bin:/bin" &&
       cleanupCommand ===
         "./node_modules/.bin/vitest run --project e2e-live test/e2e/live/brev-workspace-cleanup.test.ts --silent=false --reporter=default" &&
       Number(cleanup["timeout-minutes"]) * MINUTE_MS >= timeouts.cleanupTimeoutMs,


### PR DESCRIPTION
## Summary

Binds the trusted issue workflow to an explicit Brev CLI PATH because ShellProbe intentionally excludes ambient workflow variables. Moves independent cleanup into a small host-side live Vitest controller so cleanup uses the same TypeScript loader boundary as the scenario.

## Related Issue

Refs #9880

## Verification

- actionlint passed
- Workflow contract tests: 11 passed
- Semantic E2E phase coverage passed
- Cleanup live controller passed without an ownership receipt
- CLI build and TypeScript passed
- Commit and push hooks passed

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging reproduction workflows by consistently configuring required command paths.
  * Increased reliability of temporary workspace cleanup during live end-to-end runs.

* **Tests**
  * Added end-to-end coverage for removing workflow-created workspaces.
  * Updated workflow validation for live cleanup execution and environment configuration.
  * Added fast-test parity coverage for cleanup and staging workflow scenarios.
  * Improved environment consistency across workspace lifecycle and script execution tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->