### PR TITLE
test(e2e): prune brittle shields-config live assertions

### DIFF
--- a/test/e2e/live/shields-config.test.ts
+++ b/test/e2e/live/shields-config.test.ts
@@ -518,19 +518,9 @@ async function readOriginalConfig(
   );
 }
 
-function readAuditEntries(): unknown[] {
-  return fs
-    .readFileSync(AUDIT_FILE, "utf8")
-    .trim()
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => JSON.parse(line));
-}
-
 function readTimerMarker(sandboxName: string): {
   pid: number;
   restoreAt: string;
-  snapshotPath: string;
 } {
   return JSON.parse(fs.readFileSync(TIMER_FILE(sandboxName), "utf8"));
 }
@@ -689,13 +679,6 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
   expect(cliVersion.exitCode, resultText(cliVersion)).toBe(0);
 
   progress.phase("establish the mutable unified OpenClaw config");
-  const configDefault = await statPath(sandbox, CONFIG_PATH, "phase-2-config-perms-default");
-  expect(configDefault.mode).toBe("660");
-  expect(configDefault.owner).toBe("sandbox:sandbox");
-  const dirDefault = await statPath(sandbox, CONFIG_DIR, "phase-2-config-dir-perms-default");
-  expect(dirDefault.mode).toBe("2770");
-  expect(dirDefault.owner).toBe("sandbox:sandbox");
-
   const doctor = await runNemoclaw(
     host,
     [
@@ -704,7 +687,7 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
       "--",
       "bash",
       "-c",
-      'openclaw doctor --fix; rc=$?; printf "doctor_exit:%s\\n" "$rc"; stat -c "doctor_file_mode:%a" /sandbox/.openclaw/openclaw.json; stat -c "doctor_dir_mode:%a" /sandbox/.openclaw',
+      'openclaw doctor --fix; rc=$?; printf "doctor_exit:%s\\n" "$rc"',
     ],
     {
       artifactName: "phase-2b-documented-exec-doctor-fix",
@@ -712,22 +695,6 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
     },
   );
   expect(doctor.exitCode, resultText(doctor)).toBe(0);
-  expect(resultText(doctor)).toMatch(/doctor_exit:\d+/);
-  expect(resultText(doctor)).toContain("doctor_file_mode:600");
-  expect(resultText(doctor)).toContain("doctor_dir_mode:700");
-
-  const configAfterDoctor = await statPath(
-    sandbox,
-    CONFIG_PATH,
-    "phase-2b-config-perms-after-doctor",
-  );
-  expect(configAfterDoctor).toMatchObject({ mode: "660", owner: "sandbox:sandbox" });
-  const dirAfterDoctor = await statPath(
-    sandbox,
-    CONFIG_DIR,
-    "phase-2b-config-dir-perms-after-doctor",
-  );
-  expect(dirAfterDoctor).toMatchObject({ mode: "2770", owner: "sandbox:sandbox" });
 
   const containerId = await findSandboxContainer(host);
   const gatewayWrite = await docker(
@@ -759,16 +726,6 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
   );
   expect(freshMutableDown.exitCode, resultText(freshMutableDown)).toBe(0);
   expect(resultText(freshMutableDown)).toContain("Config unlocked");
-  expect(await statPath(sandbox, CONFIG_PATH, "phase-2c-config-perms-after-down")).toMatchObject({
-    mode: "660",
-    owner: "sandbox:sandbox",
-  });
-  expect(await statPath(sandbox, CONFIG_DIR, "phase-2c-config-dir-perms-after-down")).toMatchObject(
-    {
-      mode: "2770",
-      owner: "sandbox:sandbox",
-    },
-  );
 
   const layoutProbe = await sandboxShell(
     sandbox,
@@ -826,7 +783,6 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
     redactionValues: [apiKey],
   });
   expect(configGet.exitCode, resultText(configGet)).toBe(0);
-  expect(configGet.stdout).toContain("{");
   expect(configGet.stdout).not.toMatch(/nvapi-|sk-|Bearer /);
   expect(configGet.stdout).not.toContain('"gateway"');
 
@@ -856,13 +812,6 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
     apiKey,
   ]);
   await expectLockedSandboxParent(host, "phase-5a-shields-up-start-recovery");
