### PR TITLE
perf(portable): reduce OpenClaw gateway readiness polling

### DIFF
--- a/src/lib/onboard/experimental/__test-helpers__/portable-demo-gateway-wait.ts
+++ b/src/lib/onboard/experimental/__test-helpers__/portable-demo-gateway-wait.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export function gatewayWaitResult(
+  result: "ready" | "not-ready" = "ready",
+  failures: {
+    notReady?: number;
+    timeouts?: number;
+    errors?: number;
+    probeMs?: number;
+    sleepMs?: number;
+  } = {},
+) {
+  const notReady = failures.notReady ?? 0;
+  const timeouts = failures.timeouts ?? 0;
+  const errors = failures.errors ?? 0;
+  const failureCount = notReady + timeouts + errors;
+  const lastFailure =
+    errors > 0 ? "error" : timeouts > 0 ? "timeout" : notReady > 0 ? "not-ready" : "none";
+  const attempts = failureCount + (result === "ready" ? 1 : 0);
+  const probeMs = failures.probeMs ?? 0;
+  const sleepMs = failures.sleepMs ?? 0;
+  return {
+    status: result === "ready" ? 0 : 75,
+    stdout: `schema=1 result=${result} attempts=${String(attempts)} notReady=${String(notReady)} timeouts=${String(timeouts)} errors=${String(errors)} lastFailure=${lastFailure} probeMs=${String(probeMs)} sleepMs=${String(sleepMs)}\n`,
+  };
+}

--- a/src/lib/onboard/experimental/__test-helpers__/portable-demo-gateway-wait.ts
+++ b/src/lib/onboard/experimental/__test-helpers__/portable-demo-gateway-wait.ts
@@ -11,7 +11,14 @@ export function gatewayWaitResult(
     sleepMs?: number;
   } = {},
 ) {
-  const notReady = failures.notReady ?? 0;
+  const defaultNotReady =
+    result === "not-ready" &&
+    failures.notReady === undefined &&
+    failures.timeouts === undefined &&
+    failures.errors === undefined
+      ? 1
+      : 0;
+  const notReady = failures.notReady ?? defaultNotReady;
   const timeouts = failures.timeouts ?? 0;
   const errors = failures.errors ?? 0;
   const failureCount = notReady + timeouts + errors;

--- a/src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts
@@ -363,11 +363,20 @@ describe("portable lifecycle recovery timing output", () => {
       }),
     ).toEqual({ kind: "already-running" });
     expect(now).toBe(2_000);
-    expect(
-      captureOpenshell.mock.calls.map(([args]) =>
-        args.find((arg) => ["true", "pgrep", "curl", "python3"].includes(arg)),
-      ),
-    ).toEqual(["true", "curl", "pgrep", "python3"]);
+    const curlCalls = captureOpenshell.mock.calls.filter(([args]) => args.includes("curl"));
+    const waiterCalls = captureOpenshell.mock.calls.filter(([args]) => args.includes("python3"));
+    expect(curlCalls).toHaveLength(1);
+    expect(waiterCalls).toHaveLength(1);
+    const waiterArgs = waiterCalls[0]?.[0] ?? [];
+    expect(waiterArgs.slice(waiterArgs.lastIndexOf("--") + 1)).toEqual([
+      "python3",
+      "-I",
+      "-c",
+      expect.any(String),
+      "18789",
+      "18000",
+      "100",
+    ]);
     expect(launchOpenshell).not.toHaveBeenCalled();
   });
 
