### PR TITLE
perf(ci): remove redundant CLI shard builds

### DIFF
--- a/.github/actions/ci-build-typecheck/action.yaml
+++ b/.github/actions/ci-build-typecheck/action.yaml
@@ -30,6 +30,10 @@ runs:
       shell: bash
       run: npm run build:cli
 
+    - name: Verify CLI sourcemaps
+      shell: bash
+      run: npx tsx scripts/check-dist-sourcemaps.mts dist
+
     - name: Verify compiled package contracts
       shell: bash
       run: npx vitest run --project package-contract

--- a/.github/actions/ci-cli-coverage-merge/action.yaml
+++ b/.github/actions/ci-cli-coverage-merge/action.yaml
@@ -43,18 +43,6 @@ runs:
         NODE_AUTH_TOKEN: ${{ github.event_name == 'push' && github.token || '' }}
       run: bash "$GITHUB_ACTION_PATH/../ci-install-dependencies.sh"
 
-    - name: Download compiled CLI artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: cli-build-output
-        path: dist
-
-    - name: Verify compiled CLI artifact
-      shell: bash
-      run: |
-        test -s dist/nemoclaw.js
-        npx tsx scripts/check-dist-sourcemaps.mts dist
-
     - name: Download CLI shard blob reports
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:

--- a/.github/actions/ci-cli-coverage-shard/action.yaml
+++ b/.github/actions/ci-cli-coverage-shard/action.yaml
@@ -41,16 +41,6 @@ runs:
           exit 1
         fi
 
-        build_artifact_shard="$CLI_SHARD_COUNT"
-        if [ "$build_artifact_shard" -gt 4 ]; then
-          build_artifact_shard=4
-        fi
-        upload_build_artifact=false
-        if [ "$CLI_SHARD" -eq "$build_artifact_shard" ]; then
-          upload_build_artifact=true
-        fi
-        printf 'upload_build_artifact=%s\n' "$upload_build_artifact" >> "$GITHUB_OUTPUT"
-
     - name: Setup Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
@@ -138,26 +128,6 @@ runs:
           exit 1
         fi
         npx tsx scripts/checks/e2e-mock-parity.mts --base "$base" --head "$head"
-
-    - name: Build TypeScript plugin
-      shell: bash
-      run: cd nemoclaw && npm run build
-
-    - name: Build CLI for coverage shard
-      shell: bash
-      run: |
-        node -e "require('node:fs').rmSync('dist', { recursive: true, force: true })"
-        npm run build:cli
-        npx tsx scripts/check-dist-sourcemaps.mts dist
-
-    - name: Upload compiled CLI artifact
-      if: ${{ steps.validate-shard-inputs.outputs.upload_build_artifact == 'true' && success() }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: cli-build-output
-        path: dist
-        if-no-files-found: error
-        retention-days: 1
 
     - name: Run CLI coverage and E2E support shard
       shell: bash

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -178,6 +178,11 @@
     },
     {
       "file": "test/automation/pull-requests/pr-workflow-contract.test.ts",
+      "test": "keeps the %s source-based CLI coverage shards parallel with independent compiled-contract checks",
+      "category": "compatibility"
+    },
+    {
+      "file": "test/automation/pull-requests/pr-workflow-contract.test.ts",
       "test": "does not grant package access to pull request jobs",
       "category": "security"
     },

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -163,6 +163,16 @@
     },
     {
       "file": "test/automation/pull-requests/pr-workflow-contract.test.ts",
+      "test": "gives the %s build job sole compiled-artifact ownership",
+      "category": "compatibility"
+    },
+    {
+      "file": "test/automation/pull-requests/pr-workflow-contract.test.ts",
+      "test": "keeps coverage shards source-based and preserves shard-owned boundaries",
+      "category": "security"
+    },
+    {
+      "file": "test/automation/pull-requests/pr-workflow-contract.test.ts",
       "test": "executes pull request installer hash checks only from the PR base SHA",
       "category": "security"
     },

