### PR TITLE
fix(onboard): reject inference route on HTTP 404 from /v1/models

### DIFF
--- a/docs/reference/troubleshooting.mdx
+++ b/docs/reference/troubleshooting.mdx
@@ -1232,6 +1232,31 @@ bash uninstall.sh --yes
 curl -fsSL https://www.nvidia.com/nemoclaw.sh | bash
 ```
 
+<AgentOnly variant="openclaw,hermes">
+
+### Onboarding fails because the inference route served no model catalog
+
+Onboarding verifies the sandbox inference route before it reports the deployment healthy.
+When `https://inference.local/v1/models` keeps returning `HTTP 404`, the route answered but served no model catalog, so nothing validated your selected model against the provider.
+Onboarding retries for the usual startup budget, then marks the `inference` check failed and exits nonzero instead of reporting a verified deployment.
+
+Re-check the route and the recorded provider and model:
+
+```bash
+$$nemoclaw <name> status
+```
+
+`$$nemoclaw <name> status` applies the same HTTP 404 rule, so onboarding and status agree about the model catalog.
+
+Confirm the provider and model are configured for this sandbox and that the endpoint serves `/v1/models`.
+This result is resumable, so correct the endpoint and continue the recorded session:
+
+```bash
+$$nemoclaw onboard --resume
+```
+
+</AgentOnly>
+
 ## Runtime
 
 <AgentOnly variant="openclaw">

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -3358,27 +3358,19 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
               {
                 executeSandboxCommand: (sandbox: string, script: string) =>
                   executeSandboxCommandForVerification(sandbox, script),
-                probeHostPort: (port: number, probePath: string) => {
-                  const result = runCapture(
-                    [
-                      "curl",
-                      "-so",
-                      "/dev/null",
-                      "-w",
-                      "%{http_code}",
-                      "--max-time",
-                      "3",
-                      `http://127.0.0.1:${port}${probePath}`,
-                    ],
-                    { ignoreError: true },
-                  );
-                  return parseInt(result.trim(), 10) || 0;
-                },
+                probeHostPort: onboardDashboard.probeVerificationHostPort,
                 captureForwardList: () =>
                   runCaptureOpenshell(["forward", "list"], { ignoreError: true }) || null,
                 getMessagingChannels: () => liveFinalFlowContext.selectedMessagingChannels || [],
                 providerExistsInGateway: (providerName: string) =>
                   providerExistsInGateway(providerName),
+                probeInferenceInvocation: () =>
+                  verifyDeploymentModule.probeOnboardInferenceInvocation({
+                    ...liveFinalFlowContext,
+                    sandboxName: name,
+                    gatewayName: GATEWAY_NAME,
+                    agentName: agent?.name,
+                  }),
               },
               {
                 diagnoseCustomOpenClawRuntime:
@@ -3386,6 +3378,10 @@ async function runOnboard(opts: OnboardOptions = {}): Promise<void> {
                     liveFinalFlowContext.fromDockerfile,
                     agent?.name,
                   ),
+                inferenceRouteContext: {
+                  agentName: agent?.name,
+                  provider: liveFinalFlowContext.provider,
+                },
               },
             );
           },

--- a/src/lib/onboard/dashboard.test.ts
+++ b/src/lib/onboard/dashboard.test.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+import * as runner from "../runner";
+import { probeVerificationHostPort } from "./dashboard";
+
+describe("probeVerificationHostPort", () => {
+  it("returns the HTTP status the forwarded port answered with", () => {
+    vi.spyOn(runner, "runCapture").mockReturnValue("200\n");
+
+    expect(probeVerificationHostPort(18789, "/health")).toBe(200);
+  });
+
+  it("probes the forwarded port on loopback with a bounded timeout", () => {
+    const runCapture = vi.spyOn(runner, "runCapture").mockReturnValue("200");
+
+    probeVerificationHostPort(18789, "/health");
+
+    expect(runCapture).toHaveBeenCalledWith(
+      expect.arrayContaining(["curl", "--max-time", "3", "http://127.0.0.1:18789/health"]),
+      { ignoreError: true },
+    );
+  });
+
+  it("reports 0 when the forward is down and curl prints nothing", () => {
+    vi.spyOn(runner, "runCapture").mockReturnValue("");
+
+    expect(probeVerificationHostPort(18789, "/health")).toBe(0);
+  });
+});

