### PR TITLE
test(e2e): exercise model override startup path

### DIFF
--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -570,6 +570,7 @@ fi
 info "27. NEMOCLAW_MODEL_OVERRIDE patches openclaw.json"
 OUT=$(docker run --rm --user root -e NEMOCLAW_MODEL_OVERRIDE="test/override-model" \
   "$IMAGE" bash -c '
+  set -e
   python3 -c "
 import json
 with open(\"/sandbox/.openclaw/openclaw.json\") as f:

--- a/test/e2e-gateway-isolation.sh
+++ b/test/e2e-gateway-isolation.sh
@@ -569,23 +569,7 @@ fi
 
 info "27. NEMOCLAW_MODEL_OVERRIDE patches openclaw.json"
 OUT=$(docker run --rm --user root -e NEMOCLAW_MODEL_OVERRIDE="test/override-model" \
-  --entrypoint "" "$IMAGE" bash -c '
-  # Source the entrypoint function without running the full startup. Keep the
-  # extraction whitespace-tolerant and fail closed if the function cannot be
-  # found, instead of sourcing an empty snippet.
-  APPLY_MODEL_OVERRIDE_SNIPPET=$(sed -n "/^[[:space:]]*apply_model_override[[:space:]]*()[[:space:]]*{/,/^[[:space:]]*}[[:space:]]*$/p" /usr/local/bin/nemoclaw-start)
-  if [ -z "$APPLY_MODEL_OVERRIDE_SNIPPET" ]; then
-    echo "EXTRACT_FAIL apply_model_override"
-    exit 1
-  fi
-  source /dev/stdin <<<"$APPLY_MODEL_OVERRIDE_SNIPPET"
-  # Keep this case scoped to the JSON rewrite. Permission normalization and
-  # owner dispatch are exercised by the dedicated cases below.
-  normalize_mutable_config_perms() { :; }
-  run_openclaw_config_as_owner() { "$@"; }
-  ensure_mutable_openclaw_config_hash() { :; }
-  export NEMOCLAW_MODEL_OVERRIDE="test/override-model"
-  apply_model_override
+  "$IMAGE" bash -c '
   python3 -c "
 import json
 with open(\"/sandbox/.openclaw/openclaw.json\") as f:
@@ -598,13 +582,19 @@ all_patched = all(
     for m in all_models
 )
 if primary == \"test/override-model\" and all_models and all_patched:
-    print(\"OVERRIDE_OK\")
+    print(\"OVERRIDE_JSON_OK\")
 else:
-    print(f\"OVERRIDE_FAIL primary={primary} models={len(all_models)} all_patched={all_patched}\")
+    raise SystemExit(f\"OVERRIDE_FAIL primary={primary} models={len(all_models)} all_patched={all_patched}\")
 "
+  cd /sandbox/.openclaw
+  sha256sum -c .config-hash --status
+  test "$(stat -c "%a %U:%G" .)" = "2770 sandbox:sandbox"
+  test "$(stat -c "%a %U:%G" openclaw.json)" = "660 sandbox:sandbox"
+  test "$(stat -c "%a %U:%G" .config-hash)" = "660 sandbox:sandbox"
+  printf "OVERRIDE_OK\n"
 ' 2>&1 || true)
 if echo "$OUT" | grep -q "OVERRIDE_OK"; then
-  pass "NEMOCLAW_MODEL_OVERRIDE patches primary, id, and name"
+  pass "model override runs through owner dispatch with valid hash and mutable modes"
 else
   fail "model override did not patch correctly: $OUT"
 fi


### PR DESCRIPTION
## Outcome

The image-level model-override test now exercises the real container entrypoint and proves the complete startup transition: JSON rewrite, refreshed hash, sandbox ownership, and mutable modes.

## Reason

PR #11001 repaired the deterministic current-main `normalize_mutable_config_perms: command not found` harness failure with local stubs. Its exact-head Delivery and Verification Advisors correctly found that those stubs bypassed production permission normalization, owner dispatch, and hash refresh. #11001 was merged externally before this correction could be published.

### Related issues

Follow-up to #11001.

## Changes

- Remove the brittle extraction of `apply_model_override` and all three local helper stubs.
- Run the built image through its real root entrypoint with `NEMOCLAW_MODEL_OVERRIDE`.
- Require the one-shot command to observe the rewritten primary and model entries.
- Require `.config-hash` to validate and the mutable directory, config, and hash to retain their sandbox ownership and expected modes.
- Fail the inner command immediately if any JSON, hash, ownership, or mode check fails, before the success marker can be emitted.

## Verification

- `shfmt` — passed.
- `shellcheck` — passed.
- Codebase growth guardrail and repository hooks — passed.
- `git diff --check origin/main...HEAD` — passed.
- Exact-head managed image E2E on #11001 proved the original 44/45 failure was resolved by the predecessor fixture update; this stronger real-entrypoint form requires its own CI run before merge.
- Diff inspection — no secrets, API keys, or credentials.

## Review notes

This is the already-prepared correction for the exact-head Advisor findings on #11001. It replaces the merged stubs rather than layering another test path. The first #11003 Advisor pass found that the new inner shell needed fail-fast behavior; the current head adds `set -e` before every required check.

---
Signed-off-by: Aaron Erickson <aerickson@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for the model-override scenario.
  - Added validation that configuration changes are correctly applied and remain consistent.
  - Added checks for configuration integrity and expected file ownership and permission settings.
  - Updated test execution to stop immediately when a validation step fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->