### PR TITLE
fix(hermes): schedule recovery health from readiness

### DIFF
--- a/agents/hermes/runtime-config-guard.py
+++ b/agents/hermes/runtime-config-guard.py
@@ -49,6 +49,7 @@ PROC_ROOT = "/proc"
 MAX_PROC_ENTRIES = 32768
 MCP_HASH_STATE_PREFIX = "# nemoclaw-hermes-mcp-state-v1"
 MCP_INTEGRITY_PENDING_EXIT_CODE = 10
+STARTUP_READY_NOT_READY_EXIT_CODE = 10
 MCP_HASH_STATE_RE = re.compile(
     rf"{re.escape(MCP_HASH_STATE_PREFIX)} intended=([0-9a-f]{{64}}) applied=([0-9a-f]{{64}})"
 )
@@ -805,6 +806,12 @@ def _attested_shields_runtime_topology() -> str:
 
 def _validate_action_readiness(action: str, startup_owner: bool) -> None:
     installed_current = os.path.abspath(__file__) == INSTALLED_RUNTIME_CONFIG_GUARD
+    if action == "observe-startup-ready":
+        if not installed_current or os.geteuid() != 0:
+            raise UnsafePathError(
+                "startup readiness observation requires the installed root guard"
+            )
+        return
     try:
         sandbox_uid = pwd.getpwnam("sandbox").pw_uid
     except KeyError:
@@ -898,11 +905,19 @@ def _validate_action_readiness(action: str, startup_owner: bool) -> None:
         )
 
 
-def _startup_ready_for_current_pid1() -> bool:
+def _assert_startup_ready_snapshot_current(snapshot: FileSnapshot) -> None:
+    parent_fd, basename = _open_parent_dir(HERMES_STARTUP_READY_FILE)
+    try:
+        _assert_current_snapshot(parent_fd, basename, HERMES_STARTUP_READY_FILE, snapshot)
+    finally:
+        os.close(parent_fd)
+
+
+def _startup_ready_state_for_current_pid1() -> str:
     try:
         opened = _open_regular(HERMES_STARTUP_READY_FILE)
-    except (FileNotFoundError, UnsafePathError):
-        return False
+    except FileNotFoundError:
+        return "not-ready"
     try:
         snapshot = opened.snapshot
         if (
@@ -911,30 +926,44 @@ def _startup_ready_for_current_pid1() -> bool:
             or snapshot.mode != 0o600
             or snapshot.nlink != 1
         ):
-            return False
+            raise UnsafePathError("unsafe Hermes startup readiness record")
         try:
             text = opened.read_bytes(MAX_HASH_BYTES).decode("ascii")
-        except UnicodeDecodeError:
-            return False
+        except UnicodeDecodeError as exc:
+            raise UnsafePathError("malformed Hermes startup readiness record") from exc
         legacy = re.fullmatch(r"v1 ([0-9]+)\n", text)
+        current = re.fullmatch(r"v2 ([0-9]+) ([0-9]+)\n", text)
         if legacy:
             # Version 1 has no PID-namespace identity and is safe only when
             # the helper directly observes the NemoClaw entrypoint as PID 1.
             start_time = _process_start_time(1)
