### PR TITLE
fix(review): restore sandbox input preparation

### DIFF
--- a/.github/workflows/pr-review-advisor.yaml
+++ b/.github/workflows/pr-review-advisor.yaml
@@ -262,6 +262,14 @@ jobs:
           name: pr-review-advisor-context-${{ github.run_id }}
           path: ${{ runner.temp }}/shared-pr-review-advisor-context
 
+      # Preparation reads the checked-out PR only before the model credential enters the environment.
+      - name: Prepare advisor sandbox inputs
+        env:
+          BASE_REF: ${{ github.event_name == 'pull_request_target' && 'target/base' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'target/base' || inputs.base_ref) }}
+          HEAD_REF: ${{ github.event_name == 'pull_request_target' && 'HEAD' || (github.event_name == 'workflow_dispatch' && inputs.target_repo != '' && inputs.target_pr != '' && 'HEAD' || inputs.head_ref) }}
+          PR_REVIEW_ADVISOR_GITHUB_CONTEXT_PATH: ${{ runner.temp }}/shared-pr-review-advisor-context/github-context.json
+        run: node --experimental-strip-types --no-warnings "$ADVISOR_DIR/tools/pr-review-advisor/specialist-lifecycle.mts" prepare
+
       # Shared lifecycle phases preserve the configure-only credential boundary.
       - name: Install OpenShell
         run: |


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

PR Review Advisor specialist jobs once again prepare their immutable sandbox context before starting OpenShell.

## Reason

The shared-runtime workflow edit accidentally removed the preparation step. Post-merge runs restored the runtime successfully but every specialist failed with `ENOENT` for `$RUNNER_TEMP/pr-review-advisor-context`.

## Changes

- Restore the trusted `specialist-lifecycle.mts prepare` step after downloading shared GitHub context.
- Keep preparation before the model credential enters the environment.

## Verification

- Post-merge runs 33589415726 and 33589410649 verified runtime build, download, and restore, then failed at sandbox creation because the prepared context directory was absent.
- Confirmed the merged workflow lacked this step and restored the prior trusted invocation and environment.
- Secrets review: the diff contains no secrets, API keys, or credentials.

---

Signed-off-by: Cesar Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a preparation step to the pull request review workflow before model credentials are made available.
  * The review advisor now receives the selected base and head references and the downloaded review context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->