### PR TITLE
fix(ci): format advisor runtime scripts

### DIFF
--- a/scripts/package-pr-review-advisor-runtime.sh
+++ b/scripts/package-pr-review-advisor-runtime.sh
@@ -5,15 +5,20 @@ set -euo pipefail
 : "${ADVISOR_DIR:?}" "${GITHUB_WORKFLOW_SHA:?}" "${GITHUB_RUN_ID:?}" "${GITHUB_RUN_ATTEMPT:?}"
 out="${1:?output directory required}"
 test -d "$ADVISOR_DIR/node_modules" && test ! -L "$ADVISOR_DIR/node_modules"
-rm -rf -- "$out"; mkdir -p -- "$out/stage/bin"
+rm -rf -- "$out"
+mkdir -p -- "$out/stage/bin"
 cp -a -- "$ADVISOR_DIR/node_modules" "$out/stage/node_modules"
-for name in rg fdfind; do source_path="$(readlink -f "$(command -v "$name")")"; test -f "$source_path" && test ! -L "$source_path"; cp -- "$source_path" "$out/stage/bin/$name"; done
+for name in rg fdfind; do
+  source_path="$(readlink -f "$(command -v "$name")")"
+  test -f "$source_path" && test ! -L "$source_path"
+  cp -- "$source_path" "$out/stage/bin/$name"
+done
 cp -- "$out/stage/bin/fdfind" "$out/stage/bin/fd"
-printf '%s\n' "$GITHUB_WORKFLOW_SHA" > "$out/stage/workflow-sha"
-printf '%s\n' "$GITHUB_RUN_ID" > "$out/stage/run-id"
-printf '%s\n' "$GITHUB_RUN_ATTEMPT" > "$out/stage/run-attempt"
+printf '%s\n' "$GITHUB_WORKFLOW_SHA" >"$out/stage/workflow-sha"
+printf '%s\n' "$GITHUB_RUN_ID" >"$out/stage/run-id"
+printf '%s\n' "$GITHUB_RUN_ATTEMPT" >"$out/stage/run-attempt"
 (cd "$out/stage" && tar --dereference --hard-dereference --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner -cf ../runtime.tar .)
-sha256sum "$out/runtime.tar" | awk '{print $1}' > "$out/runtime.sha256"
+sha256sum "$out/runtime.tar" | awk '{print $1}' >"$out/runtime.sha256"
 chmod 0600 "$out/runtime.tar" "$out/runtime.sha256"
-if [[ -n "${GITHUB_OUTPUT:-}" ]]; then printf 'payload-sha=%s\n' "$(<"$out/runtime.sha256")" >> "$GITHUB_OUTPUT"; fi
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then printf 'payload-sha=%s\n' "$(<"$out/runtime.sha256")" >>"$GITHUB_OUTPUT"; fi
 rm -rf -- "$out/stage"

--- a/scripts/restore-pr-review-advisor-runtime.sh
+++ b/scripts/restore-pr-review-advisor-runtime.sh
@@ -3,17 +3,31 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 : "${ADVISOR_DIR:?}" "${GITHUB_WORKFLOW_SHA:?}" "${GITHUB_RUN_ID:?}" "${EXPECTED_RUNTIME_SHA:?}" "${RUNNER_TEMP:?}" "${GITHUB_PATH:?}"
-artifact="${1:?artifact directory required}"; payload="$artifact/runtime.tar"
+artifact="${1:?artifact directory required}"
+payload="$artifact/runtime.tar"
 test -f "$payload" && test ! -L "$payload"
