### PR TITLE
fix(messaging): complete typed provider lifecycle

### DIFF
--- a/ci/source-architecture-budget.json
+++ b/ci/source-architecture-budget.json
@@ -25,7 +25,7 @@
       "src/lib/name-validation.ts": 19,
       "src/lib/onboard/gateway-binding.ts": 53,
       "src/lib/runner.ts": 85,
-      "src/lib/security/redact.ts": 53,
+      "src/lib/security/redact.ts": 52,
       "src/lib/state/mcp-lifecycle-lock.ts": 21,
       "src/lib/state/onboard-session.ts": 35,
       "src/lib/state/registry.ts": 97,

--- a/src/lib/actions/credentials-provider-adapter.test.ts
+++ b/src/lib/actions/credentials-provider-adapter.test.ts
@@ -45,7 +45,7 @@ function providerAdapter(
     async () => ({ ok: true, value: { state: "ready" } });
   const inspectProviderProfile: OpenShellProviderAdapter["inspectProviderProfile"] = async () => ({
     ok: true,
-    value: { credentialKeys: [] },
+    value: { credentialKeys: [], contractDigest: "test-profile-contract" },
   });
   const deleteProvider: OpenShellProviderAdapter["deleteProvider"] = async () => ({
     ok: true,
@@ -55,6 +55,14 @@ function providerAdapter(
     ok: true,
     value: { state: "detached" },
   });
+  const attachProvider: OpenShellProviderAdapter["attachProvider"] = async () => ({
+    ok: true,
+    value: { state: "attached" },
+  });
+  const configureProviderRefresh: OpenShellProviderAdapter["configureProviderRefresh"] =
+    async () => ({ ok: true, value: { state: "configured" } });
+  const getProviderRefreshStatus: OpenShellProviderAdapter["getProviderRefreshStatus"] =
+    async () => ({ ok: true, value: { status: "refreshed" } });
   return {
     listProviders: vi.fn(listProviders),
     createProvider: vi.fn(createProvider),
@@ -65,6 +73,9 @@ function providerAdapter(
     inspectProviderProfile: vi.fn(inspectProviderProfile),
     deleteProvider: vi.fn(deleteProvider),
     detachProvider: vi.fn(detachProvider),
+    attachProvider: vi.fn(attachProvider),
+    configureProviderRefresh: vi.fn(configureProviderRefresh),
+    getProviderRefreshStatus: vi.fn(getProviderRefreshStatus),
     ...overrides,
   };
 }

--- a/src/lib/actions/sandbox/policy-channel-conflict.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-conflict.test.ts
@@ -640,6 +640,11 @@ describe("addSandboxChannel cross-sandbox conflict check (#4305)", () => {
       ],
       "nemoclaw",
       { bestEffort: true, requireExactBindings: true },
+      {
+        channelName: "discord",
+        plan: expect.objectContaining({ agent: "hermes", workflow: "add-channel" }),
+        sandboxAgent: "hermes",
+      },
     );
   });
 
