### PR TITLE
fix(advisor): avoid nested context mount

### DIFF
--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -1060,14 +1060,6 @@ describe("PR review advisor OpenShell wrapper", () => {
           {
             type: "bind",
             source: fs.realpathSync(
-              path.join(env.RUNNER_TEMP as string, "pr-review-advisor-context", "specialist"),
-            ),
-            target: "/pr-workdir/.pr-review-advisor-context",
-            read_only: true,
-          },
-          {
-            type: "bind",
-            source: fs.realpathSync(
               path.join(env.RUNNER_TEMP as string, "pr-review-advisor-tools"),
             ),
             target: "/pr-review-advisor-tools",
@@ -1082,6 +1074,7 @@ describe("PR review advisor OpenShell wrapper", () => {
         ],
       },
     });
+    expect(createArgs[driverConfigIndex + 1]).not.toContain('"target":"/pr-workdir/');
     expect(createArgs).not.toContain("--upload");
     expect(createArgs).not.toContain("--no-git-ignore");
     expect(createArgs.slice(-6)).toEqual([
@@ -1107,7 +1100,7 @@ describe("PR review advisor OpenShell wrapper", () => {
         "/pr-workdir",
         "PR_REVIEW_ADVISOR_API_KEY=unused",
         "PR_REVIEW_ADVISOR_BASE_URL=https://inference.local/v1",
-        "PR_REVIEW_ADVISOR_CONTEXT_DIR=/pr-workdir/.pr-review-advisor-context",
+        "PR_REVIEW_ADVISOR_CONTEXT_DIR=/pr-review-advisor-context/specialist",
         "PR_REVIEW_ADVISOR_GITHUB_CONTEXT_PATH=/pr-review-advisor-context/github-context.json",
         "GIT_DIR=/pr-workdir/.git",
         "GIT_WORK_TREE=/pr-workdir",

--- a/tools/pr-review-advisor/openshell.mts
+++ b/tools/pr-review-advisor/openshell.mts
@@ -45,7 +45,7 @@ const SANDBOX_CONTEXT_DIR = `/${ADVISOR_CONTEXT_DIRECTORY_NAME}`;
 const SANDBOX_RUNTIME_DIR = `/sandbox/${ADVISOR_RUNTIME_DIRECTORY_NAME}`;
 const SANDBOX_TOOLS_DIR = `/${ADVISOR_TOOLS_DIRECTORY_NAME}`;
 const SANDBOX_CONTEXT_PATH = `${SANDBOX_CONTEXT_DIR}/${ADVISOR_CONTEXT_FILE_NAME}`;
-const SANDBOX_SPECIALIST_CONTEXT_DIR = `${SANDBOX_WORKDIR}/.${ADVISOR_CONTEXT_DIRECTORY_NAME}`;
+const SANDBOX_SPECIALIST_CONTEXT_DIR = `${SANDBOX_CONTEXT_DIR}/${ADVISOR_SPECIALIST_CONTEXT_DIRECTORY_NAME}`;
 const ADVISOR_RUNTIME_TMPFS_BYTES = 512 * 1024 * 1024;
 const SANDBOX_API_KEY = "unused";
 const DEFAULT_SANDBOX_TIMEOUT_SECONDS = 2100;
@@ -141,7 +141,6 @@ function requireGitMetadataDirectory(directory: string, name: string): void {
 function advisorSandboxDriverConfig(input: {
   advisorDirectory: string;
   contextDirectory: string;
-  specialistContextDirectory: string;
   toolsDirectory: string;
   workdir: string;
 }): Readonly<Record<string, unknown>> {
@@ -164,12 +163,6 @@ function advisorSandboxDriverConfig(input: {
           type: "bind",
           source: input.contextDirectory,
           target: SANDBOX_CONTEXT_DIR,
-          read_only: true,
-        },
-        {
-          type: "bind",
-          source: input.specialistContextDirectory,
-          target: SANDBOX_SPECIALIST_CONTEXT_DIR,
           read_only: true,
         },
         {
@@ -306,10 +299,6 @@ export function createAdvisorSandbox(
       driverConfig: advisorSandboxDriverConfig({
         advisorDirectory,
         contextDirectory,
-        specialistContextDirectory: path.join(
-          contextDirectory,
-          ADVISOR_SPECIALIST_CONTEXT_DIRECTORY_NAME,
-        ),
         toolsDirectory,
         workdir: advisorWorkdir,
       }),

--- a/tools/pr-review-advisor/run-specialist.mts
+++ b/tools/pr-review-advisor/run-specialist.mts
@@ -104,7 +104,7 @@ async function main(): Promise<void> {
   delete process.env.GITHUB_TOKEN;
 
   const diffPath = path.join(
-    process.env.PR_REVIEW_ADVISOR_CONTEXT_DIR || "/pr-workdir/.pr-review-advisor-context",
+    process.env.PR_REVIEW_ADVISOR_CONTEXT_DIR || "/pr-review-advisor-context/specialist",
     SPECIALIST_DIFF_FILE_NAME,
   );
   const diffStat = fs.lstatSync(diffPath);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

PR Review Advisor specialist sandboxes can provision their immutable context without a nested bind mount beneath the read-only PR worktree.

## Reason

The specialist-only refactor mounted prepared context at /pr-workdir/.pr-review-advisor-context after /pr-workdir had already been mounted read-only. Docker could not create the nested mountpoint and rejected sandbox startup.

## Changes

- Read specialist diff evidence from the specialist directory already included in the top-level read-only advisor context mount.
- Remove the redundant nested bind mount beneath /pr-workdir.
- Assert that generated Docker mount targets never nest beneath the read-only PR worktree.

## Verification

- Contributor validation: Commit pre-commit and commit-msg hooks passed; npm run validate:pr passed.
- Tests: npx vitest run --project integration test/automation/pull-requests/pr-review-advisor-openshell.test.ts (43 passed); npm run validate:pr (passed in an isolated clean worktree with current built artifacts)
- Broad gate: npm run validate:pr
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>
