### PR TITLE
build(pkg): adopt npm workspaces for repository source packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
       ],
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "workspaces": [
+        "nemoclaw"
+      ],
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "3.1046.0",
         "@oclif/core": "^4.10.5",
@@ -58,6 +61,45 @@
         "@connectrpc/connect-node": "2.1.2",
         "@nvidia/openshell-sdk": "0.0.106"
       }
+    },
+    "nemoclaw": {
+      "name": "nemoclaw-plugin",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "^9.6.1",
+        "json5": "^2.2.3",
+        "tar": "7.5.21",
+        "yaml": "2.8.3"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "oxfmt": "0.63.0",
+        "oxlint": "1.78.0",
+        "oxlint-tsgolint": "7.0.2001",
+        "typescript": "6.0.3",
+        "vitest": "^4.1.9"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "nemoclaw/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "nemoclaw/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -1637,9 +1679,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1657,9 +1696,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1677,9 +1713,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1697,9 +1730,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1717,9 +1747,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3615,6 +3642,18 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@j178/prek": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@j178/prek/-/prek-0.3.6.tgz",
@@ -3912,9 +3951,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3932,9 +3968,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3952,9 +3985,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3972,9 +4002,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3992,9 +4019,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4012,9 +4036,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4032,9 +4053,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4052,9 +4070,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4343,9 +4358,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4363,9 +4375,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4383,9 +4392,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4403,9 +4409,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4423,9 +4426,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4443,9 +4443,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4463,9 +4460,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4483,9 +4477,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5467,6 +5458,15 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }
@@ -7120,6 +7120,18 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsx-ast-utils-x": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
@@ -7586,10 +7598,21 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/ms": {
@@ -7624,6 +7647,10 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/nemoclaw-plugin": {
+      "resolved": "nemoclaw",
+      "link": true
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
@@ -8348,6 +8375,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8822,6 +8865,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.1.0",
   "description": "NemoClaw — run OpenClaw inside OpenShell with NVIDIA inference",
   "license": "Apache-2.0",
+  "workspaces": [
+    "nemoclaw"
+  ],
   "exports": {
     "./lifecycle": {
       "types": "./dist/lifecycle/index.d.ts",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

`npm ci` at the repository root now installs `nemoclaw` as a declared npm workspace. The package resolves through `node_modules/nemoclaw-plugin` as a workspace link, and its dependency graph is recorded once in the root `package-lock.json` instead of a second lockfile under `nemoclaw/`.

## Reason

The repository source packages each carry an independent lockfile, so the same dependency can resolve to two different versions and a root install never installs the plugin package. Measured against `origin/main`: `package-lock.json` and `nemoclaw/package-lock.json` share 150 packages, of which 22 are pinned to different versions (for example `@oxc-project/types` at 0.139.0 versus 0.137.0, and every `@rolldown/binding-*` at 1.1.5 versus 1.1.3), and the root lockfile contains no `node_modules/nemoclaw-plugin` entry. Declaring the workspace makes a single root install produce one linked, version-consistent graph, which the later packaging steps in RFC 0002 depend on.

### Related issues

Second preparation step of [Discussion #9909 (RFC 0002)](https://github.com/NVIDIA/NemoClaw/discussions/9909). Follows #10518, which landed the package identity separation this step builds on.

## Changes

- Declare `"workspaces": ["nemoclaw"]` in the root `package.json`.
- Record the `nemoclaw-plugin` workspace link and its hoisted dependency entries in the root `package-lock.json`.
- Leave standalone sandbox-image lockfiles unchanged, because those graphs are built in isolated images and must stay independent.

## Verification

- `npm ci --ignore-scripts --no-audit --no-fund --dry-run` — exit 0; the rebased lockfile is consistent with the current root `package.json`.
- `npm ci --ignore-scripts --no-audit --no-fund` — installed 514 packages with no lockfile rewrite.
- Workspace linkage confirmed in the resulting lockfile: `packages["nemoclaw"].name === "nemoclaw-plugin"` and `packages["node_modules/nemoclaw-plugin"] === {"resolved":"nemoclaw","link":true}`.
- `npm run build -w nemoclaw` — exit 0; the workspace-scoped form resolves and builds the package as `nemoclaw-plugin`, which is the behavior this declaration adds.
- `npm run validate:pr` — passed on a clean tree: 17 hooks passed, 17 skipped as not applicable, 0 failed, including `gitleaks (secret scan)`, `Codebase growth guardrails`, and `TypeScript (CLI)`.
- Rebased onto `origin/main` at `189043e740` with no conflicts; the branch contains exactly one commit (`f073694d1c`) whose parent is that revision, and the worktree is clean.
- Collision search — `"workspaces"` is still absent from `origin/main:package.json`, and no open PR declares it. #10518 (merged) covered package identity only and does not add the workspace declaration.
- Version-drift measurement reproduced with the two lockfiles read directly from `origin/main`; the 150/22 counts above come from that comparison.
- Secret review — the diff touches only `package.json` and `package-lock.json` and contains no secrets, API keys, or credentials.

## Review notes

This step adds `+119/-64`. The growth is entirely the root lockfile recording the workspace link plus the dependency entries hoisted out of `nemoclaw/package-lock.json`; that file's 82 removed lines already landed with #10518, so the two steps together reduce total lockfile lines. No new script, helper, or compatibility path is introduced — the change is a single declaration plus the lockfile state npm derives from it.

This PR was previously opened as #10520 and closed only to stay within the contributor open-PR limit while #10518 was under review. #10518 merged on 2026-09-09, so the dependency is resolved and the branch is rebased onto current `main`.

---
Signed-off-by: Ho Lim <subhoya@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project configuration to support an additional package.
  - No user-facing features or behavior have changed in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->