### PR TITLE
refactor(debug): use typed sandbox observer

### DIFF
--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -27,7 +27,7 @@
       "src/lib/runner.ts": 86,
       "src/lib/security/redact.ts": 54,
       "src/lib/state/onboard-session.ts": 36,
-      "src/lib/state/registry.ts": 101,
+      "src/lib/state/registry.ts": 100,
       "src/lib/state/state-root.ts": 21,
       "src/lib/subprocess-env.ts": 24,
       "src/lib/validation.ts": 24

--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -23,7 +23,7 @@
       "src/lib/inference/config.ts": 30,
       "src/lib/inference/web-search.ts": 21,
       "src/lib/messaging/channels/index.ts": 25,
-      "src/lib/onboard/gateway-binding.ts": 52,
+      "src/lib/onboard/gateway-binding.ts": 53,
       "src/lib/runner.ts": 86,
       "src/lib/security/redact.ts": 54,
       "src/lib/state/onboard-session.ts": 36,

--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -9,7 +9,7 @@
       "src/lib/adapters/openshell/client.ts": 20,
       "src/lib/adapters/openshell/resolve.ts": 27,
       "src/lib/adapters/openshell/runtime.ts": 55,
-      "src/lib/adapters/openshell/timeouts.ts": 39,
+      "src/lib/adapters/openshell/timeouts.ts": 38,
       "src/lib/agent/defs.ts": 33,
       "src/lib/cli/branding.ts": 86,
       "src/lib/cli/nemoclaw-oclif-command.ts": 107,

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -4,75 +4,9 @@
 import { Flags } from "@oclif/core";
 import { NemoClawCommand } from "../lib/cli/nemoclaw-oclif-command";
 
-import { CLI_NAME } from "../lib/cli/branding";
-import { runDebug } from "../lib/diagnostics/debug";
 import type { DebugOptions } from "../lib/diagnostics/debug";
-import type { RunDebugCommandDeps } from "../lib/diagnostics/debug-command";
 import { runDebugCommandWithOptions } from "../lib/diagnostics/debug-command";