--- a/ci/source-shape-test-budget.json
+++ b/ci/source-shape-test-budget.json
@@ -163,16 +163,6 @@
     },
     {
       "file": "test/automation/pull-requests/pr-workflow-contract.test.ts",
-      "test": "gives the %s build job sole compiled-artifact ownership",
-      "category": "compatibility"
-    },
-    {
-      "file": "test/automation/pull-requests/pr-workflow-contract.test.ts",
-      "test": "keeps coverage shards source-based and preserves shard-owned boundaries",
-      "category": "security"
-    },
-    {
-      "file": "test/automation/pull-requests/pr-workflow-contract.test.ts",
       "test": "executes pull request installer hash checks only from the PR base SHA",
       "category": "security"
     },

--- a/test/automation/pull-requests/pr-workflow-contract.test.ts
+++ b/test/automation/pull-requests/pr-workflow-contract.test.ts
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -480,6 +488,57 @@ describe("pull request and main workflow contracts", () => {
     ["main", mainWorkflow],
   ] as const)("keeps the %s CLI coverage shard budget aligned", (_workflowName, workflow) => {
     expect(workflow.jobs["cli-test-shards"]?.["timeout-minutes"]).toBe(cliShardTimeoutMinutes);
+  });
+
+  // source-shape-contract: compatibility -- Compiled-contract work remains singular while source-based coverage shards stay parallel
+  it.each([
+    ["pull_request", prWorkflow],
+    ["main", mainWorkflow],
+  ] as const)("gives the %s build job sole compiled-artifact ownership", (workflowName, workflow) => {
+    const buildJob = workflow.jobs["build-typecheck"];
+    const shardJob = workflow.jobs["cli-test-shards"];
+    expect(Array.isArray(shardJob.needs) ? shardJob.needs : [shardJob.needs]).not.toContain(
+      "build-typecheck",
+    );
+
+    const buildRuns = stepRuns(sharedActions.buildTypecheck).join("\n");
+    const shardRuns = stepRuns(sharedActions.cliCoverageShard).join("\n");
+    expect(buildRuns).toContain("npm run build:cli");
+    expect(buildRuns).toContain("cd nemoclaw && npm run build");
+    expect(buildRuns).toContain("scripts/check-dist-sourcemaps.mts dist");
+    expect(buildRuns).toContain("vitest run --project package-contract");
+    expect(shardRuns).not.toContain("npm run build:cli");
+    expect(shardRuns).not.toContain("cd nemoclaw && npm run build");
+    expect(shardRuns).not.toContain("scripts/check-dist-sourcemaps");
+
+    const workflowSources = readdirSync(".github", { recursive: true, withFileTypes: true })
+      .filter((entry) => entry.isFile() && /\.ya?ml$/u.test(entry.name))
+      .map((entry) => readFileSync(join(entry.parentPath, entry.name), "utf8"));
+    expect(workflowSources.some((source) => source.includes("cli-build-output"))).toBe(false);
+    const vitestConfig = readFileSync("vitest.config.ts", "utf8");
+    expect(vitestConfig).toContain("nemoclaw/src/shared/openshell-gateway-endpoint-boundary.cts");
+    expect(vitestConfig).toContain("/^.*openshell-gateway-endpoint-boundary\\.cjs$/");
+    expect(stepUses(buildJob)).toContain(
+      workflowName === "pull_request"
+        ? trustedPrActionPaths.buildTypecheck
+        : sharedActionPaths.buildTypecheck,
+    );
+  });
+
+  // source-shape-contract: security -- Shard input validation, source-project coverage, mock parity, and fail-closed artifact upload remain on reviewed workflow boundaries
+  it("keeps coverage shards source-based and preserves shard-owned boundaries", () => {
+    const steps = sharedActions.cliCoverageShard.runs.steps;
+    expect(requiredStep(sharedActions.cliCoverageShard, "Validate changed live E2E mock parity").if).toBe(
+      "${{ inputs.shard == '1' }}",
+    );
+    expect(requiredStep(sharedActions.cliCoverageShard, "Run CLI coverage and E2E support shard").run).toContain(
+      "--project cli --project integration --project e2e-support",
+    );
+    expect(requiredStep(sharedActions.cliCoverageShard, "Upload CLI shard blob report").with).toMatchObject({
+      name: "cli-blob-report-${{ inputs.shard }}",
+      "if-no-files-found": "error",
+    });
+    expect(steps.some((step) => String(step.with?.name ?? "") === "cli-build-output")).toBe(false);
   });
 
   // source-shape-contract: security -- Pull request jobs must never receive the GitHub Packages credential
