### PR TITLE
test(policy): cover Hermes Slack preset recovery

### DIFF
--- a/test/runtime/policy/hermes-slack-policy-reconciliation.test.ts
+++ b/test/runtime/policy/hermes-slack-policy-reconciliation.test.ts
@@ -111,7 +111,7 @@ exit 1
       },
     });
 
-    expect(result.status).toBe(0);
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     const payload = parseResultPayload(result.stdout);
     expect(payload.appliedBefore).toEqual([]);
     expect(payload.appliedAfter).toEqual(["slack"]);

--- a/test/runtime/policy/hermes-slack-policy-reconciliation.test.ts
+++ b/test/runtime/policy/hermes-slack-policy-reconciliation.test.ts
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, it } from "vitest";
+import YAML from "yaml";
+
+import {
+  livePolicyMetadata,
+  managedSandboxEntry,
+  parseResultPayload,
+  SANDBOX_ID,
+} from "../../helpers/live-policy-fixture";
+
+const REPO_ROOT = path.join(import.meta.dirname, "../../..");
+const POLICIES_PATH = JSON.stringify(path.join(REPO_ROOT, "src", "lib", "policy", "index.ts"));
+const POLICY_PRESET_SYNC_PATH = JSON.stringify(
+  path.join(REPO_ROOT, "src", "lib", "onboard", "policy-preset-sync.ts"),
+);
+const REGISTRY_PATH = JSON.stringify(path.join(REPO_ROOT, "src", "lib", "state", "registry.ts"));
+const MESSAGING_PLAN_FIXTURES_PATH = JSON.stringify(
+  path.join(REPO_ROOT, "test", "helpers", "messaging-plan-fixtures.ts"),
+);
+const SOURCE_NODE_ARGS = ["--import", "tsx"];
+
+it("applies a missing live Hermes Slack preset despite legacy applied state (#10678)", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-policy-hermes-slack-"));
+  const fakeOpenshell = path.join(tmpDir, "openshell");
+  const policyOut = path.join(tmpDir, "policy.yaml");
+  const legacyRegistration = {
+    ...managedSandboxEntry("hermes-sandbox", "hermes"),
+    policies: ["slack"],
+  };
+  const script = String.raw`
+const fs = require("node:fs");
+const registry = require(${REGISTRY_PATH});
+const policies = require(${POLICIES_PATH});
+const { syncPresetSelection } = require(${POLICY_PRESET_SYNC_PATH});
+const { makeMessagingPlan } = require(${MESSAGING_PLAN_FIXTURES_PATH});
+registry.registerSandbox({
+  ...${JSON.stringify(legacyRegistration)},
+  messaging: {
+    schemaVersion: 1,
+    plan: makeMessagingPlan({
+      sandboxName: "hermes-sandbox",
+      agent: "hermes",
+      channels: ["slack"],
+    }),
+  },
+});
+const appliedBefore = policies.getAppliedPresets("hermes-sandbox");
+syncPresetSelection("hermes-sandbox", appliedBefore, ["slack"]);
+const appliedAfter = policies.getAppliedPresets("hermes-sandbox");
+process.stdout.write("\n__RESULT__" + JSON.stringify({
+  appliedBefore,
+  appliedAfter,
+  policy: fs.readFileSync(process.env.POLICY_OUT, "utf-8"),
+  registry: registry.getSandbox("hermes-sandbox"),
+}));
+`;
+  fs.writeFileSync(
+    fakeOpenshell,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1 $2" = "sandbox get" ]; then
+  printf 'Name: hermes-sandbox\nId: ${SANDBOX_ID}\nPhase: Ready\n'
+  exit 0
+fi
+if [ "$1 $2" = "policy get" ]; then
+  if [[ " $* " == *" --output json "* ]]; then
+    printf '%s\n' ${JSON.stringify(livePolicyMetadata("hermes-sandbox"))}
+    exit 0
+  fi
+  if [ -f ${JSON.stringify(policyOut)} ]; then
+    cat ${JSON.stringify(policyOut)}
+  else
+    printf 'Version: 1\nHash: test\n---\nversion: 1\n\nnetwork_policies: {}\n'
+  fi
+  exit 0
+fi
+if [ "$1 $2" = "policy set" ]; then
+  policy_file=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--policy" ]; then
+      policy_file="$2"
+      break
+    fi
+    shift
+  done
+  cp "$policy_file" ${JSON.stringify(policyOut)}
+  printf 'Policy version 2 submitted\nPolicy version 2 loaded\n'
+  exit 0
+fi
+exit 1
+`,
+    { mode: 0o755 },
+  );
+
+  try {
+    const result = spawnSync(process.execPath, [...SOURCE_NODE_ARGS, "-e", script], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        HOME: tmpDir,
+        NEMOCLAW_OPENSHELL_BIN: fakeOpenshell,
+        POLICY_OUT: policyOut,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    const payload = parseResultPayload(result.stdout);
+    expect(payload.appliedBefore).toEqual([]);
+    expect(payload.appliedAfter).toEqual(["slack"]);
+    const parsed = YAML.parse(payload.policy);
+    const binaries = parsed.network_policies.slack.binaries.map(
+      (entry: { path: string }) => entry.path,
+    );
+    expect(binaries).toEqual([
+      "/usr/local/bin/hermes",
+      "/usr/bin/python3*",
+      "/opt/hermes/.venv/bin/python",
+    ]);
+    expect(binaries).not.toContain("/usr/local/bin/node");
+    expect(binaries).not.toContain("/usr/bin/node");
+    expect(payload.registry).not.toHaveProperty("policies");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Preset reconciliation treats an absent live Hermes Slack block as unapplied even when a v0.0.115 registry record says `slack` was applied. It writes the Hermes-specific Slack block with Hermes and Python binaries and no Node binaries.

## Reason

v0.0.115 read applied preset names from the registry, so onboarding could skip Slack when the live OpenShell policy did not contain the `slack` block. Current `main` already contains the production fix from #10515, which made the live OpenShell policy the policy source. This issue-specific regression protects that state transition without adding a second policy mechanism.

### Related issues

Fixes #10678

## Changes

- Add a focused integration test with a configured Hermes Slack plan, legacy applied state, and an empty live OpenShell policy.
- Reconcile the selected Slack preset and verify the live preset changes from absent to applied.
- Verify the applied Slack policy contains `/usr/local/bin/hermes`, `/usr/bin/python3*`, and `/opt/hermes/.venv/bin/python`, and excludes both supported Node paths.

## Verification

- `npx vitest run test/runtime/policy/hermes-slack-policy-reconciliation.test.ts` — 1 test passed.
- `npm run test:changed` — 33 growth-guardrail tests passed; no affected CLI, plugin, or E2E-support tests were selected.
- `npm run checks:repository` — repository boundaries, project membership, test title style, and growth checks passed.
- Normal `pre-commit`, `commit-msg`, and `pre-push` hooks — formatting, lint, repository checks, secret scanning, growth checks, commitlint, and CLI type-check passed.
- Diff review — no secrets, API keys, or credential values are present.

## Review notes

This is regression coverage for the existing network-policy repair. The test uses the standard credential-free messaging plan fixture and checks the negative Node-binary boundary explicitly. The existing Hermes Slack live E2E remains the owner of the real sandbox and Slack transport boundary.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for reconciling Slack policies when legacy state exists but the current preset state is missing.
  * Verified policy synchronization, required runtime binaries, and cleanup of obsolete policy state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->