@@ -668,6 +673,27 @@ describe("addSandboxChannel cross-sandbox conflict check (#4305)", () => {
         .map(([args]) => (args as string[]).join(" "))
         .filter((command) => command.includes("provider detach") || command.includes("delete")),
     ).toEqual([]);
+  });
+
+  it("reports state-neutral recovery after provider replacement cannot recreate (#9806)", async () => {
+    arrangeRegistry({ current: makeEmptyEntry("alpha") });
+    getCredentialMock.mockReturnValue(TELEGRAM_TOKEN);
+    upsertMock.mockImplementationOnce(() => {
+      throw Object.assign(new Error("provider create failed"), {
+        code: "NEMOCLAW_MESSAGING_PROVIDER_MUTATION_FAILURE",
+        mutatedProviderNames: ["alpha-telegram-bridge"],
+        createdProviderNames: [],
+      });
+    });
+
+    await expect(addSandboxChannel("alpha", { channel: "telegram" })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(loggedText()).toContain(
+      "Provider replacement or update is incomplete for alpha-telegram-bridge; rerun 'nemoclaw alpha channels add telegram' to reconcile it.",
+    );
+    expect(loggedText()).not.toContain("resolve the conflicting provider");
   });
 
   it("does not persist a multi-provider add when identity preflight fails", async () => {

--- a/src/lib/actions/sandbox/policy-channel-dependencies.ts
+++ b/src/lib/actions/sandbox/policy-channel-dependencies.ts
@@ -2,13 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { inspectOpenShellSandboxIdentityFingerprint } from "../../adapters/openshell/policy-state";
+import { createCliOpenShellProviderAdapter } from "../../adapters/openshell/provider-adapter-cli";
 import { runOpenshell } from "../../adapters/openshell/runtime";
+import { namedOpenShellGateway } from "../../adapters/openshell/sandbox-observer";
+import { getCredential, normalizeCredentialValue } from "../../credentials/store";
+import { REPOSITORY_ROOT } from "../../core/repository-root";
+import {
+  isMessagingProviderBindingConflict as isTypedMessagingProviderBindingConflict,
+  isMessagingProviderMutationFailure as isTypedMessagingProviderMutationFailure,
+} from "../../messaging/applier/openshell-provider";
+import { buildMessagingProviderApplication } from "../../messaging/applier/provider-application";
+import { MessagingSetupApplier } from "../../messaging/applier/setup-applier";
+import type { SandboxMessagingPlan } from "../../messaging/manifest";
 
 type MessagingProviderTokenDefinition = {
   name: string;
   envKey: string;
   token: string | null;
   providerType?: string;
+  additionalCredentials?: Array<{ envKey: string; token: string | null }>;
 };
 
 type MessagingProviderUpsertOptions = {
@@ -99,6 +111,7 @@ export const policyChannelDependencies = {
     readonly mutatedProviderNames: readonly string[];
     readonly createdProviderNames?: readonly string[];
   } {
+    if (isTypedMessagingProviderBindingConflict(error)) return true;
     const providers = require("../../onboard/providers") as LegacyOnboardProvidersModule;
     return providers.isMessagingProviderBindingConflict(error);
   },
@@ -106,16 +119,68 @@ export const policyChannelDependencies = {
     readonly mutatedProviderNames: readonly string[];
     readonly createdProviderNames: readonly string[];
   } {
+    if (isTypedMessagingProviderMutationFailure(error)) return true;
     const providers = require("../../onboard/providers") as LegacyOnboardProvidersModule;
     return providers.isMessagingProviderMutationFailure(error);
+  },
+  async attachMessagingProvider(
+    providerName: string,
+    sandboxName: string,
+    gatewayName: string,
+  ): Promise<void> {
+    const result = await createCliOpenShellProviderAdapter().attachProvider({
+      target: namedOpenShellGateway(gatewayName),
+      providerName,
+      sandboxName,
+    });
+    if (!result.ok) {
+      throw new Error(
+        `OpenShell did not attach messaging provider '${providerName}' to sandbox '${sandboxName}': ${result.error.message}`,
+      );
+    }
+  },
+  async deleteMessagingProvider(providerName: string, gatewayName: string): Promise<boolean> {
+    const result = await createCliOpenShellProviderAdapter().deleteProvider({
+      target: namedOpenShellGateway(gatewayName),
+      providerName,
+    });
+    return (
+      result.ok ||
+      (result.error.kind === "command" && result.error.reason === "not_found")
+    );
   },
   upsertMessagingProviders(
     tokenDefs: MessagingProviderTokenDefinition[],
     gatewayName: string,
     options?: MessagingProviderUpsertOptions,
-  ): string[] {
-    const providers = require("../../onboard/providers") as LegacyOnboardProvidersModule;
-    return providers.upsertMessagingProviders(tokenDefs, gatewayRunner(gatewayName), options);
+    context?: {
+      readonly plan: SandboxMessagingPlan;
+      readonly channelName: string;
+      readonly sandboxAgent: string | null | undefined;
+    },
+  ): string[] | Promise<string[]> {
+    if (!context) return Promise.reject(new Error("Messaging provider application context is missing."));
+    const application = buildMessagingProviderApplication({
+      tokenDefs,
+      root: REPOSITORY_ROOT,
+      agent: context.sandboxAgent,
+      getCredential,
+      env: process.env,
+      normalizeCredentialValue: (value) =>
+        normalizeCredentialValue(value as string | undefined),
+      channelIdForCredential: () => context.channelName,
+    });
+    if (application.otherTokenDefs.length > 0) {
+      return Promise.reject(new Error("Channel add produced a non-messaging provider definition."));
+    }
+    return MessagingSetupApplier.applyCredentialsAtOpenShell(context.plan, {
+      providerAdapter: createCliOpenShellProviderAdapter(),
+      target: namedOpenShellGateway(gatewayName),
+      definitions: application.definitions,
+      refreshes: application.refreshes,
+      bestEffort: options?.bestEffort,
+      log: (message) => console.error(`  ${message}`),
+    }).then((result) => [...result.providerNames]);
   },
   rebuildSandbox(
     sandboxName: Parameters<RebuildModule["rebuildSandbox"]>[0],

--- a/src/lib/actions/sandbox/policy-channel.ts
+++ b/src/lib/actions/sandbox/policy-channel.ts
@@ -188,8 +188,23 @@ function withSandboxMutationLockUnlessPreview<T>(
  */
 export interface AddSandboxChannelDependencies {
   readonly googlechatNonInteractiveAudienceCapability?: GooglechatNonInteractiveAudienceCapability;
-  readonly upsertMessagingProviders?: typeof policyChannelDependencies.upsertMessagingProviders;
+  readonly upsertMessagingProviders?: ChannelMessagingProviderApplication;
 }
+
+type ChannelMessagingProviderApplication = (
+  tokenDefs: MessagingTokenDef[],
+  gatewayName: string,
+  options: {
+    readonly bestEffort?: boolean;
+    readonly replaceExisting?: boolean;
+    readonly requireExactBindings?: boolean;
+  },
+  context?: {
+    readonly plan: SandboxMessagingPlan;
+    readonly channelName: string;
+    readonly sandboxAgent: string | null | undefined;
+  },
+) => string[] | Promise<string[]>;
 
 const messagingManifestRegistry = createBuiltInChannelManifestRegistry();
 
@@ -826,8 +841,10 @@ async function applyChannelAddToGatewayAndRegistry(
   sandboxName: string,
   channelName: string,
   acquired: Record<string, string>,
+  plan: SandboxMessagingPlan,
   applyPolicyAfterAttachment?: () => boolean,
-  upsertMessagingProviders = policyChannelDependencies.upsertMessagingProviders,
+  upsertMessagingProviders: ChannelMessagingProviderApplication =
+    policyChannelDependencies.upsertMessagingProviders,
   cleanupCredentialFreePolicy?: () => void,
 ): Promise<boolean | null> {
   const sandboxAgent = registry.getSandbox(sandboxName)?.agent;
@@ -886,21 +903,22 @@ async function applyChannelAddToGatewayAndRegistry(
   try {
     // bestEffort: failures throw (instead of process.exit inside the helper)
     // so a partial add can be torn down below before exiting.
-    const providerNames = upsertMessagingProviders(tokenDefs, gatewayName, {
-      bestEffort: true,
-      requireExactBindings: true,
-    });
+    const providerNames = await upsertMessagingProviders(
+      tokenDefs,
+      gatewayName,
+      {
+        bestEffort: true,
+        requireExactBindings: true,
+      },
+      { plan, channelName, sandboxAgent },
+    );
     for (const providerName of providerNames) {
       revalidateMessagingProviderAttachmentTarget(sandboxName, gatewayName);
-      const attached = runOpenshell(
-        ["sandbox", "provider", "attach", "-g", gatewayName, sandboxName, providerName],
-        { ignoreError: true, stdio: ["ignore", "pipe", "pipe"] },
+      await policyChannelDependencies.attachMessagingProvider(
+        providerName,
+        sandboxName,
+        gatewayName,
       );
-      if (attached.status !== 0) {
-        throw new Error(
-          `OpenShell did not attach messaging provider '${providerName}' to sandbox '${sandboxName}'.`,
-        );
-      }
       revalidateMessagingProviderAttachmentTarget(sandboxName, gatewayName);
     }
     if (applyPolicyAfterAttachment && !applyPolicyAfterAttachment()) {
@@ -918,21 +936,24 @@ async function applyChannelAddToGatewayAndRegistry(
     ) {
       const createdProviderNames = [...(err.createdProviderNames ?? [])];
       const createdProviders = new Set(createdProviderNames);
-      const cleanupFailures = createdProviderNames.filter((providerName) => {
-        const result = policyChannelDependencies.runGatewayOpenshell(
-          gatewayName,
-          ["provider", "delete", providerName],
-          { ignoreError: true, stdio: ["ignore", "pipe", "pipe"] },
-        );
-        const output = `${result.stdout || ""}${result.stderr || ""}`;
-        return result.status !== 0 && !/\bNotFound\b|not found/i.test(output);
-      });
+      const cleanupOutcomes = await Promise.all(
+        createdProviderNames.map(async (providerName) => ({
+          providerName,
+          removed: await policyChannelDependencies.deleteMessagingProvider(
+            providerName,
+            gatewayName,
+          ),
+        })),
+      );
+      const cleanupFailures = cleanupOutcomes
+        .filter(({ removed }) => !removed)
+        .map(({ providerName }) => providerName);
       const updatedProviderNames = err.mutatedProviderNames.filter(
         (providerName) => !createdProviders.has(providerName),
       );
       if (updatedProviderNames.length > 0) {
         console.error(
-          `  ${YW}⚠${R} Updated provider state remains for ${updatedProviderNames.join(", ")}; resolve the conflicting provider, then rerun '${CLI_NAME} ${sandboxName} channels add ${channelName}'.`,
+          `  ${YW}⚠${R} Provider replacement or update is incomplete for ${updatedProviderNames.join(", ")}; rerun '${CLI_NAME} ${sandboxName} channels add ${channelName}' to reconcile it.`,
         );
       }
       if (cleanupFailures.length > 0) {
@@ -1478,6 +1499,7 @@ async function addSandboxChannelUnlocked(
       sandboxName,
       canonical,
       {},
+      plan,
       undefined,
       dependencies.upsertMessagingProviders,
     );
@@ -1540,6 +1562,7 @@ async function addSandboxChannelUnlocked(
     sandboxName,
     canonical,
     acquired,
+    plan,
     () =>
       applyChannelPresetIfAvailable(sandboxName, canonical, "add", {
         disclosedPresetState,
@@ -1548,7 +1571,7 @@ async function addSandboxChannelUnlocked(
     cleanupCredentialFreePolicy,
   );
   if (registeredBridge === null) {
-    await rollbackChannelAdd(sandboxName, channelDef, canonical, {
+    await rollbackChannelAdd(sandboxName, channelDef, canonical, plan, {
       wasAlreadyEnabled,
       priorCreds,
     });
@@ -1561,7 +1584,7 @@ async function addSandboxChannelUnlocked(
 
   if (!MessagingHostStateApplier.applyPlanToRegistry(sandboxName, plan)) {
     console.error(`  ${YW}⚠${R} Could not persist messaging plan for '${sandboxName}'.`);
-    await rollbackChannelAdd(sandboxName, channelDef, canonical, {
+    await rollbackChannelAdd(sandboxName, channelDef, canonical, plan, {
       wasAlreadyEnabled,
       priorCreds,
     });
@@ -1579,6 +1602,7 @@ async function rollbackChannelAdd(
   sandboxName: string,
   channel: ChannelDef,
   canonical: string,
+  plan: SandboxMessagingPlan,
   snapshot: {
     wasAlreadyEnabled: boolean;
     priorCreds: Record<string, string>;
@@ -1611,11 +1635,16 @@ async function rollbackChannelAdd(
           token,
           providerType: MESSAGING_CREDENTIAL_PROVIDER_TYPE,
         }));
-        policyChannelDependencies.upsertMessagingProviders(
+        await policyChannelDependencies.upsertMessagingProviders(
           priorTokenDefs,
           getSandboxTargetGatewayName(sandboxName),
           {
             bestEffort: true,
+          },
+          {
+            plan,
+            channelName: canonical,
+            sandboxAgent: registry.getSandbox(sandboxName)?.agent,
           },
         );
       } catch (err) {

--- a/src/lib/adapters/openshell/provider-adapter-cli.test.ts
+++ b/src/lib/adapters/openshell/provider-adapter-cli.test.ts
@@ -3,7 +3,12 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { createCliOpenShellProviderAdapter, type RunProviderCommand } from "./provider-adapter-cli";
+import {
+  createCliOpenShellProviderAdapter,
+  createCliOpenShellProviderInspectionAdapter,
+  type RunProviderCommand,
+} from "./provider-adapter-cli";
+import { providerProfileContractDigest } from "./provider-profile-contract";
 import { namedOpenShellGateway, selectedOpenShellGateway } from "./sandbox-observer";
 
 function captured(status: number | null, stdout = "", stderr = "", error?: Error) {
@@ -63,6 +68,36 @@ describe("CLI OpenShell provider adapter", () => {
       stdio: ["ignore", "pipe", "pipe"],
       suppressOutput: true,
       timeout: 4_321,
+    });
+  });
+
+  it("returns the same typed provider result to synchronous onboarding inspection (#9806)", () => {
+    const run = vi.fn(() =>
+      captured(
+        0,
+        [
+          "Name: search-prod",
+          "Type: tavily",
+          "Credential keys: TAVILY_API_KEY",
+          "Config keys: <none>",
+        ].join("\n"),
+      ),
+    );
+    const inspector = createCliOpenShellProviderInspectionAdapter({ run });
+
+    expect(
+      inspector.getProvider({
+        target: namedOpenShellGateway("nemoclaw-18080"),
+        providerName: "search-prod",
+      }),
+    ).toEqual({
+      ok: true,
+      value: {
+        name: "search-prod",
+        type: "tavily",
+        credentialKeys: ["TAVILY_API_KEY"],
+        configKeys: [],
+      },
     });
   });
 
@@ -278,14 +313,31 @@ describe("CLI OpenShell provider adapter", () => {
   });
 
   it("returns sorted unique credential keys from a provider profile (#9806)", async () => {
-    const run = vi.fn(() =>
-      captured(
-        0,
-        JSON.stringify({
-          credentials: [{ env_vars: ["ZETA_TOKEN", "ALPHA_TOKEN"] }, { env_vars: ["ALPHA_TOKEN"] }],
-        }),
-      ),
-    );
+    const profile = {
+      id: "custom",
+      credentials: [
+        {
+          name: "token",
+          env_vars: ["ZETA_TOKEN", "ALPHA_TOKEN"],
+          required: true,
+          auth_style: "bearer",
+          header_name: "Authorization",
+          query_param: "",
+        },
+        {
+          name: "backup",
+          env_vars: ["ALPHA_TOKEN"],
+          required: false,
+          auth_style: "header",
+          header_name: "x-backup-token",
+          query_param: "",
+        },
+      ],
+      endpoints: [],
+      binaries: [],
+      inference_capable: false,
+    };
+    const run = vi.fn(() => captured(0, JSON.stringify(profile)));
     const adapter = createCliOpenShellProviderAdapter({ run });
 
     await expect(
@@ -295,12 +347,73 @@ describe("CLI OpenShell provider adapter", () => {
       }),
     ).resolves.toEqual({
       ok: true,
-      value: { credentialKeys: ["ALPHA_TOKEN", "ZETA_TOKEN"] },
+      value: {
+        credentialKeys: ["ALPHA_TOKEN", "ZETA_TOKEN"],
+        contractDigest: providerProfileContractDigest(profile),
+      },
     });
     expect(run).toHaveBeenCalledWith(
       ["provider", "profile", "export", "custom", "--output", "json"],
       expect.any(Object),
     );
+  });
+
+  it("ignores explanatory refresh text but detects credential-boundary changes (#9806)", () => {
+    const profile = {
+      id: "custom",
+      credentials: [
+        {
+          name: "access_token",
+          env_vars: ["ACCESS_TOKEN"],
+          required: true,
+          auth_style: "bearer",
+          header_name: "Authorization",
+          query_param: "",
+          refresh: {
+            strategy: "test-refresh",
+            scopes: ["scope:a"],
+            material: [
+              { name: "private_key", description: "Original text", required: true, secret: true },
+            ],
+          },
+        },
+      ],
+      endpoints: [],
+      binaries: [],
+      inference_capable: false,
+    };
+    const digest = providerProfileContractDigest(profile);
+
+    expect(
+      providerProfileContractDigest({
+        ...profile,
+        credentials: [
+          {
+            ...profile.credentials[0],
+            refresh: {
+              ...profile.credentials[0].refresh,
+              material: [
+                {
+                  ...profile.credentials[0].refresh.material[0],
+                  description: "Rewritten explanatory text",
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toBe(digest);
+    expect(
+      providerProfileContractDigest({
+        ...profile,
+        credentials: [
+          {
+            ...profile.credentials[0],
+            refresh: { ...profile.credentials[0].refresh, scopes: ["scope:b"] },
+          },
+        ],
+      }),
+    ).not.toBe(digest);
   });
 
   it("reconciles an endpointless profile inside the CLI adapter (#9806)", async () => {
@@ -412,6 +525,122 @@ describe("CLI OpenShell provider adapter", () => {
     expect(run).toHaveBeenCalledWith(
       ["sandbox", "provider", "detach", "-g", "nemoclaw-18080", "alpha", "search-prod"],
       expect.objectContaining({ ignoreError: true, timeout: 30_000 }),
+    );
+  });
+
+  it("places a named gateway flag before attach arguments (#9806)", async () => {
+    const run = vi.fn(() => captured(0));
+    const adapter = createCliOpenShellProviderAdapter({ run });
+
+    await expect(
+      adapter.attachProvider({
+        target: namedOpenShellGateway("nemoclaw-18080"),
+        providerName: "search-prod",
+        sandboxName: "alpha",
+      }),
+    ).resolves.toEqual({ ok: true, value: { state: "attached" } });
+    expect(run).toHaveBeenCalledWith(
+      ["sandbox", "provider", "attach", "-g", "nemoclaw-18080", "alpha", "search-prod"],
+      expect.objectContaining({ ignoreError: true, timeout: 30_000 }),
+    );
+  });
+
+  it("configures refresh secrets through the child environment (#9806)", async () => {
+    const run = vi.fn<RunProviderCommand>(() => captured(0));
+    const adapter = createCliOpenShellProviderAdapter({ run });
+    const privateKey = "host-only-private-key";
+
+    await expect(
+      adapter.configureProviderRefresh({
+        target: namedOpenShellGateway("nemoclaw"),
+        providerName: "google-chat",
+        credentialKey: "GOOGLE_CHAT_ACCESS_TOKEN",
+        strategy: "google-service-account-jwt",
+        material: [{ key: "client_email", value: "bot@example.com" }],
+        secretMaterial: [{ key: "private_key", value: privateKey }],
+      }),
+    ).resolves.toEqual({ ok: true, value: { state: "configured" } });
+    expect(run).toHaveBeenCalledWith(
+      [
+        "provider",
+        "refresh",
+        "-g",
+        "nemoclaw",
+        "configure",
+        "--credential-key",
+        "GOOGLE_CHAT_ACCESS_TOKEN",
+        "--strategy",
+        "google-service-account-jwt",
+        "--material",
+        "client_email=bot@example.com",
+        "--secret-material-env",
+        "private_key=NEMOCLAW_PROVIDER_REFRESH_SECRET_0",
+        "google-chat",
+      ],
+      expect.objectContaining({
+        env: { NEMOCLAW_PROVIDER_REFRESH_SECRET_0: privateKey },
+      }),
+    );
+    expect(run.mock.calls[0]?.[0].join(" ")).not.toContain(privateKey);
+  });
+
+  it("redacts refresh secrets from typed failures (#9806)", async () => {
+    const privateKey = "host-only-private-key";
+    const adapter = createCliOpenShellProviderAdapter({
+      run: () => captured(1, "", `refresh rejected ${privateKey}`),
+    });
+
+    const result = await adapter.configureProviderRefresh({
+      target: selectedOpenShellGateway(),
+      providerName: "google-chat",
+      credentialKey: "GOOGLE_CHAT_ACCESS_TOKEN",
+      strategy: "google-service-account-jwt",
+      material: [],
+      secretMaterial: [{ key: "private_key", value: privateKey }],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        kind: "command",
+        reason: "failed",
+        message: "refresh rejected <REDACTED>",
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(privateKey);
+  });
+
+  it("parses a typed refresh status from a named gateway (#9806)", async () => {
+    const run = vi.fn(() =>
+      captured(
+        0,
+        [
+          "PROVIDER    KEY           STRATEGY                    STATUS",
+          "google-chat  GOOGLE_CHAT_ACCESS_TOKEN  google-service-account-jwt  refreshed",
+        ].join("\n"),
+      ),
+    );
+    const adapter = createCliOpenShellProviderAdapter({ run });
+
+    await expect(
+      adapter.getProviderRefreshStatus({
+        target: namedOpenShellGateway("nemoclaw"),
+        providerName: "google-chat",
+        credentialKey: "GOOGLE_CHAT_ACCESS_TOKEN",
+      }),
+    ).resolves.toEqual({ ok: true, value: { status: "refreshed" } });
+    expect(run).toHaveBeenCalledWith(
+      [
+        "provider",
+        "refresh",
+        "-g",
+        "nemoclaw",
+        "status",
+        "google-chat",
+        "--credential-key",
+        "GOOGLE_CHAT_ACCESS_TOKEN",
+      ],
+      expect.objectContaining({ suppressOutput: true }),
     );
   });
 

--- a/src/lib/adapters/openshell/provider-adapter-cli.ts
+++ b/src/lib/adapters/openshell/provider-adapter-cli.ts
@@ -5,15 +5,19 @@ import { NAME_MAX_LENGTH, NAME_VALID_PATTERN } from "../../name-validation";
 import { redactFull } from "../../security/redact";
 import { parseCliOpenShellProviderNames, runOpenshellProviderCommand } from "./provider-command";
 import {
+  type AttachOpenShellProviderRequest,
+  type ConfigureOpenShellProviderRefreshRequest,
   type CreateOpenShellProviderRequest,
   type DeleteOpenShellProviderRequest,
   type DetachOpenShellProviderRequest,
   type EnsureOpenShellEndpointlessProviderProfileRequest,
   type GetOpenShellProviderRequest,
+  type GetOpenShellProviderRefreshStatusRequest,
   type ImportOpenShellProviderProfileRequest,
   type InspectOpenShellProviderProfileRequest,
   type OpenShellProviderAdapter,
   type OpenShellProviderError,
+  type OpenShellProviderInspectionAdapter,
   type OpenShellProviderRequest,
   type OpenShellProviderResult,
   type UpdateOpenShellProviderRequest,
@@ -26,6 +30,7 @@ import {
 import type { OpenShellGatewayTarget } from "./sandbox-observer";
 import { ensureEndpointlessProviderProfile as reconcileEndpointlessProviderProfile } from "./provider-profile";
 import { OPENSHELL_OPERATION_TIMEOUT_MS } from "./timeouts";
+import { providerProfileContractDigest } from "./provider-profile-contract";
 
 export type CapturedProviderCommandResult = Readonly<{
   status: number | null;
@@ -209,19 +214,52 @@ function parseProfileCredentialKeys(output: string): string[] | null {
   return [...keys].sort();
 }
 
-export function createCliOpenShellProviderAdapter(
-  deps: CliOpenShellProviderAdapterDeps = {},
-): OpenShellProviderAdapter {
+function parseProviderProfile(output: string):
+  | Readonly<{ credentialKeys: readonly string[]; contractDigest: string }>
+  | null {
+  let profile: unknown;
+  try {
+    profile = JSON.parse(output);
+  } catch {
+    return null;
+  }
+  const credentialKeys = parseProfileCredentialKeys(output);
+  const contractDigest = providerProfileContractDigest(profile);
+  return credentialKeys && contractDigest ? { credentialKeys, contractDigest } : null;
+}
+
+function parseRefreshStatus(output: string, credentialKey: string): string | null {
+  const row = output
+    .split("\n")
+    .map((line) => line.replace(ANSI_RE, "").trim())
+    .find((line) => line.includes(credentialKey));
+  const columns = (row ?? "").split(/\s{2,}/u).filter(Boolean);
+  const keyIndex = columns.indexOf(credentialKey);
+  return keyIndex < 0 ? null : (columns[keyIndex + 2] ?? null);
+}
+
+type InvokeProviderCommand = (
+  args: string[],
+  request: OpenShellProviderRequest,
+  env?: Record<string, string>,
+  gatewayFlagIndex?: number,
+  suppressOutput?: boolean,
+  maxBuffer?: number,
+) => CapturedProviderCommandResult;
+
+function createProviderCommandInvoker(
+  deps: CliOpenShellProviderAdapterDeps,
+): InvokeProviderCommand {
   const run = deps.run ?? runOpenshellProviderCommand;
   const timeoutFor = (request: OpenShellProviderRequest) =>
     request.timeoutMs ?? deps.defaultTimeoutMs ?? OPENSHELL_OPERATION_TIMEOUT_MS;
-  const invoke = (
-    args: string[],
-    request: OpenShellProviderRequest,
-    env?: Record<string, string>,
+  return (
+    args,
+    request,
+    env,
     gatewayFlagIndex = 2,
     suppressOutput = false,
-    maxBuffer?: number,
+    maxBuffer,
   ) =>
     run(scopedArgs(args, request.target, gatewayFlagIndex), {
       ...(env ? { env } : {}),
@@ -231,6 +269,89 @@ export function createCliOpenShellProviderAdapter(
       ...(suppressOutput ? { suppressOutput: true } : {}),
       timeout: timeoutFor(request),
     });
+}
+
+function inspectProvider(
+  invoke: InvokeProviderCommand,
+  request: GetOpenShellProviderRequest,
+): ReturnType<OpenShellProviderInspectionAdapter["getProvider"]> {
+  if (!isValidCliOpenShellProviderIdentifier(request.providerName)) {
+    return failure({ kind: "validation", message: "Provider name is invalid." });
+  }
+  const result = invoke(
+    ["provider", "get", request.providerName],
+    request,
+    undefined,
+    2,
+    true,
+    PROVIDER_GET_DIAGNOSTIC_LIMIT,
+  );
+  const output = commandOutput(result);
+  if (
+    result.status === 1 &&
+    reportsExactProviderNotFound(output, request.providerName, PROVIDER_GET_DIAGNOSTIC_LIMIT)
+  ) {
+    return failure({
+      kind: "command",
+      reason: "not_found",
+      message: `OpenShell provider '${request.providerName}' was not found.`,
+    });
+  }
+  const error = commandError(result);
+  if (error) {
+    return failure(
+      error.kind === "command" && error.reason === "not_found"
+        ? {
+            kind: "command",
+            reason: "failed",
+            message: "OpenShell could not inspect the selected provider.",
+          }
+        : error,
+    );
+  }
+  const metadata = parseCliOpenShellProviderMetadata(output);
+  return metadata?.name === request.providerName
+    ? success(metadata)
+    : failure({ kind: "schema", message: "OpenShell returned invalid provider metadata." });
+}
+
+function inspectProfile(
+  invoke: InvokeProviderCommand,
+  request: InspectOpenShellProviderProfileRequest,
+): ReturnType<OpenShellProviderInspectionAdapter["inspectProviderProfile"]> {
+  const result = invoke(
+    ["provider", "profile", "export", request.profileType, "--output", "json"],
+    request,
+    undefined,
+    2,
+    true,
+  );
+  const error = commandError(result);
+  if (error) return failure(error);
+  const inspection = parseProviderProfile(bufferOrStringToText(result.stdout));
+  return inspection
+    ? success(inspection)
+    : failure({
+        kind: "schema",
+        message: "OpenShell returned an invalid provider profile.",
+      });
+}
+
+/** Create the synchronous typed inspection boundary used by onboarding planning. */
+export function createCliOpenShellProviderInspectionAdapter(
+  deps: CliOpenShellProviderAdapterDeps = {},
+): OpenShellProviderInspectionAdapter {
+  const invoke = createProviderCommandInvoker(deps);
+  return {
+    getProvider: (request) => inspectProvider(invoke, request),
+    inspectProviderProfile: (request) => inspectProfile(invoke, request),
+  };
+}
+
+export function createCliOpenShellProviderAdapter(
+  deps: CliOpenShellProviderAdapterDeps = {},
+): OpenShellProviderAdapter {
+  const invoke = createProviderCommandInvoker(deps);
 
   const listProviders: OpenShellProviderAdapter["listProviders"] = async (request) => {
     const result = invoke(["provider", "list", "--names"], request);
@@ -278,46 +399,7 @@ export function createCliOpenShellProviderAdapter(
 
   const getProvider: OpenShellProviderAdapter["getProvider"] = async (
     request: GetOpenShellProviderRequest,
-  ) => {
-    if (!isValidCliOpenShellProviderIdentifier(request.providerName)) {
-      return failure({ kind: "validation", message: "Provider name is invalid." });
-    }
-    const result = invoke(
-      ["provider", "get", request.providerName],
-      request,
-      undefined,
-      2,
-      true,
-      PROVIDER_GET_DIAGNOSTIC_LIMIT,
-    );
-    const output = commandOutput(result);
-    if (
-      result.status === 1 &&
-      reportsExactProviderNotFound(output, request.providerName, PROVIDER_GET_DIAGNOSTIC_LIMIT)
-    ) {
-      return failure({
-        kind: "command",
-        reason: "not_found",
-        message: `OpenShell provider '${request.providerName}' was not found.`,
-      });
-    }
-    const error = commandError(result);
-    if (error) {
-      return failure(
-        error.kind === "command" && error.reason === "not_found"
-          ? {
-              kind: "command",
-              reason: "failed",
-              message: "OpenShell could not inspect the selected provider.",
-            }
-          : error,
-      );
-    }
-    const metadata = parseCliOpenShellProviderMetadata(output);
-    return metadata?.name === request.providerName
-      ? success(metadata)
-      : failure({ kind: "schema", message: "OpenShell returned invalid provider metadata." });
-  };
+  ) => inspectProvider(invoke, request);
 
   const updateProvider: OpenShellProviderAdapter["updateProvider"] = async (
     request: UpdateOpenShellProviderRequest,
@@ -382,21 +464,7 @@ export function createCliOpenShellProviderAdapter(
 
   const inspectProviderProfile: OpenShellProviderAdapter["inspectProviderProfile"] = async (
     request: InspectOpenShellProviderProfileRequest,
-  ) => {
-    const result = invoke(
-      ["provider", "profile", "export", request.profileType, "--output", "json"],
-      request,
-    );
-    const error = commandError(result);
-    if (error) return failure(error);
-    const credentialKeys = parseProfileCredentialKeys(bufferOrStringToText(result.stdout));
-    return credentialKeys
-      ? success({ credentialKeys })
-      : failure({
-          kind: "schema",
-          message: "OpenShell returned an invalid provider profile.",
-        });
-  };
+  ) => inspectProfile(invoke, request);
 
   const deleteProvider: OpenShellProviderAdapter["deleteProvider"] = async (
     request: DeleteOpenShellProviderRequest,
@@ -423,6 +491,81 @@ export function createCliOpenShellProviderAdapter(
     return error ? failure(error) : success({ state: "detached" });
   };
 
+  const attachProvider: OpenShellProviderAdapter["attachProvider"] = async (
+    request: AttachOpenShellProviderRequest,
+  ) => {
+    const result = invoke(
+      ["sandbox", "provider", "attach", request.sandboxName, request.providerName],
+      request,
+      undefined,
+      3,
+    );
+    const error = commandError(result);
+    return error ? failure(error) : success({ state: "attached" });
+  };
+
+  const configureProviderRefresh: OpenShellProviderAdapter["configureProviderRefresh"] = async (
+    request: ConfigureOpenShellProviderRefreshRequest,
+  ) => {
+    if (
+      !isValidCliOpenShellProviderIdentifier(request.providerName) ||
+      !ENV_NAME_PATTERN.test(request.credentialKey) ||
+      !request.strategy ||
+      request.material.some((entry) => !entry.key || !entry.value) ||
+      request.secretMaterial.some((entry) => !entry.key || !entry.value)
+    ) {
+      return failure({ kind: "validation", message: "Provider refresh input is invalid." });
+    }
+    const args = [
+      "provider",
+      "refresh",
+      "configure",
+      "--credential-key",
+      request.credentialKey,
+      "--strategy",
+      request.strategy,
+    ];
+    for (const entry of request.material) args.push("--material", `${entry.key}=${entry.value}`);
+    const env: Record<string, string> = {};
+    request.secretMaterial.forEach((entry, index) => {
+      const envName = `NEMOCLAW_PROVIDER_REFRESH_SECRET_${index}`;
+      env[envName] = entry.value;
+      args.push("--secret-material-env", `${entry.key}=${envName}`);
+    });
+    args.push(request.providerName);
+    const result = invoke(args, request, env);
+    const error = commandError(result, Object.values(env));
+    return error ? failure(error) : success({ state: "configured" });
+  };
+
+  const getProviderRefreshStatus: OpenShellProviderAdapter["getProviderRefreshStatus"] = async (
+    request: GetOpenShellProviderRefreshStatusRequest,
+  ) => {
+    const result = invoke(
+      [
+        "provider",
+        "refresh",
+        "status",
+        request.providerName,
+        "--credential-key",
+        request.credentialKey,
+      ],
+      request,
+      undefined,
+      2,
+      true,
+    );
+    const error = commandError(result);
+    return error
+      ? failure(error)
+      : success({
+          status: parseRefreshStatus(
+            bufferOrStringToText(result.stdout),
+            request.credentialKey,
+          ),
+        });
+  };
+
   return {
     listProviders,
     createProvider,
@@ -433,5 +576,8 @@ export function createCliOpenShellProviderAdapter(
     inspectProviderProfile,
     deleteProvider,
     detachProvider,
+    attachProvider,
+    configureProviderRefresh,
+    getProviderRefreshStatus,
   };
 }

--- a/src/lib/adapters/openshell/provider-adapter.ts
+++ b/src/lib/adapters/openshell/provider-adapter.ts
@@ -57,6 +57,7 @@ export type OpenShellProviderMetadata = Readonly<{
 
 export type OpenShellProviderProfileInspection = Readonly<{
   credentialKeys: readonly string[];
+  contractDigest: string;
 }>;
 
 export type CreateOpenShellProviderRequest = OpenShellProviderRequest &
@@ -106,6 +107,21 @@ export type DetachOpenShellProviderRequest = DeleteOpenShellProviderRequest &
     sandboxName: string;
   }>;
 
+export type AttachOpenShellProviderRequest = DetachOpenShellProviderRequest;
+
+export type ConfigureOpenShellProviderRefreshRequest = GetOpenShellProviderRequest &
+  Readonly<{
+    credentialKey: string;
+    strategy: string;
+    material: readonly Readonly<{ key: string; value: string }>[];
+    secretMaterial: readonly Readonly<{ key: string; value: string }>[];
+  }>;
+
+export type GetOpenShellProviderRefreshStatusRequest = GetOpenShellProviderRequest &
+  Readonly<{
+    credentialKey: string;
+  }>;
+
 export type OpenShellProviderProfileImport = Readonly<{
   state: "already_present" | "imported";
 }>;
@@ -128,6 +144,18 @@ export type OpenShellProviderDelete = Readonly<{
 
 export type OpenShellProviderDetach = Readonly<{
   state: "absent" | "detached";
+}>;
+
+export type OpenShellProviderAttach = Readonly<{
+  state: "attached";
+}>;
+
+export type OpenShellProviderRefreshConfiguration = Readonly<{
+  state: "configured";
+}>;
+
+export type OpenShellProviderRefreshStatus = Readonly<{
+  status: string | null;
 }>;
 
 /** Transport-neutral provider operations used by NemoClaw consumers. */
@@ -167,4 +195,27 @@ export interface OpenShellProviderAdapter {
   detachProvider(
     request: DetachOpenShellProviderRequest,
   ): Promise<OpenShellProviderResult<OpenShellProviderDetach>>;
+
+  attachProvider(
+    request: AttachOpenShellProviderRequest,
+  ): Promise<OpenShellProviderResult<OpenShellProviderAttach>>;
+
+  configureProviderRefresh(
+    request: ConfigureOpenShellProviderRefreshRequest,
+  ): Promise<OpenShellProviderResult<OpenShellProviderRefreshConfiguration>>;
+
+  getProviderRefreshStatus(
+    request: GetOpenShellProviderRefreshStatusRequest,
+  ): Promise<OpenShellProviderResult<OpenShellProviderRefreshStatus>>;
+}
+
+/** Synchronous typed reads for onboarding decisions made before async provider mutation. */
+export interface OpenShellProviderInspectionAdapter {
+  getProvider(
+    request: GetOpenShellProviderRequest,
+  ): OpenShellProviderResult<OpenShellProviderMetadata>;
+
+  inspectProviderProfile(
+    request: InspectOpenShellProviderProfileRequest,
+  ): OpenShellProviderResult<OpenShellProviderProfileInspection>;
 }

--- a/src/lib/adapters/openshell/provider-profile-contract.ts
+++ b/src/lib/adapters/openshell/provider-profile-contract.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from "node:crypto";
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((entry) => canonicalize(entry));
+  if (!value || typeof value !== "object") return value;
+  const record = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(record)
+      .sort()
+      .map((key) => [key, canonicalize(record[key])]),
+  );
+}
+
+function refreshContract(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const refresh = value as Record<string, unknown>;
+  if (
+    typeof refresh.strategy !== "string" ||
+    !refresh.strategy ||
+    !Array.isArray(refresh.scopes) ||
+    refresh.scopes.some((scope) => typeof scope !== "string") ||
+    !Array.isArray(refresh.material)
+  ) {
+    return null;
+  }
+  const material = refresh.material.map((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    const entry = value as Record<string, unknown>;
+    if (typeof entry.name !== "string" || !entry.name) return null;
+    return {
+      name: entry.name,
+      required: entry.required,
+      secret: entry.secret,
+    };
+  });
+  if (material.some((entry) => entry === null)) return null;
+  return {
+    strategy: refresh.strategy,
+    scopes: refresh.scopes,
+    material,
+  };
+}
+
+function providerProfileContract(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const profile = value as Record<string, unknown>;
+  if (
+    typeof profile.id !== "string" ||
+    !Array.isArray(profile.credentials) ||
+    !Array.isArray(profile.endpoints) ||
+    !Array.isArray(profile.binaries) ||
+    typeof profile.inference_capable !== "boolean"
+  ) {
+    return null;
+  }
+  const credentials = profile.credentials.map((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    const credential = value as Record<string, unknown>;
+    if (
+      typeof credential.name !== "string" ||
+      !credential.name ||
+      !Array.isArray(credential.env_vars) ||
+      credential.env_vars.some((envVar) => typeof envVar !== "string") ||
+      typeof credential.required !== "boolean" ||
+      typeof credential.auth_style !== "string" ||
+      typeof credential.header_name !== "string" ||
+      typeof credential.query_param !== "string"
+    ) {
+      return null;
+    }
+    const refresh = credential.refresh === undefined ? null : refreshContract(credential.refresh);
+    if (credential.refresh !== undefined && refresh === null) return null;
+    return {
+      name: credential.name,
+      env_vars: credential.env_vars,
+      required: credential.required,
+      auth_style: credential.auth_style,
+      header_name: credential.header_name,
+      query_param: credential.query_param,
+      refresh,
+    };
+  });
+  if (credentials.some((credential) => credential === null)) return null;
+  return {
+    id: profile.id,
+    credentials,
+    endpoints: profile.endpoints,
+    binaries: profile.binaries,
+    inference_capable: profile.inference_capable,
+  };
+}
+
+/** Stable digest of the provider fields that define its credential boundary. */
+export function providerProfileContractDigest(value: unknown): string | null {
+  const contract = providerProfileContract(value);
+  if (!contract) return null;
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalize(contract)))
+    .digest("hex");
+}

--- a/src/lib/messaging/AGENTS.md
+++ b/src/lib/messaging/AGENTS.md
@@ -43,6 +43,14 @@ The design goal is to keep messaging channel behavior out of core onboard/rebuil
 - Hook outputs must match manifest declarations and be JSON-serializable. Add outputs to the manifest before consuming them.
 - Channel render/build-file targets must stay inside `/sandbox/.openclaw` or `/sandbox/.hermes`; rely on existing applier validation instead of bypassing it.
 - Disabled channels are not active. Always filter effects through `enabledPlanChannels()` or `filterEnabledPlanEntries()` when applying providers, policies, render, hooks, runtime setup, or conflicts.
+- Route messaging provider profile inspection, get, create, update, standalone attachment, replacement, verification, and refresh observation through typed `OpenShellProviderAdapter` or `OpenShellProviderInspectionAdapter` results.
+- Atomic sandbox creation may pass preflighted provider names through `sandbox create --provider`; do not use that path for standalone attachment or provider state inspection.
+- Preflight every provider definition before profile preparation or mutation, and preserve exact created or mutated provider names on a partial failure.
+- Provider replacement must be explicit, identity-revalidated, and limited to the caller's authorized sandbox attachments.
+- Keep persistent source credentials in the existing environment or credential store; never copy them into serializable messaging plans.
+- During provider application, short-lived host-side copies may exist in token definitions, the application plan, adapter requests, and the OpenShell child environment.
+- Never place those copies in command arguments, logs, persistence, serializable plans, or typed adapter results.
+- Let the short-lived references leave scope after the awaited provider lifecycle returns; JavaScript does not guarantee immediate memory erasure.
 - Conflict detection has two axes: generic credential-hash overlap in `applier/conflict-detection/` and channel-owned `pre-enable` hooks such as Slack Socket Mode gateway checks.
 - Keep transitional compatibility tables derived from manifests. `src/lib/sandbox/channels.ts` intentionally builds legacy CLI metadata from `listBuiltInMessagingChannelManifests()`.
 
@@ -81,7 +89,9 @@ Start with `channels/<channel>/manifest.ts`.
 - New prompt, token, allowlist, provider, policy, render, package install, runtime setup, state hydration, or health-check metadata belongs in a channel manifest.
 - Nontrivial render derivation belongs in a channel template resolver.
 - Enrollment, external reachability checks, QR capture, channel-specific conflict checks, runtime status, and health probes belong in hooks.
-- Provider creation/reuse, policy application, config-file writes, plan env encoding, and registry persistence belong in `applier/`.
+- Provider preflight, profile validation, creation, reuse, replacement, verification, and refresh observation belong in `applier/` behind the typed OpenShell adapter.
+- Translation from onboarding token definitions to typed messaging provider definitions belongs in `applier/provider-application.ts`.
+- Policy application, config-file writes, plan env encoding, and registry persistence belong in `applier/`.
 - Onboard and `actions/sandbox/policy-channel.ts` should orchestrate planner/applier calls, not grow channel-specific rules.
 - Build-time config generation should use the compiled plan and `applier/build/messaging-build-applier.mts`; do not reintroduce channel-specific config rendering in `scripts/generate-openclaw-config.mts` or `agents/hermes/generate-config.ts`.
 

--- a/src/lib/messaging/README.md
+++ b/src/lib/messaging/README.md
@@ -19,6 +19,7 @@ flowchart TD
   compiler["ManifestCompiler"]
   plan["SandboxMessagingPlan"]
   setup["MessagingSetupApplier"]
+  provider["typed OpenShell provider adapter"]
   dockerfile["src/lib/onboard/dockerfile-patch.ts"]
   build["applier/build/messaging-build-applier.mts"]
   openshell["OpenShell providers, policy, forwards, and config files"]
@@ -30,7 +31,8 @@ flowchart TD
   planner --> compiler
   compiler --> plan
   plan --> setup
-  setup --> openshell
+  setup --> provider
+  provider --> openshell
   setup --> dockerfile
   dockerfile --> build
   build --> openshell
@@ -186,6 +188,22 @@ Important plan sections are:
 
 Disabled channels must not produce side effects.
 Use `enabledPlanChannels()` and `filterEnabledPlanEntries()` before applying providers, policy, render entries, runtime setup, hooks, host forwards, or conflict checks.
+
+## Provider Lifecycle Boundary
+
+`applier/provider-application.ts` translates onboarding and channel token definitions into typed provider definitions, checked-in profile contracts, and refresh requests.
+`MessagingSetupApplier.applyCredentialsAtOpenShell()` owns provider preflight, profile preparation, create or update, replacement, verification, and refresh observation.
+All provider inspection and mutation crosses a typed adapter boundary; asynchronous lifecycle work uses `OpenShellProviderAdapter`, while synchronous onboarding preflight uses `OpenShellProviderInspectionAdapter`.
+Callers do not classify provider state from raw CLI text.
+
+The applier preflights every definition before it prepares profiles or changes provider state.
+Checked-in profiles are imported and then compared by a stable digest of their credential-boundary fields.
+Replacement is opt-in and may detach only explicitly allowed sandboxes after identity revalidation.
+Failures report the exact provider names already created or mutated so channel recovery can remove new providers and explain incomplete replacements or updates.
+Persistent source credentials remain in the existing environment or credential store and never enter serializable messaging plans.
+During provider application, short-lived copies may exist in token definitions, the application plan, adapter requests, and the OpenShell child environment.
+The CLI does not put those copies in command arguments, logs, persistence, or typed adapter results, and their local references leave scope after the awaited lifecycle returns.
+Sandbox create, reuse, direct channel add, and rollback await this lifecycle before publishing provider attachments or registry state.
 
 ## Hooks Architecture
 

--- a/src/lib/messaging/README.md
+++ b/src/lib/messaging/README.md
@@ -446,7 +446,7 @@ await planner.buildChannelAddPlanFromSandboxEntry({
 ```ts
 MessagingSetupApplier.writePlanToEnv(plan);
 
-MessagingSetupApplier.applyCredentialsAtOpenShell(plan, credentialOptions);
+await MessagingSetupApplier.applyCredentialsAtOpenShell(plan, credentialOptions);
 MessagingSetupApplier.applyPolicyAtOpenShell(plan, policyOptions);
 await MessagingSetupApplier.applyPreEnableChecks(plan, hookOptions);
 await MessagingSetupApplier.applyAgentConfigAtOpenShell(plan, configOptions);

--- a/src/lib/messaging/applier/openshell-provider.test.ts
+++ b/src/lib/messaging/applier/openshell-provider.test.ts
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { OpenShellProviderAdapter } from "../../adapters/openshell/provider-adapter";
+import type { SandboxMessagingPlan } from "../manifest";
+import { applyCredentialsAtOpenShell } from "./openshell-provider";
+
+const TELEGRAM_PROVIDER = "demo-telegram-bridge";
+const TELEGRAM_TOKEN = "123456:telegram-token";
+
+function telegramPlan(): SandboxMessagingPlan {
+  return {
+    schemaVersion: 1,
+    sandboxName: "demo",
+    agent: "openclaw",
+    workflow: "onboard",
+    channels: [
+      {
+        channelId: "telegram",
+        displayName: "Telegram",
+        authMode: "token-paste",
+        active: true,
+        selected: true,
+        configured: true,
+        disabled: false,
+        inputs: [],
+        hooks: [],
+      },
+    ],
+    disabledChannels: [],
+    credentialBindings: [
+      {
+        channelId: "telegram",
+        credentialId: "telegram-bot-token",
+        sourceInput: "bot-token",
+        providerName: TELEGRAM_PROVIDER,
+        providerEnvKey: "TELEGRAM_BOT_TOKEN",
+        placeholder: "openshell:resolve:env:TELEGRAM_BOT_TOKEN",
+        credentialAvailable: true,
+      },
+    ],
+    networkPolicy: { presets: [], entries: [] },
+    agentRender: [],
+    buildSteps: [],
+    stateUpdates: [],
+    healthChecks: [],
+  };
+}
+
+describe("messaging OpenShell provider application", () => {
+  it.each([
+    {
+      label: "string output",
+      output: JSON.stringify({
+        id: "nemoclaw-mcp-v1",
+        credentials: [],
+        endpoints: [],
+        binaries: [],
+        inference_capable: false,
+      }),
+    },
+    {
+      label: "stdio array output",
+      output: [
+        null,
+        JSON.stringify({
+          id: "nemoclaw-mcp-v1",
+          credentials: [],
+          endpoints: [],
+          binaries: [],
+          inference_capable: false,
+        }),
+        "",
+      ],
+    },
+  ])("accepts a valid profile from legacy $label (#9806)", async ({ output }) => {
+    const result = await applyCredentialsAtOpenShell(telegramPlan(), {
+      env: {},
+      runOpenshell: (args) =>
+        args[1] === "profile"
+          ? { status: 0, output }
+          : { status: 1, output: `provider '${TELEGRAM_PROVIDER}' not found` },
+    });
+
+    expect(result.missing).toEqual([expect.objectContaining({ providerName: TELEGRAM_PROVIDER })]);
+  });
+
+  it("makes provider decisions from typed adapter results (#9806)", async () => {
+    const getProvider = vi
+      .fn<OpenShellProviderAdapter["getProvider"]>()
+      .mockResolvedValueOnce({
+        ok: false,
+        error: {
+          kind: "command",
+          reason: "not_found",
+          message: "OpenShell provider was not found.",
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: {
+          name: TELEGRAM_PROVIDER,
+          type: "nemoclaw-mcp-v1",
+          credentialKeys: ["TELEGRAM_BOT_TOKEN"],
+          configKeys: [],
+        },
+      });
+    const createProvider = vi.fn<OpenShellProviderAdapter["createProvider"]>(async () => ({
+      ok: true,
+      value: { state: "created" },
+    }));
+    const providerAdapter = {
+      ensureEndpointlessProviderProfile: vi.fn(async () => ({
+        ok: true as const,
+        value: { state: "ready" as const },
+      })),
+      getProvider,
+      createProvider,
+    } as unknown as OpenShellProviderAdapter;
+
+    const result = await applyCredentialsAtOpenShell(telegramPlan(), {
+      env: { TELEGRAM_BOT_TOKEN: TELEGRAM_TOKEN },
+      providerAdapter,
+    });
+
+    expect(createProvider).toHaveBeenCalledWith({
+      target: { kind: "selected" },
+      name: TELEGRAM_PROVIDER,
+      type: "nemoclaw-mcp-v1",
+      credentials: [{ name: "TELEGRAM_BOT_TOKEN", value: TELEGRAM_TOKEN }],
+      config: [],
+      fromExisting: false,
+    });
+    expect(result.upserted).toEqual([
+      expect.objectContaining({ action: "create", providerName: TELEGRAM_PROVIDER }),
+    ]);
+    expect(JSON.stringify(result)).not.toContain(TELEGRAM_TOKEN);
+  });
+
+  it("does not expose a rejected CLI runner through the typed boundary (#9806)", async () => {
+    const result = applyCredentialsAtOpenShell(telegramPlan(), {
+      env: { TELEGRAM_BOT_TOKEN: TELEGRAM_TOKEN },
+      runOpenshell: (args) =>
+        args[1] === "profile"
+          ? {
+              status: 0,
+              stdout: JSON.stringify({
+                id: "nemoclaw-mcp-v1",
+                credentials: [],
+                endpoints: [],
+                binaries: [],
+                inference_capable: false,
+              }),
+            }
+          : (() => {
+              throw new Error(`untrusted runner diagnostic with ${TELEGRAM_TOKEN}`);
+            })(),
+    });
+
+    await expect(result).rejects.toThrow(
+      `Could not inspect messaging provider '${TELEGRAM_PROVIDER}'.`,
+    );
+    await expect(result).rejects.not.toThrow(/telegram-token/u);
+  });
+});

--- a/src/lib/messaging/applier/openshell-provider.test.ts
+++ b/src/lib/messaging/applier/openshell-provider.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { OpenShellProviderAdapter } from "../../adapters/openshell/provider-adapter";
 import type { SandboxMessagingPlan } from "../manifest";
-import { applyCredentialsAtOpenShell } from "./openshell-provider";
+import { applyCredentialsAtOpenShell, MessagingProviderApplyError } from "./openshell-provider";
 
 const TELEGRAM_PROVIDER = "demo-telegram-bridge";
 const TELEGRAM_TOKEN = "123456:telegram-token";
@@ -72,6 +72,22 @@ function telegramPlan(): SandboxMessagingPlan {
     buildSteps: [],
     stateUpdates: [],
     healthChecks: [],
+  };
+}
+
+function telegramDefinition(value: string | null = TELEGRAM_TOKEN) {
+  return {
+    channelId: "telegram" as const,
+    credentialId: "telegram-bot-token",
+    providerName: TELEGRAM_PROVIDER,
+    providerType: "nemoclaw-mcp-v1",
+    credentials: [{ name: "TELEGRAM_BOT_TOKEN", value }],
+    profile: {
+      kind: "endpointless" as const,
+      profilePath: "/repo/nemoclaw-mcp-v1.yaml",
+      profileType: "nemoclaw-mcp-v1",
+      inferenceCapable: false as const,
+    },
   };
 }
 
@@ -144,6 +160,30 @@ describe("messaging OpenShell provider application", () => {
     expect(updateProvider).not.toHaveBeenCalled();
   });
 
+  it("refuses partial credential material before provider creation (#9806)", async () => {
+    const createProvider = vi.fn<OpenShellProviderAdapter["createProvider"]>();
+    const adapter = providerAdapter({
+      getProvider: vi.fn(async () => PROVIDER_NOT_FOUND),
+      createProvider,
+    });
+
+    await expect(
+      applyCredentialsAtOpenShell(telegramPlan(), {
+        providerAdapter: adapter,
+        definitions: [
+          {
+            ...telegramDefinition(),
+            credentials: [
+              { name: "TELEGRAM_BOT_TOKEN", value: TELEGRAM_TOKEN },
+              { name: "TELEGRAM_SECONDARY_TOKEN", value: null },
+            ],
+          },
+        ],
+      }),
+    ).rejects.toThrow("is missing required credential material for creation");
+    expect(createProvider).not.toHaveBeenCalled();
+  });
+
   it.each([
     { action: "create", observed: PROVIDER_NOT_FOUND },
     { action: "update", observed: { ok: true as const, value: EXACT_PROVIDER } },
@@ -206,5 +246,480 @@ describe("messaging OpenShell provider application", () => {
     );
     expect(updateProvider).toHaveBeenCalledOnce();
     expect(getProvider).toHaveBeenCalledTimes(2);
+  });
+
+  it("preflights every provider before preparing profiles or mutating state (#9806)", async () => {
+    const ensureEndpointlessProviderProfile = vi.fn();
+    const createProvider = vi.fn<OpenShellProviderAdapter["createProvider"]>();
+    const adapter = providerAdapter({
+      getProvider: vi.fn(async ({ providerName }) =>
+        providerName === TELEGRAM_PROVIDER
+          ? PROVIDER_NOT_FOUND
+          : {
+              ok: true as const,
+              value: {
+                name: providerName,
+                type: "foreign",
+                credentialKeys: ["SECOND_TOKEN"],
+                configKeys: [],
+              },
+            },
+      ),
+      ensureEndpointlessProviderProfile,
+      createProvider,
+    });
+
+    await expect(
+      applyCredentialsAtOpenShell(telegramPlan(), {
+        providerAdapter: adapter,
+        definitions: [
+          telegramDefinition(),
+          {
+            ...telegramDefinition("second-token"),
+            channelId: "slack",
+            credentialId: "second-token",
+            providerName: "demo-second-bridge",
+            credentials: [{ name: "SECOND_TOKEN", value: "second-token" }],
+          },
+        ],
+      }),
+    ).rejects.toThrow("does not match the required endpointless credential binding");
+    expect(ensureEndpointlessProviderProfile).not.toHaveBeenCalled();
+    expect(createProvider).not.toHaveBeenCalled();
+  });
+
+  it("replaces an authorized attached provider before recreating it (#9806)", async () => {
+    const operations: string[] = [];
+    const getProvider = vi
+      .fn<OpenShellProviderAdapter["getProvider"]>()
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { ...EXACT_PROVIDER, type: "foreign" },
+      })
+      .mockResolvedValueOnce({ ok: true, value: EXACT_PROVIDER });
+    const deleteProvider = vi
+      .fn<OpenShellProviderAdapter["deleteProvider"]>()
+      .mockImplementationOnce(async () => {
+        operations.push("delete");
+        return {
+          ok: false,
+          error: {
+            kind: "command",
+            reason: "attached",
+            message: "provider is attached",
+            attachedSandboxes: ["demo"],
+          },
+        };
+      })
+      .mockImplementationOnce(async () => {
+        operations.push("delete");
+        return { ok: true, value: { state: "deleted" } };
+      });
+    const detachProvider = vi.fn<OpenShellProviderAdapter["detachProvider"]>(async () => {
+      operations.push("detach:demo");
+      return { ok: true, value: { state: "detached" } };
+    });
+    const createProvider = vi.fn<OpenShellProviderAdapter["createProvider"]>(async () => {
+      operations.push("create");
+      return { ok: true, value: { state: "created" } };
+    });
+    const revalidateSandboxIdentity = vi.fn();
+
+    const result = await applyCredentialsAtOpenShell(telegramPlan(), {
+      providerAdapter: providerAdapter({
+        getProvider,
+        deleteProvider,
+        detachProvider,
+        createProvider,
+      }),
+      definitions: [telegramDefinition()],
+      replaceExisting: true,
+      allowedSandboxes: ["demo"],
+      revalidateSandboxIdentity,
+    });
+
+    expect(operations).toEqual(["delete", "detach:demo", "delete", "create"]);
+    expect(revalidateSandboxIdentity.mock.calls.map(([operation]) => operation)).toEqual([
+      `delete messaging provider "${TELEGRAM_PROVIDER}"`,
+      `detach messaging provider "${TELEGRAM_PROVIDER}" from sandbox "demo"`,
+      `delete messaging provider "${TELEGRAM_PROVIDER}"`,
+    ]);
+    expect(result.upserted).toEqual([
+      expect.objectContaining({ action: "create", providerName: TELEGRAM_PROVIDER }),
+    ]);
+  });
+
+  it("reports a deleted provider as an incomplete replacement when recreate fails (#9806)", async () => {
+    const adapter = providerAdapter({
+      getProvider: vi.fn(async () => ({
+        ok: true as const,
+        value: { ...EXACT_PROVIDER, type: "foreign" },
+      })),
+      deleteProvider: vi.fn(async () => ({
+        ok: true as const,
+        value: { state: "deleted" as const },
+      })),
+      createProvider: vi.fn(async () => ({
+        ok: false as const,
+        error: {
+          kind: "command" as const,
+          reason: "failed" as const,
+          message: "provider create failed",
+        },
+      })),
+    });
+
+    await expect(
+      applyCredentialsAtOpenShell(telegramPlan(), {
+        providerAdapter: adapter,
+        definitions: [telegramDefinition()],
+        replaceExisting: true,
+      }),
+    ).rejects.toMatchObject({
+      mutatedProviderNames: [TELEGRAM_PROVIDER],
+      createdProviderNames: [],
+    });
+  });
+
+  it("does not report or perform a mutation for an unauthorized attachment (#9806)", async () => {
+    const detachProvider = vi.fn<OpenShellProviderAdapter["detachProvider"]>();
+    const createProvider = vi.fn<OpenShellProviderAdapter["createProvider"]>();
+    const adapter = providerAdapter({
+      getProvider: vi.fn(async () => ({
+        ok: true as const,
+        value: { ...EXACT_PROVIDER, type: "foreign" },
+      })),
+      deleteProvider: vi.fn(async () => ({
+        ok: false as const,
+        error: {
+          kind: "command" as const,
+          reason: "attached" as const,
+          message: "provider is attached",
+          attachedSandboxes: ["other-sandbox"],
+        },
+      })),
+      detachProvider,
+      createProvider,
+    });
+
+    await expect(
+      applyCredentialsAtOpenShell(telegramPlan(), {
+        providerAdapter: adapter,
+        definitions: [telegramDefinition()],
+        replaceExisting: true,
+        allowedSandboxes: ["demo"],
+      }),
+    ).rejects.toMatchObject({
+      mutatedProviderNames: [],
+      createdProviderNames: [],
+    });
+    expect(detachProvider).not.toHaveBeenCalled();
+    expect(createProvider).not.toHaveBeenCalled();
+  });
+
+  it("returns exact partial-mutation evidence when create verification fails (#9806)", async () => {
+    const getProvider = vi
+      .fn<OpenShellProviderAdapter["getProvider"]>()
+      .mockResolvedValueOnce(PROVIDER_NOT_FOUND)
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { ...EXACT_PROVIDER, type: "foreign" },
+      });
+    const createProvider = vi.fn<OpenShellProviderAdapter["createProvider"]>(async () => ({
+      ok: true,
+      value: { state: "created" },
+    }));
+
+    const result = applyCredentialsAtOpenShell(telegramPlan(), {
+      providerAdapter: providerAdapter({ getProvider, createProvider }),
+      definitions: [telegramDefinition()],
+    });
+
+    await expect(result).rejects.toBeInstanceOf(MessagingProviderApplyError);
+    await expect(result).rejects.toMatchObject({
+      mutatedProviderNames: [TELEGRAM_PROVIDER],
+      createdProviderNames: [TELEGRAM_PROVIDER],
+    });
+  });
+
+  it("imports and verifies a checked-in provider profile before reuse (#9806)", async () => {
+    const contractDigest = "profile-contract-digest";
+    const importProviderProfile = vi.fn(async () => ({
+      ok: true as const,
+      value: { state: "already_present" as const },
+    }));
+    const inspectProviderProfile = vi.fn(async () => ({
+      ok: true as const,
+      value: { credentialKeys: ["GOOGLE_CHAT_ACCESS_TOKEN"], contractDigest },
+    }));
+    const definition = {
+      ...telegramDefinition(null),
+      channelId: "googlechat" as const,
+      credentialId: "google-chat-access-token",
+      providerName: "demo-google-chat-bridge",
+      providerType: "google-chat-bridge",
+      credentials: [{ name: "GOOGLE_CHAT_ACCESS_TOKEN", value: null }],
+      profile: {
+        kind: "checked-in" as const,
+        profilePath: "/repo/google-chat.yaml",
+        profileType: "google-chat-bridge",
+        contractDigest,
+      },
+    };
+    const adapter = providerAdapter({
+      getProvider: vi.fn(async () => ({
+        ok: true as const,
+        value: {
+          name: definition.providerName,
+          type: definition.providerType,
+          credentialKeys: ["GOOGLE_CHAT_ACCESS_TOKEN"],
+          configKeys: [],
+        },
+      })),
+      importProviderProfile,
+      inspectProviderProfile,
+    });
+
+    const result = await applyCredentialsAtOpenShell(telegramPlan(), {
+      providerAdapter: adapter,
+      definitions: [definition],
+    });
+
+    expect(importProviderProfile).toHaveBeenCalledWith({
+      target: { kind: "selected" },
+      profilePath: "/repo/google-chat.yaml",
+    });
+    expect(inspectProviderProfile).toHaveBeenCalledWith({
+      target: { kind: "selected" },
+      profileType: "google-chat-bridge",
+    });
+    expect(result.reused).toEqual([
+      expect.objectContaining({ providerName: definition.providerName }),
+    ]);
+  });
+
+  it("rejects a checked-in profile contract mismatch before provider mutation (#9806)", async () => {
+    const createProvider = vi.fn<OpenShellProviderAdapter["createProvider"]>();
+    const definition = {
+      ...telegramDefinition(),
+      providerType: "google-chat-bridge",
+      profile: {
+        kind: "checked-in" as const,
+        profilePath: "/repo/google-chat.yaml",
+        profileType: "google-chat-bridge",
+        contractDigest: "expected-digest",
+      },
+    };
+    const adapter = providerAdapter({
+      getProvider: vi.fn(async () => PROVIDER_NOT_FOUND),
+      importProviderProfile: vi.fn(async () => ({
+        ok: true as const,
+        value: { state: "imported" as const },
+      })),
+      inspectProviderProfile: vi.fn(async () => ({
+        ok: true as const,
+        value: { credentialKeys: ["TELEGRAM_BOT_TOKEN"], contractDigest: "foreign-digest" },
+      })),
+      createProvider,
+    });
+
+    await expect(
+      applyCredentialsAtOpenShell(telegramPlan(), {
+        providerAdapter: adapter,
+        definitions: [definition],
+      }),
+    ).rejects.toThrow("does not match NemoClaw's checked-in credential contract");
+    expect(createProvider).not.toHaveBeenCalled();
+  });
+
+  it("rejects conflicting definitions for one checked-in profile before inspection (#9806)", async () => {
+    const getProvider = vi.fn<OpenShellProviderAdapter["getProvider"]>();
+    const definition = {
+      ...telegramDefinition(),
+      providerType: "google-chat-bridge",
+      profile: {
+        kind: "checked-in" as const,
+        profilePath: "/repo/google-chat.yaml",
+        profileType: "google-chat-bridge",
+        contractDigest: "expected-digest",
+      },
+    };
+
+    await expect(
+      applyCredentialsAtOpenShell(telegramPlan(), {
+        providerAdapter: providerAdapter({ getProvider }),
+        definitions: [
+          definition,
+          {
+            ...definition,
+            providerName: "demo-second-google-chat-bridge",
+            profile: { ...definition.profile, contractDigest: "different-digest" },
+          },
+        ],
+      }),
+    ).rejects.toThrow("profile 'google-chat-bridge' has conflicting definitions");
+    expect(getProvider).not.toHaveBeenCalled();
+  });
+
+  it("rejects refresh credentials outside the provider definition before inspection (#9806)", async () => {
+    const getProvider = vi.fn<OpenShellProviderAdapter["getProvider"]>();
+
+    await expect(
+      applyCredentialsAtOpenShell(telegramPlan(), {
+        providerAdapter: providerAdapter({ getProvider }),
+        definitions: [telegramDefinition()],
+        refreshes: [
+          {
+            channelId: "googlechat",
+            providerName: TELEGRAM_PROVIDER,
+            credentialKey: "FOREIGN_TOKEN",
+            strategy: "test-refresh",
+            material: [{ key: "client_email", value: "bot@example.com" }],
+            secretMaterial: [{ key: "private_key", value: "host-only-private-key" }],
+          },
+        ],
+      }),
+    ).rejects.toThrow(
+      `Messaging provider '${TELEGRAM_PROVIDER}' has an invalid refresh definition.`,
+    );
+    expect(getProvider).not.toHaveBeenCalled();
+  });
+
+  it("configures and observes refresh through typed secret-safe results (#9806)", async () => {
+    const privateKey = "host-only-private-key";
+    const getProvider = vi
+      .fn<OpenShellProviderAdapter["getProvider"]>()
+      .mockResolvedValueOnce({ ok: true, value: EXACT_PROVIDER })
+      .mockResolvedValueOnce({ ok: true, value: EXACT_PROVIDER });
+    const configureProviderRefresh = vi.fn(async () => ({
+      ok: true as const,
+      value: { state: "configured" as const },
+    }));
+    const getProviderRefreshStatus = vi
+      .fn<OpenShellProviderAdapter["getProviderRefreshStatus"]>()
+      .mockResolvedValueOnce({ ok: true, value: { status: "pending" } })
+      .mockResolvedValueOnce({ ok: true, value: { status: "refreshed" } });
+    const sleep = vi.fn(async () => undefined);
+    const adapter = providerAdapter({
+      getProvider,
+      updateProvider: vi.fn(async () => ({
+        ok: true as const,
+        value: { state: "updated" as const },
+      })),
+      configureProviderRefresh,
+      getProviderRefreshStatus,
+    });
+
+    const result = await applyCredentialsAtOpenShell(telegramPlan(), {
+      providerAdapter: adapter,
+      definitions: [telegramDefinition()],
+      refreshes: [
+        {
+          channelId: "googlechat",
+          providerName: TELEGRAM_PROVIDER,
+          credentialKey: "TELEGRAM_BOT_TOKEN",
+          strategy: "test-refresh",
+          material: [{ key: "client_email", value: "bot@example.com" }],
+          secretMaterial: [{ key: "private_key", value: privateKey }],
+        },
+      ],
+      sleep,
+      now: () => 0,
+    });
+
+    expect(configureProviderRefresh).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerName: TELEGRAM_PROVIDER,
+        secretMaterial: [{ key: "private_key", value: privateKey }],
+      }),
+    );
+    expect(getProviderRefreshStatus).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(3_000);
+    expect(JSON.stringify(result)).not.toContain(privateKey);
+  });
+
+  it("preserves a typed refresh observation failure instead of reporting an unknown status (#9806)", async () => {
+    const adapter = providerAdapter({
+      getProvider: vi
+        .fn<OpenShellProviderAdapter["getProvider"]>()
+        .mockResolvedValueOnce({ ok: true, value: EXACT_PROVIDER })
+        .mockResolvedValueOnce({ ok: true, value: EXACT_PROVIDER }),
+      updateProvider: vi.fn(async () => ({
+        ok: true as const,
+        value: { state: "updated" as const },
+      })),
+      configureProviderRefresh: vi.fn(async () => ({
+        ok: true as const,
+        value: { state: "configured" as const },
+      })),
+      getProviderRefreshStatus: vi.fn(async () => ({
+        ok: false as const,
+        error: {
+          kind: "authentication" as const,
+          message: "OpenShell could not authenticate the provider operation.",
+        },
+      })),
+    });
+
+    await expect(
+      applyCredentialsAtOpenShell(telegramPlan(), {
+        providerAdapter: adapter,
+        definitions: [telegramDefinition()],
+        refreshes: [
+          {
+            channelId: "googlechat",
+            providerName: TELEGRAM_PROVIDER,
+            credentialKey: "TELEGRAM_BOT_TOKEN",
+            strategy: "test-refresh",
+            material: [],
+            secretMaterial: [{ key: "private_key", value: "host-only-private-key" }],
+          },
+        ],
+        sleep: async () => undefined,
+        now: () => 0,
+      }),
+    ).rejects.toThrow(
+      "Could not observe gateway token minting for messaging provider 'demo-telegram-bridge': OpenShell could not authenticate the provider operation.",
+    );
+  });
+
+  it("reports the last successful pending refresh status separately from observation errors (#9806)", async () => {
+    const adapter = providerAdapter({
+      getProvider: vi
+        .fn<OpenShellProviderAdapter["getProvider"]>()
+        .mockResolvedValueOnce({ ok: true, value: EXACT_PROVIDER })
+        .mockResolvedValueOnce({ ok: true, value: EXACT_PROVIDER }),
+      updateProvider: vi.fn(async () => ({
+        ok: true as const,
+        value: { state: "updated" as const },
+      })),
+      configureProviderRefresh: vi.fn(async () => ({
+        ok: true as const,
+        value: { state: "configured" as const },
+      })),
+      getProviderRefreshStatus: vi.fn(async () => ({
+        ok: true as const,
+        value: { status: "pending" },
+      })),
+    });
+
+    await expect(
+      applyCredentialsAtOpenShell(telegramPlan(), {
+        providerAdapter: adapter,
+        definitions: [telegramDefinition()],
+        refreshes: [
+          {
+            channelId: "googlechat",
+            providerName: TELEGRAM_PROVIDER,
+            credentialKey: "TELEGRAM_BOT_TOKEN",
+            strategy: "test-refresh",
+            material: [],
+            secretMaterial: [{ key: "private_key", value: "host-only-private-key" }],
+          },
+        ],
+        sleep: async () => undefined,
+        now: () => 0,
+      }),
+    ).rejects.toThrow("last status 'pending'");
   });
 });

--- a/src/lib/messaging/applier/openshell-provider.test.ts
+++ b/src/lib/messaging/applier/openshell-provider.test.ts
@@ -10,6 +10,32 @@ import { applyCredentialsAtOpenShell } from "./openshell-provider";
 const TELEGRAM_PROVIDER = "demo-telegram-bridge";
 const TELEGRAM_TOKEN = "123456:telegram-token";
 
+const EXACT_PROVIDER = {
+  name: TELEGRAM_PROVIDER,
+  type: "nemoclaw-mcp-v1",
+  credentialKeys: ["TELEGRAM_BOT_TOKEN"],
+  configKeys: [],
+} as const;
+
+const PROVIDER_NOT_FOUND = {
+  ok: false as const,
+  error: {
+    kind: "command" as const,
+    reason: "not_found" as const,
+    message: "OpenShell provider was not found.",
+  },
+};
+
+function providerAdapter(operations: Partial<OpenShellProviderAdapter>): OpenShellProviderAdapter {
+  return {
+    ensureEndpointlessProviderProfile: vi.fn(async () => ({
+      ok: true as const,
+      value: { state: "ready" as const },
+    })),
+    ...operations,
+  } as unknown as OpenShellProviderAdapter;
+}
+
 function telegramPlan(): SandboxMessagingPlan {
   return {
     schemaVersion: 1,
@@ -50,43 +76,6 @@ function telegramPlan(): SandboxMessagingPlan {
 }
 
 describe("messaging OpenShell provider application", () => {
-  it.each([
-    {
-      label: "string output",
-      output: JSON.stringify({
-        id: "nemoclaw-mcp-v1",
-        credentials: [],
-        endpoints: [],
-        binaries: [],
-        inference_capable: false,
-      }),
-    },
-    {
-      label: "stdio array output",
-      output: [
-        null,
-        JSON.stringify({
-          id: "nemoclaw-mcp-v1",
-          credentials: [],
-          endpoints: [],
-          binaries: [],
-          inference_capable: false,
-        }),
-        "",
-      ],
-    },
-  ])("accepts a valid profile from legacy $label (#9806)", async ({ output }) => {
-    const result = await applyCredentialsAtOpenShell(telegramPlan(), {
-      env: {},
-      runOpenshell: (args) =>
-        args[1] === "profile"
-          ? { status: 0, output }
-          : { status: 1, output: `provider '${TELEGRAM_PROVIDER}' not found` },
-    });
-
-    expect(result.missing).toEqual([expect.objectContaining({ providerName: TELEGRAM_PROVIDER })]);
-  });
-
   it("makes provider decisions from typed adapter results (#9806)", async () => {
     const getProvider = vi
       .fn<OpenShellProviderAdapter["getProvider"]>()
@@ -100,29 +89,20 @@ describe("messaging OpenShell provider application", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        value: {
-          name: TELEGRAM_PROVIDER,
-          type: "nemoclaw-mcp-v1",
-          credentialKeys: ["TELEGRAM_BOT_TOKEN"],
-          configKeys: [],
-        },
+        value: EXACT_PROVIDER,
       });
     const createProvider = vi.fn<OpenShellProviderAdapter["createProvider"]>(async () => ({
       ok: true,
       value: { state: "created" },
     }));
-    const providerAdapter = {
-      ensureEndpointlessProviderProfile: vi.fn(async () => ({
-        ok: true as const,
-        value: { state: "ready" as const },
-      })),
+    const adapter = providerAdapter({
       getProvider,
       createProvider,
-    } as unknown as OpenShellProviderAdapter;
+    });
 
     const result = await applyCredentialsAtOpenShell(telegramPlan(), {
       env: { TELEGRAM_BOT_TOKEN: TELEGRAM_TOKEN },
-      providerAdapter,
+      providerAdapter: adapter,
     });
 
     expect(createProvider).toHaveBeenCalledWith({
@@ -139,29 +119,92 @@ describe("messaging OpenShell provider application", () => {
     expect(JSON.stringify(result)).not.toContain(TELEGRAM_TOKEN);
   });
 
-  it("does not expose a rejected CLI runner through the typed boundary (#9806)", async () => {
-    const result = applyCredentialsAtOpenShell(telegramPlan(), {
-      env: { TELEGRAM_BOT_TOKEN: TELEGRAM_TOKEN },
-      runOpenshell: (args) =>
-        args[1] === "profile"
-          ? {
-              status: 0,
-              stdout: JSON.stringify({
-                id: "nemoclaw-mcp-v1",
-                credentials: [],
-                endpoints: [],
-                binaries: [],
-                inference_capable: false,
-              }),
-            }
-          : (() => {
-              throw new Error(`untrusted runner diagnostic with ${TELEGRAM_TOKEN}`);
-            })(),
+  it("refuses a provider collision before mutation (#9806)", async () => {
+    const createProvider = vi.fn<OpenShellProviderAdapter["createProvider"]>();
+    const updateProvider = vi.fn<OpenShellProviderAdapter["updateProvider"]>();
+    const adapter = providerAdapter({
+      getProvider: vi.fn(async () => ({
+        ok: true as const,
+        value: {
+          ...EXACT_PROVIDER,
+          credentialKeys: ["TELEGRAM_BOT_TOKEN", "FOREIGN_TOKEN"],
+        },
+      })),
+      createProvider,
+      updateProvider,
     });
 
-    await expect(result).rejects.toThrow(
-      `Could not inspect messaging provider '${TELEGRAM_PROVIDER}'.`,
+    await expect(
+      applyCredentialsAtOpenShell(telegramPlan(), {
+        env: { TELEGRAM_BOT_TOKEN: TELEGRAM_TOKEN },
+        providerAdapter: adapter,
+      }),
+    ).rejects.toThrow("does not match the required endpointless credential binding");
+    expect(createProvider).not.toHaveBeenCalled();
+    expect(updateProvider).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { action: "create", observed: PROVIDER_NOT_FOUND },
+    { action: "update", observed: { ok: true as const, value: EXACT_PROVIDER } },
+  ])(
+    "does not expose credentials when provider $action fails (#9806)",
+    async ({ action, observed }) => {
+      const createProvider = vi.fn<OpenShellProviderAdapter["createProvider"]>(async () => ({
+        ok: false as const,
+        error: {
+          kind: "command" as const,
+          reason: "failed" as const,
+          message: "OpenShell could not create the selected provider.",
+        },
+      }));
+      const updateProvider = vi.fn<OpenShellProviderAdapter["updateProvider"]>(async () => ({
+        ok: false as const,
+        error: {
+          kind: "command" as const,
+          reason: "failed" as const,
+          message: "OpenShell could not update the selected provider.",
+        },
+      }));
+      const adapter = providerAdapter({
+        getProvider: vi.fn(async () => observed),
+        createProvider,
+        updateProvider,
+      });
+
+      const result = applyCredentialsAtOpenShell(telegramPlan(), {
+        env: { TELEGRAM_BOT_TOKEN: TELEGRAM_TOKEN },
+        providerAdapter: adapter,
+      });
+      await expect(result).rejects.toThrow(`Failed to ${action} messaging provider`);
+      await expect(result).rejects.not.toThrow(/telegram-token/u);
+      expect(action === "create" ? createProvider : updateProvider).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("rejects a changed provider binding after update (#9806)", async () => {
+    const getProvider = vi
+      .fn<OpenShellProviderAdapter["getProvider"]>()
+      .mockResolvedValueOnce({ ok: true, value: EXACT_PROVIDER })
+      .mockResolvedValueOnce({
+        ok: true,
+        value: { ...EXACT_PROVIDER, type: "foreign" },
+      });
+    const updateProvider = vi.fn<OpenShellProviderAdapter["updateProvider"]>(async () => ({
+      ok: true,
+      value: { state: "updated" },
+    }));
+    const adapter = providerAdapter({ getProvider, updateProvider });
+
+    await expect(
+      applyCredentialsAtOpenShell(telegramPlan(), {
+        env: { TELEGRAM_BOT_TOKEN: TELEGRAM_TOKEN },
+        providerAdapter: adapter,
+      }),
+    ).rejects.toThrow(
+      `OpenShell did not confirm messaging provider '${TELEGRAM_PROVIDER}' after update.`,
     );
-    await expect(result).rejects.not.toThrow(/telegram-token/u);
+    expect(updateProvider).toHaveBeenCalledOnce();
+    expect(getProvider).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/messaging/applier/openshell-provider.ts
+++ b/src/lib/messaging/applier/openshell-provider.ts
@@ -1,12 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { inspectGatewayCredentialFamilyProviderBinding } from "../../onboard/gateway-provider-metadata";
+import type {
+  OpenShellProviderAdapter,
+  OpenShellProviderError,
+  OpenShellProviderMetadata,
+} from "../../adapters/openshell/provider-adapter";
+import { createCliOpenShellProviderAdapter } from "../../adapters/openshell/provider-adapter-cli";
+import { selectedOpenShellGateway } from "../../adapters/openshell/sandbox-observer";
+import { matchesGatewayCredentialFamilyProviderBinding } from "../../onboard/gateway-provider-metadata";
 import { REPOSITORY_ROOT } from "../../core/repository-root";
-import { redact } from "../../security/redact";
 import type { SandboxMessagingCredentialBindingPlan, SandboxMessagingPlan } from "../manifest";
 import {
-  ensureMessagingCredentialProviderProfile,
+  messagingCredentialProviderProfilePath,
   MESSAGING_CREDENTIAL_PROVIDER_TYPE,
 } from "../provider-profile";
 import type { MessagingCredentialApplyOptions, MessagingCredentialApplyResult } from "./types";
@@ -20,44 +26,45 @@ type MessagingCredentialBindingLike = Pick<
   "channelId" | "credentialId" | "providerName" | "providerEnvKey"
 >;
 
-export function applyCredentialsAtOpenShell(
+export async function applyCredentialsAtOpenShell(
   plan: SandboxMessagingPlan,
   options: MessagingCredentialApplyOptions,
-): MessagingCredentialApplyResult {
+): Promise<MessagingCredentialApplyResult> {
   const env = options.env ?? process.env;
-  const runOpenshell = options.runOpenshell;
+  const adapter = providerAdapter(options);
+  const target = selectedOpenShellGateway();
   const upserted: MessagingCredentialApplyEntry[] = [];
   const reused: MessagingCredentialReuseEntry[] = [];
   const missing: MessagingMissingCredentialEntry[] = [];
   const activeBindings = filterEnabledPlanEntries(plan, plan.credentialBindings);
 
   if (activeBindings.length > 0) {
-    ensureMessagingCredentialProviderProfile({
-      root: REPOSITORY_ROOT,
-      runOpenshell: (args, runOptions) => runOpenshell(args, runOptions),
+    const profile = await adapter.ensureEndpointlessProviderProfile({
+      target,
+      profilePath: messagingCredentialProviderProfilePath(REPOSITORY_ROOT),
+      profileType: MESSAGING_CREDENTIAL_PROVIDER_TYPE,
+      inferenceCapable: false,
     });
+    if (!profile.ok) throw profileFailure(profile.error);
   }
 
   for (const binding of activeBindings) {
     const credential = readCredentialEnv(env, binding.providerEnvKey);
-    const providerState = inspectGatewayCredentialFamilyProviderBinding(
-      {
-        name: binding.providerName,
-        type: MESSAGING_CREDENTIAL_PROVIDER_TYPE,
-        credentialKey: binding.providerEnvKey,
-      },
-      runOpenshell,
-    );
-    if (providerState.kind === "indeterminate") {
+    const observed = await adapter.getProvider({
+      target,
+      providerName: binding.providerName,
+    });
+    const providerState = classifyProviderBinding(observed, binding);
+    if (providerState === "indeterminate") {
       throw new Error(`Could not inspect messaging provider '${binding.providerName}'.`);
     }
-    if (providerState.kind === "collision") {
+    if (providerState === "collision") {
       throw new Error(
         `Messaging provider '${binding.providerName}' does not match the required endpointless credential binding.`,
       );
     }
     if (!credential) {
-      if (providerState.kind === "exact") {
+      if (providerState === "exact") {
         reused.push(toReuseEntry(binding));
       } else {
         missing.push(toMissingEntry(binding));
@@ -65,29 +72,35 @@ export function applyCredentialsAtOpenShell(
       continue;
     }
 
-    const action = providerState.kind === "exact" ? "update" : "create";
-    const result = runOpenshell(
-      buildProviderArgs(action, binding.providerName, binding.providerEnvKey),
-      {
-        ignoreError: true,
-        env: { [binding.providerEnvKey]: credential },
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
-    if (result.status !== 0) {
+    const action = providerState === "exact" ? "update" : "create";
+    const credentials = [{ name: binding.providerEnvKey, value: credential }];
+    const result =
+      action === "create"
+        ? await adapter.createProvider({
+            target,
+            name: binding.providerName,
+            type: MESSAGING_CREDENTIAL_PROVIDER_TYPE,
+            credentials,
+            config: [],
+            fromExisting: false,
+          })
+        : await adapter.updateProvider({
+            target,
+            providerName: binding.providerName,
+            credentials,
+            config: [],
+          });
+    if (!result.ok) {
       throw new Error(
-        `Failed to ${action} messaging provider '${binding.providerName}': ${compactOutput(result)}`,
+        `Failed to ${action} messaging provider '${binding.providerName}': ${result.error.message}`,
       );
     }
-    const verified = inspectGatewayCredentialFamilyProviderBinding(
-      {
-        name: binding.providerName,
-        type: MESSAGING_CREDENTIAL_PROVIDER_TYPE,
-        credentialKey: binding.providerEnvKey,
-      },
-      runOpenshell,
-    );
-    if (verified.kind !== "exact") {
+    const verification = await adapter.getProvider({
+      target,
+      providerName: binding.providerName,
+    });
+    const verified = classifyProviderBinding(verification, binding);
+    if (verified !== "exact") {
       throw new Error(
         `OpenShell did not confirm messaging provider '${binding.providerName}' after ${action}.`,
       );
@@ -125,25 +138,6 @@ function readCredentialEnv(env: NodeJS.ProcessEnv, envKey: string): string | nul
   return normalized || null;
 }
 
-function buildProviderArgs(
-  action: "create" | "update",
-  providerName: string,
-  credentialEnv: string,
-): string[] {
-  return action === "create"
-    ? [
-        "provider",
-        "create",
-        "--name",
-        providerName,
-        "--type",
-        MESSAGING_CREDENTIAL_PROVIDER_TYPE,
-        "--credential",
-        credentialEnv,
-      ]
-    : ["provider", "update", providerName, "--credential", credentialEnv];
-}
-
 function toReuseEntry(binding: MessagingCredentialBindingLike): MessagingCredentialReuseEntry {
   return {
     channelId: binding.channelId,
@@ -162,13 +156,100 @@ function toMissingEntry(binding: MessagingCredentialBindingLike): MessagingMissi
   };
 }
 
-function compactOutput(result: { readonly stdout?: unknown; readonly stderr?: unknown }): string {
-  const output = redact(`${String(result.stderr ?? "")}${String(result.stdout ?? "")}`)
-    .replace(/\r/g, "")
-    .trim();
-  return output || "OpenShell command failed.";
-}
-
 function uniqueStrings(values: readonly string[]): string[] {
   return [...new Set(values.filter(Boolean))];
+}
+
+function legacyOutputText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Buffer.isBuffer(value)) return value.toString("utf8");
+  return "";
+}
+
+function legacyOutputStreams(result: {
+  readonly output?: unknown;
+  readonly stdout?: unknown;
+  readonly stderr?: unknown;
+}): { readonly stdout?: string; readonly stderr?: string } {
+  const outputStdout = Array.isArray(result.output)
+    ? legacyOutputText(result.output[1])
+    : legacyOutputText(result.output);
+  const outputStderr = Array.isArray(result.output) ? legacyOutputText(result.output[2]) : "";
+  const stdout = legacyOutputText(result.stdout) || outputStdout;
+  const stderr = legacyOutputText(result.stderr) || outputStderr;
+  return {
+    ...(stdout ? { stdout } : {}),
+    ...(stderr ? { stderr } : {}),
+  };
+}
+
+function providerAdapter(options: MessagingCredentialApplyOptions): OpenShellProviderAdapter {
+  if (options.providerAdapter) return options.providerAdapter;
+  return createCliOpenShellProviderAdapter({
+    run: (args, runOptions) => {
+      const { env: rawEnv, ...safeRunOptions } = runOptions;
+      const env = rawEnv
+        ? Object.fromEntries(
+            Object.entries(rawEnv).filter(
+              (entry): entry is [string, string] => entry[1] !== undefined,
+            ),
+          )
+        : undefined;
+      let result;
+      try {
+        result = options.runOpenshell(args, {
+          ...safeRunOptions,
+          ...(env ? { env } : {}),
+        });
+      } catch {
+        return {
+          status: null,
+          error: new Error("The OpenShell provider runner failed."),
+        };
+      }
+      const streams = legacyOutputStreams(result);
+      return {
+        status: result.status ?? null,
+        ...streams,
+        ...(result.error instanceof Error ? { error: result.error } : {}),
+      };
+    },
+  });
+}
+
+function profileFailure(error: OpenShellProviderError): Error {
+  if (error.kind === "command" && error.reason === "profile_import_failed") {
+    return new Error("Could not import the OpenShell messaging credential profile.");
+  }
+  if (error.kind === "command" && error.reason === "profile_export_failed") {
+    return new Error(
+      `OpenShell provider profile '${MESSAGING_CREDENTIAL_PROVIDER_TYPE}' could not be exported for validation.`,
+    );
+  }
+  if (error.kind === "command" && error.reason === "profile_incompatible") {
+    return new Error(
+      `OpenShell provider profile '${MESSAGING_CREDENTIAL_PROVIDER_TYPE}' already exists but does not match NemoClaw's endpointless messaging credential contract.`,
+    );
+  }
+  return new Error(`Could not prepare the OpenShell messaging credential profile: ${error.message}`);
+}
+
+function classifyProviderBinding(
+  result:
+    | Readonly<{ ok: true; value: OpenShellProviderMetadata }>
+    | Readonly<{ ok: false; error: OpenShellProviderError }>,
+  binding: MessagingCredentialBindingLike,
+): "collision" | "exact" | "indeterminate" | "missing" {
+  if (!result.ok) {
+    return result.error.kind === "command" && result.error.reason === "not_found"
+      ? "missing"
+      : "indeterminate";
+  }
+  return matchesGatewayCredentialFamilyProviderBinding(result.value, {
+    name: binding.providerName,
+    type: MESSAGING_CREDENTIAL_PROVIDER_TYPE,
+    credentialKey: binding.providerEnvKey,
+  })
+    ? "exact"
+    : "collision";
 }

--- a/src/lib/messaging/applier/openshell-provider.ts
+++ b/src/lib/messaging/applier/openshell-provider.ts
@@ -2,115 +2,219 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {
-  OpenShellProviderAdapter,
   OpenShellProviderError,
   OpenShellProviderMetadata,
+  OpenShellProviderResult,
 } from "../../adapters/openshell/provider-adapter";
 import { selectedOpenShellGateway } from "../../adapters/openshell/sandbox-observer";
-import { matchesGatewayCredentialFamilyProviderBinding } from "../../onboard/gateway-provider-metadata";
 import { REPOSITORY_ROOT } from "../../core/repository-root";
 import type { SandboxMessagingCredentialBindingPlan, SandboxMessagingPlan } from "../manifest";
 import {
   messagingCredentialProviderProfilePath,
   MESSAGING_CREDENTIAL_PROVIDER_TYPE,
 } from "../provider-profile";
-import type { MessagingCredentialApplyOptions, MessagingCredentialApplyResult } from "./types";
+import type {
+  MessagingCredentialApplyOptions,
+  MessagingCredentialApplyResult,
+  MessagingCredentialProviderDefinition,
+  MessagingCredentialProviderProfile,
+  MessagingProviderRefreshDefinition,
+} from "./types";
 import { filterEnabledPlanEntries } from "./plan-filter";
 
 type MessagingCredentialApplyEntry = MessagingCredentialApplyResult["upserted"][number];
 type MessagingCredentialReuseEntry = MessagingCredentialApplyResult["reused"][number];
 type MessagingMissingCredentialEntry = MessagingCredentialApplyResult["missing"][number];
-type MessagingCredentialBindingLike = Pick<
-  SandboxMessagingCredentialBindingPlan,
-  "channelId" | "credentialId" | "providerName" | "providerEnvKey"
->;
+type ProviderBindingState = "collision" | "exact" | "indeterminate" | "missing";
+
+const MESSAGING_PROVIDER_BINDING_CONFLICT = "NEMOCLAW_MESSAGING_PROVIDER_BINDING_CONFLICT";
+const MESSAGING_PROVIDER_MUTATION_FAILURE = "NEMOCLAW_MESSAGING_PROVIDER_MUTATION_FAILURE";
+const REFRESH_POLL_ATTEMPTS = 50;
+const REFRESH_POLL_INTERVAL_MS = 3_000;
+const REFRESH_DEADLINE_MS = 300_000;
+const REFRESH_STATUS_TIMEOUT_MS = 15_000;
+
+export class MessagingProviderApplyError extends Error {
+  readonly code: string;
+  readonly mutatedProviderNames: readonly string[];
+  readonly createdProviderNames: readonly string[];
+
+  constructor(input: {
+    readonly message: string;
+    readonly bindingConflict?: boolean;
+    readonly mutatedProviderNames?: readonly string[];
+    readonly createdProviderNames?: readonly string[];
+    readonly cause?: unknown;
+  }) {
+    super(input.message, input.cause === undefined ? undefined : { cause: input.cause });
+    this.name = "MessagingProviderApplyError";
+    this.code = input.bindingConflict
+      ? MESSAGING_PROVIDER_BINDING_CONFLICT
+      : MESSAGING_PROVIDER_MUTATION_FAILURE;
+    this.mutatedProviderNames = uniqueStrings(input.mutatedProviderNames ?? []);
+    this.createdProviderNames = uniqueStrings(input.createdProviderNames ?? []);
+  }
+}
+
+export function isMessagingProviderBindingConflict(
+  error: unknown,
+): error is MessagingProviderApplyError {
+  return (
+    error instanceof Error &&
+    Reflect.get(error, "code") === MESSAGING_PROVIDER_BINDING_CONFLICT
+  );
+}
+
+export function isMessagingProviderMutationFailure(
+  error: unknown,
+): error is MessagingProviderApplyError {
+  return (
+    error instanceof Error &&
+    Reflect.get(error, "code") === MESSAGING_PROVIDER_MUTATION_FAILURE
+  );
+}
 
 export async function applyCredentialsAtOpenShell(
   plan: SandboxMessagingPlan,
   options: MessagingCredentialApplyOptions,
 ): Promise<MessagingCredentialApplyResult> {
   const env = options.env ?? process.env;
-  const adapter = options.providerAdapter;
-  const target = selectedOpenShellGateway();
+  const target = options.target ?? selectedOpenShellGateway();
+  const definitions =
+    options.definitions ??
+    definitionsFromPlan(
+      env,
+      filterEnabledPlanEntries(plan, plan.credentialBindings),
+    );
+  assertUniqueDefinitions(definitions);
+  assertRefreshDefinitions(options.refreshes ?? [], definitions);
+
+  const states = new Map<string, ProviderBindingState>();
+  for (const definition of definitions) {
+    const observed = await options.providerAdapter.getProvider({
+      target,
+      providerName: definition.providerName,
+    });
+    const state = classifyProviderDefinition(observed, definition);
+    const credentialAvailability = definition.credentials.map(({ value }) => Boolean(value));
+    const hasAnyCredential = credentialAvailability.some(Boolean);
+    const hasEveryCredential = credentialAvailability.every(Boolean);
+    states.set(definition.providerName, state);
+    if (state === "indeterminate") {
+      throw new MessagingProviderApplyError({
+        message: `Could not inspect messaging provider '${definition.providerName}'.`,
+      });
+    }
+    if (
+      state === "collision" &&
+      (!options.replaceExisting || !hasEveryCredential)
+    ) {
+      throw new MessagingProviderApplyError({
+        message:
+          definition.providerType === MESSAGING_CREDENTIAL_PROVIDER_TYPE
+            ? `Messaging provider '${definition.providerName}' does not match the required endpointless credential binding.`
+            : `Messaging provider '${definition.providerName}' does not match the required '${definition.providerType}' credential binding.`,
+        bindingConflict: true,
+      });
+    }
+    if (state === "missing" && hasAnyCredential && !hasEveryCredential) {
+      throw new MessagingProviderApplyError({
+        message: `Messaging provider '${definition.providerName}' is missing required credential material for creation.`,
+      });
+    }
+  }
+  await prepareProfiles(definitions, options);
+
   const upserted: MessagingCredentialApplyEntry[] = [];
   const reused: MessagingCredentialReuseEntry[] = [];
   const missing: MessagingMissingCredentialEntry[] = [];
-  const activeBindings = filterEnabledPlanEntries(plan, plan.credentialBindings);
+  const mutatedProviderNames: string[] = [];
+  const createdProviderNames: string[] = [];
+  const failures: string[] = [];
 
-  if (activeBindings.length > 0) {
-    const profile = await adapter.ensureEndpointlessProviderProfile({
-      target,
-      profilePath: messagingCredentialProviderProfilePath(REPOSITORY_ROOT),
-      profileType: MESSAGING_CREDENTIAL_PROVIDER_TYPE,
-      inferenceCapable: false,
-    });
-    if (!profile.ok) throw profileFailure(profile.error);
-  }
-
-  for (const binding of activeBindings) {
-    const credential = readCredentialEnv(env, binding.providerEnvKey);
-    const observed = await adapter.getProvider({
-      target,
-      providerName: binding.providerName,
-    });
-    const providerState = classifyProviderBinding(observed, binding);
-    if (providerState === "indeterminate") {
-      throw new Error(`Could not inspect messaging provider '${binding.providerName}'.`);
-    }
-    if (providerState === "collision") {
-      throw new Error(
-        `Messaging provider '${binding.providerName}' does not match the required endpointless credential binding.`,
-      );
-    }
-    if (!credential) {
-      if (providerState === "exact") {
-        reused.push(toReuseEntry(binding));
-      } else {
-        missing.push(toMissingEntry(binding));
-      }
+  for (const definition of definitions) {
+    let state = states.get(definition.providerName) ?? "indeterminate";
+    const credentials = definition.credentials.filter(
+      (credential): credential is Readonly<{ name: string; value: string }> =>
+        typeof credential.value === "string" && credential.value.length > 0,
+    );
+    if (credentials.length === 0) {
+      if (state === "exact") reused.push(toReuseEntry(definition));
+      else missing.push(toMissingEntry(definition));
       continue;
     }
 
-    const action = providerState === "exact" ? "update" : "create";
-    const credentials = [{ name: binding.providerEnvKey, value: credential }];
+    if (state === "collision") {
+      try {
+        await deleteProviderForReplacement(definition.providerName, options);
+      } catch (error) {
+        throw withMutationEvidence(error, mutatedProviderNames, createdProviderNames);
+      }
+      mutatedProviderNames.push(definition.providerName);
+      state = "missing";
+    }
+
+    const action = state === "exact" ? "update" : "create";
     const result =
       action === "create"
-        ? await adapter.createProvider({
+        ? await options.providerAdapter.createProvider({
             target,
-            name: binding.providerName,
-            type: MESSAGING_CREDENTIAL_PROVIDER_TYPE,
+            name: definition.providerName,
+            type: definition.providerType,
             credentials,
             config: [],
             fromExisting: false,
           })
-        : await adapter.updateProvider({
+        : await options.providerAdapter.updateProvider({
             target,
-            providerName: binding.providerName,
+            providerName: definition.providerName,
             credentials,
             config: [],
           });
     if (!result.ok) {
-      throw new Error(
-        `Failed to ${action} messaging provider '${binding.providerName}': ${result.error.message}`,
-      );
+      const message = `Failed to ${action} messaging provider '${definition.providerName}': ${result.error.message}`;
+      if (options.bestEffort) {
+        failures.push(message);
+        continue;
+      }
+      throw withMutationEvidence(message, mutatedProviderNames, createdProviderNames);
     }
-    const verification = await adapter.getProvider({
+    mutatedProviderNames.push(definition.providerName);
+    if (action === "create" && state === "missing") {
+      createdProviderNames.push(definition.providerName);
+    }
+
+    const verification = await options.providerAdapter.getProvider({
       target,
-      providerName: binding.providerName,
+      providerName: definition.providerName,
     });
-    const verified = classifyProviderBinding(verification, binding);
-    if (verified !== "exact") {
-      throw new Error(
-        `OpenShell did not confirm messaging provider '${binding.providerName}' after ${action}.`,
+    if (classifyProviderDefinition(verification, definition) !== "exact") {
+      throw withMutationEvidence(
+        `OpenShell did not confirm messaging provider '${definition.providerName}' after ${action}.`,
+        mutatedProviderNames,
+        createdProviderNames,
       );
     }
     upserted.push({
-      channelId: binding.channelId,
-      credentialId: binding.credentialId,
-      providerName: binding.providerName,
-      envKey: binding.providerEnvKey,
+      channelId: definition.channelId,
+      credentialId: definition.credentialId,
+      providerName: definition.providerName,
+      envKey: definition.credentials[0]?.name ?? "",
       action,
     });
+  }
+
+  if (failures.length > 0) {
+    throw withMutationEvidence(
+      failures.join("; "),
+      mutatedProviderNames,
+      createdProviderNames,
+    );
+  }
+  try {
+    await configureRefreshes(options.refreshes ?? [], options);
+  } catch (error) {
+    throw withMutationEvidence(error, mutatedProviderNames, createdProviderNames);
   }
 
   const providerNames = uniqueStrings([
@@ -130,6 +234,150 @@ export async function applyCredentialsAtOpenShell(
   };
 }
 
+function definitionsFromPlan(
+  env: NodeJS.ProcessEnv,
+  bindings: readonly SandboxMessagingCredentialBindingPlan[],
+): MessagingCredentialProviderDefinition[] {
+  const profile: MessagingCredentialProviderProfile = {
+    kind: "endpointless",
+    profilePath: messagingCredentialProviderProfilePath(REPOSITORY_ROOT),
+    profileType: MESSAGING_CREDENTIAL_PROVIDER_TYPE,
+    inferenceCapable: false,
+  };
+  return bindings.map((binding) => ({
+    channelId: binding.channelId,
+    credentialId: binding.credentialId,
+    providerName: binding.providerName,
+    providerType: MESSAGING_CREDENTIAL_PROVIDER_TYPE,
+    credentials: [
+      {
+        name: binding.providerEnvKey,
+        value: readCredentialEnv(env, binding.providerEnvKey),
+      },
+    ],
+    profile,
+  }));
+}
+
+function assertUniqueDefinitions(
+  definitions: readonly MessagingCredentialProviderDefinition[],
+): void {
+  const names = new Set<string>();
+  const profileContracts = new Map<string, string>();
+  for (const definition of definitions) {
+    if (names.has(definition.providerName)) {
+      throw new MessagingProviderApplyError({
+        message: `Messaging provider '${definition.providerName}' is defined more than once.`,
+      });
+    }
+    names.add(definition.providerName);
+    if (
+      definition.profile.profileType !== definition.providerType ||
+      definition.credentials.length === 0 ||
+      new Set(definition.credentials.map(({ name }) => name)).size !==
+        definition.credentials.length
+    ) {
+      throw new MessagingProviderApplyError({
+        message: `Messaging provider '${definition.providerName}' has an invalid credential profile definition.`,
+      });
+    }
+    const profileContract = profileContractKey(definition.profile);
+    const existingProfileContract = profileContracts.get(definition.profile.profileType);
+    if (existingProfileContract && existingProfileContract !== profileContract) {
+      throw new MessagingProviderApplyError({
+        message: `Messaging provider profile '${definition.profile.profileType}' has conflicting definitions.`,
+      });
+    }
+    profileContracts.set(definition.profile.profileType, profileContract);
+  }
+}
+
+function assertRefreshDefinitions(
+  refreshes: readonly MessagingProviderRefreshDefinition[],
+  definitions: readonly MessagingCredentialProviderDefinition[],
+): void {
+  const definitionsByName = new Map(
+    definitions.map((definition) => [definition.providerName, definition]),
+  );
+  const refreshKeys = new Set<string>();
+  for (const refresh of refreshes) {
+    const definition = definitionsByName.get(refresh.providerName);
+    const refreshKey = `${refresh.providerName}\u0000${refresh.credentialKey}`;
+    const materialKeys = [
+      ...refresh.material.map(({ key }) => key),
+      ...refresh.secretMaterial.map(({ key }) => key),
+    ];
+    if (
+      refreshKeys.has(refreshKey) ||
+      !definition ||
+      !definition.credentials.some(({ name }) => name === refresh.credentialKey) ||
+      !refresh.strategy ||
+      materialKeys.length === 0 ||
+      materialKeys.some((key) => !key) ||
+      new Set(materialKeys).size !== materialKeys.length
+    ) {
+      throw new MessagingProviderApplyError({
+        message: `Messaging provider '${refresh.providerName}' has an invalid refresh definition.`,
+      });
+    }
+    refreshKeys.add(refreshKey);
+  }
+}
+
+function profileContractKey(profile: MessagingCredentialProviderProfile): string {
+  return profile.kind === "endpointless"
+    ? JSON.stringify([
+        profile.kind,
+        profile.profilePath,
+        profile.profileType,
+        profile.inferenceCapable,
+      ])
+    : JSON.stringify([
+        profile.kind,
+        profile.profilePath,
+        profile.profileType,
+        profile.contractDigest,
+      ]);
+}
+
+async function prepareProfiles(
+  definitions: readonly MessagingCredentialProviderDefinition[],
+  options: MessagingCredentialApplyOptions,
+): Promise<void> {
+  const target = options.target ?? selectedOpenShellGateway();
+  const profiles = new Map<string, MessagingCredentialProviderProfile>();
+  for (const definition of definitions) {
+    profiles.set(definition.profile.profileType, definition.profile);
+  }
+  for (const profile of profiles.values()) {
+    if (profile.kind === "endpointless") {
+      const result = await options.providerAdapter.ensureEndpointlessProviderProfile({
+        target,
+        profilePath: profile.profilePath,
+        profileType: profile.profileType,
+        inferenceCapable: profile.inferenceCapable,
+      });
+      if (!result.ok) throw profileFailure(result.error, profile.profileType, profile.kind);
+      continue;
+    }
+    const imported = await options.providerAdapter.importProviderProfile({
+      target,
+      profilePath: profile.profilePath,
+    });
+    if (!imported.ok) throw profileFailure(imported.error, profile.profileType, profile.kind);
+    const inspected = await options.providerAdapter.inspectProviderProfile({
+      target,
+      profileType: profile.profileType,
+    });
+    if (!inspected.ok) throw profileFailure(inspected.error, profile.profileType, profile.kind);
+    if (inspected.value.contractDigest !== profile.contractDigest) {
+      throw new MessagingProviderApplyError({
+        message: `OpenShell provider profile '${profile.profileType}' does not match NemoClaw's checked-in credential contract.`,
+      });
+    }
+  }
+}
+
 function readCredentialEnv(env: NodeJS.ProcessEnv, envKey: string): string | null {
   const raw = env[envKey];
   if (typeof raw !== "string") return null;
@@ -137,21 +385,25 @@ function readCredentialEnv(env: NodeJS.ProcessEnv, envKey: string): string | nul
   return normalized || null;
 }
 
-function toReuseEntry(binding: MessagingCredentialBindingLike): MessagingCredentialReuseEntry {
+function toReuseEntry(
+  definition: MessagingCredentialProviderDefinition,
+): MessagingCredentialReuseEntry {
   return {
-    channelId: binding.channelId,
-    credentialId: binding.credentialId,
-    providerName: binding.providerName,
-    envKey: binding.providerEnvKey,
+    channelId: definition.channelId,
+    credentialId: definition.credentialId,
+    providerName: definition.providerName,
+    envKey: definition.credentials[0]?.name ?? "",
   };
 }
 
-function toMissingEntry(binding: MessagingCredentialBindingLike): MessagingMissingCredentialEntry {
+function toMissingEntry(
+  definition: MessagingCredentialProviderDefinition,
+): MessagingMissingCredentialEntry {
   return {
-    channelId: binding.channelId,
-    credentialId: binding.credentialId,
-    providerName: binding.providerName,
-    envKey: binding.providerEnvKey,
+    channelId: definition.channelId,
+    credentialId: definition.credentialId,
+    providerName: definition.providerName,
+    envKey: definition.credentials[0]?.name ?? "",
   };
 }
 
@@ -159,39 +411,169 @@ function uniqueStrings(values: readonly string[]): string[] {
   return [...new Set(values.filter(Boolean))];
 }
 
-function profileFailure(error: OpenShellProviderError): Error {
+function profileFailure(
+  error: OpenShellProviderError,
+  profileType: string,
+  profileKind: MessagingCredentialProviderProfile["kind"],
+): Error {
   if (error.kind === "command" && error.reason === "profile_import_failed") {
     return new Error("Could not import the OpenShell messaging credential profile.");
   }
   if (error.kind === "command" && error.reason === "profile_export_failed") {
     return new Error(
-      `OpenShell provider profile '${MESSAGING_CREDENTIAL_PROVIDER_TYPE}' could not be exported for validation.`,
+      `OpenShell provider profile '${profileType}' could not be exported for validation.`,
     );
   }
   if (error.kind === "command" && error.reason === "profile_incompatible") {
     return new Error(
-      `OpenShell provider profile '${MESSAGING_CREDENTIAL_PROVIDER_TYPE}' already exists but does not match NemoClaw's endpointless messaging credential contract.`,
+      `OpenShell provider profile '${profileType}' already exists but does not match NemoClaw's ${profileKind === "endpointless" ? "endpointless " : ""}messaging credential contract.`,
     );
   }
   return new Error(`Could not prepare the OpenShell messaging credential profile: ${error.message}`);
 }
 
-function classifyProviderBinding(
-  result:
-    | Readonly<{ ok: true; value: OpenShellProviderMetadata }>
-    | Readonly<{ ok: false; error: OpenShellProviderError }>,
-  binding: MessagingCredentialBindingLike,
-): "collision" | "exact" | "indeterminate" | "missing" {
+function classifyProviderDefinition(
+  result: OpenShellProviderResult<OpenShellProviderMetadata>,
+  definition: MessagingCredentialProviderDefinition,
+): ProviderBindingState {
   if (!result.ok) {
     return result.error.kind === "command" && result.error.reason === "not_found"
       ? "missing"
       : "indeterminate";
   }
-  return matchesGatewayCredentialFamilyProviderBinding(result.value, {
-    name: binding.providerName,
-    type: MESSAGING_CREDENTIAL_PROVIDER_TYPE,
-    credentialKey: binding.providerEnvKey,
-  })
+  const expectedCredentialKeys = definition.credentials.map(({ name }) => name).sort();
+  const actualCredentialKeys = [...result.value.credentialKeys].sort();
+  return result.value.name === definition.providerName &&
+    result.value.type === definition.providerType &&
+    actualCredentialKeys.length === expectedCredentialKeys.length &&
+    actualCredentialKeys.every((key, index) => key === expectedCredentialKeys[index])
     ? "exact"
     : "collision";
+}
+
+async function deleteProviderForReplacement(
+  providerName: string,
+  options: MessagingCredentialApplyOptions,
+): Promise<void> {
+  const target = options.target ?? selectedOpenShellGateway();
+  options.revalidateSandboxIdentity?.(`delete messaging provider ${JSON.stringify(providerName)}`);
+  let result = await options.providerAdapter.deleteProvider({ target, providerName });
+  if (result.ok) return;
+  if (result.error.kind !== "command" || result.error.reason !== "attached") {
+    throw new MessagingProviderApplyError({
+      message: `Could not replace messaging provider '${providerName}': ${result.error.message}`,
+    });
+  }
+  const attached = result.error.attachedSandboxes;
+  const allowed = new Set(options.allowedSandboxes ?? []);
+  if (!attached || attached.length === 0 || attached.some((name) => !allowed.has(name))) {
+    throw new MessagingProviderApplyError({
+      message: `Could not replace messaging provider '${providerName}' because its sandbox attachments are not authorized for this operation.`,
+    });
+  }
+  let detachedProvider = false;
+  for (const sandboxName of attached) {
+    options.revalidateSandboxIdentity?.(
+      `detach messaging provider ${JSON.stringify(providerName)} from sandbox ${JSON.stringify(sandboxName)}`,
+    );
+    const detached = await options.providerAdapter.detachProvider({
+      target,
+      providerName,
+      sandboxName,
+    });
+    if (!detached.ok) {
+      throw new MessagingProviderApplyError({
+        message: `Could not detach messaging provider '${providerName}' from sandbox '${sandboxName}': ${detached.error.message}`,
+        mutatedProviderNames: detachedProvider ? [providerName] : [],
+      });
+    }
+    detachedProvider ||= detached.value.state === "detached";
+  }
+  options.revalidateSandboxIdentity?.(`delete messaging provider ${JSON.stringify(providerName)}`);
+  result = await options.providerAdapter.deleteProvider({ target, providerName });
+  if (!result.ok) {
+    throw new MessagingProviderApplyError({
+      message: `Could not replace messaging provider '${providerName}': ${result.error.message}`,
+      mutatedProviderNames: detachedProvider ? [providerName] : [],
+    });
+  }
+}
+
+async function configureRefreshes(
+  refreshes: readonly MessagingProviderRefreshDefinition[],
+  options: MessagingCredentialApplyOptions,
+): Promise<void> {
+  const target = options.target ?? selectedOpenShellGateway();
+  const sleep = options.sleep ?? defaultSleep;
+  const now = options.now ?? Date.now;
+  for (const refresh of refreshes) {
+    const configured = await options.providerAdapter.configureProviderRefresh({
+      target,
+      providerName: refresh.providerName,
+      credentialKey: refresh.credentialKey,
+      strategy: refresh.strategy,
+      material: refresh.material,
+      secretMaterial: refresh.secretMaterial,
+    });
+    if (!configured.ok) {
+      throw new MessagingProviderApplyError({
+        message: `Could not configure gateway token minting for messaging provider '${refresh.providerName}': ${configured.error.message}`,
+      });
+    }
+    options.log?.(`Waiting for the gateway to mint ${refresh.credentialKey}.`);
+    const deadline = now() + REFRESH_DEADLINE_MS;
+    let status: string | null = null;
+    let observationError: OpenShellProviderError | null = null;
+    for (let attempt = 0; attempt < REFRESH_POLL_ATTEMPTS && now() < deadline; attempt += 1) {
+      const observed = await options.providerAdapter.getProviderRefreshStatus({
+        target,
+        providerName: refresh.providerName,
+        credentialKey: refresh.credentialKey,
+        timeoutMs: REFRESH_STATUS_TIMEOUT_MS,
+      });
+      if (observed.ok) {
+        status = observed.value.status;
+        observationError = null;
+      } else {
+        observationError = observed.error;
+      }
+      if (status === "refreshed") break;
+      if (attempt + 1 < REFRESH_POLL_ATTEMPTS && now() < deadline) {
+        await sleep(REFRESH_POLL_INTERVAL_MS);
+      }
+    }
+    if (status !== "refreshed") {
+      if (observationError) {
+        throw new MessagingProviderApplyError({
+          message: `Could not observe gateway token minting for messaging provider '${refresh.providerName}': ${observationError.message}`,
+        });
+      }
+      throw new MessagingProviderApplyError({
+        message: `Gateway token minting did not complete for messaging provider '${refresh.providerName}' (last status '${status ?? "unknown"}').`,
+      });
+    }
+  }
+}
+
+async function defaultSleep(milliseconds: number): Promise<void> {
+  if (process.env.VITEST === "true" || process.env.NEMOCLAW_TEST_NO_SLEEP === "1") return;
+  await new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function withMutationEvidence(
+  error: unknown,
+  mutatedProviderNames: readonly string[],
+  createdProviderNames: readonly string[],
+): MessagingProviderApplyError {
+  const message = error instanceof Error ? error.message : String(error);
+  const existingMutated =
+    error instanceof MessagingProviderApplyError ? error.mutatedProviderNames : [];
+  const existingCreated =
+    error instanceof MessagingProviderApplyError ? error.createdProviderNames : [];
+  return new MessagingProviderApplyError({
+    message,
+    mutatedProviderNames: [...existingMutated, ...mutatedProviderNames],
+    createdProviderNames: [...existingCreated, ...createdProviderNames],
+    cause: error,
+  });
 }

--- a/src/lib/messaging/applier/openshell-provider.ts
+++ b/src/lib/messaging/applier/openshell-provider.ts
@@ -6,7 +6,6 @@ import type {
   OpenShellProviderError,
   OpenShellProviderMetadata,
 } from "../../adapters/openshell/provider-adapter";
-import { createCliOpenShellProviderAdapter } from "../../adapters/openshell/provider-adapter-cli";
 import { selectedOpenShellGateway } from "../../adapters/openshell/sandbox-observer";
 import { matchesGatewayCredentialFamilyProviderBinding } from "../../onboard/gateway-provider-metadata";
 import { REPOSITORY_ROOT } from "../../core/repository-root";
@@ -31,7 +30,7 @@ export async function applyCredentialsAtOpenShell(
   options: MessagingCredentialApplyOptions,
 ): Promise<MessagingCredentialApplyResult> {
   const env = options.env ?? process.env;
-  const adapter = providerAdapter(options);
+  const adapter = options.providerAdapter;
   const target = selectedOpenShellGateway();
   const upserted: MessagingCredentialApplyEntry[] = [];
   const reused: MessagingCredentialReuseEntry[] = [];
@@ -158,63 +157,6 @@ function toMissingEntry(binding: MessagingCredentialBindingLike): MessagingMissi
 
 function uniqueStrings(values: readonly string[]): string[] {
   return [...new Set(values.filter(Boolean))];
-}
-
-function legacyOutputText(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (Buffer.isBuffer(value)) return value.toString("utf8");
-  return "";
-}
-
-function legacyOutputStreams(result: {
-  readonly output?: unknown;
-  readonly stdout?: unknown;
-  readonly stderr?: unknown;
-}): { readonly stdout?: string; readonly stderr?: string } {
-  const outputStdout = Array.isArray(result.output)
-    ? legacyOutputText(result.output[1])
-    : legacyOutputText(result.output);
-  const outputStderr = Array.isArray(result.output) ? legacyOutputText(result.output[2]) : "";
-  const stdout = legacyOutputText(result.stdout) || outputStdout;
-  const stderr = legacyOutputText(result.stderr) || outputStderr;
-  return {
-    ...(stdout ? { stdout } : {}),
-    ...(stderr ? { stderr } : {}),
-  };
-}
-
-function providerAdapter(options: MessagingCredentialApplyOptions): OpenShellProviderAdapter {
-  if (options.providerAdapter) return options.providerAdapter;
-  return createCliOpenShellProviderAdapter({
-    run: (args, runOptions) => {
-      const { env: rawEnv, ...safeRunOptions } = runOptions;
-      const env = rawEnv
-        ? Object.fromEntries(
-            Object.entries(rawEnv).filter(
-              (entry): entry is [string, string] => entry[1] !== undefined,
-            ),
-          )
-        : undefined;
-      let result;
-      try {
-        result = options.runOpenshell(args, {
-          ...safeRunOptions,
-          ...(env ? { env } : {}),
-        });
-      } catch {
-        return {
-          status: null,
-          error: new Error("The OpenShell provider runner failed."),
-        };
-      }
-      const streams = legacyOutputStreams(result);
-      return {
-        status: result.status ?? null,
-        ...streams,
-        ...(result.error instanceof Error ? { error: result.error } : {}),
-      };
-    },
-  });
 }
 
 function profileFailure(error: OpenShellProviderError): Error {

--- a/src/lib/messaging/applier/provider-application.test.ts
+++ b/src/lib/messaging/applier/provider-application.test.ts
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { MESSAGING_BRIDGE_PENDING_VALUE } from "../../onboard/messaging-bridge-provider";
+import { buildMessagingProviderApplication } from "./provider-application";
+
+const STATIC_PROFILE = `
+id: discord-hermes
+credentials:
+  - name: bot_token
+    env_vars: [DISCORD_BOT_TOKEN]
+    required: true
+    auth_style: bearer
+    header_name: Authorization
+    query_param: ''
+endpoints: []
+binaries: [/usr/local/bin/hermes]
+inference_capable: false
+`;
+
+const GOOGLE_CHAT_PROFILE = `
+id: google-chat-bridge
+credentials:
+  - name: access_token
+    env_vars: [GOOGLE_CHAT_ACCESS_TOKEN]
+    required: true
+    auth_style: bearer
+    header_name: Authorization
+    query_param: ''
+    refresh:
+      strategy: google-service-account-jwt
+      scopes: [https://www.googleapis.com/auth/chat.bot]
+      material:
+        - name: client_email
+          required: true
+        - name: private_key
+          required: true
+          secret: true
+        - name: scope
+endpoints:
+  - host: chat.googleapis.com
+    port: 443
+    protocol: rest
+    access: read-write
+    enforcement: enforce
+binaries: [/usr/local/bin/node]
+inference_capable: false
+`;
+
+describe("messaging provider application planning", () => {
+  it("separates typed messaging definitions from unrelated providers (#9806)", () => {
+    const plan = buildMessagingProviderApplication({
+      tokenDefs: [
+        {
+          name: "demo-telegram-bridge",
+          envKey: "TELEGRAM_BOT_TOKEN",
+          token: "telegram-token",
+          providerType: "nemoclaw-mcp-v1",
+        },
+        {
+          name: "demo-tavily-search",
+          envKey: "TAVILY_API_KEY",
+          token: "search-token",
+          providerType: "tavily",
+        },
+      ],
+      root: "/repo",
+      agent: "openclaw",
+      getCredential: () => null,
+      profiles: [],
+    });
+
+    expect(plan.definitions).toEqual([
+      expect.objectContaining({
+        providerName: "demo-telegram-bridge",
+        providerType: "nemoclaw-mcp-v1",
+        credentials: [{ name: "TELEGRAM_BOT_TOKEN", value: "telegram-token" }],
+        profile: expect.objectContaining({ kind: "endpointless" }),
+      }),
+    ]);
+    expect(plan.otherTokenDefs).toEqual([expect.objectContaining({ name: "demo-tavily-search" })]);
+  });
+
+  it("binds a static messaging provider to its checked-in profile digest (#9806)", () => {
+    const profilePath = "/repo/discord-hermes.yaml";
+    const plan = buildMessagingProviderApplication({
+      tokenDefs: [
+        {
+          name: "demo-discord-bridge",
+          envKey: "DISCORD_BOT_TOKEN",
+          token: "discord-token",
+          providerType: "discord-hermes",
+        },
+      ],
+      root: "/repo",
+      agent: "hermes",
+      getCredential: () => null,
+      profiles: [
+        {
+          channelId: "discord",
+          agent: "hermes",
+          profilePath,
+          profileId: "discord-hermes",
+          credentialKey: "DISCORD_BOT_TOKEN",
+          strategy: null,
+          scopes: [],
+          secretMaterialKeys: [],
+          sourceSecretEnv: "DISCORD_BOT_TOKEN",
+        },
+      ],
+      readFileSync: (file) => {
+        expect(file).toBe(profilePath);
+        return STATIC_PROFILE;
+      },
+    });
+
+    expect(plan.definitions[0]).toMatchObject({
+      channelId: "discord",
+      providerType: "discord-hermes",
+      profile: {
+        kind: "checked-in",
+        profilePath,
+        profileType: "discord-hermes",
+        contractDigest: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      },
+    });
+    expect(plan.refreshes).toEqual([]);
+  });
+
+  it("keeps Google Chat private key material in the typed secret field (#9806)", () => {
+    const privateKey = "host-only-private-key";
+    const sourceSecret = JSON.stringify({
+      client_email: "bot@example.com",
+      private_key: privateKey,
+    });
+    const plan = buildMessagingProviderApplication({
+      tokenDefs: [
+        {
+          name: "demo-google-chat-bridge",
+          envKey: "GOOGLE_CHAT_ACCESS_TOKEN",
+          token: MESSAGING_BRIDGE_PENDING_VALUE,
+          providerType: "google-chat-bridge",
+        },
+      ],
+      root: "/repo",
+      agent: "openclaw",
+      getCredential: (envKey) => (envKey === "GOOGLECHAT_SERVICE_ACCOUNT" ? sourceSecret : null),
+      profiles: [
+        {
+          channelId: "googlechat",
+          agent: "openclaw",
+          profilePath: "/repo/google-chat.yaml",
+          profileId: "google-chat-bridge",
+          credentialKey: "GOOGLE_CHAT_ACCESS_TOKEN",
+          strategy: "google-service-account-jwt",
+          scopes: ["https://www.googleapis.com/auth/chat.bot"],
+          secretMaterialKeys: ["private_key"],
+          sourceSecretEnv: "GOOGLECHAT_SERVICE_ACCOUNT",
+        },
+      ],
+      readFileSync: () => GOOGLE_CHAT_PROFILE,
+    });
+
+    expect(plan.definitions[0]).toMatchObject({
+      providerName: "demo-google-chat-bridge",
+      credentials: [
+        {
+          name: "GOOGLE_CHAT_ACCESS_TOKEN",
+          value: MESSAGING_BRIDGE_PENDING_VALUE,
+        },
+      ],
+    });
+    expect(plan.refreshes).toEqual([
+      expect.objectContaining({
+        providerName: "demo-google-chat-bridge",
+        credentialKey: "GOOGLE_CHAT_ACCESS_TOKEN",
+        material: [
+          { key: "client_email", value: "bot@example.com" },
+          {
+            key: "scope",
+            value: "https://www.googleapis.com/auth/chat.bot",
+          },
+        ],
+        secretMaterial: [{ key: "private_key", value: privateKey }],
+      }),
+    ]);
+    expect(JSON.stringify(plan.refreshes[0]?.material)).not.toContain(privateKey);
+  });
+
+  it("fails closed when refresh secret material is unavailable (#9806)", () => {
+    expect(() =>
+      buildMessagingProviderApplication({
+        tokenDefs: [
+          {
+            name: "demo-google-chat-bridge",
+            envKey: "GOOGLE_CHAT_ACCESS_TOKEN",
+            token: MESSAGING_BRIDGE_PENDING_VALUE,
+            providerType: "google-chat-bridge",
+          },
+        ],
+        root: "/repo",
+        agent: "openclaw",
+        getCredential: () => null,
+        profiles: [
+          {
+            channelId: "googlechat",
+            agent: "openclaw",
+            profilePath: "/repo/google-chat.yaml",
+            profileId: "google-chat-bridge",
+            credentialKey: "GOOGLE_CHAT_ACCESS_TOKEN",
+            strategy: "google-service-account-jwt",
+            scopes: [],
+            secretMaterialKeys: ["private_key"],
+            sourceSecretEnv: "GOOGLECHAT_SERVICE_ACCOUNT",
+          },
+        ],
+        readFileSync: () => GOOGLE_CHAT_PROFILE,
+      }),
+    ).toThrow("bridge secret material is unavailable");
+  });
+});

--- a/src/lib/messaging/applier/provider-application.ts
+++ b/src/lib/messaging/applier/provider-application.ts
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from "node:fs";
+import YAML from "yaml";
+
+import { providerProfileContractDigest } from "../../adapters/openshell/provider-profile-contract";
+import type {
+  MessagingCredentialProviderDefinition,
+  MessagingCredentialProviderProfile,
+  MessagingProviderRefreshDefinition,
+} from "./types";
+import {
+  messagingCredentialProviderProfilePath,
+  MESSAGING_CREDENTIAL_PROVIDER_TYPE,
+} from "../provider-profile";
+import {
+  buildMessagingBridgeRefreshMaterial,
+  listMessagingBridgeProfiles,
+  messagingBridgeProfilesForAgent,
+  resolveMessagingBridgeSecret,
+  type MessagingBridgeProfile,
+  type RefreshingMessagingBridgeProfile,
+} from "../../onboard/messaging-bridge-provider";
+import type { MessagingTokenDef } from "../../onboard/messaging-prep";
+
+export interface BuildMessagingProviderApplicationInput {
+  readonly tokenDefs: readonly MessagingTokenDef[];
+  readonly root: string;
+  readonly agent: string | null | undefined;
+  readonly getCredential: (envKey: string) => string | null;
+  readonly env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  readonly normalizeCredentialValue?: (value: unknown) => string;
+  readonly channelIdForCredential?: (envKey: string, providerName: string) => string | null;
+  readonly profiles?: readonly MessagingBridgeProfile[];
+  readonly readFileSync?: (file: string) => string;
+}
+
+export interface MessagingProviderApplicationPlan {
+  readonly messagingTokenDefs: readonly MessagingTokenDef[];
+  readonly otherTokenDefs: readonly MessagingTokenDef[];
+  readonly definitions: readonly MessagingCredentialProviderDefinition[];
+  readonly refreshes: readonly MessagingProviderRefreshDefinition[];
+}
+
+export interface ResolveCheckedInMessagingProviderProfileInput {
+  readonly root: string;
+  readonly profileType: string;
+  readonly profiles?: readonly MessagingBridgeProfile[];
+  readonly readFileSync?: (file: string) => string;
+}
+
+/** Read the checked-in contract used to verify an existing static messaging provider. */
+export function resolveCheckedInMessagingProviderProfile(
+  input: ResolveCheckedInMessagingProviderProfileInput,
+): Extract<MessagingCredentialProviderProfile, { kind: "checked-in" }> | null {
+  const profile = (input.profiles ?? listMessagingBridgeProfiles({ root: input.root })).find(
+    (candidate) => candidate.profileId === input.profileType && candidate.strategy === null,
+  );
+  if (!profile) return null;
+  return checkedInProfile(
+    profile,
+    input.readFileSync ?? ((file: string) => fs.readFileSync(file, "utf8")),
+  );
+}
+
+/** Convert onboarding token definitions into the typed messaging-provider boundary. */
+export function buildMessagingProviderApplication(
+  input: BuildMessagingProviderApplicationInput,
+): MessagingProviderApplicationPlan {
+  const profiles = messagingBridgeProfilesForAgent(
+    input.agent,
+    input.profiles ?? listMessagingBridgeProfiles({ root: input.root }),
+  );
+  const profilesByType = new Map(profiles.map((profile) => [profile.profileId, profile]));
+  const messagingTokenDefs: MessagingTokenDef[] = [];
+  const otherTokenDefs: MessagingTokenDef[] = [];
+  const definitions: MessagingCredentialProviderDefinition[] = [];
+  const refreshes: MessagingProviderRefreshDefinition[] = [];
+  const readFileSync = input.readFileSync ?? ((file: string) => fs.readFileSync(file, "utf8"));
+
+  for (const tokenDef of input.tokenDefs) {
+    const profileType = tokenDef.providerType ?? "generic";
+    const bridgeProfile = profilesByType.get(profileType);
+    if (profileType !== MESSAGING_CREDENTIAL_PROVIDER_TYPE && !bridgeProfile) {
+      otherTokenDefs.push(tokenDef);
+      continue;
+    }
+    messagingTokenDefs.push(tokenDef);
+    const channelId =
+      bridgeProfile?.channelId ??
+      input.channelIdForCredential?.(tokenDef.envKey, tokenDef.name) ??
+      "messaging";
+    const profile = bridgeProfile
+      ? checkedInProfile(bridgeProfile, readFileSync)
+      : endpointlessProfile(input.root);
+    definitions.push({
+      channelId,
+      credentialId: tokenDef.envKey,
+      providerName: tokenDef.name,
+      providerType: profileType,
+      credentials: [
+        { name: tokenDef.envKey, value: normalizeToken(tokenDef.token) },
+        ...(tokenDef.additionalCredentials ?? []).map(({ envKey, token }) => ({
+          name: envKey,
+          value: normalizeToken(token),
+        })),
+      ],
+      profile,
+    });
+    if (bridgeProfile?.strategy) {
+      refreshes.push(
+        buildRefreshDefinition(
+          tokenDef,
+          { ...bridgeProfile, strategy: bridgeProfile.strategy },
+          input,
+        ),
+      );
+    }
+  }
+  return { messagingTokenDefs, otherTokenDefs, definitions, refreshes };
+}
+
+function endpointlessProfile(root: string): MessagingCredentialProviderProfile {
+  return {
+    kind: "endpointless",
+    profilePath: messagingCredentialProviderProfilePath(root),
+    profileType: MESSAGING_CREDENTIAL_PROVIDER_TYPE,
+    inferenceCapable: false,
+  };
+}
+
+function checkedInProfile(
+  profile: MessagingBridgeProfile,
+  readFileSync: (file: string) => string,
+): Extract<MessagingCredentialProviderProfile, { kind: "checked-in" }> {
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(readFileSync(profile.profilePath));
+  } catch (error) {
+    throw new Error(
+      `Could not read the checked-in '${profile.profileId}' messaging provider profile.`,
+      { cause: error },
+    );
+  }
+  const contractDigest = providerProfileContractDigest(parsed);
+  if (!contractDigest) {
+    throw new Error(
+      `The checked-in '${profile.profileId}' messaging provider profile is malformed.`,
+    );
+  }
+  return {
+    kind: "checked-in",
+    profilePath: profile.profilePath,
+    profileType: profile.profileId,
+    contractDigest,
+  };
+}
+
+function buildRefreshDefinition(
+  tokenDef: MessagingTokenDef,
+  profile: RefreshingMessagingBridgeProfile,
+  input: BuildMessagingProviderApplicationInput,
+): MessagingProviderRefreshDefinition {
+  const secret = resolveMessagingBridgeSecret(profile.sourceSecretEnv, {
+    getCredential: input.getCredential,
+    env: input.env,
+    normalizeCredentialValue: input.normalizeCredentialValue ?? normalizeUnknownCredential,
+  });
+  if (!secret) {
+    throw new Error(
+      `${profile.channelId} bridge secret material is unavailable for gateway token minting.`,
+    );
+  }
+  const built = buildMessagingBridgeRefreshMaterial(profile, secret);
+  if (!built.ok) {
+    throw new Error(
+      `${profile.channelId} bridge cannot configure gateway token minting: ${built.reason}.`,
+    );
+  }
+  const secretKeys = new Set(built.secretKeys);
+  return {
+    channelId: profile.channelId,
+    providerName: tokenDef.name,
+    credentialKey: profile.credentialKey,
+    strategy: profile.strategy,
+    material: built.material.filter(({ key }) => !secretKeys.has(key)),
+    secretMaterial: built.material.filter(({ key }) => secretKeys.has(key)),
+  };
+}
+
+function normalizeToken(value: string | null): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.replace(/\r/gu, "").trim();
+  return normalized || null;
+}
+
+function normalizeUnknownCredential(value: unknown): string {
+  return typeof value === "string" ? (normalizeToken(value) ?? "") : "";
+}

--- a/src/lib/messaging/applier/setup-applier.test.ts
+++ b/src/lib/messaging/applier/setup-applier.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 import YAML from "yaml";
 
+import { createCliOpenShellProviderAdapter } from "../../adapters/openshell/provider-adapter-cli";
 import {
   createBuiltInChannelManifestRegistry,
   createBuiltInRenderTemplateResolver,
@@ -82,6 +83,10 @@ const ALL_CHANNELS = createBuiltInChannelManifestRegistry()
   .listAvailable({ agent: "hermes" })
   .map((manifest) => manifest.id);
 const E2E_STOP_START_CHANNELS = ["telegram", "discord", "wechat", "slack", "whatsapp"] as const;
+
+function cliProviderAdapter(runOpenshell: MessagingOpenShellRunner) {
+  return createCliOpenShellProviderAdapter({ run: runOpenshell as never });
+}
 
 async function withEnv<T>(
   values: Readonly<Record<string, string | undefined>>,
@@ -439,7 +444,7 @@ describe("MessagingSetupApplier", () => {
         SLACK_BOT_TOKEN: "xoxb-slack-token",
         SLACK_APP_TOKEN: "xapp-slack-token",
       },
-      runOpenshell,
+      providerAdapter: cliProviderAdapter(runOpenshell),
     });
 
     expect(calls.map((call) => call.args)).toEqual([
@@ -511,7 +516,7 @@ describe("MessagingSetupApplier", () => {
     await expect(
       MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: { TELEGRAM_BOT_TOKEN: "123456:telegram-token" },
-        runOpenshell,
+        providerAdapter: cliProviderAdapter(runOpenshell),
       }),
     ).rejects.toThrow(/does not match the required endpointless credential binding/);
     expect(calls.some((command) => /provider (create|update)/u.test(command))).toBe(false);
@@ -526,7 +531,7 @@ describe("MessagingSetupApplier", () => {
     await expect(
       MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: {},
-        runOpenshell: (args) => {
+        providerAdapter: cliProviderAdapter((args) => {
           calls.push(args.join(" "));
           switch (`${args[1]} ${args[2]}`) {
             case "profile import":
@@ -549,7 +554,7 @@ describe("MessagingSetupApplier", () => {
                   "Name: demo-telegram-bridge\nType: nemoclaw-mcp-v1\nCredential keys: TELEGRAM_BOT_TOKEN\nConfig keys: <none>\n",
               };
           }
-        },
+        }),
       }),
     ).rejects.toThrow(/does not match NemoClaw's endpointless messaging credential contract/u);
     expect(calls.some((command) => /provider (create|update)/u.test(command))).toBe(false);
@@ -578,7 +583,7 @@ describe("MessagingSetupApplier", () => {
     try {
       await MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: { TELEGRAM_BOT_TOKEN: "tokensecretvalue" },
-        runOpenshell,
+        providerAdapter: cliProviderAdapter(runOpenshell),
       });
     } catch (error) {
       message = error instanceof Error ? error.message : String(error);
@@ -596,12 +601,12 @@ describe("MessagingSetupApplier", () => {
     await expect(
       MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: { TELEGRAM_BOT_TOKEN: "123456:telegram-token" },
-        runOpenshell: (args) => {
+        providerAdapter: cliProviderAdapter((args) => {
           calls.push(args.join(" "));
           return args[1] === "profile"
             ? EXACT_MESSAGING_PROFILE
             : { status: 1, stderr: "gateway unavailable" };
-        },
+        }),
       }),
     ).rejects.toThrow("Could not inspect messaging provider 'demo-telegram-bridge'.");
     expect(calls.some((command) => command.startsWith("provider create"))).toBe(false);
@@ -615,7 +620,7 @@ describe("MessagingSetupApplier", () => {
     await expect(
       MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: { TELEGRAM_BOT_TOKEN: "123456:telegram-token" },
-        runOpenshell: (args) => {
+        providerAdapter: cliProviderAdapter((args) => {
           switch (args[1]) {
             case "profile":
               return EXACT_MESSAGING_PROFILE;
@@ -624,7 +629,7 @@ describe("MessagingSetupApplier", () => {
             default:
               return { status: null, stderr: "transport closed" };
           }
-        },
+        }),
       }),
     ).rejects.toThrow("Failed to create messaging provider 'demo-telegram-bridge'");
   });
@@ -638,7 +643,7 @@ describe("MessagingSetupApplier", () => {
     await expect(
       MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: { TELEGRAM_BOT_TOKEN: "123456:telegram-token" },
-        runOpenshell: (args) => {
+        providerAdapter: cliProviderAdapter((args) => {
           switch (args[1]) {
             case "profile":
               return EXACT_MESSAGING_PROFILE;
@@ -654,7 +659,7 @@ describe("MessagingSetupApplier", () => {
                       "Name: demo-telegram-bridge\nType: generic\nCredential keys: TELEGRAM_BOT_TOKEN\nConfig keys: <none>\n",
                   };
           }
-        },
+        }),
       }),
     ).rejects.toThrow(
       "OpenShell did not confirm messaging provider 'demo-telegram-bridge' after create.",
@@ -670,7 +675,7 @@ describe("MessagingSetupApplier", () => {
     await expect(
       MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: { TELEGRAM_BOT_TOKEN: "123456:telegram-token" },
-        runOpenshell: (args) => {
+        providerAdapter: cliProviderAdapter((args) => {
           calls.push(args.join(" "));
           return args[1] === "profile"
             ? EXACT_MESSAGING_PROFILE
@@ -678,7 +683,7 @@ describe("MessagingSetupApplier", () => {
                 status: 1,
                 stderr: 'Error: status: Unavailable, message: "provider not found"',
               };
-        },
+        }),
       }),
     ).rejects.toThrow(/Could not inspect messaging provider/u);
     expect(calls.some((command) => /provider (create|update)/u.test(command))).toBe(false);
@@ -881,7 +886,7 @@ describe("MessagingSetupApplier", () => {
 
     const credentialResult = await MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
       env: ALL_CHANNEL_ENV,
-      runOpenshell: (args) => {
+      providerAdapter: cliProviderAdapter((args) => {
         switch (args[1]) {
           case "profile":
             return EXACT_MESSAGING_PROFILE;
@@ -899,7 +904,7 @@ describe("MessagingSetupApplier", () => {
             providers.set(String(args[3]), String(args[7]));
         }
         return { status: 0 };
-      },
+      }),
     });
     const policyResult = MessagingSetupApplier.applyPolicyAtOpenShell(plan, {
       applyPresets: (_sandboxName, presetNames, context) => {
@@ -1029,7 +1034,7 @@ describe("MessagingSetupApplier", () => {
         SLACK_BOT_TOKEN: "xoxb-slack-token",
         SLACK_APP_TOKEN: "xapp-slack-token",
       },
-      runOpenshell: (args) => {
+      providerAdapter: cliProviderAdapter((args) => {
         providerCalls.push([...args]);
         switch (args[1]) {
           case "profile":
@@ -1048,7 +1053,7 @@ describe("MessagingSetupApplier", () => {
             providers.set(String(args[3]), String(args[7]));
         }
         return { status: 0 };
-      },
+      }),
     });
     expect(providerCalls.some((args) => args.includes("demo-telegram-bridge"))).toBe(false);
     expect(credentialResult.providerNames).toEqual(["demo-slack-bridge", "demo-slack-app"]);

--- a/src/lib/messaging/applier/setup-applier.test.ts
+++ b/src/lib/messaging/applier/setup-applier.test.ts
@@ -433,7 +433,7 @@ describe("MessagingSetupApplier", () => {
       return { status: 0 };
     };
 
-    const result = MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
+    const result = await MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
       env: {
         TELEGRAM_BOT_TOKEN: "123456:telegram-token",
         SLACK_BOT_TOKEN: "xoxb-slack-token",
@@ -508,12 +508,12 @@ describe("MessagingSetupApplier", () => {
           : { status: 0 };
     };
 
-    expect(() =>
+    await expect(
       MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: { TELEGRAM_BOT_TOKEN: "123456:telegram-token" },
         runOpenshell,
       }),
-    ).toThrow(/does not match the required endpointless credential binding/);
+    ).rejects.toThrow(/does not match the required endpointless credential binding/);
     expect(calls.some((command) => /provider (create|update)/u.test(command))).toBe(false);
   });
 
@@ -523,7 +523,7 @@ describe("MessagingSetupApplier", () => {
     ]);
     const calls: string[] = [];
 
-    expect(() =>
+    await expect(
       MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: {},
         runOpenshell: (args) => {
@@ -551,7 +551,7 @@ describe("MessagingSetupApplier", () => {
           }
         },
       }),
-    ).toThrow(/does not match NemoClaw's endpointless messaging credential contract/u);
+    ).rejects.toThrow(/does not match NemoClaw's endpointless messaging credential contract/u);
     expect(calls.some((command) => /provider (create|update)/u.test(command))).toBe(false);
   });
 
@@ -576,7 +576,7 @@ describe("MessagingSetupApplier", () => {
 
     let message = "";
     try {
-      MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
+      await MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: { TELEGRAM_BOT_TOKEN: "tokensecretvalue" },
         runOpenshell,
       });
@@ -584,7 +584,7 @@ describe("MessagingSetupApplier", () => {
       message = error instanceof Error ? error.message : String(error);
     }
 
-    expect(message).toContain("TELEGRAM_BOT_TOKEN=toke");
+    expect(message).toContain("TELEGRAM_BOT_TOKEN=<REDACTED>");
     expect(message).not.toContain("tokensecretvalue");
   });
 
@@ -593,7 +593,7 @@ describe("MessagingSetupApplier", () => {
       "telegram",
     ]);
     const calls: string[] = [];
-    expect(() =>
+    await expect(
       MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: { TELEGRAM_BOT_TOKEN: "123456:telegram-token" },
         runOpenshell: (args) => {
@@ -603,7 +603,7 @@ describe("MessagingSetupApplier", () => {
             : { status: 1, stderr: "gateway unavailable" };
         },
       }),
-    ).toThrow("Could not inspect messaging provider 'demo-telegram-bridge'.");
+    ).rejects.toThrow("Could not inspect messaging provider 'demo-telegram-bridge'.");
     expect(calls.some((command) => command.startsWith("provider create"))).toBe(false);
   });
 
@@ -612,7 +612,7 @@ describe("MessagingSetupApplier", () => {
       "telegram",
     ]);
 
-    expect(() =>
+    await expect(
       MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: { TELEGRAM_BOT_TOKEN: "123456:telegram-token" },
         runOpenshell: (args) => {
@@ -626,7 +626,7 @@ describe("MessagingSetupApplier", () => {
           }
         },
       }),
-    ).toThrow("Failed to create messaging provider 'demo-telegram-bridge'");
+    ).rejects.toThrow("Failed to create messaging provider 'demo-telegram-bridge'");
   });
 
   it("rejects a provider mutation whose exact postcondition is absent (#9875)", async () => {
@@ -635,7 +635,7 @@ describe("MessagingSetupApplier", () => {
     ]);
     let lookups = 0;
 
-    expect(() =>
+    await expect(
       MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: { TELEGRAM_BOT_TOKEN: "123456:telegram-token" },
         runOpenshell: (args) => {
@@ -656,7 +656,9 @@ describe("MessagingSetupApplier", () => {
           }
         },
       }),
-    ).toThrow("OpenShell did not confirm messaging provider 'demo-telegram-bridge' after create.");
+    ).rejects.toThrow(
+      "OpenShell did not confirm messaging provider 'demo-telegram-bridge' after create.",
+    );
   });
 
   it("does not mutate after a not-found message with an unavailable status (#9875)", async () => {
@@ -665,7 +667,7 @@ describe("MessagingSetupApplier", () => {
     ]);
     const calls: string[] = [];
 
-    expect(() =>
+    await expect(
       MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
         env: { TELEGRAM_BOT_TOKEN: "123456:telegram-token" },
         runOpenshell: (args) => {
@@ -678,7 +680,7 @@ describe("MessagingSetupApplier", () => {
               };
         },
       }),
-    ).toThrow(/Could not inspect messaging provider/u);
+    ).rejects.toThrow(/Could not inspect messaging provider/u);
     expect(calls.some((command) => /provider (create|update)/u.test(command))).toBe(false);
   });
 
@@ -877,7 +879,7 @@ describe("MessagingSetupApplier", () => {
         : { status: written === undefined ? 1 : 0 };
     };
 
-    const credentialResult = MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
+    const credentialResult = await MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
       env: ALL_CHANNEL_ENV,
       runOpenshell: (args) => {
         switch (args[1]) {
@@ -1021,7 +1023,7 @@ describe("MessagingSetupApplier", () => {
 
     const providerCalls: string[][] = [];
     const providers = new Map<string, string>();
-    const credentialResult = MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
+    const credentialResult = await MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
       env: {
         TELEGRAM_BOT_TOKEN: "123456:telegram-token",
         SLACK_BOT_TOKEN: "xoxb-slack-token",

--- a/src/lib/messaging/applier/setup-applier.test.ts
+++ b/src/lib/messaging/applier/setup-applier.test.ts
@@ -448,8 +448,10 @@ describe("MessagingSetupApplier", () => {
     });
 
     expect(calls.map((call) => call.args)).toEqual([
-      ["provider", "profile", "export", "nemoclaw-mcp-v1", "--output", "json"],
       ["provider", "get", "demo-telegram-bridge"],
+      ["provider", "get", "demo-slack-bridge"],
+      ["provider", "get", "demo-slack-app"],
+      ["provider", "profile", "export", "nemoclaw-mcp-v1", "--output", "json"],
       [
         "provider",
         "create",
@@ -461,10 +463,8 @@ describe("MessagingSetupApplier", () => {
         "TELEGRAM_BOT_TOKEN",
       ],
       ["provider", "get", "demo-telegram-bridge"],
-      ["provider", "get", "demo-slack-bridge"],
       ["provider", "update", "demo-slack-bridge", "--credential", "SLACK_BOT_TOKEN"],
       ["provider", "get", "demo-slack-bridge"],
-      ["provider", "get", "demo-slack-app"],
       [
         "provider",
         "create",
@@ -477,7 +477,7 @@ describe("MessagingSetupApplier", () => {
       ],
       ["provider", "get", "demo-slack-app"],
     ]);
-    expect(calls[2]?.env).toEqual({ TELEGRAM_BOT_TOKEN: "123456:telegram-token" });
+    expect(calls[4]?.env).toEqual({ TELEGRAM_BOT_TOKEN: "123456:telegram-token" });
     expect(result.upserted.map((entry) => `${entry.action}:${entry.providerName}`)).toEqual([
       "create:demo-telegram-bridge",
       "update:demo-slack-bridge",

--- a/src/lib/messaging/applier/setup-applier.ts
+++ b/src/lib/messaging/applier/setup-applier.ts
@@ -171,7 +171,7 @@ export class MessagingSetupApplier {
   static applyCredentialsAtOpenShell(
     plan: SandboxMessagingPlan,
     options: MessagingCredentialApplyOptions,
-  ): MessagingCredentialApplyResult {
+  ): Promise<MessagingCredentialApplyResult> {
     return applyCredentialsPlanAtOpenShell(plan, options);
   }
 

--- a/src/lib/messaging/applier/types.ts
+++ b/src/lib/messaging/applier/types.ts
@@ -17,6 +17,7 @@ import type {
   MessagingHookRunResult,
 } from "../hooks";
 import type { OpenShellProviderAdapter } from "../../adapters/openshell/provider-adapter";
+import type { OpenShellGatewayTarget } from "../../adapters/openshell/sandbox-observer";
 
 export const MESSAGING_SETUP_APPLIER_ENV_KEY = "NEMOCLAW_MESSAGING_PLAN_B64";
 
@@ -70,8 +71,52 @@ export type MessagingOpenShellRunner = (
   options?: MessagingOpenShellRunOptions,
 ) => MessagingOpenShellRunResult;
 
+export type MessagingCredentialProviderProfile =
+  | Readonly<{
+      kind: "endpointless";
+      profilePath: string;
+      profileType: string;
+      inferenceCapable: false;
+    }>
+  | Readonly<{
+      kind: "checked-in";
+      profilePath: string;
+      profileType: string;
+      contractDigest: string;
+    }>;
+
+export type MessagingCredentialProviderDefinition = Readonly<{
+  channelId: MessagingChannelId;
+  credentialId: string;
+  providerName: string;
+  providerType: string;
+  credentials: readonly Readonly<{ name: string; value: string | null }>[];
+  profile: MessagingCredentialProviderProfile;
+}>;
+
+export type MessagingProviderRefreshDefinition = Readonly<{
+  channelId: MessagingChannelId;
+  providerName: string;
+  credentialKey: string;
+  strategy: string;
+  material: readonly Readonly<{ key: string; value: string }>[];
+  secretMaterial: readonly Readonly<{ key: string; value: string }>[];
+}>;
+
 export type MessagingCredentialApplyOptions = MessagingSetupEnvOptions &
-  Readonly<{ providerAdapter: OpenShellProviderAdapter }>;
+  Readonly<{
+    providerAdapter: OpenShellProviderAdapter;
+    target?: OpenShellGatewayTarget;
+    definitions?: readonly MessagingCredentialProviderDefinition[];
+    refreshes?: readonly MessagingProviderRefreshDefinition[];
+    replaceExisting?: boolean;
+    bestEffort?: boolean;
+    allowedSandboxes?: readonly string[];
+    revalidateSandboxIdentity?(operation: string): void;
+    sleep?(milliseconds: number): Promise<void>;
+    now?(): number;
+    log?(message: string): void;
+  }>;
 
 export interface MessagingCredentialApplyResult {
   readonly upserted: readonly {

--- a/src/lib/messaging/applier/types.ts
+++ b/src/lib/messaging/applier/types.ts
@@ -16,6 +16,7 @@ import type {
   MessagingHookOutputMap,
   MessagingHookRunResult,
 } from "../hooks";
+import type { OpenShellProviderAdapter } from "../../adapters/openshell/provider-adapter";
 
 export const MESSAGING_SETUP_APPLIER_ENV_KEY = "NEMOCLAW_MESSAGING_PLAN_B64";
 
@@ -69,9 +70,17 @@ export type MessagingOpenShellRunner = (
   options?: MessagingOpenShellRunOptions,
 ) => MessagingOpenShellRunResult;
 
-export interface MessagingCredentialApplyOptions extends MessagingSetupEnvOptions {
-  readonly runOpenshell: MessagingOpenShellRunner;
-}
+export type MessagingCredentialApplyOptions = MessagingSetupEnvOptions &
+  (
+    | Readonly<{
+        providerAdapter: OpenShellProviderAdapter;
+        runOpenshell?: never;
+      }>
+    | Readonly<{
+        providerAdapter?: never;
+        runOpenshell: MessagingOpenShellRunner;
+      }>
+  );
 
 export interface MessagingCredentialApplyResult {
   readonly upserted: readonly {

--- a/src/lib/messaging/applier/types.ts
+++ b/src/lib/messaging/applier/types.ts
@@ -71,16 +71,7 @@ export type MessagingOpenShellRunner = (
 ) => MessagingOpenShellRunResult;
 
 export type MessagingCredentialApplyOptions = MessagingSetupEnvOptions &
-  (
-    | Readonly<{
-        providerAdapter: OpenShellProviderAdapter;
-        runOpenshell?: never;
-      }>
-    | Readonly<{
-        providerAdapter?: never;
-        runOpenshell: MessagingOpenShellRunner;
-      }>
-  );
+  Readonly<{ providerAdapter: OpenShellProviderAdapter }>;
 
 export interface MessagingCredentialApplyResult {
   readonly upserted: readonly {

--- a/src/lib/onboard.ts
+++ b/src/lib/onboard.ts
@@ -904,7 +904,7 @@ const registeredCredentialProviders =
     migratedLegacyKeys,
     persistMigratedLegacyKeys,
   });
-const { upsertProvider, upsertMessagingProviders, providerMatchesGatewayCredential } =
+const { applyMessagingProviders, upsertProvider, providerMatchesGatewayCredential } =
   registeredCredentialProviders;
 const providerExistsInGateway = (name: string, gatewayName: string = GATEWAY_NAME) =>
   onboardProviders.providerExistsInGateway(
@@ -1625,7 +1625,7 @@ const sandboxCreateOrchestrationRuntime = {
   step,
   stringSetsEqual,
   toolDisclosureFlow,
-  upsertMessagingProviders,
+  applyMessagingProviders,
   usesManagedDcodeIdentity,
   validateName,
   verifyDirectSandboxGpu,

--- a/src/lib/onboard/credential-provider-registration.test.ts
+++ b/src/lib/onboard/credential-provider-registration.test.ts
@@ -252,8 +252,8 @@ describe("credential provider registration", () => {
       ),
     ).toBe(true);
     expect(runOpenshell.mock.calls.map(([args]) => args.join(" "))).toEqual([
-      "provider profile -g test-gateway export discord-hermes-static-v1 --output json",
       "provider get -g test-gateway alpha-discord-bridge",
+      "provider profile -g test-gateway export discord-hermes-static-v1 --output json",
     ]);
   });
 
@@ -452,7 +452,7 @@ describe("credential provider registration", () => {
 
   it("creates a missing messaging provider and records its receipt (#6743)", async () => {
     const session = { stagedCredentialProviders: [] } as unknown as Session;
-    const missing = { status: 1, stdout: "", stderr: "not found" };
+    const missing = { status: 1, stdout: "", stderr: "Provider not found" };
     const success = { status: 0, stdout: "", stderr: "" };
     const runOpenshell = vi.fn((args: string[]) =>
       args[0] === "provider" && args[1] === "get" ? missing : success,
@@ -496,7 +496,7 @@ describe("credential provider registration", () => {
 
   it("registers one static Hermes Discord provider from the checkpoint binding", async () => {
     const session = { stagedCredentialProviders: [] } as unknown as Session;
-    const missing = { status: 1, stdout: "", stderr: "not found" };
+    const missing = { status: 1, stdout: "", stderr: "Provider not found" };
     const success = { status: 0, stdout: "", stderr: "" };
     const runOpenshell = vi.fn((args: string[]) =>
       (args[0] === "provider" && args.includes("profile") && args.includes("export")) ||
@@ -630,7 +630,7 @@ describe("credential provider registration", () => {
     const session = {
       stagedCredentialProviders: ["alpha-slack-bridge", "alpha-slack-app"],
     } as unknown as Session;
-    const missing = { status: 1, stdout: "", stderr: "not found" };
+    const missing = { status: 1, stdout: "", stderr: "Provider not found" };
     const success = { status: 0, stdout: "", stderr: "" };
     const responses = new Map([
       [
@@ -705,7 +705,7 @@ describe("credential provider registration", () => {
   it.each([
     {
       condition: "the app provider is missing",
-      appProvider: { status: 1, stdout: "", stderr: "not found" },
+      appProvider: { status: 1, stdout: "", stderr: "Provider not found" },
       error:
         "A required credential provider is missing and no credential is available to recreate it.",
     },
@@ -720,7 +720,7 @@ describe("credential provider registration", () => {
       const session = {
         stagedCredentialProviders: ["alpha-slack-bridge", "alpha-slack-app"],
       } as unknown as Session;
-      const missing = { status: 1, stdout: "", stderr: "not found" };
+      const missing = { status: 1, stdout: "", stderr: "Provider not found" };
       const success = { status: 0, stdout: "", stderr: "" };
       const responses = new Map([
         ["provider get -g test-gateway alpha-slack-bridge", missing],
@@ -872,7 +872,7 @@ describe("credential provider registration", () => {
     const session = { stagedCredentialProviders: [] } as unknown as Session;
     const runOpenshell = vi.fn((args: string[]) =>
       args[1] === "get"
-        ? { status: 1, stdout: "", stderr: "not found" }
+        ? { status: 1, stdout: "", stderr: "Provider not found" }
         : { status: 0, stdout: "", stderr: "" },
     );
     const deps = registrationDeps(runOpenshell, session);
@@ -912,7 +912,7 @@ describe("credential provider registration", () => {
     const session = { stagedCredentialProviders: [] } as unknown as Session;
     const runOpenshell = vi.fn((args: string[]) =>
       args[1] === "get"
-        ? { status: 1, stdout: "", stderr: "not found" }
+        ? { status: 1, stdout: "", stderr: "Provider not found" }
         : { status: 0, stdout: "", stderr: "" },
     );
     const deps = registrationDeps(runOpenshell, session);

--- a/src/lib/onboard/credential-provider-registration.ts
+++ b/src/lib/onboard/credential-provider-registration.ts
@@ -2,10 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { WebSearchConfig } from "../inference/web-search";
+import {
+  createCliOpenShellProviderAdapter,
+  createCliOpenShellProviderInspectionAdapter,
+} from "../adapters/openshell/provider-adapter-cli";
+import { namedOpenShellGateway } from "../adapters/openshell/sandbox-observer";
+import {
+  buildMessagingProviderApplication,
+  resolveCheckedInMessagingProviderProfile,
+} from "../messaging/applier/provider-application";
+import { MessagingSetupApplier } from "../messaging/applier/setup-applier";
+import type { SandboxMessagingPlan } from "../messaging/manifest";
 import type { CheckpointProviderBinding } from "../state/onboard-checkpoint-types";
 import type { Session } from "../state/onboard-session";
 import * as gatewayProviderMetadata from "./gateway-provider-metadata";
-import * as messagingBridgeProvider from "./messaging-bridge-provider";
 import { hasConfiguredMessagingCredential, type MessagingTokenDef } from "./messaging-prep";
 import type { OpenshellCliHelpers } from "./openshell-cli";
 import { createGatewayScopedOpenshellRunner } from "./setup-inference";
@@ -170,6 +180,8 @@ const EXISTING_BINDING_ERROR =
   "An existing credential provider does not match the required binding.";
 const MISSING_BINDING_ERROR =
   "A required credential provider is missing and no credential is available to recreate it.";
+const BINDING_INSPECTION_ERROR =
+  "The required credential provider could not be inspected through the selected gateway.";
 
 function isCanonicalBinding(binding: CheckpointProviderBinding): boolean {
   return [binding.name, binding.type, binding.credentialEnv].every(
@@ -257,11 +269,54 @@ export function createCredentialProviderRegistration(deps: CredentialProviderReg
     options: MessagingProviderRegistrationOptions = {},
     runOpenshell: OpenshellCliHelpers["runOpenshell"] = deps.runOpenshell,
   ): string[] {
-    const upserted = credentialProviderRegistrationDependencies.upsertMessagingProviders(
-      tokenDefs,
-      runOpenshell,
-      options,
-    );
+    const override = liveE2eCredentialProviderOverride();
+    let upserted: string[];
+    if (override) {
+      upserted = credentialProviderRegistrationDependencies.upsertMessagingProviders(
+        tokenDefs,
+        runOpenshell,
+        options,
+      );
+    } else {
+      const plan = MessagingSetupApplier.readPlanFromEnv() ?? emptyMessagingPlan();
+      const application = buildMessagingProviderApplication({
+        tokenDefs,
+        root: deps.root,
+        agent: plan.agent,
+        getCredential: deps.getCredential,
+        env: process.env,
+        channelIdForCredential: (envKey, providerName) =>
+          channelIdForProvider(plan, envKey, providerName),
+      });
+      const otherProviderNames =
+        application.otherTokenDefs.length > 0
+          ? credentialProviderRegistrationDependencies.upsertMessagingProviders(
+              [...application.otherTokenDefs],
+              runOpenshell,
+              options,
+            )
+          : [];
+      for (const definition of application.definitions) {
+        if (
+          !credentialBindingMatchesGateway(
+            {
+              name: definition.providerName,
+              type: definition.providerType,
+              credentialEnv: definition.credentials[0]?.name ?? "",
+            },
+            runOpenshell,
+          )
+        ) {
+          throw new Error(
+            `Messaging provider '${definition.providerName}' was not staged through the typed provider applier.`,
+          );
+        }
+      }
+      upserted = [
+        ...otherProviderNames,
+        ...application.definitions.map(({ providerName }) => providerName),
+      ];
+    }
     recordMigratedLegacyMessagingCredentials(
       tokenDefs,
       upserted,
@@ -271,23 +326,114 @@ export function createCredentialProviderRegistration(deps: CredentialProviderReg
     return upserted;
   }
 
+  async function applyMessagingProviders(
+    tokenDefs: MessagingTokenDef[],
+    options: MessagingProviderRegistrationOptions = {},
+    runOpenshell: OpenshellCliHelpers["runOpenshell"] = deps.runOpenshell,
+  ): Promise<string[]> {
+    const override = liveE2eCredentialProviderOverride();
+    const applied = override
+      ? credentialProviderRegistrationDependencies.upsertMessagingProviders(
+          tokenDefs,
+          runOpenshell,
+          options,
+        )
+      : await applyProviderDefinitions(tokenDefs, runOpenshell, options);
+    recordMigratedLegacyMessagingCredentials(
+      tokenDefs,
+      applied,
+      deps,
+      options.revalidateSandboxIdentity,
+    );
+    return applied;
+  }
+
+  async function applyProviderDefinitions(
+    tokenDefs: MessagingTokenDef[],
+    runOpenshell: OpenshellCliHelpers["runOpenshell"],
+    options: MessagingProviderRegistrationOptions,
+  ): Promise<string[]> {
+    const plan = MessagingSetupApplier.readPlanFromEnv() ?? emptyMessagingPlan();
+    const application = buildMessagingProviderApplication({
+      tokenDefs,
+      root: deps.root,
+      agent: plan.agent,
+      getCredential: deps.getCredential,
+      env: process.env,
+      channelIdForCredential: (envKey, providerName) =>
+        channelIdForProvider(plan, envKey, providerName),
+    });
+    const otherProviderNames =
+      application.otherTokenDefs.length > 0
+        ? providers.upsertMessagingProviders(
+            application.otherTokenDefs,
+            runOpenshell,
+            options,
+          )
+        : [];
+    if (application.definitions.length === 0) return otherProviderNames;
+    const providerAdapter = createCliOpenShellProviderAdapter({ run: runOpenshell });
+    const result = await MessagingSetupApplier.applyCredentialsAtOpenShell(plan, {
+      providerAdapter,
+      target: namedOpenShellGateway(deps.getGatewayName()),
+      definitions: application.definitions,
+      refreshes: application.refreshes,
+      replaceExisting: options.replaceExisting,
+      bestEffort: options.bestEffort,
+      allowedSandboxes: options.allowedSandboxes,
+      revalidateSandboxIdentity: options.revalidateSandboxIdentity,
+      log: (message) => console.error(`  ${message}`),
+    });
+    return [...otherProviderNames, ...result.providerNames];
+  }
+
+  type CredentialBindingInspection = "collision" | "exact" | "indeterminate" | "missing";
+
+  function inspectCredentialBinding(
+    binding: CheckpointProviderBinding,
+    runOpenshell: OpenshellCliHelpers["runOpenshell"],
+  ): CredentialBindingInspection {
+    const inspector = createCliOpenShellProviderInspectionAdapter({ run: runOpenshell });
+    const target = namedOpenShellGateway(deps.getGatewayName());
+    const provider = inspector.getProvider({ target, providerName: binding.name });
+    if (!provider.ok) {
+      return provider.error.kind === "command" && provider.error.reason === "not_found"
+        ? "missing"
+        : "indeterminate";
+    }
+    if (
+      !gatewayProviderMetadata.matchesGatewayCredentialFamilyProviderBinding(provider.value, {
+        name: binding.name,
+        type: binding.type,
+        credentialKey: binding.credentialEnv,
+      })
+    ) {
+      return "collision";
+    }
+    const expectedProfile = resolveCheckedInMessagingProviderProfile({
+      root: deps.root,
+      profileType: binding.type,
+    });
+    if (!expectedProfile) return "exact";
+    const profile = inspector.inspectProviderProfile({
+      target,
+      profileType: binding.type,
+    });
+    if (!profile.ok) {
+      return profile.error.kind === "command" && profile.error.reason === "not_found"
+        ? "collision"
+        : "indeterminate";
+    }
+    return profile.value.contractDigest === expectedProfile.contractDigest
+      ? "exact"
+      : "collision";
+  }
+
   function credentialBindingMatchesGateway(
     binding: CheckpointProviderBinding,
     runOpenshell: OpenshellCliHelpers["runOpenshell"],
   ): boolean {
-    const staticProfileMatches = messagingBridgeProvider.matchesRegisteredStaticMessagingProfile(
-      binding.type,
-      { root: deps.root, runOpenshell },
-    );
-    if (staticProfileMatches === false) return false;
-    return gatewayProviderMetadata.matchesGatewayCredentialFamilyProviderBinding(
-      providers.readGatewayProviderMetadata(binding.name, runOpenshell, deps.getGatewayName()),
-      {
-        name: binding.name,
-        type: binding.type,
-        credentialKey: binding.credentialEnv,
-      },
-    );
+    return inspectCredentialBinding(binding, runOpenshell) === "exact";
   }
 
   function providerMatchesGatewayCredential(
@@ -295,7 +441,14 @@ export function createCredentialProviderRegistration(deps: CredentialProviderReg
     type: string,
     credentialEnv: string,
   ): boolean {
-    return credentialBindingMatchesGateway({ name, type, credentialEnv }, gatewayRunner());
+    return credentialBindingMatchesGateway(
+      {
+        name,
+        type,
+        credentialEnv,
+      },
+      gatewayRunner(),
+    );
   }
 
   function preflightRequiredCredentialProviderBindings(
@@ -305,15 +458,16 @@ export function createCredentialProviderRegistration(deps: CredentialProviderReg
     replaceExisting: boolean,
   ): void {
     for (const binding of requiredBindings) {
-      if (!providers.providerExistsInGateway(binding.name, runOpenshell)) {
+      const inspection = inspectCredentialBinding(binding, runOpenshell);
+      if (inspection === "indeterminate") throw new Error(BINDING_INSPECTION_ERROR);
+      if (inspection === "missing") {
         const tokenDef = plannedTokenDefs.get(binding.name);
         if (!tokenDef || !hasConfiguredMessagingCredential(tokenDef)) {
           throw new Error(MISSING_BINDING_ERROR);
         }
         continue;
       }
-      const matches = credentialBindingMatchesGateway(binding, runOpenshell);
-      if (matches) continue;
+      if (inspection === "exact") continue;
       const tokenDef = plannedTokenDefs.get(binding.name);
       if (!replaceExisting || !tokenDef || !hasConfiguredMessagingCredential(tokenDef)) {
         throw new Error(EXISTING_BINDING_ERROR);
@@ -349,7 +503,7 @@ export function createCredentialProviderRegistration(deps: CredentialProviderReg
       false,
       deps,
     );
-    const registered = upsertMessagingProviders(
+    const registered = await applyMessagingProviders(
       tokenDefs,
       {
         replaceExisting: input.replaceExisting === true,
@@ -369,8 +523,39 @@ export function createCredentialProviderRegistration(deps: CredentialProviderReg
 
   return {
     providerMatchesGatewayCredential,
+    applyMessagingProviders,
     stageSandboxCredentialProviders,
     upsertProvider,
     upsertMessagingProviders,
   };
+}
+
+function emptyMessagingPlan(): SandboxMessagingPlan {
+  return {
+    schemaVersion: 1,
+    sandboxName: "provider-application",
+    agent: "openclaw",
+    workflow: "onboard",
+    channels: [],
+    disabledChannels: [],
+    credentialBindings: [],
+    networkPolicy: { presets: [], entries: [] },
+    agentRender: [],
+    buildSteps: [],
+    stateUpdates: [],
+    healthChecks: [],
+  };
+}
+
+function channelIdForProvider(
+  plan: SandboxMessagingPlan,
+  envKey: string,
+  providerName: string,
+): string | null {
+  return (
+    plan.credentialBindings.find(
+      (binding) =>
+        binding.providerName === providerName || binding.providerEnvKey === envKey,
+    )?.channelId ?? null
+  );
 }

--- a/src/lib/onboard/experimental/hermes-portable-build-context-files.ts
+++ b/src/lib/onboard/experimental/hermes-portable-build-context-files.ts
@@ -179,6 +179,8 @@ export const HERMES_PORTABLE_BUILD_CONTEXT_FILES = [
   { path: "src/lib/messaging/applier/openshell-provider.ts", mode: "100644" },
   { path: "src/lib/messaging/applier/plan-filter.ts", mode: "100644" },
   { path: "src/lib/messaging/applier/policy.ts", mode: "100644" },
+  { path: "src/lib/messaging/applier/provider-application.test.ts", mode: "100644" },
+  { path: "src/lib/messaging/applier/provider-application.ts", mode: "100644" },
   { path: "src/lib/messaging/applier/setup-applier-credential-env.test.ts", mode: "100644" },
   { path: "src/lib/messaging/applier/setup-applier.test.ts", mode: "100644" },
   { path: "src/lib/messaging/applier/setup-applier.ts", mode: "100644" },

--- a/src/lib/onboard/experimental/hermes-portable-build-context-files.ts
+++ b/src/lib/onboard/experimental/hermes-portable-build-context-files.ts
@@ -175,6 +175,7 @@ export const HERMES_PORTABLE_BUILD_CONTEXT_FILES = [
   { path: "src/lib/messaging/applier/index.ts", mode: "100644" },
   { path: "src/lib/messaging/applier/openclaw-plugin-allow.test.ts", mode: "100644" },
   { path: "src/lib/messaging/applier/openclaw-plugin-allow.ts", mode: "100644" },
+  { path: "src/lib/messaging/applier/openshell-provider.test.ts", mode: "100644" },
   { path: "src/lib/messaging/applier/openshell-provider.ts", mode: "100644" },
   { path: "src/lib/messaging/applier/plan-filter.ts", mode: "100644" },
   { path: "src/lib/messaging/applier/policy.ts", mode: "100644" },

--- a/src/lib/onboard/managed-workload/onboard-orchestration.ts
+++ b/src/lib/onboard/managed-workload/onboard-orchestration.ts
@@ -88,8 +88,8 @@ export { normalizeRuntimeProviderIdentity, removeManagedHermesStateVolume };
 export type ManagedHermesStateVolumeOnboardLifecycle = {
   materializeSandboxCreatePlan(
     input: MaterializeSandboxCreatePlanInput,
-    materialize: (input: MaterializeSandboxCreatePlanInput) => SandboxCreatePlan,
-  ): SandboxCreatePlan;
+    materialize: (input: MaterializeSandboxCreatePlanInput) => Promise<SandboxCreatePlan>,
+  ): Promise<SandboxCreatePlan>;
   commit(): void;
 };
 
@@ -432,7 +432,7 @@ export async function prepareOnboardSandboxWorkloadLaunch(
       ? input.workload.source.reference
       : `${requireLegacyBuildContext(legacyBuildContext).buildCtx}/Dockerfile`;
   const messagingTokenDefs = await input.plan.rebindMessagingTokenDefs();
-  const createPlan = input.dependencies.materializeSandboxCreatePlan({
+  const createPlan = await input.dependencies.materializeSandboxCreatePlan({
     intent: input.plan.intent,
     fromRef,
     policylessCreate: input.plan.policylessCreate,

--- a/src/lib/onboard/messaging-bridge-provider.ts
+++ b/src/lib/onboard/messaging-bridge-provider.ts
@@ -70,7 +70,9 @@ export interface MessagingBridgeProfile {
   readonly sourceSecretEnv: string;
 }
 
-type RefreshingMessagingBridgeProfile = MessagingBridgeProfile & { readonly strategy: string };
+export type RefreshingMessagingBridgeProfile = MessagingBridgeProfile & {
+  readonly strategy: string;
+};
 
 function hasRefreshStrategy(
   profile: MessagingBridgeProfile,
@@ -324,7 +326,7 @@ export function listMessagingBridgeProfiles(
  * key resolution). Using `getCredential` alone misses non-interactive runs where
  * the value arrives through the passed-in env.
  */
-function resolveBridgeSecret(
+export function resolveMessagingBridgeSecret(
   envKey: string,
   deps: MessagingBridgeSecretResolveDeps,
 ): string | null {
@@ -383,7 +385,7 @@ export function collectMessagingBridgeTokenDefs(
     if (input.disabledChannelNames.has(profile.channelId)) continue;
     if (input.enabledChannels != null && !input.enabledChannels.includes(profile.channelId))
       continue;
-    const secret = resolveBridgeSecret(profile.sourceSecretEnv, input);
+    const secret = resolveMessagingBridgeSecret(profile.sourceSecretEnv, input);
     if (!secret) continue;
     defs.push({
       name: bridgeProviderNameFor(input.sandboxName, profile.channelId),
@@ -547,7 +549,7 @@ export function ensureMessagingBridgeProfiles(
   }
 }
 
-function buildRefreshMaterial(
+export function buildMessagingBridgeRefreshMaterial(
   profile: RefreshingMessagingBridgeProfile,
   secret: string,
 ):
@@ -692,7 +694,7 @@ export function configureMessagingBridgeRefreshes(
     );
     if (!bridge) continue;
 
-    const secret = resolveBridgeSecret(profile.sourceSecretEnv, deps);
+    const secret = resolveMessagingBridgeSecret(profile.sourceSecretEnv, deps);
     if (!secret) {
       warn(
         `\n  ✗ ${profile.channelId} bridge: secret material unavailable; cannot configure gateway token minting.`,
@@ -700,7 +702,7 @@ export function configureMessagingBridgeRefreshes(
       return { ok: false, reason: "secret material unavailable" };
     }
 
-    const built = buildRefreshMaterial(profile, secret);
+    const built = buildMessagingBridgeRefreshMaterial(profile, secret);
     if (!built.ok) {
       warn(
         `\n  ✗ ${profile.channelId} bridge: ${built.reason}; cannot configure gateway token minting.`,

--- a/src/lib/onboard/sandbox-create-intent-types.ts
+++ b/src/lib/onboard/sandbox-create-intent-types.ts
@@ -105,7 +105,7 @@ export type MaterializeSandboxCreatePlanInput = {
       allowedSandboxes: readonly [string];
       revalidateSandboxIdentity?(operation: string): void;
     },
-  ): string[];
+  ): string[] | Promise<string[]>;
   getHermesToolGatewayProviderName(sandboxName: string): string;
   discloseInitialSandboxPolicy?(policy: InitialSandboxPolicy): void;
   prepareInitialSandboxCreatePolicy?: PrepareInitialSandboxCreatePolicy;

--- a/src/lib/onboard/sandbox-create-plan-materialization.ts
+++ b/src/lib/onboard/sandbox-create-plan-materialization.ts
@@ -80,7 +80,7 @@ export type SandboxCreatePlan = {
   sandboxGpuLogMessage: string | null;
   /** One-shot provider activation owned by the post-create verification boundary. */
   activateDeferredProviderEffects:
-    | ((revalidateSandboxIdentity: (operation: string) => void) => readonly string[])
+    | ((revalidateSandboxIdentity: (operation: string) => void) => Promise<readonly string[]>)
     | null;
 };
 
@@ -277,7 +277,7 @@ function assertDeferredProviderPlanSupported(
 }
 
 /** Materialize policy, route metadata, resources, and providers from a secretless intent. */
-export function materializeSandboxCreatePlan({
+export async function materializeSandboxCreatePlan({
   intent,
   fromRef,
   policylessCreate = false,
@@ -289,7 +289,7 @@ export function materializeSandboxCreatePlan({
   getHermesToolGatewayProviderName,
   discloseInitialSandboxPolicy,
   prepareInitialSandboxCreatePolicy = getInitialSandboxCreatePolicy,
-}: MaterializeSandboxCreatePlanInput): SandboxCreatePlan {
+}: MaterializeSandboxCreatePlanInput): Promise<SandboxCreatePlan> {
   const enabledMessagingTokenDefs = validateSandboxCreateIntentBindings(intent, messagingTokenDefs);
   const driverConfig = buildSandboxDriverConfig(intent, managedStateMount);
   const { initialSandboxPolicy, compatibilityPolicyPath } = prepareSandboxGpuRoutePolicies(
@@ -353,17 +353,17 @@ export function materializeSandboxCreatePlan({
     }
   }
 
-  const activateProviderEffects = (
+  const activateProviderEffects = async (
     revalidateSandboxIdentity?: (operation: string) => void,
-  ): readonly string[] => {
+  ): Promise<readonly string[]> => {
     runProviderPreDeleteCleanup(revalidateSandboxIdentity);
     const activatedMessagingProviders = filterMessagingProvidersForSandboxCreate(
       [
-        ...upsertMessagingProviders(enabledMessagingTokenDefs, {
+        ...(await upsertMessagingProviders(enabledMessagingTokenDefs, {
           replaceExisting: true,
           allowedSandboxes: [intent.sandboxName],
           ...(revalidateSandboxIdentity ? { revalidateSandboxIdentity } : {}),
-        }),
+        })),
         ...intent.reusableMessagingProviders,
       ],
       intent.messagingProviderRequests,
@@ -386,8 +386,13 @@ export function materializeSandboxCreatePlan({
     return [...createProviders];
   };
   if (!deferSandboxEffectsUntilIdentityVerification) {
-    for (const provider of activateProviderEffects()) {
-      createArgs.push("--provider", provider);
+    try {
+      for (const provider of await activateProviderEffects()) {
+        createArgs.push("--provider", provider);
+      }
+    } catch (error) {
+      initialSandboxPolicy.cleanup?.();
+      throw error;
     }
   }
 

--- a/src/lib/onboard/sandbox-create-plan.test.ts
+++ b/src/lib/onboard/sandbox-create-plan.test.ts
@@ -134,7 +134,7 @@ function materializeDiscordCreatePlan(
   });
 }
 
-function expectCredentialBindingFailure({
+async function expectCredentialBindingFailure({
   expectedMessage,
   materializedTokenDefs,
   plannedTokenDef,
@@ -142,7 +142,7 @@ function expectCredentialBindingFailure({
   expectedMessage: string;
   materializedTokenDefs: MessagingTokenDef[];
   plannedTokenDef: MessagingTokenDef;
-}): void {
+}): Promise<void> {
   const intent = resolveSandboxCreateIntent({
     basePolicyPath: "/repo/policy.yaml",
     sandboxName: "sandbox",
@@ -169,7 +169,7 @@ function expectCredentialBindingFailure({
   const cleanupProviders = vi.fn();
   const upsertProviders = vi.fn(() => []);
 
-  expect(() =>
+  await expect(
     materializeSandboxCreatePlan({
       intent,
       fromRef: "/tmp/nemoclaw-build-1/Dockerfile",
@@ -179,7 +179,7 @@ function expectCredentialBindingFailure({
       upsertMessagingProviders: upsertProviders,
       getHermesToolGatewayProviderName: vi.fn(),
     }),
-  ).toThrow(expectedMessage);
+  ).rejects.toThrow(expectedMessage);
   expect(preparePolicy).not.toHaveBeenCalled();
   expect(cleanupProviders).not.toHaveBeenCalled();
   expect(upsertProviders).not.toHaveBeenCalled();
@@ -227,14 +227,14 @@ describe("resolveSandboxCreatePolicyTier", () => {
     expect(resolveSandboxCreatePolicyTier()).toBe("personal");
   });
 
-  it("ends policy-tier transport after initial policy composition", () => {
+  it("ends policy-tier transport after initial policy composition", async () => {
     const resolved = resolveDiscordCreateIntent({ selected: false, policyTier: "balanced" });
     const preparePolicy = vi.fn(() => ({
       policyPath: "/tmp/policy.yaml",
       appliedPresets: ["openclaw-diagnostics-otel-local"],
     }));
 
-    const plan = materializeDiscordCreatePlan(resolved, {
+    const plan = await materializeDiscordCreatePlan(resolved, {
       prepareInitialSandboxCreatePolicy: preparePolicy,
     });
 
@@ -359,7 +359,7 @@ describe("resolveSandboxCreateIntent", () => {
   it(
     "omits Discord create-time effects when an unselected credential is available",
     testTimeoutOptions(15_000),
-    () => {
+    async () => {
       const { intent, messagingTokenDefs } = resolveDiscordCreateIntent({
         selected: false,
         reusable: true,
@@ -368,7 +368,7 @@ describe("resolveSandboxCreateIntent", () => {
         tokenDefs.map(({ name }) => name),
       );
 
-      const plan = materializeDiscordCreatePlan(
+      const plan = await materializeDiscordCreatePlan(
         { intent, messagingTokenDefs },
         { upsertMessagingProviders },
       );
@@ -389,12 +389,12 @@ describe("resolveSandboxCreateIntent", () => {
     },
   );
 
-  it("attaches the selected Discord provider to its create-time policy", () => {
+  it("attaches the selected Discord provider to its create-time policy", async () => {
     const { intent, messagingTokenDefs } = resolveDiscordCreateIntent({
       selected: true,
     });
 
-    const plan = materializeDiscordCreatePlan({ intent, messagingTokenDefs });
+    const plan = await materializeDiscordCreatePlan({ intent, messagingTokenDefs });
 
     expect(plan.activeMessagingChannels).toEqual(["discord"]);
     expect(plan.initialSandboxPolicy.appliedPresets).toContain("discord");
@@ -404,22 +404,22 @@ describe("resolveSandboxCreateIntent", () => {
     plan.initialSandboxPolicy.cleanup?.();
   });
 
-  it("rejects selected Discord when its provider cannot be prepared", () => {
+  it("rejects selected Discord when its provider cannot be prepared", async () => {
     const { intent, messagingTokenDefs } = resolveDiscordCreateIntent({
       selected: true,
     });
 
-    expect(() =>
+    await expect(
       materializeDiscordCreatePlan(
         { intent, messagingTokenDefs },
         { upsertMessagingProviders: vi.fn(() => []) },
       ),
-    ).toThrow(
+    ).rejects.toThrow(
       `Cannot create sandbox; create-time policy requires credential provider '${discordProviderName}', but the sandbox create plan does not attach it.`,
     );
   });
 
-  it("rejects every create-time policy credential binding missing from the provider set", () => {
+  it("rejects every create-time policy credential binding missing from the provider set", async () => {
     const { intent, messagingTokenDefs } = resolveDiscordCreateIntent({
       selected: true,
     });
@@ -427,7 +427,7 @@ describe("resolveSandboxCreateIntent", () => {
     const cleanupProviders = vi.fn();
     const upsertMessagingProviders = vi.fn(() => [discordProviderName]);
 
-    expect(() =>
+    await expect(
       materializeDiscordCreatePlan(
         { intent, messagingTokenDefs },
         {
@@ -441,7 +441,7 @@ describe("resolveSandboxCreateIntent", () => {
           upsertMessagingProviders,
         },
       ),
-    ).toThrow(
+    ).rejects.toThrow(
       "Cannot create sandbox; create-time policy requires credential provider 'sandbox-missing-provider', but the sandbox create plan does not attach it.",
     );
     expect(cleanupPolicy).toHaveBeenCalledOnce();
@@ -449,7 +449,7 @@ describe("resolveSandboxCreateIntent", () => {
     expect(upsertMessagingProviders).not.toHaveBeenCalled();
   });
 
-  it("attaches a retained static provider while its channel runtime is stopped (#9773)", () => {
+  it("attaches a retained static provider while its channel runtime is stopped (#9773)", async () => {
     const intent = resolveSandboxCreateIntent({
       basePolicyPath: "/repo/hermes-policy.yaml",
       sandboxName: "sandbox",
@@ -472,7 +472,7 @@ describe("resolveSandboxCreateIntent", () => {
     });
     const upsertMessagingProviders = vi.fn(() => []);
 
-    const plan = materializeSandboxCreatePlan({
+    const plan = await materializeSandboxCreatePlan({
       intent,
       fromRef: "/tmp/Dockerfile",
       messagingTokenDefs: [],
@@ -494,7 +494,7 @@ describe("resolveSandboxCreateIntent", () => {
     expect(plan.createArgs).toContain("sandbox-discord-bridge");
   });
 
-  it("keeps the real gateway provider while excluding direct host-local inference policy", () => {
+  it("keeps the real gateway provider while excluding direct host-local inference policy", async () => {
     const intent = resolveSandboxCreateIntent({
       basePolicyPath: "/repo/policy.yaml",
       sandboxName: "sandbox",
@@ -519,7 +519,7 @@ describe("resolveSandboxCreateIntent", () => {
       appliedPresets: [],
     }));
 
-    const plan = materializeSandboxCreatePlan({
+    const plan = await materializeSandboxCreatePlan({
       intent,
       fromRef: "/tmp/nemoclaw-build-1/Dockerfile",
       messagingTokenDefs: [],
@@ -540,7 +540,7 @@ describe("resolveSandboxCreateIntent", () => {
     expect(plan.createArgs).not.toContain("local-inference");
   });
 
-  it("materializes policy and provider effects after resolving intent", () => {
+  it("materializes policy and provider effects after resolving intent", async () => {
     const tokenDefs = [
       {
         name: "sandbox-telegram-bridge",
@@ -573,7 +573,7 @@ describe("resolveSandboxCreateIntent", () => {
     const serializedIntent = JSON.stringify(intent);
     const events: string[] = [];
 
-    const result = materializeSandboxCreatePlan({
+    const result = await materializeSandboxCreatePlan({
       intent,
       fromRef: "/tmp/nemoclaw-build-1/Dockerfile",
       messagingTokenDefs: tokenDefs,
@@ -627,7 +627,7 @@ describe("resolveSandboxCreateIntent", () => {
     expect(JSON.stringify(intent)).toBe(serializedIntent);
   });
 
-  it("rejects deferred provider plans before provider effects or sandbox creation (#9833)", () => {
+  it("rejects deferred provider plans before provider effects or sandbox creation (#9833)", async () => {
     const tokenDefs = [
       {
         name: "sandbox-telegram-bridge",
@@ -672,7 +672,7 @@ describe("resolveSandboxCreateIntent", () => {
       return "sandbox-hermes-tools";
     });
 
-    expect(() =>
+    await expect(
       materializeSandboxCreatePlan({
         intent,
         fromRef: "example.invalid/image@sha256:abc",
@@ -687,7 +687,7 @@ describe("resolveSandboxCreateIntent", () => {
         upsertMessagingProviders,
         getHermesToolGatewayProviderName,
       }),
-    ).toThrow("No sandbox was created");
+    ).rejects.toThrow("No sandbox was created");
 
     expect(events).toEqual(["policy-cleanup"]);
     expect(cleanupPolicy).toHaveBeenCalledOnce();
@@ -696,7 +696,7 @@ describe("resolveSandboxCreateIntent", () => {
     expect(getHermesToolGatewayProviderName).not.toHaveBeenCalled();
   });
 
-  it("keeps the NemoClaw policy on a managed create when effects are deferred (#9833)", () => {
+  it("keeps the NemoClaw policy on a managed create when effects are deferred (#9833)", async () => {
     const intent = resolveSandboxCreateIntent({
       basePolicyPath: "/repo/policy.yaml",
       sandboxName: "sandbox",
@@ -716,7 +716,7 @@ describe("resolveSandboxCreateIntent", () => {
       sandboxGpuLogMessage: null,
       agentName: "openclaw",
     });
-    const plan = materializeSandboxCreatePlan({
+    const plan = await materializeSandboxCreatePlan({
       intent,
       fromRef: "example.invalid/image@sha256:abc",
       deferSandboxEffectsUntilIdentityVerification: true,
@@ -775,7 +775,7 @@ describe("resolveSandboxCreateIntent", () => {
     expect(plan.createArgs).not.toContain("--gpu-device");
   });
 
-  it("rejects GPU device driver config without the typed GPU request", () => {
+  it("rejects GPU device driver config without the typed GPU request", async () => {
     const intent = resolveSandboxCreateIntent({
       basePolicyPath: "/repo/policy.yaml",
       sandboxName: "sandbox",
@@ -793,7 +793,7 @@ describe("resolveSandboxCreateIntent", () => {
       sandboxGpuLogMessage: null,
     });
 
-    expect(() =>
+    await expect(
       materializeSandboxCreatePlan({
         intent,
         fromRef: "/tmp/nemoclaw-build-1/Dockerfile",
@@ -803,10 +803,10 @@ describe("resolveSandboxCreateIntent", () => {
         upsertMessagingProviders: vi.fn(() => []),
         getHermesToolGatewayProviderName: vi.fn(),
       }),
-    ).toThrow("Sandbox GPU device selection requires the OpenShell GPU request.");
+    ).rejects.toThrow("Sandbox GPU device selection requires the OpenShell GPU request.");
   });
 
-  it("materializes a read-only Docker bind beside the DCode tmpfs mount", () => {
+  it("materializes a read-only Docker bind beside the DCode tmpfs mount", async () => {
     const intent = resolveSandboxCreateIntent({
       basePolicyPath: "/repo/policy.yaml",
       sandboxName: "sandbox",
@@ -825,7 +825,7 @@ describe("resolveSandboxCreateIntent", () => {
       sandboxGpuLogMessage: null,
       agentName: "langchain-deepagents-code",
     });
-    const plan = materializeSandboxCreatePlan({
+    const plan = await materializeSandboxCreatePlan({
       intent,
       fromRef: "/tmp/nemoclaw-build-1/Dockerfile",
       messagingTokenDefs: [],
@@ -859,7 +859,7 @@ describe("resolveSandboxCreateIntent", () => {
     expect(driverConfig.podman.mounts).toEqual([driverConfig.docker.mounts[0]]);
   });
 
-  it("passes the managed Hermes state volume through the Docker driver config", () => {
+  it("passes the managed Hermes state volume through the Docker driver config", async () => {
     const intent = resolveSandboxCreateIntent({
       basePolicyPath: "/repo/policy.yaml",
       sandboxName: "hermes-box",
@@ -877,7 +877,7 @@ describe("resolveSandboxCreateIntent", () => {
       sandboxGpuLogMessage: null,
       agentName: "hermes",
     });
-    const plan = materializeSandboxCreatePlan({
+    const plan = await materializeSandboxCreatePlan({
       intent,
       fromRef: `ghcr.io/nvidia/nemoclaw/hermes@sha256:${"a".repeat(64)}`,
       managedStateMount: {
@@ -911,7 +911,7 @@ describe("resolveSandboxCreateIntent", () => {
     });
   });
 
-  it("rejects host mounts that overlap the managed Hermes state root", () => {
+  it("rejects host mounts that overlap the managed Hermes state root", async () => {
     const intent = resolveSandboxCreateIntent({
       basePolicyPath: "/repo/policy.yaml",
       sandboxName: "hermes-box",
@@ -931,7 +931,7 @@ describe("resolveSandboxCreateIntent", () => {
       agentName: "hermes",
     });
 
-    expect(() =>
+    await expect(
       materializeSandboxCreatePlan({
         intent,
         fromRef: `ghcr.io/nvidia/nemoclaw/hermes@sha256:${"a".repeat(64)}`,
@@ -950,10 +950,10 @@ describe("resolveSandboxCreateIntent", () => {
         upsertMessagingProviders: vi.fn(() => []),
         getHermesToolGatewayProviderName: vi.fn(),
       }),
-    ).toThrow(/conflicts with the managed Hermes state root/u);
+    ).rejects.toThrow(/conflicts with the managed Hermes state root/u);
   });
 
-  it("cleans up the prepared policy when disclosure fails before provider effects (#7179)", () => {
+  it("cleans up the prepared policy when disclosure fails before provider effects (#7179)", async () => {
     const intent = resolveSandboxCreateIntent({
       basePolicyPath: "/repo/policy.yaml",
       sandboxName: "sandbox",
@@ -974,7 +974,7 @@ describe("resolveSandboxCreateIntent", () => {
     const cleanupProviders = vi.fn();
     const upsertProviders = vi.fn(() => []);
 
-    expect(() =>
+    await expect(
       materializeSandboxCreatePlan({
         intent,
         fromRef: "/tmp/nemoclaw-build-1/Dockerfile",
@@ -991,14 +991,14 @@ describe("resolveSandboxCreateIntent", () => {
         upsertMessagingProviders: upsertProviders,
         getHermesToolGatewayProviderName: vi.fn(),
       }),
-    ).toThrow("disclosure failed");
+    ).rejects.toThrow("disclosure failed");
     expect(cleanupPolicy).toHaveBeenCalledOnce();
     expect(cleanupProviders).not.toHaveBeenCalled();
     expect(upsertProviders).not.toHaveBeenCalled();
   });
 
-  it("rejects changed credential availability before running effects", () => {
-    expectCredentialBindingFailure({
+  it("rejects changed credential availability before running effects", async () => {
+    await expectCredentialBindingFailure({
       plannedTokenDef: {
         name: "sandbox-telegram-bridge",
         envKey: "TELEGRAM_BOT_TOKEN",
@@ -1016,8 +1016,8 @@ describe("resolveSandboxCreateIntent", () => {
     });
   });
 
-  it("rejects a missing credential binding before running effects", () => {
-    expectCredentialBindingFailure({
+  it("rejects a missing credential binding before running effects", async () => {
+    await expectCredentialBindingFailure({
       plannedTokenDef: {
         name: "sandbox-telegram-bridge",
         envKey: "TELEGRAM_BOT_TOKEN",
@@ -1029,8 +1029,8 @@ describe("resolveSandboxCreateIntent", () => {
     });
   });
 
-  it("rejects a changed provider type before running effects", () => {
-    expectCredentialBindingFailure({
+  it("rejects a changed provider type before running effects", async () => {
+    await expectCredentialBindingFailure({
       plannedTokenDef: {
         name: "sandbox-brave-search",
         envKey: "BRAVE_API_KEY",
@@ -1050,7 +1050,7 @@ describe("resolveSandboxCreateIntent", () => {
     });
   });
 
-  it("materializes a managed image reference without a Dockerfile suffix", () => {
+  it("materializes a managed image reference without a Dockerfile suffix", async () => {
     const reference = `ghcr.io/nvidia/nemoclaw/openclaw@sha256:${"a".repeat(64)}`;
     const intent = resolveSandboxCreateIntent({
       basePolicyPath: "/repo/policy.yaml",
@@ -1069,7 +1069,7 @@ describe("resolveSandboxCreateIntent", () => {
       sandboxGpuLogMessage: null,
     });
 
-    const plan = materializeSandboxCreatePlan({
+    const plan = await materializeSandboxCreatePlan({
       intent,
       fromRef: reference,
       messagingTokenDefs: [],

--- a/src/lib/onboard/sandbox-create/orchestration.test.ts
+++ b/src/lib/onboard/sandbox-create/orchestration.test.ts
@@ -523,7 +523,7 @@ describe("deferred provider effect authority", () => {
         cleanupCreateSources: vi.fn(),
       },
       runVerifiedSandboxCreateEffects: null,
-      activateDeferredProviderEffects: (revalidate) => {
+      activateDeferredProviderEffects: async (revalidate) => {
         revalidate("cleaning up providers for sandbox 'alpha'");
         return ["first", "second"];
       },
@@ -1023,7 +1023,7 @@ describe("sandbox create identity checks", () => {
         cleanupCreateSources: vi.fn(),
       },
       runVerifiedSandboxCreateEffects: null,
-      activateDeferredProviderEffects: () => ["credential-provider"],
+      activateDeferredProviderEffects: async () => ["credential-provider"],
       revalidateSandboxIdentityBeforeCreate: vi.fn(),
     });
     const error = await runSandboxCreateWithIdentityVerification({

--- a/src/lib/onboard/sandbox-create/orchestration.ts
+++ b/src/lib/onboard/sandbox-create/orchestration.ts
@@ -950,7 +950,7 @@ export function createProviderEffectBoundary(input: {
   readonly preparationDeps: ProviderPreparationDeps;
   readonly runVerifiedSandboxCreateEffects: import("../types").VerifiedSandboxCreateEffects | null;
   readonly activateDeferredProviderEffects:
-    | ((revalidateSandboxIdentity: (operation: string) => void) => readonly string[])
+    | ((revalidateSandboxIdentity: (operation: string) => void) => Promise<readonly string[]>)
     | null;
   readonly revalidateSandboxIdentityBeforeCreate: () => void;
 }): ProviderEffectBoundary {
@@ -986,7 +986,7 @@ export function createProviderEffectBoundary(input: {
         `activating deferred providers for sandbox '${input.sandboxName}'`,
       );
       const providerNames =
-        input.activateDeferredProviderEffects?.(context.revalidateSandboxIdentity) ?? [];
+        (await input.activateDeferredProviderEffects?.(context.revalidateSandboxIdentity)) ?? [];
       await validate();
       context.revalidateSandboxIdentity(
         `publishing deferred providers for sandbox '${input.sandboxName}'`,
@@ -1283,7 +1283,7 @@ export function createSandboxWithBaseImageResolution(runtime: SandboxCreateOrche
       step,
       stringSetsEqual,
       toolDisclosureFlow,
-      upsertMessagingProviders,
+      applyMessagingProviders,
       usesManagedDcodeIdentity,
       validateName,
       verifyDirectSandboxGpu,
@@ -1771,7 +1771,7 @@ export function createSandboxWithBaseImageResolution(runtime: SandboxCreateOrche
               revalidateSandboxIdentity(true, `reusing sandbox '${sandboxName}'`);
               // Upsert messaging providers even on reuse so credential changes take
               // effect without requiring a full sandbox recreation.
-              upsertMessagingProviders(messagingTokenDefs, {
+              await applyMessagingProviders(messagingTokenDefs, {
                 revalidateSandboxIdentity: (operation) =>
                   revalidateSandboxIdentity(true, operation),
               });
@@ -1819,7 +1819,7 @@ export function createSandboxWithBaseImageResolution(runtime: SandboxCreateOrche
             console.log("  Choosing 'n' will delete the existing sandbox and create a new one.");
             if (await promptYesNoOrDefault("  Reuse existing sandbox?", null, true)) {
               revalidateSandboxIdentity(true, `reusing sandbox '${sandboxName}'`);
-              upsertMessagingProviders(messagingTokenDefs, {
+              await applyMessagingProviders(messagingTokenDefs, {
                 revalidateSandboxIdentity: (operation) =>
                   revalidateSandboxIdentity(true, operation),
               });
@@ -2098,7 +2098,7 @@ export function createSandboxWithBaseImageResolution(runtime: SandboxCreateOrche
                 });
               },
               upsertMessagingProviders: (tokenDefs, options) =>
-                upsertMessagingProviders(tokenDefs, {
+                applyMessagingProviders(tokenDefs, {
                   ...options,
                   revalidateSandboxIdentity: (operation) =>
                     (

--- a/src/lib/onboard/sandbox-create/provider-publication.test.ts
+++ b/src/lib/onboard/sandbox-create/provider-publication.test.ts
@@ -62,7 +62,7 @@ function typedProviderAdapter(
     })),
     inspectProviderProfile: vi.fn(async () => ({
       ok: true as const,
-      value: { credentialKeys: [] },
+      value: { credentialKeys: [], contractDigest: "test-profile-contract" },
     })),
     deleteProvider: vi.fn(async () => ({
       ok: true as const,
@@ -71,6 +71,18 @@ function typedProviderAdapter(
     detachProvider: vi.fn(async () => ({
       ok: true as const,
       value: { state: "detached" as const },
+    })),
+    attachProvider: vi.fn(async () => ({
+      ok: true as const,
+      value: { state: "attached" as const },
+    })),
+    configureProviderRefresh: vi.fn(async () => ({
+      ok: true as const,
+      value: { state: "configured" as const },
+    })),
+    getProviderRefreshStatus: vi.fn(async () => ({
+      ok: true as const,
+      value: { status: "refreshed" },
     })),
   };
   return { ...adapter, ...overrides };

--- a/test/channels/channels-add-bridge-lifecycle.test.ts
+++ b/test/channels/channels-add-bridge-lifecycle.test.ts
@@ -34,6 +34,49 @@ class ExitError extends Error {
   }
 }
 
+const GOOGLE_CHAT_PROVIDER_PROFILE = {
+  id: "google-chat-bridge",
+  credentials: [
+    {
+      name: "access_token",
+      env_vars: ["GOOGLE_CHAT_ACCESS_TOKEN"],
+      required: true,
+      auth_style: "bearer",
+      header_name: "Authorization",
+      query_param: "",
+      refresh: {
+        strategy: "google-service-account-jwt",
+        scopes: ["https://www.googleapis.com/auth/chat.bot"],
+        material: [
+          {
+            name: "client_email",
+            description: "Service-account client email (JWT issuer)",
+            required: true,
+          },
+          {
+            name: "private_key",
+            description: "Service-account RSA private key (PEM); signs the JWT assertion",
+            required: true,
+            secret: true,
+          },
+          { name: "scope", description: "OAuth scope(s) to mint the token for" },
+        ],
+      },
+    },
+  ],
+  endpoints: [
+    {
+      host: "chat.googleapis.com",
+      port: 443,
+      protocol: "rest",
+      access: "read-write",
+      enforcement: "enforce",
+    },
+  ],
+  binaries: ["/usr/local/bin/node", "/usr/bin/node"],
+  inference_capable: false,
+};
+
 const SA_JSON = JSON.stringify({
   client_email: "bot@p.iam.gserviceaccount.com",
   private_key: "fake-test-private-key-material",
@@ -185,17 +228,45 @@ beforeEach(() => {
     return command[0] === "provider" && command[1] === "refresh" && command[2] === "status";
   };
 
+  const providers = new Set<string>();
   runOpenshellSpy = vi.spyOn(runtime, "runOpenshell").mockImplementation((args) => {
     const command = withoutGateway(args);
-    const providerMissing = command[0] === "provider" && command[1] === "get";
-    return {
-      pid: 0,
-      output: [null, "", ""],
-      stdout: isRefreshStatus(args) ? refreshStatusTable(command) : "",
-      stderr: providerMissing ? `provider '${args[args.length - 1]}' not found` : "",
-      status: providerMissing ? 1 : 0,
-      signal: null,
-    };
+    const profileExport = command.slice(0, 3).join(" ") === "provider profile export";
+    const mutatedProviderName =
+      command[0] !== "provider"
+        ? null
+        : command[1] === "create"
+          ? command[3]
+          : command[1] === "update"
+            ? command[2]
+            : null;
+    mutatedProviderName ? providers.add(mutatedProviderName) : undefined;
+    const providerName = command[0] === "provider" && command[1] === "get" ? command[2] : null;
+    const providerMissing = Boolean(providerName && !providers.has(providerName));
+    const providerMetadata = providerName
+      ? `Name: ${providerName}\nType: google-chat-bridge\nCredential keys: GOOGLE_CHAT_ACCESS_TOKEN\nConfig keys: <none>\n`
+      : "";
+    return profileExport
+      ? {
+          pid: 0,
+          output: [null, JSON.stringify(GOOGLE_CHAT_PROVIDER_PROFILE), ""],
+          stdout: JSON.stringify(GOOGLE_CHAT_PROVIDER_PROFILE),
+          stderr: "",
+          status: 0,
+          signal: null,
+        }
+      : {
+          pid: 0,
+          output: [null, providerMetadata, ""],
+          stdout: isRefreshStatus(args)
+            ? refreshStatusTable(command)
+            : providerMissing
+              ? ""
+              : providerMetadata,
+          stderr: providerMissing ? `provider '${args[args.length - 1]}' not found` : "",
+          status: providerMissing ? 1 : 0,
+          signal: null,
+        };
   });
 
   const healthyGatewayState = {
@@ -244,6 +315,7 @@ describe("channels add owns the bridge-provider lifecycle (#6120)", () => {
       ],
       "nemoclaw",
       { bestEffort: true, requireExactBindings: true },
+      expect.objectContaining({ channelName: "googlechat", sandboxAgent: "openclaw" }),
     );
     const refreshCall = runOpenshellSpy.mock.calls.find(
       (call) =>
@@ -254,10 +326,10 @@ describe("channels add owns the bridge-provider lifecycle (#6120)", () => {
     expect(refreshCall).toBeDefined();
     const refreshArgs = refreshCall?.[0] as string[];
     expect(refreshArgs).toContain("--secret-material-env");
-    expect(refreshArgs).toContain("private_key=MESSAGING_BRIDGE_SECRET_0");
+    expect(refreshArgs).toContain("private_key=NEMOCLAW_PROVIDER_REFRESH_SECRET_0");
     expect(refreshArgs.join(" ")).not.toContain("fake-test-private-key-material");
     expect(refreshCall?.[1]).toMatchObject({
-      env: { MESSAGING_BRIDGE_SECRET_0: "fake-test-private-key-material" },
+      env: { NEMOCLAW_PROVIDER_REFRESH_SECRET_0: "fake-test-private-key-material" },
     });
     expect(JSON.stringify({ registryEntry, session })).not.toContain(
       "fake-test-private-key-material",

--- a/test/e2e/live/channels-stop-start-helpers.ts
+++ b/test/e2e/live/channels-stop-start-helpers.ts
@@ -169,7 +169,6 @@ export function installGooglechatCredentialFixture(
   assertChannelsStopStartSandboxName(sandboxName, agent);
   const ensureProfiles = dependencies.ensureProfiles ?? ensureMessagingBridgeProfiles;
   const channelDependencies = dependencies.channelDependencies ?? policyChannelDependencies;
-  const originalChannelUpsert = channelDependencies.upsertMessagingProviders;
   const expectedName = `${sandboxName}-googlechat-bridge`;
   const expectedType = PROVIDER_TYPE_BY_AGENT[agent];
   const directUpsert: InstalledGooglechatCredentialFixture["upsertMessagingProviders"] = (
@@ -187,10 +186,9 @@ export function installGooglechatCredentialFixture(
       throw new Error("Google Chat live fixture received an unexpected provider definition");
     }
     const delegatedTokenDefs = tokenDefs.filter(({ name }) => name !== expectedName);
-    const delegatedProviderNames =
-      delegatedTokenDefs.length === 0
-        ? []
-        : originalChannelUpsert.call(channelDependencies, delegatedTokenDefs, gatewayName, options);
+    if (delegatedTokenDefs.length > 0) {
+      throw new Error("Google Chat live fixture received unrelated provider definitions");
+    }
     const effectiveRun: typeof runOpenshell = (args, runOptions) =>
       channelDependencies.runGatewayOpenshell(gatewayName, args, runOptions);
     ensureProfiles(fixtureTokenDefs, {
@@ -233,7 +231,7 @@ export function installGooglechatCredentialFixture(
     if (mutated.status !== 0) {
       throw new Error(`Google Chat live fixture could not ${action} provider '${expectedName}'`);
     }
-    const registered = new Set([...delegatedProviderNames, expectedName]);
+    const registered = new Set([expectedName]);
     return tokenDefs.map(({ name }) => name).filter((name) => registered.has(name));
   };
   const providerDependencies =

--- a/test/onboarding/onboard-messaging.test.ts
+++ b/test/onboarding/onboard-messaging.test.ts
@@ -648,7 +648,7 @@ const { createSandbox } = require(${onboardPath});
       assert.deepEqual(deniedPayload.temporaryCreateSources, []);
       assert.match(
         deniedPayload.error,
-        /did not confirm messaging provider 'my-assistant-telegram-bridge' before sandbox creation/,
+        /Could not inspect messaging provider 'my-assistant-telegram-bridge'/,
       );
       const combinedOutput = result.stdout + result.stderr + denied.stdout + denied.stderr;
       assert.equal(


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Messaging provider setup now uses typed OpenShell results across the active onboarding, reuse, direct channel, replacement, verification, and refresh lifecycle.
Provider replacement is explicit and sandbox-authorized, partial mutation evidence is preserved for recovery, and credentials stay out of command arguments and returned adapter results.

## Reason

Accepted issue #9806 requires Phase 1 messaging consumers to stop classifying provider state from raw CLI output and complete the typed OpenShell migration through active lifecycle callers.
This PR builds on the provider adapter foundation and the onboarding work in #10719.

### Related issues

Partial #9806

Depends on #10719

Relates to #9813

## Changes

- add typed provider/profile inspection, attachment, replacement, refresh, and contract-digest results
- translate messaging token definitions into typed provider applications for OpenClaw, Hermes, and refresh-minted bridge profiles
- route active onboarding, credential reuse, staged sandbox creation, and direct channel registration through the typed boundary
- validate every provider definition and checked-in profile before mutation, then verify the exact non-secret binding after create or update
- require explicit replacement authority, revalidate sandbox identity, and detach only authorized sandbox attachments before recreation
- preserve exact created and mutated provider names so recovery removes new providers and reports incomplete replacements or updates accurately
- pass credentials and refresh secrets through child environments, with redacted typed failures and no secret-bearing result objects
- extend deterministic regression coverage for collisions, profile drift, partial credentials, refresh failures, replacement recovery, identity drift, and secret custody

## Verification

- focused adapter, applier, onboarding, and channel suite: 5 files, 119 tests passed
- `npm run typecheck:cli`: passed
- `npm run validate:pr`: passed, including repository checks, secret scan, Markdown, growth guardrails, and pre-push TypeScript
- `npm run docs`: passed
- `git diff --check`: passed
- commit signature: valid Git SSH signature
- DCO: `Signed-off-by` present
- secret review: no credentials, API keys, or private keys are committed; tests use synthetic values

## Review notes

The PR remains a draft and depends on #10719.
`npm run test:changed` completed with 6,742 passing and 2 skipped tests; its 26 failures were classified as local-environment evidence from world-writable `/private/tmp` ancestry checks, unrelated uninstall concurrency timeouts, and the host Python 3.9 runtime lacking `zip(..., strict=...)`.
The affected focused suites and repository validation pass.
`npm run review:local` was attempted twice after focused validation, but the trusted launcher exited without its completion line and published no `artifacts/pr-review-advisor-local` directory, so no local advisor result is claimed.
Fresh GitHub advisor checks will be inspected on this exact commit.

- [x] Independent documentation writer reviewed the completed exact commit
- Result: `docs-not-needed`
- Base: `910c4ea1705d5240d4c5415e65cd07b12e8751be`
- Commit: `d8d8858c6a037e1760c144de70350457c40b95ae`
- Evidence: Reviewed all 33 changed paths, including active guidance, README claims, comments, error and recovery text, and test titles. The typed inspection boundary, atomic sandbox-create exception, secret custody wording, refresh observation errors, and replacement recovery guidance match the implementation.
- Independent validation: focused suite passed 119 tests; `npm run test:titles:check` passed; `git diff --check` passed.
- Public documentation: no `docs/**` or Fern sources changed.
- Blockers: none
- Suggestions: none
- Agent: Codex Desktop documentation writer (`docs_review_10726_exact`)
<!-- docs-review-head-sha: d8d8858c6a -->
<!-- docs-review-agents-blob-sha: b538c112a2 -->

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved messaging-provider setup with profile validation, credential application, replacement, and refresh support.
  * Added support for provider attachments and gateway-targeted configuration.
  * Onboarding now waits for provider activation before publishing sandbox state.

* **Bug Fixes**
  * Improved handling of missing, conflicting, or partially updated providers.
  * Added clearer failure reporting and state-neutral recovery guidance.
  * Strengthened credential validation and secret redaction in errors and logs.

* **Documentation**
  * Documented provider lifecycle, credential handling, refresh behavior, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->