### PR TITLE
fix: reject reserved custom policy keys during dry-run

### DIFF
--- a/src/lib/actions/sandbox/policy-channel-refresh.test.ts
+++ b/src/lib/actions/sandbox/policy-channel-refresh.test.ts
@@ -214,6 +214,31 @@ describe("applyExternalPreset refresh contract (--from-file)", () => {
     expect(refreshSpy).not.toHaveBeenCalled();
   });
 
+  it("rejects a reserved network policy key during --from-file dry-run (#10773)", async () => {
+    loadPresetFromFileMock.mockRestore();
+    fs.writeFileSync(
+      tempFile,
+      `preset:
+  name: qa-npm-test
+network_policies:
+  npm_yarn:
+    name: npm_yarn
+    endpoints:
+      - { host: api.example.com, port: 443, protocol: rest }
+`,
+    );
+
+    await expect(
+      captureExit(() => addSandboxPolicy("alpha", { fromFile: tempFile, yes: true, dryRun: true })),
+    ).resolves.toBe(1);
+
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Custom presets cannot own reserved network policy key 'npm_yarn'"),
+    );
+    expect(applyPresetContentMock).not.toHaveBeenCalled();
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
   it("rejects a link-local metadata endpoint during --from-file dry-run", async () => {
     loadPresetFromFileMock.mockReturnValue({
       presetName: "metadata",

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -2269,9 +2269,7 @@ function applyPresetContent(
       console.error(`  Preset '${presetName}' has invalid or missing network_policies.`);
       return false;
     }
-    const reservedKey = [OPENCLAW_NPM_PRESET_KEY, PERSONAL_OPEN_INTERNET_POLICY_KEY].find((key) =>
-      Object.prototype.hasOwnProperty.call(np, key),
-    );
+    const reservedKey = reservedCustomNetworkPolicyKey(np);
     if (reservedKey) {
       console.error(`  Custom presets cannot own reserved network policy key '${reservedKey}'.`);
       return false;
@@ -2638,6 +2636,14 @@ function applyPresets(sandboxName: string, presetNames: string[]): boolean {
  * a name collision with a built-in preset (built-ins must be addressed by
  * their own name, so the custom file must be renamed).
  */
+function reservedCustomNetworkPolicyKey(networkPolicies: PolicyObject): string | null {
+  return (
+    [OPENCLAW_NPM_PRESET_KEY, PERSONAL_OPEN_INTERNET_POLICY_KEY].find((key) =>
+      Object.prototype.hasOwnProperty.call(networkPolicies, key),
+    ) ?? null
+  );
+}
+
 function loadPresetFromFile(filePath: string): { presetName: string; content: string } | null {
   const abs = path.resolve(filePath);
   if (!/\.ya?ml$/i.test(abs)) {
@@ -2733,6 +2739,11 @@ function loadPresetFromFile(filePath: string): { presetName: string; content: st
     return null;
   }
   const np = parsed.network_policies as PolicyObject;
+  const reservedKey = reservedCustomNetworkPolicyKey(np);
+  if (reservedKey) {
+    console.error(`  Custom presets cannot own reserved network policy key '${reservedKey}': ${filePath}`);
+    return null;
+  }
   if (networkPoliciesHasAllowedIps(np)) {
     console.error(
       `  Preset '${presetName}' contains 'allowed_ips', which is not permitted in user-supplied presets: ${filePath}`,

--- a/src/lib/policy/preset-allowed-ips.test.ts
+++ b/src/lib/policy/preset-allowed-ips.test.ts
@@ -88,6 +88,24 @@ network_policies:
     expect(loadPresetFromFile(file)).toBeNull();
   });
 
+  it("rejects a custom preset that owns the reserved npm policy key (#10773)", () => {
+    const file = writePreset(
+      "reserved-npm",
+      `\
+preset:
+  name: reserved-npm
+  description: user-authored reserved policy key
+network_policies:
+  npm_yarn:
+    name: npm_yarn
+    endpoints:
+      - host: api.example.com
+        port: 443
+`,
+    );
+    expect(loadPresetFromFile(file)).toBeNull();
+  });
+
   it("accepts a valid preset with no allowed_ips", () => {
     const file = writePreset(
       "good-preset",


### PR DESCRIPTION
## Summary
- reject user-supplied preset files that own reserved network policy keys during `loadPresetFromFile`
- share the reserved-key check used by the real apply path so `--from-file --dry-run` fails before rendering a preview
- add regression coverage for the dry-run channel path and preset-file loader

Fixes #10773.

## Checks
- `npm run build:policy-boundary`
- `npm run catalog:compile`
- `npm exec vitest run -- --project cli src/lib/policy/preset-allowed-ips.test.ts src/lib/actions/sandbox/policy-channel-refresh.test.ts`
- `npm run format:check -- src/lib/policy/index.ts src/lib/policy/preset-allowed-ips.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom policy presets now consistently reject reserved network-policy keys, including `npm_yarn` and `personal_open_internet`.
  * Invalid presets loaded from files are rejected before they can be applied or refresh sandbox policy settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->