### PR TITLE
docs(network-policy): describe baseline policy entry fields

### DIFF
--- a/docs/network-policy/change-baseline-network-policy.mdx
+++ b/docs/network-policy/change-baseline-network-policy.mdx
@@ -37,20 +37,101 @@ Open `agents/langchain-deepagents-code/policy-additions.yaml` and add or modify 
 </AgentOnly>
 
 Edit YAML manually when a maintained preset does not cover the required host, such as a reviewed public partner API.
-Each entry in the `network_policies` section defines an endpoint group with these fields:
+Each entry in the `network_policies` section defines an endpoint group.
+The schema in `schemas/network-policy.schema.json` defines the entry format.
+Onboarding fails when an entry does not match it.
+Each entry requires these fields:
+
+`name`
+: The entry name as a string.
+Use the same value as the policy key.
 
 `endpoints`
-: Host and port pairs that the sandbox can reach.
+: A list of endpoints that the sandbox can reach.
+Each endpoint sets `host` and `port`.
+For an HTTP API, each endpoint also sets `protocol: rest`, `enforcement: enforce`, and its own `rules` list.
 
 `binaries`
-: Executables allowed to use the endpoint.
+: A list of `{ path: <absolute path> }` mappings that name the executables allowed to use the endpoints.
+A bare path string is rejected.
+
+Each endpoint accepts these fields:
 
 `rules`
-: HTTP methods and paths that the endpoint permits.
+: A list of `allow` mappings whose shape follows the endpoint's `protocol`.
+For `protocol: rest`, each rule is `allow: { method: <HTTP method>, path: <route> }`.
+`method` accepts `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`, or `*`.
+`path` is a route pattern that starts with `/`, such as `/v1/**`.
+The `websocket`, `json-rpc`, and `mcp` protocols match on different fields, so read `schemas/network-policy.schema.json` for those shapes.
 
 `allow_encoded_slash`
-: Allows percent-encoded slashes such as `%2F` in request paths.
-Leave this field disabled unless the service uses encoded slashes in its documented route format, such as ClawHub scoped package names.
+: An optional boolean that allows percent-encoded slashes such as `%2F` in request paths.
+Leave this field unset unless the service uses encoded slashes in its documented route format, such as ClawHub scoped package names.
+
+The following entry allows `GET` requests to one partner API:
+
+<AgentOnly variant="openclaw">
+
+```yaml
+network_policies:
+  partner_api:
+    name: partner_api
+    endpoints:
+      - host: api.example.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/v1/**" }
+    binaries:
+      - { path: /usr/local/bin/openclaw }
+      - { path: /usr/local/bin/node }
+```
+
+</AgentOnly>
+<AgentOnly variant="hermes">
+
+```yaml
+network_policies:
+  partner_api:
+    name: partner_api
+    endpoints:
+      - host: api.example.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/v1/**" }
+    binaries:
+      - { path: /usr/local/bin/hermes }
+      - { path: /usr/bin/python3* }
+      - { path: /opt/hermes/.venv/bin/python }
+```
+
+</AgentOnly>
+<AgentOnly variant="deepagents">
+
+```yaml
+network_policies:
+  partner_api:
+    name: partner_api
+    endpoints:
+      - host: api.example.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          - allow: { method: GET, path: "/v1/**" }
+    binaries:
+      - { path: /usr/local/bin/dcode }
+      - { path: /opt/venv/bin/python3* }
+```
+
+</AgentOnly>
+
+Add the entry under the existing `network_policies` key.
+List only the executables that open the connection.
+Use the executable path that `openshell term` reports for a blocked request.
 
 To include a maintained preset in the baseline policy, merge its `network_policies` entries into the applicable baseline file.
 Use [Apply Policy Presets](apply-policy-presets) when you need to add a preset to one running sandbox.
@@ -92,3 +173,4 @@ Use `openshell policy get <name>` when you need to inspect the effective OpenShe
 - [Customize the Network Policy](../customize-network-policy) helps you choose the correct policy workflow.
 - [Create Custom Policy Presets](create-custom-policy-presets) adds durable access for one sandbox without changing the baseline.
 - [Network Policies](../../reference/network-policies) explains the baseline policy schema and tiers.
