### PR TITLE
ci(review): serialize advisor runs

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -39,9 +39,11 @@ on:
 # credential or the untrusted PR worktree.
 permissions: {}
 
+# Admit one complete advisor run at a time so all specialists can return fast
+# feedback without concurrent PRs overwhelming the shared inference endpoint.
 concurrency:
-  group: pr-review-advisor-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.target_repo || github.repository }}-${{ inputs.target_pr || '' }}
-  cancel-in-progress: true
+  group: pr-review-advisor-global
+  cancel-in-progress: false
 
 jobs:
   discover-specialists:

--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -44,6 +44,7 @@ permissions: {}
 concurrency:
   group: pr-review-advisor-global
   cancel-in-progress: false
+  queue: max
 
 jobs:
   discover-specialists:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

PR Review Advisor runs no longer overlap across pull requests, while all specialists in the active run still execute in parallel.

## Reason

Concurrent advisor runs created large inference bursts and produced repeated HTTP 429 responses. A workflow-wide concurrency group limits the shared endpoint load without slowing specialist feedback within one review.

## Changes

- Place all PR Review Advisor executions in one repository-wide concurrency group.
- Keep the active run running when a newer review enters the pending slot.
- Retain unrestricted specialist matrix parallelism within the active run.

## Verification

- Contributor validation: `npm run validate:pr` passed all applicable pre-commit, commit-message, and pre-push checks.
- Tests: `npx vitest run --project e2e-support test/e2e/support/e2e-operations-workflow-boundary.test.ts` — 75 tests passed; `npm run validate:pr` — passed.
- Secrets review: The diff contains no secrets, API keys, or credentials
<!-- nemoclaw-docs-review:start -->
- Documentation review: `no-docs-needed`
- Documentation evidence: Workflow-only change; no user documentation is affected.
- Documentation agent: openai/openai/gpt-5.6-sol
<!-- docs-review-head-sha: b7d3c5e1bccb3f3e022ea94cfe6344e6112f0537 -->
<!-- docs-review-agents-blob-sha: dd3528f6e332f7f09f4841555c2ed11cb2139fb9 -->
<!-- nemoclaw-docs-review:end -->
<!-- nemoclaw-targeted-validation:start -->
- Targeted validation: `npx vitest run --project e2e-support test/e2e/support/e2e-operations-workflow-boundary.test.ts` — 75 tests passed.
<!-- nemoclaw-targeted-validation:end -->
<!-- nemoclaw-broad-gate:start -->
- Broad gate: passed — `npm run validate:pr` passed after the queue repair.
<!-- nemoclaw-broad-gate:end -->

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated review advisor workflow scheduling to support the maximum pending queue.
  * Existing runs now complete without being canceled when newer runs start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->