### PR TITLE
docs(deployment): name the gateway service unit for each authority mode

### DIFF
--- a/docs/deployment/gateway-lifecycle-authority.mdx
+++ b/docs/deployment/gateway-lifecycle-authority.mdx
@@ -177,6 +177,8 @@ $$nemoclaw status
 $$nemoclaw status --json
 ```
 
+In `nemoclaw-managed` mode, the owner is the source `packaged-service` or `standalone`, and `gatewayAuthority.supervisor` is `null`.
+In `externally-supervised` mode, the owner is the declared supervisor `kind`, `serviceName`, and `execPath`.
 `$$nemoclaw debug` also records `gatewayAuthority` in `onboard-session-summary.txt`.
 The status and debug views omit the external state directory and never include credential values.
 
@@ -207,18 +209,40 @@ It does not transfer process ownership to NemoClaw.
 
 ## Fix a failure
 
+Run `$$nemoclaw status` to read the `Gateway authority` mode before you inspect a service.
+
+### Fix an Externally Supervised Gateway
+
 Resolve an external gateway failure through the declared supervisor.
-For `systemd-system`, inspect the declared service with:
+Replace `<serviceName>` with the `serviceName` value from your declaration.
+For `systemd-system`, inspect the declared unit with the system manager:
 
 ```bash
-systemctl status openshell-gateway.service
+systemctl status <serviceName>
 ```
 
 For `systemd-user`, use the user manager:
 
 ```bash
-systemctl --user status openshell-gateway.service
+systemctl --user status <serviceName>
 ```
 
 Bring the supervised gateway up, leave exactly one verified process holding the configured port, and rerun `$$nemoclaw onboard`.
 To hand the lifecycle back to NemoClaw, remove the platform gateway service and declare `nemoclaw-managed`, or remove the declaration.
+
+### Inspect a NemoClaw-Managed Gateway
+
+In `nemoclaw-managed` mode, no declaration names a unit.
+NemoClaw uses a managed service only for the default gateway port `8080`.
+The service depends on the install.
+
+| Install | Service | Status command |
+|---|---|---|
+| Linux package install | The `openshell-gateway.service` user unit installed by the OpenShell package | `systemctl --user status openshell-gateway` |
+| Linux tarball install | The `nemoclaw-openshell-gateway.service` user unit staged by the NemoClaw installer | `systemctl --user status nemoclaw-openshell-gateway` |
+| macOS with the `nvidia/openshell/openshell` Homebrew formula | The `openshell` formula service | `brew services info openshell` |
+
+Both Linux units belong to the systemd user manager.
+A `systemctl status` command without `--user` reports that the unit cannot be found.
+NemoClaw runs a standalone gateway with no service when no service manager owns the gateway or the gateway uses another port.
+To restart the service or the standalone gateway and recover the sandbox, follow [Reconnect after a host reboot](../reference/troubleshooting#reconnect-after-a-host-reboot).

--- a/docs/deployment/gateway-lifecycle-authority.mdx
+++ b/docs/deployment/gateway-lifecycle-authority.mdx
@@ -211,7 +211,7 @@ It does not transfer process ownership to NemoClaw.
 
 Run `$$nemoclaw status` to read the `Gateway authority` mode before you inspect a service.
 
-### Fix an Externally Supervised Gateway
+### Fix an externally supervised gateway
 
 Resolve an external gateway failure through the declared supervisor.
 Replace `<serviceName>` with the `serviceName` value from your declaration.
@@ -230,7 +230,7 @@ systemctl --user status <serviceName>
 Bring the supervised gateway up, leave exactly one verified process holding the configured port, and rerun `$$nemoclaw onboard`.
 To hand the lifecycle back to NemoClaw, remove the platform gateway service and declare `nemoclaw-managed`, or remove the declaration.
 
-### Inspect a NemoClaw-Managed Gateway
+### Inspect a NemoClaw-managed gateway
 
 In `nemoclaw-managed` mode, no declaration names a unit.
 NemoClaw uses a managed service only for the default gateway port `8080`.

--- a/docs/deployment/gateway-lifecycle-authority.mdx
+++ b/docs/deployment/gateway-lifecycle-authority.mdx
@@ -177,7 +177,8 @@ $$nemoclaw status
 $$nemoclaw status --json
 ```
 
