### PR TITLE
test(package): install packed CLI as a consumer

### DIFF
--- a/test/package-contract/managed-image-registry-transport.test.ts
+++ b/test/package-contract/managed-image-registry-transport.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -41,19 +41,26 @@ describe("managed image registry transport package contract", () => {
       prefix: "nemoclaw-managed-registry-pack-",
       entries: ["dist"],
     });
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "nemoclaw-managed-registry-package-"));
+    const archiveRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-managed-registry-archive-"),
+    );
+    const consumerRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "nemoclaw-managed-registry-consumer-"),
+    );
     try {
       const packed = spawnSync(
         "npm",
-        ["pack", "--ignore-scripts", "--silent", "--pack-destination", tempDir],
+        ["pack", "--ignore-scripts", "--silent", "--pack-destination", archiveRoot],
         { cwd: fixtureRoot, encoding: "utf8", timeout: 120_000 },
       );
       expect(packed.status, `${packed.stdout}${packed.stderr}`).toBe(0);
-      const archives = fs.readdirSync(tempDir).filter((entry) => entry.endsWith(".tgz"));
+      const archives = fs.readdirSync(archiveRoot).filter((entry) => entry.endsWith(".tgz"));
       expect(archives).toHaveLength(1);
-      execFileSync("tar", ["-xzf", path.join(tempDir, archives[0]!), "-C", tempDir]);
 
-      const installedRoot = path.join(tempDir, "package");
+      fs.writeFileSync(
+        path.join(consumerRoot, "package.json"),
+        `${JSON.stringify({ name: "managed-image-registry-consumer", private: true })}\n`,
+      );
       const installed = spawnSync(
         "npm",
         [
@@ -63,10 +70,12 @@ describe("managed image registry transport package contract", () => {
           "--no-audit",
           "--no-fund",
           "--no-package-lock",
+          "--no-save",
           "--prefer-offline",
+          path.join(archiveRoot, archives[0]!),
         ],
         {
-          cwd: installedRoot,
+          cwd: consumerRoot,
           encoding: "utf8",
           timeout: 120_000,
           env: { ...process.env, npm_config_update_notifier: "false" },
@@ -77,7 +86,7 @@ describe("managed image registry transport package contract", () => {
       const installedProductionTree = spawnSync(
         "npm",
         ["ls", "undici", "--omit=dev", "--all", "--json"],
-        { cwd: installedRoot, encoding: "utf8" },
+        { cwd: consumerRoot, encoding: "utf8" },
       );
       expect(
         installedProductionTree.status,
@@ -106,13 +115,18 @@ session.close().then(
 );
 `,
         ],
-        { cwd: installedRoot, encoding: "utf8", timeout: 10_000 },
+        {
+          cwd: path.join(consumerRoot, "node_modules", "nemoclaw"),
+          encoding: "utf8",
+          timeout: 10_000,
+        },
       );
       expect(probe.status, `${probe.stdout}${probe.stderr}`).toBe(0);
       expect(probe.stdout).toBe("constructed");
     } finally {
       fs.rmSync(fixtureRoot, { recursive: true, force: true });
-      fs.rmSync(tempDir, { recursive: true, force: true });
+      fs.rmSync(archiveRoot, { recursive: true, force: true });
+      fs.rmSync(consumerRoot, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The managed-image registry transport package contract now installs the packed CLI through a consumer project. The test still verifies the production `undici` dependency and transport load without asking npm to resolve NemoClaw's development graph.

## Reason

Main's `build-typecheck` job fails in this contract because npm 10.9.8 crashes with `Cannot read properties of null (reading 'edgesOut')`. The test caused the crash by unpacking the tarball and treating it as the root project, which makes npm resolve development-only optional peers despite `--omit=dev`. A consumer install models the published package boundary that the test intends to verify.

Failure: https://github.com/NVIDIA/NemoClaw/actions/runs/33777143937/job/100722012206

## Changes

- Install the packed CLI archive into a minimal consumer project with `--omit=dev` and `--no-save`.
- Inspect `undici` from the consumer's production dependency tree.
- Load the registry transport from the installed `nemoclaw` package.

## Verification

- `npx vitest run --project package-contract test/package-contract/managed-image-registry-transport.test.ts --reporter=verbose` - passed on commit `16a7cedd8a7103f914c14335a17688c0dae5daeb` after refresh to main.
- `npm run test:titles:check` - passed.
- `npm run validate:pr` - passed.
- `npm run review:local` - unavailable because the temporary OpenShell gateway refused connections during Advisor configuration.
- The package-contract aggregate executed the changed test successfully. Other tests had existing macOS environment failures from the unavailable private SDK artifact and five-second timeouts.
- The validated diff contains no secrets, API keys, or credentials.

---
Signed-off-by: Rebecca Sliter <571084+rsliter@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved package installation verification by testing installation from a packaged archive in a separate consumer project.
  * Added validation of dependency integrity and runtime behavior from the installed package location.
  * Enhanced cleanup of temporary test artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->