### PR TITLE
fix(onboard): retire disabled channel providers on rebuild

### DIFF
--- a/src/lib/onboard/sandbox-create/orchestration.ts
+++ b/src/lib/onboard/sandbox-create/orchestration.ts
@@ -214,6 +214,7 @@ function selectRebuildCreatePolicy(
     return source;
   });
   return materializeRebuildPolicyHandoff({
+    sandboxName,
     livePolicyPath: policySourcePath,
     replacementPolicy: generatedPolicy,
     requiredNetworkPolicyKeys,

--- a/src/lib/onboard/sandbox-create/rebuild-policy-handoff.test.ts
+++ b/src/lib/onboard/sandbox-create/rebuild-policy-handoff.test.ts
@@ -369,4 +369,100 @@ network_policies:
       "host-added-provider",
     ]);
   });
+
+  it.each([
+    { agent: "OpenClaw", sandboxName: "openclaw-channel-test", telegramKey: "telegram_bot" },
+    { agent: "Hermes", sandboxName: "hermes-channel-test", telegramKey: "telegram" },
+  ])(
+    "removes disabled-channel provider artifacts before the $agent rebuild handoff",
+    ({ sandboxName, telegramKey }) => {
+      const teamsProvider = `${sandboxName}-teams-bridge`;
+      const telegramProvider = `${sandboxName}-telegram`;
+      const livePath = tempPolicy(
+        `${sandboxName}-live.yaml`,
+        `version: 1
+network_policies:
+  host_edit:
+    endpoints: [{host: host.example.com, port: 443}]
+  outlook_graph:
+    endpoints:
+      - host: login.microsoftonline.com
+        port: 443
+        credential_binding: {provider: ${teamsProvider}}
+  teams:
+    endpoints:
+      - host: login.microsoftonline.com
+        port: 443
+        credential_binding: {provider: ${teamsProvider}}
+  ${telegramKey}:
+    endpoints:
+      - host: api.telegram.org
+        port: 443
+        credential_binding: {provider: ${telegramProvider}}
+  _provider_disabled_channels:
+    endpoints:
+      - host: provider-composed.example.com
+        port: 443
+        credential_binding: {provider: ${telegramProvider}}
+`,
+      );
+      const replacementPath = tempPolicy(
+        `${sandboxName}-replacement.yaml`,
+        "version: 1\nnetwork_policies: {}\n",
+      );
+      const handoff = materializeRebuildPolicyHandoff({
+        livePolicyPath: livePath,
+        replacementPolicy: {
+          policyPath: replacementPath,
+          appliedPresets: [],
+          credentialBindingProviders: [],
+        },
+        removedNetworkPolicyKeys: [telegramKey, "teams"],
+        sandboxName,
+      });
+      const materialized = readPrivatePolicy(handoff.policyPath).policy as {
+        network_policies: Record<string, unknown>;
+      };
+
+      expect(materialized.network_policies).toEqual({
+        host_edit: { endpoints: [{ host: "host.example.com", port: 443 }] },
+        outlook_graph: {
+          endpoints: [{ host: "login.microsoftonline.com", port: 443 }],
+        },
+      });
+      expect(handoff.credentialBindingProviders).toEqual([]);
+      expect(handoff.cleanup?.()).toBe(true);
+    },
+  );
+
+  it("refuses to remove a non-Teams Outlook credential binding", () => {
+    const livePath = tempPolicy(
+      "foreign-outlook-binding.yaml",
+      `version: 1
+network_policies:
+  outlook_graph:
+    endpoints:
+      - host: login.microsoftonline.com
+        port: 443
+        credential_binding: {provider: operator-owned}
+`,
+    );
+    const replacementPath = tempPolicy(
+      "foreign-outlook-replacement.yaml",
+      "version: 1\nnetwork_policies: {}\n",
+    );
+
+    expect(() =>
+      materializeRebuildPolicyHandoff({
+        sandboxName: "channel-test",
+        livePolicyPath: livePath,
+        replacementPolicy: {
+          policyPath: replacementPath,
+          appliedPresets: [],
+          credentialBindingProviders: [],
+        },
+        removedNetworkPolicyKeys: ["teams"],
+      }),
+    ).toThrow("the existing credential binding is not owned by Teams");
+  });
 });

--- a/src/lib/onboard/sandbox-create/rebuild-policy-handoff.ts
+++ b/src/lib/onboard/sandbox-create/rebuild-policy-handoff.ts
@@ -5,7 +5,8 @@ import fs from "node:fs";
 import { isDeepStrictEqual } from "node:util";
 import YAML from "yaml";
 
-import { parseOpenShellPolicy } from "../../policy/merge";
+import { reconcileTeamsOutlookLoginCredentialBinding } from "../../policy";
+import { parseOpenShellPolicy, stripProviderComposedPolicies } from "../../policy/merge";
 import { getCredentialBindingProviders, type InitialSandboxPolicy } from "../initial-policy";
 import { cleanupTempDir, createExactTempFileCleanup, secureTempFile } from "../temp-files";
 
