### PR TITLE
ci(e2e): explain trace guard failures

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2916,6 +2916,7 @@ jobs:
           expected_trace_dir="${RUNNER_TEMP}/nemoclaw-e2e-traces/${TARGET_ID}"
           if [ -z "${RUNNER_TEMP}" ] || [ "${NEMOCLAW_TRACE_DIR}" != "${expected_trace_dir}" ]; then
             echo "::error title=E2E trace sanitization refused::NEMOCLAW_TRACE_DIR does not match its workflow-owned RUNNER_TEMP path. No raw traces were read or uploaded. Correct the trace path configuration before rerunning." >&2
+            printf 'Expected trace path: %s\n' "${expected_trace_dir}" >&2
             exit 1
           fi
           python3 scripts/e2e/sanitize-trace-timing.py \
@@ -2934,7 +2935,8 @@ jobs:
           NEMOCLAW_TRACE_DIR="${NEMOCLAW_TRACE_DIR:-}"
           expected_trace_dir="${RUNNER_TEMP}/nemoclaw-e2e-traces/${TARGET_ID}"
           if [ -z "${RUNNER_TEMP}" ] || [ "${NEMOCLAW_TRACE_DIR}" != "${expected_trace_dir}" ]; then
-            echo "::error title=E2E trace cleanup refused::NEMOCLAW_TRACE_DIR does not match its workflow-owned RUNNER_TEMP path. No files were deleted. Correct the trace path configuration before rerunning; GitHub-hosted runner cleanup removes runner-local traces." >&2
+            echo "::error title=E2E trace cleanup refused::NEMOCLAW_TRACE_DIR does not match its workflow-owned RUNNER_TEMP path. No files were deleted. Correct the trace path configuration before rerunning." >&2
+            printf 'Expected trace path: %s\n' "${expected_trace_dir}" >&2
             exit 1
           fi
           rm -rf -- "${NEMOCLAW_TRACE_DIR}"
@@ -5628,6 +5630,7 @@ jobs:
           expected_trace_dir="${RUNNER_TEMP}/nemoclaw-cloud-onboard-traces"
           if [ -z "${RUNNER_TEMP}" ] || [ "${NEMOCLAW_TRACE_DIR}" != "${expected_trace_dir}" ]; then
             echo "::error title=E2E trace sanitization refused::NEMOCLAW_TRACE_DIR does not match its workflow-owned RUNNER_TEMP path. No raw traces were read or uploaded. Correct the trace path configuration before rerunning." >&2
+            printf 'Expected trace path: %s\n' "${expected_trace_dir}" >&2
             exit 1
           fi
           python3 scripts/e2e/sanitize-trace-timing.py \
@@ -5648,7 +5651,8 @@ jobs:
           NEMOCLAW_TRACE_DIR="${NEMOCLAW_TRACE_DIR:-}"
           expected_trace_dir="${RUNNER_TEMP}/nemoclaw-cloud-onboard-traces"
           if [ -z "${RUNNER_TEMP}" ] || [ "${NEMOCLAW_TRACE_DIR}" != "${expected_trace_dir}" ]; then
-            echo "::error title=E2E trace cleanup refused::NEMOCLAW_TRACE_DIR does not match its workflow-owned RUNNER_TEMP path. No files were deleted. Correct the trace path configuration before rerunning; GitHub-hosted runner cleanup removes runner-local traces." >&2
+            echo "::error title=E2E trace cleanup refused::NEMOCLAW_TRACE_DIR does not match its workflow-owned RUNNER_TEMP path. No files were deleted. Correct the trace path configuration before rerunning." >&2
+            printf 'Expected trace path: %s\n' "${expected_trace_dir}" >&2
             exit 1
           fi
           rm -rf -- "${NEMOCLAW_TRACE_DIR}"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2912,9 +2912,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          NEMOCLAW_TRACE_DIR="${NEMOCLAW_TRACE_DIR:-}"
           expected_trace_dir="${RUNNER_TEMP}/nemoclaw-e2e-traces/${TARGET_ID}"
           if [ -z "${RUNNER_TEMP}" ] || [ "${NEMOCLAW_TRACE_DIR}" != "${expected_trace_dir}" ]; then
-            echo "::error::Refusing to sanitize unexpected raw trace path" >&2
+            echo "::error title=E2E trace sanitization refused::NEMOCLAW_TRACE_DIR does not match its workflow-owned RUNNER_TEMP path. No raw traces were read or uploaded. Correct the trace path configuration before rerunning." >&2
             exit 1
           fi
           python3 scripts/e2e/sanitize-trace-timing.py \
@@ -2930,9 +2931,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          NEMOCLAW_TRACE_DIR="${NEMOCLAW_TRACE_DIR:-}"
           expected_trace_dir="${RUNNER_TEMP}/nemoclaw-e2e-traces/${TARGET_ID}"
           if [ -z "${RUNNER_TEMP}" ] || [ "${NEMOCLAW_TRACE_DIR}" != "${expected_trace_dir}" ]; then
