### PR TITLE
feat(onboard): add dormant MXC distribution authority

### DIFF
--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment-test-fixture.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment-test-fixture.ts
@@ -3,8 +3,11 @@
 
 import {
   createMxcOpenShellAttachmentTestAuthority,
+  createMxcOpenShellDistributionAuthority,
+  MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID,
   type MxcOpenShellAttachmentAuthority,
   type MxcOpenShellAttachmentObservation,
+  type MxcOpenShellDistributionAuthority,
 } from "./mxc-openshell-attachment";
 
 export const MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS = {
@@ -46,6 +49,35 @@ export function mxcOpenShellAttachmentFixture(version = "0.0.21"): {
       gatewayPath: "C:\\OpenShell\\bin\\openshell-gateway.exe",
       wxcExecPath: "C:\\mxc-kit\\bin\\wxc-exec.exe",
       gatewayConfigPath: "C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml",
+    },
+  };
+}
+
+export function mxcOpenShellV0_0_24QualificationFixture(): {
+  readonly authority: MxcOpenShellDistributionAuthority;
+  readonly observation: MxcOpenShellAttachmentObservation;
+} {
+  const source = mxcOpenShellAttachmentFixture("0.0.24").observation;
+  return {
+    authority: createMxcOpenShellDistributionAuthority(
+      MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID,
+    ),
+    observation: {
+      ...source,
+      distribution: {
+        version: "0.0.24",
+        revision: "e1b48323e4efcb560900508bdcd76d2b5d216678",
+        sha256: "296ba2677f8f692b1c3f14b4fae6bb2a75d52f94c071ec2ebdf676405a80613d",
+      },
+      components: {
+        cliSha256: "23d00a88daa5f2aa6151d9112a6845e843ca1e08cbaf55f8eaa337b72dd9155a",
+        gatewaySha256: "62b3e231f5d40c5d178d08172ddb65536f124bdb8c7c04d90fb9dca50a5ac137",
+        wxcExecSha256: "6049c64723af1173c3739dc6cd6b2f33f6c021bb2832c4216233cba7f71aee9a",
+      },
+      gateway: {
+        ...source.gateway,
+        configSha256: "1c86a32a52d068677b5140975c6b870d5ed46dc553500ebb790b58e207ac7290",
+      },
     },
   };
 }

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment-test-fixture.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment-test-fixture.ts
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  createMxcOpenShellAttachmentTestAuthority,
-  createMxcOpenShellDistributionTestAuthority,
+  createMxcOpenShellDistributionAuthority,
   MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
+  MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE,
+  MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID,
+  resolveMxcOpenShellDistributionAuthority,
   type MxcOpenShellAttachmentAuthority,
   type MxcOpenShellAttachmentObservation,
   type MxcOpenShellDistributionAuthority,
