### PR TITLE
perf(review): reduce advisor endpoint and setup pressure

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -80,6 +80,56 @@ jobs:
           overwrite: true
           retention-days: 1
 
+  build-advisor-runtime:
+    name: Build trusted advisor runtime
+    if: ${{ github.repository == 'NVIDIA/NemoClaw' }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    outputs:
+      payload-sha: ${{ steps.package.outputs.payload-sha }}
+    env:
+      ADVISOR_DIR: ${{ github.workspace }}/advisor
+      FD_FIND_VERSION: "9.0.0-1"
+      RIPGREP_VERSION: "14.1.0-1"
+    steps:
+      - name: Checkout trusted advisor code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: NVIDIA/NemoClaw
+          ref: ${{ github.workflow_sha }}
+          path: advisor
+          persist-credentials: false
+          lfs: false
+          submodules: false
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: advisor/package-lock.json
+      - name: Install locked runtime
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends "fd-find=${FD_FIND_VERSION}" "ripgrep=${RIPGREP_VERSION}"
+          test "$(dpkg-query -W -f='${Version}' fd-find)" = "$FD_FIND_VERSION"
+          test "$(dpkg-query -W -f='${Version}' ripgrep)" = "$RIPGREP_VERSION"
+          (cd "$ADVISOR_DIR" && npm ci --ignore-scripts --no-audit --no-fund)
+      - name: Package trusted runtime
+        id: package
+        env:
+          GITHUB_WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: bash "$ADVISOR_DIR/scripts/package-pr-review-advisor-runtime.sh" "$RUNNER_TEMP/advisor-runtime"
+      - name: Upload trusted runtime
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-review-advisor-runtime-${{ github.run_id }}
+          path: ${{ runner.temp }}/advisor-runtime/
+          overwrite: true
+          retention-days: 1
+
   review-specialists:
     name: Specialist / ${{ matrix.advisor.label }}
     if: ${{ github.repository == 'NVIDIA/NemoClaw' }}
@@ -89,7 +139,7 @@ jobs:
       actions: read
     runs-on: ubuntu-24.04
     timeout-minutes: 40
-    needs: discover-specialists
+    needs: [discover-specialists, build-advisor-runtime]
     strategy:
       fail-fast: false
       matrix:
@@ -185,7 +235,6 @@ jobs:
           node --experimental-strip-types \
             "$ADVISOR_DIR/tools/pr-review-advisor/prepare-target-pr.mts"
 
-      # The advisor reads repository files inside OpenShell. Remove worktree
       # symlinks first so an untrusted link cannot redirect a read outside the
       # uploaded repository. Git still retains the committed link target.
       - name: Remove symlinks from analysis workspace
@@ -195,61 +244,23 @@ jobs:
             rm -- "$link"
           done < <(find "$ADVISOR_WORKDIR" -type l -print0)
 
-      - name: Install Pi SDK
-        run: |
-          set -euo pipefail
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
-            "fd-find=${FD_FIND_VERSION}" \
-            "ripgrep=${RIPGREP_VERSION}"
+      - name: Download trusted advisor runtime
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-review-advisor-runtime-${{ github.run_id }}
+          path: ${{ runner.temp }}/shared-pr-review-advisor-runtime
 
-          INSTALLED_FD_FIND_VERSION="$(dpkg-query -W -f='${Version}' fd-find)"
-          INSTALLED_RIPGREP_VERSION="$(dpkg-query -W -f='${Version}' ripgrep)"
-          if [ "$INSTALLED_FD_FIND_VERSION" != "$FD_FIND_VERSION" ]; then
-            echo "::error::fd-find package version $INSTALLED_FD_FIND_VERSION does not match $FD_FIND_VERSION"
-            exit 1
-          fi
-          if [ "$INSTALLED_RIPGREP_VERSION" != "$RIPGREP_VERSION" ]; then
-            echo "::error::ripgrep package version $INSTALLED_RIPGREP_VERSION does not match $RIPGREP_VERSION"
-            exit 1
-          fi
-
-          command -v fdfind >/dev/null
-          command -v rg >/dev/null
-          EXPECTED_FD_BINARY_VERSION="${FD_FIND_VERSION%%-*}"
-          EXPECTED_RG_BINARY_VERSION="${RIPGREP_VERSION%%-*}"
-          FD_BINARY_VERSION="$(fdfind --version)"
-          RG_BINARY_VERSION="$(rg --version)"
-          RG_BINARY_VERSION="${RG_BINARY_VERSION%%$'\n'*}"
-          if [ "$FD_BINARY_VERSION" != "fdfind $EXPECTED_FD_BINARY_VERSION" ]; then
-            echo "::error::fdfind binary version $FD_BINARY_VERSION does not match fdfind $EXPECTED_FD_BINARY_VERSION"
-            exit 1
-          fi
-          if [ "$RG_BINARY_VERSION" != "ripgrep $EXPECTED_RG_BINARY_VERSION" ]; then
-            echo "::error::rg binary version $RG_BINARY_VERSION does not match ripgrep $EXPECTED_RG_BINARY_VERSION"
-            exit 1
-          fi
-
-          # Install only from the trusted workflow checkout's committed lockfile.
-          # --ignore-scripts keeps package lifecycle code out of this secret-bearing job.
-          (
-            cd "$ADVISOR_DIR"
-            npm ci --ignore-scripts --no-audit --no-fund
-          )
+      - name: Restore trusted advisor runtime
+        env:
+          GITHUB_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          EXPECTED_RUNTIME_SHA: ${{ needs.build-advisor-runtime.outputs.payload-sha }}
+        run: bash "$ADVISOR_DIR/scripts/restore-pr-review-advisor-runtime.sh" "$RUNNER_TEMP/shared-pr-review-advisor-runtime"
 
       - name: Download GitHub review context
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pr-review-advisor-context-${{ github.run_id }}
           path: ${{ runner.temp }}/shared-pr-review-advisor-context
-
-      # Preparation reads the checked-out PR only before the model credential enters the environment.
-      - name: Prepare advisor sandbox inputs
-        env:
-          BASE_REF: ${{ github.event_name == 'pull_request_target' && 'target/base' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'target/base' || inputs.base_ref) }}
-          HEAD_REF: ${{ github.event_name == 'pull_request_target' && 'HEAD' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'HEAD' || inputs.head_ref) }}
-          PR_REVIEW_ADVISOR_GITHUB_CONTEXT_PATH: ${{ runner.temp }}/shared-pr-review-advisor-context/github-context.json
-        run: node --experimental-strip-types --no-warnings "$ADVISOR_DIR/tools/pr-review-advisor/specialist-lifecycle.mts" prepare
 
       # Shared lifecycle phases preserve the configure-only credential boundary.
       - name: Install OpenShell