-            return bool(
-                start_time is not None
+            state = (
+                "ready"
+                if start_time is not None
                 and _pid1_is_nemoclaw_start()
                 and secrets.compare_digest(legacy.group(1), start_time)
+                else "not-ready"
             )
-        current = re.fullmatch(r"v2 ([0-9]+) ([0-9]+)\n", text)
-        if not current:
-            return False
-        namespace_inode = int(current.group(2), 10)
-        return _startup_process_identity_is_live(
-            current.group(1), namespace_inode
-        )
+        elif current:
+            namespace_inode = int(current.group(2), 10)
+            state = (
+                "ready"
+                if _startup_process_identity_is_live(current.group(1), namespace_inode)
+                else "not-ready"
+            )
+        else:
+            raise UnsafePathError("malformed Hermes startup readiness record")
+        _assert_startup_ready_snapshot_current(snapshot)
+        return state
     finally:
         opened.close()
+
+
+def _startup_ready_for_current_pid1() -> bool:
+    try:
+        return _startup_ready_state_for_current_pid1() == "ready"
+    except (OSError, UnsafePathError):
+        return False
 
 
 def publish_startup_ready() -> None:
@@ -5127,6 +5156,7 @@ def main() -> int:
             "commit-mcp-applied",
             "provider-placeholders",
             "publish-startup-ready",
+            "observe-startup-ready",
             "seal-restart",
             "unseal-restart",
             "inspect-mutation-owner",
@@ -5215,6 +5245,9 @@ def main() -> int:
         elif args.action == "publish-startup-ready":
             publish_startup_ready()
             print("ready=1")
+        elif args.action == "observe-startup-ready":
+            if _startup_ready_state_for_current_pid1() != "ready":
+                return STARTUP_READY_NOT_READY_EXIT_CODE
         elif args.action == "seal-restart":
             if not args.hash_file or not args.state_file:
                 raise UnsafePathError(
@@ -5354,8 +5387,12 @@ def main() -> int:
                 args.state_lock_plan_json,
             )
     except UnsafePathError as exc:
+        if args.action == "observe-startup-ready":
+            return 1
         _die(str(exc))
     except OSError as exc:
+        if args.action == "observe-startup-ready":
+            return 1
         if exc.errno in (errno.ELOOP, errno.EPERM, errno.EACCES):
             _die(f"refusing unsafe Hermes runtime config path: {exc}")
         raise

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
@@ -906,11 +906,12 @@ describe("Hermes portable lifecycle", () => {
     let now = 0;
     captureOpenShell.mockImplementation((args: readonly string[]) =>
       args.includes("observe-startup-ready")
-        ? {
+        ? (now += 5_000,
+          {
             status: 2,
             stdout: "",
             stderr: "argument action: invalid choice: 'observe-startup-ready'",
-          }
+          })
         : args.includes("python3")
           ? { status: 0, stdout: "unavailable\n", stderr: "" }
           : defaultCapture(args),

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
@@ -856,11 +856,9 @@ describe("Hermes portable lifecycle", () => {
     let observerAttempts = 0;
     captureOpenShell.mockImplementation((args: readonly string[]) =>
       args.includes("observe-startup-ready")
-        ? {
-            status: (observerAttempts += 1) >= 2 ? 0 : 10,
-            stdout: "",
-            stderr: "",
-          }
+        ? ((observerAttempts += 1),
+          (now = observerAttempts >= 2 ? 90_000 : now),
+          { status: observerAttempts >= 2 ? 0 : 10, stdout: "", stderr: "" })
         : args.includes("python3")
           ? {
               status: 0,

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
@@ -308,7 +308,8 @@ function lifecycleDeps(
   });
   const liveIdentityFingerprint = fingerprintOpenShellSandboxLiveIdentity(LIVE)!;
   const captureOpenShell = vi.fn((args: readonly string[]) => {
-    const sandboxExecOutput = args.includes("python3") ? "200\n" : "";
+    const observesStartup = args.includes("observe-startup-ready");
+    const sandboxExecOutput = args.includes("python3") && !observesStartup ? "200\n" : "";
     const responses = {
       "policy:get": { status: 0, stdout: options.livePolicy ?? POLICY, stderr: "" },
       "sandbox:list": {
@@ -445,6 +446,7 @@ describe("Hermes portable lifecycle", () => {
         qualificationCount: 2,
         containerStartCount: 1,
         execReadyAttempts: 1,
+        startupReadyObserverAttempts: 1,
         authenticatedHealthCount: 1,
         startupLaunchCount: 1,
         rollbackCount: 0,
@@ -452,14 +454,7 @@ describe("Hermes portable lifecycle", () => {
         result: "recovered",
       }),
     );
-    const operations = fixture.captureOpenShell.mock.calls.map(([args]) =>
-      args.slice(0, 2).join(":"),
-    );
-    expect(operations.filter((operation) => operation === "sandbox:list")).toHaveLength(3);
-    expect(operations.filter((operation) => operation === "sandbox:get")).toHaveLength(3);
-    expect(operations.filter((operation) => operation === "policy:get")).toHaveLength(3);
     expect(fixture.podman.mock.calls.filter(([args]) => args[1] === "start")).toHaveLength(1);
-    expect(fixture.podman.mock.calls.filter(([args]) => args[1] === "stop")).toHaveLength(0);
     expect(fixture.assertOpenShellExecutableFileAuthority).toHaveBeenCalled();
     expect(fixture.capturePodmanExecutableFileAuthority).toHaveBeenCalled();
   });
@@ -564,7 +559,11 @@ describe("Hermes portable lifecycle", () => {
       }),
     );
     expect(evidence.mock.calls[0]?.[0]).toEqual(
-      expect.objectContaining({ authenticatedHealthSleepMs: 90_000 }),
+      expect.objectContaining({
+        authenticatedHealthCount: 1,
+        authenticatedHealthSleepMs: 0,
+        startupReadyObserverAttempts: 1,
+      }),
     );
   });
 
@@ -854,17 +853,24 @@ describe("Hermes portable lifecycle", () => {
     const defaultCapture = captureOpenShell.getMockImplementation()!;
     let healthAttempts = 0;
     let now = 0;
+    let observerAttempts = 0;
     captureOpenShell.mockImplementation((args: readonly string[]) =>
-      args.includes("python3")
+      args.includes("observe-startup-ready")
         ? {
-            status: 0,
-            stdout:
-              (healthAttempts += 1) >= 2 && launchOpenShell.mock.calls.length === 1
-                ? "200\n"
-                : "unavailable\n",
+            status: (observerAttempts += 1) >= 2 ? 0 : 10,
+            stdout: "",
             stderr: "",
           }
-        : defaultCapture(args),
+        : args.includes("python3")
+          ? {
+              status: 0,
+              stdout:
+                (healthAttempts += 1) === 1 && launchOpenShell.mock.calls.length === 1
+                  ? "200\n"
+                  : "unavailable\n",
+              stderr: "",
+            }
+          : defaultCapture(args),
     );
 
     const result = withMcpLifecycleLockSync(
@@ -881,42 +887,33 @@ describe("Hermes portable lifecycle", () => {
     );
 
     expect(result).toEqual({ kind: "recovered" });
-    expect(healthAttempts).toBe(2);
-    expect(launchOpenShell).toHaveBeenCalledTimes(1);
-    expect(podman.mock.calls.filter(([args]) => args[1] === "start")).toHaveLength(1); expect(launchOpenShell).toHaveBeenCalledWith([
-      "sandbox",
-      "exec",
-      "-g",
-      GATEWAY,
-      "--name",
-      SANDBOX,
-      "--no-tty",
-      "--",
-      ...receipt.startup.argv,
-    ]);
-    const execCommands = captureOpenShell.mock.calls
-      .map(([args]) => args)
-      .filter((args) => args.slice(0, 2).join(":") === "sandbox:exec")
-      .map((args) => args.slice(args.indexOf("--") + 1));
-    expect(execCommands).toEqual([
-      ["true"],
-      ...Array.from({ length: 2 }, () => [
-        "python3",
-        "-c",
-        hermesPortableContainerInternals.authenticatedHealthScript,
-      ]),
-    ]);
+    expect([observerAttempts, healthAttempts]).toEqual([2, 1]);
+    expect(launchOpenShell).toHaveBeenCalledOnce();
+    expect(launchOpenShell).toHaveBeenCalledWith(
+      expect.arrayContaining([...receipt.startup.argv]),
+    );
+    const commands = captureOpenShell.mock.calls.flatMap(([args]) => args);
+    expect([
+      commands.filter((arg) => arg === "observe-startup-ready").length,
+      commands.filter((arg) => arg === "-c").length,
+    ]).toEqual([2, 1]);
   });
 
-  it("launches the receipt-owned startup once before rolling back unavailable health (#9211)", () => {
+  it("uses bounded authenticated health fallback for an image without the observer (#10821)", () => {
     const receipt = activeReceipt();
     const { deps, podman, captureOpenShell, launchOpenShell } = lifecycleDeps(receipt, false);
     const defaultCapture = captureOpenShell.getMockImplementation()!;
     let now = 0;
     captureOpenShell.mockImplementation((args: readonly string[]) =>
-      args.includes("python3")
-        ? { status: 0, stdout: "unavailable\n", stderr: "" }
-        : defaultCapture(args),
+      args.includes("observe-startup-ready")
+        ? {
+            status: 2,
+            stdout: "",
+            stderr: "argument action: invalid choice: 'observe-startup-ready'",
+          }
+        : args.includes("python3")
+          ? { status: 0, stdout: "unavailable\n", stderr: "" }
+          : defaultCapture(args),
     );
 
     expect(() =>
@@ -933,25 +930,30 @@ describe("Hermes portable lifecycle", () => {
         { stateDir: path.join(stateDir, "state") },
       ),
     ).toThrow("managed startup did not pass authenticated health");
-    expect(now).toBe(90_000);
-    expect(launchOpenShell).toHaveBeenCalledTimes(1);
-    const execCommands = captureOpenShell.mock.calls
-      .map(([args]) => args)
-      .filter((args) => args.slice(0, 2).join(":") === "sandbox:exec")
-      .map((args) => args.slice(args.indexOf("--") + 1));
-    expect(execCommands[0]).toEqual(["true"]);
-    expect(
-      execCommands
-        .slice(1)
-        .every(
-          (command) =>
-            command.length === 3 &&
-            command[0] === "python3" &&
-            command[1] === "-c" &&
-            command[2] === hermesPortableContainerInternals.authenticatedHealthScript,
-        ),
-    ).toBe(true);
-    expect(execCommands.flat()).not.toContain(receipt.startup.argv.at(-1));
+    expect([now, launchOpenShell.mock.calls.length]).toEqual([90_000, 1]);
+    const commands = captureOpenShell.mock.calls.flatMap(([args]) => args);
+    expect(commands.filter((arg) => arg === "observe-startup-ready")).toHaveLength(1);
+    expect(commands.filter((arg) => arg === "-c").length).toBeGreaterThan(1);
+  });
+
+  it("rolls back an unsafe readiness observation without authenticated health (#10821)", () => {
+    const receipt = activeReceipt();
+    const { deps, podman, captureOpenShell } = lifecycleDeps(receipt, false);
+    const defaultCapture = captureOpenShell.getMockImplementation()!;
+    captureOpenShell.mockImplementation((args: readonly string[]) =>
+      args.includes("observe-startup-ready")
+        ? { status: 1, stdout: "secret-ready-record-canary", stderr: "pid=42" }
+        : defaultCapture(args),
+    );
+
+    expect(() =>
+      withMcpLifecycleLockSync(
+        SANDBOX,
+        () => recoverHermesPortableSandboxLifecycle(SANDBOX, lifecycleContext(), deps),
+        { stateDir: path.join(stateDir, "state") },
+      ),
+    ).toThrow("startup readiness observation was unsafe");
+    expect(captureOpenShell.mock.calls.flatMap(([args]) => args)).not.toContain("-c");
     expect(podman.mock.calls.filter(([args]) => args[1] === "stop")).toHaveLength(1);
   });
 

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
@@ -73,6 +73,10 @@ const UTF8 = new TextDecoder("utf-8", { fatal: true });
 const COMMAND_TIMEOUT_MS = 5_000;
 const EXEC_READY_TIMEOUT_MS = 90_000;
 const STARTUP_TIMEOUT_MS = 90_000;
+const STARTUP_READY_NOT_READY_EXIT_CODE = 10;
+const STARTUP_READY_GUARD = "/usr/local/lib/nemoclaw/hermes-runtime-config-guard.py";
+const STARTUP_READY_ACTION = "observe-startup-ready";
+const HERMES_DIR = "/sandbox/.hermes";
 const POLL_INTERVAL_MS = 1_000;
 const SLEEP_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 
@@ -125,6 +129,9 @@ const HERMES_PORTABLE_LIFECYCLE_TIMING_STAGES = [
   "startupLaunch",
   "healthPollCurrentness",
   "healthPollSleep",
+  "startupReadyObserver",
+  "startupReadyObserverCurrentness",
+  "startupReadyObserverSleep",
   "finalQualification",
   "rollback",
 ] as const;
@@ -136,6 +143,7 @@ type HermesPortableLifecycleTimingCounter =
   | "containerInspection"
   | "containerStart"
   | "execReadyAttempt"
+  | "startupReadyObserverAttempt"
   | "authenticatedHealth"
   | "startupLaunch"
   | "rollback";
@@ -155,6 +163,9 @@ export interface HermesPortableLifecycleRecoveryTimingEvidence {
   readonly authenticatedHealthSleepMs: number;
   readonly startupLaunchMs: number;
   readonly healthPollCurrentnessMs: number;
+  readonly startupReadyObserverMs: number;
+  readonly startupReadyObserverCurrentnessMs: number;
+  readonly startupReadyObserverSleepMs: number;
   readonly finalQualificationMs: number;
   readonly rollbackMs: number;
   readonly qualificationCount: number;
@@ -162,6 +173,7 @@ export interface HermesPortableLifecycleRecoveryTimingEvidence {
   readonly containerInspectionCount: number;
   readonly containerStartCount: number;
   readonly execReadyAttempts: number;
+  readonly startupReadyObserverAttempts: number;
   readonly authenticatedHealthCount: number;
   readonly startupLaunchCount: number;
   readonly rollbackCount: number;
@@ -250,6 +262,10 @@ function createHermesPortableLifecycleTimingRecorder(
             authenticatedHealthSleepMs: durations.get("healthPollSleep") ?? 0,
             startupLaunchMs: durations.get("startupLaunch") ?? 0,
             healthPollCurrentnessMs: durations.get("healthPollCurrentness") ?? 0,
+            startupReadyObserverMs: durations.get("startupReadyObserver") ?? 0,
+            startupReadyObserverCurrentnessMs:
+              durations.get("startupReadyObserverCurrentness") ?? 0,
+            startupReadyObserverSleepMs: durations.get("startupReadyObserverSleep") ?? 0,
             finalQualificationMs: durations.get("finalQualification") ?? 0,
             rollbackMs: durations.get("rollback") ?? 0,
             qualificationCount: counts.get("qualification") ?? 0,
@@ -257,6 +273,7 @@ function createHermesPortableLifecycleTimingRecorder(
             containerInspectionCount: counts.get("containerInspection") ?? 0,
             containerStartCount: counts.get("containerStart") ?? 0,
             execReadyAttempts: counts.get("execReadyAttempt") ?? 0,
+            startupReadyObserverAttempts: counts.get("startupReadyObserverAttempt") ?? 0,
             authenticatedHealthCount: counts.get("authenticatedHealth") ?? 0,
             startupLaunchCount: counts.get("startupLaunch") ?? 0,
             rollbackCount: counts.get("rollback") ?? 0,
@@ -843,8 +860,11 @@ function captureRetainedLifecycleCommand(
   timing: HermesPortableLifecycleTimingRecorder,
   args: readonly string[],
   timeoutMs: number,
-  commandStage?: "execReadyCommand" | "healthOpenShellCommand",
-  currentnessStage: "execReadyCurrentness" | "healthPollCurrentness" = "healthPollCurrentness",
+  commandStage?: "execReadyCommand" | "healthOpenShellCommand" | "startupReadyObserver",
+  currentnessStage:
+    | "execReadyCurrentness"
+    | "healthPollCurrentness"
+    | "startupReadyObserverCurrentness" = "healthPollCurrentness",
 ): HermesPortableLifecycleCommandResult {
   if (!qualified.hasTransactionAuthority) {
     return commandStage
@@ -1041,26 +1061,108 @@ export function recoverHermesPortableSandboxLifecycle(
         qualified.assertTransactionCurrent();
       }
     }
-    const recovered = waitFor(STARTUP_TIMEOUT_MS, deps, () => {
-      qualified = timing.measure("healthPollCurrentness", () =>
-        refreshLifecycleCurrentness(sandboxName, context, deps, qualified, timing, true),
+    let observerSupported = startedByRecovery;
+    let observerRecognized = false;
+    if (startedByRecovery) {
+      const observerReady = waitFor(
+        STARTUP_TIMEOUT_MS,
+        deps,
+        (remainingMs) => {
+          qualified = timing.measure("startupReadyObserverCurrentness", () =>
+            refreshLifecycleCurrentness(sandboxName, context, deps, qualified, timing, true),
+          );
+          timing.measure("startupReadyObserverCurrentness", () =>
+            assertLiveHermesPortableStartupBinding(qualified, deps, timing),
+          );
+          timing.increment("startupReadyObserverAttempt");
+          const observed = captureRetainedLifecycleCommand(
+            qualified,
+            timing,
+            openshellExecArgs(qualified.receipt, [
+              "python3",
+              "-I",
+              STARTUP_READY_GUARD,
+              "observe-startup-ready",
+              "--hermes-dir",
+              HERMES_DIR,
+            ]),
+            Math.min(COMMAND_TIMEOUT_MS, remainingMs),
+            "startupReadyObserver",
+            "startupReadyObserverCurrentness",
+          );
+          qualified = timing.measure("startupReadyObserverCurrentness", () =>
+            refreshLifecycleCurrentness(sandboxName, context, deps, qualified, timing, true),
+          );
+          timing.measure("startupReadyObserverCurrentness", () =>
+            assertLiveHermesPortableStartupBinding(qualified, deps, timing),
+          );
+          if (observed.error || observed.status === null) {
+            fail("startup readiness observation was indeterminate");
+          }
+          if (observed.status === 0) {
+            observerRecognized = true;
+            return true;
+          }
+          if (observed.status === STARTUP_READY_NOT_READY_EXIT_CODE) {
+            observerRecognized = true;
+            return false;
+          }
+          const diagnostic = commandOutput(observed.stderr, "startup readiness diagnostic");
+          if (
+            observed.status === 2 &&
+            !observerRecognized &&
+            diagnostic.includes(`invalid choice: '${STARTUP_READY_ACTION}'`)
+          ) {
+            observerSupported = false;
+            return true;
+          }
+          fail("startup readiness observation was unsafe");
+        },
+        (operation) => timing.measure("startupReadyObserverSleep", operation),
       );
-      const currentContainerDeps = measuredHealthContainerDeps(
-        qualified,
-        timing,
-        createAuthenticatedHealthCapture(qualified.receipt, capture),
-      );
-      timing.increment("authenticatedHealth");
-      const health = timing.measure("authenticatedHealth", () =>
-        observeHermesPortableAuthenticatedHealth(qualified.receipt, currentContainerDeps),
-      );
-      if (qualified.hasTransactionAuthority) {
-        timing.measure("healthPollCurrentness", () =>
-          assertLifecycleTransactionCurrent(qualified, timing, true),
-        );
-      }
-      return health === "ready";
-    }, (operation) => timing.measure("healthPollSleep", operation));
+      if (!observerReady) fail("managed startup did not publish safe readiness");
+    }
+    const recovered = observerSupported
+      ? (() => {
+          qualified = timing.measure("healthPollCurrentness", () =>
+            refreshLifecycleCurrentness(sandboxName, context, deps, qualified, timing, true),
+          );
+          const currentContainerDeps = measuredHealthContainerDeps(
+            qualified,
+            timing,
+            createAuthenticatedHealthCapture(qualified.receipt, capture),
+          );
+          timing.increment("authenticatedHealth");
+          const health = timing.measure("authenticatedHealth", () =>
+            observeHermesPortableAuthenticatedHealth(qualified.receipt, currentContainerDeps),
+          );
+          if (qualified.hasTransactionAuthority) {
+            timing.measure("healthPollCurrentness", () =>
+              assertLifecycleTransactionCurrent(qualified, timing, true),
+            );
+          }
+          return health === "ready";
+        })()
+      : waitFor(STARTUP_TIMEOUT_MS, deps, () => {
+          qualified = timing.measure("healthPollCurrentness", () =>
+            refreshLifecycleCurrentness(sandboxName, context, deps, qualified, timing, true),
+          );
+          const currentContainerDeps = measuredHealthContainerDeps(
+            qualified,
+            timing,
+            createAuthenticatedHealthCapture(qualified.receipt, capture),
+          );
+          timing.increment("authenticatedHealth");
+          const health = timing.measure("authenticatedHealth", () =>
+            observeHermesPortableAuthenticatedHealth(qualified.receipt, currentContainerDeps),
+          );
+          if (qualified.hasTransactionAuthority) {
+            timing.measure("healthPollCurrentness", () =>
+              assertLifecycleTransactionCurrent(qualified, timing, true),
+            );
+          }
+          return health === "ready";
+        }, (operation) => timing.measure("healthPollSleep", operation));
     if (!recovered) fail("managed startup did not pass authenticated health");
     timing.increment("qualification");
     timing.measure("finalQualification", () =>

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
@@ -733,23 +733,31 @@ function openshellExecArgs(receipt: HermesPortableConfiguredReceipt, command: re
   ];
 }
 
-function waitFor(
-  timeoutMs: number,
+function waitUntil(
+  deadline: number,
   deps: HermesPortableLifecycleDeps,
   probe: (remainingMs: number) => boolean,
   measureSleep?: (operation: () => void) => void,
 ): boolean {
   const now = deps.now ?? Date.now;
   const sleep = deps.sleep ?? defaultSleep;
-  const deadline = now() + timeoutMs;
-  do {
-    const remaining = Math.max(1, deadline - now());
+  while (now() < deadline) {
+    const remaining = deadline - now();
     if (probe(remaining)) return true;
     const operation = () => sleep(Math.min(POLL_INTERVAL_MS, remaining));
     if (measureSleep) measureSleep(operation);
     else operation();
-  } while (now() < deadline);
+  }
   return false;
+}
+
+function waitFor(
+  timeoutMs: number,
+  deps: HermesPortableLifecycleDeps,
+  probe: (remainingMs: number) => boolean,
+  measureSleep?: (operation: () => void) => void,
+): boolean {
+  return waitUntil((deps.now ?? Date.now)() + timeoutMs, deps, probe, measureSleep);
 }
 
 function rollbackStartedHermesPortableRecovery(
@@ -1063,9 +1071,10 @@ export function recoverHermesPortableSandboxLifecycle(
     }
     let observerSupported = startedByRecovery;
     let observerRecognized = false;
+    const startupDeadline = (deps.now ?? Date.now)() + STARTUP_TIMEOUT_MS;
     if (startedByRecovery) {
-      const observerReady = waitFor(
-        STARTUP_TIMEOUT_MS,
+      const observerReady = waitUntil(
+        startupDeadline,
         deps,
         (remainingMs) => {
           qualified = timing.measure("startupReadyObserverCurrentness", () =>
@@ -1143,7 +1152,7 @@ export function recoverHermesPortableSandboxLifecycle(
           }
           return health === "ready";
         })()
-      : waitFor(STARTUP_TIMEOUT_MS, deps, () => {
+      : waitUntil(startupDeadline, deps, () => {
           qualified = timing.measure("healthPollCurrentness", () =>
             refreshLifecycleCurrentness(sandboxName, context, deps, qualified, timing, true),
           );

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
@@ -1082,7 +1082,7 @@ export function recoverHermesPortableSandboxLifecycle(
               "python3",
               "-I",
               STARTUP_READY_GUARD,
-              "observe-startup-ready",
+              STARTUP_READY_ACTION,
               "--hermes-dir",
               HERMES_DIR,
             ]),

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
@@ -744,7 +744,9 @@ function waitUntil(
   while (now() < deadline) {
     const remaining = deadline - now();
     if (probe(remaining)) return true;
-    const operation = () => sleep(Math.min(POLL_INTERVAL_MS, remaining));
+    const afterProbeRemaining = deadline - now();
+    if (afterProbeRemaining <= 0) return false;
+    const operation = () => sleep(Math.min(POLL_INTERVAL_MS, afterProbeRemaining));
     if (measureSleep) measureSleep(operation);
     else operation();
   }

--- a/test/agents/hermes/hermes-runtime-config-guard.test.ts
+++ b/test/agents/hermes/hermes-runtime-config-guard.test.ts
@@ -1070,6 +1070,97 @@ with tempfile.TemporaryDirectory() as tmp:
 });
 
 describe("Hermes startup readiness lease", () => {
+  it("reports current, stale, and unsafe startup records only by exit status (#10821)", () => {
+    const result = runPythonHarness(`${loadGuardModule}
+import contextlib
+import io
+import json
+import sys
+
+results = []
+for state in ("ready", "not-ready", "unsafe"):
+    guard.__file__ = guard.INSTALLED_RUNTIME_CONFIG_GUARD
+    guard.os.geteuid = lambda: 0
+    def observe(current=state):
+        if current == "unsafe":
+            raise guard.UnsafePathError("secret-ready-record-canary")
+        return current
+    guard._startup_ready_state_for_current_pid1 = observe
+    sys.argv = [
+        guard.INSTALLED_RUNTIME_CONFIG_GUARD,
+        "observe-startup-ready",
+        "--hermes-dir",
+        "/sandbox/.hermes",
+    ]
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        status = guard.main()
+    results.append({"state": state, "status": status, "stdout": stdout.getvalue(), "stderr": stderr.getvalue()})
+print(json.dumps(results))
+`);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual([
+      { state: "ready", status: 0, stdout: "", stderr: "" },
+      { state: "not-ready", status: 10, stdout: "", stderr: "" },
+      { state: "unsafe", status: 1, stdout: "", stderr: "" },
+    ]);
+    expect(result.stdout).not.toContain("secret-ready-record-canary");
+  });
+
+  it("distinguishes missing, stale, malformed, and replaced readiness records (#10821)", () => {
+    const result = runPythonHarness(`${loadGuardModule}
+import json
+from types import SimpleNamespace
+
+snapshot = SimpleNamespace(uid=0, gid=0, mode=0o600, nlink=1)
+class Opened:
+    def __init__(self, text, current_snapshot=snapshot):
+        self.snapshot = current_snapshot
+        self.text = text
+    def read_bytes(self, _limit):
+        return self.text
+    def close(self):
+        pass
+
+def classify(first, initial=snapshot, current=snapshot, live=False):
+    def opened(_path):
+        if first is None:
+            raise FileNotFoundError()
+        return Opened(first, initial)
+    guard._open_regular = opened
+    guard._assert_startup_ready_snapshot_current = lambda observed: (
+        None if observed is current else (_ for _ in ()).throw(guard.UnsafePathError("changed"))
+    )
+    guard._startup_process_identity_is_live = lambda *_args: live
+    try:
+        return guard._startup_ready_state_for_current_pid1()
+    except guard.UnsafePathError:
+        return "unsafe"
+
+print(json.dumps({
+    "missing": classify(None),
+    "current": classify(b"v2 101 202\\n", live=True),
+    "stale_start_or_namespace": classify(b"v2 101 202\\n", live=False),
+    "malformed": classify(b"secret-ready-record-canary"),
+    "wrong_mode": classify(b"v2 101 202\\n", SimpleNamespace(uid=0, gid=0, mode=0o644, nlink=1), live=True),
+    "replaced": classify(b"v2 101 202\\n", current=SimpleNamespace(uid=0, gid=0, mode=0o600, nlink=1, changed=True), live=True),
+}))
+`);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      missing: "not-ready",
+      current: "ready",
+      stale_start_or_namespace: "not-ready",
+      malformed: "unsafe",
+      wrong_mode: "unsafe",
+      replaced: "unsafe",
+    });
+    expect(result.stdout).not.toContain("secret-ready-record-canary");
+  });
+
   it("rejects a supervisor argv polluted with the appended startup command (#6110)", () => {
     const result = runPythonHarness(`${loadGuardModule}
 import json
@@ -1298,6 +1389,7 @@ class FakeOpen:
 
 guard._process_start_time = lambda pid: "424242" if pid == 1 else None
 guard._pid1_is_nemoclaw_start = lambda: True
+guard._assert_startup_ready_snapshot_current = lambda _snapshot: None
 payload = b"v1 111111\\n"
 guard._open_regular = lambda _path: FakeOpen(payload)
 stale = guard._startup_ready_for_current_pid1()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome
Stopped Hermes Portable recovery now polls the image-owned startup readiness record through short discrete OpenShell exec calls, then performs exactly one authenticated health proof. Unsafe observations fail closed and roll back the exact started container; older supported images retain bounded authenticated-health polling.

## Reason
The existing recovery path could spend multiple authenticated health attempts waiting for startup even though the Hermes image already publishes a root-owned readiness record. The observer schedules the credential-bearing final proof without treating the record itself as authenticated health.

### Related issues
Fixes #10821

## Changes
- Add the exit-only `observe-startup-ready` Hermes runtime guard action. Exit 0 means current readiness, exit 10 means absent or stale readiness, and unsafe or indeterminate records fail closed without output.
- Revalidate the root-owned, mode 0600, single-link record against its pathname after PID start-time and namespace checks.
- Poll the observer under the existing 90-second startup budget with receipt, transaction, executable, socket, container, policy, sandbox, and registry currentness checks around each observation.
- Run one final authenticated health request after readiness, preserve a narrowly identified old-image argparse fallback, and retain exact-container rollback.
- Extend guard and lifecycle regression coverage for ready, stale, unsafe, fallback, one-proof, timing, and rollback behavior.

## Verification
- `npx vitest run --project cli src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts` — 36 tests passed.
- `npx vitest run --project integration test/agents/hermes/hermes-runtime-config-guard.test.ts` — 29 tests passed.
- Normal `pre-commit`, `commit-msg`, and `pre-push` hooks — passed, including repository checks, growth guardrails, and CLI TypeScript.
- GitHub commit verification — commit `d47437ecd247fd365d83e6e33ca7260186b4f2f9` is Verified.
- Secret review — the diff contains no credentials, API keys, or secret values.

## Review notes
This changes a root-owned readiness record and a credential-bearing recovery transition. The observer exposes only exit status, preserves the authenticated health request as the final readiness proof, and rolls back on unsafe or ambiguous state. The trusted local PR Review Advisor was attempted after installing OpenShell 0.0.106, but its macOS Docker sandbox entered `ContainerRestarting` during initialization and produced no review artifacts. All actionable findings from an independent local security review were addressed before push: ambiguous fallback classification, the startup deadline, and final pathname binding.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added startup-readiness observation for managed Hermes services.
  - Supports legacy and namespace-bound readiness markers.
  - Falls back to authenticated health checks when observation is unavailable.
  - Reports clear readiness states and automation-friendly exit codes.

- **Bug Fixes**
  - Detects missing, stale, malformed, unsafe, or changed readiness records.
  - Prevents race-related startup issues during validation.
  - Rolls back safely when readiness information cannot be trusted.
  - Keeps readiness-record contents out of command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->