### PR TITLE
perf(cli): reduce Hermes forward recovery subprocess overhead

### DIFF
--- a/src/lib/actions/sandbox/forward-recovery.ts
+++ b/src/lib/actions/sandbox/forward-recovery.ts
@@ -1,13 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { resolveOpenshell } from "../../adapters/openshell/resolve";
 import {
   launchForwardService,
   type ForwardServiceTarget,
 } from "../../adapters/openshell/forward-service";
+import { resolveOpenshell } from "../../adapters/openshell/resolve";
 import { isLegacySandboxForwardListed } from "../../adapters/openshell/forward-service-migration";
-import { captureOpenshell, runOpenshell } from "../../adapters/openshell/runtime";
+import {
+  captureOpenshell,
+  captureResolvedOpenshell,
+  runOpenshell,
+} from "../../adapters/openshell/runtime";
 import { OPENSHELL_PROBE_TIMEOUT_MS } from "../../adapters/openshell/timeouts";
 import * as agentRuntime from "../../agent/runtime";
 import { DASHBOARD_PORT, HERMES_OPENAI_API_PORT } from "../../core/ports";
@@ -76,40 +80,43 @@ export function createHermesPortableForwardRecoveryInput(input: {
     deps: {
       assertCurrent: input.assertCurrent,
       assertRollbackCurrent: input.assertRollbackCurrent,
-      isReachable: isLocalForwardReachable,
-      launch: (port) =>
-        launchForwardService(
-          forwardServiceTarget(
-            input.commandAuthority.executablePath,
-            input.gatewayName,
-            input.sandboxName,
-            port,
-            "127.0.0.1",
-          ),
-          { sourceEnvironment: input.commandAuthority.env },
-        ),
-      migrateLegacy: (ports) =>
-        retireProductionLegacySandboxForwards(input.sandboxName, input.gatewayName, ports, {
-          capture: (gatewayName) =>
-            captureOpenshell(["forward", "list", "--gateway", gatewayName], {
-              env: input.commandAuthority.env,
-              openshellBinary: input.commandAuthority.executablePath,
-              replaceEnv: true,
-              ignoreError: true,
-              includeStreams: true,
-              timeout: OPENSHELL_PROBE_TIMEOUT_MS,
-            }),
-          isReachable: isLocalForwardReachable,
-          run: (gatewayName, sandboxName, port) =>
-            runOpenshell(["forward", "stop", String(port), sandboxName, "--gateway", gatewayName], {
-              env: input.commandAuthority.env,
-              openshellBinary: input.commandAuthority.executablePath,
-              replaceEnv: true,
-              ignoreError: true,
-              stdio: "ignore",
-              timeout: 30_000,
-            }),
+      captureCurrentList: (args, timeout) =>
+        captureResolvedOpenshell([...args], {
+          env: input.commandAuthority.env,
+          openshellBinary: input.commandAuthority.executablePath,
+          replaceEnv: true,
+          ignoreError: true,
+          includeStreams: true,
+          timeout,
         }),
+      captureRollbackList: (args, timeout) =>
+        captureResolvedOpenshell([...args], {
+          env: input.commandAuthority.env,
+          openshellBinary: input.commandAuthority.executablePath,
+          replaceEnv: true,
+          ignoreError: true,
+          includeStreams: true,
+          timeout,
+        }),
+      runCurrentMutation: (args, timeout) =>
+        runOpenshell([...args], {
+          env: input.commandAuthority.env,
+          openshellBinary: input.commandAuthority.executablePath,
+          replaceEnv: true,
+          ignoreError: true,
+          stdio: "ignore",
+          timeout,
+        }),
+      runRollbackMutation: (args, timeout) =>
+        runOpenshell([...args], {
+          env: input.commandAuthority.env,
+          openshellBinary: input.commandAuthority.executablePath,
+          replaceEnv: true,
+          ignoreError: true,
+          stdio: "ignore",
+          timeout,
+        }),
+      isPortReachable: isLocalForwardReachable,
     },
   };
 }

--- a/src/lib/actions/sandbox/probe/hermes-portable-forward-recovery.test.ts
+++ b/src/lib/actions/sandbox/probe/hermes-portable-forward-recovery.test.ts
@@ -1,67 +1,1061 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  connectModulePath,
+  createConnectHarness,
+  requireDist,
+} from "../../../../../test/support/connect-flow-test-harness";
+import {
+  configureMissingHermesForwardCapture,
+  createHermesPortableForwardRecoveryFixture as createRecoveryFixture,
+} from "../../../../../test/support/hermes-portable-forward-recovery-fixture";
+import {
+  HermesPortableForwardRecoveryError,
   prepareHermesPortableLaunchForwards,
   recoverHermesPortableLaunchForwards,
   verifyHermesPortableLaunchForwards,
-  type HermesPortableForwardRecoveryInput,
 } from "./hermes-portable-forward-recovery";
 
-function input(reachable: Set<number>): HermesPortableForwardRecoveryInput {
-  return {
-    intent: "connect-probe-only",
-    sandboxName: "hermes",
-    gatewayName: "nemoclaw",
-    operationTimeoutMs: 30_000,
-    ports: [18_789, 8_642],
-    probeTimeoutMs: 1_000,
-    deps: {
-      assertCurrent: vi.fn(),
-      assertRollbackCurrent: vi.fn(),
-      isReachable: (port) => reachable.has(port),
-      launch: (port) => {
-        expect(reachable.has(port)).toBe(false);
-        reachable.add(port);
-      },
-      migrateLegacy: vi.fn(),
-    },
+type RunForwardMutation = ReturnType<
+  typeof createRecoveryFixture
+>["input"]["deps"]["runCurrentMutation"];
+
+function runThen(
+  run: RunForwardMutation,
+  command: string,
+  afterRun: () => void,
+): RunForwardMutation {
+  const afterRunByCommand = new Map([[command, afterRun]]);
+  return (args, timeout) => {
+    const result = run(args, timeout);
+    afterRunByCommand.get(args[1] ?? "")?.();
+    return result;
   };
 }
 
-describe("Hermes Portable ForwardTcp recovery", () => {
-  it("launches each missing forward through the natural OpenShell lifecycle", () => {
-    const reachable = new Set<number>();
-    const request = input(reachable);
+describe("Hermes Portable probe-only forward recovery", () => {
+  it("starts missing forwards sequentially before one joint settlement observation (#10926)", () => {
+    const fixture = createRecoveryFixture({ ports: [18_789, 8_642] });
 
-    expect(recoverHermesPortableLaunchForwards(request)).toEqual({
+    expect(recoverHermesPortableLaunchForwards(fixture.input)).toEqual({
       kind: "restored",
       restoredPorts: [18_789, 8_642],
     });
-    expect(request.deps.migrateLegacy).toHaveBeenCalledWith([18_789, 8_642]);
+
+    const starts = fixture.currentCalls.filter((args) => args[1] === "start");
+    expect(starts).toEqual([
+      ["forward", "start", "--background", "18789", "alpha", "--gateway", "nemoclaw"],
+      ["forward", "start", "--background", "8642", "alpha", "--gateway", "nemoclaw"],
+    ]);
+    expect(fixture.currentCalls.filter((args) => args[1] === "stop")).toEqual([]);
+    expect(fixture.currentCalls.filter((args) => args[1] === "list")).toHaveLength(2);
+    expect(fixture.currentCaptureCalls.every((args) => args[1] === "list")).toBe(true);
+    expect(fixture.currentMutationCalls).toEqual(starts);
+    expect(fixture.rollbackCalls).toEqual([]);
+    expect([...fixture.records.keys()]).toEqual([18_789, 8_642]);
   });
 
-  it("does not relaunch reachable ports", () => {
-    const request = input(new Set([18_789, 8_642]));
-    expect(recoverHermesPortableLaunchForwards(request)).toEqual({
+  it("keeps an already healthy forward set verification-only", () => {
+    const fixture = createRecoveryFixture({ ports: [18_789, 8_642], running: [18_789, 8_642] });
+
+    expect(recoverHermesPortableLaunchForwards(fixture.input)).toEqual({
       kind: "verified",
       restoredPorts: [],
     });
-    expect(request.deps.migrateLegacy).not.toHaveBeenCalled();
+    expect(fixture.currentCalls).toEqual([["forward", "list", "--gateway", "nemoclaw"]]);
+    expect(fixture.rollbackCalls).toEqual([]);
   });
 
-  it("verifies reachability without inspecting or signaling a process", () => {
-    expect(verifyHermesPortableLaunchForwards(input(new Set([18_789, 8_642])))).toEqual({
-      kind: "healthy",
+  it("reports a missing forward without starting or stopping it", () => {
+    const fixture = createRecoveryFixture({ ports: [18_789, 8_642], running: [18_789] });
+
+    expect(verifyHermesPortableLaunchForwards(fixture.input)).toEqual({ kind: "unhealthy" });
+    expect(fixture.currentCalls).toEqual([["forward", "list", "--gateway", "nemoclaw"]]);
+    expect(fixture.rollbackCalls).toEqual([]);
+  });
+
+  it("verifies exact forward ownership and reachability without mutation", () => {
+    const fixture = createRecoveryFixture({ ports: [18_789, 8_642], running: [18_789, 8_642] });
+
+    expect(verifyHermesPortableLaunchForwards(fixture.input)).toEqual({ kind: "healthy" });
+    expect(fixture.currentCalls).toEqual([["forward", "list", "--gateway", "nemoclaw"]]);
+    expect(fixture.rollbackCalls).toEqual([]);
+  });
+
+  it("keeps exact active forwards verification-only", () => {
+    const fixture = createRecoveryFixture({ ports: [18_789, 8_642], active: [18_789, 8_642] });
+
+    expect(recoverHermesPortableLaunchForwards(fixture.input)).toEqual({
+      kind: "verified",
+      restoredPorts: [],
+    });
+    expect(fixture.currentCalls).toEqual([["forward", "list", "--gateway", "nemoclaw"]]);
+    expect(fixture.rollbackCalls).toEqual([]);
+  });
+
+  it.each([
+    ["stopped", { stopped: [18_789] }],
+    ["dead after the host session ends", { dead: [18_789] }],
+  ])("restores an exact %s forward", (_state, options) => {
+    const fixture = createRecoveryFixture(options);
+
+    expect(recoverHermesPortableLaunchForwards(fixture.input)).toEqual({
+      kind: "restored",
+      restoredPorts: [18_789],
+    });
+    expect(fixture.currentCalls.filter((args) => args[1] === "stop")).toHaveLength(1);
+    expect(fixture.currentCalls.filter((args) => args[1] === "start")).toHaveLength(1);
+    expect(fixture.currentCalls.filter((args) => args[1] === "list")).toHaveLength(2);
+    expect(fixture.rollbackCalls).toEqual([]);
+  });
+
+  it.each(["dead", "stopped"])(
+    "restarts a target-owned %s row even when the port remains reachable",
+    (status) => {
+      const fixture = createRecoveryFixture(
+        status === "dead" ? { dead: [18_789] } : { stopped: [18_789] },
+      );
+      fixture.records.get(18_789)!.reachable = true;
+
+      expect(recoverHermesPortableLaunchForwards(fixture.input).kind).toBe("restored");
+      expect(
+        fixture.currentCalls
+          .filter((args) => ["start", "stop"].includes(args[1]!))
+          .map((args) => args[1]),
+      ).toEqual(["stop", "start"]);
+    },
+  );
+
+  it("restarts a target-owned live forward that is unreachable", () => {
+    const fixture = createRecoveryFixture({ running: [18_789] });
+    fixture.records.get(18_789)!.reachable = false;
+
+    expect(recoverHermesPortableLaunchForwards(fixture.input)).toEqual({
+      kind: "restored",
+      restoredPorts: [18_789],
+    });
+    expect(
+      fixture.currentCalls
+        .filter((args) => ["start", "stop"].includes(args[1]!))
+        .map((args) => args[1]),
+    ).toEqual(["stop", "start"]);
+  });
+
+  it.each(["dead", "stopped"])("rejects a foreign %s row before mutation", (status) => {
+    const fixture = createRecoveryFixture({
+      listOutput: `SANDBOX BIND PORT PID STATUS\nbeta 127.0.0.1 18789 12345 ${status}`,
+    });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "forward-occupied" }),
+    );
+    expect(fixture.currentCalls.some((args) => ["start", "stop"].includes(args[1]!))).toBe(false);
+  });
+
+  it("rejects a reachable port with no listed owner before mutation", () => {
+    const fixture = createRecoveryFixture();
+    Object.assign(fixture.input.deps, { isPortReachable: () => true });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "forward-occupied" }),
+    );
+    expect(fixture.currentCalls.some((args) => ["start", "stop"].includes(args[1]!))).toBe(false);
+  });
+
+  it("records command counts and overlapping settlement timing for an absent forward", () => {
+    const fixture = createRecoveryFixture();
+    const capture = fixture.input.deps.captureCurrentList;
+    const runMutation = fixture.input.deps.runCurrentMutation;
+    let now = 0;
+    Object.assign(fixture.input.deps, {
+      captureCurrentList: (args: readonly string[], timeout: number) => {
+        const result = capture(args, timeout);
+        now += 2;
+        return result;
+      },
+      runCurrentMutation: (args: readonly string[], timeout: number) => {
+        const result = runMutation(args, timeout);
+        now += args[1] === "stop" ? 3 : 5;
+        return result;
+      },
+      now: () => now,
+      sleep: (milliseconds: number) => {
+        now += milliseconds;
+      },
+    });
+    const onComplete = vi.fn();
+    Object.assign(fixture.input, { timing: { now: () => now, onComplete } });
+
+    expect(recoverHermesPortableLaunchForwards(fixture.input).kind).toBe("restored");
+    expect(onComplete).toHaveBeenCalledWith({
+      listMs: 4,
+      listCount: 2,
+      stopMs: 0,
+      stopCount: 0,
+      startMs: 5,
+      startCount: 1,
+      settleMs: 2,
+      settleCount: 1,
+      totalMs: 9,
+      result: "proved",
     });
   });
 
-  it("keeps rollback free of process control", () => {
-    const request = input(new Set<number>());
-    const prepared = prepareHermesPortableLaunchForwards(request);
-    prepared.rollback();
-    expect(request.deps.assertRollbackCurrent).toHaveBeenCalledOnce();
+  it("keeps timing output outside forward recovery behavior", async () => {
+    const fixture = createRecoveryFixture();
+    Object.assign(fixture.input, {
+      timing: {
+        onComplete: () => Promise.reject(new Error("timing sink canary")),
+      },
+    });
+
+    expect(recoverHermesPortableLaunchForwards(fixture.input).kind).toBe("restored");
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+
+  it("accepts a returned nonzero start only after the exact owner settles healthy", () => {
+    const fixture = createRecoveryFixture({ startStatus: 1 });
+
+    expect(recoverHermesPortableLaunchForwards(fixture.input).kind).toBe("restored");
+    expect(fixture.currentCalls.filter((args) => args[1] === "start")).toHaveLength(1);
+  });
+
+  it("rolls back a possibly started forward when detached mutation transport throws", () => {
+    const fixture = createRecoveryFixture();
+    const runMutation = fixture.input.deps.runCurrentMutation;
+    const captureRollbackList = fixture.input.deps.captureRollbackList;
+    const rollbackSequence: string[] = [];
+    const onComplete = vi.fn((evidence: { readonly result: "proved" | "failed" }) =>
+      rollbackSequence.push(`timing:${evidence.result}`),
+    );
+    Object.assign(fixture.input.deps, {
+      runCurrentMutation: runThen(runMutation, "start", () => {
+        throw new Error("detached mutation transport canary");
+      }),
+      captureRollbackList: (args: readonly string[], timeout: number) => {
+        const result = captureRollbackList(args, timeout);
+        rollbackSequence.push("rollback-list");
+        return result;
+      },
+    });
+    Object.assign(fixture.input, { timing: { onComplete } });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "recovery-failed" }),
+    );
+    expect(fixture.rollbackMutationCalls).toContainEqual([
+      "forward",
+      "stop",
+      "18789",
+      "alpha",
+      "--gateway",
+      "nemoclaw",
+    ]);
+    expect(fixture.records.has(18_789)).toBe(false);
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ result: "failed", startCount: 1 }),
+    );
+    expect(rollbackSequence.at(-1)).toBe("timing:failed");
+  });
+
+  it("rejects a returned nonzero start without the exact settled owner", () => {
+    const fixture = createRecoveryFixture({ startStatus: 1, startUpdatesState: false });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "recovery-failed" }),
+    );
+    expect(fixture.records.has(18_789)).toBe(false);
+    expect(fixture.elapsedMs()).toBe(3_000);
+    expect(fixture.currentCalls.filter((args) => args[1] === "start")).toHaveLength(1);
+    expect(fixture.rollbackCalls.some((args) => args[1] === "stop")).toBe(true);
+  });
+
+  it.each([
+    ["foreign occupied", { occupied: [18_789] }, "forward-occupied"],
+    ["unavailable", { listStatus: 1 }, "forward-state-unavailable"],
+    ["malformed", { malformedList: true }, "forward-state-unavailable"],
+  ] as const)("rejects %s forward state before mutation", (_label, options, failure) => {
+    const fixture = createRecoveryFixture(options);
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure }),
+    );
+    expect(fixture.currentCalls.some((args) => ["start", "stop"].includes(args[1]!))).toBe(false);
+    expect(fixture.rollbackCalls).toEqual([]);
+  });
+
+  it.each([
+    ["active PID", "alpha 127.0.0.1 18789 not-a-pid active"],
+    ["dead PID", "alpha 127.0.0.1 18789 not-a-pid dead"],
+    ["bind", "alpha not-an-address 18789 12345 running"],
+    ["port", "alpha 127.0.0.1 70000 12345 running"],
+    ["status", "alpha 127.0.0.1 18789 12345 uncertain"],
+    ["extra column", "alpha 127.0.0.1 18789 12345 running extra"],
+  ])("rejects a malformed relevant-row %s before mutation", (_field, row) => {
+    const fixture = createRecoveryFixture({
+      listOutput: `SANDBOX BIND PORT PID STATUS\n${row}`,
+    });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "forward-state-unavailable" }),
+    );
+    expect(fixture.currentCalls.some((args) => ["start", "stop"].includes(args[1]!))).toBe(false);
+    expect(fixture.rollbackCalls).toEqual([]);
+  });
+
+  it.each(["*", "0.0.0.0", "::1", "[::1]"])(
+    "rejects non-exact loopback bind %s before mutation",
+    (bind) => {
+      const fixture = createRecoveryFixture({
+        listOutput: `SANDBOX BIND PORT PID STATUS\nalpha ${bind} 18789 12345 running`,
+      });
+
+      expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+        expect.objectContaining({ failure: "forward-state-unavailable" }),
+      );
+      expect(fixture.currentMutationCalls).toEqual([]);
+    },
+  );
+
+  it("passes the shrinking joint-settlement budget to list and TCP probes", () => {
+    const fixture = createRecoveryFixture({ startUpdatesState: false });
+    const listTimeouts: number[] = [];
+    const probeTimeouts: number[] = [];
+    const capture = fixture.input.deps.captureCurrentList;
+    Object.assign(fixture.input.deps, {
+      captureCurrentList: (args: readonly string[], timeout: number) => {
+        listTimeouts.push(timeout);
+        return capture(args, timeout);
+      },
+      isPortReachable: (_port: number, timeout?: number) => {
+        probeTimeouts.push(timeout ?? -1);
+        return false;
+      },
+    });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow();
+    expect(listTimeouts.slice(1)).toEqual(expect.arrayContaining([3_000, 2_900]));
+    expect(probeTimeouts.slice(1)).toEqual(expect.arrayContaining([3_000, 2_900]));
+  });
+
+  it("refuses rollback when the settled PID changes before stop", () => {
+    const fixture = createRecoveryFixture();
+    const prepared = prepareHermesPortableLaunchForwards(fixture.input);
+    const captureRollback = fixture.input.deps.captureRollbackList;
+    Object.assign(fixture.input.deps, {
+      captureRollbackList: (args: readonly string[], timeout: number) => {
+        const result = captureRollback(args, timeout);
+        return { ...result, output: String(result.output).replace("12345", "54321") };
+      },
+    });
+
+    expect(() => prepared.rollback()).toThrow(
+      expect.objectContaining({ failure: "restoration-unproved" }),
+    );
+    expect(fixture.rollbackMutationCalls).toEqual([]);
+  });
+
+  it("fails closed when current authority drifts before recovery", () => {
+    const fixture = createRecoveryFixture();
+    fixture.setCurrentAllowed(false);
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "authority-drift" }),
+    );
+    expect(fixture.currentCalls).toEqual([]);
+  });
+
+  it("rejects ambiguous duplicate rows before mutation", () => {
+    const fixture = createRecoveryFixture({ active: [18_789] });
+    Object.assign(fixture.input.deps, {
+      captureCurrentList: () => ({
+        status: 0,
+        output:
+          "SANDBOX BIND PORT PID STATUS\n" +
+          "alpha 127.0.0.1 18789 12345 active\n" +
+          "alpha 127.0.0.1 18789 12346 active",
+      }),
+    });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "forward-state-unavailable" }),
+    );
+    expect(fixture.rollbackCalls).toEqual([]);
+  });
+
+  it("rejects a foreign active owner before mutation", () => {
+    const fixture = createRecoveryFixture({
+      listOutput: "SANDBOX BIND PORT PID STATUS\nbeta 127.0.0.1 18789 12345 active",
+    });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "forward-occupied" }),
+    );
+    expect(fixture.currentCalls.some((args) => ["start", "stop"].includes(args[1]!))).toBe(false);
+    expect(fixture.rollbackCalls).toEqual([]);
+  });
+
+  it("restores the exact missing state when authority drifts after start", () => {
+    const fixture = createRecoveryFixture({ driftCurrentAfterStart: true });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "authority-drift" }),
+    );
+    expect(fixture.rollbackCalls).toContainEqual([
+      "forward",
+      "stop",
+      "18789",
+      "alpha",
+      "--gateway",
+      "nemoclaw",
+    ]);
+    expect(fixture.records.has(18_789)).toBe(false);
+  });
+
+  it("rolls back a possibly started forward when the final currentness fence fails", () => {
+    const baseline = createRecoveryFixture();
+    const baselineAssertCurrent = vi.fn();
+    Object.assign(baseline.input.deps, { assertCurrent: baselineAssertCurrent });
+    expect(recoverHermesPortableLaunchForwards(baseline.input).kind).toBe("restored");
+
+    const fixture = createRecoveryFixture();
+    const assertCurrent = vi.fn();
+    Array.from({ length: baselineAssertCurrent.mock.calls.length - 1 }).forEach(() =>
+      assertCurrent.mockImplementationOnce(() => undefined),
+    );
+    assertCurrent.mockImplementationOnce(() => {
+      throw new Error("final currentness canary");
+    });
+    Object.assign(fixture.input.deps, { assertCurrent });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "authority-drift" }),
+    );
+    expect(fixture.rollbackCalls).toContainEqual([
+      "forward",
+      "stop",
+      "18789",
+      "alpha",
+      "--gateway",
+      "nemoclaw",
+    ]);
+    expect(fixture.records.has(18_789)).toBe(false);
+  });
+
+  it("accepts an unreachable target-owned stale row as restored during rollback", () => {
+    const fixture = createRecoveryFixture();
+    const prepared = prepareHermesPortableLaunchForwards(fixture.input);
+    const runRollbackMutation = fixture.input.deps.runRollbackMutation;
+    Object.assign(fixture.input.deps, {
+      runRollbackMutation: runThen(runRollbackMutation, "stop", () => {
+        fixture.records.set(18_789, { owner: "alpha", reachable: false, status: "dead" });
+      }),
+    });
+
+    expect(() => prepared.rollback()).not.toThrow();
+  });
+
+  it("rejects a reachable target-owned stale row as restored during rollback", () => {
+    const fixture = createRecoveryFixture();
+    const prepared = prepareHermesPortableLaunchForwards(fixture.input);
+    const runRollbackMutation = fixture.input.deps.runRollbackMutation;
+    Object.assign(fixture.input.deps, {
+      runRollbackMutation: runThen(runRollbackMutation, "stop", () => {
+        fixture.records.set(18_789, { owner: "alpha", reachable: true, status: "dead" });
+      }),
+    });
+
+    expect(() => prepared.rollback()).toThrow(
+      expect.objectContaining({ failure: "restoration-unproved" }),
+    );
+  });
+
+  it("rolls back every touched forward in reverse order after a partial recovery", () => {
+    const fixture = createRecoveryFixture({
+      ports: [18_789, 8_642],
+      dropStartedPort: 8_642,
+    });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "recovery-failed" }),
+    );
+    expect(
+      fixture.rollbackCalls.filter((args) => args[1] === "stop").map((args) => args[2]),
+    ).toEqual(["8642", "18789"]);
+    expect(fixture.records.size).toBe(0);
+  });
+
+  it("rejects settlement when a previously healthy required port disappears", () => {
+    const fixture = createRecoveryFixture({ ports: [18_789, 8_642], running: [18_789] });
+    const runMutation = fixture.input.deps.runCurrentMutation;
+    Object.assign(fixture.input.deps, {
+      runCurrentMutation: runThen(runMutation, "start", () => fixture.records.delete(18_789)),
+    });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "recovery-failed" }),
+    );
+    expect(fixture.rollbackCalls).toContainEqual([
+      "forward",
+      "stop",
+      "8642",
+      "alpha",
+      "--gateway",
+      "nemoclaw",
+    ]);
+  });
+
+  it("reports restoration uncertainty when rollback command authority drifts", () => {
+    const fixture = createRecoveryFixture({ startUpdatesState: false });
+    fixture.setRollbackAllowed(false);
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      expect.objectContaining({ failure: "restoration-unproved" }),
+    );
+  });
+
+  it("rejects invalid or duplicate recorded ports before any command", () => {
+    const fixture = createRecoveryFixture({ ports: [18_789, 18_789] });
+
+    expect(() => recoverHermesPortableLaunchForwards(fixture.input)).toThrow(
+      HermesPortableForwardRecoveryError,
+    );
+    expect(fixture.currentCalls).toEqual([]);
+  });
+});
+
+describe("Hermes Portable connect composition", () => {
+  const originalStdoutIsTty = process.stdout.isTTY;
+
+  const acceptedHermesReadiness = () => {
+    const entry = {
+      name: "alpha",
+      agent: "hermes",
+      provider: "ollama-local",
+      model: "qwen3-vl:4b",
+      policies: [],
+      openshellDriver: "docker",
+      gatewayName: "nemoclaw",
+      lifecycleGeneration: "generation-1",
+    } as never;
+    return {
+      entry,
+      readinessDecision: {
+        kind: "accepted" as const,
+        category: "accepted" as const,
+        agent: { name: "hermes" },
+        sb: entry,
+      },
+    };
+  };
+
+  const bindAcceptedReadinessToCurrentEntry = (
+    harness: ReturnType<typeof createConnectHarness>,
+  ): void => {
+    harness.inspectLaunchReadinessSpy.mockResolvedValue({
+      kind: "accepted",
+      category: "accepted",
+      agent: { name: "hermes" },
+      sb: harness.registryEntries[0]!,
+    } as never);
+  };
+
+  beforeEach(() => {
+    process.env.NEMOCLAW_TEST_NO_SLEEP = "1";
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+    vi.spyOn(process, "exit").mockImplementation(((code?: number | string | null) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: originalStdoutIsTty,
+    });
+    delete process.env.NEMOCLAW_TEST_NO_SLEEP;
+    delete require.cache[requireDist.resolve(connectModulePath)];
+  });
+
+  it("restores a transition-missing forward before launch-readiness publication (#10423)", async () => {
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: { name: "hermes" },
+      portableReceiptDisposition: { kind: "hermes", phase: "active" },
+      portableRecoveryResult: { kind: "already-running" },
+    });
+    configureMissingHermesForwardCapture(harness);
+    harness.recoverPortableDemoLifecycleSpy.mockImplementation((...args) => {
+      args[5]?.onComplete({
+        receiptReadMs: 1,
+        receiptReadCount: 2,
+        socketAuthorityMs: 3,
+        socketAuthorityCount: 4,
+        openshellExecutableMs: 5,
+        openshellExecutableCount: 6,
+        podmanExecutableMs: 7,
+        podmanExecutableCount: 8,
+        podmanPathResolutionMs: 0,
+        podmanPathResolutionCount: 0,
+        podmanCanonicalRealpathMs: 0,
+        podmanCanonicalRealpathCount: 0,
+        podmanDirectoryChainMs: 0,
+        podmanDirectoryChainCount: 0,
+        podmanExecutableMetadataMs: 0,
+        podmanExecutableMetadataCount: 0,
+        podmanContentReadMs: 0,
+        podmanContentReadCount: 0,
+        podmanContentHashMs: 0,
+        podmanContentHashCount: 0,
+        podmanAuthorityCompareMs: 0,
+        podmanAuthorityCompareCount: 0,
+        containerInspectMs: 9,
+        containerInspectCount: 10,
+        transactionCompareMs: 11,
+        transactionCompareCount: 12,
+      });
+      args[6]?.onComplete({
+        preGuardMs: 13,
+        preGuardCount: 14,
+        podmanCaptureMs: 15,
+        podmanCaptureCount: 16,
+        postGuardMs: 17,
+        postGuardCount: 18,
+        jsonParseMs: 19,
+        jsonParseCount: 20,
+        identityCompareMs: 21,
+        identityCompareCount: 22,
+      });
+      return { kind: "already-running" };
+    });
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).resolves.toBeUndefined();
+
+    expect(harness.recoverPortableDemoLifecycleSpy).toHaveBeenCalledWith(
+      "alpha",
+      expect.objectContaining({ agent: "hermes" }),
+      "nemoclaw",
+      expect.objectContaining({
+        assertCurrent: harness.assertHermesPortableOperatingCommandCurrentSpy,
+      }),
+      expect.objectContaining({ onComplete: expect.any(Function) }),
+      expect.objectContaining({ onComplete: expect.any(Function) }),
+      expect.objectContaining({ onComplete: expect.any(Function) }),
+    );
+    const startCall = harness.runOpenshellSpy.mock.calls.find(
+      ([args]) => Array.isArray(args) && args[0] === "forward" && args[1] === "start",
+    );
+    expect(startCall?.[0]).toEqual([
+      "forward",
+      "start",
+      "--background",
+      "18789",
+      "alpha",
+      "--gateway",
+      "nemoclaw",
+    ]);
+    expect(startCall?.[1]).toEqual(
+      expect.objectContaining({
+        ignoreError: true,
+        openshellBinary: "/usr/bin/openshell",
+        replaceEnv: true,
+        stdio: "ignore",
+        timeout: 30_000,
+      }),
+    );
+    expect(
+      harness.captureResolvedOpenshellSpy.mock.calls.every(
+        ([args]) =>
+          !Array.isArray(args) ||
+          args[0] !== "forward" ||
+          !["start", "stop"].includes(String(args[1])),
+      ),
+    ).toBe(true);
+    expect(harness.publishLaunchReadinessSpy).toHaveBeenCalledOnce();
+    expect(harness.runOpenshellSpy.mock.invocationCallOrder.at(-1)!).toBeLessThan(
+      harness.publishLaunchReadinessSpy.mock.invocationCallOrder[0]!,
+    );
+    expect(harness.logSpy.mock.calls.flat().join("\n")).toMatch(
+      /forwardAction=restored result=ready/,
+    );
+    expect(harness.logSpy.mock.calls.flat().join("\n")).toMatch(
+      /Hermes Portable forward recovery timing: list=\d+ms listCount=2 stop=0ms stopCount=0 start=\d+ms startCount=1 settle=\d+ms settleCount=1 total=\d+ms result=proved/u,
+    );
+    expect(harness.logSpy.mock.calls.flat().join("\n")).toContain(
+      "Hermes Portable currentness timing: receiptRead=1ms receiptReadCount=2 socketAuthority=3ms socketAuthorityCount=4 openshellExecutable=5ms openshellExecutableCount=6 podmanExecutable=7ms podmanExecutableCount=8 podmanPathResolution=0ms podmanPathResolutionCount=0 podmanCanonicalRealpath=0ms podmanCanonicalRealpathCount=0 podmanDirectoryChain=0ms podmanDirectoryChainCount=0 podmanExecutableMetadata=0ms podmanExecutableMetadataCount=0 podmanContentRead=0ms podmanContentReadCount=0 podmanContentHash=0ms podmanContentHashCount=0 podmanAuthorityCompare=0ms podmanAuthorityCompareCount=0 containerInspect=9ms containerInspectCount=10 transactionCompare=11ms transactionCompareCount=12",
+    );
+    expect(harness.logSpy.mock.calls.flat().join("\n")).toContain(
+      "Hermes Portable inspection timing: preGuard=13ms preGuardCount=14 podmanCapture=15ms podmanCaptureCount=16 postGuard=17ms postGuardCount=18 jsonParse=19ms jsonParseCount=20 identityCompare=21ms identityCompareCount=22",
+    );
+  });
+
+  it("restores an exact dead forward once before launch-readiness publication (#10423)", async () => {
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: { name: "hermes" },
+      portableReceiptDisposition: { kind: "hermes", phase: "active" },
+      portableRecoveryResult: { kind: "already-running" },
+    });
+    configureMissingHermesForwardCapture(harness, {
+      initialStatus: "dead",
+      afterStart: () => {
+        expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();
+      },
+    });
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).resolves.toBeUndefined();
+
+    const mutations = harness.runOpenshellSpy.mock.calls
+      .filter(
+        ([args]) =>
+          Array.isArray(args) &&
+          args[0] === "forward" &&
+          ["start", "stop"].includes(String(args[1])),
+      )
+      .map(([args]) => (args as string[])[1]);
+    expect(mutations).toEqual(["stop", "start"]);
+    expect(harness.publishLaunchReadinessSpy).toHaveBeenCalledOnce();
+    expect(harness.logSpy.mock.calls.flat().join("\n")).toMatch(
+      /forwardAction=restored result=ready/,
+    );
+    expect(harness.logSpy.mock.calls.flat().join("\n")).toMatch(
+      /Hermes Portable forward recovery timing: list=\d+ms listCount=2 stop=\d+ms stopCount=1 start=\d+ms startCount=1 settle=\d+ms settleCount=1 total=\d+ms result=proved/u,
+    );
+  });
+
+  it.each([
+    ["missing", ["start"]],
+    ["dead", ["stop", "start"]],
+  ] as const)(
+    "restores an accepted-readiness %s forward before reporting probe success",
+    async (initialStatus, expectedMutations) => {
+      const accepted = acceptedHermesReadiness();
+      const harness = createConnectHarness({
+        agentName: "hermes",
+        sessionAgent: { name: "hermes" },
+        registryEntry: accepted.entry,
+        portableReceiptDisposition: { kind: "hermes", phase: "active" },
+        portableRecoveryResult: { kind: "already-running" },
+        readinessDecision: accepted.readinessDecision,
+      });
+      bindAcceptedReadinessToCurrentEntry(harness);
+      configureMissingHermesForwardCapture(harness, {
+        initialStatus,
+        afterStart: () => {
+          expect(harness.logSpy.mock.calls.flat().join("\n")).not.toContain(
+            "Probe complete: launch readiness is healthy",
+          );
+        },
+      });
+
+      await expect(harness.connectSandbox("alpha", { probeOnly: true })).resolves.toBeUndefined();
+
+      const mutations = harness.runOpenshellSpy.mock.calls
+        .filter(
+          ([args]) =>
+            Array.isArray(args) &&
+            args[0] === "forward" &&
+            ["start", "stop"].includes(String(args[1])),
+        )
+        .map(([args]) => (args as string[])[1]);
+      expect(mutations).toEqual(expectedMutations);
+      expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();
+      expect(harness.logSpy.mock.calls.flat().join("\n")).toContain(
+        "Probe complete: launch readiness is healthy for 'alpha'.",
+      );
+    },
+  );
+
+  it("does not report accepted readiness when forward recovery fails", async () => {
+    const accepted = acceptedHermesReadiness();
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: { name: "hermes" },
+      registryEntry: accepted.entry,
+      portableReceiptDisposition: { kind: "hermes", phase: "active" },
+      portableRecoveryResult: { kind: "already-running" },
+      readinessDecision: accepted.readinessDecision,
+    });
+    bindAcceptedReadinessToCurrentEntry(harness);
+    const captureResolved = harness.captureResolvedOpenshellSpy.getMockImplementation()!;
+    harness.captureResolvedOpenshellSpy.mockImplementation(((args: unknown, options: unknown) => {
+      const argv = Array.isArray(args) ? args : [];
+      return argv[0] === "forward" && argv[1] === "list"
+        ? { status: 0, output: "malformed canary" }
+        : captureResolved(args, options);
+    }) as never);
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(harness.logSpy.mock.calls.flat().join("\n")).not.toContain(
+      "Probe complete: launch readiness is healthy",
+    );
+    expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();
+    expect(harness.logSpy.mock.calls.flat().join("\n")).toMatch(
+      /Hermes Portable forward recovery timing: .*listCount=1 .*result=failed/u,
+    );
+    expect(
+      harness.runOpenshellSpy.mock.calls.some(
+        ([args]) => Array.isArray(args) && ["start", "stop"].includes(String(args[1])),
+      ),
+    ).toBe(false);
+  });
+
+  it("restores a recovered Ollama runtime when forward settlement fails", async () => {
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: { name: "hermes" },
+      portableReceiptDisposition: { kind: "hermes", phase: "active" },
+      portableRecoveryResult: { kind: "already-running" },
+    });
+    let ollamaRunning = false;
+    harness.recoverHermesPortableOllamaInferenceSpy.mockImplementation(((input: {
+      verifyRoute: () => unknown;
+      prepareProbeDependency?: () => { release: () => void; rollback: () => void };
+    }) => {
+      ollamaRunning = true;
+      try {
+        input.verifyRoute();
+        input.prepareProbeDependency?.().release();
+        return "recovered";
+      } catch (error) {
+        ollamaRunning = false;
+        throw error;
+      }
+    }) as never);
+    let forwardStarted = false;
+    const forward = configureMissingHermesForwardCapture(harness, {
+      afterStart: () => {
+        forwardStarted = true;
+      },
+    });
+    const captureForward = harness.captureResolvedOpenshellSpy.getMockImplementation()!;
+    harness.captureResolvedOpenshellSpy.mockImplementation(((args: unknown, options: unknown) => {
+      const argv = Array.isArray(args) ? args : [];
+      return forwardStarted && forward.isRunning() && argv[0] === "forward" && argv[1] === "list"
+        ? { status: 0, output: "malformed canary" }
+        : captureForward(args, options);
+    }) as never);
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(forward.isRunning()).toBe(true);
+    expect(ollamaRunning).toBe(false);
+    expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();
+  });
+
+  it("restores prepared forwards when Ollama finalization fails", async () => {
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: { name: "hermes" },
+      portableReceiptDisposition: { kind: "hermes", phase: "active" },
+      portableRecoveryResult: { kind: "already-running" },
+    });
+    let ollamaRunning = false;
+    harness.recoverHermesPortableOllamaInferenceSpy.mockImplementation(((input: {
+      verifyRoute: () => unknown;
+      prepareProbeDependency?: () => { rollback: () => void };
+    }) => {
+      ollamaRunning = true;
+      input.verifyRoute();
+      const dependency = input.prepareProbeDependency?.();
+      dependency?.rollback();
+      ollamaRunning = false;
+      throw new Error("finalization canary");
+    }) as never);
+    const forward = configureMissingHermesForwardCapture(harness);
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(forward.isRunning()).toBe(false);
+    expect(ollamaRunning).toBe(false);
+    expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();
+    expect(harness.errorSpy.mock.calls.flat().join("\n")).not.toContain("finalization canary");
+  });
+
+  it("reports forward restoration uncertainty after restoring Ollama", async () => {
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: { name: "hermes" },
+      portableReceiptDisposition: { kind: "hermes", phase: "active" },
+      portableRecoveryResult: { kind: "already-running" },
+    });
+    let ollamaRunning = false;
+    harness.recoverHermesPortableOllamaInferenceSpy.mockImplementation(((input: {
+      verifyRoute: () => unknown;
+      prepareProbeDependency?: () => { rollback: () => void };
+    }) => {
+      ollamaRunning = true;
+      input.verifyRoute();
+      const dependency = input.prepareProbeDependency?.();
+      harness.assertHermesPortableOperatingCommandCurrentSpy.mockImplementation(() => {
+        throw new Error("rollback authority canary");
+      });
+      try {
+        dependency?.rollback();
+      } catch (error) {
+        ollamaRunning = false;
+        throw error;
+      }
+      throw new Error("expected rollback failure");
+    }) as never);
+    const forward = configureMissingHermesForwardCapture(harness);
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(forward.isRunning()).toBe(true);
+    expect(ollamaRunning).toBe(false);
+    expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();
+    const output = harness.errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("returned to a stopped state");
+    expect(output).not.toContain("rollback authority canary");
+  });
+
+  it("stops before publication when the owning gateway forward list is malformed", async () => {
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: { name: "hermes" },
+      portableReceiptDisposition: { kind: "hermes", phase: "active" },
+      portableRecoveryResult: { kind: "already-running" },
+    });
+    const captureResolved = harness.captureResolvedOpenshellSpy.getMockImplementation()!;
+    harness.captureResolvedOpenshellSpy.mockImplementation(((args: unknown, options: unknown) => {
+      const argv = Array.isArray(args) ? args : [];
+      return argv[0] === "forward" && argv[1] === "list"
+        ? { status: 0, output: "malformed canary" }
+        : captureResolved(args, options);
+    }) as never);
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();
+    expect(
+      harness.runOpenshellSpy.mock.calls.some(
+        ([args]) => Array.isArray(args) && ["start", "stop"].includes(String(args[1])),
+      ),
+    ).toBe(false);
+    const output = harness.errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("Hermes Portable host-forward recovery");
+    expect(output).not.toContain("malformed canary");
+  });
+
+  it("rejects a same-path executable generation change before forward mutation", async () => {
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: { name: "hermes" },
+      portableReceiptDisposition: { kind: "hermes", phase: "active" },
+      portableRecoveryResult: { kind: "already-running" },
+    });
+    harness.assertHermesPortableOperatingCommandCurrentSpy
+      .mockImplementationOnce(() => undefined)
+      .mockImplementation(() => {
+        throw new Error("same-path executable replacement canary");
+      });
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(
+      harness.captureResolvedOpenshellSpy.mock.calls.some(
+        ([args]) => Array.isArray(args) && args[0] === "forward",
+      ),
+    ).toBe(false);
+    expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();
+    const output = harness.errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("changed during launch-readiness verification");
+    expect(output).not.toContain("same-path executable replacement canary");
+  });
+
+  it("reports restoration uncertainty when executable identity changes after start", async () => {
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: { name: "hermes" },
+      portableReceiptDisposition: { kind: "hermes", phase: "active" },
+      portableRecoveryResult: { kind: "already-running" },
+    });
+    const forward = configureMissingHermesForwardCapture(harness, {
+      afterStart: () => {
+        harness.assertHermesPortableOperatingCommandCurrentSpy.mockImplementation(() => {
+          throw new Error("same-path executable replacement canary");
+        });
+      },
+    });
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(forward.isRunning()).toBe(true);
+    expect(
+      harness.runOpenshellSpy.mock.calls.filter(
+        ([args]) => Array.isArray(args) && args[0] === "forward" && args[1] === "stop",
+      ),
+    ).toHaveLength(0);
+    expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();
+    const output = harness.errorSpy.mock.calls.flat().join("\n");
+    expect(output).toContain("returned to a stopped state");
+    expect(output).not.toContain("same-path executable replacement canary");
+  });
+
+  it("restores the missing state when registry authority drifts after start", async () => {
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: { name: "hermes" },
+      portableReceiptDisposition: { kind: "hermes", phase: "active" },
+      portableRecoveryResult: { kind: "already-running" },
+    });
+    const forward = configureMissingHermesForwardCapture(harness, {
+      afterStart: () => {
+        harness.registryEntries[0]!.gatewayName = "changed-gateway";
+      },
+    });
+
+    await expect(harness.connectSandbox("alpha", { probeOnly: true })).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    expect(
+      harness.runOpenshellSpy.mock.calls.some(
+        ([args]) => Array.isArray(args) && args[0] === "forward" && args[1] === "stop",
+      ),
+    ).toBe(true);
+    expect(forward.isRunning()).toBe(false);
+    expect(harness.publishLaunchReadinessSpy).not.toHaveBeenCalled();
+    expect(harness.errorSpy.mock.calls.flat().join("\n")).toContain(
+      "authority changed during host-forward recovery",
+    );
+  });
+
+  it("keeps direct interactive connect outside the probe-only forward recovery seam", async () => {
+    const harness = createConnectHarness({
+      agentName: "hermes",
+      sessionAgent: { name: "hermes" },
+      portableReceiptDisposition: { kind: "hermes", phase: "active" },
+      portableRecoveryResult: { kind: "already-running" },
+    });
+
+    await expect(harness.connectSandbox("alpha")).rejects.toThrow("process.exit(0)");
+
+    expect(
+      harness.runOpenshellSpy.mock.calls.some(
+        ([args]) => Array.isArray(args) && args[0] === "forward",
+      ),
+    ).toBe(false);
   });
 });

