### PR TITLE
perf(cli): wait in sandbox for Hermes readiness

### DIFF
--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
@@ -308,7 +308,11 @@ function lifecycleDeps(
   });
   const liveIdentityFingerprint = fingerprintOpenShellSandboxLiveIdentity(LIVE)!;
   const captureOpenShell = vi.fn((args: readonly string[]) => {
-    const sandboxExecOutput = args.includes("python3") ? "200\n" : "";
+    const sandboxExecOutput = args.includes(hermesPortableLifecycleInternals.healthWaitProgram)
+      ? "schema=1 result=ready attempts=1 notReady=0 timeouts=0 errors=0 lastFailure=none probeMs=0 sleepMs=0\n"
+      : args.includes("python3")
+        ? "200\n"
+        : "";
     const responses = {
       "policy:get": { status: 0, stdout: options.livePolicy ?? POLICY, stderr: "" },
       "sandbox:list": {
@@ -804,11 +808,16 @@ describe("Hermes portable lifecycle", () => {
         "--no-tty",
         "--",
         "python3",
+        "-I",
         "-c",
-        hermesPortableContainerInternals.authenticatedHealthScript,
+        hermesPortableLifecycleInternals.healthWaitProgram,
+        "8642",
+        "18000",
+        "100",
       ],
-      40_000,
+      20_000,
     );
+    expect(captureOpenShell.mock.calls.flat(2)).toContain(hermesPortableContainerInternals.authenticatedHealthScript);
   });
 
   it("starts through the exact OpenShell Stopped phase before proving Ready health (#9203)", () => {
@@ -852,25 +861,29 @@ describe("Hermes portable lifecycle", () => {
     const receipt = activeReceipt();
     const { deps, podman, captureOpenShell, launchOpenShell } = lifecycleDeps(receipt, false);
     const defaultCapture = captureOpenShell.getMockImplementation()!;
+    const inspectCount = () =>
+      podman.mock.calls.filter(([command]) => command[1] === "inspect").length;
+    const healthBoundaries: number[] = [];
+    const sleepBoundaries: Array<{ inspectsBefore: number; milliseconds: number }> = [];
+    let healthAttempts = 0;
     let now = 0;
-    const healthInspections: number[] = [];
-    const sleepInspections: number[] = [];
+    const observeHealth = () => {
+      healthBoundaries.push(inspectCount());
+      healthAttempts += 1;
+      return {
+        status: 0,
+        stdout:
+          launchOpenShell.mock.calls.length === 1
+            ? "schema=1 result=ready attempts=2 notReady=1 timeouts=0 errors=0 lastFailure=not-ready probeMs=10 sleepMs=100\n"
+            : "unavailable\n",
+        stderr: "",
+      };
+    };
     captureOpenShell.mockImplementation((args: readonly string[]) =>
-      args.join("\0") ===
-      `sandbox\0exec\0-g\0${receipt.gatewayName}\0--name\0${receipt.sandboxName}\0--no-tty\0--\0python3\0-c\0${hermesPortableContainerInternals.authenticatedHealthScript}`
-        ? {
-            status: 0,
-            stdout:
-              healthInspections.push(
-                podman.mock.calls.filter(([command]) => command[1] === "inspect").length,
-              ) >= 2 && launchOpenShell.mock.calls.length === 1
-                ? "200\n"
-                : "unavailable\n",
-            stderr: "",
-          }
+      args.includes(hermesPortableLifecycleInternals.healthWaitProgram)
+        ? observeHealth()
         : defaultCapture(args),
     );
-
     const result = withMcpLifecycleLockSync(
       SANDBOX,
       () =>
@@ -878,37 +891,21 @@ describe("Hermes portable lifecycle", () => {
           ...deps,
           now: () => now,
           sleep: (milliseconds) => {
-            sleepInspections.push(
-              podman.mock.calls.filter(([command]) => command[1] === "inspect").length,
-            );
+            sleepBoundaries.push({ inspectsBefore: inspectCount(), milliseconds });
             now += milliseconds;
           },
         }),
       { stateDir: path.join(stateDir, "state") },
     );
-
+    const healthRunInspects = podman.mock.calls.filter(
+      ([args]) => args[0] === "container" && args[1] === "inspect",
+    );
     expect(result).toEqual({ kind: "recovered" });
-    const inspectionCount = podman.mock.calls.filter(([args]) => args[1] === "inspect").length;
-    expect({ healthCount: healthInspections.length, inspectionCount, now }).toEqual({
-      healthCount: 2,
-      inspectionCount: 11,
-      now: 1_000,
-    });
-    expect(sleepInspections).toEqual([healthInspections[0]! + 1]);
-    expect(healthInspections[1]).toBeGreaterThan(sleepInspections[0]!);
-    expect(inspectionCount).toBeGreaterThan(healthInspections[1]!);
+    expect(healthAttempts).toBe(1);
+    expect(healthBoundaries).toHaveLength(1);
+    expect(healthRunInspects.length).toBeGreaterThan(healthBoundaries[0]!);
+    expect([sleepBoundaries, launchOpenShell.mock.calls]).toEqual([[], [expect.any(Array)]]);
     expect(podman.mock.calls.filter(([args]) => args[1] === "start")).toHaveLength(1);
-    expect(launchOpenShell).toHaveBeenCalledExactlyOnceWith([
-      "sandbox",
-      "exec",
-      "-g",
-      GATEWAY,
-      "--name",
-      SANDBOX,
-      "--no-tty",
-      "--",
-      ...receipt.startup.argv,
-    ]);
   });
 
   it("launches the receipt-owned startup once before rolling back unavailable health (#9211)", () => {
@@ -948,10 +945,13 @@ describe("Hermes portable lifecycle", () => {
         .slice(1)
         .every(
           (command) =>
-            command.length === 3 &&
+            command.length === 7 &&
             command[0] === "python3" &&
-            command[1] === "-c" &&
-            command[2] === hermesPortableContainerInternals.authenticatedHealthScript,
+            command[1] === "-I" &&
+            command[2] === "-c" &&
+            command[3] === hermesPortableLifecycleInternals.healthWaitProgram &&
+            command[4] === "8642" &&
+            command[6] === "100",
         ),
     ).toBe(true);
     expect(execCommands.flat()).not.toContain(receipt.startup.argv.at(-1));

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
@@ -21,7 +21,7 @@ import {
   HERMES_PORTABLE_OPENSHELL_VERSION,
   type HermesPortableOpenShellExecutableAuthority,
 } from "../../adapters/openshell/resolve-shared";
-import { isMcpLifecycleLockHeld } from "../../state/mcp-lifecycle-lock/inspection";
+import { isMcpLifecycleLockHeld } from "../../state/mcp-lifecycle-lock-acquisition";
 import { assertCurrentPortableHostFenceHeld } from "../../state/portable-uninstall-retirement";
 import type { SandboxEntry } from "../../state/registry/types";
 import {
@@ -73,8 +73,81 @@ import { defaultPortableDemoStateDir } from "./portable-runtime-receipt-readines
 const UTF8 = new TextDecoder("utf-8", { fatal: true });
 const COMMAND_TIMEOUT_MS = 5_000;
 const EXEC_READY_TIMEOUT_MS = 90_000;
+const EXEC_READY_POLL_INTERVAL_MS = 100;
 const STARTUP_TIMEOUT_MS = 90_000;
 const POLL_INTERVAL_MS = 1_000;
+const HEALTH_WAIT_COMMAND_TIMEOUT_MS = 20_000;
+const HEALTH_WAIT_COMMAND_RESERVE_MS = 2_000;
+const HEALTH_WAIT_POLL_INTERVAL_MS = 100;
+const HEALTH_WAIT_RETRY_INTERVAL_MS = 1_000;
+const HEALTH_WAIT_MAX_ATTEMPTS = 9_999;
+const HEALTH_WAIT_RECEIPT_ROUNDING_TOLERANCE_MS = 1;
+const HEALTH_WAIT_PROGRAM = [
+  "import http.client",
+  "import sys",
+  "import time",
+  "",
+  "try:",
+  "    port = int(sys.argv[1])",
+  "    timeout_ms = int(sys.argv[2])",
+  "    interval_ms = int(sys.argv[3])",
+  "except (IndexError, ValueError):",
+  "    raise SystemExit(64)",
+  "if not (1 <= port <= 65535 and 1 <= timeout_ms <= 18000 and 10 <= interval_ms <= 1000):",
+  "    raise SystemExit(64)",
+  "deadline = time.monotonic() + timeout_ms / 1000",
+  "attempts = 0",
+  "not_ready = 0",
+  "timeouts = 0",
+  "errors = 0",
+  "probe_seconds = 0.0",
+  "sleep_seconds = 0.0",
+  'last_failure = "none"',
+  "",
+  "def finish(result, status):",
+  "    probe_ms = round(probe_seconds * 1000)",
+  "    sleep_ms = round(sleep_seconds * 1000)",
+  '    print(f"schema=1 result={result} attempts={attempts} notReady={not_ready} timeouts={timeouts} errors={errors} lastFailure={last_failure} probeMs={probe_ms} sleepMs={sleep_ms}")',
+  "    raise SystemExit(status)",
+  "",
+  "while True:",
+  "    remaining = deadline - time.monotonic()",
+  "    if remaining <= 0:",
+  '        finish("not-ready", 75)',
+  "    attempts += 1",
+  "    connection = None",
+  "    ready = False",
+  "    probe_started = time.monotonic()",
+  "    try:",
+  '        connection = http.client.HTTPConnection("127.0.0.1", port, timeout=min(3, remaining))',
+  '        connection.request("GET", "/health")',
+  "        response = connection.getresponse()",
+  "        status = response.status",
+  "        response.close()",
+  "        if status == 200:",
+  "            ready = True",
+  "        else:",
+  "            not_ready += 1",
+  '            last_failure = "not-ready"',
+  "    except TimeoutError:",
+  "        timeouts += 1",
+  '        last_failure = "timeout"',
+  "    except (OSError, http.client.HTTPException):",
+  "        errors += 1",
+  '        last_failure = "error"',
+  "    finally:",
+  "        if connection is not None:",
+  "            connection.close()",
+  "        probe_seconds += time.monotonic() - probe_started",
+  "    if ready:",
+  '        finish("ready", 0)',
+  "    remaining = deadline - time.monotonic()",
+  "    if remaining <= 0:",
+  '        finish("not-ready", 75)',
+  "    sleep_started = time.monotonic()",
+  "    time.sleep(min(interval_ms / 1000, remaining))",
+  "    sleep_seconds += time.monotonic() - sleep_started",
+].join("\n");
 const SLEEP_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 
 export interface HermesPortableLifecycleCommandResult {
@@ -83,6 +156,17 @@ export interface HermesPortableLifecycleCommandResult {
   readonly stderr: string | Buffer;
   readonly error?: Error;
 }
+
+type HealthWaitReceipt = {
+  readonly result: "ready" | "not-ready";
+  readonly attempts: number;
+  readonly notReady: number;
+  readonly timeouts: number;
+  readonly errors: number;
+  readonly lastFailure: "none" | "not-ready" | "timeout" | "error";
+  readonly probeMs: number;
+  readonly sleepMs: number;
+};
 
 export interface HermesPortableLifecycleDeps {
   readonly stateDir?: string;
@@ -545,7 +629,7 @@ function createAuthenticatedHealthCapture(
   capture: NonNullable<HermesPortableLifecycleDeps["captureOpenShell"]>,
 ): NonNullable<HermesPortableContainerDeps["authenticatedHealth"]> {
   return (script, timeoutMs) => {
-    const result = capture(openshellExecArgs(receipt, ["python3", "-c", script]), timeoutMs);
+    const result = capture(openshellExecArgs(receipt, ["python3", "-I", "-c", script]), timeoutMs);
     return {
       status: result.status,
       stdout: commandOutput(result.stdout, "authenticated health output"),
@@ -866,6 +950,7 @@ function waitFor(
   deps: HermesPortableLifecycleDeps,
   probe: (remainingMs: number) => boolean,
   measureSleep?: (operation: () => void) => void,
+  pollIntervalMs = POLL_INTERVAL_MS,
 ): boolean {
   const now = deps.now ?? Date.now;
   const sleep = deps.sleep ?? defaultSleep;
@@ -873,11 +958,44 @@ function waitFor(
   do {
     const remaining = Math.max(1, deadline - now());
     if (probe(remaining)) return true;
-    const operation = () => sleep(Math.min(POLL_INTERVAL_MS, remaining));
+    const operation = () => sleep(Math.min(pollIntervalMs, remaining));
     if (measureSleep) measureSleep(operation);
     else operation();
   } while (now() < deadline);
   return false;
+}
+
+function parseHealthWaitReceipt(raw: string): HealthWaitReceipt | null {
+  const match =
+    /^schema=1 result=(ready|not-ready) attempts=(\d{1,4}) notReady=(\d{1,4}) timeouts=(\d{1,4}) errors=(\d{1,4}) lastFailure=(none|not-ready|timeout|error) probeMs=(\d{1,5}) sleepMs=(\d{1,5})\n?$/u.exec(
+      raw,
+    );
+  if (!match) return null;
+  const receipt: HealthWaitReceipt = {
+    result: match[1] as HealthWaitReceipt["result"],
+    attempts: Number(match[2]),
+    notReady: Number(match[3]),
+    timeouts: Number(match[4]),
+    errors: Number(match[5]),
+    lastFailure: match[6] as HealthWaitReceipt["lastFailure"],
+    probeMs: Number(match[7]),
+    sleepMs: Number(match[8]),
+  };
+  const failures = receipt.notReady + receipt.timeouts + receipt.errors;
+  if (
+    receipt.attempts < 1 ||
+    receipt.attempts > HEALTH_WAIT_MAX_ATTEMPTS ||
+    receipt.probeMs > HEALTH_WAIT_COMMAND_TIMEOUT_MS ||
+    receipt.sleepMs > HEALTH_WAIT_COMMAND_TIMEOUT_MS ||
+    receipt.attempts !== failures + (receipt.result === "ready" ? 1 : 0) ||
+    (failures === 0) !== (receipt.lastFailure === "none") ||
+    (receipt.lastFailure === "not-ready" && receipt.notReady === 0) ||
+    (receipt.lastFailure === "timeout" && receipt.timeouts === 0) ||
+    (receipt.lastFailure === "error" && receipt.errors === 0)
+  ) {
+    return null;
+  }
+  return receipt;
 }
 
 function rollbackStartedHermesPortableRecovery(
@@ -1019,6 +1137,70 @@ function captureRetainedLifecycleCommand(
   }
 }
 
+function waitForHermesReadiness(
+  qualified: QualifiedHermesPortableLifecycle,
+  context: PortableDemoLifecycleContext,
+  deps: HermesPortableLifecycleDeps,
+  timing: HermesPortableLifecycleTimingRecorder,
+  currentnessTiming: HermesPortableCurrentnessTimingRecorder,
+): QualifiedHermesPortableLifecycle | null {
+  const now = deps.now ?? Date.now;
+  const sleep = deps.sleep ?? defaultSleep;
+  const deadline = now() + STARTUP_TIMEOUT_MS;
+  do {
+    qualified = refreshLifecycleCurrentness(
+      qualified.receipt.sandboxName,
+      context,
+      deps,
+      qualified,
+      timing,
+      true,
+      ["Ready"],
+      currentnessTiming,
+    );
+    const remainingMs = Math.max(1, deadline - now());
+    const commandTimeoutMs = Math.min(HEALTH_WAIT_COMMAND_TIMEOUT_MS, remainingMs);
+    const commandReserveMs = Math.min(
+      HEALTH_WAIT_COMMAND_RESERVE_MS,
+      Math.floor(commandTimeoutMs / 2),
+    );
+    const waiterTimeoutMs = Math.max(1, commandTimeoutMs - commandReserveMs);
+    const result = captureRetainedLifecycleCommand(
+      qualified,
+      timing,
+      openshellExecArgs(qualified.receipt, [
+        "python3",
+        "-I",
+        "-c",
+        HEALTH_WAIT_PROGRAM,
+        String(qualified.receipt.startup.health.port),
+        String(waiterTimeoutMs),
+        String(HEALTH_WAIT_POLL_INTERVAL_MS),
+      ]),
+      commandTimeoutMs,
+      "healthOpenShellCommand",
+    );
+    const receipt = result.error
+      ? null
+      : parseHealthWaitReceipt(commandOutput(result.stdout, "authenticated health wait output"));
+    const accepted =
+      receipt !== null &&
+      receipt.probeMs + receipt.sleepMs <=
+        waiterTimeoutMs + HEALTH_WAIT_RECEIPT_ROUNDING_TOLERANCE_MS &&
+      ((receipt.result === "ready" && result.status === 0) ||
+        (receipt.result === "not-ready" && result.status === 75));
+    timing.measure("healthPollCurrentness", () =>
+      assertLifecycleTransactionCurrent(qualified, timing, true, currentnessTiming),
+    );
+    if (accepted && receipt.result === "ready") return qualified;
+    if (now() >= deadline) return null;
+    timing.measure("healthPollSleep", () =>
+      sleep(Math.min(accepted ? HEALTH_WAIT_POLL_INTERVAL_MS : HEALTH_WAIT_RETRY_INTERVAL_MS, deadline - now())),
+    );
+  } while (now() < deadline);
+  return null;
+}
+
 /** Rebind the live target immediately before the name-addressed startup command. */
 function assertLiveHermesPortableStartupBinding(
   qualified: QualifiedHermesPortableLifecycle,
@@ -1121,16 +1303,11 @@ export function recoverHermesPortableSandboxLifecycle(
         throw startError;
       }
       qualified = timing.measure("postStartCurrentness", () =>
-        refreshLifecycleCurrentness(
-          sandboxName,
-          context,
-          instrumentedDeps,
-          qualified,
-          timing,
-          true,
-          ["Ready", "Error", "Stopped"],
-          currentnessTiming,
-        ),
+        refreshLifecycleCurrentness(sandboxName, context, instrumentedDeps, qualified, timing, true, [
+          "Ready",
+          "Error",
+          "Stopped",
+        ], currentnessTiming),
       );
     }
     const commandEnv = deps.env ?? process.env;
@@ -1146,33 +1323,28 @@ export function recoverHermesPortableSandboxLifecycle(
         args.includes("python3") ? "healthOpenShellCommand" : undefined,
       );
     const execReady = timing.measure("execReady", () =>
-      waitFor(
-        EXEC_READY_TIMEOUT_MS,
-        deps,
-        (remainingMs) => {
-          timing.increment("execReadyAttempt");
-          if (qualified.hasTransactionAuthority) {
-            timing.measure("execReadyCurrentness", () =>
-              assertLifecycleTransactionCurrent(qualified, timing, true, currentnessTiming),
-            );
-          }
-          const result = captureRetainedLifecycleCommand(
-            qualified,
-            timing,
-            openshellExecArgs(qualified.receipt, ["true"]),
-            Math.min(COMMAND_TIMEOUT_MS, remainingMs),
-            "execReadyCommand",
-            "execReadyCurrentness",
+      waitFor(EXEC_READY_TIMEOUT_MS, deps, (remainingMs) => {
+        timing.increment("execReadyAttempt");
+        if (qualified.hasTransactionAuthority) {
+          timing.measure("execReadyCurrentness", () =>
+            assertLifecycleTransactionCurrent(qualified, timing, true, currentnessTiming),
           );
-          if (qualified.hasTransactionAuthority) {
-            timing.measure("execReadyCurrentness", () =>
-              assertLifecycleTransactionCurrent(qualified, timing, true, currentnessTiming),
-            );
-          }
-          return result.status === 0 && !result.error;
-        },
-        (operation) => timing.measure("execReadySleep", operation),
-      ),
+        }
+        const result = captureRetainedLifecycleCommand(
+          qualified,
+          timing,
+          openshellExecArgs(qualified.receipt, ["true"]),
+          Math.min(COMMAND_TIMEOUT_MS, remainingMs),
+          "execReadyCommand",
+          "execReadyCurrentness",
+        );
+        if (qualified.hasTransactionAuthority) {
+          timing.measure("execReadyCurrentness", () =>
+            assertLifecycleTransactionCurrent(qualified, timing, true, currentnessTiming),
+          );
+        }
+        return result.status === 0 && !result.error;
+      }, (operation) => timing.measure("execReadySleep", operation), EXEC_READY_POLL_INTERVAL_MS),
     );
     if (!execReady) fail("did not reconnect to the selected OpenShell gateway");
     qualified = timing.measure("preHealthCurrentness", () =>
@@ -1232,15 +1404,15 @@ export function recoverHermesPortableSandboxLifecycle(
     if (startedByRecovery) {
       qualified = timing.measure("healthPollCurrentness", () =>
         refreshLifecycleCurrentness(
-          sandboxName,
-          context,
-          instrumentedDeps,
-          qualified,
-          timing,
-          true,
-          ["Ready"],
-          currentnessTiming,
-        ),
+        sandboxName,
+        context,
+        instrumentedDeps,
+        qualified,
+        timing,
+        true,
+        ["Ready"],
+        currentnessTiming,
+      ),
       );
       const assertExecutable =
         deps.assertOpenShellExecutableAuthority ?? assertHermesPortableOpenShellExecutableAuthority;
@@ -1266,44 +1438,74 @@ export function recoverHermesPortableSandboxLifecycle(
         qualified.assertTransactionCurrent();
       }
     }
-    const recovered = waitFor(
-      STARTUP_TIMEOUT_MS,
-      deps,
-      () => {
-        qualified = timing.measure("healthPollCurrentness", () =>
-          refreshLifecycleCurrentness(
-            sandboxName,
-            context,
-            instrumentedDeps,
+    const readyQualification = startedByRecovery
+      ? waitForHermesReadiness(
+          qualified,
+          context,
+          instrumentedDeps,
+          timing,
+          currentnessTiming,
+        )
+      : null;
+    if (startedByRecovery && !readyQualification) {
+      fail("managed startup did not pass authenticated health");
+    }
+    if (readyQualification) qualified = readyQualification;
+    const recovered = startedByRecovery
+      ? (() => {
+          const currentContainerDeps = measuredHealthContainerDeps(
             qualified,
             timing,
-            true,
-            ["Ready"],
-            currentnessTiming,
-          ),
-        );
-        const currentContainerDeps = measuredHealthContainerDeps(
-          qualified,
-          timing,
-          createAuthenticatedHealthCapture(qualified.receipt, capture),
-        );
-        timing.increment("authenticatedHealth");
-        const health = timing.measure("authenticatedHealth", () =>
-          observeHermesPortableAuthenticatedHealth(
-            qualified.receipt,
-            currentContainerDeps,
-            qualified.container,
-          ),
-        );
-        if (qualified.hasTransactionAuthority) {
-          timing.measure("healthPollCurrentness", () =>
-            assertLifecycleTransactionCurrent(qualified, timing, true, currentnessTiming),
+            createAuthenticatedHealthCapture(qualified.receipt, capture),
           );
-        }
-        return health === "ready";
-      },
-      (operation) => timing.measure("healthPollSleep", operation),
-    );
+          timing.increment("authenticatedHealth");
+          return (
+            timing.measure("authenticatedHealth", () =>
+              observeHermesPortableAuthenticatedHealth(
+                qualified.receipt,
+                currentContainerDeps,
+              ),
+            ) === "ready"
+          );
+        })()
+      : waitFor(
+          STARTUP_TIMEOUT_MS,
+          deps,
+          () => {
+            qualified = timing.measure("healthPollCurrentness", () =>
+              refreshLifecycleCurrentness(
+                sandboxName,
+                context,
+                instrumentedDeps,
+                qualified,
+                timing,
+                true,
+                ["Ready"],
+                currentnessTiming,
+              ),
+            );
+            const currentContainerDeps = measuredHealthContainerDeps(
+              qualified,
+              timing,
+              createAuthenticatedHealthCapture(qualified.receipt, capture),
+            );
+            timing.increment("authenticatedHealth");
+            const health = timing.measure("authenticatedHealth", () =>
+              observeHermesPortableAuthenticatedHealth(
+                qualified.receipt,
+                currentContainerDeps,
+                qualified.container,
+              ),
+            );
+            if (qualified.hasTransactionAuthority) {
+              timing.measure("healthPollCurrentness", () =>
+                assertLifecycleTransactionCurrent(qualified, timing, true, currentnessTiming),
+              );
+            }
+            return health === "ready";
+          },
+          (operation) => timing.measure("healthPollSleep", operation),
+        );
     if (!recovered) fail("managed startup did not pass authenticated health");
     timing.increment("qualification");
     timing.measure("finalQualification", () =>
@@ -1635,6 +1837,8 @@ export function stopHermesPortableSandboxLifecycle(
 export const hermesPortableLifecycleInternals = {
   buildHermesPortableOpenShellEnv,
   createContainerDeps,
+  healthWaitProgram: HEALTH_WAIT_PROGRAM,
+  parseHealthWaitReceipt,
   qualify,
   retainRequalifiedOperatingAuthority,
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome
Hermes stopped-container recovery now waits for readiness inside one sandbox command instead of repeating host-side authenticated probes during startup. Recovery still requires one final credential-bearing authenticated health check and full final qualification before success.

## Reason
Live Portable evidence on the original candidate `df4578a517` showed successful stopped recovery while repeated host-to-sandbox readiness probes added Podman and OpenShell round trips. Moving the bounded readiness wait into the sandbox removes those repeated host crossings without changing lifecycle authority.

### Related issues
Relates to #10423
Relates to #10822
Stacked on #10983

## Changes
- Run one isolated Python readiness waiter inside the sandbox after the receipt-owned startup launch.
- Parse one bounded numeric readiness receipt and reject malformed, inconsistent, over-budget, or command-status-inconsistent output.
- Keep the existing exact-container currentness checks before and after the waiter.
- Perform the existing credential-bearing authenticated health probe after the waiter reports ready.
- Preserve final receipt, registry, socket, executable, container, and OpenShell qualification before recovery succeeds.
- Reduce the OpenShell exec-readiness polling interval from one second to 100 ms within the existing 90-second bound.

## Verification
- `npx vitest run --project cli src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts src/lib/onboard/experimental/hermes-portable-operating-authority.test.ts src/lib/onboard/experimental/hermes-portable-container.test.ts src/lib/onboard/experimental/hermes-currentness-timing.test.ts src/lib/onboard/experimental/hermes-container-inspection-timing.test.ts` — 89 tests passed.
- `npm run typecheck:cli` — passed.
- `npm run build:cli` — passed.
- Normal pre-commit hooks — formatting, lint, secret scan, test-size guardrail, and commitlint passed. The repository check reports a stale PR-base architecture budget: `mcp-lifecycle-lock-acquisition.ts` fan-in is 21 while the base limit is 20. This change does not import or modify that file.
- Pre-push CLI TypeScript check — passed.
- `git verify-commit HEAD` — valid SSH signature.
- GitHub commit verification — `df09cc12f0b343addb3452e4aa38e2db6ead054b` is Verified with reason `valid`.
- Live Portable stopped recovery — the original readiness-wait candidate `df4578a517` completed one successful seat recovery. The rebased commit preserves that readiness algorithm but also repairs compatibility with #10983 current-observation freshness. The rebased commit has not received a separate live run.
- Diff and gitleaks checks — no bearer value, API key, credential, environment value, endpoint, command output, stdout, or stderr enters the readiness receipt.

## Review notes
This draft intentionally excludes four later debug-seat experiments from the requested five-commit stack. Those commits disabled socket, executable, transaction-currentness, and final-qualification checks; the cumulative stack failed four focused lifecycle tests and had no successful live stopped recovery. Their rebased form is preserved locally on `perf/hermes-gfn-authority-experiments` and is not published as production-ready.

The sandbox waiter probes loopback `/health` without credentials and is only an availability hint. It cannot establish recovery success. The existing credential-bearing authenticated health probe remains mandatory afterward, and its credential stays inside the sandbox.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>
