### PR TITLE
fix(advisor): prepare nested specialist mountpoint

### DIFF
--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -810,7 +810,7 @@ describe("PR review advisor OpenShell wrapper", () => {
     }
   });
 
-  it("prepares specialist diff evidence before the worktree becomes read-only", async () => {
+  it("prepares specialist diff evidence and its mountpoint before the worktree becomes read-only", async () => {
     const env = advisorEnvironment();
     const workdir = env.ADVISOR_WORKDIR as string;
     fs.rmSync(path.join(workdir, ".git"), { recursive: true });
@@ -857,9 +857,23 @@ describe("PR review advisor OpenShell wrapper", () => {
     );
     expect(fs.readFileSync(diffPath, "utf8")).toContain("+changed");
     expect(fs.statSync(diffPath).mode & 0o777).toBe(0o444);
-    expect(fs.existsSync(path.join(workdir, ".pr-review-advisor-context"))).toBe(false);
+    const mountpoint = path.join(workdir, ".pr-review-advisor-context");
+    expect(fs.lstatSync(mountpoint).isDirectory()).toBe(true);
+    expect(fs.readdirSync(mountpoint)).toEqual([]);
+    expect(fs.statSync(mountpoint).mode & 0o777).toBe(0o555);
     fs.chmodSync(path.dirname(diffPath), 0o700);
     fs.chmodSync(diffPath, 0o600);
+  });
+
+  it("fails closed when review content occupies the specialist mountpoint", async () => {
+    const env = advisorEnvironment();
+    const mountpoint = path.join(env.ADVISOR_WORKDIR as string, ".pr-review-advisor-context");
+    fs.writeFileSync(mountpoint, "review content\n");
+
+    await expect(prepareAdvisorSandboxInputs(env)).rejects.toThrow(
+      "Advisor specialist mountpoint must be an empty directory",
+    );
+    expect(fs.readFileSync(mountpoint, "utf8")).toBe("review content\n");
   });
 
   it("requires repository metadata before placing immutable-boundary proof files", async () => {

--- a/tools/pr-review-advisor/openshell.mts
+++ b/tools/pr-review-advisor/openshell.mts
@@ -38,6 +38,7 @@ const ADVISOR_BOUNDARY_PROOF_SOURCE_NAME = "source";
 const ADVISOR_BOUNDARY_PROOF_TARGET_NAME = "target";
 const ADVISOR_CONTEXT_FILE_NAME = "github-context.json";
 const ADVISOR_SPECIALIST_CONTEXT_DIRECTORY_NAME = "specialist";
+const ADVISOR_WORKDIR_CONTEXT_DIRECTORY_NAME = `.${ADVISOR_CONTEXT_DIRECTORY_NAME}`;
 const SANDBOX_ADVISOR_DIR = "/advisor";
 const SANDBOX_WORKDIR = "/pr-workdir";
 const SANDBOX_GIT_DIR = `${SANDBOX_WORKDIR}/.git`;
@@ -45,7 +46,7 @@ const SANDBOX_CONTEXT_DIR = `/${ADVISOR_CONTEXT_DIRECTORY_NAME}`;
 const SANDBOX_RUNTIME_DIR = `/sandbox/${ADVISOR_RUNTIME_DIRECTORY_NAME}`;
 const SANDBOX_TOOLS_DIR = `/${ADVISOR_TOOLS_DIRECTORY_NAME}`;
 const SANDBOX_CONTEXT_PATH = `${SANDBOX_CONTEXT_DIR}/${ADVISOR_CONTEXT_FILE_NAME}`;
-const SANDBOX_SPECIALIST_CONTEXT_DIR = `${SANDBOX_WORKDIR}/.${ADVISOR_CONTEXT_DIRECTORY_NAME}`;
+const SANDBOX_SPECIALIST_CONTEXT_DIR = `${SANDBOX_WORKDIR}/${ADVISOR_WORKDIR_CONTEXT_DIRECTORY_NAME}`;
 const ADVISOR_RUNTIME_TMPFS_BYTES = 512 * 1024 * 1024;
 const SANDBOX_API_KEY = "unused";
 const DEFAULT_SANDBOX_TIMEOUT_SECONDS = 2100;
@@ -63,6 +64,19 @@ function runnerDirectory(env: NodeJS.ProcessEnv, name: string): string {
 function resetDirectory(directory: string): void {
   fs.rmSync(directory, { recursive: true, force: true });
   fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+}
+
+function prepareEmptyReadOnlyMountpoint(directory: string): void {
+  try {
+    const stat = fs.lstatSync(directory);
+    if (!stat.isDirectory() || fs.readdirSync(directory).length !== 0) {
+      throw new Error("Advisor specialist mountpoint must be an empty directory");
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    fs.mkdirSync(directory, { mode: 0o555 });
+  }
+  fs.chmodSync(directory, 0o555);
 }
 
 function createBoundaryProof(directory: string, relativeProofDirectory: string): void {
@@ -209,6 +223,7 @@ export async function prepareAdvisorSandboxInputs(
   const toolsDirectory = runnerDirectory(env, ADVISOR_TOOLS_DIRECTORY_NAME);
   requireGitMetadataDirectory(advisorDirectory, "ADVISOR_DIR");
   requireGitMetadataDirectory(advisorWorkdir, "ADVISOR_WORKDIR");
+  prepareEmptyReadOnlyMountpoint(path.join(advisorWorkdir, ADVISOR_WORKDIR_CONTEXT_DIRECTORY_NAME));
   resetDirectory(contextDirectory);
   resetDirectory(toolsDirectory);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

PR Review Advisor can create its specialist sandbox without Docker trying to create a nested mountpoint below the already read-only review checkout. The review checkout and specialist diff remain independently read-only.

## Reason

On current `main`, every specialist in run `33457317520` reached container creation and then failed because `/pr-workdir/.pr-review-advisor-context` did not exist before `/pr-workdir` was mounted read-only.

### Related issues

Fixes #10730

## Changes

- Create the reserved specialist-context mountpoint in the dedicated ephemeral `pr-workdir` before the immutable mount plan is used.
- Require the mountpoint to be a real empty directory and set it to mode `0555`.
- Fail closed without replacing review content if a file, symlink, or non-empty directory occupies the reserved path.
- Protect the mountpoint precondition, read-only mode, empty state, and collision behavior with deterministic tests.

## Verification

- Exact candidate: `6caaaae4006f3ae4c6b029f9bbcc015b16b9ee2c`; canonical base: `9322588b8dde6677af7d9af8bcee4029008d425f`.
- `npx vitest run --project integration test/automation/pull-requests/pr-review-advisor-openshell.test.ts` — 44 tests passed.
- `npm run build:cli` — passed.
- `npm run validate:pr` — passed after building the fresh isolated worktree, including repository checks, gitleaks, source-shape checks, codebase growth guardrails, commitlint, and CLI TypeScript.
- GitHub reports the exact candidate commit signature as verified.
- The diff contains no secrets, API keys, or credentials.

## Review notes

The failing hosted evidence is [PR Review Advisor run `33457317520`](https://github.com/NVIDIA/NemoClaw/actions/runs/33457317520); [Operations job `99699995895`](https://github.com/NVIDIA/NemoClaw/actions/runs/33457317520/job/99699995895) records the exact OCI read-only mountpoint failure and successful sandbox cleanup.

The PR Review Advisor workflow intentionally executes trusted base-revision tooling. Therefore this PR's own Advisor run cannot exercise the candidate repair before merge; the deterministic regression test covers the candidate, and a post-merge trusted run is required to prove the hosted boundary.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>
