### PR TITLE
perf(tools): parallelize advisor summary reads

### DIFF
--- a/.dsh/tools/read_nemoclaw_advisor_run_summaries/index.ts
+++ b/.dsh/tools/read_nemoclaw_advisor_run_summaries/index.ts
@@ -126,8 +126,8 @@ process_artifact() {
   bound=${maxCharacters * 4 + 1}
   [ "\$expected" -le "\$bound" ] || expected=\$bound
   [ "\$actual" -eq "\$expected" ] || { echo 'summary size differs from archive metadata' >&2; return 25; }
-  printf '%.1000s\n' "\$summary"
-  [ "\$actual" -gt ${maxCharacters * 4} ] && printf '1\n' || printf '0\n'
+  printf '%.1000s\t' "\$summary"
+  [ "\$actual" -gt ${maxCharacters * 4} ] && printf '1\t' || printf '0\t'
   base64 -w 0 "\$dir/summary"
 }
 run_artifact() {
@@ -149,12 +149,17 @@ while [ "\$running" -gt 0 ]; do
 done
 for specification in ${specifications}; do
   index=\${specification%%:*}
-  status=\$(<"\$tmp/\$index.status")
-  printf '%s\t%s\t' "\$status" "\$index"
-  if [ "\$status" -eq 0 ]; then
-    base64 -w 0 "\$tmp/\$index.out"
+  if IFS= read -r status < "\$tmp/\$index.status" 2>/dev/null && [[ "\$status" =~ ^[0-9]{1,3}$ ]]; then
+    if [ "\$status" -eq 0 ]; then
+      printf '0\t%s\t' "\$index"
+      cat "\$tmp/\$index.out"
+    else
+      printf '%s\t%s\t' "\$status" "\$index"
+      head -c 2000 "\$tmp/\$index.err" | base64 -w 0
+    fi
   else
-    head -c 2000 "\$tmp/\$index.err" | base64 -w 0
+    printf '99\t%s\t' "\$index"
+    printf 'artifact worker status was missing or malformed' | base64 -w 0
   fi
   printf '\n'
 done`;
@@ -165,7 +170,7 @@ done`;
           command,
           workdir: input.workdir,
           description: "Read bounded advisor artifact summaries",
-          timeoutMs: 60000,
+          timeoutMs: Math.min(300000, 60000 * Math.ceil(eligible.length / 4)),
         });
   const batchRecords = new Map();
   let batchFailureDetail = "artifact summary batch processing failed";
@@ -178,12 +183,24 @@ done`;
     });
     batchFailureDetail = projected.text || batchFailureDetail;
   }
-  if (batch?.kind === "foreground" && !batch.stdout.truncated) {
-    for (const line of batch.stdout.text.split("\n")) {
+  if (batch?.kind === "foreground") {
+    let completeOutput = batch.stdout.text;
+    if (batch.stdout.truncated) {
+      const firstNewline = completeOutput.indexOf("\n");
+      completeOutput = firstNewline < 0 ? "" : completeOutput.slice(firstNewline + 1);
+    }
+    const lastNewline = completeOutput.lastIndexOf("\n");
+    completeOutput = lastNewline < 0 ? "" : completeOutput.slice(0, lastNewline);
+    for (const line of completeOutput.split("\n")) {
       if (!line) continue;
       const fields = line.split("\t");
       const index = Number(fields[1]);
-      if (fields.length === 3 && Number.isSafeInteger(index)) batchRecords.set(index, fields);
+      if (
+        (fields.length === 3 || fields.length === 5) &&
+        Number.isSafeInteger(index) &&
+        eligible.some((item) => item.index === index)
+      )
+        batchRecords.set(index, fields);
     }
   }
   const summaries = [];
@@ -202,23 +219,20 @@ done`;
       });
       continue;
     }