-  const configAfterLockedRestart = await statPath(
-    sandbox,
-    CONFIG_PATH,
-    "phase-5a-config-after-shields-up-start-recovery",
-  );
-  expect(configAfterLockedRestart.mode).toMatch(/^4[0-4][0-4]$/);
-  expect(configAfterLockedRestart.owner).toBe("root:root");
   await expectCredentialsTraversalBoundary(host, sandbox, containerId);
 
   progress.phase("detect host-root config drift and refuse resealing");
@@ -1016,16 +965,6 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
   await expectStopStartRecovery(host, sandbox, "DOWN", "phase-7a-shields-down-start-recovery", [
     apiKey,
   ]);
-  const configAfterMutableRestart = await statPath(
-    sandbox,
-    CONFIG_PATH,
-    "phase-7a-config-after-shields-down-start-recovery",
-  );
-  expect(configAfterMutableRestart).toMatchObject({
-    mode: "660",
-    owner: "sandbox:sandbox",
-  });
-
   const restoreUp = await runNemoclaw(host, [SANDBOX_NAME, "shields", "up"], {
     artifactName: "phase-7-restore-shields-up",
   });
@@ -1033,17 +972,7 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
 
   expect(fs.existsSync(AUDIT_FILE), `${AUDIT_FILE} should exist`).toBe(true);
   const auditText = fs.readFileSync(AUDIT_FILE, "utf8");
-  const auditEntries = readAuditEntries();
-  const upCount = auditText.split('"shields_up"').length - 1;
-  const downCount = auditText.split('"shields_down"').length - 1;
-  expect(upCount).toBeGreaterThanOrEqual(2);
-  expect(downCount).toBeGreaterThanOrEqual(1);
   expect(auditText).not.toMatch(/nvapi-|sk-|Bearer /);
-  await artifacts.writeJson("phase-8-audit-summary.json", {
-    entries: auditEntries.length,
-    upCount,
-    downCount,
-  });
 
   progress.phase("recover shields after a dead restore timer");
   const timerDown = await runNemoclaw(
@@ -1077,37 +1006,12 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
     }
   }
   expect(restored, lastTimerStatus).toBe(true);
-  const dirTimer = await statPath(
-    sandbox,
-    CONFIG_DIR,
-    "phase-9-config-dir-perms-after-dead-timer-inline-restore",
-  );
-  expect(dirTimer).toMatchObject({ mode: "755", owner: "root:root" });
   const configTimer = await statPath(
     sandbox,
     CONFIG_PATH,
     "phase-9-config-perms-after-dead-timer-inline-restore",
   );
   expect(configTimer).toMatchObject({ mode: "444", owner: "root:root" });