-In `nemoclaw-managed` mode, the owner is the source `packaged-service` or `standalone`, and `gatewayAuthority.supervisor` is `null`.
+In `nemoclaw-managed` mode, `gatewayAuthority.supervisor` is `null`.
+The owner source is `declared` when a declaration selected that mode; without a declaration it is the resolved lifecycle source, `packaged-service` or `standalone`.
 In `externally-supervised` mode, the owner is the declared supervisor `kind`, `serviceName`, and `execPath`.
 `$$nemoclaw debug` also records `gatewayAuthority` in `onboard-session-summary.txt`.
 The status and debug views omit the external state directory and never include credential values.
@@ -234,13 +235,16 @@ To hand the lifecycle back to NemoClaw, remove the platform gateway service and 
 
 In `nemoclaw-managed` mode, no declaration names a unit.
 NemoClaw uses a managed service only for the default gateway port `8080`.
-The service depends on the install.
+Read the `Owner` value before looking for a service.
+An owner of `standalone` has no service unit.
+For `packaged-service` or a declared managed mode, use the exact service inspection or recovery command that NemoClaw reports; the owner record does not include the resolved user-service name.
+Do not infer the selected Linux unit from install type alone: a tarball installation can adopt a verified upstream package unit, while a host without a usable user manager keeps the standalone gateway.
 
-| Install | Service | Status command |
+| Platform | Possible selected service | Inspection |
 |---|---|---|