--- a/src/lib/actions/sandbox/probe/hermes-portable-forward-recovery.ts
+++ b/src/lib/actions/sandbox/probe/hermes-portable-forward-recovery.ts
@@ -1,6 +1,28 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isIP } from "node:net";
+
+import { isLocalForwardReachable } from "../forward-health";
+
+const FORWARD_SETTLEMENT_TIMEOUT_MS = 3_000;
+const FORWARD_SETTLEMENT_INTERVAL_MS = 100;
+const FORWARD_SETTLEMENT_MAX_OBSERVATIONS =
+  Math.ceil(FORWARD_SETTLEMENT_TIMEOUT_MS / FORWARD_SETTLEMENT_INTERVAL_MS) + 2;
+
+type CommandResult = {
+  readonly error?: unknown;
+  readonly output?: string | null;
+  readonly status?: number | null;
+};
+
+type ForwardState = "absent" | "healthy" | "occupied" | "stale-reachable" | "stale-unreachable";
+type ForwardTimingStage = "list" | "settle" | "start" | "stop";
+type ForwardObservation = {
+  readonly entries: ReadonlyMap<number, StrictForwardEntry>;
+  readonly states: Map<number, ForwardState>;
+};
+
 export interface HermesPortableForwardRecoveryTimingEvidence {
   readonly listMs: number;
   readonly listCount: number;
@@ -16,7 +38,7 @@ export interface HermesPortableForwardRecoveryTimingEvidence {
 
 export interface HermesPortableForwardRecoveryTiming {
   readonly now?: () => number;
-  readonly onComplete: (evidence: HermesPortableForwardRecoveryTimingEvidence) => void;
+  readonly onComplete: (evidence: HermesPortableForwardRecoveryTimingEvidence) => unknown;
 }
 
 export type HermesPortableForwardRecoveryFailure =
@@ -35,9 +57,13 @@ export class HermesPortableForwardRecoveryError extends Error {
 export interface HermesPortableForwardRecoveryDeps {
   readonly assertCurrent: () => void;
   readonly assertRollbackCurrent: () => void;
-  readonly isReachable?: (port: number) => boolean;
-  readonly launch: (port: number) => void;
-  readonly migrateLegacy: (ports: readonly number[]) => void;
+  readonly captureCurrentList: (args: readonly string[], timeout: number) => CommandResult;
+  readonly captureRollbackList: (args: readonly string[], timeout: number) => CommandResult;
+  readonly runCurrentMutation: (args: readonly string[], timeout: number) => unknown;
+  readonly runRollbackMutation: (args: readonly string[], timeout: number) => unknown;
+  readonly isPortReachable?: (port: number, timeoutMs?: number) => boolean;
+  readonly now?: () => number;
+  readonly sleep?: (milliseconds: number) => void;
 }
 
 export interface HermesPortableForwardRecoveryInput {
@@ -66,14 +92,237 @@ export interface PreparedHermesPortableForwardRecovery {
   readonly rollback: () => void;
 }
 
-function failure(kind: HermesPortableForwardRecoveryFailure): never {
-  throw new HermesPortableForwardRecoveryError(kind);
+function failure(failureClass: HermesPortableForwardRecoveryFailure): never {
+  throw new HermesPortableForwardRecoveryError(failureClass);
 }
 
-function validate(input: HermesPortableForwardRecoveryInput): void {
+function normalizeFailure(error: unknown): HermesPortableForwardRecoveryError {
+  return error instanceof HermesPortableForwardRecoveryError
+    ? error
+    : new HermesPortableForwardRecoveryError("recovery-failed");
+}
+
+function safeTimingNow(now: () => number): number | null {
+  try {
+    const value = now();
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function createForwardTimingRecorder(timing?: HermesPortableForwardRecoveryTiming): {
+  readonly finish: (result: HermesPortableForwardRecoveryTimingEvidence["result"]) => void;
+  readonly measure: <T>(stage: ForwardTimingStage, operation: () => T) => T;
+} {
+  const now = timing?.now ?? (() => performance.now());
+  const startedAt = safeTimingNow(now);
+  const durations = new Map<ForwardTimingStage, number>();
+  const counts = new Map<ForwardTimingStage, number>();
+  let finished = false;
+  const elapsed = (start: number | null, end: number | null): number => {
+    if (start === null || end === null) return 0;
+    const value = Math.round(end - start);
+    return Number.isFinite(value) ? Math.min(9_999_999, Math.max(0, value)) : 0;
+  };
+  return Object.freeze({
+    measure<T>(stage: ForwardTimingStage, operation: () => T): T {
+      const stageStartedAt = safeTimingNow(now);
+      counts.set(stage, (counts.get(stage) ?? 0) + 1);
+      try {
+        return operation();
+      } finally {
+        durations.set(
+          stage,
+          Math.min(
+            9_999_999,
+            (durations.get(stage) ?? 0) + elapsed(stageStartedAt, safeTimingNow(now)),
+          ),
+        );
+      }
+    },
+    finish(result): void {
+      if (finished) return;
+      finished = true;
+      if (!timing) return;
+      try {
+        const completion = timing.onComplete(
+          Object.freeze({
+            listMs: durations.get("list") ?? 0,
+            listCount: counts.get("list") ?? 0,
+            stopMs: durations.get("stop") ?? 0,
+            stopCount: counts.get("stop") ?? 0,
+            startMs: durations.get("start") ?? 0,
+            startCount: counts.get("start") ?? 0,
+            settleMs: durations.get("settle") ?? 0,
+            settleCount: counts.get("settle") ?? 0,
+            totalMs: elapsed(startedAt, safeTimingNow(now)),
+            result,
+          }),
+        );
+        if (completion instanceof Promise) void completion.catch(() => undefined);
+      } catch {
+        // Timing output must not change forward recovery.
+      }
+    },
+  });
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/gu, "");
+}
+
+function isSupportedBind(value: string): boolean {
+  return value === "127.0.0.1";
+}
+
+function isSupportedForwardRow(parts: readonly string[]): boolean {
+  if (parts.length !== 5) return false;
+  const [sandboxName, bind, portValue, pidValue, status] = parts;
+  const port = Number(portValue);
+  const pid = Number(pidValue);
+  return (
+    /^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(sandboxName) &&
+    isSupportedBind(bind) &&
+    /^\d+$/u.test(portValue) &&
+    Number.isSafeInteger(port) &&
+    port >= 1 &&
+    port <= 65_535 &&
+    /^\d+$/u.test(pidValue) &&
+    Number.isSafeInteger(pid) &&
+    pid > 0 &&
+    ["active", "dead", "running", "stopped"].includes(status.toLowerCase())
+  );
+}
+
+type StrictForwardEntry = {
+  readonly sandboxName: string;
+  readonly bind: string;
+  readonly port: string;
+  readonly pid: number;
+  readonly status: string;
+};
+
+function parseStrictForwardList(output: unknown): StrictForwardEntry[] | null {
+  if (typeof output !== "string") return null;
+  const lines = stripAnsi(output)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0 || !/^SANDBOX\s+BIND\s+PORT\s+PID\s+STATUS$/iu.test(lines[0])) {
+    return null;
+  }
+  const rows = lines.slice(1).map((line) => line.split(/\s+/u));
+  if (rows.some((parts) => !isSupportedForwardRow(parts))) return null;
+  return rows.map(([sandboxName, bind, port, pid, status]) => ({
+    sandboxName,
+    bind,
+    port,
+    pid: Number(pid),
+    status: status.toLowerCase(),
+  }));
+}
+
+function requireCurrent(input: HermesPortableForwardRecoveryInput, rollback: boolean): void {
+  try {
+    if (rollback) input.deps.assertRollbackCurrent();
+    else input.deps.assertCurrent();
+  } catch {
+    failure(rollback ? "restoration-unproved" : "authority-drift");
+  }
+}
+
+function remainingBudget(deadline: number | undefined, now: () => number, limit: number): number {
+  if (deadline === undefined) return limit;
+  const remaining = Math.floor(deadline - readClock(now));
+  if (remaining <= 0) failure("recovery-failed");
+  return Math.min(limit, remaining);
+}
+
+function captureForwardEntries(
+  input: HermesPortableForwardRecoveryInput,
+  rollback: boolean,
+  timing?: ReturnType<typeof createForwardTimingRecorder>,
+  deadline?: number,
+  now: () => number = input.deps.now ?? Date.now,
+): StrictForwardEntry[] {
+  requireCurrent(input, rollback);
+  let result: CommandResult;
+  try {
+    const capture = rollback ? input.deps.captureRollbackList : input.deps.captureCurrentList;
+    const operation = () =>
+      capture(
+        ["forward", "list", "--gateway", input.gatewayName],
+        remainingBudget(deadline, now, input.probeTimeoutMs),
+      );
+    result = timing ? timing.measure("list", operation) : operation();
+  } catch (error) {
+    if (error instanceof HermesPortableForwardRecoveryError) throw error;
+    failure(rollback ? "restoration-unproved" : "forward-state-unavailable");
+  }
+  requireCurrent(input, rollback);
+  if (result.error || result.status !== 0) {
+    failure(rollback ? "restoration-unproved" : "forward-state-unavailable");
+  }
+  const entries = parseStrictForwardList(result.output);
+  if (!entries) failure(rollback ? "restoration-unproved" : "forward-state-unavailable");
+  return entries;
+}
+
+function observeForwards(
+  input: HermesPortableForwardRecoveryInput,
+  rollback: boolean,
+  timing?: ReturnType<typeof createForwardTimingRecorder>,
+  deadline?: number,
+  now: () => number = input.deps.now ?? Date.now,
+): ForwardObservation {
+  const listedEntries = captureForwardEntries(input, rollback, timing, deadline, now);
+  const entries = new Map<number, StrictForwardEntry>();
+  const states = new Map<number, ForwardState>();
+  const reachable = input.deps.isPortReachable ?? isLocalForwardReachable;
+  for (const port of input.ports) {
+    const portEntries = listedEntries.filter((entry) => entry.port === String(port));
+    if (portEntries.some((entry) => entry.sandboxName !== input.sandboxName)) {
+      states.set(port, "occupied");
+      continue;
+    }
+    if (portEntries.length > 1) {
+      failure(rollback ? "restoration-unproved" : "forward-state-unavailable");
+    }
+    const entry = portEntries[0];
+    if (entry) entries.set(port, entry);
+    requireCurrent(input, rollback);
+    let portReachable: boolean;
+    try {
+      portReachable = reachable(port, remainingBudget(deadline, now, input.probeTimeoutMs));
+    } catch {
+      failure(rollback ? "restoration-unproved" : "forward-state-unavailable");
+    }
+    requireCurrent(input, rollback);
+    if (entry) {
+      states.set(
+        port,
+        ["active", "running"].includes(entry.status) && portReachable
+          ? "healthy"
+          : portReachable
+            ? "stale-reachable"
+            : "stale-unreachable",
+      );
+    } else {
+      states.set(port, portReachable ? "occupied" : "absent");
+    }
+  }
+  return { entries, states };
+}
+
+function validatePorts(input: HermesPortableForwardRecoveryInput): void {
   if (
     input.intent !== "connect-probe-only" ||
+    !Number.isFinite(input.operationTimeoutMs) ||
+    input.operationTimeoutMs <= 0 ||
     input.ports.length === 0 ||
+    !Number.isFinite(input.probeTimeoutMs) ||
+    input.probeTimeoutMs <= 0 ||
     new Set(input.ports).size !== input.ports.length ||
     input.ports.some((port) => !Number.isInteger(port) || port < 1024 || port > 65_535)
   ) {
@@ -81,87 +330,256 @@ function validate(input: HermesPortableForwardRecoveryInput): void {
   }
 }
 
-function reachablePorts(input: HermesPortableForwardRecoveryInput): Set<number> {
-  const isReachable = input.deps.isReachable ?? (() => false);
-  return new Set(input.ports.filter((port) => isReachable(port)));
+function requireNoOccupied(states: Map<number, ForwardState>): void {
+  if ([...states.values()].includes("occupied")) failure("forward-occupied");
 }
 
-function timing(
+function invokeMutation(
   input: HermesPortableForwardRecoveryInput,
-  startedAt: number,
-  startCount: number,
-  result: "proved" | "failed",
+  stage: "start" | "stop",
+  args: readonly string[],
+  timing: ReturnType<typeof createForwardTimingRecorder>,
 ): void {
-  input.timing?.onComplete({
-    listMs: 0,
-    listCount: input.ports.length,
-    stopMs: 0,
-    stopCount: 0,
-    startMs: 0,
-    startCount,
-    settleMs: 0,
-    settleCount: 0,
-    totalMs: Math.max(0, Math.round((input.timing?.now ?? (() => performance.now()))() - startedAt)),
-    result,
+  requireCurrent(input, false);
+  try {
+    timing.measure(stage, () => input.deps.runCurrentMutation(args, input.operationTimeoutMs));
+  } catch (error) {
+    throw normalizeFailure(error);
+  }
+  requireCurrent(input, false);
+}
+
+function readClock(now: () => number, previous?: number): number {
+  const current = now();
+  if (!Number.isFinite(current) || (previous !== undefined && current < previous)) {
+    failure("recovery-failed");
+  }
+  return current;
+}
+
+function settleTouchedPorts(
+  input: HermesPortableForwardRecoveryInput,
+  requiredHealthy: ReadonlySet<number>,
+  timing: ReturnType<typeof createForwardTimingRecorder>,
+): ForwardObservation {
+  return timing.measure("settle", () => {
+    const now = input.deps.now ?? Date.now;
+    const sleep = input.deps.sleep ?? sleepMilliseconds;
+    let previous = readClock(now);
+    const deadline = previous + Math.min(input.operationTimeoutMs, FORWARD_SETTLEMENT_TIMEOUT_MS);
+    if (!Number.isFinite(deadline)) failure("recovery-failed");
+
+    for (let observation = 0; observation < FORWARD_SETTLEMENT_MAX_OBSERVATIONS; observation += 1) {
+      const observed = observeForwards(input, false, timing, deadline, now);
+      requireNoOccupied(observed.states);
+      if ([...requiredHealthy].every((port) => observed.states.get(port) === "healthy")) {
+        return observed;
+      }
+
+      const current = readClock(now, previous);
+      previous = current;
+      if (current >= deadline) break;
+      sleep(Math.min(FORWARD_SETTLEMENT_INTERVAL_MS, deadline - current));
+    }
+    failure("recovery-failed");
   });
 }
 
+function sameForwardIdentity(expected: StrictForwardEntry, actual?: StrictForwardEntry): boolean {
+  return (
+    actual !== undefined &&
+    actual.sandboxName === expected.sandboxName &&
+    actual.bind === expected.bind &&
+    actual.port === expected.port &&
+    actual.pid === expected.pid
+  );
+}
+
+function rollbackPort(
+  input: HermesPortableForwardRecoveryInput,
+  port: number,
+  expected: StrictForwardEntry | undefined,
+): void {
+  const now = input.deps.now ?? Date.now;
+  const sleep = input.deps.sleep ?? sleepMilliseconds;
+  let previous = readClock(now);
+  const deadline = previous + Math.min(input.operationTimeoutMs, FORWARD_SETTLEMENT_TIMEOUT_MS);
+  if (!Number.isFinite(deadline)) failure("restoration-unproved");
+  try {
+    const beforeStop = observeForwards(input, true, undefined, deadline, now);
+    const currentEntry = beforeStop.entries.get(port);
+    if (expected && !sameForwardIdentity(expected, currentEntry)) failure("restoration-unproved");
+    if (!expected && currentEntry && currentEntry.sandboxName !== input.sandboxName) {
+      failure("restoration-unproved");
+    }
+    if (["occupied", "stale-reachable"].includes(beforeStop.states.get(port) ?? "")) {
+      failure("restoration-unproved");
+    }
+    requireCurrent(input, true);
+    input.deps.runRollbackMutation(
+      ["forward", "stop", String(port), input.sandboxName, "--gateway", input.gatewayName],
+      remainingBudget(deadline, now, input.operationTimeoutMs),
+    );
+    requireCurrent(input, true);
+  } catch {
+    failure("restoration-unproved");
+  }
+
+  for (let observation = 0; observation < FORWARD_SETTLEMENT_MAX_OBSERVATIONS; observation += 1) {
+    let state: ForwardState | undefined;
+    try {
+      state = observeForwards(input, true, undefined, deadline, now).states.get(port);
+    } catch {
+      failure("restoration-unproved");
+    }
+    if (state === "absent" || state === "stale-unreachable") return;
+    if (state === "occupied" || state === "stale-reachable") {
+      failure("restoration-unproved");
+    }
+    const current = readClock(now, previous);
+    previous = current;
+    if (current >= deadline) break;
+    sleep(Math.min(FORWARD_SETTLEMENT_INTERVAL_MS, deadline - current));
+  }
+  failure("restoration-unproved");
+}
+
+function rollbackTouchedPorts(
+  input: HermesPortableForwardRecoveryInput,
+  touchedPorts: readonly number[],
+  identities: ReadonlyMap<number, StrictForwardEntry>,
+): void {
+  for (const port of [...touchedPorts].reverse()) rollbackPort(input, port, identities.get(port));
+}
+
+function retainForwardRecovery(
+  input: HermesPortableForwardRecoveryInput,
+  touchedPorts: readonly number[],
+  identities: ReadonlyMap<number, StrictForwardEntry>,
+  result: HermesPortableForwardRecoveryResult,
+): PreparedHermesPortableForwardRecovery {
+  let state: "prepared" | "released" | "rolled-back" = "prepared";
+  return Object.freeze({
+    result,
+    release: () => {
+      if (state !== "prepared") failure("recovery-failed");
+      state = "released";
+      return result;
+    },
+    rollback: () => {
+      if (state !== "prepared") failure("restoration-unproved");
+      state = "rolled-back";
+      if (touchedPorts.length > 0) rollbackTouchedPorts(input, touchedPorts, identities);
+    },
+  });
+}
+
+/** Prepare the exact launch-readiness forward set while retaining rollback authority. */
 export function prepareHermesPortableLaunchForwards(
   input: HermesPortableForwardRecoveryInput,
 ): PreparedHermesPortableForwardRecovery {
-  validate(input);
-  const now = input.timing?.now ?? (() => performance.now());
-  const startedAt = now();
-  let startCount = 0;
+  const timing = createForwardTimingRecorder(input.timing);
+  const touchedPorts: number[] = [];
+  const identities = new Map<number, StrictForwardEntry>();
   try {
-    input.deps.assertCurrent();
-    const missing = input.ports.filter((port) => !reachablePorts(input).has(port));
-    if (missing.length > 0) {
-      input.deps.migrateLegacy(missing);
-      input.deps.assertCurrent();
-      for (const port of missing) {
-        input.deps.launch(port);
-        startCount += 1;
-        input.deps.assertCurrent();
-      }
+    validatePorts(input);
+    const initial = observeForwards(input, false, timing);
+    requireNoOccupied(initial.states);
+    const missing = input.ports.filter((port) => initial.states.get(port) !== "healthy");
+    if (missing.length === 0) {
+      requireCurrent(input, false);
+      timing.finish("proved");
+      return retainForwardRecovery(input, touchedPorts, identities, {
+        kind: "verified",
+        restoredPorts: [],
+      });
     }
-    if (reachablePorts(input).size !== input.ports.length) failure("recovery-failed");
-    const result: HermesPortableForwardRecoveryResult = {
-      kind: missing.length === 0 ? "verified" : "restored",
-      restoredPorts: missing,
-    };
-    timing(input, startedAt, startCount, "proved");
-    let released = false;
-    return {
-      result,
-      release: () => {
-        if (released) failure("recovery-failed");
-        released = true;
-        return result;
-      },
-      rollback: () => {
-        if (released) failure("restoration-unproved");
-        input.deps.assertRollbackCurrent();
-        released = true;
-      },
-    };
+
+    const requiredHealthy = new Set(input.ports);
+    for (const port of missing) {
+      touchedPorts.push(port);
+      if (["stale-reachable", "stale-unreachable"].includes(initial.states.get(port) ?? "")) {
+        invokeMutation(
+          input,
+          "stop",
+          ["forward", "stop", String(port), input.sandboxName, "--gateway", input.gatewayName],
+          timing,
+        );
+      }
+      invokeMutation(
+        input,
+        "start",
+        [
+          "forward",
+          "start",
+          "--background",
+          String(port),
+          input.sandboxName,
+          "--gateway",
+          input.gatewayName,
+        ],
+        timing,
+      );
+    }
+    const final = settleTouchedPorts(input, requiredHealthy, timing);
+
+    requireNoOccupied(final.states);
+    if (input.ports.some((port) => final.states.get(port) !== "healthy")) {
+      failure("recovery-failed");
+    }
+    for (const port of touchedPorts) {
+      const entry = final.entries.get(port);
+      if (!entry) failure("recovery-failed");
+      identities.set(port, entry);
+    }
+    requireCurrent(input, false);
+    timing.finish("proved");
+    return retainForwardRecovery(input, touchedPorts, identities, {
+      kind: "restored",
+      restoredPorts: [...missing],
+    });
   } catch (error) {
-    timing(input, startedAt, startCount, "failed");
-    throw error instanceof HermesPortableForwardRecoveryError
-      ? error
-      : new HermesPortableForwardRecoveryError("recovery-failed");
+    let normalized = normalizeFailure(error);
+    try {
+      if (touchedPorts.length > 0) {
+        rollbackTouchedPorts(input, touchedPorts, identities);
+      }
+    } catch {
+      normalized = new HermesPortableForwardRecoveryError("restoration-unproved");
+    } finally {
+      timing.finish("failed");
+    }
+    throw normalized;
   }
 }
 
+/** Restore and commit the exact launch-readiness forward set for one Hermes probe. */
 export function recoverHermesPortableLaunchForwards(
   input: HermesPortableForwardRecoveryInput,
 ): HermesPortableForwardRecoveryResult {
   return prepareHermesPortableLaunchForwards(input).release();
 }
 
+/** Verify the exact launch-readiness forward set without starting or stopping a forward. */
 export function verifyHermesPortableLaunchForwards(
   input: HermesPortableForwardRecoveryInput,
 ): HermesPortableForwardVerificationResult {
-  validate(input);
-  return { kind: reachablePorts(input).size === input.ports.length ? "healthy" : "unhealthy" };
+  validatePorts(input);
+  try {
+    const observed = observeForwards(input, false);
+    requireNoOccupied(observed.states);
+    requireCurrent(input, false);
+    return Object.freeze({
+      kind: input.ports.every((port) => observed.states.get(port) === "healthy")
+        ? "healthy"
+        : "unhealthy",
+    });
+  } catch (error) {
+    throw normalizeFailure(error);
+  }
+}
+
+function sleepMilliseconds(milliseconds: number): void {
+  if (milliseconds <= 0 || !Number.isFinite(milliseconds)) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
 }

--- a/src/lib/adapters/openshell/local-forward-listener.test.ts
+++ b/src/lib/adapters/openshell/local-forward-listener.test.ts
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createServer } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { probeLocalForwardListener } from "./local-forward-listener";
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+describe("local forward listener probe", () => {
+  it("detects a loopback listener without sending application data (#10926)", async () => {
+    let receivedBytes = 0;
+    const server = createServer((socket) => {
+      socket.on("data", (chunk) => {
+        receivedBytes += chunk.length;
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address() as import("node:net").AddressInfo;
+
+    expect(probeLocalForwardListener(address.port)).toBe(true);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(receivedBytes).toBe(0);
+  });
+
+  it("fails closed for a refused or invalid port (#10926)", async () => {
+    const server = createServer();
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address() as import("node:net").AddressInfo;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+
+    expect(probeLocalForwardListener(address.port)).toBe(false);
+    expect(probeLocalForwardListener(0)).toBe(false);
+    expect(probeLocalForwardListener(65_536)).toBe(false);
+  });
+});

--- a/src/lib/adapters/openshell/local-forward-listener.ts
+++ b/src/lib/adapters/openshell/local-forward-listener.ts
@@ -1,23 +1,67 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from "node:child_process";
+import { Worker } from "node:worker_threads";
 
-import { buildOpenShellSubprocessEnv } from "./resolve-shared";
+const DEFAULT_PROBE_TIMEOUT_MS = 1_000;
+const WORKER_RESPONSE_GRACE_MS = 50;
+const PROBE_WORKER_SOURCE = `const { parentPort } = require("node:worker_threads");
+const net = require("node:net");
+parentPort.on("message", ({ port, timeout, state }) => {
+  const result = new Int32Array(state);
+  let finished = false;
+  const socket = net.createConnection({ host: "127.0.0.1", port });
+  const finish = (value) => {
+    if (finished) return;
+    finished = true;
+    socket.destroy();
+    Atomics.store(result, 0, value);
+    Atomics.notify(result, 0);
+  };
+  socket.setTimeout(timeout);
+  socket.once("connect", () => finish(1));
+  socket.once("error", () => finish(2));
+  socket.once("timeout", () => finish(2));
+});`;
+
+let probeWorker: Worker | null = null;
+
+function getProbeWorker(): Worker {
+  if (probeWorker) return probeWorker;
+  const worker = new Worker(PROBE_WORKER_SOURCE, { eval: true });
+  worker.unref();
+  worker.on("error", () => {
+    if (probeWorker === worker) probeWorker = null;
+  });
+  worker.on("exit", () => {
+    if (probeWorker === worker) probeWorker = null;
+  });
+  probeWorker = worker;
+  return worker;
+}
 
 /** Transport evidence only; callers must establish listener ownership separately. */
-export function probeLocalForwardListener(port: number): boolean {
-  const script =
-    "const net=require('node:net');" +
-    `const s=net.createConnection({host:'127.0.0.1',port:${String(port)}});` +
-    "s.setTimeout(1000);" +
-    "s.on('connect',()=>{s.destroy();process.exit(0)});" +
-    "s.on('error',()=>process.exit(1));" +
-    "s.on('timeout',()=>{s.destroy();process.exit(1)});";
-  const result = spawnSync(process.execPath, ["-e", script], {
-    env: buildOpenShellSubprocessEnv(),
-    stdio: "ignore",
-    timeout: 2_000,
-  });
-  return result.status === 0;
+export function probeLocalForwardListener(
+  port: number,
+  timeoutMs = DEFAULT_PROBE_TIMEOUT_MS,
+): boolean {
+  if (
+    !Number.isSafeInteger(port) ||
+    port < 1 ||
+    port > 65_535 ||
+    !Number.isFinite(timeoutMs) ||
+    timeoutMs <= 0
+  ) {
+    return false;
+  }
+  const timeout = Math.max(1, Math.floor(timeoutMs));
+  const state = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+  try {
+    getProbeWorker().postMessage({ port, timeout, state: state.buffer });
+  } catch {
+    probeWorker = null;
+    return false;
+  }
+  Atomics.wait(state, 0, 0, timeout + WORKER_RESPONSE_GRACE_MS);
+  return Atomics.load(state, 0) === 1;
 }

--- a/test/support/hermes-portable-forward-recovery-fixture.ts
+++ b/test/support/hermes-portable-forward-recovery-fixture.ts
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { vi } from "vitest";
+
+import type { HermesPortableForwardRecoveryInput } from "../../src/lib/actions/sandbox/probe/hermes-portable-forward-recovery";
+import { type ConnectHarness, requireDist } from "./connect-flow-test-harness";
+
+type ForwardRecord = {
+  owner: string;
+  reachable: boolean;
+  status: "active" | "dead" | "running" | "stopped";
+};
+
+function forwardList(records: ReadonlyMap<number, ForwardRecord>): string {
+  return [
+    "SANDBOX BIND PORT PID STATUS",
+    ...[...records].map(
+      ([port, record]) => `${record.owner} 127.0.0.1 ${String(port)} 12345 ${record.status}`,
+    ),
+  ].join("\n");
+}
+
+export function createHermesPortableForwardRecoveryFixture({
+  ports = [18_789],
+  active = [],
+  dead = [],
+  running = [],
+  stopped = [],
+  occupied = [],
+  malformedList = false,
+  listStatus = 0,
+  startStatus = 0,
+  startUpdatesState = true,
+  driftCurrentAfterStart = false,
+  dropStartedPort,
+  listOutput,
+}: {
+  ports?: readonly number[];
+  active?: readonly number[];
+  dead?: readonly number[];
+  running?: readonly number[];
+  stopped?: readonly number[];
+  occupied?: readonly number[];
+  malformedList?: boolean;
+  listStatus?: number;
+  startStatus?: number;
+  startUpdatesState?: boolean;
+  driftCurrentAfterStart?: boolean;
+  dropStartedPort?: number;
+  listOutput?: string;
+} = {}) {
+  const records = new Map<number, ForwardRecord>();
+  for (const port of active) {
+    records.set(port, { owner: "alpha", reachable: true, status: "active" });
+  }
+  for (const port of dead) {
+    records.set(port, { owner: "alpha", reachable: false, status: "dead" });
+  }
+  for (const port of running) {
+    records.set(port, { owner: "alpha", reachable: true, status: "running" });
+  }
+  for (const port of stopped) {
+    records.set(port, { owner: "alpha", reachable: false, status: "stopped" });
+  }
+  for (const port of occupied) {
+    records.set(port, { owner: "beta", reachable: true, status: "running" });
+  }
+  const currentCalls: string[][] = [];
+  const rollbackCalls: string[][] = [];
+  const currentCaptureCalls: string[][] = [];
+  const currentMutationCalls: string[][] = [];
+  const rollbackCaptureCalls: string[][] = [];
+  const rollbackMutationCalls: string[][] = [];
+  let currentAllowed = true;
+  let rollbackAllowed = true;
+  let now = 0;
+
+  const capture = (args: readonly string[], rollback: boolean) => {
+    const calls = rollback ? rollbackCalls : currentCalls;
+    calls.push([...args]);
+    (rollback ? rollbackCaptureCalls : currentCaptureCalls).push([...args]);
+    if (args[0] !== "forward" || args[1] !== "list") throw new Error("unexpected capture");
+    return {
+      status: listStatus,
+      output: listOutput ?? (malformedList ? "not a forward list" : forwardList(records)),
+    };
+  };
+  const mutate = (args: readonly string[], rollback: boolean) => {
+    const calls = rollback ? rollbackCalls : currentCalls;
+    calls.push([...args]);
+    (rollback ? rollbackMutationCalls : currentMutationCalls).push([...args]);
+    const port = Number(args[1] === "stop" ? args[2] : args[3]);
+    if (args[1] === "stop") {
+      records.delete(port);
+      return { status: 0, output: "" };
+    }
+    if (args[1] === "start") {
+      if (startUpdatesState) {
+        records.set(port, { owner: "alpha", reachable: true, status: "running" });
+      }
+      if (port === dropStartedPort) records.delete(port);
+      if (driftCurrentAfterStart) currentAllowed = false;
+      return { status: startStatus, output: "" };
+    }
+    throw new Error("unexpected command");
+  };
+  const input: HermesPortableForwardRecoveryInput = {
+    intent: "connect-probe-only",
+    sandboxName: "alpha",
+    gatewayName: "nemoclaw",
+    operationTimeoutMs: 30_000,
+    ports,
+    probeTimeoutMs: 10_000,
+    deps: {
+      assertCurrent: () => {
+        if (!currentAllowed) throw new Error("current authority canary");
+      },
+      assertRollbackCurrent: () => {
+        if (!rollbackAllowed) throw new Error("rollback authority canary");
+      },
+      captureCurrentList: (args) => capture(args, false),
+      captureRollbackList: (args) => capture(args, true),
+      runCurrentMutation: (args) => mutate(args, false),
+      runRollbackMutation: (args) => mutate(args, true),
+      isPortReachable: (port) => records.get(port)?.reachable === true,
+      now: () => now,
+      sleep: (milliseconds) => {
+        now += milliseconds;
+      },
+    },
+  };
+  return {
+    currentCalls,
+    currentCaptureCalls,
+    currentMutationCalls,
+    elapsedMs: () => now,
+    input,
+    records,
+    rollbackCalls,
+    rollbackCaptureCalls,
+    rollbackMutationCalls,
+    setCurrentAllowed(value: boolean) {
+      currentAllowed = value;
+    },
+    setRollbackAllowed(value: boolean) {
+      rollbackAllowed = value;
+    },
+  };
+}
+
+export function configureMissingHermesForwardCapture(
+  harness: ConnectHarness,
+  options: {
+    readonly afterStart?: () => void;
+    readonly initialStatus?: "dead" | "missing";
+  } = {},
+): { readonly isRunning: () => boolean; readonly reachabilitySpy: ReturnType<typeof vi.spyOn> } {
+  let forwardStatus: "dead" | "missing" | "running" = options.initialStatus ?? "missing";
+  const forwardHealth = requireDist("../../src/lib/actions/sandbox/forward-health.js");
+  const reachabilitySpy = vi
+    .spyOn(forwardHealth, "isLocalForwardReachable")
+    .mockImplementation(() => forwardStatus === "running");
+  const captureResolved = harness.captureResolvedOpenshellSpy.getMockImplementation()!;
+  const runOpenshell = harness.runOpenshellSpy.getMockImplementation()!;
+  harness.captureResolvedOpenshellSpy.mockImplementation(((
+    args: unknown,
+    captureOptions: unknown,
+  ) => {
+    const argv = Array.isArray(args) ? args.map(String) : [];
+    if (argv[0] === "forward" && argv[1] === "list") {
+      return {
+        status: 0,
+        output:
+          forwardStatus === "missing"
+            ? "SANDBOX BIND PORT PID STATUS"
+            : `SANDBOX BIND PORT PID STATUS\nalpha 127.0.0.1 18789 12345 ${forwardStatus}`,
+      };
+    }
+    return captureResolved(args, captureOptions);
+  }) as never);
+  harness.runOpenshellSpy.mockImplementation(((args: unknown, runOptions: unknown) => {
+    const argv = Array.isArray(args) ? args.map(String) : [];
+    if (argv[0] === "forward" && argv[1] === "stop") {
+      forwardStatus = "missing";
+      return { status: 0 };
+    }
+    if (argv[0] === "forward" && argv[1] === "start") {
+      forwardStatus = "running";
+      options.afterStart?.();
+      return { status: 0 };
+    }
+    return runOpenshell(args, runOptions);
+  }) as never);
+  return {
+    isRunning: () => forwardStatus === "running",
+    reachabilitySpy,
+  };
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Hermes Portable probe-only recovery now restores its required localhost forwards with one strict ownership snapshot, sequential fenced mutations, and one joint settlement loop. Local TCP liveness checks run in process instead of starting a Node subprocess for each port, while TCP remains transport evidence only.

## Reason

The previous path paid subprocess startup and serial settlement overhead for each required forward. Issue #10926 accepts a bounded in-process probe and joint settlement while preserving ownership, currentness, and rollback controls.

### Related issues

Refs #10926

## Changes

- Replace the subprocess-backed loopback TCP check with a bounded worker-backed socket probe that sends no application data and fails closed.
- Parse the owning OpenShell forward list strictly, require the exact `127.0.0.1` bind, and keep ownership independent from TCP reachability.
- Run start and stop mutations sequentially behind currentness fences, then settle every required port from one bounded observation loop.
- Retain settled PID identity for rollback, refuse to stop a replacement forward, and roll touched ports back in reverse order.
- Keep timing callbacks outside recovery behavior and add focused recovery, failure, settlement, authority-drift, and rollback coverage.

## Verification

- `npx vitest run --project cli src/lib/actions/sandbox/probe/hermes-portable-forward-recovery.test.ts src/lib/adapters/openshell/local-forward-listener.test.ts` — 59 tests passed.
- `npm run typecheck:cli` — passed.
- `npm run build:cli` — passed.
- `npm run checks:repository` — passed.
- `npm run validate:pr` — passed, including pre-commit, commit-message, and pre-push checks.
- `npm run review:local` — passed twice after the final implementation review; no retained review artifact or unresolved candidate-owned blocker.
- GitHub commit verification — commit `68c6f72d375f07a150fc66bb8f94efc63a082b5e` is Verified.
- Secret review — the diff contains no secrets, API keys, or credentials.

## Review notes

This changes a security-sensitive host-forward recovery path. OpenShell list identity remains authoritative; TCP only proves liveness. The recovery refuses foreign, duplicate, malformed, non-loopback, replaced, or authority-drifted state and preserves reverse rollback. It does not combine or alter Hermes authenticated health verification.

Live Portable validation was not run at the contributor's direction. This draft reports operation-count reduction only: two missing forwards use one initial list and one joint settlement list instead of separate per-port settlement rounds; no wall-clock improvement is claimed without exact-candidate live evidence.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hermes connection recovery by validating forward state, detecting stale or occupied ports, and restoring connections more reliably.
  * Added safer rollback and failure handling to prevent partial recovery from leaving inconsistent connection states.
  * Improved local port checks with timeout support and clearer handling of invalid, unavailable, or unreachable ports.
  * Enhanced recovery coordination during connection setup, including readiness reporting and related service coordination.

* **Tests**
  * Expanded coverage for recovery ordering, state validation, rollback behavior, authority changes, timing, and connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->