### PR TITLE
refactor(inference): remove duplicate Ollama probe coverage

### DIFF
--- a/src/lib/inference/local.ts
+++ b/src/lib/inference/local.ts
@@ -512,7 +512,7 @@ function runOllamaLocalCurlProbe(
   host: string,
   runCaptureExImpl: RunCaptureExFn = runCaptureEx,
 ): CurlProbeResult {
-  const command = getOllamaApiCommand(buildValidatedCurlCommandArgs(["-f", ...argv]), host);
+  const command = ["curl", ...buildValidatedCurlCommandArgs(["-f", ...argv])];
   const result = createOllamaApiCaptureEx(runCaptureExImpl, host)(command);
   const ok = result.exitCode === 0;
   const stderr = String(result.stderr ?? "");

--- a/test/e2e/support/e2e-clients.test.ts
+++ b/test/e2e/support/e2e-clients.test.ts
@@ -7,10 +7,6 @@ import path from "node:path";
 
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import {
-  getOllamaApiCommand,
-  OLLAMA_HOST_DOCKER_INTERNAL,
-} from "../../../src/lib/inference/local.ts";
-import {
   assertExitZero,
   type CommandRunner,
   GatewayClient,
@@ -81,21 +77,6 @@ class FakeRunner implements CommandRunner {
 }
 
 describe("E2E fixture clients", () => {
-  it("uses a digest-pinned image for the live Windows-host transport", () => {
-    const command = getOllamaApiCommand(
-      ["-sf", "http://host.docker.internal:11434/api/tags"],
-      OLLAMA_HOST_DOCKER_INTERNAL,
-    );
-
-    expect(command.slice(0, 4)).toEqual([
-      "docker",
-      "run",
-      "--rm",
-      expect.stringMatching(/^docker\.io\/curlimages\/curl@sha256:[a-f0-9]{64}$/u),
-    ]);
-    expect(command).not.toContain("curlimages/curl:8.10.1");
-  });
-
   it.each([
     "a2345678901234567890",
     "e2e--sandbox",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Windows-host Ollama curl probes now have one transport-translation owner, and the E2E support suite no longer duplicates the focused inference transport test.

## Reason

A post-merge review of #10741 identified one redundant pre-translation before the shared capture wrapper and one duplicate helper-output test. Both added maintenance surface without distinct behavior coverage.

## Changes

- Pass the validated raw curl command to `createOllamaApiCaptureEx`, which owns Docker Desktop translation and credential isolation.
- Remove the duplicate E2E support assertion; retain the focused Windows transport boundary suite.

## Verification

- Windows-host transport suite: 20 tests passed.
- Local inference suite: 97 tests passed.
- E2E fixture client suite: 75 tests passed.
- `npm run typecheck:cli` passed.
- Repository hooks passed formatting, lint, repository checks, secret scan, source-shape budget, and growth guardrails.
- The public diff and PR text contain no private bug identifiers or non-public third-party names.

## Review notes

This is a narrow follow-up to #10741. It does not change the supported host allowlist, Docker credential isolation, cleanup behavior, or public command surface.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local Ollama connectivity probing across Docker host environments.
  * Preserved existing probe behavior and result handling while improving command execution compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->