### PR TITLE
test(onboard): align retained Podman proof assertion

### DIFF
--- a/src/lib/onboard/experimental/hermes-portable-podman-authority.test.ts
+++ b/src/lib/onboard/experimental/hermes-portable-podman-authority.test.ts
@@ -213,9 +213,7 @@ describe("Hermes portable Podman executable and endpoint authority", () => {
   it("recaptures exact executable identity without querying Podman for read-only proof", () => {
     const generation = { executableInode: 10n, parentInode: 20n };
     const capture = successfulCapture();
-    const executableAuthorityDeps = executableDeps(generation);
-    const readFile = vi.spyOn(executableAuthorityDeps, "readFile");
-    const deps = authorityDeps(capture, executableAuthorityDeps);
+    const deps = authorityDeps(capture, executableDeps(generation));
     const runtime = runtimeAuthority();
     const sourceEnv = { PATH: "/usr/bin", HOME: "/home/test" };
     const recorded = captureHermesPortablePodmanExecutableAuthority(
@@ -225,7 +223,6 @@ describe("Hermes portable Podman executable and endpoint authority", () => {
       deps,
     );
     capture.mockClear();
-    readFile.mockClear();
 
     expect(
       captureHermesPortablePodmanExecutableFileAuthority(
@@ -236,7 +233,6 @@ describe("Hermes portable Podman executable and endpoint authority", () => {
       ),
     ).toEqual(recorded);
     expect(capture).not.toHaveBeenCalled();
-    expect(readFile).not.toHaveBeenCalled();
   });
 
   it("rejects retained file proof when Podman executable metadata drifts", () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

The Hermes portable Podman authority test now matches the retained proof's full executable-content validation, allowing the affected main CI shard to complete.

## Reason

PR #10999 intentionally restored full executable authority validation for retained proofs, but its test still asserted that the executable bytes were never read. The contradictory assertion deterministically failed main CI even though the production security check was operating as intended.

## Changes

- Remove only the obsolete readFile spy and no-call assertion while preserving the test's contract that retained proof validation does not invoke the Podman process.
- Keep the adjacent executable metadata-drift and full authority boundary tests unchanged so content and identity validation remain covered.

## Verification

- Contributor validation: npm run validate:pr passed pre-commit, commitlint, and pre-push checks after rebuilding exact-base plugin artifacts.
- Tests: npx vitest run --project cli src/lib/onboard/experimental/hermes-portable-podman-authority.test.ts — 12 tests passed; npm run validate:pr — passed.
- Secrets review: The diff contains no secrets, API keys, or credentials

## Review notes

- Sensitive-path review: Self-review confirmed this is test-only and removes a stale performance assertion without weakening production executable authority validation or the adjacent security regression tests.

---

Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified an executable file-proof reuse test to focus on verifying authority reuse without invoking Podman.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->