-| Linux package install | The `openshell-gateway.service` user unit installed by the OpenShell package | `systemctl --user status openshell-gateway` |
-| Linux tarball install | The `nemoclaw-openshell-gateway.service` user unit staged by the NemoClaw installer | `systemctl --user status nemoclaw-openshell-gateway` |
-| macOS with the `nvidia/openshell/openshell` Homebrew formula | The `openshell` formula service | `brew services info openshell` |
+| Linux | The verified upstream `openshell-gateway.service` user unit | `systemctl --user status openshell-gateway` |
+| Linux | The marked `nemoclaw-openshell-gateway.service` user unit staged by the NemoClaw installer | `systemctl --user status nemoclaw-openshell-gateway` |
+| macOS | The `openshell` service from the `nvidia/openshell/openshell` Homebrew formula | Continue with [Reconnect after a host reboot](../reference/troubleshooting#reconnect-after-a-host-reboot) so NemoClaw performs trust-scoped inspection and recovery. Do not run `brew services` directly. |
 
 Both Linux units belong to the systemd user manager.
 A `systemctl status` command without `--user` reports that the unit cannot be found.

--- a/docs/deployment/gateway-lifecycle-authority.mdx
+++ b/docs/deployment/gateway-lifecycle-authority.mdx
@@ -235,18 +235,6 @@ To hand the lifecycle back to NemoClaw, remove the platform gateway service and 
 
 In `nemoclaw-managed` mode, no declaration names a unit.
 NemoClaw uses a managed service only for the default gateway port `8080`.
-Read the `Owner` value before looking for a service.
 An owner of `standalone` has no service unit.
-For `packaged-service` or a declared managed mode, use the exact service inspection or recovery command that NemoClaw reports; the owner record does not include the resolved user-service name.
-Do not infer the selected Linux unit from install type alone: a tarball installation can adopt a verified upstream package unit, while a host without a usable user manager keeps the standalone gateway.
-
-| Platform | Possible selected service | Inspection |
-|---|---|---|
-| Linux | The verified upstream `openshell-gateway.service` user unit | `systemctl --user status openshell-gateway` |
-| Linux | The marked `nemoclaw-openshell-gateway.service` user unit staged by the NemoClaw installer | `systemctl --user status nemoclaw-openshell-gateway` |
-| macOS | The `openshell` service from the `nvidia/openshell/openshell` Homebrew formula | Continue with [Reconnect after a host reboot](../reference/troubleshooting#reconnect-after-a-host-reboot) so NemoClaw performs trust-scoped inspection and recovery. Do not run `brew services` directly. |
-
-Both Linux units belong to the systemd user manager.
-A `systemctl status` command without `--user` reports that the unit cannot be found.
-NemoClaw runs a standalone gateway with no service when no service manager owns the gateway or the gateway uses another port.
-To restart the service or the standalone gateway and recover the sandbox, follow [Reconnect after a host reboot](../reference/troubleshooting#reconnect-after-a-host-reboot).
+For `packaged-service` or a declared managed mode, the owner record does not identify the concrete service, so do not infer a unit from the install type.
+Follow [Reconnect after a host reboot](../reference/troubleshooting#reconnect-after-a-host-reboot) for NemoClaw-owned service inspection, trust-scoped recovery, and standalone recovery.

--- a/docs/deployment/gateway-lifecycle-authority.mdx
+++ b/docs/deployment/gateway-lifecycle-authority.mdx
@@ -229,7 +229,8 @@ systemctl --user status <serviceName>
 ```
 
 Bring the supervised gateway up, leave exactly one verified process holding the configured port, and rerun `$$nemoclaw onboard`.
-To hand the lifecycle back to NemoClaw, remove the platform gateway service and declare `nemoclaw-managed`, or remove the declaration.
+To hand the lifecycle back to NemoClaw, first stop and remove or disable the external supervisor and its gateway so no process remains on the configured port.
+Then declare `nemoclaw-managed` or remove the declaration, and rerun `$$nemoclaw onboard`.
 
 ### Inspect a NemoClaw-managed gateway
 


### PR DESCRIPTION
## Outcome

Before, the Gateway Lifecycle Authority page told every reader to run `systemctl status openshell-gateway.service` and `systemctl --user status openshell-gateway.service`, and a reader with the default `nemoclaw-managed` gateway got `Unit openshell-gateway.service could not be found`.
After, the externally supervised commands use the `serviceName` from the reader's declaration, and a new NemoClaw-managed section names the user unit or Homebrew service for each install with the status command NemoClaw itself prints.

## Reason

`openshell-gateway.service` on the page is only the example value of the externally supervised declaration's `serviceName`.
In `nemoclaw-managed` mode NemoClaw never installs a system unit: a Linux tarball install stages the `nemoclaw-openshell-gateway.service` user unit, a Linux package install adopts the package's `openshell-gateway.service` user unit, and macOS uses the `openshell` Homebrew formula service (`src/lib/onboard/docker-driver-gateway-service.ts:24-27`, `183-189`, `329-339`, `610-686`).
The page never named those units, so the reporter had no way to tell whether the gateway was broken or the page was wrong.
The reporter's second point, that `nemoclaw status --json` shows no `serviceName`, matches the source: `gatewayAuthority.supervisor` is `null` in managed mode (`src/lib/onboard/gateway-ownership.ts:159-168`, `505-529`), and the page now says so.

### Related issues

Fixes #10870

## Changes

- `docs/deployment/gateway-lifecycle-authority.mdx`, section "Fix a failure": split into "Fix an Externally Supervised Gateway" and "Inspect a NemoClaw-Managed Gateway".
- Externally supervised commands now read `systemctl status <serviceName>` and `systemctl --user status <serviceName>` with an instruction to substitute the declared `serviceName`, which is the value NemoClaw probes with the same manager scope (`src/lib/onboard/gateway-host-runtime.ts:213-228`).
- New table for `nemoclaw-managed` mode: Linux package install `systemctl --user status openshell-gateway`, Linux tarball install `systemctl --user status nemoclaw-openshell-gateway`, macOS Homebrew formula `brew services info openshell`; these are the `statusCommand` values NemoClaw prints (`docker-driver-gateway-service.ts:620`, `635`, `682`).
- States that a managed service exists only for the default port `8080` (`src/lib/onboard/gateway-host-runtime.ts:141-143`, `src/lib/onboard/gateway-binding/identity.ts:15-17`), that both Linux units belong to the systemd user manager, and that other cases run a standalone gateway with no service.
- Links the restart and recovery procedure that `docs/reference/troubleshooting.mdx` owns ("Reconnect after a host reboot") instead of repeating it.
- Section "Inspect the selected authority": states what the owner line shows in each mode and that `gatewayAuthority.supervisor` is `null` in managed mode (`src/lib/inventory/index.ts:702-711`).
- The declaration example keeps `openshell-gateway.service` because it models a platform-owned system unit; the troubleshooting and architecture pages already name both Linux units correctly and are unchanged.

## Verification

All commands ran on the NVIDIA-provided Linux test host in a worktree at base `19bb9860a662e25418f1afbc7e0589d7f22f2497` (`upstream/main`).

- `npm run docs` — passed, exit 0. `docs:prepare` regenerated `docs/_build/agent-variants/deployment/gateway-lifecycle-authority.{openclaw,hermes,deepagents}.generated.mdx`; `docs:check-starter-prompt`, `docs:check-agent-variants`, and `docs:check-routes` passed (`check-docs-published-routes: OK — 69 guarded page(s)`); `fern check` reported `Found 0 errors and 2 warnings`; `fern check --warnings` shows both are site-level and not about this page (the redirects check is skipped without `FERN_TOKEN`, and the light-mode accent contrast ratio is 2.41:1).
- Generated variants inspected — the OpenClaw, Hermes, and Deep Agents pages render `nemoclaw status`, `nemohermes status`, and `nemo-deepagents status` respectively; the unit names, `systemctl --user` commands, and the `../reference/troubleshooting#reconnect-after-a-host-reboot` link are identical in all three.
- `npm run checks:repository` — passed (source architecture budget, onboarding entry composition boundary, Vitest project membership, test title style, and the remaining repository checks all reported passed).
- `npm run validate:pr` — passed, exit 0, against a throwaway local commit carrying this diff and this commit message (`prek` pre-commit stage: trailing whitespace, end-of-file, mixed line ending, force-added ignored files, merge conflicts, large files, case conflicts, private keys, shebang, gitleaks, and codebase growth guardrails passed, the rest reported no files to check; `commitlint` passed; pre-push TypeScript hooks reported no files to check). No hook changed the file.
- Source verification — unit and formula names, trusted unit paths, status commands, and the default-port gate read from `src/lib/onboard/docker-driver-gateway-service.ts`, `src/lib/onboard/gateway-host-runtime.ts`, `src/lib/onboard/gateway-binding/identity.ts`, `src/lib/onboard/gateway-ownership.ts`, `src/lib/onboard/gateway-management.ts` (`serviceName` must name one `.service` unit, lines 252-256), and `src/lib/inventory/index.ts`; the installer stages the same unit name (`scripts/install.sh:1500`, `1823-1824`).
- Read-only host check — the test host has no `*gateway*` user unit file, no `openshell-gateway.service` under `/usr/lib/systemd/user`, and only `default.target.wants` under `~/.config/systemd/user`, which is the standalone case the new section describes.
- Independent documentation writer review — not yet obtained; requested through PR review.
- The diff contains no secrets, API keys, or credentials.

## Review notes

`openshell-gateway.service` is a real unit on some hosts: the OpenShell package installs it as a systemd user unit, and a platform image can supervise the gateway with a system unit of that name.
The fix therefore makes the instruction conditional on the authority mode and install instead of renaming the unit everywhere.

---
Signed-off-by: Kushagar Garg <dreamstick909@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified managed gateway owner reporting and the distinction between declared ownership and resolved packaged-service or standalone sources.
  - Updated external-supervisor troubleshooting to use service names from the declaration.
  - Added guidance to stop, remove, or disable the external supervisor and clear the configured port before returning lifecycle ownership to NemoClaw.
  - Added redeclaration and onboarding steps after ownership is restored.
  - Directed NemoClaw-managed gateway recovery through the reboot troubleshooting flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->