### PR TITLE
test(review): align conflict fixer inference expectation

### DIFF
--- a/test/automation/pull-requests/pr-merge-conflict-fixer.test.ts
+++ b/test/automation/pull-requests/pr-merge-conflict-fixer.test.ts
@@ -551,8 +551,7 @@ describe("PR merge conflict fixer", () => {
         "terra",
         "--model",
         "azure/openai/gpt-5.6-terra",
-        "--timeout",
-        "900",
+        "--no-verify",
       ],
       expect.anything(),
     );


### PR DESCRIPTION
## Outcome

The PR conflict-fixer test now matches the shared OpenShell inference setup. Main CI no longer fails because the test expects the removed 900-second verification timeout.

## Reason

PR #10841 changed shared inference setup from `--timeout 900` to `--no-verify`, but the conflict-fixer expectation retained the former arguments.

### Related issues

Refs #10841

## Changes

- Update the conflict-fixer inference expectation to require `--no-verify`.
- Keep production runtime behavior unchanged.

## Verification

- `npm exec -- vitest run --project integration test/automation/pull-requests/pr-merge-conflict-fixer.test.ts` — 14 tests passed.
- `npm exec -- vitest run --project integration test/automation/pull-requests/pr-review-advisor-openshell.test.ts test/automation/pull-requests/pr-merge-conflict-fixer.test.ts` — 58 tests passed.
- `npm run validate:pr` — passed against canonical main `156bddd20e7e50ca129e1b86a7e218e8e3a762a2`.
- Reviewed the diff for secrets, API keys, and credentials — none found.

---
Signed-off-by: Prekshi Vyas <prekshiv@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automation coverage to expect the revised command-line option used during OpenShell inference configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->