### PR TITLE
fix(onboard): preserve served model route

### DIFF
--- a/src/lib/onboard/setup-nim-flow-vllm-resume.test.ts
+++ b/src/lib/onboard/setup-nim-flow-vllm-resume.test.ts
@@ -101,6 +101,7 @@ describe("createSetupNim vLLM resume", () => {
       expect(env?.NEMOCLAW_VLLM_MODEL).toBe(alias);
       return { id: servedModel, servedModelId: servedModel };
     });
+    const revalidateSandboxIdentity = vi.fn();
     const setupNim = createSetupNim(
       makeDeps({
         isNonInteractive: () => true,
@@ -122,16 +123,52 @@ describe("createSetupNim vLLM resume", () => {
       }),
     );
 
-    await expect(setupNim(null, null, null, true)).rejects.toThrow("vLLM install failed");
+    await expect(
+      setupNim(
+        null,
+        null,
+        null,
+        true,
+        null,
+        null,
+        undefined,
+        undefined,
+        undefined,
+        revalidateSandboxIdentity,
+      ),
+    ).rejects.toThrow("vLLM install failed");
     expect(checkpointedModel).toBe(alias);
     expect(handleVllmSelection).not.toHaveBeenCalled();
 
-    await expect(setupNim(null, null, null, true)).resolves.toMatchObject({
-      model: servedModel,
-      provider: "vllm-local",
-    });
+    await expect(
+      setupNim(
+        null,
+        null,
+        null,
+        true,
+        null,
+        null,
+        undefined,
+        undefined,
+        undefined,
+        revalidateSandboxIdentity,
+      ),
+    ).resolves.toMatchObject({ model: servedModel, provider: "vllm-local" });
+    expect(revalidateSandboxIdentity).toHaveBeenCalledWith(
+      {
+        provider: "vllm-local",
+        model: servedModel,
+        endpointUrl: null,
+        credentialEnv: null,
+        preferredInferenceApi: "openai-completions",
+      },
+      "record managed vLLM install intent",
+    );
     expect(checkpointVllmInstallModel).toHaveBeenCalledTimes(2);
     expect(checkpointVllmInstallModel).toHaveBeenLastCalledWith(alias);
+    expect(revalidateSandboxIdentity.mock.invocationCallOrder[0]).toBeLessThan(
+      checkpointVllmInstallModel.mock.invocationCallOrder[0],
+    );
     expect(selectVllmModelFromEnv).toHaveBeenCalledTimes(2);
   });
 
