### PR TITLE
fix(readiness): preserve gateway probe error detail

### DIFF
--- a/src/lib/readiness/gateway.test.ts
+++ b/src/lib/readiness/gateway.test.ts
@@ -195,6 +195,35 @@ describe("gateway readiness projection (#7411)", () => {
     expect(serialized).toContain("<gateway-state>");
   });
 
+  it("reports the underlying error when managed gateway observation throws", async () => {
+    const deps = dependencies(managedOwner());
+    vi.mocked(deps.observeManagedGateway).mockRejectedValueOnce(
+      new Error("spawnSync docker ENOENT"),
+    );
+
+    const projection = projectGatewayReadiness(
+      await collectGatewayObservations(deps, { now: () => NOW }),
+      { now: () => NOW },
+    );
+
+    expect(JSON.stringify(projection)).toContain("spawnSync docker ENOENT");
+  });
+
+  it("reports the underlying error when the external attachment probe throws unexpectedly", async () => {
+    const owner = externalOwner();
+    const deps = dependencies(owner);
+    vi.mocked(deps.probeAttachment).mockRejectedValueOnce(new Error("ECONNREFUSED 127.0.0.1:8080"));
+
+    const projection = projectGatewayReadiness(
+      await collectGatewayObservations(deps, { now: () => NOW }),
+      { now: () => NOW },
+    );
+    const serialized = JSON.stringify(projection);
+
+    expect(serialized).toContain("ECONNREFUSED 127.0.0.1:8080");
+    expect(serialized).not.toContain(owner.stateDir);
+  });
+
   it("fails closed when lifecycle authority cannot be resolved", async () => {
     const deps = dependencies(managedOwner());
     vi.mocked(deps.resolveOwner).mockImplementationOnce(() => {

--- a/src/lib/readiness/gateway.test.ts
+++ b/src/lib/readiness/gateway.test.ts
@@ -212,7 +212,9 @@ describe("gateway readiness projection (#7411)", () => {
   it("reports the underlying error when the external attachment probe throws unexpectedly", async () => {
     const owner = externalOwner();
     const deps = dependencies(owner);
-    vi.mocked(deps.probeAttachment).mockRejectedValueOnce(new Error("ECONNREFUSED 127.0.0.1:8080"));
+    vi.mocked(deps.probeAttachment).mockRejectedValueOnce(
+      new Error(`ECONNREFUSED 127.0.0.1:8080: ${owner.stateDir}`),
+    );
 
     const projection = projectGatewayReadiness(
       await collectGatewayObservations(deps, { now: () => NOW }),
@@ -222,6 +224,7 @@ describe("gateway readiness projection (#7411)", () => {
 
     expect(serialized).toContain("ECONNREFUSED 127.0.0.1:8080");
     expect(serialized).not.toContain(owner.stateDir);
+    expect(serialized).toContain("<gateway-state>");
   });
 
   it("fails closed when lifecycle authority cannot be resolved", async () => {

--- a/src/lib/readiness/gateway.ts
+++ b/src/lib/readiness/gateway.ts
@@ -182,7 +182,7 @@ async function observeGateway(
           driftState: "not-applicable",
           portConflictState: "unknown",
         },
-        failure: "The externally supervised gateway attachment probe failed safely.",
+        failure: `The externally supervised gateway attachment probe failed safely: ${safeOwnerFailureText(probeFailureDetail(error), owner)}`,
       };
     }
   }
@@ -202,7 +202,7 @@ async function observeGateway(
           : undefined,
       },
     };
-  } catch {
+  } catch (error) {
     return {
       observedAt,
       observations: {
@@ -212,9 +212,14 @@ async function observeGateway(
         driftState: "unknown",
         portConflictState: "unknown",
       },
-      failure: "Managed gateway observations could not be collected safely.",
+      failure: `Managed gateway observations could not be collected safely: ${safeOwnerFailureText(probeFailureDetail(error), owner)}`,
     };
   }
+}
+
+/** Render a caught probe error as reportable text without assuming its shape. */
+function probeFailureDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function observation(


### PR DESCRIPTION
## Outcome

Before: a managed-gateway or externally-supervised attachment probe failure always reported the same generic message ("...could not be collected safely"), regardless of what actually failed. After: the caught error's message is included, sanitized through the existing redaction helpers.

## Reason

This made a real bug (#10984 — Docker-hardcoded gateway observation breaking Podman onboarding) very hard to diagnose: onboarding reported three failed capabilities with no indication it was actually a `docker: command not found` failure underneath. Finding the cause required reading source.

### Related issues

Fixes #10985. Relates to #10984.

## Changes

- `src/lib/readiness/gateway.ts`: bind the caught error in both the managed-gateway observation catch and the externally-supervised attachment-probe fallback catch. Added a `probeFailureDetail()` helper to render the error as text without assuming its shape, and route it through the existing `safeOwnerFailureText`/`safeReportText` redaction pipeline already used for every other failure/evidence string in this file.
- `src/lib/readiness/gateway.test.ts`: two new tests confirming the real error message surfaces in the projection for both catch paths, and that state-dir redaction still applies to the externally-supervised path.

## Verification

- `npx vitest run src/lib/readiness/gateway.test.ts` — 12 passed (10 existing + 2 new)
- `npm run typecheck:cli` — clean
- `npm run test:changed` — 121 passed, no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Readiness reports now include sanitized details when gateway observation or external attachment checks encounter unexpected errors.
  * External probe error messages omit private state directory information while retaining relevant gateway status placeholders.
  * Error details are consistently presented in readiness projections without exposing sensitive local paths or implementation-specific information.

* **Tests**
  * Added coverage verifying that unexpected errors are included and sensitive information is correctly sanitized in readiness reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->