### PR TITLE
ci(docs): clarify documentation job names

### DIFF
--- a/.github/workflows/docs-cli-parity-pr.yaml
+++ b/.github/workflows/docs-cli-parity-pr.yaml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   cli-parity:
+    name: Docs / Verify CLI and installer reference parity
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/docs-links-pr.yaml
+++ b/.github/workflows/docs-links-pr.yaml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   markdown-links:
+    name: Docs / Check changed Markdown links
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/docs-preview-pr.yaml
+++ b/.github/workflows/docs-preview-pr.yaml
@@ -30,6 +30,7 @@ env:
 
 jobs:
   preview:
+    name: Docs / Validate and publish PR preview
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/docs-publish-public.yaml
+++ b/.github/workflows/docs-publish-public.yaml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   publish:
+    name: Docs / Publish release documentation
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: docs-public

--- a/.github/workflows/docs-publish-staging.yaml
+++ b/.github/workflows/docs-publish-staging.yaml
@@ -27,6 +27,7 @@ env:
 
 jobs:
   publish:
+    name: Docs / Publish staging documentation
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: docs-staging
@@ -58,6 +59,7 @@ jobs:
           npx --yes "fern-api@${FERN_VERSION}" generate --docs --instance "$FERN_STAGING_INSTANCE"
 
   delete-preview:
+    name: Docs / Delete PR previews
     runs-on: ubuntu-latest
     needs: publish
     timeout-minutes: 5

--- a/.github/workflows/post-merge-docs.yaml
+++ b/.github/workflows/post-merge-docs.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   gate:
-    name: Select documentation PR ownership
+    name: Docs / Select documentation PR ownership
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: read
@@ -48,7 +48,7 @@ jobs:
           fi
 
   author:
-    name: Author and review documentation catch-up
+    name: Docs / Author and review documentation catch-up
     needs: gate
     if: ${{ github.repository == 'NVIDIA/NemoClaw' && needs.gate.outputs.automate == 'true' }}
     runs-on: ubuntu-24.04
@@ -151,7 +151,7 @@ jobs:
           retention-days: 3
 
   publish:
-    name: Publish documentation catch-up
+    name: Docs / Publish documentation catch-up
     needs: author
     runs-on: ubuntu-24.04
     timeout-minutes: 10


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome

Documentation workflow jobs now use unique `Docs / ...` display names in GitHub Actions. Job IDs and workflow behavior remain unchanged.

## Reason

The GitHub Actions check list mixed implicit job IDs with natural-language names. A scoped Docs prefix improves navigation without changing required checks or name-based automation.

## Changes

- Add outcome-oriented job names to six documentation workflows.
- Preserve all job IDs, triggers, permissions, dependencies, environments, and commands.
- Exclude required checks and workflows with job-name consumers from this change.

## Verification

- Contributor validation: `npm run validate:pr` passed against canonical `origin/main` at `c1d55e860d7b4e48ec86cc8954963238b5cb92fc`.
- Tests: `npm run test:changed` passed 45 tests; focused documentation, release, and workflow-name tests passed 85 tests.
- Repository checks: `npm run checks:repository` passed.
- Workflow inspection: all nine documentation jobs have unique `Docs / ...` names.
- Secrets review: The diff contains no secrets, API keys, or credentials.

---
Signed-off-by: Carlos Villela <cvillela@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added clear, consistent names to documentation validation, preview, publishing, and cleanup jobs.
  * Standardized post-merge documentation job labels with a “Docs /” prefix.
  * Improved visibility into workflow status and purpose without changing workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->