--- a/scripts/package-pr-review-advisor-runtime.sh
+++ b/scripts/package-pr-review-advisor-runtime.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+: "${ADVISOR_DIR:?}" "${GITHUB_WORKFLOW_SHA:?}" "${GITHUB_RUN_ID:?}" "${GITHUB_RUN_ATTEMPT:?}"
+out="${1:?output directory required}"
+test -d "$ADVISOR_DIR/node_modules" && test ! -L "$ADVISOR_DIR/node_modules"
+rm -rf -- "$out"; mkdir -p -- "$out/stage/bin"
+cp -a -- "$ADVISOR_DIR/node_modules" "$out/stage/node_modules"
+for name in rg fdfind; do source_path="$(command -v "$name")"; test -f "$source_path" && test ! -L "$source_path"; cp -- "$source_path" "$out/stage/bin/$name"; done
+cp -- "$out/stage/bin/fdfind" "$out/stage/bin/fd"
+printf '%s\n' "$GITHUB_WORKFLOW_SHA" > "$out/stage/workflow-sha"
+printf '%s\n' "$GITHUB_RUN_ID" > "$out/stage/run-id"
+printf '%s\n' "$GITHUB_RUN_ATTEMPT" > "$out/stage/run-attempt"
+(cd "$out/stage" && tar --dereference --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner -cf ../runtime.tar .)
+sha256sum "$out/runtime.tar" | awk '{print $1}' > "$out/runtime.sha256"
+chmod 0600 "$out/runtime.tar" "$out/runtime.sha256"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then printf 'payload-sha=%s\n' "$(<"$out/runtime.sha256")" >> "$GITHUB_OUTPUT"; fi
+rm -rf -- "$out/stage"

