### PR TITLE
feat(runtime): bind MXC create requests

### DIFF
--- a/src/lib/onboard/runtime-provider/mxc-bootstrap.ts
+++ b/src/lib/onboard/runtime-provider/mxc-bootstrap.ts
@@ -4,6 +4,7 @@
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 
 import { parseNativeArtifactWorkloadReceiptV1 } from "../workload/native-artifact";
 import {
@@ -185,6 +186,38 @@ function preparePlan(
   const providerHandle = `mxc-native-artifact-v1:${sha256Json(operationIdentity)}`;
   const authority = { ...operationIdentity, providerHandle };
   return frozen({ ...authority, authoritySha256: sha256Json(authority) });
+}
+
+/**
+ * Rebuild and validate one provider-owned bootstrap plan before it crosses a control-plane
+ * boundary. The returned value is a fresh frozen plan; caller aliases are never retained.
+ */
+export function validateMxcNativeArtifactBootstrapPlan(
+  value: unknown,
+): RuntimeProviderNativeArtifactBootstrapPlan {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null)
+  ) {
+    throw new MxcNativeArtifactBootstrapError("bootstrap plan must be a plain object");
+  }
+  const candidate = value as Record<string, unknown>;
+  const expected = preparePlan({
+    providerId: candidate.providerId as string,
+    sandboxName: candidate.sandboxName as string,
+    lifecycleGeneration: candidate.lifecycleGeneration as string,
+    driveRoot: candidate.driveRoot as string,
+    artifactRoot: candidate.artifactRoot as string,
+    workload: candidate.workload as RuntimeProviderNativeArtifactBootstrapInput["workload"],
+  });
+  if (!isDeepStrictEqual(candidate, expected)) {
+    throw new MxcNativeArtifactBootstrapError(
+      "bootstrap plan does not match its provider-owned authority",
+    );
+  }
+  return expected;
 }
 
 function result(

--- a/src/lib/onboard/runtime-provider/mxc-bootstrap.ts
+++ b/src/lib/onboard/runtime-provider/mxc-bootstrap.ts
@@ -23,6 +23,7 @@ const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
 const PROVIDER_HANDLE_PATTERN = /^mxc-native-artifact-v1:[a-f0-9]{64}$/u;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
 const MAX_PATH_BYTES = 4096;
+const ISSUED_BOOTSTRAP_PLANS = new WeakSet<RuntimeProviderNativeArtifactBootstrapPlan>();
 
 export class MxcNativeArtifactBootstrapError extends Error {
   constructor(message: string) {
@@ -185,7 +186,9 @@ function preparePlan(
   } as const;
   const providerHandle = `mxc-native-artifact-v1:${sha256Json(operationIdentity)}`;
   const authority = { ...operationIdentity, providerHandle };
-  return frozen({ ...authority, authoritySha256: sha256Json(authority) });
+  const plan = frozen({ ...authority, authoritySha256: sha256Json(authority) });
+  ISSUED_BOOTSTRAP_PLANS.add(plan);
+  return plan;
 }
 
 /**
@@ -202,6 +205,11 @@ export function validateMxcNativeArtifactBootstrapPlan(
     (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null)
   ) {
     throw new MxcNativeArtifactBootstrapError("bootstrap plan must be a plain object");
+  }
+  if (!ISSUED_BOOTSTRAP_PLANS.has(value as RuntimeProviderNativeArtifactBootstrapPlan)) {
+    throw new MxcNativeArtifactBootstrapError(
+      "bootstrap plan was not issued by the provider-owned bootstrap surface",
+    );
   }
   const candidate = value as Record<string, unknown>;
   const expected = preparePlan({

--- a/src/lib/onboard/runtime-provider/mxc-openshell-create-request.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-create-request.test.ts
@@ -172,10 +172,18 @@ describe("inactive MXC OpenShell create request", () => {
       mutate(changed);
 
       expect(() => projectMxcOpenShellCreateRequest(changed as never)).toThrow(
-        /bootstrap plan does not match its provider-owned authority/u,
+        /bootstrap plan was not issued by the provider-owned bootstrap surface/u,
       );
     },
   );
+
+  it("rejects a copied self-consistent plan without provider provenance (#8178)", async () => {
+    const copied = structuredClone(await bootstrapPlan());
+
+    expect(() => projectMxcOpenShellCreateRequest(copied)).toThrow(
+      /bootstrap plan was not issued by the provider-owned bootstrap surface/u,
+    );
+  });
 
   it("passes the same canonical request to create, readiness, and recovery (#8178)", async () => {
     const plan = await bootstrapPlan();

--- a/src/lib/onboard/runtime-provider/mxc-openshell-create-request.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-create-request.test.ts
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import { encodeManagedStartupProfile } from "../managed-startup/profile";
+import { nativeArtifactWorkloadReceiptFixture } from "../workload/native-artifact-test-fixture";
+import type {
+  RuntimeProviderNativeArtifactBootstrapInput,
+  RuntimeProviderNativeArtifactBootstrapPlan,
+  RuntimeProviderNativeArtifactVerifyAndCreateOutcome,
+} from "./contract";
+import { createMxcNativeArtifactBootstrapSurface } from "./mxc-bootstrap";
+import {
+  createMxcOpenShellRequestScopedControlPlane,
+  projectMxcOpenShellCreateRequest,
+  type MxcOpenShellRequestScopedOperations,
+} from "./mxc-openshell-create-request";
+
+const REQUIRED_ENVIRONMENT = [
+  "HOME",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_HOME",
+  "OPENCLAW_STATE_DIR",
+  "PATH",
+  "TEMP",
+  "TMP",
+  "USERPROFILE",
+] as const;
+
+type DeepMutable<T> = T extends readonly (infer Item)[]
+  ? DeepMutable<Item>[]
+  : T extends object
+    ? { -readonly [Key in keyof T]: DeepMutable<T[Key]> }
+    : T;
+
+type MutableBootstrapPlan = DeepMutable<RuntimeProviderNativeArtifactBootstrapPlan>;
+
+const PLAN_DRIFT_CASES: readonly [string, (plan: MutableBootstrapPlan) => void][] = [
+  [
+    "artifact digest",
+    (plan) => {
+      plan.workload.artifact.digest = `sha256:${"d".repeat(64)}`;
+    },
+  ],
+  [
+    "executable path",
+    (plan) => {
+      plan.executablePath = "C:\\other\\node.exe";
+    },
+  ],
+  [
+    "launch arguments",
+    (plan) => {
+      plan.workload.launch.arguments.push("--unsafe");
+    },
+  ],
+  [
+    "working directory",
+    (plan) => {
+      plan.workingDirectory = "C:\\other";
+    },
+  ],
+  [
+    "environment",
+    (plan) => {
+      plan.environment.HOME = "C:\\other";
+    },
+  ],
+  [
+    "lifecycle identity",
+    (plan) => {
+      plan.lifecycleGeneration = "generation-8";
+    },
+  ],
+];
+
+function bootstrapInput(): RuntimeProviderNativeArtifactBootstrapInput {
+  const workload = nativeArtifactWorkloadReceiptFixture(
+    encodeManagedStartupProfile(managedStartupE2eProfile("openclaw")),
+  );
+  return {
+    providerId: "mxc",
+    sandboxName: "alpha",
+    lifecycleGeneration: "generation-7",
+    driveRoot: "C:\\",
+    artifactRoot: "C:\\openclaw-2026-7-1",
+    workload: {
+      ...workload,
+      launch: { ...workload.launch, environmentNames: REQUIRED_ENVIRONMENT },
+    },
+  };
+}
+
+async function bootstrapPlan(): Promise<RuntimeProviderNativeArtifactBootstrapPlan> {
+  let observed: RuntimeProviderNativeArtifactBootstrapPlan | undefined;
+  const surface = createMxcNativeArtifactBootstrapSurface({
+    verifyAndCreate: async (plan) => {
+      observed = plan;
+      return { status: "not-created", reason: "create-rejected" };
+    },
+    verifyReadiness: async () => {
+      throw new Error("readiness must not run");
+    },
+    recoverCreate: async () => ({ status: "absent" }),
+  });
+  await surface.run(bootstrapInput());
+  expect(observed).toBeDefined();
+  return observed!;
+}
+
+function created(
+  plan: RuntimeProviderNativeArtifactBootstrapPlan,
+): Extract<RuntimeProviderNativeArtifactVerifyAndCreateOutcome, { status: "created" }> {
+  return {
+    status: "created",
+    authoritySha256: plan.authoritySha256,
+    providerHandle: plan.providerHandle,
+    sandboxName: plan.sandboxName,
+    lifecycleGeneration: plan.lifecycleGeneration,
+    artifactDigest: plan.workload.artifact.digest,
+    executableDigest: plan.workload.launch.executable.digest,
+  };
+}
+
+describe("inactive MXC OpenShell create request", () => {
+  it("projects one provenance-bound per-sandbox driver request (#8178)", async () => {
+    const plan = await bootstrapPlan();
+    const request = projectMxcOpenShellCreateRequest(plan);
+
+    expect(JSON.parse(request.driverConfigJson)).toEqual({
+      mxc: {
+        command: ["C:\\openclaw-2026-7-1\\node\\node.exe", "openclaw.mjs", "gateway"],
+        cwd: "C:\\openclaw-2026-7-1",
+      },
+    });
+    expect(request).toMatchObject({
+      contractVersion: 1,
+      providerId: "mxc",
+      authoritySha256: plan.authoritySha256,
+      providerHandle: plan.providerHandle,
+      sandboxName: "alpha",
+      lifecycleGeneration: "generation-7",
+      workload: {
+        agent: "openclaw",
+        platform: "windows/x64",
+        artifactRoot: "C:\\openclaw-2026-7-1",
+        artifactDigest: plan.workload.artifact.digest,
+        artifactVersion: "2026.7.1",
+        sourceRepository: "NVIDIA/NemoClaw",
+        sourceRevision: "b".repeat(40),
+        executablePath: "C:\\openclaw-2026-7-1\\node\\node.exe",
+        executableDigest: plan.workload.launch.executable.digest,
+      },
+      writableShare: plan.shareDirectory,
+      hostEnvironmentReferences: ["PATH"],
+      environment: plan.environment,
+    });
+    expect(request.requestSha256).toMatch(/^[a-f0-9]{64}$/u);
+    expect(JSON.stringify(request)).not.toContain("encodedProfile");
+    expect(JSON.stringify(request)).not.toContain("NVIDIA_API_KEY");
+    expect(Object.isFrozen(request)).toBe(true);
+    expect(Object.isFrozen(request.environment)).toBe(true);
+    expect(Object.isFrozen(request.workload)).toBe(true);
+  });
+
+  it.each(PLAN_DRIFT_CASES)(
+    "rejects %s drift before producing an OpenShell request (#8178)",
+    async (_label, mutate) => {
+      const changed = structuredClone(await bootstrapPlan()) as MutableBootstrapPlan;
+      mutate(changed);
+
+      expect(() => projectMxcOpenShellCreateRequest(changed as never)).toThrow(
+        /bootstrap plan does not match its provider-owned authority/u,
+      );
+    },
+  );
+
+  it("passes the same canonical request to create, readiness, and recovery (#8178)", async () => {
+    const plan = await bootstrapPlan();
+    const verifyAndCreate = vi.fn<MxcOpenShellRequestScopedOperations["verifyAndCreate"]>(
+      async () => created(plan),
+    );
+    const verifyReadiness = vi.fn<MxcOpenShellRequestScopedOperations["verifyReadiness"]>(
+      async () => ({
+        authoritySha256: plan.authoritySha256,
+        providerHandle: plan.providerHandle,
+        sandboxName: plan.sandboxName,
+        lifecycleGeneration: plan.lifecycleGeneration,
+        artifactDigest: plan.workload.artifact.digest,
+        executableDigest: plan.workload.launch.executable.digest,
+        ready: true,
+      }),
+    );
+    const recoverCreate = vi.fn<MxcOpenShellRequestScopedOperations["recoverCreate"]>(async () => ({
+      status: "absent",
+    }));
+    const controlPlane = createMxcOpenShellRequestScopedControlPlane({
+      verifyAndCreate,
+      verifyReadiness,
+      recoverCreate,
+    });
+    const creation = await controlPlane.verifyAndCreate(plan);
+    expect(creation.status).toBe("created");
+    await controlPlane.verifyReadiness(plan, created(plan));
+    await controlPlane.recoverCreate(plan);
+
+    const createRequest = verifyAndCreate.mock.calls[0]![0];
+    expect(verifyReadiness.mock.calls[0]![0]).toEqual(createRequest);
+    expect(recoverCreate.mock.calls[0]![0]).toEqual(createRequest);
+  });
+
+  it("rejects an incomplete request-scoped operation boundary (#8178)", () => {
+    expect(() =>
+      createMxcOpenShellRequestScopedControlPlane({
+        verifyAndCreate: undefined,
+        verifyReadiness: async () => {
+          throw new Error("unreachable");
+        },
+        recoverCreate: async () => ({ status: "absent" }),
+      } as never),
+    ).toThrow(/verify-and-create, readiness, and recovery operations are required/u);
+  });
+});

--- a/src/lib/onboard/runtime-provider/mxc-openshell-create-request.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-create-request.ts
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+import { cloneAndDeepFreeze } from "../../core/immutable";
+import type {
+  RuntimeProviderNativeArtifactBootstrapPlan,
+  RuntimeProviderNativeArtifactReadinessEvidence,
+  RuntimeProviderNativeArtifactRecoveryOutcome,
+  RuntimeProviderNativeArtifactVerifyAndCreateOutcome,
+} from "./contract";
+import { validateMxcNativeArtifactBootstrapPlan } from "./mxc-bootstrap";
+import {
+  MXC_NATIVE_ARTIFACT_CONTROL_PLANE_CONTRACT_VERSION,
+  type MxcNativeArtifactControlPlane,
+} from "./mxc-bootstrap-operations";
+
+export const MXC_OPENSHELL_CREATE_REQUEST_CONTRACT_VERSION = 1 as const;
+
+export interface MxcOpenShellCreateRequest {
+  readonly contractVersion: typeof MXC_OPENSHELL_CREATE_REQUEST_CONTRACT_VERSION;
+  readonly providerId: "mxc";
+  readonly requestSha256: string;
+  readonly authoritySha256: string;
+  readonly providerHandle: string;
+  readonly sandboxName: string;
+  readonly lifecycleGeneration: string;
+  readonly workload: {
+    readonly agent: "openclaw";
+    readonly platform: "windows/x64";
+    readonly artifactRoot: string;
+    readonly artifactDigest: string;
+    readonly artifactVersion: string;
+    readonly sourceRepository: "NVIDIA/NemoClaw";
+    readonly sourceRevision: string;
+    readonly executablePath: string;
+    readonly executableDigest: string;
+  };
+  readonly writableShare: string;
+  readonly driverConfigJson: string;
+  /** Accepted environment names that the live adapter must resolve without placing values in argv. */
+  readonly hostEnvironmentReferences: readonly string[];
+  readonly environment: {
+    readonly HOME: string;
+    readonly OPENCLAW_CONFIG_PATH: string;
+    readonly OPENCLAW_HOME: string;
+    readonly OPENCLAW_STATE_DIR: string;
+    readonly TEMP: string;
+    readonly TMP: string;
+    readonly USERPROFILE: string;
+  };
+}
+
+export interface MxcOpenShellRequestScopedOperations {
+  verifyAndCreate(
+    request: MxcOpenShellCreateRequest,
+  ): Promise<RuntimeProviderNativeArtifactVerifyAndCreateOutcome>;
+  verifyReadiness(
+    request: MxcOpenShellCreateRequest,
+    created: Extract<RuntimeProviderNativeArtifactVerifyAndCreateOutcome, { status: "created" }>,
+  ): Promise<RuntimeProviderNativeArtifactReadinessEvidence>;
+  recoverCreate(
+    request: MxcOpenShellCreateRequest,
+  ): Promise<RuntimeProviderNativeArtifactRecoveryOutcome>;
+}
+
+export class MxcOpenShellCreateRequestError extends Error {
+  constructor(message: string) {
+    super(`Invalid OpenShell MXC create request: ${message}`);
+    this.name = "MxcOpenShellCreateRequestError";
+  }
+}
+
+function sha256Json(value: object): string {
+  return createHash("sha256").update(JSON.stringify(value), "utf8").digest("hex");
+}
+
+/** Project one qualified native-artifact plan into OpenShell's per-sandbox MXC request shape. */
+export function projectMxcOpenShellCreateRequest(
+  value: RuntimeProviderNativeArtifactBootstrapPlan,
+): MxcOpenShellCreateRequest {
+  const plan = validateMxcNativeArtifactBootstrapPlan(value);
+  const command = [plan.executablePath, ...plan.workload.launch.arguments];
+  const driverConfigJson = JSON.stringify({
+    mxc: {
+      command,
+      cwd: plan.workingDirectory,
+    },
+  });
+  const boundEnvironmentNames = new Set(Object.keys(plan.environment));
+  const hostEnvironmentReferences = plan.workload.launch.environmentNames.filter(
+    (name) => !boundEnvironmentNames.has(name),
+  );
+  const identity = {
+    contractVersion: MXC_OPENSHELL_CREATE_REQUEST_CONTRACT_VERSION,
+    providerId: "mxc" as const,
+    authoritySha256: plan.authoritySha256,
+    providerHandle: plan.providerHandle,
+    sandboxName: plan.sandboxName,
+    lifecycleGeneration: plan.lifecycleGeneration,
+    workload: {
+      agent: plan.workload.agent,
+      platform: plan.workload.platform,
+      artifactRoot: plan.artifactRoot,
+      artifactDigest: plan.workload.artifact.digest,
+      artifactVersion: plan.workload.artifact.version,
+      sourceRepository: plan.workload.artifact.source.repository,
+      sourceRevision: plan.workload.artifact.source.revision,
+      executablePath: plan.executablePath,
+      executableDigest: plan.workload.launch.executable.digest,
+    },
+    writableShare: plan.shareDirectory,
+    driverConfigJson,
+    hostEnvironmentReferences,
+    environment: plan.environment,
+  };
+  return cloneAndDeepFreeze({ ...identity, requestSha256: sha256Json(identity) });
+}
+
+/**
+ * Bind the generic MXC bootstrap contract to request-scoped OpenShell operations.
+ *
+ * The injected operations remain responsible for stable artifact verification, sandbox mutation,
+ * readiness, and recovery. This adapter guarantees that all three receive the same canonical,
+ * provenance-bound OpenShell request instead of caller-provided command or environment data.
+ */
+export function createMxcOpenShellRequestScopedControlPlane(
+  operations: MxcOpenShellRequestScopedOperations,
+): MxcNativeArtifactControlPlane {
+  if (
+    typeof operations?.verifyAndCreate !== "function" ||
+    typeof operations.verifyReadiness !== "function" ||
+    typeof operations.recoverCreate !== "function"
+  ) {
+    throw new MxcOpenShellCreateRequestError(
+      "verify-and-create, readiness, and recovery operations are required",
+    );
+  }
+  const verifyAndCreate = operations.verifyAndCreate.bind(operations);
+  const verifyReadiness = operations.verifyReadiness.bind(operations);
+  const recoverCreate = operations.recoverCreate.bind(operations);
+  const controlPlane: MxcNativeArtifactControlPlane = {
+    contractVersion: MXC_NATIVE_ARTIFACT_CONTROL_PLANE_CONTRACT_VERSION,
+    providerId: "mxc",
+    verifyAndCreate: (plan) => verifyAndCreate(projectMxcOpenShellCreateRequest(plan)),
+    verifyReadiness: (plan, created) =>
+      verifyReadiness(projectMxcOpenShellCreateRequest(plan), created),
+    recoverCreate: (plan) => recoverCreate(projectMxcOpenShellCreateRequest(plan)),
+  };
+  return Object.freeze(controlPlane);
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The inactive Windows MXC provider now projects its qualified native-artifact bootstrap plan into one canonical OpenShell per-sandbox create request. Artifact, executable, lifecycle, command, working-directory, environment-reference, and writable-share drift are rejected before request-scoped operations can mutate OpenShell.

## Reason

OpenShell's MXC driver accepts workload command and working directory through per-sandbox driver configuration, while NemoClaw owns the accepted OpenClaw artifact and launch identity. A typed request boundary is required so the later live adapter cannot reinterpret caller-provided paths, arguments, or environment values between qualification and sandbox creation.

### Related issues

Part of #8178.

## Changes

- Add a versioned, frozen OpenShell MXC create request that binds the qualified artifact and executable identity to canonical `mxc.command`, `mxc.cwd`, writable-share, environment bindings, and host environment references. The upcoming inactive live adapter is its current consumer; direct CLI argument construction would duplicate and weaken the provider-owned workload contract. Focused tests protect the exact projection and secret-free shape.
- Add a request-scoped control-plane adapter so create, readiness, and recovery receive the same canonical request. The existing native-artifact bootstrap still validates returned identity and recovery evidence. Focused tests protect operation parity and reject incomplete operation boundaries.
- Rebuild and validate a bootstrap plan before projection, returning a fresh frozen plan and rejecting artifact, executable, arguments, working-directory, environment, or lifecycle drift. Table-driven tests cover each fail-closed case.

## Verification

- `npx vitest run --project cli src/lib/onboard/runtime-provider/mxc-openshell-create-request.test.ts src/lib/onboard/runtime-provider/mxc-bootstrap.test.ts src/lib/onboard/runtime-provider/mxc-bootstrap-operations.test.ts src/lib/onboard/runtime-provider/mxc.test.ts src/lib/onboard/windows-mxc/inactive-onboarding.test.ts` — 5 files and 64 tests passed.
- `npm run test:changed` — 5 files and 61 affected tests passed after the growth-guardrail integration suite passed 32 tests.
- `npm run typecheck:cli` — passed.
- `npm run checks:repository` — layer boundaries, architecture, project membership, and repository checks passed.
- Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed through head `80ce03ef7e62cfe787b5c1f1e0267780ea4a206b`.
- GitHub reports every commit through `80ce03ef7e62cfe787b5c1f1e0267780ea4a206b` as `Verified` with reason `valid`.
- The diff contains no secrets, API keys, or credentials.

## Review notes

This is a sensitive runtime/onboarding boundary. MXC remains absent from production provider selection, CLI onboarding, and activation. The adapter performs no OpenShell mutation itself; injected request-scoped operations remain responsible for stable artifact verification, sandbox creation, readiness, and exact-identity recovery.

Security review against the repository's nine-category rubric passed with no remaining findings. The review added and verified an opaque provider-owned plan capability so a copied or self-consistent caller plan cannot reach request-scoped operations.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>
