### PR TITLE
fix(connect): name the container identity boundary on a terminal phase

### DIFF
--- a/src/lib/actions/sandbox/connect-boundary-refusal.ts
+++ b/src/lib/actions/sandbox/connect-boundary-refusal.ts
@@ -1,6 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { DockerSandboxIdentityRow } from "../../adapters/docker/inspect";
+import {
+  OPENSHELL_SANDBOX_ID_LABEL,
+  OPENSHELL_SANDBOX_NAME_LABEL,
+  OPENSHELL_SANDBOX_WORKSPACE_LABEL,
+  inspectDockerSandboxNameLabeledContainers,
+  resolveOpenShellSandboxOwnershipLabel,
+} from "../../onboard/openshell-docker-sandbox-containers";
+import { sanitizeReadinessText } from "../../readiness/sanitize";
+import { getSandboxDockerRuntime, isDockerDriverSandbox } from "./docker-health";
 import {
   type GatewayRestartFailureLayer,
   gatewayIntegrityRepairLines,
@@ -13,6 +23,8 @@ import {
 } from "./mcp-bridge-hermes-reconciliation";
 
 type ConnectBoundaryContext = "Probe" | "Connect";
+
+const IDENTITY_VALUE_MAX_LENGTH = 256;
 
 /**
  * A managed recovery that failed on a deterministic integrity refusal cannot be
@@ -96,4 +108,55 @@ export function exitOnMcpReconciliationRefusal(
     console.error(`  ${line}`);
   }
   process.exit(1);
+}
+
+function describeSandboxNameLabeledContainer(
+  row: DockerSandboxIdentityRow,
+  ownershipLabel: string,
+): string {
+  const display = (value: string): string =>
+    JSON.stringify(sanitizeReadinessText(value || "<none>", IDENTITY_VALUE_MAX_LENGTH));
+  return (
+    `${row.id.slice(0, 12)} (${ownershipLabel}=${display(row.managedBy)}, ` +
+    `${OPENSHELL_SANDBOX_WORKSPACE_LABEL}=${display(row.workspace)}, ` +
+    `${OPENSHELL_SANDBOX_ID_LABEL}=${display(row.sandboxId)})`
+  );
+}
+
+/**
+ * Explain a terminal sandbox phase that follows from an unmatched container
+ * identity rather than from a crashed sandbox. NemoClaw matches a docker-driver
+ * sandbox only to a managed container that OpenShell named for it in the
+ * default workspace, so a container that borrows the sandbox-name label with
+ * another workspace is refused without any runtime fault (#10869). Returns null
+ * when the sandbox is not on the docker driver, when a container matched, when
+ * Docker could not be inspected, or when no container carries the label; the
+ * caller then keeps its runtime-fault guidance.
+ */
+export function unmatchedSandboxContainerLines(
+  sandboxName: string,
+  rerunCommand: string,
+): string[] | null {
+  if (!isDockerDriverSandbox(sandboxName) || getSandboxDockerRuntime(sandboxName).containerName) {
+    return null;
+  }
+  const observation = inspectDockerSandboxNameLabeledContainers(sandboxName);
+  if (observation.status !== "observed") return null;
+  const { malformedRows, rows } = observation;
+  if (rows.length === 0 && malformedRows === 0) return null;
+  const ownership = resolveOpenShellSandboxOwnershipLabel();
+  const lines = [
+    `No Docker container matches sandbox '${sandboxName}' in the default OpenShell workspace.`,
+    `${String(rows.length)} container(s) carry the '${OPENSHELL_SANDBOX_NAME_LABEL}=${sandboxName}' label:`,
+    ...rows.map((row) => `  ${describeSandboxNameLabeledContainer(row, ownership.label)}`),
+  ];
+  if (malformedRows > 0) {
+    lines.push(`Docker returned ${String(malformedRows)} malformed container identity row(s).`);
+  }
+  lines.push(
+    "NemoClaw matches only a managed container that OpenShell named for this sandbox in the default workspace.",
+    "Resolve each listed container through the workflow that owns it.",
+    `Then rerun '${rerunCommand}'.`,
+  );
+  return lines;
 }

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -64,6 +64,7 @@ import {
   exitOnMcpReconciliationRefusal,
   exitOnSecretBoundaryRefusal,
   printGatewayIntegrityRepairGuidance,
+  unmatchedSandboxContainerLines,
 } from "./connect-boundary-refusal";
 import { prepareHermesLightTerminalSkin } from "./connect-hermes-light-skin";
 import {
@@ -1091,6 +1092,28 @@ function failConnectReadinessDockerRuntimeDown(sandboxName: string): never {
   process.exit(1);
 }
 
+// A terminal phase can follow from a container identity that NemoClaw refused
+// to match rather than from a crashed sandbox. Name that boundary instead of
+// steering the user to runtime logs and status (#10869).
+function failConnectReadinessTerminalPhase(
+  sandboxName: string,
+  transition: string,
+  { inspectDockerIdentity, retryCommand }: { inspectDockerIdentity: boolean; retryCommand: string },
+): never {
+  console.error("");
+  console.error(`  Sandbox '${sandboxName}' ${transition} state.`);
+  const identityLines = inspectDockerIdentity
+    ? unmatchedSandboxContainerLines(sandboxName, `${CLI_NAME} ${sandboxName} ${retryCommand}`)
+    : null;
+  if (identityLines) {
+    for (const line of identityLines) console.error(`  ${line}`);
+  } else {
+    console.error(`  Run:  ${CLI_NAME} ${sandboxName} logs --follow`);
+    console.error(`  Run:  ${CLI_NAME} ${sandboxName} status`);
+  }
+  process.exit(1);
+}
+
 function failIfGatewayBlocksConnectReadiness(sandboxName: string): void {
   const sb = registry.getSandbox(sandboxName);
   const lifecycle = getNamedGatewayLifecycleState(resolveSandboxGatewayName(sb));
@@ -1773,11 +1796,10 @@ export async function waitForSandboxReadyOrExit(
   let remainingInitialErrorGracePolls =
     allowInitialErrorAfterStart && status === "Error" ? START_INITIAL_ERROR_GRACE_POLLS - 1 : 0;
   if (status && TERMINAL_SANDBOX_PHASES.has(status) && remainingInitialErrorGracePolls === 0) {
-    console.error("");
-    console.error(`  Sandbox '${sandboxName}' is in '${status}' state.`);
-    console.error(`  Run:  ${CLI_NAME} ${sandboxName} logs --follow`);
-    console.error(`  Run:  ${CLI_NAME} ${sandboxName} status`);
-    process.exit(1);
+    failConnectReadinessTerminalPhase(sandboxName, `is in '${status}'`, {
+      inspectDockerIdentity: allowDockerRuntimeInspection,
+      retryCommand,
+    });
   }
   if (allowDockerRuntimeInspection && isDockerRuntimeDown(sandboxName)) {
     failConnectReadinessDockerRuntimeDown(sandboxName);
@@ -1811,11 +1833,10 @@ export async function waitForSandboxReadyOrExit(
       remainingInitialErrorGracePolls = 0;
     }
     if (TERMINAL_SANDBOX_PHASES.has(cur) && !waitingThroughInitialError) {
-      console.error("");
-      console.error(`  Sandbox '${sandboxName}' entered '${cur}' state.`);
-      console.error(`  Run:  ${CLI_NAME} ${sandboxName} logs --follow`);
-      console.error(`  Run:  ${CLI_NAME} ${sandboxName} status`);
-      process.exit(1);
+      failConnectReadinessTerminalPhase(sandboxName, `entered '${cur}'`, {
+        inspectDockerIdentity: allowDockerRuntimeInspection,
+        retryCommand,
+      });
     }
     if (allowDockerRuntimeInspection && isDockerRuntimeDown(sandboxName)) {
       failConnectReadinessDockerRuntimeDown(sandboxName);

--- a/src/lib/actions/sandbox/docker-health.ts
+++ b/src/lib/actions/sandbox/docker-health.ts
@@ -57,17 +57,23 @@ const defaultDeps: ResolveDeps = {
     ),
 };
 
+/** True only when the registry records the sandbox on the docker driver. */
+export function isDockerDriverSandbox(
+  sandboxName: string,
+  getSandbox: ResolveDeps["getSandbox"] = defaultDeps.getSandbox,
+): boolean {
+  try {
+    return getSandbox(sandboxName)?.openshellDriver === "docker";
+  } catch {
+    return false;
+  }
+}
+
 function resolveDockerDriverSandboxContainer(
   sandboxName: string,
   deps: ResolveDeps,
 ): string | null {
-  try {
-    if (deps.getSandbox(sandboxName)?.openshellDriver !== "docker") {
-      return null;
-    }
-  } catch {
-    return null;
-  }
+  if (!isDockerDriverSandbox(sandboxName, deps.getSandbox)) return null;
   return resolveSandboxContainerOwner(deps.dockerPsNames(), sandboxName, deps.listSandboxNames());
 }
 
@@ -124,11 +130,7 @@ export function getSandboxDockerRuntime(
   depsOverride: Partial<ResolveDeps> = {},
 ): SandboxDockerRuntime {
   const deps: ResolveDeps = { ...defaultDeps, ...depsOverride };
-  try {
-    if (deps.getSandbox(sandboxName)?.openshellDriver !== "docker") {
-      return { health: "none", paused: false, running: false, containerName: null };
-    }
-  } catch {
+  if (!isDockerDriverSandbox(sandboxName, deps.getSandbox)) {
     return { health: "none", paused: false, running: false, containerName: null };
   }
   let labeledContainers: ReturnType<typeof findLabeledSandboxContainers>;

--- a/src/lib/actions/sandbox/start-wait.test.ts
+++ b/src/lib/actions/sandbox/start-wait.test.ts
@@ -3,7 +3,42 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { createConnectHarness } from "../../../../test/support/connect-flow-test-harness";
+import {
+  type ConnectHarness,
+  type ConnectHarnessOptions,
+  createConnectHarness,
+} from "../../../../test/support/connect-flow-test-harness";
+
+const EXIT_ONE = 'process.exit unexpectedly called with "1"';
+
+// The #10869 reproduction: a managed container whose name no longer matches the
+// sandbox, plus a busybox that borrows the sandbox-name label with another
+// workspace and no managed marker.
+const PARKED_MANAGED = {
+  id: "aaaa000000000000",
+  managedBy: "openshell",
+  workspace: "default",
+  sandboxId: "sb-real",
+};
+const FOREIGN_WORKSPACE = {
+  id: "ffff000000000000",
+  managedBy: "",
+  workspace: "other-workspace",
+  sandboxId: "",
+};
+
+function observed(rows: (typeof PARKED_MANAGED)[], malformedRows = 0) {
+  return { status: "observed" as const, rows, malformedRows };
+}
+
+/** A docker-driver sandbox whose container NemoClaw could not match. */
+function unmatchedIdentityHarness(options: ConnectHarnessOptions): ConnectHarness {
+  return createConnectHarness({
+    registryEntry: { openshellDriver: "docker" },
+    dockerRuntime: { containerName: null, running: false },
+    ...options,
+  });
+}
 
 describe("sandbox start readiness", () => {
   it("waits through the stopped sandbox Error phase after start (#9753)", async () => {
@@ -131,4 +166,147 @@ describe("sandbox start readiness", () => {
       );
     },
   );
+});
+
+describe("sandbox readiness container identity boundary", () => {
+  it("names the foreign workspace when the terminal Error phase follows an unmatched container (#10869)", async () => {
+    const harness = unmatchedIdentityHarness({
+      listOutputs: ["alpha Provisioning", "alpha Error"],
+      sandboxNameLabeledContainers: observed([PARKED_MANAGED, FOREIGN_WORKSPACE]),
+    });
+
+    await expect(harness.waitForSandboxReadyOrExit("alpha")).rejects.toThrow(EXIT_ONE);
+
+    const output = harness.errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Sandbox 'alpha' entered 'Error' state.");
+    expect(output).toContain(
+      "No Docker container matches sandbox 'alpha' in the default OpenShell workspace.",
+    );
+    expect(output).toContain("2 container(s) carry the 'openshell.ai/sandbox-name=alpha' label:");
+    expect(output).toContain(
+      'aaaa00000000 (openshell.ai/managed-by="openshell", openshell.ai/sandbox-workspace="default", openshell.ai/sandbox-id="sb-real")',
+    );
+    expect(output).toContain(
+      'ffff00000000 (openshell.ai/managed-by="<none>", openshell.ai/sandbox-workspace="other-workspace", openshell.ai/sandbox-id="<none>")',
+    );
+    expect(output).toContain("Then rerun 'nemoclaw alpha connect'.");
+    expect(output).not.toContain("logs --follow");
+    expect(output).not.toContain("nemoclaw alpha status");
+  });
+
+  it("names the boundary for an initial terminal phase with the caller's retry command (#10869)", async () => {
+    const harness = unmatchedIdentityHarness({
+      listOutputs: ["alpha Failed"],
+      sandboxNameLabeledContainers: observed([FOREIGN_WORKSPACE]),
+    });
+
+    await expect(
+      harness.waitForSandboxReadyOrExit("alpha", { retryCommand: "start" }),
+    ).rejects.toThrow(EXIT_ONE);
+
+    const output = harness.errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Sandbox 'alpha' is in 'Failed' state.");
+    expect(output).toContain("1 container(s) carry the 'openshell.ai/sandbox-name=alpha' label:");
+    expect(output).toContain("Then rerun 'nemoclaw alpha start'.");
+    expect(harness.captureOpenshellSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the runtime-fault guidance when the terminal phase belongs to a matched container (#10869)", async () => {
+    const harness = unmatchedIdentityHarness({
+      listOutputs: ["alpha Error"],
+      dockerRuntime: { containerName: "openshell-alpha", running: true },
+      sandboxNameLabeledContainers: observed([PARKED_MANAGED, FOREIGN_WORKSPACE]),
+    });
+
+    await expect(harness.waitForSandboxReadyOrExit("alpha")).rejects.toThrow(EXIT_ONE);
+
+    const output = harness.errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Run:  nemoclaw alpha logs --follow");
+    expect(output).toContain("Run:  nemoclaw alpha status");
+    expect(output).not.toContain("sandbox-workspace");
+    expect(harness.inspectSandboxNameLabeledContainersSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["no container carries the sandbox-name label", observed([])],
+    [
+      "the Docker identity probe fails",
+      { status: "probe-failed" as const, detail: "Cannot connect to the Docker daemon" },
+    ],
+  ])("keeps the runtime-fault guidance when %s (#10869)", async (_condition, observation) => {
+    const harness = unmatchedIdentityHarness({
+      listOutputs: ["alpha Error"],
+      sandboxNameLabeledContainers: observation,
+    });
+
+    await expect(harness.waitForSandboxReadyOrExit("alpha")).rejects.toThrow(EXIT_ONE);
+
+    const output = harness.errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Run:  nemoclaw alpha logs --follow");
+    expect(output).not.toContain("No Docker container matches");
+  });
+
+  it("does not inspect Docker identity for a sandbox that is not on the docker driver (#10869)", async () => {
+    const harness = unmatchedIdentityHarness({
+      listOutputs: ["alpha Error"],
+      registryEntry: { openshellDriver: "vm" },
+      sandboxNameLabeledContainers: observed([FOREIGN_WORKSPACE]),
+    });
+
+    await expect(harness.waitForSandboxReadyOrExit("alpha")).rejects.toThrow(EXIT_ONE);
+
+    const output = harness.errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Run:  nemoclaw alpha logs --follow");
+    expect(harness.inspectSandboxNameLabeledContainersSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not inspect Docker identity when the caller disables Docker runtime inspection (#10869)", async () => {
+    const harness = unmatchedIdentityHarness({
+      listOutputs: ["alpha Error"],
+      sandboxNameLabeledContainers: observed([FOREIGN_WORKSPACE]),
+    });
+
+    await expect(
+      harness.waitForSandboxReadyOrExit("alpha", { allowDockerRuntimeInspection: false }),
+    ).rejects.toThrow(EXIT_ONE);
+
+    const output = harness.errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Run:  nemoclaw alpha logs --follow");
+    expect(harness.inspectSandboxNameLabeledContainersSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports malformed identity rows without rendering their content (#10869)", async () => {
+    const harness = unmatchedIdentityHarness({
+      listOutputs: ["alpha Error"],
+      sandboxNameLabeledContainers: observed([FOREIGN_WORKSPACE], 1),
+    });
+
+    await expect(harness.waitForSandboxReadyOrExit("alpha")).rejects.toThrow(EXIT_ONE);
+
+    const output = harness.errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("1 container(s) carry the 'openshell.ai/sandbox-name=alpha' label:");
+    expect(output).toContain("Docker returned 1 malformed container identity row(s).");
+  });
+
+  it("quotes and escapes label values so a container cannot forge adjacent fields (#10869)", async () => {
+    const forged = {
+      ...FOREIGN_WORKSPACE,
+      managedBy: 'openshell", openshell.ai/sandbox-workspace="default',
+      workspace: "other\u001b[31mworkspace",
+    };
+    const harness = unmatchedIdentityHarness({
+      listOutputs: ["alpha Error"],
+      sandboxNameLabeledContainers: observed([forged]),
+    });
+
+    await expect(harness.waitForSandboxReadyOrExit("alpha")).rejects.toThrow(EXIT_ONE);
+
+    const output = harness.errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain(`openshell.ai/managed-by=${JSON.stringify(forged.managedBy)}`);
+    expect(output).not.toContain(
+      'openshell.ai/managed-by="openshell", openshell.ai/sandbox-workspace="default"',
+    );
+    expect(output).not.toContain("\u001b");
+    expect(output).toContain('openshell.ai/sandbox-workspace="other\\\\u001b[31mworkspace"');
+  });
 });

--- a/test/support/connect-flow-test-harness.ts
+++ b/test/support/connect-flow-test-harness.ts
@@ -9,6 +9,7 @@ import type { ManagedGatewayControlCompletion } from "../../src/lib/actions/sand
 import type { SecretBoundaryRefusalReason } from "../../src/lib/actions/sandbox/hermes-secret-boundary-recovery";
 import type { WslDetectionOptions } from "../../src/lib/platform";
 import type { ConfigObject } from "../../src/lib/security/credential-filter";
+import type { DockerSandboxIdentityObservation } from "../../src/lib/adapters/docker/inspect";
 import type { SandboxEntry } from "../../src/lib/state/registry";
 
 type ConnectSandbox = (typeof import("../../src/lib/actions/sandbox/connect"))["connectSandbox"];
@@ -43,6 +44,7 @@ export type ConnectHarness = {
   ensureLiveSandboxSpy: MockInstance;
   getSandboxDockerRuntimeSpy: MockInstance;
   dockerStartSpy: MockInstance;
+  inspectSandboxNameLabeledContainersSpy: MockInstance;
   errorSpy: MockInstance;
   logSpy: MockInstance;
   inspectLaunchReadinessSpy: MockInstance;
@@ -135,6 +137,7 @@ export type ConnectHarnessOptions = {
     containerName?: string | null;
   };
   dockerStartStatus?: number | null;
+  sandboxNameLabeledContainers?: DockerSandboxIdentityObservation;
   spawnSignal?: NodeJS.Signals | null;
   spawnStatus?: number | null;
   sttyThrows?: boolean;
@@ -400,6 +403,14 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
   const dockerStartSpy = vi.spyOn(dockerAdapter, "dockerStart").mockReturnValue({
     status: options.dockerStartStatus === undefined ? 0 : options.dockerStartStatus,
   });
+  const openshellDockerSandboxContainers = requireDist(
+    "../../src/lib/onboard/openshell-docker-sandbox-containers.js",
+  );
+  const inspectSandboxNameLabeledContainersSpy = vi
+    .spyOn(openshellDockerSandboxContainers, "inspectDockerSandboxNameLabeledContainers")
+    .mockReturnValue(
+      options.sandboxNameLabeledContainers ?? { status: "observed", rows: [], malformedRows: 0 },
+    );
   const inferenceProbeResponses = [...(options.inferenceProbeResponses ?? [])];
   const listOutputs = [...(options.listOutputs ?? [])];
   const captureOpenshellImplementation = (args: unknown) => {
@@ -589,6 +600,7 @@ export function createConnectHarness(options: ConnectHarnessOptions = {}): Conne
     ensureLiveSandboxSpy,
     getSandboxDockerRuntimeSpy,
     dockerStartSpy,
+    inspectSandboxNameLabeledContainersSpy,
     errorSpy,
     logSpy,
     inspectLaunchReadinessSpy,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Before: when NemoClaw could not match any Docker container to a sandbox, `nemoclaw <sandbox> connect` (and `start` and `connect --probe-only`, which share the readiness wait) printed only `Sandbox 'X' entered 'Error' state.` and pointed at `logs --follow` and `status`, so the user went looking for a runtime fault that does not exist.

After: the same exit lists every container that carries the `openshell.ai/sandbox-name` label with its `managed-by`, `sandbox-workspace`, and `sandbox-id` labels, states that NemoClaw matches only a managed container that OpenShell named for the sandbox in the default workspace, and asks the user to resolve each listed container through its owning workflow before rerunning the command. The refusal itself and its exit status are unchanged.

```text
  Sandbox 'alpha' entered 'Error' state.
  No Docker container matches sandbox 'alpha' in the default OpenShell workspace.
  2 container(s) carry the 'openshell.ai/sandbox-name=alpha' label:
    aaaa00000000 (openshell.ai/managed-by="openshell", openshell.ai/sandbox-workspace="default", openshell.ai/sandbox-id="sb-real")
    ffff00000000 (openshell.ai/managed-by="<none>", openshell.ai/sandbox-workspace="other-workspace", openshell.ai/sandbox-id="<none>")
  NemoClaw matches only a managed container that OpenShell named for this sandbox in the default workspace.
  Resolve each listed container through the workflow that owns it.
  Then rerun 'nemoclaw alpha connect'.
```

The runtime-fault guidance (`logs --follow`, `status`) is unchanged when a container matched, when the sandbox is not on the docker driver, when the caller disables Docker runtime inspection, when Docker could not be inspected, or when no container carries the label.

## Reason

`waitForSandboxReadyOrExit` treated every terminal phase as a crashed sandbox. The container matcher in `docker-health.ts` accepts only a managed container whose name OpenShell assigned for the sandbox in the default workspace, so a foreign-workspace container that borrows the sandbox-name label is refused silently. Issue #10869 reproduced this on a DGX Station GB300: the output contained no mention of the workspace or identity boundary, and the two suggested follow-up commands misdirected the user.

### Related issues

- Fixes #10869.
- Relates to #8999, which made `destroy` fail closed on the same foreign-container condition; this change names the boundary on the readiness path.

## Changes

- `src/lib/actions/sandbox/connect-boundary-refusal.ts`: add `unmatchedSandboxContainerLines`, which returns the explanation only for a docker-driver sandbox with no matched container and at least one name-labeled container. Label values are sanitized with `sanitizeReadinessText` and JSON-quoted, so a label cannot forge an adjacent field or emit terminal control characters. Malformed Docker identity rows are counted, not rendered.
- `src/lib/actions/sandbox/connect.ts`: route both terminal-phase exits (initial observation and polling) through one `failConnectReadinessTerminalPhase` helper that prints the identity explanation or the existing runtime-fault guidance. The rerun hint uses the caller's `retryCommand` (`connect`, `connect --probe-only`, or `start`).
- `src/lib/actions/sandbox/docker-health.ts`: export one `isDockerDriverSandbox` helper that replaces the two inline `openshellDriver === "docker"` checks; behavior is unchanged.
- `test/support/connect-flow-test-harness.ts`: stub `inspectDockerSandboxNameLabeledContainers` (default: no rows) and expose the spy, so no harness test can reach a real `docker ps`.
- `src/lib/actions/sandbox/start-wait.test.ts`: nine regression cases at the `waitForSandboxReadyOrExit` boundary: the #10869 reproduction (parked managed container plus foreign-workspace impostor), the initial terminal phase with the `start` retry command, a matched container, no labeled container, a failed Docker probe, a non-docker driver, disabled Docker runtime inspection, malformed rows, and forged or control-character label values.

No new mechanism beyond the explanation itself: the classification reuses the existing container matcher and the existing sandbox-name identity probe that `destroy` already uses.

Documentation for the new output is deferred to `Docs / Author Post-Merge Catch-Up`.

## Verification

All commands ran on a Linux x86_64 host at the PR commit.

- `npx vitest run --project cli src/lib/actions/sandbox/start-wait.test.ts src/lib/actions/sandbox/docker-health.test.ts src/lib/actions/sandbox/destroy-container-identity.test.ts src/lib/actions/sandbox/connect-probe-observe.test.ts src/lib/actions/sandbox/connect-flow-hermes-boundary.test.ts src/lib/actions/sandbox/connect-route-lifecycle.test.ts src/lib/actions/sandbox/connect-hermes-accepted-readiness.test.ts src/lib/actions/sandbox/connect-hermes-readiness-epoch-change.test.ts src/lib/actions/sandbox/connect-hermes-light-theme.test.ts src/lib/actions/sandbox/connect-flow-dcode-probe-preamble.test.ts src/lib/actions/sandbox/connect-hermes-portable-inference-recovery-errors.test.ts` — 11 files, 171 tests passed (every consumer of the changed harness plus the changed source's tests).
- `npm run build:cli` and `npx vitest run --project integration test/cli/connect-readiness.test.ts test/runtime/sandbox/sandbox-stuck-recovery.test.ts` — 7 tests passed; the CLI-level terminal-phase tests still see the unchanged runtime-fault guidance for a sandbox without a docker driver record.
- `npm run typecheck:cli` — passed.
- `npm run checks:repository` — passed, including the source-architecture budget (`connect.ts` fan-out is unchanged; the helper lives in `connect-boundary-refusal.ts`, which `connect.ts` already imports).
- `npx oxlint` on the five changed files — 0 warnings, 0 errors.
- `npx oxfmt --check` on the five changed files — four files clean; `docker-health.ts` reports one pre-existing issue on the unchanged `listSandboxNames` chain (line 43), which this PR does not touch.
- `npm run validate:pr` — passed: every pre-commit hook (Oxfmt, Oxlint fixes, repository checks, `NEMOCLAW_*` env-var documentation gate, gitleaks, source-shape test budget, codebase growth guardrails), commitlint, and the pre-push CLI TypeScript check.
- Growth guardrails by inspection: the changed test file has 312 lines, adds no `if` statement and no loop, and no new `createRequire` use.
- The diff contains no secrets, API keys, or credentials.

Not run: a live DGX Station reproduction. The fix changes only the explanation printed at an exit that the unit tests exercise with the same observation shapes that the Docker adapter returns.

## Review notes

- Sibling paths with the same generic wording that this PR leaves unchanged, as deferred scope: `status` (`printNonReadySandboxPhaseGuidance` in `status-lookup-rendering.ts`) and `ensureLiveSandboxOrExit` in `gateway-state.ts` print `stuck in 'Error' phase` with `start`/`rebuild` guidance. They no longer receive users from the connect exit, because the identity explanation replaces the `logs`/`status` hints.
- Security: the new output renders Docker label values. Every value passes through `sanitizeReadinessText` (redaction, control-character escaping, 256-character cap) and `JSON.stringify`; the regression test proves a forged `managed-by` value cannot spoof a `sandbox-workspace` field and that an ESC byte is escaped. The probe is read-only (`docker ps`) and runs only on the failure path for docker-driver sandboxes.

---
Signed-off-by: Kushagar Garg <dreamstick909@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added targeted guidance when Docker sandbox identity cannot be matched to a runtime container.
  * Displays sanitized container identity details and suggested retry steps.
  * Improved readiness failure messages for both initial and polled connection attempts.

* **Bug Fixes**
  * Improved handling of malformed, missing, failed, or forged Docker container identity data.
  * Preserved appropriate fallback behavior for non-Docker sandboxes and unavailable inspections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->