### PR TITLE
fix(e2e): preserve host PATH in shell probes

### DIFF
--- a/test/e2e/fixtures/shell-probe.ts
+++ b/test/e2e/fixtures/shell-probe.ts
@@ -216,13 +216,17 @@ export class ShellProbe {
     const startedAtMs = Date.now();
     const commandOutputObserver =
       options.onOutput === this.progress.onOutput ? undefined : options.onOutput;
+    const commandEnv: NodeJS.ProcessEnv = {
+      ...(process.env.PATH === undefined ? {} : { PATH: process.env.PATH }),
+      ...(options.env ?? {}),
+    };
     const child = spawnObservedChild(command, args, {
       activityLabel: `command: ${activityName}`,
       progress: this.progress,
       spawn: {
         cwd: options.cwd,
         detached: true,
-        env: { ...(options.env ?? {}) },
+        env: commandEnv,
         stdio: ["ignore", "pipe", "pipe"],
       },
     });


### PR DESCRIPTION
## Outcome

`ShellProbe` now preserves the host `PATH` when a command supplies explicit environment overrides. Commands installed outside `/usr/bin:/bin` can be resolved while ambient workflow variables remain excluded.

## Reason

The explicit command environment replaced the entire child environment. On hosts where Node.js is installed outside the operating system's default executable search path, the existing regression test failed with `spawn node ENOENT`.

### Related issues

Unblocks #10357.

## Changes

- Carry only the host `PATH` into the child environment before applying explicit command overrides.
- Keep the existing explicit-environment boundary for all other ambient variables.
- Use the existing shell-probe PATH regression test as the durable detection boundary.

## Verification

- `npx vitest run --project e2e-support test/e2e/support/e2e-fixture-context.test.ts` — 18 passed.
- `npm run typecheck:cli -- --incremental` — passed.
- `npm run test:projects:check` — exact membership across 2,608 candidates and seven projects.
- `npx oxlint test/e2e/fixtures/shell-probe.ts` — passed.
- `npx oxfmt --check test/e2e/fixtures/shell-probe.ts` — passed.
- `npm run test:titles:check` — passed.
- Normal commit and push hooks — passed.
- Diff reviewed for secrets, API keys, and credentials — none present.

## Review notes

This keeps the child environment fail-closed: it preserves executable discovery without inheriting ambient workflow secrets.

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shell probe processes now retain the parent environment’s `PATH` by default.
  * Explicitly provided environment variables continue to be applied as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->