--- a/scripts/restore-pr-review-advisor-runtime.sh
+++ b/scripts/restore-pr-review-advisor-runtime.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+: "${ADVISOR_DIR:?}" "${GITHUB_WORKFLOW_SHA:?}" "${GITHUB_RUN_ID:?}" "${EXPECTED_RUNTIME_SHA:?}" "${RUNNER_TEMP:?}" "${GITHUB_PATH:?}"
+artifact="${1:?artifact directory required}"; payload="$artifact/runtime.tar"
+test -f "$payload" && test ! -L "$payload"
+actual_sha="$(sha256sum "$payload" | awk '{print $1}')"; test "$actual_sha" = "$EXPECTED_RUNTIME_SHA"
+while IFS= read -r member; do case "$member" in .|./|./node_modules|./node_modules/|./node_modules/*|./bin|./bin/|./bin/rg|./bin/fdfind|./bin/fd|./workflow-sha|./run-id|./run-attempt) ;; *) echo "::error::unexpected advisor runtime member: $member"; exit 1;; esac; done < <(tar -tf "$payload")
+if tar -tvf "$payload" | awk '$1 !~ /^[d-]/ { bad=1 } END { exit bad ? 0 : 1 }'; then echo "::error::advisor runtime contains a link or special entry"; exit 1; fi
+stage="$(mktemp -d "$RUNNER_TEMP/advisor-runtime.XXXXXX")"; trap 'rm -rf -- "$stage"' EXIT
+tar --no-same-owner --no-same-permissions -xf "$payload" -C "$stage"
+test "$(<"$stage/workflow-sha")" = "$GITHUB_WORKFLOW_SHA"; test "$(<"$stage/run-id")" = "$GITHUB_RUN_ID"
+case "$(<"$stage/run-attempt")" in ''|*[!0-9]*) exit 1;; esac
+test -d "$stage/node_modules" && test ! -L "$stage/node_modules"
+for name in rg fdfind fd; do test -f "$stage/bin/$name" && test ! -L "$stage/bin/$name"; done
+test ! -e "$ADVISOR_DIR/node_modules"; mv -- "$stage/node_modules" "$ADVISOR_DIR/node_modules"
+runtime_bin="$RUNNER_TEMP/pr-review-advisor-runtime-bin"; rm -rf -- "$runtime_bin"; mv -- "$stage/bin" "$runtime_bin"
+printf '%s\n' "$runtime_bin" >> "$GITHUB_PATH"

--- a/test/automation/pull-requests/advisor-session-runner.test.ts
+++ b/test/automation/pull-requests/advisor-session-runner.test.ts
@@ -360,16 +360,26 @@ afterEach(() => {
 });
 
 describe("advisor session runner", () => {
-  it("uses one bounded provider-aware retry layer for transient failures", () => {
-    expect(advisorRetrySettings("azure/openai/gpt-5.6-terra")).toEqual({
+  it("uses one bounded, specialist-spread retry layer for transient failures", () => {
+    const behavior = advisorRetrySettings(
+      "azure/openai/gpt-5.6-terra",
+      "pr-review-behavior",
+    );
+    const dependencyUse = advisorRetrySettings(
+      "openai/openai/gpt-5.6-terra",
+      "pr-review-dependency-use",
+    );
+
+    expect(behavior).toEqual({
       enabled: true,
-      maxRetries: 4,
-      baseDelayMs: 6_000,
+      maxRetries: 5,
+      baseDelayMs: 13_909,
       provider: {
         maxRetries: 0,
         maxRetryDelayMs: 60_000,
       },
     });
+    expect(dependencyUse.baseDelayMs).toBe(14_827);
   });
 
   it("configures Pi's proxy transport before an OpenShell SDK session", async () => {

--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -277,6 +277,37 @@ describe("PR review advisor specialist lifecycle", () => {
     expect(calls).toEqual(["create", "run", "download", "remove"]);
   });
 
+  it("reports deterministic specialist lifecycle phase durations", async () => {
+    const timingLines: string[] = [];
+    const timestamps = [0, 11, 11, 34, 34, 71, 71, 76, 76, 83];
+    const lifecycle: AdvisorSpecialistLifecycle = {
+      prepare: async () => undefined,
+      startGateway: () => ({ configure: Promise.resolve() }),
+      create: () => undefined,
+      run: () => undefined,
+      download: () => undefined,
+      remove: () => undefined,
+    };
+
+    await runAdvisorSpecialist({
+      env: {},
+      lifecycle,
+      validate: () => undefined,
+      timing: {
+        now: () => timestamps.shift() as number,
+        write: (line) => timingLines.push(line),
+      },
+    });
+
+    expect(timingLines).toEqual([
+      "PR Review Advisor timing: phase=configure duration_ms=11",
+      "PR Review Advisor timing: phase=sandbox-create-readiness duration_ms=23",
+      "PR Review Advisor timing: phase=pi-run duration_ms=37",
+      "PR Review Advisor timing: phase=artifact-download-validation duration_ms=5",
+      "PR Review Advisor timing: phase=cleanup duration_ms=7",
+    ]);
+  });
+
   it.each([
     { failedStage: "configure", expectedDownload: false },
     { failedStage: "create", expectedDownload: false },

--- a/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-openshell.test.ts
@@ -969,8 +969,7 @@ describe("PR review advisor OpenShell wrapper", () => {
         "advisor",
         "--model",
         DEFAULT_ADVISOR_MODEL,
-        "--timeout",
-        "900",
+        "--no-verify",
       ],
       expect.anything(),
     ]);
@@ -981,8 +980,7 @@ describe("PR review advisor OpenShell wrapper", () => {
     expect(providerCalls).toHaveLength(1);
     expect(providerCalls[0]?.[2].env.OPENAI_API_KEY).toBe("model-host-secret");
     expect(providerCalls[0]?.[2].timeout).toBeGreaterThan(0);
-    const inferenceCall = calls.find(([, args]) => args.slice(0, 2).join(" ") === "inference set");
-    expect(inferenceCall?.[2].timeout).toBeGreaterThan(900_000);
+    expect(calls.filter(([, args]) => args.slice(0, 2).join(" ") === "inference set")).toHaveLength(1);
     calls.forEach(([command, args, options]) => {
       expect(options.env.GH_TOKEN, `${command} ${args.join(" ")}`).toBeUndefined();
       expect(options.env.GITHUB_TOKEN, `${command} ${args.join(" ")}`).toBeUndefined();

--- a/test/automation/pull-requests/pr-review-advisor-runtime-artifact.test.ts
+++ b/test/automation/pull-requests/pr-review-advisor-runtime-artifact.test.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const packageScript = path.join(root, "scripts/package-pr-review-advisor-runtime.sh");
+const restoreScript = path.join(root, "scripts/restore-pr-review-advisor-runtime.sh");
+
+function fixture() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "advisor-runtime-"));
+  const advisor = path.join(directory, "advisor");
+  const bin = path.join(directory, "bin");
+  fs.mkdirSync(path.join(advisor, "node_modules", "package"), { recursive: true });
+  fs.mkdirSync(bin);
+  fs.writeFileSync(path.join(advisor, "node_modules", "package", "index.js"), "export {};\n");
+  for (const name of ["rg", "fdfind"])
+    fs.writeFileSync(path.join(bin, name), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+  return { directory, advisor, bin };
+}
+
+function environment(input: ReturnType<typeof fixture>): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ADVISOR_DIR: input.advisor,
+    GITHUB_WORKFLOW_SHA: "a".repeat(40),
+    GITHUB_RUN_ID: "1234",
+    GITHUB_RUN_ATTEMPT: "2",
+    RUNNER_TEMP: input.directory,
+    GITHUB_PATH: path.join(input.directory, "github-path"),
+    PATH: `${input.bin}:${process.env.PATH ?? ""}`,
+  };
+}
+
+describe("PR Review Advisor runtime artifact", () => {
+  it("packages and restores the trusted runtime", () => {
+    const input = fixture();
+    const env = environment(input);
+    const artifact = path.join(input.directory, "artifact");
+    execFileSync(packageScript, [artifact], { env });
+    fs.rmSync(path.join(input.advisor, "node_modules"), { recursive: true });
+    env.EXPECTED_RUNTIME_SHA = fs
+      .readFileSync(path.join(artifact, "runtime.sha256"), "utf8")
+      .trim();
+    execFileSync(restoreScript, [artifact], { env });
+    expect(fs.readFileSync(path.join(input.advisor, "node_modules/package/index.js"), "utf8")).toBe(
+      "export {};\n",
+    );
+    expect(fs.readFileSync(env.GITHUB_PATH as string, "utf8")).toContain("pr-review-advisor-runtime-bin");
+  });
+
+  it("rejects a payload whose digest changed", () => {
+    const input = fixture();
+    const env = environment(input);
+    const artifact = path.join(input.directory, "artifact");
+    execFileSync(packageScript, [artifact], { env });
+    fs.rmSync(path.join(input.advisor, "node_modules"), { recursive: true });
+    env.EXPECTED_RUNTIME_SHA = "0".repeat(64);
+    expect(() => execFileSync(restoreScript, [artifact], { env })).toThrow();
+    expect(fs.existsSync(path.join(input.advisor, "node_modules"))).toBe(false);
+  });
+});

--- a/tools/advisors/session.mts
+++ b/tools/advisors/session.mts
@@ -70,11 +70,15 @@ export {
 
 const ADVISOR_BASE_URL_ENV = "PR_REVIEW_ADVISOR_BASE_URL";
 
-export function advisorRetrySettings(_modelId?: string) {
+export function advisorRetrySettings(modelId = DEFAULT_ADVISOR_MODEL, identity = "advisor") {
+  let hash = 0;
+  for (const character of `${modelId}:${identity}`) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
+  }
   return {
     enabled: true,
-    maxRetries: 4,
-    baseDelayMs: 6_000,
+    maxRetries: 5,
+    baseDelayMs: 12_000 + (hash % 8_000),
     provider: {
       maxRetries: 0,
       maxRetryDelayMs: 60_000,
@@ -381,7 +385,7 @@ export async function runReadOnlyAdvisor(
 
   const settingsManager = SettingsManager.inMemory({
     compaction: { enabled: false },
-    retry: advisorRetrySettings(),
+    retry: advisorRetrySettings(modelId, options.logPrefix),
   });
   const resourceLoader = new DefaultResourceLoader({
     cwd: options.cwd,

--- a/tools/openshell-agent/runtime.mts
+++ b/tools/openshell-agent/runtime.mts
@@ -58,26 +58,9 @@ export type OpenShellUpload = {
   destination: string;
 };
 
-const INFERENCE_CONFIGURATION_ATTEMPTS = 6;
 const PROVIDER_CONFIGURATION_TIMEOUT_MS = 60_000;
-const INFERENCE_CONFIGURATION_TIMEOUT_MS = 930_000;
 const PROCESS_TERMINATION_GRACE_MS = 250;
 const PROCESS_KILL_TIMEOUT_MS = 5_000;
-
-function inferenceConfigurationRetryDelay(
-  env: NodeJS.ProcessEnv,
-  input: OpenShellInferenceOptions,
-  attempt: number,
-): number {
-  const identity = [
-    input.modelId,
-    env.PR_REVIEW_ADVISOR_INTEREST ?? "primary",
-    env.SANDBOX_NAME ?? input.gatewayId,
-  ].join(":");
-  let hash = 0;
-  for (const character of identity) hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
-  return 2000 * 2 ** attempt + (hash % 8000);
-}
 
 export type CreateOpenShellSandboxOptions = {
   command: readonly string[];
@@ -362,22 +345,9 @@ function startOpenShellInference(
         input.providerName,
         "--model",
         input.modelId,
-        "--timeout",
-        "900",
+        "--no-verify",
       ] as const;
-      for (let attempt = 0; attempt < INFERENCE_CONFIGURATION_ATTEMPTS; attempt += 1) {
-        try {
-          tools.run("openshell", inferenceArgs, {
-            env: commandEnv,
-            timeout: INFERENCE_CONFIGURATION_TIMEOUT_MS,
-          });
-          return;
-        } catch (error) {
-          if (attempt === INFERENCE_CONFIGURATION_ATTEMPTS - 1) throw error;
-          await tools.wait(inferenceConfigurationRetryDelay(env, input, attempt));
-        }
-      }
-      throw new OpenShellAgentError("OpenShell inference configuration did not complete");
+      tools.run("openshell", inferenceArgs, { env: commandEnv });
     } catch (error) {
       if (input.ownGateway) {
         try {

--- a/tools/pr-review-advisor/specialist-lifecycle.mts
+++ b/tools/pr-review-advisor/specialist-lifecycle.mts
@@ -43,6 +43,26 @@ function diagnostic(error: unknown): string {
     error instanceof Error ? error.message : "Unknown non-Error failure",
   );
 }
+
+type AdvisorLifecycleTiming = {
+  now?: () => number;
+  write?: (line: string) => void;
+};
+
+async function timeLifecyclePhase<T>(
+  phase: string,
+  timing: AdvisorLifecycleTiming | undefined,
+  action: () => T | Promise<T>,
+): Promise<T> {
+  const now = timing?.now ?? performance.now.bind(performance);
+  const write = timing?.write ?? console.log;
+  const started = now();
+  try {
+    return await action();
+  } finally {
+    write(`PR Review Advisor timing: phase=${phase} duration_ms=${Math.round(now() - started)}`);
+  }
+}
 export const defaultAdvisorSpecialistLifecycle: AdvisorSpecialistLifecycle = {
   prepare: prepareAdvisorSandboxInputs,
   startGateway: startAdvisorOpenShellInference,
@@ -65,6 +85,7 @@ export async function runAdvisorSpecialist(input: {
   validate?: () => void;
   setActiveCleanup?: (cleanup: (() => Promise<void>) | undefined) => void;
   cancelled?: () => boolean;
+  timing?: AdvisorLifecycleTiming;
 }): Promise<"complete" | "cancelled"> {
   const lifecycle = input.lifecycle ?? defaultAdvisorSpecialistLifecycle;
   const env = {
@@ -122,47 +143,55 @@ export async function runAdvisorSpecialist(input: {
     if (input.prepare !== false) await lifecycle.prepare(env);
     if (input.cancelled?.()) result = "cancelled";
     stage = "configure";
-    if (result === "complete") gateway = lifecycle.startGateway(env);
-    input.setActiveCleanup?.(cleanup);
-    await gateway?.configure;
+    await timeLifecyclePhase("configure", input.timing, async () => {
+      if (result === "complete") gateway = lifecycle.startGateway(env);
+      input.setActiveCleanup?.(cleanup);
+      await gateway?.configure;
+    });
     if (input.cancelled?.()) result = "cancelled";
     if (result === "complete") {
       stage = "create";
       // The cryptographically unique name is owned by this invocation before creation starts,
       // so cleanup can reconcile a sandbox left by a partially failed create command.
       sandbox = true;
-      lifecycle.create(env);
+      await timeLifecyclePhase("sandbox-create-readiness", input.timing, () =>
+        lifecycle.create(env),
+      );
       stage = "run";
-      execution = lifecycle.run(env) || undefined;
-      if (execution) {
-        const cancellation = new Promise<"cancelled">(
-          (resolve) => (settleCancellation = () => resolve("cancelled")),
-        );
-        const completion = execution.completion.then(
-          () => ({ error: undefined }),
-          (error: unknown) => ({ error }),
-        );
-        const settled = await Promise.race([completion, cancellation]);
-        if (settled === "cancelled" || input.cancelled?.()) result = "cancelled";
-        else {
-          execution = undefined;
-          settleCancellation = undefined;
-          if (settled.error) throw settled.error;
+      await timeLifecyclePhase("pi-run", input.timing, async () => {
+        execution = lifecycle.run(env) || undefined;
+        if (execution) {
+          const cancellation = new Promise<"cancelled">(
+            (resolve) => (settleCancellation = () => resolve("cancelled")),
+          );
+          const completion = execution.completion.then(
+            () => ({ error: undefined }),
+            (error: unknown) => ({ error }),
+          );
+          const settled = await Promise.race([completion, cancellation]);
+          if (settled === "cancelled" || input.cancelled?.()) result = "cancelled";
+          else {
+            execution = undefined;
+            settleCancellation = undefined;
+            if (settled.error) throw settled.error;
+          }
         }
-      }
+      });
       if (input.cancelled?.()) result = "cancelled";
       if (result === "complete") {
         stage = "download";
-        lifecycle.download(env);
-        stage = "validate";
-        input.validate?.();
+        await timeLifecyclePhase("artifact-download-validation", input.timing, () => {
+          lifecycle.download(env);
+          stage = "validate";
+          input.validate?.();
+        });
       }
     }
   } catch (error) {
     primary = failure(stage, env, error);
   } finally {
     try {
-      await cleanup();
+      await timeLifecyclePhase("cleanup", input.timing, cleanup);
     } catch (error) {
       cleanupError = error;
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

PR Review Advisor now centralizes rate-limit recovery in Pi, reports phase timings, and installs its locked runtime once per workflow run instead of once per specialist.

## Reason

Concurrent OpenShell verification and layered retries amplified requests to the shared inference endpoint, while nine identical dependency installations added avoidable workflow work.

## Changes

- Skip OpenShell model verification and let Pi perform bounded, specialist-spread retries without nested provider retries.
- Report configure, sandbox readiness, Pi execution, artifact handling, and cleanup durations in specialist logs.
- Build one credential-free runtime artifact from the trusted workflow revision, verify its digest and provenance, and restore it in every specialist job.

## Verification

- Contributor validation: focused validation passed; the full hook is currently blocked by unrelated nested `.dsh-worktrees` source-shape noise.
- Tests: `npx vitest run --project integration test/automation/pull-requests/pr-review-advisor-runtime-artifact.test.ts test/automation/pull-requests/pr-review-advisor-openshell.test.ts test/automation/pull-requests/advisor-session-runner.test.ts` (83 passed).
- Typecheck: `npm run typecheck:cli` passed.
- Workflow YAML parsed with the repository `yaml` package.
- Secrets review: the diff contains no secrets, API keys, or credentials.

---

Signed-off-by: Cesar Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - PR review advisor workflows now use a packaged runtime that is validated before execution.
  - Runtime archives undergo integrity and safety checks before restoration.
  - Advisor retries now support five attempts with deterministic, specialist-specific delays.
  - Inference configuration uses a single streamlined setup without the previous timeout behavior.
  - Specialist lifecycle phases now report timing information for improved visibility.

- **Tests**
  - Added coverage for runtime packaging, restoration, integrity failures, retry settings, and lifecycle timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->