### PR TITLE
fix(review): correct OpenAI advisor model ID

### DIFF
--- a/test/automation/pull-requests/pr-review-advisor-specialists.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-specialists.test.ts
@@ -144,7 +144,7 @@ describe("PR review advisor specialist prompts", () => {
     expect(matrix.map(({ interest }) => interest)).toEqual(ADVISOR_INTERESTS);
     expect(matrix.map(({ model }) => model)).toEqual(
       ADVISOR_INTERESTS.map((_, index) =>
-        index % 2 === 0 ? "openai/openai/gpt-5.6-terra" : "azure/openai/gpt-5.6-terra",
+        index % 2 === 0 ? "openai/gpt-5.6-terra" : "azure/openai/gpt-5.6-terra",
       ),
     );
     expect(matrix.every((entry) => !("sandbox_name" in entry))).toBe(true);

--- a/tools/pr-review-advisor/render-specialist-matrix.mts
+++ b/tools/pr-review-advisor/render-specialist-matrix.mts
@@ -8,7 +8,7 @@ import { ADVISOR_SPECIALISTS } from "./specialist-catalog.mts";
 const configuredModel = process.env.PR_REVIEW_ADVISOR_MODEL?.trim();
 const models = configuredModel
   ? [configuredModel]
-  : ["openai/openai/gpt-5.6-terra", "azure/openai/gpt-5.6-terra"];
+  : ["openai/gpt-5.6-terra", "azure/openai/gpt-5.6-terra"];
 const matrix = ADVISOR_SPECIALISTS.map(({ interest, label }, index) => ({
   interest,
   label,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

OpenAI-routed PR Review Advisor specialists configure successfully while the inference service continues to receive `openai/openai/gpt-5.6-terra`.

## Reason

The Pi registry prepends its local `openai` provider name to the configured model ID. Supplying `openai/openai/gpt-5.6-terra` therefore attempted to resolve `openai/openai/openai/gpt-5.6-terra` and caused half of each advisor matrix to fail before inference.

## Changes

- Configure the OpenAI matrix lane with `openai/gpt-5.6-terra`.
- Update the matrix expectation to protect the corrected identifier.

## Verification

- Local validation intentionally skipped for this urgent two-line correction at maintainer direction.
- Runtime evidence: advisor run 33576202233 showed all OpenAI-lane specialists failing to configure the triply prefixed identifier while Azure-lane specialists succeeded.
- Secrets review: The diff contains no secrets, API keys, or credentials.

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default OpenAI model configuration to use the proper identifier.
  * Updated workflow validation to reflect the corrected model setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->