### PR TITLE
docs(skills): remove volatile skill counts

### DIFF
--- a/.agents/skills/nemoclaw-skills-guide/SKILL.md
+++ b/.agents/skills/nemoclaw-skills-guide/SKILL.md
@@ -25,7 +25,7 @@ The prefix in each skill name indicates who it is for.
 For end users operating a NemoClaw sandbox.
 Covers routing human users' AI agents to the canonical NemoClaw Markdown documentation.
 
-### `nemoclaw-maintainer-*` (21 skills)
+### `nemoclaw-maintainer-*`
 
 For project maintainers.
 Covers the daily maintainer cadence, trusted E2E dispatch, continuous E2E maintenance, runtime-provider integration and qualification, Launchable validation, workflow policy, CI failure classification, CI performance analysis, pull request value-stream analysis, documentation refactors, releases, review selection, comparison, triage, security review, and stale bug verification.
@@ -99,10 +99,10 @@ Ask the user which role best describes them:
 
 Skills are cumulative. Each role includes the skills from the roles above it:
 
-| Role | Skills included | Count | Start with |
-|------|----------------|-------|------------|
-| User | `nemoclaw-user-*` | 1 | `nemoclaw-user-guide` |
-| Contributor | `nemoclaw-user-*` + `nemoclaw-contributor-*` | 7 | `nemoclaw-contributor-onboard` |
-| Maintainer | All skills | 28 | `nemoclaw-maintainer-morning` |
+| Role | Skills included | Start with |
+|------|----------------|------------|
+| User | `nemoclaw-user-*` | `nemoclaw-user-guide` |
+| Contributor | `nemoclaw-user-*` + `nemoclaw-contributor-*` | `nemoclaw-contributor-onboard` |
+| Maintainer | All skills | `nemoclaw-maintainer-morning` |
 
 After identifying the role, present the applicable skills from the Skill Catalog above and recommend the starting skill.


### PR DESCRIPTION
## Outcome

Removes volatile skill-count labels from the NemoClaw skills guide.

## Reason

Follow-up to maintainer comments on #10856. The audience buckets and role table should describe routing without embedding counts that drift whenever skills are added or removed.

## Changes

- Remove the maintainer skill count from the bucket heading.
- Remove the Count column from the cumulative role table.

## Verification

- npm run validate:pr
- npm run checks:repository
- npx markdownlint-cli2 .agents/skills/nemoclaw-skills-guide/SKILL.md
- Independent documentation review: no findings

## Related

Follow-up to #10856.

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the maintainer skill guide by removing skill-count details while preserving role-based skill groups and recommended starting skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->