### PR TITLE
fix(rebuild): keep the configured OpenClaw heartbeat across restore

### DIFF
--- a/src/lib/state/openclaw-config-merge.test.ts
+++ b/src/lib/state/openclaw-config-merge.test.ts
@@ -745,3 +745,73 @@ describe("mergeOpenClawRestoredConfig", () => {
     ).toThrow("missing explicit load paths");
   });
 });
+
+// Regression: NemoClaw #10244. `agents` restores from the backup, so a
+// snapshot taken before the sandbox was configured with
+// NEMOCLAW_AGENT_HEARTBEAT_EVERY replaced the freshly generated heartbeat and
+// the rebuilt sandbox silently ran OpenClaw's own default interval.
+describe("mergeOpenClawRestoredConfig agent heartbeat ownership (#10244)", () => {
+  type MergedAgents = {
+    agents?: { defaults?: Record<string, unknown>; list?: unknown[] };
+  };
+
+  function merge(backup: unknown, fresh: unknown): MergedAgents {
+    return mergeOpenClawRestoredConfig(backup, fresh) as MergedAgents;
+  }
+
+  it("keeps the freshly configured heartbeat when the backup carries none", () => {
+    const merged = merge(
+      { agents: { defaults: { thinkingDefault: "off" } } },
+      { agents: { defaults: { heartbeat: { every: "2m" } } } },
+    );
+
+    expect(merged.agents?.defaults?.heartbeat).toEqual({ every: "2m" });
+  });
+
+  it("keeps the freshly configured heartbeat over a different backed-up interval", () => {
+    const merged = merge(
+      { agents: { defaults: { heartbeat: { every: "30m" } } } },
+      { agents: { defaults: { heartbeat: { every: "2m" } } } },
+    );
+
+    expect(merged.agents?.defaults?.heartbeat).toEqual({ every: "2m" });
+  });
+
+  it("lets a fresh profile that configures no heartbeat drop a backed-up one", () => {
+    const merged = merge(
+      { agents: { defaults: { heartbeat: { every: "30m" } } } },
+      { agents: { defaults: { thinkingDefault: "off" } } },
+    );
+
+    expect(merged.agents?.defaults).not.toHaveProperty("heartbeat");
+  });
+
+  it("does not copy the merged heartbeat by reference from the fresh config", () => {
+    const fresh = { agents: { defaults: { heartbeat: { every: "2m" } } } };
+    const merged = merge({ agents: { defaults: {} } }, fresh);
+
+    expect(merged.agents?.defaults?.heartbeat).not.toBe(fresh.agents.defaults.heartbeat);
+  });
+
+  it("restores unrelated durable agent settings alongside the fresh heartbeat", () => {
+    const merged = merge(
+      {
+        agents: {
+          defaults: { heartbeat: { every: "30m" }, thinkingDefault: "off" },
+          list: [{ id: "researcher", model: "inference/pinned-by-user" }],
+        },
+      },
+      { agents: { defaults: { heartbeat: { every: "2m" } } } },
+    );
+
+    expect(merged.agents?.defaults?.heartbeat).toEqual({ every: "2m" });
+    expect(merged.agents?.defaults?.thinkingDefault).toBe("off");
+    expect(merged.agents?.list).toEqual([{ id: "researcher", model: "inference/pinned-by-user" }]);
+  });
+
+  it("leaves configs without any agent section untouched", () => {
+    const merged = merge({ tools: {} }, { tools: {} });
+
+    expect(merged).not.toHaveProperty("agents");
+  });
+});

--- a/src/lib/state/openclaw-config-merge.ts
+++ b/src/lib/state/openclaw-config-merge.ts
@@ -38,11 +38,17 @@ export const OPENCLAW_CONFIG_RESTORE_OWNERSHIP = {
    * `agents` is durable except its primary model routing reference, which the
    * fresh rebuild re-owns (see `agentPrimaryModelPath`) so a managed-model
    * switch followed by rebuild does not leave the agent pinned to the old
-   * model.
+   * model, and its heartbeat, which the fresh managed startup profile re-owns
+   * (see `agentHeartbeatPath`).
    */
   backupDurableSections: ["mcp", "mcpServers", "customAgents", "agents"],
   /** Fresh rebuild owns the agent's primary model routing within `agents`. */
   agentPrimaryModelPath: ["agents", "defaults", "model", "primary"],
+  /**
+   * Fresh managed startup profile owns the agent heartbeat within `agents`,
+   * including its absence when the profile configures no heartbeat.
+   */
+  agentHeartbeatPath: ["agents", "defaults", "heartbeat"],
   /** NemoClaw's cross-agent disclosure selection owns this generated key. */
   currentGeneratedToolFields: ["toolSearch"],
 } as const;
