### PR TITLE
fix(advisor): generate valid sandbox names

### DIFF
--- a/test/automation/pull-requests/pr-review-advisor-local.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-local.test.ts
@@ -463,7 +463,7 @@ describe("local PR review advisor", () => {
         calls.push("configure:" + env.PR_REVIEW_ADVISOR_INTEREST);
         expect(env.OPENSHELL_GATEWAY_ENDPOINT).toBe("http://127.0.0.1:8080");
         expect(env.PI_IMAGE).toMatch(/@sha256:[0-9a-f]{64}$/u);
-        expect(env.SANDBOX_NAME).toMatch(/^pr-adv-[A-Za-z0-9_-]{12}$/u);
+        expect(env.SANDBOX_NAME).toMatch(/^pr-adv-[a-f0-9]{12}$/u);
         expect(env.SANDBOX_NAME).toHaveLength(19);
         return { configure: Promise.resolve(), stop: stopGateway };
       },

--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -432,7 +432,7 @@ describe("PR review advisor specialist lifecycle", () => {
     await command;
 
     expect(calls).toEqual(["create", "cancel", "sandbox", "gateway", "listeners", "restore"]);
-    expect(sandboxNames).toEqual([expect.stringMatching(/^pr-adv-[A-Za-z0-9_-]{12}$/u), sandboxNames[0], sandboxNames[0]]);
+    expect(sandboxNames).toEqual([expect.stringMatching(/^pr-adv-[a-f0-9]{12}$/u), sandboxNames[0], sandboxNames[0]]);
     expect(restore).toHaveBeenCalledWith("SIGTERM");
     expect(stderr).not.toHaveBeenCalled();
     expect(calls).not.toContain("download");
@@ -482,7 +482,7 @@ describe("PR review advisor specialist lifecycle", () => {
     await command;
 
     expect(stderr).toHaveBeenCalledWith(expect.stringContaining("execution cleanup"));
-    expect(stderr).toHaveBeenCalledWith(expect.stringMatching(/sandbox pr-adv-[A-Za-z0-9_-]{12}/u));
+    expect(stderr).toHaveBeenCalledWith(expect.stringMatching(/sandbox pr-adv-[a-f0-9]{12}/u));
     expect(stderr).not.toHaveBeenCalledWith(expect.stringContaining(credential));
     expect(events).toEqual(["diagnostic", "restore"]);
     expect(restore).toHaveBeenCalledWith("SIGHUP");

--- a/tools/pr-review-advisor/specialist-lifecycle.mts
+++ b/tools/pr-review-advisor/specialist-lifecycle.mts
@@ -69,7 +69,7 @@ export async function runAdvisorSpecialist(input: {
   const lifecycle = input.lifecycle ?? defaultAdvisorSpecialistLifecycle;
   const env = {
     ...input.env,
-    SANDBOX_NAME: `pr-adv-${randomBytes(9).toString("base64url")}`,
+    SANDBOX_NAME: `pr-adv-${randomBytes(6).toString("hex")}`,
   };
   let gateway: ReturnType<AdvisorSpecialistLifecycle["startGateway"]>;
   let sandbox = false;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

PR Review Advisor specialist jobs now create OpenShell sandboxes with names accepted by the lowercase naming contract.

## Reason

The advisor used Base64URL suffixes, which can contain uppercase letters or underscores. OpenShell rejected those generated names before specialist analysis could start.

## Changes

- Generate the 12-character random sandbox suffix as lowercase hexadecimal while preserving the existing 19-character name length and 48 bits of entropy.
- Tighten hosted and local advisor lifecycle assertions to accept only the lowercase hexadecimal sandbox-name contract.

## Verification

- Contributor validation: Commit pre-commit and commit-msg hooks passed; npm run validate:pr passed.
- Tests: npx vitest run --project integration test/automation/pull-requests/pr-review-advisor-openshell.test.ts test/automation/pull-requests/pr-review-advisor-local.test.ts (61 passed); npm run validate:pr (passed in an isolated clean worktree with current built artifacts)
- Broad gate: npm run validate:pr
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>
