### PR TITLE
ci: explain skipped conflict publication

### DIFF
--- a/.github/workflows/pr-merge-conflict-fixer.yaml
+++ b/.github/workflows/pr-merge-conflict-fixer.yaml
@@ -155,11 +155,11 @@ jobs:
           path: ${{ env.ARTIFACT_DIR }}
 
       - name: Explain missing resolution patch
-        if: ${{ always() && steps.download.outcome != 'success' }}
+        if: ${{ steps.download.outcome == 'failure' }}
         env:
           PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ matrix.item.pr_number }}
         run: |
-          echo "::warning title=Conflict resolution was not published::The trusted publisher could not download the validated resolution patch for ${PR_URL}. No pull request branch was modified. Inspect the matching Resolve PR job before retrying."
+          echo "::warning title=Conflict resolution was not published::The trusted publisher could not download the resolution patch for ${PR_URL}. No pull request branch was modified. Inspect the matching Resolve PR job and artifact download error before retrying."
 
       - name: Validate and publish the merge commit
         if: ${{ steps.download.outcome == 'success' }}

--- a/.github/workflows/pr-merge-conflict-fixer.yaml
+++ b/.github/workflows/pr-merge-conflict-fixer.yaml
@@ -154,6 +154,13 @@ jobs:
           name: pr-conflict-resolution-${{ matrix.item.pr_number }}-${{ matrix.item.head_sha }}-${{ matrix.item.base_sha }}
           path: ${{ env.ARTIFACT_DIR }}
 
+      - name: Explain missing resolution patch
+        if: ${{ always() && steps.download.outcome != 'success' }}
+        env:
+          PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ matrix.item.pr_number }}
+        run: |
+          echo "::warning title=Conflict resolution was not published::The trusted publisher could not download the validated resolution patch for ${PR_URL}. No pull request branch was modified. Inspect the matching Resolve PR job before retrying."
+
       - name: Validate and publish the merge commit
         if: ${{ steps.download.outcome == 'success' }}
         env:

--- a/test/automation/pull-requests/pr-merge-conflict-fixer-workflow-boundary.test.ts
+++ b/test/automation/pull-requests/pr-merge-conflict-fixer-workflow-boundary.test.ts
@@ -167,15 +167,6 @@ describe("PR merge conflict fixer workflow boundary", () => {
     expect(record(download.with).name).toBe(record(upload.with).name);
     expect(record(download.with).path).toBe("${{ env.ARTIFACT_DIR }}");
 
-    const warning = namedStep(publish, "Explain missing resolution patch");
-    expect(warning.if).toBe("${{ always() && steps.download.outcome != 'success' }}");
-    expect(record(warning.env).PR_URL).toBe(
-      "${{ github.server_url }}/${{ github.repository }}/pull/${{ matrix.item.pr_number }}",
-    );
-    expect(warning.run).toContain("::warning title=Conflict resolution was not published::");
-    expect(warning.run).toContain("for ${PR_URL}. No pull request branch was modified.");
-    expect(warning.run).toContain("Inspect the matching Resolve PR job before retrying.");
-
     const publisher = namedStep(publish, "Validate and publish the merge commit");
     expect(publisher.if).toBe("${{ steps.download.outcome == 'success' }}");
     expect(record(publisher.env).GITHUB_TOKEN).toBe("${{ github.token }}");

--- a/test/automation/pull-requests/pr-merge-conflict-fixer-workflow-boundary.test.ts
+++ b/test/automation/pull-requests/pr-merge-conflict-fixer-workflow-boundary.test.ts
@@ -167,6 +167,15 @@ describe("PR merge conflict fixer workflow boundary", () => {
     expect(record(download.with).name).toBe(record(upload.with).name);
     expect(record(download.with).path).toBe("${{ env.ARTIFACT_DIR }}");
 
+    const warning = namedStep(publish, "Explain missing resolution patch");
+    expect(warning.if).toBe("${{ always() && steps.download.outcome != 'success' }}");
+    expect(record(warning.env).PR_URL).toBe(
+      "${{ github.server_url }}/${{ github.repository }}/pull/${{ matrix.item.pr_number }}",
+    );
+    expect(warning.run).toContain("::warning title=Conflict resolution was not published::");
+    expect(warning.run).toContain("for ${PR_URL}. No pull request branch was modified.");
+    expect(warning.run).toContain("Inspect the matching Resolve PR job before retrying.");
+
     const publisher = namedStep(publish, "Validate and publish the merge commit");
     expect(publisher.if).toBe("${{ steps.download.outcome == 'success' }}");
     expect(record(publisher.env).GITHUB_TOKEN).toBe("${{ github.token }}");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

A failed merge-conflict resolution patch handoff now emits a clickable, non-blocking warning instead of silently skipping publication.

## Reason

The publisher already stopped safely when the patch download failed, but it did not explain the affected pull request, the safe stopped state, or the next action.

## Changes

- Add an always-run warning when the resolution patch download does not succeed.
- Link directly to the affected pull request using trusted GitHub workflow context.
- State that no pull request branch was modified and direct maintainers to the matching resolver job.
- Extend the existing workflow boundary contract while preserving the guarded publication condition.

## Verification

- Focused test: `npx vitest run --project integration test/automation/pull-requests/pr-merge-conflict-fixer-workflow-boundary.test.ts` — 10 passed
- Contributor validation: `npm run validate:pr` — passed
- Broad gate: `npm run validate:pr` — passed
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution patch warnings so they appear only when artifact downloads fail.
  * Updated warning guidance to reference the resolution patch and artifact-download error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->