### PR TITLE
refactor(onboard): centralize native artifact dispatch

### DIFF
--- a/src/lib/onboard/runtime-provider/native-artifact-onboarding.test.ts
+++ b/src/lib/onboard/runtime-provider/native-artifact-onboarding.test.ts
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { managedStartupE2eProfile } from "../../../../scripts/checks/generate-managed-startup-profile-fixture.mts";
+import { encodeManagedStartupProfile } from "../managed-startup/profile";
+import { nativeArtifactWorkloadReceiptFixture } from "../workload/native-artifact-test-fixture";
+import type {
+  RuntimeProviderBundle,
+  RuntimeProviderNativeArtifactBootstrapInput,
+  RuntimeProviderNativeArtifactBootstrapResult,
+} from "./contract";
+import {
+  recoverInactiveNativeArtifactOnboarding,
+  runInactiveNativeArtifactOnboarding,
+} from "./native-artifact-onboarding";
+
+const WORKLOAD = nativeArtifactWorkloadReceiptFixture(
+  encodeManagedStartupProfile(managedStartupE2eProfile("openclaw")),
+);
+
+const READY_RESULT: RuntimeProviderNativeArtifactBootstrapResult = Object.freeze({
+  outcome: "ready",
+  reason: null,
+  authoritySha256: "a".repeat(64),
+  providerHandle: `future-native:${"b".repeat(64)}`,
+  sandboxName: "alpha",
+  lifecycleGeneration: "generation-1",
+  resourceState: "active",
+  cleanup: {
+    attempted: false,
+    resourceRemovalAuthorized: false,
+    removed: false,
+  },
+  recoveryRequired: false,
+});
+
+function bootstrapInput() {
+  return {
+    sandboxName: "alpha",
+    lifecycleGeneration: "generation-1",
+    driveRoot: "C:\\",
+    artifactRoot: "C:\\openclaw-artifact",
+    workload: WORKLOAD,
+  } as const;
+}
+
+function providerFixture(
+  input: {
+    readonly acceptsWorkload?: boolean;
+    readonly bootstrapProviderId?: string;
+  } = {},
+) {
+  const providerId = "future-native";
+  const run = vi.fn(async (_value: RuntimeProviderNativeArtifactBootstrapInput) => READY_RESULT);
+  const recover = vi.fn(async (_value: RuntimeProviderNativeArtifactBootstrapInput) => ({
+    ...READY_RESULT,
+    outcome: "not-created" as const,
+    reason: "recovered" as const,
+    resourceState: "absent" as const,
+  }));
+  const provider = {
+    identity: { id: providerId },
+    plan: { providerId, supported: true, gatewayLauncher: "openshell" },
+    workload: {
+      providerId,
+      supported: true,
+      acceptsReceipt: vi.fn(() => input.acceptsWorkload !== false),
+    },
+    bootstrap: {
+      providerId: input.bootstrapProviderId ?? providerId,
+      supported: true,
+      bootstrapKind: "native-artifact",
+      contractVersion: 1,
+      run,
+      recover,
+    },
+  } as unknown as RuntimeProviderBundle;
+  return { provider, recover, run };
+}
+
+describe("inactive provider-neutral native-artifact onboarding", () => {
+  it("uses the qualified provider identity without registering it (#8178)", async () => {
+    const { provider, run } = providerFixture();
+
+    const result = await runInactiveNativeArtifactOnboarding({
+      provider,
+      bootstrap: bootstrapInput(),
+    });
+
+    expect(result.computePlan).toEqual({
+      driverName: "future-native",
+      gatewayLauncher: "openshell",
+    });
+    expect(result.bootstrapResult).toBe(READY_RESULT);
+    expect(run).toHaveBeenCalledWith({
+      ...bootstrapInput(),
+      providerId: "future-native",
+    });
+  });
+
+  it("rejects an unaccepted workload before bootstrap (#8178)", async () => {
+    const { provider, run } = providerFixture({ acceptsWorkload: false });
+
+    await expect(
+      runInactiveNativeArtifactOnboarding({ provider, bootstrap: bootstrapInput() }),
+    ).rejects.toThrow(/does not match the provider workload contract/u);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("rejects bootstrap identity drift before bootstrap (#8178)", async () => {
+    const { provider, run } = providerFixture({ bootstrapProviderId: "other-provider" });
+
+    await expect(
+      runInactiveNativeArtifactOnboarding({ provider, bootstrap: bootstrapInput() }),
+    ).rejects.toThrow(/identity-consistent native-artifact bootstrap contract/u);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("routes recovery through the same qualified provider (#8178)", async () => {
+    const { provider, recover, run } = providerFixture();
+
+    const result = await recoverInactiveNativeArtifactOnboarding({
+      provider,
+      bootstrap: bootstrapInput(),
+    });
+
+    expect(result.bootstrapResult).toMatchObject({
+      outcome: "not-created",
+      reason: "recovered",
+      resourceState: "absent",
+    });
+    expect(recover).toHaveBeenCalledWith({
+      ...bootstrapInput(),
+      providerId: "future-native",
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/onboard/runtime-provider/native-artifact-onboarding.ts
+++ b/src/lib/onboard/runtime-provider/native-artifact-onboarding.ts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { projectRuntimeProviderComputePlan, type OpenShellComputePlan } from "../compute/plan";
+import type {
+  RuntimeProviderBundle,
+  RuntimeProviderNativeArtifactBootstrapInput,
+  RuntimeProviderNativeArtifactBootstrapResult,
+  RuntimeProviderNativeArtifactBootstrapSurface,
+} from "./contract";
+
+export type InactiveNativeArtifactOnboardingBootstrapInput = Omit<
+  RuntimeProviderNativeArtifactBootstrapInput,
+  "providerId"
+>;
+
+export interface InactiveNativeArtifactOnboardingInput {
+  readonly provider: RuntimeProviderBundle;
+  readonly bootstrap: InactiveNativeArtifactOnboardingBootstrapInput;
+}
+
+export interface InactiveNativeArtifactOnboardingResult {
+  readonly provider: RuntimeProviderBundle;
+  readonly computePlan: OpenShellComputePlan;
+  readonly bootstrapResult: RuntimeProviderNativeArtifactBootstrapResult;
+}
+
+export class InactiveNativeArtifactOnboardingError extends Error {
+  constructor(message: string) {
+    super(`Inactive native-artifact onboarding failed: ${message}`);
+    this.name = "InactiveNativeArtifactOnboardingError";
+  }
+}
+
+function requireNativeArtifactBootstrap(
+  provider: RuntimeProviderBundle,
+): RuntimeProviderNativeArtifactBootstrapSurface {
+  if (
+    !provider.bootstrap.supported ||
+    provider.bootstrap.providerId !== provider.identity.id ||
+    provider.bootstrap.bootstrapKind !== "native-artifact"
+  ) {
+    throw new InactiveNativeArtifactOnboardingError(
+      "the provider does not expose an identity-consistent native-artifact bootstrap contract",
+    );
+  }
+  return provider.bootstrap;
+}
+
+async function execute(
+  input: InactiveNativeArtifactOnboardingInput,
+  operation: "run" | "recover",
+): Promise<InactiveNativeArtifactOnboardingResult> {
+  if (!input.provider.workload.supported) {
+    throw new InactiveNativeArtifactOnboardingError(
+      "the provider does not expose a workload contract",
+    );
+  }
+  if (!input.provider.workload.acceptsReceipt(input.bootstrap.workload)) {
+    throw new InactiveNativeArtifactOnboardingError(
+      "the native artifact does not match the provider workload contract",
+    );
+  }
+  const bootstrap = requireNativeArtifactBootstrap(input.provider);
+  const bootstrapResult = await bootstrap[operation]({
+    ...input.bootstrap,
+    providerId: input.provider.identity.id,
+  });
+  return Object.freeze({
+    provider: input.provider,
+    computePlan: Object.freeze(projectRuntimeProviderComputePlan(input.provider)),
+    bootstrapResult,
+  });
+}
+
+/** Run one qualified native artifact without registering or selecting its provider. */
+export function runInactiveNativeArtifactOnboarding(
+  input: InactiveNativeArtifactOnboardingInput,
+): Promise<InactiveNativeArtifactOnboardingResult> {
+  return execute(input, "run");
+}
+
+/** Reconcile one prior native-artifact attempt through the same qualified provider. */
+export function recoverInactiveNativeArtifactOnboarding(
+  input: InactiveNativeArtifactOnboardingInput,
+): Promise<InactiveNativeArtifactOnboardingResult> {
+  return execute(input, "recover");
+}

--- a/src/lib/onboard/windows-mxc/inactive-onboarding.test.ts
+++ b/src/lib/onboard/windows-mxc/inactive-onboarding.test.ts
@@ -187,7 +187,7 @@ describe("inactive native Windows OpenShell MXC onboarding", () => {
         ...input,
         bootstrap: { ...input.bootstrap, workload } as typeof input.bootstrap,
       }),
-    ).rejects.toThrow(/does not match the attached provider workload contract/u);
+    ).rejects.toThrow(/does not match the provider workload contract/u);
     expect(nativeBoundary.observeFileDigest).toHaveBeenCalledTimes(5);
     expect(operations.verifyAndCreate).not.toHaveBeenCalled();
   });

--- a/src/lib/onboard/windows-mxc/inactive-onboarding.ts
+++ b/src/lib/onboard/windows-mxc/inactive-onboarding.ts
@@ -1,26 +1,25 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { projectRuntimeProviderComputePlan, type OpenShellComputePlan } from "../compute/plan";
+import type { OpenShellComputePlan } from "../compute/plan";
 import type {
   RuntimeProviderBundle,
-  RuntimeProviderNativeArtifactBootstrapInput,
   RuntimeProviderNativeArtifactBootstrapResult,
-  RuntimeProviderNativeArtifactBootstrapSurface,
 } from "../runtime-provider/contract";
 import type { MxcOpenShellAttachmentReceipt } from "../runtime-provider/mxc-openshell-attachment";
+import {
+  recoverInactiveNativeArtifactOnboarding,
+  runInactiveNativeArtifactOnboarding,
+  type InactiveNativeArtifactOnboardingBootstrapInput,
+} from "../runtime-provider/native-artifact-onboarding";
 import {
   attachMxcWindowsExistingInstallation,
   type MxcWindowsExistingInstallationInput,
 } from "./existing-installation";
 import type { WindowsMxcHostFacts } from "./host-qualification";
 
-const PROVIDER_ID = "mxc" as const;
-
-export type MxcWindowsInactiveOnboardingBootstrapInput = Omit<
-  RuntimeProviderNativeArtifactBootstrapInput,
-  "providerId"
->;
+export type MxcWindowsInactiveOnboardingBootstrapInput =
+  InactiveNativeArtifactOnboardingBootstrapInput;
 
 export interface MxcWindowsInactiveOnboardingInput {
   readonly installation: MxcWindowsExistingInstallationInput;
@@ -35,54 +34,25 @@ export interface MxcWindowsInactiveOnboardingResult {
   readonly bootstrapResult: RuntimeProviderNativeArtifactBootstrapResult;
 }
 
-export class MxcWindowsInactiveOnboardingError extends Error {
-  constructor(message: string) {
-    super(`Inactive Windows OpenShell MXC onboarding failed: ${message}`);
-    this.name = "MxcWindowsInactiveOnboardingError";
-  }
-}
-
-function requireNativeArtifactBootstrap(
-  provider: RuntimeProviderBundle,
-): RuntimeProviderNativeArtifactBootstrapSurface {
-  if (
-    !provider.bootstrap.supported ||
-    provider.bootstrap.providerId !== PROVIDER_ID ||
-    provider.bootstrap.bootstrapKind !== "native-artifact"
-  ) {
-    throw new MxcWindowsInactiveOnboardingError(
-      "the attached provider does not expose the accepted native-artifact bootstrap contract",
-    );
-  }
-  return provider.bootstrap;
-}
-
 async function execute(
   input: MxcWindowsInactiveOnboardingInput,
   operation: "run" | "recover",
 ): Promise<MxcWindowsInactiveOnboardingResult> {
   const attachment = await attachMxcWindowsExistingInstallation(input.installation);
-  if (!attachment.provider.workload.supported) {
-    throw new MxcWindowsInactiveOnboardingError(
-      "the attached provider does not expose a workload contract",
-    );
-  }
-  if (!attachment.provider.workload.acceptsReceipt(input.bootstrap.workload)) {
-    throw new MxcWindowsInactiveOnboardingError(
-      "the native artifact does not match the attached provider workload contract",
-    );
-  }
-  const bootstrap = requireNativeArtifactBootstrap(attachment.provider);
-  const bootstrapResult = await bootstrap[operation]({
-    ...input.bootstrap,
-    providerId: PROVIDER_ID,
+  const onboarding = await (
+    operation === "run"
+      ? runInactiveNativeArtifactOnboarding
+      : recoverInactiveNativeArtifactOnboarding
+  )({
+    provider: attachment.provider,
+    bootstrap: input.bootstrap,
   });
   return Object.freeze({
-    provider: attachment.provider,
-    computePlan: Object.freeze(projectRuntimeProviderComputePlan(attachment.provider)),
+    provider: onboarding.provider,
+    computePlan: onboarding.computePlan,
     attachmentReceipt: attachment.attachmentReceipt,
     hostFacts: attachment.hostFacts,
-    bootstrapResult,
+    bootstrapResult: onboarding.bootstrapResult,
   });
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Inactive native-artifact onboarding now dispatches through a provider-neutral owner. The Windows MXC composition supplies its qualified provider and exact workload, while MXC remains absent from production selection, CLI onboarding, and activation.

## Reason

The native-artifact workload and bootstrap checks were owned by the Windows MXC wrapper. Epic #8178 requires central orchestration to remain free of MXC identity branches before native Windows onboarding can consume the inactive provider.

### Related issues

- Part of #8178

## Changes

- Add provider-neutral native-artifact start and recovery dispatch that derives the bootstrap identity from the qualified provider.
- Reject unsupported workloads and provider/bootstrap identity drift before invoking bootstrap operations.
- Make the inactive Windows MXC composition consume the neutral dispatch instead of owning generic bootstrap logic.
- Add focused positive, rejection, identity-drift, and recovery tests using a non-MXC provider identity.

## Verification

- `npx vitest run --project cli src/lib/onboard/runtime-provider/native-artifact-onboarding.test.ts src/lib/onboard/windows-mxc/inactive-onboarding.test.ts src/lib/onboard/runtime-provider/activation.test.ts src/lib/onboard/runtime-provider/current.test.ts` — 29 tests passed.
- `npx vitest run --project integration test/repository/layer-import-boundaries.test.ts test/repository/source-architecture.test.ts` — 42 tests passed.
- `npm run typecheck:cli` — passed.
- `npx tsc -p tsconfig.src.json --noEmit` — passed.
- Normal pre-commit and pre-push hooks — passed against NVIDIA `upstream/main`, including repository checks, growth guardrails, formatting, lint, gitleaks, commitlint, and CLI TypeScript.
- The diff contains no secrets, API keys, or credentials.

## Review notes

- This PR does not accept an OpenShell distribution, install or select MXC, expose public onboarding, mutate production registration, or activate Windows support.
- Workload rejection and provider/bootstrap identity mismatch fail before the provider-owned start or recovery operation.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for inactive native-artifact onboarding and recovery.
  - Added provider-aware execution with validated workload and bootstrap contracts.
  - Added recovery handling that preserves provider identity and returns the resulting compute plan.

- **Bug Fixes**
  - Improved validation for invalid workload contracts and bootstrap identity mismatches.
  - Updated Windows MXC onboarding to use consistent shared validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->