+- [OpenShell Policy Schema](https://docs.nvidia.com/openshell/latest/reference/policy-schema.html) provides the complete endpoint schema.

--- a/docs/network-policy/change-baseline-network-policy.mdx
+++ b/docs/network-policy/change-baseline-network-policy.mdx
@@ -49,7 +49,7 @@ Use the same value as the policy key.
 `endpoints`
 : A list of endpoints that the sandbox can reach.
 Each endpoint sets `host` and exactly one of `port` or `ports`.
-Do not add `allowed_ips` to a baseline entry. That field widens the private ranges that OpenShell checks for server-side request forgery. To reach a private host, use the trusted private host flow in [Create Custom Policy Presets](create-custom-policy-presets) instead.
+An endpoint can also pin `allowed_ips`, as the shipped baseline does for the local inference host. That field widens the private ranges that OpenShell checks for server-side request forgery, so review each resolved address before you add one.
 For an HTTP API, each endpoint also sets `protocol: rest` and either its own `rules` list or `access`. The examples below use `enforcement: enforce` with `rules`, which is the least-privilege form.
 
 `binaries`

--- a/docs/network-policy/change-baseline-network-policy.mdx
+++ b/docs/network-policy/change-baseline-network-policy.mdx
@@ -48,7 +48,7 @@ Use the same value as the policy key.
 
 `endpoints`
 : A list of endpoints that the sandbox can reach.
-Each endpoint sets `host` and `port`.
+Each endpoint sets `host` or `allowed_ips`, and exactly one of `port` or `ports`.
 For an HTTP API, each endpoint also sets `protocol: rest`, `enforcement: enforce`, and its own `rules` list.
 
 `binaries`

--- a/docs/network-policy/change-baseline-network-policy.mdx
+++ b/docs/network-policy/change-baseline-network-policy.mdx
@@ -48,7 +48,8 @@ Use the same value as the policy key.
 
 `endpoints`
 : A list of endpoints that the sandbox can reach.
-Each endpoint sets `host` and exactly one of `port` or `ports`.
+Each endpoint sets exactly one of `port` or `ports`, and at least one destination: `host`, `allowed_ips`, or both.
+`allowed_ips` changes the server-side request forgery boundary that OpenShell enforces, so review each address before you add one.
 For an HTTP API, each endpoint also sets `protocol: rest` and either its own `rules` list or `access`. The examples below use `enforcement: enforce` with `rules`, which is the least-privilege form.
 
 `binaries`

--- a/docs/network-policy/change-baseline-network-policy.mdx
+++ b/docs/network-policy/change-baseline-network-policy.mdx
@@ -49,7 +49,6 @@ Use the same value as the policy key.
 `endpoints`
 : A list of endpoints that the sandbox can reach.
 Each endpoint sets `host` and exactly one of `port` or `ports`.
-An endpoint can also pin `allowed_ips`, as the shipped baseline does for the local inference host. That field widens the private ranges that OpenShell checks for server-side request forgery, so review each resolved address before you add one.
 For an HTTP API, each endpoint also sets `protocol: rest` and either its own `rules` list or `access`. The examples below use `enforcement: enforce` with `rules`, which is the least-privilege form.
 
 `binaries`

--- a/docs/network-policy/change-baseline-network-policy.mdx
+++ b/docs/network-policy/change-baseline-network-policy.mdx
@@ -48,8 +48,9 @@ Use the same value as the policy key.
 
 `endpoints`
 : A list of endpoints that the sandbox can reach.
-Each endpoint sets `host` or `allowed_ips`, and exactly one of `port` or `ports`.
-For an HTTP API, each endpoint also sets `protocol: rest`, `enforcement: enforce`, and its own `rules` list.
+Each endpoint sets `host` and exactly one of `port` or `ports`.
+Do not add `allowed_ips` to a baseline entry. That field widens the private ranges that OpenShell checks for server-side request forgery. To reach a private host, use the trusted private host flow in [Create Custom Policy Presets](create-custom-policy-presets) instead.
+For an HTTP API, each endpoint also sets `protocol: rest` and either its own `rules` list or `access`. The examples below use `enforcement: enforce` with `rules`, which is the least-privilege form.
 
 `binaries`
 : A list of `{ path: <absolute path> }` mappings that name the executables allowed to use the endpoints.
@@ -173,4 +174,4 @@ Use `openshell policy get <name>` when you need to inspect the effective OpenShe
 - [Customize the Network Policy](../customize-network-policy) helps you choose the correct policy workflow.
 - [Create Custom Policy Presets](create-custom-policy-presets) adds durable access for one sandbox without changing the baseline.
 - [Network Policies](../../reference/network-policies) explains the baseline policy schema and tiers.
-- [OpenShell Policy Schema](https://docs.nvidia.com/openshell/latest/reference/policy-schema.html) provides the complete endpoint schema.
+- [OpenShell Policy Schema](https://docs.nvidia.com/openshell/latest/reference/policy-schema.html) provides the complete endpoint schema. For NemoClaw onboarding, `schemas/network-policy.schema.json` in this repository is authoritative, and it requires the `name` field.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The Change the Baseline Network Policy page now describes a `network_policies` entry as the shipped schema defines it: a required `name`, a required `endpoints` list whose endpoints carry their own `rules`, and a required `binaries` list of `{ path: ... }` mappings.
Each guide variant (OpenClaw, Hermes, Deep Agents) shows a copy-pasteable example whose binaries match that agent's shipped baseline.
Before this change, the page listed `endpoints`, `binaries`, `rules`, and `allow_encoded_slash` as sibling fields, omitted `name`, and described `binaries` as executables, so an entry written to the page failed schema validation and onboarding exited nonzero.

## Reason

Issue #10871 isolated three defects in the page's field list, each sufficient to fail onboarding: the missing `name` field, `rules` shown at the entry level instead of inside each endpoint, and `binaries` read as bare path strings.
The page carried no YAML example, so a reader had no second source to correct the description.
`schemas/network-policy.schema.json` (`networkPolicyEntry.required` = `name`, `endpoints`, `binaries`; `binary` = object with `path`; `rules` and `allow_encoded_slash` under `endpoint`) is the contract that `scripts/validate-configs.mts` enforces in CI and that `parseAndValidateSandboxPolicy` (`src/lib/policy/sandbox-policy-validation.ts`, called from `resolveAgentBaselinePolicy` in `src/lib/policy/index.ts`) enforces at runtime.

### Related issues

Fixes #10871

## Changes

- `docs/network-policy/change-baseline-network-policy.mdx`: describe the entry fields (`name`, `endpoints`, `binaries`) and the endpoint fields (`rules`, `allow_encoded_slash`) as the schema defines them, state that onboarding fails when an entry does not match the schema, and add one `partner_api` example per guide variant inside `<AgentOnly>` blocks. The OpenClaw example uses the binaries of the shipped `openclaw_api` entry, the Hermes example uses the binaries of the shipped `nous_research` entry, and the Deep Agents example uses the `dcode` and managed Python binaries of the shipped `github` entry.
- Add the OpenShell Policy Schema reference link to Related Topics, matching the link already used on Configure Raw TLS Passthrough.

No runtime behavior, schema, preset, navigation, route, or redirect changes. The page keeps its complete shared scope (OpenClaw, Hermes, Deep Agents) and its existing headings and anchors.

## Verification

All commands ran on the NVIDIA-provided test server against this branch at upstream `b08eaa084`.

- Validator proof, `PROOF PASSED: 7 cases, 0 mismatches` (each documented example merged into its agent's shipped baseline file, then `scripts/validate-configs.mts` against `schemas/sandbox-policy.schema.json`, and the same document passed to `parseAndValidateSandboxPolicy`):
  - OpenClaw example merged into `nemoclaw-blueprint/policies/openclaw-sandbox.yaml` — `OK`, accepted.
  - Hermes example merged into `agents/hermes/policy-additions.yaml` — `OK`, accepted.
  - Deep Agents example merged into `agents/langchain-deepagents-code/policy-additions.yaml` — `OK`, accepted.
  - The issue's step-3 entry written to the old field list — rejected: `must have required property 'name'`, `/binaries/0: must be object`.
  - Documented entry without `name` — rejected: `must have required property 'name'`.
  - Documented entry with `rules` moved to the entry level — rejected: `/endpoints/0: must have required property 'rules'`.
  - Documented entry with bare-string `binaries` — rejected: `/binaries/0: must be object`, `/binaries/1: must be object`.
- `npm run docs` — passed: agent variants generated, `check-docs-published-routes: OK — 69 guarded page(s)`, `fern check`: `Found 0 errors and 2 warnings` (both pre-existing and unrelated: the redirects check is skipped without `FERN_TOKEN`, and the light-mode accent contrast ratio).
- Generated variants `docs/_build/agent-variants/network-policy/change-baseline-network-policy.{openclaw,hermes,deepagents}.generated.mdx` — each contains exactly one YAML block with that agent's binaries, no `AgentOnly` tags, and the CLI placeholder rewritten (`nemoclaw onboard`, `nemohermes onboard`, `nemo-deepagents onboard`).
- `npx vitest run test/generation/network-policies-published-routes.test.ts` — 30 passed.
- `npx prek run --stage pre-commit`, `npx commitlint`, and `npx prek run --stage pre-push` over `upstream/main..HEAD` — all passed, working tree unchanged.
- `npm run checks:repository` — fails on `pi-qualification-receipt-refresh` with `Pi image inputs changed after receipt source revision 49b70f08a9a375d45c275f7fd4924caf58a10ca4`. This failure reproduces on unmodified `b08eaa084` with no changes applied, so it is pre-existing on main and unrelated to this documentation change.
- Independent documentation writer review of the diff against `docs/CONTRIBUTING.md`, `WRITING.md`, `docs/STYLE.md`, and the controlled word list — no blockers; one terminology finding (`entry key` replaced with the controlled term `policy key`) was applied before the final gate rerun. Reviewed categories: task completeness and accuracy against `schemas/network-policy.schema.json` and the shipped baselines; commands and expected results; variant, route, navigation, and redirect coverage; ownership; security and lifecycle claims; writing and style compliance.
- The diff contains no secrets, API keys, or credentials.

---
Signed-off-by: Kushagar Garg <dreamstick909@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated network policy guidance to require `host` for baseline endpoints.
  - Clarified that baseline entries cannot use `allowed_ips`; private-host access should use the trusted custom-policy workflow.
  - Documented HTTP endpoint configuration using either `rules` or `access`, with enforced-rule examples.
  - Clarified that the OpenShell repository schema is authoritative for onboarding and requires a `name`.
  - Expanded guidance for ports, hosts, and protocol-specific network rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->