### PR TITLE
fix(review): resolve runtime tool symlinks

### DIFF
--- a/scripts/package-pr-review-advisor-runtime.sh
+++ b/scripts/package-pr-review-advisor-runtime.sh
@@ -7,7 +7,7 @@ out="${1:?output directory required}"
 test -d "$ADVISOR_DIR/node_modules" && test ! -L "$ADVISOR_DIR/node_modules"
 rm -rf -- "$out"; mkdir -p -- "$out/stage/bin"
 cp -a -- "$ADVISOR_DIR/node_modules" "$out/stage/node_modules"
-for name in rg fdfind; do source_path="$(command -v "$name")"; test -f "$source_path" && test ! -L "$source_path"; cp -- "$source_path" "$out/stage/bin/$name"; done
+for name in rg fdfind; do source_path="$(readlink -f "$(command -v "$name")")"; test -f "$source_path" && test ! -L "$source_path"; cp -- "$source_path" "$out/stage/bin/$name"; done
 cp -- "$out/stage/bin/fdfind" "$out/stage/bin/fd"
 printf '%s\n' "$GITHUB_WORKFLOW_SHA" > "$out/stage/workflow-sha"
 printf '%s\n' "$GITHUB_RUN_ID" > "$out/stage/run-id"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The trusted advisor runtime packager now resolves distribution-provided tool symlinks before validating and copying their regular-file targets.

## Reason

Ubuntu 24.04 provides `/usr/bin/fdfind` as a symlink, so the new runtime producer exited before uploading its artifact and skipped every specialist.

## Changes

- Resolve `rg` and `fdfind` through `readlink -f` before regular-file validation and packaging.

## Verification

- Per maintainer request, no local validation was run to expedite the production repair.
- The failure was reproduced at the exact `test ! -L /usr/bin/fdfind` guard before this change.
- Secrets review: the diff contains no secrets, API keys, or credentials.

---

Signed-off-by: Cesar Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaging reliability by resolving search utility commands to their canonical executable paths before including them in the runtime bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->