### PR TITLE
fix(ci): isolate blueprint apply smoke

### DIFF
--- a/test/e2e-test.sh
+++ b/test/e2e-test.sh
@@ -157,15 +157,45 @@ info "4b. Verify blueprint runner apply smoke test"
 # Apply runs the full codepath (profile resolution, sandbox creation,
 # provider setup, state save) against a fixture CLI. Policy mutation reads must
 # return the same metadata + YAML shape as OpenShell 0.0.72; an empty successful
-# response is intentionally rejected by the runner.
+# response is intentionally rejected by the runner. Use an independent
+# blueprint so shipped policy endpoints cannot preempt the apply behavior under
+# test.
 FAKE_OPENSHELL_BIN=$(mktemp -d)
+APPLY_BLUEPRINT_PATH=$(mktemp -d)
 APPLY_OUTPUT=$(mktemp)
 APPLY_CALLS="$FAKE_OPENSHELL_BIN/calls"
 cleanup_apply_fixture() {
-  rm -rf "$FAKE_OPENSHELL_BIN"
+  rm -rf "$FAKE_OPENSHELL_BIN" "$APPLY_BLUEPRINT_PATH"
   rm -f "$APPLY_OUTPUT" "$APPLY_CALLS"
 }
 trap cleanup_apply_fixture EXIT
+cat >"$APPLY_BLUEPRINT_PATH/blueprint.yaml" <<'YAML'
+components:
+  sandbox:
+    image: openclaw
+    name: openclaw
+    forward_ports:
+      - 18789
+  inference:
+    profiles:
+      ncp:
+        provider_type: nvidia
+        provider_name: nvidia-ncp
+        model: nvidia/nemotron-3-super-120b-a12b
+  policy:
+    additions:
+      fixture_service:
+        name: fixture_service
+        endpoints:
+          - host: 93.184.216.34
+            port: 8000
+            access: full
+YAML
+cat >"$APPLY_BLUEPRINT_PATH/sandbox-policy.yaml" <<'YAML'
+version: 1
+network_policies: {}
+YAML
+cp /opt/nemoclaw-blueprint/private-networks.yaml "$APPLY_BLUEPRINT_PATH/private-networks.yaml"
 cat >"$FAKE_OPENSHELL_BIN/openshell" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -199,7 +229,7 @@ if [ "${1:-} ${2:-}" = "policy get" ]; then
 fi
 if [ "${1:-} ${2:-}" = "policy get" ] && [[ " $* " == *" --output json "* ]]; then
   sandbox="${@: -1}"
-  policy_file=/opt/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+  policy_file="${OPENSHELL_SANDBOX_POLICY:?}"
   policy_hash=sha256:fixture-policy
   policy_version=1
   if [ -f "${BASH_SOURCE[0]%/*}/effective-policy.yaml" ]; then
@@ -229,8 +259,12 @@ case "$*" in
       echo "unexpected policy read: expected policy get -g fixture-gateway --base <sandbox>" >&2
       exit 64
     fi
+    policy_file="${OPENSHELL_SANDBOX_POLICY:?}"
+    if [ -f "${BASH_SOURCE[0]%/*}/effective-policy.yaml" ]; then
+      policy_file="${BASH_SOURCE[0]%/*}/effective-policy.yaml"
+    fi
     printf '%s\n' 'Policy for sandbox fixture' '---'
-    cat /opt/nemoclaw-blueprint/policies/openclaw-sandbox.yaml
+    cat "$policy_file"
     ;;
   "policy get "*)
     echo "unexpected policy read: expected policy get -g fixture-gateway --base <sandbox>" >&2
@@ -240,8 +274,8 @@ esac
 SH
 chmod 0755 "$FAKE_OPENSHELL_BIN/openshell"
 PATH="$FAKE_OPENSHELL_BIN:$PATH" \
-  NEMOCLAW_BLUEPRINT_PATH=/opt/nemoclaw-blueprint \
-  OPENSHELL_SANDBOX_POLICY=/opt/nemoclaw-blueprint/policies/openclaw-sandbox.yaml \
+  NEMOCLAW_BLUEPRINT_PATH="$APPLY_BLUEPRINT_PATH" \
+  OPENSHELL_SANDBOX_POLICY="$APPLY_BLUEPRINT_PATH/sandbox-policy.yaml" \
   node --input-type=module -e "
   const { main } = await import('/opt/nemoclaw/dist/blueprint/runner.js');
   await main(['apply', '--profile', 'ncp']);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The sandbox image apply smoke now owns the blueprint input needed to exercise its policy mutation contract. Shipped blueprint changes can no longer reject the smoke before apply or remove the policy read that the smoke asserts.

## Reason

The compiled apply smoke was coupled to the shipped product blueprint. The private-host validation introduced by #10856 rejected its `nim_service` addition before apply. After current main removed that addition, apply completed but the smoke still failed because no base-policy read occurred. The test needs its own stable policy addition.

### Related issues

Relates to #10856 and #10908.

## Changes

- Create a temporary apply-only blueprint with a public fixture policy endpoint.
- Use a minimal fixture sandbox policy and the production private-network registry.
- Make the fixture OpenShell return the configured and effective policies through the same typed read and reconciliation path as before.
- Leave the shipped blueprint and fail-closed private-host validation unchanged.

## Verification

- Current-main baseline harness at `3509b5a43` completed apply but failed `Apply did not use the gateway-pinned base-policy read`.
- Pre-removal baseline harness reproduced `Blueprint policy addition 'nim_service' endpoint 1 is rejected: policy host is private or reserved`.
- Patched local apply harness passed run ID, sandbox creation, policy mutation, provider configuration, completion, gateway-pinned policy read, and persisted-state checks.
- `npm --prefix nemoclaw run build` passed.
- `npx vitest run --project plugin nemoclaw/src/blueprint/runner-openshell-072-policy.test.ts` passed 34 tests.
- `npx vitest run --project plugin nemoclaw/src/blueprint/runner.test.ts nemoclaw/src/blueprint/private-networks.test.ts` passed 151 tests.
- `npm run checks:repository` passed.
- `npm run validate:pr` passed against exact main `3509b5a43`.
- Local PR Advisor bootstrap succeeded, but its OpenShell gateway repeatedly refused the connection before analysis began. Hosted exact-head Advisor review is required before readiness.
- The one-file diff contains no secrets, API keys, or credentials.

## Review notes

The Docker sandbox boundary is owned by CI. The candidate does not change production policy or validation behavior.

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the apply smoke test to use isolated temporary fixtures and policies.
  * Improved test cleanup by removing temporary blueprint data after execution.
  * Updated policy handling to validate effective-policy changes during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->