### PR TITLE
ci(e2e): warn when no results are reported

### DIFF
--- a/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
@@ -183,6 +183,7 @@ async function executeReport(options: {
   apiJobs?: ReportApiJob[];
   testMatrix?: CredentialFreeTestMatrixRow[];
   jobs?: string;
+  targets?: string;
   needs?: ReportNeeds;
   paginateError?: Error;
 }): Promise<{
@@ -194,6 +195,7 @@ async function executeReport(options: {
     apiJobs = [],
     testMatrix = DEFAULT_TEST_MATRIX,
     jobs = testMatrix.map(({ id }) => id).join(","),
+    targets = "",
     needs = {
       "generate-matrix": { result: "success" },
       "shared-e2e": { result: "failure" },
@@ -213,7 +215,7 @@ async function executeReport(options: {
     EXPLICIT_ONLY_JOBS: "",
     TEST_MATRIX: JSON.stringify(testMatrix),
     JOB_PR_NUMBER: "42",
-    JOB_TARGETS: "",
+    JOB_TARGETS: targets,
     JOBS: jobs,
   };
 
@@ -608,26 +610,24 @@ it("reports cancelled tests alongside passing tests as a partial pass", () => {
   expect(report.body).toContain("⚠️ Some tests cancelled — partial pass");
 });
 
-it("reports empty selectors without claiming an E2E was omitted", () => {
-  const report = renderE2eReport({
+it("warns when empty selectors produce no E2E results", async () => {
+  const { body, setFailed, warning } = await executeReport({
+    testMatrix: [],
+    jobs: "",
+    targets: "mcp-bridge-dev",
     needs: {
       "generate-matrix": { result: "success" },
     },
-    env: {
-      EXPLICIT_ONLY_JOBS: "mcp-bridge-dev",
-      TEST_MATRIX: "[]",
-      JOB_PR_NUMBER: "42",
-      JOB_TARGETS: "",
-      JOBS: "",
-    },
-    apiJobs: [],
-    apiJobsLoaded: true,
-    context: REPORT_CONTEXT,
   });
 
-  expect(report.body).not.toContain("jobs skipped");
-  expect(report.body).toContain("✅ All tests selected by empty selectors passed");
-  expect(report.body).toContain("**Requested targets:** _(no target selector)_");
+  expect(setFailed).not.toHaveBeenCalled();
+  expect(warning).toHaveBeenCalledWith(
+    "No E2E target reported a result. The check remains successful but provides no affirmative E2E qualification evidence.",
+  );
+  expect(body).not.toContain("jobs skipped");
+  expect(body).not.toContain("All tests selected by empty selectors passed");
+  expect(body).toContain("⚠️ No E2E results reported");
+  expect(body).toContain("**Requested targets:** `mcp-bridge-dev`");
 });
 
 it("reports matrix children by test ID without fabricating a missing child result", async () => {

--- a/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
+++ b/test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts
@@ -630,6 +630,36 @@ it("warns when empty selectors produce no E2E results", async () => {
   expect(body).toContain("**Requested targets:** `mcp-bridge-dev`");
 });
 
+it("preserves a matrix-planning failure in a selective report", () => {
+  const report = renderE2eReport({
+    needs: { "generate-matrix": { result: "failure" } },
+    env: { TEST_MATRIX: "[]", JOB_TARGETS: "mcp-bridge-dev" },
+    apiJobs: [],
+    apiJobsLoaded: true,
+    context: REPORT_CONTEXT,
+  });
+
+  expect(report.body).toContain(`| [generate-matrix](${RUN_URL}) | ❌ failure | — |`);
+  expect(report.body).toContain("❌ Some tests failed");
+  expect(report.body).not.toContain("No E2E results reported");
+});
+
+it("distinguishes unavailable job data from no reported results", async () => {
+  const { body, warning } = await executeReport({
+    testMatrix: [],
+    jobs: "",
+    targets: "mcp-bridge-dev",
+    needs: { "generate-matrix": { result: "success" } },
+    paginateError: new Error("API unavailable"),
+  });
+
+  expect(warning).toHaveBeenCalledWith(
+    "Could not load per-test results; reporting them as unknown: API unavailable",
+  );
+  expect(body).toContain("⚠️ E2E results unavailable");
+  expect(body).not.toContain("No E2E results reported");
+});
+
 it("reports matrix children by test ID without fabricating a missing child result", async () => {
   const { body, setFailed, warning } = await executeReport({
     apiJobs: [

--- a/tools/e2e/report-e2e-results.mts
+++ b/tools/e2e/report-e2e-results.mts
@@ -337,21 +337,20 @@ export function renderE2eReport(input: {
   const missingRequestedTestIds = selectorValidationPassed
     ? requestedTestIds.filter((testId) => !allEntries.some(([name]) => name === testId))
     : [];
+  const isSelectiveReportEntry = ([name, { result }]: [string, ReportEntry]) =>
+    result !== "skipped" &&
+    (name !== "generate-matrix" || result === "failure" || result === "cancelled");
   const selectedEntries =
     requestedTestIds.length > 0
       ? allEntries.filter(([name]) => requestedTestIdSet.has(name))
       : selectiveDispatch
-        ? allEntries.filter(
-            ([name, { result }]) => result !== "skipped" && name !== "generate-matrix",
-          )
+        ? allEntries.filter(isSelectiveReportEntry)
         : allEntries;
   const reportedEntries =
     selectedEntries.length > 0
       ? selectedEntries
       : selectiveDispatch
-        ? allEntries.filter(
-            ([name, { result }]) => result !== "skipped" && name !== "generate-matrix",
-          )
+        ? allEntries.filter(isSelectiveReportEntry)
         : allEntries;
   const rows = reportedEntries.map(([name, { jobUrl, result, wallClockRange }]) => {
     const label = result === "failure" ? `[${name}](${jobUrl ?? runUrl})` : name;
@@ -369,7 +368,9 @@ export function renderE2eReport(input: {
   const unknown = ran.filter(([, v]) => v.result === "unknown");
   const sharedJobAggregateFailed = sharedJobAggregateResult === "failure";
   const sharedJobAggregateCancelled = sharedJobAggregateResult === "cancelled";
-  const noResultsReported = reportedEntries.length === 0 && missingRequestedTestIds.length === 0;
+  const noResultEntries = reportedEntries.length === 0 && missingRequestedTestIds.length === 0;
+  const resultsUnavailable = !apiJobsLoaded && noResultEntries;
+  const noResultsReported = apiJobsLoaded && noResultEntries;
   if (noResultsReported) {
     warnings.push(
       "No E2E target reported a result. The check remains successful but provides no affirmative E2E qualification evidence.",
@@ -390,7 +391,9 @@ export function renderE2eReport(input: {
           ? "⚠️ Some tests cancelled — partial pass"
           : unknown.length > 0
             ? "⚠️ Per-test results incomplete"
-            : noResultsReported
+            : resultsUnavailable
+              ? "⚠️ E2E results unavailable"
+              : noResultsReported
               ? "⚠️ No E2E results reported"
               : skipped.length > 0 && passed.length === 0
                 ? "⚠️ No selected tests ran"

--- a/tools/e2e/report-e2e-results.mts
+++ b/tools/e2e/report-e2e-results.mts
@@ -349,7 +349,9 @@ export function renderE2eReport(input: {
     selectedEntries.length > 0
       ? selectedEntries
       : selectiveDispatch
-        ? allEntries.filter(([, { result }]) => result !== "skipped")
+        ? allEntries.filter(
+            ([name, { result }]) => result !== "skipped" && name !== "generate-matrix",
+          )
         : allEntries;
   const rows = reportedEntries.map(([name, { jobUrl, result, wallClockRange }]) => {
     const label = result === "failure" ? `[${name}](${jobUrl ?? runUrl})` : name;
@@ -367,6 +369,12 @@ export function renderE2eReport(input: {
   const unknown = ran.filter(([, v]) => v.result === "unknown");
   const sharedJobAggregateFailed = sharedJobAggregateResult === "failure";
   const sharedJobAggregateCancelled = sharedJobAggregateResult === "cancelled";
+  const noResultsReported = reportedEntries.length === 0 && missingRequestedTestIds.length === 0;
+  if (noResultsReported) {
+    warnings.push(
+      "No E2E target reported a result. The check remains successful but provides no affirmative E2E qualification evidence.",
+    );
+  }
   const passingStatus =
     requestedTestIds.length > 0
       ? "✅ All requested tests passed"
@@ -382,9 +390,11 @@ export function renderE2eReport(input: {
           ? "⚠️ Some tests cancelled — partial pass"
           : unknown.length > 0
             ? "⚠️ Per-test results incomplete"
-            : skipped.length > 0 && passed.length === 0
-              ? "⚠️ No selected tests ran"
-              : passingStatus;
+            : noResultsReported
+              ? "⚠️ No E2E results reported"
+              : skipped.length > 0 && passed.length === 0
+                ? "⚠️ No selected tests ran"
+                : passingStatus;
 
   const lines = [
     `### E2E Target Results — ${status}`,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

E2E reports with no selected target results now stay successful while visibly warning that they provide no affirmative qualification evidence, instead of claiming every selected test passed.

## Reason

An empty target result set can be legitimate, but presenting it as a passing E2E result hides the absence of test evidence.

## Changes

- Exclude the matrix-planning job from selective-dispatch result fallback so it cannot masquerade as an E2E target result.
- Classify a truly empty target result set with a warning annotation and an explicit no-results report status.
- Cover the warning-only successful behavior through the existing E2E report execution boundary.

## Verification

- Contributor validation: npm run validate:pr — passed
- Tests: npx vitest run --project e2e-support test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts — 37 passed
- Broad gate: npm run validate:pr — passed
- Secrets review: The diff contains no secrets, API keys, or credentials
<!-- nemoclaw-docs-review:start -->
- Documentation review: `no-docs-needed`
- Documentation evidence: Internal CI report semantics only; no user-facing docs changed.
- Documentation agent: openai/openai/gpt-5.6-sol
<!-- docs-review-head-sha: 3580bf76b77636d92c5d3327e347063958ba75fc -->
<!-- docs-review-agents-blob-sha: dd3528f6e332f7f09f4841555c2ed11cb2139fb9 -->
<!-- nemoclaw-docs-review:end -->
<!-- nemoclaw-targeted-validation:start -->
- Targeted validation: npx vitest run --project e2e-support test/e2e/support/e2e-report-to-pr-workflow-boundary.test.ts — 39 passed
<!-- nemoclaw-targeted-validation:end -->
<!-- nemoclaw-broad-gate:start -->
- Broad gate: passed — npm run validate:pr — passed
<!-- nemoclaw-broad-gate:end -->

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved selective E2E reporting by preserving failed or cancelled matrix-generation results.
  - Continued excluding successful and skipped matrix-generation entries from selective reports.
  - Reports now distinguish unavailable job data from successfully loaded data with no results.
  - Added clearer warning and status messages when no E2E results are available.
- **Tests**
  - Added regression coverage for matrix-planning failures and empty-result reporting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->