### PR TITLE
perf(cli): detail Hermes currentness inspection timing

### DIFF
--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -112,6 +112,7 @@ import type {
   HermesPortableCurrentnessTimingEvidence,
   HermesPortableLifecycleRecoveryTimingEvidence,
 } from "../../onboard/experimental/hermes-portable-lifecycle";
+import type { HermesPortableContainerInspectionTimingEvidence } from "../../onboard/experimental/hermes-portable-container";
 import {
   checkAndRecoverSandboxProcesses,
   executeSandboxExecCommand,
@@ -737,6 +738,14 @@ function writeHermesPortableCurrentnessTiming(
 ): void {
   console.log(
     `  Hermes Portable currentness timing: receiptRead=${String(evidence.receiptReadMs)}ms receiptReadCount=${String(evidence.receiptReadCount)} socketAuthority=${String(evidence.socketAuthorityMs)}ms socketAuthorityCount=${String(evidence.socketAuthorityCount)} openshellExecutable=${String(evidence.openshellExecutableMs)}ms openshellExecutableCount=${String(evidence.openshellExecutableCount)} podmanExecutable=${String(evidence.podmanExecutableMs)}ms podmanExecutableCount=${String(evidence.podmanExecutableCount)} containerInspect=${String(evidence.containerInspectMs)}ms containerInspectCount=${String(evidence.containerInspectCount)} transactionCompare=${String(evidence.transactionCompareMs)}ms transactionCompareCount=${String(evidence.transactionCompareCount)}`,
+  );
+}
+
+function writeHermesPortableInspectionTiming(
+  evidence: HermesPortableContainerInspectionTimingEvidence,
+): void {
+  console.log(
+    `  Hermes Portable inspection timing: preGuard=${String(evidence.preGuardMs)}ms preGuardCount=${String(evidence.preGuardCount)} podmanCapture=${String(evidence.podmanCaptureMs)}ms podmanCaptureCount=${String(evidence.podmanCaptureCount)} postGuard=${String(evidence.postGuardMs)}ms postGuardCount=${String(evidence.postGuardCount)} jsonParse=${String(evidence.jsonParseMs)}ms jsonParseCount=${String(evidence.jsonParseCount)} identityCompare=${String(evidence.identityCompareMs)}ms identityCompareCount=${String(evidence.identityCompareCount)}`,
   );
 }
 
@@ -2358,6 +2367,7 @@ async function prepareConnectSandboxWithinLifecycleFence(
               undefined,
               { onComplete: writeHermesPortableLifecycleRecoveryTiming },
               { onComplete: writeHermesPortableCurrentnessTiming },
+              { onComplete: writeHermesPortableInspectionTiming },
             ),
           );
           if (recovery.kind === "not-installed") {

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -108,7 +108,10 @@ import {
   settlePortableOpenClawPairing,
   withLaunchReadinessMutationGate,
 } from "./launch-readiness";
-import type { HermesPortableLifecycleRecoveryTimingEvidence } from "../../onboard/experimental/hermes-portable-lifecycle";
+import type {
+  HermesPortableCurrentnessTimingEvidence,
+  HermesPortableLifecycleRecoveryTimingEvidence,
+} from "../../onboard/experimental/hermes-portable-lifecycle";
 import {
   checkAndRecoverSandboxProcesses,
   executeSandboxExecCommand,
@@ -726,6 +729,14 @@ function writeHermesPortableForwardRecoveryTiming(
 ): void {
   console.log(
     `  Hermes Portable forward recovery timing: list=${String(evidence.listMs)}ms listCount=${String(evidence.listCount)} stop=${String(evidence.stopMs)}ms stopCount=${String(evidence.stopCount)} start=${String(evidence.startMs)}ms startCount=${String(evidence.startCount)} settle=${String(evidence.settleMs)}ms settleCount=${String(evidence.settleCount)} total=${String(evidence.totalMs)}ms result=${evidence.result}`,
+  );
+}
+
+function writeHermesPortableCurrentnessTiming(
+  evidence: HermesPortableCurrentnessTimingEvidence,
+): void {
+  console.log(
+    `  Hermes Portable currentness timing: receiptRead=${String(evidence.receiptReadMs)}ms receiptReadCount=${String(evidence.receiptReadCount)} socketAuthority=${String(evidence.socketAuthorityMs)}ms socketAuthorityCount=${String(evidence.socketAuthorityCount)} openshellExecutable=${String(evidence.openshellExecutableMs)}ms openshellExecutableCount=${String(evidence.openshellExecutableCount)} podmanExecutable=${String(evidence.podmanExecutableMs)}ms podmanExecutableCount=${String(evidence.podmanExecutableCount)} containerInspect=${String(evidence.containerInspectMs)}ms containerInspectCount=${String(evidence.containerInspectCount)} transactionCompare=${String(evidence.transactionCompareMs)}ms transactionCompareCount=${String(evidence.transactionCompareCount)}`,
   );
 }
 
@@ -2346,6 +2357,7 @@ async function prepareConnectSandboxWithinLifecycleFence(
               resolveSandboxGatewayName(registered),
               undefined,
               { onComplete: writeHermesPortableLifecycleRecoveryTiming },
+              { onComplete: writeHermesPortableCurrentnessTiming },
             ),
           );
           if (recovery.kind === "not-installed") {

--- a/src/lib/actions/sandbox/gateway-state.ts
+++ b/src/lib/actions/sandbox/gateway-state.ts
@@ -79,7 +79,10 @@ import {
   recoverPortableAgentSandboxLifecycle,
   requireHermesPortableActiveLifecycleAuthority,
 } from "../../onboard/experimental/portable-agent-lifecycle";
-import type { HermesPortableLifecycleRecoveryTiming } from "../../onboard/experimental/hermes-portable-lifecycle";
+import type {
+  HermesPortableCurrentnessTiming,
+  HermesPortableLifecycleRecoveryTiming,
+} from "../../onboard/experimental/hermes-portable-lifecycle";
 import type { PortableDemoLifecycleRecoveryResult } from "../../onboard/experimental/portable-demo-lifecycle";
 import { compareAndSetLegacySandboxLifecycleGeneration } from "../../state/registry/lifecycle-generation";
 import type { SandboxEntry } from "../../state/registry/types";
@@ -207,6 +210,7 @@ export function recoverPortableDemoSandboxLifecycleForConnect(
   gatewayName: string,
   commandAuthority?: ReturnType<typeof qualifyHermesPortableOperatingCommandAuthority>,
   lifecycleTiming?: HermesPortableLifecycleRecoveryTiming,
+  currentnessTiming?: HermesPortableCurrentnessTiming,
 ): PortableDemoLifecycleRecoveryResult {
   const capture = (args: readonly string[], timeoutMs: number) => {
     commandAuthority?.assertTransactionCurrent();
@@ -266,6 +270,7 @@ export function recoverPortableDemoSandboxLifecycleForConnect(
         captureOpenshell: capture,
         readRegistry: (name) => (sandbox?.name === name ? sandbox : null),
         ...(lifecycleTiming ? { recoveryTiming: lifecycleTiming } : {}),
+        ...(currentnessTiming ? { currentnessTiming } : {}),
       },
     );
   } finally {

--- a/src/lib/actions/sandbox/gateway-state.ts
+++ b/src/lib/actions/sandbox/gateway-state.ts
@@ -80,6 +80,7 @@ import {
   requireHermesPortableActiveLifecycleAuthority,
 } from "../../onboard/experimental/portable-agent-lifecycle";
 import type {
+  HermesPortableContainerInspectionRecoveryTiming,
   HermesPortableCurrentnessTiming,
   HermesPortableLifecycleRecoveryTiming,
 } from "../../onboard/experimental/hermes-portable-lifecycle";
@@ -211,6 +212,7 @@ export function recoverPortableDemoSandboxLifecycleForConnect(
   commandAuthority?: ReturnType<typeof qualifyHermesPortableOperatingCommandAuthority>,
   lifecycleTiming?: HermesPortableLifecycleRecoveryTiming,
   currentnessTiming?: HermesPortableCurrentnessTiming,
+  inspectionTiming?: HermesPortableContainerInspectionRecoveryTiming,
 ): PortableDemoLifecycleRecoveryResult {
   const capture = (args: readonly string[], timeoutMs: number) => {
     commandAuthority?.assertTransactionCurrent();
@@ -271,6 +273,7 @@ export function recoverPortableDemoSandboxLifecycleForConnect(
         readRegistry: (name) => (sandbox?.name === name ? sandbox : null),
         ...(lifecycleTiming ? { recoveryTiming: lifecycleTiming } : {}),
         ...(currentnessTiming ? { currentnessTiming } : {}),
+        ...(inspectionTiming ? { inspectionTiming } : {}),
       },
     );
   } finally {

--- a/src/lib/onboard/experimental/hermes-container-inspection-timing.test.ts
+++ b/src/lib/onboard/experimental/hermes-container-inspection-timing.test.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createHermesPortableContainerInspectionTiming } from "./hermes-portable-container";
+
+describe("Hermes container inspection timing", () => {
+  it("records only bounded numeric stage evidence", () => {
+    let now = 0;
+    const complete = vi.fn();
+    const timing = createHermesPortableContainerInspectionTiming(complete, () => now);
+    const result = timing.measure("podmanCapture", () => {
+      now += 2_130;
+      return "secret inspect output";
+    });
+    timing.finish();
+
+    expect(result).toBe("secret inspect output");
+    expect(complete).toHaveBeenCalledWith(
+      expect.objectContaining({ podmanCaptureMs: 2_130, podmanCaptureCount: 1 }),
+    );
+    expect(JSON.stringify(complete.mock.calls[0]?.[0])).not.toContain("secret inspect output");
+  });
+
+  it("keeps clock and callback failures observational", () => {
+    const complete = vi.fn(() => {
+      throw new Error("timing sink failed");
+    });
+    const timing = createHermesPortableContainerInspectionTiming(complete, () => {
+      throw new Error("clock failed");
+    });
+
+    expect(timing.measure("jsonParse", () => 42)).toBe(42);
+    expect(() => timing.finish()).not.toThrow();
+    expect(() => timing.finish()).not.toThrow();
+    expect(complete).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/onboard/experimental/hermes-currentness-timing.test.ts
+++ b/src/lib/onboard/experimental/hermes-currentness-timing.test.ts
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { HermesPortableCurrentnessTimingEvidence } from "./hermes-portable-lifecycle";
+
+const NUMERIC_FIELDS = [
+  "receiptReadMs",
+  "receiptReadCount",
+  "socketAuthorityMs",
+  "socketAuthorityCount",
+  "openshellExecutableMs",
+  "openshellExecutableCount",
+  "podmanExecutableMs",
+  "podmanExecutableCount",
+  "containerInspectMs",
+  "containerInspectCount",
+  "transactionCompareMs",
+  "transactionCompareCount",
+] as const satisfies readonly (keyof HermesPortableCurrentnessTimingEvidence)[];
+
+describe("Hermes currentness timing evidence", () => {
+  it("keeps the public evidence schema numeric and credential-free", () => {
+    const evidence = Object.fromEntries(NUMERIC_FIELDS.map((field, index) => [field, index]));
+
+    expect(Object.keys(evidence).sort()).toEqual([...NUMERIC_FIELDS].sort());
+    expect(Object.values(evidence).every(Number.isFinite)).toBe(true);
+    expect(JSON.stringify(evidence)).not.toMatch(
+      /argv|authorization|bearer|endpoint|env|stderr|stdout|token/iu,
+    );
+  });
+
+  it("allows a timing callback to reject evidence without exposing operation data", () => {
+    const callback = vi.fn((_evidence: HermesPortableCurrentnessTimingEvidence) => {
+      throw new Error("timing sink failed");
+    });
+    const evidence = Object.fromEntries(
+      NUMERIC_FIELDS.map((field) => [field, 0]),
+    ) as unknown as HermesPortableCurrentnessTimingEvidence;
+
+    expect(() => callback(evidence)).toThrow("timing sink failed");
+    expect(callback).toHaveBeenCalledWith(evidence);
+  });
+});

--- a/src/lib/onboard/experimental/hermes-portable-container.ts
+++ b/src/lib/onboard/experimental/hermes-portable-container.ts
@@ -92,6 +92,92 @@ export interface HermesPortableContainerInspection {
   readonly status: string;
 }
 
+export type HermesPortableContainerInspectionTimingStage =
+  | "preGuard"
+  | "podmanCapture"
+  | "postGuard"
+  | "jsonParse"
+  | "identityCompare";
+
+export interface HermesPortableContainerInspectionTiming {
+  readonly measure: <T>(
+    stage: HermesPortableContainerInspectionTimingStage,
+    operation: () => T,
+  ) => T;
+}
+
+export interface HermesPortableContainerInspectionTimingEvidence {
+  readonly preGuardMs: number;
+  readonly preGuardCount: number;
+  readonly podmanCaptureMs: number;
+  readonly podmanCaptureCount: number;
+  readonly postGuardMs: number;
+  readonly postGuardCount: number;
+  readonly jsonParseMs: number;
+  readonly jsonParseCount: number;
+  readonly identityCompareMs: number;
+  readonly identityCompareCount: number;
+}
+
+export function createHermesPortableContainerInspectionTiming(
+  onComplete: (evidence: HermesPortableContainerInspectionTimingEvidence) => void,
+  now: () => number = () => performance.now(),
+): HermesPortableContainerInspectionTiming & { readonly finish: () => void } {
+  const durations = new Map<HermesPortableContainerInspectionTimingStage, number>();
+  const counts = new Map<HermesPortableContainerInspectionTimingStage, number>();
+  let finished = false;
+  return Object.freeze({
+    measure<T>(stage: HermesPortableContainerInspectionTimingStage, operation: () => T): T {
+      const startedAt = safeTimingNow(now);
+      counts.set(stage, Math.min(9_999_999, (counts.get(stage) ?? 0) + 1));
+      try {
+        return operation();
+      } finally {
+        const endedAt = safeTimingNow(now);
+        const duration = startedAt === null || endedAt === null ? 0 : endedAt - startedAt;
+        durations.set(
+          stage,
+          Math.min(9_999_999, (durations.get(stage) ?? 0) + Math.max(0, Math.round(duration))),
+        );
+      }
+    },
+    finish(): void {
+      if (finished) return;
+      finished = true;
+      const duration = (stage: HermesPortableContainerInspectionTimingStage) =>
+        durations.get(stage) ?? 0;
+      const count = (stage: HermesPortableContainerInspectionTimingStage) => counts.get(stage) ?? 0;
+      try {
+        onComplete(
+          Object.freeze({
+            preGuardMs: duration("preGuard"),
+            preGuardCount: count("preGuard"),
+            podmanCaptureMs: duration("podmanCapture"),
+            podmanCaptureCount: count("podmanCapture"),
+            postGuardMs: duration("postGuard"),
+            postGuardCount: count("postGuard"),
+            jsonParseMs: duration("jsonParse"),
+            jsonParseCount: count("jsonParse"),
+            identityCompareMs: duration("identityCompare"),
+            identityCompareCount: count("identityCompare"),
+          }),
+        );
+      } catch {
+        // Timing output must not change container authority checks.
+      }
+    },
+  });
+}
+
+function safeTimingNow(now: () => number): number | null {
+  try {
+    const value = now();
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 export interface HermesPortableContainerDeps {
   readonly podman: HermesPortablePodmanCapture;
   readonly authenticatedHealth?: HermesPortableAuthenticatedHealthCapture;
@@ -99,6 +185,7 @@ export interface HermesPortableContainerDeps {
   readonly assertSocketAuthority?: typeof assertPodmanSocketAuthority;
   readonly now?: () => number;
   readonly sleep?: (milliseconds: number) => void;
+  readonly inspectionTiming?: HermesPortableContainerInspectionTiming;
 }
 
 export type HermesPortableContainerStartResult = "already-running" | "started";
@@ -269,17 +356,22 @@ function inspectExact(
   containerId: string,
   deps: HermesPortableContainerDeps,
 ): HermesPortableContainerInspection {
-  assertSocket(receipt, deps);
-  const output = requireCommand(
-    deps.podman(["container", "inspect", containerId], INSPECT_TIMEOUT_MS),
-    "exact inspect",
+  const measure = deps.inspectionTiming?.measure ?? ((_stage, operation) => operation());
+  measure("preGuard", () => assertSocket(receipt, deps));
+  const output = measure("podmanCapture", () =>
+    requireCommand(
+      deps.podman(["container", "inspect", containerId], INSPECT_TIMEOUT_MS),
+      "exact inspect",
+    ),
   );
-  assertSocket(receipt, deps);
-  return parseInspection(output, {
-    sandboxName: receipt.sandboxName,
-    sandboxId,
-    containerId,
-  });
+  measure("postGuard", () => assertSocket(receipt, deps));
+  return measure("jsonParse", () =>
+    parseInspection(output, {
+      sandboxName: receipt.sandboxName,
+      sandboxId,
+      containerId,
+    }),
+  );
 }
 
 /** Enroll exactly one live OpenShell-managed container after Ready. */
@@ -344,7 +436,10 @@ export function assertCurrentHermesPortableContainer(
     running: _currentState,
     ...current
   } = inspected.authority;
-  if (!isDeepStrictEqual(current, recorded)) fail("live immutable identity disagrees with receipt");
+  const compare = deps.inspectionTiming?.measure ?? ((_stage, operation) => operation());
+  compare("identityCompare", () => {
+    if (!isDeepStrictEqual(current, recorded)) fail("live immutable identity disagrees with receipt");
+  });
   return inspected;
 }
 

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
@@ -108,6 +108,27 @@ export interface HermesPortableLifecycleDeps {
   readonly sleep?: (milliseconds: number) => void;
   readonly log?: (message: string) => void;
   readonly recoveryTiming?: HermesPortableLifecycleRecoveryTiming;
+  readonly currentnessTiming?: HermesPortableCurrentnessTiming;
+}
+
+export interface HermesPortableCurrentnessTimingEvidence {
+  readonly receiptReadMs: number;
+  readonly receiptReadCount: number;
+  readonly socketAuthorityMs: number;
+  readonly socketAuthorityCount: number;
+  readonly openshellExecutableMs: number;
+  readonly openshellExecutableCount: number;
+  readonly podmanExecutableMs: number;
+  readonly podmanExecutableCount: number;
+  readonly containerInspectMs: number;
+  readonly containerInspectCount: number;
+  readonly transactionCompareMs: number;
+  readonly transactionCompareCount: number;
+}
+
+export interface HermesPortableCurrentnessTiming {
+  readonly now?: () => number;
+  readonly onComplete: (evidence: HermesPortableCurrentnessTimingEvidence) => void;
 }
 
 const HERMES_PORTABLE_LIFECYCLE_TIMING_STAGES = [
@@ -175,6 +196,19 @@ export interface HermesPortableLifecycleRecoveryTiming {
   readonly onComplete: (evidence: HermesPortableLifecycleRecoveryTimingEvidence) => void;
 }
 
+type HermesPortableCurrentnessTimingStage =
+  | "receiptRead"
+  | "socketAuthority"
+  | "openshellExecutable"
+  | "podmanExecutable"
+  | "containerInspect"
+  | "transactionCompare";
+
+type HermesPortableCurrentnessTimingRecorder = {
+  readonly measure: <T>(stage: HermesPortableCurrentnessTimingStage, operation: () => T) => T;
+  readonly finish: () => void;
+};
+
 type HermesPortableLifecycleTimingRecorder = {
   readonly measure: <T>(stage: HermesPortableLifecycleTimingStage, operation: () => T) => T;
   readonly increment: (counter: HermesPortableLifecycleTimingCounter) => void;
@@ -189,6 +223,58 @@ function safeTimingNow(now: () => number): number | null {
   } catch {
     return null;
   }
+}
+
+function createHermesPortableCurrentnessTimingRecorder(
+  timing: HermesPortableCurrentnessTiming | undefined,
+): HermesPortableCurrentnessTimingRecorder {
+  const now = timing?.now ?? (() => performance.now());
+  const durations = new Map<HermesPortableCurrentnessTimingStage, number>();
+  const counts = new Map<HermesPortableCurrentnessTimingStage, number>();
+  let finished = false;
+  return Object.freeze({
+    measure<T>(stage: HermesPortableCurrentnessTimingStage, operation: () => T): T {
+      const startedAt = safeTimingNow(now);
+      counts.set(stage, Math.min(9_999_999, (counts.get(stage) ?? 0) + 1));
+      try {
+        return operation();
+      } finally {
+        const endedAt = safeTimingNow(now);
+        const duration = startedAt === null || endedAt === null ? 0 : endedAt - startedAt;
+        durations.set(
+          stage,
+          Math.min(9_999_999, (durations.get(stage) ?? 0) + Math.max(0, Math.round(duration))),
+        );
+      }
+    },
+    finish(): void {
+      if (finished) return;
+      finished = true;
+      if (!timing) return;
+      const duration = (stage: HermesPortableCurrentnessTimingStage) => durations.get(stage) ?? 0;
+      const count = (stage: HermesPortableCurrentnessTimingStage) => counts.get(stage) ?? 0;
+      try {
+        timing.onComplete(
+          Object.freeze({
+            receiptReadMs: duration("receiptRead"),
+            receiptReadCount: count("receiptRead"),
+            socketAuthorityMs: duration("socketAuthority"),
+            socketAuthorityCount: count("socketAuthority"),
+            openshellExecutableMs: duration("openshellExecutable"),
+            openshellExecutableCount: count("openshellExecutable"),
+            podmanExecutableMs: duration("podmanExecutable"),
+            podmanExecutableCount: count("podmanExecutable"),
+            containerInspectMs: duration("containerInspect"),
+            containerInspectCount: count("containerInspect"),
+            transactionCompareMs: duration("transactionCompare"),
+            transactionCompareCount: count("transactionCompare"),
+          }),
+        );
+      } catch {
+        // Timing output must not change lifecycle recovery.
+      }
+    },
+  });
 }
 
 function createHermesPortableLifecycleTimingRecorder(
@@ -552,6 +638,7 @@ function qualify(
   expected?: HermesPortableReceiptSnapshot,
   acceptedPhases: readonly string[] = ["Ready"],
   options: { readonly permitSchema5Requalification?: boolean } = {},
+  currentnessTiming = createHermesPortableCurrentnessTimingRecorder(deps.currentnessTiming),
 ): QualifiedHermesPortableLifecycle {
   const commandEnv = deps.env ?? process.env;
   assertNoOpenShellGatewayEndpointOverride(commandEnv);
@@ -560,9 +647,11 @@ function qualify(
   if (!isMcpLifecycleLockHeld(sandboxName, lockStateDir)) {
     fail("mutation requires the sandbox lifecycle lock");
   }
-  const snapshot = options.permitSchema5Requalification
-    ? readHermesPortableLifecycleReceiptForRequalification(sandboxName, stateDir)
-    : readHermesPortableLifecycleReceipt(sandboxName, stateDir);
+  const snapshot = currentnessTiming.measure("receiptRead", () =>
+    options.permitSchema5Requalification
+      ? readHermesPortableLifecycleReceiptForRequalification(sandboxName, stateDir)
+      : readHermesPortableLifecycleReceipt(sandboxName, stateDir),
+  );
   if (!snapshot) fail("active receipt authority disappeared");
   if (expected && !sameSnapshot(snapshot, expected)) fail("receipt authority changed");
   if (snapshot.receipt.phase !== "active") {
@@ -572,7 +661,7 @@ function qualify(
     snapshot as HermesPortableReceiptSnapshot & {
       readonly receipt: HermesPortableConfiguredReceipt;
     },
-    deps.operatingAuthority,
+    { ...deps.operatingAuthority, timing: currentnessTiming },
     options,
   );
   operatingAuthority.assertCurrent();
@@ -615,7 +704,9 @@ function qualify(
     ...baseContainerDeps,
     authenticatedHealth: createAuthenticatedHealthCapture(receipt, capture),
   };
-  const container = assertCurrentHermesPortableContainer(receipt, containerDeps);
+  const container = currentnessTiming.measure("containerInspect", () =>
+    assertCurrentHermesPortableContainer(receipt, containerDeps),
+  );
   if (container.paused || container.authority.restartPolicy !== "unless-stopped") {
     fail("container state or restart policy disagrees with active authority");
   }
@@ -762,13 +853,16 @@ function assertLifecycleTransactionCurrent(
   qualified: QualifiedHermesPortableLifecycle,
   timing: HermesPortableLifecycleTimingRecorder,
   expectedRunning: boolean,
+  currentnessTiming: HermesPortableCurrentnessTimingRecorder,
 ): HermesPortableContainerInspection {
   timing.increment("transactionCurrentness");
-  qualified.assertTransactionCurrent();
+  currentnessTiming.measure("transactionCompare", qualified.assertTransactionCurrent);
   timing.increment("containerInspection");
-  const current = assertCurrentHermesPortableContainer(qualified.receipt, qualified.containerDeps);
+  const current = currentnessTiming.measure("containerInspect", () =>
+    assertCurrentHermesPortableContainer(qualified.receipt, qualified.containerDeps),
+  );
   timing.increment("transactionCurrentness");
-  qualified.assertTransactionCurrent();
+  currentnessTiming.measure("transactionCompare", qualified.assertTransactionCurrent);
   if (
     current.authority.running !== expectedRunning ||
     current.paused ||
@@ -788,6 +882,7 @@ function refreshLifecycleCurrentness(
   timing: HermesPortableLifecycleTimingRecorder,
   expectedRunning: boolean,
   acceptedPhases: readonly string[] = ["Ready"],
+  currentnessTiming = createHermesPortableCurrentnessTimingRecorder(deps.currentnessTiming),
 ): QualifiedHermesPortableLifecycle {
   if (!qualified.hasTransactionAuthority) {
     timing.increment("qualification");
@@ -795,7 +890,12 @@ function refreshLifecycleCurrentness(
   }
   return {
     ...qualified,
-    container: assertLifecycleTransactionCurrent(qualified, timing, expectedRunning),
+    container: assertLifecycleTransactionCurrent(
+      qualified,
+      timing,
+      expectedRunning,
+      currentnessTiming,
+    ),
   };
 }
 
@@ -890,13 +990,23 @@ export function recoverHermesPortableSandboxLifecycle(
   deps: HermesPortableLifecycleDeps = {},
 ): PortableDemoLifecycleRecoveryResult {
   const timing = createHermesPortableLifecycleTimingRecorder(deps.recoveryTiming);
+  const currentnessTiming = createHermesPortableCurrentnessTimingRecorder(deps.currentnessTiming);
   timing.increment("qualification");
   let qualified: QualifiedHermesPortableLifecycle;
   try {
     qualified = timing.measure("entryQualification", () =>
-      qualify(sandboxName, context, deps, undefined, ["Ready", "Error", "Stopped"]),
+      qualify(
+        sandboxName,
+        context,
+        deps,
+        undefined,
+        ["Ready", "Error", "Stopped"],
+        {},
+        currentnessTiming,
+      ),
     );
   } catch (error) {
+    currentnessTiming.finish();
     timing.finish("failed");
     throw error;
   }
@@ -942,7 +1052,7 @@ export function recoverHermesPortableSandboxLifecycle(
           "Ready",
           "Error",
           "Stopped",
-        ]),
+        ], currentnessTiming),
       );
     }
     const commandEnv = deps.env ?? process.env;
@@ -962,7 +1072,7 @@ export function recoverHermesPortableSandboxLifecycle(
         timing.increment("execReadyAttempt");
         if (qualified.hasTransactionAuthority) {
           timing.measure("execReadyCurrentness", () =>
-            assertLifecycleTransactionCurrent(qualified, timing, true),
+            assertLifecycleTransactionCurrent(qualified, timing, true, currentnessTiming),
           );
         }
         const result = captureRetainedLifecycleCommand(
@@ -975,7 +1085,7 @@ export function recoverHermesPortableSandboxLifecycle(
         );
         if (qualified.hasTransactionAuthority) {
           timing.measure("execReadyCurrentness", () =>
-            assertLifecycleTransactionCurrent(qualified, timing, true),
+            assertLifecycleTransactionCurrent(qualified, timing, true, currentnessTiming),
           );
         }
         return result.status === 0 && !result.error;
@@ -983,7 +1093,16 @@ export function recoverHermesPortableSandboxLifecycle(
     );
     if (!execReady) fail("did not reconnect to the selected OpenShell gateway");
     qualified = timing.measure("preHealthCurrentness", () =>
-      refreshLifecycleCurrentness(sandboxName, context, deps, qualified, timing, true),
+      refreshLifecycleCurrentness(
+        sandboxName,
+        context,
+        deps,
+        qualified,
+        timing,
+        true,
+        ["Ready"],
+        currentnessTiming,
+      ),
     );
     const transactionContainerDeps = measuredHealthContainerDeps(
       qualified,
@@ -998,24 +1117,42 @@ export function recoverHermesPortableSandboxLifecycle(
       );
       if (qualified.hasTransactionAuthority) {
         timing.measure("healthPollCurrentness", () =>
-          assertLifecycleTransactionCurrent(qualified, timing, true),
+          assertLifecycleTransactionCurrent(qualified, timing, true, currentnessTiming),
         );
       }
       if (initialHealth === "ready") {
         timing.increment("qualification");
         timing.measure("finalQualification", () =>
-          qualify(sandboxName, context, deps, qualified.snapshot),
+          qualify(
+            sandboxName,
+            context,
+            deps,
+            qualified.snapshot,
+            ["Ready"],
+            {},
+            currentnessTiming,
+          ),
         );
         const result = wasRunning
           ? { kind: "already-running" as const }
           : { kind: "recovered" as const };
+        currentnessTiming.finish();
         timing.finish(result.kind);
         return result;
       }
     }
     if (startedByRecovery) {
       qualified = timing.measure("healthPollCurrentness", () =>
-        refreshLifecycleCurrentness(sandboxName, context, deps, qualified, timing, true),
+        refreshLifecycleCurrentness(
+        sandboxName,
+        context,
+        deps,
+        qualified,
+        timing,
+        true,
+        ["Ready"],
+        currentnessTiming,
+      ),
       );
       const assertExecutable =
         deps.assertOpenShellExecutableAuthority ?? assertHermesPortableOpenShellExecutableAuthority;
@@ -1043,7 +1180,16 @@ export function recoverHermesPortableSandboxLifecycle(
     }
     const recovered = waitFor(STARTUP_TIMEOUT_MS, deps, () => {
       qualified = timing.measure("healthPollCurrentness", () =>
-        refreshLifecycleCurrentness(sandboxName, context, deps, qualified, timing, true),
+        refreshLifecycleCurrentness(
+        sandboxName,
+        context,
+        deps,
+        qualified,
+        timing,
+        true,
+        ["Ready"],
+        currentnessTiming,
+      ),
       );
       const currentContainerDeps = measuredHealthContainerDeps(
         qualified,
@@ -1056,7 +1202,7 @@ export function recoverHermesPortableSandboxLifecycle(
       );
       if (qualified.hasTransactionAuthority) {
         timing.measure("healthPollCurrentness", () =>
-          assertLifecycleTransactionCurrent(qualified, timing, true),
+          assertLifecycleTransactionCurrent(qualified, timing, true, currentnessTiming),
         );
       }
       return health === "ready";
@@ -1064,13 +1210,23 @@ export function recoverHermesPortableSandboxLifecycle(
     if (!recovered) fail("managed startup did not pass authenticated health");
     timing.increment("qualification");
     timing.measure("finalQualification", () =>
-      qualify(sandboxName, context, deps, qualified.snapshot),
+      qualify(
+        sandboxName,
+        context,
+        deps,
+        qualified.snapshot,
+        ["Ready"],
+        {},
+        currentnessTiming,
+      ),
     );
     if (wasRunning) {
+      currentnessTiming.finish();
       timing.finish("already-running");
       return { kind: "already-running" };
     }
     (deps.log ?? console.log)(`  Hermes portable lifecycle recovered sandbox '${sandboxName}'.`);
+    currentnessTiming.finish();
     timing.finish("recovered");
     return { kind: "recovered" };
   } catch (error) {
@@ -1087,6 +1243,7 @@ export function recoverHermesPortableSandboxLifecycle(
           ),
         );
       } catch (rollbackError) {
+        currentnessTiming.finish();
         timing.finish("failed");
         throw new AggregateError(
           [error, rollbackError],
@@ -1094,6 +1251,7 @@ export function recoverHermesPortableSandboxLifecycle(
         );
       }
     }
+    currentnessTiming.finish();
     timing.finish("failed");
     throw error;
   }

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
@@ -33,6 +33,7 @@ import {
 import { assertNoOpenShellGatewayEndpointOverride } from "../../openshell-gateway-endpoint-guard";
 import {
   assertCurrentHermesPortableContainer,
+  createHermesPortableContainerInspectionTiming,
   observeHermesPortableAuthenticatedHealth,
   startHermesPortableContainer,
   stopHermesPortableContainer,
@@ -109,6 +110,12 @@ export interface HermesPortableLifecycleDeps {
   readonly log?: (message: string) => void;
   readonly recoveryTiming?: HermesPortableLifecycleRecoveryTiming;
   readonly currentnessTiming?: HermesPortableCurrentnessTiming;
+  readonly inspectionTiming?: HermesPortableContainerInspectionRecoveryTiming;
+}
+
+export interface HermesPortableContainerInspectionRecoveryTiming {
+  readonly now?: () => number;
+  readonly onComplete: Parameters<typeof createHermesPortableContainerInspectionTiming>[0];
 }
 
 export interface HermesPortableCurrentnessTimingEvidence {
@@ -991,6 +998,24 @@ export function recoverHermesPortableSandboxLifecycle(
 ): PortableDemoLifecycleRecoveryResult {
   const timing = createHermesPortableLifecycleTimingRecorder(deps.recoveryTiming);
   const currentnessTiming = createHermesPortableCurrentnessTimingRecorder(deps.currentnessTiming);
+  const inspectionTiming = deps.inspectionTiming
+    ? createHermesPortableContainerInspectionTiming(
+        deps.inspectionTiming.onComplete,
+        deps.inspectionTiming.now,
+      )
+    : undefined;
+  const instrumentedDeps: HermesPortableLifecycleDeps = inspectionTiming
+    ? {
+        ...deps,
+        container: (receipt) => ({
+          ...(typeof deps.container === "function"
+            ? deps.container(receipt)
+            : (deps.container ??
+              createContainerDeps(receipt, deps.env ?? process.env, deps.podmanAuthorityDeps))),
+          inspectionTiming,
+        }),
+      }
+    : deps;
   timing.increment("qualification");
   let qualified: QualifiedHermesPortableLifecycle;
   try {
@@ -998,7 +1023,7 @@ export function recoverHermesPortableSandboxLifecycle(
       qualify(
         sandboxName,
         context,
-        deps,
+        instrumentedDeps,
         undefined,
         ["Ready", "Error", "Stopped"],
         {},
@@ -1006,6 +1031,7 @@ export function recoverHermesPortableSandboxLifecycle(
       ),
     );
   } catch (error) {
+    inspectionTiming?.finish();
     currentnessTiming.finish();
     timing.finish("failed");
     throw error;
@@ -1048,7 +1074,7 @@ export function recoverHermesPortableSandboxLifecycle(
         throw startError;
       }
       qualified = timing.measure("postStartCurrentness", () =>
-        refreshLifecycleCurrentness(sandboxName, context, deps, qualified, timing, true, [
+        refreshLifecycleCurrentness(sandboxName, context, instrumentedDeps, qualified, timing, true, [
           "Ready",
           "Error",
           "Stopped",
@@ -1096,7 +1122,7 @@ export function recoverHermesPortableSandboxLifecycle(
       refreshLifecycleCurrentness(
         sandboxName,
         context,
-        deps,
+        instrumentedDeps,
         qualified,
         timing,
         true,
@@ -1126,7 +1152,7 @@ export function recoverHermesPortableSandboxLifecycle(
           qualify(
             sandboxName,
             context,
-            deps,
+            instrumentedDeps,
             qualified.snapshot,
             ["Ready"],
             {},
@@ -1136,6 +1162,7 @@ export function recoverHermesPortableSandboxLifecycle(
         const result = wasRunning
           ? { kind: "already-running" as const }
           : { kind: "recovered" as const };
+        inspectionTiming?.finish();
         currentnessTiming.finish();
         timing.finish(result.kind);
         return result;
@@ -1146,7 +1173,7 @@ export function recoverHermesPortableSandboxLifecycle(
         refreshLifecycleCurrentness(
         sandboxName,
         context,
-        deps,
+        instrumentedDeps,
         qualified,
         timing,
         true,
@@ -1183,7 +1210,7 @@ export function recoverHermesPortableSandboxLifecycle(
         refreshLifecycleCurrentness(
         sandboxName,
         context,
-        deps,
+        instrumentedDeps,
         qualified,
         timing,
         true,
@@ -1213,7 +1240,7 @@ export function recoverHermesPortableSandboxLifecycle(
       qualify(
         sandboxName,
         context,
-        deps,
+        instrumentedDeps,
         qualified.snapshot,
         ["Ready"],
         {},
@@ -1221,11 +1248,13 @@ export function recoverHermesPortableSandboxLifecycle(
       ),
     );
     if (wasRunning) {
+      inspectionTiming?.finish();
       currentnessTiming.finish();
       timing.finish("already-running");
       return { kind: "already-running" };
     }
     (deps.log ?? console.log)(`  Hermes portable lifecycle recovered sandbox '${sandboxName}'.`);
+    inspectionTiming?.finish();
     currentnessTiming.finish();
     timing.finish("recovered");
     return { kind: "recovered" };
@@ -1237,12 +1266,13 @@ export function recoverHermesPortableSandboxLifecycle(
           rollbackStartedHermesPortableRecovery(
             sandboxName,
             context,
-            deps,
+            instrumentedDeps,
             rollbackAuthority,
             timing,
           ),
         );
       } catch (rollbackError) {
+        inspectionTiming?.finish();
         currentnessTiming.finish();
         timing.finish("failed");
         throw new AggregateError(
@@ -1251,6 +1281,7 @@ export function recoverHermesPortableSandboxLifecycle(
         );
       }
     }
+    inspectionTiming?.finish();
     currentnessTiming.finish();
     timing.finish("failed");
     throw error;

--- a/src/lib/onboard/experimental/hermes-portable-operating-authority.ts
+++ b/src/lib/onboard/experimental/hermes-portable-operating-authority.ts
@@ -25,8 +25,16 @@ import {
   type HermesPortableSuccessorReceipt,
 } from "./hermes-portable-receipt";
 
+export interface HermesPortableOperatingAuthorityTiming {
+  readonly measure: <T>(
+    stage: "socketAuthority" | "openshellExecutable" | "podmanExecutable" | "transactionCompare",
+    operation: () => T,
+  ) => T;
+}
+
 export interface HermesPortableOperatingAuthorityDeps {
   readonly env?: NodeJS.ProcessEnv;
+  readonly timing?: HermesPortableOperatingAuthorityTiming;
   readonly captureSocketAuthority?: (socketPath: string, uid: number) => PodmanSocketAuthority;
   readonly captureOpenShellExecutableAuthority?: (
     executablePath: string,
@@ -158,6 +166,7 @@ export function qualifyHermesPortableOperatingAuthority(
     };
   }
   const env = deps.env ?? process.env;
+  const measure = deps.timing?.measure ?? ((_stage, operation) => operation());
   const expected = snapshot.successor?.receipt ?? createHermesPortableSuccessorReceipt(snapshot);
   const captureSocket =
     deps.captureSocketAuthority ??
@@ -181,19 +190,27 @@ export function qualifyHermesPortableOperatingAuthority(
     ((socketAuthority, receipt, sourceEnv) =>
       captureHermesPortablePodmanExecutableFileAuthority(socketAuthority, receipt, sourceEnv));
   const capture = () => {
-    const socket = captureSocket(
-      snapshot.receipt.runtimeAuthority.socketPath,
-      snapshot.receipt.runtimeAuthority.uid,
+    const socket = measure("socketAuthority", () =>
+      captureSocket(
+        snapshot.receipt.runtimeAuthority.socketPath,
+        snapshot.receipt.runtimeAuthority.uid,
+      ),
     );
     const childEnv = buildOpenShellSubprocessEnv(env, snapshot.receipt.runtimeAuthority);
-    const openshell = captureOpenShell(
-      expected.openshellExecutableAuthority.executable.executablePath,
-      childEnv,
-      env,
+    const openshell = measure("openshellExecutable", () =>
+      captureOpenShell(
+        expected.openshellExecutableAuthority.executable.executablePath,
+        childEnv,
+        env,
+      ),
     );
     const receiptWithCurrentSocket = { ...snapshot.receipt, socketAuthority: socket };
-    const podman = capturePodman(socket, receiptWithCurrentSocket, env);
-    requireStableAuthority(expected, snapshot.receipt, socket, openshell, podman);
+    const podman = measure("podmanExecutable", () =>
+      capturePodman(socket, receiptWithCurrentSocket, env),
+    );
+    measure("transactionCompare", () =>
+      requireStableAuthority(expected, snapshot.receipt, socket, openshell, podman),
+    );
     return {
       socket,
       openshell,
@@ -208,21 +225,27 @@ export function qualifyHermesPortableOperatingAuthority(
   };
   const initial = capture();
   const assertTransactionCurrent = (): void => {
-    const socket = captureSocket(
-      snapshot.receipt.runtimeAuthority.socketPath,
-      snapshot.receipt.runtimeAuthority.uid,
+    const socket = measure("socketAuthority", () =>
+      captureSocket(
+        snapshot.receipt.runtimeAuthority.socketPath,
+        snapshot.receipt.runtimeAuthority.uid,
+      ),
     );
     buildOpenShellSubprocessEnv(env, snapshot.receipt.runtimeAuthority);
-    assertOpenShellFile(initial.openshell, env);
+    measure("openshellExecutable", () => assertOpenShellFile(initial.openshell, env));
     const receiptWithCurrentSocket = { ...snapshot.receipt, socketAuthority: socket };
-    const podman = capturePodmanFile(socket, receiptWithCurrentSocket, env);
-    requireStableAuthority(expected, snapshot.receipt, socket, initial.openshell, podman);
-    if (
-      !isDeepStrictEqual(socket, initial.socket) ||
-      !isDeepStrictEqual(podman, initial.podman)
-    ) {
-      fail("operation-local filesystem or runtime identity changed");
-    }
+    const podman = measure("podmanExecutable", () =>
+      capturePodmanFile(socket, receiptWithCurrentSocket, env),
+    );
+    measure("transactionCompare", () => {
+      requireStableAuthority(expected, snapshot.receipt, socket, initial.openshell, podman);
+      if (
+        !isDeepStrictEqual(socket, initial.socket) ||
+        !isDeepStrictEqual(podman, initial.podman)
+      ) {
+        fail("operation-local filesystem or runtime identity changed");
+      }
+    });
   };
   return {
     receipt: initial.receipt,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome
Hermes stopped-container recovery now reports credential-safe timing for retained currentness and exact-container inspection internals. The change is measurement-only: it preserves command order, authority checks, health behavior, startup, currentness, and rollback.

## Reason
Live Portable evidence identified exact container inspection as the dominant retained-currentness cost. The added measurements distinguish receipt reads, socket and executable authority, transaction comparison, exact inspection, Podman capture, local JSON validation, guard work, and immutable identity comparison before any further optimization is considered.

### Related issues
Relates to #10423
Relates to #10822

## Changes
- Add opt-in currentness timing for receipt read/hash, socket authority, OpenShell executable authority, Podman executable authority, exact container inspection, and transaction comparison.
- Split exact-container inspection into pre-guard, Podman capture, post-guard, JSON parse/validation, and immutable identity comparison.
- Emit only bounded numeric durations and counts through the existing connect-probe timing sink.
- Make non-finite or throwing clocks record zero, make each recorder finish once, and prevent timing callback failure from changing lifecycle recovery.
- Add focused timing-schema, credential-safety, clock-failure, callback-failure, lifecycle, operating-authority, container, and connect tests.
- Exclude the readiness-event prototype, its revert sequence, and unrelated behavior optimizations.

## Verification
- `npx vitest run --project cli src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts src/lib/onboard/experimental/hermes-portable-operating-authority.test.ts src/lib/onboard/experimental/hermes-portable-container.test.ts src/lib/onboard/experimental/hermes-currentness-timing.test.ts src/lib/onboard/experimental/hermes-container-inspection-timing.test.ts src/lib/actions/sandbox/connect-hermes-accepted-readiness.test.ts` — 106 tests passed.
- `npm run typecheck:cli` — passed.
- `npm run build:cli` — passed.
- `npm --prefix nemoclaw run build` — passed.
- `npm run checks:repository` — passed.
- `npm run validate:pr` — passed, including pre-commit, commit-message, and pre-push checks.
- `git verify-commit` — both commits have valid SSH signatures.
- GitHub commit verification — both commits are Verified with reason `valid`.
- Diff review and secret scan — no readiness-event files, argv, generated scripts, stdout, stderr, environment values, endpoints, Authorization headers, Bearer values, tokens, or credentials are emitted.

## Review notes
This instruments a credential-bearing authenticated-health and container lifecycle boundary without changing its controls. Existing exact receipt, socket, executable, sandbox, policy, registry, container identity, paused-state, restart-policy, health, and rollback checks remain in their original order.

Live Portable stopped-container recovery evidence:

- Recovery succeeded: 42.534 seconds internal and 43.665 seconds wall clock.
- Retained currentness measured 15.666 seconds across 7 exact-container inspection groups.
- Deeper inspection observed 13 exact inspections.
- Podman capture consumed 27.692 seconds, about 2.130 seconds per inspection and 99.9% of measured inspection internals.
- Explicit pre-guard work consumed 7 ms total.
- JSON parse and validation consumed 13 ms total.
- Post-guard and identity comparison were below 1 ms in aggregate.

The Podman capture field includes the bound engine's own before/after socket and executable guards plus the CLI/API round trip. Nested measurements must not be added as independent wall time.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added more detailed timing and invocation metrics for sandbox recovery, currentness checks, authority validation, and container inspection.
  * Diagnostics now track key lifecycle stages while avoiding sensitive credential and operation details.
  * Timing collection remains non-blocking, so reporting issues do not disrupt recovery, validation, startup, or rollback flows.
  * Improved resilience of measurement callbacks, including safe handling of clock failures and repeated completion events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->