### PR TITLE
docs: document post-merge authoring workflow

### DIFF
--- a/docs/resources/engineer-agentic-documentation.mdx
+++ b/docs/resources/engineer-agentic-documentation.mdx
@@ -41,22 +41,39 @@ A polished site with weak retrieval or verification is not agent-ready.
 
 ## Move Documentation Into the Engineering Loop
 
-A push to `main` that changes a path outside the allowed documentation paths starts `Docs / Author Post-Merge Catch-Up`. The workflow examines the implementation, tests, and documentation from the latest reachable semver tag through the pushed commit.
+A push to `main` that changes a path outside the allowed documentation paths starts `Docs / Author Post-Merge Catch-Up` on a GitHub-hosted runner.
+The workflow examines implementation, tests, and documentation from the latest reachable semver tag through the exact pushed commit.
+It proceeds only while no managed documentation PR exists or the existing managed PR remains a draft.
+Marking that PR ready for review transfers ownership to maintainers and stops later runs before model work begins.
 
-1. It authors documentation changes in a credential-free OpenShell sandbox.
-2. A separate offline sandbox reviews the documentation candidate with a read-only repository checkout.
-3. For an approved nonempty patch, a publisher with no model credential creates or refreshes one cumulative draft PR with a GitHub-verified commit.
+1. **Author.** GitHub Actions launches the Pi coding agent in a pinned OpenShell sandbox.
+   The author prompt directs the agent to read the committed range and repository guidance, verify behavior in source and tests, and edit only `docs/**`, `fern/docs.yml`, and `fern/assets/**`.
+2. **Validate.** The runner applies the candidate patch to a trusted checkout, runs `npm run docs`, and confirms that validation did not mutate the patch.
+3. **Review.** GitHub Actions launches a separate Pi agent in an offline OpenShell sandbox.
+   The repository is mounted read-only and the agent has no editing tools.
+   The reviewer evaluates whether the cumulative patch is complete, accurate, and non-speculative; a rejection uploads the review report.
+4. **Publish.** An approval record binds the exact patch hash, repository, reviewed `main` commit, range-start tag, and target release tag.
+   A separate publisher revalidates that record and the current GitHub state before creating or refreshing one cumulative draft PR.
 
