### PR TITLE
docs: catch up post-merge runtime guidance

### DIFF
--- a/docs/inference/set-up-ollama.mdx
+++ b/docs/inference/set-up-ollama.mdx
@@ -36,6 +36,10 @@ A missing or changed value causes a configuration drift error instead of runner 
 It then creates the runner, sends one validation request for the selected model, and confirms that Ollama loaded the selected model.
 This path does not inspect, start, or use a host Ollama process, and it does not use the default Docker runtime.
 
+If the published runner later stops, use `$$nemoclaw <name> recover` or `$$nemoclaw <name> connect --probe-only` to resume only the exact receipt-owned runner.
+Ordinary `connect` and direct `launch` do not recover it.
+Follow [Recover Portable Published Ollama](../../manage-sandboxes/operate-sandboxes/recover-and-rebuild-sandboxes#recover-portable-published-ollama) for the authority checks, route proof, and failure procedure.
+
 <Warning title="Portable Cleanup Boundary">
 Run `$$nemoclaw uninstall` for full cleanup of a receipt-owned Portable Ollama runner.
 Before its first mutation, NemoClaw records the schema `5` lifecycle receipt, sandbox registry revision and lifecycle generation, sandbox and Podman container identities, committed gateway provider revision and profile, inference runtime, socket, and Portable network.

--- a/docs/inference/set-up-openai-compatible-endpoint.mdx
+++ b/docs/inference/set-up-openai-compatible-endpoint.mdx
@@ -219,7 +219,10 @@ Use [Switch Inference Providers](../manage-inference/switch-providers) when you 
 
 Endpoint validation is a point-in-time onboarding check, not continuous health monitoring.
 During onboarding, NemoClaw sends an authenticated Chat Completions request for the selected model.
-After route setup, applicable flows also verify that the sandbox receives non-empty assistant content through `inference.local`.
+<AgentOnly variant="openclaw">
+After the sandbox and inference route exist, OpenClaw onboarding also verifies that the sandbox receives non-empty assistant content through `inference.local`, even when you select no messaging channel.
+A failure stops onboarding before policy selection and final deployment verification.
+</AgentOnly>
 These checks do not provide continuous availability monitoring or automatic failover.
 
 NemoClaw consumes and deletes a descriptor only after its file metadata passes these checks.
@@ -295,9 +298,13 @@ NEMOCLAW_PROVIDER=custom \
 | `NEMOCLAW_TRUSTED_PRIVATE_INFERENCE_HOSTS` | Inference-only compatibility alias for `NEMOCLAW_TRUSTED_PRIVATE_HOSTS`. Inference onboarding combines entries from both variables. |
 | `COMPATIBLE_API_KEY` | Endpoint API key. Required unless loopback no-auth mode is selected. |
 
+<AgentOnly variant="openclaw">
+
 A loopback endpoint onboarded in no-auth mode keeps that binding after onboarding.
-`nemoclaw <sandbox-name> inference set` accepts the recorded endpoint URL, or no `--endpoint-url` at all, and verifies the new route from inside the sandbox because the gateway reaches the endpoint through a local proxy.
+`$$nemoclaw <sandbox-name> inference set` accepts the recorded endpoint URL, or no `--endpoint-url` at all, and verifies the new route from inside the sandbox because the gateway reaches the endpoint through a local proxy.
 Omit `--credential-env`: the recorded no-auth binding is the only value this route accepts, and only onboarding can rebuild that binding.
+
+</AgentOnly>
 
 <AgentOnly variant="openclaw">
 

--- a/docs/manage-sandboxes/add-channels-after-onboarding.mdx
+++ b/docs/manage-sandboxes/add-channels-after-onboarding.mdx
@@ -75,7 +75,7 @@ Verify the gateway bridge before relying on the channel.
 Restore the preset YAML and rerun the original command.
 
 Choose the rebuild so the running sandbox image picks up the new channel.
-For Telegram, Discord, Slack, and Microsoft Teams, `channels add` checks the rebuilt runtime for the selected bridge and reports startup, credential, or missing-plugin warnings before returning.
+For Telegram, Discord, and Slack, `channels add` checks the rebuilt runtime for the selected bridge and reports startup, credential, or missing-plugin warnings before returning.
 If you defer the rebuild, apply the change later:
 
 ```bash

--- a/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
+++ b/docs/manage-sandboxes/recover-rebuild-sandboxes.mdx
@@ -105,6 +105,25 @@ If gate reacquisition or cron validation fails, `recover` exits nonzero and reta
 
 Portable Hermes recovery follows the exact receipt-bound start, authenticated-health, and rollback contract in the [`recover` command reference](../../reference/commands#nemoclaw-name-recover).
 
+### Recover Portable Published Ollama
+
+When an active Portable Hermes sandbox uses a published receipt-owned Ollama runner, use one of these commands to recover it:
+
+```bash
+$$nemoclaw <sandbox-name> recover
+$$nemoclaw <sandbox-name> connect --probe-only
+```
+
+These commands verify the published inference receipt, sandbox registry, provider and lifecycle authority, recovery journal, and exact Podman runtime identity.
+They verify and reuse an already-running exact runner without restarting it.
+When the exact runner is stopped, they resume only that runner; they do not select another runtime, model, network, or provider.
+Missing authority, a same-name replacement, or other drift stops recovery before NemoClaw treats another resource as the runner.
+Success requires a final route proof from inside the sandbox.
+
+Ordinary `connect` and direct `launch` do not resume the runner.
+If a check fails after recovery starts a stopped runner, NemoClaw returns the runner to stopped and returns the registry to its prior state.
+If the output says that restoration could not be proved, preserve the current Portable state and do not run another recovery probe or `launch` until you inspect the recorded runtime and registry authority.
+
 Use `gateway restart` when you intentionally need a supported Hermes gateway to reload runtime configuration or plugins.
 
 ```bash

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1422,6 +1422,14 @@ If Ollama does not become healthy within 30 seconds, the command identifies the 
 The command does not take over a system service or an unrelated user-managed Ollama daemon.
 </AgentOnly>
 
+<AgentOnly variant="hermes">
+For an active Portable Hermes sandbox with a published receipt-owned Ollama runner, only `connect --probe-only` can resume the exact stopped runner.
+An ordinary `connect` does not recover it.
+The probe verifies an already-running exact runner without restarting it, refuses missing, replaced, or drifted authority instead of selecting an alternate runtime, and reports success only after the final in-sandbox inference route passes.
+If recovery changed a stopped runner and a later check fails, NemoClaw restores the prior stopped state.
+When it cannot prove that restoration, preserve the current Portable state and do not run another recovery probe or `launch` until you inspect the recorded runtime and registry authority.
+</AgentOnly>
+
 Before reading or changing the live OpenShell gateway inference route, `connect` verifies the shared provider and sandbox metadata.
 When the live route differs and the metadata is compatible, `connect` warns and re-points the route to the target sandbox's recorded provider and model.
 Refer to [Use Shared Gateway Routes](../inference/manage-inference/use-shared-gateway-routes) for provider-global identity, route drift, and hard-error recovery.
@@ -1955,6 +1963,11 @@ Before it reports success, every completion path verifies the authenticated prox
 </AgentOnly>
 
 <AgentOnly variant="hermes">
+
+For a published receipt-owned Portable Ollama runner, `recover` uses the same exact-runtime recovery contract as [`connect --probe-only`](#$$nemoclaw-name-connect).
+It verifies an already-running runner without restarting it, resumes only the exact stopped runner, and requires the final in-sandbox inference route to pass.
+It does not select an alternate runtime, model, network, or provider.
+If rollback to the prior stopped state cannot be proved after a failure, do not run another recovery probe or `launch` until you inspect the recorded Portable authority.
 
 For an active Portable Hermes receipt, `recover` starts only the exact receipt-owned Podman container when it is stopped.
 If authenticated health is not ready after that start, recovery launches the receipt-owned `nemoclaw-start` command once and waits for authenticated Hermes health.
@@ -4284,7 +4297,7 @@ For a remote server, connect through SSH and run `openshell term` on that server
 
 Start optional host auxiliary services.
 This is the cloudflared tunnel when `cloudflared` is installed, which exposes the dashboard with a public URL.
-Channel messaging (Telegram, Discord, Slack) is not started here; it is configured during `$$nemoclaw onboard` and runs through OpenShell-managed constructs.
+Channel messaging is not started here; it is configured during `$$nemoclaw onboard` and runs through OpenShell-managed constructs.
 
 ```bash
 $$nemoclaw tunnel start

--- a/docs/reference/network-policies.mdx
+++ b/docs/reference/network-policies.mdx
@@ -133,12 +133,14 @@ During onboarding, the wizard prompts for a policy tier that determines the defa
 The baseline policy is always applied regardless of the selected tier.
 An operator can persistently exclude a specific baseline entry with [`policy exclude`](#excluding-a-baseline-entry) when they accept reduced, unsupported functionality.
 This is the supported registry-backed way to replay a live key removal during rebuild; raw `openshell policy set` edits are not replayed, while edits made to the source baseline itself are applied when the sandbox is recreated.
+The table records canonical tier membership, which also determines whether an existing preset can be retained during reuse or rebuild.
+Fresh onboarding filters those presets by the active agent and selected integrations before it presents the policy review.
 
 | Tier | Presets included | Description |
 |------|------------------|-------------|
 | Restricted | No tier defaults | Starts from the baseline policy. Web search or messaging integrations selected earlier can still suggest their required presets; deselect them during policy review for baseline-only access. Restricted suppresses other agent-required additions; reapply them later with `policy add` only after reviewing the additional egress. |
-| Balanced (default) | `npm`, `pypi`, `huggingface`, `brew`, `brave`; selected `tavily` web search access when supported | Full dev tooling and tier-default Brave egress. Selecting Tavily adds its preset when the active agent supports it; the `brave` tier default remains applied. No messaging platform access. Apply the `weather` preset explicitly if your agent needs read-only weather lookups. |
-| Open | `npm`, `pypi`, `huggingface`, `brew`, `brave`, `weather`, `public-reference`, `slack`, `discord`, `telegram`, `wechat` (experimental), `whatsapp` (experimental), `teams` (experimental), `jira`, `outlook`; selected `tavily` web search access when supported | Broad access across third-party services including messaging, productivity, weather, and public-reference APIs. Selecting Tavily adds its preset; the `brave` tier default remains applied. |
+| Balanced (default) | `npm`, `pypi`, `huggingface`, `brew`, `brave`; selected `tavily` web search access when supported | Full dev tooling. Fresh onboarding filters web-search egress to the provider selected for the active agent. No messaging platform access. Apply the `weather` preset explicitly if your agent needs read-only weather lookups. |
+| Open | `npm`, `pypi`, `huggingface`, `brew`, `brave`, `weather`, `public-reference`, `slack`, `discord`, `telegram`, `wechat` (experimental), `whatsapp` (experimental), `teams` (experimental), `jira`, `outlook`; selected `tavily` web search access when supported | Broad access across third-party services including messaging, productivity, weather, and public-reference APIs. Fresh onboarding filters web-search egress to the provider selected for the active agent. |
 | Personal | `personal-open-internet` (mandatory) | Lets every sandbox binary open TCP connections to public and private address ranges on destination ports `80` and `443`. The broad route replaces overlapping web endpoints while preserving non-web policy. Unspecified, loopback, and link-local ranges remain blocked. |
 
 When Personal is selected or carried forward, the `personal-open-internet` preset is mandatory for every agent and every onboarding entry point.
@@ -179,7 +181,8 @@ Deep Agents can use the maintained `tavily` opt-in path, but messaging channel p
 </AgentOnly>
 NemoClaw automatically suggests the preset that matches the selected provider and removes stale web search presets during resume reconciliation when you switch providers or disable web search.
 <AgentOnly variant="openclaw">
-When reuse or rebuild retains a recorded Balanced or Open tier, NemoClaw keeps an applied `brave` preset even if you disable web search or select Tavily.
+On fresh onboarding, OpenClaw suggests `brave` only when you select Brave Search and `tavily` only when you select Tavily Search.
+When reuse or rebuild retains a recorded Balanced or Open tier, NemoClaw keeps an already-applied `brave` preset even if you disable web search or select Tavily.
 NemoClaw removes a built-in web search preset only when it is neither required by the recorded tier nor selected by the active web search provider.
 </AgentOnly>
 <AgentOnly variant="openclaw,hermes">

--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -206,10 +206,29 @@ Onboarding preflight prints this warning before the first image pull and then co
 NemoClaw reads the config from `$DOCKER_CONFIG/config.json` when `DOCKER_CONFIG` is set, and from `~/.docker/config.json` otherwise.
 On WSL, NemoClaw probes the credential helper with a read-only `list` call instead of relying on session markers, because WSLg can set `DISPLAY` in every WSL shell.
 
-To work around a failed pull, resume onboarding with an isolated Docker config so every remaining image pull bypasses the unavailable helper:
+On WSL, NemoClaw automatically uses a temporary credential-free Docker configuration for public managed image pulls, generated image builds, GPU probes, and local-inference probe images when all of these conditions apply:
+
+- The current Docker context is `default` and `DOCKER_HOST` is unset.
+- The client configuration selects the Docker Desktop credential helper.
+- The read-only helper probe fails.
+- The operation does not require registry credentials.
+
+NemoClaw does not modify your Docker client configuration.
+It removes the temporary directory after the Docker operation.
+If cleanup fails, the warning prints the exact credential-free directory; wait for Docker to finish using it, then remove that directory.
+
+An explicit Docker host, a non-default context, a responsive helper, a custom Dockerfile, and an operation that might require private-registry credentials continue to use the configured Docker client state.
+Restore the Docker Desktop session or helper access for those operations.
+
+For a public-image-only retry outside the automatic WSL path, resume onboarding with a temporary isolated configuration:
 
 ```bash
-DOCKER_CONFIG=$(mktemp -d) $$nemoclaw onboard --resume
+(
+  set -eu
+  temporary_docker_config="$(mktemp -d)"
+  trap 'rm -rf -- "$temporary_docker_config"' EXIT
+  DOCKER_CONFIG="$temporary_docker_config" $$nemoclaw onboard --resume
+)
 ```
 
 Alternatively, temporarily remove the `credsStore` entry from the Docker client config named above, then rerun `$$nemoclaw onboard`.
@@ -1671,8 +1690,8 @@ Follow these steps to reconnect.
    $$nemoclaw tunnel start
    ```
 
-   OpenShell-managed channel messaging handles Telegram, Discord, Slack, WeChat, and WhatsApp at onboarding, not through a separate bridge process from `$$nemoclaw tunnel start`.
-   WeChat and WhatsApp are experimental.
+   OpenShell-managed channel messaging is configured during onboarding, not through a separate bridge process from `$$nemoclaw tunnel start`.
+   Use `$$nemoclaw <name> channels list` to inspect the configured channels and [Choose Messaging Channels](../manage-sandboxes/messaging-channels/choose-messaging-channels) for each channel's support status.
    To pause a single bridge without destroying the sandbox, use `$$nemoclaw <name> channels stop <channel>`.
 
 </AgentOnly>
@@ -2540,7 +2559,7 @@ $$nemoclaw <name> status
 
 <AgentOnly variant="openclaw,hermes">
 
-### Agent fails at runtime after onboarding succeeds with a compatible endpoint
+### Compatible endpoint fails sandbox validation or later at runtime
 
 Some OpenAI-compatible servers (such as SGLang) expose `/v1/responses` but their
 streaming mode is incomplete.
@@ -2560,8 +2579,17 @@ $$nemoclaw onboard
 If you previously set `NEMOCLAW_PREFERRED_API=openai-responses` to force the
 Responses API, unset it before re-running onboard.
 
-When you enable Telegram messaging with an OpenAI-compatible endpoint, onboarding also checks `inference.local` from inside the sandbox.
-If that smoke check fails, fix the compatible-endpoint base URL, credentials, model, or network route before testing the Telegram bot again.
+</AgentOnly>
+
+<AgentOnly variant="openclaw">
+
+Every OpenClaw onboarding run with an OpenAI-compatible endpoint sends a validation request through `inference.local` from inside the sandbox, even when you select no messaging channel.
+If that sandbox validation request fails, fix the compatible-endpoint base URL, credentials, model, or network route before continuing onboarding.
+Messaging setup is not the root cause.
+
+</AgentOnly>
+
+<AgentOnly variant="openclaw,hermes">
 
 Do not rely on `NEMOCLAW_INFERENCE_API_OVERRIDE` alone.
 It patches the config at container startup but does not update the Dockerfile ARG baked into the image.
@@ -2739,15 +2767,14 @@ Run the equivalent host-side command instead:
 
 ```bash
 $$nemoclaw <sandbox> channels list
-$$nemoclaw <sandbox> channels add <telegram|discord|slack|wechat|whatsapp>
-$$nemoclaw <sandbox> channels remove <telegram|discord|slack|wechat|whatsapp>
+$$nemoclaw <sandbox> channels add <channel>
+$$nemoclaw <sandbox> channels remove <channel>
 ```
 
 `channels add` registers credentials with the OpenShell gateway and `channels remove` clears them.
 Both offer to rebuild the sandbox so the image reflects the new channel set.
 In non-interactive mode (`NEMOCLAW_NON_INTERACTIVE=1`, or any run without a terminal on stdin), the commands stage the change and leave the rebuild to a follow-up `$$nemoclaw <sandbox> rebuild`.
-WeChat and WhatsApp are experimental.
-Review [Choose Messaging Channels](../manage-sandboxes/messaging-channels/choose-messaging-channels) before enabling them.
+Review [Choose Messaging Channels](../manage-sandboxes/messaging-channels/choose-messaging-channels) for the supported channel IDs, prerequisites, and experimental status before enabling a channel.
 
 WeChat captures its bot token through a host-side QR scan during `$$nemoclaw onboard` or `channels add wechat`.
 You scan the iLink QR from WeChat on your phone and NemoClaw registers the captured token with the OpenShell gateway.

--- a/docs/resources/starter-prompt.md
+++ b/docs/resources/starter-prompt.md
@@ -220,7 +220,7 @@ Choices:
 ## Messaging During Initial Onboarding
 
 For OpenClaw or Hermes, ask before the first sandbox build: "Do you want to configure a messaging channel during onboarding?"
-Choices: No, Telegram, Discord, Slack, WhatsApp, WeChat (experimental).
+Before offering choices, read the selected agent's current **Enable Channels During Onboarding** page and present every channel in that picker; do not rely on a copied channel list.
 Skip messaging for Deep Agents.
 Configure one channel at a time, then ask whether to add another.
 Collect messaging before policy selection so the first image includes channel configuration and matching network presets.
@@ -230,6 +230,8 @@ Collect messaging before policy selection so the first image includes channel co
 - Slack requires `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN`; optional settings include allowed users and channels.
 - WhatsApp uses documented allowed IDs for non-interactive selection, followed by QR pairing after startup.
 - WeChat requires an interactive QR handshake; explain the limitation before installation and never leave an unsupported UI waiting.
+- Microsoft Teams is experimental and requires `MSTEAMS_APP_ID`, `MSTEAMS_APP_PASSWORD`, and `MSTEAMS_TENANT_ID`, plus a public HTTPS messaging endpoint ending in `/api/messages`; optional settings include an Entra user allowlist, webhook port, and mention mode.
+- Google Chat is experimental and requires service-account JSON. Follow the selected agent's setup page: OpenClaw uses an interactive public `/googlechat` webhook enrollment, while Hermes requires a Google Cloud project ID, complete Pub/Sub subscription name, and email sender allowlist.
 
 Collect messaging secrets through the reviewed helper and URL-specific SSH flow.
 Do not manually set `NEMOCLAW_MESSAGING_PLAN_B64`; NemoClaw compiles the selected messaging configuration into this derived sandbox image build artifact and removes the full plan from the runtime environment.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

NemoClaw documentation now matches merged behavior for inference validation and recovery, onboarding policy selection, WSL Docker credential fallback, and supported messaging channels. Stale channel health-check and command examples are corrected without documenting dormant native Windows or MXC work as supported.

## Reason

A post-merge audit of `v0.0.115..8c42560869ca7003b652217b769831b6b8b342d4` found user-visible behavior that was missing from its owning pages or described by stale enumerations.

## Changes

- Document OpenClaw compatible-endpoint sandbox validation and Hermes Portable published Ollama recovery, including exact-authority checks, route proof, rollback, and operator stop conditions.
- Correct messaging onboarding, tunnel, restart, channel-command, credential, and post-rebuild health-check guidance for the current manifest-backed channel set.
- Clarify fresh-onboarding versus retained-tier web-search policy behavior.
- Document the bounded WSL credential-free Docker fallback and its cleanup boundary.

## Verification

- `npm run docs` — passed with 0 errors; Fern reported 2 unrelated warnings.
- `npm run validate:pr` — passed all applicable pre-commit, commit-message, and pre-push checks.
- Independent documentation-writer review of diff SHA-256 `5b3f971ec5ca1d681c588f0ac6f1ae3d3253ddaf9a291a1abde8da99c5637930` — no findings.
- `git diff --check` — passed.
- No tests were added because this is documentation-only catch-up; the claims were checked against the existing implementation and regression tests.
- The diff contains no secrets, API keys, or credentials.

---
Signed-off-by: Apurv Kumaria <akumaria@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for recovering and reconnecting stopped Portable Hermes sandboxes, including validation, rollback, and inference checks.
  * Clarified onboarding validation for OpenAI-compatible endpoints and no-auth loopback configurations.
  * Updated channel setup and verification guidance, including experimental Microsoft Teams and Google Chat requirements.
  * Clarified network policy behavior for retained presets and provider-specific web search.
  * Expanded troubleshooting for Docker credentials, messaging configuration, and compatible endpoints.
  * Clarified that tunnel startup does not start channel messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->