### PR TITLE
fix(policy): validate reserved keys during dry-run

### DIFF
--- a/docs/network-policy/create-custom-policy-presets.mdx
+++ b/docs/network-policy/create-custom-policy-presets.mdx
@@ -48,7 +48,11 @@ Replace `/path/to/requesting-binary` with the exact executable path reported for
   `/opt/venv/bin/python3*`. Authorize only the process that needs the reviewed endpoint.
 </AgentOnly>
 
-The top-level `preset.name` must be a lowercase RFC 1123 label with letters, digits, and hyphens. It must not collide with a maintained preset name such as `slack` or `pypi`. Rename `preset.name` if NemoClaw reports a collision. Custom preset `network_policies` entries must not use `npm_yarn`. NemoClaw reserves that key for the maintained `npm` preset and rejects the file before applying it.
+The top-level `preset.name` must be a lowercase RFC 1123 label with letters, digits, and hyphens.
+It must not collide with a maintained preset name such as `slack` or `pypi`.
+Rename `preset.name` if NemoClaw reports a collision.
+Custom preset `network_policies` entries must not use `npm_yarn` or `personal_open_internet`.
+NemoClaw reserves those keys for maintained presets and rejects the file before preview or application.
 
 Each endpoint must name a specific host or a scoped subdomain wildcard such as `*.example.com`. NemoClaw rejects catch-all destinations, including `*`, `0.0.0.0`, `0.0.0.0/0`, `::`, and `::/0`. Rule matchers must match the endpoint protocol.
 

