### PR TITLE
fix(advisor): restore specialist job summaries

### DIFF
--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -135,6 +135,28 @@ describe("PR review advisor specialist lifecycle", () => {
     );
   });
 
+  it("rejects a specialist summary symlink without publishing its target", () => {
+    const workspace = temporaryDirectory();
+    const artifactDirectory = "pr-review-specialist-behavior";
+    const artifactPath = path.join(workspace, "artifacts", artifactDirectory);
+    const jobSummary = path.join(workspace, "job-summary.md");
+    const target = path.join(workspace, "untrusted.md");
+    fs.mkdirSync(artifactPath, { recursive: true });
+    fs.writeFileSync(jobSummary, "Existing summary.\n");
+    fs.writeFileSync(target, "Untrusted replacement.\n");
+    fs.symlinkSync(target, path.join(artifactPath, "pr-review-behavior-summary.md"));
+
+    expect(() =>
+      publishSpecialistJobSummary({
+        GITHUB_STEP_SUMMARY: jobSummary,
+        GITHUB_WORKSPACE: workspace,
+        PR_REVIEW_ADVISOR_ARTIFACT_DIR: artifactDirectory,
+        PR_REVIEW_ADVISOR_INTEREST: "behavior",
+      }),
+    ).toThrow();
+    expect(fs.readFileSync(jobSummary, "utf8")).toBe("Existing summary.\n");
+  });
+
   it("keeps local specialist analysis independent from GitHub job summaries", async () => {
     const calls: string[] = [];
     const lifecycle: AdvisorSpecialistLifecycle = {

--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -34,6 +34,7 @@ import {
 } from "../../../tools/pr-review-advisor/openshell.mts";
 import { runPrReviewAdvisorAnalysis } from "../../../tools/pr-review-advisor/run-analysis.mts";
 import {
+  publishSpecialistJobSummary,
   runAdvisorSpecialistCommand,
   type AdvisorSpecialistLifecycle,
 } from "../../../tools/pr-review-advisor/specialist-lifecycle.mts";
@@ -110,18 +111,65 @@ afterEach(() => {
 });
 
 describe("PR review advisor specialist lifecycle", () => {
+  it("appends the completed hosted specialist review to the GitHub job summary", () => {
+    const workspace = temporaryDirectory();
+    const artifactDirectory = "pr-review-specialist-behavior";
+    const artifactPath = path.join(workspace, "artifacts", artifactDirectory);
+    const jobSummary = path.join(workspace, "job-summary.md");
+    fs.mkdirSync(artifactPath, { recursive: true });
+    fs.writeFileSync(jobSummary, "Existing summary.\n");
+    fs.writeFileSync(
+      path.join(artifactPath, "pr-review-behavior-summary.md"),
+      "# Behavior specialist\n\nNo behavior finding.\n",
+    );
+
+    publishSpecialistJobSummary({
+      GITHUB_STEP_SUMMARY: jobSummary,
+      GITHUB_WORKSPACE: workspace,
+      PR_REVIEW_ADVISOR_ARTIFACT_DIR: artifactDirectory,
+      PR_REVIEW_ADVISOR_INTEREST: "behavior",
+    });
+
+    expect(fs.readFileSync(jobSummary, "utf8")).toBe(
+      "Existing summary.\n# Behavior specialist\n\nNo behavior finding.\n",
+    );
+  });
+
+  it("keeps local specialist analysis independent from GitHub job summaries", async () => {
+    const calls: string[] = [];
+    const lifecycle: AdvisorSpecialistLifecycle = {
+      prepare: async () => undefined,
+      startGateway: () => ({ configure: Promise.resolve() }),
+      create: () => void calls.push("create"),
+      run: () => void calls.push("run"),
+      download: () => void calls.push("download"),
+      remove: () => void calls.push("remove"),
+    };
+
+    await runAdvisorSpecialistCommand(
+      "analysis",
+      { PR_REVIEW_ADVISOR_RUN_ANALYSIS: "1" },
+      lifecycle,
+    );
+
+    expect(calls).toEqual(["create", "run", "download", "remove"]);
+  });
+
   it("cancels active analysis, cleans owned resources, and restores termination (#10611)", async () => {
     const calls: string[] = [];
     let receive!: (signal: NodeJS.Signals) => void;
     let interrupt!: () => void;
-    const completion = new Promise<void>((_resolve, reject) =>
-      (interrupt = () => reject(new Error("analysis stopped by SIGTERM"))),
+    const completion = new Promise<void>(
+      (_resolve, reject) => (interrupt = () => reject(new Error("analysis stopped by SIGTERM"))),
     );
     const stderr = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const restore = vi.fn();
     const lifecycle: AdvisorSpecialistLifecycle = {
       prepare: async () => undefined,
-      startGateway: () => ({ configure: Promise.resolve(), stop: async () => void calls.push("gateway") }),
+      startGateway: () => ({
+        configure: Promise.resolve(),
+        stop: async () => void calls.push("gateway"),
+      }),
       create: () => void calls.push("create"),
       run: () => ({
         completion,
@@ -232,7 +280,11 @@ describe("PR review advisor specialist lifecycle", () => {
         unavailable: () => void calls.push("unavailable"),
       };
 
-      await runAdvisorSpecialistCommand("prepare", { PR_REVIEW_ADVISOR_RUN_ANALYSIS: enabled }, lifecycle);
+      await runAdvisorSpecialistCommand(
+        "prepare",
+        { PR_REVIEW_ADVISOR_RUN_ANALYSIS: enabled },
+        lifecycle,
+      );
       await runAdvisorSpecialistCommand(
         "analysis",
         { PR_REVIEW_ADVISOR_RUN_ANALYSIS: enabled, OPENAI_API_KEY: "analysis-secret" },

--- a/tools/pr-review-advisor/specialist-lifecycle.mts
+++ b/tools/pr-review-advisor/specialist-lifecycle.mts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+import fs from "node:fs";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   createAdvisorSandbox,
@@ -184,6 +186,29 @@ export async function runAdvisorSpecialist(input: {
   if (cleanupError) throw cleanupError;
   return result;
 }
+export function publishSpecialistJobSummary(env: NodeJS.ProcessEnv): void {
+  const interest = env.PR_REVIEW_ADVISOR_INTEREST;
+  const artifactDirectory = env.PR_REVIEW_ADVISOR_ARTIFACT_DIR;
+  const workspace = env.GITHUB_WORKSPACE;
+  const jobSummary = env.GITHUB_STEP_SUMMARY;
+  if (!interest || !artifactDirectory || !workspace || !jobSummary) {
+    throw new Error(
+      "Hosted specialist summary publication requires its interest, artifact directory, workspace, and job summary path",
+    );
+  }
+  const summary = path.join(
+    workspace,
+    "artifacts",
+    artifactDirectory,
+    `pr-review-${interest}-summary.md`,
+  );
+  const stat = fs.lstatSync(summary);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error("Specialist job summary source must be a regular file");
+  }
+  fs.appendFileSync(jobSummary, fs.readFileSync(summary));
+}
+
 export async function runAdvisorSpecialistCommand(
   command: string | undefined,
   env: NodeJS.ProcessEnv = process.env,
@@ -221,7 +246,7 @@ export async function runAdvisorSpecialistCommand(
     void activeCleanup?.().catch((error) => (cancellationFailure ??= error));
   });
   try {
-    await runAdvisorSpecialist({
+    const result = await runAdvisorSpecialist({
       env,
       lifecycle,
       prepare: false,
@@ -231,6 +256,7 @@ export async function runAdvisorSpecialistCommand(
       },
       cancelled: () => received !== undefined,
     });
+    if (result === "complete" && env.GITHUB_STEP_SUMMARY) publishSpecialistJobSummary(env);
   } catch (error) {
     cancellationFailure ??= error;
     if (!received) throw error;

--- a/tools/pr-review-advisor/specialist-lifecycle.mts
+++ b/tools/pr-review-advisor/specialist-lifecycle.mts
@@ -202,11 +202,15 @@ export function publishSpecialistJobSummary(env: NodeJS.ProcessEnv): void {
     artifactDirectory,
     `pr-review-${interest}-summary.md`,
   );
-  const stat = fs.lstatSync(summary);
-  if (!stat.isFile() || stat.isSymbolicLink()) {
-    throw new Error("Specialist job summary source must be a regular file");
+  const descriptor = fs.openSync(summary, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  try {
+    if (!fs.fstatSync(descriptor).isFile()) {
+      throw new Error("Specialist job summary source must be a regular file");
+    }
+    fs.appendFileSync(jobSummary, fs.readFileSync(descriptor));
+  } finally {
+    fs.closeSync(descriptor);
   }
-  fs.appendFileSync(jobSummary, fs.readFileSync(summary));
 }
 
 export async function runAdvisorSpecialistCommand(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Restore specialist analyses in each PR Review Advisor GitHub Actions job summary.

## Reason

The shared specialist lifecycle refactor kept Markdown artifacts but stopped appending successful hosted analyses to GITHUB_STEP_SUMMARY, making results harder to inspect.

## Changes

- Append the completed specialist Markdown artifact to GITHUB_STEP_SUMMARY after a successful hosted lifecycle run.
- Keep local review execution unchanged by gating publication on GitHub's job-summary environment.
- Cover hosted publication and summary-free local analysis with focused regression tests.

## Verification

- Contributor validation: Commit hooks passed except the primary checkout source-shape scan encountered a pre-existing stale nested .dsh-worktrees symlink; the complete npm run validate:pr gate passed in a clean isolated worktree at 868bb7b282f6248dba627249c56278fd7677a930.
- Tests: 58 focused advisor tests passed; CLI typecheck and repository checks passed; npm run validate:pr passed in a clean isolated worktree.
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completed hosted specialist reviews now publish their summaries to the GitHub job summary.
  * Local specialist analysis remains independent and does not require a GitHub job summary.

* **Bug Fixes**
  * Summaries are published only after successful review completion.
  * Invalid or symlinked summary files are rejected without altering the job summary.

* **Tests**
  * Added coverage for hosted summary publishing, invalid files, and local analysis behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->