@@ -608,6 +617,13 @@ describe("portable lifecycle recovery timing output", () => {
     [
       "a receipt with a mismatched exit status",
       { ...gatewayWaitResult("ready", { notReady: 1 }), status: 75 },
+      "gatewayTimeouts=0 gatewayErrors=1",
+      "lastFailure=error",
+      1_000,
+    ],
+    [
+      "a receipt whose timing exceeds the waiter budget",
+      gatewayWaitResult("ready", { probeMs: 18_002 }),
       "gatewayTimeouts=0 gatewayErrors=1",
       "lastFailure=error",
       1_000,

--- a/src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts
@@ -329,6 +329,48 @@ describe("portable lifecycle recovery timing output", () => {
     ]);
   });
 
+  it("uses one bounded waiter when the managed startup process already exists (#9200)", () => {
+    const stateDir = temporaryStateDir();
+    const podman = createPodman(true);
+    const launchOpenshell = vi.fn();
+    let now = 0;
+    installReceipt(stateDir, podman);
+    const captureOpenshell = vi.fn((args: readonly string[]) => {
+      const command = args.find((arg) => ["true", "pgrep", "curl", "python3"].includes(arg));
+      switch (command) {
+        case "true":
+        case "pgrep":
+          return { status: 0 };
+        case "curl":
+          return { status: 0, stdout: "000" };
+        case "python3":
+          now += 2_000;
+          return gatewayWaitResult("ready", { notReady: 1, sleepMs: 2_000 });
+        default:
+          throw new Error(`Unexpected OpenShell command: ${args.join(" ")}`);
+      }
+    });
+
+    expect(
+      recover(stateDir, {
+        podman,
+        captureOpenshell,
+        launchOpenshell,
+        now: () => now,
+        sleep: (milliseconds) => {
+          now += milliseconds;
+        },
+      }),
+    ).toEqual({ kind: "already-running" });
+    expect(now).toBe(2_000);
+    expect(
+      captureOpenshell.mock.calls.map(([args]) =>
+        args.find((arg) => ["true", "pgrep", "curl", "python3"].includes(arg)),
+      ),
+    ).toEqual(["true", "curl", "pgrep", "python3"]);
+    expect(launchOpenshell).not.toHaveBeenCalled();
+  });
+
   it("preserves recovered lifecycle semantics when the startup timing read throws (#9200)", () => {
     const stateDir = temporaryStateDir();
     const podman = createPodman(false);
@@ -646,8 +688,21 @@ describe("portable lifecycle recovery timing output", () => {
     expect(() =>
       recover(stateDir, {
         podman,
-        captureOpenshell: (args) =>
-          args.includes("curl") ? { status: 0, stdout: "000" } : { status: 0 },
+        captureOpenshell: (args) => {
+          const command = args.find((arg) => ["true", "pgrep", "curl", "python3"].includes(arg));
+          switch (command) {
+            case "true":
+            case "pgrep":
+              return { status: 0 };
+            case "curl":
+              return { status: 0, stdout: "000" };
+            case "python3":
+              deadlineNow = 90_000;
+              return gatewayWaitResult("not-ready");
+            default:
+              throw new Error(`Unexpected OpenShell command: ${args.join(" ")}`);
+          }
+        },
         launchOpenshell: vi.fn(),
         log,
         now: () => deadlineNow,
@@ -662,7 +717,7 @@ describe("portable lifecycle recovery timing output", () => {
     ).toThrow("has a startup process, but its agent gateway did not pass");
     expect(timingLines(log)).toHaveLength(1);
     expect(timingLines(log)[0]).toContain(
-      "gatewayAttempts=91 gatewayNotReady=91 gatewayTimeouts=0 gatewayErrors=0",
+      "gatewayAttempts=2 gatewayNotReady=2 gatewayTimeouts=0 gatewayErrors=0",
     );
     expect(timingLines(log)[0]).toContain("result=failed failedStage=gatewayReady");
     expect(timingLines(log)[0]).not.toContain("has a startup process");
@@ -694,7 +749,7 @@ describe("portable lifecycle recovery timing output", () => {
         status: 1,
         error: Object.assign(new Error("transport"), { code: "EPIPE" }),
       },
-      { status: 0, stdout: "200" },
+      gatewayWaitResult(),
     ];
     installReceipt(stateDir, podman);
 
@@ -702,12 +757,13 @@ describe("portable lifecycle recovery timing output", () => {
       recover(stateDir, {
         podman,
         captureOpenshell: (args) => {
-          const command = args.find((arg) => ["true", "pgrep", "curl"].includes(arg));
+          const command = args.find((arg) => ["true", "pgrep", "curl", "python3"].includes(arg));
           switch (command) {
             case "true":
               return execResults.shift() ?? { status: 0 };
             case "curl":
-              return gatewayResults.shift() ?? { status: 0, stdout: "200" };
+            case "python3":
+              return gatewayResults.shift() ?? gatewayWaitResult();
             case "pgrep":
               return { status: 0 };
             default:

--- a/src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PodmanSocketAuthorityDeps } from "../../adapters/podman";
 import type { CheckpointPortableRuntimeAuthority } from "../../state/onboard-checkpoint-types";
+import { gatewayWaitResult } from "./__test-helpers__/portable-demo-gateway-wait";
 import {
   installPortableDemoSandboxLifecycle,
   type PortableDemoLifecycleDeps,
@@ -215,17 +216,19 @@ describe("portable lifecycle recovery timing output", () => {
       recover(stateDir, {
         podman,
         captureOpenshell: (args, timeoutMs) => {
-          const command = args.find((arg) => ["true", "pgrep", "curl", "node"].includes(arg));
+          const command = args.find((arg) =>
+            ["true", "pgrep", "curl", "node", "python3"].includes(arg),
+          );
           switch (command) {
+            case "python3":
+              epochNow = EPOCH_BASE_MS + 2_110;
+              return gatewayWaitResult();
             case "true":
               return { status: 0 };
             case "pgrep":
               return { status: 1 };
-            case "curl": {
-              const launched = launchOpenshell.mock.calls.length > 0;
-              epochNow = launched ? EPOCH_BASE_MS + 2_110 : epochNow;
-              return { status: 0, stdout: launched ? "200" : "000" };
-            }
+            case "curl":
+              return { status: 0, stdout: "000" };
             case "node":
               timingReadAttempts += 1;
               readTimeouts.push(timeoutMs);
@@ -297,17 +300,19 @@ describe("portable lifecycle recovery timing output", () => {
       recover(stateDir, {
         podman,
         captureOpenshell: (args) => {
-          const command = args.find((arg) => ["true", "pgrep", "curl", "node"].includes(arg));
+          const command = args.find((arg) =>
+            ["true", "pgrep", "curl", "node", "python3"].includes(arg),
+          );
           switch (command) {
+            case "python3":
+              epochNow += 1_000;
+              return gatewayWaitResult();
             case "true":
               return { status: 0 };
             case "pgrep":
               return { status: 1 };
-            case "curl": {
-              const launched = launchOpenshell.mock.calls.length > 0;
-              epochNow += launched ? 1_000 : 0;
-              return { status: 0, stdout: launched ? "200" : "000" };
-            }
+            case "curl":
+              return { status: 0, stdout: "000" };
             case "node":
               throw new Error("credential-bearing diagnostic failure");
             default:
@@ -344,17 +349,19 @@ describe("portable lifecycle recovery timing output", () => {
       recover(stateDir, {
         podman,
         captureOpenshell: (args, timeoutMs) => {
-          const command = args.find((arg) => ["true", "pgrep", "curl", "node"].includes(arg));
+          const command = args.find((arg) =>
+            ["true", "pgrep", "curl", "node", "python3"].includes(arg),
+          );
           switch (command) {
+            case "python3":
+              epochNow = EPOCH_BASE_MS + 2_110;
+              return gatewayWaitResult();
             case "true":
               return { status: 0 };
             case "pgrep":
               return { status: 1 };
-            case "curl": {
-              const launched = launchOpenshell.mock.calls.length > 0;
-              epochNow = launched ? EPOCH_BASE_MS + 2_110 : epochNow;
-              return { status: 0, stdout: launched ? "200" : "000" };
-            }
+            case "curl":
+              return { status: 0, stdout: "000" };
             case "node": {
               const separator = args.lastIndexOf("--");
               const readCommand = args.slice(separator + 1);
@@ -388,7 +395,7 @@ describe("portable lifecycle recovery timing output", () => {
     expect(gatewayTimingLines(log)[0]).toContain(`diagnosticReadOutcome=${outcome}`);
   });
 
-  it("measures launched gateway probes and sleeps without changing polling (#9200)", () => {
+  it("observes launched gateway health inside one bounded OpenShell exec (#9200)", () => {
     const stateDir = temporaryStateDir();
     const podman = createPodman(false);
     const launchOpenshell = vi.fn();
@@ -397,26 +404,50 @@ describe("portable lifecycle recovery timing output", () => {
     let deadlineNow = 0;
     let diagnosticNow = 0;
     let epochNow = EPOCH_BASE_MS;
-    let gatewayAttempts = 0;
+    let gatewayWaitArgs: readonly string[] | null = null;
+    let gatewayWaitTimeout = 0;
     installReceipt(stateDir, podman);
 
     expect(
       recover(stateDir, {
         podman,
-        captureOpenshell: (args) => {
-          const command = args.find((arg) => ["true", "pgrep", "curl", "node"].includes(arg));
+        captureOpenshell: (args, timeoutMs) => {
+          const command = args.find((arg) =>
+            ["true", "pgrep", "curl", "node", "python3"].includes(arg),
+          );
           switch (command) {
+            case "python3": {
+              gatewayWaitArgs = args;
+              gatewayWaitTimeout = timeoutMs;
+              const separator = args.lastIndexOf("--");
+              const waitCommand = [...args.slice(separator + 1)];
+              expect(waitCommand.slice(0, 3)).toEqual(["python3", "-I", "-c"]);
+              expect(waitCommand[3]).toContain('HTTPConnection("127.0.0.1"');
+              expect(waitCommand[3]).toContain('connection.request("GET", "/health")');
+              expect(waitCommand[3]).toContain("if status in (200, 401):");
+              waitCommand[4] = "0";
+              const validation = spawnSync("python3", waitCommand.slice(1), {
+                encoding: "utf8",
+                timeout: 1_000,
+              });
+              expect(validation.status).toBe(64);
+              expect(validation.stdout).toBe("");
+              expect(validation.stderr).toBe("");
+              deadlineNow += 250;
+              diagnosticNow += 250;
+              epochNow = EPOCH_BASE_MS + 2_110;
+              return gatewayWaitResult("ready", {
+                notReady: 2,
+                probeMs: 50,
+                sleepMs: 200,
+              });
+            }
             case "true":
               return { status: 0 };
             case "pgrep":
               return { status: 1 };
-            case "curl": {
-              diagnosticNow += 25;
-              gatewayAttempts += 1;
-              const ready = gatewayAttempts >= 3;
-              epochNow = ready ? EPOCH_BASE_MS + 2_110 : epochNow;
-              return { status: 0, stdout: ready ? "200" : "000" };
-            }
+            case "curl":
+              return { status: 0, stdout: "000" };
             case "node":
               diagnosticNow += 20;
               return { status: 0, stdout: startupTimingRecord() };
@@ -436,13 +467,103 @@ describe("portable lifecycle recovery timing output", () => {
         },
       }),
     ).toEqual({ kind: "recovered" });
-    expect(gatewayAttempts).toBe(3);
-    expect(sleeps).toEqual([1_000]);
-    expect(timingLines(log)[0]).toContain("gatewayReady=1050ms");
+    expect(gatewayWaitArgs).toEqual(
+      expect.arrayContaining(["python3", "-I", "-c", "18789", "18000", "100"]),
+    );
+    expect(gatewayWaitTimeout).toBe(20_000);
+    expect(sleeps).toEqual([]);
+    expect(timingLines(log)[0]).toContain(
+      "gatewayAttempts=4 gatewayNotReady=3 gatewayTimeouts=0 gatewayErrors=0",
+    );
+    expect(timingLines(log)[0]).toContain("gatewayReady=250ms");
     expect(gatewayTimingLines(log)[0]).toContain(
-      "probe=50ms sleep=1000ms firstReadyAttempt=2 lastFailure=not-ready diagnosticRead=20ms diagnosticReadOutcome=recorded",
+      "probe=50ms sleep=200ms firstReadyAttempt=3 lastFailure=not-ready diagnosticRead=20ms diagnosticReadOutcome=recorded",
     );
   });
+
+  it.each([
+    [
+      "a transport timeout",
+      {
+        status: null,
+        error: Object.assign(new Error("credential-bearing timeout"), { code: "ETIMEDOUT" }),
+      },
+      "gatewayTimeouts=1 gatewayErrors=0",
+      "lastFailure=timeout",
+    ],
+    [
+      "an inconsistent receipt",
+      {
+        status: 0,
+        stdout:
+          "schema=1 result=ready attempts=2 notReady=0 timeouts=0 errors=0 lastFailure=none probeMs=0 sleepMs=0\n",
+      },
+      "gatewayTimeouts=0 gatewayErrors=1",
+      "lastFailure=error",
+    ],
+    [
+      "a receipt with a mismatched exit status",
+      { ...gatewayWaitResult("ready", { notReady: 1 }), status: 75 },
+      "gatewayTimeouts=0 gatewayErrors=1",
+      "lastFailure=error",
+    ],
+  ] as const)(
+    "retries launched gateway observation after %s without accepting it as ready (#9200)",
+    (_label, firstResult, attemptCounts, lastFailure) => {
+      const stateDir = temporaryStateDir();
+      const podman = createPodman(false);
+      const launchOpenshell = vi.fn();
+      const log = vi.fn();
+      const sleeps: number[] = [];
+      let deadlineNow = 0;
+      let diagnosticNow = 0;
+      let epochNow = EPOCH_BASE_MS;
+      let waitAttempts = 0;
+      installReceipt(stateDir, podman);
+
+      expect(
+        recover(stateDir, {
+          podman,
+          captureOpenshell: (args) => {
+            const command = args.find((arg) =>
+              ["true", "pgrep", "curl", "node", "python3"].includes(arg),
+            );
+            switch (command) {
+              case "python3":
+                waitAttempts += 1;
+                epochNow = waitAttempts === 1 ? epochNow : EPOCH_BASE_MS + 2_110;
+                return waitAttempts === 1 ? firstResult : gatewayWaitResult();
+              case "true":
+                return { status: 0 };
+              case "pgrep":
+                return { status: 1 };
+              case "curl":
+                return { status: 0, stdout: "000" };
+              case "node":
+                return { status: 0, stdout: startupTimingRecord() };
+              default:
+                throw new Error(`Unexpected OpenShell command: ${args.join(" ")}`);
+            }
+          },
+          launchOpenshell,
+          log,
+          now: () => deadlineNow,
+          timingNow: () => diagnosticNow,
+          gatewayStartupEpochNow: () => epochNow,
+          sleep: (milliseconds) => {
+            sleeps.push(milliseconds);
+            deadlineNow += milliseconds;
+            diagnosticNow += milliseconds;
+          },
+        }),
+      ).toEqual({ kind: "recovered" });
+      expect(waitAttempts).toBe(2);
+      expect(sleeps).toEqual([1_000]);
+      expect(timingLines(log)[0]).toContain(attemptCounts);
+      expect(gatewayTimingLines(log)[0]).toContain(`firstReadyAttempt=2 ${lastFailure}`);
+      expect(gatewayTimingLines(log)[0]).not.toContain("credential-bearing");
+    },
+  );
 
   it("emits one redacted failed timing line before preserving the recovery error (#9200)", () => {
     const stateDir = temporaryStateDir();

--- a/src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 
@@ -60,6 +62,45 @@ function temporaryStateDir(): string {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-lifecycle-timing-"));
   temporaryDirectories.push(directory);
   return directory;
+}
+
+function runCommand(
+  command: string,
+  args: readonly string[],
+): Promise<{ status: number | null; stderr: string; stdout: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [...args], { stdio: ["ignore", "pipe", "pipe"] });
+    let stderr = "";
+    let stdout = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (status) => resolve({ status, stderr, stdout }));
+  });
+}
+
+async function withLoopbackHealthStatus<T>(
+  statusCode: number,
+  run: (port: number) => Promise<T>,
+): Promise<T> {
+  const server = createServer((_request, response) => {
+    response.writeHead(statusCode).end();
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  try {
+    return await run(address.port);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
 }
 
 function socketAuthorityDeps(): PodmanSocketAuthorityDeps {
@@ -395,7 +436,7 @@ describe("portable lifecycle recovery timing output", () => {
     expect(gatewayTimingLines(log)[0]).toContain(`diagnosticReadOutcome=${outcome}`);
   });
 
-  it("observes launched gateway health inside one bounded OpenShell exec (#9200)", () => {
+  it("executes the launched gateway health waiter against loopback responses (#9200)", async () => {
     const stateDir = temporaryStateDir();
     const podman = createPodman(false);
     const launchOpenshell = vi.fn();
@@ -405,6 +446,7 @@ describe("portable lifecycle recovery timing output", () => {
     let diagnosticNow = 0;
     let epochNow = EPOCH_BASE_MS;
     let gatewayWaitTimeout = 0;
+    let gatewayWaitCommand: string[] | undefined;
     installReceipt(stateDir, podman);
 
     expect(
@@ -417,6 +459,7 @@ describe("portable lifecycle recovery timing output", () => {
           switch (command) {
             case "python3": {
               gatewayWaitTimeout = timeoutMs;
+              gatewayWaitCommand = args.slice(args.lastIndexOf("--") + 1);
               deadlineNow += 250;
               diagnosticNow += 250;
               epochNow = EPOCH_BASE_MS + 2_110;
@@ -460,6 +503,42 @@ describe("portable lifecycle recovery timing output", () => {
     expect(gatewayTimingLines(log)[0]).toContain(
       "probe=50ms sleep=200ms firstReadyAttempt=3 lastFailure=not-ready diagnosticRead=20ms diagnosticReadOutcome=recorded",
     );
+
+    expect(gatewayWaitCommand).toBeDefined();
+    const emittedGatewayWaitCommand = gatewayWaitCommand as string[];
+    const runEmittedWaiter = (statusCode: number) =>
+      withLoopbackHealthStatus(statusCode, (port) => {
+        const [command, ...args] = emittedGatewayWaitCommand;
+        args[3] = String(port);
+        args[4] = "100";
+        args[5] = "10";
+        return runCommand(command, args);
+      });
+
+    const readyReceipt = expect.stringMatching(
+      /^schema=1 result=ready attempts=1 notReady=0 timeouts=0 errors=0 lastFailure=none probeMs=\d+ sleepMs=0\n$/u,
+    );
+    await expect(runEmittedWaiter(200)).resolves.toEqual({
+      status: 0,
+      stderr: "",
+      stdout: readyReceipt,
+    });
+    await expect(runEmittedWaiter(401)).resolves.toEqual({
+      status: 0,
+      stderr: "",
+      stdout: readyReceipt,
+    });
+
+    const notReady = await runEmittedWaiter(503);
+    expect(notReady.status).toBe(75);
+    expect(notReady.stderr).toBe("");
+    const receipt =
+      /^schema=1 result=not-ready attempts=(\d+) notReady=(\d+) timeouts=0 errors=0 lastFailure=not-ready probeMs=(\d+) sleepMs=(\d+)\n$/u.exec(
+        notReady.stdout,
+      );
+    expect(receipt).not.toBeNull();
+    expect(Number(receipt?.[1])).toBeGreaterThan(0);
+    expect(receipt?.[2]).toBe(receipt?.[1]);
   });
 
   it.each([

--- a/src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts
@@ -490,6 +490,7 @@ describe("portable lifecycle recovery timing output", () => {
       },
       "gatewayTimeouts=1 gatewayErrors=0",
       "lastFailure=timeout",
+      1_000,
     ],
     [
       "an inconsistent receipt",
@@ -500,16 +501,25 @@ describe("portable lifecycle recovery timing output", () => {
       },
       "gatewayTimeouts=0 gatewayErrors=1",
       "lastFailure=error",
+      1_000,
     ],
     [
       "a receipt with a mismatched exit status",
       { ...gatewayWaitResult("ready", { notReady: 1 }), status: 75 },
       "gatewayTimeouts=0 gatewayErrors=1",
       "lastFailure=error",
+      1_000,
+    ],
+    [
+      "a valid not-ready receipt",
+      gatewayWaitResult("not-ready"),
+      "gatewayTimeouts=0 gatewayErrors=0",
+      "lastFailure=not-ready",
+      100,
     ],
   ] as const)(
     "retries launched gateway observation after %s without accepting it as ready (#9200)",
-    (_label, firstResult, attemptCounts, lastFailure) => {
+    (_label, firstResult, attemptCounts, lastFailure, retryDelay) => {
       const stateDir = temporaryStateDir();
       const podman = createPodman(false);
       const launchOpenshell = vi.fn();
@@ -558,7 +568,7 @@ describe("portable lifecycle recovery timing output", () => {
         }),
       ).toEqual({ kind: "recovered" });
       expect(waitAttempts).toBe(2);
-      expect(sleeps).toEqual([1_000]);
+      expect(sleeps).toEqual([retryDelay]);
       expect(timingLines(log)[0]).toContain(attemptCounts);
       expect(gatewayTimingLines(log)[0]).toContain(`firstReadyAttempt=2 ${lastFailure}`);
       expect(gatewayTimingLines(log)[0]).not.toContain("credential-bearing");

--- a/src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts
@@ -404,7 +404,6 @@ describe("portable lifecycle recovery timing output", () => {
     let deadlineNow = 0;
     let diagnosticNow = 0;
     let epochNow = EPOCH_BASE_MS;
-    let gatewayWaitArgs: readonly string[] | null = null;
     let gatewayWaitTimeout = 0;
     installReceipt(stateDir, podman);
 
@@ -417,22 +416,7 @@ describe("portable lifecycle recovery timing output", () => {
           );
           switch (command) {
             case "python3": {
-              gatewayWaitArgs = args;
               gatewayWaitTimeout = timeoutMs;
-              const separator = args.lastIndexOf("--");
-              const waitCommand = [...args.slice(separator + 1)];
-              expect(waitCommand.slice(0, 3)).toEqual(["python3", "-I", "-c"]);
-              expect(waitCommand[3]).toContain('HTTPConnection("127.0.0.1"');
-              expect(waitCommand[3]).toContain('connection.request("GET", "/health")');
-              expect(waitCommand[3]).toContain("if status in (200, 401):");
-              waitCommand[4] = "0";
-              const validation = spawnSync("python3", waitCommand.slice(1), {
-                encoding: "utf8",
-                timeout: 1_000,
-              });
-              expect(validation.status).toBe(64);
-              expect(validation.stdout).toBe("");
-              expect(validation.stderr).toBe("");
               deadlineNow += 250;
               diagnosticNow += 250;
               epochNow = EPOCH_BASE_MS + 2_110;
@@ -467,9 +451,6 @@ describe("portable lifecycle recovery timing output", () => {
         },
       }),
     ).toEqual({ kind: "recovered" });
-    expect(gatewayWaitArgs).toEqual(
-      expect.arrayContaining(["python3", "-I", "-c", "18789", "18000", "100"]),
-    );
     expect(gatewayWaitTimeout).toBe(20_000);
     expect(sleeps).toEqual([]);
     expect(timingLines(log)[0]).toContain(

--- a/src/lib/onboard/experimental/portable-demo-lifecycle-timing.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle-timing.ts
@@ -86,6 +86,7 @@ export type PortableLifecycleTimingRecorder = {
   beginOpenClawGatewayStartup(): void;
   measureOpenClawGatewayProbe<T>(operation: () => T): T;
   measureOpenClawGatewaySleep<T>(operation: () => T): T;
+  recordOpenClawGatewayWaitSleep(milliseconds: number): void;
   readOpenClawGatewayStartupTiming(
     operation: () => PortableOpenClawGatewayTimingReadResult,
     maxCorrelationWindowMs: number,
@@ -336,6 +337,13 @@ export function createPortableLifecycleTimingRecorder(
       return measureGatewayDuration(operation, (elapsed) => {
         gatewaySleepMs += elapsed;
       });
+    },
+    recordOpenClawGatewayWaitSleep(milliseconds: number): void {
+      // The enclosing OpenShell command is measured as probe time. Reclassify
+      // only the fixed waiter's reported sleep into the existing sleep field.
+      const boundedSleep = Math.min(gatewayProbeMs, boundedGatewayTimingValue(milliseconds));
+      gatewayProbeMs -= boundedSleep;
+      gatewaySleepMs += boundedSleep;
     },
     readOpenClawGatewayStartupTiming(
       operation: () => PortableOpenClawGatewayTimingReadResult,

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
@@ -930,7 +930,7 @@ describe("portable demo sandbox lifecycle", () => {
         case "curl":
           return { status: 0, stdout: "000" };
         case "python3":
-          now += 90_000;
+          now += 89_900;
           return gatewayWaitResult(launchOpenshell.mock.calls.length < 2 ? "not-ready" : "ready");
         default:
           throw new Error(`Unexpected OpenShell command: ${args.join(" ")}`);

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
@@ -810,7 +810,7 @@ describe("portable demo sandbox lifecycle", () => {
       const command = args.find((arg) => ["true", "pgrep", "curl", "python3"].includes(arg));
       switch (command) {
         case "true":
-          return { status: now >= 31_000 ? 0 : 1 };
+          return { status: now >= 30_100 ? 0 : 1 };
         case "pgrep":
           return { status: 1 };
         case "curl":
@@ -839,7 +839,7 @@ describe("portable demo sandbox lifecycle", () => {
         },
       ),
     ).toEqual({ kind: "recovered" });
-    expect(now).toBe(31_000);
+    expect(now).toBe(30_100);
     expect(launchOpenshell).toHaveBeenCalledOnce();
   });
 

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PodmanSocketAuthorityDeps } from "../../adapters/podman";
 import type { CheckpointPortableRuntimeAuthority } from "../../state/onboard-checkpoint-types";
 import type { SandboxEntry } from "../../state/registry";
+import { gatewayWaitResult } from "./__test-helpers__/portable-demo-gateway-wait";
 import { recordUserLocalOllamaOwnership } from "./ollama-user-local-runtime";
 import {
   installPortableDemoSandboxLifecycle,
@@ -752,16 +753,16 @@ describe("portable demo sandbox lifecycle", () => {
     const launchOpenshell = vi.fn();
     const log = vi.fn();
     const captureOpenshell = vi.fn((args: readonly string[]) => {
-      const command = args.find((arg) => ["true", "pgrep", "curl"].includes(arg));
+      const command = args.find((arg) => ["true", "pgrep", "curl", "python3"].includes(arg));
       switch (command) {
         case "true":
           return { status: 0 };
         case "pgrep":
           return { status: 1 };
         case "curl":
-          return launchOpenshell.mock.calls.length === 0
-            ? { status: 0, stdout: "000" }
-            : { status: 0, stdout: "200" };
+          return { status: 0, stdout: "000" };
+        case "python3":
+          return gatewayWaitResult();
         default:
           throw new Error(`Unexpected OpenShell command: ${args.join(" ")}`);
       }
@@ -806,16 +807,16 @@ describe("portable demo sandbox lifecycle", () => {
     const launchOpenshell = vi.fn();
     let now = 0;
     const captureOpenshell = vi.fn((args: readonly string[]) => {
-      const command = args.find((arg) => ["true", "pgrep", "curl"].includes(arg));
+      const command = args.find((arg) => ["true", "pgrep", "curl", "python3"].includes(arg));
       switch (command) {
         case "true":
           return { status: now >= 31_000 ? 0 : 1 };
         case "pgrep":
           return { status: 1 };
         case "curl":
-          return launchOpenshell.mock.calls.length === 0
-            ? { status: 0, stdout: "000" }
-            : { status: 0, stdout: "200" };
+          return { status: 0, stdout: "000" };
+        case "python3":
+          return gatewayWaitResult();
         default:
           throw new Error(`Unexpected OpenShell command: ${args.join(" ")}`);
       }
@@ -920,16 +921,17 @@ describe("portable demo sandbox lifecycle", () => {
     const launchOpenshell = vi.fn();
     let now = 0;
     const captureOpenshell = vi.fn((args: readonly string[]) => {
-      const command = args.find((arg) => ["true", "pgrep", "curl"].includes(arg));
+      const command = args.find((arg) => ["true", "pgrep", "curl", "python3"].includes(arg));
       switch (command) {
         case "true":
           return { status: 0 };
         case "pgrep":
           return { status: 1 };
         case "curl":
-          return launchOpenshell.mock.calls.length >= 2
-            ? { status: 0, stdout: "200" }
-            : { status: 0, stdout: "000" };
+          return { status: 0, stdout: "000" };
+        case "python3":
+          now += 90_000;
+          return gatewayWaitResult(launchOpenshell.mock.calls.length < 2 ? "not-ready" : "ready");
         default:
           throw new Error(`Unexpected OpenShell command: ${args.join(" ")}`);
       }

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.test.ts
@@ -843,26 +843,32 @@ describe("portable demo sandbox lifecycle", () => {
     expect(launchOpenshell).toHaveBeenCalledOnce();
   });
 
-  it("waits for the agent gateway to pass its health check when the managed startup process already exists (#8441)", () => {
+  it("fails after the startup timeout when the managed startup process exists and the agent gateway does not pass its health check (#8441)", () => {
     const stateDir = temporaryStateDir();
     const runtime = createPodman();
     installReceipt(stateDir, runtime.podman);
     const launchOpenshell = vi.fn();
     let now = 0;
     const captureOpenshell = vi.fn((args: readonly string[]) => {
-      const command = args.find((arg) => ["true", "pgrep", "curl"].includes(arg));
+      const command = args.find((arg) => ["true", "pgrep", "curl", "python3"].includes(arg));
       switch (command) {
         case "true":
         case "pgrep":
           return { status: 0 };
         case "curl":
-          return { status: 0, stdout: now >= 2_000 ? "200" : "000" };
+          return { status: 0, stdout: "000" };
+        case "python3": {
+          const emittedCommand = args.slice(args.lastIndexOf("--") + 1);
+          const waiterTimeoutMs = Number(emittedCommand.at(-2));
+          now += waiterTimeoutMs;
+          return gatewayWaitResult("not-ready", { sleepMs: waiterTimeoutMs });
+        }
         default:
           throw new Error(`Unexpected OpenShell command: ${args.join(" ")}`);
       }
     });
 
-    expect(
+    expect(() =>
       recoverPortableDemoSandboxLifecycle(
         "alpha",
         { agent: sandboxEntry().agent, gatewayName: "nemoclaw" },
@@ -878,37 +884,9 @@ describe("portable demo sandbox lifecycle", () => {
           },
         },
       ),
-    ).toEqual({ kind: "already-running" });
-    expect(now).toBe(2_000);
-    expect(launchOpenshell).not.toHaveBeenCalled();
-  });
-
-  it("fails after the startup timeout when the managed startup process exists and the agent gateway does not pass its health check (#8441)", () => {
-    const stateDir = temporaryStateDir();
-    const runtime = createPodman();
-    installReceipt(stateDir, runtime.podman);
-    const launchOpenshell = vi.fn();
-    let now = 0;
-
-    expect(() =>
-      recoverPortableDemoSandboxLifecycle(
-        "alpha",
-        { agent: sandboxEntry().agent, gatewayName: "nemoclaw" },
-        {
-          platform: "linux",
-          stateDir,
-          podman: runtime.podman,
-          captureOpenshell: (args) =>
-            args.includes("curl") ? { status: 0, stdout: "000" } : { status: 0 },
-          launchOpenshell,
-          now: () => now,
-          sleep: (milliseconds) => {
-            now += milliseconds;
-          },
-        },
-      ),
     ).toThrow("has a startup process, but its agent gateway did not pass");
     expect(now).toBe(90_000);
+    expect(captureOpenshell.mock.calls.filter(([args]) => args.includes("curl"))).toHaveLength(1);
     expect(launchOpenshell).not.toHaveBeenCalled();
   });
 

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.ts
@@ -1640,9 +1640,14 @@ export function recoverPortableDemoSandboxLifecycle(
     if (startupProbe.status === 0 && !startupProbe.error) {
       lifecycleTiming.setGatewayAction("waited");
       const recovered = lifecycleTiming.measure("gatewayReady", () =>
-        waitFor(STARTUP_TIMEOUT_MS, timing, (remainingMs) => {
-          return gatewayIsRunning(receipt, gatewayName, capture, remainingMs, lifecycleTiming);
-        }),
+        waitForLaunchedGateway(
+          receipt,
+          gatewayName,
+          capture,
+          STARTUP_TIMEOUT_MS,
+          timing,
+          lifecycleTiming,
+        ),
       );
       if (recovered) {
         lifecycleTiming.finish("already-running");

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.ts
@@ -73,6 +73,8 @@ const GATEWAY_HEALTH_WAIT_COMMAND_RESERVE_MS = 2_000;
 const GATEWAY_HEALTH_WAIT_POLL_INTERVAL_MS = 100;
 const GATEWAY_HEALTH_WAIT_RETRY_INTERVAL_MS = 1_000;
 const GATEWAY_HEALTH_WAIT_MAX_ATTEMPTS = 9_999;
+// The waiter rounds probe and sleep totals independently, so their sum can exceed its budget by 1 ms.
+const GATEWAY_HEALTH_WAIT_RECEIPT_ROUNDING_TOLERANCE_MS = 1;
 const GATEWAY_HEALTH_WAIT_PROGRAM = [
   "import http.client",
   "import sys",
@@ -1214,7 +1216,12 @@ function waitForLaunchedGateway(
     const validReady = waitReceipt?.result === "ready" && result.status === 0 && !result.error;
     const validNotReady =
       waitReceipt?.result === "not-ready" && result.status === 75 && !result.error;
-    const acceptedReceipt = waitReceipt && (validReady || validNotReady) ? waitReceipt : null;
+    const receiptWithinBudget =
+      waitReceipt !== null &&
+      waitReceipt.probeMs + waitReceipt.sleepMs <=
+        waiterTimeoutMs + GATEWAY_HEALTH_WAIT_RECEIPT_ROUNDING_TOLERANCE_MS;
+    const acceptedReceipt =
+      waitReceipt && receiptWithinBudget && (validReady || validNotReady) ? waitReceipt : null;
     if (acceptedReceipt) {
       lifecycleTiming.recordOpenClawGatewayWaitSleep(acceptedReceipt.sleepMs);
       recordGatewayHealthWaitReceipt(acceptedReceipt, lifecycleTiming);

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.ts
@@ -67,6 +67,77 @@ const STARTUP_TIMEOUT_MS = 90_000;
 const GATEWAY_STARTUP_TIMING_READ_TIMEOUT_MS = 1_000;
 const GATEWAY_STARTUP_TIMING_RECORD_WAIT_TIMEOUT_MS = 2_000;
 const GATEWAY_STARTUP_TIMING_RECORD_POLL_INTERVAL_MS = 100;
+const GATEWAY_HEALTH_WAIT_COMMAND_TIMEOUT_MS = 20_000;
+const GATEWAY_HEALTH_WAIT_COMMAND_RESERVE_MS = 2_000;
+const GATEWAY_HEALTH_WAIT_POLL_INTERVAL_MS = 100;
+const GATEWAY_HEALTH_WAIT_RETRY_INTERVAL_MS = 1_000;
+const GATEWAY_HEALTH_WAIT_MAX_ATTEMPTS = 9_999;
+const GATEWAY_HEALTH_WAIT_PROGRAM = [
+  "import http.client",
+  "import sys",
+  "import time",
+  "",
+  "try:",
+  "    port = int(sys.argv[1])",
+  "    timeout_ms = int(sys.argv[2])",
+  "    interval_ms = int(sys.argv[3])",
+  "except (IndexError, ValueError):",
+  "    raise SystemExit(64)",
+  "if not (1 <= port <= 65535 and 1 <= timeout_ms <= 18000 and 10 <= interval_ms <= 1000):",
+  "    raise SystemExit(64)",
+  "deadline = time.monotonic() + timeout_ms / 1000",
+  "attempts = 0",
+  "not_ready = 0",
+  "timeouts = 0",
+  "errors = 0",
+  "probe_seconds = 0.0",
+  "sleep_seconds = 0.0",
+  'last_failure = "none"',
+  "",
+  "def finish(result, status):",
+  "    probe_ms = round(probe_seconds * 1000)",
+  "    sleep_ms = round(sleep_seconds * 1000)",
+  '    print(f"schema=1 result={result} attempts={attempts} notReady={not_ready} timeouts={timeouts} errors={errors} lastFailure={last_failure} probeMs={probe_ms} sleepMs={sleep_ms}")',
+  "    raise SystemExit(status)",
+  "",
+  "while True:",
+  "    remaining = deadline - time.monotonic()",
+  "    if remaining <= 0:",
+  '        finish("not-ready", 75)',
+  "    attempts += 1",
+  "    connection = None",
+  "    ready = False",
+  "    probe_started = time.monotonic()",
+  "    try:",
+  '        connection = http.client.HTTPConnection("127.0.0.1", port, timeout=min(3, remaining))',
+  '        connection.request("GET", "/health")',
+  "        response = connection.getresponse()",
+  "        status = response.status",
+  "        response.close()",
+  "        if status in (200, 401):",
+  "            ready = True",
+  "        else:",
+  "            not_ready += 1",
+  '            last_failure = "not-ready"',
+  "    except TimeoutError:",
+  "        timeouts += 1",
+  '        last_failure = "timeout"',
+  "    except (OSError, http.client.HTTPException):",
+  "        errors += 1",
+  '        last_failure = "error"',
+  "    finally:",
+  "        if connection is not None:",
+  "            connection.close()",
+  "        probe_seconds += time.monotonic() - probe_started",
+  "    if ready:",
+  '        finish("ready", 0)',
+  "    remaining = deadline - time.monotonic()",
+  "    if remaining <= 0:",
+  '        finish("not-ready", 75)',
+  "    sleep_started = time.monotonic()",
+  "    time.sleep(min(interval_ms / 1000, remaining))",
+  "    sleep_seconds += time.monotonic() - sleep_started",
+].join("\n");
 const GATEWAY_STARTUP_TIMING_READ_PROGRAM = [
   'const fs=require("node:fs");',
   "let descriptor;",
@@ -101,6 +172,17 @@ export type PortablePodmanLifecycleCommandResult = {
 };
 
 type CommandResult = PortablePodmanLifecycleCommandResult;
+
+type GatewayHealthWaitReceipt = {
+  result: "ready" | "not-ready";
+  attempts: number;
+  notReady: number;
+  timeouts: number;
+  errors: number;
+  lastFailure: Exclude<PortableLifecycleAttemptOutcome, "ready"> | "none";
+  probeMs: number;
+  sleepMs: number;
+};
 
 interface PortableDemoLifecycleReceipt {
   schemaVersion: 1 | 2 | 3 | 4;
@@ -1013,6 +1095,62 @@ function commandAttemptOutcome(
   return "not-ready";
 }
 
+function parseGatewayHealthWaitReceipt(raw: string): GatewayHealthWaitReceipt | null {
+  const match =
+    /^schema=1 result=(ready|not-ready) attempts=(\d{1,4}) notReady=(\d{1,4}) timeouts=(\d{1,4}) errors=(\d{1,4}) lastFailure=(none|not-ready|timeout|error) probeMs=(\d{1,5}) sleepMs=(\d{1,5})\n?$/u.exec(
+      raw,
+    );
+  if (!match) return null;
+  const receipt: GatewayHealthWaitReceipt = {
+    result: match[1] as GatewayHealthWaitReceipt["result"],
+    attempts: Number(match[2]),
+    notReady: Number(match[3]),
+    timeouts: Number(match[4]),
+    errors: Number(match[5]),
+    lastFailure: match[6] as GatewayHealthWaitReceipt["lastFailure"],
+    probeMs: Number(match[7]),
+    sleepMs: Number(match[8]),
+  };
+  const failures = receipt.notReady + receipt.timeouts + receipt.errors;
+  const readyAttempts = receipt.result === "ready" ? 1 : 0;
+  if (
+    receipt.attempts < 1 ||
+    receipt.attempts > GATEWAY_HEALTH_WAIT_MAX_ATTEMPTS ||
+    receipt.probeMs > GATEWAY_HEALTH_WAIT_COMMAND_TIMEOUT_MS ||
+    receipt.sleepMs > GATEWAY_HEALTH_WAIT_COMMAND_TIMEOUT_MS ||
+    receipt.probeMs + receipt.sleepMs > GATEWAY_HEALTH_WAIT_COMMAND_TIMEOUT_MS ||
+    receipt.attempts !== failures + readyAttempts ||
+    (failures === 0) !== (receipt.lastFailure === "none") ||
+    (receipt.lastFailure === "not-ready" && receipt.notReady === 0) ||
+    (receipt.lastFailure === "timeout" && receipt.timeouts === 0) ||
+    (receipt.lastFailure === "error" && receipt.errors === 0)
+  ) {
+    return null;
+  }
+  return receipt;
+}
+
+function recordGatewayHealthWaitReceipt(
+  receipt: GatewayHealthWaitReceipt,
+  lifecycleTiming: PortableLifecycleTimingRecorder,
+): void {
+  const remaining = {
+    "not-ready": receipt.notReady,
+    timeout: receipt.timeouts,
+    error: receipt.errors,
+  };
+  if (receipt.lastFailure !== "none") remaining[receipt.lastFailure] -= 1;
+  for (const outcome of ["not-ready", "timeout", "error"] as const) {
+    for (let attempt = 0; attempt < remaining[outcome]; attempt += 1) {
+      lifecycleTiming.recordGatewayAttempt(outcome);
+    }
+  }
+  if (receipt.lastFailure !== "none") {
+    lifecycleTiming.recordGatewayAttempt(receipt.lastFailure);
+  }
+  if (receipt.result === "ready") lifecycleTiming.recordGatewayAttempt("ready");
+}
+
 function gatewayIsRunning(
   receipt: PortableDemoLifecycleReceipt,
   gatewayName: string,
@@ -1036,6 +1174,64 @@ function gatewayIsRunning(
   const ready = result.status === 0 && /(?:^|\D)(?:200|401)\s*$/u.test(String(result.stdout ?? ""));
   lifecycleTiming.recordGatewayAttempt(commandAttemptOutcome(result, ready));
   return ready;
+}
+
+function waitForLaunchedGateway(
+  receipt: PortableDemoLifecycleReceipt,
+  gatewayName: string,
+  capture: NonNullable<PortableDemoLifecycleDeps["captureOpenshell"]>,
+  timeoutMs: number,
+  deps: Required<Pick<PortableDemoLifecycleDeps, "now" | "sleep">>,
+  lifecycleTiming: PortableLifecycleTimingRecorder,
+): boolean {
+  const deadline = deps.now() + timeoutMs;
+  do {
+    const remainingMs = Math.max(1, deadline - deps.now());
+    const commandTimeoutMs = Math.min(GATEWAY_HEALTH_WAIT_COMMAND_TIMEOUT_MS, remainingMs);
+    const commandReserveMs = Math.min(
+      GATEWAY_HEALTH_WAIT_COMMAND_RESERVE_MS,
+      Math.floor(commandTimeoutMs / 2),
+    );
+    const waiterTimeoutMs = Math.max(1, commandTimeoutMs - commandReserveMs);
+    const result = lifecycleTiming.measureOpenClawGatewayProbe(() =>
+      capture(
+        openshellExecArgs(gatewayName, receipt.sandboxName, [
+          "python3",
+          "-I",
+          "-c",
+          GATEWAY_HEALTH_WAIT_PROGRAM,
+          String(receipt.dashboardPort),
+          String(waiterTimeoutMs),
+          String(GATEWAY_HEALTH_WAIT_POLL_INTERVAL_MS),
+        ]),
+        commandTimeoutMs,
+      ),
+    );
+    const waitReceipt = result.error
+      ? null
+      : parseGatewayHealthWaitReceipt(String(result.stdout ?? ""));
+    const validReady = waitReceipt?.result === "ready" && result.status === 0 && !result.error;
+    const validNotReady =
+      waitReceipt?.result === "not-ready" && result.status === 75 && !result.error;
+    const acceptedReceipt = waitReceipt && (validReady || validNotReady) ? waitReceipt : null;
+    if (acceptedReceipt) {
+      lifecycleTiming.recordOpenClawGatewayWaitSleep(acceptedReceipt.sleepMs);
+      recordGatewayHealthWaitReceipt(acceptedReceipt, lifecycleTiming);
+      if (validReady) return true;
+    } else {
+      lifecycleTiming.recordGatewayAttempt(
+        result.error ? commandAttemptOutcome(result, false) : "error",
+      );
+    }
+    if (deps.now() >= deadline) return false;
+    const retryIntervalMs = acceptedReceipt
+      ? GATEWAY_HEALTH_WAIT_POLL_INTERVAL_MS
+      : GATEWAY_HEALTH_WAIT_RETRY_INTERVAL_MS;
+    lifecycleTiming.measureOpenClawGatewaySleep(() =>
+      deps.sleep(Math.min(retryIntervalMs, deadline - deps.now())),
+    );
+  } while (deps.now() < deadline);
+  return false;
 }
 
 function ollamaIsHealthy(
@@ -1466,12 +1662,12 @@ export function recoverPortableDemoSandboxLifecycle(
     launch(openshellExecArgs(gatewayName, sandboxName, startupArgv(receipt))),
   );
   const recovered = lifecycleTiming.measure("gatewayReady", () =>
-    waitFor(
+    waitForLaunchedGateway(
+      receipt,
+      gatewayName,
+      capture,
       STARTUP_TIMEOUT_MS,
       timing,
-      (remainingMs) => {
-        return gatewayIsRunning(receipt, gatewayName, capture, remainingMs, lifecycleTiming);
-      },
       lifecycleTiming,
     ),
   );

--- a/src/lib/onboard/experimental/portable-demo-lifecycle.ts
+++ b/src/lib/onboard/experimental/portable-demo-lifecycle.ts
@@ -61,6 +61,7 @@ const MAX_RECEIPT_DIRECTORY_ENTRIES = 1024;
 const COMMAND_TIMEOUT_MS = 30_000;
 const PROBE_TIMEOUT_MS = 5_000;
 const EXEC_READY_TIMEOUT_MS = 90_000;
+const EXEC_READY_POLL_INTERVAL_MS = 100;
 const STOP_SETTLEMENT_TIMEOUT_MS = 30_000;
 const STARTUP_STOP_TIMEOUT_MS = 30_000;
 const STARTUP_TIMEOUT_MS = 90_000;
@@ -1559,15 +1560,21 @@ export function recoverPortableDemoSandboxLifecycle(
   const timing = { now: clock, sleep: deps.sleep ?? defaultSleep };
   const gatewayName = context.gatewayName;
   const execReady = lifecycleTiming.measure("execReady", () =>
-    waitFor(EXEC_READY_TIMEOUT_MS, timing, (remainingMs) => {
-      const result = capture(
-        openshellExecArgs(gatewayName, sandboxName, ["true"]),
-        Math.min(PROBE_TIMEOUT_MS, remainingMs),
-      );
-      const ready = result.status === 0 && !result.error;
-      lifecycleTiming.recordExecAttempt(commandAttemptOutcome(result, ready));
-      return ready;
-    }),
+    waitFor(
+      EXEC_READY_TIMEOUT_MS,
+      timing,
+      (remainingMs) => {
+        const result = capture(
+          openshellExecArgs(gatewayName, sandboxName, ["true"]),
+          Math.min(PROBE_TIMEOUT_MS, remainingMs),
+        );
+        const ready = result.status === 0 && !result.error;
+        lifecycleTiming.recordExecAttempt(commandAttemptOutcome(result, ready));
+        return ready;
+      },
+      undefined,
+      EXEC_READY_POLL_INTERVAL_MS,
+    ),
   );
   if (!execReady) {
     lifecycleTiming.markFailureStage("execReady");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

OpenClaw Portable recovery now observes gateway readiness with one bounded OpenShell exec that polls loopback health every 100 ms inside the sandbox. The same waiter covers both newly launched gateways and gateways owned by an already-running managed startup process. After a stopped container restarts, NemoClaw also retries OpenShell exec registration every 100 ms instead of every second. The exact `/health` readiness contract (HTTP 200 or 401), the outer 90-second lifecycle deadline, and recovery failure behavior remain unchanged.

## Reason

The retained first post-HOME-transition recovery receipt measured `gatewayReady=11844ms` across 12 attempts, including `probe=843ms` and `sleep=11000ms`; its correlated OpenClaw receipt measured `launchToFirstHealth=11846ms` and `spawnToFirstHealth=10729ms`. The one-second host polling cadence therefore added observer delay and repeated OpenShell command setup after gateway launch.

The same receipt measured `execReady=1033ms` with one not-ready attempt before success. That stage used the generic one-second lifecycle poll even though it only waits for the restarted container to re-register with OpenShell. The narrower 100 ms interval reduces the retry floor while preserving the 90-second deadline. These changes reduce NemoClaw observer overhead; they do not claim to reduce OpenClaw's remaining startup work.

### Related issues

Relates to #9200.

## Changes

- Run one fixed `python3 -I` loopback health observer per bounded 18-second in-sandbox window, inside a 20-second host command timeout.
- Validate a fixed schema-1 observer receipt, its exit status, attempt accounting, and bounded timing before accepting readiness.
- Reject receipt timing that exceeds the exact requested waiter budget, with only a 1 ms allowance for independently rounded probe and sleep totals.
- Retry transport, malformed, mismatched, or over-budget receipts conservatively without exposing subprocess diagnostics.
- Preserve the existing public gateway timing receipt by separating the observer's reported polling sleep from probe time.
- Use the bounded waiter when recovery launches a gateway or discovers an existing managed startup process; retain one initial `curl` only to classify an already-healthy gateway.
- Retry only post-container-start OpenShell exec registration at 100 ms; keep other lifecycle polling and all deadlines unchanged.
- Execute the emitted gateway waiter against controlled HTTP 200, 401, and 503 loopback responses.
- Cover the exact command boundary, readiness statuses, receipt validation, timing accounting, retry behavior, redaction, and recovery retry contract.

## Verification

- `npx vitest run --project cli src/lib/onboard/experimental/portable-demo-lifecycle.test.ts src/lib/onboard/experimental/portable-demo-lifecycle-recovery-timing.test.ts` — 63 tests passed.
- `npm run typecheck:cli` — passed after the normal CLI build generated required local artifacts.
- `npm run build:cli` — passed.
- Changed-file Oxlint and Oxfmt checks — passed.
- Growth guardrails — 32 tests passed; the legacy lifecycle test remains below its 1,500-line budget.
- Normal pre-commit hooks — passed, including repository checks, source-shape budget, growth guardrails, gitleaks, and commitlint.
- Normal pre-push hooks — passed.
- Current-head GitHub source CI — build/typecheck, static checks, installer/plugin checks, all 12 CLI shards, merged coverage, and the aggregate gate passed.
- Current-head managed-image validation — OpenClaw, Hermes, and Deep Agents Code startup; both exact OpenClaw MCP discovery passes; and all-agent runtime activation passed.
- GitHub commit verification — commits `c043496a5c9bee6d794551261065119894edd731`, `d6aafd86f7ec9c011d8c8bf699a37f388ac68372`, `f2ab64f3506ef0085006b632bc8997ae98df41e4`, `3f3930d142b8ee16515a183e00f5f5971a882ccd`, `9bd9987585f7bd84c951c1dc186ed65e5cf9a271`, and `385eba2bbdc0f584ec309977fd6a11135338cf34` are `Verified`.
- Diff inspection — no secrets, API keys, or credentials are present.

## Review notes

- `npm run test:changed` passed its 32 growth guardrails, then recorded 5,711 passes and 2 skips across affected projects. One additional unrelated test failed: `mcp-bridge-adapter-hermes.test.ts` requires PyYAML, which this Mac's isolated `python3` does not provide. The changed OpenClaw lifecycle suites passed.
- The PR Review Advisor completed on `9bd9987585f7bd84c951c1dc186ed65e5cf9a271` with no specialist findings. On `385eba2bbdc0f584ec309977fd6a11135338cf34`, all specialists stopped before analysis because the shared workflow sandbox lacked `origin/main`; no review artifacts or code findings were produced. The run was not retried outside repository retry policy.
- CodeRabbit's existing-startup-process polling finding is addressed by `9bd9987585f7bd84c951c1dc186ed65e5cf9a271`. Its receipt-budget and test-coupling findings are addressed by `385eba2bbdc0f584ec309977fd6a11135338cf34`.
- No live post-fix Brev timing is claimed in this PR. The retained benchmark VM and its exact-source evidence were not mutated for these commits.
- No documentation changes are needed because this changes only the existing experimental recovery observer and preserves its command and receipt contracts.

---
Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded gateway health checks with structured readiness and failure reporting.
  * Gateway checks now accept expected authenticated and unauthenticated health responses.
  * Added timing information for gateway wait and retry activity.

* **Bug Fixes**
  * Improved handling of gateway timeouts, malformed responses, inconsistent status results, and failed commands.
  * Preserved accurate failure classification when readiness checks report no explicit failure count.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
