### PR TITLE
ci: explain missing docs rejection report

### DIFF
--- a/.github/workflows/post-merge-docs.yaml
+++ b/.github/workflows/post-merge-docs.yaml
@@ -126,20 +126,11 @@ jobs:
           SANDBOX_NAME: docs-main-review
         run: node --experimental-strip-types --no-warnings "$TRUSTED_CHECKOUT/tools/post-merge-docs/run.mts" execute
 
-      - name: Explain missing independent review report
-        if: ${{ failure() && steps.review.outcome == 'failure' }}
-        env:
-          REVIEW_REPORT: ${{ github.workspace }}/approved/review-report.txt
-        run: |
-          if [[ ! -f "$REVIEW_REPORT" ]]; then
-            echo "::warning title=Documentation rejection report is missing::The independent documentation review failed without producing its rejection report. No documentation patch was published. Inspect the Independently review the candidate step before retrying."
-          fi
-
       - name: Upload the independent review report
         if: ${{ failure() && steps.review.outcome == 'failure' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          if-no-files-found: ignore
+          if-no-files-found: warn
           name: post-merge-docs-review-rejection
           path: ${{ github.workspace }}/approved/review-report.txt
           retention-days: 3

--- a/.github/workflows/post-merge-docs.yaml
+++ b/.github/workflows/post-merge-docs.yaml
@@ -126,6 +126,15 @@ jobs:
           SANDBOX_NAME: docs-main-review
         run: node --experimental-strip-types --no-warnings "$TRUSTED_CHECKOUT/tools/post-merge-docs/run.mts" execute
 
+      - name: Explain missing independent review report
+        if: ${{ failure() && steps.review.outcome == 'failure' }}
+        env:
+          REVIEW_REPORT: ${{ github.workspace }}/approved/review-report.txt
+        run: |
+          if [[ ! -f "$REVIEW_REPORT" ]]; then
+            echo "::warning title=Documentation rejection report is missing::The independent documentation review failed without producing its rejection report. No documentation patch was published. Inspect the Independently review the candidate step before retrying."
+          fi
+
       - name: Upload the independent review report
         if: ${{ failure() && steps.review.outcome == 'failure' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/post-merge-docs.yaml
+++ b/.github/workflows/post-merge-docs.yaml
@@ -126,6 +126,11 @@ jobs:
           SANDBOX_NAME: docs-main-review
         run: node --experimental-strip-types --no-warnings "$TRUSTED_CHECKOUT/tools/post-merge-docs/run.mts" execute
 
+      - name: Explain failed independent review
+        if: ${{ failure() && steps.review.outcome == 'failure' }}
+        run: |
+          echo "::warning title=Documentation candidate was not published::The independent documentation review failed, so no documentation patch was published. Inspect the failed review step and its rejection-report artifact, when available, before retrying."
+
       - name: Upload the independent review report
         if: ${{ failure() && steps.review.outcome == 'failure' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

A failed independent post-merge documentation review now emits a non-blocking warning when it does not produce its expected rejection report.

## Reason

The workflow already stops publication after a rejected review, but an abnormal failure before report generation leaves maintainers without the durable rejection explanation.

## Changes

- Check for the expected rejection report only when the independent review fails.
- Warn when that report is absent.
- State the safe stopped condition: no documentation patch was published.
- Direct maintainers to the failed independent-review step before retrying.
- Preserve the existing best-effort report upload and fail-closed approved-patch publication.

## Verification

- Contributor validation: `npm run validate:pr` — passed
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation review feedback by warning when an independent review fails or its rejection report is unavailable.
  * Clearly indicates when no documentation patch was published.
  * Directs users to inspect the review details and rejection report for more information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->