### PR TITLE
fix(ci): restore compiled inputs to CLI shards

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Run static checks
         uses: ./.github/actions/ci-static-checks
 
-  build-typecheck:
+  compile-artifacts:
     permissions:
       contents: read
       packages: read
@@ -51,8 +51,15 @@ jobs:
       - name: Compile and verify CLI and plugin outputs
         uses: ./.github/actions/ci-compile-artifacts
 
-      - name: Run package-contract and type checks
-        uses: ./.github/actions/ci-build-typecheck
+      - name: Upload compiled test inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: compiled-test-inputs
+          path: |
+            dist
+            nemoclaw/dist
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Upload compiled CLI artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -61,6 +68,43 @@ jobs:
           path: dist
           if-no-files-found: error
           retention-days: 1
+
+  build-typecheck:
+    needs: compile-artifacts
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download compiled test inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: compiled-test-inputs
+          path: .
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            nemoclaw/package-lock.json
+
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ github.token }}
+        run: bash .github/actions/ci-install-dependencies.sh
+
+      - name: Run package-contract and type checks
+        uses: ./.github/actions/ci-build-typecheck
 
   installer-integration:
     permissions:
@@ -159,7 +203,9 @@ jobs:
         run: npx vitest run --project integration test/agents/openclaw/openclaw-security-audit-suppressions-real.test.ts --silent=false --reporter=default
 
   cli-test-shards:
+    needs: compile-artifacts
     permissions:
+      actions: read
       contents: read
       packages: read
     runs-on: ubuntu-24.04
@@ -176,6 +222,20 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Download compiled test inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: compiled-test-inputs
+          path: .
+
+      - name: Verify compiled test inputs
+        run: |
+          test -s dist/nemoclaw.js
+          test -s dist/managed-inference/catalog.json
+          test -s nemoclaw/dist/index.js
+          test -s nemoclaw/dist/shared/openshell-gateway-endpoint-boundary.cjs
+          test -s nemoclaw/dist/shared/sandbox-name.cjs
 
       - name: Run CLI coverage shard
         uses: ./.github/actions/ci-cli-coverage-shard

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -325,7 +325,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  build-typecheck:
+  compile-artifacts:
     needs: [changes, openshell-sdk-package]
     if: needs.changes.outputs.code == 'true'
     permissions:
@@ -371,8 +371,15 @@ jobs:
       - name: Compile and verify CLI and plugin outputs
         uses: ./.trusted-ci-actions/.github/actions/ci-compile-artifacts
 
-      - name: Run package-contract and type checks
-        uses: ./.trusted-ci-actions/.github/actions/ci-build-typecheck
+      - name: Upload compiled test inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: compiled-test-inputs
+          path: |
+            dist
+            nemoclaw/dist
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Upload compiled CLI artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -381,6 +388,65 @@ jobs:
           path: dist
           if-no-files-found: error
           retention-days: 1
+
+  build-typecheck:
+    needs: [changes, compile-artifacts, openshell-sdk-package]
+    if: needs.changes.outputs.code == 'true'
+    permissions:
+      actions: read
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Checkout trusted CI actions
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .trusted-ci-actions
+          persist-credentials: false
+          sparse-checkout: |
+            .github/actions/ci-build-typecheck
+            .github/actions/ci-install-dependencies.sh
+            ci/reviewed-npm-audit.json
+            scripts/audit-reviewed-npm-graph.mts
+            scripts/checks/prepare-ci-npm-install.mts
+            scripts/lib/openclaw-npm-remediation.mts
+            scripts/lib/reviewed-npm-archive.mts
+            scripts/lib/reviewed-npm-audit.mts
+          sparse-checkout-cone-mode: false
+
+      - name: Download verified OpenShell SDK archive
+        if: needs.openshell-sdk-package.outputs.required == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: openshell-sdk-package
+          path: ${{ runner.temp }}/openshell-sdk
+
+      - name: Download compiled test inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: compiled-test-inputs
+          path: .
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            nemoclaw/package-lock.json
+
+      - name: Install dependencies
+        run: bash .trusted-ci-actions/.github/actions/ci-install-dependencies.sh
+
+      - name: Run package-contract and type checks
+        uses: ./.trusted-ci-actions/.github/actions/ci-build-typecheck
 
   installer-integration:
     needs: [changes, openshell-sdk-package]
