### PR TITLE
fix(portable): report OpenClaw readiness timings

### DIFF
--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -860,6 +860,46 @@ describe("connectSandbox flow", () => {
     );
   });
 
+  it("records OpenClaw readiness observations through final publication (#10612)", async () => {
+    const harness = createConnectHarness();
+    harness.inspectLaunchReadinessSpy.mockImplementationOnce(async (...args: unknown[]) => {
+      const deps = args[1] as {
+        recordObservationTiming: (stage: string, elapsedMs: number) => void;
+      };
+      deps.recordObservationTiming("sandbox-identity", 7);
+      return {
+        kind: "fallback",
+        category: "missing",
+        fence: { epochId: "a".repeat(64) },
+        gatewayName: "nemoclaw",
+        gatewayPort: 8080,
+        fenceFailed: false,
+        recoveryBlocked: false,
+      };
+    });
+    harness.publishLaunchReadinessSpy.mockImplementationOnce(async (...args: unknown[]) => {
+      const deps = args[1] as {
+        recordObservationTiming: (stage: string, elapsedMs: number) => void;
+        recordObservationFailure: (stage: string) => void;
+      };
+      deps.recordObservationTiming("gateway-health", 8_229);
+      deps.recordObservationFailure("gateway-health");
+      return { kind: "validation-failed", category: "health" };
+    });
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    const output = harness.logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("readiness.sandbox-identity=7ms");
+    expect(output).toContain("readiness.sandbox-identity.attempts=1");
+    expect(output).toContain("readiness.gateway-health=8229ms");
+    expect(output).toContain("readiness.gateway-health.attempts=1");
+    expect(output).toContain("readiness.firstFailedObservation=gateway-health");
+    expect(output).toMatch(/result=failed failedStage=publication/);
+  });
+
   it("probe-only mode exits before reporting success when inference.local returns no trusted result (#8502)", async () => {
     const harness = createConnectHarness({
       registryEntry: {

--- a/src/lib/actions/sandbox/connect-flow.test.ts
+++ b/src/lib/actions/sandbox/connect-flow.test.ts
@@ -649,20 +649,32 @@ describe("connectSandbox flow", () => {
     const sb = { name: "alpha", agent: "openclaw", provider: null, model: null, policies: [] };
     const harness = createConnectHarness();
     harness.inspectLaunchReadinessSpy
-      .mockResolvedValueOnce({
-        kind: "fallback",
-        category: "config",
-        fence: { epochId: "a".repeat(64) },
-        gatewayName: "nemoclaw",
-        gatewayPort: 8080,
-        fenceFailed: false,
-        recoveryBlocked: false,
+      .mockImplementationOnce(async (...args: unknown[]) => {
+        const deps = args[1] as {
+          recordObservationTiming: (stage: string, elapsedMs: number) => void;
+        };
+        deps.recordObservationTiming("sandbox-identity", 3);
+        return {
+          kind: "fallback",
+          category: "config",
+          fence: { epochId: "a".repeat(64) },
+          gatewayName: "nemoclaw",
+          gatewayPort: 8080,
+          fenceFailed: false,
+          recoveryBlocked: false,
+        };
       })
-      .mockResolvedValueOnce({
-        kind: "accepted",
-        category: "accepted",
-        agent: { name: "openclaw" },
-        sb,
+      .mockImplementationOnce(async (...args: unknown[]) => {
+        const deps = args[1] as {
+          recordObservationTiming: (stage: string, elapsedMs: number) => void;
+        };
+        deps.recordObservationTiming("sandbox-identity", 5);
+        return {
+          kind: "accepted",
+          category: "accepted",
+          agent: { name: "openclaw" },
+          sb,
+        };
       });
     harness.launchReadinessMutationGateSpy.mockResolvedValueOnce({ kind: "changed" });
 
@@ -672,9 +684,10 @@ describe("connectSandbox flow", () => {
     expect(harness.checkAndRecoverSpy).not.toHaveBeenCalled();
     expect(harness.ensureLiveSandboxSpy).not.toHaveBeenCalled();
     expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();
-    expect(harness.logSpy.mock.calls.flat().join("\n")).toContain(
-      "Probe complete: launch readiness is healthy for 'alpha'.",
-    );
+    const output = harness.logSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Probe complete: launch readiness is healthy for 'alpha'.");
+    expect(output).toContain("readiness.sandbox-identity=8ms");
+    expect(output).toContain("readiness.sandbox-identity.attempts=2");
   });
 
   it("probe-only refuses runtime recovery when prior evidence cannot be fenced (#8942)", async () => {

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -569,6 +569,17 @@ type HermesPortableReadinessCommandAuthority = ReturnType<
   typeof qualifyHermesPortableOperatingCommandAuthority
 >;
 
+function probeTimingLaunchReadinessDeps(
+  probeTiming?: ProbeTimingRecorder,
+): NonNullable<Parameters<typeof inspectLaunchReadiness>[1]> {
+  return probeTiming
+    ? {
+        recordObservationTiming: probeTiming.recordReadinessObservation,
+        recordObservationFailure: probeTiming.recordReadinessObservationFailure,
+      }
+    : {};
+}
+
 function captureHermesPortableReadinessObservation(
   authority: HermesPortableReadinessCommandAuthority,
   args: string[],
@@ -599,12 +610,7 @@ function hermesPortableLaunchReadinessDeps(
   ) => captureHermesPortableReadinessObservation(authority, args, options, assertCurrent);
   return {
     ...createBoundLaunchReadinessDeps(capture),
-    ...(probeTiming
-      ? {
-          recordObservationTiming: probeTiming.recordReadinessObservation,
-          recordObservationFailure: probeTiming.recordReadinessObservationFailure,
-        }
-      : {}),
+    ...probeTimingLaunchReadinessDeps(probeTiming),
   };
 }
 
@@ -2350,7 +2356,7 @@ async function prepareConnectSandboxWithinLifecycleFence(
           sandboxName,
           hermesReadinessAuthority
             ? hermesPortableLaunchReadinessDeps(hermesReadinessAuthority.command, probeTiming)
-            : {},
+            : probeTimingLaunchReadinessDeps(probeTiming),
         ),
       );
       probeTiming!.recordReadinessDecision(readiness.category);
@@ -2603,7 +2609,9 @@ async function prepareConnectSandboxWithinLifecycleFence(
         const published = await probeTiming!.measureAsync("publication", () =>
           publishLaunchReadiness(
             publicationRequest,
-            retainedCommand ? hermesPortableLaunchReadinessDeps(retainedCommand, probeTiming) : {},
+            retainedCommand
+              ? hermesPortableLaunchReadinessDeps(retainedCommand, probeTiming)
+              : probeTimingLaunchReadinessDeps(probeTiming),
           ),
         );
         if (retainedCommand) {
@@ -2649,7 +2657,7 @@ async function prepareConnectSandboxWithinLifecycleFence(
           }
         } else {
           readiness = await probeTiming!.measureAsync("readiness", () =>
-            inspectLaunchReadiness(sandboxName),
+            inspectLaunchReadiness(sandboxName, probeTimingLaunchReadinessDeps(probeTiming)),
           );
         }
         probeTiming!.recordReadinessDecision(readiness.category);


### PR DESCRIPTION
## Outcome

OpenClaw `connect --probe-only` receipts now report per-observation readiness timings for initial inspection, final publication, and changed-epoch reinspection. The change preserves commands, recovery decisions, and failure behavior.

## Reason

An exact-main post-HOME recovery reached `failedStage=publication` after 8,229 ms, but every OpenClaw `readiness.*` observation remained zero. The missing numeric split prevented attribution to sandbox identity, policy, inference, gateway health, forward health, or route reachability.

## Changes

- Reuse the existing probe timing callbacks for OpenClaw launch-readiness observations.
- Keep the Hermes bound-command observer path unchanged while sharing the numeric callback attachment.
- Add a failure-path regression test that preserves the publication failure and identifies `gateway-health` as the failed observation.

## Verification

- `CI=1 npx vitest run --project cli src/lib/actions/sandbox/connect-flow.test.ts --reporter=verbose` — PASS, 60 tests.
- `npm run typecheck:cli` — PASS.
- `npm run validate:pr` — PASS, including gitleaks and CLI TypeScript.
- `git diff --check` — PASS.
- Diff contains no secrets, API keys, or credentials.

---

Signed-off-by: Senthil Ravichandran <senthilr@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launch-readiness monitoring to consistently capture stage timing, attempt counts, and the first failed observation.
  * Ensured readiness inspection and publication use consistent timing information across supported connection paths.
  * Improved diagnostic reporting for sandbox identity and gateway-health checks.

* **Tests**
  * Added regression coverage for readiness publication failures and their recorded diagnostic details.
  * Added coverage validating aggregated timing and attempt-count information across repeated readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->