-The first nonempty patch creates the managed PR.
-Its title names the next patch tag after the range-start tag.
-Its body names both tags, identifies the reviewed `main` boundary, states the branch owner, and
-links to the canonical development and release-cutoff procedure.
-Later pushes to `main` refresh that same PR only when they change a path outside `docs/**`, `fern/docs.yml`, and `fern/assets/**`.
-Each refresh uses a cumulative patch based on the triggering commit.
-Each refresh creates a merge commit whose tree exactly matches the reviewed patch applied to `main`, then fast-forwards the branch. The publisher never force-pushes or replaces a branch head that a person changed.
-A push that changes only the allowed documentation paths does not start another catch-up run.
-Follow [Post-Merge Documentation Catch-Up](https://github.com/NVIDIA/NemoClaw/blob/main/docs/AUTOMATION.md#post-merge-documentation-catch-up) for the automation lifecycle and recovery. The maintainer release-train policy linked there owns release cutoff.
-The signed release brief records a proceed decision.
+Repository administrators retain the `POST_MERGE_DOCS_API_KEY` Actions secret until rotation or removal.
+The workflow exposes it only while the runner configures isolated inference, and hosted-runner cleanup removes the gateway runtime copy.
+Neither Pi sandbox, the review artifacts, nor the publisher receives that secret.
+The publisher receives GitHub write permission but no model credential, so the system that reasons about documentation cannot publish directly.
+
+When no managed PR exists, an approved empty patch completes without creating one.
+An existing managed draft remains pending when a later candidate is empty or unchanged.
+When a nonempty candidate changes the managed draft, the publisher creates or refreshes the PR and deliberately reports that documentation remains pending.
+The PR title names the next patch tag after the range-start tag, and its body records how to recover the reviewed `main` boundary from the latest workflow-created commit.
+Each refresh creates a merge commit whose tree exactly matches the reviewed patch applied to `main`, then fast-forwards the branch.
+The publisher never force-pushes or replaces a branch head or managed PR metadata that a person changed.
+
+At release cutoff, a maintainer takes ownership, adds or verifies the canonical changelog entry, completes human review and required checks, and merges the documentation PR.
+The release decision inventories commits after the last automated coverage point and records whether to proceed, update documentation, or stop.
+A push that changes only the allowed documentation paths does not start another catch-up run, so merging the cumulative documentation PR does not create an empty follow-up receipt.
+
+Follow [Post-Merge Documentation Catch-Up](https://github.com/NVIDIA/NemoClaw/blob/main/docs/AUTOMATION.md#post-merge-documentation-catch-up) for the PR lifecycle and recovery procedure.
+The maintainer release-train policy linked there owns the cutoff evidence and signed proceed decision.
+The [post-merge automation guide](https://github.com/NVIDIA/NemoClaw/blob/main/tools/post-merge-docs/README.md) owns the credential boundary.
 
 ## Use a Layered Architecture
 
@@ -534,7 +551,8 @@ The current NemoClaw repository provides concrete examples for each layer.
 | Guide variant generation | `scripts/sync-agent-variant-docs.mts`. |
 | Route validation | `scripts/check-docs-published-routes.mts`. |
 | Documentation accuracy tests | Compiled CLI and installer parity, environment-variable coverage, generated platform documentation, and targeted procedure and guide variant regression tests under `test/`. |
-| Post-merge update workflow | `.github/workflows/post-merge-docs.yaml`, `tools/post-merge-docs/`, and `.agents/skills/nemoclaw-contributor-update-docs/SKILL.md`. |
+| Post-merge author and independent review | `.github/workflows/post-merge-docs.yaml`, `tools/post-merge-docs/run.mts`, `tools/post-merge-docs/README.md`, and `.agents/skills/nemoclaw-contributor-update-docs/SKILL.md`. |
+| Managed documentation PR publication and release handoff | `tools/post-merge-docs/publish.mts`, `docs/AUTOMATION.md`, and `.agents/skills/nemoclaw-maintainer-policies/references/release-train.md`. |
 | Information-architecture workflow | `.agents/skills/nemoclaw-maintainer-refactor-docs/SKILL.md`. |
 | Pull-request assurance | Docs link, product parity, and preview workflows under `.github/workflows/`. |
 | Release history | Dated entries under `docs/changelog/` that land before the release tag. |

--- a/docs/resources/engineer-agentic-documentation.mdx
+++ b/docs/resources/engineer-agentic-documentation.mdx
@@ -42,14 +42,15 @@ A polished site with weak retrieval or verification is not agent-ready.
 ## Move Documentation Into the Engineering Loop
 
 A push to `main` that changes a path outside the allowed documentation paths starts `Docs / Author Post-Merge Catch-Up` on a GitHub-hosted runner.
-The workflow examines implementation, tests, and documentation from the latest reachable semver tag through the exact pushed commit.
+The workflow examines implementation, tests, and documentation after the latest reachable release tag through the pushed commit.
 It proceeds only while no managed documentation PR exists or the existing managed PR remains a draft.
 Marking that PR ready for review transfers ownership to maintainers and stops later runs before model work begins.
 
 1. **Author.** GitHub Actions launches the Pi coding agent in a pinned OpenShell sandbox.
    The author prompt directs the agent to read the committed range and repository guidance, verify behavior in source and tests, and edit only `docs/**`, `fern/docs.yml`, and `fern/assets/**`.
-2. **Validate.** The runner applies the candidate patch to a trusted checkout, runs `npm run docs`, and confirms that validation did not mutate the patch.
-3. **Review.** GitHub Actions launches a separate Pi agent in an offline OpenShell sandbox.
+2. **Validate.** The runner runs `npm run docs` in `author/repo`, the candidate checkout prepared from the trusted source repository, and confirms that validation did not mutate the patch.
+3. **Review.** The runner applies the exact candidate patch to a separate `review/repo` checkout.
+   GitHub Actions then launches a separate Pi agent in an offline OpenShell sandbox.
    The repository is mounted read-only and the agent has no editing tools.
    The reviewer evaluates whether the cumulative patch is complete, accurate, and non-speculative; a rejection uploads the review report.
 4. **Publish.** An approval record binds the exact patch hash, repository, reviewed `main` commit, range-start tag, and target release tag.

--- a/docs/resources/engineer-agentic-documentation.mdx
+++ b/docs/resources/engineer-agentic-documentation.mdx
@@ -41,10 +41,8 @@ A polished site with weak retrieval or verification is not agent-ready.
 
 ## Move Documentation Into the Engineering Loop
 
-A push to `main` that changes a path outside the allowed documentation paths starts `Docs / Author Post-Merge Catch-Up` on a GitHub-hosted runner.
-The workflow examines implementation, tests, and documentation after the latest reachable release tag through the pushed commit.
-It proceeds only while no managed documentation PR exists or the existing managed PR remains a draft.
-Marking that PR ready for review transfers ownership to maintainers and stops later runs before model work begins.
+On qualifying pushes to `main`, `Docs / Author Post-Merge Catch-Up` examines implementation, tests, and documentation after the latest reachable release tag through the pushed commit.
+Automation owns one cumulative documentation draft until a maintainer marks it ready for review.
 
 1. **Author.** GitHub Actions launches the Pi coding agent in a pinned OpenShell sandbox.
    The author prompt directs the agent to read the committed range and repository guidance, verify behavior in source and tests, and edit only `docs/**`, `fern/docs.yml`, and `fern/assets/**`.
@@ -56,25 +54,11 @@ Marking that PR ready for review transfers ownership to maintainers and stops la
 4. **Publish.** An approval record binds the exact patch hash, repository, reviewed `main` commit, range-start tag, and target release tag.
    A separate publisher revalidates that record and the current GitHub state before creating or refreshing one cumulative draft PR.
 
-Repository administrators retain the `POST_MERGE_DOCS_API_KEY` Actions secret until rotation or removal.
-The workflow exposes it only while the runner configures isolated inference, and hosted-runner cleanup removes the gateway runtime copy.
-Neither Pi sandbox, the review artifacts, nor the publisher receives that secret.
-The publisher receives GitHub write permission but no model credential, so the system that reasons about documentation cannot publish directly.
+The stages separate authority: the model-assisted author cannot publish, the reviewer is offline and read-only, and the GitHub-authorized publisher cannot invoke the model.
+The cumulative draft is the durable tracking record for approved agent updates until maintainers take ownership for release review.
 
-When no managed PR exists, an approved empty patch completes without creating one.
-An existing managed draft remains pending when a later candidate is empty or unchanged.
-When a nonempty candidate changes the managed draft, the publisher creates or refreshes the PR and deliberately reports that documentation remains pending.
-The PR title names the next patch tag after the range-start tag, and its body records how to recover the reviewed `main` boundary from the latest workflow-created commit.
-Each refresh creates a merge commit whose tree exactly matches the reviewed patch applied to `main`, then fast-forwards the branch.
-The publisher never force-pushes or replaces a branch head or managed PR metadata that a person changed.
-
-At release cutoff, a maintainer takes ownership, adds or verifies the canonical changelog entry, completes human review and required checks, and merges the documentation PR.
-The release decision inventories commits after the last automated coverage point and records whether to proceed, update documentation, or stop.
-A push that changes only the allowed documentation paths does not start another catch-up run, so merging the cumulative documentation PR does not create an empty follow-up receipt.
-
-Follow [Post-Merge Documentation Catch-Up](https://github.com/NVIDIA/NemoClaw/blob/main/docs/AUTOMATION.md#post-merge-documentation-catch-up) for the PR lifecycle and recovery procedure.
-The maintainer release-train policy linked there owns the cutoff evidence and signed proceed decision.
-The [post-merge automation guide](https://github.com/NVIDIA/NemoClaw/blob/main/tools/post-merge-docs/README.md) owns the credential boundary.
+Follow [Post-Merge Documentation Catch-Up](https://github.com/NVIDIA/NemoClaw/blob/main/docs/AUTOMATION.md#post-merge-documentation-catch-up) for trigger paths, managed-PR lifecycle, recovery, release cutoff, and the signed proceed decision.
+The [post-merge automation guide](https://github.com/NVIDIA/NemoClaw/blob/main/tools/post-merge-docs/README.md) owns the credential and trust boundary.
 
 ## Use a Layered Architecture
 

--- a/docs/resources/engineer-agentic-documentation.mdx
+++ b/docs/resources/engineer-agentic-documentation.mdx
@@ -41,20 +41,23 @@ A polished site with weak retrieval or verification is not agent-ready.
 
 ## Move Documentation Into the Engineering Loop
 
+NemoClaw keeps documentation current while separating documentation reasoning, publication authority, and maintainer release ownership.
+
+### Author and Independently Review the Candidate
+
 On qualifying pushes to `main`, `Docs / Author Post-Merge Catch-Up` examines implementation, tests, and documentation after the latest reachable release tag through the pushed commit.
+GitHub Actions launches the Pi coding agent in a pinned OpenShell sandbox, validates its bounded documentation patch in `author/repo`, and confirms that validation did not mutate the patch.
+The runner then applies that exact patch to `review/repo`, where a separate Pi agent reviews it in an offline, read-only sandbox without editing tools.
+
+### Separate Reasoning From Publication
+
+An approval record binds the exact patch hash, repository, reviewed `main` commit, range-start tag, and target release tag.
+A separate publisher revalidates that record and the current GitHub state before creating or refreshing a draft PR.
+The model-assisted author cannot publish, the reviewer is offline and read-only, and the GitHub-authorized publisher cannot invoke the model.
+
+### Maintain One Cumulative Draft Through Release Cutoff
+
 Automation owns one cumulative documentation draft until a maintainer marks it ready for review.
-
-1. **Author.** GitHub Actions launches the Pi coding agent in a pinned OpenShell sandbox.
-   The author prompt directs the agent to read the committed range and repository guidance, verify behavior in source and tests, and edit only `docs/**`, `fern/docs.yml`, and `fern/assets/**`.
-2. **Validate.** The runner runs `npm run docs` in `author/repo`, the candidate checkout prepared from the trusted source repository, and confirms that validation did not mutate the patch.
-3. **Review.** The runner applies the exact candidate patch to a separate `review/repo` checkout.
-   GitHub Actions then launches a separate Pi agent in an offline OpenShell sandbox.
-   The repository is mounted read-only and the agent has no editing tools.
-   The reviewer evaluates whether the cumulative patch is complete, accurate, and non-speculative; a rejection uploads the review report.
-4. **Publish.** An approval record binds the exact patch hash, repository, reviewed `main` commit, range-start tag, and target release tag.
-   A separate publisher revalidates that record and the current GitHub state before creating or refreshing one cumulative draft PR.
-
-The stages separate authority: the model-assisted author cannot publish, the reviewer is offline and read-only, and the GitHub-authorized publisher cannot invoke the model.
 The cumulative draft is the durable tracking record for approved agent updates until maintainers take ownership for release review.
 
 Follow [Post-Merge Documentation Catch-Up](https://github.com/NVIDIA/NemoClaw/blob/main/docs/AUTOMATION.md#post-merge-documentation-catch-up) for trigger paths, managed-PR lifecycle, recovery, release cutoff, and the signed proceed decision.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The engineer agentic-documentation guide now explains the complete post-merge documentation authoring, independent review, publication, and maintainer handoff model.
Previously, the page named only the high-level sandbox and publisher steps; it now identifies the Pi agents, trust boundaries, evidence binding, managed draft behavior, and release cutoff.

## Reason

The post-merge workflow replaced the former same-PR writer receipt, but the architecture guide did not fully explain where the new agents run, how their authority is separated, or how documentation coverage is tracked through release preparation.

## Changes

- Document the GitHub-hosted author, validation, independent review, and publication sequence, including the Pi and OpenShell execution boundaries.
- Explain the model-secret lifetime, read-only reviewer, exact approval binding, cumulative draft lifecycle, empty and unchanged candidate behavior, and maintainer release cutoff.
- Split the implementation map between author/reviewer ownership and managed-PR/release-handoff ownership.
- Add no runtime mechanism or product behavior; this change updates the owning public architecture guide and links to the canonical operational contracts.

## Verification

- `npm run docs` — passed, including agent-variant generation, route checks, and Fern validation with 0 errors.
- `npm run validate:pr` — passed against the canonical validation surface from `origin/main`.
- `git diff --check` — passed.
- Independent documentation writer review — passed against the final candidate on canonical base `7cbc48dba3831f3c90904961865c371d1fbc7a36`.
- Product tests — not applicable because this documentation-only change does not alter runtime behavior.
- Secret review — the diff contains no secrets, API keys, or credentials.

---
Signed-off-by: Miyoung Choi <miyoungc@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reorganized post-merge documentation guidance into clear author/review, publication-authority, and cumulative-draft sections.
  - Added instructions for pinned execution, isolated author and reviewer repositories, offline read-only review, patch-integrity validation, and approval-record revalidation.
  - Clarified authority boundaries between documentation authoring, review, managed publication, and release handoff.
  - Linked detailed lifecycle and release-cutoff procedures to separate operational documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->