### PR TITLE
test(e2e): retain Brev readiness failure evidence

### DIFF
--- a/test/e2e/fixtures/brev-launchable.ts
+++ b/test/e2e/fixtures/brev-launchable.ts
@@ -194,7 +194,10 @@ export class BrevLaunchableFixture {
     timeoutMs = DEFAULT_BREV_EXEC_READY_TIMEOUT_MS,
   ): Promise<void> {
     const deadline = Date.now() + timeoutMs;
+    let attempts = 0;
+    let lastResult: ShellProbeResult | undefined;
     while (Date.now() < deadline) {
+      attempts += 1;
       const remaining = deadline - Date.now();
       const result = await this.exec(ownership, "true", {
         artifactName: "brev-exec-readiness",
@@ -202,9 +205,18 @@ export class BrevLaunchableFixture {
         timeoutMs: Math.min(30_000, remaining),
       });
       if (result.exitCode === 0) return;
+      lastResult = result;
       await delay(Math.min(this.pollMs, Math.max(1, deadline - Date.now())));
     }
-    throw new Error("Brev exec readiness timed out");
+    await this.artifacts.writeJson("brev-exec-readiness-failure.json", {
+      attempts,
+      lastResult,
+      workspaceId: ownership.id,
+      workspaceName: ownership.name,
+    });
+    throw new Error(
+      `Brev exec readiness timed out after ${attempts} attempts: ${lastResult ? resultText(lastResult) : "no command result"}`,
+    );
   }
 
   private async exec(

--- a/test/e2e/fixtures/brev-launchable.ts
+++ b/test/e2e/fixtures/brev-launchable.ts
@@ -55,6 +55,9 @@ export interface BrevLaunchableFixtureOptions {
 const IMAGE_REPOSITORY = "brevdev/nemoclaw-image";
 const IMAGE_WORKFLOW = "build-launchable-e2e-image.yml";
 const DEFAULT_POLL_MS = 15_000;
+const BREV_EXEC_READY_CAPTURE_LIMIT_BYTES = 4 * 1024;
+const BREV_EXEC_READY_DIAGNOSTIC_LIMIT_CHARACTERS = 2 * 1024;
+const DIAGNOSTIC_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f-\u009f]/gu;
 const DEFAULT_BREV_WORKSPACE_CREATE_RECONCILE_TIMEOUT_MS = 2 * 60_000;
 export const DEFAULT_BREV_STAGING_HANDOFF_COMMAND_TIMEOUT_MS = 60_000;
 export const DEFAULT_BREV_STAGING_HANDOFF_TIMEOUT_MS =
@@ -201,6 +204,7 @@ export class BrevLaunchableFixture {
       const remaining = deadline - Date.now();
       const result = await this.exec(ownership, "true", {
         artifactName: "brev-exec-readiness",
+        captureLimitBytes: BREV_EXEC_READY_CAPTURE_LIMIT_BYTES,
         persistArtifacts: false,
         timeoutMs: Math.min(30_000, remaining),
       });
@@ -208,14 +212,22 @@ export class BrevLaunchableFixture {
       lastResult = result;
       await delay(Math.min(this.pollMs, Math.max(1, deadline - Date.now())));
     }
+    const lastAttempt = lastResult
+      ? {
+          diagnostic: boundedReadinessDiagnostic(this.secrets.redact(resultText(lastResult))),
+          exitCode: lastResult.exitCode,
+          signal: lastResult.signal,
+          timedOut: lastResult.timedOut,
+        }
+      : undefined;
     await this.artifacts.writeJson("brev-exec-readiness-failure.json", {
       attempts,
-      lastResult,
+      lastAttempt,
       workspaceId: ownership.id,
       workspaceName: ownership.name,
     });
     throw new Error(
-      `Brev exec readiness timed out after ${attempts} attempts: ${lastResult ? resultText(lastResult) : "no command result"}`,
+      `Brev exec readiness timed out after ${attempts} attempts: ${lastAttempt?.diagnostic ?? "no command result"}`,
     );
   }
 
@@ -493,6 +505,16 @@ export class BrevLaunchableFixture {
       env: { PATH: this.path, ...(options.env ?? {}), HOME: this.home },
     });
   }