@@ -229,8 +230,19 @@ export function mergeReplacementPolicyAccess(
   requiredNetworkPolicyKeys: readonly string[] = [],
   removedNetworkPolicyKeys: readonly string[] = [],
   requiredNetworkPolicySources: readonly string[] = [],
+  sandboxName?: string,
 ): { readonly changed: boolean; readonly source: string } {
-  const live = structuredClone(parseOpenShellPolicy(livePolicySource).policy) as PolicyMapping;
+  const providerNormalizedLivePolicySource = stripProviderComposedPolicies(livePolicySource);
+  const normalizedLivePolicySource = removedNetworkPolicyKeys.includes("teams")
+    ? reconcileTeamsOutlookLoginCredentialBinding(
+        providerNormalizedLivePolicySource,
+        sandboxName,
+        false,
+      )
+    : providerNormalizedLivePolicySource;
+  const live = structuredClone(
+    parseOpenShellPolicy(normalizedLivePolicySource).policy,
+  ) as PolicyMapping;
   const replacement = parseOpenShellPolicy(replacementPolicySource).policy as PolicyMapping;
   const processChanged = mergeMissingReplacementProcessIdentity(live, replacement);
   const filesystemChanged = mergeReplacementFilesystemAccess(live, replacement);
@@ -241,14 +253,19 @@ export function mergeReplacementPolicyAccess(
     removedNetworkPolicyKeys,
     requiredNetworkPolicySources,
   );
-  const changed = processChanged || filesystemChanged || networkChanged;
+  const changed =
+    normalizedLivePolicySource !== livePolicySource ||
+    processChanged ||
+    filesystemChanged ||
+    networkChanged;
   return changed
     ? { changed: true, source: YAML.stringify(live) }
-    : { changed: false, source: livePolicySource };
+    : { changed: false, source: normalizedLivePolicySource };
 }
 
 /** Materialize the single ephemeral policy input consumed by an explicit rebuild. */
 export function materializeRebuildPolicyHandoff(input: {
+  readonly sandboxName?: string;
   readonly livePolicyPath: string;
   readonly replacementPolicy: InitialSandboxPolicy;
   readonly requiredNetworkPolicyKeys?: readonly string[];
@@ -266,6 +283,7 @@ export function materializeRebuildPolicyHandoff(input: {
     input.requiredNetworkPolicyKeys,
     input.removedNetworkPolicyKeys,
     input.requiredNetworkPolicySources,
+    input.sandboxName,
   );
   if (!merged.changed) {
     return {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Disabling every configured messaging channel can rebuild both OpenClaw and Hermes without carrying removed credential providers into the replacement policy. The rebuild still preserves host policy edits and rejects any provider or Outlook binding that is not part of the verified replacement plan.

## Reason

Root-cause key: `rebuild policy handoff / channel-disable rebuild / removed credential provider remains in the live policy`

OpenShell's live policy contains generated `_provider_*` network entries, and the active Teams policy temporarily copies its sandbox-owned credential binding onto the overlapping Outlook login endpoint. The channel-disable plan correctly removes the durable channel policy keys and excludes their providers from rebuild authority, but the handoff retained these two live-policy artifacts. The unchanged fail-closed provider check then stopped the rebuild before deletion.

Evidence:

- Main E2E run [33350578179](https://github.com/NVIDIA/NemoClaw/actions/runs/33350578179), attempt 1, tested SHA `0ac27fc96694c4bf97b2fd51c3d29642855cecd4`
  - OpenClaw job [99363410557](https://github.com/NVIDIA/NemoClaw/actions/runs/33350578179/job/99363410557)
  - Hermes job [99363410850](https://github.com/NVIDIA/NemoClaw/actions/runs/33350578179/job/99363410850)
- Prior main E2E run [33338035605](https://github.com/NVIDIA/NemoClaw/actions/runs/33338035605), tested SHA `8708e19b1ff01590ab1147341dadb5f0c7b921e8`
  - OpenClaw job [99332664763](https://github.com/NVIDIA/NemoClaw/actions/runs/33338035605/job/99332664763)
  - Hermes job [99332664979](https://github.com/NVIDIA/NemoClaw/actions/runs/33338035605/job/99332664979)
- Earliest actionable phase in all affected paths: `disable channels and rebuild sandbox`
- Stable signature: `Cannot prepare rebuild policy handoff: live policy references a credential provider outside the verified replacement plan.`
- All four jobs completed E2E resource cleanup successfully.

## Changes

- Normalize the live rebuild input with the existing OpenShell policy boundary, which removes only generated `_provider_*` entries that must never be resubmitted.
- Pass the sandbox name into the handoff and use the existing Teams/Outlook reconciliation guard when Teams is explicitly removed. The guard removes only the exact sandbox-owned Teams binding and rejects a foreign binding.
- Add a parameterized regression for the OpenClaw and Hermes policy keys, plus negative coverage that proves an operator-owned Outlook binding remains protected.

## Verification

- `npx vitest run --project cli src/lib/onboard/sandbox-create/rebuild-policy-handoff.test.ts` before the product fix — reproduced the stable signature in both the OpenClaw and Hermes cases
- `npx vitest run --project cli src/lib/onboard/sandbox-create/rebuild-policy-handoff.test.ts` — 17 tests passed
- `npx vitest run --project integration test/runtime/policy/policies-teams.test.ts` — 6 tests passed
- `npm run test:changed` — 83 tests passed
- `npm run build:cli && npm run typecheck:cli` — passed
- `npm run validate:pr` against canonical main `5708798a5b5909ba71a72984d37b07b723d99464` — passed
- Normal `pre-commit`, `commit-msg`, and `pre-push` hooks — passed
- GitHub commit verification for `6074c2738f30fcf825111d477807ea2da9d36c50` — Verified
- Complete diff and nine-category security review — no findings; the provider authorization failure remains fail-closed
- Diff inspection and hook secret scan — no secrets, API keys, or credentials

## Review notes

This changes a credential-policy handoff. It reuses the canonical OpenShell provider-composition filter and the existing ownership-checked Teams/Outlook reconciler; it does not authorize a removed provider, weaken the provider check, add a retry, or add a supported product surface. Completion requires the targeted `channels-stop-start` E2E to pass for both OpenClaw and Hermes on the latest PR commit.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