-    let payload = "";
-    try {
-      if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(fields[2]))
-        throw new Error("invalid base64");
-      payload = Buffer.from(fields[2], "base64").toString("utf8");
-    } catch {
-      failures.push({
-        index,
-        artifactId: artifact.artifactId,
-        artifactName: artifact.artifactName,
-        detail: "artifact summary response was malformed",
-      });
-      continue;
-    }
     if (fields[0] !== "0") {
+      let detail = "";
+      try {
+        if (
+          fields.length !== 3 ||
+          !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(fields[2])
+        )
+          throw new Error("invalid failure record");
+        detail = Buffer.from(fields[2], "base64").toString("utf8");
+      } catch {
+        detail = "artifact summary response was malformed";
+      }
       const projected = await tools.project_diagnostic_text({
-        lines: [payload],
+        lines: [detail],
         maxLines: 5,
         maxCharacters: 1000,
         maxLineCharacters: 500,
@@ -231,13 +245,7 @@ done`;
       });
       continue;
     }
-    const first = payload.indexOf("\n");
-    const second = payload.indexOf("\n", first + 1);
-    if (
-      first < 0 ||
-      second < 0 ||
-      (payload.slice(first + 1, second) !== "0" && payload.slice(first + 1, second) !== "1")
-    ) {
+    if (fields.length !== 5 || (fields[3] !== "0" && fields[3] !== "1")) {
       failures.push({
         index,
         artifactId: artifact.artifactId,
@@ -248,10 +256,9 @@ done`;
     }
     let decoded = "";
     try {
-      const encoded = payload.slice(second + 1).trim();
-      if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(encoded))
+      if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(fields[4]))
         throw new Error("invalid base64");
-      decoded = Buffer.from(encoded, "base64").toString("utf8");
+      decoded = Buffer.from(fields[4], "base64").toString("utf8");
     } catch {
       failures.push({
         index,
@@ -261,7 +268,7 @@ done`;
       });
       continue;
     }
-    const clipped = payload.slice(first + 1, second) === "1" || decoded.length > maxCharacters;
+    const clipped = fields[3] === "1" || decoded.length > maxCharacters;
     const projected = await tools.project_diagnostic_text({
       lines: (clipped ? decoded.slice(0, maxCharacters) : decoded).split("\n"),
       clipMode: "head",
@@ -273,7 +280,7 @@ done`;
     summaries.push({
       artifactId: artifact.artifactId,
       artifactName: artifact.artifactName,
-      entry: payload.slice(0, first).slice(0, 1000),
+      entry: fields[2].slice(0, 1000),
       text: projected.text,
       truncated: projected.truncated,
       index,

--- a/.dsh/tools/read_nemoclaw_advisor_run_summaries/index.ts
+++ b/.dsh/tools/read_nemoclaw_advisor_run_summaries/index.ts
@@ -43,138 +43,227 @@ export default async function read_nemoclaw_advisor_run_summaries(input: {
   const all = listing.items.filter(
     (item) => typeof item.name === "string" && item.name.startsWith("pr-review-specialist-"),
   );
-  const listingTruncated = listing.truncated;
   const selected = all.slice(0, maxArtifacts);
-  const quote = (value) => "'" + String(value).replaceAll("'", "'\"'\"'") + "'";
-  const summaries = [];
+  const artifacts = selected.map((raw) => ({
+    artifactId: Number(raw.id ?? 0),
+    artifactName: String(raw.name ?? "").slice(0, 300),
+    expired: Boolean(raw.expired),
+    size: raw.size_in_bytes,
+  }));
   const failures = [];
-  for (const raw of selected) {
-    const artifactId = Number(raw.id ?? 0);
-    const artifactName = String(raw.name ?? "").slice(0, 300);
-    if (!Number.isSafeInteger(artifactId) || artifactId < 1 || raw.expired) {
+  const eligible = [];
+  let cumulativeCompressedBytes = 0;
+  for (const [index, artifact] of artifacts.entries()) {
+    if (!Number.isSafeInteger(artifact.artifactId) || artifact.artifactId < 1 || artifact.expired) {
       failures.push({
-        artifactId: Number.isSafeInteger(artifactId) ? artifactId : 0,
-        artifactName,
-        detail: raw.expired ? "artifact expired" : "invalid artifact identity",
+        index,
+        artifactId: Number.isSafeInteger(artifact.artifactId) ? artifact.artifactId : 0,
+        artifactName: artifact.artifactName,
+        detail: artifact.expired ? "artifact expired" : "invalid artifact identity",
       });
       continue;
     }
     if (
-      typeof raw.size_in_bytes !== "number" ||
-      !Number.isSafeInteger(raw.size_in_bytes) ||
-      raw.size_in_bytes < 0 ||
-      raw.size_in_bytes > 5000000
+      typeof artifact.size !== "number" ||
+      !Number.isSafeInteger(artifact.size) ||
+      artifact.size < 0 ||
+      artifact.size > 5000000
     ) {
       failures.push({
-        artifactId,
-        artifactName,
+        index,
+        artifactId: artifact.artifactId,
+        artifactName: artifact.artifactName,
         detail: "compressed artifact exceeds the 5,000,000-byte bound or has invalid size metadata",
       });
       continue;
     }
-    const command = `set -euo pipefail
+    if (cumulativeCompressedBytes + artifact.size > 50000000) {
+      failures.push({
+        index,
+        artifactId: artifact.artifactId,
+        artifactName: artifact.artifactName,
+        detail: "cumulative compressed artifact metadata exceeds the 50,000,000-byte bound",
+      });
+      continue;
+    }
+    cumulativeCompressedBytes += artifact.size;
+    eligible.push({ index, artifactId: artifact.artifactId });
+  }
+  const specifications = eligible.map((item) => item.index + ":" + item.artifactId).join(" ");
+  const command = `set -euo pipefail
 umask 077
-tmp=\$(mktemp -d "\${TMPDIR:-/tmp}/advisor-summary.XXXXXX")
+tmp=\$(mktemp -d "\${TMPDIR:-/tmp}/advisor-summaries.XXXXXX")
 trap 'rm -rf "\$tmp"' EXIT
-zip="\$tmp/artifact.zip"
-set +e
-gh api ${quote(`repos/${repo}/actions/artifacts/${artifactId}/zip`)} | head -c 5000001 > "\$zip"
-statuses=("\${PIPESTATUS[@]}")
-producer=\${statuses[0]}
-consumer=\${statuses[1]}
-set -e
-[ "\$consumer" -eq 0 ] && { [ "\$producer" -eq 0 ] || [ "\$producer" -eq 141 ]; } || exit 19
-bytes=\$(stat -c %s "\$zip")
-[ "\$bytes" -le 5000000 ] || { echo 'compressed artifact exceeds bound' >&2; exit 20; }
-test_summary=\$(LC_ALL=C zipinfo -t "\$zip" 2>/dev/null) || { echo 'artifact ZIP is malformed' >&2; exit 21; }
-[[ "\$test_summary" != *$'\n'* && "\$test_summary" =~ ^([0-9]+)[[:space:]]files?,[[:space:]]([0-9]+)[[:space:]]bytes[[:space:]]uncompressed, ]] || { echo 'artifact ZIP summary is ambiguous' >&2; exit 21; }
-[ "\${BASH_REMATCH[1]}" -le 100 ] || { echo 'artifact inventory exceeds 100 entries' >&2; exit 21; }
-[ "\${BASH_REMATCH[2]}" -le 20000000 ] || { echo 'expanded artifact exceeds 20,000,000 bytes' >&2; exit 21; }
-LC_ALL=C zipinfo -l "\$zip" > "\$tmp/listing" 2>/dev/null || exit 21
-LC_ALL=C zipinfo -1 "\$zip" > "\$tmp/names" 2>/dev/null || exit 21
-[ "\$(wc -c < "\$tmp/listing")" -le 1000000 ] || { echo 'artifact listing exceeds bound' >&2; exit 21; }
-awk -v declared_count="\${BASH_REMATCH[1]}" 'NR==FNR { exact[FNR]=$0; names=FNR; next } BEGIN { count=0; state="ok" } FNR <= 2 { next } /^[bcdlps-][rwxStTs-]{9}[[:space:]]/ { count++; mode=substr($0,1,1); size=$4; line=$0; for (i=1;i<=9;i++) sub(/^[^[:space:]]+[[:space:]]+/, "", line); name=exact[count]; if (line != name || (mode != "-" && mode != "d") || size !~ /^[0-9]+$/) state="unsafe"; parts=split(name, component, "/"); if (name == "" || substr(name,1,1) == "-" || substr(name,1,1) == "/" || index(name,sprintf("%c",92)) || name ~ /[[:cntrl:]]/ || index(name,"*") || index(name,"?") || index(name,"[") || seen[name]++) state="unsafe"; for (part=1; part<=parts; part++) if (component[part] == "..") state="unsafe"; if (mode == "-" && name ~ /summary[.]md$/) { selected++; selected_size=size; selected_name=name } } END { if (state != "ok" || count != names || count != declared_count) exit 2; if (selected != 1) exit 3; printf "%s\t%s", selected_size, selected_name }' "\$tmp/names" "\$tmp/listing" > "\$tmp/selected" || { echo 'artifact entries are unsafe, ambiguous, or missing one summary' >&2; exit 22; }
-IFS=\$'\t' read -r declared summary < "\$tmp/selected" || [ -n "\$summary" ]
-[ -n "\$summary" ] && [[ "\$declared" =~ ^[0-9]+$ ]] || { echo 'artifact summary metadata is invalid' >&2; exit 24; }
-[ "\$declared" -le 20000000 ] || { echo 'summary entry exceeds expanded-size bound' >&2; exit 24; }
-set +e
-unzip -p "\$zip" "\$summary" | head -c ${maxCharacters * 4 + 1} > "\$tmp/summary"
-statuses=("\${PIPESTATUS[@]}")
-producer=\${statuses[0]}
-consumer=\${statuses[1]}
-set -e
-[ "\$consumer" -eq 0 ] && { [ "\$producer" -eq 0 ] || [ "\$producer" -eq 141 ]; } || exit 25
-actual=\$(stat -c %s "\$tmp/summary")
-expected=\$declared
-bound=${maxCharacters * 4 + 1}
-[ "\$expected" -le "\$bound" ] || expected=\$bound
-[ "\$actual" -eq "\$expected" ] || { echo 'summary size differs from archive metadata' >&2; exit 25; }
-printf '%s\n' "\$summary"
-[ "\$(stat -c %s \"\$tmp/summary\")" -gt ${maxCharacters * 4} ] && printf '1\n' || printf '0\n'
-base64 -w 0 "\$tmp/summary"`;
-    const result = await tools.bash({
-      command,
-      workdir: input.workdir,
-      description: "Read bounded advisor artifact summary",
-      timeoutMs: 60000,
+process_artifact() {
+  local index=\$1 artifact_id=\$2 dir zip test_summary declared summary actual expected bound
+  dir="\$tmp/\$index"
+  mkdir "\$dir"
+  zip="\$dir/artifact.zip"
+  set +e
+  gh api "repos/${repo}/actions/artifacts/\$artifact_id/zip" | head -c 5000001 > "\$zip"
+  local statuses=("\${PIPESTATUS[@]}")
+  set -e
+  [ "\${statuses[1]}" -eq 0 ] && { [ "\${statuses[0]}" -eq 0 ] || [ "\${statuses[0]}" -eq 141 ]; } || return 19
+  [ "\$(stat -c %s "\$zip")" -le 5000000 ] || { echo 'compressed artifact exceeds bound' >&2; return 20; }
+  test_summary=\$(LC_ALL=C zipinfo -t "\$zip" 2>/dev/null) || { echo 'artifact ZIP is malformed' >&2; return 21; }
+  [[ "\$test_summary" != *$'\n'* && "\$test_summary" =~ ^([0-9]+)[[:space:]]files?,[[:space:]]([0-9]+)[[:space:]]bytes[[:space:]]uncompressed, ]] || { echo 'artifact ZIP summary is ambiguous' >&2; return 21; }
+  [ "\${BASH_REMATCH[1]}" -le 100 ] || { echo 'artifact inventory exceeds 100 entries' >&2; return 21; }
+  [ "\${BASH_REMATCH[2]}" -le 20000000 ] || { echo 'expanded artifact exceeds 20,000,000 bytes' >&2; return 21; }
+  LC_ALL=C zipinfo -l "\$zip" > "\$dir/listing" 2>/dev/null || return 21
+  LC_ALL=C zipinfo -1 "\$zip" > "\$dir/names" 2>/dev/null || return 21
+  [ "\$(wc -c < "\$dir/listing")" -le 1000000 ] || { echo 'artifact listing exceeds bound' >&2; return 21; }
+  awk -v declared_count="\${BASH_REMATCH[1]}" 'NR==FNR { exact[FNR]=$0; names=FNR; next } BEGIN { count=0; state="ok" } FNR <= 2 { next } /^[bcdlps-][rwxStTs-]{9}[[:space:]]/ { count++; mode=substr($0,1,1); size=$4; line=$0; for (i=1;i<=9;i++) sub(/^[^[:space:]]+[[:space:]]+/, "", line); name=exact[count]; if (line != name || (mode != "-" && mode != "d") || size !~ /^[0-9]+$/) state="unsafe"; parts=split(name, component, "/"); if (name == "" || substr(name,1,1) == "-" || substr(name,1,1) == "/" || index(name,sprintf("%c",92)) || name ~ /[[:cntrl:]]/ || index(name,"*") || index(name,"?") || index(name,"[") || seen[name]++) state="unsafe"; for (part=1; part<=parts; part++) if (component[part] == "..") state="unsafe"; if (mode == "-" && name ~ /summary[.]md$/) { selected++; selected_size=size; selected_name=name } } END { if (state != "ok" || count != names || count != declared_count) exit 2; if (selected != 1) exit 3; printf "%s\t%s", selected_size, selected_name }' "\$dir/names" "\$dir/listing" > "\$dir/selected" || { echo 'artifact entries are unsafe, ambiguous, or missing one summary' >&2; return 22; }
+  IFS=\$'\t' read -r declared summary < "\$dir/selected" || [ -n "\$summary" ]
+  [ -n "\$summary" ] && [[ "\$declared" =~ ^[0-9]+$ ]] || { echo 'artifact summary metadata is invalid' >&2; return 24; }
+  [ "\$declared" -le 20000000 ] || { echo 'summary entry exceeds expanded-size bound' >&2; return 24; }
+  set +e
+  unzip -p "\$zip" "\$summary" | head -c ${maxCharacters * 4 + 1} > "\$dir/summary"
+  statuses=("\${PIPESTATUS[@]}")
+  set -e
+  [ "\${statuses[1]}" -eq 0 ] && { [ "\${statuses[0]}" -eq 0 ] || [ "\${statuses[0]}" -eq 141 ]; } || return 25
+  actual=\$(stat -c %s "\$dir/summary")
+  expected=\$declared
+  bound=${maxCharacters * 4 + 1}
+  [ "\$expected" -le "\$bound" ] || expected=\$bound
+  [ "\$actual" -eq "\$expected" ] || { echo 'summary size differs from archive metadata' >&2; return 25; }
+  printf '%.1000s\n' "\$summary"
+  [ "\$actual" -gt ${maxCharacters * 4} ] && printf '1\n' || printf '0\n'
+  base64 -w 0 "\$dir/summary"
+}
+run_artifact() {
+  local specification=\$1 index=\${1%%:*} artifact_id=\${1#*:}
+  ( if process_artifact "\$index" "\$artifact_id" > "\$tmp/\$index.out" 2> "\$tmp/\$index.err"; then status=0; else status=\$?; fi; printf '%s\n' "\$status" > "\$tmp/\$index.status" ) &
+}
+running=0
+for specification in ${specifications}; do
+  run_artifact "\$specification"
+  running=\$((running + 1))
+  if [ "\$running" -eq 4 ]; then
+    wait -n
+    running=\$((running - 1))
+  fi
+done
+while [ "\$running" -gt 0 ]; do
+  wait -n
+  running=\$((running - 1))
+done
+for specification in ${specifications}; do
+  index=\${specification%%:*}
+  status=\$(<"\$tmp/\$index.status")
+  printf '%s\t%s\t' "\$status" "\$index"
+  if [ "\$status" -eq 0 ]; then
+    base64 -w 0 "\$tmp/\$index.out"
+  else
+    head -c 2000 "\$tmp/\$index.err" | base64 -w 0
+  fi
+  printf '\n'
+done`;
+  const batch =
+    eligible.length === 0
+      ? null
+      : await tools.bash({
+          command,
+          workdir: input.workdir,
+          description: "Read bounded advisor artifact summaries",
+          timeoutMs: 60000,
+        });
+  const batchRecords = new Map();
+  let batchFailureDetail = "artifact summary batch processing failed";
+  if (batch?.kind === "foreground" && batch.exitCode !== 0) {
+    const projected = await tools.project_diagnostic_text({
+      lines: [batch.stderr.text],
+      maxLines: 5,
+      maxCharacters: 1000,
+      maxLineCharacters: 500,
     });
-    if (result.kind !== "foreground") throw new Error("Unexpected background result");
-    if (result.exitCode !== 0) {
+    batchFailureDetail = projected.text || batchFailureDetail;
+  }
+  if (batch?.kind === "foreground" && !batch.stdout.truncated) {
+    for (const line of batch.stdout.text.split("\n")) {
+      if (!line) continue;
+      const fields = line.split("\t");
+      const index = Number(fields[1]);
+      if (fields.length === 3 && Number.isSafeInteger(index)) batchRecords.set(index, fields);
+    }
+  }
+  const summaries = [];
+  for (const { index } of eligible) {
+    const artifact = artifacts[index];
+    const fields = batchRecords.get(index);
+    if (!fields) {
+      failures.push({
+        index,
+        artifactId: artifact.artifactId,
+        artifactName: artifact.artifactName,
+        detail:
+          batch?.kind === "foreground" && batch.stdout.truncated
+            ? "artifact summary response exceeded the transport bound"
+            : batchFailureDetail,
+      });
+      continue;
+    }
+    let payload = "";
+    try {
+      if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(fields[2]))
+        throw new Error("invalid base64");
+      payload = Buffer.from(fields[2], "base64").toString("utf8");
+    } catch {
+      failures.push({
+        index,
+        artifactId: artifact.artifactId,
+        artifactName: artifact.artifactName,
+        detail: "artifact summary response was malformed",
+      });
+      continue;
+    }
+    if (fields[0] !== "0") {
       const projected = await tools.project_diagnostic_text({
-        lines: [result.stderr.text],
+        lines: [payload],
         maxLines: 5,
         maxCharacters: 1000,
         maxLineCharacters: 500,
       });
       failures.push({
-        artifactId,
-        artifactName,
+        index,
+        artifactId: artifact.artifactId,
+        artifactName: artifact.artifactName,
         detail: projected.text || "artifact summary read failed",
       });
       continue;
     }
-    if (result.stdout.truncated) {
+    const first = payload.indexOf("\n");
+    const second = payload.indexOf("\n", first + 1);
+    if (
+      first < 0 ||
+      second < 0 ||
+      (payload.slice(first + 1, second) !== "0" && payload.slice(first + 1, second) !== "1")
+    ) {
       failures.push({
-        artifactId,
-        artifactName,
-        detail: "artifact summary response exceeded the transport bound",
-      });
-      continue;
-    }
-    const newline = result.stdout.text.indexOf("\n");
-    if (newline < 0) {
-      failures.push({
-        artifactId,
-        artifactName,
+        index,
+        artifactId: artifact.artifactId,
+        artifactName: artifact.artifactName,
         detail: "artifact summary response was malformed",
       });
       continue;
     }
-    const entry = result.stdout.text.slice(0, newline).slice(0, 1000);
-    const clippedNewline = result.stdout.text.indexOf("\n", newline + 1);
-    if (clippedNewline < 0) {
-      failures.push({
-        artifactId,
-        artifactName,
-        detail: "artifact summary response was malformed",
-      });
-      continue;
-    }
-    const byteClipped = result.stdout.text.slice(newline + 1, clippedNewline) === "1";
     let decoded = "";
     try {
-      const encoded = result.stdout.text.slice(clippedNewline + 1).trim();
+      const encoded = payload.slice(second + 1).trim();
       if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(encoded))
         throw new Error("invalid base64");
       decoded = Buffer.from(encoded, "base64").toString("utf8");
     } catch {
-      failures.push({ artifactId, artifactName, detail: "artifact summary was not valid base64" });
+      failures.push({
+        index,
+        artifactId: artifact.artifactId,
+        artifactName: artifact.artifactName,
+        detail: "artifact summary was not valid base64",
+      });
       continue;
     }
-    const clipped = byteClipped || decoded.length > maxCharacters;
-    const text = clipped ? decoded.slice(0, maxCharacters) : decoded;
+    const clipped = payload.slice(first + 1, second) === "1" || decoded.length > maxCharacters;
     const projected = await tools.project_diagnostic_text({
-      lines: text.split("\n"),
+      lines: (clipped ? decoded.slice(0, maxCharacters) : decoded).split("\n"),
       clipMode: "head",
       maxLines: 500,
       maxCharacters,
@@ -182,21 +271,24 @@ base64 -w 0 "\$tmp/summary"`;
       sourceTruncated: clipped,
     });
     summaries.push({
-      artifactId,
-      artifactName,
-      entry,
+      artifactId: artifact.artifactId,
+      artifactName: artifact.artifactName,
+      entry: payload.slice(0, first).slice(0, 1000),
       text: projected.text,
       truncated: projected.truncated,
+      index,
     });
   }
+  summaries.sort((left, right) => left.index - right.index);
+  failures.sort((left, right) => left.index - right.index);
   return {
     repo,
     runId: input.runId,
     artifactsFound: all.length,
     summariesRead: summaries.length,
     truncated:
-      listingTruncated || all.length > selected.length || summaries.some((item) => item.truncated),
-    summaries,
-    failures,
+      listing.truncated || all.length > selected.length || summaries.some((item) => item.truncated),
+    summaries: summaries.map(({ index: _index, ...summary }) => summary),
+    failures: failures.map(({ index: _index, ...failure }) => failure),
   };
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Advisor summary retrieval now downloads and validates up to four specialist artifacts concurrently instead of processing each artifact serially.

## Reason

Retained advisor summaries are available only inside artifact ZIP files. Serial downloads make the tool wait for every artifact in sequence.

## Changes

- Batch eligible artifact reads into one private temporary workspace and keep four workers active.
- Preserve artifact order and existing ZIP safety, extraction, clipping, and diagnostic projection checks.
- Limit selected compressed artifact metadata to 50,000,000 bytes and bound each worker response before aggregation.

## Verification

- Contributor validation: The signed commit completed pre-commit and commit-msg hooks successfully. Focused oxfmt, oxlint, and git diff --check also passed.
- Tests: Not applicable — Project-authored DSH tools use representative harness exercises instead of repository tests. The changed source read all nine ordered summaries from retained run 33327127857 with no failures. Invalid maxArtifacts and maxSummaryCharacters values remained rejected.
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved artifact processing reliability and performance through bounded, concurrent processing.
  * Added safeguards for oversized, invalid, or incomplete artifacts before processing.
  * Results now remain consistently ordered with clear success and failure details.
  * Improved handling of truncated output and duplicate data.
  * Enhanced error reporting distinguishes download, command, metadata, and content-processing failures.
  * Added clearer reporting when artifact listings, selections, or generated summaries are incomplete or truncated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->