### PR TITLE
fix(dns): probe Docker authority before patching

### DIFF
--- a/src/lib/actions/dns/index.test.ts
+++ b/src/lib/actions/dns/index.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it, vi } from "vitest";
+import type { DockerHostProbe, DockerVersionIdentity } from "../../platform";
 import type { CommandResult } from "./index";
 import { runFixCoreDns, runSetupDnsProxy } from "./index.js";
 
@@ -13,12 +14,57 @@ function fail(stderr = "failed"): CommandResult {
   return { status: 1, stdout: "", stderr };
 }
 
+const DEFAULT_AUTHORITY = "docker-cli-default";
+
+/**
+ * Answer the Docker probe from a fixed table of hosts that have a daemon
+ * behind them. Every other host is unreachable, which is what a socket file
+ * left behind by an engine that is not running looks like.
+ */
+function probeAnswers(answers: Record<string, DockerVersionIdentity>): DockerHostProbe {
+  return (dockerHost) => {
+    const identity = answers[dockerHost ?? DEFAULT_AUTHORITY];
+    return identity ? { reachable: true, identity } : { reachable: false, identity: "unknown" };
+  };
+}
+
+/** No engine answers anywhere, so nothing is adopted. */
+const NOTHING_ANSWERS = probeAnswers({});
+
+const PODMAN_SOCKET = "/run/user/1000/podman/podman.sock";
+
+/** A clean Linux environment, so an ambient `DOCKER_HOST` cannot leak in. */
+const LINUX_ENV = {
+  DOCKER_HOST: undefined,
+  HOME: "/home/test",
+  XDG_RUNTIME_DIR: undefined,
+};
+
+function patchingRunDocker(dockerInfo: string) {
+  const calls: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = [];
+  const runDocker = vi.fn((args: string[], options: { env?: NodeJS.ProcessEnv } = {}) => {
+    calls.push({ args, env: options.env });
+    const answers: Array<[boolean, CommandResult]> = [
+      [args[0] === "info", ok(dockerInfo)],
+      [args[0] === "ps", ok("openshell-cluster-nemoclaw\n")],
+      [args[0] === "exec" && args[2] === "cat", ok("nameserver 9.9.9.9\n")],
+    ];
+    return answers.find(([matched]) => matched)?.[1] ?? ok();
+  });
+  return { calls, runDocker };
+}
+
 describe("runFixCoreDns", () => {
   it("skips cleanly when no supported local Docker socket is detected", () => {
     const log = vi.fn();
     const result = runFixCoreDns(
       {},
-      { env: { HOME: "/tmp/none" }, existsSocket: () => false, log },
+      {
+        env: { ...LINUX_ENV, HOME: "/tmp/none" },
+        existsSocket: () => false,
+        log,
+        probeDockerHost: NOTHING_ANSWERS,
+      },
     );
 
     expect(result).toEqual({ exitCode: 0, runtime: "unknown", skipped: true });
@@ -50,19 +96,148 @@ describe("runFixCoreDns", () => {
     const result = runFixCoreDns(
       {},
       {
-        env: { HOME: "/Users/test" },
+        env: { ...LINUX_ENV, HOME: "/Users/test" },
         existsSocket: (socketPath) => socketPath === "/var/run/docker.sock",
         log,
         platform: "darwin",
+        probeDockerHost: probeAnswers({ "unix:///var/run/docker.sock": "docker" }),
         runDocker,
+      },
+    );
+
+    expect(result).toEqual({ exitCode: 0, runtime: "custom", skipped: true });
+    expect(runDocker).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(
+      "Skipping CoreDNS patch: no supported Colima or Podman Docker socket found.",
+    );
+  });
+
+  it("does not adopt a Podman socket that exists without a daemon behind it (#10632)", () => {
+    const log = vi.fn();
+    const runDocker = vi.fn();
+    const result = runFixCoreDns(
+      {},
+      {
+        env: LINUX_ENV,
+        existsSocket: (socketPath) => socketPath === PODMAN_SOCKET,
+        log,
+        platform: "linux",
+        probeDockerHost: NOTHING_ANSWERS,
+        runDocker,
+        uid: () => "1000",
       },
     );
 
     expect(result).toEqual({ exitCode: 0, runtime: "unknown", skipped: true });
     expect(runDocker).not.toHaveBeenCalled();
-    expect(log).toHaveBeenCalledWith(
-      "Skipping CoreDNS patch: no supported Colima or Podman Docker socket found.",
+  });
+
+  it("keeps a working Docker CLI default when a stale Podman socket file is present (#10632)", () => {
+    const { calls, runDocker } = patchingRunDocker("Name: colima\nServer Version: 27.0.0\n");
+    const result = runFixCoreDns(
+      { gatewayName: "nemoclaw" },
+      {
+        commandExists: () => false,
+        env: LINUX_ENV,
+        existsSocket: (socketPath) => socketPath === PODMAN_SOCKET,
+        log: vi.fn(),
+        platform: "linux",
+        probeDockerHost: probeAnswers({ [DEFAULT_AUTHORITY]: "docker" }),
+        readFile: () => "nameserver 1.1.1.1\n",
+        runDocker,
+        uid: () => "1000",
+      },
     );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runtime).toBe("colima");
+    expect(result.upstreamDns).toBe("9.9.9.9");
+    expect(calls.map((call) => call.env?.DOCKER_HOST)).not.toContain(`unix://${PODMAN_SOCKET}`);
+  });
+
+  it("adopts a discovered Podman socket once it answers", () => {
+    const { calls, runDocker } = patchingRunDocker("");
+    const result = runFixCoreDns(
+      { gatewayName: "nemoclaw" },
+      {
+        env: LINUX_ENV,
+        existsSocket: (socketPath) => socketPath === PODMAN_SOCKET,
+        log: vi.fn(),
+        platform: "linux",
+        probeDockerHost: probeAnswers({ [`unix://${PODMAN_SOCKET}`]: "podman" }),
+        readFile: () => "nameserver 1.1.1.1\n",
+        runDocker,
+        uid: () => "1000",
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runtime).toBe("podman");
+    expect(calls.every((call) => call.env?.DOCKER_HOST === `unix://${PODMAN_SOCKET}`)).toBe(true);
+  });
+
+  it("locates the rootless Podman socket under XDG_RUNTIME_DIR", () => {
+    const xdgSocket = "/run/user/501/podman/podman.sock";
+    const { calls, runDocker } = patchingRunDocker("");
+    const result = runFixCoreDns(
+      { gatewayName: "nemoclaw" },
+      {
+        env: { ...LINUX_ENV, XDG_RUNTIME_DIR: "/run/user/501" },
+        existsSocket: (socketPath) => socketPath === xdgSocket,
+        log: vi.fn(),
+        platform: "linux",
+        probeDockerHost: probeAnswers({ [`unix://${xdgSocket}`]: "podman" }),
+        readFile: () => "nameserver 1.1.1.1\n",
+        runDocker,
+        uid: () => "1000",
+      },
+    );
+
+    expect(result.runtime).toBe("podman");
+    expect(calls.every((call) => call.env?.DOCKER_HOST === `unix://${xdgSocket}`)).toBe(true);
+  });
+
+  it("skips rather than guess when two engines answer", () => {
+    const runDocker = vi.fn();
+    const result = runFixCoreDns(
+      {},
+      {
+        env: LINUX_ENV,
+        existsSocket: (socketPath) =>
+          socketPath === PODMAN_SOCKET || socketPath === "/run/docker.sock",
+        log: vi.fn(),
+        platform: "linux",
+        probeDockerHost: probeAnswers({
+          "unix:///run/docker.sock": "docker",
+          [`unix://${PODMAN_SOCKET}`]: "podman",
+        }),
+        runDocker,
+        uid: () => "1000",
+      },
+    );
+
+    expect(result).toEqual({ exitCode: 0, runtime: "unknown", skipped: true });
+    expect(runDocker).not.toHaveBeenCalled();
+  });
+
+  it("labels a Podman default from its version banner without reading docker info", () => {
+    const { calls, runDocker } = patchingRunDocker("Server Version: 5.6.2\nOperating System: fedora");
+    const result = runFixCoreDns(
+      { gatewayName: "nemoclaw" },
+      {
+        env: LINUX_ENV,
+        existsSocket: () => false,
+        log: vi.fn(),
+        platform: "linux",
+        probeDockerHost: probeAnswers({ [DEFAULT_AUTHORITY]: "podman" }),
+        readFile: () => "nameserver 1.1.1.1\n",
+        runDocker,
+        uid: () => "1000",
+      },
+    );
+
+    expect(result.runtime).toBe("podman");
+    expect(calls.map((call) => call.args[0])).not.toContain("info");
   });
 
   it("patches CoreDNS through docker with JSON-escaped Corefile payload", () => {
@@ -159,6 +334,31 @@ describe("runFixCoreDns", () => {
 });
 
 describe("runSetupDnsProxy", () => {
+  it("keeps the Docker CLI default when a stale Podman socket file is present (#10632)", () => {
+    const calls: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = [];
+    const runDocker = vi.fn((args: string[], options: { env?: NodeJS.ProcessEnv } = {}) => {
+      calls.push({ args, env: options.env });
+      return ok();
+    });
+
+    const result = runSetupDnsProxy(
+      { gatewayName: "nemoclaw", sandboxName: "box" },
+      {
+        env: LINUX_ENV,
+        existsSocket: (socketPath) => socketPath === PODMAN_SOCKET,
+        log: vi.fn(),
+        probeDockerHost: probeAnswers({ [DEFAULT_AUTHORITY]: "docker" }),
+        runDocker,
+        sleep: vi.fn(),
+        uid: () => "1000",
+      },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].env?.DOCKER_HOST).toBeUndefined();
+  });
+
   it("configures the DNS proxy through kubectl-in-docker argv calls", () => {
     const calls: string[][] = [];
     const log = vi.fn();

--- a/src/lib/actions/dns/index.ts
+++ b/src/lib/actions/dns/index.ts
@@ -16,6 +16,12 @@ import {
   selectOpenshellClusterContainer,
   type ContainerRuntime,
 } from "../../domain/dns/coredns";
+import type {
+  ContainerRuntime as PlatformContainerRuntime,
+  DockerHostProbe,
+  DockerHostProbeResult,
+} from "../../platform";
+import { detectDockerHost, inferContainerRuntime, probeDockerHost } from "../../platform";
 import {
   buildDnsProxyPython,
   buildDnsReadyProbePython,
@@ -35,6 +41,7 @@ export interface FixCoreDnsDeps {
   existsSocket?: (socketPath: string) => boolean;
   log?: (message: string) => void;
   platform?: NodeJS.Platform;
+  probeDockerHost?: DockerHostProbe;
   readFile?: (filePath: string) => string;
   run?: (command: string, args: string[], options?: { env?: NodeJS.ProcessEnv }) => CommandResult;
   runDocker?: (args: string[], options?: { env?: NodeJS.ProcessEnv }) => CommandResult;
@@ -101,46 +108,81 @@ function socketExists(socketPath: string, env: NodeJS.ProcessEnv): boolean {
   }
 }
 
-function findFirstSocket(
-  candidates: string[],
-  deps: Required<Pick<FixCoreDnsDeps, "existsSocket">>,
-): string | null {
-  return candidates.find((candidate) => deps.existsSocket(candidate)) ?? null;
+function parseUid(uid: string | undefined): number | undefined {
+  const parsed = Number.parseInt(uid ?? "", 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
 }
 
-function detectDockerHost(
+interface DockerAuthority {
+  dockerHost?: string;
+  probeDefault: () => DockerHostProbeResult;
+}
+
+/**
+ * Choose the Docker authority for the DNS commands.
+ *
+ * These commands run outside `runner.ts`, so the `DOCKER_HOST` it pins never
+ * reaches them and they have to select the authority themselves. They do it
+ * through the shared selector, which keeps a Docker CLI default that already
+ * answers, adopts a discovered socket only once that socket answers and names
+ * its engine, and refuses to choose when two engines answer. A socket file that
+ * merely exists is not evidence of a daemon behind it (#10632).
+ */
+function resolveDockerAuthority(env: NodeJS.ProcessEnv, deps: FixCoreDnsDeps): DockerAuthority {
+  const probe = deps.probeDockerHost ?? ((host?: string) => probeDockerHost(host, env));
+  const observed = new Map<string | undefined, DockerHostProbeResult>();
+  const probeOnce = (host: string | undefined): DockerHostProbeResult => {
+    const cached = observed.get(host);
+    if (cached) return cached;
+    const observation = probe(host);
+    observed.set(host, observation);
+    return observation;
+  };
+
+  const detection = detectDockerHost({
+    env,
+    existsSync: deps.existsSocket ?? ((socketPath: string) => socketExists(socketPath, env)),
+    home: env.HOME || os.tmpdir(),
+    platform: deps.platform,
+    probeDockerHost: probeOnce,
+    uid: parseUid(deps.uid?.()),
+  });
+
+  return { dockerHost: detection?.dockerHost, probeDefault: () => probeOnce(undefined) };
+}
+
+// `inferContainerRuntime` reports the engine families the whole CLI recognises;
+// the DNS commands carry their own narrower vocabulary, where a plain Docker
+// Engine is just another host CoreDNS does not need patching for.
+const DEFAULT_HOST_RUNTIMES: Record<PlatformContainerRuntime, ContainerRuntime> = {
+  colima: "colima",
+  docker: "custom",
+  "docker-desktop": "docker-desktop",
+  podman: "podman",
+  unknown: "unknown",
+};
+
+/**
+ * Label the runtime behind the selected authority.
+ *
+ * When the selector hands back a socket, the socket path names the runtime and
+ * the probe has already confirmed a daemon answering there. When it keeps the
+ * CLI default there is no path to read, so ask the daemon instead: the probe's
+ * `docker version` banner names Podman even behind its Docker-compatible socket
+ * (#7320), and `docker info` separates the Docker-family engines the banner
+ * reports alike, the same way onboarding's own CoreDNS gate reads them.
+ */
+function detectRuntime(
+  authority: DockerAuthority,
   env: NodeJS.ProcessEnv,
-  deps: FixCoreDnsDeps,
-): { dockerHost?: string; runtime: ContainerRuntime } {
-  if (env.DOCKER_HOST)
-    return { dockerHost: env.DOCKER_HOST, runtime: dockerHostRuntime(env.DOCKER_HOST) ?? "custom" };
-
-  const home = env.HOME || os.tmpdir();
-  const existsSocket = deps.existsSocket ?? ((socketPath: string) => socketExists(socketPath, env));
-  const colimaSocket = findFirstSocket(
-    [
-      path.join(home, ".colima/default/docker.sock"),
-      path.join(home, ".config/colima/default/docker.sock"),
-    ],
-    { existsSocket },
-  );
-  if (colimaSocket) return { dockerHost: `unix://${colimaSocket}`, runtime: "colima" };
-
-  const podmanCandidates =
-    (deps.platform ?? process.platform) === "darwin"
-      ? [path.join(home, ".local/share/containers/podman/machine/podman.sock")]
-      : [
-          path.join(
-            env.XDG_RUNTIME_DIR || `/run/user/${deps.uid?.() ?? "1000"}`,
-            "podman/podman.sock",
-          ),
-          `/run/user/${deps.uid?.() ?? "1000"}/podman/podman.sock`,
-          "/run/podman/podman.sock",
-        ];
-  const podmanSocket = findFirstSocket(podmanCandidates, { existsSocket });
-  if (podmanSocket) return { dockerHost: `unix://${podmanSocket}`, runtime: "podman" };
-
-  return { runtime: "unknown" };
+  runDocker: NonNullable<FixCoreDnsDeps["runDocker"]>,
+): ContainerRuntime {
+  const fromSocket = dockerHostRuntime(authority.dockerHost);
+  if (fromSocket) return fromSocket;
+  const observation = authority.probeDefault();
+  if (!observation.reachable) return "unknown";
+  if (observation.identity === "podman") return "podman";
+  return DEFAULT_HOST_RUNTIMES[inferContainerRuntime(commandOutput(runDocker(["info"], { env })))];
 }
 
 function commandOutput(result: CommandResult): string {
@@ -204,14 +246,15 @@ export function runFixCoreDns(
   const log = deps.log ?? console.log;
   const readFile = deps.readFile ?? ((filePath: string) => fs.readFileSync(filePath, "utf-8"));
   const runDocker = deps.runDocker ?? defaultRunDocker;
-  const detected = detectDockerHost(env, deps);
+  const authority = resolveDockerAuthority(env, deps);
+  const runtime = detectRuntime(authority, env, runDocker);
 
-  if (!detected.dockerHost || (detected.runtime !== "colima" && detected.runtime !== "podman")) {
+  if (runtime !== "colima" && runtime !== "podman") {
     log("Skipping CoreDNS patch: no supported Colima or Podman Docker socket found.");
-    return { exitCode: 0, runtime: detected.runtime, skipped: true };
+    return { exitCode: 0, runtime, skipped: true };
   }
 
-  const dockerEnv = { ...env, DOCKER_HOST: detected.dockerHost };
+  const dockerEnv = authority.dockerHost ? { ...env, DOCKER_HOST: authority.dockerHost } : env;
   const clustersOutput = commandOutput(
     runDocker(["ps", "--filter", "name=openshell-cluster", "--format", "{{.Names}}"], {
       env: dockerEnv,
@@ -223,7 +266,7 @@ export function runFixCoreDns(
     return {
       exitCode: 1,
       message: `ERROR: Could not uniquely determine the openshell cluster container${target}.`,
-      runtime: detected.runtime,
+      runtime,
     };
   }
 
@@ -232,20 +275,20 @@ export function runFixCoreDns(
   );
   const hostResolvConf = readFile("/etc/resolv.conf");
   const colimaVmResolvConf =
-    detected.runtime === "colima" ? getColimaVmResolvConf(deps, dockerEnv) : undefined;
+    runtime === "colima" ? getColimaVmResolvConf(deps, dockerEnv) : undefined;
   const upstreamDns = resolveCoreDnsUpstream({
     colimaVmResolvConf,
     containerResolvConf,
     hostResolvConf,
-    runtime: detected.runtime,
+    runtime,
   });
 
   if (!upstreamDns) {
     return {
       cluster,
       exitCode: 1,
-      message: `ERROR: Could not determine a non-loopback DNS upstream for ${detected.runtime}.`,
-      runtime: detected.runtime,
+      message: `ERROR: Could not determine a non-loopback DNS upstream for ${runtime}.`,
+      runtime,
     };
   }
 
@@ -254,7 +297,7 @@ export function runFixCoreDns(
       cluster,
       exitCode: 1,
       message: `ERROR: UPSTREAM_DNS='${upstreamDns}' contains invalid characters. Aborting.`,
-      runtime: detected.runtime,
+      runtime,
       upstreamDns,
     };
   }
@@ -284,7 +327,7 @@ export function runFixCoreDns(
         cluster,
         exitCode: result.status ?? 1,
         message: result.stderr.trim(),
-        runtime: detected.runtime,
+        runtime,
         upstreamDns,
       };
     }
@@ -310,13 +353,13 @@ export function runFixCoreDns(
       cluster,
       exitCode: rollout.status ?? 1,
       message: rollout.stderr.trim(),
-      runtime: detected.runtime,
+      runtime,
       upstreamDns,
     };
   }
 
   log("Done. DNS should resolve in ~10 seconds.");
-  return { cluster, exitCode: 0, runtime: detected.runtime, upstreamDns };
+  return { cluster, exitCode: 0, runtime, upstreamDns };
 }
 
 export function runSetupDnsProxy(
@@ -327,8 +370,8 @@ export function runSetupDnsProxy(
   const log = deps.log ?? console.log;
   const runDocker = deps.runDocker ?? defaultRunDocker;
   const sleep = deps.sleep ?? sleepSync;
-  const detected = detectDockerHost(env, deps);
-  const dockerEnv = detected.dockerHost ? { ...env, DOCKER_HOST: detected.dockerHost } : env;
+  const authority = resolveDockerAuthority(env, deps);
+  const dockerEnv = authority.dockerHost ? { ...env, DOCKER_HOST: authority.dockerHost } : env;
 
   const clustersOutput = commandOutput(
     runDocker(["ps", "--filter", "name=openshell-cluster", "--format", "{{.Names}}"], {

--- a/src/lib/domain/dns/coredns.test.ts
+++ b/src/lib/domain/dns/coredns.test.ts
@@ -15,6 +15,7 @@ import {
 describe("CoreDNS domain helpers", () => {
   it("classifies Docker host socket runtimes", () => {
     expect(dockerHostRuntime("unix:///Users/me/.colima/default/docker.sock")).toBe("colima");
+    expect(dockerHostRuntime("unix:///Users/me/.colima/docker.sock")).toBe("colima");
     expect(dockerHostRuntime("unix:///run/user/1000/podman/podman.sock")).toBe("podman");
     expect(dockerHostRuntime("unix:///Users/me/.docker/run/docker.sock")).toBe("docker-desktop");
     expect(dockerHostRuntime("tcp://docker.example:2376")).toBe("custom");

--- a/src/lib/domain/dns/coredns.ts
+++ b/src/lib/domain/dns/coredns.ts
@@ -7,7 +7,11 @@ export function dockerHostRuntime(dockerHost: string | undefined): ContainerRunt
   if (!dockerHost) return null;
   if (
     dockerHost.includes("/.colima/default/docker.sock") ||
-    dockerHost.includes("/.config/colima/default/docker.sock")
+    dockerHost.includes("/.config/colima/default/docker.sock") ||
+    // Some Colima profiles place the socket at the top level rather than under
+    // `default/` (#3503). The shared socket candidate list offers that layout,
+    // so the runtime label has to recognise it too.
+    dockerHost.includes("/.colima/docker.sock")
   ) {
     return "colima";
   }

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -13,6 +13,7 @@ export interface PlatformLookupOptions {
   platform?: NodeJS.Platform;
   home?: string;
   uid?: number;
+  env?: NodeJS.ProcessEnv;
 }
 
 export interface WslDetectionOptions {
@@ -188,6 +189,10 @@ function shouldPatchCoredns(runtime: ContainerRuntime, opts: WslDetectionOptions
   return runtime === "colima" || runtime === "podman";
 }
 
+function dedupe(paths: string[]): string[] {
+  return [...new Set(paths)];
+}
+
 function getColimaDockerSocketCandidates(opts: PlatformLookupOptions = {}): string[] {
   const home = opts.home ?? process.env.HOME ?? "/tmp";
   return [
@@ -211,6 +216,7 @@ function findColimaDockerSocket(
 function getPodmanSocketCandidates(opts: PlatformLookupOptions = {}): string[] {
   const home = opts.home ?? process.env.HOME ?? "/tmp";
   const platform = opts.platform ?? process.platform;
+  const env = opts.env ?? process.env;
   const uid = opts.uid ?? process.getuid?.() ?? 1000;
 
   if (platform === "darwin") {
@@ -221,7 +227,16 @@ function getPodmanSocketCandidates(opts: PlatformLookupOptions = {}): string[] {
   }
 
   if (platform === "linux") {
-    return [`/run/user/${String(uid)}/podman/podman.sock`, "/run/podman/podman.sock"];
+    // Rootless Podman puts its socket under the session runtime directory.
+    // `XDG_RUNTIME_DIR` names that directory and is not always `/run/user/$UID`
+    // — systemd user sessions on some hosts relocate it, and the DNS commands
+    // have honoured it since before they shared this candidate list (#10632).
+    const runtimeDir = env.XDG_RUNTIME_DIR;
+    return dedupe([
+      ...(runtimeDir ? [path.join(runtimeDir, "podman/podman.sock")] : []),
+      `/run/user/${String(uid)}/podman/podman.sock`,
+      "/run/podman/podman.sock",
+    ]);
   }
 
   return [];
@@ -241,7 +256,7 @@ function getDockerSocketCandidates(opts: PlatformLookupOptions = {}): string[] {
 
   if (platform === "linux") {
     return [
-      ...getPodmanSocketCandidates({ home, platform, uid: opts.uid }),
+      ...getPodmanSocketCandidates({ env: opts.env, home, platform, uid: opts.uid }),
       "/run/docker.sock",
       "/var/run/docker.sock",
     ];
@@ -266,7 +281,7 @@ function detectDockerHost(opts: DockerHostDetectionOptions = {}): DockerHostDete
   const fileExists = opts.existsSync ?? defaultExistsSync;
   let selection: DockerHostDetection | null = null;
   let selectedIdentity: Exclude<DockerVersionIdentity, "unknown"> | null = null;
-  for (const socketPath of getDockerSocketCandidates(opts)) {
+  for (const socketPath of getDockerSocketCandidates({ ...opts, env })) {
     if (!fileExists(socketPath)) continue;
     const dockerHost = `unix://${socketPath}`;
     const observation = probe(dockerHost);
@@ -291,5 +306,6 @@ export {
   getPodmanSocketCandidates,
   inferContainerRuntime,
   isWsl,
+  probeDockerHost,
   shouldPatchCoredns,
 };

--- a/test/e2e-runtime/platform.test.ts
+++ b/test/e2e-runtime/platform.test.ts
@@ -57,8 +57,48 @@ describe("platform helpers", () => {
 
     it("returns Linux Podman socket paths with uid", () => {
       expect(
-        getPodmanSocketCandidates({ platform: "linux", home: "/tmp/test-home", uid: 1001 }),
+        getPodmanSocketCandidates({ env: {}, platform: "linux", home: "/tmp/test-home", uid: 1001 }),
       ).toEqual(["/run/user/1001/podman/podman.sock", "/run/podman/podman.sock"]);
+    });
+
+    it("prefers the runtime directory XDG_RUNTIME_DIR names over the uid-derived one", () => {
+      expect(
+        getPodmanSocketCandidates({
+          env: { XDG_RUNTIME_DIR: "/run/user/501" },
+          platform: "linux",
+          home: "/tmp/test-home",
+          uid: 1001,
+        }),
+      ).toEqual([
+        "/run/user/501/podman/podman.sock",
+        "/run/user/1001/podman/podman.sock",
+        "/run/podman/podman.sock",
+      ]);
+    });
+
+    it("does not repeat the runtime directory when XDG_RUNTIME_DIR is the uid-derived one", () => {
+      expect(
+        getPodmanSocketCandidates({
+          env: { XDG_RUNTIME_DIR: "/run/user/1001" },
+          platform: "linux",
+          home: "/tmp/test-home",
+          uid: 1001,
+        }),
+      ).toEqual(["/run/user/1001/podman/podman.sock", "/run/podman/podman.sock"]);
+    });
+
+    it("ignores XDG_RUNTIME_DIR on macOS, where Podman uses a machine socket", () => {
+      const home = "/tmp/test-home";
+      expect(
+        getPodmanSocketCandidates({
+          env: { XDG_RUNTIME_DIR: "/run/user/501" },
+          platform: "darwin",
+          home,
+        }),
+      ).toEqual([
+        path.join(home, ".local/share/containers/podman/machine/podman.sock"),
+        "/var/run/docker.sock",
+      ]);
     });
 
     it("returns no Podman socket paths on unsupported platforms", () => {
@@ -81,8 +121,25 @@ describe("platform helpers", () => {
 
     it("returns Linux candidates (Podman > native Docker)", () => {
       expect(
-        getDockerSocketCandidates({ platform: "linux", home: "/tmp/test-home", uid: 1000 }),
+        getDockerSocketCandidates({ env: {}, platform: "linux", home: "/tmp/test-home", uid: 1000 }),
       ).toEqual([
+        "/run/user/1000/podman/podman.sock",
+        "/run/podman/podman.sock",
+        "/run/docker.sock",
+        "/var/run/docker.sock",
+      ]);
+    });
+
+    it("carries the XDG_RUNTIME_DIR Podman socket into the Linux candidates", () => {
+      expect(
+        getDockerSocketCandidates({
+          env: { XDG_RUNTIME_DIR: "/run/user/501" },
+          platform: "linux",
+          home: "/tmp/test-home",
+          uid: 1000,
+        }),
+      ).toEqual([
+        "/run/user/501/podman/podman.sock",
         "/run/user/1000/podman/podman.sock",
         "/run/podman/podman.sock",
         "/run/docker.sock",


### PR DESCRIPTION
## Outcome

Internal DNS commands now use the shared Docker authority selector. A stale socket file no longer redirects commands away from a healthy Docker default, and discovered sockets are used only after a live probe confirms the engine.

## Reason

The DNS commands carried a second selector that trusted socket-file existence alone. This could send Docker operations to an inactive Podman socket and prevent DNS setup on hosts with a healthy Docker default.

### Related issues

Fixes #10632

## Changes

- Reuse `detectDockerHost` and its injected Docker probe from both DNS entry points.
- Preserve `XDG_RUNTIME_DIR` Podman socket discovery and runtime labeling, including top-level Colima sockets.
- Add regression coverage for stale sockets, live socket adoption, multiple answering engines, and the setup-proxy path.

## Verification

- `npx vitest run --no-file-parallelism src/lib/actions/dns/index.test.ts src/lib/actions/sandbox/connect-flow-dcode-probe-preamble.test.ts src/lib/actions/sandbox/connect-flow.test.ts src/lib/actions/sandbox/connect-route-containment.test.ts src/lib/actions/sandbox/connect-route-lifecycle.test.ts src/lib/domain/dns/coredns.test.ts test/e2e-runtime/platform.test.ts test/e2e-runtime/runner.test.ts test/platform/images/docker-authority-profile.test.ts` — 209 passed.
- `npm run typecheck:cli` — passed.
- `npm --prefix nemoclaw run typecheck` — passed.
- `npm run lint` — passed.
- Normal pre-commit and pre-push hooks — passed, including CLI, plugin, and JS-config TypeScript checks.
- Negative control — disabling discovered-socket visibility caused 3 regression-test failures; the restored change passes all 209 tests.
- `npm run review:local` — passed.
- No secrets, API keys, or credentials are included.

## Review notes

No documentation files changed. Tests stub the external Docker probe and Docker commands; live Docker, hardware, and sandbox validation were not run.

---
Signed-off-by: harjoth <harjoth.khara@gmail.com>

P.S. — you should hire me. 115+ contributions to open source: https://github.com/harjothkhara


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS setup and CoreDNS repair when Docker or Podman uses non-default socket locations.
  * Added support for discovering Podman sockets through `XDG_RUNTIME_DIR`.
  * Prevented stale or unavailable Podman sockets from overriding a working Docker connection.
  * Improved runtime detection for Docker, Podman, and Colima environments.
  * Reduced duplicate socket candidates during runtime discovery.
  * Improved Docker authority selection for DNS proxy setup and CoreDNS repair.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->