### PR TITLE
fix(advisor): pass target refs into sandbox

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -133,6 +133,8 @@ jobs:
       ADVISOR_DIR: ${{ github.workspace }}/advisor
       TARGET_REPO: ${{ github.event_name == 'pull_request_target' && github.repository || inputs.target_repo || github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.target_pr }}
+      BASE_REF: ${{ github.event_name == 'pull_request_target' && 'target/base' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'target/base' || inputs.base_ref) }}
+      HEAD_REF: ${{ github.event_name == 'pull_request_target' && 'HEAD' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'HEAD' || inputs.head_ref) }}
     steps: &advisor-analysis-steps
       - name: Checkout trusted advisor code (workflow revision)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -893,6 +893,10 @@ describe("PR review advisor OpenShell wrapper", () => {
         "GIT_WORK_TREE=/pr-workdir",
         "TARGET_REPO=NVIDIA/NemoClaw",
         "/advisor/tools/pr-review-advisor/run-analysis.mts",
+        "--base",
+        "target/base",
+        "--head",
+        "HEAD",
       ]),
     );
     expect(runArgs.join("\n")).not.toContain("github-host-secret");
@@ -956,6 +960,7 @@ describe("PR review advisor OpenShell wrapper", () => {
     );
     fs.symlinkSync(sessionDirectory, sessionAlias, "dir");
     env.PR_REVIEW_ADVISOR_SPECIALIST_SESSION_DIR = sessionAlias;
+    env.PR_REVIEW_ADVISOR_INTEREST = "behavior";
     const tools = advisorTools();
 
     createAdvisorSandbox(env, tools);
@@ -975,11 +980,12 @@ describe("PR review advisor OpenShell wrapper", () => {
       vi
         .mocked(tools.runAsync)
         .mock.calls.find(([, args]) =>
-          args.includes("/advisor/tools/pr-review-advisor/run-analysis.mts"),
+          args.includes("/advisor/tools/pr-review-advisor/run-specialist.mts"),
         )?.[1] ?? [];
     expect(runArgs).toContain(
       "PR_REVIEW_ADVISOR_SPECIALIST_SESSION_DIR=/pr-workdir/.pr-review-advisor-sessions",
     );
+    expect(runArgs.slice(-4)).toEqual(["--base", "target/base", "--head", "HEAD"]);
     expect(runArgs).not.toContain(expect.stringContaining("session-reader"));
   });
 

--- a/test/e2e/support/e2e-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-operations-workflow-boundary.test.ts
@@ -1484,7 +1484,7 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
 
       writeFileSync(
         advisorPath,
-        'permissions: read-all\njobs:\n  advisor:\n    permissions:\n      actions: "write"\n    steps:\n      - run: createWorkflowDispatch()\n',
+        'permissions: read-all\njobs:\n  review-specialists:\n    env: { BASE_REF: target/base~1, HEAD_REF: HEAD~1 }\n    permissions:\n      actions: "write"\n    steps:\n      - run: createWorkflowDispatch()\n',
       );
       expect(validateE2eOperationsWorkflow(workflow, advisorPath)).toEqual(
         expect.arrayContaining([

--- a/test/e2e/support/e2e-operations-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-operations-workflow-boundary.test.ts
@@ -1490,6 +1490,7 @@ const interpolatedNeeds = \${{   toJSON ( needs )   }};
         expect.arrayContaining([
           "Unified advisor must not hold actions: write",
           "Unified advisor must not auto-dispatch workflows",
+          "Unified advisor specialists must retain target refs through execution",
         ]),
       );
     } finally {

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -1453,12 +1453,9 @@ function validateUnifiedAdvisorBoundary(errors: string[], advisorPath: string): 
     errors.push("Unified advisor must not auto-dispatch workflows");
   }
   const specialistEnv = advisor.jobs?.["review-specialists"]?.env ?? {};
-  if (
-    typeof specialistEnv.BASE_REF !== "string" ||
-    !specialistEnv.BASE_REF.includes("target/base") ||
-    typeof specialistEnv.HEAD_REF !== "string" ||
-    !specialistEnv.HEAD_REF.includes("HEAD")
-  ) {
+  const expectedBaseRef = "${{ github.event_name == 'pull_request_target' && 'target/base' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'target/base' || inputs.base_ref) }}";
+  const expectedHeadRef = "${{ github.event_name == 'pull_request_target' && 'HEAD' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'HEAD' || inputs.head_ref) }}";
+  if (specialistEnv.BASE_REF !== expectedBaseRef || specialistEnv.HEAD_REF !== expectedHeadRef) {
     errors.push("Unified advisor specialists must retain target refs through execution");
   }
 }

--- a/tools/e2e/operations-workflow-boundary.mts
+++ b/tools/e2e/operations-workflow-boundary.mts
@@ -1452,6 +1452,15 @@ function validateUnifiedAdvisorBoundary(errors: string[], advisorPath: string): 
   if (/createWorkflowDispatch|workflow_dispatches/u.test(source)) {
     errors.push("Unified advisor must not auto-dispatch workflows");
   }
+  const specialistEnv = advisor.jobs?.["review-specialists"]?.env ?? {};
+  if (
+    typeof specialistEnv.BASE_REF !== "string" ||
+    !specialistEnv.BASE_REF.includes("target/base") ||
+    typeof specialistEnv.HEAD_REF !== "string" ||
+    !specialistEnv.HEAD_REF.includes("HEAD")
+  ) {
+    errors.push("Unified advisor specialists must retain target refs through execution");
+  }
 }
 
 export function validateE2eOperationsWorkflow(

--- a/tools/pr-review-advisor/openshell.mts
+++ b/tools/pr-review-advisor/openshell.mts
@@ -432,6 +432,10 @@ export function runAdvisorSandboxAsync(
         env.PR_REVIEW_ADVISOR_INTEREST
           ? `${SANDBOX_ADVISOR_DIR}/tools/pr-review-advisor/run-specialist.mts`
           : `${SANDBOX_ADVISOR_DIR}/tools/pr-review-advisor/run-analysis.mts`,
+        "--base",
+        required(env.BASE_REF, "BASE_REF"),
+        "--head",
+        required(env.HEAD_REF, "HEAD_REF"),
       ],
     },
     tools,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

PR Review Advisor specialists receive the workflow-selected comparison refs inside OpenShell sandboxes.

## Reason

Fork PR Advisor jobs prepared target/base and HEAD, but sandboxed specialist execution fell back to origin/main because the refs were not supplied as command arguments. The read-only checkout has no origin/main ref, so every specialist failed before producing artifacts.

### Related issues

Refs #10527

## Changes

- Pass the required base and head refs explicitly to sandboxed Advisor analysis and specialist entrypoints.
- Cover both ordinary analysis and specialist execution at the OpenShell command boundary.

## Verification

- Contributor validation: npm run validate:pr passed against canonical origin/main 7478a880f1fae3779a6cb020b5ebb593e580d8e4.
- Tests: npx vitest run --project integration test/automation/pull-requests/pr-review-advisor-openshell.test.ts (38 passed); npm run validate:pr passed.
- Broad gate: npm run validate:pr passed, including repository checks and CLI TypeScript validation.
- Secrets review: The diff contains no secrets, API keys, or credentials
<!-- nemoclaw-docs-review:start -->
- Documentation review: `no-docs-needed`
- Documentation evidence: Internal Advisor workflow command-boundary repair; no user-facing documentation surface changes.
- Documentation agent: openai/openai/gpt-5.6-sol
<!-- docs-review-head-sha: 48c119379691371a2d2424716c86ffc2da3de65b -->
<!-- docs-review-agents-blob-sha: dd3528f6e332f7f09f4841555c2ed11cb2139fb9 -->
<!-- nemoclaw-docs-review:end -->
<!-- nemoclaw-targeted-validation:start -->
- Targeted validation: Focused Advisor command and workflow-boundary suites passed (117 tests); the review follow-up E2E-support suite passed (78 tests); npm run validate:pr passed. Exact-commit workflow_dispatch validation passed at https://github.com/NVIDIA/NemoClaw/actions/runs/33335093964: discovery and all nine specialist lifecycle, artifact upload, and outcome-verification jobs succeeded. Commit 48c119379691371a2d2424716c86ffc2da3de65b additionally requires exact workflow ref expressions and rejects target/base~1 and HEAD~1 lookalikes.
<!-- nemoclaw-targeted-validation:end -->
<!-- nemoclaw-broad-gate:start -->
- Broad gate: passed — npm run validate:pr passed at 48c119379691371a2d2424716c86ffc2da3de65b, including YAML, repository, source-shape, growth, and CLI TypeScript checks.
<!-- nemoclaw-broad-gate:end -->

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request review analysis by consistently specifying the target base and current head revisions.
  * Updated specialist review sessions to use the correct execution flow and behavior settings.
  * Enhanced automated checks to verify revision-aware analysis and specialist execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->