### PR TITLE
ci(review): distribute specialists across models

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -39,13 +39,6 @@ on:
 # credential or the untrusted PR worktree.
 permissions: {}
 
-# Admit one complete advisor run at a time so all specialists can return fast
-# feedback without concurrent PRs overwhelming the shared inference endpoint.
-concurrency:
-  group: pr-review-advisor-global
-  cancel-in-progress: false
-  queue: max
-
 jobs:
   discover-specialists:
     name: Discover review specialists and collect GitHub context

--- a/test/automation/pull-requests/pr-review-advisor-specialists.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-specialists.test.ts
@@ -139,9 +139,14 @@ describe("PR review advisor specialist prompts", () => {
       ["--experimental-strip-types", "render-specialist-matrix.mts"],
       { cwd: directory, encoding: "utf8", env: { PATH: process.env.PATH } },
     );
-    const matrix = JSON.parse(output) as Array<{ interest: string }>;
+    const matrix = JSON.parse(output) as Array<{ interest: string; model: string }>;
 
     expect(matrix.map(({ interest }) => interest)).toEqual(ADVISOR_INTERESTS);
+    expect(matrix.map(({ model }) => model)).toEqual(
+      ADVISOR_INTERESTS.map((_, index) =>
+        index % 2 === 0 ? "openai/openai/gpt-5.6-terra" : "azure/openai/gpt-5.6-terra",
+      ),
+    );
     expect(matrix.every((entry) => !("sandbox_name" in entry))).toBe(true);
   });
 

--- a/tools/pr-review-advisor/render-specialist-matrix.mts
+++ b/tools/pr-review-advisor/render-specialist-matrix.mts
@@ -5,11 +5,14 @@ import fs from "node:fs";
 
 import { ADVISOR_SPECIALISTS } from "./specialist-catalog.mts";
 
-const model = process.env.PR_REVIEW_ADVISOR_MODEL?.trim() || "azure/openai/gpt-5.6-terra";
-const matrix = ADVISOR_SPECIALISTS.map(({ interest, label }) => ({
+const configuredModel = process.env.PR_REVIEW_ADVISOR_MODEL?.trim();
+const models = configuredModel
+  ? [configuredModel]
+  : ["openai/openai/gpt-5.6-terra", "azure/openai/gpt-5.6-terra"];
+const matrix = ADVISOR_SPECIALISTS.map(({ interest, label }, index) => ({
   interest,
   label,
-  model,
+  model: models[index % models.length],
   artifact_dir: `pr-review-specialist-${interest}`,
   artifact_name: `pr-review-specialist-${interest}`,
 }));


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

PR Review Advisor runs can execute concurrently again, with specialists distributed across two independently rate-limited inference models.

## Reason

Serializing complete advisor runs contained HTTP 429 responses but created a predictable review queue. The inference service applies separate limits to the OpenAI and Azure model routes, so alternating specialist assignments reduces pressure without delaying entire PR reviews.

## Changes

- Remove the repository-wide PR Review Advisor concurrency queue.
- Alternate default specialist assignments between `openai/openai/gpt-5.6-terra` and `azure/openai/gpt-5.6-terra`.
- Preserve `PR_REVIEW_ADVISOR_MODEL` as a single-model override.
- Assert the default model distribution in the specialist matrix test.

## Verification

- Tests: `npx vitest run --project integration test/automation/pull-requests/pr-review-advisor-specialists.test.ts` — 29 passed.
- Tests: `npx vitest run --project e2e-support test/e2e/support/e2e-operations-workflow-boundary.test.ts` — 75 passed.
- Contributor validation: clean-worktree pre-commit, repository, source-shape, growth, and TypeScript checks passed after building required artifacts. The final push used the maintainer-authorized pre-push bypass because current `main` contains an unrelated duplicate `now` property in `src/lib/onboard/sandbox-readiness-tracing.test.ts`.
- Secrets review: The diff contains no secrets, API keys, or credentials.

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the review advisor’s model through an optional setting.
  - Review specialists now alternate between OpenAI and Azure GPT-5.6 Terra models by default.

- **Improvements**
  - Review advisor runs are no longer restricted by a single workflow-wide concurrency limit.

- **Tests**
  - Expanded validation to confirm model assignments alternate as expected while preserving existing specialist configuration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->