### PR TITLE
fix(onboard): require the tracked Hermes base image

### DIFF
--- a/src/lib/agent/base-image-handoff.test.ts
+++ b/src/lib/agent/base-image-handoff.test.ts
@@ -62,7 +62,7 @@ function fixture(options: { canonicalSource?: boolean } = {}) {
     requireOpenshellSandboxAbi: process.platform === "linux",
     rootDir: ROOT,
     pinnedRemoteRef,
-    preferPinnedRemoteRef: true,
+    requirePinnedRemoteRef: true,
     validateImage: () => true,
     validationDescription:
       "the required MCP Streamable HTTP and ACP runtimes and the immutable security package inventory",

--- a/src/lib/agent/base-image-hermes-resolution.test.ts
+++ b/src/lib/agent/base-image-hermes-resolution.test.ts
@@ -148,6 +148,56 @@ describe("Hermes base-image resolver integration", () => {
     );
   }, 15_000);
 
+  it("stops before a release fallback when the tracked Hermes base fails qualification (#10826)", () => {
+    const versionRef = "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base:v0.0.118";
+    const fallbackDigest = `sha256:${"c".repeat(64)}`;
+    const fallbackRef = `ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@${fallbackDigest}`;
+    vi.stubEnv("NEMOCLAW_SANDBOX_BASE_VERSION_TAG", "v0.0.118");
+
+    const inspectStatusByRef = new Map([
+      [trackedRef, 0],
+      [versionRef, 0],
+      [fallbackRef, 0],
+    ]);
+    const inspectOutputByKey = new Map([
+      [`{{json .RepoDigests}}\0${versionRef}`, JSON.stringify([fallbackRef])],
+      [
+        `{{json .}}\0${fallbackRef}`,
+        JSON.stringify({
+          Architecture: "arm64",
+          Id: imageId,
+          Os: "linux",
+          RepoDigests: [fallbackRef],
+        }),
+      ],
+    ]);
+    dockerMocks.imageInspect.mockImplementation((ref: string) => ({
+      status: inspectStatusByRef.get(ref) ?? 1,
+    }));
+    dockerMocks.imageInspectFormat.mockImplementation((format: string, ref: string) =>
+      (inspectOutputByKey.get(`${format}\0${ref}`) ?? "").trim(),
+    );
+    const captureByEntrypointAndRef = new Map([
+      [`/opt/hermes/.venv/bin/python\0${trackedRef}`, ""],
+      [`/opt/hermes/.venv/bin/python\0${fallbackRef}`, "nemoclaw-hermes-mcp-runtime-ok"],
+      [`/bin/sh\0${fallbackRef}`, "nemoclaw-security-inventory-ok"],
+    ]);
+    dockerMocks.capture.mockImplementation((args: string[]) => {
+      const entrypointIndex = args.indexOf("--entrypoint");
+      return (
+        captureByEntrypointAndRef.get(
+          `${args[entrypointIndex + 1]}\0${args[entrypointIndex + 2]}`,
+        ) ?? ""
+      );
+    });
+
+    expect(() => stageHermesSandbox()).toThrow(
+      `Hermes Agent sandbox base image '${trackedRef}' is required but could not be pulled or did not pass the required MCP Streamable HTTP and ACP runtimes and the immutable security package inventory. No compatible local base image could be produced.`,
+    );
+    expect(dockerMocks.imageInspect).not.toHaveBeenCalledWith(versionRef, expect.anything());
+    expect(dockerMocks.build).not.toHaveBeenCalled();
+  });
+
   it("rejects an explicit platform digest override without pinned provenance", () => {
     vi.stubEnv("NEMOCLAW_HERMES_SANDBOX_BASE_IMAGE_REF", platformRef);
 

--- a/src/lib/agent/base-image-hermes-resolution.test.ts
+++ b/src/lib/agent/base-image-hermes-resolution.test.ts
@@ -12,6 +12,7 @@ import { makeAgent } from "../../../test/helpers/base-image-test-harness";
 const dockerMocks = vi.hoisted(() => ({
   build: vi.fn(),
   capture: vi.fn(),
+  forceRm: vi.fn(),
   imageInspect: vi.fn(),
   imageInspectFormat: vi.fn(),
   infoFormat: vi.fn(),
@@ -28,6 +29,7 @@ const sourceMocks = vi.hoisted(() => ({
 vi.mock("../adapters/docker", () => ({
   dockerBuild: dockerMocks.build,
   dockerCapture: dockerMocks.capture,
+  dockerForceRm: dockerMocks.forceRm,
   dockerImageInspect: dockerMocks.imageInspect,
   dockerImageInspectFormat: dockerMocks.imageInspectFormat,
   dockerInfoFormat: dockerMocks.infoFormat,
@@ -72,6 +74,7 @@ describe("Hermes base-image resolver integration", () => {
     sourceMocks.nearestTags.mockReturnValue([]);
     dockerMocks.infoFormat.mockReturnValue("linux/aarch64\n");
     dockerMocks.pull.mockReturnValue({ status: 1 });
+    dockerMocks.forceRm.mockReturnValue({ status: 0 });
     testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-hermes-resolution-test-"));
 
     const dockerfile = fs.readFileSync(makeAgent().dockerfilePath ?? "", "utf8");
@@ -149,6 +152,7 @@ describe("Hermes base-image resolver integration", () => {
   }, 15_000);
 
   it("stops before a release fallback when the tracked Hermes base fails qualification (#10826)", () => {
+    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     const versionRef = "ghcr.io/nvidia/nemoclaw/hermes-sandbox-base:v0.0.118";
     const fallbackDigest = `sha256:${"c".repeat(64)}`;
     const fallbackRef = `ghcr.io/nvidia/nemoclaw/hermes-sandbox-base@${fallbackDigest}`;
@@ -191,11 +195,16 @@ describe("Hermes base-image resolver integration", () => {
       );
     });
 
-    expect(() => stageHermesSandbox()).toThrow(
-      `Hermes Agent sandbox base image '${trackedRef}' is required but could not be pulled or did not pass the required MCP Streamable HTTP and ACP runtimes and the immutable security package inventory. No compatible local base image could be produced.`,
-    );
-    expect(dockerMocks.imageInspect).not.toHaveBeenCalledWith(versionRef, expect.anything());
-    expect(dockerMocks.build).not.toHaveBeenCalled();
+    try {
+      expect(() => stageHermesSandbox()).toThrow(
+        `Hermes Agent sandbox base image '${trackedRef}' is required but could not be pulled or did not pass the required MCP Streamable HTTP and ACP runtimes and the immutable security package inventory. No compatible local base image could be produced.`,
+      );
+      expect(dockerMocks.imageInspect).not.toHaveBeenCalledWith(versionRef, expect.anything());
+      expect(dockerMocks.forceRm).toHaveBeenCalledTimes(2);
+      expect(dockerMocks.build).not.toHaveBeenCalled();
+    } finally {
+      platform.mockRestore();
+    }
   });
 
   it("rejects an explicit platform digest override without pinned provenance", () => {

--- a/src/lib/agent/base-image.ts
+++ b/src/lib/agent/base-image.ts
@@ -357,7 +357,7 @@ function createAgentBaseImageResolutionOptions(
     forceRefresh: options.forceBaseImageRefresh,
     rootDir: ROOT,
     pinnedRemoteRef,
-    preferPinnedRemoteRef: agent.name === "hermes" && pinnedRemoteRef !== undefined,
+    requirePinnedRemoteRef: agent.name === "hermes" && pinnedRemoteRef !== undefined,
     ...validationOptions,
   };
 }

--- a/src/lib/sandbox-base-image-platform-digest.test.ts
+++ b/src/lib/sandbox-base-image-platform-digest.test.ts
@@ -122,7 +122,7 @@ describe("sandbox base-image pinned platform digest resolution", () => {
     const resolved = resolveSandboxBaseImage({
       ...resolutionOptions(),
       pinnedRemoteRef: REF,
-      preferPinnedRemoteRef: true,
+      requirePinnedRemoteRef: true,
     });
 
     expect(resolved).toEqual({
@@ -181,7 +181,7 @@ describe("sandbox base-image pinned platform digest resolution", () => {
     const resolved = resolveSandboxBaseImage({
       ...resolutionOptions(),
       pinnedRemoteRef: REF,
-      preferPinnedRemoteRef: true,
+      requirePinnedRemoteRef: true,
     });
 
     expect(resolved).toMatchObject({
@@ -221,7 +221,7 @@ describe("sandbox base-image pinned platform digest resolution", () => {
     const resolved = resolveSandboxBaseImage({
       ...resolutionOptions(),
       pinnedRemoteRef: REF,
-      preferPinnedRemoteRef: true,
+      requirePinnedRemoteRef: true,
     });
 
     expect(resolved).toMatchObject({

--- a/src/lib/sandbox-base-image-resolution.test.ts
+++ b/src/lib/sandbox-base-image-resolution.test.ts
@@ -790,18 +790,37 @@ describe("sandbox base-image warm resolution", () => {
     expect(dockerMocks.build).not.toHaveBeenCalled();
   });
 
-  it("prefers an explicitly trusted pin over an available source-SHA image", () => {
+  it("requires an explicitly trusted pin instead of an available source-SHA image", () => {
     dockerMocks.imageInspect.mockReturnValue({ status: 0 });
 
     const resolved = resolveSandboxBaseImage({
       ...resolutionOptions(),
       pinnedRemoteRef: REF,
-      preferPinnedRemoteRef: true,
+      requirePinnedRemoteRef: true,
     });
 
     expect(resolved).toMatchObject({ ref: REF, source: "pinned" });
     expect(dockerMocks.imageInspect).toHaveBeenCalledTimes(1);
     expect(dockerMocks.imageInspect).toHaveBeenCalledWith(REF, {
+      ignoreError: true,
+      suppressOutput: true,
+    });
+    expect(dockerMocks.build).not.toHaveBeenCalled();
+  });
+
+  it("uses a proven local image after a required remote pin fails (#10826)", () => {
+    const options = resolutionOptions();
+    const provenance = `${createSandboxBaseImageBuildProvenanceKey(options)}.${"c".repeat(64)}`;
+    mockLocalFallback(options, provenance);
+
+    const resolved = resolveSandboxBaseImage({
+      ...options,
+      pinnedRemoteRef: REF,
+      requirePinnedRemoteRef: true,
+    });
+
+    expect(resolved).toMatchObject({ ref: options.localTag, source: "local" });
+    expect(dockerMocks.pull).toHaveBeenCalledWith(REF, {
       ignoreError: true,
       suppressOutput: true,
     });

--- a/src/lib/sandbox-base-image-resolution.test.ts
+++ b/src/lib/sandbox-base-image-resolution.test.ts
@@ -808,6 +808,18 @@ describe("sandbox base-image warm resolution", () => {
     expect(dockerMocks.build).not.toHaveBeenCalled();
   });
 
+  it("rejects required pin mode without a pinned remote reference (#10826)", () => {
+    expect(() =>
+      resolveSandboxBaseImage({
+        ...resolutionOptions(),
+        requirePinnedRemoteRef: true,
+      }),
+    ).toThrow("Sandbox base image requires a non-empty pinned remote reference.");
+    expect(dockerMocks.imageInspect).not.toHaveBeenCalled();
+    expect(dockerMocks.pull).not.toHaveBeenCalled();
+    expect(dockerMocks.build).not.toHaveBeenCalled();
+  });
+
   it("uses a proven local image after a required remote pin fails (#10826)", () => {
     const options = resolutionOptions();
     const provenance = `${createSandboxBaseImageBuildProvenanceKey(options)}.${"c".repeat(64)}`;
@@ -820,10 +832,12 @@ describe("sandbox base-image warm resolution", () => {
     });
 
     expect(resolved).toMatchObject({ ref: options.localTag, source: "local" });
-    expect(dockerMocks.pull).toHaveBeenCalledWith(REF, {
-      ignoreError: true,
-      suppressOutput: true,
-    });
+    const dockerOptions = { ignoreError: true, suppressOutput: true };
+    expect(dockerMocks.pull.mock.calls).toEqual([[REF, dockerOptions]]);
+    expect(dockerMocks.imageInspect.mock.calls).toEqual([
+      [REF, dockerOptions],
+      [options.localTag, dockerOptions],
+    ]);
     expect(dockerMocks.build).not.toHaveBeenCalled();
   });
 

--- a/src/lib/sandbox-base-image.ts
+++ b/src/lib/sandbox-base-image.ts
@@ -510,7 +510,7 @@ export function resolveSandboxBaseImage(
   } else {
     const rootDir = options.rootDir || ROOT;
     const inputPaths = [options.dockerfilePath, ...(options.inputPaths ?? [])];
-    const preferPinnedRemoteRef = options.preferPinnedRemoteRef === true;
+    const requirePinnedRemoteRef = options.requirePinnedRemoteRef === true;
     const versionTags = getVersionedBaseImageTags(options.rootDir || ROOT, env);
     const resolveVersionTags = (tags: string[]): SandboxBaseImageResolution | null => {
       for (const tag of tags) {
@@ -536,7 +536,7 @@ export function resolveSandboxBaseImage(
     };
     if (baseImageInputsDirty(rootDir, env, inputPaths)) return resolveChangedInputs();
 
-    if (preferPinnedRemoteRef && options.pinnedRemoteRef) {
+    if (requirePinnedRemoteRef && options.pinnedRemoteRef) {
       const resolved = resolvePulledCandidate(
         options.imageName,
         options.pinnedRemoteRef,
@@ -545,6 +545,16 @@ export function resolveSandboxBaseImage(
         { pinnedRemoteRef: options.pinnedRemoteRef },
       );
       if (resolved) return finish(resolved);
+      const local = resolveLocalCandidate(options);
+      if (local) return finish(local);
+      const validationFailure = options.validationDescription
+        ? `did not pass ${options.validationDescription}`
+        : "did not pass required compatibility checks";
+      throw new SandboxBaseImageResolutionError(
+        `${options.label || "Sandbox base image"} '${options.pinnedRemoteRef}' is required but ` +
+          `could not be pulled or ${validationFailure}. No compatible local base image could ` +
+          "be produced.",
+      );
     }
 
     const versionTagResolution = resolveVersionTags(versionTags);
@@ -558,7 +568,7 @@ export function resolveSandboxBaseImage(
 
     if (baseImageInputsChangedSinceMain(rootDir, env, inputPaths)) return resolveChangedInputs();
 
-    if (!preferPinnedRemoteRef && options.pinnedRemoteRef) {
+    if (options.pinnedRemoteRef) {
       const resolved = resolvePulledCandidate(
         options.imageName,
         options.pinnedRemoteRef,

--- a/src/lib/sandbox-base-image.ts
+++ b/src/lib/sandbox-base-image.ts
@@ -464,8 +464,13 @@ export function resolveSandboxBaseImage(
   options: ResolveBaseImageOptions,
 ): SandboxBaseImageResolution | null {
   const env = options.env || process.env;
-  const resolutionKey = createSandboxBaseImageResolutionKey(options);
   const override = options.envVar ? String(env[options.envVar] || "").trim() : "";
+  if (options.requirePinnedRemoteRef === true && !options.pinnedRemoteRef?.trim()) {
+    throw new SandboxBaseImageResolutionError(
+      `${options.label || "Sandbox base image"} requires a non-empty pinned remote reference.`,
+    );
+  }
+  const resolutionKey = createSandboxBaseImageResolutionKey(options);
 
   if (!options.forceRefresh) {
     const reused = reuseSandboxBaseImageResolutionHint(options, resolutionKey);

--- a/src/lib/sandbox-base-image/resolution-key.test.ts
+++ b/src/lib/sandbox-base-image/resolution-key.test.ts
@@ -150,14 +150,14 @@ describe("sandbox base-image resolution key", () => {
     expect(second).not.toBe(first);
   });
 
-  it("isolates pinned-first resolution policy", () => {
+  it("isolates required pinned resolution policy", () => {
     const root = fixture();
     const base = {
       ...options(root),
       pinnedRemoteRef: "example/base@sha256:first",
     };
 
-    expect(createSandboxBaseImageResolutionKey({ ...base, preferPinnedRemoteRef: true })).not.toBe(
+    expect(createSandboxBaseImageResolutionKey({ ...base, requirePinnedRemoteRef: true })).not.toBe(
       createSandboxBaseImageResolutionKey(base),
     );
   });
@@ -166,7 +166,7 @@ describe("sandbox base-image resolution key", () => {
     const root = fixture();
     const base = options(root);
 
-    expect(createSandboxBaseImageResolutionKey({ ...base, preferPinnedRemoteRef: false })).toBe(
+    expect(createSandboxBaseImageResolutionKey({ ...base, requirePinnedRemoteRef: false })).toBe(
       createSandboxBaseImageResolutionKey(base),
     );
   });

--- a/src/lib/sandbox-base-image/resolution-key.ts
+++ b/src/lib/sandbox-base-image/resolution-key.ts
@@ -89,7 +89,7 @@ export function createSandboxBaseImageResolutionKey(options: ResolveBaseImageOpt
     imageName: options.imageName,
     override,
     pinnedRemoteRef: options.pinnedRemoteRef || null,
-    ...(options.preferPinnedRemoteRef === true ? { preferPinnedRemoteRef: true } : {}),
+    ...(options.requirePinnedRemoteRef === true ? { requirePinnedRemoteRef: true } : {}),
     versionTags: getVersionedBaseImageTags(rootDir, env),
     nearestVersionTags: getNearestVersionedBaseImageTags(rootDir, env),
     sourceTags: getSourceShortShaTags(rootDir, env),

--- a/src/lib/sandbox-base-image/types.ts
+++ b/src/lib/sandbox-base-image/types.ts
@@ -51,7 +51,7 @@ export type ResolveBaseImageOptions = {
   rootDir?: string;
   env?: NodeJS.ProcessEnv;
   pinnedRemoteRef?: string;
-  preferPinnedRemoteRef?: boolean;
+  requirePinnedRemoteRef?: boolean;
   validateImage?: (imageRef: string) => boolean;
   validationDescription?: string;
   resolutionHint?: SandboxBaseImageResolutionMetadata | null;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Hermes onboarding now uses its Dockerfile-tracked base image or a repository-built local base that passes the same controls. A tracked-image pull or qualification failure no longer falls through to a remote image that the final Hermes provenance guard must reject.

## Reason

The default LKG installer could replace the original tracked-image failure with a misleading final-image rejection. One failed pull or runtime qualification made the resolver select a release or source-commit image, even though Hermes could not accept that candidate's provenance.

### Related issues

Fixes #10826

## Changes

- Replace Hermes' pinned-first policy with a required-pin policy in the shared base-image resolver.
- Reject required-pin mode when its pinned reference is absent or blank, before hint reuse or candidate discovery.
- After a required pin fails, permit only the existing validated local-base path before returning the tracked-image failure.
- Include the required-pin policy in the resolution key so earlier fallback metadata cannot bypass the new order.
- Add regression coverage for the tracked-failure and available-release sequence, trusted local fallback, platform-digest normalization, rebuild handoff metadata, Linux glibc-probe cleanup, and the missing-pin invariant.

## Verification

- `npx vitest run --project cli --maxWorkers=1 src/lib/agent/base-image-hermes-resolution.test.ts src/lib/agent/base-image-handoff.test.ts src/lib/agent/base-image-hermes.test.ts src/lib/sandbox-base-image-resolution.test.ts src/lib/sandbox-base-image-platform-digest.test.ts src/lib/sandbox-base-image/resolution-key.test.ts` — 83 tests passed.
- `npx vitest run --project integration test/automation/pull-requests/growth-guardrails.test.ts` — 33 tests passed.
- `npm run build:cli` — passed.
- `npx prek run --from-ref 887efa89b75e558275dca3be5c372d92c60575da --to-ref HEAD --stage pre-commit`, commitlint, and the matching pre-push gate — passed for candidate `07dd5a3b0f4f4bf907486538747ff833f3c931ee`.
- Current-head CI: https://github.com/NVIDIA/NemoClaw/actions/runs/33576008384 — success. One unrelated `test-registration-boundary` timeout in shard 4 passed on its single job retry; all shard aggregates and required checks passed.
- Exact-head isolated branch install and forced tracked-qualification failure — passed; evidence: https://github.com/NVIDIA/NemoClaw/pull/10831#issuecomment-5502591720.
- Exact-head focused Hermes E2E — passed; workflow and job evidence: https://github.com/NVIDIA/NemoClaw/pull/10831#issuecomment-5502655438.
- CodeRabbit status for the candidate commit is `success`; all three review threads are resolved.
- GitHub marks both candidate commits as `Verified`.
- The diff contains no secrets, API keys, or credentials.

## Review notes

This change affects the Hermes base-image provenance boundary. It does not broaden accepted repositories, digests, resolution sources, explicit overrides, or trust leases. The final Hermes provenance guard remains unchanged. Negative regression coverage proves that a release candidate is not inspected after the tracked candidate fails. Existing coverage proves that a locally built base still requires current repository provenance and runtime qualification.

CodeRabbit's two valid initial findings are fixed in `07dd5a3b0f`; all review threads are resolved. The later `dockerForceRm` suggestion did not apply because failed Linux glibc-probe cleanup owns that call and current-head Linux shard 6 passed.

The PR Review Advisor failures are waived by maintainer direction because they produced no findings and failed in trusted `main` model configuration before review. Evidence: https://github.com/NVIDIA/NemoClaw/pull/10831#issuecomment-5502677669.

Documentation changes are not required. This restores the existing tracked Hermes base-image contract and changes no command, option, or configuration.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>