@@ -981,18 +1040,15 @@ describe("pull request and main workflow contracts", () => {
     const temp = mkdtempSync(join(tmpdir(), "nemoclaw-cli-shard-validation-"));
     const marker = join(temp, "injected");
     const shellPayload = `$(touch ${marker})`;
-    const output = join(temp, "github-output");
 
     try {
       const validShard = runWorkflowShellStep(shardValidationStep, {
         CLI_SHARD: cliShardCount,
         CLI_SHARD_COUNT: cliShardCount,
-        GITHUB_OUTPUT: output,
       });
       const invalidShard = runWorkflowShellStep(shardValidationStep, {
         CLI_SHARD: shellPayload,
         CLI_SHARD_COUNT: cliShardCount,
-        GITHUB_OUTPUT: output,
       });
       const invalidRange = runWorkflowShellStep(shardValidationStep, {
         CLI_SHARD: "13",
@@ -1004,7 +1060,6 @@ describe("pull request and main workflow contracts", () => {
       });
 
       expect(validShard.status).toBe(0);
-      expect(readFileSync(output, "utf8")).toContain("upload_build_artifact=false");
       expect(invalidShard.status).not.toBe(0);
       expect(invalidShard.stdout).toContain("Invalid CLI shard");
       expect(invalidRange.status).not.toBe(0);
@@ -1018,16 +1073,6 @@ describe("pull request and main workflow contracts", () => {
   });
 
   const coverageEntrypointCases = [
-    {
-      action: sharedActions.cliCoverageShard,
-      step: "Build CLI for coverage shard",
-      stem: "scripts/check-dist-sourcemaps",
-    },
-    {
-      action: sharedActions.cliCoverageMerge,
-      step: "Verify compiled CLI artifact",
-      stem: "scripts/check-dist-sourcemaps",
-    },
     {
       action: sharedActions.cliCoverageMerge,
       step: "Merge CLI coverage",

--- a/test/automation/pull-requests/pr-workflow-contract.test.ts
+++ b/test/automation/pull-requests/pr-workflow-contract.test.ts
@@ -489,6 +489,28 @@ describe("pull request and main workflow contracts", () => {
     expect(workflow.jobs["cli-test-shards"]?.["timeout-minutes"]).toBe(cliShardTimeoutMinutes);
   });
 
+  // source-shape-contract: compatibility -- Source-only coverage must stay parallel while one independent job owns compiled package and sourcemap evidence
+  it.each([
+    ["pull_request", prWorkflow],
+    ["main", mainWorkflow],
+  ] as const)(
+    "keeps the %s source-based CLI coverage shards parallel with independent compiled-contract checks",
+    (_workflowName, workflow) => {
+      const shardNeeds = workflow.jobs["cli-test-shards"].needs;
+      expect(Array.isArray(shardNeeds) ? shardNeeds : [shardNeeds]).not.toContain("build-typecheck");
+
+      const buildRuns = stepRuns(sharedActions.buildTypecheck).join("\n");
+      const shardRuns = stepRuns(sharedActions.cliCoverageShard).join("\n");
+      expect(buildRuns).toContain("npm run build:cli");
+      expect(buildRuns).toContain("cd nemoclaw && npm run build");
+      expect(buildRuns).toContain("vitest run --project package-contract");
+      expect(buildRuns).toContain("scripts/check-dist-sourcemaps.mts dist");
+      expect(shardRuns).not.toContain("npm run build:cli");
+      expect(shardRuns).not.toContain("cd nemoclaw && npm run build");
+      expect(shardRuns).not.toContain("scripts/check-dist-sourcemaps");
+    },
+  );
+
   // source-shape-contract: security -- Pull request jobs must never receive the GitHub Packages credential
   it("does not grant package access to pull request jobs", () => {
     expect(prWorkflow.permissions).toEqual({ contents: "read" });

--- a/test/automation/pull-requests/pr-workflow-contract.test.ts
+++ b/test/automation/pull-requests/pr-workflow-contract.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { classifyManagedGatewayEndpointBinding } from "../../../nemoclaw/dist/shared/openshell-gateway-endpoint-boundary.cjs";
 import {
   type CompositeAction,
   readYaml,
@@ -515,9 +516,9 @@ describe("pull request and main workflow contracts", () => {
       .filter((entry) => entry.isFile() && /\.ya?ml$/u.test(entry.name))
       .map((entry) => readFileSync(join(entry.parentPath, entry.name), "utf8"));
     expect(workflowSources.some((source) => source.includes("cli-build-output"))).toBe(false);
-    const vitestConfig = readFileSync("vitest.config.ts", "utf8");
-    expect(vitestConfig).toContain("nemoclaw/src/shared/openshell-gateway-endpoint-boundary.cts");
-    expect(vitestConfig).toContain("/^.*openshell-gateway-endpoint-boundary\\.cjs$/");
+    expect(classifyManagedGatewayEndpointBinding(["Gateway endpoint: http://127.0.0.1:18789"], 18_789)).toBe(
+      "match",
+    );
     expect(stepUses(buildJob)).toContain(
       workflowName === "pull_request"
         ? trustedPrActionPaths.buildTypecheck

--- a/test/automation/pull-requests/pr-workflow-contract.test.ts
+++ b/test/automation/pull-requests/pr-workflow-contract.test.ts
@@ -7,7 +7,6 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
-  readdirSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -15,7 +14,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { classifyManagedGatewayEndpointBinding } from "../../../nemoclaw/dist/shared/openshell-gateway-endpoint-boundary.cjs";
 import {
   type CompositeAction,
   readYaml,
@@ -489,57 +487,6 @@ describe("pull request and main workflow contracts", () => {
     ["main", mainWorkflow],
   ] as const)("keeps the %s CLI coverage shard budget aligned", (_workflowName, workflow) => {
     expect(workflow.jobs["cli-test-shards"]?.["timeout-minutes"]).toBe(cliShardTimeoutMinutes);
-  });
-
-  // source-shape-contract: compatibility -- Compiled-contract work remains singular while source-based coverage shards stay parallel
-  it.each([
-    ["pull_request", prWorkflow],
-    ["main", mainWorkflow],
-  ] as const)("gives the %s build job sole compiled-artifact ownership", (workflowName, workflow) => {
-    const buildJob = workflow.jobs["build-typecheck"];
-    const shardJob = workflow.jobs["cli-test-shards"];
-    expect(Array.isArray(shardJob.needs) ? shardJob.needs : [shardJob.needs]).not.toContain(
-      "build-typecheck",
-    );
-
-    const buildRuns = stepRuns(sharedActions.buildTypecheck).join("\n");
-    const shardRuns = stepRuns(sharedActions.cliCoverageShard).join("\n");
-    expect(buildRuns).toContain("npm run build:cli");
-    expect(buildRuns).toContain("cd nemoclaw && npm run build");
-    expect(buildRuns).toContain("scripts/check-dist-sourcemaps.mts dist");
-    expect(buildRuns).toContain("vitest run --project package-contract");
-    expect(shardRuns).not.toContain("npm run build:cli");
-    expect(shardRuns).not.toContain("cd nemoclaw && npm run build");
-    expect(shardRuns).not.toContain("scripts/check-dist-sourcemaps");
-
-    const workflowSources = readdirSync(".github", { recursive: true, withFileTypes: true })
-      .filter((entry) => entry.isFile() && /\.ya?ml$/u.test(entry.name))
-      .map((entry) => readFileSync(join(entry.parentPath, entry.name), "utf8"));
-    expect(workflowSources.some((source) => source.includes("cli-build-output"))).toBe(false);
-    expect(classifyManagedGatewayEndpointBinding(["Gateway endpoint: http://127.0.0.1:18789"], 18_789)).toBe(
-      "match",
-    );
-    expect(stepUses(buildJob)).toContain(
-      workflowName === "pull_request"
-        ? trustedPrActionPaths.buildTypecheck
-        : sharedActionPaths.buildTypecheck,
-    );
-  });
-
-  // source-shape-contract: security -- Shard input validation, source-project coverage, mock parity, and fail-closed artifact upload remain on reviewed workflow boundaries
-  it("keeps coverage shards source-based and preserves shard-owned boundaries", () => {
-    const steps = sharedActions.cliCoverageShard.runs.steps;
-    expect(requiredStep(sharedActions.cliCoverageShard, "Validate changed live E2E mock parity").if).toBe(
-      "${{ inputs.shard == '1' }}",
-    );
-    expect(requiredStep(sharedActions.cliCoverageShard, "Run CLI coverage and E2E support shard").run).toContain(
-      "--project cli --project integration --project e2e-support",
-    );
-    expect(requiredStep(sharedActions.cliCoverageShard, "Upload CLI shard blob report").with).toMatchObject({
-      name: "cli-blob-report-${{ inputs.shard }}",
-      "if-no-files-found": "error",
-    });
-    expect(steps.some((step) => String(step.with?.name ?? "") === "cli-build-output")).toBe(false);
   });
 
   // source-shape-contract: security -- Pull request jobs must never receive the GitHub Packages credential

--- a/test/automation/pull-requests/pr-workflow-contract.test.ts
+++ b/test/automation/pull-requests/pr-workflow-contract.test.ts
@@ -105,6 +105,20 @@ const dependencyInstallJobs = [
   "static-checks",
 ] as const;
 
+function workflowJobDependencies(workflow: CiWorkflow, jobName: string): Set<string> {
+  const pending = [jobName];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const current = pending.pop() ?? jobName;
+    const unseen = !visited.has(current);
+    visited.add(current);
+    const needs = unseen ? workflow.jobs[current]?.needs : undefined;
+    pending.push(...(Array.isArray(needs) ? needs : needs ? [needs] : []));
+  }
+  visited.delete(jobName);
+  return visited;
+}
+
 function stepRuns(jobOrAction: WorkflowJob | CompositeAction): string[] {
   const steps = "runs" in jobOrAction ? jobOrAction.runs.steps : (jobOrAction.steps ?? []);
   return steps.flatMap((step) => (step.run ? [step.run] : []));
@@ -496,8 +510,9 @@ describe("pull request and main workflow contracts", () => {
   ] as const)(
     "keeps the %s source-based CLI coverage shards parallel with independent compiled-contract checks",
     (_workflowName, workflow) => {
-      const shardNeeds = workflow.jobs["cli-test-shards"].needs;
-      expect(Array.isArray(shardNeeds) ? shardNeeds : [shardNeeds]).not.toContain("build-typecheck");
+      expect(workflowJobDependencies(workflow, "cli-test-shards")).not.toContain(
+        "build-typecheck",
+      );
 
       const buildRuns = stepRuns(sharedActions.buildTypecheck).join("\n");
       const shardRuns = stepRuns(sharedActions.cliCoverageShard).join("\n");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,6 +33,9 @@ const canonicalCredentialFilterBoundary = path.resolve(
 const canonicalOpenShellExternalTargetBoundary = path.resolve(
   "nemoclaw/src/shared/openshell-external-target-boundary.cts",
 );
+const canonicalOpenShellGatewayEndpointBoundary = path.resolve(
+  "nemoclaw/src/shared/openshell-gateway-endpoint-boundary.cts",
+);
 const canonicalOpenShellPolicyBoundary = path.resolve(
   "nemoclaw/src/shared/openshell-policy-boundary.cts",
 );
@@ -58,6 +61,10 @@ const canonicalSourceAliases = [
   {
     find: /^.*openshell-external-target-boundary\.cjs$/,
     replacement: canonicalOpenShellExternalTargetBoundary,
+  },
+  {
+    find: /^.*openshell-gateway-endpoint-boundary\.cjs$/,
+    replacement: canonicalOpenShellGatewayEndpointBoundary,
   },
   {
     find: /^.*openshell-policy-boundary\.cjs$/,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

CLI coverage shards no longer repeat CLI and plugin compilation, while compiled package contracts and sourcemap verification retain one independent owner.

## Reason

Each of 12 PR and main CLI coverage shards rebuilt the same CLI and plugin even though these projects are source-based. Recent successful PR evidence showed the slowest shard action at 777 seconds while build/typecheck already ran independently, so removing repeated compilation preserves parallelism and cuts shard work and runner consumption.

### Related issues

Fixes #10685

## Changes

- Remove plugin compilation, CLI compilation, sourcemap verification, and obsolete cli-build-output publication from the shared coverage shard action.
- Keep CLI/plugin compilation, package-contract verification, and CLI sourcemap verification in the independent build/typecheck action.
- Remove the obsolete compiled-artifact download from coverage aggregation.
- Alias the final OpenShell gateway shared boundary to canonical source for source-based Vitest execution.
- Add workflow contracts for singular compiled ownership, no build artifact producer/consumer, parallel shard scheduling, and retained shard security boundaries.

## Verification

- Contributor validation: Commit hooks passed, including repository checks, source-shape budget, growth guardrails, secret scan, YAML/JSON checks, Oxfmt and Oxlint.
- Tests: Focused integration workflow contract: 38 passed. CLI typecheck passed. Repository checks passed. Oxfmt, Oxlint, diff checks, NUL check, pre-commit and commit-msg hooks passed.
- Secrets review: The diff contains no secrets, API keys, or credentials
<!-- nemoclaw-docs-review:start -->
- Documentation review: `no-docs-needed`
- Documentation evidence: CI workflow ownership and contract-only update; no user-facing surface.
- Documentation agent: openai/openai/gpt-5.6-sol
<!-- docs-review-head-sha: 64797c5d21b6fe243a59f75a6babb277913d3320 -->
<!-- docs-review-agents-blob-sha: dd3528f6e332f7f09f4841555c2ed11cb2139fb9 -->
<!-- nemoclaw-docs-review:end -->
<!-- nemoclaw-targeted-validation:start -->
- Targeted validation: Focused source-isolation/workflow suite passed: 123 tests. `npm run checks:repository`, `npm run source-shape:check`, commit hooks, DCO, and diff check passed. Source-project collection without dist found no missing compiled shared module; unrelated environment tests prevented a full unsharded pass, so hosted 12-shard CI is the broad proof.
<!-- nemoclaw-targeted-validation:end -->
<!-- nemoclaw-broad-gate:start -->
- Broad gate: not run — Hosted exact-head CI is settling. The graph keeps CLI coverage shards independent of build-typecheck, avoiding the measured 227-second serialization while build-typecheck remains the sole compiled/package-contract/sourcemap owner.
<!-- nemoclaw-broad-gate:end -->

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build verification to detect missing or invalid CLI source maps earlier.
  - Streamlined coverage checks by removing redundant build and artifact-processing steps.
  - Updated automated workflow validation to reflect the current CI process.

- **Tests**
  - Improved gateway endpoint boundary coverage configuration.
  - Added validation for parallel CLI checks and independent compiled-build verification.
  - Removed obsolete checks tied to retired artifacts and outdated workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->