### PR TITLE
fix(onboard): end create handoff after durable ID

### DIFF
--- a/src/lib/onboard/created-sandbox-failure.ts
+++ b/src/lib/onboard/created-sandbox-failure.ts
@@ -5,6 +5,7 @@ import { redact } from "../security/redact";
 import { cliName } from "./branding";
 import type { CreatedSandboxReadinessResult } from "./sandbox-readiness-tracing";
 
+/** Format recovery without authorizing mutable-name deletion or an unsafe onboarding retry. */
 export function formatRetainedSandboxRecoveryMessage(input: {
   sandboxName: string;
   gatewayName: string;
@@ -24,8 +25,10 @@ export function formatRetainedSandboxRecoveryMessage(input: {
     createAttemptEvidence +
     `Durable sandbox identity fingerprint: ${input.sandboxIdentityFingerprint}. ` +
     `NemoClaw stopped before owning-gateway publication and identity verification completed for sandbox '${input.sandboxName}' through gateway '${input.gatewayName}'. ` +
-    `Do not delete the sandbox by mutable name. Run '${cliName()} ${input.sandboxName} destroy' to use the retained identity. ` +
-    "If OpenShell still reports the sandbox present, preserve the recovery record. Give the create-attempt label to an OpenShell administrator for identity-bound removal, then rerun destroy."
+    `Do not delete the sandbox by mutable name. Run '${cliName()} ${input.sandboxName} destroy'. ` +
+    "If OpenShell reports the sandbox present, the command removes nothing and preserves the recovery record. " +
+    "Give the create-attempt label to an OpenShell administrator for identity-bound removal. " +
+    `After OpenShell confirms removal, run '${cliName()} ${input.sandboxName} destroy --yes' to reconcile the recovery record.`
   );
 }
 

--- a/src/lib/onboard/created-sandbox-failure.ts
+++ b/src/lib/onboard/created-sandbox-failure.ts
@@ -2,7 +2,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { redact } from "../security/redact";
+import { cliName } from "./branding";
 import type { CreatedSandboxReadinessResult } from "./sandbox-readiness-tracing";
+
+export function formatRetainedSandboxRecoveryMessage(input: {
+  sandboxName: string;
+  gatewayName: string;
+  createAttemptLabel: string;
+  sandboxIdentityFingerprint: string | null;
+}): string {
+  const createAttemptEvidence = `Create-attempt label: ${input.createAttemptLabel}. `;
+  if (!input.sandboxIdentityFingerprint) {
+    return (
+      createAttemptEvidence +
+      `Sandbox '${input.sandboxName}' reached Ready before OpenShell returned one exact durable create identity. Gateway '${input.gatewayName}'. ` +
+      "OpenShell did not return one exact durable sandbox identity for this create attempt. " +
+      "Do not delete a sandbox by mutable name; preserve it until an OpenShell administrator resolves the create-attempt label to one sandbox."
+    );
+  }
+  return (
+    createAttemptEvidence +
+    `Durable sandbox identity fingerprint: ${input.sandboxIdentityFingerprint}. ` +
+    `NemoClaw stopped before owning-gateway publication and identity verification completed for sandbox '${input.sandboxName}' through gateway '${input.gatewayName}'. ` +
+    `Do not delete the sandbox by mutable name. Run '${cliName()} ${input.sandboxName} destroy' to use the retained identity. ` +
+    "If OpenShell still reports the sandbox present, preserve the recovery record. Give the create-attempt label to an OpenShell administrator for identity-bound removal, then rerun destroy."
+  );
+}
 
 export type SandboxCreateFailureReportOptions = {
   sandboxName: string;

--- a/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
@@ -531,8 +531,8 @@ describe("created sandbox identity gate", () => {
   });
 
   it.each([
-    ["returns false", () => false],
-    ["throws", () => {
+    ["returns false", (): boolean => false],
+    ["throws", (): boolean => {
       throw new Error("recovery writer failed");
     }],
   ] as const)(

--- a/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
@@ -420,7 +420,7 @@ describe("created sandbox identity gate", () => {
     expect(deps.sleep).not.toHaveBeenCalled();
   });
 
-  it("keeps the create client running while the create-attempt selector returns no sandbox ID (#10769)", async () => {
+  it("returns false and blocks effects when the create-attempt selector returns no sandbox ID (#10769)", async () => {
     const input = noGpuInput();
     input.verifyCreatedSandboxBeforeEffects = vi.fn();
     input.revalidateVerifiedSandboxBeforeEffect = vi.fn();
@@ -439,6 +439,57 @@ describe("created sandbox identity gate", () => {
       "stop after the Ready identity check",
     );
 
+    expect(input.verifyCreatedSandboxBeforeEffects).not.toHaveBeenCalled();
+    expect(input.revalidateVerifiedSandboxBeforeEffect).not.toHaveBeenCalled();
+    expect(patch.exitOnPatchError).not.toHaveBeenCalled();
+    expect(patch.ensureApplied).not.toHaveBeenCalled();
+  });
+
+  it("persists recovery before reporting a create-client handoff timeout after an ID appears (#10769)", async () => {
+    let nonce = "";
+    const input = noGpuInput();
+    input.verifyCreatedSandboxBeforeEffects = vi.fn();
+    input.revalidateVerifiedSandboxBeforeEffect = vi.fn();
+    const patch = createGpuPatchFixture();
+    mocks.createDockerGpuSandboxCreatePatch.mockReturnValue(patch);
+    mocks.streamSandboxCreate.mockImplementation(async (_command, args, _env, options) => {
+      nonce = createAttemptNonce(args);
+      expect(options.readyCheck?.()).toBe(true);
+      return {
+        status: 1,
+        output: "OpenShell create client did not exit after Ready; aborting cutover.",
+        sawProgress: true,
+        readyTerminationTimedOut: true,
+      };
+    });
+    const deps = createGpuFlowDeps();
+    vi.mocked(deps.runCaptureOpenshell)
+      .mockReturnValueOnce("alpha Ready")
+      .mockImplementationOnce(() =>
+        sandboxListJson("alpha-sandbox-id", { [NEMOCLAW_CREATE_ATTEMPT_LABEL]: nonce }),
+      );
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit:1");
+    });
+
+    await expect(runSandboxGpuCreateFlow(input, deps)).rejects.toThrow("process.exit:1");
+
+    const fingerprint = fingerprintSandboxRecreateValue("alpha-sandbox-id");
+    expect(input.persistRetainedSandboxRecovery).toHaveBeenCalledExactlyOnceWith(
+      expect.stringMatching(
+        new RegExp(
+          `^Create-attempt label: ${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${nonce}\\. Durable sandbox identity fingerprint: ${fingerprint}\\.`,
+          "u",
+        ),
+      ),
+      fingerprint,
+      nonce,
+    );
+    expect(input.persistRetainedSandboxRecovery).toHaveBeenCalledBefore(exit);
+    const output = vi.mocked(console.error).mock.calls.flat().join("\n");
+    expect(output).toContain(`${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${nonce}`);
+    expect(output).toContain(`Durable sandbox identity fingerprint: ${fingerprint}`);
+    expect(output).not.toContain("alpha-sandbox-id");
     expect(input.verifyCreatedSandboxBeforeEffects).not.toHaveBeenCalled();
     expect(input.revalidateVerifiedSandboxBeforeEffect).not.toHaveBeenCalled();
     expect(patch.exitOnPatchError).not.toHaveBeenCalled();

--- a/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
@@ -530,6 +530,36 @@ describe("created sandbox identity gate", () => {
     expect(deps.installPortableDemoLifecycle).not.toHaveBeenCalled();
   });
 
+  it("blocks a restart-safe handoff timeout without create-attempt identity (#10769)", async () => {
+    const input = noGpuInput();
+    input.persistStartupCommand = true;
+    const patch = createGpuPatchFixture();
+    mocks.createDockerGpuSandboxCreatePatch.mockReturnValue(patch);
+    mocks.streamSandboxCreate.mockImplementation(async (_command, _args, _env, options) => {
+      expect(options.waitForReadyTermination).toBe(true);
+      expect(options.readyCheck?.()).toBe(true);
+      return {
+        status: 1,
+        output:
+          "Created sandbox: alpha\nOpenShell create client did not exit after Ready; aborting cutover.",
+        sawProgress: true,
+        readyTerminationTimedOut: true,
+      };
+    });
+    const deps = createGpuFlowDeps();
+
+    await expect(runSandboxGpuCreateFlow(input, deps)).rejects.toThrow(
+      "No create-attempt identity was available for retained recovery",
+    );
+
+    expect(input.persistRetainedSandboxRecovery).not.toHaveBeenCalled();
+    expect(patch.exitOnPatchError).not.toHaveBeenCalled();
+    expect(patch.ensureApplied).not.toHaveBeenCalled();
+    expect(patch.waitForSupervisorReconnectIfNeeded).not.toHaveBeenCalled();
+    expect(patch.commitAfterReady).not.toHaveBeenCalled();
+    expect(mocks.waitForCreatedSandboxReadyWithTrace).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["returns false", (): boolean => false],
     ["throws", (): boolean => {

--- a/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
@@ -117,69 +117,6 @@ function refuseEffectStartingWith(prefix: string): (operation: string) => void {
   };
 }
 
-async function expectReadyTerminationTimeoutRecovery(createOutput: string): Promise<void> {
-  let nonce = "";
-  const input = noGpuInput();
-  input.verifyCreatedSandboxBeforeEffects = vi.fn();
-  input.revalidateVerifiedSandboxBeforeEffect = vi.fn();
-  const patch = createGpuPatchFixture();
-  mocks.createDockerGpuSandboxCreatePatch.mockReturnValue(patch);
-  mocks.streamSandboxCreate.mockImplementation(async (_command, args, _env, options) => {
-    nonce = createAttemptNonce(args);
-    expect(options.readyCheck?.()).toBe(true);
-    return {
-      status: 1,
-      output: createOutput,
-      sawProgress: true,
-      readyTerminationTimedOut: true,
-    };
-  });
-  const deps = createGpuFlowDeps();
-  deps.installPortableDemoLifecycle = vi.fn();
-  vi.mocked(deps.runCaptureOpenshell)
-    .mockReturnValueOnce("alpha Ready")
-    .mockImplementationOnce(() =>
-      sandboxListJson("alpha-sandbox-id", { [NEMOCLAW_CREATE_ATTEMPT_LABEL]: nonce }),
-    );
-  const exit = vi.spyOn(process, "exit").mockImplementation(() => {
-    throw new Error("process.exit:1");
-  });
-
-  await expect(runSandboxGpuCreateFlow(input, deps)).rejects.toThrow(
-    "OpenShell create client did not exit after Ready for sandbox 'alpha'",
-  );
-
-  const fingerprint = fingerprintSandboxRecreateValue("alpha-sandbox-id");
-  expect(input.persistRetainedSandboxRecovery).toHaveBeenCalledExactlyOnceWith(
-    expect.stringMatching(
-      new RegExp(
-        `^Create-attempt label: ${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${nonce}\\. Durable sandbox identity fingerprint: ${fingerprint}\\.`,
-        "u",
-      ),
-    ),
-    fingerprint,
-    nonce,
-  );
-  expect(exit).not.toHaveBeenCalled();
-  const output = vi.mocked(console.error).mock.calls.flat().join("\n");
-  expect(output).toContain(`${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${nonce}`);
-  expect(output).toContain(`Durable sandbox identity fingerprint: ${fingerprint}`);
-  expect(output).toContain("Run 'nemoclaw alpha destroy' to use the retained identity");
-  expect(output).toContain("Give the create-attempt label to an OpenShell administrator");
-  expect(output).not.toContain("alpha-sandbox-id");
-  expect(output).not.toContain("Recovery:");
-  expect(output).not.toContain("Or:      nemoclaw onboard");
-  expect(output).not.toContain("onboard --resume");
-  expect(input.verifyCreatedSandboxBeforeEffects).not.toHaveBeenCalled();
-  expect(input.revalidateVerifiedSandboxBeforeEffect).not.toHaveBeenCalled();
-  expect(patch.exitOnPatchError).not.toHaveBeenCalled();
-  expect(patch.ensureApplied).not.toHaveBeenCalled();
-  expect(patch.waitForSupervisorReconnectIfNeeded).not.toHaveBeenCalled();
-  expect(patch.commitAfterReady).not.toHaveBeenCalled();
-  expect(mocks.waitForCreatedSandboxReadyWithTrace).not.toHaveBeenCalled();
-  expect(deps.installPortableDemoLifecycle).not.toHaveBeenCalled();
-}
-
 beforeEach(() => setupGpuFlowMocks(mocks));
 afterEach(resetGpuFlowMocks);
 
@@ -508,16 +445,80 @@ describe("created sandbox identity gate", () => {
     expect(patch.ensureApplied).not.toHaveBeenCalled();
   });
 
-  it("persists recovery before reporting a create-client handoff timeout after an ID appears (#10769)", async () => {
-    await expectReadyTerminationTimeoutRecovery(
-      "OpenShell create client did not exit after Ready; aborting cutover.",
-    );
-  });
+  it("persists recovery before reporting a handoff timeout that looks like an incomplete create (#10769)", async () => {
+    const events: string[] = [];
+    let nonce = "";
+    const input = noGpuInput();
+    input.persistRetainedSandboxRecovery = vi.fn(() => {
+      events.push("persist-recovery");
+      return true;
+    });
+    input.verifyCreatedSandboxBeforeEffects = vi.fn();
+    input.revalidateVerifiedSandboxBeforeEffect = vi.fn();
+    const patch = createGpuPatchFixture();
+    mocks.createDockerGpuSandboxCreatePatch.mockReturnValue(patch);
+    mocks.streamSandboxCreate.mockImplementation(async (_command, args, _env, options) => {
+      nonce = createAttemptNonce(args);
+      expect(options.readyCheck?.()).toBe(true);
+      return {
+        status: 1,
+        output:
+          "Created sandbox: alpha\nOpenShell create client did not exit after Ready; aborting cutover.",
+        sawProgress: true,
+        readyTerminationTimedOut: true,
+      };
+    });
+    const deps = createGpuFlowDeps();
+    deps.installPortableDemoLifecycle = vi.fn();
+    vi.mocked(deps.runCaptureOpenshell)
+      .mockReturnValueOnce("alpha Ready")
+      .mockImplementationOnce(() =>
+        sandboxListJson("alpha-sandbox-id", { [NEMOCLAW_CREATE_ATTEMPT_LABEL]: nonce }),
+      );
+    vi.mocked(console.error).mockImplementation(() => {
+      events.push("report-recovery");
+    });
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit:1");
+    });
 
-  it("blocks post-create effects when handoff-timeout output contains a created-sandbox marker (#10769)", async () => {
-    await expectReadyTerminationTimeoutRecovery(
-      "Created sandbox: alpha\nOpenShell create client did not exit after Ready; aborting cutover.",
+    await expect(runSandboxGpuCreateFlow(input, deps)).rejects.toThrow(
+      "OpenShell create client did not exit after Ready for sandbox 'alpha'",
     );
+
+    const fingerprint = fingerprintSandboxRecreateValue("alpha-sandbox-id");
+    expect(input.persistRetainedSandboxRecovery).toHaveBeenCalledExactlyOnceWith(
+      expect.stringMatching(
+        new RegExp(
+          `^Create-attempt label: ${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${nonce}\\. Durable sandbox identity fingerprint: ${fingerprint}\\.`,
+          "u",
+        ),
+      ),
+      fingerprint,
+      nonce,
+    );
+    expect(events.slice(0, 2)).toEqual(["persist-recovery", "report-recovery"]);
+    expect(exit).not.toHaveBeenCalled();
+    const output = vi.mocked(console.error).mock.calls.flat().join("\n");
+    expect(output).toContain(`${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${nonce}`);
+    expect(output).toContain(`Durable sandbox identity fingerprint: ${fingerprint}`);
+    expect(output).toContain("Run 'nemoclaw alpha destroy'");
+    expect(output).toContain("the command removes nothing and preserves the recovery record");
+    expect(output).toContain("Give the create-attempt label to an OpenShell administrator");
+    expect(output).toContain("After OpenShell confirms removal");
+    expect(output).toContain("run 'nemoclaw alpha destroy --yes'");
+    expect(output).not.toContain("alpha-sandbox-id");
+    expect(output).not.toContain("Recovery:");
+    expect(output).not.toContain("Or:      nemoclaw onboard");
+    expect(output).not.toContain("onboard --resume");
+    expect(input.verifyCreatedSandboxBeforeEffects).not.toHaveBeenCalled();
+    expect(input.revalidateVerifiedSandboxBeforeEffect).not.toHaveBeenCalled();
+    expect(patch.exitOnPatchError).not.toHaveBeenCalled();
+    expect(patch.ensureApplied).not.toHaveBeenCalled();
+    expect(patch.waitForSupervisorReconnectIfNeeded).not.toHaveBeenCalled();
+    expect(patch.commitAfterReady).not.toHaveBeenCalled();
+    expect(mocks.waitForCreatedSandboxReadyWithTrace).not.toHaveBeenCalled();
+    expect(deps.installPortableDemoLifecycle).not.toHaveBeenCalled();
   });
 
   it("carries Hermes receipt authority from selector settlement through publication lookup (#10423)", async () => {

--- a/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
@@ -283,7 +283,7 @@ describe("created sandbox identity gate", () => {
     expect(mocks.streamSandboxCreate).not.toHaveBeenCalled();
   });
 
-  it("settles the exact created sandbox before ending the Ready handoff and post-create effects (#9211)", async () => {
+  it("ends the create-client handoff after a nonce-owned ID appears and settles metadata before effects (#10769)", async () => {
     const events: string[] = [];
     let nonce = "";
     const input = noGpuInput();
@@ -317,7 +317,6 @@ describe("created sandbox identity gate", () => {
       expect(nonce).toMatch(/^[0-9a-f]{62}$/u);
       expect(nonce).toHaveLength(NEMOCLAW_CREATE_ATTEMPT_NONCE_HEX_LENGTH);
       expect(nonce.length).toBeLessThanOrEqual(63);
-      expect(options.readyCheck?.()).toBe(false);
       expect(options.readyCheck?.()).toBe(true);
       return { status: 0, output: "Created sandbox: alpha", sawProgress: true };
     });
@@ -359,22 +358,8 @@ describe("created sandbox identity gate", () => {
         );
       })
       .mockImplementationOnce((args) => {
-        expect(args).not.toContain("--selector");
-        events.push("ready-visible-again");
-        return "alpha Ready";
-      })
-      .mockImplementationOnce((args) => {
         expect(args).toContain("--selector");
         events.push("identity-matched");
-        expect(input.verifyCreatedSandboxBeforeEffects).not.toHaveBeenCalled();
-        expect(patch.exitOnPatchError).not.toHaveBeenCalled();
-        return sandboxListJson("alpha-sandbox-id", {
-          [NEMOCLAW_CREATE_ATTEMPT_LABEL]: nonce,
-        });
-      })
-      .mockImplementationOnce((args) => {
-        expect(args).toContain("--selector");
-        events.push("identity-revalidated");
         expect(input.verifyCreatedSandboxBeforeEffects).not.toHaveBeenCalled();
         expect(patch.exitOnPatchError).not.toHaveBeenCalled();
         return sandboxListJson("alpha-sandbox-id", {
@@ -388,9 +373,7 @@ describe("created sandbox identity gate", () => {
       "create",
       "ready-visible",
       "identity-metadata-pending",
-      "ready-visible-again",
       "identity-matched",
-      "identity-revalidated",
       "verify-created",
       "revalidate:validate runtime patch for sandbox 'alpha'",
       "runtime-check",
@@ -435,6 +418,31 @@ describe("created sandbox identity gate", () => {
       expect.anything(),
     );
     expect(deps.sleep).not.toHaveBeenCalled();
+  });
+
+  it("keeps the create client running while the create-attempt selector returns no sandbox ID (#10769)", async () => {
+    const input = noGpuInput();
+    input.verifyCreatedSandboxBeforeEffects = vi.fn();
+    input.revalidateVerifiedSandboxBeforeEffect = vi.fn();
+    const patch = createGpuPatchFixture();
+    mocks.createDockerGpuSandboxCreatePatch.mockReturnValue(patch);
+    mocks.streamSandboxCreate.mockImplementation(async (_command, _args, _env, options) => {
+      expect(options.readyCheck?.()).toBe(false);
+      throw new Error("stop after the Ready identity check");
+    });
+    const deps = createGpuFlowDeps();
+    vi.mocked(deps.runCaptureOpenshell)
+      .mockReturnValueOnce("alpha Ready")
+      .mockReturnValueOnce("[]");
+
+    await expect(runSandboxGpuCreateFlow(input, deps)).rejects.toThrow(
+      "stop after the Ready identity check",
+    );
+
+    expect(input.verifyCreatedSandboxBeforeEffects).not.toHaveBeenCalled();
+    expect(input.revalidateVerifiedSandboxBeforeEffect).not.toHaveBeenCalled();
+    expect(patch.exitOnPatchError).not.toHaveBeenCalled();
+    expect(patch.ensureApplied).not.toHaveBeenCalled();
   });
 
   it("carries Hermes receipt authority from selector settlement through publication lookup (#10423)", async () => {

--- a/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
@@ -70,6 +70,9 @@ import {
 import { runSandboxGpuCreateFlow } from "./sandbox-gpu-create-flow";
 import { fingerprintSandboxRecreateValue } from "./sandbox-recreate-transaction";
 
+const ALPHA_SANDBOX_ID_FINGERPRINT =
+  "8174fa2a5d65755138d8339e086c03d736633130b22dca10952e80e74750c01d";
+
 function sandboxListJson(
   sandboxId: string,
   labels: Readonly<Record<string, string>>,
@@ -428,21 +431,27 @@ describe("created sandbox identity gate", () => {
     mocks.createDockerGpuSandboxCreatePatch.mockReturnValue(patch);
     mocks.streamSandboxCreate.mockImplementation(async (_command, _args, _env, options) => {
       expect(options.readyCheck?.()).toBe(false);
-      throw new Error("stop after the Ready identity check");
+      return { status: 0, output: "", sawProgress: true };
     });
     const deps = createGpuFlowDeps();
+    deps.installPortableDemoLifecycle = vi.fn();
     vi.mocked(deps.runCaptureOpenshell)
       .mockReturnValueOnce("alpha Ready")
       .mockReturnValueOnce("[]");
 
     await expect(runSandboxGpuCreateFlow(input, deps)).rejects.toThrow(
-      "stop after the Ready identity check",
+      "did not return one exact durable sandbox identity before post-create effects",
     );
 
+    expect(input.persistRetainedSandboxRecovery).toHaveBeenCalledOnce();
     expect(input.verifyCreatedSandboxBeforeEffects).not.toHaveBeenCalled();
     expect(input.revalidateVerifiedSandboxBeforeEffect).not.toHaveBeenCalled();
     expect(patch.exitOnPatchError).not.toHaveBeenCalled();
     expect(patch.ensureApplied).not.toHaveBeenCalled();
+    expect(patch.waitForSupervisorReconnectIfNeeded).not.toHaveBeenCalled();
+    expect(patch.commitAfterReady).not.toHaveBeenCalled();
+    expect(mocks.waitForCreatedSandboxReadyWithTrace).not.toHaveBeenCalled();
+    expect(deps.installPortableDemoLifecycle).not.toHaveBeenCalled();
   });
 
   it("persists recovery before reporting a handoff timeout that looks like an incomplete create (#10769)", async () => {
@@ -486,7 +495,7 @@ describe("created sandbox identity gate", () => {
       "OpenShell create client did not exit after Ready for sandbox 'alpha'",
     );
 
-    const fingerprint = fingerprintSandboxRecreateValue("alpha-sandbox-id");
+    const fingerprint = ALPHA_SANDBOX_ID_FINGERPRINT;
     expect(input.persistRetainedSandboxRecovery).toHaveBeenCalledExactlyOnceWith(
       expect.stringMatching(
         new RegExp(
@@ -520,6 +529,64 @@ describe("created sandbox identity gate", () => {
     expect(mocks.waitForCreatedSandboxReadyWithTrace).not.toHaveBeenCalled();
     expect(deps.installPortableDemoLifecycle).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["returns false", () => false],
+    ["throws", () => {
+      throw new Error("recovery writer failed");
+    }],
+  ] as const)(
+    "blocks the create after retained recovery persistence %s (#10769)",
+    async (_failureMode, persistRecovery) => {
+      let nonce = "";
+      const input = noGpuInput();
+      input.persistRetainedSandboxRecovery = vi.fn(persistRecovery);
+      input.verifyCreatedSandboxBeforeEffects = vi.fn();
+      input.revalidateVerifiedSandboxBeforeEffect = vi.fn();
+      const patch = createGpuPatchFixture();
+      mocks.createDockerGpuSandboxCreatePatch.mockReturnValue(patch);
+      mocks.streamSandboxCreate.mockImplementation(async (_command, args, _env, options) => {
+        nonce = createAttemptNonce(args);
+        expect(options.readyCheck?.()).toBe(true);
+        return {
+          status: 1,
+          output: "OpenShell create client did not exit after Ready; aborting cutover.",
+          sawProgress: true,
+          readyTerminationTimedOut: true,
+        };
+      });
+      const deps = createGpuFlowDeps();
+      vi.mocked(deps.runCaptureOpenshell)
+        .mockReturnValueOnce("alpha Ready")
+        .mockImplementationOnce(() =>
+          sandboxListJson("alpha-sandbox-id", { [NEMOCLAW_CREATE_ATTEMPT_LABEL]: nonce }),
+        );
+
+      await expect(runSandboxGpuCreateFlow(input, deps)).rejects.toThrow(
+        "NemoClaw could not save the retained sandbox recovery record for this create attempt",
+      );
+
+      expect(input.persistRetainedSandboxRecovery).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining(
+          `Durable sandbox identity fingerprint: ${ALPHA_SANDBOX_ID_FINGERPRINT}`,
+        ),
+        ALPHA_SANDBOX_ID_FINGERPRINT,
+        nonce,
+      );
+      const output = vi.mocked(console.error).mock.calls.flat().join("\n");
+      expect(output).toContain(`${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${nonce}`);
+      expect(output).toContain(
+        "NemoClaw could not save the retained sandbox recovery record for this create attempt",
+      );
+      expect(output).not.toContain("alpha-sandbox-id");
+      expect(input.verifyCreatedSandboxBeforeEffects).not.toHaveBeenCalled();
+      expect(input.revalidateVerifiedSandboxBeforeEffect).not.toHaveBeenCalled();
+      expect(patch.exitOnPatchError).not.toHaveBeenCalled();
+      expect(patch.ensureApplied).not.toHaveBeenCalled();
+      expect(patch.waitForSupervisorReconnectIfNeeded).not.toHaveBeenCalled();
+      expect(patch.commitAfterReady).not.toHaveBeenCalled();
+    },
+  );
 
   it("carries Hermes receipt authority from selector settlement through publication lookup (#10423)", async () => {
     const events: string[] = [];

--- a/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
+++ b/src/lib/onboard/sandbox-gpu-create-identity-gate.test.ts
@@ -117,6 +117,69 @@ function refuseEffectStartingWith(prefix: string): (operation: string) => void {
   };
 }
 
+async function expectReadyTerminationTimeoutRecovery(createOutput: string): Promise<void> {
+  let nonce = "";
+  const input = noGpuInput();
+  input.verifyCreatedSandboxBeforeEffects = vi.fn();
+  input.revalidateVerifiedSandboxBeforeEffect = vi.fn();
+  const patch = createGpuPatchFixture();
+  mocks.createDockerGpuSandboxCreatePatch.mockReturnValue(patch);
+  mocks.streamSandboxCreate.mockImplementation(async (_command, args, _env, options) => {
+    nonce = createAttemptNonce(args);
+    expect(options.readyCheck?.()).toBe(true);
+    return {
+      status: 1,
+      output: createOutput,
+      sawProgress: true,
+      readyTerminationTimedOut: true,
+    };
+  });
+  const deps = createGpuFlowDeps();
+  deps.installPortableDemoLifecycle = vi.fn();
+  vi.mocked(deps.runCaptureOpenshell)
+    .mockReturnValueOnce("alpha Ready")
+    .mockImplementationOnce(() =>
+      sandboxListJson("alpha-sandbox-id", { [NEMOCLAW_CREATE_ATTEMPT_LABEL]: nonce }),
+    );
+  const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("process.exit:1");
+  });
+
+  await expect(runSandboxGpuCreateFlow(input, deps)).rejects.toThrow(
+    "OpenShell create client did not exit after Ready for sandbox 'alpha'",
+  );
+
+  const fingerprint = fingerprintSandboxRecreateValue("alpha-sandbox-id");
+  expect(input.persistRetainedSandboxRecovery).toHaveBeenCalledExactlyOnceWith(
+    expect.stringMatching(
+      new RegExp(
+        `^Create-attempt label: ${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${nonce}\\. Durable sandbox identity fingerprint: ${fingerprint}\\.`,
+        "u",
+      ),
+    ),
+    fingerprint,
+    nonce,
+  );
+  expect(exit).not.toHaveBeenCalled();
+  const output = vi.mocked(console.error).mock.calls.flat().join("\n");
+  expect(output).toContain(`${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${nonce}`);
+  expect(output).toContain(`Durable sandbox identity fingerprint: ${fingerprint}`);
+  expect(output).toContain("Run 'nemoclaw alpha destroy' to use the retained identity");
+  expect(output).toContain("Give the create-attempt label to an OpenShell administrator");
+  expect(output).not.toContain("alpha-sandbox-id");
+  expect(output).not.toContain("Recovery:");
+  expect(output).not.toContain("Or:      nemoclaw onboard");
+  expect(output).not.toContain("onboard --resume");
+  expect(input.verifyCreatedSandboxBeforeEffects).not.toHaveBeenCalled();
+  expect(input.revalidateVerifiedSandboxBeforeEffect).not.toHaveBeenCalled();
+  expect(patch.exitOnPatchError).not.toHaveBeenCalled();
+  expect(patch.ensureApplied).not.toHaveBeenCalled();
+  expect(patch.waitForSupervisorReconnectIfNeeded).not.toHaveBeenCalled();
+  expect(patch.commitAfterReady).not.toHaveBeenCalled();
+  expect(mocks.waitForCreatedSandboxReadyWithTrace).not.toHaveBeenCalled();
+  expect(deps.installPortableDemoLifecycle).not.toHaveBeenCalled();
+}
+
 beforeEach(() => setupGpuFlowMocks(mocks));
 afterEach(resetGpuFlowMocks);
 
@@ -446,54 +509,15 @@ describe("created sandbox identity gate", () => {
   });
 
   it("persists recovery before reporting a create-client handoff timeout after an ID appears (#10769)", async () => {
-    let nonce = "";
-    const input = noGpuInput();
-    input.verifyCreatedSandboxBeforeEffects = vi.fn();
-    input.revalidateVerifiedSandboxBeforeEffect = vi.fn();
-    const patch = createGpuPatchFixture();
-    mocks.createDockerGpuSandboxCreatePatch.mockReturnValue(patch);
-    mocks.streamSandboxCreate.mockImplementation(async (_command, args, _env, options) => {
-      nonce = createAttemptNonce(args);
-      expect(options.readyCheck?.()).toBe(true);
-      return {
-        status: 1,
-        output: "OpenShell create client did not exit after Ready; aborting cutover.",
-        sawProgress: true,
-        readyTerminationTimedOut: true,
-      };
-    });
-    const deps = createGpuFlowDeps();
-    vi.mocked(deps.runCaptureOpenshell)
-      .mockReturnValueOnce("alpha Ready")
-      .mockImplementationOnce(() =>
-        sandboxListJson("alpha-sandbox-id", { [NEMOCLAW_CREATE_ATTEMPT_LABEL]: nonce }),
-      );
-    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit:1");
-    });
-
-    await expect(runSandboxGpuCreateFlow(input, deps)).rejects.toThrow("process.exit:1");
-
-    const fingerprint = fingerprintSandboxRecreateValue("alpha-sandbox-id");
-    expect(input.persistRetainedSandboxRecovery).toHaveBeenCalledExactlyOnceWith(
-      expect.stringMatching(
-        new RegExp(
-          `^Create-attempt label: ${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${nonce}\\. Durable sandbox identity fingerprint: ${fingerprint}\\.`,
-          "u",
-        ),
-      ),
-      fingerprint,
-      nonce,
+    await expectReadyTerminationTimeoutRecovery(
+      "OpenShell create client did not exit after Ready; aborting cutover.",
     );
-    expect(input.persistRetainedSandboxRecovery).toHaveBeenCalledBefore(exit);
-    const output = vi.mocked(console.error).mock.calls.flat().join("\n");
-    expect(output).toContain(`${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${nonce}`);
-    expect(output).toContain(`Durable sandbox identity fingerprint: ${fingerprint}`);
-    expect(output).not.toContain("alpha-sandbox-id");
-    expect(input.verifyCreatedSandboxBeforeEffects).not.toHaveBeenCalled();
-    expect(input.revalidateVerifiedSandboxBeforeEffect).not.toHaveBeenCalled();
-    expect(patch.exitOnPatchError).not.toHaveBeenCalled();
-    expect(patch.ensureApplied).not.toHaveBeenCalled();
+  });
+
+  it("blocks post-create effects when handoff-timeout output contains a created-sandbox marker (#10769)", async () => {
+    await expectReadyTerminationTimeoutRecovery(
+      "Created sandbox: alpha\nOpenShell create client did not exit after Ready; aborting cutover.",
+    );
   });
 
   it("carries Hermes receipt authority from selector settlement through publication lookup (#10423)", async () => {

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -695,12 +695,18 @@ export function createSandboxGpuCreateAttemptRunner(
                 : undefined,
           }),
       );
-      if (createResult.readyTerminationTimedOut && readyCheckCreatedSandboxId) {
-        persistIdentitySettlementRecovery(
-          fingerprintSandboxRecreateValue(readyCheckCreatedSandboxId),
-        );
+      if (createResult.readyTerminationTimedOut) {
+        if (createAttemptNonce) {
+          persistIdentitySettlementRecovery(
+            readyCheckCreatedSandboxId
+              ? fingerprintSandboxRecreateValue(readyCheckCreatedSandboxId)
+              : null,
+          );
+        }
         throw new Error(
-          `OpenShell create client did not exit after Ready for sandbox '${input.sandboxName}'. NemoClaw retained the sandbox and blocked post-create effects. Follow the retained recovery action above.`,
+          createAttemptNonce
+            ? `OpenShell create client did not exit after Ready for sandbox '${input.sandboxName}'. NemoClaw retained the sandbox and blocked post-create effects. Follow the retained recovery action above.`
+            : `OpenShell create client did not exit after Ready for sandbox '${input.sandboxName}'. NemoClaw blocked post-create effects. No create-attempt identity was available for retained recovery. Preserve the sandbox for identity-bound OpenShell administrator recovery; do not delete it by mutable name.`,
         );
       }
       return createResult;

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -664,7 +664,9 @@ export function createSandboxGpuCreateAttemptRunner(
                 return failReadyCheckCreatedIdentity("selector-identity-changed");
               }
               readyCheckCreatedSandboxId = observation.sandboxId;
-              return observation.state === "matched";
+              // End only the create-client handoff. Strict metadata settlement still
+              // runs before any post-create effect.
+              return true;
             },
             ...(deferPostCreateEffects
               ? {}

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -375,19 +375,6 @@ function checkSandboxExecutableReadiness(
     : "probe_failed";
 }
 
-function stopAfterReadyTerminationTimeout(
-  createResult: StreamSandboxCreateResult,
-  sandboxId: string | null,
-  persistRecovery: (sandboxIdentityFingerprint: string) => void,
-  sandboxName: string,
-): void {
-  if (!createResult?.readyTerminationTimedOut || !sandboxId) return;
-  persistRecovery(fingerprintSandboxRecreateValue(sandboxId));
-  throw new Error(
-    `OpenShell create client did not exit after Ready for sandbox '${sandboxName}'. NemoClaw retained the sandbox and blocked post-create effects. Follow the retained recovery action above.`,
-  );
-}
-
 class ManagedBootstrapCreateStreamFailure extends Error {
   constructor(readonly result: Awaited<ReturnType<typeof streamSandboxCreate>>) {
     super("Managed bootstrap held workload did not complete its create stream.");
@@ -704,12 +691,14 @@ export function createSandboxGpuCreateAttemptRunner(
                 : undefined,
           }),
       );
-      stopAfterReadyTerminationTimeout(
-        createResult,
-        readyCheckCreatedSandboxId,
-        persistIdentitySettlementRecovery,
-        input.sandboxName,
-      );
+      if (createResult.readyTerminationTimedOut && readyCheckCreatedSandboxId) {
+        persistIdentitySettlementRecovery(
+          fingerprintSandboxRecreateValue(readyCheckCreatedSandboxId),
+        );
+        throw new Error(
+          `OpenShell create client did not exit after Ready for sandbox '${input.sandboxName}'. NemoClaw retained the sandbox and blocked post-create effects. Follow the retained recovery action above.`,
+        );
+      }
       return createResult;
     };
     let createResult: Awaited<ReturnType<typeof streamSandboxCreate>> | null = null;

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -23,7 +23,10 @@ import { getReadyCheckOutputPatternsForAgent } from "../sandbox/create-stream-re
 import { isSandboxReady } from "../state/gateway";
 import type { SandboxGpuProofResult } from "../state/registry";
 import { classifySandboxCreateFailure } from "../validation";
-import { reportSandboxCreateFailure } from "./created-sandbox-failure";
+import {
+  formatRetainedSandboxRecoveryMessage,
+  reportSandboxCreateFailure,
+} from "./created-sandbox-failure";
 import * as dockerGpuLocalInference from "./docker-gpu-local-inference";
 import type { SelectedDockerGpuRoute } from "./docker-gpu-route";
 import { createDockerGpuSandboxCreatePatch } from "./docker-gpu-sandbox-create";
@@ -372,13 +375,17 @@ function checkSandboxExecutableReadiness(
     : "probe_failed";
 }
 
-function persistReadyTerminationTimeoutRecovery(
-  createResult: StreamSandboxCreateResult | null,
+function stopAfterReadyTerminationTimeout(
+  createResult: StreamSandboxCreateResult,
   sandboxId: string | null,
   persistRecovery: (sandboxIdentityFingerprint: string) => void,
+  sandboxName: string,
 ): void {
   if (!createResult?.readyTerminationTimedOut || !sandboxId) return;
   persistRecovery(fingerprintSandboxRecreateValue(sandboxId));
+  throw new Error(
+    `OpenShell create client did not exit after Ready for sandbox '${sandboxName}'. NemoClaw retained the sandbox and blocked post-create effects. Follow the retained recovery action above.`,
+  );
 }
 
 class ManagedBootstrapCreateStreamFailure extends Error {
@@ -469,13 +476,12 @@ export function createSandboxGpuCreateAttemptRunner(
       if (!persist) {
         throw new Error("Verified sandbox creation has no durable recovery evidence owner.");
       }
-      const identityEvidence = sandboxIdentityFingerprint
-        ? `Durable sandbox identity fingerprint: ${sandboxIdentityFingerprint}. NemoClaw stopped before owning-gateway publication and identity verification completed for sandbox '${input.sandboxName}' through gateway '${input.gatewayName}'. `
-        : `Sandbox '${input.sandboxName}' reached Ready before OpenShell returned one exact durable create identity. Gateway '${input.gatewayName}'. OpenShell did not return one exact durable sandbox identity for this create attempt. `;
-      const message =
-        `Create-attempt label: ${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${createAttemptNonce}. ` +
-        identityEvidence +
-        "Do not delete a sandbox by mutable name; preserve it until an OpenShell administrator resolves the create-attempt label to one sandbox.";
+      const message = formatRetainedSandboxRecoveryMessage({
+        sandboxName: input.sandboxName,
+        gatewayName: input.gatewayName,
+        createAttemptLabel: `${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${createAttemptNonce}`,
+        sandboxIdentityFingerprint,
+      });
       let persisted = false;
       try {
         persisted = sandboxIdentityFingerprint
@@ -634,8 +640,8 @@ export function createSandboxGpuCreateAttemptRunner(
       }
       return sandboxId;
     };
-    const streamCreate = () =>
-      streamSandboxCreateWithPublicImageCredentialIsolation(
+    const streamCreate = async () => {
+      const createResult = await streamSandboxCreateWithPublicImageCredentialIsolation(
         managedBootstrap != null,
         input.sandboxName,
         input.sandboxEnv,
@@ -698,6 +704,14 @@ export function createSandboxGpuCreateAttemptRunner(
                 : undefined,
           }),
       );
+      stopAfterReadyTerminationTimeout(
+        createResult,
+        readyCheckCreatedSandboxId,
+        persistIdentitySettlementRecovery,
+        input.sandboxName,
+      );
+      return createResult;
+    };
     let createResult: Awaited<ReturnType<typeof streamSandboxCreate>> | null = null;
     let resumedSandboxId: string | null = null;
     let managedIncompleteCreateRecovered = false;
@@ -849,11 +863,6 @@ export function createSandboxGpuCreateAttemptRunner(
       createResult = await streamCreate();
     }
     if (createResult && !state.firstCreateOutput) state.firstCreateOutput = createResult.output;
-    persistReadyTerminationTimeoutRecovery(
-      createResult,
-      readyCheckCreatedSandboxId,
-      persistIdentitySettlementRecovery,
-    );
     if (!deferPostCreateEffects) await runtimePatch.exitOnPatchError();
     if (createResult && createResult.status !== 0) {
       const failure = classifySandboxCreateFailure(createResult.output);

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -372,6 +372,15 @@ function checkSandboxExecutableReadiness(
     : "probe_failed";
 }
 
+function persistReadyTerminationTimeoutRecovery(
+  createResult: StreamSandboxCreateResult | null,
+  sandboxId: string | null,
+  persistRecovery: (sandboxIdentityFingerprint: string) => void,
+): void {
+  if (!createResult?.readyTerminationTimedOut || !sandboxId) return;
+  persistRecovery(fingerprintSandboxRecreateValue(sandboxId));
+}
+
 class ManagedBootstrapCreateStreamFailure extends Error {
   constructor(readonly result: Awaited<ReturnType<typeof streamSandboxCreate>>) {
     super("Managed bootstrap held workload did not complete its create stream.");
@@ -461,7 +470,7 @@ export function createSandboxGpuCreateAttemptRunner(
         throw new Error("Verified sandbox creation has no durable recovery evidence owner.");
       }
       const identityEvidence = sandboxIdentityFingerprint
-        ? `Durable sandbox identity fingerprint: ${sandboxIdentityFingerprint}. Sandbox '${input.sandboxName}' did not remain visible through owning gateway '${input.gatewayName}' before identity verification completed. `
+        ? `Durable sandbox identity fingerprint: ${sandboxIdentityFingerprint}. NemoClaw stopped before owning-gateway publication and identity verification completed for sandbox '${input.sandboxName}' through gateway '${input.gatewayName}'. `
         : `Sandbox '${input.sandboxName}' reached Ready before OpenShell returned one exact durable create identity. Gateway '${input.gatewayName}'. OpenShell did not return one exact durable sandbox identity for this create attempt. `;
       const message =
         `Create-attempt label: ${NEMOCLAW_CREATE_ATTEMPT_LABEL}=${createAttemptNonce}. ` +
@@ -840,6 +849,11 @@ export function createSandboxGpuCreateAttemptRunner(
       createResult = await streamCreate();
     }
     if (createResult && !state.firstCreateOutput) state.firstCreateOutput = createResult.output;
+    persistReadyTerminationTimeoutRecovery(
+      createResult,
+      readyCheckCreatedSandboxId,
+      persistIdentitySettlementRecovery,
+    );
     if (!deferPostCreateEffects) await runtimePatch.exitOnPatchError();
     if (createResult && createResult.status !== 0) {
       const failure = classifySandboxCreateFailure(createResult.output);

--- a/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
+++ b/src/lib/onboard/sandbox-gpu-create-run-attempt.ts
@@ -470,18 +470,22 @@ export function createSandboxGpuCreateAttemptRunner(
         sandboxIdentityFingerprint,
       });
       let persisted = false;
+      let persistenceCause: unknown;
       try {
         persisted = sandboxIdentityFingerprint
           ? persist(message, sandboxIdentityFingerprint, createAttemptNonce)
           : persist(message, undefined, createAttemptNonce);
-      } catch {
-        persisted = false;
+      } catch (error) {
+        persistenceCause = error;
       }
       console.error(`  ${message}`);
       if (!persisted) {
+        const persistenceFailureMessage =
+          "NemoClaw could not save the retained sandbox recovery record for this create attempt.";
         console.error(
-          "  NemoClaw could not save this create-attempt evidence. Preserve the terminal output for an OpenShell administrator.",
+          `  ${persistenceFailureMessage} Preserve the terminal output for an OpenShell administrator.`,
         );
+        throw new Error(persistenceFailureMessage, { cause: persistenceCause });
       }
     };
     const waitForCreatedSandboxPublication = (sandboxId: string): void => {

--- a/src/lib/sandbox/create-stream.test.ts
+++ b/src/lib/sandbox/create-stream.test.ts
@@ -192,11 +192,40 @@ describe("sandbox-create-stream", () => {
     await vi.advanceTimersByTimeAsync(5_001);
     await expect(promise).resolves.toMatchObject({
       status: 1,
+      readyTerminationTimedOut: true,
       output: expect.stringContaining("did not exit after Ready; aborting cutover"),
     });
     expect((await promise).forcedReady).toBeUndefined();
     expect(child.kill).toHaveBeenCalledWith("SIGKILL");
     expect(child.unref).not.toHaveBeenCalled();
+  });
+
+  it("keeps the create client active while the ready check returns false (#10769)", async () => {
+    vi.useFakeTimers();
+
+    const child = new FakeChild();
+    const readyCheck = vi.fn(() => false);
+    const settled = vi.fn();
+    const promise = streamSandboxCreate("echo create", dockerEnv, {
+      spawnImpl: () => child,
+      readyCheck,
+      waitForReadyTermination: true,
+      pollIntervalMs: 5,
+      heartbeatIntervalMs: 1_000,
+      silentPhaseMs: 10_000,
+      logLine: vi.fn(),
+    });
+    void promise.then(settled);
+
+    child.stdout.emit("data", Buffer.from("Created sandbox: demo\n"));
+    await vi.advanceTimersByTimeAsync(6);
+
+    expect(readyCheck).toHaveBeenCalled();
+    expect(settled).not.toHaveBeenCalled();
+    expect(child.kill).not.toHaveBeenCalled();
+
+    child.emit("close", 0);
+    await expect(promise).resolves.toMatchObject({ status: 0 });
   });
 
   it("traces ready-check errors and keeps polling without forcing ready", async () => {

--- a/src/lib/sandbox/create-stream.ts
+++ b/src/lib/sandbox/create-stream.ts
@@ -20,6 +20,7 @@ export interface StreamSandboxCreateResult {
   output: string;
   sawProgress: boolean;
   forcedReady?: boolean;
+  readyTerminationTimedOut?: boolean;
 }
 
 export interface StreamSandboxCreateOptions {
@@ -446,7 +447,7 @@ export function streamSandboxCreate(
               readyTerminationTimer = setTimeout(() => {
                 lines.push("OpenShell create client did not exit after Ready; aborting cutover.");
                 terminateChild("SIGKILL");
-                finish(1);
+                finish(1, { readyTerminationTimedOut: true });
               }, READY_TERMINATION_TIMEOUT_MS);
               readyTerminationTimer.unref?.();
               sawProgress = true;


### PR DESCRIPTION
## Outcome

Fresh onboarding now ends the OpenShell create client when the create-attempt selector returns a validated sandbox ID. NemoClaw still settles identity metadata and verifies the sandbox before post-create effects.

## Reason

On WSL2 ARM, OpenShell could report `Ready` and return the create-attempt ID while publication metadata was incomplete. NemoClaw kept the create client open, which allowed affected OpenClaw sandboxes to move from `Ready` to `Error`.

### Related issues

Fixes #10769

## Changes

- Treat a nonce-owned sandbox ID as sufficient to end the create-client handoff.
- Preserve strict metadata settlement, sandbox ID binding, and verification before post-create effects.
- Persist fingerprint-bound recovery and stop if the create client does not exit after the handoff.
- Cover pending metadata, missing sandbox ID, and handoff-timeout states.

## Verification

- Targeted CLI regression suite across eight files - passed 195 tests. The original handoff regression failed before the source fix.
- `npm run typecheck:cli` - passed.
- `npm run checks:repository` - passed.
- `npm run test:titles:check` - passed.
- Normal `pre-commit`, `commit-msg`, and `pre-push` hooks - passed.
- `git diff --check` - passed.
- GitHub commit verification - latest commit `b1a6d06db4` is Verified.
- Secret scan - the normal pre-commit secret scan passed.
- Documentation review - no documentation change is needed because the fix restores the documented identity settlement contract.

## Review notes

This change handles untrusted OpenShell CLI output. Existing validation still rejects an invalid, missing, or changed sandbox ID before post-create effects. A create-client handoff timeout now persists the identity fingerprint, blocks every post-create effect, and directs recovery through `nemoclaw <sandbox-name> destroy`. It does not change credential handling.

A local WSL2 ARM retest was unavailable on macOS. The regression test covers the deterministic identity handoff boundary. GitHub CI and WSL2 ARM QA provide the remaining platform evidence.

- [x] Documentation writer subagent reviewed the completed changes
- Result: `no-docs-needed`
- Evidence: Existing documentation already defines durable sandbox identity settlement, missing-identity escalation, and retained-sandbox recovery. No command, option, support claim, or user procedure changed.
- Agent: Codex Desktop
<!-- docs-review-head-sha: b1a6d06db4 -->
<!-- docs-review-agents-blob-sha: dd3528f6e3 -->

---

Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU sandbox recovery when identity verification is incomplete or fails.
  * Prevented follow-up actions until sandbox ownership is confirmed.
  * Preserved original failure details when recovery persistence fails.
  * Added recovery handling when the create process does not exit after becoming ready.
* **New Features**
  * Added clearer recovery instructions and reconciliation commands.
  * Added reporting for create-process termination timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->