--- a/src/lib/onboard/dashboard.ts
+++ b/src/lib/onboard/dashboard.ts
@@ -792,3 +792,27 @@ export function createOnboardDashboardHelpers(deps: OnboardDashboardDeps): Onboa
     stopAllDashboardForwards,
   };
 }
+
+const HOST_PROBE_MAX_SECONDS = "3";
+
+/**
+ * Probe a dashboard-chain port on the host through its forward, for the
+ * onboarding deployment verification. Returns the HTTP status, or 0 when the
+ * forward is down.
+ */
+export function probeVerificationHostPort(port: number, probePath: string): number {
+  const result = defaultRunCapture(
+    [
+      "curl",
+      "-so",
+      "/dev/null",
+      "-w",
+      "%{http_code}",
+      "--max-time",
+      HOST_PROBE_MAX_SECONDS,
+      `http://127.0.0.1:${port}${probePath}`,
+    ],
+    { ignoreError: true },
+  );
+  return parseInt(result.trim(), 10) || 0;
+}

--- a/src/lib/verify-deployment-inference-route.test.ts
+++ b/src/lib/verify-deployment-inference-route.test.ts
@@ -283,4 +283,20 @@ describe("verifyDeployment inference route model-catalog validation", () => {
       detail: "no provider and model were recorded for this sandbox",
     });
   });
+
+  it("fails closed when a model was recorded without its provider (#10543)", () => {
+    const result = probeOnboardInferenceInvocation({
+      sandboxName: "my-sandbox",
+      gatewayName: "my-gateway",
+      agentName: DCODE_AGENT,
+      model: "openai/gpt-4o-mini",
+      provider: null,
+      preferredInferenceApi: null,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      detail: "no provider and model were recorded for this sandbox",
+    });
+  });
 });

--- a/src/lib/verify-deployment-inference-route.test.ts
+++ b/src/lib/verify-deployment-inference-route.test.ts
@@ -77,6 +77,36 @@ describe("verifyDeployment inference route model-catalog validation", () => {
     expect(result.verification.inferenceRouteWorking).toBe(true);
   });
 