@@ -140,12 +177,14 @@ describe("createSetupNim vLLM resume", () => {
     const checkpointVllmInstallModel = vi.fn();
     const installEffect = vi.fn();
     const handleVllmSelection = vi.fn<SetupNimFlowDeps["handleVllmSelection"]>();
+    const alias = "nemotron-3-nano-4b";
+    const servedModel = "nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8";
     vi.spyOn(onboardSession, "loadSession").mockReturnValue({
-      vllmInstallModel: "nvidia/resumed-model",
+      vllmInstallModel: alias,
       steps: { provider_selection: { status: "failed" } },
     } as unknown as ReturnType<typeof onboardSession.loadSession>);
     const installVllm = vi.fn<SetupNimFlowDeps["installVllm"]>(async (_profile, options) => {
-      options.checkpointInstallIntent?.("nvidia/resumed-model");
+      options.checkpointInstallIntent?.(alias);
       installEffect();
       options.beforeInstall?.("nvidia/resumed-model");
       return { ok: true };
@@ -163,6 +202,10 @@ describe("createSetupNim vLLM resume", () => {
           }),
         installVllm,
         handleVllmSelection,
+        selectVllmModelFromEnv: (env) => {
+          expect(env?.NEMOCLAW_VLLM_MODEL).toBe(alias);
+          return { id: servedModel, servedModelId: servedModel };
+        },
       }),
     );
     const revalidateSandboxIdentity = vi.fn(() => {
@@ -187,7 +230,7 @@ describe("createSetupNim vLLM resume", () => {
     expect(revalidateSandboxIdentity).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "vllm-local",
-        model: "nvidia/resumed-model",
+        model: servedModel,
         endpointUrl: null,
         credentialEnv: null,
         preferredInferenceApi: "openai-completions",

--- a/src/lib/onboard/setup-nim-flow-vllm-resume.test.ts
+++ b/src/lib/onboard/setup-nim-flow-vllm-resume.test.ts
@@ -69,16 +69,26 @@ describe("createSetupNim vLLM resume", () => {
     expect(prompt).not.toHaveBeenCalled();
   });
 
-  it("normalizes a checkpointed catalog alias before validating the installed vLLM", async () => {
+  it("resumes an interrupted catalog alias with the served vLLM route", async () => {
     const alias = "nemotron-3-nano-4b";
     const servedModel = "nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8";
     const profile = { name: "Linux NVIDIA GPU" } as VllmProfile;
-    const checkpointVllmInstallModel = vi.fn();
-    const installVllm = vi.fn<SetupNimFlowDeps["installVllm"]>(async (_profile, options) => {
-      options.beforeInstall?.(servedModel);
-      options.checkpointInstallIntent?.(alias);
-      return { ok: true };
+    let checkpointedModel: string | null = null;
+    const checkpointVllmInstallModel = vi.fn((modelId: string) => {
+      checkpointedModel = modelId;
     });
+    const installVllm = vi
+      .fn<SetupNimFlowDeps["installVllm"]>()
+      .mockImplementationOnce(async (_selected, options) => {
+        expect(options.modelIntent).toBeUndefined();
+        options.checkpointInstallIntent?.(alias);
+        return { ok: false };
+      })
+      .mockImplementationOnce(async (_selected, options) => {
+        expect(options.modelIntent).toBe(alias);
+        options.checkpointInstallIntent?.(alias);
+        return { ok: true };
+      });
     const handleVllmSelection = vi.fn<SetupNimFlowDeps["handleVllmSelection"]>(async (state) => {
       expect(state.model).toBe(servedModel);
       state.provider = "vllm-local";
@@ -95,8 +105,11 @@ describe("createSetupNim vLLM resume", () => {
       makeDeps({
         isNonInteractive: () => true,
         getNonInteractiveProvider: () => "install-vllm",
-        getVllmInstallResumeModel: () => null,
+        getVllmInstallResumeModel: () => checkpointedModel,
         checkpointVllmInstallModel,
+        abortNonInteractive: (message) => {
+          throw new Error(message);
+        },
         detectInferenceProviderHostState: () =>
           makeHostState({
             vllmProfile: profile,
@@ -109,12 +122,17 @@ describe("createSetupNim vLLM resume", () => {
       }),
     );
 
+    await expect(setupNim(null, null, null, true)).rejects.toThrow("vLLM install failed");
+    expect(checkpointedModel).toBe(alias);
+    expect(handleVllmSelection).not.toHaveBeenCalled();
+
     await expect(setupNim(null, null, null, true)).resolves.toMatchObject({
       model: servedModel,
       provider: "vllm-local",
     });
-    expect(checkpointVllmInstallModel).toHaveBeenCalledWith(alias);
-    expect(selectVllmModelFromEnv).toHaveBeenCalledOnce();
+    expect(checkpointVllmInstallModel).toHaveBeenCalledTimes(2);
+    expect(checkpointVllmInstallModel).toHaveBeenLastCalledWith(alias);
+    expect(selectVllmModelFromEnv).toHaveBeenCalledTimes(2);
   });
 
   it("refuses checkpoint-first vLLM installation when sandbox identity changes (#9833)", async () => {

--- a/src/lib/onboard/setup-nim-flow-vllm-resume.test.ts
+++ b/src/lib/onboard/setup-nim-flow-vllm-resume.test.ts
@@ -69,6 +69,54 @@ describe("createSetupNim vLLM resume", () => {
     expect(prompt).not.toHaveBeenCalled();
   });
 
+  it("normalizes a checkpointed catalog alias before validating the installed vLLM", async () => {
+    const alias = "nemotron-3-nano-4b";
+    const servedModel = "nvidia/NVIDIA-Nemotron-3-Nano-4B-FP8";
+    const profile = { name: "Linux NVIDIA GPU" } as VllmProfile;
+    const checkpointVllmInstallModel = vi.fn();
+    const installVllm = vi.fn<SetupNimFlowDeps["installVllm"]>(async (_profile, options) => {
+      options.beforeInstall?.(servedModel);
+      options.checkpointInstallIntent?.(alias);
+      return { ok: true };
+    });
+    const handleVllmSelection = vi.fn<SetupNimFlowDeps["handleVllmSelection"]>(async (state) => {
+      expect(state.model).toBe(servedModel);
+      state.provider = "vllm-local";
+      state.endpointUrl = "http://127.0.0.1:8000/v1";
+      state.credentialEnv = null;
+      state.preferredInferenceApi = "openai-completions";
+      return "selected";
+    });
+    const selectVllmModelFromEnv = vi.fn((env?: NodeJS.ProcessEnv) => {
+      expect(env?.NEMOCLAW_VLLM_MODEL).toBe(alias);
+      return { id: servedModel, servedModelId: servedModel };
+    });
+    const setupNim = createSetupNim(
+      makeDeps({
+        isNonInteractive: () => true,
+        getNonInteractiveProvider: () => "install-vllm",
+        getVllmInstallResumeModel: () => null,
+        checkpointVllmInstallModel,
+        detectInferenceProviderHostState: () =>
+          makeHostState({
+            vllmProfile: profile,
+            hasVllmImage: true,
+            vllmEntries: [{ key: "install-vllm", label: "Start vLLM" }],
+          }),
+        installVllm,
+        handleVllmSelection,
+        selectVllmModelFromEnv,
+      }),
+    );
+
+    await expect(setupNim(null, null, null, true)).resolves.toMatchObject({
+      model: servedModel,
+      provider: "vllm-local",
+    });
+    expect(checkpointVllmInstallModel).toHaveBeenCalledWith(alias);
+    expect(selectVllmModelFromEnv).toHaveBeenCalledOnce();
+  });
+
   it("refuses checkpoint-first vLLM installation when sandbox identity changes (#9833)", async () => {
     const profile = { name: "DGX Spark" } as VllmProfile;
     const checkpointVllmInstallModel = vi.fn();

--- a/src/lib/onboard/setup-nim-flow.ts
+++ b/src/lib/onboard/setup-nim-flow.ts
@@ -651,21 +651,18 @@ function requestedVllmServingProfileModel(
   return requested?.backend === "vllm" ? requested : null;
 }
 
-/** Model ID that an explicit managed-vLLM model selection exposes through `/v1/models`. */
-function requestedManagedVllmModel(
-  resolve: SetupNimFlowDeps["selectVllmModelFromEnv"],
-): string | null {
-  if (!resolve) throw new Error("Managed vLLM model selection could not be resolved.");
-  const requested = resolve();
-  return requested?.servedModelId ?? requested?.id ?? null;
-}
-
 /** Preserve explicit route intent while converting a known catalog alias to its served name. */
 function requestedManagedVllmRouteModel(input: {
   requestedModel: string | null;
   selectVllmModelFromEnv: SetupNimFlowDeps["selectVllmModelFromEnv"];
 }): string | null {
-  if (!input.requestedModel) return requestedManagedVllmModel(input.selectVllmModelFromEnv);
+  if (!input.requestedModel) {
+    if (!input.selectVllmModelFromEnv) {
+      throw new Error("Managed vLLM model selection could not be resolved.");
+    }
+    const requested = input.selectVllmModelFromEnv();
+    return requested?.servedModelId ?? requested?.id ?? null;
+  }
   if (!input.selectVllmModelFromEnv) return input.requestedModel;
   try {
     const catalogModel = input.selectVllmModelFromEnv({
@@ -1263,11 +1260,7 @@ export function createSetupNim(
           if (vllmRunning) {
             const hasGpuSelection =
               String(process.env.NEMOCLAW_VLLM_GPU_DEVICE ?? "").trim() !== "";
-            const message = vllmPortConflictMessage(
-              gpu?.platform,
-              deps.vllmPort,
-              hasGpuSelection,
-            );
+            const message = vllmPortConflictMessage(gpu?.platform, deps.vllmPort, hasGpuSelection);
             deps.error(`  ${message}`);
             if (deps.isNonInteractive()) {
               deps.abortNonInteractive(message);

--- a/src/lib/onboard/setup-nim-flow.ts
+++ b/src/lib/onboard/setup-nim-flow.ts
@@ -769,13 +769,18 @@ function policyCheckedVllmInstallRecovery(
   recovery: ReturnType<typeof vllmInstallRecoveryOptions>,
   state: SetupNimSelectionState,
   seedVllmInstallRoute: (modelId: string) => void,
+  selectVllmModelFromEnv: SetupNimFlowDeps["selectVllmModelFromEnv"],
 ): ReturnType<typeof vllmInstallRecoveryOptions> {
   const checkpointInstallIntent = recovery.checkpointInstallIntent;
   if (!checkpointInstallIntent) return recovery;
   return {
     ...recovery,
     checkpointInstallIntent: (modelId: string) => {
-      seedVllmInstallRoute(modelId);
+      const routeModel = requestedManagedVllmRouteModel({
+        requestedModel: modelId,
+        selectVllmModelFromEnv,
+      });
+      seedVllmInstallRoute(routeModel ?? modelId);
       state.revalidateSandboxIdentity?.("record managed vLLM install intent");
       checkpointInstallIntent(modelId);
     },
@@ -1283,6 +1288,7 @@ export function createSetupNim(
             vllmInstallRecoveryOptions(deps),
             vllmState,
             seedVllmInstallRoute,
+            deps.selectVllmModelFromEnv,
           );
           const result = await deps.installVllm(vllmProfile, {
             hasImage: hasVllmImage,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome
<!-- State the result first. Describe the before-and-after behavior in 1–3 sentences. -->

Managed vLLM onboarding now keeps the catalog's served model identity when a resumable install checkpoint records a short model alias. Fresh installs no longer reject their own endpoint because the checkpoint replaced the canonical route with the `NEMOCLAW_VLLM_MODEL` selector.

## Reason
<!-- Explain why this change is needed. -->

The resume checkpoint records install intent, while route validation compares the endpoint identity. Treating the selector as the route identity made a valid catalog alias conflict with the model that the managed endpoint actually serves.

### Related issues
<!-- Name each issue relationship with the keyword that applies, such as Fixes, Closes, Resolves, Refs, Relates to, or Part of. Remove this subsection if no issue applies. -->

Fixes #10876

## Changes
<!-- List the concrete changes that produce the stated outcome. If this adds a mechanism, name its current requirement and consumer. Explain why a direct change is insufficient. Identify the test that protects the mechanism. -->

- Normalise a checkpointed catalog selector through the existing managed-vLLM alias resolver before seeding route state.
- Preserve the original checkpoint value for resume compatibility and retain exact unknown model identifiers.
- Keep strict managed-endpoint mismatch validation unchanged; weakening that guard would admit genuine model conflicts.
- Add a regression test that reproduces the canonical install seed followed by the alias checkpoint overwrite.

## Verification
<!-- List each completed command or manual check and its result. If no test applies, explain why. For a broad change, record the applicable broad gate and result. Do not claim a gate that you did not run. For documentation changes, record the docs build result and applicable style or new-page checks. Confirm that the diff contains no secrets, API keys, or credentials. -->
- `npx vitest run src/lib/onboard/setup-nim-flow-vllm-resume.test.ts src/lib/onboard/setup-nim-vllm.test.ts src/lib/inference/vllm-fixed-catalog-install.test.ts` — 52 tests passed
- `npm run build:cli` — passed
- `npm run typecheck:cli` — passed locally and in the pre-push hook
- `npm run format:check` — passed
- `npx oxlint src/lib/onboard/setup-nim-flow.ts src/lib/onboard/setup-nim-flow-vllm-resume.test.ts` — passed with no lint errors
- `npm run source-shape:check` — passed
- `npm run checks:repository` — passed
- `git diff --check` — passed
- Secrets review — the diff contains no secrets, API keys, or credentials

## Review notes
<!-- Remove this section if no note applies.
For a sensitive-path change, record the review context or maintainer-approved waiver.
For an accepted non-success, skipped, or missing CI check, name the check, approval link, and follow-up issue.
If scripts/prepare-dgx-station-host.sh changes, identify the tested commit, Station profile or scenario, result, and supporting link. Maintainers must review that evidence before merge. If repository governance permits an exception, document the reason. -->

- Sensitive-path context: the change only adapts catalog-backed checkpoint input before route-state validation. Strict endpoint identity validation and checkpoint persistence remain unchanged.
- Documentation review: one read-only review completed with no missing, stale, unsafe, or inaccurate documentation findings. Existing alias documentation remains accurate.
- Exploratory adjacent run: 81 tests passed; five existing Spark-selection cases in `setup-nim-flow.test.ts` timed out locally without assertion failures. Those paths do not execute the changed checkpoint adapter; the directly affected suites pass 52/52.

---
<!-- DCO sign-off is required in this PR description. Every commit must appear as Verified in GitHub. -->
Signed-off-by: Tinson Lai <tinsonl@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vLLM installation recovery when configured models use aliases.
  * Ensured aliases resolve to the correct served model before resuming installation.
  * Improved checkpoint sequencing during interrupted installations.
  * Added stronger sandbox identity and model-availability validation during recovery.
  * Improved recovery handling for failed installation attempts, including non-interactive setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->