### PR TITLE
perf(cli): reuse Hermes executable proof during recovery

### DIFF
--- a/src/lib/actions/sandbox/connect-hermes-accepted-readiness.test.ts
+++ b/src/lib/actions/sandbox/connect-hermes-accepted-readiness.test.ts
@@ -236,7 +236,7 @@ describe("Hermes accepted launch-readiness probe", () => {
     expect(harness.publishLaunchReadinessSpy).toHaveBeenCalledOnce();
   });
 
-  it("routes typed publication health failure to existing recovery under one mutation gate", async () => {
+  it("settles transient final Hermes publication health without another recovery", async () => {
     const harness = missingHermesHarness();
     harness.publishLaunchReadinessSpy
       .mockResolvedValueOnce({ kind: "validation-failed", category: "health" })
@@ -248,6 +248,23 @@ describe("Hermes accepted launch-readiness probe", () => {
     expect(harness.recoverPortableDemoLifecycleSpy).toHaveBeenCalledOnce();
     expect(harness.recoverHermesPortableOllamaInferenceSpy).toHaveBeenCalledOnce();
     expect(harness.publishLaunchReadinessSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds final Hermes publication settlement before reporting persistent health failure", async () => {
+    const harness = missingHermesHarness();
+    harness.publishLaunchReadinessSpy.mockResolvedValue({
+      kind: "validation-failed",
+      category: "health",
+    });
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(harness.launchReadinessMutationGateSpy).toHaveBeenCalledOnce();
+    expect(harness.recoverPortableDemoLifecycleSpy).toHaveBeenCalledOnce();
+    // One accepted-runtime attempt enters recovery; final settlement is then capped at three.
+    expect(harness.publishLaunchReadinessSpy).toHaveBeenCalledTimes(4);
   });
 
   it.each([

--- a/src/lib/actions/sandbox/connect.ts
+++ b/src/lib/actions/sandbox/connect.ts
@@ -26,7 +26,7 @@ import type { AgentDefinition } from "../../agent/defs";
 import * as agentRuntime from "../../agent/runtime";
 import { CLI_NAME } from "../../cli/branding";
 import { D, G, R, YW } from "../../cli/terminal-style";
-import { retryUntil } from "../../core/retry";
+import { retryUntil, retryUntilAsync } from "../../core/retry";
 
 import { spawnExitCode } from "../../core/process-exit";
 import { shellQuote } from "../../core/shell-quote";
@@ -140,6 +140,19 @@ import { runTerminalAgentConnectProbe } from "./terminal-connect-probe";
 import { applyOpenShellVmDnsMonkeypatch, shouldApplyVmDnsMonkeypatch } from "./vm-dns-monkeypatch";
 
 export { runConnectAutoPairApprovalPass, waitForManagedGatewaySupervisor };
+
+const HERMES_READINESS_PUBLICATION_SETTLE_DELAYS_MS = [100, 250] as const;
+
+async function publishHermesLaunchReadinessWithSettlement(
+  publication: Parameters<typeof publishLaunchReadiness>[0],
+  deps: Parameters<typeof publishLaunchReadiness>[1],
+) {
+  return retryUntilAsync(() => publishLaunchReadiness(publication, deps), {
+    accept: (result) => result.kind !== "validation-failed" || result.category !== "health",
+    retryDelaysMs: HERMES_READINESS_PUBLICATION_SETTLE_DELAYS_MS,
+    sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  });
+}
 
 export type SandboxConnectOptions = {
   probeOnly?: boolean;
@@ -2697,7 +2710,9 @@ async function prepareConnectSandboxWithinLifecycleFence(
           probeTiming!.measure("authority", retainedCommand.assertCurrent);
         }
         const published = await probeTiming!.measureAsync("publication", () =>
-          publishLaunchReadiness(
+          (retainedCommand
+            ? publishHermesLaunchReadinessWithSettlement
+            : publishLaunchReadiness)(
             publicationRequest,
             retainedCommand
               ? hermesPortableLaunchReadinessDeps(retainedCommand, probeTiming)

--- a/src/lib/adapters/openshell/resolve-shared.ts
+++ b/src/lib/adapters/openshell/resolve-shared.ts
@@ -6,6 +6,7 @@ import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { HERMES_LIFECYCLE_DEFINITION } from "../../domain/lifecycle/hermes-definition";
 import {
   assertPodmanExecutableAuthority,
+  assertPodmanExecutableMetadataAuthority,
   capturePodmanExecutableAuthority,
   type PodmanExecutableAuthority,
   type PodmanExecutableAuthorityDeps,
@@ -144,7 +145,7 @@ export function assertHermesPortableOpenShellExecutableFileAuthority(
     failExecutableAuthority("disagrees with the current OpenShell resolution");
   }
   try {
-    assertPodmanExecutableAuthority(expected.executable, deps);
+    assertPodmanExecutableMetadataAuthority(expected.executable, deps);
   } catch {
     failExecutableAuthority("executable generation changed after reservation");
   }

--- a/src/lib/adapters/openshell/resolve-shared.ts
+++ b/src/lib/adapters/openshell/resolve-shared.ts
@@ -6,7 +6,7 @@ import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { HERMES_LIFECYCLE_DEFINITION } from "../../domain/lifecycle/hermes-definition";
 import {
   assertPodmanExecutableAuthority,
-  assertPodmanExecutableMetadataAuthority,
+
   capturePodmanExecutableAuthority,
   type PodmanExecutableAuthority,
   type PodmanExecutableAuthorityDeps,
@@ -145,7 +145,7 @@ export function assertHermesPortableOpenShellExecutableFileAuthority(
     failExecutableAuthority("disagrees with the current OpenShell resolution");
   }
   try {
-    assertPodmanExecutableMetadataAuthority(expected.executable, deps);
+    assertPodmanExecutableAuthority(expected.executable, deps);
   } catch {
     failExecutableAuthority("executable generation changed after reservation");
   }

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts
@@ -336,9 +336,8 @@ function lifecycleDeps(
   const captureSocketAuthority = vi.fn(() => ({ ...receipt.socketAuthority, inode: "102" }));
   const captureOpenShellExecutableAuthority = vi.fn(() => receipt.openshellExecutableAuthority);
   const capturePodmanExecutableAuthority = vi.fn(() => receipt.podmanExecutableAuthority);
-  const assertOpenShellExecutableFileAuthority = vi.fn(
-    () => receipt.openshellExecutableAuthority.executable.executablePath,
-  );
+  const assertOpenShellExecutableAuthority = vi.fn(() => "/usr/bin/openshell");
+  const assertOpenShellExecutableFileAuthority = vi.fn(() => "/usr/bin/openshell");
   const capturePodmanExecutableFileAuthority = vi.fn(() => receipt.podmanExecutableAuthority);
   return {
     deps: {
@@ -362,7 +361,7 @@ function lifecycleDeps(
         }) as SandboxEntry,
       captureOpenShell,
       launchOpenShell,
-      assertOpenShellExecutableAuthority: vi.fn(() => "/usr/bin/openshell"),
+      assertOpenShellExecutableAuthority,
       operatingAuthority: {
         env: {
           HOME: receipt.runtimeAuthority.homeDir,
@@ -385,6 +384,7 @@ function lifecycleDeps(
     captureSocketAuthority,
     captureOpenShellExecutableAuthority,
     capturePodmanExecutableAuthority,
+    assertOpenShellExecutableAuthority,
     assertOpenShellExecutableFileAuthority,
     capturePodmanExecutableFileAuthority,
   };

--- a/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
+++ b/src/lib/onboard/experimental/hermes-portable-lifecycle.ts
@@ -802,17 +802,18 @@ function qualify(
     },
     options,
   );
-  operatingAuthority.assertCurrent();
   const receipt = operatingAuthority.receipt;
   if (!contextMatches(receipt, context)) fail("registry context disagrees with the active receipt");
   assertCurrentHermesPortableStoredStartupContract(receipt.startup, sandboxName);
   const assertExecutable =
     deps.assertOpenShellExecutableAuthority ?? assertHermesPortableOpenShellExecutableAuthority;
-  const initialCommandAuthority = buildHermesPortableOpenShellCommandAuthority(
-    receipt,
-    commandEnv,
-    assertExecutable,
-  );
+  const hasTransactionAuthority = snapshot.successor !== undefined;
+  const initialCommandAuthority = hasTransactionAuthority
+    ? {
+        env: buildHermesPortableOpenShellEnv(commandEnv, receipt.runtimeAuthority),
+        executablePath: receipt.openshellExecutableAuthority.executable.executablePath,
+      }
+    : buildHermesPortableOpenShellCommandAuthority(receipt, commandEnv, assertExecutable);
   const rawCapture =
     deps.captureOpenShell ??
     defaultCaptureOpenShell(
@@ -824,8 +825,16 @@ function qualify(
     args,
     timeoutMs,
   ) => {
-    buildHermesPortableOpenShellCommandAuthority(receipt, commandEnv, assertExecutable);
-    return rawCapture(args, timeoutMs);
+    if (!hasTransactionAuthority) {
+      buildHermesPortableOpenShellCommandAuthority(receipt, commandEnv, assertExecutable);
+      return rawCapture(args, timeoutMs);
+    }
+    operatingAuthority.assertTransactionCurrent();
+    try {
+      return rawCapture(args, timeoutMs);
+    } finally {
+      operatingAuthority.assertTransactionCurrent();
+    }
   };
   const liveIdentity = observeOpenShellIdentity(receipt, capture, acceptedPhases);
   requireRegistry(receipt, liveIdentity.liveIdentityFingerprint, deps);
@@ -848,8 +857,8 @@ function qualify(
   if (container.paused || container.authority.restartPolicy !== "unless-stopped") {
     fail("container state or restart policy disagrees with active authority");
   }
-  operatingAuthority.assertCurrent();
-  const hasTransactionAuthority = snapshot.successor !== undefined;
+  if (hasTransactionAuthority) operatingAuthority.assertTransactionCurrent();
+  else operatingAuthority.assertCurrent();
   const assertTransactionCurrent = hasTransactionAuthority
     ? retainRequalifiedOperatingAuthority(
         sandboxName,

--- a/src/lib/onboard/experimental/hermes-portable-operating-authority.ts
+++ b/src/lib/onboard/experimental/hermes-portable-operating-authority.ts
@@ -207,19 +207,6 @@ export function qualifyHermesPortableOperatingAuthority(
         sourceEnv,
         podmanAuthorityDeps,
       ));
-  const assertOpenShellFile =
-    deps.assertOpenShellExecutableFileAuthority ??
-    ((expected: HermesPortableOpenShellExecutableAuthority, resolutionEnv: NodeJS.ProcessEnv) =>
-      assertHermesPortableOpenShellExecutableFileAuthority(expected, resolutionEnv));
-  const capturePodmanFile =
-    deps.capturePodmanExecutableFileAuthority ??
-    ((socketAuthority, receipt, sourceEnv) =>
-      captureHermesPortablePodmanExecutableFileAuthority(
-        socketAuthority,
-        receipt,
-        sourceEnv,
-        podmanAuthorityDeps,
-      ));
   const capture = () => {
     const socket = measure("socketAuthority", () =>
       captureSocket(
@@ -254,6 +241,19 @@ export function qualifyHermesPortableOperatingAuthority(
       } satisfies HermesPortableConfiguredReceipt,
     };
   };
+  const assertOpenShellFile =
+    deps.assertOpenShellExecutableFileAuthority ??
+    ((expected: HermesPortableOpenShellExecutableAuthority, resolutionEnv: NodeJS.ProcessEnv) =>
+      assertHermesPortableOpenShellExecutableFileAuthority(expected, resolutionEnv));
+  const capturePodmanFile =
+    deps.capturePodmanExecutableFileAuthority ??
+    ((socketAuthority, receipt, sourceEnv) =>
+      captureHermesPortablePodmanExecutableFileAuthority(
+        socketAuthority,
+        receipt,
+        sourceEnv,
+        podmanAuthorityDeps,
+      ));
   const initial = capture();
   const assertTransactionCurrent = (): void => {
     const socket = measure("socketAuthority", () =>

--- a/src/lib/onboard/experimental/hermes-portable-podman-authority.ts
+++ b/src/lib/onboard/experimental/hermes-portable-podman-authority.ts
@@ -4,7 +4,7 @@
 import { isDeepStrictEqual } from "node:util";
 
 import {
-  assertPodmanExecutableMetadataAuthority,
+  assertPodmanExecutableAuthority,
   capturePodmanExecutableAuthority,
   createPodmanContainerEngine,
   createPodmanExecutableOperationProof,
@@ -294,7 +294,7 @@ export function captureHermesPortablePodmanExecutableFileAuthority(
   requireRuntimeAuthority(receipt.runtimeAuthority, socketAuthority, deps);
   buildHermesPortablePodmanEnvironment(receipt.runtimeAuthority, sourceEnv);
   requireResolvedExecutable(receipt.podmanExecutableAuthority, sourceEnv, deps);
-  assertPodmanExecutableMetadataAuthority(
+  assertPodmanExecutableAuthority(
     receipt.podmanExecutableAuthority.executable,
     deps.executableAuthorityDeps,
   );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome
Hermes Portable stopped-container recovery now reuses one live executable proof within each qualified lifecycle transaction. Intermediate commands keep exact executable metadata and receipt-owned socket guards, while entry and final qualification still perform full executable validation, exact container and policy checks, authenticated health, ambiguity reconciliation, and rollback.

The probe also settles a transient final Hermes readiness-publication health result with two bounded retries before failing closed.

## Reason
Repeated full executable hashing and behavior checks dominated the measured stopped-container recovery path. Senthil's merged OpenClaw and Hermes optimizations established the operation-scoped pattern: fully qualify authority, retain it only inside the transaction, revalidate currentness around commands, and return stale or changed state to checked recovery.

The prior debug-seat ceiling experiment reduced startup from 17.080 seconds to 7.063 seconds, a 10.017-second (58.6%) improvement. That unconditional experiment is not included. This guarded slice preserves the checked entry and final boundaries; guarded live timing remains separate.

### Related issues
Closes #10822
Relates to #10423

## Changes
- Reuse the schema-8 operation's fully qualified OpenShell executable path instead of repeating its version and full-content proof before every command.
- Sandwich each retained OpenShell command with operation-currentness checks.
- Change retained OpenShell file currentness from a full content hash to exact canonical path, device, inode, owner, mode, size, mtime, ctime, and directory-chain validation.
- Keep Podman commands on their existing adapter-minted operation proof, per-command executable metadata checks, periodic full rehash, failure latching, and exact receipt-owned socket guards.
- Preserve a separate full final `qualify()` after authenticated health, plus full qualification for rollback reconciliation.
- Keep schema-7 and unknown authority on the existing fully checked path.
- Retry only typed final Hermes publication-health failures after 100 ms and 250 ms. Persistent health failure remains nonzero; identity, configuration, policy, and evidence failures are not retried.

## Verification
- `npx vitest run --project cli src/lib/onboard/experimental/hermes-portable-lifecycle.test.ts src/lib/onboard/experimental/hermes-portable-operating-authority.test.ts src/lib/actions/sandbox/connect-hermes-accepted-readiness.test.ts` — 82 tests passed.
- `npm run typecheck:cli` — passed.
- `npm run build:cli` — passed.
- `npm run review:local` — exited 0 with no published actionable findings.
- Independent final focused review of `244cf8fac171776138a343174c6f7b09723c334d` — no blockers found for per-command guards, metadata/socket currentness, full entry/final qualification, rollback, fallback, or bounded publication settlement.
- Pre-push CLI TypeScript hook — passed.
- `npm run validate:pr` — every applicable PR-diff check passed except the current-main `ci/e2e-assertion-budget.json` drift in unrelated `test/e2e/live/hermes-discord.test.ts`. This PR changes no `test/e2e/**` or assertion-budget file.
- Diff and gitleaks hook — no secrets, credentials, private keys, environment values, or command output are included.

## Review notes
The 10.017-second result is the prior unconditional debug-seat ceiling, not a timing claim for this guarded implementation. A live stopped-container attempt on the existing Portable seat did not reach mutation or timing: current source correctly rejected the older receipt because its stored startup authority disagreed with the candidate manifest. The exact receipt-owned container remained running and healthy with full ID `53b3a635d88fc529c8b8d3e44036aac5d35e4d4ad6a7f061860cfa7acd77f7b9`; no rollback or replacement occurred. A same-source guarded timing sample remains pending.

The unsafe root-owned Portable JSON attestation design from the first draft revision was removed completely. This revision does not infer trust from a hostname, mutable image tag, environment variable, or local statement. It reuses only live authority minted by the existing full qualification and keeps the fully checked fallback and final proof.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Hermes launch-readiness handling by retrying temporary health-validation failures before reporting success or failure.
  - Added bounded handling for persistent readiness failures to prevent indefinite attempts.
  - Improved command authorization checks so execution remains aligned with the latest transaction or receipt state.
  - Strengthened OpenShell and Podman executable-authority validation during onboarding and runtime operations.

- **Tests**
  - Expanded coverage for temporary recovery and persistent launch-readiness failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->