### PR TITLE
fix(ci): accept validated artifact data descriptors

### DIFF
--- a/scripts/lib/read-artifact-zip.mts
+++ b/scripts/lib/read-artifact-zip.mts
@@ -4,9 +4,12 @@
 import zlib from "node:zlib";
 
 const ZIP_CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const ZIP_DATA_DESCRIPTOR_FLAG = 0x0008;
 const ZIP_DATA_DESCRIPTOR_SIGNATURE = 0x08074b50;
 const ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
 const ZIP_LOCAL_FILE_SIGNATURE = 0x04034b50;
+const ZIP_UTF8_NAMES_FLAG = 0x0800;
+const ZIP_SUPPORTED_GENERAL_PURPOSE_FLAGS = ZIP_DATA_DESCRIPTOR_FLAG | ZIP_UTF8_NAMES_FLAG;
 
 type ParseOptions = {
   maxEntries: number;
@@ -154,7 +157,7 @@ function parseValidatedArtifactZip(
       totalUncompressedBytes > options.maxTotalUncompressedBytes ||
       seen.has(name) ||
       diskStart !== 0 ||
-      (flags & 0x1) !== 0 ||
+      (flags & ~ZIP_SUPPORTED_GENERAL_PURPOSE_FLAGS) !== 0 ||
       (compressionMethod !== 0 && compressionMethod !== 8) ||
       (creatorSystem !== 0 && creatorSystem !== 3) ||
       (creatorSystem === 3 && unixFileType !== 0 && unixFileType !== 0x8000) ||
@@ -174,7 +177,7 @@ function parseValidatedArtifactZip(
     const localNameEnd = localHeaderOffset + 30 + localNameLength;
     const compressedDataOffset = localNameEnd + localExtraLength;
     const dataEnd = compressedDataOffset + compressedSize;
-    const usesDataDescriptor = (flags & 0x8) !== 0;
+    const usesDataDescriptor = (flags & ZIP_DATA_DESCRIPTOR_FLAG) !== 0;
     const descriptorEnd = usesDataDescriptor
       ? matchingDataDescriptorEnd(
           archive,

--- a/scripts/lib/read-artifact-zip.mts
+++ b/scripts/lib/read-artifact-zip.mts
@@ -4,6 +4,7 @@
 import zlib from "node:zlib";
 
 const ZIP_CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const ZIP_DATA_DESCRIPTOR_SIGNATURE = 0x08074b50;
 const ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
 const ZIP_LOCAL_FILE_SIGNATURE = 0x04034b50;
 
@@ -58,6 +59,30 @@ function isSafeIntegerAtLeast(value: number, minimum: number): boolean {
   return Number.isSafeInteger(value) && value >= minimum;
 }
 
+function matchingDataDescriptorEnd(
+  archive: Buffer,
+  offset: number,
+  boundary: number,
+  expectedCrc: number,
+  compressedSize: number,
+  uncompressedSize: number,
+): number | null {
+  const matchesAt = (fieldsOffset: number): boolean =>
+    fieldsOffset + 12 <= boundary &&
+    archive.readUInt32LE(fieldsOffset) === expectedCrc &&
+    archive.readUInt32LE(fieldsOffset + 4) === compressedSize &&
+    archive.readUInt32LE(fieldsOffset + 8) === uncompressedSize;
+
+  if (
+    offset + 4 <= boundary &&
+    archive.readUInt32LE(offset) === ZIP_DATA_DESCRIPTOR_SIGNATURE &&
+    matchesAt(offset + 4)
+  ) {
+    return offset + 16;
+  }
+  return matchesAt(offset) ? offset + 12 : null;
+}
+
 /** Owns all ZIP parsing, structural validation, optional inflation, and CRC checks. */
 function parseValidatedArtifactZip(
   archive: Buffer,
@@ -88,6 +113,7 @@ function parseValidatedArtifactZip(
   }
 
   const entries: ValidatedArtifactZipEntry[] = [];
+  const localRecords: Array<{ end: number; start: number; usesDataDescriptor: boolean }> = [];
   const seen = new Set<string>();
   let totalUncompressedBytes = 0;
   let offset = centralDirectoryOffset;
@@ -128,7 +154,7 @@ function parseValidatedArtifactZip(
       totalUncompressedBytes > options.maxTotalUncompressedBytes ||
       seen.has(name) ||
       diskStart !== 0 ||
-      (flags & 0x9) !== 0 ||
+      (flags & 0x1) !== 0 ||
       (compressionMethod !== 0 && compressionMethod !== 8) ||
       (creatorSystem !== 0 && creatorSystem !== 3) ||
       (creatorSystem === 3 && unixFileType !== 0 && unixFileType !== 0x8000) ||
@@ -148,14 +174,30 @@ function parseValidatedArtifactZip(
     const localNameEnd = localHeaderOffset + 30 + localNameLength;
     const compressedDataOffset = localNameEnd + localExtraLength;
     const dataEnd = compressedDataOffset + compressedSize;
+    const usesDataDescriptor = (flags & 0x8) !== 0;
+    const descriptorEnd = usesDataDescriptor
+      ? matchingDataDescriptorEnd(
+          archive,
+          dataEnd,
+          centralDirectoryOffset,
+          expectedCrc,
+          compressedSize,
+          uncompressedSize,
+        )
+      : dataEnd;
     if (
       localNameEnd > centralDirectoryOffset ||
       dataEnd > centralDirectoryOffset ||
       localFlags !== flags ||
       localCompressionMethod !== compressionMethod ||
-      localCrc !== expectedCrc ||
-      localCompressedSize !== compressedSize ||
-      localUncompressedSize !== uncompressedSize ||
+      (usesDataDescriptor
+        ? localCrc !== 0 ||
+          localCompressedSize !== 0 ||
+          localUncompressedSize !== 0 ||
+          descriptorEnd === null
+        : localCrc !== expectedCrc ||
+          localCompressedSize !== compressedSize ||
+          localUncompressedSize !== uncompressedSize) ||
       !archive.subarray(localHeaderOffset + 30, localNameEnd).equals(nameBytes)
     ) {
       return null;
@@ -177,9 +219,24 @@ function parseValidatedArtifactZip(
 
     seen.add(name);
     entries.push({ name, bytes });
+    localRecords.push({
+      end: descriptorEnd ?? dataEnd,
+      start: localHeaderOffset,
+      usesDataDescriptor,
+    });
     offset = entryEnd;
   }
-  return offset === endOffset ? entries : null;
+  if (offset !== endOffset) return null;
+
+  localRecords.sort((left, right) => left.start - right.start);
+  for (let index = 0; index < localRecords.length; index += 1) {
+    const record = localRecords[index]!;
+    const nextBoundary = localRecords[index + 1]?.start ?? centralDirectoryOffset;
+    if (record.end > nextBoundary || (record.usesDataDescriptor && record.end !== nextBoundary)) {
+      return null;
+    }
+  }
+  return entries;
 }
 
 /**

--- a/test/e2e/support/artifact-zip.test.ts
+++ b/test/e2e/support/artifact-zip.test.ts
@@ -132,15 +132,71 @@ describe("validated GitHub artifact ZIP reader", () => {
   );
 
   it.each([false, true])(
-    "rejects unsupported bit-3 data descriptors (signature: %s)",
+    "returns validated bytes for a bit-3 data descriptor (signature: %s)",
     (signature) => {
       const archive = withDataDescriptor(
         artifactZip([{ name: "summary.json", contents: '{"safe":true}' }], 8),
         signature,
       );
+      expect(readValidatedArtifactZipEntries(archive, LIMITS)).toEqual([
+        { name: "summary.json", bytes: Buffer.from('{"safe":true}') },
+      ]);
+    },
+  );
+
+  it.each([
+    [false, "CRC", 0],
+    [false, "compressed size", 4],
+    [false, "uncompressed size", 8],
+    [true, "CRC", 0],
+    [true, "compressed size", 4],
+    [true, "uncompressed size", 8],
+  ])(
+    "rejects a bit-3 data descriptor mismatch (signature: %s, field: %s)",
+    (signature, _field, fieldOffset) => {
+      const archive = withDataDescriptor(
+        artifactZip([{ name: "summary.json", contents: '{"safe":true}' }], 8),
+        signature,
+      );
+      const centralOffset = archive.readUInt32LE(archive.length - 6);
+      const descriptorOffset = centralOffset - (signature ? 16 : 12) + (signature ? 4 : 0);
+      const offset = descriptorOffset + fieldOffset;
+      archive.writeUInt32LE(archive.readUInt32LE(offset) + 1, offset);
       expect(readValidatedArtifactZipEntries(archive, LIMITS)).toBeNull();
     },
   );
+
+  it.each([
+    ["CRC", 14, 16],
+    ["compressed size", 18, 20],
+    ["uncompressed size", 22, 24],
+  ])(
+    "rejects a bit-3 data descriptor with a populated local %s",
+    (_field, localOffset, centralFieldOffset) => {
+      const archive = withDataDescriptor(
+        artifactZip([{ name: "summary.json", contents: '{"safe":true}' }], 8),
+        true,
+      );
+      const centralOffset = archive.readUInt32LE(archive.length - 6);
+      archive.writeUInt32LE(archive.readUInt32LE(centralOffset + centralFieldOffset), localOffset);
+      expect(readValidatedArtifactZipEntries(archive, LIMITS)).toBeNull();
+    },
+  );
+
+  it("rejects trailing data between a bit-3 descriptor and the central directory", () => {
+    const archive = withDataDescriptor(
+      artifactZip([{ name: "summary.json", contents: '{"safe":true}' }], 8),
+      true,
+    );
+    const centralOffset = archive.readUInt32LE(archive.length - 6);
+    const result = Buffer.concat([
+      archive.subarray(0, centralOffset),
+      Buffer.from([0]),
+      archive.subarray(centralOffset),
+    ]);
+    result.writeUInt32LE(centralOffset + 1, result.length - 6);
+    expect(readValidatedArtifactZipEntries(result, LIMITS)).toBeNull();
+  });
 
   it("rejects encryption, local method disagreement, corrupt data, and CRC mismatch", () => {
     const encrypted = artifactZip([{ name: "summary.json", contents: "safe" }]);

--- a/test/e2e/support/artifact-zip.test.ts
+++ b/test/e2e/support/artifact-zip.test.ts
@@ -198,6 +198,27 @@ describe("validated GitHub artifact ZIP reader", () => {
     expect(readValidatedArtifactZipEntries(result, LIMITS)).toBeNull();
   });
 
+  it("accepts the UTF-8 names flag", () => {
+    const archive = artifactZip([{ name: "résumé.json", contents: "safe" }]);
+    const centralOffset = archive.readUInt32LE(archive.length - 6);
+    archive.writeUInt16LE(archive.readUInt16LE(6) | 0x0800, 6);
+    archive.writeUInt16LE(archive.readUInt16LE(centralOffset + 8) | 0x0800, centralOffset + 8);
+    expect(readValidatedArtifactZipEntries(archive, LIMITS)).toEqual([
+      { name: "résumé.json", bytes: Buffer.from("safe") },
+    ]);
+  });
+
+  it.each([
+    ["compression option", 0x0002],
+    ["patched data", 0x0020],
+  ])("rejects the unsupported %s flag", (_flag, flag) => {
+    const archive = artifactZip([{ name: "summary.json", contents: "safe" }]);
+    const centralOffset = archive.readUInt32LE(archive.length - 6);
+    archive.writeUInt16LE(archive.readUInt16LE(6) | flag, 6);
+    archive.writeUInt16LE(archive.readUInt16LE(centralOffset + 8) | flag, centralOffset + 8);
+    expect(readValidatedArtifactZipEntries(archive, LIMITS)).toBeNull();
+  });
+
   it("rejects encryption, local method disagreement, corrupt data, and CRC mismatch", () => {
     const encrypted = artifactZip([{ name: "summary.json", contents: "safe" }]);
     const encryptedCentral = encrypted.readUInt32LE(encrypted.length - 6);


### PR DESCRIPTION
## Outcome

The release `base-image-publication` gate can consume the immutable ZIP archives currently returned by GitHub Actions while retaining fail-closed contract validation.

## Reason

The successful image publisher for the `v0.0.119` candidate produced a valid one-file artifact ZIP with the standard bit-3 data-descriptor flag. The shared reader rejected that encoding before it could validate `contract.json`, which blocked the candidate verifier even though artifact identity and digest checks passed.

### Related issues

Refs #9340

## Changes

- Accept signed and unsigned 32-bit ZIP data descriptors only when their CRC and sizes match the central directory.
- Reject every unsupported general-purpose ZIP flag; only data descriptors and UTF-8 names are accepted.
- Require descriptor-based entries to keep zeroed local CRC/size fields and end exactly at the next local record or central directory.
- Preserve encryption, unsafe-entry, size-bound, decompression, CRC, identity, and digest rejection.
- Cover the accepted GitHub layout plus mismatched CRC/sizes, populated local fields, and trailing-data rejection.

## Verification

- `npx vitest run --project e2e-support test/e2e/support/artifact-zip.test.ts test/e2e/support/exact-artifact-download.test.ts` — 73 tests passed.
- Actual artifact `managed-base-33681468103-1-langchain-deepagents-code` — the reader returned exactly `contract.json` (1,122 bytes), reproducing and then resolving the failed gate input.
- `npx biome check scripts/lib/read-artifact-zip.mts test/e2e/support/artifact-zip.test.ts` — passed.
- `npm run validate:pr` against canonical `main` at `0673b122147433e8025222a135c7b8a3ebdbd27a` — passed.
- Commit hooks — formatting, lint, repository checks, secret scan, source-shape budget, growth guardrails, and commit lint passed.
- `npx vitest run --project e2e-support` — local aggregate was inconclusive under host saturation: 3,648 passed, 39 skipped, and 65 unrelated failures dominated by subprocess timeouts plus missing host `ip`/Python `yaml`; the changed parser suites remained green.
- Diff review — no secrets, API keys, or credentials.

## Review notes

- Security review: no findings across the nine-category rubric. Artifact identity/digest binding remains outside this parser and unchanged; accepted bytes still pass bounded inflation and CRC checks before materialization.
- Independent documentation review: no public docs or changelog update is required for this internal verifier compatibility fix.

---

Signed-off-by: Charan Jagwani <cjagwani@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ZIP archives using signed or unsigned data descriptors are now supported.
  - UTF-8 file names in ZIP archives are accepted.

- **Bug Fixes**
  - Improved validation of ZIP metadata, including CRC values, file sizes, record boundaries, and trailing data.
  - Archives using unsupported ZIP flags or malformed, overlapping, or improperly bounded records are rejected more reliably.

- **Tests**
  - Added coverage for valid data descriptors, UTF-8 names, unsupported flags, and malformed archive scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->