### PR TITLE
fix(review): register selected advisor model

### DIFF
--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -538,8 +538,13 @@ describe("PR review advisor OpenShell wrapper", () => {
     ).toThrow("must use an approved advisor inference endpoint");
   });
 
-  it("preserves hosted provider compatibility", () => {
-    const config = openAiAdvisorProviderConfig("PR_REVIEW_ADVISOR_API_KEY") as {
+  it("registers the selected advisor model", () => {
+    const selectedModel = "openai/openai/gpt-5.6-terra";
+    const config = openAiAdvisorProviderConfig(
+      "PR_REVIEW_ADVISOR_API_KEY",
+      ADVISOR_OPENAI_COMPATIBLE_BASE_URL,
+      selectedModel,
+    ) as {
       apiKey: string;
       baseUrl: string;
       models: Array<{ id: string; compat?: Record<string, unknown>; reasoning: boolean }>;
@@ -549,7 +554,7 @@ describe("PR review advisor OpenShell wrapper", () => {
     expect(config.baseUrl).toBe(ADVISOR_OPENAI_COMPATIBLE_BASE_URL);
     expect(config.models).toContainEqual(
       expect.objectContaining({
-        id: DEFAULT_ADVISOR_MODEL,
+        id: selectedModel,
         reasoning: false,
         compat: expect.objectContaining({
           supportsDeveloperRole: false,

--- a/test/automation/pull-requests/pr-review-advisor-specialists.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-specialists.test.ts
@@ -144,7 +144,7 @@ describe("PR review advisor specialist prompts", () => {
     expect(matrix.map(({ interest }) => interest)).toEqual(ADVISOR_INTERESTS);
     expect(matrix.map(({ model }) => model)).toEqual(
       ADVISOR_INTERESTS.map((_, index) =>
-        index % 2 === 0 ? "openai/gpt-5.6-terra" : "azure/openai/gpt-5.6-terra",
+        index % 2 === 0 ? "openai/openai/gpt-5.6-terra" : "azure/openai/gpt-5.6-terra",
       ),
     );
     expect(matrix.every((entry) => !("sandbox_name" in entry))).toBe(true);

--- a/tools/advisors/session.mts
+++ b/tools/advisors/session.mts
@@ -202,13 +202,14 @@ export function advisorInferenceBaseUrl(env: NodeJS.ProcessEnv = process.env): s
 export function openAiAdvisorProviderConfig(
   credentialEnv: string,
   baseUrl = ADVISOR_OPENAI_COMPATIBLE_BASE_URL,
+  modelId = DEFAULT_ADVISOR_MODEL,
 ): AdvisorProviderConfig {
   return {
     api: "openai-completions",
     baseUrl,
     models: [
       advisorModel(
-        DEFAULT_ADVISOR_MODEL,
+        modelId,
         "GPT-5.6 Terra",
         256000,
         32768,
@@ -336,6 +337,7 @@ export async function runReadOnlyAdvisor(
     provider,
     options.credentialEnv,
     baseUrl,
+    modelId,
   );
   const model = modelRegistry.find(provider, modelId);
   if (!model || !modelRegistry.hasConfiguredAuth(model)) {
@@ -902,6 +904,7 @@ function prepareAdvisorConfig(
   provider: string,
   credentialEnv: string,
   baseUrl: string,
+  modelId: string,
 ): { authStorage: AuthStorage; modelRegistry: ModelRegistry } {
   const authStorage = AuthStorage.inMemory();
   const modelRegistry = ModelRegistry.inMemory(authStorage);
@@ -909,7 +912,10 @@ function prepareAdvisorConfig(
   if (credential) {
     try {
       authStorage.setRuntimeApiKey(provider, credential);
-      modelRegistry.registerProvider(provider, openAiAdvisorProviderConfig(credentialEnv, baseUrl));
+      modelRegistry.registerProvider(
+        provider,
+        openAiAdvisorProviderConfig(credentialEnv, baseUrl, modelId),
+      );
     } finally {
       delete process.env[credentialEnv];
     }

--- a/tools/pr-review-advisor/render-specialist-matrix.mts
+++ b/tools/pr-review-advisor/render-specialist-matrix.mts
@@ -8,7 +8,7 @@ import { ADVISOR_SPECIALISTS } from "./specialist-catalog.mts";
 const configuredModel = process.env.PR_REVIEW_ADVISOR_MODEL?.trim();
 const models = configuredModel
   ? [configuredModel]
-  : ["openai/gpt-5.6-terra", "azure/openai/gpt-5.6-terra"];
+  : ["openai/openai/gpt-5.6-terra", "azure/openai/gpt-5.6-terra"];
 const matrix = ADVISOR_SPECIALISTS.map(({ interest, label }, index) => ({
   interest,
   label,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Both PR Review Advisor model lanes use their complete upstream model IDs and configure successfully in the embedded advisor registry.

## Reason

OpenShell forwards the configured model ID verbatim and requires `openai/openai/gpt-5.6-terra`. The embedded Pi registry previously registered only the Azure default, so the complete OpenAI ID failed local lookup. Shortening that ID passed local lookup only after changing the matrix, but OpenShell then rejected it with HTTP 403 because the key was not authorized for `openai/gpt-5.6-terra`.

## Changes

- Restore the complete `openai/openai/gpt-5.6-terra` matrix identifier.
- Register the selected runtime model ID in the embedded advisor provider configuration.
- Pass the selected ID through advisor configuration setup.
- Cover selected-model registration and the restored matrix value.

## Verification

- Local validation intentionally skipped at maintainer direction for this follow-up.
- Runtime evidence: post-#10835 run 33577784873 reached OpenShell with the shortened ID and received `key_model_access_denied` for `openai/gpt-5.6-terra`; Azure specialists succeeded.
- Secrets review: The diff contains no secrets, API keys, or credentials.

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Advisor workflows now support selecting and registering the specified model instead of always using a default.
  - Updated specialist model identifiers improve compatibility across OpenAI and Azure configurations.

- **Bug Fixes**
  - Corrected model provider paths and workflow expectations for GPT-5.6 Terra.
  - Improved validation ensures the selected advisor model is properly recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->