@@ -493,9 +559,10 @@ jobs:
           report-dir: artifacts/reviewed-npm-audit
 
   cli-test-shards:
-    needs: [changes, openshell-sdk-package]
+    needs: [changes, compile-artifacts, openshell-sdk-package]
     if: needs.changes.outputs.code == 'true'
     permissions:
+      actions: read
       contents: read
     runs-on: ubuntu-24.04
     # Coverage startup plus the stable, duration-weighted roster can exceed
@@ -541,6 +608,20 @@ jobs:
         with:
           name: openshell-sdk-package
           path: ${{ runner.temp }}/openshell-sdk
+
+      - name: Download compiled test inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: compiled-test-inputs
+          path: .
+
+      - name: Verify compiled test inputs
+        run: |
+          test -s dist/nemoclaw.js
+          test -s dist/managed-inference/catalog.json
+          test -s nemoclaw/dist/index.js
+          test -s nemoclaw/dist/shared/openshell-gateway-endpoint-boundary.cjs
+          test -s nemoclaw/dist/shared/sandbox-name.cjs
 
       - name: Run CLI coverage shard
         uses: ./.trusted-ci-actions/.github/actions/ci-cli-coverage-shard

--- a/test/automation/pull-requests/pr-workflow-contract.test.ts
+++ b/test/automation/pull-requests/pr-workflow-contract.test.ts
@@ -508,6 +508,7 @@ describe("pull request and main workflow contracts", () => {
       ["build-typecheck", "read"],
       ["cli-test-shards", "read"],
       ["cli-tests", "read"],
+      ["compile-artifacts", "read"],
       ["installer-integration", "read"],
       ["plugin-tests", "read"],
       ["static-checks", "read"],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Restore all generated CLI and plugin inputs required by the 12 CLI coverage shards without rebuilding in each shard.

## Reason

After #10699, shard tests still execute compiled launchers, read generated catalogs, and import shared plugin CJS boundaries. All shards failed when those exact outputs were absent.

### Related issues

Fixes #10685

## Changes

- Split compilation into one producer so package/type checks and all 12 shards fan out after the unavoidable compile barrier.
- Publish complete `dist/` and `nemoclaw/dist/` trees once and restore and verify them in each shard before Vitest.
- Preserve base-SHA trusted PR execution, pinned artifact actions, the 12-shard roster, and least-privilege permissions.

## Verification

- Contributor validation: Commit hooks passed YAML, formatting, repository checks, secret scan, source-shape budget, growth guardrails, and commitlint.
- Tests: Workflow contracts: 37/37 passed. Package-contract: 1,232/1,232 passed. Local shard 1 reached 2,852 passing tests with no missing compiled-input failures; two host-only Python exec-format failures prevented a complete local shard pass.
- Secrets review: The diff contains no secrets, API keys, or credentials
<!-- nemoclaw-docs-review:start -->
- Documentation review: `no-docs-needed`
- Documentation evidence: Workflow-only CI orchestration change; no user-facing documentation changed.
- Documentation agent: openai/openai/gpt-5.6-sol
<!-- docs-review-head-sha: 82e09a40427373f1b282bdb1af7056d5487b32d0 -->
<!-- docs-review-agents-blob-sha: dd3528f6e332f7f09f4841555c2ed11cb2139fb9 -->
<!-- nemoclaw-docs-review:end -->
<!-- nemoclaw-targeted-validation:start -->
- Targeted validation: Workflow contracts 37/37; package-contract 1,232/1,232; exact-head compile producer, build/typecheck, all 12 CLI shards, and aggregate cli-tests passed in run 33445972480.
<!-- nemoclaw-targeted-validation:end -->
<!-- nemoclaw-broad-gate:start -->
- Broad gate: passed — CI / Pull Request run 33445972480 succeeded at exact head 82e09a40427373f1b282bdb1af7056d5487b32d0.
<!-- nemoclaw-broad-gate:end -->

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated checks by compiling shared test artifacts before type, package, and CLI validation.
  * Added verification that required compiled outputs are available before coverage tests run.
  * Updated workflow checks to validate package access permissions.

* **Chores**
  * Improved CI job sequencing and artifact sharing for more consistent pull request and main-branch validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->