--- a/src/lib/actions/sandbox/policy-channel-custom-preset-dry-run.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-custom-preset-dry-run.test.ts
@@ -64,13 +64,16 @@ afterEach(() => {
 });
 
 describe("policy add --from-file --dry-run custom preset validation", () => {
-  it("rejects npm_yarn before preview or policy mutation (#10773)", async () => {
+  it.each([
+    ["npm_yarn", "npm-yarn"],
+    ["personal_open_internet", "personal-open-internet"],
+  ])("rejects reserved key %s before preview or policy mutation (#10773)", async (key, name) => {
     const file = writePreset(
-      "npm-yarn",
+      name,
       `preset:
-  name: qa-npm-test
+  name: qa-${name}
 network_policies:
-  npm_yarn:
+  ${key}:
     endpoints:
       - host: api.example.com
         port: 443
@@ -82,7 +85,7 @@ network_policies:
     ).resolves.toBe(1);
 
     expect(printedText()).toContain(
-      "Custom presets cannot own reserved network policy key 'npm_yarn'.",
+      `Custom presets cannot own reserved network policy key '${key}'.`,
     );
     expect(printedText()).not.toContain("Effective egress that would be opened:");
     expect(applyPresetContentSpy).not.toHaveBeenCalled();

--- a/src/lib/actions/sandbox/policy-channel-custom-preset-dry-run.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-custom-preset-dry-run.test.ts
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+
+import * as policies from "../../policy";
+import { addSandboxPolicy } from "./policy-channel";
+import * as policyContextRefresh from "./policy-context-refresh";
+
+class ExitError extends Error {
+  constructor(public readonly code: number | undefined) {
+    super(`process.exit(${code})`);
+  }
+}
+
+let tempDir: string;
+let logSpy: MockInstance;
+let errorSpy: MockInstance;
+let applyPresetContentSpy: MockInstance;
+let refreshSpy: MockInstance;
+
+function writePreset(name: string, content: string): string {
+  const file = path.join(tempDir, `${name}.yaml`);
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+function printedText(): string {
+  return [...logSpy.mock.calls, ...errorSpy.mock.calls]
+    .map((call) => call.map(String).join(" "))
+    .join("\n");
+}
+
+async function captureExit(action: () => Promise<void>): Promise<number | undefined> {
+  try {
+    await action();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ExitError);
+    return (error as ExitError).code;
+  }
+  throw new Error("Expected process.exit to be called");
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "policy-custom-dry-run-"));
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ExitError(code);
+  }) as never);
+  applyPresetContentSpy = vi.spyOn(policies, "applyPresetContent").mockReturnValue(true);
+  refreshSpy = vi
+    .spyOn(policyContextRefresh, "refreshSandboxPolicyContextFile")
+    .mockReturnValue({ outcome: "ok", written: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("policy add --from-file --dry-run custom preset validation", () => {
+  it("rejects npm_yarn before preview or policy mutation (#10773)", async () => {
+    const file = writePreset(
+      "npm-yarn",
+      `preset:
+  name: qa-npm-test
+network_policies:
+  npm_yarn:
+    endpoints:
+      - host: api.example.com
+        port: 443
+`,
+    );
+
+    await expect(
+      captureExit(() => addSandboxPolicy("test-sandbox", { fromFile: file, dryRun: true })),
+    ).resolves.toBe(1);
+
+    expect(printedText()).toContain(
+      "Custom presets cannot own reserved network policy key 'npm_yarn'.",
+    );
+    expect(printedText()).not.toContain("Effective egress that would be opened:");
+    expect(applyPresetContentSpy).not.toHaveBeenCalled();
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects allowed_ips before preview or policy mutation (#10773)", async () => {
+    const file = writePreset(
+      "allowed-ips",
+      `preset:
+  name: qa-allowed-ips
+network_policies:
+  custom:
+    endpoints:
+      - host: api.example.com
+        port: 443
+        allowed_ips:
+          - 192.0.2.1
+`,
+    );
+
+    await expect(
+      captureExit(() => addSandboxPolicy("test-sandbox", { fromFile: file, dryRun: true })),
+    ).resolves.toBe(1);
+
+    expect(printedText()).toContain("contains 'allowed_ips'");
+    expect(printedText()).not.toContain("Effective egress that would be opened:");
+    expect(applyPresetContentSpy).not.toHaveBeenCalled();
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it("previews a valid custom preset without policy mutation (#10773)", async () => {
+    const file = writePreset(
+      "valid",
+      `preset:
+  name: qa-valid
+network_policies:
+  custom:
+    endpoints:
+      - host: api.example.com
+        port: 443
+`,
+    );
+
+    await addSandboxPolicy("test-sandbox", { fromFile: file, dryRun: true });
+
+    expect(printedText()).toContain("Effective egress that would be opened:");
+    expect(printedText()).toContain("--dry-run: 'qa-valid' not applied.");
+    expect(applyPresetContentSpy).not.toHaveBeenCalled();
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -1358,6 +1358,16 @@ function logPresetScopeForState(
 
 const OPENCLAW_NPM_BASELINE_KEY = "npm_registry";
 const OPENCLAW_NPM_PRESET_KEY = "npm_yarn";
+const CUSTOM_PRESET_RESERVED_NETWORK_POLICY_KEYS = [
+  OPENCLAW_NPM_PRESET_KEY,
+  PERSONAL_OPEN_INTERNET_POLICY_KEY,
+] as const;
+
+function findReservedCustomNetworkPolicyKey(networkPolicies: PolicyObject): string | undefined {
+  return CUSTOM_PRESET_RESERVED_NETWORK_POLICY_KEYS.find((key) =>
+    Object.prototype.hasOwnProperty.call(networkPolicies, key),
+  );
+}
 
 function npmCompatibilityEntry(
   baselineEntry: PolicyObject,
@@ -2264,9 +2274,7 @@ function applyPresetContent(
       console.error(`  Preset '${presetName}' has invalid or missing network_policies.`);
       return false;
     }
-    const reservedKey = [OPENCLAW_NPM_PRESET_KEY, PERSONAL_OPEN_INTERNET_POLICY_KEY].find((key) =>
-      Object.prototype.hasOwnProperty.call(np, key),
-    );
+    const reservedKey = findReservedCustomNetworkPolicyKey(np);
     if (reservedKey) {
       console.error(`  Custom presets cannot own reserved network policy key '${reservedKey}'.`);
       return false;
@@ -2719,6 +2727,11 @@ function loadPresetFromFile(filePath: string): { presetName: string; content: st
     return null;
   }
   const np = parsed.network_policies as PolicyObject;
+  const reservedKey = findReservedCustomNetworkPolicyKey(np);
+  if (reservedKey) {
+    console.error(`  Custom presets cannot own reserved network policy key '${reservedKey}'.`);
+    return null;
+  }
   if (networkPoliciesHasAllowedIps(np)) {
     console.error(
       `  Preset '${presetName}' contains 'allowed_ips', which is not permitted in user-supplied presets: ${filePath}`,

--- a/test/runtime/policy/personal-open-internet-policy.test.ts
+++ b/test/runtime/policy/personal-open-internet-policy.test.ts
@@ -206,7 +206,10 @@ describe("Personal open internet policy preset", () => {
     ).toThrow(/does not match the reviewed built-in preset/);
   });
 
-  it("reserves the Personal network-policy key for the reviewed built-in preset", () => {
+  it("rejects direct custom Personal key ownership before reading live state", () => {
+    const registryLookup = vi.spyOn(registry, "getSandbox").mockImplementation(() => {
+      throw new Error("registry must not be read");
+    });
     const errors: string[] = [];
     const errorSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
       errors.push(args.map(String).join(" "));
@@ -230,9 +233,11 @@ describe("Personal open internet policy preset", () => {
           { custom: { sourcePath: "/tmp/spoofed-personal.yaml" } },
         ),
       ).toBe(false);
+      expect(registryLookup).not.toHaveBeenCalled();
       expect(errors.join("\n")).toContain("reserved network policy key 'personal_open_internet'");
     } finally {
       errorSpy.mockRestore();
+      registryLookup.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Outcome

Custom preset dry-runs now reject `npm_yarn` and every reserved network-policy key before printing a preview. Preview and real apply now use the same reserved-key ownership check.

## Reason

`loadPresetFromFile` did not enforce the reserved-key check in `applyPresetContent`. This let the documented review step accept input that real apply rejected.

### Related issues

Fixes #10773

## Changes

- Added one reserved-key resolver for custom presets. The file loader and apply path both consume it, replacing the duplicated apply-only lookup that allowed the paths to drift.
- Added command-level regression coverage for `npm_yarn`, `personal_open_internet`, `allowed_ips`, and a valid custom preset. The tests prove dry-run does not call policy apply or context refresh.
- Strengthened the direct-apply regression to prove reserved-key validation stops before live-state access.
- Updated the custom-preset guide to name both reserved keys and the pre-preview rejection behavior.

## Verification

- `./node_modules/.bin/vitest run --project cli src/lib/actions/sandbox/policy-channel-custom-preset-dry-run.test.ts --maxWorkers=1 --reporter=default` — passed on the merged candidate, 4 tests.
- `./node_modules/.bin/vitest run --project integration test/runtime/policy/personal-open-internet-policy.test.ts --maxWorkers=1 --reporter=default` — passed, 16 tests.
- `npm run docs:sync-agent-variants` — passed; the corrected restriction appears in the OpenClaw, Hermes, and Deep Agents variants.
- `npm run docs` — passed with no errors.
- `./node_modules/.bin/vitest run --project cli src/lib/policy/*.test.ts src/lib/actions/sandbox/policy-channel-custom-preset-dry-run.test.ts src/lib/actions/sandbox/policy-channel-refresh.test.ts --maxWorkers=1 --reporter=default` — 240 tests passed before the review-only test expansion; one unrelated trusted-private test exceeded its 5-second suite timeout.
- `./node_modules/.bin/vitest run --project cli src/lib/policy/trusted-private-endpoints.test.ts -t "pins trusted endpoints across every policy protocol" --maxWorkers=1 --reporter=default` — passed in isolation, 1 test passed and 9 skipped.
- `npm run test:changed -- --maxWorkers=1 --reporter=default` — inconclusive under host contention: 2,127 tests passed, 52 unrelated tests timed out or inherited state after timeouts, and 20 tests skipped.
- `npm run typecheck:cli` — passed.
- Targeted Oxlint and Oxfmt checks — passed.
- `npm run test:projects:check` — passed.
- `npm run checks:repository` — passed.
- `npm run validate:pr` — passed against canonical `main` after the final review repair.
- Reviewed the diff for secrets, API keys, and credentials — none found.

## Review notes

The changed trust boundary is user-authored custom preset YAML before policy preview or mutation. Reserved ownership now fails closed at file load, while the apply-time check remains in place through the same helper. Built-in presets, trusted-private capability validation, and custom-preset namespacing are unchanged. Both `--from-file` and `--from-dir` inherit the shared loader check.

---

Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for custom sandbox network policies.
  * Reserved settings are rejected before previews or policy changes are applied.
  * Custom presets now reject untrusted private endpoint hosts unless explicitly permitted.
  * Invalid configurations produce clear errors, while valid presets show an egress preview without applying changes.

* **Documentation**
  * Clarified that reserved network-policy settings cannot be used in custom presets.

* **Tests**
  * Added coverage for reserved, forbidden, and valid custom preset scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->