@@ -12,41 +14,41 @@ import {
 import type { MxcOpenShellAttachmentObservationRequest } from "./mxc-openshell-observer";
 
 export const MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS = {
-  distribution: "1".repeat(64),
-  cli: "2".repeat(64),
-  gateway: "3".repeat(64),
-  wxcExec: "4".repeat(64),
-  config: "5".repeat(64),
+  distribution:
+    MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE.expectation.distribution.sha256,
+  cli: MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE.expectation.components.cliSha256,
+  gateway:
+    MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE.expectation.components.gatewaySha256,
+  wxcExec:
+    MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE.expectation.components.wxcExecSha256,
+  config:
+    MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE.expectation.gateway.configSha256,
 } as const;
 
 export const MXC_OPENSHELL_ATTACHMENT_TEST_DISTRIBUTION_ARTIFACT_PATH =
-  "C:\\OpenShell\\packages\\openshell-test.zip";
+  "C:\\OpenShell\\packages\\openshell-mxc-demo-v0.0.24.zip";
 
-export function mxcOpenShellAttachmentFixture(version = "0.0.21"): {
+export function mxcOpenShellAttachmentFixture(
+  version = MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE.expectation.distribution
+    .version,
+): {
   readonly authority: MxcOpenShellAttachmentAuthority;
   readonly observation: MxcOpenShellAttachmentObservation;
 } {
+  const distributionAuthority = createMxcOpenShellDistributionAuthority(
+    MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID,
+  );
   const accepted = {
+    ...structuredClone(MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE.expectation),
     distribution: {
+      ...MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE.expectation.distribution,
       version,
-      revision: "a".repeat(40),
-      sha256: MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS.distribution,
-    },
-    components: {
-      cliSha256: MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS.cli,
-      gatewaySha256: MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS.gateway,
-      wxcExecSha256: MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS.wxcExec,
-    },
-    gateway: {
-      configSha256: MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS.config,
-      driver: "mxc" as const,
-      backend: "process_container" as const,
     },
   };
   return {
-    authority: createMxcOpenShellAttachmentTestAuthority(version),
+    authority: resolveMxcOpenShellDistributionAuthority(distributionAuthority),
     observation: {
-      ...structuredClone(accepted),
+      ...accepted,
       distributionRoot: "C:\\OpenShell",
       mxcRoot: "C:\\mxc-kit",
       cliPath: "C:\\OpenShell\\bin\\openshell.exe",
@@ -57,13 +59,18 @@ export function mxcOpenShellAttachmentFixture(version = "0.0.21"): {
   };
 }
 
-export function mxcOpenShellDistributionTestFixture(version = "0.0.21"): {
+export function mxcOpenShellDistributionTestFixture(
+  version = MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE.expectation.distribution
+    .version,
+): {
   readonly authority: MxcOpenShellDistributionAuthority;
   readonly observation: MxcOpenShellAttachmentObservation;
 } {
   const source = mxcOpenShellAttachmentFixture(version).observation;
   return {
-    authority: createMxcOpenShellDistributionTestAuthority(version),
+    authority: createMxcOpenShellDistributionAuthority(
+      MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID,
+    ),
     observation: source,
   };
 }

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment-test-fixture.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment-test-fixture.ts
@@ -3,12 +3,13 @@
 
 import {
   createMxcOpenShellAttachmentTestAuthority,
-  createMxcOpenShellDistributionAuthority,
-  MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID,
+  createMxcOpenShellDistributionTestAuthority,
+  MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
   type MxcOpenShellAttachmentAuthority,
   type MxcOpenShellAttachmentObservation,
   type MxcOpenShellDistributionAuthority,
 } from "./mxc-openshell-attachment";
+import type { MxcOpenShellAttachmentObservationRequest } from "./mxc-openshell-observer";
 
 export const MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS = {
   distribution: "1".repeat(64),
@@ -17,6 +18,9 @@ export const MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS = {
   wxcExec: "4".repeat(64),
   config: "5".repeat(64),
 } as const;
+
+export const MXC_OPENSHELL_ATTACHMENT_TEST_DISTRIBUTION_ARTIFACT_PATH =
+  "C:\\OpenShell\\packages\\openshell-test.zip";
 
 export function mxcOpenShellAttachmentFixture(version = "0.0.21"): {
   readonly authority: MxcOpenShellAttachmentAuthority;
@@ -53,31 +57,52 @@ export function mxcOpenShellAttachmentFixture(version = "0.0.21"): {
   };
 }
 
-export function mxcOpenShellV0_0_24QualificationFixture(): {
+export function mxcOpenShellDistributionTestFixture(version = "0.0.21"): {
   readonly authority: MxcOpenShellDistributionAuthority;
   readonly observation: MxcOpenShellAttachmentObservation;
 } {
-  const source = mxcOpenShellAttachmentFixture("0.0.24").observation;
+  const source = mxcOpenShellAttachmentFixture(version).observation;
   return {
-    authority: createMxcOpenShellDistributionAuthority(
-      MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID,
-    ),
-    observation: {
-      ...source,
-      distribution: {
-        version: "0.0.24",
-        revision: "e1b48323e4efcb560900508bdcd76d2b5d216678",
-        sha256: "296ba2677f8f692b1c3f14b4fae6bb2a75d52f94c071ec2ebdf676405a80613d",
-      },
-      components: {
-        cliSha256: "23d00a88daa5f2aa6151d9112a6845e843ca1e08cbaf55f8eaa337b72dd9155a",
-        gatewaySha256: "62b3e231f5d40c5d178d08172ddb65536f124bdb8c7c04d90fb9dca50a5ac137",
-        wxcExecSha256: "6049c64723af1173c3739dc6cd6b2f33f6c021bb2832c4216233cba7f71aee9a",
-      },
-      gateway: {
-        ...source.gateway,
-        configSha256: "1c86a32a52d068677b5140975c6b870d5ed46dc553500ebb790b58e207ac7290",
-      },
+    authority: createMxcOpenShellDistributionTestAuthority(version),
+    observation: source,
+  };
+}
+
+export function mxcOpenShellAttachmentObservationRequest(
+  observed = mxcOpenShellDistributionTestFixture().observation,
+): MxcOpenShellAttachmentObservationRequest {
+  return {
+    contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
+    providerId: "mxc",
+    mode: "attach-existing",
+    observedDistribution: {
+      version: observed.distribution.version,
+      revision: observed.distribution.revision,
+    },
+    observedGateway: {
+      driver: "mxc",
+      backend: "process_container",
+    },
+    installation: {
+      distributionArtifactPath: MXC_OPENSHELL_ATTACHMENT_TEST_DISTRIBUTION_ARTIFACT_PATH,
+      distributionRoot: observed.distributionRoot,
+      mxcRoot: observed.mxcRoot,
+      cliPath: observed.cliPath,
+      gatewayPath: observed.gatewayPath,
+      wxcExecPath: observed.wxcExecPath,
+      gatewayConfigPath: observed.gatewayConfigPath,
     },
   };
+}
+
+export function mxcOpenShellAttachmentDigestMap(
+  observed = mxcOpenShellDistributionTestFixture().observation,
+): Map<string, string> {
+  return new Map([
+    [MXC_OPENSHELL_ATTACHMENT_TEST_DISTRIBUTION_ARTIFACT_PATH, observed.distribution.sha256],
+    [observed.cliPath, observed.components.cliSha256],
+    [observed.gatewayPath, observed.components.gatewaySha256],
+    [observed.wxcExecPath, observed.components.wxcExecSha256],
+    [observed.gatewayConfigPath, observed.gateway.configSha256],
+  ]);
 }

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
@@ -5,11 +5,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
+  MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE,
+  MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID,
   MxcOpenShellAttachmentError,
   createMxcOpenShellDistributionAuthority,
   qualifyMxcOpenShellAttachment,
   resolveMxcOpenShellDistributionAuthority,
   type MxcOpenShellAttachmentObservation,
+  type MxcOpenShellDistributionProfileId,
 } from "./mxc-openshell-attachment";
 import {
   MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS as DIGESTS,
@@ -18,7 +21,7 @@ import {
 } from "./mxc-openshell-attachment-test-fixture";
 
 describe("inactive OpenShell MXC installation attachment", () => {
-  it("binds one accepted distribution and gateway configuration without installing it (#8178)", () => {
+  it("binds one qualified development checkpoint without installing it (#10583)", () => {
     const { authority, observation } = mxcOpenShellAttachmentFixture();
     const receipt = qualifyMxcOpenShellAttachment(authority, observation);
 
@@ -27,7 +30,7 @@ describe("inactive OpenShell MXC installation attachment", () => {
       providerId: "mxc",
       mode: "attach-existing",
       acceptance: "qualification",
-      distributionProfileId: "test-fixture",
+      distributionProfileId: MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID,
       acceptedIdentitySha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
     });
     expect(Object.isFrozen(authority)).toBe(true);
@@ -36,11 +39,13 @@ describe("inactive OpenShell MXC installation attachment", () => {
       providerId: "mxc",
       mode: "attach-existing",
       acceptance: "qualification",
-      distributionProfileId: "test-fixture",
+      distributionProfileId: MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID,
       authoritySha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
       distribution: {
-        version: "0.0.21",
-        revision: "a".repeat(40),
+        version: "0.0.24",
+        revision:
+          MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE.expectation.distribution
+            .revision,
         sha256: DIGESTS.distribution,
         root: "C:\\OpenShell",
       },
@@ -70,10 +75,27 @@ describe("inactive OpenShell MXC installation attachment", () => {
     expect(Object.isFrozen(receipt.components.gateway)).toBe(true);
   });
 
-  it("keeps distribution authority unavailable before provider acceptance (#10583)", () => {
-    expect(() => createMxcOpenShellDistributionAuthority()).toThrow(
-      /accepted distribution authority is unavailable/u,
+  it("creates qualification authority only from the provider-owned checkpoint (#10583)", () => {
+    const authority = createMxcOpenShellDistributionAuthority(
+      MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID,
     );
+
+    expect(authority).toMatchObject({
+      acceptance: "qualification",
+      profileId: MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID,
+    });
+    expect(resolveMxcOpenShellDistributionAuthority(authority)).toMatchObject({
+      acceptance: "qualification",
+      distributionProfileId: MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID,
+    });
+  });
+
+  it("rejects an unknown distribution profile before observation (#10583)", () => {
+    expect(() =>
+      createMxcOpenShellDistributionAuthority(
+        "openshell-observed-locally" as MxcOpenShellDistributionProfileId,
+      ),
+    ).toThrow(/distribution profile is not provider-owned/u);
   });
 
   it("rejects caller-constructed distribution authority before observation (#10583)", () => {
@@ -205,12 +227,12 @@ describe("inactive OpenShell MXC installation attachment", () => {
   });
 
   it.each(["0.0.21-rc.1+build.2", "1.0.0-alpha.0", "1.0.0+build.2"])(
-    "accepts complete SemVer identity %s (#8178)",
+    "parses complete SemVer identity %s before rejecting version drift (#8178)",
     (version) => {
       const { authority, observation } = mxcOpenShellAttachmentFixture(version);
 
-      expect(qualifyMxcOpenShellAttachment(authority, observation).distribution.version).toBe(
-        version,
+      expect(() => qualifyMxcOpenShellAttachment(authority, observation)).toThrow(
+        /observed distribution identity does not match/u,
       );
     },
   );
@@ -218,7 +240,10 @@ describe("inactive OpenShell MXC installation attachment", () => {
   it.each(["01.0.0", "1.01.0", "1.0.01", "1.0.0-01", "1.0.0-", "1.0.0+"])(
     "rejects noncanonical SemVer identity %s (#8178)",
     (version) => {
-      expect(() => mxcOpenShellAttachmentFixture(version)).toThrow(/version is invalid/u);
+      const { authority, observation } = mxcOpenShellAttachmentFixture(version);
+      expect(() => qualifyMxcOpenShellAttachment(authority, observation)).toThrow(
+        /version is invalid/u,
+      );
     },
   );
 });

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
@@ -5,13 +5,19 @@ import { describe, expect, it } from "vitest";
 
 import {
   MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
+  MXC_OPENSHELL_DISTRIBUTION_AUTHORITY_CONTRACT_VERSION,
+  MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID,
   MxcOpenShellAttachmentError,
+  createMxcOpenShellDistributionAuthority,
   qualifyMxcOpenShellAttachment,
+  resolveMxcOpenShellDistributionAuthority,
   type MxcOpenShellAttachmentObservation,
+  type MxcOpenShellDistributionProfileId,
 } from "./mxc-openshell-attachment";
 import {
   MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS as DIGESTS,
   mxcOpenShellAttachmentFixture,
+  mxcOpenShellV0_0_24QualificationFixture,
 } from "./mxc-openshell-attachment-test-fixture";
 
 describe("inactive OpenShell MXC installation attachment", () => {
@@ -23,6 +29,8 @@ describe("inactive OpenShell MXC installation attachment", () => {
       contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
       providerId: "mxc",
       mode: "attach-existing",
+      acceptance: "qualification",
+      distributionProfileId: "test-fixture",
       acceptedIdentitySha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
     });
     expect(Object.isFrozen(authority)).toBe(true);
@@ -30,6 +38,8 @@ describe("inactive OpenShell MXC installation attachment", () => {
       contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
       providerId: "mxc",
       mode: "attach-existing",
+      acceptance: "qualification",
+      distributionProfileId: "test-fixture",
       authoritySha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
       distribution: {
         version: "0.0.21",
@@ -61,6 +71,47 @@ describe("inactive OpenShell MXC installation attachment", () => {
     });
     expect(Object.isFrozen(receipt)).toBe(true);
     expect(Object.isFrozen(receipt.components.gateway)).toBe(true);
+  });
+
+  it("resolves the pinned v0.0.24 profile as qualification-only provider authority (#10583)", () => {
+    const { authority, observation } = mxcOpenShellV0_0_24QualificationFixture();
+
+    expect(authority).toEqual({
+      contractVersion: MXC_OPENSHELL_DISTRIBUTION_AUTHORITY_CONTRACT_VERSION,
+      providerId: "mxc",
+      profileId: MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID,
+      acceptance: "qualification",
+      acceptedIdentitySha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+    });
+    expect(Object.isFrozen(authority)).toBe(true);
+    expect(
+      qualifyMxcOpenShellAttachment(
+        resolveMxcOpenShellDistributionAuthority(authority),
+        observation,
+      ),
+    ).toMatchObject({
+      acceptance: "qualification",
+      distributionProfileId: MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID,
+      distribution: {
+        version: "0.0.24",
+        revision: "e1b48323e4efcb560900508bdcd76d2b5d216678",
+      },
+    });
+  });
+
+  it("rejects unknown and caller-constructed distribution authority before observation (#10583)", () => {
+    expect(() =>
+      createMxcOpenShellDistributionAuthority(
+        "openshell-observed-locally" as MxcOpenShellDistributionProfileId,
+      ),
+    ).toThrow(/distribution profile is not provider-owned/u);
+
+    const authority = createMxcOpenShellDistributionAuthority(
+      MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID,
+    );
+    expect(() => resolveMxcOpenShellDistributionAuthority({ ...authority })).toThrow(
+      /distribution authority is not provider-owned/u,
+    );
   });
 
   it.each([

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.test.ts
@@ -5,19 +5,16 @@ import { describe, expect, it } from "vitest";
 
 import {
   MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
-  MXC_OPENSHELL_DISTRIBUTION_AUTHORITY_CONTRACT_VERSION,
-  MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID,
   MxcOpenShellAttachmentError,
   createMxcOpenShellDistributionAuthority,
   qualifyMxcOpenShellAttachment,
   resolveMxcOpenShellDistributionAuthority,
   type MxcOpenShellAttachmentObservation,
-  type MxcOpenShellDistributionProfileId,
 } from "./mxc-openshell-attachment";
 import {
   MXC_OPENSHELL_ATTACHMENT_TEST_DIGESTS as DIGESTS,
   mxcOpenShellAttachmentFixture,
-  mxcOpenShellV0_0_24QualificationFixture,
+  mxcOpenShellDistributionTestFixture,
 } from "./mxc-openshell-attachment-test-fixture";
 
 describe("inactive OpenShell MXC installation attachment", () => {
@@ -73,42 +70,14 @@ describe("inactive OpenShell MXC installation attachment", () => {
     expect(Object.isFrozen(receipt.components.gateway)).toBe(true);
   });
 
-  it("resolves the pinned v0.0.24 profile as qualification-only provider authority (#10583)", () => {
-    const { authority, observation } = mxcOpenShellV0_0_24QualificationFixture();
-
-    expect(authority).toEqual({
-      contractVersion: MXC_OPENSHELL_DISTRIBUTION_AUTHORITY_CONTRACT_VERSION,
-      providerId: "mxc",
-      profileId: MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID,
-      acceptance: "qualification",
-      acceptedIdentitySha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
-    });
-    expect(Object.isFrozen(authority)).toBe(true);
-    expect(
-      qualifyMxcOpenShellAttachment(
-        resolveMxcOpenShellDistributionAuthority(authority),
-        observation,
-      ),
-    ).toMatchObject({
-      acceptance: "qualification",
-      distributionProfileId: MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID,
-      distribution: {
-        version: "0.0.24",
-        revision: "e1b48323e4efcb560900508bdcd76d2b5d216678",
-      },
-    });
+  it("keeps distribution authority unavailable before provider acceptance (#10583)", () => {
+    expect(() => createMxcOpenShellDistributionAuthority()).toThrow(
+      /accepted distribution authority is unavailable/u,
+    );
   });
 
-  it("rejects unknown and caller-constructed distribution authority before observation (#10583)", () => {
-    expect(() =>
-      createMxcOpenShellDistributionAuthority(
-        "openshell-observed-locally" as MxcOpenShellDistributionProfileId,
-      ),
-    ).toThrow(/distribution profile is not provider-owned/u);
-
-    const authority = createMxcOpenShellDistributionAuthority(
-      MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID,
-    );
+  it("rejects caller-constructed distribution authority before observation (#10583)", () => {
+    const authority = mxcOpenShellDistributionTestFixture().authority;
     expect(() => resolveMxcOpenShellDistributionAuthority({ ...authority })).toThrow(
       /distribution authority is not provider-owned/u,
     );

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
@@ -7,7 +7,10 @@ import path from "node:path";
 
 import { cloneAndDeepFreeze } from "../../core/immutable";
 
-export const MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION = 2 as const;
+export const MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION = 3 as const;
+export const MXC_OPENSHELL_DISTRIBUTION_AUTHORITY_CONTRACT_VERSION = 1 as const;
+export const MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID =
+  "openshell-v0-0-24-qualification" as const;
 
 const PROVIDER_ID = "mxc";
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
@@ -42,6 +45,11 @@ interface MxcOpenShellAttachmentExpectation {
   readonly gateway: ExactGatewayIdentity;
 }
 
+export type MxcOpenShellDistributionAcceptance = "qualification" | "accepted";
+
+export type MxcOpenShellDistributionProfileId =
+  typeof MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID;
+
 export interface MxcOpenShellAttachmentObservation extends MxcOpenShellAttachmentExpectation {
   readonly distributionRoot: string;
   readonly mxcRoot: string;
@@ -55,6 +63,16 @@ export interface MxcOpenShellAttachmentAuthority {
   readonly contractVersion: typeof MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION;
   readonly providerId: "mxc";
   readonly mode: "attach-existing";
+  readonly acceptance: MxcOpenShellDistributionAcceptance;
+  readonly distributionProfileId: MxcOpenShellDistributionProfileId | "test-fixture";
+  readonly acceptedIdentitySha256: string;
+}
+
+export interface MxcOpenShellDistributionAuthority {
+  readonly contractVersion: typeof MXC_OPENSHELL_DISTRIBUTION_AUTHORITY_CONTRACT_VERSION;
+  readonly providerId: "mxc";
+  readonly profileId: MxcOpenShellDistributionProfileId;
+  readonly acceptance: MxcOpenShellDistributionAcceptance;
   readonly acceptedIdentitySha256: string;
 }
 
@@ -62,6 +80,8 @@ export interface MxcOpenShellAttachmentReceipt {
   readonly contractVersion: typeof MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION;
   readonly providerId: "mxc";
   readonly mode: "attach-existing";
+  readonly acceptance: MxcOpenShellDistributionAcceptance;
+  readonly distributionProfileId: MxcOpenShellDistributionProfileId | "test-fixture";
   readonly authoritySha256: string;
   readonly distribution: ExactDistributionIdentity & { readonly root: string };
   readonly components: {
@@ -81,8 +101,43 @@ export class MxcOpenShellAttachmentError extends Error {
 
 const ACCEPTED_IDENTITIES = new WeakMap<
   MxcOpenShellAttachmentAuthority,
-  MxcOpenShellAttachmentExpectation
+  Readonly<{
+    acceptance: MxcOpenShellDistributionAcceptance;
+    distributionProfileId: MxcOpenShellAttachmentAuthority["distributionProfileId"];
+    expectation: MxcOpenShellAttachmentExpectation;
+  }>
 >();
+
+const DISTRIBUTION_AUTHORITIES = new WeakMap<
+  MxcOpenShellDistributionAuthority,
+  MxcOpenShellAttachmentAuthority
+>();
+
+/** Exact credential-free v0.0.24 qualification inputs; this is not product acceptance. */
+const V0_0_24_QUALIFICATION_EXPECTATION = {
+  distribution: {
+    version: "0.0.24",
+    revision: "e1b48323e4efcb560900508bdcd76d2b5d216678",
+    sha256: "296ba2677f8f692b1c3f14b4fae6bb2a75d52f94c071ec2ebdf676405a80613d",
+  },
+  components: {
+    cliSha256: "23d00a88daa5f2aa6151d9112a6845e843ca1e08cbaf55f8eaa337b72dd9155a",
+    gatewaySha256: "62b3e231f5d40c5d178d08172ddb65536f124bdb8c7c04d90fb9dca50a5ac137",
+    wxcExecSha256: "6049c64723af1173c3739dc6cd6b2f33f6c021bb2832c4216233cba7f71aee9a",
+  },
+  gateway: {
+    configSha256: "1c86a32a52d068677b5140975c6b870d5ed46dc553500ebb790b58e207ac7290",
+    driver: "mxc",
+    backend: "process_container",
+  },
+} as const;
+
+const DISTRIBUTION_PROFILES = {
+  [MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID]: {
+    acceptance: "qualification",
+    expectation: V0_0_24_QUALIFICATION_EXPECTATION,
+  },
+} as const;
 
 function record(value: unknown, label: string): Record<string, unknown> {
   if (
@@ -267,6 +322,8 @@ function sameIdentity(
  */
 function createMxcOpenShellAttachmentAuthority(
   expectation: unknown,
+  acceptance: MxcOpenShellDistributionAcceptance,
+  distributionProfileId: MxcOpenShellAttachmentAuthority["distributionProfileId"],
 ): MxcOpenShellAttachmentAuthority {
   const accepted = cloneAndDeepFreeze(parseExpectation(expectation, "accepted attachment"));
   const acceptedIdentitySha256 = createHash("sha256")
@@ -275,6 +332,8 @@ function createMxcOpenShellAttachmentAuthority(
         contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
         providerId: PROVIDER_ID,
         mode: "attach-existing",
+        acceptance,
+        distributionProfileId,
         accepted,
       }),
       "utf8",
@@ -284,10 +343,67 @@ function createMxcOpenShellAttachmentAuthority(
     contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
     providerId: PROVIDER_ID,
     mode: "attach-existing" as const,
+    acceptance,
+    distributionProfileId,
     acceptedIdentitySha256,
   });
-  ACCEPTED_IDENTITIES.set(authority, accepted);
+  ACCEPTED_IDENTITIES.set(
+    authority,
+    cloneAndDeepFreeze({ acceptance, distributionProfileId, expectation: accepted }),
+  );
   return authority;
+}
+
+function createDistributionAuthority(
+  profileId: MxcOpenShellDistributionAuthority["profileId"],
+  acceptance: MxcOpenShellDistributionAcceptance,
+  expectation: unknown,
+): MxcOpenShellDistributionAuthority {
+  const attachmentAuthority = createMxcOpenShellAttachmentAuthority(
+    expectation,
+    acceptance,
+    profileId,
+  );
+  const authority = Object.freeze({
+    contractVersion: MXC_OPENSHELL_DISTRIBUTION_AUTHORITY_CONTRACT_VERSION,
+    providerId: PROVIDER_ID,
+    profileId,
+    acceptance,
+    acceptedIdentitySha256: attachmentAuthority.acceptedIdentitySha256,
+  });
+  DISTRIBUTION_AUTHORITIES.set(authority, attachmentAuthority);
+  return authority;
+}
+
+/**
+ * Resolve one provider-owned dormant distribution profile.
+ *
+ * Profile identifiers select immutable records compiled into NemoClaw. Callers cannot supply or
+ * derive accepted hashes from the installation being observed. The current v0.0.24 record is a
+ * qualification fixture only and does not approve installation, selection, activation, or support.
+ */
+export function createMxcOpenShellDistributionAuthority(
+  profileId: MxcOpenShellDistributionProfileId,
+): MxcOpenShellDistributionAuthority {
+  if (!Object.hasOwn(DISTRIBUTION_PROFILES, profileId)) {
+    throw new MxcOpenShellAttachmentError("distribution profile is not provider-owned");
+  }
+  const profile = DISTRIBUTION_PROFILES[profileId];
+  return createDistributionAuthority(profileId, profile.acceptance, profile.expectation);
+}
+
+/** Resolve the opaque attachment capability carried by a provider-owned distribution authority. */
+export function resolveMxcOpenShellDistributionAuthority(
+  authority: MxcOpenShellDistributionAuthority,
+): MxcOpenShellAttachmentAuthority {
+  if (typeof authority !== "object" || authority === null) {
+    throw new MxcOpenShellAttachmentError("distribution authority is not provider-owned");
+  }
+  const attachmentAuthority = DISTRIBUTION_AUTHORITIES.get(authority);
+  if (!attachmentAuthority) {
+    throw new MxcOpenShellAttachmentError("distribution authority is not provider-owned");
+  }
+  return attachmentAuthority;
 }
 
 /**
@@ -299,26 +415,34 @@ function createMxcOpenShellAttachmentAuthority(
 export function createMxcOpenShellAttachmentTestAuthority(
   version: string,
 ): MxcOpenShellAttachmentAuthority {
-  return createMxcOpenShellAttachmentAuthority({
-    distribution: {
-      version,
-      revision: "a".repeat(40),
-      sha256: "1".repeat(64),
+  return createMxcOpenShellAttachmentAuthority(
+    {
+      distribution: {
+        version,
+        revision: "a".repeat(40),
+        sha256: "1".repeat(64),
+      },
+      components: {
+        cliSha256: "2".repeat(64),
+        gatewaySha256: "3".repeat(64),
+        wxcExecSha256: "4".repeat(64),
+      },
+      gateway: {
+        configSha256: "5".repeat(64),
+        driver: "mxc",
+        backend: "process_container",
+      },
     },
-    components: {
-      cliSha256: "2".repeat(64),
-      gatewaySha256: "3".repeat(64),
-      wxcExecSha256: "4".repeat(64),
-    },
-    gateway: {
-      configSha256: "5".repeat(64),
-      driver: "mxc",
-      backend: "process_container",
-    },
-  });
+    "qualification",
+    "test-fixture",
+  );
 }
 
-function acceptedIdentity(authority: unknown): MxcOpenShellAttachmentExpectation {
+function acceptedIdentity(authority: unknown): Readonly<{
+  acceptance: MxcOpenShellDistributionAcceptance;
+  distributionProfileId: MxcOpenShellAttachmentAuthority["distributionProfileId"];
+  expectation: MxcOpenShellAttachmentExpectation;
+}> {
   if (typeof authority !== "object" || authority === null) {
     throw new MxcOpenShellAttachmentError("accepted identity authority is not provider-owned");
   }
@@ -340,9 +464,9 @@ export function qualifyMxcOpenShellAttachment(
   authority: MxcOpenShellAttachmentAuthority,
   observation: unknown,
 ): MxcOpenShellAttachmentReceipt {
-  const expected = acceptedIdentity(authority);
+  const accepted = acceptedIdentity(authority);
   const observed = parseObservation(observation);
-  if (!sameIdentity(expected, observed)) {
+  if (!sameIdentity(accepted.expectation, observed)) {
     throw new MxcOpenShellAttachmentError(
       "observed distribution identity does not match the accepted identity",
     );
@@ -351,6 +475,8 @@ export function qualifyMxcOpenShellAttachment(
     contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
     providerId: PROVIDER_ID,
     mode: "attach-existing" as const,
+    acceptance: accepted.acceptance,
+    distributionProfileId: accepted.distributionProfileId,
     distribution: { ...observed.distribution, root: observed.distributionRoot },
     components: {
       cli: { path: observed.cliPath, sha256: observed.components.cliSha256 },

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
@@ -9,6 +9,8 @@ import { cloneAndDeepFreeze } from "../../core/immutable";
 
 export const MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION = 3 as const;
 export const MXC_OPENSHELL_DISTRIBUTION_AUTHORITY_CONTRACT_VERSION = 1 as const;
+export const MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID =
+  "openshell-v0-0-24-mxc-v0-7-0-rc1-qualification" as const;
 
 const PROVIDER_ID = "mxc";
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
@@ -45,7 +47,8 @@ interface MxcOpenShellAttachmentExpectation {
 
 export type MxcOpenShellDistributionAcceptance = "qualification" | "accepted";
 
-export type MxcOpenShellDistributionProfileId = string;
+export type MxcOpenShellDistributionProfileId =
+  typeof MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID;
 
 export interface MxcOpenShellAttachmentObservation extends MxcOpenShellAttachmentExpectation {
   readonly distributionRoot: string;
@@ -61,7 +64,7 @@ export interface MxcOpenShellAttachmentAuthority {
   readonly providerId: "mxc";
   readonly mode: "attach-existing";
   readonly acceptance: MxcOpenShellDistributionAcceptance;
-  readonly distributionProfileId: MxcOpenShellDistributionProfileId | "test-fixture";
+  readonly distributionProfileId: MxcOpenShellDistributionProfileId;
   readonly acceptedIdentitySha256: string;
 }
 
@@ -78,7 +81,7 @@ export interface MxcOpenShellAttachmentReceipt {
   readonly providerId: "mxc";
   readonly mode: "attach-existing";
   readonly acceptance: MxcOpenShellDistributionAcceptance;
-  readonly distributionProfileId: MxcOpenShellDistributionProfileId | "test-fixture";
+  readonly distributionProfileId: MxcOpenShellDistributionProfileId;
   readonly authoritySha256: string;
   readonly distribution: ExactDistributionIdentity & { readonly root: string };
   readonly components: {
@@ -109,6 +112,39 @@ const DISTRIBUTION_AUTHORITIES = new WeakMap<
   MxcOpenShellDistributionAuthority,
   MxcOpenShellAttachmentAuthority
 >();
+
+/** Immutable development checkpoint supplied by the OpenShell/MXC team. */
+export const MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE = cloneAndDeepFreeze({
+  profileId: MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID,
+  acceptance: "qualification" as const,
+  compatibility: {
+    nativeArchitecture: "x64" as const,
+    backend: "process_container" as const,
+    mxcVersion: "0.7.0-rc1",
+  },
+  expectation: {
+    distribution: {
+      version: "0.0.24",
+      revision: "e1b48323e4efcb560900508bdcd76d2b5d216678",
+      sha256: "296ba2677f8f692b1c3f14b4fae6bb2a75d52f94c071ec2ebdf676405a80613d",
+    },
+    components: {
+      cliSha256: "23d00a88daa5f2aa6151d9112a6845e843ca1e08cbaf55f8eaa337b72dd9155a",
+      gatewaySha256: "62b3e231f5d40c5d178d08172ddb65536f124bdb8c7c04d90fb9dca50a5ac137",
+      wxcExecSha256: "6049c64723af1173c3739dc6cd6b2f33f6c021bb2832c4216233cba7f71aee9a",
+    },
+    gateway: {
+      configSha256: "1c86a32a52d068677b5140975c6b870d5ed46dc553500ebb790b58e207ac7290",
+      driver: "mxc" as const,
+      backend: "process_container" as const,
+    },
+  },
+});
+
+const DISTRIBUTION_PROFILES = {
+  [MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID]:
+    MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE,
+} as const;
 
 function record(value: unknown, label: string): Record<string, unknown> {
   if (
@@ -347,13 +383,19 @@ function createDistributionAuthority(
 }
 
 /**
- * Create authority only after OpenShell publishes an accepted immutable distribution record.
+ * Create qualification authority from one provider-owned immutable development checkpoint.
  *
- * No accepted Windows distribution is currently registered. Prototype measurements and host
- * observations therefore fail closed instead of becoming provider authority.
+ * Stable-release acceptance remains a separate record and decision. Host observations cannot add
+ * or replace a record in this catalogue.
  */
-export function createMxcOpenShellDistributionAuthority(): MxcOpenShellDistributionAuthority {
-  throw new MxcOpenShellAttachmentError("accepted distribution authority is unavailable");
+export function createMxcOpenShellDistributionAuthority(
+  profileId: MxcOpenShellDistributionProfileId,
+): MxcOpenShellDistributionAuthority {
+  if (!Object.hasOwn(DISTRIBUTION_PROFILES, profileId)) {
+    throw new MxcOpenShellAttachmentError("distribution profile is not provider-owned");
+  }
+  const profile = DISTRIBUTION_PROFILES[profileId];
+  return createDistributionAuthority(profile.profileId, profile.acceptance, profile.expectation);
 }
 
 /** Resolve the opaque attachment capability carried by a provider-owned distribution authority. */
@@ -368,49 +410,6 @@ export function resolveMxcOpenShellDistributionAuthority(
     throw new MxcOpenShellAttachmentError("distribution authority is not provider-owned");
   }
   return attachmentAuthority;
-}
-
-/**
- * Create the fixed, non-production authority used by attachment contract tests.
- *
- * The caller may vary only the SemVer value under test. Component identities stay fixed so this
- * helper cannot turn caller-observed digests into accepted provider authority.
- */
-export function createMxcOpenShellAttachmentTestAuthority(
-  version: string,
-): MxcOpenShellAttachmentAuthority {
-  return createMxcOpenShellAttachmentAuthority(
-    testExpectation(version),
-    "qualification",
-    "test-fixture",
-  );
-}
-
-/** Create a fixed synthetic distribution authority for deterministic tests only. */
-export function createMxcOpenShellDistributionTestAuthority(
-  version: string,
-): MxcOpenShellDistributionAuthority {
-  return createDistributionAuthority("test-fixture", "qualification", testExpectation(version));
-}
-
-function testExpectation(version: string): MxcOpenShellAttachmentExpectation {
-  return {
-    distribution: {
-      version,
-      revision: "a".repeat(40),
-      sha256: "1".repeat(64),
-    },
-    components: {
-      cliSha256: "2".repeat(64),
-      gatewaySha256: "3".repeat(64),
-      wxcExecSha256: "4".repeat(64),
-    },
-    gateway: {
-      configSha256: "5".repeat(64),
-      driver: "mxc",
-      backend: "process_container",
-    },
-  };
 }
 
 function acceptedIdentity(authority: unknown): Readonly<{

--- a/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-attachment.ts
@@ -9,8 +9,6 @@ import { cloneAndDeepFreeze } from "../../core/immutable";
 
 export const MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION = 3 as const;
 export const MXC_OPENSHELL_DISTRIBUTION_AUTHORITY_CONTRACT_VERSION = 1 as const;
-export const MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID =
-  "openshell-v0-0-24-qualification" as const;
 
 const PROVIDER_ID = "mxc";
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
@@ -47,8 +45,7 @@ interface MxcOpenShellAttachmentExpectation {
 
 export type MxcOpenShellDistributionAcceptance = "qualification" | "accepted";
 
-export type MxcOpenShellDistributionProfileId =
-  typeof MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID;
+export type MxcOpenShellDistributionProfileId = string;
 
 export interface MxcOpenShellAttachmentObservation extends MxcOpenShellAttachmentExpectation {
   readonly distributionRoot: string;
@@ -112,32 +109,6 @@ const DISTRIBUTION_AUTHORITIES = new WeakMap<
   MxcOpenShellDistributionAuthority,
   MxcOpenShellAttachmentAuthority
 >();
-
-/** Exact credential-free v0.0.24 qualification inputs; this is not product acceptance. */
-const V0_0_24_QUALIFICATION_EXPECTATION = {
-  distribution: {
-    version: "0.0.24",
-    revision: "e1b48323e4efcb560900508bdcd76d2b5d216678",
-    sha256: "296ba2677f8f692b1c3f14b4fae6bb2a75d52f94c071ec2ebdf676405a80613d",
-  },
-  components: {
-    cliSha256: "23d00a88daa5f2aa6151d9112a6845e843ca1e08cbaf55f8eaa337b72dd9155a",
-    gatewaySha256: "62b3e231f5d40c5d178d08172ddb65536f124bdb8c7c04d90fb9dca50a5ac137",
-    wxcExecSha256: "6049c64723af1173c3739dc6cd6b2f33f6c021bb2832c4216233cba7f71aee9a",
-  },
-  gateway: {
-    configSha256: "1c86a32a52d068677b5140975c6b870d5ed46dc553500ebb790b58e207ac7290",
-    driver: "mxc",
-    backend: "process_container",
-  },
-} as const;
-
-const DISTRIBUTION_PROFILES = {
-  [MXC_OPENSHELL_V0_0_24_QUALIFICATION_PROFILE_ID]: {
-    acceptance: "qualification",
-    expectation: V0_0_24_QUALIFICATION_EXPECTATION,
-  },
-} as const;
 
 function record(value: unknown, label: string): Record<string, unknown> {
   if (
@@ -376,20 +347,13 @@ function createDistributionAuthority(
 }
 
 /**
- * Resolve one provider-owned dormant distribution profile.
+ * Create authority only after OpenShell publishes an accepted immutable distribution record.
  *
- * Profile identifiers select immutable records compiled into NemoClaw. Callers cannot supply or
- * derive accepted hashes from the installation being observed. The current v0.0.24 record is a
- * qualification fixture only and does not approve installation, selection, activation, or support.
+ * No accepted Windows distribution is currently registered. Prototype measurements and host
+ * observations therefore fail closed instead of becoming provider authority.
  */
-export function createMxcOpenShellDistributionAuthority(
-  profileId: MxcOpenShellDistributionProfileId,
-): MxcOpenShellDistributionAuthority {
-  if (!Object.hasOwn(DISTRIBUTION_PROFILES, profileId)) {
-    throw new MxcOpenShellAttachmentError("distribution profile is not provider-owned");
-  }
-  const profile = DISTRIBUTION_PROFILES[profileId];
-  return createDistributionAuthority(profileId, profile.acceptance, profile.expectation);
+export function createMxcOpenShellDistributionAuthority(): MxcOpenShellDistributionAuthority {
+  throw new MxcOpenShellAttachmentError("accepted distribution authority is unavailable");
 }
 
 /** Resolve the opaque attachment capability carried by a provider-owned distribution authority. */
@@ -416,26 +380,37 @@ export function createMxcOpenShellAttachmentTestAuthority(
   version: string,
 ): MxcOpenShellAttachmentAuthority {
   return createMxcOpenShellAttachmentAuthority(
-    {
-      distribution: {
-        version,
-        revision: "a".repeat(40),
-        sha256: "1".repeat(64),
-      },
-      components: {
-        cliSha256: "2".repeat(64),
-        gatewaySha256: "3".repeat(64),
-        wxcExecSha256: "4".repeat(64),
-      },
-      gateway: {
-        configSha256: "5".repeat(64),
-        driver: "mxc",
-        backend: "process_container",
-      },
-    },
+    testExpectation(version),
     "qualification",
     "test-fixture",
   );
+}
+
+/** Create a fixed synthetic distribution authority for deterministic tests only. */
+export function createMxcOpenShellDistributionTestAuthority(
+  version: string,
+): MxcOpenShellDistributionAuthority {
+  return createDistributionAuthority("test-fixture", "qualification", testExpectation(version));
+}
+
+function testExpectation(version: string): MxcOpenShellAttachmentExpectation {
+  return {
+    distribution: {
+      version,
+      revision: "a".repeat(40),
+      sha256: "1".repeat(64),
+    },
+    components: {
+      cliSha256: "2".repeat(64),
+      gatewaySha256: "3".repeat(64),
+      wxcExecSha256: "4".repeat(64),
+    },
+    gateway: {
+      configSha256: "5".repeat(64),
+      driver: "mxc",
+      backend: "process_container",
+    },
+  };
 }
 
 function acceptedIdentity(authority: unknown): Readonly<{

--- a/src/lib/onboard/runtime-provider/mxc-openshell-observer.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc-openshell-observer.test.ts
@@ -38,7 +38,7 @@ const PATHS = {
 
 function request(): MxcOpenShellAttachmentObservationRequest {
   return {
-    contractVersion: 2,
+    contractVersion: 3,
     providerId: "mxc",
     mode: "attach-existing",
     observedDistribution: {

--- a/src/lib/onboard/runtime-provider/mxc.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc.test.ts
@@ -19,8 +19,11 @@ import {
   createMxcRuntimeProviderBundle,
 } from "./mxc";
 import type { MxcNativeArtifactControlPlane } from "./mxc-bootstrap-operations";
-import { mxcOpenShellAttachmentFixture } from "./mxc-openshell-attachment-test-fixture";
-import type { MxcOpenShellAttachmentObservationRequest } from "./mxc-openshell-observer";
+import {
+  mxcOpenShellAttachmentDigestMap,
+  mxcOpenShellAttachmentFixture,
+  mxcOpenShellAttachmentObservationRequest,
+} from "./mxc-openshell-attachment-test-fixture";
 import {
   createRuntimeProviderBundleRegistry,
   RuntimeProviderRegistrationError,
@@ -57,32 +60,6 @@ function candidateBundle() {
   });
 }
 
-function attachmentObservation(): MxcOpenShellAttachmentObservationRequest {
-  const source = mxcOpenShellAttachmentFixture().observation;
-  return {
-    contractVersion: 3,
-    providerId: "mxc",
-    mode: "attach-existing",
-    observedDistribution: {
-      version: source.distribution.version,
-      revision: source.distribution.revision,
-    },
-    observedGateway: {
-      driver: source.gateway.driver,
-      backend: source.gateway.backend,
-    },
-    installation: {
-      distributionArtifactPath: "C:\\OpenShell\\packages\\openshell-0.0.21.zip",
-      distributionRoot: source.distributionRoot,
-      mxcRoot: source.mxcRoot,
-      cliPath: source.cliPath,
-      gatewayPath: source.gatewayPath,
-      wxcExecPath: source.wxcExecPath,
-      gatewayConfigPath: source.gatewayConfigPath,
-    },
-  };
-}
-
 function bootstrapInput(): RuntimeProviderNativeArtifactBootstrapInput {
   return {
     providerId: "mxc",
@@ -116,14 +93,7 @@ describe("inactive OpenShell MXC runtime provider", () => {
       ...inactiveBootstrapControlPlane(),
       verifyAndCreate: vi.fn(async () => ({ status: "unknown" as const })),
     };
-    const accepted = attachment.observation;
-    const digests = new Map<string, string>([
-      ["C:\\OpenShell\\packages\\openshell-0.0.21.zip", accepted.distribution.sha256],
-      ["C:\\OpenShell\\bin\\openshell.exe", accepted.components.cliSha256],
-      ["C:\\OpenShell\\bin\\openshell-gateway.exe", accepted.components.gatewaySha256],
-      ["C:\\mxc-kit\\bin\\wxc-exec.exe", accepted.components.wxcExecSha256],
-      ["C:\\ProgramData\\NVIDIA\\OpenShell\\gateway.toml", accepted.gateway.configSha256],
-    ]);
+    const digests = mxcOpenShellAttachmentDigestMap(attachment.observation);
     const observeFileDigest = vi.fn(async (filePath: string) => digests.get(filePath)!);
 
     const { provider } = await attachMxcRuntimeProviderBundleFromExistingInstallation({
@@ -133,14 +103,14 @@ describe("inactive OpenShell MXC runtime provider", () => {
         release: "10.0.28000.1836",
       },
       openshellAttachmentAuthority: attachment.authority,
-      attachmentObservation: attachmentObservation(),
+      attachmentObservation: mxcOpenShellAttachmentObservationRequest(),
       bootstrapControlPlane: controlPlane,
       observeFileDigest,
     });
 
     expect(provider.preflightDoctor.inspectHost()).toMatchObject({
       status: "info",
-      detail: expect.stringMatching(/OpenShell 0\.0\.21/u),
+      detail: expect.stringMatching(/OpenShell 0\.0\.24/u),
     });
     expect(observeFileDigest).toHaveBeenCalledTimes(5);
     expect(controlPlane.verifyAndCreate).not.toHaveBeenCalled();
@@ -176,7 +146,7 @@ describe("inactive OpenShell MXC runtime provider", () => {
         release: "10.0.28000.1836",
       },
       openshellAttachmentAuthority: attachment.authority,
-      attachmentObservation: attachmentObservation(),
+      attachmentObservation: mxcOpenShellAttachmentObservationRequest(),
       bootstrapControlPlane: {
         contractVersion: 1,
         providerId: "mxc",
@@ -223,7 +193,7 @@ describe("inactive OpenShell MXC runtime provider", () => {
         release: "10.0.28000.1836",
       },
       openshellAttachmentAuthority: attachment.authority,
-      attachmentObservation: attachmentObservation(),
+      attachmentObservation: mxcOpenShellAttachmentObservationRequest(),
       bootstrapControlPlane: {
         contractVersion: 1,
         providerId: "mxc",
@@ -259,13 +229,8 @@ describe("inactive OpenShell MXC runtime provider", () => {
   it("rejects installed-file substitution before constructing the candidate (#8178)", async () => {
     const attachment = mxcOpenShellAttachmentFixture();
     const accepted = attachment.observation;
-    const observedDigests = new Map<string, string>([
-      ["C:\\OpenShell\\packages\\openshell-0.0.21.zip", accepted.distribution.sha256],
-      [accepted.cliPath, accepted.components.cliSha256],
-      [accepted.gatewayPath, "6".repeat(64)],
-      [accepted.wxcExecPath, accepted.components.wxcExecSha256],
-      [accepted.gatewayConfigPath, accepted.gateway.configSha256],
-    ]);
+    const observedDigests = mxcOpenShellAttachmentDigestMap(accepted);
+    observedDigests.set(accepted.gatewayPath, "6".repeat(64));
     const observeFileDigest = vi.fn(async (filePath: string) => observedDigests.get(filePath)!);
     const verifyAndCreate = vi.fn(async () => ({ status: "unknown" as const }));
 
@@ -277,7 +242,7 @@ describe("inactive OpenShell MXC runtime provider", () => {
           release: "10.0.28000.1836",
         },
         openshellAttachmentAuthority: attachment.authority,
-        attachmentObservation: attachmentObservation(),
+        attachmentObservation: mxcOpenShellAttachmentObservationRequest(),
         bootstrapControlPlane: {
           ...inactiveBootstrapControlPlane(),
           verifyAndCreate,
@@ -338,10 +303,10 @@ describe("inactive OpenShell MXC runtime provider", () => {
       label: "OpenShell MXC process_container candidate",
       status: "info",
       detail:
-        "Windows x64 build 28000 and OpenShell 0.0.21 match the inactive attachment contract.",
+        "Windows x64 build 28000 and OpenShell 0.0.24 match the inactive attachment contract.",
       hint:
-        "This check does not enable MXC. Maintainers must qualify the accepted OpenShell " +
-        "distribution and required live E2E coverage before adding production selection.",
+        "This check does not enable MXC. Maintainers must accept a stable OpenShell distribution " +
+        "and complete required live E2E coverage before adding production selection.",
     });
 
     const attachment = mxcOpenShellAttachmentFixture();

--- a/src/lib/onboard/runtime-provider/mxc.test.ts
+++ b/src/lib/onboard/runtime-provider/mxc.test.ts
@@ -60,7 +60,7 @@ function candidateBundle() {
 function attachmentObservation(): MxcOpenShellAttachmentObservationRequest {
   const source = mxcOpenShellAttachmentFixture().observation;
   return {
-    contractVersion: 2,
+    contractVersion: 3,
     providerId: "mxc",
     mode: "attach-existing",
     observedDistribution: {

--- a/src/lib/onboard/runtime-provider/mxc.ts
+++ b/src/lib/onboard/runtime-provider/mxc.ts
@@ -101,8 +101,8 @@ function inspectMxcHost(
         `Windows x64 build ${assessment.windowsBuild} and OpenShell ${attachment.distribution.version} ` +
         "match the inactive attachment contract.",
       hint:
-        "This check does not enable MXC. Maintainers must qualify the accepted OpenShell " +
-        "distribution and required live E2E coverage before adding production selection.",
+        "This check does not enable MXC. Maintainers must accept a stable OpenShell distribution " +
+        "and complete required live E2E coverage before adding production selection.",
     };
   } catch (error) {
     return {

--- a/src/lib/onboard/windows-mxc/existing-installation.test.ts
+++ b/src/lib/onboard/windows-mxc/existing-installation.test.ts
@@ -18,7 +18,7 @@ vi.mock("./native-host-facts", () => ({
 
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "../runtime-provider/current";
 import type { MxcNativeArtifactControlPlane } from "../runtime-provider/mxc-bootstrap-operations";
-import { mxcOpenShellAttachmentFixture } from "../runtime-provider/mxc-openshell-attachment-test-fixture";
+import { mxcOpenShellV0_0_24QualificationFixture } from "../runtime-provider/mxc-openshell-attachment-test-fixture";
 import { MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION } from "../runtime-provider/mxc-openshell-attachment";
 import type { MxcOpenShellAttachmentObservationRequest } from "../runtime-provider/mxc-openshell-observer";
 import { attachMxcWindowsExistingInstallation } from "./existing-installation";
@@ -36,7 +36,7 @@ function controlPlane(): MxcNativeArtifactControlPlane {
 }
 
 function observationRequest(
-  observed = mxcOpenShellAttachmentFixture("0.0.24").observation,
+  observed = mxcOpenShellV0_0_24QualificationFixture().observation,
 ): MxcOpenShellAttachmentObservationRequest {
   return {
     contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
@@ -62,7 +62,7 @@ function observationRequest(
   };
 }
 
-function acceptedDigests(observed = mxcOpenShellAttachmentFixture("0.0.24").observation) {
+function acceptedDigests(observed = mxcOpenShellV0_0_24QualificationFixture().observation) {
   return new Map<string, string>([
     ["C:\\OpenShell\\packages\\openshell-0.0.24.zip", observed.distribution.sha256],
     [observed.cliPath, observed.components.cliSha256],
@@ -80,7 +80,7 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
   });
 
   it("retains the qualified receipt without entering runtime selection (#8178)", async () => {
-    const attachment = mxcOpenShellAttachmentFixture("0.0.24");
+    const attachment = mxcOpenShellV0_0_24QualificationFixture();
     const digests = acceptedDigests(attachment.observation);
     const bootstrapControlPlane = controlPlane();
     nativeBoundary.observeHostFacts.mockReturnValue({
@@ -93,14 +93,16 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
     );
 
     const result = await attachMxcWindowsExistingInstallation({
-      openshellAttachmentAuthority: attachment.authority,
+      openshellDistributionAuthority: attachment.authority,
       attachmentObservation: observationRequest(attachment.observation),
       bootstrapControlPlane,
     });
 
     expect(result.attachmentReceipt).toMatchObject({
-      contractVersion: 2,
+      contractVersion: 3,
       providerId: "mxc",
+      acceptance: "qualification",
+      distributionProfileId: "openshell-v0-0-24-qualification",
       distribution: { root: "C:\\OpenShell" },
       components: {
         wxcExec: {
@@ -123,7 +125,7 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
   });
 
   it("rejects WSL before observing installation files (#8178)", async () => {
-    const attachment = mxcOpenShellAttachmentFixture("0.0.24");
+    const attachment = mxcOpenShellV0_0_24QualificationFixture();
     nativeBoundary.observeHostFacts.mockReturnValue({
       platform: "linux",
       nativeArchitecture: "x64",
@@ -132,7 +134,7 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
 
     await expect(
       attachMxcWindowsExistingInstallation({
-        openshellAttachmentAuthority: attachment.authority,
+        openshellDistributionAuthority: attachment.authority,
         attachmentObservation: observationRequest(attachment.observation),
         bootstrapControlPlane: controlPlane(),
       }),
@@ -141,7 +143,7 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
   });
 
   it("rejects an unqualified architecture before observing installation files (#8178)", async () => {
-    const attachment = mxcOpenShellAttachmentFixture("0.0.24");
+    const attachment = mxcOpenShellV0_0_24QualificationFixture();
     nativeBoundary.observeHostFacts.mockReturnValue({
       platform: "win32",
       nativeArchitecture: "arm64",
@@ -150,7 +152,7 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
 
     await expect(
       attachMxcWindowsExistingInstallation({
-        openshellAttachmentAuthority: attachment.authority,
+        openshellDistributionAuthority: attachment.authority,
         attachmentObservation: observationRequest(attachment.observation),
         bootstrapControlPlane: controlPlane(),
       }),
@@ -158,24 +160,17 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
     expect(nativeBoundary.observeFileDigest).not.toHaveBeenCalled();
   });
 
-  it("rejects a caller-constructed attachment authority before provider composition (#8178)", async () => {
-    const attachment = mxcOpenShellAttachmentFixture("0.0.24");
-    const digests = acceptedDigests(attachment.observation);
-    nativeBoundary.observeHostFacts.mockReturnValue({
-      platform: "win32",
-      nativeArchitecture: "x64",
-      release: "10.0.28120.2760",
-    });
-    nativeBoundary.observeFileDigest.mockImplementation(async (filePath: string) =>
-      digests.get(filePath)!,
-    );
+  it("rejects a caller-constructed distribution authority before host observation (#10583)", async () => {
+    const authority = mxcOpenShellV0_0_24QualificationFixture().authority;
 
     await expect(
       attachMxcWindowsExistingInstallation({
-        openshellAttachmentAuthority: { ...attachment.authority },
-        attachmentObservation: observationRequest(attachment.observation),
+        openshellDistributionAuthority: { ...authority },
+        attachmentObservation: observationRequest(),
         bootstrapControlPlane: controlPlane(),
       }),
-    ).rejects.toThrow(/accepted identity authority is not provider-owned/u);
+    ).rejects.toThrow(/distribution authority is not provider-owned/u);
+    expect(nativeBoundary.observeHostFacts).not.toHaveBeenCalled();
+    expect(nativeBoundary.observeFileDigest).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/onboard/windows-mxc/existing-installation.test.ts
+++ b/src/lib/onboard/windows-mxc/existing-installation.test.ts
@@ -18,9 +18,11 @@ vi.mock("./native-host-facts", () => ({
 
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "../runtime-provider/current";
 import type { MxcNativeArtifactControlPlane } from "../runtime-provider/mxc-bootstrap-operations";
-import { mxcOpenShellV0_0_24QualificationFixture } from "../runtime-provider/mxc-openshell-attachment-test-fixture";
-import { MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION } from "../runtime-provider/mxc-openshell-attachment";
-import type { MxcOpenShellAttachmentObservationRequest } from "../runtime-provider/mxc-openshell-observer";
+import {
+  mxcOpenShellAttachmentDigestMap,
+  mxcOpenShellAttachmentObservationRequest,
+  mxcOpenShellDistributionTestFixture,
+} from "../runtime-provider/mxc-openshell-attachment-test-fixture";
 import { attachMxcWindowsExistingInstallation } from "./existing-installation";
 
 function controlPlane(): MxcNativeArtifactControlPlane {
@@ -35,43 +37,6 @@ function controlPlane(): MxcNativeArtifactControlPlane {
   };
 }
 
-function observationRequest(
-  observed = mxcOpenShellV0_0_24QualificationFixture().observation,
-): MxcOpenShellAttachmentObservationRequest {
-  return {
-    contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
-    providerId: "mxc",
-    mode: "attach-existing",
-    observedDistribution: {
-      version: observed.distribution.version,
-      revision: observed.distribution.revision,
-    },
-    observedGateway: {
-      driver: "mxc",
-      backend: "process_container",
-    },
-    installation: {
-      distributionArtifactPath: "C:\\OpenShell\\packages\\openshell-0.0.24.zip",
-      distributionRoot: observed.distributionRoot,
-      mxcRoot: observed.mxcRoot,
-      cliPath: observed.cliPath,
-      gatewayPath: observed.gatewayPath,
-      wxcExecPath: observed.wxcExecPath,
-      gatewayConfigPath: observed.gatewayConfigPath,
-    },
-  };
-}
-
-function acceptedDigests(observed = mxcOpenShellV0_0_24QualificationFixture().observation) {
-  return new Map<string, string>([
-    ["C:\\OpenShell\\packages\\openshell-0.0.24.zip", observed.distribution.sha256],
-    [observed.cliPath, observed.components.cliSha256],
-    [observed.gatewayPath, observed.components.gatewaySha256],
-    [observed.wxcExecPath, observed.components.wxcExecSha256],
-    [observed.gatewayConfigPath, observed.gateway.configSha256],
-  ]);
-}
-
 describe("inactive native Windows OpenShell MXC existing-installation composition", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -80,8 +45,8 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
   });
 
   it("retains the qualified receipt without entering runtime selection (#8178)", async () => {
-    const attachment = mxcOpenShellV0_0_24QualificationFixture();
-    const digests = acceptedDigests(attachment.observation);
+    const attachment = mxcOpenShellDistributionTestFixture();
+    const digests = mxcOpenShellAttachmentDigestMap(attachment.observation);
     const bootstrapControlPlane = controlPlane();
     nativeBoundary.observeHostFacts.mockReturnValue({
       platform: "win32",
@@ -94,7 +59,7 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
 
     const result = await attachMxcWindowsExistingInstallation({
       openshellDistributionAuthority: attachment.authority,
-      attachmentObservation: observationRequest(attachment.observation),
+      attachmentObservation: mxcOpenShellAttachmentObservationRequest(attachment.observation),
       bootstrapControlPlane,
     });
 
@@ -102,7 +67,7 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
       contractVersion: 3,
       providerId: "mxc",
       acceptance: "qualification",
-      distributionProfileId: "openshell-v0-0-24-qualification",
+      distributionProfileId: "test-fixture",
       distribution: { root: "C:\\OpenShell" },
       components: {
         wxcExec: {
@@ -125,7 +90,7 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
   });
 
   it("rejects WSL before observing installation files (#8178)", async () => {
-    const attachment = mxcOpenShellV0_0_24QualificationFixture();
+    const attachment = mxcOpenShellDistributionTestFixture();
     nativeBoundary.observeHostFacts.mockReturnValue({
       platform: "linux",
       nativeArchitecture: "x64",
@@ -135,7 +100,7 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
     await expect(
       attachMxcWindowsExistingInstallation({
         openshellDistributionAuthority: attachment.authority,
-        attachmentObservation: observationRequest(attachment.observation),
+        attachmentObservation: mxcOpenShellAttachmentObservationRequest(attachment.observation),
         bootstrapControlPlane: controlPlane(),
       }),
     ).rejects.toThrow(/WSL is not a native Windows host/u);
@@ -143,7 +108,7 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
   });
 
   it("rejects an unqualified architecture before observing installation files (#8178)", async () => {
-    const attachment = mxcOpenShellV0_0_24QualificationFixture();
+    const attachment = mxcOpenShellDistributionTestFixture();
     nativeBoundary.observeHostFacts.mockReturnValue({
       platform: "win32",
       nativeArchitecture: "arm64",
@@ -153,7 +118,7 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
     await expect(
       attachMxcWindowsExistingInstallation({
         openshellDistributionAuthority: attachment.authority,
-        attachmentObservation: observationRequest(attachment.observation),
+        attachmentObservation: mxcOpenShellAttachmentObservationRequest(attachment.observation),
         bootstrapControlPlane: controlPlane(),
       }),
     ).rejects.toThrow(/currently qualifies x64 only/u);
@@ -161,12 +126,12 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
   });
 
   it("rejects a caller-constructed distribution authority before host observation (#10583)", async () => {
-    const authority = mxcOpenShellV0_0_24QualificationFixture().authority;
+    const authority = mxcOpenShellDistributionTestFixture().authority;
 
     await expect(
       attachMxcWindowsExistingInstallation({
         openshellDistributionAuthority: { ...authority },
-        attachmentObservation: observationRequest(),
+        attachmentObservation: mxcOpenShellAttachmentObservationRequest(),
         bootstrapControlPlane: controlPlane(),
       }),
     ).rejects.toThrow(/distribution authority is not provider-owned/u);

--- a/src/lib/onboard/windows-mxc/existing-installation.test.ts
+++ b/src/lib/onboard/windows-mxc/existing-installation.test.ts
@@ -18,6 +18,7 @@ vi.mock("./native-host-facts", () => ({
 
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "../runtime-provider/current";
 import type { MxcNativeArtifactControlPlane } from "../runtime-provider/mxc-bootstrap-operations";
+import { MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID } from "../runtime-provider/mxc-openshell-attachment";
 import {
   mxcOpenShellAttachmentDigestMap,
   mxcOpenShellAttachmentObservationRequest,
@@ -67,7 +68,7 @@ describe("inactive native Windows OpenShell MXC existing-installation compositio
       contractVersion: 3,
       providerId: "mxc",
       acceptance: "qualification",
-      distributionProfileId: "test-fixture",
+      distributionProfileId: MXC_OPENSHELL_V0_0_24_MXC_V0_7_0_RC1_QUALIFICATION_PROFILE_ID,
       distribution: { root: "C:\\OpenShell" },
       components: {
         wxcExec: {

--- a/src/lib/onboard/windows-mxc/existing-installation.ts
+++ b/src/lib/onboard/windows-mxc/existing-installation.ts
@@ -7,9 +7,10 @@ import {
   type MxcExistingInstallationRuntimeProviderAttachment,
 } from "../runtime-provider/mxc";
 import type { MxcNativeArtifactControlPlane } from "../runtime-provider/mxc-bootstrap-operations";
-import type {
-  MxcOpenShellAttachmentAuthority,
-  MxcOpenShellAttachmentReceipt,
+import {
+  resolveMxcOpenShellDistributionAuthority,
+  type MxcOpenShellAttachmentReceipt,
+  type MxcOpenShellDistributionAuthority,
 } from "../runtime-provider/mxc-openshell-attachment";
 import type {
   MxcOpenShellAttachmentObservationRequest,
@@ -23,7 +24,7 @@ import {
 import { observeWindowsMxcNativeHostFacts } from "./native-host-facts";
 
 export interface MxcWindowsExistingInstallationInput {
-  readonly openshellAttachmentAuthority: MxcOpenShellAttachmentAuthority;
+  readonly openshellDistributionAuthority: MxcOpenShellDistributionAuthority;
   readonly attachmentObservation: MxcOpenShellAttachmentObservationRequest;
   readonly bootstrapControlPlane: MxcNativeArtifactControlPlane;
 }
@@ -54,7 +55,7 @@ function defaultBoundary(): MxcWindowsExistingInstallationBoundary {
 }
 
 /**
- * Compose the inactive native Windows provider from one accepted existing installation.
+ * Compose the inactive native Windows provider from one provider-owned distribution authority.
  *
  * This function observes and qualifies host artifacts only. It does not register,
  * select, install, or activate MXC and does not call the OpenShell control plane.
@@ -62,6 +63,9 @@ function defaultBoundary(): MxcWindowsExistingInstallationBoundary {
 export async function attachMxcWindowsExistingInstallation(
   input: MxcWindowsExistingInstallationInput,
 ): Promise<MxcWindowsExistingInstallationComposition> {
+  const openshellAttachmentAuthority = resolveMxcOpenShellDistributionAuthority(
+    input.openshellDistributionAuthority,
+  );
   const boundary = defaultBoundary();
   const hostFacts = boundary.observeHostFacts();
   const assessment = assessWindowsMxcProcessContainerCandidate(hostFacts);
@@ -71,7 +75,7 @@ export async function attachMxcWindowsExistingInstallation(
 
   const attachment = await attachMxcRuntimeProviderBundleFromExistingInstallation({
     hostFacts,
-    openshellAttachmentAuthority: input.openshellAttachmentAuthority,
+    openshellAttachmentAuthority,
     attachmentObservation: input.attachmentObservation,
     bootstrapControlPlane: input.bootstrapControlPlane,
     observeFileDigest: boundary.observeFileDigest,

--- a/src/lib/onboard/windows-mxc/inactive-onboarding.test.ts
+++ b/src/lib/onboard/windows-mxc/inactive-onboarding.test.ts
@@ -20,9 +20,11 @@ vi.mock("./native-host-facts", () => ({
 
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "../runtime-provider/current";
 import type { MxcNativeArtifactControlPlane } from "../runtime-provider/mxc-bootstrap-operations";
-import { mxcOpenShellV0_0_24QualificationFixture } from "../runtime-provider/mxc-openshell-attachment-test-fixture";
-import { MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION } from "../runtime-provider/mxc-openshell-attachment";
-import type { MxcOpenShellAttachmentObservationRequest } from "../runtime-provider/mxc-openshell-observer";
+import {
+  mxcOpenShellAttachmentDigestMap,
+  mxcOpenShellAttachmentObservationRequest,
+  mxcOpenShellDistributionTestFixture,
+} from "../runtime-provider/mxc-openshell-attachment-test-fixture";
 import { encodeManagedStartupProfile } from "../managed-startup/profile";
 import { nativeArtifactWorkloadReceiptFixture } from "../workload/native-artifact-test-fixture";
 import {
@@ -68,40 +70,6 @@ function controlPlane(): MxcNativeArtifactControlPlane {
   };
 }
 
-function observationRequest(): MxcOpenShellAttachmentObservationRequest {
-  const observed = mxcOpenShellV0_0_24QualificationFixture().observation;
-  return {
-    contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
-    providerId: "mxc",
-    mode: "attach-existing",
-    observedDistribution: {
-      version: observed.distribution.version,
-      revision: observed.distribution.revision,
-    },
-    observedGateway: { driver: "mxc", backend: "process_container" },
-    installation: {
-      distributionArtifactPath: "C:\\OpenShell\\packages\\openshell-0.0.24.zip",
-      distributionRoot: observed.distributionRoot,
-      mxcRoot: observed.mxcRoot,
-      cliPath: observed.cliPath,
-      gatewayPath: observed.gatewayPath,
-      wxcExecPath: observed.wxcExecPath,
-      gatewayConfigPath: observed.gatewayConfigPath,
-    },
-  };
-}
-
-function acceptedDigests(): Map<string, string> {
-  const observed = mxcOpenShellV0_0_24QualificationFixture().observation;
-  return new Map([
-    ["C:\\OpenShell\\packages\\openshell-0.0.24.zip", observed.distribution.sha256],
-    [observed.cliPath, observed.components.cliSha256],
-    [observed.gatewayPath, observed.components.gatewaySha256],
-    [observed.wxcExecPath, observed.components.wxcExecSha256],
-    [observed.gatewayConfigPath, observed.gateway.configSha256],
-  ]);
-}
-
 function onboardingInput(
   bootstrapControlPlane: MxcNativeArtifactControlPlane,
 ): MxcWindowsInactiveOnboardingInput {
@@ -110,8 +78,8 @@ function onboardingInput(
   );
   return {
     installation: {
-      openshellDistributionAuthority: mxcOpenShellV0_0_24QualificationFixture().authority,
-      attachmentObservation: observationRequest(),
+      openshellDistributionAuthority: mxcOpenShellDistributionTestFixture().authority,
+      attachmentObservation: mxcOpenShellAttachmentObservationRequest(),
       bootstrapControlPlane,
     },
     bootstrap: {
@@ -135,7 +103,7 @@ describe("inactive native Windows OpenShell MXC onboarding", () => {
       nativeArchitecture: "x64",
       release: "10.0.28120.2760",
     });
-    const digests = acceptedDigests();
+    const digests = mxcOpenShellAttachmentDigestMap();
     nativeBoundary.observeFileDigest.mockImplementation(async (filePath) =>
       Promise.resolve(digests.get(filePath) ?? "0".repeat(64)),
     );
@@ -161,7 +129,7 @@ describe("inactive native Windows OpenShell MXC onboarding", () => {
 
   it("rejects attachment drift before the create operation (#8178)", async () => {
     const operations = controlPlane();
-    const digests = acceptedDigests();
+    const digests = mxcOpenShellAttachmentDigestMap();
     let observations = 0;
     nativeBoundary.observeFileDigest.mockImplementation(async (filePath) => {
       observations += 1;

--- a/src/lib/onboard/windows-mxc/inactive-onboarding.test.ts
+++ b/src/lib/onboard/windows-mxc/inactive-onboarding.test.ts
@@ -20,7 +20,7 @@ vi.mock("./native-host-facts", () => ({
 
 import { CURRENT_RUNTIME_PROVIDER_BUNDLES } from "../runtime-provider/current";
 import type { MxcNativeArtifactControlPlane } from "../runtime-provider/mxc-bootstrap-operations";
-import { mxcOpenShellAttachmentFixture } from "../runtime-provider/mxc-openshell-attachment-test-fixture";
+import { mxcOpenShellV0_0_24QualificationFixture } from "../runtime-provider/mxc-openshell-attachment-test-fixture";
 import { MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION } from "../runtime-provider/mxc-openshell-attachment";
 import type { MxcOpenShellAttachmentObservationRequest } from "../runtime-provider/mxc-openshell-observer";
 import { encodeManagedStartupProfile } from "../managed-startup/profile";
@@ -69,7 +69,7 @@ function controlPlane(): MxcNativeArtifactControlPlane {
 }
 
 function observationRequest(): MxcOpenShellAttachmentObservationRequest {
-  const observed = mxcOpenShellAttachmentFixture("0.0.24").observation;
+  const observed = mxcOpenShellV0_0_24QualificationFixture().observation;
   return {
     contractVersion: MXC_OPENSHELL_ATTACHMENT_CONTRACT_VERSION,
     providerId: "mxc",
@@ -92,7 +92,7 @@ function observationRequest(): MxcOpenShellAttachmentObservationRequest {
 }
 
 function acceptedDigests(): Map<string, string> {
-  const observed = mxcOpenShellAttachmentFixture("0.0.24").observation;
+  const observed = mxcOpenShellV0_0_24QualificationFixture().observation;
   return new Map([
     ["C:\\OpenShell\\packages\\openshell-0.0.24.zip", observed.distribution.sha256],
     [observed.cliPath, observed.components.cliSha256],
@@ -105,13 +105,12 @@ function acceptedDigests(): Map<string, string> {
 function onboardingInput(
   bootstrapControlPlane: MxcNativeArtifactControlPlane,
 ): MxcWindowsInactiveOnboardingInput {
-  const attachment = mxcOpenShellAttachmentFixture("0.0.24");
   const workload = nativeArtifactWorkloadReceiptFixture(
     encodeManagedStartupProfile(managedStartupE2eProfile("openclaw")),
   );
   return {
     installation: {
-      openshellAttachmentAuthority: attachment.authority,
+      openshellDistributionAuthority: mxcOpenShellV0_0_24QualificationFixture().authority,
       attachmentObservation: observationRequest(),
       bootstrapControlPlane,
     },

--- a/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
+++ b/test/e2e/support/windows-mxc-openclaw-process-container.test.ts
@@ -306,7 +306,7 @@ describe("inactive Windows MXC OpenClaw process_container qualification", () => 
     expect(
       createWindowsMxcOpenShellAttachmentObservationRequest(parsed, gatewayConfigPath),
     ).toEqual({
-      contractVersion: 2,
+      contractVersion: 3,
       providerId: "mxc",
       mode: "attach-existing",
       observedDistribution: {


### PR DESCRIPTION
## Outcome

NemoClaw now has a provider-owned authority record for the exact OpenShell v0.0.24 and MXC v0.7.0-rc1 development checkpoint. The record is marked `qualification`, not `accepted`, and binds the distribution, CLI, gateway, `wxc-exec`, and gateway configuration hashes before NemoClaw observes an installed package.

This remains dormant infrastructure. It does not register or select MXC, expose MXC onboarding, activate Windows support, or establish an official stable OpenShell/MXC release.

## Reason

The inactive existing-installation composition needs an immutable provider decision before it can trust local package measurements. Prototype evidence, caller-provided hashes, copied capability objects, and local observations must not become or replace provider authority.

The two-stage contract lets development continue against one exact checkpoint while preserving a separate stable-release acceptance gate.

### Related issues

- Part of #8178
- Refs #10583

## Changes

- Register the exact OpenShell v0.0.24 and MXC v0.7.0-rc1 checkpoint as a provider-owned `qualification` profile.
- Bind the distribution version, source revision, archive hash, component hashes, gateway configuration hash, architecture, and backend into the attachment authority.
- Allow authority creation only for a checked-in provider profile; reject unknown, copied, and caller-constructed authority.
- Remove production-callable synthetic test authority constructors and make tests use the same checked-in qualification record.
- Keep stable `accepted` authority, production registration, runtime selection, onboarding, and activation absent.

## Verification

- Focused CLI runtime-provider and Windows MXC tests: 101 tests passed.
- Focused Windows MXC E2E-support tests: 58 tests passed.
- Focused architecture tests: 42 tests passed.
- `npm run typecheck:cli` — passed.
- `npm run checks:repository` — passed against the exact upstream base.
- Normal pre-commit, commit-msg, and pre-push hooks — passed.
- GitHub reports latest PR commit `44c6c686f7d7023bca1b2075e4db660595472e62` as verified.
- The checked-in archive and component hashes match the supplied v0.0.24 qualification package.
- The diff contains no secrets, API keys, credentials, host access details, or private package locations.

## Review notes

OpenShell v0.0.24 and MXC v0.7.0-rc1 are a development qualification checkpoint only. A future stable package requires a new provider-owned record, contract compatibility review, and physical regression evidence before it can be marked `accepted`. Production selection and activation remain tracked separately in #8178 and #10583.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the OpenShell v0.0.24 qualification profile.
  - Distribution verification now uses registered, provider-owned qualification metadata.
  - Windows existing-installation onboarding now accepts distribution authority information.

- **Bug Fixes**
  - Improved validation for unknown or copied distribution authorities.
  - Updated version and digest checks to reflect the v0.0.24 distribution.

- **User Guidance**
  - Updated preflight messaging to require acceptance of a stable OpenShell distribution before production selection.
  - Attachment observations now use contract version 3 for consistent verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->