@@ -438,12 +444,18 @@ function ensureMergedObject(record: Record<string, unknown>, key: string): Recor
   return created;
 }
 
-/** Read the fresh rebuild's `agents.defaults.model.primary`, or undefined. */
-function readAgentPrimaryModelRef(config: Record<string, unknown>): string | undefined {
+/** Read a config's `agents.defaults` object, or undefined when absent. */
+function readAgentDefaults(config: Record<string, unknown>): Record<string, unknown> | undefined {
   const agents = config.agents;
   if (!isPlainObject(agents)) return undefined;
   const defaults = agents.defaults;
-  if (!isPlainObject(defaults)) return undefined;
+  return isPlainObject(defaults) ? (defaults as Record<string, unknown>) : undefined;
+}
+
+/** Read the fresh rebuild's `agents.defaults.model.primary`, or undefined. */
+function readAgentPrimaryModelRef(config: Record<string, unknown>): string | undefined {
+  const defaults = readAgentDefaults(config);
+  if (!defaults) return undefined;
   const model = defaults.model;
   if (!isPlainObject(model)) return undefined;
   return typeof model.primary === "string" ? model.primary : undefined;
@@ -499,6 +511,36 @@ function reconcileAgentPrimaryModel(
   updateMainAgentListModel(agents, freshPrimary);
 }
 
+/**
+ * Re-own the agent heartbeat from the fresh managed startup profile.
+ *
+ * `agents` is backup-durable, so the overlay inherits the snapshot's
+ * `agents.defaults.heartbeat` — including one captured before the sandbox was
+ * configured with `NEMOCLAW_AGENT_HEARTBEAT_EVERY`, or none at all. Without
+ * this the rebuilt sandbox silently falls back to OpenClaw's own default
+ * interval despite the configured value reaching the generated config (#10244,
+ * on the supported heartbeat behavior established by #2880 and #3158).
+ *
+ * Unlike the primary model above, absence is authoritative in both directions:
+ * a profile that configures no heartbeat must not have one restored from a
+ * stale backup. That mirrors how the fresh generator owns `tools.web.search`.
+ */
+function reconcileAgentHeartbeat(
+  merged: Record<string, unknown>,
+  currentConfig: Record<string, unknown>,
+): void {
+  const freshDefaults = readAgentDefaults(currentConfig);
+  if (freshDefaults && "heartbeat" in freshDefaults) {
+    const defaults = ensureMergedObject(ensureMergedObject(merged, "agents"), "defaults");
+    defaults.heartbeat = cloneJson(freshDefaults.heartbeat);
+    return;
+  }
+  // Drop a backup-only heartbeat without materializing empty containers for
+  // configs that never carried one.
+  const mergedDefaults = readAgentDefaults(merged);
+  if (mergedDefaults) delete mergedDefaults.heartbeat;
+}
+
 export function mergeOpenClawRestoredConfig(
   backedUpConfig: unknown,
   currentConfig: unknown,
@@ -537,6 +579,7 @@ export function mergeOpenClawRestoredConfig(
   );
   merged.tools = mergeOpenClawTools(backedUpConfig.tools, currentConfig.tools);
   reconcileAgentPrimaryModel(merged, currentConfig);
+  reconcileAgentHeartbeat(merged, currentConfig);
 
   return merged;
 }

--- a/src/lib/state/sandbox-recreated-openclaw-restore.test.ts
+++ b/src/lib/state/sandbox-recreated-openclaw-restore.test.ts
@@ -271,6 +271,60 @@ describe("recreated OpenClaw state restore", () => {
     });
   });
 
