### PR TITLE
test(ci): skip Linux classifier process tests on macOS

### DIFF
--- a/test/automation/classify-ci-failure.test.ts
+++ b/test/automation/classify-ci-failure.test.ts
@@ -307,7 +307,7 @@ describe("GitHub CLI production resolver", () => {
   });
 });
 
-describe("CI failure classifier process", () => {
+describe.skipIf(process.platform !== "linux")("CI failure classifier process", () => {
   test("redacts credentials from classified diagnostic output", () => {
     const secrets = [
       "Authorization: Bearer full authorization value with spaces",


### PR DESCRIPTION
## Outcome

macOS compatibility jobs no longer execute the Linux-only CI classifier process suite. Platform-neutral GitHub CLI resolver tests still run on macOS. Linux and WSL continue to run all classifier process tests.

## Reason

PR #10856 added process tests that require Linux `/proc` and Linux system executable paths. The macOS compatibility job ran those tests and failed before their behavior assertions.

## Changes

- Limit the classifier process suite to Linux, which matches the production classifier platform guard.
- Keep the platform-neutral production resolver suite active on macOS.

## Verification

- Pre-fix: `vitest run --project integration test/automation/classify-ci-failure.test.ts` on macOS failed 64 of 74 tests. The first failure was `ENOENT` for `/usr/bin/bash`.
- Post-fix: the same focused command on macOS passed with 5 tests passed and 69 Linux-only cases skipped.
- `bash test/e2e/e2e-cloud-experimental/features/skill/lib/validate_repo_skills.sh` passed all 29 repository skills.
- `npm run validate:pr` passed pre-commit, commitlint, and pre-push checks after generating the required local build artifacts.
- `npm run review:local` could not start its OpenShell gateway and cleanup reported `EACCES`. It produced no review finding.
- Diff inspection found no secrets, API keys, or credentials.

---

Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Limited CI failure classifier process tests to Linux platforms; they are skipped on non-Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->