### PR TITLE
test(e2e): describe direct blueprint checks accurately

### DIFF
--- a/test/e2e-test.sh
+++ b/test/e2e-test.sh
@@ -65,11 +65,9 @@ else
 fi
 
 # -------------------------------------------------------
-info "3b. Verify blueprint profile validation from compiled TypeScript"
+info "3b. Verify blueprint profile and policy YAML contracts"
 # -------------------------------------------------------
-# Independent backstop for validate-blueprint.test.ts — exercises the same
-# checks from the compiled TS inside the Docker container so a vitest
-# loading bug cannot hide a broken blueprint.
+# Direct YAML backstop for profile declarations, definitions, and base policy.
 if node --input-type=module -e "
   import { createRequire } from 'node:module';
   import { readFileSync } from 'node:fs';
@@ -103,9 +101,9 @@ if node --input-type=module -e "
 
   console.log('Validated ' + declared.length + ' profiles: ' + declared.join(', '));
 "; then
-  pass "Blueprint validation from compiled TS inside Docker"
+  pass "Blueprint profile and policy YAML contracts are valid"
 else
-  fail "Blueprint validation from compiled TS failed"
+  fail "Blueprint profile or policy YAML contract is invalid"
 fi
 
 # -------------------------------------------------------


### PR DESCRIPTION
## Outcome

Corrects the E2E blueprint-validation step so its name and diagnostics describe the boundary it actually exercises.

## Reason

The step parses the packaged blueprint and base policy directly with YAML. It does not call a compiled NemoClaw validator, so the previous “compiled TypeScript” wording overstated its evidence. This was identified by the Behavior specialist in [PR Advisor run 33691244770](https://github.com/NVIDIA/NemoClaw/actions/runs/33691244770).

## Changes

- Rename the step as direct blueprint profile and policy YAML contract validation.
- Replace the stale reference to a nonexistent validation test and compiled-TypeScript execution.
- Update pass and failure diagnostics to match the direct YAML checks.

The profile and policy assertions are unchanged. Adding a new production validator would expand runtime behavior without a current product requirement, so this follow-up takes the Advisor's smaller recommended correction.

## Verification

- `npm run validate:pr`: passed.
- `npm run checks:repository`: passed.
- `bash -n test/e2e-test.sh`: passed.
- `git diff --check`: passed.
- Local Behavior Advisor review: no behavior issue in the changed area.

## Documentation

No user-facing behavior or documentation changed.

Refs #10908.

Signed-off-by: Carlos Villela <cvillela@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated blueprint profile testing to validate profile and base-policy YAML contracts directly.
  * Revised test success and failure messages to reflect the updated validation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->