### PR TITLE
ci(security): authorize fast-uri lock transition

### DIFF
--- a/ci/reviewed-npm-audit.json
+++ b/ci/reviewed-npm-audit.json
@@ -96,7 +96,8 @@
       "integrity": "sha512-ge/Xss99CHAjPL/ikmH/UFoiOrjcxDB4sW3y9mhyCD+dYW3wzV7TKbAVdkrXFgAG2d2BjpJofP97zUZ+umxo8g==",
       "tarballUrl": "https://registry.npmjs.org/openclaw/-/openclaw-2026.7.1.tgz",
       "directory": "agents/openclaw/openclaw-runtime",
-      "lockSha256": "60f816dcff6f35179b1c48b4c06db9473497760d45ca1831252c27e8b1d2d665"
+      "lockSha256": "60f816dcff6f35179b1c48b4c06db9473497760d45ca1831252c27e8b1d2d665",
+      "replacementLockSha256": "248d881ca125bb83da293c4b3f40b46d057095a9fe90b5165255da0de78af9f9"
     },
     {
       "id": "mcporter-runtime",
@@ -105,7 +106,8 @@
       "integrity": "sha512-egoPVYqTnWb3NjRIxo+xc8OrAI0dlPrJm9pAiZx0pImuNIV5rKhGtTnIfH/Y1ldGPVu74ibj3KR5c9U/QSdQFA==",
       "tarballUrl": "https://registry.npmjs.org/mcporter/-/mcporter-0.7.3.tgz",
       "directory": "agents/openclaw/mcporter-runtime",
-      "lockSha256": "17f2372a0a6949df928333a2f98862ae563013a7682b19a8ce63825c4696a064"
+      "lockSha256": "17f2372a0a6949df928333a2f98862ae563013a7682b19a8ce63825c4696a064",
+      "replacementLockSha256": "720c0e3ec2efcccd2c820ce2a39d733f7bd5bf9d3e6fb95310e7f6cd369db83c"
     },
     {
       "id": "mcp-tool-discovery-runtime",
@@ -114,7 +116,8 @@
       "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "tarballUrl": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
       "directory": "tools/mcp-tool-discovery-runtime",
-      "lockSha256": "bc7e34d9eb1f72cf3016c8b88c72d3b7682a4f234903cb93b9476b10d7e954eb"
+      "lockSha256": "bc7e34d9eb1f72cf3016c8b88c72d3b7682a4f234903cb93b9476b10d7e954eb",
+      "replacementLockSha256": "0697681f948bda0b59fc1ff2e4c6dbe2693cc89eec64b11b5be604160643c6e5"
     }
   ]
 }


### PR DESCRIPTION
## Outcome

Authorizes one bounded reviewed-lock transition from fast-uri 3.1.5 to 3.1.6 for the three dedicated production graphs.

## Reason

PR #10892 updates vulnerable fast-uri locks, but the trusted base audit correctly rejects replacement lock hashes not pre-authorized by base-controlled configuration.

## Changes

- Add one replacementLockSha256 per affected reviewed graph.
- Preserve current lock hashes until PR #10892 lands and removes the transition entries.

## Verification

- JSON validation passed.
- Existing parser rejects malformed, equal, or non-SHA replacement hashes.

Prerequisite for PR #10892 and PR #10866.

Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated locked runtime dependency metadata for OpenClaw, mcporter, and MCP tool discovery.
  * Existing lock integrity values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->