+  it("keeps the configured heartbeat during an ordinary sandbox re-create (#10244)", () => {
+    const result = runRestoreScenario({
+      previousPluginInstalls: [],
+      freshPluginInstalls: [],
+      backupExtensionDirs: [],
+      backupConfig: {
+        agents: {
+          defaults: {
+            heartbeat: { every: "30m" },
+            thinkingDefault: "off",
+          },
+        },
+      },
+      freshConfig: {
+        agents: { defaults: { heartbeat: { every: "2m" } } },
+      },
+    });
+
+    expectSuccessfulRestore(result);
+    expect(result.restoredConfig.agents).toEqual({
+      defaults: {
+        heartbeat: { every: "2m" },
+        thinkingDefault: "off",
+      },
+    });
+  });
+
+  it("drops a backed-up heartbeat when the fresh profile configures none (#10244)", () => {
+    const result = runRestoreScenario({
+      previousPluginInstalls: [],
+      freshPluginInstalls: [],
+      backupExtensionDirs: [],
+      backupConfig: {
+        agents: {
+          defaults: {
+            heartbeat: { every: "30m" },
+            thinkingDefault: "off",
+          },
+        },
+      },
+      freshConfig: {
+        agents: { defaults: { model: { primary: "inference/fresh-model" } } },
+      },
+    });
+
+    expectSuccessfulRestore(result);
+    expect(result.restoredConfig.agents).toEqual({
+      defaults: {
+        model: { primary: "inference/fresh-model" },
+        thinkingDefault: "off",
+      },
+    });
+  });
+
   it("reconciles populated previous and fresh image-plugin provenance during config restore", () => {
     const previousWeather = imageInstall("weather", "weather-v1");
     const freshWeather = imageInstall("weather", "weather-v2");


### PR DESCRIPTION
## Outcome

A sandbox configured with `NEMOCLAW_AGENT_HEARTBEAT_EVERY` kept OpenClaw's own
default heartbeat interval after a supported rebuild, because the restored
backup's `agents.defaults.heartbeat` replaced the freshly generated one. The
fresh managed startup profile now owns that path, so the configured interval
survives restore and a profile that configures no heartbeat is no longer given
one back by a stale backup.

## Reason

`mergeOpenClawRestoredConfig` treats `agents` as backup-durable and re-owns only
`agents.defaults.model.primary`. Nothing re-owned the heartbeat, so a snapshot
captured before the sandbox was configured — or one carrying an older interval —
won during state restore. The configured value reaches the generated config
correctly; it was overwritten one step later.

Absence has to be authoritative in both directions, otherwise a profile that
deliberately configures no heartbeat gets one restored from an old backup. That
mirrors how the fresh generator already owns `tools.web.search`.

### Related issues

Fixes #10244

## Changes

- `src/lib/state/openclaw-config-merge.ts`
  - Add `reconcileAgentHeartbeat`, applied after `reconcileAgentPrimaryModel`:
    the fresh config's `agents.defaults.heartbeat` wins when present, and its
    absence removes a backup-only heartbeat without materializing empty
    `agents.defaults` containers for configs that never carried one.
  - Extract `readAgentDefaults` from `readAgentPrimaryModelRef` so both
    reconcilers share one reader instead of repeating the path walk.
  - Declare `agentHeartbeatPath` in `OPENCLAW_CONFIG_RESTORE_OWNERSHIP` and
    extend the `backupDurableSections` note, matching the existing
    `agentPrimaryModelPath` entry so the ownership contract stays complete.

- `src/lib/state/sandbox-recreated-openclaw-restore.test.ts`
  - Cover both directions through the public `restoreRecreatedSandboxState`
    entry point, so the fix is bound to the restore path operators actually
    reach and not only to the merge helper.

No new mechanism: this reuses the file's established "fresh output owns this
path, including its absence" idiom already used for `tools.web.search` and
`tools.toolSearch`.

## Verification

- `npx vitest run --project cli src/lib/state/openclaw-config-merge.test.ts src/lib/state/openclaw-config-merge-tool-search.test.ts src/lib/state/openclaw-config-restore-input.test.ts src/lib/state/sandbox-recreated-openclaw-restore.test.ts` — 45 passed
- Reverted only `openclaw-config-merge.ts` and reran the new tests — 3 of the 6
  merge-helper cases fail without the fix (fresh-wins-over-different-interval,
  fresh-omission-wins, durable-settings-alongside-fresh-heartbeat) and both new
  `restoreRecreatedSandboxState` cases fail; the remaining 3 pin behavior that
  must not change, so they pass in both states
- `npm run typecheck:cli` — clean
- `npm run checks:repository` — all checks passed
- `npx oxlint --config oxlint.config.ts` on both changed files — no findings
- `npm run format` — no changes
- `npx vitest run --project cli src/lib/state/` — 886 passed, 4 failed in
  `mcp-lifecycle-lock-acquisition` and `registry-route-reservation`; both files
  pass in isolation on this branch (114 passed) and neither touches the config
  merger, so these are load-dependent timeouts on the local host, not this change
- Diff contains no secrets, API keys, or credentials

## Review notes

Scope is the merge-regression slice the issue lists first. The issue's
managed-image lifecycle evidence — binding the startup profile receipt to
OpenClaw's effective 120000 ms interval through a real rebuild and restart —
needs sandbox runtime and is not covered here; happy to follow up or defer to an
E2E target if a maintainer prefers it in this PR.

---
Signed-off-by: Kushagar Garg <dreamstick909@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration restoration so current heartbeat settings are preserved correctly.
  * Removed outdated backed-up heartbeat settings when no current heartbeat configuration exists.
  * Preserved unrelated agent settings during configuration merging.
  * Prevented changes to configurations that do not include agent settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->