-  const hashTimer = await statPath(
-    sandbox,
-    CONFIG_HASH_PATH,
-    "phase-9-config-hash-perms-after-dead-timer-inline-restore",
-  );
-  expect(hashTimer).toMatchObject({ mode: "444", owner: "root:root" });
-  const stateAfterTimer = JSON.parse(fs.readFileSync(STATE_FILE(SANDBOX_NAME), "utf8"));
-  expect(stateAfterTimer.fileHashes).toMatchObject({
-    [CONFIG_PATH]: expect.any(String),
-    [CONFIG_HASH_PATH]: expect.any(String),
-  });
-  expect(readAuditEntries()).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        action: "shields_auto_restore",
-        policy_snapshot: timerMarker.snapshotPath,
-      }),
-    ]),
-  );
 
   progress.phase("reject duplicate shields transitions");
   const doubleUp = await runNemoclaw(host, [SANDBOX_NAME, "shields", "up"], {
@@ -1156,7 +1060,6 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
     "phase-12-live-startup-census",
   );
   expect(liveCensus).toMatchObject({ count: 1, pid: expect.any(Number) });
-  expect(liveCensus.pid).not.toBeNull();
   // OpenShell's supervised non-root compatibility path legitimately permits
   // ordinary Shields changes while its startup child is healthy. Exercise the
   // failed-startup admission boundary through the installed guard, then prove
@@ -1168,10 +1071,6 @@ test("shields-config: live Shields lifecycle restores stopped OpenClaw under bot
   );
   expect(liveChildRefusal.exitCode, resultText(liveChildRefusal)).not.toBe(0);
   expect(resultText(liveChildRefusal)).toContain('"code": "startup-not-ready"');
-  expect(await statPath(sandbox, CONFIG_PATH, "phase-12-config-still-locked")).toMatchObject({
-    mode: "444",
-    owner: "root:root",
-  });
 
   // A running OpenShell PID 1 can restart its child while the recovery guard
   // scans procfs, but pausing PID 1 before `policy set --wait` also prevents


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The `shields-config` live target repeated deterministic checks that a smaller test lane already owns. It now proves one locked posture and one mutable posture on the real container and leaves the contract detail to the lanes that own it.

Assertions drop from 132 to 109. Lines drop from 1306 to 1205.

## Reason

Repeated permission matrices, audit record counting, and persisted-state shape assertions raise the cost and brittleness of an expensive live run without proving another external boundary. Only a real container proves that the filesystem reaches the locked and mutable postures, so one live proof of each is kept.

### Related issues

Refs #10517

## Changes

Removed from the live target, with the deterministic owner that already covers each:

| Removed live assertion | Deterministic owner |
|---|---|
| Config and directory mode and owner matrices at the default, post-`doctor`, post-`down`, and post-restart points | `src/lib/shields/mutable-config-perms.test.ts` |
| `shields_up` and `shields_down` record counting and the audit summary artifact | `src/lib/shields/audit-format.test.ts`, `src/lib/shields/audit-reader.test.ts` |
| `shields_auto_restore` record and its `policy_snapshot` value | `src/lib/shields/timer.test.ts`, `src/lib/shields/timer-recovery-budget.test.ts`, `src/lib/shields/audit-format.test.ts` |
| Persisted `fileHashes` shape after the dead-timer restore | `src/lib/shields/index.test.ts`, `src/lib/shields/policy-transition.test.ts` |
| Duplicated startup-census PID check | Retained census assertion in the same phase already proves a numeric PID |

Deleted without replacement as third-party or incidental output:

- `openclaw doctor --fix` file and directory mode reporting, and the tautological `doctor_exit` pattern match. The NemoClaw-owned fact in that phase, that a gateway write still succeeds after `doctor --fix`, is retained. `mutable-config-perms.test.ts` owns rejection of the `600` and `700` modes that `doctor --fix` applies.
- The `config get` opening-brace output check. Its redaction negatives are retained.

Also removed the now-unused `readAuditEntries` helper and the unused `snapshotPath` field on the timer-marker reader.

No live selector, matrix permutation, or replacement assertion was added. No production logic changed. No coverage gap is recorded, because every removed assertion has an existing deterministic owner named above.

## Verification

Retained live coverage, unchanged by this PR: lock and unlock, content-drift refusal, perms-only `.config-hash` drift reseal, dead-timer inline auto-restore, stopped-agent start recovery under both postures, installed failed-startup live-child refusal, supported childless recovery, locked sandbox parent, credentials traversal boundary, and every redaction negative including the audit-file secret scan.

- `npm run validate:pr` — passed, including Oxfmt, Oxlint, gitleaks, repository checks, E2E semantic phase plans, source-shape test budget, codebase growth guardrails, and TypeScript (CLI).
- `npm run typecheck:cli` — passed, 0 errors.
- `npx oxlint test/e2e/live/shields-config.test.ts` — no findings.
- The `e2e-live` project is opt-in and mutates real external state, so this target was not executed here. The change removes assertions and adds none, and the phase list and test structure are unchanged.
- The diff contains no secrets, API keys, or credentials.

## Review notes

The `state-lock-plan.json` read in `runInstalledFailedStartupUnlock` is live harness plumbing that supplies the guard its plan argument, not a plan-metadata assertion, so it is left in place per the issue's instruction not to move live harness logic into unit tests.

---
Signed-off-by: Vishnu Rajeev <19866703+VishnuR23@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined live end-to-end validation by removing redundant checks.
  * Retained key lifecycle, security posture, redaction, command success, and configuration permission checks.
  * Removed obsolete audit parsing and timer marker handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->