-actual_sha="$(sha256sum "$payload" | awk '{print $1}')"; test "$actual_sha" = "$EXPECTED_RUNTIME_SHA"
-while IFS= read -r member; do case "$member" in .|./|./node_modules|./node_modules/|./node_modules/*|./bin|./bin/|./bin/rg|./bin/fdfind|./bin/fd|./workflow-sha|./run-id|./run-attempt) ;; *) echo "::error::unexpected advisor runtime member: $member"; exit 1;; esac; done < <(tar -tf "$payload")
-if tar -tvf "$payload" | awk '$1 !~ /^[d-]/ { bad=1 } END { exit bad ? 0 : 1 }'; then echo "::error::advisor runtime contains a link or special entry"; exit 1; fi
-stage="$(mktemp -d "$RUNNER_TEMP/advisor-runtime.XXXXXX")"; trap 'rm -rf -- "$stage"' EXIT
+actual_sha="$(sha256sum "$payload" | awk '{print $1}')"
+test "$actual_sha" = "$EXPECTED_RUNTIME_SHA"
+while IFS= read -r member; do case "$member" in . | ./ | ./node_modules | ./node_modules/ | ./node_modules/* | ./bin | ./bin/ | ./bin/rg | ./bin/fdfind | ./bin/fd | ./workflow-sha | ./run-id | ./run-attempt) ;; *)
+  echo "::error::unexpected advisor runtime member: $member"
+  exit 1
+  ;;
+esac done < <(tar -tf "$payload")
+if tar -tvf "$payload" | awk '$1 !~ /^[d-]/ { bad=1 } END { exit bad ? 0 : 1 }'; then
+  echo "::error::advisor runtime contains a link or special entry"
+  exit 1
+fi
+stage="$(mktemp -d "$RUNNER_TEMP/advisor-runtime.XXXXXX")"
+trap 'rm -rf -- "$stage"' EXIT
 tar --no-same-owner --no-same-permissions -xf "$payload" -C "$stage"
-test "$(<"$stage/workflow-sha")" = "$GITHUB_WORKFLOW_SHA"; test "$(<"$stage/run-id")" = "$GITHUB_RUN_ID"
-case "$(<"$stage/run-attempt")" in ''|*[!0-9]*) exit 1;; esac
+test "$(<"$stage/workflow-sha")" = "$GITHUB_WORKFLOW_SHA"
+test "$(<"$stage/run-id")" = "$GITHUB_RUN_ID"
+case "$(<"$stage/run-attempt")" in '' | *[!0-9]*) exit 1 ;; esac
 test -d "$stage/node_modules" && test ! -L "$stage/node_modules"
 for name in rg fdfind fd; do test -f "$stage/bin/$name" && test ! -L "$stage/bin/$name"; done
-test ! -e "$ADVISOR_DIR/node_modules"; mv -- "$stage/node_modules" "$ADVISOR_DIR/node_modules"
-runtime_bin="$RUNNER_TEMP/pr-review-advisor-runtime-bin"; rm -rf -- "$runtime_bin"; mv -- "$stage/bin" "$runtime_bin"
-printf '%s\n' "$runtime_bin" >> "$GITHUB_PATH"
+test ! -e "$ADVISOR_DIR/node_modules"
+mv -- "$stage/node_modules" "$ADVISOR_DIR/node_modules"
+runtime_bin="$RUNNER_TEMP/pr-review-advisor-runtime-bin"
+rm -rf -- "$runtime_bin"
+mv -- "$stage/bin" "$runtime_bin"
+printf '%s\n' "$runtime_bin" >>"$GITHUB_PATH"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Static checks no longer modify the advisor runtime shell scripts during CI.

## Reason

The scripts on main were not in canonical shfmt form, causing all-files static checks to fail after rewriting them.

## Changes

- Apply shfmt's canonical formatting to the advisor runtime package and restore scripts without changing behavior.

## Verification

- Contributor validation: Commit hooks and npm run validate:pr passed.
- Tests: Not applicable — Formatting-only shell changes do not alter behavior; the targeted shfmt hook and shellcheck in npm run validate:pr verify the change.
- Broad gate: npm run validate:pr passed against refreshed origin/main.
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reformatted runtime packaging and restoration scripts for improved readability.
  * Preserved existing packaging, validation, installation, metadata, hashing, cleanup, and environment update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->