-            echo "::error::Refusing to delete unexpected raw trace path" >&2
+            echo "::error title=E2E trace cleanup refused::NEMOCLAW_TRACE_DIR does not match its workflow-owned RUNNER_TEMP path. No files were deleted. Correct the trace path configuration before rerunning; GitHub-hosted runner cleanup removes runner-local traces." >&2
             exit 1
           fi
           rm -rf -- "${NEMOCLAW_TRACE_DIR}"
@@ -5622,9 +5624,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          NEMOCLAW_TRACE_DIR="${NEMOCLAW_TRACE_DIR:-}"
           expected_trace_dir="${RUNNER_TEMP}/nemoclaw-cloud-onboard-traces"
           if [ -z "${RUNNER_TEMP}" ] || [ "${NEMOCLAW_TRACE_DIR}" != "${expected_trace_dir}" ]; then
-            echo "::error::Refusing to sanitize unexpected raw trace path" >&2
+            echo "::error title=E2E trace sanitization refused::NEMOCLAW_TRACE_DIR does not match its workflow-owned RUNNER_TEMP path. No raw traces were read or uploaded. Correct the trace path configuration before rerunning." >&2
             exit 1
           fi
           python3 scripts/e2e/sanitize-trace-timing.py \
@@ -5642,9 +5645,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          NEMOCLAW_TRACE_DIR="${NEMOCLAW_TRACE_DIR:-}"
           expected_trace_dir="${RUNNER_TEMP}/nemoclaw-cloud-onboard-traces"
           if [ -z "${RUNNER_TEMP}" ] || [ "${NEMOCLAW_TRACE_DIR}" != "${expected_trace_dir}" ]; then
-            echo "::error::Refusing to delete unexpected raw trace path" >&2
+            echo "::error title=E2E trace cleanup refused::NEMOCLAW_TRACE_DIR does not match its workflow-owned RUNNER_TEMP path. No files were deleted. Correct the trace path configuration before rerunning; GitHub-hosted runner cleanup removes runner-local traces." >&2
             exit 1
           fi
           rm -rf -- "${NEMOCLAW_TRACE_DIR}"

--- a/test/e2e/support/e2e-workflow-trace.test.ts
+++ b/test/e2e/support/e2e-workflow-trace.test.ts
@@ -147,5 +147,6 @@ const TRACE_SOURCE_ASSIGNMENT =
 const TRACE_SOURCE_GUARD =
   'if [ -z "${RUNNER_TEMP}" ] || [ "${NEMOCLAW_TRACE_DIR}" != "${expected_trace_dir}" ]; then\n' +
   '  echo "::error title=E2E trace sanitization refused::NEMOCLAW_TRACE_DIR does not match its workflow-owned RUNNER_TEMP path. No raw traces were read or uploaded. Correct the trace path configuration before rerunning." >&2\n' +
+  '  printf \'Expected trace path: %s\\n\' "${expected_trace_dir}" >&2\n' +
   "  exit 1\n" +
   "fi\n";

--- a/test/e2e/support/e2e-workflow-trace.test.ts
+++ b/test/e2e/support/e2e-workflow-trace.test.ts
@@ -146,6 +146,6 @@ const TRACE_SOURCE_ASSIGNMENT =
   'expected_trace_dir="${RUNNER_TEMP}/nemoclaw-e2e-traces/${TARGET_ID}"\n';
 const TRACE_SOURCE_GUARD =
   'if [ -z "${RUNNER_TEMP}" ] || [ "${NEMOCLAW_TRACE_DIR}" != "${expected_trace_dir}" ]; then\n' +
-  '  echo "::error::Refusing to sanitize unexpected raw trace path" >&2\n' +
+  '  echo "::error title=E2E trace sanitization refused::NEMOCLAW_TRACE_DIR does not match its workflow-owned RUNNER_TEMP path. No raw traces were read or uploaded. Correct the trace path configuration before rerunning." >&2\n' +
   "  exit 1\n" +
   "fi\n";


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

E2E trace guard failures explain the safe stopped state and the next action.

## Reason

Vitest already reports test failures, but workflow-owned trace sanitization and cleanup guards previously emitted only a generic refusal.

## Changes

- Add titled GitHub annotations for live and cloud-onboard trace sanitization refusals.
- Explain whether traces were read, uploaded, or deleted and direct operators to correct the trace path before rerunning.
- Normalize an unset trace directory so always-run guards reach the actionable diagnostic.
- Preserve the existing trace guard contract test.

## Verification

- Contributor validation: Commit hooks and npm run validate:pr passed.
- Tests: Focused e2e-support validation: 2 files and 89 tests passed. npm run validate:pr passed after npm run build:cli.
- Broad gate: npm run validate:pr passed at 26b4ccbe589050a6338d61920ced2dd026b5740a.
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end workflow diagnostics for trace sanitization and cleanup failures.
  * Error messages now show the expected temporary trace path, making path mismatches easier to identify and correct.
  * Streamlined cleanup diagnostics by removing unnecessary runner-specific notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->