### PR TITLE
fix(docs): keep the network policy decision table contiguous

### DIFF
--- a/docs/network-policy/customize-network-policy.mdx
+++ b/docs/network-policy/customize-network-policy.mdx
@@ -19,19 +19,14 @@ Choose the policy workflow that matches the scope and persistence of the network
 | Change every future sandbox for an agent | [Change the Baseline Network Policy](configure-policies/change-baseline-network-policy) |
 | Add or remove a maintained preset for one sandbox | [Apply Policy Presets](configure-policies/apply-policy-presets) |
 | Add an operator-reviewed endpoint that no maintained preset covers | [Create Custom Policy Presets](configure-policies/create-custom-policy-presets) |
-
 <AgentOnly variant="openclaw,hermes">
-  | Allow direct TLS negotiation for an exact endpoint | [Configure Raw TLS
-  Passthrough](configure-policies/configure-raw-tls-passthrough) |
+| Allow direct TLS negotiation for an exact endpoint | [Configure Raw TLS Passthrough](configure-policies/configure-raw-tls-passthrough) |
 </AgentOnly>
-| Replace the complete live policy | [Replace the Live Network
-Policy](configure-policies/replace-live-network-policy) |
+| Replace the complete live policy | [Replace the Live Network Policy](configure-policies/replace-live-network-policy) |
 <AgentOnly variant="openclaw,hermes">
-  | Give the sandbox agent a redacted policy summary | [Explain Network Policy to
-  Agents](explain-network-policy-to-agents) |
+| Give the sandbox agent a redacted policy summary | [Explain Network Policy to Agents](explain-network-policy-to-agents) |
 </AgentOnly>
-| Approve or deny one blocked request | [Approve or Deny Network Requests](approve-network-requests)
-|
+| Approve or deny one blocked request | [Approve or Deny Network Requests](approve-network-requests) |
 
 <Note>
 If a sandbox needs an HTTP service on the host, expose the service on a host IP that the OpenShell gateway can reach.

--- a/test/generation/network-policies-published-routes.test.ts
+++ b/test/generation/network-policies-published-routes.test.ts
@@ -24,6 +24,17 @@ const INTEGRATION_POLICY_SOURCE = "network-policy/integration-policy-examples.md
 const GMAIL_SOURCE = "network-policy/set-up-gmail-with-an-app-password.mdx";
 const APPROVAL_LINK_TEXT = "Approve or Deny Agent Network Requests";
 const GMAIL_LINK_TEXT = "Set Up Gmail With an App Password";
+const CUSTOMIZE_SHARED_WORKFLOWS = [
+  "Change the Baseline Network Policy",
+  "Apply Policy Presets",
+  "Create Custom Policy Presets",
+  "Replace the Live Network Policy",
+  "Approve or Deny Network Requests",
+] as const;
+const CUSTOMIZE_AGENT_WORKFLOWS = [
+  "Configure Raw TLS Passthrough",
+  "Explain Network Policy to Agents",
+] as const;
 const SHARED_CONFIGURATION_SOURCES = [
   BASELINE_POLICY_SOURCE,
   APPLY_PRESETS_SOURCE,
@@ -140,6 +151,35 @@ describe("shared Network Policies published routes", () => {
 
     expect(findBrokenPublishedRoutes(CUSTOMIZE_POLICY_SOURCE, index)).toEqual([]);
   });
+
+  it.each([
+    ["openclaw", true],
+    ["hermes", true],
+    ["deepagents", false],
+  ] as const)(
+    "keeps the customize decision table contiguous for %s",
+    (variant, includesAgentWorkflows) => {
+      const rendered = renderAgentVariantPage(readDoc(CUSTOMIZE_POLICY_SOURCE), variant);
+      const tableLines =
+        rendered
+          .match(/\| Goal \| Use this workflow \|\n(?:\|[^\n]+\|\n)+/)?.[0]
+          .trimEnd()
+          .split("\n") ?? [];
+      const expectedWorkflows = includesAgentWorkflows
+        ? [...CUSTOMIZE_SHARED_WORKFLOWS, ...CUSTOMIZE_AGENT_WORKFLOWS]
+        : CUSTOMIZE_SHARED_WORKFLOWS;
+
+      expect(tableLines).toHaveLength(expectedWorkflows.length + 2);
+      expect(tableLines.slice(2)).toEqual(
+        expect.arrayContaining(
+          expectedWorkflows.map((workflow) => expect.stringContaining(`[${workflow}]`)),
+        ),
+      );
+      expect(
+        tableLines.slice(2).every((row) => /^\| [^|\n]+ \| \[[^\]\n]+\]\([^)]+\) \|$/.test(row)),
+      ).toBe(true);
+    },
+  );
 
   it.each(DEEPAGENTS_POLICY_ROUTES)("publishes the Deep Agents policy route %s", (route) => {
     const index = buildPublishedRouteIndex();


### PR DESCRIPTION
## Summary

Salvages the accepted documentation fix from #10787 onto a same-repository branch so the required trusted code CI can validate its regression test. The original contributor PR remains the issue-closing attribution PR.

## Related Work

- Supports #10772.
- Preserves the fix from #10787 without closing either item from this helper PR.

## Changes

- Keep the network-policy decision-table rows contiguous after agent-variant rendering.
- Add focused generation coverage for OpenClaw, Hermes, and Deep Agents row counts and Markdown row shape.

## Verification

- `npx vitest run test/generation/network-policies-published-routes.test.ts --reporter=dot`: 30/30 passed.
- The source tree matches the reviewed two-file tree from #10787 at `1d74ef09c87a3192e1fb9d61550ca9dc55b6b4e0`.

## Scope

No runtime behavior, product surface, dependency, or live E2E target changes. Live E2E is not applicable because the behavior is deterministic documentation generation.

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted network workflow table links and surrounding content for improved readability.

* **Tests**
  * Added coverage verifying customization decision tables display the expected workflows and valid links across supported agent variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->