+  it.each(["200junk", "20", "0200"])(
+    "fails the deployment when the models route answers with the malformed token %j (#10609)",
+    async (stdout) => {
+      const result = await verifyDeployment(
+        "my-sandbox",
+        buildChain(),
+        makeModelsRouteDeps(stdout),
+        NO_RETRY,
+      );
+
+      expect(result.verification.inferenceRouteWorking).toBe(false);
+    },
+  );
+
+  it("fails the deployment when the models-route command exits nonzero (#10609)", async () => {
+    const result = await verifyDeployment(
+      "my-sandbox",
+      buildChain(),
+      makeModelsRouteDeps("200", {
+        executeSandboxCommand: (_name: string, script: string) =>
+          script.includes("inference.local")
+            ? { status: 1, stdout: "200", stderr: "curl: (6) could not resolve host" }
+            : { status: 0, stdout: "200", stderr: "" },
+      }),
+      NO_RETRY,
+    );
+
+    expect(result.verification.inferenceRouteWorking).toBe(false);
+  });
+
   it("accepts the Deep Agents Code OpenRouter 404 when an inference request succeeds (#9834)", async () => {
     const result = await verifyDeployment(
       "my-sandbox",

--- a/src/lib/verify-deployment-inference-route.test.ts
+++ b/src/lib/verify-deployment-inference-route.test.ts
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { buildChain } from "./dashboard/contract.js";
+import { probeOnboardInferenceInvocation, verifyDeployment } from "./verify-deployment.js";
+
+const NO_RETRY = { retryDelaysMs: [], sleep: async (_ms: number) => {} };
+const DCODE_AGENT = "langchain-deepagents-code";
+
+function makeDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    executeSandboxCommand: (_name: string, _script: string) => ({
+      status: 0,
+      stdout: "200",
+      stderr: "",
+    }),
+    probeHostPort: (_port: number, _path: string) => 200,
+    captureForwardList: () => "my-sandbox  127.0.0.1  18789  12345  running",
+    getMessagingChannels: (_name: string) => [] as string[],
+    providerExistsInGateway: (_name: string) => true,
+    ...overrides,
+  };
+}
+
+/** Answer the models route with `code` and every other probe with HTTP 200. */
+function makeModelsRouteDeps(code: string, overrides: Record<string, unknown> = {}) {
+  return makeDeps({
+    executeSandboxCommand: (_name: string, script: string) =>
+      script.includes("inference.local")
+        ? { status: 0, stdout: code, stderr: "" }
+        : { status: 0, stdout: "200", stderr: "" },
+    ...overrides,
+  });
+}
+
+describe("verifyDeployment inference route model-catalog validation", () => {
+  it("fails the deployment when the models route returns HTTP 404 (#10543)", async () => {
+    const result = await verifyDeployment("my-sandbox", buildChain(), makeModelsRouteDeps("404"), {
+      ...NO_RETRY,
+      inferenceRouteContext: { agentName: "openclaw", provider: "openrouter-api" },
+    });
+
+    expect(result.verification.inferenceRouteWorking).toBe(false);
+    expect(result.healthy).toBe(false);
+  });
+
+  it("names the unvalidated model catalog as the reason for a 404 (#10543)", async () => {
+    const result = await verifyDeployment("my-sandbox", buildChain(), makeModelsRouteDeps("404"), {
+      ...NO_RETRY,
+      inferenceRouteContext: { agentName: "openclaw", provider: "openrouter-api" },
+    });
+
+    const inference = result.diagnostics.find((entry) => entry.link === "inference");
+    expect(inference?.status).toBe("fail");
+    expect(inference?.detail).toContain("HTTP 404");
+    expect(inference?.detail).toContain("model catalog");
+  });
+
+  it("fails a 404 for every agent when no route context is wired (#10543)", async () => {
+    const result = await verifyDeployment(
+      "my-sandbox",
+      buildChain(),
+      makeModelsRouteDeps("404"),
+      NO_RETRY,
+    );
+
+    expect(result.verification.inferenceRouteWorking).toBe(false);
+  });
+
+  it("keeps a credential-gated HTTP 401 models route healthy (#2342)", async () => {
+    const result = await verifyDeployment("my-sandbox", buildChain(), makeModelsRouteDeps("401"), {
+      ...NO_RETRY,
+      inferenceRouteContext: { agentName: "openclaw", provider: "openrouter-api" },
+    });
+
+    expect(result.verification.inferenceRouteWorking).toBe(true);
+  });
+
+  it("accepts the Deep Agents Code OpenRouter 404 when an inference request succeeds (#9834)", async () => {
+    const result = await verifyDeployment(
+      "my-sandbox",
+      buildChain(),
+      makeModelsRouteDeps("404", { probeInferenceInvocation: () => ({ ok: true }) }),
+      {
+        ...NO_RETRY,
+        inferenceRouteContext: { agentName: DCODE_AGENT, provider: "openrouter-api" },
+      },
+    );
+
+    expect(result.verification.inferenceRouteWorking).toBe(true);
+  });
+
+  it("fails the Deep Agents Code OpenRouter 404 when the inference request fails (#10543)", async () => {
+    const result = await verifyDeployment(
+      "my-sandbox",
+      buildChain(),
+      makeModelsRouteDeps("404", {
+        probeInferenceInvocation: () => ({ ok: false, detail: "HTTP 401" }),
+      }),
+      {
+        ...NO_RETRY,
+        inferenceRouteContext: { agentName: DCODE_AGENT, provider: "openrouter-api" },
+      },
+    );
+
+    expect(result.verification.inferenceRouteWorking).toBe(false);
+  });
+
+  it("fails the Deep Agents Code OpenRouter 404 when no invocation probe is wired (#10543)", async () => {
+    const result = await verifyDeployment("my-sandbox", buildChain(), makeModelsRouteDeps("404"), {
+      ...NO_RETRY,
+      inferenceRouteContext: { agentName: DCODE_AGENT, provider: "openrouter-api" },
+    });
+
+    expect(result.verification.inferenceRouteWorking).toBe(false);
+  });
+
+  it("points a failed by-design 404 at the inference request, not the model catalog (#10543)", async () => {
+    const result = await verifyDeployment(
+      "my-sandbox",
+      buildChain(),
+      makeModelsRouteDeps("404", {
+        probeInferenceInvocation: () => ({ ok: false, detail: "HTTP 401" }),
+      }),
+      {
+        ...NO_RETRY,
+        inferenceRouteContext: { agentName: DCODE_AGENT, provider: "openrouter-api" },
+      },
+    );
+
+    const inference = result.diagnostics.find((entry) => entry.link === "inference");
+    expect(inference?.hint).toContain("serve no model catalog");
+    expect(inference?.hint).not.toContain("endpoint serves");
+  });
+
+  it("tells a plain 404 to make the model catalog available (#10543)", async () => {
+    const result = await verifyDeployment("my-sandbox", buildChain(), makeModelsRouteDeps("404"), {
+      ...NO_RETRY,
+      inferenceRouteContext: { agentName: "openclaw", provider: "openrouter-api" },
+    });
+
+    const inference = result.diagnostics.find((entry) => entry.link === "inference");
+    expect(inference?.hint).toContain("served no model catalog");
+    expect(inference?.hint).toContain("/v1/models");
+  });
+
+  it("fails a 404 for the default agent that onboarding leaves unnamed (#10543)", async () => {
+    const result = await verifyDeployment("my-sandbox", buildChain(), makeModelsRouteDeps("404"), {
+      ...NO_RETRY,
+      inferenceRouteContext: { agentName: undefined, provider: "openrouter-api" },
+    });
+
+    expect(result.verification.inferenceRouteWorking).toBe(false);
+  });
+
+  it("gives a plain 404 the startup budget before failing it closed (#10543)", async () => {
+    let modelsRouteCalls = 0;
+    const deps = makeDeps({
+      executeSandboxCommand: (_name: string, script: string) => {
+        const isModelsRoute = script.includes("inference.local");
+        modelsRouteCalls += isModelsRoute ? 1 : 0;
+        return isModelsRoute
+          ? { status: 0, stdout: "404", stderr: "" }
+          : { status: 0, stdout: "200", stderr: "" };
+      },
+    });
+
+    const result = await verifyDeployment("my-sandbox", buildChain(), deps, {
+      retryDelaysMs: [1, 1, 1],
+      sleep: async (_ms: number) => {},
+      inferenceRouteContext: { agentName: "openclaw", provider: "openrouter-api" },
+    });
+
+    expect(modelsRouteCalls).toBe(4);
+    expect(result.verification.inferenceRouteWorking).toBe(false);
+  });
+
+  it("recovers when the model catalog registers after a late 404 (#6849)", async () => {
+    const responses = ["404", "404", "200"];
+    let modelsRouteCalls = 0;
+    const deps = makeDeps({
+      executeSandboxCommand: (_name: string, script: string) => {
+        const isModelsRoute = script.includes("inference.local");
+        modelsRouteCalls += isModelsRoute ? 1 : 0;
+        return isModelsRoute
+          ? { status: 0, stdout: responses[modelsRouteCalls - 1] ?? "200", stderr: "" }
+          : { status: 0, stdout: "200", stderr: "" };
+      },
+    });
+
+    const result = await verifyDeployment("my-sandbox", buildChain(), deps, {
+      retryDelaysMs: [1, 1, 1],
+      sleep: async (_ms: number) => {},
+      inferenceRouteContext: { agentName: "openclaw", provider: "openrouter-api" },
+    });
+
+    expect(result.verification.inferenceRouteWorking).toBe(true);
+  });
+
+  it("spends no models-route retry budget on the expected Deep Agents Code 404 (#10543)", async () => {
+    let modelsRouteCalls = 0;
+    const deps = makeDeps({
+      executeSandboxCommand: (_name: string, script: string) => {
+        const isModelsRoute = script.includes("inference.local");
+        modelsRouteCalls += isModelsRoute ? 1 : 0;
+        return isModelsRoute
+          ? { status: 0, stdout: "404", stderr: "" }
+          : { status: 0, stdout: "200", stderr: "" };
+      },
+      probeInferenceInvocation: () => ({ ok: true }),
+    });
+
+    await verifyDeployment("my-sandbox", buildChain(), deps, {
+      retryDelaysMs: [1, 1, 1],
+      sleep: async (_ms: number) => {},
+      inferenceRouteContext: { agentName: DCODE_AGENT, provider: "openrouter-api" },
+    });
+
+    expect(modelsRouteCalls).toBe(1);
+  });
+
+  it("runs the invocation probe once for the Deep Agents Code 404 exception (#10543)", async () => {
+    let invocationCalls = 0;
+    const deps = makeModelsRouteDeps("404", {
+      probeInferenceInvocation: () => {
+        invocationCalls += 1;
+        return { ok: false, detail: "HTTP 500" };
+      },
+    });
+
+    await verifyDeployment("my-sandbox", buildChain(), deps, {
+      retryDelaysMs: [1, 1, 1],
+      sleep: async (_ms: number) => {},
+      inferenceRouteContext: { agentName: DCODE_AGENT, provider: "openrouter-api" },
+    });
+
+    expect(invocationCalls).toBe(1);
+  });
+
+  it("fails closed when no provider and model were recorded for the sandbox (#10543)", () => {
+    const result = probeOnboardInferenceInvocation({
+      sandboxName: "my-sandbox",
+      gatewayName: "my-gateway",
+      agentName: DCODE_AGENT,
+      model: null,
+      provider: "openrouter-api",
+      preferredInferenceApi: null,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      detail: "no provider and model were recorded for this sandbox",
+    });
+  });
+});

--- a/src/lib/verify-deployment.ts
+++ b/src/lib/verify-deployment.ts
@@ -20,6 +20,11 @@
 import os from "node:os";
 
 import { parseVersionFromText } from "./adapters/openshell/client";
+import {
+  isDcodeOpenRouterModelsRoute404,
+  runSandboxInferenceInvocationProbe,
+  type SandboxInferenceRouteHealthContext,
+} from "./actions/sandbox/inference-route-health";
 import { compareChannelSets, type RuntimeChannelStatus } from "./channel-runtime-status";
 import type { DashboardDeliveryChain } from "./dashboard/contract";
 import { listMessagingChannelsWithoutCredentials } from "./messaging/channels";
@@ -108,6 +113,15 @@ export interface VerifyDeploymentDeps {
   providerExistsInGateway: (providerName: string) => boolean;
 
   /**
+   * Send one bounded inference request over the gateway route from inside the
+   * sandbox. Only consulted for the Deep Agents Code OpenRouter models route,
+   * whose HTTP 404 is expected (#9834) and can only be accepted on the
+   * evidence of a served request. Optional: when it is absent that 404 fails
+   * closed, because nothing validated the selected model (#10543).
+   */
+  probeInferenceInvocation?: () => { ok: boolean; detail?: string };
+
+  /**
    * Probe the in-sandbox agent config to learn which channels the runtime
    * would actually expose to the dashboard "Channels" snapshot. Optional:
    * onboarding only wires it when the agent has a JSON config the runtime
@@ -142,6 +156,12 @@ export interface VerifyDeploymentOptions {
    * startup paths intentionally differ.
    */
   diagnoseCustomOpenClawRuntime?: boolean;
+  /**
+   * Agent and provider behind this deployment, used to recognise the one
+   * models route that answers HTTP 404 by design (#9834). Defaults to no
+   * agent and no provider, which fails every 404 closed.
+   */
+  inferenceRouteContext?: InferenceRouteContext;
 }
 
 const DEFAULT_RETRY_DELAYS_MS: readonly number[] = [
@@ -239,31 +259,126 @@ function fetchGatewayVersion(sandboxName: string, deps: VerifyDeploymentDeps): s
 
 type InferenceRouteStatus = "ok" | "unreachable" | "unhealthy";
 
+/**
+ * Agent and provider behind the deployment, normalised into the context
+ * `status` uses so the two readiness paths cannot drift (#10080).
+ */
+export type InferenceRouteContext = {
+  agentName?: string | null;
+  provider?: string | null;
+};
+
+function toRouteHealthContext(context: InferenceRouteContext): SandboxInferenceRouteHealthContext {
+  return { agentName: context.agentName ?? null, provider: context.provider ?? null };
+}
+
+type InferenceRouteProbe = {
+  status: InferenceRouteStatus;
+  detail: string;
+  /** Status the models route answered with, or 0 when it never answered. */
+  httpCode: number;
+  /** Set when the status alone would point the user at the wrong remedy. */
+  hint?: string;
+};
+
 function probeInferenceRouteOnce(
   sandboxName: string,
   deps: VerifyDeploymentDeps,
-): { status: InferenceRouteStatus; detail: string } {
+): InferenceRouteProbe {
   const script =
     `HTTP_CODE=$(curl -so /dev/null -w '%{http_code}' --max-time ${INFERENCE_ROUTE_REACHABILITY_MAX_SECONDS} ` +
     `https://inference.local/v1/models 2>/dev/null || echo 000); echo $HTTP_CODE`;
   const result = deps.executeSandboxCommand(sandboxName, script);
   if (!result) {
-    return { status: "unreachable", detail: "sandbox unreachable" };
+    return { status: "unreachable", detail: "sandbox unreachable", httpCode: 0 };
   }
   const code = parseInt(result.stdout.trim(), 10) || 0;
   if (code === 0) {
     return {
       status: "unreachable",
       detail: "inference.local unreachable (DNS or proxy not running)",
+      httpCode: 0,
     };
   }
   if (code >= 500) {
     return {
       status: "unhealthy",
       detail: `inference.local returned HTTP ${code} (route reachable but endpoint unhealthy)`,
+      httpCode: code,
     };
   }
-  return { status: "ok", detail: `inference.local responded HTTP ${code}` };
+  // A models route that answers 404 has no model catalog, so nothing validated
+  // the selected model against the provider. `status` already fails closed on
+  // that (#10080); onboarding kept calling it healthy and exiting 0, so the two
+  // readiness paths disagreed about the same route (#10543). A credential-gated
+  // 401/403 stays healthy here: that route did answer, it just wants a key
+  // (#2342).
+  if (code === 404) {
+    return {
+      status: "unhealthy",
+      detail:
+        `inference.local returned HTTP ${code}, so the selected model was never ` +
+        `validated against a model catalog`,
+      httpCode: code,
+    };
+  }
+  return { status: "ok", detail: `inference.local responded HTTP ${code}`, httpCode: code };
+}
+
+/**
+ * A 404 needs its own hint: the route answered, so neither the "unreachable
+ * proxy" nor the "5xx endpoint" remedy applies. The model catalog is what is
+ * missing (#10543).
+ */
+function buildInferenceRouteHint(inference: InferenceRouteProbe): string {
+  if (inference.status === "ok") return "";
+  if (inference.hint) return inference.hint;
+  if (inference.httpCode === 404) {
+    return (
+      "The inference route answered but served no model catalog, so the selected model was " +
+      "never validated. Confirm the provider and model are configured for this sandbox and " +
+      "that the endpoint serves /v1/models, then re-run: nemoclaw <sandbox> status."
+    );
+  }
+  if (inference.status === "unhealthy") {
+    return "The inference route is reachable but the endpoint returned a server error (HTTP 5xx). If the endpoint runs on the host, configure it to listen on a host address reachable through host.openshell.internal and restrict access with the host firewall or equivalent controls; a 127.0.0.1/localhost-only bind is not reachable from the sandbox. Then re-run: nemoclaw <sandbox> status.";
+  }
+  return "The inference proxy is unreachable. Confirm the configured endpoint is running and reachable from the sandbox, then re-run: nemoclaw <sandbox> status.";
+}
+
+/**
+ * Resolve the one 404 that is expected: Deep Agents Code on OpenRouter serves
+ * no model catalog (#9834). Matching the shared predicate is necessary but not
+ * sufficient — the route status alone proves nothing about whether the sandbox
+ * can invoke its selected model — so accept it only through a successful
+ * bounded inference request, exactly as `status` does.
+ */
+function resolveExpectedModelsRoute404(
+  probe: InferenceRouteProbe,
+  deps: VerifyDeploymentDeps,
+): InferenceRouteProbe {
+  const invocation = deps.probeInferenceInvocation?.() ?? null;
+  if (invocation?.ok) {
+    return {
+      status: "ok",
+      detail:
+        "inference.local served an inference request; its models route answers " +
+        "HTTP 404 by design for this agent and provider",
+      httpCode: probe.httpCode,
+    };
+  }
+  const reason = invocation?.detail ?? "no inference request confirmed the selected model";
+  return {
+    status: "unhealthy",
+    detail:
+      `inference.local answered HTTP ${probe.httpCode} on its models route, which is expected ` +
+      `for this agent and provider, but no inference request confirmed the selected model: ${reason}`,
+    httpCode: probe.httpCode,
+    hint:
+      "This agent and provider serve no model catalog, so the models route answering HTTP 404 is " +
+      "expected. The inference request itself failed. Confirm the provider credential and the " +
+      "selected model, then re-run: nemoclaw <sandbox> status.",
+  };
 }
 
 async function verifyInferenceRoute(
@@ -271,12 +386,21 @@ async function verifyInferenceRoute(
   deps: VerifyDeploymentDeps,
   retryDelaysMs: readonly number[],
   sleep: (ms: number) => Promise<void>,
-): Promise<{ status: InferenceRouteStatus; detail: string }> {
-  return retryUntilAsync(() => probeInferenceRouteOnce(sandboxName, deps), {
-    accept: (result) => result.status === "ok",
+  context: InferenceRouteContext,
+): Promise<InferenceRouteProbe> {
+  const routeContext = toRouteHealthContext(context);
+  const isExpected404 = (result: InferenceRouteProbe) =>
+    isDcodeOpenRouterModelsRoute404(routeContext, result.httpCode);
+  // An ordinary 404 still gets the startup budget: a route can answer before
+  // its model catalog is registered, and the inference probe already recovers
+  // a late route (#6849). Only the 404 that is expected settles immediately,
+  // so the by-design case does not wait out a budget it can never satisfy.
+  const probe = await retryUntilAsync(() => probeInferenceRouteOnce(sandboxName, deps), {
+    accept: (result) => result.status === "ok" || isExpected404(result),
     retryDelaysMs,
     sleep,
   });
+  return isExpected404(probe) ? resolveExpectedModelsRoute404(probe, deps) : probe;
 }
 
 /**
@@ -630,18 +754,14 @@ export async function verifyDeployment(
     deps,
     gateway.reachable ? retryDelaysMs : [],
     sleep,
+    options.inferenceRouteContext ?? {},
   );
   const inferenceRouteWorking = inference.status === "ok";
   diagnostics.push({
     link: "inference",
     status: inference.status === "ok" ? "ok" : "fail",
     detail: inference.detail,
-    hint:
-      inference.status === "ok"
-        ? ""
-        : inference.status === "unhealthy"
-          ? "The inference route is reachable but the endpoint returned a server error (HTTP 5xx). If the endpoint runs on the host, configure it to listen on a host address reachable through host.openshell.internal and restrict access with the host firewall or equivalent controls; a 127.0.0.1/localhost-only bind is not reachable from the sandbox. Then re-run: nemoclaw <sandbox> status."
-          : "The inference proxy is unreachable. Confirm the configured endpoint is running and reachable from the sandbox, then re-run: nemoclaw <sandbox> status.",
+    hint: buildInferenceRouteHint(inference),
   });
 
   // 5. Messaging bridges (providers attached AND runtime config exposes
@@ -732,4 +852,39 @@ export function formatVerificationDiagnostics(result: VerifyDeploymentResult): s
   lines.push(`  ${D}The sandbox was created successfully but may not be fully functional.${RESET}`);
   lines.push(`  ${D}Run: nemoclaw <sandbox> status  — to re-check after a few seconds.${RESET}`);
   return lines;
+}
+
+export type InferenceInvocationContext = {
+  sandboxName: string;
+  gatewayName: string;
+  agentName: string | null | undefined;
+  model: string | null;
+  provider: string | null;
+  preferredInferenceApi: string | null;
+};
+
+/**
+ * The standard `probeInferenceInvocation` dependency: send one bounded
+ * inference request over the gateway route, using the same probe `status`
+ * runs. Onboarding wires this so the one models route that answers HTTP 404 by
+ * design — Deep Agents Code on OpenRouter (#9834) — is accepted only on the
+ * evidence of a served request (#10543).
+ */
+export function probeOnboardInferenceInvocation(context: InferenceInvocationContext): {
+  ok: boolean;
+  detail?: string;
+} {
+  const { model, provider } = context;
+  if (!model || !provider) {
+    return { ok: false, detail: "no provider and model were recorded for this sandbox" };
+  }
+  const result = runSandboxInferenceInvocationProbe({
+    sandboxName: context.sandboxName,
+    gatewayName: context.gatewayName,
+    agentName: context.agentName ?? null,
+    provider,
+    model,
+    preferredInferenceApi: context.preferredInferenceApi,
+  });
+  return result.ok ? { ok: true } : { ok: false, detail: result.detail };
 }

--- a/src/lib/verify-deployment.ts
+++ b/src/lib/verify-deployment.ts
@@ -292,7 +292,12 @@ function probeInferenceRouteOnce(
   if (!result) {
     return { status: "unreachable", detail: "sandbox unreachable", httpCode: 0 };
   }
-  const code = parseInt(result.stdout.trim(), 10) || 0;
+  // curl writes exactly three digits and the script echoes `000` when it fails,
+  // so any other token means the probe carries no status worth trusting.
+  // `parseInt` read `200junk` as 200 and a nonzero command result was ignored
+  // outright, either of which could report an unanswered route as healthy.
+  const output = result.stdout.trim();
+  const code = result.status === 0 && /^\d{3}$/u.test(output) ? Number(output) : 0;
   if (code === 0) {
     return {
       status: "unreachable",


### PR DESCRIPTION
## Outcome

Onboarding now rejects an inference route whose `/v1/models` endpoint returns HTTP 404. It no longer reports `Deployment verified` or exits successfully when the selected model was not validated against a model catalog.

## Reason

The onboarding verifier treated every HTTP status below 500 as healthy. `nemoclaw <sandbox> status` already rejected the same OpenClaw route, so the two readiness paths disagreed.

### Related issues

Fixes #10543

## Changes

- Treat an exact HTTP 404 from `/v1/models` as unhealthy after the existing startup retry budget.
- Reject malformed status output and nonzero probe exits instead of accepting a numeric prefix.
- Add OpenClaw and Hermes regression coverage, including retry recovery and user-visible diagnostics.
- Document the resumable recovery path.

## Verification

- `npx vitest run --project cli src/lib/verify-deployment-inference-route.test.ts src/lib/verify-deployment.test.ts src/lib/verify-deployment-agent.test.ts src/lib/verify-deployment-messaging.test.ts src/lib/onboard/machine/handlers/finalization.test.ts --no-file-parallelism` — 5 files, 98 tests passed.
- Targeted mutation dropping the provider guard in `probeOnboardInferenceInvocation` made only the new missing-provider test fail; restoring it returned the focused suite to green.
- `npm run typecheck:cli` — passed.
- `npm run checks:repository` — passed, including architecture and growth guardrails.
- `npm run docs` — passed with 0 errors and 2 warnings.
- `npm run validate:pr` — passed.
- Documentation writer review — PASS (`no-docs-needed`) on `a4a687deb0` with root `AGENTS.md` blob `dd3528f6e332f7f09f4841555c2ed11cb2139fb9`.
- `git diff --check` and secret scan — passed.

## Review notes

- A plain 404 keeps the existing startup retry budget so a late model catalog can recover (#6849).
- HTTP 401 and 403 retain the existing onboarding behavior tracked under #2342.
- This change is limited to the reported HTTP 404. It does not claim full status-policy parity for other HTTP responses.
- Deep Agents Code is unaffected because finalization already skips deployment verification for terminal agents without forwards; that boundary is covered by the existing terminal-agent test.
- No live WSL/OpenShell sandbox was used; the tests drive the production verifier with only command and host-port boundaries stubbed.

---
<!-- DCO sign-off is required in this PR description. Every commit must appear as Verified in GitHub. -->
<!-- documentation-writer-review
result: PASS
reviewed-head: a4a687deb073fefbf3a62a23d915494b5ae99f3c
agents-blob: dd3528f6e332f7f09f4841555c2ed11cb2139fb9
agent-surface: Claude Code documentation-writer subagent
-->
Signed-off-by: harjoth <harjoth.khara@gmail.com>

P.S. — you should hire me. 115+ contributions to open source: https://github.com/harjothkhara


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment verification for inference endpoints with clearer diagnostics, authentication handling, retry support, and safer failure reporting.
  * Added validation for model catalogs and inference responses, including supported handling for expected OpenRouter responses after successful inference.
  * Improved dashboard connectivity checks with timeout handling and reliable status reporting.

* **Documentation**
  * Added troubleshooting guidance for onboarding failures caused by `/v1/models` returning HTTP 404, including endpoint validation and recovery steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
