### PR TITLE
fix(policy): reject reserved keys in policy dry-run preview (Fixes #10773)

### DIFF
--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -1359,6 +1359,19 @@ function logPresetScopeForState(
 const OPENCLAW_NPM_BASELINE_KEY = "npm_registry";
 const OPENCLAW_NPM_PRESET_KEY = "npm_yarn";
 
+const CUSTOM_PRESET_RESERVED_NETWORK_POLICY_KEYS = [
+  OPENCLAW_NPM_PRESET_KEY,
+  PERSONAL_OPEN_INTERNET_POLICY_KEY,
+] as const;
+
+function findReservedCustomPresetNetworkPolicyKey(
+  networkPolicies: PolicyObject,
+): string | undefined {
+  return CUSTOM_PRESET_RESERVED_NETWORK_POLICY_KEYS.find((key) =>
+    Object.prototype.hasOwnProperty.call(networkPolicies, key),
+  );
+}
+
 function npmCompatibilityEntry(
   baselineEntry: PolicyObject,
   npmPresetEntry: PolicyObject,
@@ -2264,9 +2277,7 @@ function applyPresetContent(
       console.error(`  Preset '${presetName}' has invalid or missing network_policies.`);
       return false;
     }
-    const reservedKey = [OPENCLAW_NPM_PRESET_KEY, PERSONAL_OPEN_INTERNET_POLICY_KEY].find((key) =>
-      Object.prototype.hasOwnProperty.call(np, key),
-    );
+    const reservedKey = findReservedCustomPresetNetworkPolicyKey(np);
     if (reservedKey) {
       console.error(`  Custom presets cannot own reserved network policy key '${reservedKey}'.`);
       return false;
@@ -2719,6 +2730,11 @@ function loadPresetFromFile(filePath: string): { presetName: string; content: st
     return null;
   }
   const np = parsed.network_policies as PolicyObject;
+  const reservedKey = findReservedCustomPresetNetworkPolicyKey(np);
+  if (reservedKey) {
+    console.error(`  Custom presets cannot own reserved network policy key '${reservedKey}'.`);
+    return null;
+  }
   if (networkPoliciesHasAllowedIps(np)) {
     console.error(
       `  Preset '${presetName}' contains 'allowed_ips', which is not permitted in user-supplied presets: ${filePath}`,

--- a/src/lib/policy/preset-allowed-ips.test.ts
+++ b/src/lib/policy/preset-allowed-ips.test.ts
@@ -26,6 +26,58 @@ afterEach(() => {
   fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
+describe("loadPresetFromFile reserved network policy key guard (#10773)", () => {
+  it("rejects a preset whose network_policies key is npm_yarn", () => {
+    const file = writePreset(
+      "qa-npm-test",
+      `\
+preset:
+  name: qa-npm-test
+  description: doc validation fixture
+network_policies:
+  npm_yarn:
+    name: npm_yarn
+    endpoints:
+      - host: api.example.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/**" }
+    binaries:
+      - { path: /usr/bin/curl }
+`,
+    );
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(loadPresetFromFile(file)).toBeNull();
+    expect(error).toHaveBeenCalledWith(
+      "  Custom presets cannot own reserved network policy key 'npm_yarn'.",
+    );
+    error.mockRestore();
+  });
+
+  it("rejects a preset whose network_policies key is personal_open_internet", () => {
+    const file = writePreset(
+      "spoofed-personal",
+      `\
+preset:
+  name: spoofed-personal
+network_policies:
+  personal_open_internet:
+    endpoints:
+      - host: attacker.example
+        port: 443
+`,
+    );
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(loadPresetFromFile(file)).toBeNull();
+    expect(error).toHaveBeenCalledWith(
+      "  Custom presets cannot own reserved network policy key 'personal_open_internet'.",
+    );
+    error.mockRestore();
+  });
+});
+
 describe("loadPresetFromFile allowed_ips guard (#6073)", () => {
   it("rejects a preset whose endpoint declares allowed_ips", () => {
     const file = writePreset(


### PR DESCRIPTION
## Summary

`policy add --from-file --dry-run` accepted custom presets that used the reserved `npm_yarn` network policy key even though the real apply path correctly refused them. Operators use dry-run as the documented review step, so the preview falsely reported an applyable preset.

## Related Issue

Fixes #10773

## Changes

- `src/lib/policy/index.ts`: reject reserved custom preset network policy keys (`npm_yarn`, `personal_open_internet`) during `loadPresetFromFile`, the same entry point already used for the `allowed_ips` guard before dry-run preview.
- `src/lib/policy/preset-allowed-ips.test.ts`: add regression coverage for both reserved keys at file-load time.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Quality Gates

- [x] Tests added or updated: two focused `loadPresetFromFile` cases for `npm_yarn` and `personal_open_internet`.
- [x] Existing tests cover the change: `applyPresetContent` reserved-key guard remains and shares the same helper.
- [ ] Sensitive-path review: not applicable.
- [ ] Skipped or missing CI: pending fork PR workflow approval via copy-pr-bot.

## Documentation Writer Review

Reviewed latest PR commit for the complete final change set. No docs changes required; behavior now matches the existing custom-preset documentation that reserves `npm_yarn`.

## DGX Station Hardware Evidence

Not applicable.

## Verification

```bash
npx vitest run src/lib/policy/preset-allowed-ips.test.ts
npm test
```

- `src/lib/policy/preset-allowed-ips.test.ts`: 16/16 passed locally.
- Full `npm test` completed with 358 pre-existing unrelated failures in this environment (timing-sensitive CLI/integration suites); the changed policy preset tests passed.

Signed-off-by: Deepak Jain <deepujain@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented custom network-policy presets from overriding reserved policy keys.
  * Applied consistent validation when presets are loaded or used.

* **Tests**
  * Added coverage confirming invalid presets are rejected and appropriate errors are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->