+}
+
+function boundedReadinessDiagnostic(value: string): string {
+  const sanitized = value.replace(DIAGNOSTIC_CONTROL_CHARACTERS, " ").replace(/\s+/gu, " ").trim();
+  if (!sanitized) return "no output";
+  if (sanitized.length <= BREV_EXEC_READY_DIAGNOSTIC_LIMIT_CHARACTERS) return sanitized;
+  const omitted = sanitized.length - BREV_EXEC_READY_DIAGNOSTIC_LIMIT_CHARACTERS;
+  return `[Brev exec diagnostic omitted ${omitted} earlier characters] ${sanitized.slice(
+    -BREV_EXEC_READY_DIAGNOSTIC_LIMIT_CHARACTERS,
+  )}`;
 }
 
 function normalizeWorkspace(value: unknown): BrevWorkspaceRecord | null {

--- a/test/e2e/support/brev-launchable-fixture.test.ts
+++ b/test/e2e/support/brev-launchable-fixture.test.ts
@@ -15,12 +15,13 @@ import {
   type StagingHandoff,
 } from "../fixtures/brev-launchable.ts";
 import type { HostCliClient } from "../fixtures/clients/host.ts";
-import type { SecretStore } from "../fixtures/secrets.ts";
+import { SecretStore } from "../fixtures/secrets.ts";
 import type { ShellProbeResult, ShellProbeRunOptions } from "../fixtures/shell-probe.ts";
 
 const roots: string[] = [];
 
 afterEach(() => {
+  vi.useRealTimers();
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
@@ -294,22 +295,45 @@ describe("the Brev Launchable fixture binds staging identity and workspace lifec
   });
 
   it("records the last failed Brev exec readiness attempt", async () => {
+    vi.useFakeTimers();
     const root = temporaryRoot();
-    const command = vi.fn(ownedExecCommand("", 1, "ssh unavailable"));
+    const command = vi.fn(
+      ownedExecCommand(
+        "",
+        1,
+        (attempt) => `${"x".repeat(3 * 1024)}\u0000\nssh unavailable ${attempt} fixture-secret`,
+      ),
+    );
     const fixture = createFixture(root, command);
 
-    await expect(fixture.waitForExec(recordedOwnership(), 10)).rejects.toThrow(
-      "Brev exec readiness timed out",
+    const rejection = expect(fixture.waitForExec(recordedOwnership(), 3)).rejects.toThrow(
+      /timed out after 3 attempts: \[Brev exec diagnostic omitted \d+ earlier characters\] x+ ssh unavailable 3 \[REDACTED\]$/u,
     );
+    await vi.advanceTimersByTimeAsync(3);
+    await rejection;
     const evidence = JSON.parse(
       fs.readFileSync(path.join(root, "brev-exec-readiness-failure.json"), "utf8"),
     );
-    expect(evidence).toMatchObject({
-      attempts: expect.any(Number),
-      lastResult: { exitCode: 1, stderr: "ssh unavailable" },
+    expect(evidence).toEqual({
+      attempts: 3,
+      lastAttempt: {
+        diagnostic: expect.stringMatching(
+          /^\[Brev exec diagnostic omitted \d+ earlier characters\] x+ ssh unavailable 3 \[REDACTED\]$/u,
+        ),
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+      },
       workspaceId: "owned-id",
       workspaceName: "fixture-workspace",
     });
+    expect(evidence.lastAttempt.diagnostic.length).toBeLessThanOrEqual(2 * 1024 + 80);
+    expect(JSON.stringify(evidence)).not.toContain("fixture-secret");
+    expect(
+      command.mock.calls
+        .filter((call) => call[1][0] === "exec")
+        .every((call) => Number(call[2]?.captureLimitBytes) > 0),
+    ).toBe(true);
   });
 
   it("refuses a replacement before Brev exec readiness without executing on it", async () => {
@@ -469,9 +493,9 @@ function createFixture(
   command: (...args: any[]) => Promise<ShellProbeResult>,
 ): BrevLaunchableFixture {
   const host = { command } as unknown as HostCliClient;
-  const secrets = {
-    required: () => "fixture-secret",
-  } as unknown as SecretStore;
+  const secrets = new SecretStore({ NEMOCLAW_IMAGE_DISPATCH_TOKEN: "fixture-secret" }, (note) => {
+    throw new Error(note ?? "test skipped");
+  });
   return new BrevLaunchableFixture({ artifacts: new ArtifactSink(root), host, pollMs: 1, secrets });
 }
 
@@ -516,14 +540,18 @@ function recordedOwnership(): BrevWorkspaceOwnership {
 function ownedExecCommand(
   stdout: string,
   exitCode = 0,
-  stderr = "",
+  stderr: string | ((attempt: number) => string) = "",
 ): (_binary: string, args: string[], _options?: ShellProbeRunOptions) => Promise<ShellProbeResult> {
+  let execAttempts = 0;
   return async (_binary, args, _options) => {
     switch (args[0]) {
       case "ls":
         return workspaceResult("owned-id");
-      case "exec":
-        return { ...result(stdout), exitCode, stderr };
+      case "exec": {
+        execAttempts += 1;
+        const attemptStderr = typeof stderr === "function" ? stderr(execAttempts) : stderr;
+        return { ...result(stdout), exitCode, stderr: attemptStderr };
+      }
       default:
         throw new Error(`unexpected command: ${args.join(" ")}`);
     }

--- a/test/e2e/support/brev-launchable-fixture.test.ts
+++ b/test/e2e/support/brev-launchable-fixture.test.ts
@@ -293,6 +293,25 @@ describe("the Brev Launchable fixture binds staging identity and workspace lifec
     expect(ownership.id).toBe("owned-id");
   });
 
+  it("records the last failed Brev exec readiness attempt", async () => {
+    const root = temporaryRoot();
+    const command = vi.fn(ownedExecCommand("", 1, "ssh unavailable"));
+    const fixture = createFixture(root, command);
+
+    await expect(fixture.waitForExec(recordedOwnership(), 10)).rejects.toThrow(
+      "Brev exec readiness timed out",
+    );
+    const evidence = JSON.parse(
+      fs.readFileSync(path.join(root, "brev-exec-readiness-failure.json"), "utf8"),
+    );
+    expect(evidence).toMatchObject({
+      attempts: expect.any(Number),
+      lastResult: { exitCode: 1, stderr: "ssh unavailable" },
+      workspaceId: "owned-id",
+      workspaceName: "fixture-workspace",
+    });
+  });
+
   it("refuses a replacement before Brev exec readiness without executing on it", async () => {
     const root = temporaryRoot();
     const lifecycle = replaceableWorkspaceCommand();
@@ -496,13 +515,15 @@ function recordedOwnership(): BrevWorkspaceOwnership {
 
 function ownedExecCommand(
   stdout: string,
+  exitCode = 0,
+  stderr = "",
 ): (_binary: string, args: string[], _options?: ShellProbeRunOptions) => Promise<ShellProbeResult> {
   return async (_binary, args, _options) => {
     switch (args[0]) {
       case "ls":
         return workspaceResult("owned-id");
       case "exec":
-        return result(stdout);
+        return { ...result(stdout), exitCode, stderr };
       default:
         throw new Error(`unexpected command: ${args.join(" ")}`);
     }


### PR DESCRIPTION
## Summary

Retains the final failed `brev exec` result and attempt count when a staging workspace never becomes remotely executable. The previous run created and later removed the workspace, but discarded every readiness stderr message, leaving only a timeout.

## Related Issue

Refs #9880

## Verification

- Brev fixture tests: 28 passed
- CLI build and TypeScript passed
- Commit and push hooks passed

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness timeout errors with attempt counts and the latest shell probe result.
  * Added sanitized, size-limited diagnostic evidence, including workspace details, exit codes, and error output, when execution readiness fails.
  * Improved timeout records to capture structured failure details while preventing excessive or unsafe diagnostic output.

* **Tests**
  * Added end-to-end coverage for timeout diagnostics, redaction, output limits, and attempt metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->