### PR TITLE
fix(e2e): preserve hosted inference for Brev

### DIFF
--- a/test/e2e/live/full-e2e.test.ts
+++ b/test/e2e/live/full-e2e.test.ts
@@ -470,9 +470,7 @@ test("full e2e: install, onboard, inference, cli operations, and cleanup", {
         artifactName: "phase-1-brev-launchable-quickstart",
         env: env({
           ...hosted.env,
-          NVIDIA_API_KEY: hosted.apiKey,
           NEMOCLAW_AGENT: "openclaw",
-          NEMOCLAW_PROVIDER: "build",
         }),
         redactionValues,
         timeoutMs: INSTALL_TIMEOUT_MS,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Outcome
The exact staging Brev Launchable now preserves the shared hosted-compatible inference configuration. Before this change, its preinstalled onboarding path replaced that configuration with the `build` provider and rejected a valid non-`nvapi-` credential before inference.

## Reason
The repository `NVIDIA_INFERENCE_API_KEY` targets `https://inference-api.nvidia.com/v1` through the custom compatible provider. The Brev-specific provider override bypassed that shared contract and caused issue #10975.

### Related issues
Fixes #10975

## Changes
- Remove the Brev-only `NEMOCLAW_PROVIDER=build` override.
- Remove the duplicate `NVIDIA_API_KEY` projection.
- Let `brev-quickstart` receive the existing `custom` provider, compatible endpoint, model, and `COMPATIBLE_API_KEY` values from the hosted-inference fixture.

## Verification
- `npx vitest run --project e2e-support test/e2e/support/hosted-inference.test.ts` — 16 tests passed.
- `npm run test:changed` — 45 growth-guardrail tests passed; no changed CLI, plugin, or E2E-support test files required another test.
- `npm run test:e2e-phases:check` — 132 live E2E tests across 88 files passed phase validation.
- `npm run review:local` — completed successfully against the committed patch with no published finding artifacts.
- Normal `pre-commit`, `commit-msg`, and `pre-push` hooks passed after building the required CLI artifacts.
- `git diff origin/main...HEAD` contains no secret or credential value.

## Review notes
This change affects a credential-bearing E2E path. It does not expand credential access or lifetime. The repository secret remains in the Brev guest for the job, and the existing redaction and workspace cleanup controls remain unchanged. The change removes the alternate provider route that imposed the wrong credential contract.

---
Signed-off-by: Julie Yaunches <jyaunches@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the preinstalled quickstart environment configuration to use the OpenClaw agent setting.
  * Removed the NVIDIA API key and build-provider environment settings from the end-to-end test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->