### PR TITLE
docs(monitoring): correct recovery guidance

### DIFF
--- a/docs/monitoring/monitor-sandbox-activity.mdx
+++ b/docs/monitoring/monitor-sandbox-activity.mdx
@@ -79,14 +79,16 @@ Inspect the session directory from the host by running a sandbox command.
 $$nemoclaw <name> exec -- ls -lh /sandbox/.openclaw/agents/main/sessions
 ```
 
-Copy a session log for offline review with the OpenShell sandbox download command.
+List the stored session keys, then export the session you need for offline review.
 
 ```bash
-openshell sandbox download <name> /sandbox/.openclaw/agents/main/sessions/<session-id>.jsonl .
+$$nemoclaw <name> sessions list
+$$nemoclaw <name> sessions export <key>
 ```
 
 Handle exported session logs as sensitive data.
 They can contain prompts, tool inputs, tool outputs, file paths, and cost metadata from the agent run.
+The export command copies only the selected session files and writes them owner-only (`0600`).
 
 ## Monitor Network Activity in the TUI
 
@@ -128,7 +130,9 @@ If the request fails, check these items.
 1. Run `$$nemoclaw <name> status` to confirm the active provider and endpoint.
    Check the main `Inference` line first.
    If it shows `unauthorized`, `unhealthy`, `unreachable`, or `not probed`, inspect the labeled upstream, local-backend, and auth-proxy diagnostics to identify the failing hop.
+   Refresh the provider credential when the main result is `unauthorized`.
    Restart a local backend only when its own diagnostic fails.
+   If the auth-proxy diagnostic fails, re-run onboarding so NemoClaw can recreate the proxy token, restart the proxy, and refresh the route.
 2. Run `$$nemoclaw <name> logs --follow` to view error messages from the blueprint runner.
 3. Verify that the host can reach the inference endpoint.
 4. If the agent reports a context-overflow or token-limit error, clear the conversation with `/reset` (or start a fresh one with `/new`) in the TUI before retrying.


### PR DESCRIPTION
## Outcome

The monitoring guide now exports OpenClaw session logs through NemoClaw's restricted session-export path and gives operators a recovery action for each failed inference diagnostic.

## Reason

The independent documentation review for PR #10642 found that the page recommended a raw sandbox download for sensitive session data and did not explain how to recover a failed auth proxy or unauthorized provider route.

## Changes

- Replace the raw OpenShell session download with `nemoclaw <name> sessions list` and `nemoclaw <name> sessions export <key>`.
- State that session exports are restricted to selected files and written owner-only (`0600`).
- Direct operators to refresh an unauthorized provider credential, restart only a failed local backend, and re-run onboarding for a failed auth proxy.

## Verification

- `npm run docs` — passed with 0 errors, the existing 2 Fern warnings, 69 guarded routes, native changelog links, and direct redirects.
- `npm run validate:pr` — passed the pre-commit, commit-message, and pre-push validation lanes.
- `git diff --check` — passed.
- Manual comparison with the owning `sessions export` command reference and inference-timeout troubleshooting guidance — behavior and recovery steps match.
- The diff contains no secrets, API keys, or credentials.

## Review notes

- Repairs the Trust and Operations findings from [PR Review Advisor run 33386753092](https://github.com/NVIDIA/NemoClaw/actions/runs/33386753092).

---
Signed-off-by: San Dang <sdang@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated session inspection guidance to use session listing and export commands.
  * Clarified that exported session files are restricted to owner-only access.
  * Added troubleshooting steps for unauthorized inference results, including credential refresh.
  * Added guidance to rerun onboarding when the authentication-proxy diagnostic fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->