### PR TITLE
test(inference): isolate lifecycle lock state

### DIFF
--- a/src/lib/inference/gateway-route-mutation-lock.test.ts
+++ b/src/lib/inference/gateway-route-mutation-lock.test.ts
@@ -2,16 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AsyncResource } from "node:async_hooks";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
+  resolveCurrentUserModelRouterLockStateDir,
+  resolveModelRouterPortLifecycleLockOptions,
   withGatewayRouteMutationLock,
   withGatewayRouteMutationLockSync,
+  withModelRouterPortLifecycleLock,
 } from "./gateway-route-mutation-lock";
 
+function observeNextLockPublicationAttempt(): { attempted: Promise<void>; restore: () => void } {
+  let reportAttempted!: () => void;
+  const attempted = new Promise<void>((resolve) => {
+    reportAttempted = resolve;
+  });
+  const link = fsSync.promises.link.bind(fsSync.promises);
+  const spy = vi.spyOn(fsSync.promises, "link").mockImplementation(async (existingPath, newPath) => {
+    reportAttempted();
+    await link(existingPath, newPath);
+  });
+  return { attempted, restore: () => spy.mockRestore() };
+}
+
 describe("gateway route mutation lock", () => {
+  it("resolves default and overridden router lock directories without filesystem access", () => {
+    const homeDir = "/srv/nemoclaw-controller";
+    const expectedStateDir = path.join(homeDir, ".nemoclaw", "state");
+    expect(resolveCurrentUserModelRouterLockStateDir(homeDir)).toBe(expectedStateDir);
+    expect(resolveModelRouterPortLifecycleLockOptions({}, homeDir).stateDir).toBe(expectedStateDir);
+    expect(
+      resolveModelRouterPortLifecycleLockOptions({ stateDir: "/isolated" }, homeDir).stateDir,
+    ).toBe("/isolated");
+  });
+
   it("serializes separate operations for the same gateway", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "nemoclaw-gateway-lock-"));
     let releaseFirst!: () => void;
@@ -24,8 +51,11 @@ describe("gateway route mutation lock", () => {
     });
     const events: string[] = [];
     const options = { stateDir, pollIntervalMs: 1, timeoutMs: 5_000 };
+    let first: Promise<void> | undefined;
+    let second: Promise<void> | undefined;
+    let restorePublication = (): void => {};
     try {
-      const first = withGatewayRouteMutationLock(
+      first = withGatewayRouteMutationLock(
         "nemoclaw",
         async () => {
           events.push("first-enter");
@@ -36,20 +66,26 @@ describe("gateway route mutation lock", () => {
         options,
       );
       await firstEntered;
-      const second = withGatewayRouteMutationLock(
+      const publication = observeNextLockPublicationAttempt();
+      restorePublication = publication.restore;
+      second = withGatewayRouteMutationLock(
         "nemoclaw",
         () => {
           events.push("second-enter");
         },
         options,
       );
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await publication.attempted;
+      restorePublication();
+      restorePublication = (): void => {};
       expect(events).toEqual(["first-enter"]);
       releaseFirst();
       await Promise.all([first, second]);
       expect(events).toEqual(["first-enter", "first-exit", "second-enter"]);
     } finally {
+      restorePublication();
       releaseFirst();
+      await Promise.allSettled([first, second].filter((value): value is Promise<void> => Boolean(value)));
       await fs.rm(stateDir, { recursive: true, force: true });
     }
   });
@@ -116,9 +152,8 @@ describe("gateway route mutation lock", () => {
     }
   });
 
-  it("keeps cross-gateway router onboarding publication ahead of teardown", async () => {
-    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "nemoclaw-router-port-lock-"));
-    const homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+  it("serializes router lifecycle operations for the same port", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "nemoclaw-router-port-lock-"));
     let publishPeer!: () => void;
     const peerPublished = new Promise<void>((resolve) => {
       publishPeer = resolve;
@@ -128,12 +163,12 @@ describe("gateway route mutation lock", () => {
       reportOnboardEntered = resolve;
     });
     const events: string[] = [];
-    const options = { pollIntervalMs: 1, timeoutMs: 5_000 };
+    const options = { stateDir, pollIntervalMs: 1, timeoutMs: 5_000 };
+    let onboarding: Promise<void> | undefined;
+    let teardown: Promise<void> | undefined;
+    let restorePublication = (): void => {};
     try {
-      vi.stubEnv("NEMOCLAW_GATEWAY_PORT", "18080");
-      vi.resetModules();
-      const firstGateway = await import("./gateway-route-mutation-lock");
-      const onboarding = firstGateway.withModelRouterPortLifecycleLock(
+      onboarding = withModelRouterPortLifecycleLock(
         4000,
         async () => {
           events.push("onboard-enter");
@@ -144,10 +179,9 @@ describe("gateway route mutation lock", () => {
         options,
       );
       await onboardEntered;
-      vi.stubEnv("NEMOCLAW_GATEWAY_PORT", "18081");
-      vi.resetModules();
-      const secondGateway = await import("./gateway-route-mutation-lock");
-      const teardown = secondGateway.withModelRouterPortLifecycleLock(
+      const publication = observeNextLockPublicationAttempt();
+      restorePublication = publication.restore;
+      teardown = withModelRouterPortLifecycleLock(
         4000,
         () => {
           events.push("teardown-peer-scan");
@@ -155,16 +189,20 @@ describe("gateway route mutation lock", () => {
         options,
       );
 
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await publication.attempted;
+      restorePublication();
+      restorePublication = (): void => {};
       expect(events).toEqual(["onboard-enter"]);
       publishPeer();
       await Promise.all([onboarding, teardown]);
       expect(events).toEqual(["onboard-enter", "peer-published", "teardown-peer-scan"]);
     } finally {
+      restorePublication();
       publishPeer();
-      vi.unstubAllEnvs();
-      homedirSpy.mockRestore();
-      await fs.rm(homeDir, { recursive: true, force: true });
+      await Promise.allSettled(
+        [onboarding, teardown].filter((value): value is Promise<void> => Boolean(value)),
+      );
+      await fs.rm(stateDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/lib/inference/gateway-route-mutation-lock.ts
+++ b/src/lib/inference/gateway-route-mutation-lock.ts
@@ -18,6 +18,17 @@ export function resolveCurrentUserModelRouterLockStateDir(homeDir: string = os.h
   return path.join(resolveSharedLocalAdapterStateRoot(homeDir), "state");
 }
 
+/** Resolve Model Router lock options without touching the filesystem. */
+export function resolveModelRouterPortLifecycleLockOptions(
+  options: McpLifecycleLockOptions = {},
+  homeDir?: string,
+): McpLifecycleLockOptions & { stateDir: string } {
+  return {
+    ...options,
+    stateDir: options.stateDir ?? resolveCurrentUserModelRouterLockStateDir(homeDir),
+  };
+}
+
 /**
  * Serializes host-side reads and writes of OpenShell's one-route-per-gateway
  * inference state. The non-sandbox prefix keeps this lock namespace disjoint
@@ -60,9 +71,5 @@ export function withModelRouterPortLifecycleLock<T>(
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new Error("Model Router port must be an integer from 1 to 65535.");
   }
-  const stateDir = options.stateDir ?? resolveCurrentUserModelRouterLockStateDir();
-  return withMcpLifecycleLock(`${MODEL_ROUTER_PORT_LOCK_PREFIX}${String(port)}`, operation, {
-    ...options,
-    stateDir,
-  });
+  return withMcpLifecycleLock(`${MODEL_ROUTER_PORT_LOCK_PREFIX}${String(port)}`, operation, resolveModelRouterPortLifecycleLockOptions(options));
 }

--- a/src/lib/inference/vllm-station-cluster-lifecycle.test.ts
+++ b/src/lib/inference/vllm-station-cluster-lifecycle.test.ts
@@ -485,38 +485,6 @@ describe("dual-Station managed vLLM lifecycle", () => {
     expect(fake.operations).toEqual([]);
   });
 
-  it("anchors the default lock under the host-global managed state home", async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-station-lock-home-"));
-    const accountHome = path.join(root, "account-home");
-    const managedHome = path.join(root, "managed-home");
-    fs.mkdirSync(accountHome, { mode: 0o700 });
-    const userInfo = os.userInfo();
-    const userInfoSpy = vi.spyOn(os, "userInfo").mockReturnValue({
-      ...userInfo,
-      homedir: accountHome,
-    });
-    vi.stubEnv("HOME", managedHome);
-    try {
-      await withDualStationVllmLifecycleLock(
-        () => {
-          expect(
-            fs.existsSync(path.join(managedHome, ".nemoclaw", "state", "mcp-lifecycle-locks")),
-          ).toBe(true);
-          expect(fs.existsSync(path.join(accountHome, ".nemoclaw"))).toBe(false);
-        },
-        { pollIntervalMs: 5, timeoutMs: 250, corruptLockGraceMs: 5 },
-        {
-          readControllerUid: () => userInfo.uid,
-          effectiveControllerUid: () => userInfo.uid,
-        },
-      );
-    } finally {
-      vi.unstubAllEnvs();
-      userInfoSpy.mockRestore();
-      fs.rmSync(root, { recursive: true, force: true });
-    }
-  });
-
   it("provides a read-only ownership preflight before download work", () => {
     const fake = harness();
 

--- a/src/lib/inference/vllm-station-lifecycle-lock.test.ts
+++ b/src/lib/inference/vllm-station-lifecycle-lock.test.ts
@@ -9,6 +9,7 @@ import {
   DUAL_STATION_CONTROLLER_UID_FILE,
   type DualStationControllerUidFileStat,
   readDualStationControllerUid,
+  resolveHostGlobalVllmLifecycleLockOptions,
   withDualStationVllmLifecycleLock,
   withHostGlobalVllmLifecycleLock,
 } from "./vllm-station-lifecycle-lock";
@@ -119,39 +120,29 @@ describe("dual-Station controller UID binding", () => {
     }
   });
 
-  it("shares the managed-state home even when passwd and HOME directories differ", async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-managed-vllm-lock-"));
-    const passwdHome = path.join(root, "passwd-home");
-    const managedHome = path.join(root, "managed-home");
-    fs.mkdirSync(passwdHome, { mode: 0o700 });
-    fs.mkdirSync(managedHome, { mode: 0o700 });
-    const userInfo = os.userInfo();
-    const userInfoSpy = vi.spyOn(os, "userInfo").mockReturnValue({
-      ...userInfo,
-      homedir: passwdHome,
-    });
-    vi.stubEnv("HOME", managedHome);
+  it("resolves default and overridden host-global lock directories without filesystem access", () => {
+    const homeDir = "/srv/nemoclaw-controller";
+    expect(managedVllmStateDir(homeDir)).toBe(path.join(homeDir, ".nemoclaw"));
+    expect(resolveHostGlobalVllmLifecycleLockOptions({}, homeDir).stateDir).toBe(
+      path.join(homeDir, ".nemoclaw", "state"),
+    );
+    expect(resolveHostGlobalVllmLifecycleLockOptions({ stateDir: "/isolated" }, homeDir).stateDir).toBe(
+      "/isolated",
+    );
+  });
+
+  it("uses an explicitly isolated state directory for filesystem lock behavior", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-managed-vllm-lock-"));
 
     try {
-      expect(managedVllmStateDir()).toBe(path.join(managedHome, ".nemoclaw"));
       await withHostGlobalVllmLifecycleLock(
         () => {
-          expect(
-            fs.existsSync(path.join(managedHome, ".nemoclaw", "state", "mcp-lifecycle-locks")),
-          ).toBe(true);
-          expect(fs.existsSync(path.join(passwdHome, ".nemoclaw"))).toBe(false);
+          expect(fs.existsSync(path.join(stateDir, "mcp-lifecycle-locks"))).toBe(true);
         },
-        {
-          stateDir: path.join(managedVllmStateDir(), "state"),
-          pollIntervalMs: 5,
-          timeoutMs: 250,
-          corruptLockGraceMs: 5,
-        },
+        { stateDir },
       );
     } finally {
-      vi.unstubAllEnvs();
-      userInfoSpy.mockRestore();
-      fs.rmSync(root, { recursive: true, force: true });
+      fs.rmSync(stateDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/lib/inference/vllm-station-lifecycle-lock.ts
+++ b/src/lib/inference/vllm-station-lifecycle-lock.ts
@@ -8,6 +8,17 @@ import { type McpLifecycleLockOptions, withMcpLifecycleLock } from "../state/mcp
 import { managedVllmStateDir } from "./vllm-api-key";
 
 const HOST_GLOBAL_VLLM_LIFECYCLE_LOCK = "dual-station-vllm:host-global";
+
+/** Resolve host-global vLLM lock options without touching the filesystem. */
+export function resolveHostGlobalVllmLifecycleLockOptions(
+  options: McpLifecycleLockOptions = {},
+  homeDir?: string,
+): McpLifecycleLockOptions & { stateDir: string } {
+  return {
+    ...options,
+    stateDir: options.stateDir ?? path.join(managedVllmStateDir(homeDir), "state"),
+  };
+}
 const DUAL_STATION_CONTROLLER_CONFIG_DIR = "/etc/nemoclaw";
 export const DUAL_STATION_CONTROLLER_UID_FILE = path.join(
   DUAL_STATION_CONTROLLER_CONFIG_DIR,
@@ -129,11 +140,11 @@ export function withHostGlobalVllmLifecycleLock<T>(
   operation: () => Promise<T> | T,
   options: McpLifecycleLockOptions = {},
 ): Promise<T> {
-  const stateDir = options.stateDir ?? path.join(managedVllmStateDir(), "state");
-  return withMcpLifecycleLock(HOST_GLOBAL_VLLM_LIFECYCLE_LOCK, operation, {
-    ...options,
-    stateDir,
-  });
+  return withMcpLifecycleLock(
+    HOST_GLOBAL_VLLM_LIFECYCLE_LOCK,
+    operation,
+    resolveHostGlobalVllmLifecycleLockOptions(options),
+  );
 }
 
 /**


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Lifecycle lock unit tests no longer contend through ambient host state or infer blocking from arbitrary sleeps.

## Reason

A main-branch CLI coverage shard failed when a unit test changed HOME and acquired the production-default dual-Station host-global lock. Nearby tests used the same ambient-path and timing patterns, allowing parallel test files to collide.

## Changes

- Extract pure option resolvers for host-global vLLM and Model Router lock directories while preserving production defaults and explicit overrides.
- Use unique temporary state directories for real filesystem lock assertions instead of mutating HOME or mocking os.homedir().
- Synchronize contention assertions on the contender atomic publication attempt, and await all started operations during cleanup.

## Verification

- Contributor validation: Commit hooks and npm run validate:pr passed at 27055e14adb2a14ebbd84cbd068b44c68a0cf956.
- Tests: Focused CLI tests: 71 passed across the three lifecycle lock test files. npm run typecheck:cli passed. npm run validate:pr passed.
- Broad gate: npm run validate:pr passed against canonical origin/main d4eff54a8d213a3a8fe5650703c8e708eab4dd7d.
- Secrets review: The diff contains no secrets, API keys, or credentials

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when starting, stopping, or reconfiguring model-serving components by coordinating competing lifecycle operations more consistently.
  - Preserved support for custom state locations while providing more predictable default state handling.

- **Tests**
  - Strengthened coverage for lifecycle coordination, lock contention, setup, teardown, and cleanup scenarios.
  - Replaced timing-dependent checks with deterministic validation for more reliable test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->