### PR TITLE
fix(review): flatten runtime hard links

### DIFF
--- a/scripts/package-pr-review-advisor-runtime.sh
+++ b/scripts/package-pr-review-advisor-runtime.sh
@@ -12,7 +12,7 @@ cp -- "$out/stage/bin/fdfind" "$out/stage/bin/fd"
 printf '%s\n' "$GITHUB_WORKFLOW_SHA" > "$out/stage/workflow-sha"
 printf '%s\n' "$GITHUB_RUN_ID" > "$out/stage/run-id"
 printf '%s\n' "$GITHUB_RUN_ATTEMPT" > "$out/stage/run-attempt"
-(cd "$out/stage" && tar --dereference --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner -cf ../runtime.tar .)
+(cd "$out/stage" && tar --dereference --hard-dereference --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner -cf ../runtime.tar .)
 sha256sum "$out/runtime.tar" | awk '{print $1}' > "$out/runtime.sha256"
 chmod 0600 "$out/runtime.tar" "$out/runtime.sha256"
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then printf 'payload-sha=%s\n' "$(<"$out/runtime.sha256")" >> "$GITHUB_OUTPUT"; fi


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Advisor runtime archives now contain ordinary files instead of GNU tar hard-link entries, allowing the strict consumer validation to restore them.

## Reason

Even with symlink dereferencing enabled, GNU tar deduplicated identical npm files as hard links. The runtime consumer intentionally rejects links and special entries, so every specialist stopped during restore.

## Changes

- Add `--hard-dereference` when packaging the trusted runtime.
- Preserve the consumer's strict regular-file and directory policy.

## Verification

- Inspected the failed artifact and confirmed its rejected entries were GNU tar hard links within `node_modules`.
- This one-line repair causes GNU tar to store those entries as ordinary file contents.
- Secrets review: the diff contains no secrets, API keys, or credentials.

---

Signed-off-by: Cesar Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime package archives now correctly include the contents of hard-linked files, improving archive reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->