-import { captureOpenshellCommand } from "../lib/adapters/openshell/client";
-import { resolveOpenshell } from "../lib/adapters/openshell/resolve";
-import { createCliOpenShellSandboxObserver } from "../lib/adapters/openshell/sandbox-observer-cli";
-import { selectedOpenShellGateway } from "../lib/adapters/openshell/sandbox-observer";
-import * as registry from "../lib/state/registry";
-
-const useColor = !process.env.NO_COLOR && !!process.stderr.isTTY;
-const B = useColor ? "\x1b[1m" : "";
-const R = useColor ? "\x1b[0m" : "";
-const RD = useColor ? "\x1b[1;31m" : "";
-
-function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
-  const sandboxObserver = createCliOpenShellSandboxObserver({
-    capture: (args, options) => {
-      const openshell = resolveOpenshell();
-      if (!openshell) return { status: 1, output: "" };
-      return captureOpenshellCommand(openshell, args, { cwd: rootDir, ...options });
-    },
-  });
-
-  const liveSandboxNames = async (): Promise<ReadonlySet<string> | undefined> => {
-    const result = await sandboxObserver.listSandboxes({ target: selectedOpenShellGateway() });
-    if (!result.ok) return undefined;
-    return new Set(result.value.sandboxes.map((sandbox) => sandbox.name));
-  };
-
-  const getDefaultSandbox = async (): Promise<string | undefined> => {
-    const { defaultSandbox, sandboxes } = registry.listSandboxes();
-    if (!defaultSandbox) return undefined;
-    if (!sandboxes.find((sandbox) => sandbox.name === defaultSandbox)) {
-      console.error(
-        `${RD}Warning:${R} default sandbox '${defaultSandbox}' is no longer in the registry.`,
-      );
-      console.error(
-        `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
-      );
-      return undefined;
-    }
-    const liveNames = await liveSandboxNames();
-    if (liveNames && !liveNames.has(defaultSandbox)) {
-      console.error(
-        `${RD}Warning:${R} default sandbox '${defaultSandbox}' exists in the local registry but not in OpenShell.`,
-      );
-      console.error(
-        `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
-      );
-      return undefined;
-    }
-    return defaultSandbox;
-  };
-
-  const isSandboxKnown = async (name: string): Promise<boolean> => {
-    const { sandboxes } = registry.listSandboxes();
-    if (!sandboxes.find((sandbox) => sandbox.name === name)) return false;
-    const liveNames = await liveSandboxNames();
-    return !liveNames || liveNames.has(name);
-  };
-
-  return {
-    getDefaultSandbox,
-    isSandboxKnown,
-    runDebug,
-  };
-}
+import { buildDebugCommandDeps } from "../lib/diagnostics/debug-command-deps";
 
 export default class DebugCliCommand extends NemoClawCommand {
   static id = "debug";

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -9,32 +9,33 @@ import { runDebug } from "../lib/diagnostics/debug";
 import type { DebugOptions } from "../lib/diagnostics/debug";
 import type { RunDebugCommandDeps } from "../lib/diagnostics/debug-command";
 import { runDebugCommandWithOptions } from "../lib/diagnostics/debug-command";
-import type { CaptureOpenshellResult } from "../lib/adapters/openshell/client";
 import { captureOpenshellCommand } from "../lib/adapters/openshell/client";
-import { OPENSHELL_PROBE_TIMEOUT_MS } from "../lib/adapters/openshell/timeouts";
-import * as registry from "../lib/state/registry";
 import { resolveOpenshell } from "../lib/adapters/openshell/resolve";
-import { parseLiveSandboxNames } from "../lib/runtime-recovery";
+import { createCliOpenShellSandboxObserver } from "../lib/adapters/openshell/sandbox-observer-cli";
+import { selectedOpenShellGateway } from "../lib/adapters/openshell/sandbox-observer";
+import * as registry from "../lib/state/registry";
 
 const useColor = !process.env.NO_COLOR && !!process.stderr.isTTY;
 const B = useColor ? "\x1b[1m" : "";
 const R = useColor ? "\x1b[0m" : "";
 const RD = useColor ? "\x1b[1;31m" : "";
 
-function captureOpenshell(rootDir: string, args: string[]): CaptureOpenshellResult {
-  const openshell = resolveOpenshell();
-  if (!openshell) {
-    return { status: 1, output: "" };
-  }
-  return captureOpenshellCommand(openshell, args, {
-    cwd: rootDir,
-    ignoreError: true,
-    timeout: OPENSHELL_PROBE_TIMEOUT_MS,
-  });
-}
-
 function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
-  const getDefaultSandbox = (): string | undefined => {
+  const sandboxObserver = createCliOpenShellSandboxObserver({
+    capture: (args, options) => {
+      const openshell = resolveOpenshell();
+      if (!openshell) return { status: 1, output: "" };
+      return captureOpenshellCommand(openshell, args, { cwd: rootDir, ...options });
+    },
+  });
+
+  const liveSandboxNames = async (): Promise<ReadonlySet<string> | undefined> => {
+    const result = await sandboxObserver.listSandboxes({ target: selectedOpenShellGateway() });
+    if (!result.ok) return undefined;
+    return new Set(result.value.sandboxes.map((sandbox) => sandbox.name));
+  };
+
+  const getDefaultSandbox = async (): Promise<string | undefined> => {
     const { defaultSandbox, sandboxes } = registry.listSandboxes();
     if (!defaultSandbox) return undefined;
     if (!sandboxes.find((sandbox) => sandbox.name === defaultSandbox)) {
@@ -46,8 +47,8 @@ function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
       );
       return undefined;
     }
-    const liveList = captureOpenshell(rootDir, ["sandbox", "list"]);
-    if (liveList.status === 0 && !parseLiveSandboxNames(liveList.output).has(defaultSandbox)) {
+    const liveNames = await liveSandboxNames();
+    if (liveNames && !liveNames.has(defaultSandbox)) {
       console.error(
         `${RD}Warning:${R} default sandbox '${defaultSandbox}' exists in the local registry but not in OpenShell.`,
       );
@@ -59,14 +60,11 @@ function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     return defaultSandbox;
   };
 
-  const isSandboxKnown = (name: string): boolean => {
+  const isSandboxKnown = async (name: string): Promise<boolean> => {
     const { sandboxes } = registry.listSandboxes();
     if (!sandboxes.find((sandbox) => sandbox.name === name)) return false;
-    const liveList = captureOpenshell(rootDir, ["sandbox", "list"]);
-    if (liveList.status === 0 && !parseLiveSandboxNames(liveList.output).has(name)) {
-      return false;
-    }
-    return true;
+    const liveNames = await liveSandboxNames();
+    return !liveNames || liveNames.has(name);
   };
 
   return {
@@ -99,6 +97,6 @@ export default class DebugCliCommand extends NemoClawCommand {
     if (flags.quick) options.quick = true;
     if (flags.output) options.output = flags.output;
     if (flags.sandbox) options.sandboxName = flags.sandbox;
-    runDebugCommandWithOptions(options, buildDebugCommandDeps(this.config.root));
+    await runDebugCommandWithOptions(options, buildDebugCommandDeps(this.config.root));
   }
 }

--- a/src/commands/simple-global-oclif-adapters.test.ts
+++ b/src/commands/simple-global-oclif-adapters.test.ts
@@ -233,6 +233,21 @@ describe("simple global oclif adapters", testTimeoutOptions(30_000), () => {
     await expect(deps.getDefaultSandbox()).resolves.toEqual({ name: "alpha", gatewayName: "nemoclaw" });
   });
 
+  it("rejects an explicit sandbox with an invalid gateway binding", async () => {
+    mocks.listSandboxes.mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha", gatewayName: "untrusted" }],
+    } as never);
+
+    await DebugCliCommand.run(["--quick"], rootDir);
+
+    const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
+    await expect(deps.getSandboxAvailability("alpha")).resolves.toEqual({
+      state: "invalid_gateway",
+    });
+    expect(mocks.captureOpenshellCommand).not.toHaveBeenCalled();
+  });
+
   it("keeps registered debug sandboxes when OpenShell observation fails", async () => {
     mocks.listSandboxes.mockReturnValue({
       defaultSandbox: "alpha",

--- a/src/commands/simple-global-oclif-adapters.test.ts
+++ b/src/commands/simple-global-oclif-adapters.test.ts
@@ -201,7 +201,7 @@ describe("simple global oclif adapters", testTimeoutOptions(30_000), () => {
 
     const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
     await expect(deps.getDefaultSandbox()).resolves.toBeNull();
-    await expect(deps.isSandboxKnown("alpha")).resolves.toBe(false);
+    await expect(deps.getSandboxAvailability("alpha")).resolves.toBe("missing");
   });
 
   it("keeps registered debug sandboxes when OpenShell observation fails", async () => {
@@ -215,7 +215,7 @@ describe("simple global oclif adapters", testTimeoutOptions(30_000), () => {
 
     const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
     await expect(deps.getDefaultSandbox()).resolves.toBe("alpha");
-    await expect(deps.isSandboxKnown("alpha")).resolves.toBe(true);
+    await expect(deps.getSandboxAvailability("alpha")).resolves.toBe("available");
   });
 
   it("maps gateway-token flags to the gateway token action", async () => {

--- a/src/commands/simple-global-oclif-adapters.test.ts
+++ b/src/commands/simple-global-oclif-adapters.test.ts
@@ -200,7 +200,7 @@ describe("simple global oclif adapters", testTimeoutOptions(30_000), () => {
     await DebugCliCommand.run(["--quick"], rootDir);
 
     const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
-    await expect(deps.getDefaultSandbox()).resolves.toBeUndefined();
+    await expect(deps.getDefaultSandbox()).resolves.toBeNull();
     await expect(deps.isSandboxKnown("alpha")).resolves.toBe(false);
   });
 

--- a/src/commands/simple-global-oclif-adapters.test.ts
+++ b/src/commands/simple-global-oclif-adapters.test.ts
@@ -172,15 +172,18 @@ describe("simple global oclif adapters", testTimeoutOptions(30_000), () => {
   it("builds debug defaults from the sandbox registry and OpenShell liveness", async () => {
     mocks.listSandboxes.mockReturnValue({
       defaultSandbox: "alpha",
-      sandboxes: [{ name: "alpha" }],
+      sandboxes: [{ name: "alpha", gatewayPort: 18080 }],
     } as never);
     await DebugCliCommand.run(["--quick"], rootDir);
 
     const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
-    await expect(deps.getDefaultSandbox()).resolves.toBe("alpha");
+    await expect(deps.getDefaultSandbox()).resolves.toEqual({
+      name: "alpha",
+      gatewayName: "nemoclaw-18080",
+    });
     expect(mocks.captureOpenshellCommand).toHaveBeenCalledWith(
       "/usr/bin/openshell",
-      ["sandbox", "list"],
+      ["sandbox", "list", "-g", "nemoclaw-18080"],
       expect.objectContaining({
         cwd: rootDir,
         ignoreError: true,
@@ -201,7 +204,7 @@ describe("simple global oclif adapters", testTimeoutOptions(30_000), () => {
 
     const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
     await expect(deps.getDefaultSandbox()).resolves.toBeNull();
-    await expect(deps.getSandboxAvailability("alpha")).resolves.toBe("missing");
+    await expect(deps.getSandboxAvailability("alpha")).resolves.toEqual({ state: "missing" });
   });
 
   it("rejects a fallback registered sandbox missing from OpenShell", async () => {
@@ -227,7 +230,7 @@ describe("simple global oclif adapters", testTimeoutOptions(30_000), () => {
     await DebugCliCommand.run(["--quick"], rootDir);
 
     const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
-    await expect(deps.getDefaultSandbox()).resolves.toBe("alpha");
+    await expect(deps.getDefaultSandbox()).resolves.toEqual({ name: "alpha", gatewayName: "nemoclaw" });
   });
 
   it("keeps registered debug sandboxes when OpenShell observation fails", async () => {
@@ -240,8 +243,8 @@ describe("simple global oclif adapters", testTimeoutOptions(30_000), () => {
     await DebugCliCommand.run(["--quick"], rootDir);
 
     const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
-    await expect(deps.getDefaultSandbox()).resolves.toBe("alpha");
-    await expect(deps.getSandboxAvailability("alpha")).resolves.toBe("available");
+    await expect(deps.getDefaultSandbox()).resolves.toEqual({ name: "alpha", gatewayName: "nemoclaw" });
+    await expect(deps.getSandboxAvailability("alpha")).resolves.toEqual({ state: "available", gatewayName: "nemoclaw" });
   });
 
   it("maps gateway-token flags to the gateway token action", async () => {

--- a/src/commands/simple-global-oclif-adapters.test.ts
+++ b/src/commands/simple-global-oclif-adapters.test.ts
@@ -204,6 +204,32 @@ describe("simple global oclif adapters", testTimeoutOptions(30_000), () => {
     await expect(deps.getSandboxAvailability("alpha")).resolves.toBe("missing");
   });
 
+  it("rejects a fallback registered sandbox missing from OpenShell", async () => {
+    mocks.listSandboxes.mockReturnValue({
+      defaultSandbox: null,
+      sandboxes: [{ name: "alpha" }],
+    } as never);
+    mocks.captureOpenshellCommand.mockReturnValue({ status: 0, output: "beta\n" });
+
+    await DebugCliCommand.run(["--quick"], rootDir);
+
+    const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
+    await expect(deps.getDefaultSandbox()).resolves.toBeNull();
+  });
+
+  it("keeps a fallback registered sandbox when OpenShell observation fails", async () => {
+    mocks.listSandboxes.mockReturnValue({
+      defaultSandbox: null,
+      sandboxes: [{ name: "alpha" }],
+    } as never);
+    mocks.captureOpenshellCommand.mockReturnValue({ status: 1, output: "unavailable" });
+
+    await DebugCliCommand.run(["--quick"], rootDir);
+
+    const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
+    await expect(deps.getDefaultSandbox()).resolves.toBe("alpha");
+  });
+
   it("keeps registered debug sandboxes when OpenShell observation fails", async () => {
     mocks.listSandboxes.mockReturnValue({
       defaultSandbox: "alpha",

--- a/src/commands/simple-global-oclif-adapters.test.ts
+++ b/src/commands/simple-global-oclif-adapters.test.ts
@@ -233,6 +233,24 @@ describe("simple global oclif adapters", testTimeoutOptions(30_000), () => {
     await expect(deps.getDefaultSandbox()).resolves.toEqual({ name: "alpha", gatewayName: "nemoclaw" });
   });
 
+  it("rejects an explicit sandbox when OpenShell authentication fails", async () => {
+    mocks.listSandboxes.mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }],
+    } as never);
+    mocks.captureOpenshellCommand.mockReturnValue({
+      status: 1,
+      output: "authentication failed",
+    });
+
+    await DebugCliCommand.run(["--quick"], rootDir);
+
+    const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
+    await expect(deps.getSandboxAvailability("alpha")).resolves.toEqual({
+      state: "observation_denied",
+    });
+  });
+
   it("rejects an explicit sandbox with an invalid gateway binding", async () => {
     mocks.listSandboxes.mockReturnValue({
       defaultSandbox: "alpha",

--- a/src/commands/simple-global-oclif-adapters.test.ts
+++ b/src/commands/simple-global-oclif-adapters.test.ts
@@ -177,12 +177,45 @@ describe("simple global oclif adapters", testTimeoutOptions(30_000), () => {
     await DebugCliCommand.run(["--quick"], rootDir);
 
     const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
-    expect(deps.getDefaultSandbox()).toBe("alpha");
+    await expect(deps.getDefaultSandbox()).resolves.toBe("alpha");
     expect(mocks.captureOpenshellCommand).toHaveBeenCalledWith(
       "/usr/bin/openshell",
       ["sandbox", "list"],
-      expect.objectContaining({ cwd: rootDir, ignoreError: true }),
+      expect.objectContaining({
+        cwd: rootDir,
+        ignoreError: true,
+        includeStderr: true,
+        includeStreams: true,
+      }),
     );
+  });
+
+  it("rejects a registered debug sandbox missing from a successful OpenShell observation", async () => {
+    mocks.listSandboxes.mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }],
+    } as never);
+    mocks.captureOpenshellCommand.mockReturnValue({ status: 0, output: "beta\n" });
+
+    await DebugCliCommand.run(["--quick"], rootDir);
+
+    const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
+    await expect(deps.getDefaultSandbox()).resolves.toBeUndefined();
+    await expect(deps.isSandboxKnown("alpha")).resolves.toBe(false);
+  });
+
+  it("keeps registered debug sandboxes when OpenShell observation fails", async () => {
+    mocks.listSandboxes.mockReturnValue({
+      defaultSandbox: "alpha",
+      sandboxes: [{ name: "alpha" }],
+    } as never);
+    mocks.captureOpenshellCommand.mockReturnValue({ status: 1, output: "unavailable" });
+
+    await DebugCliCommand.run(["--quick"], rootDir);
+
+    const deps = mocks.runDebugCommandWithOptions.mock.calls[0][1];
+    await expect(deps.getDefaultSandbox()).resolves.toBe("alpha");
+    await expect(deps.isSandboxKnown("alpha")).resolves.toBe(true);
   });
 
   it("maps gateway-token flags to the gateway token action", async () => {

--- a/src/lib/diagnostics/debug-command-deps.ts
+++ b/src/lib/diagnostics/debug-command-deps.ts
@@ -20,6 +20,16 @@ const B = useColor ? "\x1b[1m" : "";
 const R = useColor ? "\x1b[0m" : "";
 const RD = useColor ? "\x1b[1;31m" : "";
 
+function resolveDebugGatewayName(
+  sandbox: Parameters<typeof resolveSandboxGatewayName>[0],
+): string | null {
+  try {
+    return resolveSandboxGatewayName(sandbox);
+  } catch {
+    return null;
+  }
+}
+
 export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
   const sandboxObserver = createCliOpenShellSandboxObserver({
     capture: (args, options) => {
@@ -41,7 +51,14 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     const { defaultSandbox, sandboxes } = registry.listSandboxes();
     if (!defaultSandbox) {
       const registered = sandboxes.find((sandbox) => sandbox.name);
-      const gatewayName = registered ? resolveSandboxGatewayName(registered) : undefined;
+      const gatewayName = registered ? resolveDebugGatewayName(registered) : undefined;
+      if (registered && gatewayName === null) {
+        console.error(
+          `${RD}Warning:${R} sandbox '${registered.name}' has an invalid registered gateway binding.`,
+        );
+        console.error("  Remove and re-onboard the sandbox to restore a valid gateway binding.\n");
+        return null;
+      }
       const liveNames = await liveSandboxNames(
         gatewayName ? namedOpenShellGateway(gatewayName) : selectedOpenShellGateway(),
       );
@@ -67,7 +84,14 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
       );
       return null;
     }
-    const gatewayName = resolveSandboxGatewayName(registered);
+    const gatewayName = resolveDebugGatewayName(registered);
+    if (!gatewayName) {
+      console.error(
+        `${RD}Warning:${R} default sandbox '${defaultSandbox}' has an invalid registered gateway binding.`,
+      );
+      console.error("  Remove and re-onboard the sandbox to restore a valid gateway binding.\n");
+      return null;
+    }
     const liveNames = await liveSandboxNames(namedOpenShellGateway(gatewayName));
     if (liveNames && !liveNames.has(defaultSandbox)) {
       console.error(
@@ -85,7 +109,8 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     const { sandboxes } = registry.listSandboxes();
     const registered = sandboxes.find((sandbox) => sandbox.name === name);
     if (!registered) return { state: "unregistered" };
-    const gatewayName = resolveSandboxGatewayName(registered);
+    const gatewayName = resolveDebugGatewayName(registered);
+    if (!gatewayName) return { state: "invalid_gateway" };
     const liveNames = await liveSandboxNames(namedOpenShellGateway(gatewayName));
     return !liveNames || liveNames.has(name)
       ? { state: "available", gatewayName }

--- a/src/lib/diagnostics/debug-command-deps.ts
+++ b/src/lib/diagnostics/debug-command-deps.ts
@@ -30,7 +30,7 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     return new Set(result.value.sandboxes.map((sandbox) => sandbox.name));
   };
 
-  const getDefaultSandbox = async (): Promise<string | undefined> => {
+  const getDefaultSandbox = async (): Promise<string | null | undefined> => {
     const { defaultSandbox, sandboxes } = registry.listSandboxes();
     if (!defaultSandbox) return undefined;
     if (!sandboxes.find((sandbox) => sandbox.name === defaultSandbox)) {
@@ -40,7 +40,7 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
       console.error(
         `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
       );
-      return undefined;
+      return null;
     }
     const liveNames = await liveSandboxNames();
     if (liveNames && !liveNames.has(defaultSandbox)) {
@@ -50,7 +50,7 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
       console.error(
         `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
       );
-      return undefined;
+      return null;
     }
     return defaultSandbox;
   };

--- a/src/lib/diagnostics/debug-command-deps.ts
+++ b/src/lib/diagnostics/debug-command-deps.ts
@@ -30,9 +30,14 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     return new Set(result.value.sandboxes.map((sandbox) => sandbox.name));
   };
 
-  const getDefaultSandbox = async (): Promise<string | null | undefined> => {
+  const getDefaultSandbox = async (): Promise<string | null> => {
     const { defaultSandbox, sandboxes } = registry.listSandboxes();
-    if (!defaultSandbox) return undefined;
+    if (!defaultSandbox) {
+      const registeredName = sandboxes.find((sandbox) => sandbox.name)?.name;
+      if (registeredName) return registeredName;
+      const liveNames = await liveSandboxNames();
+      return liveNames?.values().next().value ?? "default";
+    }
     if (!sandboxes.find((sandbox) => sandbox.name === defaultSandbox)) {
       console.error(
         `${RD}Warning:${R} default sandbox '${defaultSandbox}' is no longer in the registry.`,
@@ -55,16 +60,18 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     return defaultSandbox;
   };
 
-  const isSandboxKnown = async (name: string): Promise<boolean> => {
+  const getSandboxAvailability = async (
+    name: string,
+  ): Promise<"available" | "unregistered" | "missing"> => {
     const { sandboxes } = registry.listSandboxes();
-    if (!sandboxes.find((sandbox) => sandbox.name === name)) return false;
+    if (!sandboxes.find((sandbox) => sandbox.name === name)) return "unregistered";
     const liveNames = await liveSandboxNames();
-    return !liveNames || liveNames.has(name);
+    return !liveNames || liveNames.has(name) ? "available" : "missing";
   };
 
   return {
     getDefaultSandbox,
-    isSandboxKnown,
+    getSandboxAvailability,
     runDebug,
   };
 }

--- a/src/lib/diagnostics/debug-command-deps.ts
+++ b/src/lib/diagnostics/debug-command-deps.ts
@@ -7,7 +7,12 @@ import type { RunDebugCommandDeps } from "./debug-command";
 import { captureOpenshellCommand } from "../adapters/openshell/client";
 import { resolveOpenshell } from "../adapters/openshell/resolve";
 import { createCliOpenShellSandboxObserver } from "../adapters/openshell/sandbox-observer-cli";
-import { selectedOpenShellGateway } from "../adapters/openshell/sandbox-observer";
+import {
+  namedOpenShellGateway,
+  selectedOpenShellGateway,
+  type OpenShellGatewayTarget,
+} from "../adapters/openshell/sandbox-observer";
+import { resolveSandboxGatewayName } from "../onboard/gateway-binding";
 import * as registry from "../state/registry";
 
 const useColor = !process.env.NO_COLOR && !!process.stderr.isTTY;
@@ -24,29 +29,36 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     },
   });
 
-  const liveSandboxNames = async (): Promise<ReadonlySet<string> | undefined> => {
-    const result = await sandboxObserver.listSandboxes({ target: selectedOpenShellGateway() });
+  const liveSandboxNames = async (
+    target: OpenShellGatewayTarget,
+  ): Promise<ReadonlySet<string> | undefined> => {
+    const result = await sandboxObserver.listSandboxes({ target });
     if (!result.ok) return undefined;
     return new Set(result.value.sandboxes.map((sandbox) => sandbox.name));
   };
 
-  const getDefaultSandbox = async (): Promise<string | null> => {
+  const getDefaultSandbox: RunDebugCommandDeps["getDefaultSandbox"] = async () => {
     const { defaultSandbox, sandboxes } = registry.listSandboxes();
     if (!defaultSandbox) {
-      const registeredName = sandboxes.find((sandbox) => sandbox.name)?.name;
-      const liveNames = await liveSandboxNames();
-      if (registeredName && liveNames && !liveNames.has(registeredName)) {
+      const registered = sandboxes.find((sandbox) => sandbox.name);
+      const gatewayName = registered ? resolveSandboxGatewayName(registered) : undefined;
+      const liveNames = await liveSandboxNames(
+        gatewayName ? namedOpenShellGateway(gatewayName) : selectedOpenShellGateway(),
+      );
+      if (registered && liveNames && !liveNames.has(registered.name)) {
         console.error(
-          `${RD}Warning:${R} sandbox '${registeredName}' exists in the local registry but not in OpenShell.`,
+          `${RD}Warning:${R} sandbox '${registered.name}' exists in the local registry but not in OpenShell.`,
         );
         console.error(
           `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
         );
         return null;
       }
-      return registeredName ?? liveNames?.values().next().value ?? "default";
+      if (registered && gatewayName) return { name: registered.name, gatewayName };
+      return { name: liveNames?.values().next().value ?? "default" };
     }
-    if (!sandboxes.find((sandbox) => sandbox.name === defaultSandbox)) {
+    const registered = sandboxes.find((sandbox) => sandbox.name === defaultSandbox);
+    if (!registered) {
       console.error(
         `${RD}Warning:${R} default sandbox '${defaultSandbox}' is no longer in the registry.`,
       );
@@ -55,7 +67,8 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
       );
       return null;
     }
-    const liveNames = await liveSandboxNames();
+    const gatewayName = resolveSandboxGatewayName(registered);
+    const liveNames = await liveSandboxNames(namedOpenShellGateway(gatewayName));
     if (liveNames && !liveNames.has(defaultSandbox)) {
       console.error(
         `${RD}Warning:${R} default sandbox '${defaultSandbox}' exists in the local registry but not in OpenShell.`,
@@ -65,16 +78,18 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
       );
       return null;
     }
-    return defaultSandbox;
+    return { name: defaultSandbox, gatewayName };
   };
 
-  const getSandboxAvailability = async (
-    name: string,
-  ): Promise<"available" | "unregistered" | "missing"> => {
+  const getSandboxAvailability: RunDebugCommandDeps["getSandboxAvailability"] = async (name) => {
     const { sandboxes } = registry.listSandboxes();
-    if (!sandboxes.find((sandbox) => sandbox.name === name)) return "unregistered";
-    const liveNames = await liveSandboxNames();
-    return !liveNames || liveNames.has(name) ? "available" : "missing";
+    const registered = sandboxes.find((sandbox) => sandbox.name === name);
+    if (!registered) return { state: "unregistered" };
+    const gatewayName = resolveSandboxGatewayName(registered);
+    const liveNames = await liveSandboxNames(namedOpenShellGateway(gatewayName));
+    return !liveNames || liveNames.has(name)
+      ? { state: "available", gatewayName }
+      : { state: "missing" };
   };
 
   return {

--- a/src/lib/diagnostics/debug-command-deps.ts
+++ b/src/lib/diagnostics/debug-command-deps.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CLI_NAME } from "../cli/branding";
+import { runDebug } from "./debug";
+import type { RunDebugCommandDeps } from "./debug-command";
+import { captureOpenshellCommand } from "../adapters/openshell/client";
+import { resolveOpenshell } from "../adapters/openshell/resolve";
+import { createCliOpenShellSandboxObserver } from "../adapters/openshell/sandbox-observer-cli";
+import { selectedOpenShellGateway } from "../adapters/openshell/sandbox-observer";
+import * as registry from "../state/registry";
+
+const useColor = !process.env.NO_COLOR && !!process.stderr.isTTY;
+const B = useColor ? "\x1b[1m" : "";
+const R = useColor ? "\x1b[0m" : "";
+const RD = useColor ? "\x1b[1;31m" : "";
+
+export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
+  const sandboxObserver = createCliOpenShellSandboxObserver({
+    capture: (args, options) => {
+      const openshell = resolveOpenshell();
+      if (!openshell) return { status: 1, output: "" };
+      return captureOpenshellCommand(openshell, args, { cwd: rootDir, ...options });
+    },
+  });
+
+  const liveSandboxNames = async (): Promise<ReadonlySet<string> | undefined> => {
+    const result = await sandboxObserver.listSandboxes({ target: selectedOpenShellGateway() });
+    if (!result.ok) return undefined;
+    return new Set(result.value.sandboxes.map((sandbox) => sandbox.name));
+  };
+
+  const getDefaultSandbox = async (): Promise<string | undefined> => {
+    const { defaultSandbox, sandboxes } = registry.listSandboxes();
+    if (!defaultSandbox) return undefined;
+    if (!sandboxes.find((sandbox) => sandbox.name === defaultSandbox)) {
+      console.error(
+        `${RD}Warning:${R} default sandbox '${defaultSandbox}' is no longer in the registry.`,
+      );
+      console.error(
+        `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
+      );
+      return undefined;
+    }
+    const liveNames = await liveSandboxNames();
+    if (liveNames && !liveNames.has(defaultSandbox)) {
+      console.error(
+        `${RD}Warning:${R} default sandbox '${defaultSandbox}' exists in the local registry but not in OpenShell.`,
+      );
+      console.error(
+        `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
+      );
+      return undefined;
+    }
+    return defaultSandbox;
+  };
+
+  const isSandboxKnown = async (name: string): Promise<boolean> => {
+    const { sandboxes } = registry.listSandboxes();
+    if (!sandboxes.find((sandbox) => sandbox.name === name)) return false;
+    const liveNames = await liveSandboxNames();
+    return !liveNames || liveNames.has(name);
+  };
+
+  return {
+    getDefaultSandbox,
+    isSandboxKnown,
+    runDebug,
+  };
+}

--- a/src/lib/diagnostics/debug-command-deps.ts
+++ b/src/lib/diagnostics/debug-command-deps.ts
@@ -34,9 +34,17 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     const { defaultSandbox, sandboxes } = registry.listSandboxes();
     if (!defaultSandbox) {
       const registeredName = sandboxes.find((sandbox) => sandbox.name)?.name;
-      if (registeredName) return registeredName;
       const liveNames = await liveSandboxNames();
-      return liveNames?.values().next().value ?? "default";
+      if (registeredName && liveNames && !liveNames.has(registeredName)) {
+        console.error(
+          `${RD}Warning:${R} sandbox '${registeredName}' exists in the local registry but not in OpenShell.`,
+        );
+        console.error(
+          `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
+        );
+        return null;
+      }
+      return registeredName ?? liveNames?.values().next().value ?? "default";
     }
     if (!sandboxes.find((sandbox) => sandbox.name === defaultSandbox)) {
       console.error(

--- a/src/lib/diagnostics/debug-command-deps.ts
+++ b/src/lib/diagnostics/debug-command-deps.ts
@@ -52,76 +52,6 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     return new Set(result.value.sandboxes.map((sandbox) => sandbox.name));
   };
 
-  const getDefaultSandbox: RunDebugCommandDeps["getDefaultSandbox"] = async () => {
-    const { defaultSandbox, sandboxes } = registry.listSandboxes();
-    if (!defaultSandbox) {
-      const registered = sandboxes.find((sandbox) => sandbox.name);
-      const gatewayName = registered ? resolveDebugGatewayName(registered) : undefined;
-      if (registered && gatewayName === null) {
-        console.error(
-          `${RD}Warning:${R} sandbox '${registered.name}' has an invalid registered gateway binding.`,
-        );
-        console.error("  Remove and re-onboard the sandbox to restore a valid gateway binding.\n");
-        return null;
-      }
-      const liveNames = await liveSandboxNames(
-        gatewayName ? namedOpenShellGateway(gatewayName) : selectedOpenShellGateway(),
-      );
-      if (liveNames === "denied") {
-        console.error(`${RD}Warning:${R} OpenShell rejected the sandbox observation.`);
-        console.error("  Verify OpenShell authentication and gateway identity, then retry.\n");
-        return null;
-      }
-      if (registered && liveNames && !liveNames.has(registered.name)) {
-        console.error(
-          `${RD}Warning:${R} sandbox '${registered.name}' exists in the local registry but not in OpenShell.`,
-        );
-        console.error(
-          `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
-        );
-        return null;
-      }
-      if (registered && gatewayName) return { name: registered.name, gatewayName };
-      return { name: liveNames?.values().next().value ?? "default" };
-    }
-    const registered = sandboxes.find((sandbox) => sandbox.name === defaultSandbox);
-    if (!registered) {
-      console.error(
-        `${RD}Warning:${R} default sandbox '${defaultSandbox}' is no longer in the registry.`,
-      );
-      console.error(
-        `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
-      );
-      return null;
-    }
-    const gatewayName = resolveDebugGatewayName(registered);
-    if (!gatewayName) {
-      console.error(
-        `${RD}Warning:${R} default sandbox '${defaultSandbox}' has an invalid registered gateway binding.`,
-      );
-      console.error("  Remove and re-onboard the sandbox to restore a valid gateway binding.\n");
-      return null;
-    }
-    const liveNames = await liveSandboxNames(namedOpenShellGateway(gatewayName));
-    if (liveNames === "denied") {
-      console.error(
-        `${RD}Warning:${R} OpenShell rejected observation of sandbox '${defaultSandbox}'.`,
-      );
-      console.error("  Verify OpenShell authentication and gateway identity, then retry.\n");
-      return null;
-    }
-    if (liveNames && !liveNames.has(defaultSandbox)) {
-      console.error(
-        `${RD}Warning:${R} default sandbox '${defaultSandbox}' exists in the local registry but not in OpenShell.`,
-      );
-      console.error(
-        `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
-      );
-      return null;
-    }
-    return { name: defaultSandbox, gatewayName };
-  };
-
   const getSandboxAvailability: RunDebugCommandDeps["getSandboxAvailability"] = async (name) => {
     const { sandboxes } = registry.listSandboxes();
     const registered = sandboxes.find((sandbox) => sandbox.name === name);
@@ -133,6 +63,53 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     return !liveNames || liveNames.has(name)
       ? { state: "available", gatewayName }
       : { state: "missing" };
+  };
+
+  const getDefaultSandbox: RunDebugCommandDeps["getDefaultSandbox"] = async () => {
+    const { defaultSandbox, sandboxes } = registry.listSandboxes();
+    const selectedName = defaultSandbox ?? sandboxes.find((sandbox) => sandbox.name)?.name;
+    if (!selectedName) {
+      const liveNames = await liveSandboxNames(selectedOpenShellGateway());
+      if (liveNames === "denied") {
+        console.error(`${RD}Warning:${R} OpenShell rejected the sandbox observation.`);
+        console.error("  Verify OpenShell authentication and gateway identity, then retry.\n");
+        return null;
+      }
+      return { name: liveNames?.values().next().value ?? "default" };
+    }
+
+    const availability = await getSandboxAvailability(selectedName);
+    if (availability.state === "available") {
+      return { name: selectedName, gatewayName: availability.gatewayName };
+    }
+
+    const label = defaultSandbox ? "default sandbox" : "sandbox";
+    if (availability.state === "unregistered") {
+      console.error(`${RD}Warning:${R} ${label} '${selectedName}' is no longer in the registry.`);
+      console.error(
+        `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
+      );
+    } else if (availability.state === "invalid_gateway") {
+      console.error(
+        `${RD}Warning:${R} ${label} '${selectedName}' has an invalid registered gateway binding.`,
+      );
+      console.error(
+        "  Restore gatewayName and gatewayPort from a trusted backup. Otherwise, back up and remove the sandbox before onboarding it again. Do not copy a gateway binding from another sandbox.\n",
+      );
+    } else if (availability.state === "observation_denied") {
+      console.error(
+        `${RD}Warning:${R} OpenShell rejected observation of sandbox '${selectedName}'.`,
+      );
+      console.error("  Verify OpenShell authentication and gateway identity, then retry.\n");
+    } else {
+      console.error(
+        `${RD}Warning:${R} ${label} '${selectedName}' exists in the local registry but not in OpenShell.`,
+      );
+      console.error(
+        `  Use ${B}--sandbox NAME${R} to target a specific sandbox, or run ${B}${CLI_NAME} onboard${R} again.\n`,
+      );
+    }
+    return null;
   };
 
   return {

--- a/src/lib/diagnostics/debug-command-deps.ts
+++ b/src/lib/diagnostics/debug-command-deps.ts
@@ -41,9 +41,14 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
 
   const liveSandboxNames = async (
     target: OpenShellGatewayTarget,
-  ): Promise<ReadonlySet<string> | undefined> => {
+  ): Promise<ReadonlySet<string> | "denied" | undefined> => {
     const result = await sandboxObserver.listSandboxes({ target });
-    if (!result.ok) return undefined;
+    if (!result.ok) {
+      const denied =
+        result.error.kind === "authentication" ||
+        (result.error.kind === "transport" && result.error.reason === "identity_mismatch");
+      return denied ? "denied" : undefined;
+    }
     return new Set(result.value.sandboxes.map((sandbox) => sandbox.name));
   };
 
@@ -62,6 +67,10 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
       const liveNames = await liveSandboxNames(
         gatewayName ? namedOpenShellGateway(gatewayName) : selectedOpenShellGateway(),
       );
+      if (liveNames === "denied") {
+        console.error(`${RD}Warning:${R} OpenShell rejected the sandbox observation.`);
+        return null;
+      }
       if (registered && liveNames && !liveNames.has(registered.name)) {
         console.error(
           `${RD}Warning:${R} sandbox '${registered.name}' exists in the local registry but not in OpenShell.`,
@@ -93,6 +102,12 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
       return null;
     }
     const liveNames = await liveSandboxNames(namedOpenShellGateway(gatewayName));
+    if (liveNames === "denied") {
+      console.error(
+        `${RD}Warning:${R} OpenShell rejected observation of sandbox '${defaultSandbox}'.`,
+      );
+      return null;
+    }
     if (liveNames && !liveNames.has(defaultSandbox)) {
       console.error(
         `${RD}Warning:${R} default sandbox '${defaultSandbox}' exists in the local registry but not in OpenShell.`,
@@ -112,6 +127,7 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
     const gatewayName = resolveDebugGatewayName(registered);
     if (!gatewayName) return { state: "invalid_gateway" };
     const liveNames = await liveSandboxNames(namedOpenShellGateway(gatewayName));
+    if (liveNames === "denied") return { state: "observation_denied" };
     return !liveNames || liveNames.has(name)
       ? { state: "available", gatewayName }
       : { state: "missing" };

--- a/src/lib/diagnostics/debug-command-deps.ts
+++ b/src/lib/diagnostics/debug-command-deps.ts
@@ -69,6 +69,7 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
       );
       if (liveNames === "denied") {
         console.error(`${RD}Warning:${R} OpenShell rejected the sandbox observation.`);
+        console.error("  Verify OpenShell authentication and gateway identity, then retry.\n");
         return null;
       }
       if (registered && liveNames && !liveNames.has(registered.name)) {
@@ -106,6 +107,7 @@ export function buildDebugCommandDeps(rootDir: string): RunDebugCommandDeps {
       console.error(
         `${RD}Warning:${R} OpenShell rejected observation of sandbox '${defaultSandbox}'.`,
       );
+      console.error("  Verify OpenShell authentication and gateway identity, then retry.\n");
       return null;
     }
     if (liveNames && !liveNames.has(defaultSandbox)) {

--- a/src/lib/diagnostics/debug-command.test.ts
+++ b/src/lib/diagnostics/debug-command.test.ts
@@ -12,7 +12,7 @@ describe("debug command", () => {
       { quick: true, output: "/tmp/out.tgz" },
       {
         getDefaultSandbox: async () => "alpha",
-        isSandboxKnown: async () => true,
+        getSandboxAvailability: async () => "available",
         runDebug,
       },
     );
@@ -25,16 +25,16 @@ describe("debug command", () => {
 
   it("accepts an explicit --sandbox name that is registered", async () => {
     const runDebug = vi.fn();
-    const isSandboxKnown = vi.fn().mockReturnValue(true);
+    const getSandboxAvailability = vi.fn().mockReturnValue("available");
     await runDebugCommandWithOptions(
       { sandboxName: "alpha" },
       {
-        getDefaultSandbox: async () => undefined,
-        isSandboxKnown,
+        getDefaultSandbox: async () => "default",
+        getSandboxAvailability,
         runDebug,
       },
     );
-    expect(isSandboxKnown).toHaveBeenCalledWith("alpha");
+    expect(getSandboxAvailability).toHaveBeenCalledWith("alpha");
     expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
   });
 
@@ -49,7 +49,7 @@ describe("debug command", () => {
         { sandboxName: "does-not-exist", output: "/tmp/out.tgz" },
         {
           getDefaultSandbox: async () => "alpha",
-          isSandboxKnown: async () => false,
+          getSandboxAvailability: async () => "unregistered",
           runDebug,
           errorLine: (msg) => errorLines.push(msg),
           exit,
@@ -61,6 +61,31 @@ describe("debug command", () => {
     expect(errorLines[0]).toContain("does-not-exist");
     expect(errorLines[0]).toContain("not registered");
     expect(errorLines.join("\n")).toContain("nemoclaw list");
+  });
+
+  it("identifies an explicit registered sandbox missing from OpenShell", async () => {
+    const runDebug = vi.fn();
+    const errorLines: string[] = [];
+    const exit = vi.fn(() => {
+      throw new Error("exit");
+    }) as unknown as (code: number) => never;
+
+    await expect(
+      runDebugCommandWithOptions(
+        { sandboxName: "alpha" },
+        {
+          getDefaultSandbox: async () => "alpha",
+          getSandboxAvailability: async () => "missing",
+          runDebug,
+          errorLine: (msg) => errorLines.push(msg),
+          exit,
+        },
+      ),
+    ).rejects.toThrow("exit");
+
+    expect(runDebug).not.toHaveBeenCalled();
+    expect(errorLines.join("\n")).toContain("local registry but not in OpenShell");
+    expect(errorLines.join("\n")).toContain("nemoclaw onboard");
   });
 
   it("validates an env-sourced sandbox name and reports the env source on failure", async () => {
@@ -75,7 +100,7 @@ describe("debug command", () => {
         {
           env: { NEMOCLAW_SANDBOX_NAME: "ghost" } as NodeJS.ProcessEnv,
           getDefaultSandbox: async () => "alpha",
-          isSandboxKnown: async () => false,
+          getSandboxAvailability: async () => "unregistered",
           runDebug,
           errorLine: (msg) => errorLines.push(msg),
           exit,
@@ -90,7 +115,7 @@ describe("debug command", () => {
 
   it("prefers NEMOCLAW_SANDBOX_NAME over NEMOCLAW_SANDBOX and SANDBOX_NAME", async () => {
     const runDebug = vi.fn();
-    const isSandboxKnown = vi.fn().mockReturnValue(true);
+    const getSandboxAvailability = vi.fn().mockReturnValue("available");
     await runDebugCommandWithOptions(
       {},
       {
@@ -99,29 +124,29 @@ describe("debug command", () => {
           NEMOCLAW_SANDBOX: "secondary",
           SANDBOX_NAME: "tertiary",
         } as NodeJS.ProcessEnv,
-        getDefaultSandbox: async () => undefined,
-        isSandboxKnown,
+        getDefaultSandbox: async () => "default",
+        getSandboxAvailability,
         runDebug,
       },
     );
-    expect(isSandboxKnown).toHaveBeenCalledWith("primary");
+    expect(getSandboxAvailability).toHaveBeenCalledWith("primary");
     expect(runDebug).toHaveBeenCalledWith({ sandboxName: "primary" });
   });
 
   it("flag overrides env vars when both are present", async () => {
     const runDebug = vi.fn();
-    const isSandboxKnown = vi.fn().mockReturnValue(true);
+    const getSandboxAvailability = vi.fn().mockReturnValue("available");
     await runDebugCommandWithOptions(
       { sandboxName: "alpha" },
       {
         env: { NEMOCLAW_SANDBOX: "beta" } as NodeJS.ProcessEnv,
-        getDefaultSandbox: async () => undefined,
-        isSandboxKnown,
+        getDefaultSandbox: async () => "default",
+        getSandboxAvailability,
         runDebug,
       },
     );
-    expect(isSandboxKnown).toHaveBeenCalledWith("alpha");
-    expect(isSandboxKnown).not.toHaveBeenCalledWith("beta");
+    expect(getSandboxAvailability).toHaveBeenCalledWith("alpha");
+    expect(getSandboxAvailability).not.toHaveBeenCalledWith("beta");
     expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
   });
 
@@ -133,7 +158,7 @@ describe("debug command", () => {
       {
         env: {} as NodeJS.ProcessEnv,
         getDefaultSandbox: async () => null,
-        isSandboxKnown: async () => true,
+        getSandboxAvailability: async () => "available",
         runDebug,
       },
     );
@@ -143,17 +168,17 @@ describe("debug command", () => {
 
   it("falls back to getDefaultSandbox when neither flag nor env is set", async () => {
     const runDebug = vi.fn();
-    const isSandboxKnown = vi.fn();
+    const getSandboxAvailability = vi.fn();
     await runDebugCommandWithOptions(
       {},
       {
         env: {} as NodeJS.ProcessEnv,
         getDefaultSandbox: async () => "alpha",
-        isSandboxKnown,
+        getSandboxAvailability,
         runDebug,
       },
     );
-    expect(isSandboxKnown).not.toHaveBeenCalled();
+    expect(getSandboxAvailability).not.toHaveBeenCalled();
     expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
   });
 });

--- a/src/lib/diagnostics/debug-command.test.ts
+++ b/src/lib/diagnostics/debug-command.test.ts
@@ -11,8 +11,8 @@ describe("debug command", () => {
     await runDebugCommandWithOptions(
       { quick: true, output: "/tmp/out.tgz" },
       {
-        getDefaultSandbox: async () => "alpha",
-        getSandboxAvailability: async () => "available",
+        getDefaultSandbox: async () => ({ name: "alpha", gatewayName: "nemoclaw" }),
+        getSandboxAvailability: async () => ({ state: "available", gatewayName: "nemoclaw" }),
         runDebug,
       },
     );
@@ -20,22 +20,23 @@ describe("debug command", () => {
       quick: true,
       output: "/tmp/out.tgz",
       sandboxName: "alpha",
+      gatewayName: "nemoclaw",
     });
   });
 
   it("accepts an explicit --sandbox name that is registered", async () => {
     const runDebug = vi.fn();
-    const getSandboxAvailability = vi.fn().mockResolvedValue("available");
+    const getSandboxAvailability = vi.fn().mockResolvedValue({ state: "available", gatewayName: "nemoclaw" });
     await runDebugCommandWithOptions(
       { sandboxName: "alpha" },
       {
-        getDefaultSandbox: async () => "default",
+        getDefaultSandbox: async () => ({ name: "default", gatewayName: "nemoclaw" }),
         getSandboxAvailability,
         runDebug,
       },
     );
     expect(getSandboxAvailability).toHaveBeenCalledWith("alpha");
-    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
+    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha", gatewayName: "nemoclaw" });
   });
 
   it("rejects an explicit --sandbox name that is not registered, exits non-zero, skips runDebug", async () => {
@@ -48,8 +49,8 @@ describe("debug command", () => {
       runDebugCommandWithOptions(
         { sandboxName: "does-not-exist", output: "/tmp/out.tgz" },
         {
-          getDefaultSandbox: async () => "alpha",
-          getSandboxAvailability: async () => "unregistered",
+          getDefaultSandbox: async () => ({ name: "alpha", gatewayName: "nemoclaw" }),
+          getSandboxAvailability: async () => ({ state: "unregistered" }),
           runDebug,
           errorLine: (msg) => errorLines.push(msg),
           exit,
@@ -74,8 +75,8 @@ describe("debug command", () => {
       runDebugCommandWithOptions(
         { sandboxName: "alpha" },
         {
-          getDefaultSandbox: async () => "alpha",
-          getSandboxAvailability: async () => "missing",
+          getDefaultSandbox: async () => ({ name: "alpha", gatewayName: "nemoclaw" }),
+          getSandboxAvailability: async () => ({ state: "missing" }),
           runDebug,
           errorLine: (msg) => errorLines.push(msg),
           exit,
@@ -99,8 +100,8 @@ describe("debug command", () => {
         {},
         {
           env: { NEMOCLAW_SANDBOX_NAME: "ghost" } as NodeJS.ProcessEnv,
-          getDefaultSandbox: async () => "alpha",
-          getSandboxAvailability: async () => "unregistered",
+          getDefaultSandbox: async () => ({ name: "alpha", gatewayName: "nemoclaw" }),
+          getSandboxAvailability: async () => ({ state: "unregistered" }),
           runDebug,
           errorLine: (msg) => errorLines.push(msg),
           exit,
@@ -115,7 +116,7 @@ describe("debug command", () => {
 
   it("prefers NEMOCLAW_SANDBOX_NAME over NEMOCLAW_SANDBOX and SANDBOX_NAME", async () => {
     const runDebug = vi.fn();
-    const getSandboxAvailability = vi.fn().mockResolvedValue("available");
+    const getSandboxAvailability = vi.fn().mockResolvedValue({ state: "available", gatewayName: "nemoclaw" });
     await runDebugCommandWithOptions(
       {},
       {
@@ -124,30 +125,30 @@ describe("debug command", () => {
           NEMOCLAW_SANDBOX: "secondary",
           SANDBOX_NAME: "tertiary",
         } as NodeJS.ProcessEnv,
-        getDefaultSandbox: async () => "default",
+        getDefaultSandbox: async () => ({ name: "default", gatewayName: "nemoclaw" }),
         getSandboxAvailability,
         runDebug,
       },
     );
     expect(getSandboxAvailability).toHaveBeenCalledWith("primary");
-    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "primary" });
+    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "primary", gatewayName: "nemoclaw" });
   });
 
   it("flag overrides env vars when both are present", async () => {
     const runDebug = vi.fn();
-    const getSandboxAvailability = vi.fn().mockResolvedValue("available");
+    const getSandboxAvailability = vi.fn().mockResolvedValue({ state: "available", gatewayName: "nemoclaw" });
     await runDebugCommandWithOptions(
       { sandboxName: "alpha" },
       {
         env: { NEMOCLAW_SANDBOX: "beta" } as NodeJS.ProcessEnv,
-        getDefaultSandbox: async () => "default",
+        getDefaultSandbox: async () => ({ name: "default", gatewayName: "nemoclaw" }),
         getSandboxAvailability,
         runDebug,
       },
     );
     expect(getSandboxAvailability).toHaveBeenCalledWith("alpha");
     expect(getSandboxAvailability).not.toHaveBeenCalledWith("beta");
-    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
+    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha", gatewayName: "nemoclaw" });
   });
 
   it("stops before diagnostics when the configured default sandbox is rejected", async () => {
@@ -163,7 +164,7 @@ describe("debug command", () => {
         {
           env: {} as NodeJS.ProcessEnv,
           getDefaultSandbox: async () => null,
-          getSandboxAvailability: async () => "available",
+          getSandboxAvailability: async () => ({ state: "available", gatewayName: "nemoclaw" }),
           runDebug,
           exit,
         },
@@ -181,12 +182,12 @@ describe("debug command", () => {
       {},
       {
         env: {} as NodeJS.ProcessEnv,
-        getDefaultSandbox: async () => "alpha",
+        getDefaultSandbox: async () => ({ name: "alpha", gatewayName: "nemoclaw" }),
         getSandboxAvailability,
         runDebug,
       },
     );
     expect(getSandboxAvailability).not.toHaveBeenCalled();
-    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
+    expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha", gatewayName: "nemoclaw" });
   });
 });

--- a/src/lib/diagnostics/debug-command.test.ts
+++ b/src/lib/diagnostics/debug-command.test.ts
@@ -153,16 +153,24 @@ describe("debug command", () => {
   it("stops before diagnostics when the configured default sandbox is rejected", async () => {
     const runDebug = vi.fn();
 
-    await runDebugCommandWithOptions(
-      {},
-      {
-        env: {} as NodeJS.ProcessEnv,
-        getDefaultSandbox: async () => null,
-        getSandboxAvailability: async () => "available",
-        runDebug,
-      },
-    );
+    const exit = vi.fn(() => {
+      throw new Error("exit");
+    }) as unknown as (code: number) => never;
 
+    await expect(
+      runDebugCommandWithOptions(
+        {},
+        {
+          env: {} as NodeJS.ProcessEnv,
+          getDefaultSandbox: async () => null,
+          getSandboxAvailability: async () => "available",
+          runDebug,
+          exit,
+        },
+      ),
+    ).rejects.toThrow("exit");
+
+    expect(exit).toHaveBeenCalledWith(1);
     expect(runDebug).not.toHaveBeenCalled();
   });
 

--- a/src/lib/diagnostics/debug-command.test.ts
+++ b/src/lib/diagnostics/debug-command.test.ts
@@ -64,6 +64,32 @@ describe("debug command", () => {
     expect(errorLines.join("\n")).toContain("nemoclaw list");
   });
 
+  it("reports safe recovery for an invalid sandbox gateway binding", async () => {
+    const runDebug = vi.fn();
+    const errorLine = vi.fn();
+    const exit = vi.fn(() => {
+      throw new Error("exit");
+    }) as unknown as (code: number) => never;
+
+    await expect(
+      runDebugCommandWithOptions(
+        { sandboxName: "alpha" },
+        {
+          getDefaultSandbox: async () => ({ name: "default", gatewayName: "nemoclaw" }),
+          getSandboxAvailability: async () => ({ state: "invalid_gateway" }),
+          runDebug,
+          errorLine,
+          exit,
+        },
+      ),
+    ).rejects.toThrow("exit");
+
+    expect(errorLine).toHaveBeenCalledWith(
+      "  Restore gatewayName and gatewayPort from a trusted backup. Otherwise, back up and remove the sandbox before onboarding it again. Do not copy a gateway binding from another sandbox.",
+    );
+    expect(runDebug).not.toHaveBeenCalled();
+  });
+
   it("identifies an explicit registered sandbox missing from OpenShell", async () => {
     const runDebug = vi.fn();
     const errorLines: string[] = [];

--- a/src/lib/diagnostics/debug-command.test.ts
+++ b/src/lib/diagnostics/debug-command.test.ts
@@ -125,6 +125,22 @@ describe("debug command", () => {
     expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
   });
 
+  it("stops before diagnostics when the configured default sandbox is rejected", async () => {
+    const runDebug = vi.fn();
+
+    await runDebugCommandWithOptions(
+      {},
+      {
+        env: {} as NodeJS.ProcessEnv,
+        getDefaultSandbox: async () => null,
+        isSandboxKnown: async () => true,
+        runDebug,
+      },
+    );
+
+    expect(runDebug).not.toHaveBeenCalled();
+  });
+
   it("falls back to getDefaultSandbox when neither flag nor env is set", async () => {
     const runDebug = vi.fn();
     const isSandboxKnown = vi.fn();

--- a/src/lib/diagnostics/debug-command.test.ts
+++ b/src/lib/diagnostics/debug-command.test.ts
@@ -25,7 +25,7 @@ describe("debug command", () => {
 
   it("accepts an explicit --sandbox name that is registered", async () => {
     const runDebug = vi.fn();
-    const getSandboxAvailability = vi.fn().mockReturnValue("available");
+    const getSandboxAvailability = vi.fn().mockResolvedValue("available");
     await runDebugCommandWithOptions(
       { sandboxName: "alpha" },
       {
@@ -115,7 +115,7 @@ describe("debug command", () => {
 
   it("prefers NEMOCLAW_SANDBOX_NAME over NEMOCLAW_SANDBOX and SANDBOX_NAME", async () => {
     const runDebug = vi.fn();
-    const getSandboxAvailability = vi.fn().mockReturnValue("available");
+    const getSandboxAvailability = vi.fn().mockResolvedValue("available");
     await runDebugCommandWithOptions(
       {},
       {
@@ -135,7 +135,7 @@ describe("debug command", () => {
 
   it("flag overrides env vars when both are present", async () => {
     const runDebug = vi.fn();
-    const getSandboxAvailability = vi.fn().mockReturnValue("available");
+    const getSandboxAvailability = vi.fn().mockResolvedValue("available");
     await runDebugCommandWithOptions(
       { sandboxName: "alpha" },
       {

--- a/src/lib/diagnostics/debug-command.test.ts
+++ b/src/lib/diagnostics/debug-command.test.ts
@@ -6,13 +6,13 @@ import { describe, expect, it, vi } from "vitest";
 import { runDebugCommandWithOptions } from "./debug-command";
 
 describe("debug command", () => {
-  it("runs parsed debug options and falls back to the default sandbox", () => {
+  it("runs parsed debug options and falls back to the default sandbox", async () => {
     const runDebug = vi.fn();
-    runDebugCommandWithOptions(
+    await runDebugCommandWithOptions(
       { quick: true, output: "/tmp/out.tgz" },
       {
-        getDefaultSandbox: () => "alpha",
-        isSandboxKnown: () => true,
+        getDefaultSandbox: async () => "alpha",
+        isSandboxKnown: async () => true,
         runDebug,
       },
     );
@@ -23,13 +23,13 @@ describe("debug command", () => {
     });
   });
 
-  it("accepts an explicit --sandbox name that is registered", () => {
+  it("accepts an explicit --sandbox name that is registered", async () => {
     const runDebug = vi.fn();
     const isSandboxKnown = vi.fn().mockReturnValue(true);
-    runDebugCommandWithOptions(
+    await runDebugCommandWithOptions(
       { sandboxName: "alpha" },
       {
-        getDefaultSandbox: () => undefined,
+        getDefaultSandbox: async () => undefined,
         isSandboxKnown,
         runDebug,
       },
@@ -38,24 +38,24 @@ describe("debug command", () => {
     expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
   });
 
-  it("rejects an explicit --sandbox name that is not registered, exits non-zero, skips runDebug", () => {
+  it("rejects an explicit --sandbox name that is not registered, exits non-zero, skips runDebug", async () => {
     const runDebug = vi.fn();
     const errorLines: string[] = [];
     const exit = vi.fn(() => {
       throw new Error("exit");
     }) as unknown as (code: number) => never;
-    expect(() =>
+    await expect(
       runDebugCommandWithOptions(
         { sandboxName: "does-not-exist", output: "/tmp/out.tgz" },
         {
-          getDefaultSandbox: () => "alpha",
-          isSandboxKnown: () => false,
+          getDefaultSandbox: async () => "alpha",
+          isSandboxKnown: async () => false,
           runDebug,
           errorLine: (msg) => errorLines.push(msg),
           exit,
         },
       ),
-    ).toThrow("exit");
+    ).rejects.toThrow("exit");
     expect(exit).toHaveBeenCalledWith(1);
     expect(runDebug).not.toHaveBeenCalled();
     expect(errorLines[0]).toContain("does-not-exist");
@@ -63,35 +63,35 @@ describe("debug command", () => {
     expect(errorLines.join("\n")).toContain("nemoclaw list");
   });
 
-  it("validates an env-sourced sandbox name and reports the env source on failure", () => {
+  it("validates an env-sourced sandbox name and reports the env source on failure", async () => {
     const runDebug = vi.fn();
     const errorLines: string[] = [];
     const exit = vi.fn(() => {
       throw new Error("exit");
     }) as unknown as (code: number) => never;
-    expect(() =>
+    await expect(
       runDebugCommandWithOptions(
         {},
         {
           env: { NEMOCLAW_SANDBOX_NAME: "ghost" } as NodeJS.ProcessEnv,
-          getDefaultSandbox: () => "alpha",
-          isSandboxKnown: () => false,
+          getDefaultSandbox: async () => "alpha",
+          isSandboxKnown: async () => false,
           runDebug,
           errorLine: (msg) => errorLines.push(msg),
           exit,
         },
       ),
-    ).toThrow("exit");
+    ).rejects.toThrow("exit");
     expect(exit).toHaveBeenCalledWith(1);
     expect(runDebug).not.toHaveBeenCalled();
     expect(errorLines[0]).toContain("ghost");
     expect(errorLines[0]).toContain("NEMOCLAW_SANDBOX_NAME");
   });
 
-  it("prefers NEMOCLAW_SANDBOX_NAME over NEMOCLAW_SANDBOX and SANDBOX_NAME", () => {
+  it("prefers NEMOCLAW_SANDBOX_NAME over NEMOCLAW_SANDBOX and SANDBOX_NAME", async () => {
     const runDebug = vi.fn();
     const isSandboxKnown = vi.fn().mockReturnValue(true);
-    runDebugCommandWithOptions(
+    await runDebugCommandWithOptions(
       {},
       {
         env: {
@@ -99,7 +99,7 @@ describe("debug command", () => {
           NEMOCLAW_SANDBOX: "secondary",
           SANDBOX_NAME: "tertiary",
         } as NodeJS.ProcessEnv,
-        getDefaultSandbox: () => undefined,
+        getDefaultSandbox: async () => undefined,
         isSandboxKnown,
         runDebug,
       },
@@ -108,14 +108,14 @@ describe("debug command", () => {
     expect(runDebug).toHaveBeenCalledWith({ sandboxName: "primary" });
   });
 
-  it("flag overrides env vars when both are present", () => {
+  it("flag overrides env vars when both are present", async () => {
     const runDebug = vi.fn();
     const isSandboxKnown = vi.fn().mockReturnValue(true);
-    runDebugCommandWithOptions(
+    await runDebugCommandWithOptions(
       { sandboxName: "alpha" },
       {
         env: { NEMOCLAW_SANDBOX: "beta" } as NodeJS.ProcessEnv,
-        getDefaultSandbox: () => undefined,
+        getDefaultSandbox: async () => undefined,
         isSandboxKnown,
         runDebug,
       },
@@ -125,14 +125,14 @@ describe("debug command", () => {
     expect(runDebug).toHaveBeenCalledWith({ sandboxName: "alpha" });
   });
 
-  it("falls back to getDefaultSandbox when neither flag nor env is set", () => {
+  it("falls back to getDefaultSandbox when neither flag nor env is set", async () => {
     const runDebug = vi.fn();
     const isSandboxKnown = vi.fn();
-    runDebugCommandWithOptions(
+    await runDebugCommandWithOptions(
       {},
       {
         env: {} as NodeJS.ProcessEnv,
-        getDefaultSandbox: () => "alpha",
+        getDefaultSandbox: async () => "alpha",
         isSandboxKnown,
         runDebug,
       },

--- a/src/lib/diagnostics/debug-command.ts
+++ b/src/lib/diagnostics/debug-command.ts
@@ -65,7 +65,10 @@ export async function runDebugCommandWithOptions(
     opts.sandboxName = explicit.name;
   } else {
     const defaultSandbox = await deps.getDefaultSandbox();
-    if (defaultSandbox === null) return;
+    if (defaultSandbox === null) {
+      exit(1);
+      return;
+    }
     opts.sandboxName = defaultSandbox;
   }
 

--- a/src/lib/diagnostics/debug-command.ts
+++ b/src/lib/diagnostics/debug-command.ts
@@ -3,10 +3,13 @@
 
 import type { DebugOptions } from "./debug";
 
-export type DebugSandboxAvailability = "available" | "unregistered" | "missing";
+export type DebugSandboxSelection = Readonly<{ name: string; gatewayName?: string }>;
+export type DebugSandboxAvailability =
+  | Readonly<{ state: "available"; gatewayName: string }>
+  | Readonly<{ state: "unregistered" | "missing" }>;
 
 export interface RunDebugCommandDeps {
-  getDefaultSandbox: () => Promise<string | null>;
+  getDefaultSandbox: () => Promise<DebugSandboxSelection | null>;
   getSandboxAvailability: (name: string) => Promise<DebugSandboxAvailability>;
   runDebug: (options: DebugOptions) => void;
   env?: NodeJS.ProcessEnv;
@@ -49,10 +52,10 @@ export async function runDebugCommandWithOptions(
   const explicit = resolveExplicitName(opts, env);
   if (explicit) {
     const availability = await deps.getSandboxAvailability(explicit.name);
-    if (availability !== "available") {
+    if (availability.state !== "available") {
       const sourceLabel =
         explicit.source === "env" && explicit.envVar ? ` (from ${explicit.envVar})` : "";
-      if (availability === "unregistered") {
+      if (availability.state === "unregistered") {
         errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} is not registered.`);
         errorLine("  Run `nemoclaw list` to see available sandboxes.");
       } else {
@@ -63,13 +66,15 @@ export async function runDebugCommandWithOptions(
       return;
     }
     opts.sandboxName = explicit.name;
+    opts.gatewayName = availability.gatewayName;
   } else {
     const defaultSandbox = await deps.getDefaultSandbox();
     if (defaultSandbox === null) {
       exit(1);
       return;
     }
-    opts.sandboxName = defaultSandbox;
+    opts.sandboxName = defaultSandbox.name;
+    opts.gatewayName = defaultSandbox.gatewayName;
   }
 
   deps.runDebug(opts);

--- a/src/lib/diagnostics/debug-command.ts
+++ b/src/lib/diagnostics/debug-command.ts
@@ -6,7 +6,7 @@ import type { DebugOptions } from "./debug";
 export type DebugSandboxSelection = Readonly<{ name: string; gatewayName?: string }>;
 export type DebugSandboxAvailability =
   | Readonly<{ state: "available"; gatewayName: string }>
-  | Readonly<{ state: "unregistered" | "missing" | "invalid_gateway" }>;
+  | Readonly<{ state: "unregistered" | "missing" | "invalid_gateway" | "observation_denied" }>;
 
 export interface RunDebugCommandDeps {
   getDefaultSandbox: () => Promise<DebugSandboxSelection | null>;
@@ -58,6 +58,11 @@ export async function runDebugCommandWithOptions(
       if (availability.state === "unregistered") {
         errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} is not registered.`);
         errorLine("  Run `nemoclaw list` to see available sandboxes.");
+      } else if (availability.state === "observation_denied") {
+        errorLine(
+          `Error: OpenShell rejected observation of sandbox '${explicit.name}'${sourceLabel}.`,
+        );
+        errorLine("  Verify OpenShell authentication and gateway identity, then retry.");
       } else if (availability.state === "invalid_gateway") {
         errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} has an invalid registered gateway binding.`);
         errorLine("  Remove and re-onboard the sandbox to restore a valid gateway binding.");

--- a/src/lib/diagnostics/debug-command.ts
+++ b/src/lib/diagnostics/debug-command.ts
@@ -4,7 +4,7 @@
 import type { DebugOptions } from "./debug";
 
 export interface RunDebugCommandDeps {
-  getDefaultSandbox: () => Promise<string | undefined>;
+  getDefaultSandbox: () => Promise<string | null | undefined>;
   isSandboxKnown: (name: string) => Promise<boolean>;
   runDebug: (options: DebugOptions) => void;
   env?: NodeJS.ProcessEnv;
@@ -56,7 +56,9 @@ export async function runDebugCommandWithOptions(
     }
     opts.sandboxName = explicit.name;
   } else {
-    opts.sandboxName = await deps.getDefaultSandbox();
+    const defaultSandbox = await deps.getDefaultSandbox();
+    if (defaultSandbox === null) return;
+    opts.sandboxName = defaultSandbox;
   }
 
   deps.runDebug(opts);

--- a/src/lib/diagnostics/debug-command.ts
+++ b/src/lib/diagnostics/debug-command.ts
@@ -3,9 +3,11 @@
 
 import type { DebugOptions } from "./debug";
 
+export type DebugSandboxAvailability = "available" | "unregistered" | "missing";
+
 export interface RunDebugCommandDeps {
-  getDefaultSandbox: () => Promise<string | null | undefined>;
-  isSandboxKnown: (name: string) => Promise<boolean>;
+  getDefaultSandbox: () => Promise<string | null>;
+  getSandboxAvailability: (name: string) => Promise<DebugSandboxAvailability>;
   runDebug: (options: DebugOptions) => void;
   env?: NodeJS.ProcessEnv;
   errorLine?: (message: string) => void;
@@ -46,11 +48,17 @@ export async function runDebugCommandWithOptions(
 
   const explicit = resolveExplicitName(opts, env);
   if (explicit) {
-    if (!(await deps.isSandboxKnown(explicit.name))) {
+    const availability = await deps.getSandboxAvailability(explicit.name);
+    if (availability !== "available") {
       const sourceLabel =
         explicit.source === "env" && explicit.envVar ? ` (from ${explicit.envVar})` : "";
-      errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} is not registered.`);
-      errorLine("  Run `nemoclaw list` to see available sandboxes.");
+      if (availability === "unregistered") {
+        errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} is not registered.`);
+        errorLine("  Run `nemoclaw list` to see available sandboxes.");
+      } else {
+        errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} exists in the local registry but not in OpenShell.`);
+        errorLine("  Run `nemoclaw onboard` again to recreate or select a sandbox.");
+      }
       exit(1);
       return;
     }

--- a/src/lib/diagnostics/debug-command.ts
+++ b/src/lib/diagnostics/debug-command.ts
@@ -6,7 +6,7 @@ import type { DebugOptions } from "./debug";
 export type DebugSandboxSelection = Readonly<{ name: string; gatewayName?: string }>;
 export type DebugSandboxAvailability =
   | Readonly<{ state: "available"; gatewayName: string }>
-  | Readonly<{ state: "unregistered" | "missing" }>;
+  | Readonly<{ state: "unregistered" | "missing" | "invalid_gateway" }>;
 
 export interface RunDebugCommandDeps {
   getDefaultSandbox: () => Promise<DebugSandboxSelection | null>;
@@ -58,6 +58,9 @@ export async function runDebugCommandWithOptions(
       if (availability.state === "unregistered") {
         errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} is not registered.`);
         errorLine("  Run `nemoclaw list` to see available sandboxes.");
+      } else if (availability.state === "invalid_gateway") {
+        errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} has an invalid registered gateway binding.`);
+        errorLine("  Remove and re-onboard the sandbox to restore a valid gateway binding.");
       } else {
         errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} exists in the local registry but not in OpenShell.`);
         errorLine("  Run `nemoclaw onboard` again to recreate or select a sandbox.");

--- a/src/lib/diagnostics/debug-command.ts
+++ b/src/lib/diagnostics/debug-command.ts
@@ -65,7 +65,9 @@ export async function runDebugCommandWithOptions(
         errorLine("  Verify OpenShell authentication and gateway identity, then retry.");
       } else if (availability.state === "invalid_gateway") {
         errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} has an invalid registered gateway binding.`);
-        errorLine("  Remove and re-onboard the sandbox to restore a valid gateway binding.");
+        errorLine(
+          "  Restore gatewayName and gatewayPort from a trusted backup. Otherwise, back up and remove the sandbox before onboarding it again. Do not copy a gateway binding from another sandbox.",
+        );
       } else {
         errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} exists in the local registry but not in OpenShell.`);
         errorLine("  Run `nemoclaw onboard` again to recreate or select a sandbox.");

--- a/src/lib/diagnostics/debug-command.ts
+++ b/src/lib/diagnostics/debug-command.ts
@@ -4,8 +4,8 @@
 import type { DebugOptions } from "./debug";
 
 export interface RunDebugCommandDeps {
-  getDefaultSandbox: () => string | undefined;
-  isSandboxKnown: (name: string) => boolean;
+  getDefaultSandbox: () => Promise<string | undefined>;
+  isSandboxKnown: (name: string) => Promise<boolean>;
   runDebug: (options: DebugOptions) => void;
   env?: NodeJS.ProcessEnv;
   errorLine?: (message: string) => void;
@@ -31,7 +31,10 @@ function resolveExplicitName(
   return null;
 }
 
-export function runDebugCommandWithOptions(options: DebugOptions, deps: RunDebugCommandDeps): void {
+export async function runDebugCommandWithOptions(
+  options: DebugOptions,
+  deps: RunDebugCommandDeps,
+): Promise<void> {
   const opts = { ...options };
   const env = deps.env ?? process.env;
   const errorLine = deps.errorLine ?? ((msg: string) => console.error(msg));
@@ -43,7 +46,7 @@ export function runDebugCommandWithOptions(options: DebugOptions, deps: RunDebug
 
   const explicit = resolveExplicitName(opts, env);
   if (explicit) {
-    if (!deps.isSandboxKnown(explicit.name)) {
+    if (!(await deps.isSandboxKnown(explicit.name))) {
       const sourceLabel =
         explicit.source === "env" && explicit.envVar ? ` (from ${explicit.envVar})` : "";
       errorLine(`Error: Sandbox '${explicit.name}'${sourceLabel} is not registered.`);
@@ -53,7 +56,7 @@ export function runDebugCommandWithOptions(options: DebugOptions, deps: RunDebug
     }
     opts.sandboxName = explicit.name;
   } else {
-    opts.sandboxName = deps.getDefaultSandbox();
+    opts.sandboxName = await deps.getDefaultSandbox();
   }
 
   deps.runDebug(opts);

--- a/src/lib/diagnostics/debug.ts
+++ b/src/lib/diagnostics/debug.ts
@@ -9,7 +9,6 @@ import { join } from "node:path";
 import { dockerExecFileSync } from "../adapters/docker/exec";
 import { openshellSandboxSshHost } from "../adapters/openshell/sandbox-ssh-host";
 import { DASHBOARD_PORT } from "../core/ports";
-import { listSandboxes } from "../state/registry";
 import { createTarball as createDiagnosticsTarball } from "./tarball";
 
 // ---------------------------------------------------------------------------
@@ -230,45 +229,6 @@ function collectDmesg(collectDir: string, opts: DebugOptions = {}): void {
   if (result.status !== 0) {
     console.log("  (command exited with non-zero status)");
   }
-}
-
-// ---------------------------------------------------------------------------
-// Auto-detect sandbox name
-// ---------------------------------------------------------------------------
-
-function detectSandboxName(): string {
-  // First, check the local registry for the default sandbox. This is
-  // the authoritative source — it reflects the user's actual onboard
-  // choices and survives gateway restarts. Falling back to "default"
-  // without checking the registry was the bug in #1728: debug always
-  // targeted a sandbox named "default" even though the user's sandbox
-  // was named something else (e.g. "my-assistant").
-  try {
-    const registry = listSandboxes();
-    if (registry.defaultSandbox) return registry.defaultSandbox;
-    const names = registry.sandboxes.map((s) => s.name).filter(Boolean);
-    if (names.length > 0) return names[0];
-  } catch {
-    /* registry unreadable — fall through to openshell probe */
-  }
-
-  // Fallback: ask the live gateway directly
-  if (!commandExists("openshell")) return "default";
-  try {
-    const output = execFileSync("openshell", ["sandbox", "list"], {
-      encoding: "utf-8",
-      timeout: 10_000,
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    const lines = output.split("\n").filter((l) => l.trim().length > 0);
-    for (const line of lines) {
-      const first = line.trim().split(/\s+/)[0];
-      if (first && first.toLowerCase() !== "name") return first;
-    }
-  } catch {
-    /* ignore */
-  }
-  return "default";
 }
 
 // ---------------------------------------------------------------------------
@@ -542,10 +502,7 @@ export function runDebug(opts: DebugOptions = {}): void {
   // documented precedence (--sandbox > NEMOCLAW_SANDBOX_NAME > NEMOCLAW_SANDBOX
   // > SANDBOX_NAME) before calling here. Reading env again would let
   // whitespace-only values bypass validation, so only trim the option.
-  let sandboxName = opts.sandboxName?.trim() ?? "";
-  if (!sandboxName) {
-    sandboxName = detectSandboxName();
-  }
+  const sandboxName = opts.sandboxName?.trim() || "default";
 
   // Create temp collection directory
   const collectDir = mkdtempSync(join(tmpdir(), "nemoclaw-debug-"));

--- a/src/lib/diagnostics/debug.ts
+++ b/src/lib/diagnostics/debug.ts
@@ -18,6 +18,8 @@ import { createTarball as createDiagnosticsTarball } from "./tarball";
 export interface DebugOptions {
   /** Target sandbox name (auto-detected if omitted). */
   sandboxName?: string;
+  /** OpenShell gateway that owns the selected registered sandbox. */
+  gatewayName?: string;
   /** Only collect minimal diagnostics. */
   quick?: boolean;
   /** Write a tarball to this path. */
@@ -322,32 +324,40 @@ function collectDocker(collectDir: string, quick: boolean): void {
   }
 }
 
-function collectOpenshell(collectDir: string, sandboxName: string, quick: boolean): void {
+function collectOpenshell(
+  collectDir: string,
+  sandboxName: string,
+  gatewayName: string | undefined,
+  quick: boolean,
+): void {
+  const gatewayArgs = gatewayName ? ["-g", gatewayName] : [];
   section("OpenShell");
-  collect(collectDir, "openshell-status", "openshell", ["status"]);
-  collect(collectDir, "openshell-sandbox-list", "openshell", ["sandbox", "list"]);
-  collect(collectDir, "openshell-sandbox-get", "openshell", ["sandbox", "get", sandboxName]);
-  collect(collectDir, "openshell-logs", "openshell", ["logs", sandboxName]);
+  collect(collectDir, "openshell-status", "openshell", ["status", ...gatewayArgs]);
+  collect(collectDir, "openshell-sandbox-list", "openshell", ["sandbox", "list", ...gatewayArgs]);
+  collect(collectDir, "openshell-sandbox-get", "openshell", [
+    "sandbox",
+    "get",
+    ...gatewayArgs,
+    sandboxName,
+  ]);
+  collect(collectDir, "openshell-logs", "openshell", ["logs", ...gatewayArgs, sandboxName]);
 
   if (!quick) {
-    collect(collectDir, "openshell-gateway-info", "openshell", ["gateway", "info"]);
+    collect(collectDir, "openshell-gateway-info", "openshell", [
+      "gateway",
+      "info",
+      ...gatewayArgs,
+    ]);
   }
 }
 
-function collectSandboxInternals(collectDir: string, sandboxName: string, quick: boolean): void {
+function collectSandboxInternals(
+  collectDir: string,
+  sandboxName: string,
+  gatewayName: string | undefined,
+  quick: boolean,
+): void {
   if (!commandExists("openshell")) return;
-
-  // Check if sandbox exists. OpenShell ssh-config may succeed for unknown
-  // names, so verify the live sandbox first.
-  try {
-    execFileSync("openshell", ["sandbox", "get", sandboxName], {
-      encoding: "utf-8",
-      timeout: 10_000,
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-  } catch {
-    return;
-  }
 
   section("Sandbox Internals");
 
@@ -355,11 +365,16 @@ function collectSandboxInternals(collectDir: string, sandboxName: string, quick:
   const sshConfigDir = mkdtempSync(join(tmpdir(), "nemoclaw-ssh-"));
   const sshConfigPath = join(sshConfigDir, "config");
   try {
-    const sshResult = spawnSync("openshell", ["sandbox", "ssh-config", sandboxName], {
+    const gatewayArgs = gatewayName ? ["-g", gatewayName] : [];
+    const sshResult = spawnSync(
+      "openshell",
+      ["sandbox", "ssh-config", ...gatewayArgs, sandboxName],
+      {
       timeout: TIMEOUT_MS,
       stdio: ["ignore", "pipe", "ignore"],
-      encoding: "utf-8",
-    });
+        encoding: "utf-8",
+      },
+    );
     if (sshResult.status !== 0) {
       warn(`Could not generate SSH config for sandbox '${sandboxName}', skipping internals`);
       return;
@@ -517,9 +532,9 @@ export function runDebug(opts: DebugOptions = {}): void {
     collectProcesses(collectDir, quick);
     collectGpu(collectDir, quick);
     collectDocker(collectDir, quick);
-    collectOpenshell(collectDir, sandboxName, quick);
+    collectOpenshell(collectDir, sandboxName, opts.gatewayName, quick);
     collectOnboardSession(collectDir, repoDir);
-    collectSandboxInternals(collectDir, sandboxName, quick);
+    collectSandboxInternals(collectDir, sandboxName, opts.gatewayName, quick);
 
     if (!quick) {
       collectNetwork(collectDir);

--- a/src/lib/diagnostics/debug.ts
+++ b/src/lib/diagnostics/debug.ts
@@ -514,7 +514,7 @@ export function runDebug(opts: DebugOptions = {}): void {
 
   // Resolve sandbox name. The CLI wrapper (runDebugCommandWithOptions) is the
   // sole supported caller; it already trims, validates, and applies the
-  // documented precedence (--sandbox > NEMOCLAW_SANDBOX_NAME > NEMOCLAW_SANDBOX
+  // command precedence (--sandbox > NEMOCLAW_SANDBOX_NAME > NEMOCLAW_SANDBOX
   // > SANDBOX_NAME) before calling here. Reading env again would let
   // whitespace-only values bypass validation, so only trim the option.
   const sandboxName = opts.sandboxName?.trim() || "default";

--- a/src/lib/diagnostics/debug.ts
+++ b/src/lib/diagnostics/debug.ts
@@ -7,7 +7,7 @@ import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { dockerExecFileSync } from "../adapters/docker/exec";
-import { openshellSandboxSshHost } from "../adapters/openshell/sandbox-ssh-host";
+import { resolveOpenshellSandboxSshHost } from "../adapters/openshell/sandbox-ssh-host";
 import { DASHBOARD_PORT } from "../core/ports";
 import { createTarball as createDiagnosticsTarball } from "./tarball";
 
@@ -379,9 +379,15 @@ function collectSandboxInternals(
       warn(`Could not generate SSH config for sandbox '${sandboxName}', skipping internals`);
       return;
     }
-    writeFileSync(sshConfigPath, sshResult.stdout ?? "");
-
-    const sshHost = openshellSandboxSshHost(sandboxName);
+    const sshConfig = sshResult.stdout ?? "";
+    const sshHost = resolveOpenshellSandboxSshHost(sandboxName, sshConfig);
+    if (!sshHost) {
+      warn(
+        `SSH config did not declare sandbox '${sandboxName}', skipping internals`,
+      );
+      return;
+    }
+    writeFileSync(sshConfigPath, sshConfig);
     const sshBase = [
       "-F",
       sshConfigPath,

--- a/test/cli/debug-command.test.ts
+++ b/test/cli/debug-command.test.ts
@@ -171,7 +171,7 @@ describe("CLI debug command", () => {
       );
       expect(r.code).not.toBe(0);
       expect(r.out).toContain("stale-box");
-      expect(r.out).toContain("not registered");
+      expect(r.out).toContain("local registry but not in OpenShell");
       expect(fs.existsSync(tarball)).toBe(false);
     },
   );

--- a/test/cli/debug-command.test.ts
+++ b/test/cli/debug-command.test.ts
@@ -121,6 +121,25 @@ describe("CLI debug command", () => {
     },
   );
 
+  it(
+    "debug scopes OpenShell commands to the registered non-default gateway",
+    testTimeoutOptions(30_000),
+    ({ resources }) => {
+      const argsLog = path.join(resources.home("nemoclaw-cli-debug-gateway-log-").home, "openshell-args.log");
+      const env = createDebugCommandTestEnv(resources, "nemoclaw-cli-debug-gateway-", {
+        gatewayPort: 18080,
+        openshellArgsLog: argsLog,
+      });
+
+      const r = runWithEnv("debug --quick", env, 30000);
+
+      expect(r.code).toBe(0);
+      const invocations = fs.readFileSync(argsLog, "utf-8");
+      expect(invocations).toContain("sandbox list -g nemoclaw-18080");
+      expect(invocations).toContain("sandbox ssh-config -g nemoclaw-18080");
+    },
+  );
+
   it("debug --sandbox NAME rejects an unregistered name and exits non-zero", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-cli-debug-unknown-"));
     writeSandboxRegistry(home);

--- a/test/cli/debug-command.test.ts
+++ b/test/cli/debug-command.test.ts
@@ -191,7 +191,7 @@ describe("CLI debug command", () => {
       { mode: 0o600 },
     );
     const r = runWithEnv("debug --quick 2>&1", { HOME: home }, 30000);
-    expect(r.code).toBe(0);
+    expect(r.code).not.toBe(0);
     expect(r.out).toContain("Warning");
     expect(r.out).toContain("ghost");
     expect(r.out).toContain("--sandbox NAME");

--- a/test/cli/helpers.ts
+++ b/test/cli/helpers.ts
@@ -508,14 +508,14 @@ export function createCloudflaredServiceDir(prefix: string): {
 export function createDebugCommandTestEnv(
   resources: OwnedTestResources,
   prefix: string,
-  options: { extraSandboxNames?: string[] } = {},
+  options: { extraSandboxNames?: string[]; gatewayPort?: number; openshellArgsLog?: string } = {},
 ): Record<string, string> {
   const { home, bin: localBin } = resources.home(prefix);
   const sandboxName = `${prefix}${process.pid.toString(36)}-${Date.now().toString(36)}`;
   fs.mkdirSync(localBin, { recursive: true });
   // Register the env-sourced sandbox plus any extra names supplied via the
   // --sandbox flag so the validation gate accepts them.
-  writeSandboxRegistry(home, sandboxName);
+  writeSandboxRegistry(home, sandboxName, options.gatewayPort ? { gatewayPort: options.gatewayPort } : {});
   if (options.extraSandboxNames && options.extraSandboxNames.length > 0) {
     const registryPath = path.join(home, ".nemoclaw", "sandboxes.json");
     const current = JSON.parse(fs.readFileSync(registryPath, "utf-8")) as {
@@ -539,6 +539,9 @@ export function createDebugCommandTestEnv(
     path.join(localBin, "openshell"),
     [
       "#!/bin/sh",
+      ...(options.openshellArgsLog
+        ? [`printf '%s\n' "$*" >> ${JSON.stringify(options.openshellArgsLog)}`]
+        : []),
       'if [ "$1" = "sandbox" ] && [ "$2" = "list" ]; then',
       ...listLines.map((line) => `  echo ${JSON.stringify(line)}`),
       "  exit 0",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Route nemoclaw debug sandbox liveness checks through the typed OpenShell sandbox observer added by #10132.

## Reason

The debug command still constructed sandbox list argv and parsed raw CLI output directly, leaving one production inspection consumer outside the accepted #9803 adapter boundary.

### Related issues

Refs #9803

## Changes

- Replace debug sandbox-list parsing with the existing CLI-backed OpenShellSandboxObserver.
- Make debug sandbox resolution asynchronous so future observer transports do not require another consumer contract migration.
- Preserve successful-absence rejection and fail-open behavior when OpenShell observation fails.
- Lower the stale OpenShell timeout fan-in architecture budget from 39 to its measured value of 38.

## Verification

- Contributor validation: npm run validate:pr passed pre-commit, commitlint, and pre-push checks.
- Tests: Focused Vitest: 22 tests passed across debug-command and simple-global-oclif-adapters; npm run validate:pr passed.
- Broad gate: npm run validate:pr
- Secrets review: The diff contains no secrets, API keys, or credentials
<!-- nemoclaw-docs-review:start -->
- Documentation review: `no-docs-needed`
- Documentation evidence: Internal command-adapter refactor; recovery guidance now matches existing troubleshooting documentation.
- Documentation agent: openai/openai/gpt-5.6-sol
<!-- docs-review-head-sha: 208ab674a4d414007151b71bfb52e8c0b935eaee -->
<!-- docs-review-agents-blob-sha: dd3528f6e332f7f09f4841555c2ed11cb2139fb9 -->
<!-- nemoclaw-docs-review:end -->
<!-- nemoclaw-targeted-validation:start -->
- Targeted validation: Focused CLI and integration tests: 43 passed across three files.
<!-- nemoclaw-targeted-validation:end -->
<!-- nemoclaw-broad-gate:start -->
- Broad gate: passed — CLI build and typecheck, repository checks, focused tests, formatting, lint, whitespace, and NUL-byte checks passed.
<!-- nemoclaw-broad-gate:end -->

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug command sandbox validation and availability checks.
  * Prevented unavailable registered sandboxes from being selected.
  * Added clearer errors and onboarding guidance when configured sandboxes are missing.
  * Improved fallback behavior when sandbox discovery is incomplete, including safer default selection.
  * Prevented debug execution when no usable sandbox is available.
  * Improved asynchronous handling during debug command execution.

* **Tests**
  * Expanded coverage for sandbox resolution, validation failures, unavailable sandboxes, and execution safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->