### PR TITLE
test(cli): guard OpenShell observation consumers

### DIFF
--- a/scripts/checks/openshell-sandbox-observation-boundary.mts
+++ b/scripts/checks/openshell-sandbox-observation-boundary.mts
@@ -1,0 +1,524 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Keep direct OpenShell sandbox observation sites classified while the typed
+ * adapter migration proceeds.
+ *
+ * invalidState: a production source adds an unclassified `sandbox list` or
+ * `sandbox get` command, or adds another binding to a legacy raw-output parser.
+ * sourceBoundary: the CLI adapter owns command construction and parsing;
+ * capability issues own each temporary production exception.
+ * whyNotSourceFix: TypeScript cannot prevent callers from constructing an
+ * equivalent string array for a generic process runner.
+ * regressionTest: test/repository/openshell-sandbox-observation-boundary.test.ts.
+ * removalCondition: remove this ledger after #9813 verifies that every
+ * production consumer uses a typed adapter or an accepted executable-level
+ * exception.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const SCAN_ROOTS = ["src", "nemoclaw/src"] as const;
+const SKIP_DIRECTORIES = new Set(["coverage", "dist", "node_modules"]);
+const SOURCE_EXTENSION = /\.(?:[cm]?[jt]s|[jt]sx)$/u;
+const TEST_SOURCE =
+  /(?:^|\/)(?:__test-helpers__\/|.*(?:\.test|-test-fixture)\.(?:[cm]?[jt]s|[jt]sx)$)/u;
+
+const LEGACY_PARSER_NAMES = new Set([
+  "getSandboxFailurePhase",
+  "hasSandboxListEntry",
+  "isOpenShellProtobufSchemaMismatch",
+  "isSandboxReady",
+  "parseCliOpenShellSandboxInventory",
+  "parseCliOpenShellSandboxPhase",
+  "parseLiveSandboxEntries",
+  "parseLiveSandboxNames",
+  "parseReadySandboxNames",
+  "parseSandboxRow",
+  "parseSandboxStatus",
+  "stripAnsi",
+  "stripOpenShellCliAnsi",
+]);
+
+const LEGACY_PARSER_MODULE_SUFFIXES = [
+  "/adapters/openshell/sandbox-observer-cli",
+  "/runtime-recovery",
+  "/state/gateway",
+] as const;
+
+export type OpenShellSandboxObservationDisposition = Readonly<{
+  directCommands: number;
+  legacyParserSites: number;
+  ownerIssues: readonly number[];
+  disposition: "adapter-boundary" | "follow-up";
+  reason: string;
+}>;
+
+export type OpenShellSandboxObservationUsage = Readonly<{
+  directCommands: number;
+  legacyParserSites: number;
+}>;
+
+export const OPEN_SHELL_SANDBOX_OBSERVATION_DISPOSITIONS: Readonly<
+  Record<string, OpenShellSandboxObservationDisposition>
+> = {
+  "nemoclaw/src/blueprint/runner.ts": {
+    directCommands: 1,
+    legacyParserSites: 0,
+    ownerIssues: [9813],
+    disposition: "follow-up",
+    reason: "The final Phase 1 sweep owns plugin and blueprint-runner consumers.",
+  },
+  "src/commands/debug.ts": {
+    directCommands: 2,
+    legacyParserSites: 1,
+    ownerIssues: [9803],
+    disposition: "follow-up",
+    reason: "PR #10537 migrates the debug liveness consumer to the typed observer.",
+  },
+  "src/lib/actions/sandbox/destroy-gateway-cleanup.ts": {
+    directCommands: 1,
+    legacyParserSites: 0,
+    ownerIssues: [9807],
+    disposition: "follow-up",
+    reason: "The gateway lifecycle slice owns final-destroy gateway cleanup observation.",
+  },
+  "src/lib/actions/sandbox/destroy-preflight.ts": {
+    directCommands: 1,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns destructive preflight observation.",
+  },
+  "src/lib/actions/sandbox/doctor.ts": {
+    directCommands: 0,
+    legacyParserSites: 1,
+    ownerIssues: [9807],
+    disposition: "follow-up",
+    reason: "The gateway lifecycle slice owns raw lifecycle status classification.",
+  },
+  "src/lib/actions/sandbox/gateway-state.ts": {
+    directCommands: 1,
+    legacyParserSites: 1,
+    ownerIssues: [9807, 9811],
+    disposition: "follow-up",
+    reason: "Gateway lifecycle and sandbox stop ownership still share this compatibility path.",
+  },
+  "src/lib/actions/sandbox/rebuild-destroy-phase.ts": {
+    directCommands: 2,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns rebuild destruction observation.",
+  },
+  "src/lib/actions/sandbox/snapshot.ts": {
+    directCommands: 7,
+    legacyParserSites: 2,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns snapshot and restore observation.",
+  },
+  "src/lib/actions/sandbox/stop.ts": {
+    directCommands: 0,
+    legacyParserSites: 1,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns sibling phase observation during stop.",
+  },
+  "src/lib/actions/sandbox/vm-dns-monkeypatch.ts": {
+    directCommands: 1,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns VM sandbox inspection before mutation.",
+  },
+  "src/lib/actions/uninstall/run-plan.ts": {
+    directCommands: 1,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns absence verification during uninstall.",
+  },
+  "src/lib/adapters/openshell/client.ts": {
+    directCommands: 1,
+    legacyParserSites: 0,
+    ownerIssues: [9803],
+    disposition: "adapter-boundary",
+    reason: "The OpenShell CLI adapter owns this compatibility command construction.",
+  },
+  "src/lib/adapters/openshell/gateway-drift.ts": {
+    directCommands: 0,
+    legacyParserSites: 1,
+    ownerIssues: [9807],
+    disposition: "adapter-boundary",
+    reason: "The gateway lifecycle adapter owns gateway status compatibility parsing.",
+  },
+  "src/lib/adapters/openshell/policy-authority.ts": {
+    directCommands: 2,
+    legacyParserSites: 0,
+    ownerIssues: [9805, 10514],
+    disposition: "adapter-boundary",
+    reason: "The accepted policy source-of-truth cutover owns these typed policy inspections.",
+  },
+  "src/lib/adapters/openshell/sandbox-identity.ts": {
+    directCommands: 3,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "adapter-boundary",
+    reason: "The sandbox lifecycle adapter owns immutable identity inspection.",
+  },
+  "src/lib/adapters/openshell/sandbox-observer-cli.ts": {
+    directCommands: 0,
+    legacyParserSites: 3,
+    ownerIssues: [9803],
+    disposition: "adapter-boundary",
+    reason: "The CLI sandbox observer owns table, ANSI, phase, and error parsing.",
+  },
+  "src/lib/diagnostics/debug.ts": {
+    directCommands: 4,
+    legacyParserSites: 0,
+    ownerIssues: [9812],
+    disposition: "follow-up",
+    reason: "The diagnostics slice owns migration or an accepted executable-level exception.",
+  },
+  "src/lib/domain/sandbox/destroy.ts": {
+    directCommands: 0,
+    legacyParserSites: 1,
+    ownerIssues: [9807],
+    disposition: "follow-up",
+    reason: "The gateway lifecycle slice owns final-destroy live-sandbox classification.",
+  },
+  "src/lib/onboard/docker-gpu-patch-diagnostics.ts": {
+    directCommands: 2,
+    legacyParserSites: 0,
+    ownerIssues: [9812],
+    disposition: "follow-up",
+    reason: "The diagnostics slice owns migration or an accepted executable-level exception.",
+  },
+  "src/lib/onboard/docker-gpu-patch.ts": {
+    directCommands: 2,
+    legacyParserSites: 1,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns Docker GPU phase decisions.",
+  },
+  "src/lib/onboard/docker-gpu-sandbox-create.ts": {
+    directCommands: 1,
+    legacyParserSites: 1,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns create failure observation.",
+  },
+  "src/lib/onboard/docker-gpu-supervisor-reconnect.ts": {
+    directCommands: 2,
+    legacyParserSites: 1,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns supervisor reconnect phase decisions.",
+  },
+  "src/lib/onboard/experimental/hermes-portable-lifecycle.ts": {
+    directCommands: 4,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns Hermes portable lifecycle observation.",
+  },
+  "src/lib/onboard/experimental/hermes-portable-onboarding.ts": {
+    directCommands: 6,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns Hermes portable onboarding observation.",
+  },
+  "src/lib/onboard/managed-bootstrap/docker.ts": {
+    directCommands: 1,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns managed bootstrap deletion observation.",
+  },
+  "src/lib/onboard/runtime-provider/snapshot.ts": {
+    directCommands: 2,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns runtime-provider snapshot inspection.",
+  },
+  "src/lib/onboard.ts": {
+    directCommands: 0,
+    legacyParserSites: 1,
+    ownerIssues: [9803, 9811],
+    disposition: "follow-up",
+    reason: "Inventory, readiness, and sandbox lifecycle slices own the legacy parser binding.",
+  },
+  "src/lib/onboard/sandbox-create-step.ts": {
+    directCommands: 1,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns create readiness observation.",
+  },
+  "src/lib/onboard/sandbox-gpu-create-attempt.ts": {
+    directCommands: 1,
+    legacyParserSites: 1,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns failed-create presence observation.",
+  },
+  "src/lib/onboard/sandbox-gpu-create-run-attempt.ts": {
+    directCommands: 4,
+    legacyParserSites: 2,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns create, readiness, and cleanup observation.",
+  },
+  "src/lib/onboard/sandbox-lifecycle.ts": {
+    directCommands: 1,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns sandbox lookup before start or stop.",
+  },
+  "src/lib/onboard/sandbox-readiness-tracing.ts": {
+    directCommands: 2,
+    legacyParserSites: 0,
+    ownerIssues: [9803],
+    disposition: "follow-up",
+    reason: "The inventory and readiness issue owns readiness trace observation.",
+  },
+  "src/lib/onboard/sandbox-recreate-probe.ts": {
+    directCommands: 2,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns recreate presence observation.",
+  },
+  "src/lib/onboard/sandbox-reuse.ts": {
+    directCommands: 5,
+    legacyParserSites: 0,
+    ownerIssues: [9811],
+    disposition: "follow-up",
+    reason: "The sandbox lifecycle slice owns onboarding reuse and identity observation.",
+  },
+  "src/lib/runtime-recovery.ts": {
+    directCommands: 0,
+    legacyParserSites: 6,
+    ownerIssues: [9803],
+    disposition: "follow-up",
+    reason: "The inventory and readiness issue owns removal of legacy list parser projections.",
+  },
+  "src/lib/shields/index.ts": {
+    directCommands: 1,
+    legacyParserSites: 1,
+    ownerIssues: [9805, 10514],
+    disposition: "follow-up",
+    reason: "The policy source-of-truth cutover owns Shields phase observation during mutation.",
+  },
+  "src/lib/state/gateway.ts": {
+    directCommands: 0,
+    legacyParserSites: 6,
+    ownerIssues: [9803, 9807],
+    disposition: "follow-up",
+    reason: "Inventory, readiness, and gateway lifecycle slices own the legacy classifiers.",
+  },
+} as const;
+
+function moduleCarriesLegacyParsers(moduleSpecifier: string): boolean {
+  const normalized = moduleSpecifier.replace(/\\/gu, "/").replace(/\.(?:[cm]?[jt]s|[jt]sx)$/u, "");
+  return LEGACY_PARSER_MODULE_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+}
+
+function importedName(element: ts.ImportSpecifier): string {
+  return element.propertyName?.text ?? element.name.text;
+}
+
+function requireModuleSpecifier(expression: ts.Expression | undefined): string | null {
+  if (
+    !expression ||
+    !ts.isCallExpression(expression) ||
+    !ts.isIdentifier(expression.expression) ||
+    expression.expression.text !== "require" ||
+    expression.arguments.length !== 1
+  ) {
+    return null;
+  }
+  const [specifier] = expression.arguments;
+  return specifier && ts.isStringLiteralLike(specifier) ? specifier.text : null;
+}
+
+function directObservationCommands(node: ts.ArrayLiteralExpression): number {
+  let commands = 0;
+  for (let index = 0; index < node.elements.length - 1; index += 1) {
+    const first = node.elements[index];
+    const second = node.elements[index + 1];
+    if (
+      first &&
+      second &&
+      ts.isStringLiteralLike(first) &&
+      first.text === "sandbox" &&
+      ts.isStringLiteralLike(second) &&
+      (second.text === "get" || second.text === "list")
+    ) {
+      commands += 1;
+    }
+  }
+  return commands;
+}
+
+export function findOpenShellSandboxObservationUsage(
+  sourceText: string,
+  filePath: string,
+): OpenShellSandboxObservationUsage {
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
+  let directCommands = 0;
+  let legacyParserSites = 0;
+
+  function visit(node: ts.Node): void {
+    if (ts.isArrayLiteralExpression(node)) {
+      directCommands += directObservationCommands(node);
+    } else if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteralLike(node.moduleSpecifier) &&
+      moduleCarriesLegacyParsers(node.moduleSpecifier.text) &&
+      node.importClause?.namedBindings
+    ) {
+      const bindings = node.importClause.namedBindings;
+      legacyParserSites += ts.isNamespaceImport(bindings)
+        ? 1
+        : bindings.elements.filter((element) => LEGACY_PARSER_NAMES.has(importedName(element)))
+            .length;
+    } else if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      const moduleSpecifier = requireModuleSpecifier(node.initializer);
+      if (moduleSpecifier && moduleCarriesLegacyParsers(moduleSpecifier)) {
+        legacyParserSites += 1;
+      }
+    } else if (ts.isVariableDeclaration(node) && ts.isObjectBindingPattern(node.name)) {
+      const moduleSpecifier = requireModuleSpecifier(node.initializer);
+      if (moduleSpecifier && moduleCarriesLegacyParsers(moduleSpecifier)) {
+        legacyParserSites += node.name.elements.filter((element) => {
+          const name = element.propertyName ?? element.name;
+          return ts.isIdentifier(name) && LEGACY_PARSER_NAMES.has(name.text);
+        }).length;
+      }
+    } else if (
+      ts.isFunctionDeclaration(node) &&
+      node.name &&
+      LEGACY_PARSER_NAMES.has(node.name.text) &&
+      (filePath.endsWith("/runtime-recovery.ts") ||
+        filePath.endsWith("/state/gateway.ts") ||
+        filePath.endsWith("/adapters/openshell/sandbox-observer-cli.ts"))
+    ) {
+      legacyParserSites += 1;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return { directCommands, legacyParserSites };
+}
+
+function isProductionSource(relativePath: string): boolean {
+  return SOURCE_EXTENSION.test(relativePath) && !TEST_SOURCE.test(relativePath);
+}
+
+function* walkProductionSources(directory: string): Generator<string> {
+  if (!existsSync(directory)) return;
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isSymbolicLink() || SKIP_DIRECTORIES.has(entry.name)) continue;
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkProductionSources(absolutePath);
+    } else if (entry.isFile()) {
+      const relativePath = path.relative(REPO_ROOT, absolutePath).split(path.sep).join("/");
+      if (isProductionSource(relativePath)) yield absolutePath;
+    }
+  }
+}
+
+export function collectOpenShellSandboxObservationSources(): ReadonlyMap<string, string> {
+  const sources = new Map<string, string>();
+  for (const root of SCAN_ROOTS) {
+    for (const absolutePath of walkProductionSources(path.join(REPO_ROOT, root))) {
+      const relativePath = path.relative(REPO_ROOT, absolutePath).split(path.sep).join("/");
+      sources.set(relativePath, readFileSync(absolutePath, "utf8"));
+    }
+  }
+  return sources;
+}
+
+export function auditOpenShellSandboxObservationSources(
+  sources: ReadonlyMap<string, string>,
+  dispositions: Readonly<
+    Record<string, OpenShellSandboxObservationDisposition>
+  > = OPEN_SHELL_SANDBOX_OBSERVATION_DISPOSITIONS,
+): void {
+  const actual = new Map<string, OpenShellSandboxObservationUsage>();
+  for (const [filePath, sourceText] of sources) {
+    const usage = findOpenShellSandboxObservationUsage(sourceText, filePath);
+    if (usage.directCommands > 0 || usage.legacyParserSites > 0) actual.set(filePath, usage);
+  }
+
+  const failures: string[] = [];
+  for (const [filePath, usage] of actual) {
+    const disposition = dispositions[filePath];
+    if (!disposition) {
+      failures.push(
+        `${filePath}: unclassified observation usage ` +
+          `(commands=${usage.directCommands}, legacyParsers=${usage.legacyParserSites})`,
+      );
+      continue;
+    }
+    if (
+      disposition.directCommands !== usage.directCommands ||
+      disposition.legacyParserSites !== usage.legacyParserSites
+    ) {
+      failures.push(
+        `${filePath}: observation usage changed; expected commands=${disposition.directCommands}, ` +
+          `legacyParsers=${disposition.legacyParserSites}; found commands=${usage.directCommands}, ` +
+          `legacyParsers=${usage.legacyParserSites}`,
+      );
+    }
+    if (disposition.ownerIssues.length === 0 || disposition.reason.trim().length === 0) {
+      failures.push(`${filePath}: disposition must name an owner issue and reason`);
+    }
+  }
+
+  for (const filePath of Object.keys(dispositions)) {
+    if (!actual.has(filePath)) {
+      failures.push(`${filePath}: stale disposition has no observation usage`);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      [
+        "OpenShell sandbox observation boundary changed.",
+        "Move the consumer to a typed adapter or update its owned follow-on disposition.",
+        ...failures.sort(),
+      ].join("\n"),
+    );
+  }
+}
+
+function main(): void {
+  try {
+    auditOpenShellSandboxObservationSources(collectOpenShellSandboxObservationSources());
+    process.stdout.write(
+      `Verified ${Object.keys(OPEN_SHELL_SANDBOX_OBSERVATION_DISPOSITIONS).length} ` +
+        "OpenShell sandbox observation dispositions.\n",
+    );
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? "")) {
+  main();
+}

--- a/scripts/checks/openshell-sandbox-observation-boundary.mts
+++ b/scripts/checks/openshell-sandbox-observation-boundary.mts
@@ -78,9 +78,9 @@ export const OPEN_SHELL_SANDBOX_OBSERVATION_DISPOSITIONS: Readonly<
   "src/commands/debug.ts": {
     directCommands: 2,
     legacyParserSites: 1,
-    ownerIssues: [9803],
+    ownerIssues: [9812],
     disposition: "follow-up",
-    reason: "PR #10537 migrates the debug liveness consumer to the typed observer.",
+    reason: "PR #10537 migrates liveness; the diagnostics slice owns remaining observation.",
   },
   "src/lib/actions/sandbox/destroy-gateway-cleanup.ts": {
     directCommands: 1,
@@ -253,9 +253,9 @@ export const OPEN_SHELL_SANDBOX_OBSERVATION_DISPOSITIONS: Readonly<
   "src/lib/onboard.ts": {
     directCommands: 0,
     legacyParserSites: 1,
-    ownerIssues: [9803, 9811],
+    ownerIssues: [9811],
     disposition: "follow-up",
-    reason: "Inventory, readiness, and sandbox lifecycle slices own the legacy parser binding.",
+    reason: "The sandbox lifecycle slice owns the onboarding legacy parser binding.",
   },
   "src/lib/onboard/sandbox-create-step.ts": {
     directCommands: 1,
@@ -288,9 +288,9 @@ export const OPEN_SHELL_SANDBOX_OBSERVATION_DISPOSITIONS: Readonly<
   "src/lib/onboard/sandbox-readiness-tracing.ts": {
     directCommands: 2,
     legacyParserSites: 0,
-    ownerIssues: [9803],
+    ownerIssues: [9811],
     disposition: "follow-up",
-    reason: "The inventory and readiness issue owns readiness trace observation.",
+    reason: "The sandbox lifecycle slice owns create readiness trace observation.",
   },
   "src/lib/onboard/sandbox-recreate-probe.ts": {
     directCommands: 2,
@@ -309,9 +309,9 @@ export const OPEN_SHELL_SANDBOX_OBSERVATION_DISPOSITIONS: Readonly<
   "src/lib/runtime-recovery.ts": {
     directCommands: 0,
     legacyParserSites: 6,
-    ownerIssues: [9803],
+    ownerIssues: [9807, 9811],
     disposition: "follow-up",
-    reason: "The inventory and readiness issue owns removal of legacy list parser projections.",
+    reason: "Gateway and sandbox lifecycle slices own removal of legacy parser projections.",
   },
   "src/lib/shields/index.ts": {
     directCommands: 1,
@@ -323,9 +323,9 @@ export const OPEN_SHELL_SANDBOX_OBSERVATION_DISPOSITIONS: Readonly<
   "src/lib/state/gateway.ts": {
     directCommands: 0,
     legacyParserSites: 6,
-    ownerIssues: [9803, 9807],
+    ownerIssues: [9807],
     disposition: "follow-up",
-    reason: "Inventory, readiness, and gateway lifecycle slices own the legacy classifiers.",
+    reason: "The gateway lifecycle slice owns the legacy sandbox and gateway classifiers.",
   },
 } as const;
 

--- a/scripts/checks/openshell-sandbox-observation-boundary.mts
+++ b/scripts/checks/openshell-sandbox-observation-boundary.mts
@@ -8,7 +8,7 @@
  * invalidState: a production source adds an unclassified `sandbox list` or
  * `sandbox get` command, or adds another binding to a legacy raw-output parser.
  * sourceBoundary: the CLI adapter owns command construction and parsing;
- * capability issues own each temporary production exception.
+ * assigned follow-on capability issues record each deferred production consumer.
  * whyNotSourceFix: TypeScript cannot prevent callers from constructing an
  * equivalent string array for a generic process runner.
  * regressionTest: test/repository/openshell-sandbox-observation-boundary.test.ts.
@@ -55,7 +55,7 @@ const LEGACY_PARSER_MODULE_SUFFIXES = [
 export type OpenShellSandboxObservationDisposition = Readonly<{
   directCommands: number;
   legacyParserSites: number;
-  ownerIssues: readonly number[];
+  trackingIssues: readonly number[];
   disposition: "adapter-boundary" | "follow-up";
   reason: string;
 }>;
@@ -71,259 +71,259 @@ export const OPEN_SHELL_SANDBOX_OBSERVATION_DISPOSITIONS: Readonly<
   "nemoclaw/src/blueprint/runner.ts": {
     directCommands: 1,
     legacyParserSites: 0,
-    ownerIssues: [9813],
+    trackingIssues: [9813],
     disposition: "follow-up",
     reason: "The final Phase 1 sweep owns plugin and blueprint-runner consumers.",
   },
   "src/commands/debug.ts": {
     directCommands: 2,
     legacyParserSites: 1,
-    ownerIssues: [9812],
+    trackingIssues: [9812],
     disposition: "follow-up",
     reason: "PR #10537 migrates liveness; the diagnostics slice owns remaining observation.",
   },
   "src/lib/actions/sandbox/destroy-gateway-cleanup.ts": {
     directCommands: 1,
     legacyParserSites: 0,
-    ownerIssues: [9807],
+    trackingIssues: [9807],
     disposition: "follow-up",
     reason: "The gateway lifecycle slice owns final-destroy gateway cleanup observation.",
   },
   "src/lib/actions/sandbox/destroy-preflight.ts": {
     directCommands: 1,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns destructive preflight observation.",
   },
   "src/lib/actions/sandbox/doctor.ts": {
     directCommands: 0,
     legacyParserSites: 1,
-    ownerIssues: [9807],
+    trackingIssues: [9807],
     disposition: "follow-up",
     reason: "The gateway lifecycle slice owns raw lifecycle status classification.",
   },
   "src/lib/actions/sandbox/gateway-state.ts": {
     directCommands: 1,
     legacyParserSites: 1,
-    ownerIssues: [9807, 9811],
+    trackingIssues: [9807, 9811],
     disposition: "follow-up",
     reason: "Gateway lifecycle and sandbox stop ownership still share this compatibility path.",
   },
   "src/lib/actions/sandbox/rebuild-destroy-phase.ts": {
     directCommands: 2,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns rebuild destruction observation.",
   },
   "src/lib/actions/sandbox/snapshot.ts": {
     directCommands: 7,
     legacyParserSites: 2,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns snapshot and restore observation.",
   },
   "src/lib/actions/sandbox/stop.ts": {
     directCommands: 0,
     legacyParserSites: 1,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns sibling phase observation during stop.",
   },
   "src/lib/actions/sandbox/vm-dns-monkeypatch.ts": {
     directCommands: 1,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns VM sandbox inspection before mutation.",
   },
   "src/lib/actions/uninstall/run-plan.ts": {
     directCommands: 1,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns absence verification during uninstall.",
   },
   "src/lib/adapters/openshell/client.ts": {
     directCommands: 1,
     legacyParserSites: 0,
-    ownerIssues: [9803],
+    trackingIssues: [9803],
     disposition: "adapter-boundary",
     reason: "The OpenShell CLI adapter owns this compatibility command construction.",
   },
   "src/lib/adapters/openshell/gateway-drift.ts": {
     directCommands: 0,
     legacyParserSites: 1,
-    ownerIssues: [9807],
+    trackingIssues: [9807],
     disposition: "adapter-boundary",
     reason: "The gateway lifecycle adapter owns gateway status compatibility parsing.",
   },
   "src/lib/adapters/openshell/policy-authority.ts": {
     directCommands: 2,
     legacyParserSites: 0,
-    ownerIssues: [9805, 10514],
+    trackingIssues: [9805, 10514],
     disposition: "adapter-boundary",
     reason: "The accepted policy source-of-truth cutover owns these typed policy inspections.",
   },
   "src/lib/adapters/openshell/sandbox-identity.ts": {
     directCommands: 3,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "adapter-boundary",
     reason: "The sandbox lifecycle adapter owns immutable identity inspection.",
   },
   "src/lib/adapters/openshell/sandbox-observer-cli.ts": {
     directCommands: 0,
     legacyParserSites: 3,
-    ownerIssues: [9803],
+    trackingIssues: [9803],
     disposition: "adapter-boundary",
     reason: "The CLI sandbox observer owns table, ANSI, phase, and error parsing.",
   },
   "src/lib/diagnostics/debug.ts": {
     directCommands: 4,
     legacyParserSites: 0,
-    ownerIssues: [9812],
+    trackingIssues: [9812],
     disposition: "follow-up",
     reason: "The diagnostics slice owns migration or an accepted executable-level exception.",
   },
   "src/lib/domain/sandbox/destroy.ts": {
     directCommands: 0,
     legacyParserSites: 1,
-    ownerIssues: [9807],
+    trackingIssues: [9807],
     disposition: "follow-up",
     reason: "The gateway lifecycle slice owns final-destroy live-sandbox classification.",
   },
   "src/lib/onboard/docker-gpu-patch-diagnostics.ts": {
     directCommands: 2,
     legacyParserSites: 0,
-    ownerIssues: [9812],
+    trackingIssues: [9812],
     disposition: "follow-up",
     reason: "The diagnostics slice owns migration or an accepted executable-level exception.",
   },
   "src/lib/onboard/docker-gpu-patch.ts": {
     directCommands: 2,
     legacyParserSites: 1,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns Docker GPU phase decisions.",
   },
   "src/lib/onboard/docker-gpu-sandbox-create.ts": {
     directCommands: 1,
     legacyParserSites: 1,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns create failure observation.",
   },
   "src/lib/onboard/docker-gpu-supervisor-reconnect.ts": {
     directCommands: 2,
     legacyParserSites: 1,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns supervisor reconnect phase decisions.",
   },
   "src/lib/onboard/experimental/hermes-portable-lifecycle.ts": {
     directCommands: 4,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns Hermes portable lifecycle observation.",
   },
   "src/lib/onboard/experimental/hermes-portable-onboarding.ts": {
     directCommands: 6,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns Hermes portable onboarding observation.",
   },
   "src/lib/onboard/managed-bootstrap/docker.ts": {
     directCommands: 1,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns managed bootstrap deletion observation.",
   },
   "src/lib/onboard/runtime-provider/snapshot.ts": {
     directCommands: 2,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns runtime-provider snapshot inspection.",
   },
   "src/lib/onboard.ts": {
     directCommands: 0,
     legacyParserSites: 1,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns the onboarding legacy parser binding.",
   },
   "src/lib/onboard/sandbox-create-step.ts": {
     directCommands: 1,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns create readiness observation.",
   },
   "src/lib/onboard/sandbox-gpu-create-attempt.ts": {
     directCommands: 1,
     legacyParserSites: 1,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns failed-create presence observation.",
   },
   "src/lib/onboard/sandbox-gpu-create-run-attempt.ts": {
     directCommands: 4,
     legacyParserSites: 2,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns create, readiness, and cleanup observation.",
   },
   "src/lib/onboard/sandbox-lifecycle.ts": {
     directCommands: 1,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns sandbox lookup before start or stop.",
   },
   "src/lib/onboard/sandbox-readiness-tracing.ts": {
     directCommands: 2,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns create readiness trace observation.",
   },
   "src/lib/onboard/sandbox-recreate-probe.ts": {
     directCommands: 2,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns recreate presence observation.",
   },
   "src/lib/onboard/sandbox-reuse.ts": {
     directCommands: 5,
     legacyParserSites: 0,
-    ownerIssues: [9811],
+    trackingIssues: [9811],
     disposition: "follow-up",
     reason: "The sandbox lifecycle slice owns onboarding reuse and identity observation.",
   },
   "src/lib/runtime-recovery.ts": {
     directCommands: 0,
     legacyParserSites: 6,
-    ownerIssues: [9807, 9811],
+    trackingIssues: [9807, 9811],
     disposition: "follow-up",
     reason: "Gateway and sandbox lifecycle slices own removal of legacy parser projections.",
   },
   "src/lib/shields/index.ts": {
     directCommands: 1,
     legacyParserSites: 1,
-    ownerIssues: [9805, 10514],
+    trackingIssues: [9805, 10514],
     disposition: "follow-up",
     reason: "The policy source-of-truth cutover owns Shields phase observation during mutation.",
   },
   "src/lib/state/gateway.ts": {
     directCommands: 0,
     legacyParserSites: 6,
-    ownerIssues: [9807],
+    trackingIssues: [9807],
     disposition: "follow-up",
     reason: "The gateway lifecycle slice owns the legacy sandbox and gateway classifiers.",
   },
@@ -484,8 +484,8 @@ export function auditOpenShellSandboxObservationSources(
           `legacyParsers=${usage.legacyParserSites}`,
       );
     }
-    if (disposition.ownerIssues.length === 0 || disposition.reason.trim().length === 0) {
-      failures.push(`${filePath}: disposition must name an owner issue and reason`);
+    if (disposition.trackingIssues.length === 0 || disposition.reason.trim().length === 0) {
+      failures.push(`${filePath}: disposition must name a tracking issue and reason`);
     }
   }
 
@@ -499,7 +499,9 @@ export function auditOpenShellSandboxObservationSources(
     throw new Error(
       [
         "OpenShell sandbox observation boundary changed.",
-        "Move the consumer to a typed adapter or update its owned follow-on disposition.",
+        "Move the consumer to a typed adapter.",
+        "Add or update a follow-up disposition only after its linked issue names an assigned " +
+          "implementation owner; this check validates only local ledger fields.",
         ...failures.sort(),
       ].join("\n"),
     );

--- a/scripts/checks/run.mts
+++ b/scripts/checks/run.mts
@@ -74,6 +74,11 @@ export const CHECKS: readonly CheckCommand[] = [
     args: ["scripts/checks/openshell-policy-mutation-read.mts"],
   },
   {
+    name: "openshell-sandbox-observation-boundary",
+    command: TSX,
+    args: ["scripts/checks/openshell-sandbox-observation-boundary.mts"],
+  },
+  {
     name: "layer-import-boundaries",
     command: TSX,
     args: ["scripts/checks/layer-import-boundaries.mts"],

--- a/test/repository/checks-runner.test.ts
+++ b/test/repository/checks-runner.test.ts
@@ -25,6 +25,14 @@ describe("checks runner", () => {
     });
   });
 
+  it("registers the OpenShell sandbox observation boundary check (#9803)", () => {
+    expect(CHECKS).toContainEqual({
+      name: "openshell-sandbox-observation-boundary",
+      command: process.platform === "win32" ? "tsx.cmd" : "tsx",
+      args: ["scripts/checks/openshell-sandbox-observation-boundary.mts"],
+    });
+  });
+
   it("registers the onboarding entry composition check", () => {
     expect(CHECKS).toContainEqual({
       name: "onboard-entry-composition",

--- a/test/repository/openshell-sandbox-observation-boundary.test.ts
+++ b/test/repository/openshell-sandbox-observation-boundary.test.ts
@@ -16,9 +16,9 @@ function disposition(
   return {
     directCommands,
     legacyParserSites,
-    ownerIssues: [9803],
+    trackingIssues: [9803],
     disposition: "follow-up",
-    reason: "The accepted inventory issue owns this synthetic consumer.",
+    reason: "The synthetic follow-up issue records this consumer.",
   };
 }
 
@@ -53,10 +53,10 @@ describe("OpenShell sandbox observation boundary", () => {
 
   it("rejects an unclassified production observation consumer", () => {
     const sources = new Map([["src/new-consumer.ts", `run(["sandbox", "list"]);`]]);
+    const audit = () => auditOpenShellSandboxObservationSources(sources, {});
 
-    expect(() => auditOpenShellSandboxObservationSources(sources, {})).toThrow(
-      /src\/new-consumer\.ts: unclassified observation usage/u,
-    );
+    expect(audit).toThrow(/src\/new-consumer\.ts: unclassified observation usage/u);
+    expect(audit).toThrow(/linked issue names an assigned implementation owner/u);
   });
 
   it("rejects another observation command in a classified consumer", () => {
@@ -83,18 +83,18 @@ describe("OpenShell sandbox observation boundary", () => {
     );
   });
 
-  it("rejects a disposition without an owner issue or reason", () => {
+  it("rejects a disposition without a tracking issue or reason", () => {
     const sources = new Map([["src/unowned-consumer.ts", `run(["sandbox", "list"]);`]]);
     const dispositions = {
       "src/unowned-consumer.ts": {
         ...disposition(1, 0),
-        ownerIssues: [],
+        trackingIssues: [],
         reason: "",
       },
     };
 
     expect(() => auditOpenShellSandboxObservationSources(sources, dispositions)).toThrow(
-      /disposition must name an owner issue and reason/u,
+      /disposition must name a tracking issue and reason/u,
     );
   });
 });

--- a/test/repository/openshell-sandbox-observation-boundary.test.ts
+++ b/test/repository/openshell-sandbox-observation-boundary.test.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import {
+  auditOpenShellSandboxObservationSources,
+  findOpenShellSandboxObservationUsage,
+  type OpenShellSandboxObservationDisposition,
+} from "../../scripts/checks/openshell-sandbox-observation-boundary.mts";
+
+function disposition(
+  directCommands: number,
+  legacyParserSites: number,
+): OpenShellSandboxObservationDisposition {
+  return {
+    directCommands,
+    legacyParserSites,
+    ownerIssues: [9803],
+    disposition: "follow-up",
+    reason: "The accepted inventory issue owns this synthetic consumer.",
+  };
+}
+
+describe("OpenShell sandbox observation boundary", () => {
+  it("counts direct list and get commands with legacy parser bindings", () => {
+    const usage = findOpenShellSandboxObservationUsage(
+      `
+        import { parseLiveSandboxEntries as parseEntries } from "./runtime-recovery";
+        const list = ["openshell", "sandbox", "list", "-g", gateway];
+        const get = ["sandbox", "get", sandboxName];
+        parseEntries(output);
+      `,
+      "src/example.ts",
+    );
+
+    expect(usage).toEqual({ directCommands: 2, legacyParserSites: 1 });
+  });
+
+  it("counts namespace bindings that expose legacy parsers", () => {
+    const usage = findOpenShellSandboxObservationUsage(
+      `
+        import * as runtimeRecovery from "./runtime-recovery";
+        const gatewayState = require("./state/gateway");
+        runtimeRecovery.parseLiveSandboxEntries(output);
+        gatewayState.parseSandboxStatus(output);
+      `,
+      "src/example.ts",
+    );
+
+    expect(usage).toEqual({ directCommands: 0, legacyParserSites: 2 });
+  });
+
+  it("rejects an unclassified production observation consumer", () => {
+    const sources = new Map([["src/new-consumer.ts", `run(["sandbox", "list"]);`]]);
+
+    expect(() => auditOpenShellSandboxObservationSources(sources, {})).toThrow(
+      /src\/new-consumer\.ts: unclassified observation usage/u,
+    );
+  });
+
+  it("rejects another observation command in a classified consumer", () => {
+    const sources = new Map([
+      ["src/existing-consumer.ts", `run(["sandbox", "list"]); run(["sandbox", "get", "alpha"]);`],
+    ]);
+    const dispositions = {
+      "src/existing-consumer.ts": disposition(1, 0),
+    };
+
+    expect(() => auditOpenShellSandboxObservationSources(sources, dispositions)).toThrow(
+      /observation usage changed/u,
+    );
+  });
+
+  it("rejects a stale disposition after its consumer migrates", () => {
+    const sources = new Map([["src/migrated-consumer.ts", "export const migrated = true;"]]);
+    const dispositions = {
+      "src/migrated-consumer.ts": disposition(1, 0),
+    };
+
+    expect(() => auditOpenShellSandboxObservationSources(sources, dispositions)).toThrow(
+      /stale disposition has no observation usage/u,
+    );
+  });
+
+  it("rejects a disposition without an owner issue or reason", () => {
+    const sources = new Map([["src/unowned-consumer.ts", `run(["sandbox", "list"]);`]]);
+    const dispositions = {
+      "src/unowned-consumer.ts": {
+        ...disposition(1, 0),
+        ownerIssues: [],
+        reason: "",
+      },
+    };
+
+    expect(() => auditOpenShellSandboxObservationSources(sources, dispositions)).toThrow(
+      /disposition must name an owner issue and reason/u,
+    );
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The repository now rejects any new or changed production OpenShell sandbox observation path unless it uses the typed adapter or has a checked-in follow-up disposition. The check classifies all 37 current direct `sandbox list` or `sandbox get` command sites and legacy raw-parser bindings without changing runtime behavior. Each current deferred disposition points to a follow-on capability issue assigned to `rsliter`.

## Reason

PR #10132 established the typed sandbox observer, but PR #10537 later found another production liveness consumer that still built CLI arguments and interpreted raw output. Issue #9803 now permits partial delivery only when every deferred consumer is named and owned. A checked-in repository guard makes that rule executable and prevents another consumer from silently bypassing the adapter seam.

### Related issues

Partial #9803

Depends on #10537

Relates to #9805, #9807, #9811, #9812, #9813, and #10514

## Changes

- Add a TypeScript source audit for production `sandbox list` and `sandbox get` argument arrays, named legacy parser imports, namespace bindings, CommonJS bindings, and the remaining parser definitions.
- Record the exact command and parser-site count, disposition, tracking issue, and reason for every current source file.
- Fail when a source is unclassified, a classified count changes, a disposition becomes stale, or a source lacks a tracking issue or reason.
- Register the audit in `npm run checks:repository` and add negative tests for each failure mode.

The checked-in ledger names every deferred consumer:

- #9805 and #10514: `src/lib/shields/index.ts`.
- #9807: `src/lib/actions/sandbox/destroy-gateway-cleanup.ts`, `src/lib/actions/sandbox/doctor.ts`, `src/lib/actions/sandbox/gateway-state.ts`, `src/lib/domain/sandbox/destroy.ts`, `src/lib/runtime-recovery.ts`, and `src/lib/state/gateway.ts`.
- #9811: `src/lib/actions/sandbox/destroy-preflight.ts`, `rebuild-destroy-phase.ts`, `snapshot.ts`, `stop.ts`, and `vm-dns-monkeypatch.ts`; `src/lib/actions/uninstall/run-plan.ts`; `src/lib/onboard.ts`; the Docker GPU patch, create, and reconnect helpers; Hermes portable lifecycle and onboarding; managed bootstrap; runtime-provider snapshots; sandbox create, GPU create, lifecycle, readiness tracing, recreate, and reuse helpers; and `src/lib/runtime-recovery.ts`.
- #9812: `src/commands/debug.ts`, `src/lib/diagnostics/debug.ts`, and `src/lib/onboard/docker-gpu-patch-diagnostics.ts`. PR #10537 owns the debug liveness migration.
- #9813: `nemoclaw/src/blueprint/runner.ts`.

The OpenShell client, gateway-drift, policy-authority, sandbox-identity, and sandbox-observer CLI files are classified as adapter-owned boundaries rather than deferred consumers.

## Verification

- `node_modules/.bin/tsx scripts/checks/openshell-sandbox-observation-boundary.mts` completed with 37 verified dispositions.
- `npx vitest run --project integration test/repository/openshell-sandbox-observation-boundary.test.ts test/repository/checks-runner.test.ts` passed 2 files and 19 tests.
- `npm run checks:repository` passed with 1,847 files, 5,864 edges, 0 cycles, and exact membership for 2,625 test candidates.
- `npm run build:cli` and `npm run typecheck:cli` passed.
- Normal pre-commit and commit-message hooks passed for all commits.
- `npm run check` passed all relevant repository, formatting, lint, secret-scan, and architecture hooks, then stopped at existing all-files Hadolint warnings in unchanged Dockerfiles. This diff changes no Dockerfile.
- `git diff --check` passed.
- The diff contains no secrets, API keys, or credentials.

### Documentation Writer Review

- Result: `no-docs-needed`
- Evidence: Reviewed exact commit `dde48cc2a6e2b8d56b7d87aed62e13da83ea3976` against trusted base `fa6b2c89eb01e2b27648cfea61208a9897d5fcb4`, including the focused Advisor repair and all four changed paths. `trackingIssues` no longer claims the local ledger proves GitHub ownership, and the diagnostic now states both the assigned-owner requirement and the check's local limit. This changes repository enforcement only and does not change a public command, option, output, configuration, supported workflow, or security boundary. Independent validation passed the exact audit, 2 focused integration files and 19 tests, and `git diff --check`; supplied repository checks, CLI build, CLI typecheck, and normal hooks also passed.
- Agent: `Codex Desktop`
<!-- docs-review-head-sha: dde48cc2a -->
<!-- docs-review-agents-blob-sha: dd3528f6e -->

## Review notes

This PR remains draft until #10537 merges. After that merge, the stale debug disposition must be removed and the exact audit, tests, and documentation review rerun on the updated base.

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>
